### PR TITLE
python: fix parsing of special characters in submission directives

### DIFF
--- a/src/bindings/python/flux/job/directives.py
+++ b/src/bindings/python/flux/job/directives.py
@@ -49,6 +49,11 @@ class Directive:
         # quoting and avoid splitting on cmdline args like --foo.
         lexer = shlex.shlex(value, posix=True, punctuation_chars=True)
         #
+        # set whitespace_split to match shell parsing of cmdlines as
+        # closely as possible as documented in the final note here:
+        # https://docs.python.org/3/library/shlex.html
+        lexer.whitespace_split = True
+        #
         # Add single-quote to escapedquotes. This is necessary to avoid
         # unclosed quote ValueError due to escaped single quote. (The
         # default in Posix mode is to escape only '"')

--- a/t/batch/directives/valid/011-quoted-punctuation.sh
+++ b/t/batch/directives/valid/011-quoted-punctuation.sh
@@ -1,0 +1,6 @@
+#flux: --output='Test_quoted.{{id}}.out'
+#flux: --output=Test_unquoted.{{id}}.out
+#flux: --output=Test_unquoted.-out
+#flux: --output=Test_unquoted.:out
+#flux: --output=Test_unquoted.@out
+#flux: --output=Test[unquoted]

--- a/t/batch/directives/valid/expected/011-quoted-punctuation.expected
+++ b/t/batch/directives/valid/expected/011-quoted-punctuation.expected
@@ -1,0 +1,6 @@
+SETARGS(['--output=Test_quoted.{{id}}.out'])
+SETARGS(['--output=Test_unquoted.{{id}}.out'])
+SETARGS(['--output=Test_unquoted.-out'])
+SETARGS(['--output=Test_unquoted.:out'])
+SETARGS(['--output=Test_unquoted.@out'])
+SETARGS(['--output=Test[unquoted]'])


### PR DESCRIPTION
A user noticed that some batch directives unexpectedly required quoting, e.g.
```console
$ cat test.sh
#!/bin/sh
#flux: --output=test.{{id}}.out
flux run -n8 hostname
$ flux python -m flux.job.directives  test.sh
SETARGS(['--output=test.', '{', '{', 'id', '}', '}', '.out'])
```

On further reading of the `shlex` python documentation, the `whitespace_split` attribute should be set to `True` for "the best shell lexing compatibility", This seems to fix the problem:

```console
$ src/cmd/flux python -m flux.job.directives test.sh
SETARGS(['--output=test.{{id}}.out'])
```

This PR makes that change and adds missing tests that exercise the issue.