### PR TITLE
sched-simple: avoid assertion failure when trying to load scheduler twice

### DIFF
--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -141,21 +141,25 @@ err:
 
 static void simple_sched_destroy (flux_t *h, struct simple_sched *ss)
 {
-    struct jobreq *job = zlistx_first (ss->queue);
-    while (job) {
-        flux_respond_error (h, job->msg, ENOSYS, "simple sched exiting");
-        job = zlistx_next (ss->queue);
+    if (ss) {
+        int saved_errno = errno;
+        struct jobreq *job = zlistx_first (ss->queue);
+        while (job) {
+            flux_respond_error (h, job->msg, ENOSYS, "simple sched exiting");
+            job = zlistx_next (ss->queue);
+        }
+        flux_future_destroy (ss->acquire_f);
+        zlistx_destroy (&ss->queue);
+        flux_watcher_destroy (ss->prep);
+        flux_watcher_destroy (ss->check);
+        flux_watcher_destroy (ss->idle);
+        schedutil_destroy (ss->util_ctx);
+        rlist_destroy (ss->rlist);
+        free (ss->alloc_mode);
+        free (ss->mode);
+        free (ss);
+        errno = saved_errno;
     }
-    flux_future_destroy (ss->acquire_f);
-    zlistx_destroy (&ss->queue);
-    flux_watcher_destroy (ss->prep);
-    flux_watcher_destroy (ss->check);
-    flux_watcher_destroy (ss->idle);
-    schedutil_destroy (ss->util_ctx);
-    rlist_destroy (ss->rlist);
-    free (ss->alloc_mode);
-    free (ss->mode);
-    free (ss);
 }
 
 static struct simple_sched * simple_sched_create (void)

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -143,13 +143,18 @@ static void simple_sched_destroy (flux_t *h, struct simple_sched *ss)
 {
     if (ss) {
         int saved_errno = errno;
-        struct jobreq *job = zlistx_first (ss->queue);
-        while (job) {
-            flux_respond_error (h, job->msg, ENOSYS, "simple sched exiting");
-            job = zlistx_next (ss->queue);
+        if (ss->queue) {
+            struct jobreq *job = zlistx_first (ss->queue);
+            while (job) {
+                flux_respond_error (h,
+                                    job->msg,
+                                    ENOSYS,
+                                    "simple sched exiting");
+                job = zlistx_next (ss->queue);
+            }
+            zlistx_destroy (&ss->queue);
         }
         flux_future_destroy (ss->acquire_f);
-        zlistx_destroy (&ss->queue);
         flux_watcher_destroy (ss->prep);
         flux_watcher_destroy (ss->check);
         flux_watcher_destroy (ss->idle);

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -43,6 +43,9 @@ test_expect_success 'sched-simple: generate jobspec for simple test job' '
 	flux run --dry-run hostname >basic.json
 '
 
+test_expect_success 'sched-simple cannot be loaded again under a new name' '
+	test_must_fail flux module load --name=newsched sched-simple
+'
 test_expect_success 'job-manager: load sched-simple w/ an illegal mode' '
 	flux module unload sched-simple &&
 	flux module load sched-simple mode=foobar


### PR DESCRIPTION
This implements @grondo's fix proposed in #5108, and removes unnecessary service de-registration code from libschedutil that was adding to the log noise when this problem was encountered.