### PR TITLE
shell: support {{name}} tag in output file templates

### DIFF
--- a/doc/man1/common/submit-standard-io.rst
+++ b/doc/man1/common/submit-standard-io.rst
@@ -15,13 +15,21 @@ emitting the job's I/O to its stdout and stderr.
 **--output=TEMPLATE**
    Specify the filename *TEMPLATE* for stdout redirection, bypassing
    the KVS.  *TEMPLATE* may be a mustache template which supports the
-   tags *{{id}}* and *{{jobid}}* which expand to the current jobid
-   in the F58 encoding.  If needed, an alternate encoding can be
-   selected by using a subkey with the name of the desired encoding,
-   e.g. *{{id.dec}}*. Supported encodings include *f58* (the default),
-   *dec*, *hex*, *dothex*, and *words*. For :man1:`flux-batch` the
-   default *TEMPLATE* is *flux-{{id}}.out*. To force output to KVS so it is
-   available with ``flux job attach``, set *TEMPLATE* to *none* or *kvs*.
+   following tags:
+
+   *{{id}}* or *{{jobid}}*
+     Expands to the current jobid in the F58 encoding. If needed, an
+     alternate encoding may be selected by using a subkey with the name
+     of the desired encoding, e.g. *{{id.dec}}*. Supported encodings
+     include *f58* (the default), *dec*, *hex*, *dothex*, and *words*.
+
+   *{{name}}*
+     Expands to the current job name. If a name is not set for the job,
+     then the basename of the command will be used.
+
+   For :man1:`flux-batch` the default *TEMPLATE* is *flux-{{id}}.out*.
+   To force output to KVS so it is available with ``flux job attach``,
+   set *TEMPLATE* to *none* or *kvs*.
 
 **--error=TEMPLATE**
    Redirect stderr to the specified filename *TEMPLATE*, bypassing the KVS.

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -164,6 +164,20 @@ test_expect_success 'flux-shell: run 1-task echo job (mustache id stdout & stder
         grep stdout:baz out${id} &&
         grep stderr:baz out${id}
 '
+test_expect_success 'flux-shell: run 1-task echo job (mustache job name)' '
+	id=$(flux submit --wait -n1 --job-name=thisname \
+	     --output="out.{{name}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+	grep stdout:baz out.thisname &&
+	grep stderr:baz out.thisname
+'
+test_expect_success 'flux-shell: run 1-task echo job (mustache job name)' '
+	id=$(flux submit --wait -n1 \
+	     --output="out.{{name}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+	grep stdout:baz out.test_echo &&
+	grep stderr:baz out.test_echo
+'
 
 test_expect_success 'flux-shell: bad mustache template still writes output' '
         id=$(flux submit -n1 \


### PR DESCRIPTION
This PR adds support for rendering a `{{name}}` tag in file output templates that expands to the job name or command.