### PR TITLE
sdbus: enable flux to communicate with a systemd user instance

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -574,6 +574,7 @@ AC_CONFIG_FILES( \
   src/modules/job-list/Makefile \
   src/modules/job-exec/Makefile \
   src/modules/resource/Makefile \
+  src/modules/sdbus/Makefile \
   src/test/Makefile \
   etc/Makefile \
   etc/flux-core.pc \

--- a/configure.ac
+++ b/configure.ac
@@ -339,6 +339,9 @@ if test "$have_libsystemd" = yes -a "$have_sd_bus_h" = yes; then
     AC_CHECK_LIB(systemd, sd_bus_set_method_call_timeout,
                  AC_DEFINE([HAVE_SD_BUS_SET_METHOD_CALL_TIMEOUT], [1],
                            [Define if you have sd_bus_set_method_call_timeout]))
+    AC_CHECK_LIB(systemd, sd_bus_message_dump,
+                 AC_DEFINE([HAVE_SD_BUS_MESSAGE_DUMP], [1],
+                           [Define if you have sd_bus_message_dump]))
 fi
 PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
 PKG_CHECK_MODULES([LZ4], [liblz4], [], [])

--- a/etc/rc1
+++ b/etc/rc1
@@ -23,6 +23,9 @@ if test $RANK -gt 0; then
 fi
 
 modload all barrier
+if test "$(flux config get --default=false systemd.enable)" = "true"; then
+    modload all sdbus
+fi
 
 if test $RANK -eq 0; then
     backingmod=$(backing_module)

--- a/etc/rc3
+++ b/etc/rc3
@@ -39,6 +39,7 @@ modrm 0 job-manager
 modrm all job-ingest
 
 modrm 0 cron
+modrm all sdbus
 modrm all barrier
 
 if test $RANK -eq 0; then

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -19,7 +19,8 @@ SUBDIRS = \
 	job-manager \
 	job-list \
 	job-exec \
-	resource
+	resource \
+	sdbus
 
 if ENABLE_CONTENT_S3
 SUBDIRS += content-s3
@@ -41,7 +42,8 @@ fluxmod_LTLIBRARIES = \
 	kvs.la \
 	kvs-watch.la \
 	resource.la \
-	sched-simple.la
+	sched-simple.la \
+	sdbus.la
 
 if ENABLE_CONTENT_S3
 fluxmod_LTLIBRARIES += content-s3.la
@@ -259,3 +261,14 @@ sched_simple_la_LIBADD = \
 	$(JANSSON_LIBS) \
 	$(HWLOC_LIBS)
 sched_simple_la_LDFLAGS = $(fluxmod_ldflags) -module
+
+sdbus_la_SOURCES =
+sdbus_la_LIBADD = \
+	$(builddir)/sdbus/libsdbus.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(JANSSON_LIBS)
+if HAVE_LIBSYSTEMD
+sdbus_la_LIBADD += $(LIBSYSTEMD_LIBS)
+endif
+sdbus_la_LDFLAGS = $(fluxmod_ldflags) -module

--- a/src/modules/sdbus/Makefile.am
+++ b/src/modules/sdbus/Makefile.am
@@ -58,7 +58,9 @@ test_ldflags = \
 TESTS =
 
 if HAVE_LIBSYSTEMD
-TESTS +=
+TESTS += \
+	 test_objpath.t \
+	 test_message.t
 endif
 
 check_PROGRAMS = $(TESTS)
@@ -66,3 +68,13 @@ check_PROGRAMS = $(TESTS)
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/config/tap-driver.sh
+
+test_objpath_t_SOURCES = test/objpath.c
+test_objpath_t_CPPFLAGS = $(test_cppflags)
+test_objpath_t_LDADD = $(test_ldadd)
+test_objpath_t_LDFLAGS = $(test_ldflags)
+
+test_message_t_SOURCES = test/message.c
+test_message_t_CPPFLAGS = $(test_cppflags)
+test_message_t_LDADD = $(test_ldadd)
+test_message_t_LDFLAGS = $(test_ldflags)

--- a/src/modules/sdbus/Makefile.am
+++ b/src/modules/sdbus/Makefile.am
@@ -1,0 +1,68 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	-I$(top_srcdir)/src/common/libccan \
+	$(JANSSON_CFLAGS)
+if HAVE_LIBSYSTEMD
+AM_CPPFLAGS += \
+	$(LIBSYSTEMD_CFLAGS)
+endif
+
+noinst_LTLIBRARIES = libsdbus.la
+
+libsdbus_la_SOURCES = \
+	main.c
+if HAVE_LIBSYSTEMD
+libsdbus_la_SOURCES += \
+	sdbus.c \
+	sdbus.h \
+	objpath.c \
+	objpath.h \
+	message.c \
+	message.h \
+	interface.c \
+	interface.h \
+	watcher.c \
+	watcher.h \
+	subscribe.c \
+	subscribe.h \
+	connect.c \
+	connect.h
+endif
+
+test_ldadd = \
+	$(builddir)/libsdbus.la \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libflux-internal.la \
+        $(JANSSON_LIBS)
+if HAVE_LIBSYSTEMD
+test_ldadd += \
+	$(LIBSYSTEMD_LIBS)
+endif
+
+test_cppflags = \
+        $(AM_CPPFLAGS)
+
+test_ldflags = \
+        -no-install
+
+TESTS =
+
+if HAVE_LIBSYSTEMD
+TESTS +=
+endif
+
+check_PROGRAMS = $(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+	$(top_srcdir)/config/tap-driver.sh

--- a/src/modules/sdbus/README.md
+++ b/src/modules/sdbus/README.md
@@ -1,0 +1,45 @@
+## flux systemd dbus bridge
+
+The Flux `sdbus` module connects to `$DBUS_SESSION_BUS_ADDRESS`, which the
+Flux systemd unit file sets to the address of the user level systemd instance
+of the `flux` user.  It then makes D-Bus method calls on behalf of Flux users
+that communicate with `sdbus` using Flux RPCs.  It also allows D-Bus signals
+to be subscribed to via a Flux streaming RPC.
+
+Useful references:
+- [D-Bus specification](https://dbus.freedesktop.org/doc/dbus-specification.html)
+- [The new sd-bus API of systemd](https://0pointer.net/blog/the-new-sd-bus-api-of-systemd.html)
+
+### Moving messages
+
+`sdbus` communicates with D-Bus at a fairly low level so it can operate
+reactively, that is, without busy-polling or blocking.  The main libsystemd
+interfaces used for this are:
+
+- [sd_bus_open_user(3)](https://man7.org/linux/man-pages/man3/sd_bus_open_user.3.html), [sd_bus_close(3)](https://man7.org/linux/man-pages/man3/sd_bus_close.3.html) and friends.
+- [sd_bus_process(3)](https://man7.org/linux/man-pages/man3/sd_bus_process.3.html), [sd_bus_get_fd(3)](https://man7.org/linux/man-pages/man3/sd_bus_get_fd.3.html) and friends
+- [sd_bus_message_send(3)](https://man7.org/linux/man-pages/man3/sd_bus_message_send.3.html)
+
+The Flux `sdbus` module takes care of matching method-reply and method-error
+messages to method-call messages.  The higher level libsystemd functions that
+handle that in the systemd code are not used.
+
+### Message translation
+
+Flux message payloads in JSON are translated to and from D-Bus messages.
+Currently `sdbus` translates a subset of possible D-Bus messages, however
+it does so in a way that leaves the door open for a future translator that
+can handle any message and uses D-Bus introspection to obtain message
+signatures on the fly.
+
+Supported (interface, member) tuples, and their signatures are listed in
+interface.c.  The low-level message translation occurs in message.c.
+Both may be amended as needed to support new method calls.
+
+### Systemd
+
+The main use case of `sdbus` is communicating with systemd.  Some useful
+references are:
+
+- [The D-Bus API of systemd/PID 1](https://www.freedesktop.org/wiki/Software/systemd/dbus/)
+- [systemd.unit(5)](https://man7.org/linux/man-pages/man5/systemd.unit.5.html)

--- a/src/modules/sdbus/connect.c
+++ b/src/modules/sdbus/connect.c
@@ -1,0 +1,154 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* connect.c - connect to sd-bus with retries
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+#include <systemd/sd-bus.h>
+
+#include "connect.h"
+
+struct sdconnect {
+    flux_t *h;
+    int attempt;
+    double retry_min;
+    double retry_max;
+    bool first_time;
+};
+
+static void sdconnect_destroy (struct sdconnect *sdc)
+{
+    if (sdc) {
+        int saved_errno = errno;
+        free (sdc);
+        errno = saved_errno;
+    }
+}
+
+static struct sdconnect *sdconnect_create (void)
+{
+    struct sdconnect *sdc;
+
+    if (!(sdc = calloc (1, sizeof (*sdc))))
+        return NULL;
+    return sdc;
+}
+
+
+static void bus_destroy (sd_bus *bus)
+{
+    if (bus) {
+        int saved_errno = errno;
+        sd_bus_flush (bus);
+        sd_bus_close (bus);
+        sd_bus_unref (bus);
+        errno = saved_errno;
+    }
+}
+
+/* The timer callback calls sd_bus_open_user().  If it succeeds, the future
+ * is fulfilled.  If it fails, the timer is re-armed for a calculated timeout.
+ * Retries proceed forever.  If they need to be capped, this can be done by
+ * specifying a flux_future_then() timeout.
+ */
+static void timer_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
+{
+    flux_future_t *f = arg;
+    struct sdconnect *sdc = flux_future_aux_get (f, "flux::sdc");
+    sd_bus *bus;
+    int e;
+    double timeout;
+
+    sdc->attempt++;
+    timeout = sdc->retry_min * sdc->attempt;
+    if (timeout > sdc->retry_max)
+        timeout = sdc->retry_max;
+
+    if ((e = sd_bus_open_user (&bus)) < 0) {
+        flux_log (sdc->h, LOG_INFO, "connect: %s", strerror (-e));
+        goto retry;
+    }
+    flux_log (sdc->h, LOG_INFO, "connected");
+    flux_future_fulfill (f, bus, (flux_free_f)bus_destroy);
+    sdc->attempt = 0;
+    return;
+retry:
+    flux_timer_watcher_reset (w, timeout, 0.);
+    flux_watcher_start (w);
+    return;
+}
+
+/* This function is called when a future returned by sdbus_connect() is
+ * passed to flux_future_get() or flux_future_then().  It starts the connect
+ * timer, which fires immediately if first_time=true; otherwise in retry_min
+ * seconds.
+ */
+static void initialize_cb (flux_future_t *f, void *arg)
+{
+    struct sdconnect *sdc = flux_future_aux_get (f, "flux::sdc");
+    flux_reactor_t *r = flux_future_get_reactor (f);
+    flux_watcher_t *w;
+    double timeout = sdc->first_time ? 0. : sdc->retry_min;
+
+    if (!(w = flux_timer_watcher_create (r, timeout, 0., timer_cb, f))
+        || flux_future_aux_set (f,
+                                NULL,
+                                w,
+                                (flux_free_f)flux_watcher_destroy) < 0) {
+        flux_watcher_destroy (w);
+        goto error;
+    }
+    flux_watcher_start (w);
+    return;
+error:
+    flux_future_fulfill_error (f, errno, NULL);
+}
+
+/* sdbus_connect() returns to the caller without interacting with sd-bus.
+ * The action begins when the user calls flux_future_then() et al on
+ * the returned future.
+ */
+flux_future_t *sdbus_connect (flux_t *h,
+                              bool first_time,
+                              double retry_min,
+                              double retry_max)
+{
+    flux_future_t *f;
+    struct sdconnect *sdc = NULL;
+
+    if (!(f = flux_future_create (initialize_cb, NULL))
+        || !(sdc = sdconnect_create ())
+        || flux_future_aux_set (f,
+                                "flux::sdc",
+                                sdc,
+                                (flux_free_f)sdconnect_destroy) < 0) {
+        sdconnect_destroy (sdc);
+        goto error;
+    }
+    sdc->h = h;
+    sdc->retry_min = retry_min;
+    sdc->retry_max = retry_max;
+    sdc->first_time = first_time;
+    flux_future_set_flux (f, h);
+    return f;
+error:
+    flux_future_destroy (f);
+    return NULL;
+}
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/sdbus/connect.h
+++ b/src/modules/sdbus/connect.h
@@ -1,0 +1,34 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SDBUS_CONNECT_H
+#define _SDBUS_CONNECT_H
+
+#include <flux/core.h>
+
+/* Connect the sd-bus with retries.  When the connect is successful, the
+ * future is fulfilled with an sd_bus object.  When the future is destroyed,
+ * the sd_bus object is flushed, closed, and unreferenced.
+ *
+ * If first_time=true, connect immediately; otherwise, wait retry_min secs.
+ * If the initial connect is unsuccessful, retry in retry_min secs.  If that
+ * is unsuccessful, back off exponentialy, leveling off at retry_max secs
+ * between attempts.
+ *
+ * Connect attempt successes and failures are logged at LOG_INFO level.
+ */
+flux_future_t *sdbus_connect (flux_t *h,
+                              bool first_time,
+                              double retry_min,
+                              double retry_max);
+
+#endif /* !_SDBUS_CONNECT_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sdbus/interface.c
+++ b/src/modules/sdbus/interface.c
@@ -1,0 +1,368 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* interface.c - D-Bus message translation to/from JSON
+ *
+ * This unfortunately falls short of a generic implementation, so each
+ * D-Bus (interface, member) that we need in Flux requires translation
+ * callbacks here for now.
+ *
+ * To list sytemd Manager methods and signatures:
+ *   busctl --user introspect \
+ *      org.freedesktop.systemd1 \
+ *      /org/freedesktop/systemd1 \
+ *      org.freedesktop.systemd1.Manager
+ *
+ * dbus-monitor(1) is a useful debugging tool.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <errno.h>
+#include <systemd/sd-bus.h>
+
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/errprintf.h"
+#include "ccan/str/str.h"
+#include "ccan/array_size/array_size.h"
+
+#include "objpath.h"
+#include "message.h"
+#include "interface.h"
+
+typedef int (*fromjson_f)(sd_bus_message *m, const char *sig, json_t *param);
+typedef int (*tojson_f)(sd_bus_message *m, const char *sig, json_t *param);
+
+struct xtab {
+    const char *member;
+    const char *fromjson_sig;
+    fromjson_f fromjson;
+    const char *tojson_sig;
+    tojson_f tojson;
+};
+
+static int generic_fromjson (sd_bus_message *m,
+                             const char *sig,
+                             json_t *param)
+{
+    return sdmsg_write (m, sig, param);
+}
+
+static int generic_tojson (sd_bus_message *m,
+                           const char *sig,
+                           json_t *params)
+{
+    return sdmsg_read (m, sig, params);
+}
+
+static int list_units_tojson (sd_bus_message *m,
+                              const char *sig,
+                              json_t *params)
+{
+    int e;
+    json_t *a;
+
+    if (!(a = json_array ()))
+        return -ENOMEM;
+    if ((e = sd_bus_message_enter_container (m, 'a', "(ssssssouso)")) <= 0)
+        goto out;
+    while ((e = sd_bus_message_enter_container (m, 'r', "ssssssouso")) > 0) {
+        json_t *entry;
+        if (!(entry = json_array ())) {
+            e = -ENOMEM;
+            goto out;
+        }
+        if ((e = sdmsg_read (m, "ssssssouso", entry)) <= 0) {
+            if (e == 0)
+                e = -EPROTO;
+            json_decref (entry);
+            goto out;
+        }
+        if (json_array_append_new (a, entry) < 0) {
+            json_decref (entry);
+            e = -ENOMEM;
+            goto out;
+        }
+        if ((e = sd_bus_message_exit_container (m)) < 0)
+            goto out;
+    }
+    if (e < 0 || (e = sd_bus_message_exit_container (m)) < 0)
+        goto out;
+    if (json_array_append_new (params, a) < 0) {
+        e = -ENOMEM;
+        goto out;
+    }
+    return 1;
+out:
+    json_decref (a);
+    return e;
+}
+
+/* This is currently unused in flux so aux is required to be an empty array.
+ */
+static int add_aux_units (sd_bus_message *m, json_t *aux)
+{
+    if (!json_is_array (aux) || json_array_size (aux) > 0)
+        return -EPROTO;
+    return sd_bus_message_append (m, "a(sa(sv))", 0);
+}
+
+// s s a(sv) a(sa(sv))
+static int start_transient_unit_fromjson (sd_bus_message *m,
+                                          const char *sig,
+                                          json_t *params)
+{
+    const char *name;
+    const char *mode;
+    json_t *props;
+    json_t *aux;
+    int e;
+
+    if (json_unpack (params, "[ssoo]", &name, &mode, &props, &aux) < 0)
+        return -EPROTO;
+    if ((e = sd_bus_message_append (m, "s", name)) < 0
+        || (e = sd_bus_message_append (m, "s", mode)) < 0
+        || (e = sdmsg_put (m, "a(sv)", props)) < 0
+        || (e = add_aux_units (m, aux)) < 0)
+        return e;
+    return 0;
+}
+
+/* Manager methods
+ */
+static const struct xtab managertab[] = {
+    { "Subscribe",
+      "",       NULL,
+      "",       NULL,
+    },
+    { "Unsubscribe",
+      "",       NULL,
+      "",       NULL,
+    },
+    { "ListUnitsByPatterns",
+      "asas",           generic_fromjson,
+      "a(ssssssouso)",  list_units_tojson,
+    },
+    { "KillUnit",
+      "ssi",    generic_fromjson,
+      "",       NULL,
+    },
+    { "StopUnit",
+      "ss",     generic_fromjson,
+      "o",      generic_tojson,
+    },
+    { "ResetFailedUnit",
+      "s",      generic_fromjson,
+      "",       NULL,
+    },
+    { "StartTransientUnit",
+      "ssa(sv)a(sa(sv))",   start_transient_unit_fromjson,
+      "o",                  generic_tojson,
+    },
+};
+
+static const struct xtab dbustab[] = {
+    { "AddMatch",
+      "s",      generic_fromjson,
+      "",       NULL
+    },
+    { "RemoveMatch",
+      "s",      generic_fromjson,
+      "",       NULL
+    },
+};
+
+static const struct xtab proptab[] = {
+    { "GetAll",
+      "s",      generic_fromjson,
+      "a{sv}",  generic_tojson
+    },
+    { "Get",
+      "ss",     generic_fromjson,
+      "v",      generic_tojson,
+    },
+    // signal
+    { "PropertiesChanged",
+      "",       NULL,
+      "sa{sv}as",generic_tojson
+    },
+};
+
+
+static const struct xtab *xtab_lookup (const char *interface,
+                                       const char *member,
+                                       flux_error_t *error)
+{
+    const struct xtab *tab = NULL;
+    size_t size = 0;
+
+    if (interface) {
+        if (streq (interface, "org.freedesktop.systemd1.Manager")) {
+            tab = managertab;
+            size = ARRAY_SIZE (managertab);
+        }
+        else if (streq (interface, "org.freedesktop.DBus")) {
+            tab = dbustab;
+            size = ARRAY_SIZE (dbustab);
+        }
+        else if (streq (interface, "org.freedesktop.DBus.Properties")) {
+            tab = proptab;
+            size = ARRAY_SIZE (proptab);
+        }
+    }
+    if (!tab) {
+        errprintf (error, "unknown interface %s", interface);
+        return NULL;
+    }
+    if (member) {
+        for (int i = 0; i < size; i++) {
+            if (streq (tab[i].member, member))
+                return &tab[i];
+        }
+    }
+    errprintf (error, "unknown member %s of interface %s", member, interface);
+    return NULL;
+}
+
+sd_bus_message *interface_request_fromjson (sd_bus *bus,
+                                            json_t *obj,
+                                            flux_error_t *error)
+{
+    json_t *params;
+    const char *destination = "org.freedesktop.systemd1";
+    const char *xpath = "/org/freedesktop/systemd1";
+    const char *interface = "org.freedesktop.systemd1.Manager";
+    const char *member;
+    char *path = NULL;
+    const struct xtab *x;
+    sd_bus_message *m;
+    int e;
+
+    if (json_unpack (obj,
+                     "{s?s s?s s?s s:s s:o}",
+                     "destination", &destination,
+                     "path", &xpath,
+                     "interface", &interface,
+                     "member", &member,
+                     "params", &params) < 0
+        || !json_is_array (params)) {
+        errprintf (error, "malformed request");
+        return NULL;
+    }
+    if (!(x = xtab_lookup (interface, member, error)))
+        return NULL;
+    if (!(path = objpath_encode (xpath))) {
+        errprintf (error, "error encoding object path %s", xpath);
+        return NULL;
+    }
+    if ((e = sd_bus_message_new_method_call (bus,
+                                             &m,
+                                             destination,
+                                             path,
+                                             interface,
+                                             member)) < 0) {
+        errprintf (error, "error creating sd-bus message: %s", strerror (-e));
+        free (path);
+        return NULL;
+    }
+    if (x->fromjson) {
+        if ((e = x->fromjson (m, x->fromjson_sig, params)) < 0) {
+            errprintf (error,
+                       "error translating JSON to %s method-call: %s",
+                       x->member,
+                       strerror (-e));
+            sd_bus_message_unref (m);
+            free (path);
+            return NULL;
+        }
+    }
+    free (path);
+    return m;
+}
+
+json_t *interface_reply_tojson (sd_bus_message *m,
+                                const char *interface,
+                                const char *member,
+                                flux_error_t *error)
+{
+    const struct xtab *x;
+    json_t *o;
+    json_t *params;
+    int e;
+
+    if (!(x = xtab_lookup (interface, member, error)))
+        return NULL;
+    if (!(o = json_pack ("{s:[]}", "params"))) {
+        errprintf (error, "error creating output parameter object");
+        return NULL;
+    }
+    params = json_object_get (o, "params");
+    if (x->tojson) {
+        if ((e = x->tojson (m, x->tojson_sig, params)) <= 0) {
+            if (e == 0)
+                e = -EPROTO;
+            errprintf (error,
+                       "error translating %s method-return to JSON: %s",
+                       x->member,
+                       strerror (-e));
+            json_decref (o);
+            return NULL;
+        }
+    }
+    return o;
+}
+
+json_t *interface_signal_tojson (sd_bus_message *m, flux_error_t *error)
+{
+    const char *iface = sd_bus_message_get_interface (m);
+    const char *member = sd_bus_message_get_member (m);
+    const char *path = sd_bus_message_get_path (m);
+    char *xpath;
+    const struct xtab *x;
+    json_t *o = NULL;
+    json_t *params;
+    int e;
+
+    if (!(x = xtab_lookup (iface, member, error)))
+        return NULL;
+    if (!(xpath = objpath_decode (path))) {
+        errprintf (error, "error decoding object path %s", path);
+        return NULL;
+    }
+    if (!(o = json_pack ("{s:s s:s s:s s:[]}",
+                         "path", xpath,
+                         "interface", iface,
+                         "member", member,
+                         "params"))) {
+        errprintf (error, "error creating output parameter object");
+        free (xpath);
+        return NULL;
+    }
+    params = json_object_get (o, "params");
+    if (x->tojson) {
+        if ((e = x->tojson (m, x->tojson_sig, params)) <= 0) {
+            if (e == 0)
+                e = -EPROTO;
+            errprintf (error,
+                       "error translating %s signal to JSON: %s",
+                       x->member,
+                       strerror (-e));
+            free (o);
+            free (xpath);
+            return NULL;
+        }
+    }
+    free (xpath);
+    return o;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sdbus/interface.h
+++ b/src/modules/sdbus/interface.h
@@ -1,0 +1,31 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SDBUS_INTERFACE_H
+#define _SDBUS_INTERFACE_H
+
+#include <systemd/sd-bus.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+sd_bus_message *interface_request_fromjson (sd_bus *bus,
+                                            json_t *req,
+                                            flux_error_t *error);
+
+json_t *interface_reply_tojson (sd_bus_message *m,
+                                const char *interface,
+                                const char *member,
+                                flux_error_t *error);
+
+json_t *interface_signal_tojson (sd_bus_message *m, flux_error_t *error);
+
+#endif /* !_SDBUS_INTERFACE_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sdbus/main.c
+++ b/src/modules/sdbus/main.c
@@ -1,0 +1,57 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* main.c - module main() for sd-bus bridge module
+ *
+ * The sdbus module is built when systemd support is not compiled in
+ * so that attempts to enable it get helpful error messages instead
+ * a generic "not found" error.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libutil/errprintf.h"
+
+#if HAVE_LIBSYSTEMD
+#include "sdbus.h"
+#endif
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+#if HAVE_LIBSYSTEMD
+    struct sdbus_ctx *ctx = NULL;
+    flux_error_t error;
+    int rc = -1;
+
+    if (!(ctx = sdbus_ctx_create (h, &error))) {
+        flux_log (h, LOG_ERR, "%s", error.text);
+        goto error;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        flux_log_error (h, "reactor exited abnormally");
+        goto error;
+    }
+    rc = 0;
+error:
+    sdbus_ctx_destroy (ctx);
+    return rc;
+#else
+    flux_log (h, LOG_ERR, "flux was not built with systemd support");
+    errno = ENOSYS;
+    return -1;
+#endif
+}
+
+MOD_NAME ("sdbus");
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sdbus/message.c
+++ b/src/modules/sdbus/message.c
@@ -1,0 +1,486 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* message.c - D-Bus message payload/JSON conversion helpers
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <errno.h>
+#include <systemd/sd-bus.h>
+#include <assert.h>
+
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/errprintf.h"
+#include "ccan/str/str.h"
+#include "ccan/array_size/array_size.h"
+
+#include "objpath.h"
+#include "message.h"
+
+typedef union {
+    uint8_t u8;
+    int16_t i16;
+    uint16_t u16;
+    int32_t i32;
+    uint32_t u32;
+    int64_t i64;
+    uint64_t u64;
+    int i;
+    double f;
+} number_t;
+
+struct tab {
+    uint8_t type;
+    const char *desc;
+};
+
+static struct tab typetab[] = {
+    { SD_BUS_MESSAGE_METHOD_CALL, "method-call" },
+    { SD_BUS_MESSAGE_METHOD_RETURN, "method-return" },
+    { SD_BUS_MESSAGE_METHOD_ERROR, "method-error" },
+    { SD_BUS_MESSAGE_SIGNAL , "signal" },
+};
+
+const char *sdmsg_typestr (sd_bus_message *m)
+{
+    uint8_t type;
+
+    if (sd_bus_message_get_type (m, &type) >= 0) {
+        for (int i = 0; i < ARRAY_SIZE (typetab); i++)
+            if (typetab[i].type == type)
+                return typetab[i].desc;
+    }
+    return "unknown";
+}
+
+static int sdmsg_put_array (sd_bus_message *m, const char *fmt, json_t *o)
+{
+    int e;
+    size_t index;
+    json_t *entry;
+
+    if ((e = sd_bus_message_open_container (m, 'a', fmt)) < 0)
+        return e;
+    json_array_foreach (o, index, entry) {
+        if ((e = sdmsg_put (m, fmt, entry)) < 0)
+            return e;
+    }
+    if ((e = sd_bus_message_close_container (m)) < 0)
+        return e;
+
+    return e;
+}
+
+static int sdmsg_put_string (sd_bus_message *m, char type, json_t *o)
+{
+    int e;
+    switch (type) {
+        case 'g':
+        case 's': {
+            const char *val = json_string_value (o);
+            if (!val)
+                return -EPROTO;
+            if ((e = sd_bus_message_append_basic (m, type, val)) < 0)
+                return e;
+            break;
+        }
+        case 'o': {
+            char *val = objpath_encode (json_string_value (o));
+            if (!val)
+                return -errno;
+            e = sd_bus_message_append_basic (m, type, val);
+            free (val);
+            if (e < 0)
+                return e;
+            break;
+        }
+        default:
+            return -EPROTO;
+    }
+    return 0;
+}
+
+static int sdmsg_put_basic (sd_bus_message *m, char type, json_t *o)
+{
+    number_t n;
+
+    if (!m || !o)
+        return -EPROTO;
+    if (type == 's' || type == 'g' || type == 'o')
+        return sdmsg_put_string (m, type, o);
+    switch (type) {
+        case 'y':
+            n.u8 = json_integer_value (o);
+            break;
+        case 'b':
+            n.i = json_is_true (o) ? 1 : 0;
+            break;
+        case 'n':
+            n.i16 = json_integer_value (o);
+            break;
+        case 'q':
+            n.u16 = json_integer_value (o);
+            break;
+        case 'i':
+            n.i32 = json_integer_value (o);
+            break;
+        case 'u':
+            n.u32 = json_integer_value (o);
+            break;
+        case 'x':
+            n.i64 = json_integer_value (o);
+            break;
+        case 't':
+            n.u64 = json_integer_value (o);
+            break;
+        case 'h':
+            n.i = json_integer_value (o);
+            break;
+        case 'd':
+            n.f = json_real_value (o);
+            break;
+        default:
+            return -EPROTO;
+    }
+    return sd_bus_message_append_basic (m, type, &n);
+}
+
+static int sdmsg_put_variant (sd_bus_message *m, json_t *o)
+{
+    const char *type;
+    json_t *val;
+    int e;
+
+    if (json_unpack (o, "[so]", &type, &val) < 0)
+        return -EPROTO;
+    if ((e = sd_bus_message_open_container (m, 'v', type)) < 0)
+        return e;
+    if ((e = sdmsg_put (m, type, val)) < 0)
+        return e;
+    if ((e = sd_bus_message_close_container (m)) < 0)
+        return e;
+    return 0;
+}
+
+static int sdmsg_put_struct (sd_bus_message *m, const char *fmt, json_t *o)
+{
+    int e;
+
+    if ((e = sd_bus_message_open_container (m, 'r', fmt)) < 0)
+        return e;
+    if ((e = sdmsg_write (m, fmt, o)) < 0)
+        return e;
+    if ((e = sd_bus_message_close_container (m)) < 0)
+        return e;
+    return 0;
+}
+
+int sdmsg_put (sd_bus_message *m, const char *fmt, json_t *o)
+{
+    int e;
+
+    if (streq (fmt, "a(sv)"))
+        e = sdmsg_put_array (m, "(sv)", o);
+    else if (streq (fmt, "a(sasb)"))
+        e = sdmsg_put_array (m, "(sasb)", o);
+    else if (fmt[0] == 'a' && strlen (fmt) == 2)
+        e = sdmsg_put_array (m, &fmt[1], o);
+    else if (streq (fmt, "(sv)"))
+        e = sdmsg_put_struct (m, "sv", o);
+    else if (streq (fmt, "(sasb)"))
+        e = sdmsg_put_struct (m, "sasb", o);
+    else if (streq (fmt, "v"))
+        e = sdmsg_put_variant (m, o);
+    else if (strlen (fmt) == 1)
+        e = sdmsg_put_basic (m, fmt[0], o);
+    else
+        e = -EPROTO;
+    return e;
+}
+
+int sdmsg_write (sd_bus_message *m, const char *fmt, json_t *o)
+{
+    int e;
+
+    if (!json_is_array (o))
+        return -EPROTO;
+
+    int cursor = 0;
+    for (int i = 0; fmt[i] != '\0';) {
+        json_t *entry;
+        char *efmt = NULL;
+
+        if (!(entry = json_array_get (o, cursor++)))
+            return -EPROTO;
+        if (!strncmp (&fmt[i], "a(sasb)", 7))
+            efmt = strndup (&fmt[i], 7);
+        else if (!strncmp (&fmt[i], "a(sv)", 5))
+            efmt = strndup (&fmt[i], 5);
+        else if (fmt[i] == 'a' && strlen (&fmt[i]) > 1)
+            efmt = strndup (&fmt[i], 2);
+        else
+            efmt = strndup (&fmt[i], 1);
+        if (!efmt)
+            return -ENOMEM;
+        if ((e = sdmsg_put (m, efmt, entry)) < 0) {
+            free (efmt);
+            return e;
+        }
+        i += strlen (efmt);
+        free (efmt);
+    }
+    return 0;
+}
+
+static int sdmsg_get_string (sd_bus_message *m, char type, json_t **op)
+{
+    int e;
+    const char *val = NULL;
+    json_t *o = NULL;
+
+    if ((e = sd_bus_message_read_basic (m, type, &val)) <= 0)
+        return e;
+    switch (type) {
+        case 'g':
+        case 's':
+            o = json_string (val);
+            break;
+        case 'o': {
+            char *tmp;
+            if (!(tmp = objpath_decode (val)))
+                return -EPROTO;
+            o = json_string (tmp);
+            free (tmp);
+            break;
+        }
+        default:
+            return -EPROTO;
+    }
+    if (!o)
+        return -ENOMEM;
+    *op = o;
+    return 1;
+}
+
+static int sdmsg_get_basic (sd_bus_message *m, char type, json_t **op)
+{
+    char peek_type;
+    int e;
+    json_t *o;
+    number_t n;
+
+    if ((e = sd_bus_message_peek_type (m, &peek_type, NULL)) <= 0)
+        return e;
+    if (type == 0)
+        type = peek_type;
+    if (type != peek_type)
+        return -EPROTO;
+    if (type == 'g' || type == 's' || type == 'o')
+        return sdmsg_get_string (m, type, op);
+    if ((e = sd_bus_message_read_basic (m, type, &n)) <= 0)
+        return e;
+    switch (type) {
+        case 'y':
+            o = json_integer (n.u8);
+            break;
+        case 'n':
+            o = json_integer (n.i16);
+            break;
+        case 'q':
+            o = json_integer (n.u16);
+            break;
+        case 'i':
+            o = json_integer (n.i32);
+            break;
+        case 'u':
+            o = json_integer (n.u32);
+            break;
+        case 'x':
+            o = json_integer (n.i64);
+            break;
+        case 't':
+            o = json_integer (n.u64);
+            break;
+        case 'b':
+            o = n.i ? json_true () : json_false ();
+            break;
+        case 'h':
+            o = json_integer (n.i);
+            break;
+        case 'd':
+            o = json_real (n.f);
+            break;
+        default:
+            return -EPROTO;
+    }
+    if (!o)
+        return -ENOMEM;
+    *op = o;
+    return 1;
+}
+
+static int sdmsg_get_array (sd_bus_message *m, const char *fmt, json_t **op)
+{
+    json_t *a;
+    int e;
+
+    if (!(a = json_array ()))
+        return -ENOMEM;
+    if ((e = sd_bus_message_enter_container (m, 'a', fmt)) <= 0) {
+        json_decref (a);
+        return e;
+    }
+    while ((e = sdmsg_read (m, fmt, a)) > 0)
+        ;
+    if (e < 0) {
+        json_decref (a);
+        return e;
+    }
+    if ((e = sd_bus_message_exit_container (m)) < 0) {
+        json_decref (a);
+        return e;
+    }
+    *op = a;
+    return 1;
+}
+
+static int sdmsg_get_unknown (sd_bus_message *m, const char *fmt, json_t **op)
+{
+    int e;
+    if ((e = sd_bus_message_skip (m, fmt)) <= 0)
+        return e;
+    *op = json_null ();
+    return e;
+}
+
+static int sdmsg_get_variant (sd_bus_message *m, json_t **op)
+{
+    const char *contents;
+    char type;
+    json_t *val = NULL;
+    json_t *o = NULL;
+    int e;
+
+    if ((e = sd_bus_message_peek_type (m, &type, &contents)) <= 0)
+        return e;
+    if (type != 'v')
+        return -EPROTO;
+    if ((e = sd_bus_message_enter_container (m, 'v', contents)) <= 0)
+        return e;
+    if (strlen (contents) == 1)
+        e = sdmsg_get_basic (m, contents[0], &val);
+    else if (strlen (contents) == 2 && contents[0] == 'a')
+        e = sdmsg_get_array (m, contents + 1, &val);
+    else
+        e = sdmsg_get_unknown (m, contents, &val);
+    if (e <= 0)
+        return e;
+    if (!(o = json_pack ("[sO]", contents, val))) {
+        json_decref (val);
+        return -ENOMEM;
+    }
+    if ((e = sd_bus_message_exit_container (m)) < 0) {
+        json_decref (val);
+        json_decref (o);
+        return e;
+    }
+    json_decref (val);
+    *op = o;
+    return 1;
+}
+
+static int sdmsg_get_property_dict (sd_bus_message *m, json_t **op)
+{
+    json_t *dict;
+    int e;
+
+    if (!(dict = json_object ()))
+        return -ENOMEM;
+    if ((e = sd_bus_message_enter_container (m, 'a', "{sv}")) <= 0)
+        goto out;
+    while ((e = sd_bus_message_enter_container (m, 'e', "sv")) > 0) {
+        const char *key;
+        json_t *val;
+        int e;
+        if ((e = sd_bus_message_read (m, "s", &key)) <= 0
+            || (e = sdmsg_get_variant (m, &val)) <= 0)
+            goto out;
+        if (json_object_set_new (dict, key, val) < 0) {
+            json_decref (val);
+            goto nomem;
+        }
+        if ((e = sd_bus_message_exit_container (m)) < 0)
+            goto out;
+    }
+    if (e < 0 || (e = sd_bus_message_exit_container (m)) < 0)
+        goto out;
+    *op = dict;
+    return 1;
+nomem:
+    e = -ENOMEM;
+out:
+    json_decref (dict);
+    return e;
+}
+
+int sdmsg_get (sd_bus_message *m, const char *fmt, json_t **op)
+{
+    int e;
+
+    if (streq (fmt, "a{sv}"))
+        e = sdmsg_get_property_dict (m, op);
+    else if (fmt[0] == 'a' && strlen (fmt) > 1)
+        e = sdmsg_get_array (m, fmt + 1, op);
+    else if (streq (fmt, "v"))
+        e = sdmsg_get_variant (m, op);
+    else if (strlen (fmt) == 1)
+        e = sdmsg_get_basic (m, fmt[0], op);
+    else
+        e = -EPROTO;
+    return e;
+}
+
+int sdmsg_read (sd_bus_message *m, const char *fmt, json_t *o)
+{
+    for (int i = 0; fmt[i] != '\0';) {
+        json_t *entry = NULL;
+        char *efmt = NULL;
+        int e;
+
+        if (!strncmp (&fmt[i], "a{sv}", 5))
+            efmt = strndup (&fmt[i], 5);
+        else if (fmt[i] == 'a' && strlen (&fmt[i]) > 1)
+            efmt = strndup (&fmt[i], 2);
+        else
+            efmt = strndup (&fmt[i], 1);
+        if (!efmt)
+            return -ENOMEM;
+
+        if ((e = sdmsg_get (m, efmt, &entry)) <= 0) {
+            free (efmt);
+            if (e == 0 && i > 0)
+                e = -EPROTO;
+            return e;
+        }
+        if (json_array_append_new (o, entry) < 0) {
+            free (efmt);
+            json_decref (entry);
+            return -ENOMEM;
+        }
+        i += strlen (efmt);
+        free (efmt);
+    }
+    return 1;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sdbus/message.h
+++ b/src/modules/sdbus/message.h
@@ -1,0 +1,44 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SDBUS_MESSAGE_H
+#define _SDBUS_MESSAGE_H
+
+#include <systemd/sd-bus.h>
+#include <jansson.h>
+
+const char *sdmsg_typestr (sd_bus_message *m);
+
+/* Put one value (or container) specified by 'fmt' from json object 'o' to
+ * current cursor position of message 'm'.  Return 0 on success, or -errno
+ * on failure.
+ */
+int sdmsg_put (sd_bus_message *m, const char *fmt, json_t *o);
+
+/* Put list of values specified by 'fmt' from json array 'o' to current cursor
+ * position of message 'm'.  Return 0 on success or -errno on failure.
+ */
+int sdmsg_write (sd_bus_message *m, const char *fmt, json_t *o);
+
+/* Get one value (or container) specified by 'fmt' from message 'm' at the
+ * current cursor position and return in a new json object assigned to 'op'.
+ * Return 1 on success, or -errno on failure.
+ */
+int sdmsg_get (sd_bus_message *m, const char *fmt, json_t **op);
+
+/* Get list of values specified by 'fmt' from message 'm' at the current cursor
+ * position and append them to the json array 'o'.
+ * Return 1 on success, or -errno on falure.
+ */
+int sdmsg_read (sd_bus_message *m, const char *fmt, json_t *o);
+
+#endif /* !_SDBUS_MESSAGE_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sdbus/objpath.c
+++ b/src/modules/sdbus/objpath.c
@@ -1,0 +1,89 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* objpath.c - helpers for dealing with D-Bus object paths
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <fnmatch.h>
+#include <stdio.h>
+#include <systemd/sd-bus.h>
+
+#include "src/common/libutil/errno_safe.h"
+
+#include "objpath.h"
+
+static bool path_is_tooshort (const char *s)
+{
+    return fnmatch ("/*", s, FNM_PATHNAME) == 0 ? true : false;
+}
+
+static char *objpath_split (const char *s, const char **suffix)
+{
+    char *cpy;
+    char *cp;
+
+    if (!(cpy = strdup (s)))
+        return NULL;
+    if ((cp = strrchr (cpy, '/')))
+        *cp++ = '\0';
+    if (suffix)
+        *suffix = cp;
+    return cpy;
+}
+
+char *objpath_decode (const char *s)
+{
+    char *prefix;
+    char *tmp = NULL;
+    char *res = NULL;
+    int e;
+
+    if (path_is_tooshort (s))
+        return strdup (s);
+    if (!(prefix = objpath_split (s, NULL)))
+        return NULL;
+    e = sd_bus_path_decode (s, prefix, &tmp);
+    if (e <= 0)
+        goto out;
+    if (asprintf (&res, "%s/%s", prefix, tmp) < 0)
+        goto out;
+out:
+    free (tmp);
+    free (prefix);
+    return res;
+}
+
+char *objpath_encode (const char *s)
+{
+    char *prefix;
+    const char *suffix;
+    char *res = NULL;
+    int e;
+
+    if (path_is_tooshort (s))
+        return strdup (s);
+    if (!(prefix = objpath_split (s, &suffix)))
+        return NULL;
+    if ((e = sd_bus_path_encode (prefix, suffix, &res)) < 0) {
+        errno = -e;
+        goto out;
+    }
+out:
+    free (prefix);
+    return res;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sdbus/objpath.h
+++ b/src/modules/sdbus/objpath.h
@@ -1,0 +1,19 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SDBUS_OBJPATH_H
+#define _SDBUS_OBJPATH_H
+
+char *objpath_encode (const char *s);
+char *objpath_decode (const char *s);
+
+#endif /* !_SDBUS_OBJPATH_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sdbus/sdbus.c
+++ b/src/modules/sdbus/sdbus.c
@@ -1,0 +1,640 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* sdbus.c - sd-bus bridge for user-mode systemd
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <systemd/sd-bus.h>
+
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/errprintf.h"
+#include "ccan/str/str.h"
+
+#include "message.h"
+#include "interface.h"
+#include "watcher.h"
+#include "subscribe.h"
+#include "connect.h"
+#include "sdbus.h"
+
+struct sdbus_ctx {
+    flux_future_t *f_conn; // owns ctx->bus
+    sd_bus *bus;
+    flux_watcher_t *bus_w;
+    flux_msg_handler_t **handlers;
+    struct flux_msglist *requests;
+    struct flux_msglist *subscribers;
+    flux_t *h;
+
+    flux_future_t *f_subscribe;
+};
+
+struct call_info {
+    uint64_t cookie;
+    char *interface;
+    char *member;
+};
+
+static void sdbus_recover (struct sdbus_ctx *ctx, const char *reason);
+
+/* Connect retry interval (seconds).
+ */
+static const double retry_min = 2;
+static const double retry_max = 60;
+
+static void bulk_respond_error (flux_t *h,
+                                struct flux_msglist *msglist,
+                                int errnum,
+                                const char *errmsg)
+{
+    const flux_msg_t *msg;
+
+    while ((msg = flux_msglist_pop (msglist))) {
+        if (flux_respond_error (h, msg, errnum, errmsg) < 0) {
+            const char *topic = "unknown";
+            (void)flux_msg_get_topic (msg, &topic);
+            flux_log_error (h, "error responding to %s request", topic);
+        }
+        flux_msg_decref (msg);
+    }
+}
+
+static void bulk_respond (flux_t *h,
+                          struct flux_msglist *msglist,
+                          json_t *payload)
+{
+    const flux_msg_t *msg;
+
+    msg = flux_msglist_first (msglist);
+    while (msg)  {
+        if (flux_respond_pack (h, msg, "O", payload) < 0) {
+            const char *topic = "unknown";
+            (void)flux_msg_get_topic (msg, &topic);
+            flux_log_error (h, "error responding to %s request", topic);
+        }
+        msg = flux_msglist_next (msglist);
+    }
+}
+
+/* Locate a pending sdbus.call request that matches a cookie from a
+ * bus method-reply or method-error message.  If infop is non-NULL, assign
+ * the message's info struct.
+ */
+static const flux_msg_t *find_request_by_cookie (struct sdbus_ctx *ctx,
+                                                 uint64_t cookie,
+                                                 struct call_info **infop)
+{
+    const flux_msg_t *msg;
+
+    msg = flux_msglist_first (ctx->requests);
+    while (msg) {
+        struct call_info *info;
+        if ((info = flux_msg_aux_get (msg, "info"))
+            && cookie == info->cookie) {
+            if (infop)
+                *infop = info;
+            return msg;
+        }
+        msg = flux_msglist_next (ctx->requests);
+    }
+    return NULL;
+}
+
+/* Log a signal message.
+ * If path refers to a systemd unit, make it pretty for the logs.
+ */
+static void log_msg_signal (flux_t *h,
+                            sd_bus_message *m,
+                            const char *disposition)
+{
+    const char *prefix = "/org/freedesktop/systemd1/unit";
+    const char *path = sd_bus_message_get_path (m);
+    char *s = NULL;
+
+    if (path)
+        (void)sd_bus_path_decode (path, prefix, &s);
+    flux_log (h,
+              LOG_DEBUG,
+              "bus %s %s %s %s",
+              disposition,
+              sdmsg_typestr (m),
+              s ? s : path,
+              sd_bus_message_get_member (m));
+    free (s);
+}
+
+/* Log a method-reply or method-error.
+ */
+static void log_msg_method_reply (flux_t *h,
+                                  sd_bus_message *m,
+                                  struct call_info *info)
+{
+    flux_log (h,
+              LOG_DEBUG,
+              "bus recv %s cookie=%ju %s",
+              sdmsg_typestr (m),
+              (uintmax_t)info->cookie,
+              info->member);
+}
+
+static void sdbus_recv (struct sdbus_ctx *ctx, sd_bus_message *m)
+{
+    if (sd_bus_message_is_signal (m, NULL, NULL)) {
+        const char *path = sd_bus_message_get_path (m);
+        const char *iface = sd_bus_message_get_interface (m);
+        const char *member = sd_bus_message_get_member (m);
+        json_t *o;
+
+        /* Apparently sd-bus, when it shuts down nicely, gives us a polite
+         * note informing us that it can no longer abide our company.
+         */
+        if (streq (path, "/org/freedesktop/DBus/Local")
+            && streq (iface, "org.freedesktop.DBus.Local")
+            && streq (member, "Disconnected")) {
+            log_msg_signal (ctx->h, m, "recv");
+            sdbus_recover (ctx, "received Disconnected signal from bus");
+            goto out;
+        }
+        /* Unhandled signals are logged as a "drop" so we know what's missed.
+         */
+        if (!(o = interface_signal_tojson (m, NULL))) {
+            log_msg_signal (ctx->h, m, "drop");
+            goto out;
+        }
+        /* Handled signals are loged as a "recv".  Dispatch them to
+         * subscribers here.  N.B. There is no subscriber filtering yet.
+         * Perhaps later if needed.
+         */
+        log_msg_signal (ctx->h, m, "recv");
+        bulk_respond (ctx->h, ctx->subscribers, o);
+        json_decref (o);
+    }
+    else if (sd_bus_message_is_method_call (m, NULL, NULL)) {
+        /* Log any method calls (for example requesting introspection) as
+         * as "drop".  Flux is purely an sd-bus client and has no methods.
+         */
+        goto log_drop;
+    }
+    else if (sd_bus_message_is_method_error (m, NULL)) {
+        int errnum = sd_bus_message_get_errno (m);
+        const sd_bus_error *error = sd_bus_message_get_error (m);
+        uint64_t cookie;
+        const flux_msg_t *msg;
+        struct call_info *info;
+
+        /* method-error messages that cannot be matched to a pending
+         * sdbus.call request are logged as a "drop".  Perhaps the client
+         * disconnected without waiting for a reply.
+         */
+        if (sd_bus_message_get_reply_cookie (m, &cookie) < 0
+            || !(msg = find_request_by_cookie (ctx, cookie, &info)))
+            goto log_drop;
+        /* method-errors that can be matched are logged and dispatched here.
+         */
+        log_msg_method_reply (ctx->h, m, info);
+        if (errnum == 0)
+            errnum = EINVAL;
+        if (flux_respond_error (ctx->h, msg, errnum, error->message) < 0)
+            flux_log_error (ctx->h, "error responding to sdbus.call");
+        flux_msglist_delete (ctx->requests); // cursor is on completed message
+    }
+    else { // method-reply
+        uint64_t cookie;
+        const flux_msg_t *msg;
+        struct call_info *info;
+        json_t *rep = NULL;
+        flux_error_t error;
+        int rc;
+
+        /* method-reply messages that cannot be matched to a pending
+         * sdbus.call request are logged as a "drop".  Perhaps the client
+         * disconnected without waiting for a reply.
+         */
+        if (sd_bus_message_get_reply_cookie (m, &cookie) < 0
+            || !(msg = find_request_by_cookie (ctx, cookie, &info)))
+            goto log_drop;
+        /* method-replies that can be matched are logged, translated to json,
+         * and dispatched here.  If there's a translation failure, we try to
+         * give the requestor a human readable error. This is helpful when
+         * developing support for new methods, if nothing else.
+         */
+        log_msg_method_reply (ctx->h, m, info);
+        if ((rep = interface_reply_tojson (m,
+                                           info->interface,
+                                           info->member,
+                                           &error)))
+            rc = flux_respond_pack (ctx->h, msg, "O", rep);
+        else
+            rc = flux_respond_error (ctx->h, msg, EINVAL, error.text);
+        if (rc < 0)
+            flux_log_error (ctx->h, "error responding to sdbus.call");
+        json_decref (rep);
+        flux_msglist_delete (ctx->requests); // cursor is on completed message
+    }
+out:
+    return;
+log_drop:
+    flux_log (ctx->h, LOG_DEBUG, "bus drop %s", sdmsg_typestr (m));
+}
+
+static void call_info_destroy (struct call_info *info)
+{
+    if (info) {
+        int saved_errno = errno;
+        free (info->interface);
+        free (info->member);
+        free (info);
+        errno = saved_errno;
+    }
+}
+
+/* Extract some info from method-call message that will be required when
+ * processing method-reply and method-error messages.  The call_info struct
+ * will be placed in the aux container of the pending sdbus.call request.
+ */
+static struct call_info *call_info_create (sd_bus_message *m, uint64_t cookie)
+{
+    struct call_info *info;
+    const char *interface = sd_bus_message_get_interface (m);
+    const char *member = sd_bus_message_get_member (m);
+
+    if (!(info = calloc (1, sizeof (*info))))
+        return NULL;
+    info->cookie = cookie;
+    if ((interface && !(info->interface = strdup (interface)))
+        || (member && !(info->member = strdup (member))))
+        goto error;
+    return info;
+error:
+    call_info_destroy (info);
+    return NULL;
+}
+
+/* Translate a sdbus.call request to an sd-bus method-call message and send
+ * it.  This function is invoked directly by the sdbus.call request handler
+ * when the bus is active.  When the bus is inactive, it is called by
+ * handle_call_request_backlog() after the bus is reconnected.
+ */
+static int handle_call_request (struct sdbus_ctx *ctx,
+                                const flux_msg_t *msg,
+                                flux_error_t *error)
+{
+    sd_bus_message *m;
+    json_t *req;
+    int e;
+    uint64_t cookie;
+    struct call_info *info;
+
+    if (flux_request_unpack (msg, NULL, "o", &req) < 0) {
+        errprintf (error, "unable to decode call request");
+        return -1;
+    }
+    if (!(m = interface_request_fromjson (ctx->bus, req, error))) {
+        errno = EINVAL;
+        goto error;
+    }
+    if ((e = sd_bus_send (NULL, m, &cookie)) < 0) {
+        errno = -e;
+        errprintf (error, "error sending sdbus request: %s", strerror (errno));
+        goto error;
+    }
+
+    flux_log (ctx->h,
+              LOG_DEBUG,
+              "bus send %s cookie=%ju %s",
+              sdmsg_typestr (m),
+              (uintmax_t)cookie,
+              sd_bus_message_get_member (m));
+
+    if (!(info = call_info_create (m, cookie))
+        || flux_msg_aux_set (msg,
+                             "info",
+                             info,
+                             (flux_free_f)call_info_destroy) < 0) {
+        call_info_destroy (info);
+        errprintf (error, "error saving call request state");
+        goto error;
+    }
+    sd_bus_message_unref (m);
+    return 0;
+error:
+    ERRNO_SAFE_WRAP (sd_bus_message_unref, m);
+    return -1;
+}
+
+/* Handle an sdbus.call request.
+ */
+static void call_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    struct sdbus_ctx *ctx = arg;
+    flux_error_t error;
+    const char *errmsg = NULL;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0)
+        goto error;
+    if (ctx->bus) { // defer request if bus is not yet connected
+        if (handle_call_request (ctx, msg, &error) < 0) {
+            errmsg = error.text;
+            goto error;
+        }
+    }
+    if (flux_msglist_append (ctx->requests, msg) < 0)
+        goto error;
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "error responding to call request");
+}
+
+/* Handle an sdbus.subscribe request.
+ */
+static void subscribe_cb (flux_t *h,
+                          flux_msg_handler_t *mh,
+                          const flux_msg_t *msg,
+                          void *arg)
+{
+    struct sdbus_ctx *ctx = arg;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0)
+        goto error;
+    if (!flux_msg_is_streaming (msg)) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (flux_msglist_append (ctx->subscribers, msg) < 0)
+        goto error;
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "error responding to sdbus.subscribe request");
+}
+
+/* Handle cancellation of an sdbus.subscribe request as described in RFC 6.
+ */
+static void subscribe_cancel_cb (flux_t *h,
+                                 flux_msg_handler_t *mh,
+                                 const flux_msg_t *msg,
+                                 void *arg)
+{
+    struct sdbus_ctx *ctx = arg;
+    flux_msglist_cancel (h, ctx->subscribers, msg);
+}
+
+/* Handle disconnection of a client as described in RFC 6.
+ */
+static void disconnect_cb (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+    struct sdbus_ctx *ctx = arg;
+
+    (void)flux_msglist_disconnect (ctx->requests, msg);
+    (void)flux_msglist_disconnect (ctx->subscribers, msg);
+}
+
+/* Handle a request to force bus disconnection and recovery for testing.
+ */
+static void reconnect_cb (flux_t *h,
+                          flux_msg_handler_t *mh,
+                          const flux_msg_t *msg,
+                          void *arg)
+{
+    struct sdbus_ctx *ctx = arg;
+    const char *errmsg = NULL;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0)
+        goto error;
+    if (!ctx->bus) {
+        errmsg = "bus is not connected";
+        errno = EINVAL;
+        goto error;
+    }
+    sdbus_recover (ctx, "user requested bus reconnect");
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to sdbus.reconnect request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "error responding to sdbus.reconnect request");
+}
+
+static struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,
+      "sdbus.disconnect",
+      disconnect_cb,
+      0
+    },
+    { FLUX_MSGTYPE_REQUEST,
+      "sdbus.call",
+      call_cb,
+      0
+    },
+    { FLUX_MSGTYPE_REQUEST,
+      "sdbus.subscribe",
+      subscribe_cb,
+      0
+    },
+    { FLUX_MSGTYPE_REQUEST,
+      "sdbus.subscribe-cancel",
+      subscribe_cancel_cb,
+      0
+    },
+    { FLUX_MSGTYPE_REQUEST,
+      "sdbus.reconnect",
+      reconnect_cb,
+      0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+/* The bus watcher callback runs sd_bus_process().  Apparently this is an
+ * edge triggered notification so we need to handle all events now, which
+ * means calling sd_bus_process() in a loop until it returns 0.
+ */
+static void sdbus_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
+{
+    struct sdbus_ctx *ctx = arg;
+    int e;
+
+    do {
+        sd_bus_message *m = NULL;
+        if ((e = sd_bus_process (ctx->bus, &m)) < 0) {
+            sdbus_recover (ctx, "error processing sd-bus events");
+            return;
+        }
+        if (m) {
+            // sdbus_recv() may call sdbus_recover() which sets ctx->bus = NULL
+            sdbus_recv (ctx, m);
+            sd_bus_message_unref (m);
+        }
+    } while (e > 0 && ctx->bus != NULL);
+}
+
+/* sdbus.call requests that arrive while the bus connect is in progress
+ * are added to ctx->requests without further processing.  Revisit them now
+ * and begin processing.  Since recovery fails any pending requests, all
+ * requests in ctx->requests are eligible.
+ */
+static void handle_call_request_backlog (struct sdbus_ctx *ctx)
+{
+    const flux_msg_t *msg;
+    flux_error_t error;
+    msg = flux_msglist_first (ctx->requests);
+    while (msg)  {
+        if (handle_call_request (ctx, msg, &error) < 0) {
+            if (flux_respond_error (ctx->h, msg, errno, error.text) < 0)
+                flux_log_error (ctx->h, "error responding to call request");
+        }
+        msg = flux_msglist_next (ctx->requests);
+    }
+}
+
+/* Bus subscribe completed.  Henceforth, sd-bus signals will be forwarded
+ * to subscribers.  Service pending sdbus.call requests.
+ * N.B. handle_call_request_backlog is called here rather than when the connect
+ * is finalized so that a user may asynchronously subscribe to signals,
+ * then initiate an action and expect the subscription to capture all signals
+ * triggered by the action.
+ */
+static void bus_subscribe_continuation (flux_future_t *f, void *arg)
+{
+    struct sdbus_ctx *ctx = arg;
+    flux_error_t error;
+
+    if (flux_rpc_get (f, NULL) < 0) {
+        errprintf (&error, "subscribe error: %s", future_strerror (f, errno));
+        goto error;
+    }
+    handle_call_request_backlog (ctx);
+    return;
+error:
+    sdbus_recover (ctx, error.text);
+}
+
+/* Connect completed. Initiate asynchonous bus subscribe.
+ */
+static void connect_continuation (flux_future_t *f, void *arg)
+{
+    struct sdbus_ctx *ctx = arg;
+    flux_error_t error;
+
+    if (flux_future_get (f, (const void **)&ctx->bus) < 0) {
+        errprintf (&error, "sdbus_connect: %s", future_strerror (f, errno));
+        goto error;
+    }
+    if (!(ctx->bus_w = sdbus_watcher_create (flux_get_reactor (ctx->h),
+                                             ctx->bus,
+                                             sdbus_cb,
+                                             ctx))) {
+        errprintf (&error, "error creating bus watcher: %s", strerror (errno));
+        goto error;
+    }
+    flux_watcher_start (ctx->bus_w);
+
+    if (!(ctx->f_subscribe = sdbus_subscribe (ctx->h))
+        || flux_future_then (ctx->f_subscribe,
+                             -1,
+                             bus_subscribe_continuation,
+                             ctx) < 0) {
+        errprintf (&error, "subscribe error: %s", strerror (errno));
+        goto error;
+    }
+    return;
+error:
+    sdbus_recover (ctx, error.text);
+}
+
+static void sdbus_recover (struct sdbus_ctx *ctx, const char *reason)
+{
+
+    flux_log (ctx->h, LOG_INFO, "disconnect: %s", reason);
+
+    /* Send any pending requests an error.
+     */
+    bulk_respond_error (ctx->h, ctx->subscribers, ENOSYS, reason);
+    bulk_respond_error (ctx->h, ctx->requests, ENOSYS, reason);
+
+    /* Destroy subscribe future.
+     */
+    flux_future_destroy (ctx->f_subscribe);
+    ctx->f_subscribe = NULL;
+
+    /* Destroy the (now defunct) bus connection and its watcher.
+     */
+    flux_watcher_destroy (ctx->bus_w);
+    ctx->bus_w = NULL;
+    flux_future_destroy (ctx->f_conn);
+    ctx->f_conn = NULL;
+    ctx->bus = NULL;
+
+    /* Begin asynchronous reconnect.
+     * Any requests that arrive while this is in progress are deferred.
+     * N.B. setting first_time=false ensures a retry_min second delay before
+     * the connect attempt.  Some small delay seems to be necessary to avoid
+     * libsystemd complaining about unexpected internal states(?) and the
+     * occasional segfault.
+     */
+    if (!(ctx->f_conn = sdbus_connect (ctx->h, false, retry_min, retry_max))
+        || flux_future_then (ctx->f_conn, -1, connect_continuation, ctx) < 0) {
+        flux_log_error (ctx->h, "error starting bus connect");
+        flux_reactor_stop_error (flux_get_reactor (ctx->h));
+    }
+}
+
+void sdbus_ctx_destroy (struct sdbus_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        flux_msglist_destroy (ctx->requests);
+        flux_msglist_destroy (ctx->subscribers);
+        flux_msg_handler_delvec (ctx->handlers);
+        flux_watcher_destroy (ctx->bus_w);
+        flux_future_destroy (ctx->f_subscribe);
+        if (ctx->bus) {
+            sd_bus_flush (ctx->bus);
+            sd_bus_close (ctx->bus);
+        }
+        flux_future_destroy (ctx->f_conn); // destroys ctx->bus
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+struct sdbus_ctx *sdbus_ctx_create (flux_t *h, flux_error_t *error)
+{
+    struct sdbus_ctx *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx)))
+        || !(ctx->f_conn = sdbus_connect (h, true, retry_min, retry_max))
+        || flux_future_then (ctx->f_conn, -1, connect_continuation, ctx) < 0
+        || flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0
+        || !(ctx->requests = flux_msglist_create ())
+        || !(ctx->subscribers = flux_msglist_create ()))
+        goto error;
+    ctx->h = h;
+    return ctx;
+error:
+    errprintf (error, "error creating sdbus context: %s", strerror (errno));
+    sdbus_ctx_destroy (ctx);
+    return NULL;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sdbus/sdbus.h
+++ b/src/modules/sdbus/sdbus.h
@@ -1,0 +1,21 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SDBUS_SDBUS_H
+#define _SDBUS_SDBUS_H
+
+#include <flux/core.h>
+
+struct sdbus_ctx *sdbus_ctx_create (flux_t *h, flux_error_t *error);
+void sdbus_ctx_destroy (struct sdbus_ctx *ctx);
+
+#endif /* !_SDBUS_SDBUS_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sdbus/subscribe.c
+++ b/src/modules/sdbus/subscribe.c
@@ -1,0 +1,76 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* subscribe.c - composite RPC for Subscribe and AddMatch
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+
+#include "subscribe.h"
+
+static const char *match_signal_all = "type=signal";
+
+
+static void subscribe_continuation (flux_future_t *f1, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f1);
+    const char *errmsg = NULL;
+    flux_future_t *f2;
+
+    if (flux_rpc_get (f1, NULL) < 0) {
+        errmsg = future_strerror (f1, errno);
+        goto error;
+    }
+    if (!(f2 = flux_rpc_pack (h,
+                              "sdbus.call",
+                              FLUX_NODEID_ANY,
+                              0,
+                              "{s:s s:s s:s s:s s:[s]}",
+                              "destination", "org.freedesktop.DBus",
+                              "path", "/org/freedesktop/DBus",
+                              "interface", "org.freedesktop.DBus",
+                              "member", "AddMatch",
+                              "params", match_signal_all))
+        || flux_future_continue (f1, f2) < 0) {
+        errmsg = "error continuing subscribe request";
+        flux_future_destroy (f2);
+        goto error;
+    }
+    goto done;
+error:
+    flux_future_continue_error (f1, errno, errmsg);
+done:
+    flux_future_destroy (f1);
+}
+
+flux_future_t *sdbus_subscribe (flux_t *h)
+{
+    flux_future_t *f1;
+    flux_future_t *fc;
+
+    if (!(f1 = flux_rpc_pack (h,
+                              "sdbus.call",
+                              FLUX_NODEID_ANY,
+                              0,
+                              "{s:s s:[]}",
+                              "member", "Subscribe",
+                              "params"))
+        || !(fc = flux_future_and_then (f1, subscribe_continuation, NULL))) {
+        flux_future_destroy (f1);
+        return NULL;
+    }
+    return fc;
+}
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/sdbus/subscribe.h
+++ b/src/modules/sdbus/subscribe.h
@@ -1,0 +1,27 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SDBUS_SUBSCRIBE_H
+#define _SDBUS_SUBSCRIBE_H
+
+#include <flux/core.h>
+
+/* sdbus RPC for Subscribe and AddMatch method-calls.
+ * The calls are made sequentially and the future is fulfilled when
+ * both complete.
+ * N.B. these are not direct method-calls.  They are RPCs to sdbus.call,
+ * so when made from sdbus itself, they rely on the fact that RPCs to self
+ * do work in broker modules.
+ */
+flux_future_t *sdbus_subscribe (flux_t *h);
+
+#endif /* !_SDBUS_SUBSCRIBE_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sdbus/test/message.c
+++ b/src/modules/sdbus/test/message.c
@@ -1,0 +1,492 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <jansson.h>
+#include <systemd/sd-bus.h>
+
+#include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
+#include "ccan/array_size/array_size.h"
+
+#include "message.h"
+
+/* Message diag is not proper TAP output so set to 0 except during development.
+ */
+#define ENABLE_MESSAGE_DIAG 0
+
+void diagjson (json_t *o)
+{
+    char *s = json_dumps (o, JSON_COMPACT);
+    diag ("%s", s ? s : "(null)");
+    free (s);
+}
+
+void diagmsg (sd_bus_message *m)
+{
+#if defined (HAVE_SD_BUS_MESSAGE_DUMP) && ENABLE_MESSAGE_DIAG
+    (void)sd_bus_message_rewind (m, true);
+    (void)sd_bus_message_dump (m, stderr, 0);
+    (void)sd_bus_message_rewind (m, true);
+#endif
+}
+
+void msgtype_is (sd_bus_message *m, const char *fmt)
+{
+    char type[65] = "";
+
+    if (m) {
+        (void)sd_bus_message_rewind (m, true);
+        for (int i = 0; i < sizeof (type) - 1; i++) {
+            if (sd_bus_message_peek_type (m, &type[i], NULL) < 1
+                || sd_bus_message_skip (m, &type[i]) < 0)
+                break;
+        }
+        (void)sd_bus_message_rewind (m, true);
+    }
+    bool match = streq (type, fmt);
+    ok (match, "message type has %s signature", fmt);
+    if (!match)
+        diag ("message type %s != %s signature", type, fmt);
+}
+
+void test_typestr (sd_bus *bus)
+{
+    const char *s;
+    sd_bus_message *m;
+
+    s = sdmsg_typestr (NULL);
+    ok (s && streq (s, "unknown"),
+        "sdmsg_typestr m=NULL returns 'unknown'");
+
+    if (sd_bus_message_new (bus, &m, SD_BUS_MESSAGE_METHOD_CALL) < 0)
+        BAIL_OUT ("could not create method call message");
+    s = sdmsg_typestr (m);
+    ok (s && streq (s, "method-call"),
+        "sdmsg_typestr m=method call returns 'method-call'");
+    sd_bus_message_unref (m);
+
+    if (sd_bus_message_new (bus, &m, SD_BUS_MESSAGE_METHOD_RETURN) < 0)
+        BAIL_OUT ("could not create method return message");
+    s = sdmsg_typestr (m);
+    ok (s && streq (s, "method-return"),
+        "sdmsg_typestr m=method return returns 'method-return'");
+    sd_bus_message_unref (m);
+
+    if (sd_bus_message_new (bus, &m, SD_BUS_MESSAGE_METHOD_ERROR) < 0)
+        BAIL_OUT ("could not create method errr message");
+    s = sdmsg_typestr (m);
+    ok (s && streq (s, "method-error"),
+        "sdmsg_typestr m=method return returns 'method-error'");
+    sd_bus_message_unref (m);
+
+    if (sd_bus_message_new (bus, &m, SD_BUS_MESSAGE_SIGNAL) < 0)
+        BAIL_OUT ("could not create signal message");
+    s = sdmsg_typestr (m);
+    ok (s && streq (s, "signal"),
+        "sdmsg_typestr m=signal returns 'signal'");
+    sd_bus_message_unref (m);
+}
+
+/* Check that an object containing all of the basic D-Bus types can be
+ * converted from json->dbus->json.  The input and output json objects
+ * are compared for equality.
+ */
+void test_basic (sd_bus *bus)
+{
+    json_t *o;
+    json_t *o2;
+    int rc;
+    sd_bus_message *m;
+
+    if (!(o = json_pack ("[ibiiiiiifsss]",
+                         42,
+                         true,
+                         -30000,
+                         48000,
+                         -100000,
+                         100000,
+                         -10,
+                         10,
+                         3.5,
+                         "string",
+                         "",
+                         "/object/path/string.suffix")))
+        BAIL_OUT ("could not pack json array");
+    diagjson (o);
+    if (sd_bus_message_new (bus, &m, SD_BUS_MESSAGE_METHOD_CALL) < 0)
+        BAIL_OUT ("could not create method call message");
+
+    const char *fmt = "ybnqiuxtdsso";
+    rc = sdmsg_write (m, fmt, o);
+    ok (rc == 0,
+        "sdmsg_write works");
+
+    if (sd_bus_message_seal (m, 42, 0) < 0
+        || sd_bus_message_rewind (m, true) < 0)
+        BAIL_OUT ("could not finalize message");
+
+    msgtype_is (m, fmt);
+
+    diagmsg (m);
+
+    if (!(o2 = json_array ()))
+        BAIL_OUT ("could not create json array");
+    rc = sdmsg_read (m, fmt, o2);
+    diag ("sdmsg_read returned %d", rc);
+    ok (rc == 1,
+        "sdmsg_read works");
+    diagjson (o2);
+    ok (sd_bus_message_at_end (m, true),
+        "all message contents were read");
+    ok (json_equal (o, o2),
+        "json in/out are the same");
+
+    json_decref (o2);
+    sd_bus_message_unref (m);
+    json_decref (o);
+}
+
+/* Check that a struct containing string, array-of-string, and boolean "(sasb)"
+ * can be converted from json->dbus.  dbus->json is not supported yet so
+ * use sd_bus_message accessors to check that dbus content is correct.
+ * N.B. An array of (sasb) is required in the StartTransientUnit request.
+ */
+void test_struct_sasb (sd_bus *bus)
+{
+    json_t *o;
+    const char *fmt = "(sasb)";
+    sd_bus_message *m;
+    const char *s;
+    int b;
+
+    if (!(o = json_pack ("[s[ss]b]", "foo", "a1", "a2", 1)))
+        BAIL_OUT ("could not pack json array for (sasb)");
+    diagjson (o);
+
+    if (sd_bus_message_new (bus, &m, SD_BUS_MESSAGE_METHOD_CALL) < 0)
+        BAIL_OUT ("could not create method call message");
+
+    ok (sdmsg_put (m, fmt, o) == 0,
+        "sdmsg_put works with struct (sasb)");
+
+    if (sd_bus_message_seal (m, 42, 0) < 0
+        || sd_bus_message_rewind (m, true) < 0)
+        BAIL_OUT ("could not finalize message");
+
+    diagmsg (m);
+
+    if (sd_bus_message_enter_container (m, 'r', "sasb") <= 0)
+        BAIL_OUT ("could not enter struct container");
+
+    ok (sd_bus_message_read (m, "s", &s) > 0
+        && streq (s, "foo"),
+        "successfully read back first (string) element");
+
+    ok (sd_bus_message_enter_container (m, 'a', "s") > 0
+        && sd_bus_message_read (m, "s", &s) > 0
+        && streq (s, "a1")
+        && sd_bus_message_read (m, "s", &s) > 0
+        && streq (s, "a2")
+        && sd_bus_message_exit_container (m) > 0,
+        "successfully read back second (array) element");
+
+    ok (sd_bus_message_read (m, "b", &b) > 0
+        && b == 1,
+        "successfully read back third (boolean) element");
+
+    if (sd_bus_message_exit_container (m) <= 0)
+        BAIL_OUT ("error exiting struct container");
+
+    sd_bus_message_unref (m);
+    json_decref (o);
+}
+
+/* Convert three variants (integer, string, float) from json->dbus->json.
+ * The input and output json objects are compared for equality.
+ */
+void test_variant (sd_bus *bus)
+{
+    json_t *o;
+    json_t *o2;
+    sd_bus_message *m;
+    int rc;
+
+    if (!(o = json_pack ("[[si][ss][sf]]",
+                         "i", 42,
+                         "s", "fubar",
+                         "d", -1.5)))
+        BAIL_OUT ("could not pack json array");
+    diagjson (o);
+
+    if (sd_bus_message_new (bus, &m, SD_BUS_MESSAGE_METHOD_CALL) < 0)
+        BAIL_OUT ("could not create method call message");
+
+    const char *fmt = "vvv";
+    rc = sdmsg_write (m, fmt, o);
+    ok (rc == 0,
+        "sdmsg_write works with variants");
+
+    if (sd_bus_message_seal (m, 42, 0) < 0
+        || sd_bus_message_rewind (m, true) < 0)
+        BAIL_OUT ("could not finalize message");
+
+    msgtype_is (m, "vvv");
+
+    diagmsg (m);
+
+    if (!(o2 = json_array ()))
+        BAIL_OUT ("could not create json array");
+    rc = sdmsg_read (m, fmt, o2);
+    diag ("sdmsg_read returned %d", rc);
+    ok (rc == 1,
+        "sdmsg_read works");
+    diagjson (o2);
+    ok (sd_bus_message_at_end (m, true),
+        "all message contents were read");
+    ok (json_equal (o, o2),
+        "json in/out are the same");
+
+    json_decref (o2);
+    sd_bus_message_unref (m);
+    json_decref (o);
+}
+
+/* Convert an array-of-string from json->dbus->json.
+ * The input and output json objects are compared for equality.
+ */
+void test_variant_as (sd_bus *bus)
+{
+    sd_bus_message *m;
+    json_t *in;
+    json_t *out;
+    const char *fmt = "v";
+    int rc;
+
+    if (!(in = json_pack ("[[s[sss]]]", "as", "foo", "bar", "baz")))
+        BAIL_OUT ("could not create json object");
+    if (sd_bus_message_new (bus, &m, SD_BUS_MESSAGE_METHOD_RETURN) < 0)
+        BAIL_OUT ("could not create message");
+    ok (sdmsg_write (m, fmt, in) == 0,
+        "sdmsg_write of variant string array works");
+
+    if (sd_bus_message_seal (m, 42, 0) < 0
+        || sd_bus_message_rewind (m, true) < 0)
+        BAIL_OUT ("could not finalize message");
+    diagmsg (m);
+    msgtype_is (m, fmt);
+
+    if (!(out = json_array ()))
+        BAIL_OUT ("could not create json array");
+
+    rc = sdmsg_read (m, fmt, out);
+    diag ("sdmsg_read returned %d", rc);
+    ok (rc == 1,
+        "sdmsg_read works on message containing string array variant");
+
+    diagjson (out);
+
+    ok (json_equal (in, out),
+        "json in/out are the same");
+
+    json_decref (out);
+    json_decref (in);
+    sd_bus_message_unref (m);
+}
+
+/* In property dicts (e.g. GetAll) we don't know how to decode all values yet.
+ * It seems most sane to decode keys with a JSON null value rather than omit
+ * those keys.  Create an sdbus message containing complex variants, then
+ * convert dbus->json.  Verify that values that can't be decoded are null.
+ */
+void test_variant_unknown (sd_bus *bus)
+{
+    sd_bus_message *m;
+    json_t *o;
+    const char *fmt = "svs";
+    uint8_t y[2] = { 99, 100 };
+    int rc;
+
+    if (sd_bus_message_new (bus, &m, SD_BUS_MESSAGE_METHOD_CALL) < 0
+        || sd_bus_message_append (m, "s", "eek") < 0
+        || sd_bus_message_open_container (m, 'v', "a(yy)") < 0
+        || sd_bus_message_open_container (m, 'a', "(yy)") < 0
+        || sd_bus_message_open_container (m, 'r', "yy") < 0
+        || sd_bus_message_append (m, "yy", y[0], y[1]) < 0
+        || sd_bus_message_close_container (m) < 0
+        || sd_bus_message_close_container (m) < 0
+        || sd_bus_message_close_container (m) < 0
+        || sd_bus_message_append (m, "s", "ook") < 0
+        || sd_bus_message_seal (m, 42, 0) < 0
+        || sd_bus_message_rewind (m, true) < 0)
+        BAIL_OUT ("could not create message containing complex variant");
+    diagmsg (m);
+    msgtype_is (m, fmt);
+    if (!(o = json_array ()))
+        BAIL_OUT ("could not create json array");
+
+    rc = sdmsg_read (m, fmt, o);
+    diag ("sdmsg_read returned %d", rc);
+    ok (rc == 1,
+        "sdmsg_read works on message containing complex variant");
+
+    diagjson (o);
+
+    const char *s1, *s2, *type;
+    ok (json_unpack (o, "[s[sn]s]", &s1, &type, &s2) == 0
+        && streq (s1, "eek")
+        && streq (type, "a(yy)")
+        && streq (s2, "ook"),
+        "complex variant was translated to json null");
+
+    json_decref (o);
+    sd_bus_message_unref (m);
+}
+
+/* StartTransientUnit wants a property array rather than the D-bus std dict.
+ * Create one and convert json->dbus.  Then since we don't require the reverse
+ * encoding, use sd_bus_message accessors to verify the result.
+ */
+void test_property_array (sd_bus *bus)
+{
+    json_t *o;
+    json_error_t error;
+    sd_bus_message *m;
+    const char *fmt = "a(sv)";
+    const char *key;
+    const char *s;
+    const char *s2;
+    int b;
+
+    if (!(o = json_pack_ex (&error,
+                            0,
+                            "["
+                            "[s[ss]]"
+                            "[s[sb]]"
+                            "[s[s[ss]]]"
+                            "[s[s[[s[ss]b]]]]"
+                            "]",
+                            "key1", "s", "val1",
+                            "key2", "b", 1,
+                            "key3", "as", "a1", "a2",
+                            "key4", "a(sasb)", "foo", "a1", "a2", 0)))
+        BAIL_OUT ("error creating properties object: %s", error.text);
+    diagjson (o);
+
+    if (sd_bus_message_new (bus, &m, SD_BUS_MESSAGE_METHOD_CALL) < 0)
+        BAIL_OUT ("could not create message");
+    ok (sdmsg_put (m, fmt, o) == 0,
+        "sdmsg_put of property array works");
+    if (sd_bus_message_seal (m, 42, 0) < 0
+        || sd_bus_message_rewind (m, true) < 0)
+        BAIL_OUT ("could not finalize message");
+    diagmsg (m);
+
+    if (sd_bus_message_enter_container (m, 'a', "(sv)") <= 0)
+        BAIL_OUT ("could not enter property array container");
+
+    ok (sd_bus_message_enter_container (m, 'r', "sv") > 0
+        && sd_bus_message_read (m, "s", &key) > 0
+        && sd_bus_message_enter_container (m, 'v', "s") > 0
+        && sd_bus_message_read (m, "s", &s) > 0
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_exit_container (m) > 0
+        && streq (key, "key1")
+        && streq (s, "val1"),
+        "successfully read back first property");
+
+    ok (sd_bus_message_enter_container (m, 'r', "sv") > 0
+        && sd_bus_message_read (m, "s", &key) > 0
+        && sd_bus_message_enter_container (m, 'v', "b") > 0
+        && sd_bus_message_read (m, "b", &b) > 0
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_exit_container (m) > 0
+        && streq (key, "key2")
+        && b == 1,
+        "successfully read back second property");
+
+    ok (sd_bus_message_enter_container (m, 'r', "sv") > 0
+        && sd_bus_message_read (m, "s", &key) > 0
+        && sd_bus_message_enter_container (m, 'v', "as") > 0
+        && sd_bus_message_enter_container (m, 'a', "s") > 0
+        && sd_bus_message_read (m, "s", &s) > 0
+        && sd_bus_message_read (m, "s", &s2) > 0
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_exit_container (m) > 0
+        && streq (key, "key3")
+        && streq (s, "a1")
+        && streq (s2, "a2"),
+        "successfully read back third property");
+
+    ok (sd_bus_message_enter_container (m, 'r', "sv") > 0
+        && sd_bus_message_read (m, "s", &key) > 0
+        && streq (key, "key4")
+        && sd_bus_message_enter_container (m, 'v', "a(sasb)") > 0
+        && sd_bus_message_enter_container (m, 'a', "(sasb)") > 0
+        && sd_bus_message_enter_container (m, 'r', "sasb") > 0
+        && sd_bus_message_read (m, "s", &s) > 0
+        && streq (s, "foo")
+        && sd_bus_message_enter_container (m, 'a', "s") > 0
+        && sd_bus_message_read (m, "s", &s) > 0
+        && streq (s, "a1")
+        && sd_bus_message_read (m, "s", &s) > 0
+        && streq (s, "a2")
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_read (m, "b", &b) > 0
+        && b == 0
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_exit_container (m) > 0,
+        "successfully read back fourth property");
+
+    if (sd_bus_message_exit_container (m) <= 0)
+        BAIL_OUT ("error exiting property array container");
+
+    json_decref (o);
+    sd_bus_message_unref (m);
+}
+
+int main (int argc, char **argv)
+{
+    sd_bus *bus;
+    int e;
+
+    plan (NO_PLAN);
+
+    if ((e = sd_bus_open_user (&bus)) < 0) {
+        diag ("could not open sdbus: %s", strerror (e));
+        if (!getenv ("DBUS_SESSION_BUS_ADDRESS"))
+            diag ("Hint: DBUS_SESSION_BUS_ADDRESS is not set");
+        if (!getenv ("XDG_RUNTIME_DIR"))
+            diag ("Hint: XDG_RUNTIME_DIR is not set");
+        plan (SKIP_ALL);
+        done_testing ();
+    }
+
+    test_typestr (bus);
+    test_basic (bus);
+    test_struct_sasb (bus);
+    test_variant (bus);
+    test_variant_as (bus);
+    test_variant_unknown (bus);
+    test_property_array (bus);
+
+    sd_bus_flush (bus);
+    sd_bus_close (bus);
+    sd_bus_unref (bus);
+
+    done_testing ();
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/modules/sdbus/test/objpath.c
+++ b/src/modules/sdbus/test/objpath.c
@@ -1,0 +1,83 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <systemd/sd-bus.h>
+
+#include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
+#include "ccan/array_size/array_size.h"
+
+#include "objpath.h"
+
+struct testvec {
+    const char *xpath;
+    const char *path;
+};
+
+static struct testvec opvec[] = {
+    { "/object/path/foo.suffix",
+      "/object/path/foo_2esuffix" },
+    { "/org/freedesktop/systemd1/unit/flux-foo.service",
+      "/org/freedesktop/systemd1/unit/flux_2dfoo_2eservice" },
+    { "/foo/flea-bag",
+      "/foo/flea_2dbag" },
+    { "/foo",
+      "/foo" },
+    { "/",
+      "/" },
+};
+
+void test_decode (sd_bus *bus)
+{
+    for (int i = 0; i < ARRAY_SIZE (opvec); i++) {
+        char *p;
+        p = objpath_encode (opvec[i].xpath);
+        diag ("%s", p);
+        ok (p && streq (p, opvec[i].path),
+            "objpath_encode %s works", opvec[i].xpath);
+        free (p);
+        p = objpath_decode (opvec[i].path);
+        ok (p && streq (p, opvec[i].xpath),
+            "objpath_decode %s works", opvec[i].path);
+        free (p);
+    }
+}
+
+int main (int argc, char **argv)
+{
+    sd_bus *bus;
+    int e;
+
+    plan (NO_PLAN);
+
+    if ((e = sd_bus_open_user (&bus)) < 0) {
+        diag ("could not open sdbus: %s", strerror (e));
+        if (!getenv ("DBUS_SESSION_BUS_ADDRESS"))
+            diag ("Hint: DBUS_SESSION_BUS_ADDRESS is not set");
+        if (!getenv ("XDG_RUNTIME_DIR"))
+            diag ("Hint: XDG_RUNTIME_DIR is not set");
+        plan (SKIP_ALL);
+        done_testing ();
+    }
+
+    test_decode (bus);
+
+    sd_bus_flush (bus);
+    sd_bus_close (bus);
+    sd_bus_unref (bus);
+
+    done_testing ();
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/modules/sdbus/watcher.c
+++ b/src/modules/sdbus/watcher.c
@@ -1,0 +1,166 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* watcher.c - a flux watcher that becomes ready when sd-bus needs service
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <poll.h>
+#include <errno.h>
+#include <time.h>
+#include <flux/core.h>
+#include <math.h>
+#include <systemd/sd-bus.h>
+
+#include "watcher.h"
+
+struct sdbus_watcher {
+    sd_bus *bus;
+    flux_watcher_t *in;
+    flux_watcher_t *out;
+    flux_watcher_t *tmout;
+    flux_watcher_t *prep;
+
+    flux_watcher_t *w;
+
+    flux_watcher_f cb;
+    void *cb_arg;
+};
+
+/* The event loop is about to (possibly) block.  The job of this function
+ * is to ensure that the appropriate watchers are enabled so the event loop
+ * unblocks when sd-bus requires service.
+ * N.B. in practice, it seems that sd_bus_get_events always returns() at
+ * least POLLIN, which makes sense given that the D-Bus spec allows the bus
+ * to send unsolicited signals like 'NameAcquired'.
+ */
+static void prep_cb (flux_reactor_t *r,
+                     flux_watcher_t *w,
+                     int revents,
+                     void *arg)
+{
+    struct sdbus_watcher *sdw = arg;
+    int events;
+    uint64_t usec;
+    struct timespec ts;
+
+    flux_watcher_stop (sdw->in);
+    flux_watcher_stop (sdw->out);
+    flux_watcher_stop (sdw->tmout);
+
+    if ((events = sd_bus_get_events (sdw->bus)) >= 0) {
+        if ((events & POLLIN))
+            flux_watcher_start (sdw->in);
+        if ((events & POLLOUT))
+            flux_watcher_start (sdw->out);
+    }
+    /* sd_bus_get_timeout(3) sets 'usec' to the absolute time when the bus
+     * wants service, or UINT64_MAX for "no timeout".  Convert that to a time
+     * relative to now wanted by the flux timer watcher.
+     * N.B.  floor() rounds 'now' down so that when it is subtracted from
+     * 'usec', the result is rounded up per sd_bus_get_timeout(3)
+     * recommendation.
+     */
+    if (sd_bus_get_timeout (sdw->bus, &usec) >= 0
+        && usec != UINT64_MAX
+        && clock_gettime (CLOCK_MONOTONIC, &ts) == 0) {
+        double now = floor (1E6*ts.tv_sec + 1E-3*ts.tv_nsec);
+        double timeout = 1E-6*(usec - now);
+
+        if (timeout >= 0.) {
+            flux_timer_watcher_reset (sdw->tmout, timeout, 0.);
+            flux_watcher_start (sdw->tmout);
+        }
+    }
+}
+
+/* The timer and/or fd watchers are ready.  Call the bus watcher callback
+ * so it can call sd_bus_process(3).
+ */
+static void bus_cb (flux_reactor_t *r,
+                    flux_watcher_t *w,
+                    int revents,
+                    void *arg)
+{
+    struct sdbus_watcher *sdw = arg;
+
+    if (sdw->cb)
+        sdw->cb (r, sdw->w, revents, sdw->cb_arg);
+}
+
+static void op_start (flux_watcher_t *w)
+{
+    struct sdbus_watcher *sdw = flux_watcher_get_data (w);
+    flux_watcher_start (sdw->prep);
+}
+
+static void op_stop (flux_watcher_t *w)
+{
+    struct sdbus_watcher *sdw = flux_watcher_get_data (w);
+    flux_watcher_stop (sdw->prep);
+    flux_watcher_stop (sdw->in);
+    flux_watcher_stop (sdw->out);
+    flux_watcher_stop (sdw->tmout);
+}
+
+static void op_destroy (flux_watcher_t *w)
+{
+    struct sdbus_watcher *sdw = flux_watcher_get_data (w);
+    flux_watcher_destroy (sdw->prep);
+    flux_watcher_destroy (sdw->in);
+    flux_watcher_destroy (sdw->out);
+    flux_watcher_destroy (sdw->tmout);
+}
+
+static struct flux_watcher_ops sdbus_watcher_ops = {
+    .start = op_start,
+    .stop = op_stop,
+    .destroy = op_destroy,
+};
+
+flux_watcher_t *sdbus_watcher_create (flux_reactor_t *r,
+                                      sd_bus *bus,
+                                      flux_watcher_f cb,
+                                      void *arg)
+{
+    flux_watcher_t *w;
+    struct sdbus_watcher *sdw;
+    int fd;
+
+    if ((fd = sd_bus_get_fd (bus)) < 0) {
+        errno = -fd;
+        return NULL;
+    }
+    if (!(w = flux_watcher_create (r,
+                                   sizeof (*sdw),
+                                   &sdbus_watcher_ops,
+                                   cb,
+                                   arg)))
+        return NULL;
+    sdw = flux_watcher_get_data (w);
+    sdw->bus = bus;
+    sdw->w = w;
+    sdw->cb = cb;
+    sdw->cb_arg = arg;
+    if (!(sdw->out = flux_fd_watcher_create (r, fd, FLUX_POLLOUT, bus_cb, sdw))
+        || !(sdw->in = flux_fd_watcher_create (r, fd, FLUX_POLLIN, bus_cb, sdw))
+        || !(sdw->tmout = flux_timer_watcher_create (r, 0., 0., bus_cb, sdw))
+        || !(sdw->prep = flux_prepare_watcher_create (r, prep_cb, sdw)))
+        goto error;
+    return w;
+error:
+    flux_watcher_destroy (w);
+    return NULL;
+}
+
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/sdbus/watcher.h
+++ b/src/modules/sdbus/watcher.h
@@ -1,0 +1,28 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SDBUS_WATCHER_H
+#define _SDBUS_WATCHER_H
+
+#include <systemd/sd-bus.h>
+#include <flux/core.h>
+
+/* This watcher is called each time the sd-bus may require service.
+ * The callback should call sd_bus_process(3) to give libsystemd the
+ * opportunity to make progress.
+ */
+flux_watcher_t *sdbus_watcher_create (flux_reactor_t *r,
+                                      sd_bus *bus,
+                                      flux_watcher_f cb,
+                                      void *arg);
+
+#endif /* !_SDBUS_WATCHER_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -175,6 +175,7 @@ TESTSCRIPTS = \
 	t2404-job-exec-multiuser.t \
 	t2405-job-exec-sdexec.t \
 	t2406-job-exec-cleanup.t \
+	t2407-sdbus.t \
 	t2410-exec-systemd.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -176,6 +176,7 @@ TESTSCRIPTS = \
 	t2405-job-exec-sdexec.t \
 	t2406-job-exec-cleanup.t \
 	t2407-sdbus.t \
+	t2408-sdbus-recovery.t \
 	t2410-exec-systemd.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \

--- a/t/issues/t3503-nofiles-limit.sh
+++ b/t/issues/t3503-nofiles-limit.sh
@@ -9,8 +9,8 @@
 #   definitely cause the broker to run over the artificially lowered
 #   fd limit.
 #
-ulimit -n 113
-ulimit -Hn 113
+ulimit -n 115
+ulimit -Hn 115
 flux start \
     sh -c '
 flux submit --cc=1-12 hostname &&

--- a/t/t2407-sdbus.t
+++ b/t/t2407-sdbus.t
@@ -82,7 +82,8 @@ bus_get_prop () {
 # Usage: bus_start_simple name description remain cmd arg1
 # where remain=True|False and cmd has exactly one argument
 bus_start_simple() {
-    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"member\":\"StartTransientUnit\",\"params\":[\"$1\",\"fail\",[ [\"Description\",[\"s\",\"$2\"]], [\"RemainAfterExit\",[\"b\",$3]], [\"ExecStart\",[\"a(sasb)\",[[\"$4\",[\"$4\",\"$5\"],False]]]] ], []]}).get_str())"
+    local cmd=$(which $4) || return 1
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"member\":\"StartTransientUnit\",\"params\":[\"$1\",\"fail\",[ [\"Description\",[\"s\",\"$2\"]], [\"RemainAfterExit\",[\"b\",$3]], [\"ExecStart\",[\"a(sasb)\",[[\"$cmd\",[\"$4\",\"$5\"],False]]]] ], []]}).get_str())"
 }
 
 bus_call_unknown_member() {

--- a/t/t2407-sdbus.t
+++ b/t/t2407-sdbus.t
@@ -1,0 +1,264 @@
+#!/bin/sh
+# ci=system
+
+test_description='Test flux systemd sd-bus bridge standalone'
+
+. $(dirname $0)/sharness.sh
+
+if ! flux version | grep systemd; then
+	skip_all="flux was not built with systemd"
+	test_done
+fi
+if ! systemctl --user show --property Version; then
+	skip_all="user systemd is not running"
+	test_done
+fi
+
+test_under_flux 1 minimal
+
+flux setattr log-stderr-level 1
+
+#
+# N.B. ListUnitsByPatterns response payload is a 'params' array whose first
+# and only item (".params[0]") is an array of units.  The jq(1) expression
+# ".params[0][][0]" extracts field 0 of each unit array entry (unit name)
+# and prints one entry per line, ".params[0][][1]" extracts field 1 of each
+# unit entry (description) and prints one entry per line, etc.
+#
+
+# Usage: bus_list_units PATTERN
+bus_list_units() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"member\":\"ListUnitsByPatterns\",\"params\":[[],[\"$1\"]]}).get_str())"
+}
+
+# Usage: bus_list_units_parsed PATTERN FIELDNUM
+bus_list_units_parsed() {
+    bus_list_units "$1" >tmp.json || return 1
+    $jq -r ".params[0][][$2]" <tmp.json
+}
+
+# Usage: bus_count_units PATTERN
+bus_count_units() {
+    bus_list_units_parsed "$1" 0 >tmp.list || return 1
+    wc -l <tmp.list
+}
+
+# Usage: bus_wait_for_unit_count TRIES COUNT PATTERN
+bus_wait_for_unit_count() {
+    local tries=$1
+    while test $tries -gt 0; do
+	test $tries -eq $1 || sleep 1
+        test $(bus_count_units $3) -eq $2 && return 0
+        tries=$(($tries-1))
+    done
+    return 1
+}
+
+# Usage: bus_reset_failed_unit name
+bus_reset_failed_unit() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"member\":\"ResetFailedUnit\",\"params\":[\"$1\"]}).get_str())"
+}
+
+# Usage: bus_stop_unit name
+bus_stop_unit() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"member\":\"StopUnit\",\"params\":[\"$1\",\"fail\"]}).get_str())"
+}
+
+# Usage: bus_kill_unit name signum
+bus_kill_unit() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"member\":\"KillUnit\",\"params\":[\"$1\",\"all\",$2]}).get_str())"
+}
+
+# Usage: bus_get_prop_all interface name
+bus_get_prop_all () {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"path\":\"/org/freedesktop/systemd1/unit/$2\",\"interface\":\"org.freedesktop.DBus.Properties\",\"member\":\"GetAll\",\"params\":[\"$1\"]}).get_str())"
+}
+
+# Usage: bus_get_prop interface name property
+bus_get_prop () {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"path\":\"/org/freedesktop/systemd1/unit/$2\",\"interface\":\"org.freedesktop.DBus.Properties\",\"member\":\"Get\",\"params\":[\"$1\",\"$3\"]}).get_str())"
+}
+
+# Usage: bus_start_simple name description remain cmd arg1
+# where remain=True|False and cmd has exactly one argument
+bus_start_simple() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"member\":\"StartTransientUnit\",\"params\":[\"$1\",\"fail\",[ [\"Description\",[\"s\",\"$2\"]], [\"RemainAfterExit\",[\"b\",$3]], [\"ExecStart\",[\"a(sasb)\",[[\"$4\",[\"$4\",\"$5\"],False]]]] ], []]}).get_str())"
+}
+
+bus_call_unknown_member() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"member\":\"UnknownMember\",\"params\":[]}).get_str())"
+}
+
+bus_call_unknown_interface() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"interface\":\"org.freedesktop.DBus.unknown\",\"member\":\"StopUnit\",\"params\":[\"$1\",\"fail\"]}).get_str())"
+}
+
+bus_call_malformed() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{}).get_str())"
+}
+
+bus_subscribe_notstreaming() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.subscribe\",{}).get_str())"
+}
+
+# Usage: bus_subscribe_cancel matchtag
+bus_subscribe_cancel () {
+    flux python -c "import flux; flux.Flux().rpc(\"sdbus.subscribe-cancel\",{\"matchtag\":$1},flags=flux.constants.FLUX_RPC_NORESPONSE)"
+}
+
+test_expect_success 'load sdbus module' '
+	flux module load sdbus
+'
+
+test_expect_success 'sdbus list-units works' '
+	count=$(bus_count_units "*") &&
+	echo Listed $count units >&2
+'
+
+clean_unit() {
+	local unit=$1
+	echo Cleaning up $unit
+	bus_reset_failed_unit $unit
+	bus_stop_unit $unit
+	return 0
+}
+
+test_expect_success 'reset/unload any flux-t2406 units from prior runs' '
+	bus_list_units_parsed "flux-t2406-*" 0 >oldunits.out &&
+	for unit in $(cat oldunits.out); do clean_unit $unit; done
+'
+test_expect_success 'there are no flux-t2406 units loaded' '
+	bus_wait_for_unit_count 10 0 "flux-t2406-*"
+'
+test_expect_success 'create subscribe script' '
+	cat >subscribe.py <<-EOT &&
+	import flux
+	handle = flux.Flux()
+	fut = handle.rpc("sdbus.subscribe",{},flags=flux.constants.FLUX_RPC_STREAMING)
+	while True:
+	    print(fut.get_str())
+	    fut.reset()
+	EOT
+	chmod +x subscribe.py
+'
+test_expect_success NO_CHAIN_LINT 'subscribe to signals in the background' '
+	flux python ./subscribe.py >signals.out 2>signals.err &
+	echo $! >signals.pid
+'
+test_expect_success 'StopUnit unknown.service fails' '
+	test_must_fail bus_stop_unit unknown.service 2>stop_unknown.err &&
+	grep "not loaded" stop_unknown.err
+'
+test_expect_success 'KillUnit unknown.service fails' '
+	test_must_fail bus_kill_unit unknown.service 15 2>kill_unknown.err &&
+	grep "not loaded" kill_unknown.err
+'
+test_expect_success 'ResetFailedUnit unknown.service fails' '
+	test_must_fail bus_reset_failed_unit unknown.service \
+	    2>rst_unknown.err &&
+	grep "not loaded" rst_unknown.err
+'
+test_expect_success 'StartTransientUnit RemainAfterExit=true cmd=true' '
+	bus_start_simple flux-t2406-1.service unit1 True true dummy
+'
+test_expect_success 'ListUnitsByPatterns shows transient unit 1' '
+	bus_wait_for_unit_count 10 1 flux-t2406-1.service
+'
+test_expect_success 'StopUnit works on transient unit 1' '
+	bus_stop_unit flux-t2406-1.service
+'
+test_expect_success 'ListUnitsByPatterns does not show transient unit 1' '
+	bus_wait_for_unit_count 10 0 flux-t2406-1.service
+'
+test_expect_success 'StartTransientUnit RemainAfterExit=false cmd=false' '
+	bus_start_simple flux-t2406-2.service unit2 False false dummy
+'
+test_expect_success 'ListUnitsByPatterns shows transient unit 2' '
+	bus_wait_for_unit_count 10 1 flux-t2406-2.service
+'
+test_expect_success 'ResetFailedUnit works on that unit' '
+	bus_reset_failed_unit flux-t2406-2.service
+'
+test_expect_success 'ListUnitsByPatterns does not show transient unit 2' '
+	bus_wait_for_unit_count 10 0 flux-t2406-2.service
+'
+test_expect_success 'StartTransientUnit RemainAfterExit=false cmd=sleep 60' '
+	bus_start_simple flux-t2406-3.service unit3 False sleep 60
+'
+test_expect_success 'ListUnitsByPatterns shows transient unit 3' '
+	bus_wait_for_unit_count 10 1 flux-t2406-3.service
+'
+test_expect_success 'GetAll shows properties of transient unit 3' '
+	bus_get_prop_all org.freedesktop.systemd1.Service \
+	    flux-t2406-3.service >prop3_all.out
+'
+test_expect_success 'GetAll returned MainPID property and it is valid' '
+	$jq <prop3_all.out .params[0].MainPID[1] >pid3.out &&
+	kill -0 $(cat pid3.out)
+'
+test_expect_success 'Get MainPID also works' '
+	bus_get_prop org.freedesktop.systemd1.Service \
+	    flux-t2406-3.service MainPID >prop3.out
+'
+test_expect_success 'Get returned the same MainPID value' '
+	$jq <prop3.out .params[0][1] >pid3.out2 &&
+	test_cmp pid3.out pid3.out2
+'
+test_expect_success 'KillUnit sends SIGTERM (15) to that unit' '
+	bus_kill_unit flux-t2406-3.service 15
+'
+test_expect_success 'ListUnitsByPatterns does not show transient unit 3' '
+	bus_wait_for_unit_count 10 0 flux-t2406-3.service
+'
+test_expect_success 'StartTransientUnit RemainAfterExit=true cmd=true' '
+	bus_start_simple flux-t2406-4.service "This is a test" True true dummy
+'
+test_expect_success 'ListUnitsByPatterns shows transient unit 4' '
+	bus_wait_for_unit_count 10 1 flux-t2406-4.service
+'
+test_expect_success 'ListUnitsByPattern shows transient unit 4 description' '
+	bus_list_units_parsed flux-t2406-4.service 1 >listdesc.out &&
+	grep "This is a test" listdesc.out
+'
+test_expect_success 'StopUnit works on that unit' '
+	bus_stop_unit flux-t2406-4.service
+'
+test_expect_success 'ListUnitsByPatterns does not show transient unit 4' '
+	bus_wait_for_unit_count 10 0 flux-t2406-4.service
+'
+test_expect_success 'calling an unknown member fails' '
+	test_must_fail bus_call_unknown_member 2>unknown_member.err &&
+	grep "unknown member" unknown_member.err
+'
+test_expect_success 'calling an unknown interface fails' '
+	test_must_fail bus_call_unknown_interface 2>unknown_interface.err &&
+	grep "unknown interface" unknown_interface.err
+'
+test_expect_success 'malformed sdbus.call request fails' '
+	test_must_fail bus_call_malformed 2>malformed.err &&
+	grep "malformed request" malformed.err
+'
+test_expect_success 'non-streaming sdbus.subscribe fails' '
+	test_must_fail bus_subscribe_notstreaming 2>subscribe.err &&
+	grep "Protocol error" subscribe.err
+'
+test_expect_success 'send a sdbus.subscribe-cancel on random matchtag for fun' '
+	(FLUX_HANDLE_TRACE=1 bus_subscribe_cancel 424242)
+'
+test_expect_success NO_CHAIN_LINT 'terminate background subscriber' '
+	kill -15 $(cat signals.pid)
+'
+test_expect_success NO_CHAIN_LINT 'PropertiesChanged signals were received' '
+	test $(grep PropertiesChanged signals.out | wc -l) -gt 0
+'
+test_expect_success NO_CHAIN_LINT 'all test units triggered signals' '
+	test $(grep flux-t2406-1 signals.out | wc -l) -gt 0 &&
+	test $(grep flux-t2406-2 signals.out | wc -l) -gt 0 &&
+	test $(grep flux-t2406-3 signals.out | wc -l) -gt 0 &&
+	test $(grep flux-t2406-4 signals.out | wc -l) -gt 0
+'
+
+test_expect_success 'remove sdbus module' '
+	flux module remove sdbus
+'
+test_done

