### PR TITLE
ci: add fedora38 builder, update flux-security default to 0.8.0

### DIFF
--- a/src/test/docker/README.md
+++ b/src/test/docker/README.md
@@ -48,7 +48,7 @@ pushed to DockerHub at `fluxrm/testenv:bionic` and
 script still runs against the new `testenv` images, e.g.:
 
 ```
-$ for i in focal el7 el8 fedora33 fedora34 fedora35; do
+$ for i in focal el7 el8 fedora33 fedora34 fedora35 fedora38; do
     make clean &&
     docker build --no-cache -t fluxrm/testenv:$i src/test/docker/$i &&
     src/test/docker/docker-run-checks.sh -j 4 --image=$i &&

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -16,7 +16,7 @@ JOBS=2
 MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
 
 if test "$PROJECT" = "flux-core"; then
-  FLUX_SECURITY_VERSION=0.7.0
+  FLUX_SECURITY_VERSION=0.8.0
   POISON=t
 fi
 

--- a/src/test/docker/fedora38/Dockerfile
+++ b/src/test/docker/fedora38/Dockerfile
@@ -1,0 +1,78 @@
+FROM fedora:38
+
+LABEL maintainer="Mark Grondona <mgrondona@llnl.gov>"
+
+#  Enable PowerTools for development packages
+RUN yum -y update \
+ && yum -y update \
+#  Utilities
+ && yum -y install \
+	wget \
+	man-db \
+	less \
+	git \
+	sudo \
+	munge \
+	ccache \
+	lua \
+	mpich \
+	valgrind \
+	jq \
+	which \
+	file \
+	vim \
+	patch \
+	diffutils \
+	hostname \
+#  Compilers, autotools
+	pkgconfig \
+	libtool \
+	autoconf \
+	automake \
+	gcc \
+	gcc-c++ \
+	libasan \
+	make \
+	cmake \
+#  Python
+	python3-devel \
+	python3-cffi \
+	python3-six \
+	python3-yaml \
+	python3-jsonschema \
+	python3-sphinx \
+#  Development dependencies
+	libsodium-devel \
+	zeromq-devel \
+	czmq-devel \
+	jansson-devel \
+	munge-devel \
+	ncurses-devel \
+	lz4-devel \
+	sqlite-devel \
+	libuuid-devel \
+	hwloc-devel \
+	mpich-devel \
+	lua-devel \
+	valgrind-devel \
+	libs3-devel \
+	libarchive-devel \
+	pam-devel \
+#  Other deps
+	perl-Time-HiRes \
+	lua-posix \
+	libfaketime \
+	cppcheck \
+	enchant \
+	aspell \
+	aspell-en \
+	glibc-langpack-en \
+ && yum clean all
+
+#  Add /usr/bin/mpicc link so MPI tests are built
+RUN alternatives --install /usr/bin/mpicc mpicc /usr/lib64/mpich/bin/mpicc 100
+
+ENV LANG=C.UTF-8
+RUN printf "LANG=C.UTF-8" > /etc/locale.conf
+
+COPY config.site /usr/share/config.site

--- a/src/test/docker/fedora38/config.site
+++ b/src/test/docker/fedora38/config.site
@@ -1,0 +1,6 @@
+# Force libdir to /usr/lib64 if prefix=/usr on this platform
+if test "$prefix" = "/usr" ; then
+    test $sysconfdir = "${prefix}/etc" && sysconfdir=/etc
+    libdir=/usr/lib64
+fi
+:

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -251,6 +251,21 @@ matrix.add_build(
     docker_tag=True,
 )
 
+# Fedora 38
+# Note: caliper does not compile on Fedora 38
+matrix.add_build(
+    name="fedora38 - gcc-13.1,py3.11",
+    image="fedora38",
+    args=(
+        "--prefix=/usr"
+        " --sysconfdir=/etc"
+        " --with-systemdsystemunitdir=/etc/systemd/system"
+        " --localstatedir=/var"
+        " --with-flux-security"
+    ),
+    docker_tag=True,
+)
+
 # inception
 matrix.add_build(
     name="inception",


### PR DESCRIPTION
This PR adds a builder for Fedora 38, since this distro has GCC 13 and Python 3.11, a combo we're not yet testing.

The caliper version we've pinned won't build in fedora38, and the newest version isn't compatible with the current code that calls it in flux-core, so I've just disabled Caliper here. Honestly, I'm wondering if we should just remove the caliper support? Eh, not too much of a headache yet, so we can save that decision for another day.