### PR TITLE
fileref: fix compile on systems without SEEK_DATA/SEEK_HOLE

### DIFF
--- a/src/common/libutil/test/fileref.c
+++ b/src/common/libutil/test/fileref.c
@@ -87,9 +87,10 @@ void rmfile (const char *name)
  */
 bool test_sparse (void)
 {
+    bool result = false;
+#ifdef SEEK_DATA
     int fd;
     struct stat sb;
-    bool result = false;
 
     fd = open (mkpath ("testhole"), O_WRONLY | O_CREAT | O_TRUNC, 0600);
     if (fd < 0)
@@ -104,6 +105,7 @@ bool test_sparse (void)
         result = true;
     close (fd);
     rmfile ("testhole");
+#endif /* SEEK_DATA */
     return result;
 }
 


### PR DESCRIPTION
Problem: The libutil/fileref code fails to compile on systems without SEEK_DATA and SEEK_HOLE defined. This occurs for example on conda-forge which uses a CentOS 6 based sysroot.

Wrap optional code in #ifdef SEEK_DATA and #ifdef SEEK_HOLE so that the code compiles without sparse file support.

(This will allow us to eventually drop this patch from the conda-forge recipe).
