### PR TITLE
python: open UtilConfig files as binary

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -1042,7 +1042,7 @@ class UtilConfig:
                     continue
 
                 try:
-                    with open(filepath) as ofile:
+                    with open(filepath, "rb") as ofile:
                         conf = self.extension_handlers[ppath.suffix](ofile)
                 except (
                     tomllib.TOMLDecodeError,


### PR DESCRIPTION
Problem: The Python 3.11 tomllib implementation requires that toml files be opened in binary mode, but the UtilConfig class opens files in normal read mode, resulting in a TypError

 File must be opened in binary mode, e.g. use `open('foo.toml', 'rb')`

Open all UtilConfig config files with mode 'rb'. This doesn't seem to cause an issue with other config file types.

Fixes #5154