### PR TITLE
sdbus: return useful errno values to requests on error

### DIFF
--- a/src/common/libtomlc99/Makefile.am
+++ b/src/common/libtomlc99/Makefile.am
@@ -51,7 +51,7 @@ test_toml_t_SOURCES = test/toml.c
 test_toml_t_LDADD = $(test_ldadd)
 test_toml_t_CPPFLAGS = $(test_cppflags)
 
-EXTRA_DIST = \
+EXTRA_DIST += \
 	BurntSushi_input/invalid/array-mixed-types-arrays-and-ints.toml \
 	BurntSushi_input/invalid/array-mixed-types-ints-and-floats.toml \
 	BurntSushi_input/invalid/array-mixed-types-strings-and-ints.toml \

--- a/src/modules/sdbus/sdbus.c
+++ b/src/modules/sdbus/sdbus.c
@@ -603,8 +603,15 @@ void sdbus_ctx_destroy (struct sdbus_ctx *ctx)
 {
     if (ctx) {
         int saved_errno = errno;
-        flux_msglist_destroy (ctx->requests);
-        flux_msglist_destroy (ctx->subscribers);
+        const char *errmsg = "module is unloading";
+        if (ctx->subscribers) {
+            bulk_respond_error (ctx->h, ctx->subscribers, ENOSYS, errmsg);
+            flux_msglist_destroy (ctx->subscribers);
+        }
+        if (ctx->requests) {
+            bulk_respond_error (ctx->h, ctx->requests, ENOSYS, errmsg);
+            flux_msglist_destroy (ctx->requests);
+        }
         flux_msg_handler_delvec (ctx->handlers);
         flux_watcher_destroy (ctx->bus_w);
         flux_future_destroy (ctx->f_subscribe);

--- a/src/modules/sdbus/sdbus.c
+++ b/src/modules/sdbus/sdbus.c
@@ -569,8 +569,8 @@ static void sdbus_recover (struct sdbus_ctx *ctx, const char *reason)
 
     /* Send any pending requests an error.
      */
-    bulk_respond_error (ctx->h, ctx->subscribers, ENOSYS, reason);
-    bulk_respond_error (ctx->h, ctx->requests, ENOSYS, reason);
+    bulk_respond_error (ctx->h, ctx->subscribers, EAGAIN, reason);
+    bulk_respond_error (ctx->h, ctx->requests, EAGAIN, reason);
 
     /* Destroy subscribe future.
      */

--- a/t/t2407-sdbus.t
+++ b/t/t2407-sdbus.t
@@ -13,6 +13,10 @@ if ! systemctl --user show --property Version; then
 	skip_all="user systemd is not running"
 	test_done
 fi
+if ! busctl --user status >/dev/null; then
+	skip_all="user dbus is not running"
+	test_done
+fi
 
 test_under_flux 1 minimal
 

--- a/t/t2408-sdbus-recovery.t
+++ b/t/t2408-sdbus-recovery.t
@@ -77,7 +77,20 @@ test_expect_success NO_CHAIN_LINT 'background subscription fails with EAGAIN' '
 	test_must_fail wait $pid &&
 	grep "Errno 11" signals.err
 '
+test_expect_success NO_CHAIN_LINT 'initiate another subscription' '
+        flux python ./subscribe.py >signals2.out 2>signals2.err &
+        echo $! >signals2.pid
+'
+# There will be another 2s delay while sdbus reconnects
+test_expect_success 'get systemd version to ensure reconnect has occurred' '
+	bus_get_manager_prop Version
+'
 test_expect_success 'remove sdbus module' '
 	flux module remove sdbus
+'
+test_expect_success NO_CHAIN_LINT 'background subscription fails with ENOSYS' '
+	pid=$(cat signals2.pid) &&
+	test_must_fail wait $pid &&
+	grep "Errno 38" signals2.err
 '
 test_done

--- a/t/t2408-sdbus-recovery.t
+++ b/t/t2408-sdbus-recovery.t
@@ -13,6 +13,10 @@ if ! systemctl --user show --property Version; then
 	skip_all="user systemd is not running"
 	test_done
 fi
+if ! busctl --user status >/dev/null; then
+	skip_all="user dbus is not running"
+	test_done
+fi
 
 test_under_flux 1 minimal
 

--- a/t/t2408-sdbus-recovery.t
+++ b/t/t2408-sdbus-recovery.t
@@ -72,10 +72,10 @@ test_expect_success 'print logs' '
 test_expect_success 'force another bus reconnect' '
 	bus_reconnect
 '
-test_expect_success NO_CHAIN_LINT 'background subscription fails' '
+test_expect_success NO_CHAIN_LINT 'background subscription fails with EAGAIN' '
 	pid=$(cat signals.pid) &&
 	test_must_fail wait $pid &&
-	grep "user request" signals.err
+	grep "Errno 11" signals.err
 '
 test_expect_success 'remove sdbus module' '
 	flux module remove sdbus


### PR DESCRIPTION
Problem: sdbus users can't tell the difference between recoverable and non-recoverable errors

Return EAGAIN on recoverable error (sdbus is reconnecting to D-Bus) and ENOSYS when the module is unloading.

There's also a small correction to the EXTRA_DIST additions in #5113