### PR TITLE
broker: improve systemd integration with sd_notify(3)

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -3,6 +3,7 @@ Description=Flux message broker
 Wants=munge.service
 
 [Service]
+NotifyAccess=main
 TimeoutStopSec=90
 KillMode=mixed
 ExecStart=/bin/bash -c '\
@@ -20,6 +21,7 @@ ExecStart=/bin/bash -c '\
   -Sbroker.quorum=0 \
   -Sbroker.quorum-timeout=none \
   -Sbroker.exit-norestart=42 \
+  -Sbroker.sd-notify=1 \
   -Scontent.restore=auto \
 '
 SyslogIdentifier=flux

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -3,6 +3,7 @@ Description=Flux message broker
 Wants=munge.service
 
 [Service]
+Type=notify
 NotifyAccess=main
 TimeoutStopSec=90
 KillMode=mixed

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -12,6 +12,7 @@ AM_CPPFLAGS = \
 	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
 	$(JANSSON_CFLAGS) \
+	$(LIBSYSTEMD_CFLAGS) \
 	$(VALGRIND_CFLAGS)
 
 fluxcmd_PROGRAMS = flux-broker
@@ -77,6 +78,7 @@ flux_broker_LDADD = \
 	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS) \
+	$(LIBSYSTEMD_LIBS) \
 	$(LIBDL)
 
 flux_broker_LDFLAGS =
@@ -96,6 +98,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(ZMQ_LIBS) \
+	$(LIBSYSTEMD_LIBS) \
 	$(JANSSON_LIBS)
 
 test_ldflags = \

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -740,7 +740,7 @@ static int create_runat_phases (broker_ctx_t *ctx)
     if (attr_get (ctx->attrs, "broker.rc2_none", NULL, NULL) == 0)
         rc2_none = true;
 
-    if (!(ctx->runat = runat_create (ctx->h, local_uri))) {
+    if (!(ctx->runat = runat_create (ctx->h, local_uri, ctx->sd_notify))) {
         log_err ("runat_create");
         return -1;
     }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -271,6 +271,19 @@ int main (int argc, char *argv[])
         goto cleanup;
     }
 
