### PR TITLE
job-validator: fix empty plugins list when one plugin fails to import

### DIFF
--- a/src/bindings/python/flux/importer.py
+++ b/src/bindings/python/flux/importer.py
@@ -36,10 +36,16 @@ def import_plugins(pkg_name, pluginpath=None):
 
     try:
         #  Load 'pkg_name' as a namespace plugin
+        #
+        #  Note: importlib.import_module() will raise ModuleNotFoundError
+        #  if pkg_name points to an empty directory, but we just want to
+        #  return an empty list in this case:
+        #
         pkg = importlib.import_module(pkg_name)
-        plugins = import_plugins_pkg(pkg)
     except ModuleNotFoundError:
         return {}
+
+    plugins = import_plugins_pkg(pkg)
 
     if pluginpath is not None:
         #  Undo any added pluginpath elements.

--- a/src/bindings/python/flux/importer.py
+++ b/src/bindings/python/flux/importer.py
@@ -16,10 +16,13 @@ import sys
 
 def import_plugins_pkg(ns_pkg):
     """Import all modules found in the namespace package ``ns_pkg``"""
-    return {
-        name: importlib.import_module(f"{ns_pkg.__name__}.{name}")
-        for finder, name, ispkg in pkgutil.iter_modules(ns_pkg.__path__)
-    }
+    result = {}
+    for finder, name, ispkg in pkgutil.iter_modules(ns_pkg.__path__):
+        try:
+            result[name] = importlib.import_module(f"{ns_pkg.__name__}.{name}")
+        except ImportError as exc:
+            raise ImportError(f"failed to import {name} plugin: {exc}")
+    return result
 
 
 def import_plugins(pkg_name, pluginpath=None):

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -51,6 +51,19 @@ test_expect_success 'validator plugin behaves when no plugins are found' '
 	EOF
 	flux python ./test-importer.py
 '
+test_expect_success 'validator plugin importer reports errors on import' '
+	mkdir t2110plugins &&
+	cat <<-EOF >t2110plugins/test.py &&
+	import froufroufoxes
+	EOF
+	cat <<-EOF >test-importer2.py &&
+	from flux.importer import import_plugins
+	import_plugins("t2110plugins")
+	EOF
+	test_must_fail flux python ./test-importer2.py >import-fail.out 2>&1 &&
+	test_debug "cat import-fail.out" &&
+	grep "No module named.*froufroufoxes" import-fail.out
+'
 test_expect_success 'flux job-validator --help shows help for selected plugins' '
 	flux job-validator --plugins=jobspec --help >help.jobspec.out 2>&1 &&
 	flux job-validator --plugins=schema --help >help.schema.out 2>&1 &&


### PR DESCRIPTION
This PR fixes an issue where `flux job-validator` reports that no plugins are available when importing any one plugin failed with an `ImportError`. This occurred because a `ModuleNotFoundError` exception was handled at the wrong spot and treated as an empty plugins directory.

Now, any import failure on a plugin will result in an exception being raised to the caller with a sensible error message.

e.g.: in the case reported in #5116 we see this
```console
$ flux job-validator --list-plugins
Available plugins:
```

Now we'll get this:
```console
$ src/cmd/flux job-validator --list-plugins
flux-job-validator: ERROR: failed to import schema plugin: No module named 'jsonschema'
```