--- a/t/t2407-sdbus.t
+++ b/t/t2407-sdbus.t
@@ -133,11 +133,13 @@ test_expect_success 'there are no flux-t2406 units loaded' '
 '
 test_expect_success 'create subscribe script' '
 	cat >subscribe.py <<-EOT &&
+	import sys
 	import flux
 	handle = flux.Flux()
 	fut = handle.rpc("sdbus.subscribe",{},flags=flux.constants.FLUX_RPC_STREAMING)
 	while True:
 	    print(fut.get_str())
+	    sys.stdout.flush()
 	    fut.reset()
 	EOT
 	chmod +x subscribe.py

--- a/t/t2408-sdbus-recovery.t
+++ b/t/t2408-sdbus-recovery.t
@@ -1,0 +1,79 @@
+#!/bin/sh
+# ci=system
+
+test_description='Test flux systemd sd-bus bridge recovery'
+
+. $(dirname $0)/sharness.sh
+
+if ! flux version | grep systemd; then
+	skip_all="flux was not built with systemd"
+	test_done
+fi
+if ! systemctl --user show --property Version; then
+	skip_all="user systemd is not running"
+	test_done
+fi
+
+test_under_flux 1 minimal
+
+flux setattr log-stderr-level 1
+
+# Usage: bus_get_manager_prop property
+bus_get_manager_prop() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"sdbus.call\",{\"path\":\"/org/freedesktop/systemd1\",\"interface\":\"org.freedesktop.DBus.Properties\",\"member\":\"Get\",\"params\":[\"org.freedesktop.systemd1.Manager\",\"$1\"]}).get_str())"
+}
+
+# Usage: bus_get_manager_prop property
+bus_reconnect() {
+    flux python -c "import flux; flux.Flux().rpc(\"sdbus.reconnect\",{}).get()"
+}
+
+test_expect_success 'load sdbus module' '
+	flux module load sdbus
+'
+test_expect_success 'create subscribe script' '
+	cat >subscribe.py <<-EOT &&
+	import sys
+	import flux
+	handle = flux.Flux()
+	fut = handle.rpc("sdbus.subscribe",{},flags=flux.constants.FLUX_RPC_STREAMING)
+	while True:
+	    print(fut.get_str())
+	    sys.stdout.flush()
+	    fut.reset()
+	EOT
+	chmod +x subscribe.py
+'
+test_expect_success 'get systemd version' '
+	bus_get_manager_prop Version
+'
+test_expect_success 'clear the broker ring buffer' '
+	flux dmesg -C
+'
+# This should trigger a 2s backoff before reconnect is attempted
+test_expect_success 'force bus reconnect' '
+	bus_reconnect
+'
+test_expect_success NO_CHAIN_LINT 'initiate subscription in the background' '
+        flux python ./subscribe.py >signals.out 2>signals.err &
+        echo $! >signals.pid
+'
+# Requests during the backoff period are delayed but still work
+test_expect_success 'get systemd version works during despite reconnect' '
+	bus_get_manager_prop Version
+'
+test_expect_success 'print logs' '
+	flux dmesg -H | grep sdbus
+'
+test_expect_success 'force another bus reconnect' '
+	bus_reconnect
+'
+test_expect_success NO_CHAIN_LINT 'background subscription fails' '
+	pid=$(cat signals.pid) &&
+	test_must_fail wait $pid &&
+	grep "user request" signals.err
+'
+test_expect_success 'remove sdbus module' '
+	flux module remove sdbus
+'
+test_done


