### PR TITLE
libioencode: fix memleaks on error paths

### DIFF
--- a/src/common/libioencode/ioencode.c
+++ b/src/common/libioencode/ioencode.c
@@ -19,7 +19,6 @@
 
 #include <jansson.h>
 
-#include "src/common/libutil/macros.h"
 #include "src/common/libccan/ccan/base64/base64.h"
 
 #include "ioencode.h"

--- a/src/common/libioencode/ioencode.c
+++ b/src/common/libioencode/ioencode.c
@@ -144,9 +144,8 @@ int iodecode (json_t *o,
                      "rank", &rank,
                      "encoding", &encoding) < 0)
         goto cleanup;
-    if (json_unpack (o, "{s:s%}", "data", &data, &len) == 0) {
+    if (json_unpack (o, "{s:s%}", "data", &data, &len) == 0)
         has_data = true;
-    }
     if (json_unpack (o, "{s:b}", "eof", &eof) == 0)
         has_eof = true;
 

--- a/src/common/libioencode/ioencode.c
+++ b/src/common/libioencode/ioencode.c
@@ -85,8 +85,10 @@ json_t *ioencode (const char *stream,
             return NULL;
     }
     if (eof) {
-        if (json_object_set_new (o, "eof", json_true ()) < 0)
+        if (json_object_set_new (o, "eof", json_true ()) < 0) {
+            json_decref (o);
             return NULL;
+        }
     }
     return o;
 }
@@ -101,8 +103,10 @@ static int decode_data_base64 (char *src,
     if (datap) {
         if (!(*datap = malloc (size)))
             return -1;
-        if ((rc = base64_decode (*datap, size, src, srclen)) < 0)
+        if ((rc = base64_decode (*datap, size, src, srclen)) < 0) {
+            free (*datap);
             return -1;
+        }
         if (lenp)
             *lenp = rc;
     }

--- a/src/common/libioencode/ioencode.c
+++ b/src/common/libioencode/ioencode.c
@@ -132,6 +132,7 @@ int iodecode (json_t *o,
     const char *rank;
     const char *encoding = NULL;
     size_t bin_len = 0;
+    char *bufp = NULL;
     char *data = NULL;
     size_t len = 0;
     int eof = 0;
@@ -165,23 +166,23 @@ int iodecode (json_t *o,
     if (rankp)
         (*rankp) = rank;
     if (datap || lenp) {
-        if (datap)
-            *datap = NULL;
         if (data) {
             if (encoding && strcmp (encoding, "base64") == 0) {
-                if (decode_data_base64 (data, len, datap, &bin_len) < 0)
+                if (decode_data_base64 (data, len, &bufp, &bin_len) < 0)
                     return -1;
             }
             else {
                 bin_len = len;
                 if (datap) {
-                    if (!(*datap = malloc (bin_len)))
+                    if (!(bufp = malloc (bin_len)))
                         return -1;
-                    memcpy (*datap, data, bin_len);
+                    memcpy (bufp, data, bin_len);
                 }
             }
         }
     }
+    if (datap)
+        (*datap) = bufp;
     if (lenp)
         (*lenp) = bin_len;
     if (eofp)

--- a/src/common/libioencode/ioencode.h
+++ b/src/common/libioencode/ioencode.h
@@ -17,6 +17,7 @@
 /* encode io data and/or EOF into RFC24 data event object
  * - to set only EOF, set data to NULL and data_len to 0
  * - it is an error to provide no data and EOF = false
+ * - returns RFC24 object on success, NULL on error with errno set
  * - returned object should be json_decref()'d after use
  */
 json_t *ioencode (const char *stream,
@@ -30,6 +31,7 @@ json_t *ioencode (const char *stream,
  * - if no data available, data set to NULL and len to 0
  * - data must be freed after return
  * - data can be NULL and len non-NULL to retrieve data length
+ * - returns 0 on success, -1 on error with errno set
  */
 int iodecode (json_t *o,
               const char **stream,


### PR DESCRIPTION
Problem: There are several memory leaks in error paths in libioencode.

Make sure to free memory on error paths.

Fixes https://github.com/flux-framework/flux-core/issues/5158

Also, cleanup some unnecessary goto statements.