### PR TITLE
shell: truncate output to KVS after 10MB

### DIFF
--- a/src/common/libioencode/ioencode.h
+++ b/src/common/libioencode/ioencode.h
@@ -29,6 +29,7 @@ json_t *ioencode (const char *stream,
  * - both data and EOF can be available
  * - if no data available, data set to NULL and len to 0
  * - data must be freed after return
+ * - data can be NULL and len non-NULL to retrieve data length
  */
 int iodecode (json_t *o,
               const char **stream,

--- a/src/common/libioencode/test/ioencode.c
+++ b/src/common/libioencode/test/ioencode.c
@@ -62,6 +62,14 @@ void basic (void)
         && eof == true,
         "iodecode returned correct info");
     free (data);
+
+    ok (iodecode (o, &stream, &rank, NULL, &len, &eof) == 0,
+        "iodecode can be passed NULL data to query len");
+    ok (!strcmp (stream, "stdout")
+        && !strcmp (rank, "[0-8]")
+        && len == 3
+        && eof == true,
+        "iodecode returned correct info");
     json_decref (o);
 
     ok ((o = ioencode ("stderr", "[4,5]", NULL, 0, true)) != NULL,
@@ -75,6 +83,14 @@ void basic (void)
         && eof == true,
         "iodecode returned correct info");
     free (data);
+
+    ok (iodecode (o, &stream, &rank, NULL, &len, &eof) == 0,
+        "iodecode can be passed NULL data to query len");
+    ok (!strcmp (stream, "stderr")
+        && !strcmp (rank, "[4,5]")
+        && len == 0
+        && eof == true,
+        "iodecode returned correct info");
     json_decref (o);
 }
 
@@ -108,6 +124,10 @@ static void binary_data (void)
     ok (memcmp (data, buffer, len) == 0,
         "data matches");
     free (data);
+    ok (iodecode (o, &stream, &rank, NULL, &len, &eof) == 0,
+        "iodecode can be passed NULL data to query len");
+    ok (len == sizeof (buffer),
+        "len is correct");
     json_decref (o);
 }
 

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -348,4 +348,15 @@ test_expect_success 'job-shell: shell errors are captured in error file' '
 	test_expect_code 127  flux run --error=test.err nosuchcommand &&
 	grep "nosuchcommand: No such file or directory" test.err
 '
+test_expect_success LONGTEST 'job-shell: output to kvs is truncated at 10MB' '
+	dd if=/dev/urandom bs=10240 count=800 | base64 --wrap 79 >expected &&
+	flux run cat expected >output 2>truncate.error &&
+	test_debug "cat truncate.error" &&
+	grep "stdout.*truncated" truncate.error
+'
+test_expect_success LONGTEST 'job-shell: stderr to kvs is truncated at 10MB' '
+	dd if=/dev/urandom bs=10240 count=800 | base64 --wrap 79 >expected &&
+	flux run sh -c "cat expected >&2"  >truncate2.error 2>&1 &&
+	grep "stderr.*truncated" truncate2.error
+'
 test_done


### PR DESCRIPTION
This is a WIP pending tests and is meant as a stopgap workaround for #5148.

This PR simply sets a static threshold for KVS output and stops writing to the output eventlog after the threshold is reached.
A warning is issued at the time output is truncated as well as at the end of the job.

Figured I'd post early to get feedback.

E.g.:
```console
$ flux run lptest 79 140000 | wc -c
4.842s: flux-shell[0]:  WARN: output: stdout will be truncated, 10MB limit exceeded
5.240s: flux-shell[0]:  WARN: output: stdout: 714240 of 11200000 bytes truncated
10485760
```