### PR TITLE
shell: support -o pmi=LIST

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -325,17 +325,22 @@ options are supported by the builtin plugins of ``flux-shell``:
   be set by the :man1:`flux-submit` and related commands --taskmap`` option.
 
 **pmi=off**
-  Disable the process management interface (PMI-1) which is required for
-  bootstrapping most parallel program environments.
+  Disable the process management interface for parallel jobs (see below).
 
-**pmi.nomap**
+**pmi=LIST**
+  Specify a comma-separated list of PMI implementations to enable.  If the
+  option is unspecified, the ``simple`` PMI-1 wire protocol implementation
+  is enabled.  Other options such as ``cray-pals`` or ``pmix`` may be
+  installed on your system.
+
+**pmi-simple.nomap**
   Skip populating the PMI ``flux.taskmap`` and ``PMI_process_mapping`` keys.
 
-**pmi.kvs=native**
+**pmi-simple.kvs=native**
   Use the native Flux KVS instead of the PMI plugin's built-in key exchange
   algorithm.
 
-**pmi.exchange.k=N**
+**pmi-simple.exchange.k=N**
   Configure the PMI plugin's built-in key exchange algorithm to use a
   virtual tree fanout of ``N`` for key gather/broadcast.  The default is 2.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -705,3 +705,4 @@ testprog
 libc
 unbuffered
 statex
+pmix

--- a/src/shell/pmi/pmi_exchange.c
+++ b/src/shell/pmi/pmi_exchange.c
@@ -27,7 +27,7 @@
  * Nodes that are peers in the ersatz tree may actually be multiple hops
  * apart on the Flux tree based overlay network at the broker level.
  */
-#define FLUX_SHELL_PLUGIN_NAME "pmi"
+#define FLUX_SHELL_PLUGIN_NAME "pmi-simple"
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/t/t2701-mini-batch.t
+++ b/t/t2701-mini-batch.t
@@ -152,7 +152,7 @@ test_expect_success 'flux mini batch: user can set broker.critical-ranks' '
 	test_cmp critical-ranks2.expected critical-ranks2.out
 '
 test_expect_success 'flux mini batch: flux can bootstrap without broker.mapping' '
