### PR TITLE
broker: signal readiness to systemd in JOIN state

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==3.4.3
 sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18
+urllib3<2

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -220,12 +220,13 @@ static void action_join (struct state_machine *s)
             sd_notifyf (0,
                         "STATUS=Joining Flux instance via %s",
                         overlay_get_parent_uri (s->ctx->overlay));
-            if (s->ctx->rank > 0)
-                sd_notify (0, "READY=1");
         }
 #endif
         join_check_parent (s);
     }
+#if HAVE_LIBSYSTEMD
+    sd_notify (0, "READY=1");
+#endif
 }
 
 static void quorum_timer_cb (flux_reactor_t *r,
@@ -365,8 +366,6 @@ static void action_run (struct state_machine *s)
                     "STATUS=Running as %s of %d node Flux instance",
                     s->ctx->rank == 0 ? "leader" : "member",
                     (int)s->ctx->size);
-        if (s->ctx->rank == 0)
-            sd_notify (0, "READY=1");
     }
 #endif
 }


### PR DESCRIPTION
Problem: the rank 0 broker currently calls sd_notify(0, "READY=1") when it reaches RUN state, but this puts an upper bound (default 90s) on the time to execute rc1, which can be too little when there are many jobs in the KVS.

Notify systemd when the broker enters JOIN state for all ranks.

Fixes #5151