### PR TITLE
shell: fix improper encoding of some hostnames in MPIR proctable

### DIFF
--- a/src/shell/mpir/nodelist.c
+++ b/src/shell/mpir/nodelist.c
@@ -8,6 +8,30 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+/* nodelist.c - compressed encoding of a list of hostnames
+ *
+ * A nodelist is a pure JSON representation of a list of possibly
+ * repeating hostnames. The implementation takes advantage of the
+ * tendency to place a numeric suffix on hostanmes of large HPC
+ * clusters and uses the rangelist implementation to encode the
+ * suffixes of a common hostname prefix.
+ *
+ * A JSON nodelist is an array of entries (entries are called a
+ * "prefix list" in the code below), where each entry represents
+ *  one or more hosts. Entries can have the following form:
+ *
+ * - a single string represents one hostname
+ * - an array entry has 2 elements:
+ *   1. a common hostname prefix
+ *   2. a rangelist representing the set of suffixes
+ *      (see rangelist.c).
+ *      An empty string (no suffix) is represented as -1.
+ *
+ * For each prefix list the common prefix is combined with the
+ * rangelist-encoded suffixes to form the list of hosts.
+ *
+ */
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/shell/mpir/nodelist.c
+++ b/src/shell/mpir/nodelist.c
@@ -134,6 +134,12 @@ static int hostname_split (char *name, int *suffix)
     int n = len - 1;
     while (n >= 0 && isdigit (name[n]))
         n--;
+    /*  Now advance past leading zeros (not including a final zero)
+     *  These will not be part of the suffix since they can't be represented
+     *  as an integer.
+     */
+    while (name[n+1] == '0' && name[n+2] != '\0')
+        n++;
     if (++n == len)
         return 0;
     *suffix = (int) strtol (name+n, NULL, 10);

--- a/src/shell/mpir/proctable.c
+++ b/src/shell/mpir/proctable.c
@@ -8,6 +8,24 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+/* proctable.c - compressed, JSON encoded MPIR_proctable
+ *
+ * An MPIR proctable is an array of MPIR_PROCDESC entries, including
+ * a taskid, hostname, executable name, and PID for every task in
+ * parallel job. In order to reduce the transfer of data back to a
+ * frontend command, the MPIR proctable is encoded by the job shell
+ * using the compression techniques in rangelist.c and nodelist.c.
+ *
+ * The shell simply encodes the proctable as 4 separate lists, each
+ * encoded in the same order:
+ *
+ *  - nodes: the list of hostnames in 'nodelist' form
+ *  - executables: the list of executables in 'nodelist' form
+ *  - taskids: the list of task ids in 'rangelist' form
+ *  - pids: the list of process ids in 'rangelist' form
+ *
+ */
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/shell/mpir/proctable.h
+++ b/src/shell/mpir/proctable.h
@@ -13,6 +13,11 @@
 #ifndef HAVE_PROCTABLE_H
 #define HAVE_PROCTABLE_H
 
+/* MPIR_PROCDESC is defined in the MPIR Process Acquisition Interface
+ * Version 1:
+ *
+ * See https://www.mpi-forum.org/docs/mpir-specification-03-01-2018.pdf
+ */
 typedef struct {
     char *host_name;
     char *executable_name;

--- a/src/shell/mpir/rangelist.c
+++ b/src/shell/mpir/rangelist.c
@@ -8,6 +8,35 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+/* rangelist.c - compressed encoding of a list of integers
+ *
+ * The rangelist encoding uses a combination of run-length, range
+ * and delta encoding to compress a possibly large set of integers
+ * into a somewhat compact JSON array.
+ *
+ * This implementation is meant for encoding data for the MPIR
+ * process table in a space efficient manner, and takes advantage
+ * of the fact that multiple PIDs and hostnames with numeric
+ * suffixes are usually adjacent (or repeated in the case of hostnames)
+ *
+ * A rangelist is an array of entries that follow these rules:
+ *
+ * - If an entry is a single integer then it represents a single number
+ *   which is delta encoded from the previous entry (or 0 if this is the
+ *   first entry in the rangelist).
+ *
+ * - If an entry is an array, it will have two elements. The fist element
+ *   is delta encoded from the previous entry (or 0 if no previous entry)
+ *   and represents the start value for a set of integers.
+ *
+ *   - if the second element is > 0, then it represents a run-length
+ *     encoded set of integers beginning at start. E.g. [1234,4] represents
+ *     1234, 1235, 1236, 1237.
+ *
+ *   - if the second element is < 0, then it represents a number of
+ *     repeats of the same value, e.g. [18, -3] represents [18, 18, 18].
+ */
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/shell/mpir/test/nodelist.c
+++ b/src/shell/mpir/test/nodelist.c
@@ -43,6 +43,32 @@ static const char *test1 [] = {
     NULL,
 };
 
+static const char *test2 [] = {
+    "test01",
+    "test02",
+    "test09",
+    "test0201",
+    "test0202",
+    "test0203",
+    "test1200",
+    "test1201",
+    "test1202",
+    NULL
+};
+
+static const char *test3 [] = {
+    "foo008",
+    "foo008",
+    "foo009",
+    "foo009",
+    "foo010",
+    "foo010",
+    "foo011",
+    "foo011",
+    NULL
+};
+
+
 struct nodelist * nodelist_from_array (const char *names[])
 {
     struct nodelist *nl = nodelist_create ();
@@ -108,6 +134,8 @@ int main (int argc, char **argv)
     plan (NO_PLAN);
     do_test (test0);
     do_test (test1);
+    do_test (test2);
+    do_test (test3);
     test_append ();
     done_testing ();
     return 0;


### PR DESCRIPTION
This PR fixes a bug in the encoding of MPIR data by the job shell when hostnames have leading zeros in the numeric suffix. The suffix is converted to an integer when encoded to the "rangelist" representation, so the leading zeros are dropped.

Also, I noticed the encoding(s) used to compress the MPIR proctable were not documented anywhere. I've added a brief description of each in the source code for future reference.