### PR TITLE
testsuite: fix column width output corner case

### DIFF
--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -662,10 +662,11 @@ test_expect_success 'kvs: ls -1RF shows directory titles' '
 	EOF
 	test_cmp expected output
 '
+# test assumes COLUMNS environment not set, clear in a subshell just in case
 test_expect_success 'kvs: ls with no options adjusts output width to 80' '
 	flux kvs unlink -Rf $DIR &&
 	${FLUX_BUILD_DIR}/t/kvs/dtree -p$DIR -h1 -w50 &&
-	flux kvs ls $DIR | wc -wl >output &&
+	$(unset COLUMNS; flux kvs ls $DIR | wc -wl >output) &&
 	cat >expected <<-EOF &&
 	      5      50
 	EOF


### PR DESCRIPTION
Problem: A test in t1000-kvs.t assumes the environment variable COLUMNS is not set before running the test.  If the environment variable is set, it can mess up the expected output.

Run part of the test in a subshell with COLUMNS unset just in case.


---

It's just not my day for running the sharness test suite ;-)

I accidentally ssh-ed to a cluster from a local docker container on my laptop, and for whatever reason, that lead to `COLUMNS=140` to be set in my session, messing up this test.  

I could unset the variable for the whole test as well, dunno if there's a strong preference from the group. 