### PR TITLE
job-manager: improve errors from jobtap initialization

### DIFF
--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -217,7 +217,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         goto done;
     }
     if (!(ctx.jobtap = jobtap_create (&ctx))) {
-        flux_log_error (h, "error creating jobtap interface");
+        flux_log (h, LOG_ERR, "error creating jobtap interface");
         goto done;
     }
     if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -393,9 +393,8 @@ static int jobtap_conf_entry (struct jobtap *jobtap,
     }
     if (load && !jobtap_load_plugin (jobtap, load, conf, &jobtap_err)) {
         return errprintf (errp,
-                          "[job-manager.plugins][%d]: load %s: %s",
+                          "[job-manager.plugins][%d]: load: %s",
                           index,
-                          load,
                           jobtap_err.text);
     }
     return 0;


### PR DESCRIPTION
This PR slightly improves the errors when a jobtap plugin fails to load.

Fixes #5098 