### PR TITLE
broker: make tbon.connect_timeout configurable

### DIFF
--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -46,6 +46,13 @@ tcp_user_timeout
    ``tbon.tcp_user_timeout`` broker attribute.  See also: :linux:man7:`tcp`,
    TCP_USER_TIMEOUT socket option.  Default: 20s.
 
+connect_timeout
+   (optional) The amount of time (in RFC 23 Flux Standard Duration format)
+   that a broker waits for a :linux:man1:`connect` attempt to its TBON parent
+   to succeed before before retrying.  A value of 0 means use the system
+   default.  The configured value may be overridden by setting the
+   ``tbon.connect_timeout`` broker attribute.  Default: 30s.
+
 zmqdebug
    (optional) Integer value indicating whether ZeroMQ socket debug logging
    should be enabled: 0=disabled, 1=enabled.  Default: ``0``.  This configured

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -214,6 +214,13 @@ tbon.tcp_user_timeout
    the :man5:`flux-config-tbon` ``tcp_user_timeout`` value, if configured.
    See also: :linux:man7:`tcp`, TCP_USER_TIMEOUT socket option.
 
+tbon.connect_timeout
+   The amount of time (in RFC 23 Flux Standard Duration format) that a broker
+   waits for a :linux:man2:`connect` attempt to its TBON parent to succeed
+   before retrying.  A value of 0 means use the system default.  This
+   attribute may not be changed during runtime.  The broker attribute
+   overrides the :man5:`flux-config-tbon` ``connect_timeout`` value, if
+   configured.
 
 LOGGING
 =======

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1955,8 +1955,7 @@ static int overlay_configure_timeout (struct overlay *ov,
             return -1;
         }
         if (fsd) {
-            if (fsd_parse_duration (fsd, &value) < 0
-                || value <= 0) {
+            if (fsd_parse_duration (fsd, &value) < 0) {
                 log_msg ("Config file error parsing %s", long_name);
                 return -1;
             }
@@ -1966,8 +1965,7 @@ static int overlay_configure_timeout (struct overlay *ov,
     /* Override with broker attribute (command line only) settings, if any.
      */
     if (attr_get (ov->attrs, long_name, &fsd, NULL) == 0) {
-        if (fsd_parse_duration (fsd, &value) < 0
-            || value < 0) {
+        if (fsd_parse_duration (fsd, &value) < 0) {
             log_msg ("Error parsing %s attribute", long_name);
             return -1;
         }

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -15,6 +15,11 @@ if flux broker ${ARGS} flux getattr tbon.tcp_user_timeout >/dev/null 2>&1; then
 else
 	test_set_prereq NOMAXRT
 fi
+if flux broker ${ARGS} flux getattr tbon.connect_timeout >/dev/null 2>&1; then
+	test_set_prereq CONNTO
+else
+	test_set_prereq NOCONNTO
+fi
 
 #
 # check config file parsing
@@ -525,6 +530,53 @@ test_expect_success 'tbon.topo is custom when bootstrap is configured' '
 		flux getattr tbon.topo >topo4.out &&
 	test_cmp topo4.exp topo4.out
 '
+test_expect_success CONNTO 'tbon.connect_timeout is 30s by default' '
+	cat <<-EOT >connto.exp &&
+	30s
+	EOT
+	flux broker ${ARGS} \
+		flux getattr tbon.connect_timeout >connto.out &&
+	test_cmp connto.exp connto.out
+'
+test_expect_success CONNTO 'tbon.connect_timeout can be configured' '
+	mkdir conf26 &&
+	cat <<-EOT2 >connto2.exp &&
+	10s
+	EOT2
+	cat <<-EOT >conf26/tbon.toml &&
+	[tbon]
+	connect_timeout = "10s"
+	EOT
+	flux broker ${ARGS} -c conf26 flux getattr tbon.connect_timeout \
+		>connto2.out &&
+	test_cmp connto2.exp connto2.out
+'
+test_expect_success CONNTO 'tbon.connect_timeout command line overrides config' '
+	cat <<-EOT >connto3.exp &&
+	1h
+	EOT
+	flux broker ${ARGS} -c conf26 \
+		-Stbon.connect_timeout=1h \
+		flux getattr tbon.connect_timeout >connto3.out &&
+	test_cmp connto3.exp connto3.out
+'
+test_expect_success NOCONNTO 'tbon.connect_timeout config cannot be set with old zeromq' '
+	mkdir conf27 &&
+	cat <<-EOT >conf27/tbon.toml &&
+	[tbon]
+	connect_timeout = "35s"
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf27 \
+		/bin/true 2>noconnto_conf.err &&
+	grep "unsupported by this zeromq version" noconnto_conf.err
+'
+test_expect_success NOCONNTO 'tbon.connect_timeout attr cannot be set with old zeromq' '
+	test_must_fail flux broker ${ARGS} \
+		-Stbon.connect_timeout=10s \
+		/bin/true 2>noconnto_attr.err &&
+	grep "unsupported by this zeromq version" noconnto_attr.err
+'
+
 
 
 test_done

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -576,7 +576,24 @@ test_expect_success NOCONNTO 'tbon.connect_timeout attr cannot be set with old z
 		/bin/true 2>noconnto_attr.err &&
 	grep "unsupported by this zeromq version" noconnto_attr.err
 '
-
-
+test_expect_success CONNTO 'tbon.connect_timeout config can be set to 0' '
+	mkdir conf28 &&
+	cat <<-EOT2 >connto_0.exp &&
+	0s
+	EOT2
+	cat <<-EOT >conf28/tbon.toml &&
+	[tbon]
+	connect_timeout = "0"
+	EOT
+	flux broker ${ARGS} -c conf28 flux getattr tbon.connect_timeout \
+		>connto_conf_0.out &&
+	test_cmp connto_0.exp connto_conf_0.out
+'
+test_expect_success CONNTO 'tbon.connect_timeout attr can be set to 0' '
+	flux broker ${ARGS} \
+		-Stbon.connect_timeout=0 \
+		flux getattr tbon.connect_timeout >connto_attr_0.out &&
+	test_cmp connto_0.exp connto_attr_0.out
+'
 
 test_done


### PR DESCRIPTION
Problem: there is no way to tune the ZMQ_CONNECT_TIMEOUT socket option.
    
Allow the connect timeout to be set either in the config:
```toml
[tbon]
connect_timeout = "10s"
 ```
or on the broker command line: `-Stbon.connect_timeout=10s`.
    
The broker command line takes precedence.
    
Set a default of 30s instead of the system default of "a long time" per [zmq_setsockopt(3)](http://api.zeromq.org/4-2:zmq-setsockopt).

Fixes #5134