+    const char *val;
+    if (attr_get (ctx.attrs, "broker.sd-notify", &val, NULL) == 0
+        && !streq (val, "0")) {
+#if !HAVE_LIBSYSTEMD
+        log_err ("broker.sd_notify is set but Flux was not built"
+                 " with systemd support.");
+        goto cleanup;
+#else
+        ctx.sd_notify = true;
+#endif
+    }
+
+
     /* Parse config.
      */
     if (!(ctx.config = brokercfg_create (ctx.h,

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -51,6 +51,8 @@ struct broker {
     char *init_shell_cmd;
     size_t init_shell_cmd_len;
 
+    bool sd_notify;
+
     int exit_rc;
 };
 

--- a/src/broker/runat.h
+++ b/src/broker/runat.h
@@ -27,7 +27,7 @@ typedef void (*runat_completion_f)(struct runat *r,
                                    const char *name,
                                    void *arg);
 
-struct runat *runat_create (flux_t *h, const char *local_uri);
+struct runat *runat_create (flux_t *h, const char *local_uri, bool sdnotify);
 void runat_destroy (struct runat *r);
 
 /* Push command, to be run under shell -c, onto named list.

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -219,6 +219,8 @@ static void action_join (struct state_machine *s)
             sd_notifyf (0,
                         "STATUS=Joining Flux instance via %s",
                         overlay_get_parent_uri (s->ctx->overlay));
+            if (s->ctx->rank > 0)
+                sd_notify (0, "READY=1");
         }
 #endif
         join_check_parent (s);
@@ -362,6 +364,8 @@ static void action_run (struct state_machine *s)
                     "STATUS=Running as %s of %d node Flux instance",
                     s->ctx->rank == 0 ? "leader" : "member",
                     (int)s->ctx->size);
+        if (s->ctx->rank == 0)
+            sd_notify (0, "READY=1");
     }
 #endif
 }

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -11,6 +11,9 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#if HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
 #include <flux/core.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -210,8 +213,16 @@ static void action_join (struct state_machine *s)
 {
     if (s->ctx->rank == 0)
         state_machine_post (s, "parent-none");
-    else
+    else {
+#if HAVE_LIBSYSTEMD
+        if (s->ctx->sd_notify) {
+            sd_notifyf (0,
+                        "STATUS=Joining Flux instance via %s",
+                        overlay_get_parent_uri (s->ctx->overlay));
+        }
+#endif
         join_check_parent (s);
+    }
 }
 
 static void quorum_timer_cb (flux_reactor_t *r,
@@ -276,6 +287,10 @@ static void action_quorum (struct state_machine *s)
 {
     flux_future_t *f;
 
+#if HAVE_LIBSYSTEMD
+    if (s->ctx->sd_notify)
+        sd_notify (0, "STATUS=Waiting for instance quorum");
+#endif
     if (!(f = flux_rpc_pack (s->ctx->h,
                              "groups.join",
                              FLUX_NODEID_ANY,
@@ -340,6 +355,15 @@ static void action_run (struct state_machine *s)
         run_check_parent (s);
     else
         state_machine_post (s, "rc2-none");
+
+#if HAVE_LIBSYSTEMD
+    if (s->ctx->sd_notify) {
+        sd_notifyf (0,
+                    "STATUS=Running as %s of %d node Flux instance",
+                    s->ctx->rank == 0 ? "leader" : "member",
+                    (int)s->ctx->size);
+    }
+#endif
 }
 
 static void action_cleanup (struct state_machine *s)
@@ -371,6 +395,13 @@ static void action_shutdown (struct state_machine *s)
 {
     if (overlay_get_child_peer_count (s->ctx->overlay) == 0)
         state_machine_post (s, "children-none");
+#if HAVE_LIBSYSTEMD
+    if (s->ctx->sd_notify) {
+        sd_notifyf (0,
+                    "STATUS=Waiting for %d peers to shutdown",
+                    overlay_get_child_peer_count (s->ctx->overlay));
+    }
+#endif
 }
 
 static void rmmod_continuation (flux_future_t *f, void *arg)
@@ -434,6 +465,10 @@ static void action_exit (struct state_machine *s)
         flux_reactor_stop (flux_get_reactor (h));
         flux_future_destroy (f);
     }
+#if HAVE_LIBSYSTEMD
+    if (s->ctx->sd_notify)
+        sd_notify (0, "STATUS=Exiting");
+#endif
 }
 
 static void process_event (struct state_machine *s, const char *event)

--- a/src/broker/test/runat.c
+++ b/src/broker/test/runat.c
@@ -69,7 +69,7 @@ void basic (flux_t *h)
 
     ctx.h = h;
 
-    r = runat_create (h, "local://notreally");
+    r = runat_create (h, "local://notreally", false);
     ok (r != NULL,
         "runat_create works");
 
@@ -267,7 +267,7 @@ void badinput (flux_t *h)
     struct runat *r;
     int rc;
 
-    if (!(r = runat_create (h, NULL)))
+    if (!(r = runat_create (h, NULL, false)))
         BAIL_OUT ("runat_create failed");
 
     ok (runat_is_defined (NULL, "foo") == false,


### PR DESCRIPTION
Systemd's [sd_notify(3)](https://www.freedesktop.org/software/systemd/man/sd_notify.html) provides a mechanism to improve systemd integration for the flux system instance brokers.

This PR contains the following improvements
1) notify systemd of the broker's status during startup/shutdown
2) delay the rank 0 unit transition to "active" by switching to `Type=notify` and sending a notification on rank 0 only once the broker has reached run state (e.g. it's ready to run stuff)

Here's a snapshot of `systemctl status flux` output during startup.  Note the new "Status:" line showing that the broker is running rc1.  Also note that the Active: line shows "activating (start)".  Later it will change to "active (running)".
```
● flux.service - Flux message broker
     Loaded: loaded (/usr/local/lib/systemd/system/flux.service; enabled; vendor preset: enabled)
     Active: activating (start) since Fri 2023-04-07 15:19:10 PDT; 2s ago
    Process: 1001585 ExecStartPre=/usr/bin/loginctl enable-linger flux (code=exited, status=0/SUCCESS)
    Process: 1001586 ExecStartPre=bash -c systemctl start user@$(id -u flux).service (code=exited, status
=0/SUCCESS)
   Main PID: 1001588 (flux-broker-0)
     Status: "Running /usr/local/etc/flux/rc1"
      Tasks: 20 (limit: 8755)
        CPU: 2.627s
     CGroup: /system.slice/flux.service
             ├─1001588 broker --config-path=/usr/local/etc/flux/system/conf.d -Scron.directory=/usr/local
/etc/flux/system/cron.d -Srundir=/run/flux -Sstatedir=/var/lib/flux -Slocal-uri=local:///run/flux/local -
Slog-stderr-level=6 -Slog-stderr-mode=local -Sbroker.rc2_none -Sbroker.quorum=0 -Sbroker.quorum-timeout=n
one -Sbroker.exit-norestart=42 -Sbroker.sd-notify=1 -Scontent.restore=auto
             ├─1001592 /bin/bash -e /usr/local/etc/flux/rc1
             ├─1001661 /bin/bash -e /usr/local/etc/flux/rc1.d/01-coral2-rc
             └─1001667 /usr/bin/python3 /usr/local/libexec/flux/cmd/flux-jobtap.py load cray_pals_port_
```

The delayed transition to active also causes `systemctl start flux` to block until the unit is active.   I _think_ this is a good thing since it gives sys admins a better feel for what is happenig when flux starts.  Note that on ranks > 0, we give the notification earlier to avoid blocking startup there, since those brokers cannot reach the run state until their upstream brokers do.

I think this delay will also delay the start up of dependent units like flux-accounting.  Not sure if that is helpful for that particular case, but it might be for future units that want to submit jobs or something.

sd_notify(3) can also be used to extend our `TimeoutStopSec=90` to solve the problem of shutdown getting interrupted if it takes too long.  That's a bit more complicated to orchestrate so I didn't try that here, but this does provide some groundwork to enable it.

This PR is currently based on top of #5077