### PR TITLE
broker: redefine broker.quorum as a size

### DIFF
--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -77,7 +77,7 @@ OPTIONS
 **--test-start-mode**\ =\ *MODE*
    Set the start mode.  If set to ``all``, all brokers are started immediately.
    If set to ``leader``, only the leader is started.  Hint: in ``leader`` mode,
-   use ``--setattr=broker.quorum=0`` to let the initial program start before
+   use ``--setattr=broker.quorum=1`` to let the initial program start before
    the other brokers are online.  Default: ``all``.
 
 **--test-rundir**\ =\ *PATH*

--- a/doc/man1/flux-uptime.rst
+++ b/doc/man1/flux-uptime.rst
@@ -59,9 +59,9 @@ init
    The local broker is waiting for the ``rc1`` script to complete locally.
 
 quorum
-   All brokers are waiting for a configured set of brokers to reach **quorum**
-   state.  The default quorum set is all brokers.  A Flux system instance
-   typically defines the quorum set to only the rank 0 broker.
+   All brokers are waiting for a configured number of brokers to reach
+   **quorum** state.  The default quorum is the instance size.  A Flux
+   system instance typically defines the quorum size to 1.
 
 run
    Flux is fully up and running.

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -107,9 +107,9 @@ broker.pid
    The process id of the local broker.
 
 broker.quorum [Updates: C]
-   An RFC 22 idset representing broker ranks that are required to be online
-   before the rank 0 broker enters the RUN state and starts the initial
-   program, if any.  Default: all ranks.
+   The number of brokers that are required to be online before the rank 0
+   broker enters the RUN state and starts the initial program, if any.
+   Default: instance size.
 
 broker.quorum-timeout [Updates: C]
    The amount of time (in RFC 23 Flux Standard Duration format) that the

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -19,7 +19,7 @@ ExecStart=/bin/bash -c '\
   -Slog-stderr-level=6 \
   -Slog-stderr-mode=local \
   -Sbroker.rc2_none \
-  -Sbroker.quorum=0 \
+  -Sbroker.quorum=1 \
   -Sbroker.quorum-timeout=none \
   -Sbroker.exit-norestart=42 \
   -Sbroker.sd-notify=1 \

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -540,7 +540,7 @@ int exec_broker (const char *cmd_argz, size_t cmd_argz_len,
         struct stat sb;
 
         add_argzf (&argz, &argz_len, "-Sbroker.recovery-mode=1");
-        add_argzf (&argz, &argz_len, "-Sbroker.quorum=0");
+        add_argzf (&argz, &argz_len, "-Sbroker.quorum=1");
         add_argzf (&argz, &argz_len, "-Slog-stderr-level=5");
 
         // if --recovery has no optional argument, assume this is the system

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -118,7 +118,7 @@ make_bootstrap_config() {
     echo "--test-hosts=$fakehosts -o,-c$workdir/conf.d"
     echo "--test-exit-mode=${TEST_UNDER_FLUX_EXIT_MODE:-leader}"
     echo "--test-exit-timeout=${TEST_UNDER_FLUX_EXIT_TIMEOUT:-0}"
-    echo "-o,-Sbroker.quorum=${TEST_UNDER_FLUX_QUORUM:-$full}"
+    echo "-o,-Sbroker.quorum=${TEST_UNDER_FLUX_QUORUM:-$size}"
     echo "--test-start-mode=${TEST_UNDER_FLUX_START_MODE:-all}"
     echo "-o,-Stbon.topo=${TEST_UNDER_FLUX_TOPO:-custom}"
     echo "-o,-Stbon.zmqdebug=1"
@@ -173,7 +173,7 @@ remove_trashdir_wrapper() {
 #    - TEST_UNDER_FLUX_EXIT_TIMEOUT
 #        Set the flux-start exit timeout (default: 0)
 #    - TEST_UNDER_FLUX_QUORUM
-#        Set the broker.quorum attribute (default: 0-<highest_rank>)
+#        Set the broker.quorum attribute (default: <size>)
 #    - TEST_UNDER_FLUX_START_MODE
 #        Set the flux-start start mode (default: all)
 #    - TEST_UNDER_FLUX_TOPO

--- a/t/t3203-instance-recovery.t
+++ b/t/t3203-instance-recovery.t
@@ -16,7 +16,7 @@ test_expect_success 'start a persistent instance of size 4' '
 test_expect_success 'expected broker attributes are set in recovery mode' '
 	cat >recov_attrs.exp <<-EOT &&
 	1
-	0
+	1
 	5
 	EOT
 	flux start --recovery=$(pwd)/test1 \

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -10,15 +10,15 @@ and ensure that it wires up.
 
 . `dirname $0`/sharness.sh
 
-export TEST_UNDER_FLUX_QUORUM=0
+export TEST_UNDER_FLUX_QUORUM=1
 export TEST_UNDER_FLUX_START_MODE=leader
 
 test_under_flux 2 system
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 
-test_expect_success 'broker.quorum was set to 0 by system test personality' '
-	echo 0 >quorum.exp &&
+test_expect_success 'broker.quorum was set to 1 by system test personality' '
+	echo 1 >quorum.exp &&
 	flux getattr broker.quorum >quorum.out &&
 	test_cmp quorum.exp quorum.out
 '

--- a/t/t3302-system-offline.t
+++ b/t/t3302-system-offline.t
@@ -12,7 +12,7 @@ confirm that the user gets a reasonable error.
 . `dirname $0`/sharness.sh
 
 export TEST_UNDER_FLUX_TOPO=kary:1
-export TEST_UNDER_FLUX_QUORUM=0
+export TEST_UNDER_FLUX_QUORUM=1
 export TEST_UNDER_FLUX_START_MODE=leader
 
 test_under_flux 3 system


### PR DESCRIPTION
Problem: broker.quorum as an idset is less useful than if it were a size threshold.
    
Redefine broker.quorum as a size.

Fixes #5145

WIP pending some manual testing...