### PR TITLE
libsubprocess: avoid assertion failure in remote_output()

### DIFF
--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -511,6 +511,15 @@ static int remote_output (flux_subprocess_t *p,
 {
     struct subprocess_channel *c;
 
+    if (!p || !p->channels || !stream) {
+        llog_debug (p,
+                    "ignoring %d bytes of %s for invalid subprocess/stream",
+                    len,
+                    stream ? stream : "(unknown)");
+        errno = EINVAL;
+        return -1;
+    }
+
     if (!(c = zhash_lookup (p->channels, stream))) {
         llog_debug (p,
                     "Error buffering %d bytes received from remote"


### PR DESCRIPTION
Problem: A broker crash was recently observed in libsubprcess remote_output() from an assertion failure in zhash_lookup() due to a NULL target hash.

Diagnosis of the underlying cause is still in progress, but for now avoid the abort by checking that the subprocess has a valid channels hash (and that stream is not NULL) before going on to process the output. Log an error if the condition is detected.

This is a w/a for issue #5094 until we can get to the root cause. I plan to roll this into a 0.49.0-2 RPM if acceptable.