### PR DESCRIPTION
Edit: after some iteration, this PR now only contains the `sdbus` module and its tests.  The `sdexec` portion will be submitted separately.

This is a rework/reimagining of @chu11's libsdprocess work from 2021 with the goal of getting  `job-exec` to launch shells as systemd transient units for the following short term benefits:
- clean up of orphaned processes when flux comes back online
- systemd cgroups containment (especially memory) on job shells

and of course to prepare groundwork for the eventual recovery of running jobs.

Two broker modules are added that enable libsubprocess to work with systemd transient units.  The modules are only loaded in an instance configured with
```toml
[systemd]
enable = true
```

One module is a D-Bus gateway module that translates Flux RPCs into D-Bus RPCs and lets flux subscribe to D-Bus "events" (called signals). It operates reactively and can handle multiple outstanding RPCs that may complete out of order.

The other module is a libsubprocess compatible remote server that launches processes as systemd transient units via the above gateway.

Both modules load on all ranks, so the `job-exec` "bulkexec" method should be able to work like it does now, just using a different subprocess server name.  (But see last todo below)

For testing, `flux-exec(1)` gets an option to use the new subprocess service, and `flux-sdctl(1)` is a C program that behaves like `systemctl(1)`.  (Ew.  Not pretty.  See second todo below)

Todo:

[snip]

This work benefited greatly from the earlier work as @chu11 did a nice job of documenting the issues he ran into and having a working example to start with greatly reduced the inertia of starting this!

My goal in posting this is to get the design out there for any initial thoughts, and to let would-be reviewers have a sneak peek so they won't have to grok the whole thing at once when it's time to review in earnest.