-	id=$(flux mini batch -N4 -o pmi.nomap \
+	id=$(flux mini batch -N4 -o pmi-simple.nomap \
 		--wrap flux resource info) &&
 	flux job status $id
 '

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -152,7 +152,7 @@ test_expect_success 'flux batch: user can set broker.critical-ranks' '
 	test_cmp critical-ranks2.expected critical-ranks2.out
 '
 test_expect_success 'flux batch: flux can bootstrap without broker.mapping' '
-	id=$(flux batch -N4 -o pmi.nomap \
+	id=$(flux batch -N4 -o pmi-simple.nomap \
 		--wrap flux resource info) &&
 	flux job status $id
 '

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -14,6 +14,24 @@ kvstest2=${FLUX_BUILD_DIR}/src/common/libpmi/test_kvstest2
 pmi_info=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi_info
 pmi2_info=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi2_info
 
+test_expect_success 'flux run sets PMI_FD' '
+	flux run printenv PMI_FD
+'
+test_expect_success 'flux run -o pmi=simple sets PMI_FD' '
+	flux run -o pmi=simple printenv PMI_FD
+'
+test_expect_success 'flux run -o pmi=simple,unknown sets PMI_FD' '
+	flux run -o pmi=simple,unknown printenv PMI_FD
+'
+test_expect_success 'flux run -o pmi=unknown,simple sets PMI_FD' '
+	flux run -o pmi=unknown,simple printenv PMI_FD
+'
+test_expect_success 'flux run -o pmi=unknown does not set PMI_FD' '
+	test_must_fail flux run -o pmi=unknown printenv PMI_FD
+'
+test_expect_success 'flux run -o pmi=off does not set PMI_FD' '
+	test_must_fail flux run -o pmi=off printenv PMI_FD
+'
 test_expect_success 'flux run -o pmi.badopt fails' '
 	test_must_fail flux run -o pmi.badopt /bin/true
 '

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -14,20 +14,17 @@ kvstest2=${FLUX_BUILD_DIR}/src/common/libpmi/test_kvstest2
 pmi_info=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi_info
 pmi2_info=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi2_info
 
-test_expect_success 'flux run -o pmi=badopt fails' '
-	test_must_fail flux run -o pmi=badopt /bin/true
-'
 test_expect_success 'flux run -o pmi.badopt fails' '
 	test_must_fail flux run -o pmi.badopt /bin/true
 '
-test_expect_success 'flux run -o pmi.exchange.badopt fails' '
-	test_must_fail flux run -o pmi.exchange.badopt /bin/true
+test_expect_success 'flux run -o pmi-simple.exchange.badopt fails' '
+	test_must_fail flux run -o pmi-simple.exchange.badopt /bin/true
 '
-test_expect_success 'flux run -o pmi.exchange.k=foo fails' '
-	test_must_fail flux run -o pmi.exchange.k=foo /bin/true
+test_expect_success 'flux run -o pmi-simple.exchange.k=foo fails' '
+	test_must_fail flux run -o pmi-simple.exchange.k=foo /bin/true
 '
-test_expect_success 'flux run -o pmi.nomap=foo fails' '
-	test_must_fail flux run -o pmi.nomap=foo /bin/true
+test_expect_success 'flux run -o pmi-simple.nomap=foo fails' '
+	test_must_fail flux run -o pmi-simple.nomap=foo /bin/true
 '
 
 test_expect_success 'pmi_info works' '
@@ -41,7 +38,7 @@ test_expect_success 'pmi_info --clique shows each node with own clique' '
 	test $count -eq ${SIZE}
 '
 test_expect_success 'pmi_info --clique none shows each task in its own clique' '
-	flux run -opmi.nomap -n${SIZE} -N${SIZE} \
+	flux run -opmi-simple.nomap -n${SIZE} -N${SIZE} \
 		${pmi_info} --clique >clique.none.out &&
 	count=$(cut -f2 -d: clique.none.out | sort | uniq | wc -l) &&
 	test $count -eq ${SIZE}
@@ -50,34 +47,34 @@ test_expect_success 'kvstest works' '
 	flux run -n${SIZE} -N${SIZE} ${kvstest}
 '
 
-test_expect_success 'kvstest works with -o pmi.exchange.k=1' '
-	flux run -n${SIZE} -N${SIZE} -o pmi.exchange.k=1 ${kvstest}
+test_expect_success 'kvstest works with -o pmi-simple.exchange.k=1' '
+	flux run -n${SIZE} -N${SIZE} -o pmi-simple.exchange.k=1 ${kvstest}
 '
-test_expect_success 'kvstest works with -o pmi.exchange.k=SIZE' '
-	flux run -n${SIZE} -N${SIZE} -o pmi.exchange.k=${SIZE} \
+test_expect_success 'kvstest works with -o pmi-simple.exchange.k=SIZE' '
+	flux run -n${SIZE} -N${SIZE} -o pmi-simple.exchange.k=${SIZE} \
 		${kvstest} 2>kvstest_k.err &&
 	grep "using k=${SIZE}" kvstest_k.err
 '
-test_expect_success 'kvstest works with -o pmi.exchange.k=SIZE+1' '
-	flux run -n${SIZE} -N${SIZE} -o pmi.exchange.k=$((${SIZE}+1)) \
+test_expect_success 'kvstest works with -o pmi-simple.exchange.k=SIZE+1' '
+	flux run -n${SIZE} -N${SIZE} -o pmi-simple.exchange.k=$((${SIZE}+1)) \
 		${kvstest} 2>kvstest_kp1.err &&
 	grep "using k=${SIZE}" kvstest_kp1.err
 '
 
-test_expect_success 'kvstest fails with -o pmi.kvs=unknown' '
-	test_must_fail flux run -o pmi.kvs=unknown ${kvstest}
+test_expect_success 'kvstest fails with -o pmi-simple.kvs=unknown' '
+	test_must_fail flux run -o pmi-simple.kvs=unknown ${kvstest}
 '
 
-test_expect_success 'kvstest works with -o pmi.kvs=native' '
-	flux run -n${SIZE} -N${SIZE} -o pmi.kvs=native ${kvstest}
+test_expect_success 'kvstest works with -o pmi-simple.kvs=native' '
+	flux run -n${SIZE} -N${SIZE} -o pmi-simple.kvs=native ${kvstest}
 '
 
 test_expect_success 'kvstest -N8 works' '
 	flux run -n${SIZE} -N${SIZE} ${kvstest} -N8
 '
 
-test_expect_success 'kvstest -N8 works with -o pmi.kvs=native' '
-	flux run -n${SIZE} -N${SIZE} -o pmi.kvs=native ${kvstest} -N8
+test_expect_success 'kvstest -N8 works with -o pmi-simple.kvs=native' '
+	flux run -n${SIZE} -N${SIZE} -o pmi-simple.kvs=native ${kvstest} -N8
 '
 
 test_expect_success 'verbose=2 shell option enables PMI server side tracing' '


### PR DESCRIPTION
This implements the idea presented in #5063 of interpreting `flux run -o pmi=VALUE` values as a list of PMI implementations to load.   It preserves the meaning of `-o pmi=off` and the behavior of loading the simple server by default, but now if `-opmi` is specified and it doesn't include `simple`, the simple server is not loaded.

This PR also renames the little used simple pmi tunables to be under an implementation specific key.  `-o pmi.kvs=native` becomes `-o pmi-simple.kvs=native`.

This gives users more control over which PMIs are active among `simple`, `pmix`, and `cray-pals`.  It will require those plugins to be modified as well to disable themselves if they are not in the list.