### PR TITLE
improve error on plugin load if flux_plugin_init() returns an error

### DIFF
--- a/doc/man3/flux_shell_getenv.rst
+++ b/doc/man3/flux_shell_getenv.rst
@@ -65,6 +65,8 @@ EINVAL
 EEXIST
    The variable already exists and ``overwrite`` was not non-zero (``flux_shell_setenvf()``).
 
+ENOENT
+   With ``flux_shell_unsetenv()``, the target variable does not exist.
 
 RESOURCES
 =========

--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -290,8 +290,9 @@ int flux_plugin_load_dso (flux_plugin_t *p, const char *path)
     if (!(p->path = strdup (path)) || !(p->name = strdup (path)))
         return plugin_seterror (p, ENOMEM, NULL);
 
-    if ((init = dlsym (p->dso, "flux_plugin_init")))
-        return (*init) (p);
+    if ((init = dlsym (p->dso, "flux_plugin_init"))
+        && (*init) (p) < 0)
+        return plugin_seterror (p, 0, "%s: flux_plugin_init failed", path);
     return 0;
 }
 

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -509,6 +509,18 @@ void test_uuid (void)
     free (ouuid);
 }
 
+void test_plugin_init_failure (void)
+{
+    flux_plugin_t *p = flux_plugin_create ();
+    if (!p || flux_plugin_set_conf (p, "{\"fail\": 1}") < 0)
+        BAIL_OUT ("flux_plugin_create/set_conf");
+    ok (flux_plugin_load_dso (p, "test/.libs/plugin_foo.so") < 0,
+        "flux_plugin_load fails if plugin init callback fails");
+    diag("%s", flux_plugin_strerror (p));
+    like (flux_plugin_strerror (p), "flux_plugin_init failed",
+        "flux_plugin_strerror() notes that plugin init failed");
+    flux_plugin_destroy (p);
+}
 
 int main (int argc, char *argv[])
 {
@@ -520,6 +532,7 @@ int main (int argc, char *argv[])
     test_load ();
     test_load_rtld_now ();
     test_uuid ();
+    test_plugin_init_failure ();
     done_testing();
     return (0);
 }

--- a/src/common/libflux/test/plugin_foo.c
+++ b/src/common/libflux/test/plugin_foo.c
@@ -36,9 +36,11 @@ static const struct flux_plugin_handler tab []= {
 
 int flux_plugin_init (flux_plugin_t *p)
 {
+    int fail = 0;
     if (flux_plugin_register (p, "plugin-test", tab) < 0)
         return -1;
-    return 0;
+    (void) flux_plugin_conf_unpack (p, "{s?i}", "fail", &fail);
+    return fail ? -1 : 0;
 }
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -416,11 +416,14 @@ int flux_shell_setenvf (flux_shell_t *shell, int overwrite,
 
 int flux_shell_unsetenv (flux_shell_t *shell, const char *name)
 {
+    int rc;
     if (!shell || !name) {
         errno = EINVAL;
         return -1;
     }
-    return json_object_del (shell->info->jobspec->environment, name);
+    if ((rc = json_object_del (shell->info->jobspec->environment, name)) < 0)
+        errno = ENOENT;
+    return rc;
 }
 
 int flux_shell_get_hwloc_xml (flux_shell_t *shell, const char **xmlp)

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -74,6 +74,8 @@ static int shell_cb (flux_plugin_t *p,
         "flux_shell_unsetenv (NULL, 'foo') returns EINVAL");
     ok (flux_shell_unsetenv (shell, NULL) < 0 && errno == EINVAL,
         "flux_shell_unsetenv (shell, NULL) returns EINVAL");
+    ok (flux_shell_unsetenv (shell, "MissingEnvVar") < 0 && errno == ENOENT,
+        "flux_shell_unsetenv (shell, MissingEnvVar) returns ENOENT");
 
     ok (flux_shell_setenvf (NULL, 0, "foo", "bar") < 0 && errno == EINVAL,
         "flux_shell_setenvf (NULL, ...) returns EINVAL");


### PR DESCRIPTION
This PR improves poor handling of errors from plugins discovered by @jameshcorbett in https://github.com/flux-framework/flux-coral2/pull/68.

Specific changes are documented in the included commits.