### PR TITLE
shell: add missing `flux_` prefix to `shell_mustache_render(3)`

### DIFF
--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -814,7 +814,7 @@ shell_output_setup_type_file (struct shell_output *out,
         return -1;
     }
 
-    if (!(ofp->path = shell_mustache_render (out->shell, path)))
+    if (!(ofp->path = flux_shell_mustache_render (out->shell, path)))
         return -1;
 
     if (flux_shell_getopt_unpack (out->shell, "output",

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -980,8 +980,13 @@ static int get_protocol_fd (int *pfd)
     return 0;
 }
 
-char *shell_mustache_render (flux_shell_t *shell, const char *fmt)
+char *flux_shell_mustache_render (flux_shell_t *shell, const char *fmt)
 {
+    if (!shell) {
+        /* Note: shell->mr and fmt checked in mustache_render */
+        errno = EINVAL;
+        return NULL;
+    }
     return mustache_render (shell->mr, fmt);
 }
 
@@ -1537,7 +1542,8 @@ static int frob_command (flux_shell_t *shell, flux_cmd_t *cmd)
     for (int i = 0; i < flux_cmd_argc (cmd); i++) {
         if (strstr (flux_cmd_arg (cmd, i), "{{")) { // possibly mustachioed
             char *narg;
-            if (!(narg = shell_mustache_render (shell, flux_cmd_arg (cmd, i)))
+            if (!(narg = flux_shell_mustache_render (shell,
+                                                     flux_cmd_arg (cmd, i)))
                 || flux_cmd_argv_insert (cmd, i, narg) < 0) {
                 free (narg);
                 return -1;

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -403,7 +403,7 @@ int flux_shell_log_setlevel (int level, const char *dest);
 
 /*  Expand mustache template.  Caller must free the result.
  */
-char *shell_mustache_render (flux_shell_t *shell, const char *fmt);
+char *flux_shell_mustache_render (flux_shell_t *shell, const char *fmt);
 
 
 #ifdef __cplusplus

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -194,6 +194,11 @@ static int shell_cb (flux_plugin_t *p,
     ok (flux_shell_task_next (NULL) == NULL && errno == EINVAL,
         "flux_shell_task_next (NULL) returns EINVAL");
 
+    ok (flux_shell_mustache_render (NULL, NULL) == NULL && errno == EINVAL,
+        "flux_shell_mustache_render (NULL, NULL) returns EINVAL");
+    ok (flux_shell_mustache_render (shell, NULL) == NULL && errno == EINVAL,
+        "flux_shell_mustache_render (shell, NULL) returns EINVAL");
+
     if (strcmp (topic, "shell.init") == 0) {
         ok (flux_shell_current_task (NULL) == NULL && errno == EINVAL,
             "flux_shell_current_task with NULL shell returns EINVAL");


### PR DESCRIPTION
The `shell_mustache_render(3)` function declared in `shell.h` is missing the `flux_` prefix. Since the shell is built to only export `flux_*` symbols, this means that this function is not available to dynamically loaded shell plugins.

Rename the function `flux_shell_mustache_render(3)`, add protection against a `NULL` `shell` parameter, and add a couple simple tests for invalid arguments to the testsuite.