### PR TITLE
job-exec: improve error message when job shell/imp execution fails

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1628,6 +1628,7 @@ void attach_completed_check (struct attach_ctx *ctx)
         flux_watcher_stop (ctx->sigint_w);
         flux_watcher_stop (ctx->sigtstp_w);
         flux_watcher_stop (ctx->stdin_w);
+        flux_watcher_stop (ctx->notify_timer);
     }
 }
 

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -221,23 +221,26 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
      *   create flux_cmd_t
      */
     if (cmd) {
-        const char *errmsg = "job shell execution error";
         if (errnum == EHOSTUNREACH) {
             if (!idset_test (job->critical_ranks, shell_rank)
                 && lost_shell (job, shell_rank, hostname) == 0)
                 return;
-            errmsg = "lost contact with job shell";
-            errnum = 0;
+            jobinfo_fatal_error (job,
+                                0,
+                                "%s on broker %s (rank %d)",
+                                "lost contact with job shell",
+                                hostname,
+                                rank);
         }
-        else
-            errmsg = "job shell exec error";
-
-        jobinfo_fatal_error (job,
-                             errnum,
-                             "%s on broker %s (rank %d)",
-                             errmsg,
-                             hostname,
-                             rank);
+        else {
+            jobinfo_fatal_error (job,
+                                 errnum,
+                                 "%s on broker %s (rank %d): %s",
+                                 "job shell exec error",
+                                 hostname,
+                                 rank,
+                                 flux_cmd_arg (cmd, 0));
+        }
     }
     else
         jobinfo_fatal_error (job,

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -183,4 +183,16 @@ test_expect_success 'job-exec: critical-ranks RPC handles unexpected input' '
             test_must_fail flux python critical-ranks.py $id 0
         )
 '
+grep 'release 7' /etc/centos-release >/dev/null 2>&1 \
+	|| test_set_prereq NOT_CENTOS7
+
+# The following test does not work on CentOS 7 since exec errno does
+#  not work with job-exec (for as yet unknown reason). Skip the test on
+#  this distro:
+test_expect_success NOT_CENTOS7 'job-exec: path to shell is emitted on exec error' '
+	test_expect_code 127 flux run \
+	  --setattr=exec.job_shell=/foo/flux-shell hostname 2>exec.err &&
+	test_debug "cat exec.err" &&
+	grep /foo/flux-shell exec.err
+'
 test_done


### PR DESCRIPTION
This PR modifies the error raised by the job-exec module when the job-shell or IMP failed to execute, which is currently a bit confusing, e.g.:
```
job shell exec error on broker pi3 (rank 0): No such file or directory
```
The new error just adds the path to the failing command, which should make it obvious what went wrong in this case.

When testing, I noticed that `flux job attach` would hang in this scenario (ctr-c works to terminate it though) because of a stray timer that was left on in the reactor, so that is fixed here as well.

For some reason, the test does not work in CentOS 7. Instead of getting an error from exec(2), execution of the job shell from a bad path returns success on this distro, then later exits with exit code 127. I didn't want to spend all day trying to get to the bottom that, since that distro is dwindling in usage. I assume it probably has something to do with limited `posix_spawn` support in that glibc(wild guess). So I've just disabled the test there for now.

I thought I had opened an issue on improving this error message, but I can't find it at the moment.