### PR TITLE
ensure license and other informational files appear in distribution tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ EXTRA_DIST = \
 	config/tap-driver.sh \
 	config/tap-driver.py \
 	NOTICE.LLNS \
+	LICENSE \
 	README.md \
 	vscode.md \
 	NEWS.md \

--- a/src/common/libccan/Makefile.am
+++ b/src/common/libccan/Makefile.am
@@ -7,6 +7,35 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS =
 
+EXTRA_DIST = \
+	licenses \
+	ccan/list/LICENSE \
+	ccan/str/LICENSE \
+	ccan/str/hex/LICENSE \
+	ccan/build_assert/LICENSE \
+	ccan/base64/LICENSE \
+	ccan/container_of/LICENSE \
+	ccan/bitmap/LICENSE \
+	ccan/compiler/LICENSE \
+	ccan/check_type/LICENSE \
+	ccan/array_size/LICENSE \
+	ccan/pushpull/LICENSE \
+	ccan/ptrint/LICENSE \
+	ccan/endian/LICENSE \
+	ccan/list/_info \
+	ccan/str/_info \
+	ccan/str/hex/_info \
+	ccan/build_assert/_info \
+	ccan/base64/_info \
+	ccan/container_of/_info \
+	ccan/bitmap/_info \
+	ccan/compiler/_info \
+	ccan/check_type/_info \
+	ccan/array_size/_info \
+	ccan/pushpull/_info \
+	ccan/ptrint/_info \
+	ccan/endian/_info
+
 noinst_LTLIBRARIES = libccan.la
 libccan_la_SOURCES = \
 	ccan/check_type/check_type.h \

--- a/src/common/libtomlc99/Makefile.am
+++ b/src/common/libtomlc99/Makefile.am
@@ -9,6 +9,10 @@ AM_LDFLAGS = \
 
 AM_CPPFLAGS =
 
+EXTRA_DIST = \
+	LICENSE \
+	README.md
+
 noinst_LTLIBRARIES = libtomlc99.la
 
 libtomlc99_la_SOURCES = \


### PR DESCRIPTION
@jan-janssen noticed that the flux-core `LICENSE` file was missing from our distribution tarball.

This PR adds that and some other missing licenses and informational files to `EXTRA_DIST` where appropriate so those files are included in the distribution.