### PR TITLE
testsuite: skip failing test on RHEL7

### DIFF
--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -183,13 +183,17 @@ test_expect_success 'job-exec: critical-ranks RPC handles unexpected input' '
             test_must_fail flux python critical-ranks.py $id 0
         )
 '
-grep 'release 7' /etc/centos-release >/dev/null 2>&1 \
-	|| test_set_prereq NOT_CENTOS7
 
-# The following test does not work on CentOS 7 since exec errno does
+if ! grep 'release 7' /etc/centos-release >/dev/null 2>&1 \
+   && ! grep 'release 7' /etc/redhat-release >/dev/null 2>&1
+then
+   test_set_prereq NOT_DISTRO7
+fi
+
+# The following test does not work on CentOS 7 / RHEL7 since exec errno does
 #  not work with job-exec (for as yet unknown reason). Skip the test on
-#  this distro:
-test_expect_success NOT_CENTOS7 'job-exec: path to shell is emitted on exec error' '
+#  these distros:
+test_expect_success NOT_DISTRO7 'job-exec: path to shell is emitted on exec error' '
 	test_expect_code 127 flux run \
 	  --setattr=exec.job_shell=/foo/flux-shell hostname 2>exec.err &&
 	test_debug "cat exec.err" &&


### PR DESCRIPTION
Problem: A test in t2400-job-exec-test.t fails on RHEL7.  It is skipped on CENTOS7 and should be skipped on RHEL7 as well.

Skip the test on both RHEL7 and CENTOS7.

Fixes #5089

----

Tested on a RHEL7 and RHEL8 box, hopefully there isn't a corner case in there (that won't be picked up via CI).