### PR TITLE
make SchedResourceList optional in flux.job.info

### DIFF
--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -22,8 +22,12 @@ from flux.core.inner import raw
 from flux.job.JobID import JobID
 from flux.job.stats import JobStats
 from flux.memoized_property import memoized_property
-from flux.resource import SchedResourceList
 from flux.uri import JobURI
+
+try:
+    from flux.resource import SchedResourceList
+except ImportError:
+    SchedResourceList = None
 
 
 def statetostr(stateid, fmt="L"):
@@ -212,7 +216,7 @@ class InstanceInfo:
     def __init__(self, uri=None):
         self.initialized = False
         try:
-            if not uri:
+            if not uri or SchedResourceList is None:
                 raise ValueError
             handle = flux.Flux(str(uri))
             future = handle.rpc("sched.resource-status")


### PR DESCRIPTION
Problem: We currently cannot package rlist.h with the install (at least without more work) and since this is a required import for flux.job.info, without it the Python bindings (installed via pip) will error.
Solution: the flux.resource module is not technically required, so we can fallback to catching the ImportError instead and using the same empty (dummy) class to handle self.resources

I am going to test this with the Python bindings, and would like to get that working first before we finalize it here! Note that I'm going to be taking a break for a few minutes but I'll be back after. I'll update the issue after I have done some testing with this branch!