### PR TITLE
libsubprocess: remove use of assert(0)

### DIFF
--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -746,8 +746,9 @@ int flux_subprocess_stream_status (flux_subprocess_t *p, const char *stream)
     if (p->local)
         ret = c->buffer_read_w_started ? 1 : 0;
     else {
-        /* fb = c->read_buffer; */
-        assert (0);
+        /* not supported on remote right now */
+        errno = EINVAL;
+        return -1;
     }
 
     return ret;

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -310,23 +310,21 @@ static void state_change_prep_cb (flux_reactor_t *r,
 
 static flux_subprocess_state_t state_change_next (flux_subprocess_t *p)
 {
-    assert (p->state != FLUX_SUBPROCESS_FAILED);
+    /* N.B. possible transition to FLUX_SUBPROCESS_STOPPED not handled
+     * here, see issue #5083
+     */
+    assert (p->state_reported != p->state);
+    assert (p->state_reported == FLUX_SUBPROCESS_INIT
+            || p->state_reported == FLUX_SUBPROCESS_RUNNING);
 
-    switch (p->state_reported) {
-    case FLUX_SUBPROCESS_INIT:
+    if (p->state_reported == FLUX_SUBPROCESS_INIT)
         /* next state must be RUNNING */
         return FLUX_SUBPROCESS_RUNNING;
-    case FLUX_SUBPROCESS_RUNNING:
+    else if (p->state_reported == FLUX_SUBPROCESS_RUNNING)
         /* next state is EXITED */
         return FLUX_SUBPROCESS_EXITED;
-    case FLUX_SUBPROCESS_EXITED:
-    case FLUX_SUBPROCESS_FAILED:
-    case FLUX_SUBPROCESS_STOPPED:
-        break;
-    }
-
     /* shouldn't be possible to reach here */
-    assert (0);
+    return p->state_reported;
 }
 
 static void state_change_check_cb (flux_reactor_t *r,


### PR DESCRIPTION
I noted in #5080 how there were some warnings/errors due to `assert(0)` usage in `libsubprocess`.  In general, shouldn't use `assert(0)`.  Should assert to check for validity of expected things vs doing a `assert(0)` to "error out" on unexpected things.  In one case it was in an user facing API function, which is bad.

Due to my recently created issue #5083 also added a note about how one function doesn't necessarily do the expected thing at the moment.