### PR TITLE
build: applicable build and test fixes for conda

### DIFF
--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -10,6 +10,7 @@
 
 #if HAVE_CONFIG_H
 #include "config.h"
+#include <signal.h>
 #endif
 #if HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -18,6 +18,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <stdio.h>
+#include <signal.h>
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/common/libeventlog/Makefile.am
+++ b/src/common/libeventlog/Makefile.am
@@ -37,4 +37,5 @@ test_eventlog_t_LDADD = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libeventlog/libeventlog.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
-	$(JANSSON_LIBS)
+	$(JANSSON_LIBS) \
+	$(LIBRT)

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -13,6 +13,7 @@
 #endif
 
 #include <unistd.h> // defines environ
+#include <signal.h>
 #include <errno.h>
 #include <flux/core.h>
 

--- a/src/common/libterminus/pty.c
+++ b/src/common/libterminus/pty.c
@@ -208,9 +208,11 @@ int flux_pty_kill (struct flux_pty *pty, int sig)
         pty->wait_for_client = false;
         pty->wait_on_close = false;
     }
+#ifdef TIOCSIG
     if (ioctl (pty->leader, TIOCSIG, sig) >= 0)
         return 0;
     llog_debug (pty, "ioctl (TIOCSIG): %s", strerror (errno));
+#endif
     if (ioctl (pty->leader, TIOCGPGRP, &pgrp) >= 0
         && pgrp > 0
         && kill (-pgrp, sig) >= 0)

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -99,13 +99,14 @@ flux_shell_LDADD = \
 	$(top_builddir)/src/bindings/lua/libfluxlua.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-taskmap.la \
+	$(top_builddir)/src/common/libflux-idset.la \
 	$(top_builddir)/src/common/libpmi/libpmi_server.la \
 	$(top_builddir)/src/common/libpmi/libpmi_common.la \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/common/libterminus/libterminus.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(LUA_LIB) \
 	$(HWLOC_LIBS) \
 	$(JANSSON_LIBS) \

--- a/t/sharness.d/01-setup.sh
+++ b/t/sharness.d/01-setup.sh
@@ -47,6 +47,15 @@ if test -n "$FLUX_TEST_INSTALLED_PATH"; then
     PATH=$FLUX_TEST_INSTALLED_PATH:$PATH
     fluxbin=$FLUX_TEST_INSTALLED_PATH/flux
 else # normal case, use ${top_builddir}/src/cmd/flux
+    #
+    #  Ensure that the path to the configured Python is first in PATH
+    #  so the correct version is found by '#!/usr/bin/env python3' in
+    #  several test scripts that use this shebang line.
+    #  N.B.: This is not a complete fix. See flux-core #5091 for details
+    #
+    PATH=$($FLUX_BUILD_DIR/src/cmd/flux python -c \
+           'import os,sys; print(os.path.dirname(sys.executable))'):$PATH
+
     PATH=$FLUX_BUILD_DIR/src/cmd:$PATH
     fluxbin=$FLUX_BUILD_DIR/src/cmd/flux
 

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -613,7 +613,8 @@ test_expect_success 'flux-help command list can be extended' '
 	grep "^test two commands" help2.out &&
 	grep "a test two" help2.out
 '
-test_expect_success 'flux-help command can display manpages for subcommands' '
+command -v man >/dev/null && test_set_prereq HAVE_MAN
+test_expect_success HAVE_MAN 'flux-help command can display manpages for subcommands' '
 	PWD=$(pwd) &&
 	mkdir -p man/man1 &&
 	cat <<-EOF > man/man1/flux-foo.1 &&
@@ -623,7 +624,7 @@ test_expect_success 'flux-help command can display manpages for subcommands' '
 	EOF
 	MANPATH=${PWD}/man FLUX_IGNORE_NO_DOCS=y flux help foo | grep "^FOO(1)"
 '
-test_expect_success 'flux-help command can display manpages for api calls' '
+test_expect_success HAVE_MAN 'flux-help command can display manpages for api calls' '
 	PWD=$(pwd) &&
 	mkdir -p man/man3 &&
 	cat <<-EOF > man/man3/flux_foo.3 &&
@@ -638,7 +639,7 @@ missing_man_code()
 	man notacommand >/dev/null 2>&1
 	echo $?
 }
-test_expect_success 'flux-help returns nonzero exit code from man(1)' '
+test_expect_success HAVE_MAN 'flux-help returns nonzero exit code from man(1)' '
 	test_expect_code $(missing_man_code) \
 		eval FLUX_IGNORE_NO_DOCS=y flux help notacommand
 '

--- a/t/t9000-system.t
+++ b/t/t9000-system.t
@@ -3,8 +3,12 @@
 
 test_description='Run tests against a system instance of Flux'
 
-if test -n "$FLUX_ENABLE_SYSTEM_TESTS" || test -n "$debug"; then
-	FLUX_TEST_INSTALLED_PATH=${FLUX_TEST_INSTALLED_PATH:-/usr/bin}
+#  Allow this test to be forced to run if debug is set _and_ a flux binary
+#  exists in the FLUX_TEST_INSTALLED_PATH or /usr/bin:
+if test -n "$debug"; then
+	if test -x ${FLUX_TEST_INSTALLED_PATH:-/usr/bin}/flux; then
+		FLUX_TEST_INSTALLED_PATH=${FLUX_TEST_INSTALLED_PATH:-/usr/bin}
+	fi
 fi
 . `dirname $0`/sharness.sh
 


### PR DESCRIPTION
This PR includes a set of fixes that were necessary under `conda`, excluding the `fwrite` changes required from `attribute_unused` in the CentOS 6 sysroot.

I figured most of these will work around future problems we may hit on other one-off platforms.