### PR TITLE
convert parent-uri attribute to remote under flux-proxy(1)

### DIFF
--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -76,6 +76,7 @@ static const char *env_blocklist[] = {
     "FLUX_TASK_LOCAL_ID",
     "FLUX_URI",
     "FLUX_KVS_NAMESPACE",
+    "FLUX_PROXY_REMOTE",
     "PMI_FD",
     "PMI_RANK",
     "PMI_SIZE",

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -43,6 +43,7 @@ struct proxy_command {
     flux_subprocess_t *p;
     int exit_code;
     uid_t proxy_user;
+    char *remote_uri_authority;
 };
 
 static const char *route_auxkey = "flux::route";
@@ -140,6 +141,12 @@ static int child_create (struct proxy_command *ctx,
     }
 
     if (flux_cmd_setenvf (cmd, 1, "FLUX_URI", "local://%s", sockpath) < 0)
+        goto error;
+    if (ctx->remote_uri_authority
+        && flux_cmd_setenvf (cmd, 1,
+                             "FLUX_PROXY_REMOTE",
+                             "%s",
+                             ctx->remote_uri_authority) < 0)
         goto error;
 
     /* We want stdio fallthrough so subprocess can capture tty if
@@ -314,6 +321,7 @@ static void proxy_command_destroy_usock_and_router (struct proxy_command *ctx)
     ctx->server = NULL;
     router_destroy (ctx->router);
     ctx->router = NULL;
+    free (ctx->remote_uri_authority);
 }
 
 /* Attempt to reconnect to broker.  If successful, wait for for broker to
@@ -396,6 +404,7 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
 
     if (!(ctx.h = flux_open (uri, flags)))
         log_err_exit ("%s", uri);
+    ctx.remote_uri_authority = uri_remote_get_authority (uri);
     free (uri);
     flux_log_set_appname (ctx.h, "proxy");
     ctx.proxy_user = getuid ();

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -331,6 +331,8 @@ int main (int argc, char *argv[])
     if (!(cmd = flux_cmd_create (argc - optindex, &argv[optindex], environ)))
         log_err_exit ("flux_cmd_create");
 
+    flux_cmd_unsetenv (cmd, "FLUX_PROXY_REMOTE");
+
     if (optparse_getopt (opts, "dir", &optargp) > 0) {
         if (!(cwd = strdup (optargp)))
             log_err_exit ("strdup");

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -103,11 +103,17 @@ const char *flux_attr_get (flux_t *h, const char *name)
         return NULL;
     if ((val = zhashx_lookup (c->cache, name)))
         return val;
-    if (!(f = flux_rpc_pack (h, "attr.get", FLUX_NODEID_ANY, 0, "{s:s}",
-                                                                "name", name)))
+    if (!(f = flux_rpc_pack (h,
+                             "attr.get",
+                             FLUX_NODEID_ANY,
+                             0,
+                             "{s:s}",
+                             "name", name)))
         return NULL;
-    if (flux_rpc_get_unpack (f, "{s:s s:i}", "value", &val,
-                                             "flags", &flags) < 0)
+    if (flux_rpc_get_unpack (f,
+                             "{s:s s:i}",
+                             "value", &val,
+                             "flags", &flags) < 0)
         goto done;
     if (!(cpy = strdup (val)))
         goto done;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -322,6 +322,11 @@ static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
+    /* Never propagate FLUX_PROXY_REMOTE to processes started from
+     * a subprocess server.
+     */
+    flux_cmd_unsetenv (cmd, "FLUX_PROXY_REMOTE");
+
     if (!(p = flux_local_exec_ex (flux_get_reactor (s->h),
                                   FLUX_SUBPROCESS_FLAGS_SETPGRP,
                                   cmd,

--- a/src/common/libutil/uri.h
+++ b/src/common/libutil/uri.h
@@ -32,6 +32,13 @@
  */
 char *uri_resolve (const char *target, flux_error_t *errp);
 
+/*  Return the authority part of a remote URI, e.g. [username@]host
+ *  Returns NULL if uri is NULL or not a remote URI.
+ *
+ *  Caller must free returned value.
+ */
+char *uri_remote_get_authority (const char *uri);
+
 #endif /* !_UTIL_URI_H */
 
 // vi:ts=4 sw=4 expandtab

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -136,6 +136,10 @@ struct shell_task *shell_task_create (struct shell_info *info,
     if (flux_cmd_setenvf (task->cmd, 1, "FLUX_JOB_ID", "%s", buf) < 0)
         goto error;
 
+    /* Always unset FLUX_PROXY_REMOTE since this never makes sense
+     * in the environment of a job task.
+     */
+    flux_cmd_unsetenv (task->cmd, "FLUX_PROXY_REMOTE");
     flux_cmd_unsetenv (task->cmd, "FLUX_URI");
     if (getenv ("FLUX_URI")) {
         if (flux_cmd_setenvf (task->cmd, 1, "FLUX_URI", "%s",


### PR DESCRIPTION
This is a WIP fix for #5132. Posting before tests are fully complete (though testing will be trivial) because I'm not sure the implementation will be acceptable.

This PR adds special handling of `parent-uri` directly to `attr_get()`. If there is a request for the `parent-uri` attribute and an environment variable `FLUX_PROXY_REMOTE` is currently set, then the local `parent-uri` is transparently transformed to a remote URI using the remote "authority" in `FLUX_PROXY_REMOTE` and is cached locally as `parent-remote-uri`.

When `flux-proxy(1)` uses a remote URI to connect to an instance, it then sets `FLUX_PROXY_REMOTE` appropriately in the environment of the spawned subprocess. Then, care is taken to unset this environment variable if other subprocesses are started, e.g. as part of a job or flux-exec, etc.

This is not the most satisfying implementation because it pushes knowledge of a specific attribute down into the attr code.
However, the end result is satisfying since even `flux getattr parent-uri` will now return a _usable_ remote URI to the flux-proxy instance, but still the local uri in other cases (i.e. jobs, the broker itself, etc).

The alternative implementation is to add a `uri_get_parent()` function or similar and convert all users of the `parent-uri` attribute to that. This would still leave `flux getattr` and `flux lsattr` and all callers that still directly use `flux_attr_get(3)` susceptible to an issue.

e.g.
```console
$ flux pstree -x
       JOBID USER     ST NTASKS NNODES  RUNTIME
 fovomNPbh3V grondo    R      1      1   25.73s flux
    f8bpyT3u grondo    R      1      1   5.975s └── flux
$ src/cmd/flux proxy fovomNPbh3V/f8bpyT3u printenv FLUX_PROXY_REMOTE
tioga31
$ src/cmd/flux proxy fovomNPbh3V/f8bpyT3u flux getattr parent-uri
ssh://tioga31/var/tmp/grondo/flux-lDWKJi/local-0
$ src/cmd/flux proxy fovomNPbh3V/f8bpyT3u flux exec -r 0 flux getattr parent-uri
local:///var/tmp/grondo/flux-lDWKJi/local-0
```