### PR TITLE
mergify: add spelling check to required checks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ queue_rules:
     conditions:
       - base=master
       - status-success="validate commits"
+      - status-success="spelling"
       - status-success="flux-sched check"
       - status-success="flux-accounting check"
       - status-success="python linting"

--- a/src/modules/sdbus/connect.h
+++ b/src/modules/sdbus/connect.h
@@ -19,7 +19,7 @@
  *
  * If first_time=true, connect immediately; otherwise, wait retry_min secs.
  * If the initial connect is unsuccessful, retry in retry_min secs.  If that
- * is unsuccessful, back off exponentialy, leveling off at retry_max secs
+ * is unsuccessful, back off exponentially, leveling off at retry_max secs
  * between attempts.
  *
  * Connect attempt successes and failures are logged at LOG_INFO level.

--- a/src/modules/sdbus/interface.c
+++ b/src/modules/sdbus/interface.c
@@ -14,7 +14,7 @@
  * D-Bus (interface, member) that we need in Flux requires translation
  * callbacks here for now.
  *
- * To list sytemd Manager methods and signatures:
+ * To list systemd Manager methods and signatures:
  *   busctl --user introspect \
  *      org.freedesktop.systemd1 \
  *      /org/freedesktop/systemd1 \

--- a/src/modules/sdbus/message.h
+++ b/src/modules/sdbus/message.h
@@ -35,7 +35,7 @@ int sdmsg_get (sd_bus_message *m, const char *fmt, json_t **op);
 
 /* Get list of values specified by 'fmt' from message 'm' at the current cursor
  * position and append them to the json array 'o'.
- * Return 1 on success, or -errno on falure.
+ * Return 1 on success, or -errno on failure.
  */
 int sdmsg_read (sd_bus_message *m, const char *fmt, json_t *o);
 

--- a/src/modules/sdbus/sdbus.c
+++ b/src/modules/sdbus/sdbus.c
@@ -172,7 +172,7 @@ static void sdbus_recv (struct sdbus_ctx *ctx, sd_bus_message *m)
             log_msg_signal (ctx->h, m, "drop");
             goto out;
         }
-        /* Handled signals are loged as a "recv".  Dispatch them to
+        /* Handled signals are logged as a "recv".  Dispatch them to
          * subscribers here.  N.B. There is no subscriber filtering yet.
          * Perhaps later if needed.
          */
@@ -529,7 +529,7 @@ error:
     sdbus_recover (ctx, error.text);
 }
 
-/* Connect completed. Initiate asynchonous bus subscribe.
+/* Connect completed. Initiate asynchronous bus subscribe.
  */
 static void connect_continuation (flux_future_t *f, void *arg)
 {


### PR DESCRIPTION
Despite https://github.com/flux-framework/flux-core/pull/5070 failing the typo/spelling check, it was merged by mergify.  Ends up we forgot to add spelling to the mergify check.

Do that and add the fixed typos.