### PR TITLE
Add false positives typos config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Check Spelling
       uses: crate-ci/typos@7ad296c72fa8265059cc03d1eda562fbdfcd6df2 # v1.9.0
-      with:
-        files: ./NEWS.md ./README.md ./doc/*.rst ./doc/*/*.rst ./doc/*/*/*.rst ./src/cmd
 
   python-lint:
     name: python linting

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,27 @@
+# do not check code copied into the project
+# do not check sha code, lots of hashing false positives
+# do not check testing data
+[files]
+extend-exclude = [
+  "config/*",
+  "src/common/libev/*",
+  "src/common/libccan/*",
+  "src/common/liblsd/*",
+  "src/common/libtomlc99/*",
+  "src/bindings/python/flux/utils/parsedatetime/*",
+  "t/sharness.sh",
+  "src/common/libutil/sha1.c",
+  "src/common/libutil/test/sha1.c",
+  "t/hwloc-data/*",
+]
+
+[default.extend-words]
+# in hwloc output
+hsi = "hsi"
+# commonly used names/variables that aren't typos
+fo = "fo"
+ba = "ba"
+inout = "inout"
+trun = "trun"
+fullset = "fullset"
+mone = "mone"


### PR DESCRIPTION
Problem: The current typos workflow check only checks a select number of files because there are so many false positives in flux-core.

Solution: Add a _typos.toml configuration file to eliminate false positives so we can run the typo check on all of flux-core.  The config file either skips files with lots of false positives or lists common false positives we wish to ignore.

----

This works when I run by hand in my build dir, we'll see if this works in CI :shrug: 

Note, this will probably fail typo checking until #5019 is merged

Edit:

yup, seems to work.  These are the ones I have in a fix in #5019

![image](https://user-images.githubusercontent.com/274859/233513604-866a72c5-3ca7-44fa-b99f-861a1295a5ce.png)
