### PR TITLE
libsubprocess: avoid segfault on error path

### DIFF
--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -569,7 +569,7 @@ static void rexec_continuation (flux_future_t *f, void *arg)
     if (subprocess_rexec_get (f) < 0) {
         if (errno == ENODATA) {
             remote_completion (p);
-            goto complete;
+            return;
         }
         goto error;
     }
@@ -594,9 +594,6 @@ error:
     p->failed_errno = errno;
     process_new_state (p, FLUX_SUBPROCESS_FAILED);
     remote_kill_nowait (p, SIGKILL);
-complete:
-    flux_future_destroy (f);
-    p->f = NULL;
 }
 
 int remote_exec (flux_subprocess_t *p)
@@ -619,6 +616,7 @@ int remote_exec (flux_subprocess_t *p)
         flux_future_destroy (f);
         return -1;
     }
+    p->f = f;
     return 0;
 }
 


### PR DESCRIPTION
Problem: libsubprocess can trigger a segfault if a remote subprocess object is destroyed before the remote protocol is complete.

The remote's future should be held by subprocess->f but in the code cleanup of 8bb3e74fad8c2178a8900121cf7aa1ef69869766, this was dropped and it now has an independent life cycle from the subprocess.

Assign the future to subprocess->f and don't destroy it separately on completion in the continuation.

Fixes #5094