### PR TITLE
systemd: avoid leaving unit in failed state after flux-shutdown(1)

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -27,6 +27,7 @@ ExecReload=@X_BINDIR@/flux config reload
 Restart=always
 RestartSec=5s
 RestartPreventExitStatus=42
+SuccessExitStatus=42
 User=flux
 Group=flux
 RuntimeDirectory=flux


### PR DESCRIPTION
Problem: when flux-shutdown(1) is used to stop flux, the systemd unit state is set to failed.

Set SuccessExitStatus=42 so the magic "norestart" exit code is considered success, in addition to 0.

Fixes #5076