### PR TITLE
cleanup:  use ccan/str in place of strcmp(), strncmp()

### DIFF
--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -4,6 +4,7 @@ AM_LDFLAGS =	$(CODE_COVERAGE_LIBS)
 AM_CPPFLAGS =	\
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
 	$(LUA_INCLUDE)
 

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -25,6 +25,8 @@
 
 #include "flux/core.h"
 
+#include "ccan/str/str.h"
+
 #include "jansson-lua.h"
 #include "zmsg-lua.h"
 #include "lutil.h"
@@ -242,9 +244,9 @@ static int l_flux_index (lua_State *L)
     if (key == NULL)
         return luaL_error (L, "flux: invalid index");
 
-    if (strcmp (key, "size") == 0)
+    if (streq (key, "size"))
         return l_flux_size (L);
-    if (strcmp (key, "rank") == 0)
+    if (streq (key, "rank"))
         return l_flux_rank (L);
 
     lua_getmetatable (L, 1);
@@ -786,7 +788,7 @@ static int l_msghandler_index (lua_State *L)
     /*
      *  Check for method names
      */
-    if (strcmp (key, "remove") == 0) {
+    if (streq (key, "remove")) {
         lua_getmetatable (L, 1);
         lua_getfield (L, -1, "remove");
         return (1);
@@ -937,7 +939,7 @@ static int l_watcher_index (lua_State *L)
     /*
      *  Check for method names
      */
-    if (strcmp (key, "remove") == 0) {
+    if (streq (key, "remove")) {
         lua_getmetatable (L, 1);
         lua_getfield (L, -1, "remove");
         return (1);
@@ -1046,9 +1048,9 @@ static int l_flux_reactor_start (lua_State *L)
     flux_t *h;
     int mode = 0;
     if ((lua_gettop (L) > 1) && (arg = lua_tostring (L, 2))) {
-        if (strcmp (arg, "once") == 0)
+        if (streq (arg, "once"))
             mode = FLUX_REACTOR_ONCE;
-        else if (strcmp (arg, "nowait") == 0)
+        else if (streq (arg, "nowait"))
             mode = FLUX_REACTOR_NOWAIT;
         else
             return lua_pusherror (L, "flux_reactor: Invalid argument");

--- a/src/bindings/lua/zmsg-lua.c
+++ b/src/bindings/lua/zmsg-lua.c
@@ -15,6 +15,7 @@
 #include <lauxlib.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "flux/core.h"
 #include "lutil.h"
@@ -121,23 +122,23 @@ static int l_zmsg_info_index (lua_State *L)
     if (key == NULL)
         return lua_pusherror (L, "zmsg: invalid member");
 
-    if (strcmp (key, "type") == 0) {
+    if (streq (key, "type")) {
         lua_pushstring (L, zmsg_type_string (zi->typemask));
         return (1);
     }
-    if (strcmp (key, "tag") == 0) {
+    if (streq (key, "tag")) {
         if (zi->tag)
             lua_pushstring (L, zi->tag);
         else
             lua_pushnil (L);
         return (1);
     }
-    if (strcmp (key, "data") == 0) {
+    if (streq (key, "data")) {
         if (!zi->o || json_object_to_lua (L, zi->o) < 0)
             lua_pushnil (L);
         return (1);
     }
-    if (strcmp (key, "errnum") == 0) {
+    if (streq (key, "errnum")) {
         int errnum;
         if (!(zi->typemask & FLUX_MSGTYPE_RESPONSE))
             return lua_pusherror (L,
@@ -146,7 +147,7 @@ static int l_zmsg_info_index (lua_State *L)
         lua_pushnumber (L, errnum);
         return (1);
     }
-    if (strcmp (key, "matchtag") == 0) {
+    if (streq (key, "matchtag")) {
         uint32_t matchtag;
         if (flux_msg_get_matchtag (zi->msg, &matchtag) < 0)
             return lua_pusherror (L, "zmsg: matchtag: %s",

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -24,6 +24,7 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
 
 #include "attr.h"
 #include "overlay.h"
@@ -378,7 +379,7 @@ int boot_config_getrankbyname (json_t *hosts, const char *name, uint32_t *rank)
         /* N.B. entry already validated by boot_config_parse().
          */
         if (json_unpack (entry, "{s:s}", "host", &host) == 0
-                    && !strcmp (name, host)) {
+            && streq (name, host)) {
             *rank = index;
             return 0;
         }

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -23,6 +23,7 @@
 #include "src/common/libutil/ipaddr.h"
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libpmi/upmi.h"
+#include "ccan/str/str.h"
 
 #include "attr.h"
 #include "overlay.h"
@@ -114,7 +115,7 @@ static bool use_ipc (attr_t *attrs)
     const char *val;
 
     if (attr_get (attrs, "tbon.prefertcp", &val, NULL) == 0
-        && strcmp (val, "0") != 0)
+        && !streq (val, "0"))
         goto done;
     if (attr_get (attrs, "broker.mapping", &val, NULL) < 0 || !val)
         goto done;

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -24,6 +24,7 @@
 #include "src/common/libutil/iterators.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libcontent/content.h"
+#include "ccan/str/str.h"
 
 #include "attr.h"
 #include "content-cache.h"
@@ -748,7 +749,7 @@ static void content_register_backing_request (flux_t *h,
         if (!(cache->backing_name = strdup (name)))
             goto error;
     }
-    if (strcmp (cache->backing_name, name) != 0) {
+    if (!streq (cache->backing_name, name)) {
         errno = EINVAL;
         errstr = "content backing store cannot be changed on the fly";
         goto error;
@@ -999,7 +1000,7 @@ static int content_cache_getattr (const char *name, const char **val, void *arg)
 {
     struct content_cache *cache = arg;
 
-    if (!strcmp (name, "content.backing-module"))
+    if (streq (name, "content.backing-module"))
         *val = cache->backing_name;
     else
         return -1;

--- a/src/broker/groups.c
+++ b/src/broker/groups.c
@@ -43,6 +43,7 @@
 #include "src/common/libidset/idset.h"
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "overlay.h"
 #include "groups.h"
@@ -727,15 +728,16 @@ static void overlay_monitor_cb (struct overlay *ov, uint32_t rank, void *arg)
     /* Generate LEAVEs for any groups 'rank' (and subtree) may be a member
      * of if transitioning to lost (crashed) or offline (shutdown).
      */
-    if (!strcmp (status, "lost") || !strcmp (status, "offline")) {
+    if (streq (status, "lost")
+        || streq (status, "offline")) {
         auto_leave (g, status, rank, ids);
     }
     /* Update broker.torpid if torpidity has changed while subtree is in
      * one of the "online" states.
      */
-    else if (!strcmp (status, "full")
-        || !strcmp (status, "partial")
-        || !strcmp (status, "degraded")) {
+    else if (streq (status, "full")
+        || streq (status, "partial")
+        || streq (status, "degraded")) {
         torpid_update (g, rank, ids, overlay_peer_is_torpid (ov, rank));
     }
 

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -23,6 +23,7 @@
 #include "src/common/libutil/wallclock.h"
 #include "src/common/libutil/stdlog.h"
 #include "src/common/libutil/timestamp.h"
+#include "ccan/str/str.h"
 
 #include "log.h"
 
@@ -255,19 +256,19 @@ static int attr_get_log (const char *name, const char **val, void *arg)
 {
     logbuf_t *logbuf = arg;
 
-    if (!strcmp (name, "log-forward-level"))
+    if (streq (name, "log-forward-level"))
         *val = int_to_string (logbuf->forward_level);
-    else if (!strcmp (name, "log-critical-level"))
+    else if (streq (name, "log-critical-level"))
         *val = int_to_string (logbuf->critical_level);
-    else if (!strcmp (name, "log-stderr-level"))
+    else if (streq (name, "log-stderr-level"))
         *val = int_to_string (logbuf->stderr_level);
-    else if (!strcmp (name, "log-stderr-mode"))
+    else if (streq (name, "log-stderr-mode"))
         *val = logbuf->stderr_mode == MODE_LEADER ? "leader" : "local";
-    else if (!strcmp (name, "log-ring-size"))
+    else if (streq (name, "log-ring-size"))
         *val = int_to_string (logbuf->ring_size);
-    else if (!strcmp (name, "log-filename"))
+    else if (streq (name, "log-filename"))
         *val = logbuf->filename;
-    else if (!strcmp (name, "log-level"))
+    else if (streq (name, "log-level"))
         *val = int_to_string (logbuf->level);
     else {
         errno = ENOENT;
@@ -281,35 +282,35 @@ static int attr_set_log (const char *name, const char *val, void *arg)
     logbuf_t *logbuf = arg;
     int rc = -1;
 
-    if (!strcmp (name, "log-forward-level")) {
+    if (streq (name, "log-forward-level")) {
         int level = strtol (val, NULL, 10);
         if (logbuf_set_forward_level (logbuf, level) < 0)
             goto done;
-    } else if (!strcmp (name, "log-critical-level")) {
+    } else if (streq (name, "log-critical-level")) {
         int level = strtol (val, NULL, 10);
         if (logbuf_set_critical_level (logbuf, level) < 0)
             goto done;
-    } else if (!strcmp (name, "log-stderr-level")) {
+    } else if (streq (name, "log-stderr-level")) {
         int level = strtol (val, NULL, 10);
         if (logbuf_set_stderr_level (logbuf, level) < 0)
             goto done;
-    } else if (!strcmp (name, "log-stderr-mode")) {
-        if (!strcmp (val, "leader"))
+    } else if (streq (name, "log-stderr-mode")) {
+        if (streq (val, "leader"))
             logbuf->stderr_mode = MODE_LEADER;
-        else if (!strcmp (val, "local"))
+        else if (streq (val, "local"))
             logbuf->stderr_mode = MODE_LOCAL;
         else {
             errno = EINVAL;
             goto done;
         }
-    } else if (!strcmp (name, "log-ring-size")) {
+    } else if (streq (name, "log-ring-size")) {
         int size = strtol (val, NULL, 10);
         if (logbuf_set_ring_size (logbuf, size) < 0)
             goto done;
-    } else if (!strcmp (name, "log-filename")) {
+    } else if (streq (name, "log-filename")) {
         if (logbuf_set_filename (logbuf, val) < 0)
             goto done;
-    } else if (!strcmp (name, "log-level")) {
+    } else if (streq (name, "log-level")) {
         int level = strtol (val, NULL, 10);
         if (logbuf_set_level (logbuf, level) < 0)
             goto done;

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -15,6 +15,7 @@
 
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libfluxutil/method.h"
+#include "ccan/str/str.h"
 
 #include "module.h"
 #include "modservice.h"
@@ -73,13 +74,13 @@ static void debug_cb (flux_t *h, flux_msg_handler_t *mh,
         }
         flux_aux_set (h, "flux::debug_flags", debug_flags, free);
     }
-    if (!strcmp (op, "setbit"))
+    if (streq (op, "setbit"))
         *debug_flags |= flags;
-    else if (!strcmp (op, "clrbit"))
+    else if (streq (op, "clrbit"))
         *debug_flags &= ~flags;
-    else if (!strcmp (op, "set"))
+    else if (streq (op, "set"))
         *debug_flags = flags;
-    else if (!strcmp (op, "clr"))
+    else if (streq (op, "clr"))
         *debug_flags = 0;
     else {
         errno = EPROTO;

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1834,9 +1834,9 @@ static int set_torpid (const char *name, const char *val, void *arg)
 
     if (fsd_parse_duration (val, &d) < 0)
         return -1;
-    if (!strcmp (name, "tbon.torpid_max"))
+    if (streq (name, "tbon.torpid_max"))
         ov->torpid_max = d;
-    else if (!strcmp (name, "tbon.torpid_min")) {
+    else if (streq (name, "tbon.torpid_min")) {
         if (d == 0)
             goto error;
         ov->torpid_min = d;
@@ -1855,9 +1855,9 @@ static int get_torpid (const char *name, const char **val, void *arg)
     static char buf[64];
     double d;
 
-    if (!strcmp (name, "tbon.torpid_max"))
+    if (streq (name, "tbon.torpid_max"))
         d = ov->torpid_max;
-    else if (!strcmp (name, "tbon.torpid_min"))
+    else if (streq (name, "tbon.torpid_min"))
         d = ov->torpid_min;
     else
         goto error;

--- a/src/broker/publisher.c
+++ b/src/broker/publisher.c
@@ -18,6 +18,7 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libccan/ccan/base64/base64.h"
+#include "ccan/str/str.h"
 
 #include "module.h"
 #include "publisher.h"
@@ -170,7 +171,7 @@ static void broker_unsubscribe (struct broker *ctx, const char *topic)
 {
     char *s = zlist_first (ctx->subscriptions);
     while (s) {
-        if (!strcmp (s, topic)) {
+        if (streq (s, topic)) {
             zlist_remove (ctx->subscriptions, s);
             break;
         }

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -32,6 +32,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/monotime.h"
+#include "ccan/str/str.h"
 
 #include "runat.h"
 
@@ -103,8 +104,8 @@ static char *get_cmdline (flux_cmd_t *cmd)
     /* Drop the "/bin/bash -c" from logging for brevity.
      */
     if (flux_cmd_argc (cmd) > 2
-        && !strcmp (flux_cmd_arg (cmd, 0), get_shell ())
-        && !strcmp (flux_cmd_arg (cmd, 1), "-c"))
+        && streq (flux_cmd_arg (cmd, 0), get_shell ())
+        && streq (flux_cmd_arg (cmd, 1), "-c"))
         start += 2;
     for (i = start; i < flux_cmd_argc (cmd); i++) {
         if (argz_add (&buf, &len, flux_cmd_arg (cmd, i)) != 0) {
@@ -219,7 +220,7 @@ static void stdio_cb (flux_subprocess_t *p, const char *stream)
     int len;
 
     if ((line = flux_subprocess_getline (p, stream, &len)) && len > 0) {
-        if (!strcmp (stream, "stderr"))
+        if (streq (stream, "stderr"))
             flux_log (r->h, LOG_ERR, "%s.%d: %s", entry->name, index, line);
         else
             flux_log (r->h, LOG_INFO, "%s.%d: %s", entry->name, index, line);

--- a/src/broker/service.c
+++ b/src/broker/service.c
@@ -15,6 +15,7 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/log.h"
+#include "ccan/str/str.h"
 
 #include "service.h"
 
@@ -97,7 +98,8 @@ json_t *service_list_byuuid (struct service_switch *sw, const char *uuid)
         return NULL;
     svc = zhash_first (sw->services);
     while (svc) {
-        if (uuid && svc->uuid && !strcmp (uuid, svc->uuid)) {
+        if (uuid && svc->uuid
+            && streq (uuid, svc->uuid)) {
             json_t *name = json_string  (zhash_cursor (sw->services));
             if (!name)
                 goto error;
@@ -124,7 +126,8 @@ void service_remove_byuuid (struct service_switch *sw, const char *uuid)
 
     svc = zhash_first (sw->services);
     while (svc != NULL) {
-        if (svc->uuid && !strcmp (svc->uuid, uuid)) {
+        if (svc->uuid
+            && streq (svc->uuid, uuid)) {
             if (!trash)
                 trash = zlist_new ();
             if (!trash)

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -178,7 +178,8 @@ static broker_state_t state_next (broker_state_t current, const char *event)
 {
     int i;
     for (i = 0; i < ARRAY_SIZE (nexttab); i++) {
-        if (nexttab[i].current == current && !strcmp (event, nexttab[i].event))
+        if (nexttab[i].current == current
+            && streq (event, nexttab[i].event))
             return nexttab[i].next;
     }
     return current;
@@ -578,7 +579,7 @@ static void runat_completion_cb (struct runat *r, const char *name, void *arg)
     if (runat_get_exit_code (r, name, &rc) < 0)
         log_err ("runat_get_exit_code %s", name);
 
-    if (!strcmp (name, "rc1")) {
+    if (streq (name, "rc1")) {
         if (rc == 0)
             state_machine_post (s, "rc1-success");
         else if (attr_get (s->ctx->attrs,
@@ -597,17 +598,17 @@ static void runat_completion_cb (struct runat *r, const char *name, void *arg)
             state_machine_post (s, "rc1-fail");
         }
     }
-    else if (!strcmp (name, "rc2")) {
+    else if (streq (name, "rc2")) {
         if (s->ctx->exit_rc == 0 && rc != 0)
             s->ctx->exit_rc = rc;
         state_machine_post (s, rc == 0 ? "rc2-success" : "rc2-fail");
     }
-    else if (!strcmp (name, "cleanup")) {
+    else if (streq (name, "cleanup")) {
         if (s->ctx->exit_rc == 0 && rc != 0)
             s->ctx->exit_rc = rc;
         state_machine_post (s, rc == 0 ? "cleanup-success" : "cleanup-fail");
     }
-    else if (!strcmp (name, "rc3")) {
+    else if (streq (name, "rc3")) {
         if (s->ctx->exit_rc == 0 && rc != 0)
             s->ctx->exit_rc = rc;
         state_machine_post (s, rc == 0 ? "rc3-success" : "rc3-fail");
@@ -794,7 +795,7 @@ static int quorum_timeout_configure (struct state_machine *s)
     char fsd[32];
 
     if (attr_get (s->ctx->attrs, name, &val, NULL) == 0) {
-        if (!strcmp (val, "none"))
+        if (streq (val, "none"))
             s->quorum.timeout = -1;
         else {
             if (fsd_parse_duration (val, &s->quorum.timeout) < 0) {

--- a/src/broker/test/attr.c
+++ b/src/broker/test/attr.c
@@ -17,6 +17,7 @@
 #include "attr.h"
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 void basic (void)
 {
@@ -47,7 +48,7 @@ void basic (void)
         "attr_get on new attr works with NULL args");
     val = NULL;
     flags = 0;
-    ok (attr_get (attrs, "foo", &val, &flags) == 0 && !strcmp (val, "bar")
+    ok (attr_get (attrs, "foo", &val, &flags) == 0 && streq (val, "bar")
         && flags == 0,
         "attr_get on new attr works returns correct val,flags");
 
@@ -66,7 +67,7 @@ void basic (void)
         "attr_add ATTR_IMMUTABLE works");
     flags = 0;
     val = NULL;
-    ok (attr_get (attrs, "foo", &val, &flags) == 0 && !strcmp (val, "baz")
+    ok (attr_get (attrs, "foo", &val, &flags) == 0 && streq (val, "baz")
         && flags == ATTR_IMMUTABLE,
         "attr_get returns correct value and flags");
     errno = 0;
@@ -86,7 +87,7 @@ void basic (void)
      * initial hash contents: foo=bar
      */
     val = attr_first (attrs);
-    ok (val && !strcmp (val, "foo"),
+    ok (val && streq (val, "foo"),
         "attr_first returned foo");
     ok (attr_next (attrs) == NULL,
         "attr_next returned NULL");
@@ -96,19 +97,19 @@ void basic (void)
         && attr_add (attrs, "foo4", "44", 0) == 0,
         "attr_add foo1, foo2, foo3, foo4 works");
     val = attr_first (attrs);
-    ok (val && !strncmp (val, "foo", 3),
+    ok (val && strstarts (val, "foo"),
         "attr_first returned foo-prefixed attr");
     val = attr_next (attrs);
-    ok (val && !strncmp (val, "foo", 3),
+    ok (val && strstarts (val, "foo"),
         "attr_next returned foo-prefixed attr");
     val = attr_next (attrs);
-    ok (val && !strncmp (val, "foo", 3),
+    ok (val && strstarts (val, "foo"),
         "attr_next returned foo-prefixed attr");
     val = attr_next (attrs);
-    ok (val && !strncmp (val, "foo", 3),
+    ok (val && strstarts (val, "foo"),
         "attr_next returned foo-prefixed attr");
     val = attr_next (attrs);
-    ok (val && !strncmp (val, "foo", 3),
+    ok (val && strstarts (val, "foo"),
         "attr_next returned foo-prefixed attr");
     ok (attr_next (attrs) == NULL,
         "attr_next returned NULL");
@@ -131,13 +132,13 @@ void active (void)
     ok (attr_add_active_int (attrs, "a", &a, 0) == 0,
         "attr_add_active_int works");
     a = 0;
-    ok (attr_get (attrs, "a", &val, NULL) == 0 && val && !strcmp (val, "0"),
+    ok (attr_get (attrs, "a", &val, NULL) == 0 && val && streq (val, "0"),
         "attr_get on active int tracks val=0");
     a = 1;
-    ok (attr_get (attrs, "a", &val, NULL) == 0 && !strcmp (val, "1"),
+    ok (attr_get (attrs, "a", &val, NULL) == 0 && streq (val, "1"),
         "attr_get on active int tracks val=1");
     a = -1;
-    ok (attr_get (attrs, "a", &val, NULL) == 0 && !strcmp (val, "-1"),
+    ok (attr_get (attrs, "a", &val, NULL) == 0 && streq (val, "-1"),
         "attr_get on active int tracks val=-1");
     a = INT_MAX - 1;
     ok (attr_get (attrs, "a", &val, NULL) == 0
@@ -162,10 +163,10 @@ void active (void)
     ok (attr_add_active_uint32 (attrs, "b", &b, 0) == 0,
         "attr_add_active_uint32 works");
     b = 0;
-    ok (attr_get (attrs, "b", &val, NULL) == 0 && val && !strcmp (val, "0"),
+    ok (attr_get (attrs, "b", &val, NULL) == 0 && val && streq (val, "0"),
         "attr_get on active uin32_t tracks val=0");
     b = 1;
-    ok (attr_get (attrs, "b", &val, NULL) == 0 && !strcmp (val, "1"),
+    ok (attr_get (attrs, "b", &val, NULL) == 0 && streq (val, "1"),
         "attr_get on active uint32_t tracks val=1");
     b = UINT_MAX - 1;
     ok (attr_get (attrs, "b", &val, NULL) == 0
@@ -184,10 +185,10 @@ void active (void)
     ok (attr_add_active_int (attrs, "c", &c, ATTR_IMMUTABLE) == 0,
         "attr_add_active_int ATTR_IMMUTABLE works");
     c = 42;
-    ok (attr_get (attrs, "c", &val, NULL) == 0 && val && !strcmp (val, "42"),
+    ok (attr_get (attrs, "c", &val, NULL) == 0 && val && streq (val, "42"),
         "attr_get returns initial val=42");
     c = 43;
-    ok (attr_get (attrs, "c", &val, NULL) == 0 && val && !strcmp (val, "42"),
+    ok (attr_get (attrs, "c", &val, NULL) == 0 && val && streq (val, "42"),
         "attr_get ignores value changes");
     errno = 0;
     ok (attr_delete (attrs, "c", true) < 0 && errno == EPERM,

--- a/src/broker/test/boot_config.c
+++ b/src/broker/test/boot_config.c
@@ -18,6 +18,7 @@
 
 #include "src/common/libtap/tap.h"
 #include "src/broker/boot_config.h"
+#include "ccan/str/str.h"
 
 
 static void
@@ -87,9 +88,9 @@ void test_parse (const char *dir)
 
     ok (conf.default_port == 42,
         "set default_port correctly");
-    ok (!strcmp (conf.default_bind, "tcp://en0:42"),
+    ok (streq (conf.default_bind, "tcp://en0:42"),
         "and set default_bind correctly (with %%p substitution)");
-    ok (!strcmp (conf.default_connect, "tcp://x%h:42"),
+    ok (streq (conf.default_connect, "tcp://x%h:42"),
         "and set default_connect correctly (with %%p substitution)");
 
     ok (boot_config_getrankbyname (hosts, "foo0", &rank) == 0
@@ -105,25 +106,25 @@ void test_parse (const char *dir)
        "boot_config_getrankbyname fails on unknown entry");
 
     ok (boot_config_getbindbyrank (hosts, &conf, 0, uri, sizeof (uri)) == 0
-        && !strcmp (uri, "tcp://en0:42"),
+        && streq (uri, "tcp://en0:42"),
         "boot_config_getbindbyrank 0 works with expected value");
     ok (boot_config_getbindbyrank (hosts, &conf, 1, uri, sizeof (uri)) == 0
-        && !strcmp (uri, "tcp://en0:42"),
+        && streq (uri, "tcp://en0:42"),
         "boot_config_getbindbyrank 1 works with expected value");
     ok (boot_config_getbindbyrank (hosts, &conf, 63, uri, sizeof (uri)) == 0
-        && !strcmp (uri, "tcp://en0:42"),
+        && streq (uri, "tcp://en0:42"),
         "boot_config_getbindbyrank 63 works with expected value");
     ok (boot_config_getbindbyrank (hosts, &conf, 64, uri, sizeof (uri))  < 0,
         "boot_config_getbindbyrank 64 fails");
 
     ok (boot_config_geturibyrank (hosts, &conf, 0, uri, sizeof (uri)) == 0
-        && !strcmp (uri, "tcp://xfoo0:42"),
+        && streq (uri, "tcp://xfoo0:42"),
         "boot_config_geturibyrank 0 works with expected value");
     ok (boot_config_geturibyrank (hosts, &conf, 1, uri, sizeof (uri)) == 0
-        && !strcmp (uri, "tcp://xfoo1:42"),
+        && streq (uri, "tcp://xfoo1:42"),
         "boot_config_geturibyrank 1 works with expected value");
     ok (boot_config_geturibyrank (hosts, &conf, 63, uri, sizeof (uri)) == 0
-        && !strcmp (uri, "tcp://xfoo63:42"),
+        && streq (uri, "tcp://xfoo63:42"),
         "boot_config_geturibyrank 63 works with expected value");
     ok (boot_config_geturibyrank (hosts, &conf, 64, uri, sizeof (uri))  < 0,
         "boot_config_geturibyrank 64 fails");
@@ -407,44 +408,44 @@ void test_format (void)
     char buf[MAX_URI + 1];
 
     ok (boot_config_format_uri (buf, sizeof (buf), "abcd", NULL, 0) == 0
-        && !strcmp (buf, "abcd"),
+        && streq (buf, "abcd"),
         "format: plain string copy works");
     ok (boot_config_format_uri (buf, sizeof (buf), "abcd:%p", NULL, 42) == 0
-        && !strcmp (buf, "abcd:42"),
+        && streq (buf, "abcd:42"),
         "format: %%p substitution works end string");
     ok (boot_config_format_uri (buf, sizeof (buf), "a%pb", NULL, 42) == 0
-        && !strcmp (buf, "a42b"),
+        && streq (buf, "a42b"),
         "format: %%p substitution works mid string");
     ok (boot_config_format_uri (buf, sizeof (buf), "%p:abcd", NULL, 42) == 0
-        && !strcmp (buf, "42:abcd"),
+        && streq (buf, "42:abcd"),
         "format: %%p substitution works begin string");
     ok (boot_config_format_uri (buf, sizeof (buf), "%h", NULL, 0) == 0
-        && !strcmp (buf, "%h"),
+        && streq (buf, "%h"),
         "format: %%h passes through when host=NULL");
     ok (boot_config_format_uri (buf, sizeof (buf), "%h", "foo", 0) == 0
-        && !strcmp (buf, "foo"),
+        && streq (buf, "foo"),
         "format: %%h substitution works");
     ok (boot_config_format_uri (buf, sizeof (buf), "%%", NULL, 0) == 0
-        && !strcmp (buf, "%"),
+        && streq (buf, "%"),
         "format: %%%% literal works");
     ok (boot_config_format_uri (buf, sizeof (buf), "a%X", NULL, 0) == 0
-        && !strcmp (buf, "a%X"),
+        && streq (buf, "a%X"),
         "format: unknown token passes through");
 
     ok (boot_config_format_uri (buf, 5, "abcd", NULL, 0) == 0
-        && !strcmp (buf, "abcd"),
+        && streq (buf, "abcd"),
         "format: copy abcd to buf[5] works");
     ok (boot_config_format_uri (buf, 4, "abcd", NULL, 0) < 0,
         "format: copy abcd to buf[4] fails");
 
     ok (boot_config_format_uri (buf, 5, "a%p", NULL, 123) == 0
-        && !strcmp (buf, "a123"),
+        && streq (buf, "a123"),
         "format: %%p substitution into exact size buf works");
     ok (boot_config_format_uri (buf, 4, "a%p", NULL, 123) < 0,
         "format: %%p substitution overflow detected");
 
     ok (boot_config_format_uri (buf, 5, "a%h", "abc", 0) == 0
-        && !strcmp (buf, "aabc"),
+        && streq (buf, "aabc"),
         "format: %%h substitution into exact size buf works");
     ok (boot_config_format_uri (buf, 4, "a%h", "abc", 0) < 0,
         "format: %%h substitution overflow detected");
@@ -515,7 +516,7 @@ void test_attr (const char *dir)
     ok (rc == 0,
         "boot_config_attr works on input hosts");
     ok (attr_get (attrs, "hostlist", &val, &flags) == 0
-        && !strcmp (val, "foo[0,4,1-3,5,14,6-9]")
+        && streq (val, "foo[0,4,1-3,5,14,6-9]")
         && flags == ATTR_IMMUTABLE,
         "attr_get returns correct value and flags");
 
@@ -543,7 +544,7 @@ void test_curve_cert (const char *dir)
 
     ok (boot_config_parse (cf, &conf, &hosts) == 0 && hosts == NULL,
         "boot_config_parse works with curve_cert");
-    ok (conf.curve_cert != NULL && !strcmp (conf.curve_cert, "meep"),
+    ok (conf.curve_cert != NULL && streq (conf.curve_cert, "meep"),
         "and curve_cert has expected value");
 
     if (unlink (path) < 0)
@@ -608,13 +609,13 @@ void test_dup_hosts (const char *dir)
     ok (hosts != NULL && json_array_size (hosts) == 128,
         "and post-processed hosts array has expected size");
     ok (json_unpack (json_array_get (hosts, 0), "{s:s}", "host", &host) == 0
-        && !strcmp (host, "test0"),
+        && streq (host, "test0"),
         "test0 has rank 0");
     ok (json_unpack (json_array_get (hosts, 65), "{s:s}", "host", &host) == 0
-        && !strcmp (host, "test65"),
+        && streq (host, "test65"),
         "test65 has rank 65");
     ok (json_unpack (json_array_get (hosts, 127), "{s:s}", "host", &host) == 0
-        && !strcmp (host, "test127"),
+        && streq (host, "test127"),
         "test127 has rank 127");
 
     if (unlink (path) < 0)

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -69,7 +69,7 @@ void check_attr (struct context *ctx, const char *k, const char *v)
 
     ok (attr_get (ctx->attrs, k, &val, NULL)  == 0
         && ((v == NULL && val == NULL)
-            || (v != NULL && val != NULL && !strcmp (v, val))),
+            || (v != NULL && val != NULL && streq (v, val))),
         "%s: %s=%s", ctx->name, k, v ? v : "NULL");
 }
 
@@ -303,7 +303,7 @@ void trio (flux_t *h)
     ok (overlay_set_parent_uri (ctx[1]->ov, parent_uri) == 0,
         "%s: overlay_set_parent_uri %s works", ctx[1]->name, parent_uri);
     tmp = overlay_get_parent_uri (ctx[1]->ov);
-    ok (tmp != NULL && !strcmp (tmp, parent_uri),
+    ok (tmp != NULL && streq (tmp, parent_uri),
         "%s: overlay_get_parent_uri returns same string", ctx[1]->name);
     ok (overlay_set_parent_pubkey (ctx[1]->ov, server_pubkey) == 0,
         "%s: overlay_set_parent_pubkey works", ctx[1]->name);
@@ -333,10 +333,10 @@ void trio (flux_t *h)
     ok (!flux_msg_is_local (rmsg),
         "%s: flux_msg_is_local fails on parent from child",
         ctx[1]->name);
-    ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "meep"),
+    ok (flux_msg_get_topic (rmsg, &topic) == 0 && streq (topic, "meep"),
         "%s: received message has expected topic", ctx[0]->name);
     ok ((sender = flux_msg_route_first (rmsg)) != NULL
-        && !strcmp (sender, ctx[1]->uuid),
+        && streq (sender, ctx[1]->uuid),
         "%s: received message sender is rank 1", ctx[0]->name);
 
     /* Send request 0->1
@@ -357,10 +357,10 @@ void trio (flux_t *h)
     ok (!flux_msg_is_local (rmsg),
         "%s: flux_msg_is_local fails on child from parent",
         ctx[1]->name);
-    ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "errr"),
+    ok (flux_msg_get_topic (rmsg, &topic) == 0 && streq (topic, "errr"),
         "%s: request has expected topic", ctx[1]->name);
     ok ((sender = flux_msg_route_first (rmsg)) != NULL
-        && !strcmp (sender, ctx[0]->uuid),
+        && streq (sender, ctx[0]->uuid),
         "%s: request sender is rank 0", ctx[1]->name);
 
     /* Response 1->0
@@ -378,7 +378,7 @@ void trio (flux_t *h)
         "%s: response was received by overlay", ctx[0]->name);
     ok (!flux_msg_is_local (rmsg),
         "%s: flux_msg_is_local returns false for response from child");
-    ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "m000"),
+    ok (flux_msg_get_topic (rmsg, &topic) == 0 && streq (topic, "m000"),
         "%s: received message has expected topic", ctx[0]->name);
     ok (flux_msg_route_count (rmsg) == 0,
         "%s: received message has no routes", ctx[0]->name);
@@ -394,7 +394,7 @@ void trio (flux_t *h)
     rmsg = recvmsg_timeout (ctx[0], 5);
     ok (rmsg != NULL,
         "%s: event was received by overlay", ctx[0]->name);
-    ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "eeek"),
+    ok (flux_msg_get_topic (rmsg, &topic) == 0 && streq (topic, "eeek"),
         "%s: received message has expected topic", ctx[0]->name);
     ok (!flux_msg_is_local (rmsg),
         "%s: flux_msg_is_local returns false for event from child");
@@ -412,7 +412,7 @@ void trio (flux_t *h)
     rmsg = recvmsg_timeout (ctx[1], 5);
     ok (msg != NULL,
         "%s: response was received by overlay", ctx[1]->name);
-    ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "moop"),
+    ok (flux_msg_get_topic (rmsg, &topic) == 0 && streq (topic, "moop"),
         "%s: response has expected topic", ctx[1]->name);
     ok (flux_msg_route_count (rmsg) == 0,
         "%s: response has no routes", ctx[1]->name);
@@ -428,7 +428,7 @@ void trio (flux_t *h)
     rmsg = recvmsg_timeout (ctx[1], 5);
     ok (rmsg != NULL,
         "%s: event was received by overlay", ctx[1]->name);
-    ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "eeeb"),
+    ok (flux_msg_get_topic (rmsg, &topic) == 0 && streq (topic, "eeeb"),
         "%s: received message has expected topic", ctx[1]->name);
 
     /* Cover some error code in overlay_bind() where the ZAP handler
@@ -559,10 +559,10 @@ void monitor_cb (struct overlay *ov, uint32_t rank, void *arg)
     const char *status = overlay_get_subtree_status (ov, rank);
     monitor_diag_cb (ov, rank, arg);
     if (overlay_parent_error (ov)
-        || !strcmp (status, "full")
-        || !strcmp (status, "partial")
-        || !strcmp (status, "lost")
-        || !strcmp (status, "offline"))
+        || streq (status, "full")
+        || streq (status, "partial")
+        || streq (status, "lost")
+        || streq (status, "offline"))
         flux_reactor_stop (flux_get_reactor (ctx->h));
 }
 

--- a/src/cmd/builtin/dump.c
+++ b/src/cmd/builtin/dump.c
@@ -24,6 +24,7 @@
 #include "src/common/libutil/fsd.h"
 #include "src/common/libutil/blobref.h"
 #include "src/common/libcontent/content.h"
+#include "ccan/str/str.h"
 
 #include "builtin.h"
 
@@ -62,7 +63,7 @@ static struct archive *dump_create (const char *outfile)
 
     if (!(ar = archive_write_new ()))
         log_msg_exit ("error creating libarchive write context");
-    if (!strcmp (outfile, "-")) {
+    if (streq (outfile, "-")) {
         if (archive_write_set_format_pax_restricted (ar) != ARCHIVE_OK
             || archive_write_open_FILE (ar, stdout) != ARCHIVE_OK)
             log_msg_exit ("%s", archive_error_string (ar));

--- a/src/cmd/builtin/help.c
+++ b/src/cmd/builtin/help.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 
 #include "src/common/libutil/setenvf.h"
+#include "ccan/str/str.h"
 #include "builtin.h"
 
 static int no_docs_set (optparse_t *p)
@@ -49,7 +50,7 @@ static int cmd_help (optparse_t *p, int ac, char *av[])
          *  O/w, assume user is asking for help on a flux command
          *   so prepend flux-
          */
-        if (strncmp (topic, "flux", 4) == 0)
+        if (strstarts (topic, "flux"))
             cmd = xasprintf ("man %s", topic);
         else
             cmd = xasprintf ("man flux-%s", topic);

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -21,6 +21,7 @@
 #include "src/common/libutil/fsd.h"
 #include "src/common/libhostlist/hostlist.h"
 #include "src/common/librlist/rlist.h"
+#include "ccan/str/str.h"
 
 #include "builtin.h"
 
@@ -514,7 +515,7 @@ static flux_future_t *health_rpc (struct status *ctx,
             flux_future_destroy (f);
             return NULL;
         }
-        if (!wait || strcmp (wait, status) == 0)
+        if (!wait || streq (wait, status))
             break;
         flux_future_reset (f);
     } while (1);
@@ -667,11 +668,11 @@ static bool show_all (struct status *ctx,
 static bool validate_wait (const char *wait)
 {
     if (wait
-        && strcmp (wait, "full") != 0
-        && strcmp (wait, "partial") != 0
-        && strcmp (wait, "degraded") != 0
-        && strcmp (wait, "lost") != 0
-        && strcmp (wait, "offline") != 0)
+        && !streq (wait, "full")
+        && !streq (wait, "partial")
+        && !streq (wait, "degraded")
+        && !streq (wait, "lost")
+        && !streq (wait, "offline"))
         return false;
     return true;
 }

--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -25,6 +25,7 @@
 #include "src/common/libutil/fsd.h"
 #include "src/common/libutil/blobref.h"
 #include "src/common/libcontent/content.h"
+#include "ccan/str/str.h"
 
 #include "builtin.h"
 
@@ -70,7 +71,7 @@ static struct archive *restore_create (const char *infile)
     if (archive_read_support_format_all (ar) != ARCHIVE_OK
         || archive_read_support_filter_all (ar) != ARCHIVE_OK)
         log_msg_exit ("%s", archive_error_string (ar));
-    if (!strcmp (infile, "-")) {
+    if (streq (infile, "-")) {
         if (archive_read_open_FILE (ar, stdin) != ARCHIVE_OK)
             log_msg_exit ("%s", archive_error_string (ar));
     }

--- a/src/cmd/builtin/startlog.c
+++ b/src/cmd/builtin/startlog.c
@@ -20,6 +20,7 @@
 #include "src/common/libkvs/treeobj.h"
 #include "src/common/libkvs/kvs_checkpoint.h"
 #include "src/common/libutil/fsd.h"
+#include "ccan/str/str.h"
 
 #include "builtin.h"
 
@@ -170,7 +171,7 @@ static void startlog_list (flux_t *h, optparse_t *p)
         if (startlog_parse_event (entry, &timestamp, &name, &context) < 0)
             continue; // ignore (but tolerate) non-conforming entries
         format_timestamp (timebuf, sizeof (timebuf), timestamp);
-        if (!strcmp (name, "start")) {
+        if (streq (name, "start")) {
             if (started) {
                 if (!quiet)
                     printf ("crashed\n");
@@ -186,7 +187,7 @@ static void startlog_list (flux_t *h, optparse_t *p)
             }
             started = true;
         }
-        else if (!strcmp (name, "finish")) {
+        else if (streq (name, "finish")) {
             if (started) {
                 fsd_format_duration_ex (fsd,
                                         sizeof (fsd),

--- a/src/cmd/builtin/uptime.c
+++ b/src/cmd/builtin/uptime.c
@@ -19,6 +19,7 @@
 
 #include "src/common/libidset/idset.h"
 #include "src/common/libutil/fsd.h"
+#include "ccan/str/str.h"
 
 #include "builtin.h"
 
@@ -281,7 +282,7 @@ static void default_summary (flux_t *h)
                                 "state", &broker_state,
                                 "duration", &duration) < 0)
         log_err_exit ("Error fetching broker state");
-    if (!strcmp (broker_state, "run")) {
+    if (streq (broker_state, "run")) {
         duration = t_now - attr_get_starttime (h);
         drained = resource_status_drained (h);
         offline = size - groups_get_count (h, "broker.online");

--- a/src/cmd/flux-R.c
+++ b/src/cmd/flux-R.c
@@ -30,6 +30,7 @@
 #include "src/common/librlist/rlist.h"
 #include "src/common/librlist/rhwloc.h"
 #include "src/common/libtomlc99/toml.h"
+#include "ccan/str/str.h"
 
 #define RSET_DOC "\
 Read, generate, and process RFC 20 Resource Set objects.\n\
@@ -350,7 +351,7 @@ static ssize_t fread_all (const char *path, char **bufp)
     ssize_t size;
     void *buf;
 
-    if (!strcmp (path, "-"))
+    if (streq (path, "-"))
         fd = STDIN_FILENO;
     else {
         if ((fd = open (path, O_RDONLY)) < 0)
@@ -771,9 +772,9 @@ int cmd_decode (optparse_t *p, int argc, char **argv)
     }
     if (optparse_getopt (p, "count", &type)) {
         int count;
-        if (strcmp (type, "node") == 0)
+        if (streq (type, "node"))
             count = rlist_nnodes (rl);
-        else if (strcmp (type, "core") == 0)
+        else if (streq (type, "core"))
             count = rl->avail;
         else
             count = rlist_count (rl, type);

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -19,6 +19,7 @@
 #include <flux/optparse.h>
 
 #include "src/common/libutil/log.h"
+#include "ccan/str/str.h"
 
 
 static int event_pub (optparse_t *p, int argc, char **argv);
@@ -65,7 +66,7 @@ static bool match_payload (const char *s1, const char *s2)
         return true;
     if (!s2 || !s1)
         return false;
-    return !strcmp (s1, s2);
+    return streq (s1, s2);
 }
 
 static bool match_payload_raw (const void *p1, int p1sz,

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -27,6 +27,7 @@
 #include "src/common/libutil/monotime.h"
 #include "src/common/libidset/idset.h"
 #include "src/common/libutil/log.h"
+#include "ccan/str/str.h"
 
 static struct optparse_option cmdopts[] = {
     { .name = "rank", .key = 'r', .has_arg = 1, .arginfo = "IDSET",
@@ -182,7 +183,7 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 
 void output_cb (flux_subprocess_t *p, const char *stream)
 {
-    FILE *fstream = !strcmp (stream, "stderr") ? stderr : stdout;
+    FILE *fstream = streq (stream, "stderr") ? stderr : stdout;
     const char *ptr;
     int lenp;
 
@@ -342,7 +343,7 @@ int main (int argc, char *argv[])
             log_err_exit ("get_current_dir_name");
     }
 
-    if (strcmp (cwd, "none") != 0) {
+    if (!streq (cwd, "none")) {
         if (flux_cmd_setcwd (cmd, cwd) < 0)
             log_err_exit ("flux_cmd_setcwd");
     }
@@ -357,7 +358,7 @@ int main (int argc, char *argv[])
         log_err_exit ("flux_get_size");
 
     if (optparse_getopt (opts, "rank", &optargp) > 0
-        && strcmp (optargp, "all")) {
+        && !streq (optargp, "all")) {
         if (!(ns = idset_decode (optargp)))
             log_err_exit ("idset_decode");
         if (!(rank_count = idset_count (ns)))

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -26,6 +26,7 @@
 #include "src/common/libutil/read_all.h"
 #include "src/common/libkvs/treeobj.h"
 #include "src/common/libeventlog/eventlog.h"
+#include "ccan/str/str.h"
 
 int cmd_namespace (optparse_t *p, int argc, char **argv);
 int cmd_get (optparse_t *p, int argc, char **argv);
@@ -865,7 +866,7 @@ int cmd_put (optparse_t *p, int argc, char **argv)
             int len;
             uint8_t *buf = NULL;
 
-            if (!strcmp (val, "-")) { // special handling for "--treeobj key=-"
+            if (streq (val, "-")) { // special handling for "--treeobj key=-"
                 if ((len = read_all (STDIN_FILENO, (void **)&buf)) < 0)
                     log_err_exit ("stdin");
                 val = (char *)buf;
@@ -881,7 +882,7 @@ int cmd_put (optparse_t *p, int argc, char **argv)
             if (optparse_hasopt (p, "append"))
                 put_flags |= FLUX_KVS_APPEND;
 
-            if (!strcmp (val, "-")) { // special handling for "--raw key=-"
+            if (streq (val, "-")) { // special handling for "--raw key=-"
                 if ((len = read_all (STDIN_FILENO, (void **)&buf)) < 0)
                     log_err_exit ("stdin");
                 val = (char *)buf;
@@ -2092,7 +2093,7 @@ void eventlog_wait_event_continuation (flux_future_t *f, void *arg)
         if (eventlog_entry_parse (value, NULL, &name, NULL) < 0)
             log_err_exit ("eventlog_entry_parse");
 
-        if (!strcmp (name, ctx->wait_event)) {
+        if (streq (name, ctx->wait_event)) {
             if (!optparse_hasopt (ctx->p, "quiet"))
                 eventlog_print (ctx->p, value);
             ctx->got_event = true;

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -390,7 +390,7 @@ char *lsmod_services_string (json_t *services, const char *skip, int maxcol)
 
     json_array_foreach (services, index, value) {
         const char *name = json_string_value (value);
-        if (name && (!skip || strcmp (name, skip) != 0))
+        if (name && (!skip || !streq (name, skip)))
             if (argz_add (&argz, &argz_len, name) != 0)
                 oom ();
     }
@@ -548,10 +548,12 @@ static void parse_json (optparse_t *p, const char *json_str)
      */
     scale = optparse_get_double (p, "scale", 1.0);
     typestr = optparse_get_str (p, "type", NULL);
-    if (json_typeof (o) == JSON_INTEGER || (typestr && !strcmp (typestr, "int"))) {
+    if (json_typeof (o) == JSON_INTEGER
+        || (typestr && streq (typestr, "int"))) {
         double d = json_number_value (o);
         printf ("%d\n", (int)(d * scale));
-    } else if (json_typeof (o) == JSON_REAL || (typestr && !strcmp (typestr, "double"))) {
+    } else if (json_typeof (o) == JSON_REAL
+        || (typestr && streq (typestr, "double"))) {
         double d = json_number_value (o);
         printf ("%lf\n", d * scale);
     } else {

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -22,6 +22,7 @@
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/tstat.h"
 #include "src/common/libutil/log.h"
+#include "ccan/str/str.h"
 
 struct ping_ctx {
     double interval;    /* interval between sends, in seconds */
@@ -137,7 +138,7 @@ void ping_continuation (flux_future_t *f, void *arg)
                       rank_bang_str (ctx->nodeid, rbuf, sizeof (rbuf)),
                       ctx->topic);
 
-    if (strcmp (ctx->pad, pad) != 0)
+    if (!streq (ctx->pad, pad))
         log_msg_exit ("%s%s: padding contents invalid",
                       rank_bang_str (ctx->nodeid, rbuf, sizeof (rbuf)),
                       ctx->topic);
@@ -225,12 +226,12 @@ int parse_nodeid (struct ping_ctx *ctx,
     int rank;
     char *endptr;
 
-    if (!strcmp (input, "any")) {
+    if (streq (input, "any")) {
         *nodeid = FLUX_NODEID_ANY;
         (*nodeidstr) = xasprintf ("%s", "any");
         return 0;
     }
-    if (!strcmp (input, "upstream")) {
+    if (streq (input, "upstream")) {
         *nodeid = FLUX_NODEID_UPSTREAM;
         (*nodeidstr) = xasprintf ("%s", "upstream");
         return 0;

--- a/src/common/libeventlog/Makefile.am
+++ b/src/common/libeventlog/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = libeventlog.la

--- a/src/common/libeventlog/eventlog.c
+++ b/src/common/libeventlog/eventlog.c
@@ -17,6 +17,7 @@
 #include <time.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "eventlog.h"
 
@@ -390,7 +391,7 @@ int eventlog_contains_event (const char *s, const char *name)
         json_t *c;
         if (eventlog_entry_parse (value, &t, &n, &c) < 0)
             goto out;
-        if (!strcmp (name, n)) {
+        if (streq (name, n)) {
             rv = 1;
             goto out;
         }

--- a/src/common/libeventlog/test/eventlog.c
+++ b/src/common/libeventlog/test/eventlog.c
@@ -14,6 +14,7 @@
 #include <stdbool.h>
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 #include "src/common/libeventlog/eventlog.h"
 
 void eventlog_entry_parsing (void)
@@ -62,7 +63,7 @@ void eventlog_entry_parsing (void)
 
     ok (eventlog_entry_parse (event, &timestamp, &name, &context) == 0
         && timestamp == 42.0
-        && !strcmp (name, "foo")
+        && streq (name, "foo")
         && !context,
         "eventlog_entry_parse on event w/o context works");
     json_decref (event);
@@ -77,12 +78,12 @@ void eventlog_entry_parsing (void)
 
     ok (eventlog_entry_parse (event, &timestamp, &name, &context) == 0
         && timestamp == 52.0
-        && !strcmp (name, "bar")
+        && streq (name, "bar")
         && context
         && json_is_object (context)
         && (jstr = json_object_get (context, "foo"))
         && (str = json_string_value (jstr))
-        && !strcmp (str, "bar"),
+        && streq (str, "bar"),
         "eventlog_entry_parse on event w/ context works");
     json_decref (event);
 }
@@ -172,7 +173,7 @@ void eventlog_decoding (void)
             "eventlog_decode input=\"%s\" success",
             printable (buf, goodevent[i]));
         s = eventlog_encode (o);
-        ok (s != NULL && !strcmp (s, goodevent[i]),
+        ok (s != NULL && streq (s, goodevent[i]),
             "eventlog_encode reversed it");
         json_decref (o);
         free (s);
@@ -184,7 +185,7 @@ void eventlog_decoding (void)
             "eventlog_decode input=\"%s\" success",
             printable (buf, goodlog[i]));
         s = eventlog_encode (o);
-        ok (s != NULL && !strcmp (s, goodlog[i]),
+        ok (s != NULL && streq (s, goodlog[i]),
             "eventlog_encode reversed it");
         json_decref (o);
         free (s);
@@ -289,9 +290,9 @@ void eventlog_entry_check (json_t *entry, double xtimestamp, const char *xname,
         context_str = json_dumps (context, JSON_COMPACT);
 
     ok ((xtimestamp == 0. || timestamp == xtimestamp)
-        && (!xname || !strcmp (name, xname))
+        && (!xname || streq (name, xname))
         && ((!xcontext && !context)
-            || (context_str && !strcmp (context_str, xcontext))),
+            || (context_str && streq (context_str, xcontext))),
         "eventlog_entry_parse time=%llu name=%s context=%s",
         (unsigned long long)xtimestamp, xname, xcontext);
 

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -16,7 +16,7 @@
 #include <stdarg.h>
 #include <jansson.h>
 
-#include "src/common/libccan/ccan/base64/base64.h"
+#include "ccan/base64/base64.h"
 
 #include "event.h"
 #include "rpc.h"

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -34,12 +34,12 @@
 #include <assert.h>
 #include <fnmatch.h>
 #include <inttypes.h>
-#include <czmq.h>
 #include <jansson.h>
 
 #include "src/common/libutil/aux.h"
 #include "src/common/libutil/errno_safe.h"
 #include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
 
 #include "message.h"
 
@@ -664,7 +664,7 @@ static bool isa_matchany (const char *s)
 {
     if (!s || strlen(s) == 0)
         return true;
-    if (!strcmp (s, "*"))
+    if (streq (s, "*"))
         return true;
     return false;
 }
@@ -697,7 +697,7 @@ bool flux_msg_cmp (const flux_msg_t *msg, struct flux_match match)
             if (fnmatch (match.topic_glob, topic, 0) != 0)
                 return false;
         } else {
-            if (strcmp (match.topic_glob, topic) != 0)
+            if (!streq (match.topic_glob, topic))
                 return false;
         }
     }
@@ -1455,7 +1455,7 @@ bool flux_msg_route_match_first (const flux_msg_t *msg1, const flux_msg_t *msg2)
 
     if (!id1 && !id2)
         return true;
-    if (id1 && id2 && strcmp (id1, id2) == 0)
+    if (id1 && id2 && streq (id1, id2))
         return true;
     return false;
 }

--- a/src/common/libflux/message_private.h
+++ b/src/common/libflux/message_private.h
@@ -14,11 +14,7 @@
 #include <stdint.h>
 #include <jansson.h>
 
-/* czmq and ccan both define streq */
-#ifdef streq
-#undef streq
-#endif
-#include "src/common/libccan/ccan/list/list.h"
+#include "ccan/list/list.h"
 
 #include "message_proto.h"
 

--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -26,6 +26,7 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/aux.h"
+#include "ccan/str/str.h"
 
 #include "plugin.h"
 
@@ -79,7 +80,7 @@ static const struct flux_plugin_handler * find_handler (flux_plugin_t *p,
 {
     struct flux_plugin_handler *h = zlistx_first (p->handlers);
     while (h) {
-        if (strcmp (h->topic, string) == 0)
+        if (streq (h->topic, string))
             return h;
         h = zlistx_next (p->handlers);
     }

--- a/src/common/libflux/test/attr.c
+++ b/src/common/libflux/test/attr.c
@@ -18,6 +18,7 @@
 #include "src/common/libtap/tap.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libtestutil/util.h"
+#include "ccan/str/str.h"
 
 struct entry {
     char *key;
@@ -44,7 +45,7 @@ static bool lookup_hardwired (const char *key, const char **val, int *flags)
 {
     int i;
     for (i = 0; hardwired[i].key != NULL; i++) {
-        if (!strcmp (hardwired[i].key, key)) {
+        if (streq (hardwired[i].key, key)) {
             if (val)
                 *val = hardwired[i].val;
             if (flags)
@@ -198,40 +199,40 @@ int main (int argc, char *argv[])
 
     get_count = 0;
     value = flux_attr_get (h, "foo");
-    ok (value && !strcmp (value, "bar") && get_count == 1,
+    ok (value && streq (value, "bar") && get_count == 1,
         "flux_attr_get foo=bar (with rpc)");
     value = flux_attr_get (h, "foo");
-    ok (value && !strcmp (value, "bar") && get_count == 2,
+    ok (value && streq (value, "bar") && get_count == 2,
         "flux_attr_get foo=bar (with 2nd rpc)");
 
     get_count = 0;
     value2 = flux_attr_get (h, "baz");
-    ok (value2 && !strcmp (value2, "meep") && get_count == 1,
+    ok (value2 && streq (value2, "meep") && get_count == 1,
         "flux_attr_get baz=meep (with rpc)");
     value2 = flux_attr_get (h, "baz");
-    ok (value2 && !strcmp (value2, "meep") && get_count == 2,
+    ok (value2 && streq (value2, "meep") && get_count == 2,
         "flux_attr_get baz=meep (with 2nd rpc)");
 
-    ok (value && !strcmp (value, "bar"),
+    ok (value && streq (value, "bar"),
         "const return value of flux_attr_get foo=bar still valid");
 
     /* get (cached) */
 
     get_count = 0;
     value = flux_attr_get (h, "cow");
-    ok (value && !strcmp (value, "moo") && get_count == 1,
+    ok (value && streq (value, "moo") && get_count == 1,
         "flux_attr_get cow=moo (with rpc)");
     get_count = 0;
     value = flux_attr_get (h, "chick");
-    ok (value && !strcmp (value, "peep") && get_count == 1,
+    ok (value && streq (value, "peep") && get_count == 1,
         "flux_attr_get chick=peep (with rpc)");
     get_count = 0;
     value = flux_attr_get (h, "cow");
-    ok (value && !strcmp (value, "moo") && get_count == 0,
+    ok (value && streq (value, "moo") && get_count == 0,
         "flux_attr_get cow=moo (cached)");
     get_count = 0;
     value = flux_attr_get (h, "chick");
-    ok (value && !strcmp (value, "peep") && get_count == 0,
+    ok (value && streq (value, "peep") && get_count == 0,
         "flux_attr_get chick=peep (cached)");
 
     /* cacheonly */
@@ -240,7 +241,7 @@ int main (int argc, char *argv[])
         "flux_attr_set_cacheonly fake=42");
     get_count = 0;
     value = flux_attr_get (h, "fake");
-    ok (value && !strcmp (value, "42") && get_count == 0,
+    ok (value && streq (value, "42") && get_count == 0,
         "flux_attr_get fake=42 (no rpc)");
 
     ok (flux_attr_set_cacheonly (h, "fake", NULL) == 0,
@@ -276,19 +277,19 @@ int main (int argc, char *argv[])
 
     /* test flux_get_hostbyrank () */
     ok ((value = flux_get_hostbyrank (NULL, 42)) != NULL
-        && !strcmp (value, "(null)"),
+        && streq (value, "(null)"),
         "flux_get_hostbyrank h=NULL returns (null)");
     ok ((value = flux_get_hostbyrank (h, FLUX_NODEID_ANY)) != NULL
-        && !strcmp (value, "any"),
+        && streq (value, "any"),
         "flux_get_hostbyrank FLUX_NODEID_ANY returns any");
     ok ((value = flux_get_hostbyrank (h, FLUX_NODEID_UPSTREAM)) != NULL
-        && !strcmp (value, "upstream"),
+        && streq (value, "upstream"),
         "flux_get_hostbyrank FLUX_NODEID_UPSTREAMreturns upstream");
     ok ((value = flux_get_hostbyrank (h, 2)) != NULL
-        && !strcmp (value, "foo2"),
+        && streq (value, "foo2"),
         "flux_get_hostbyrank 2 returns foo2");
     ok ((value = flux_get_hostbyrank (h, 3)) != NULL
-        && !strcmp (value, "(null)"),
+        && streq (value, "(null)"),
         "flux_get_hostbyrank 3 returns (null)");
 
     /* test flux_get_rankbyhost () */

--- a/src/common/libflux/test/composite_future.c
+++ b/src/common/libflux/test/composite_future.c
@@ -16,6 +16,7 @@
 #include "src/common/libflux/reactor.h"
 #include "src/common/libflux/future.h"
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 static bool init_and_fulfill_called = false;
 static bool init_no_fulfill_called = false;
@@ -73,18 +74,18 @@ static void test_composite_basic_any (flux_reactor_t *r, bool with_error)
         "flux_future_get_child (any, 'f1') == f1");
 
     s = flux_future_first_child (any);
-    ok ((s != NULL) && !strcmp (s, "f1"),
+    ok ((s != NULL) && streq (s, "f1"),
         "flux_future_first_child() == 'f1'");
 
     ok (flux_future_push (any, "f2", f2) == 0,
         "flux_future_push (any, 'f2', f2)");
 
     s = flux_future_first_child (any);
-    ok (s != NULL && (!strcmp (s, "f1") || !strcmp (s, "f2")),
+    ok (s != NULL && (streq (s, "f1") || streq (s, "f2")),
         "flux_future_first_child (any) returns one of two children");
     p = flux_future_next_child (any);
-    ok ((p != NULL) && (!strcmp (p, "f1") || !strcmp (p, "f2"))
-        && (strcmp (p, s) != 0),
+    ok ((p != NULL) && (streq (p, "f1") || streq (p, "f2"))
+        && (!streq (p, s)),
         "flux_future_next_child (any) returns different child (%s)", s);
     ok (flux_future_next_child (any) == NULL,
         "flux_future_next_child (any) == NULL signifies end of list");
@@ -135,7 +136,7 @@ static void test_composite_basic_all (flux_reactor_t *r, bool with_error)
         "flux_future_get_child (all, 'f1') == f1");
 
     s = flux_future_first_child (all);
-    ok ((s != NULL) && !strcmp (s, "f1"),
+    ok ((s != NULL) && streq (s, "f1"),
         "flux_future_first_child() == 'f1'");
 
     ok (flux_future_push (all, "f2", f2) == 0,

--- a/src/common/libflux/test/conf.c
+++ b/src/common/libflux/test/conf.c
@@ -26,6 +26,7 @@
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
+#include "ccan/str/str.h"
 
 const char *t1 = \
 "i = 1\n" \
@@ -87,7 +88,7 @@ void test_builtin (void)
     s3 = flux_conf_builtin_get ("shell_path", FLUX_CONF_AUTO);
     ok (s3 != NULL,
         "flux_conf_builtin_get shell_path AUTO works");
-    ok (s2 && s3 && !strcmp (s2, s3),
+    ok (s2 && s3 && streq (s2, s3),
         "AUTO returned INTREE value for test executable");
 
     errno = 0;
@@ -203,7 +204,7 @@ void test_basic (void)
         "unpacked double value");
     ok (b == true,
         "unpacked boolean value");
-    ok (s != NULL && !strcmp (s, "foo"),
+    ok (s != NULL && streq (s, "foo"),
         "unpacked string value");
 
     /* Check array contents
@@ -393,28 +394,28 @@ void test_globerr (void)
     memset (&error, 0, sizeof (error));
     conf_globerr (&error, "meep", GLOB_NOMATCH);
     ok (errno == ENOENT
-        && !strcmp (error.text, "meep: No match"),
+        && streq (error.text, "meep: No match"),
         "conf_globerr pat=meep rc=NOMATCH sets errno and error as expected");
 
     errno = 0;
     memset (&error, 0, sizeof (error));
     conf_globerr (&error, "moo", GLOB_NOSPACE);
     ok (errno == ENOMEM
-        && !strcmp (error.text, "moo: Out of memory"),
+        && streq (error.text, "moo: Out of memory"),
         "conf_globerr pat=moo rc=NOSPACE sets errno and error as expected");
 
     errno = 0;
     memset (&error, 0, sizeof (error));
     conf_globerr (&error, "foo", GLOB_ABORTED);
     ok (errno == EINVAL
-        && !strcmp (error.text, "foo: Read error"),
+        && streq (error.text, "foo: Read error"),
         "conf_globerr pat=moo rc=ABORTED sets errno and error as expected");
 
     errno = 0;
     memset (&error, 0, sizeof (error));
     conf_globerr (&error, "oops", 666);
     ok (errno == EINVAL
-        && !strcmp (error.text, "oops: Unknown glob error"),
+        && streq (error.text, "oops: Unknown glob error"),
         "conf_globerr pat=oops rc=666 sets errno and error as expected");
 }
 

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -14,6 +14,7 @@
 #include <flux/core.h>
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
+#include "ccan/str/str.h"
 
 void test_codec (void)
 {
@@ -41,7 +42,7 @@ void test_codec (void)
 
     topic = NULL;
     ok (flux_event_decode (msg, &topic, NULL) == 0
-        && topic != NULL && !strcmp (topic, "foo.bar"),
+        && topic != NULL && streq (topic, "foo.bar"),
         "flux_event_decode returns encoded topic");
     ok (flux_event_decode (msg, NULL, NULL) == 0,
         "flux_event_decode topic is optional");
@@ -56,7 +57,7 @@ void test_codec (void)
 
     s = NULL;
     ok (flux_event_decode (msg, NULL, &s) == 0
-        && s != NULL && !strcmp (s, json_str),
+        && s != NULL && streq (s, json_str),
         "flux_event_decode returns encoded payload");
     errno = 0;
     ok (flux_event_decode (msg, NULL, NULL) == 0,
@@ -69,7 +70,7 @@ void test_codec (void)
     i = 0;
     ok (flux_event_unpack (msg, &topic, "{s:i}", "foo", &i) == 0,
         "flux_event_unpack unpacked payload object");
-    ok (i == 42 && topic != NULL && !strcmp (topic, "foo.bar"),
+    ok (i == 42 && topic != NULL && streq (topic, "foo.bar"),
         "unpacked payload matched packed");
     flux_msg_destroy (msg);
 
@@ -80,7 +81,7 @@ void test_codec (void)
     l = 0;
     topic = NULL;
     ok (flux_event_decode_raw (msg, &topic, &d, &l) == 0
-        && topic != NULL && strcmp (topic, "foo.bar") == 0
+        && topic != NULL && streq (topic, "foo.bar")
         && d != NULL && len == len && memcmp (d, data, len) == 0,
         "flux_event_decode_raw returns encoded topic and payload");
     ok (flux_event_decode_raw (msg, NULL, &d, &l) == 0

--- a/src/common/libflux/test/handle.c
+++ b/src/common/libflux/test/handle.c
@@ -17,6 +17,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
+#include "ccan/str/str.h"
 
 /* Destructor for malloc'ed string.
  * Set flag so we know this was called when aux was destroyed.
@@ -120,7 +121,7 @@ int main (int argc, char *argv[])
         "flux_aux_get returns NULL on unknown key");
     flux_aux_set (h, "handletest::thing1", xstrdup ("hello"), aux_free);
     s = flux_aux_get (h, "handletest::thing1");
-    ok (s != NULL && !strcmp (s, "hello"),
+    ok (s != NULL && streq (s, "hello"),
         "flux_aux_get returns what was set");
     flux_aux_set (h, "handletest::thing1", NULL, NULL);
     ok (aux_destroyed,
@@ -169,7 +170,7 @@ int main (int argc, char *argv[])
        "flux_pollevents shows FLUX_POLLIN set on non-empty queue");
     ok ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL
         && flux_request_decode (msg, &topic, NULL) == 0
-        && !strcmp (topic, "foo"),
+        && streq (topic, "foo"),
         "flux_recv works and sent message was received");
     ok ((flux_pollevents (h) & FLUX_POLLIN) == 0,
        "flux_pollevents shows FLUX_POLLIN clear after queue is emptied");
@@ -195,12 +196,12 @@ int main (int argc, char *argv[])
        "flux_pollevents shows FLUX_POLLIN set after requeue");
     ok ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL
         && flux_request_decode (msg, &topic, NULL) == 0
-        && !strcmp (topic, "bar"),
+        && streq (topic, "bar"),
         "flux_recv got bar");
     flux_msg_destroy (msg);
     ok ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL
         && flux_request_decode (msg, &topic, NULL) == 0
-        && !strcmp (topic, "foo"),
+        && streq (topic, "foo"),
         "flux_recv got foo");
     flux_msg_destroy (msg);
     ok ((flux_pollevents (h) & FLUX_POLLIN) == 0,
@@ -221,12 +222,12 @@ int main (int argc, char *argv[])
        "flux_pollevents shows FLUX_POLLIN set after requeue");
     ok ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL
         && flux_request_decode (msg, &topic, NULL) == 0
-        && !strcmp (topic, "foo"),
+        && streq (topic, "foo"),
         "flux_recv got foo");
     flux_msg_destroy (msg);
     ok ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL
         && flux_request_decode (msg, &topic, NULL) == 0
-        && !strcmp (topic, "bar"),
+        && streq (topic, "bar"),
         "flux_recv got bar");
     flux_msg_destroy (msg);
     ok ((flux_pollevents (h) & FLUX_POLLIN) == 0,

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -22,6 +22,7 @@
 #include "src/common/libflux/message_proto.h"
 #include "src/common/libtap/tap.h"
 #include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
 
 static bool verbose = false;
 
@@ -577,7 +578,7 @@ void check_payload_json_formatted (void)
        "flux_msg_unpack object works");
     ok (strlen (flux_msg_last_error (msg)) == 0,
         "flux_msg_last_error is empty string after ok unpack");
-    ok (i == 42 && s != NULL && !strcmp (s, "baz"),
+    ok (i == 42 && s != NULL && streq (s, "baz"),
         "decoded content matches encoded content");
 
     /* reset payload */
@@ -587,14 +588,14 @@ void check_payload_json_formatted (void)
     s = NULL;
     ok (flux_msg_unpack (msg, "{s:i, s:s}", "foo", &i, "bar", &s) == 0,
        "flux_msg_unpack object works");
-    ok (i == 43 && s != NULL && !strcmp (s, "smurf"),
+    ok (i == 43 && s != NULL && streq (s, "smurf"),
         "decoded content matches new encoded content");
 
     i = 0;
     s = NULL;
     ok (flux_msg_unpack (msg, "{s:s, s:i}", "bar", &s, "foo", &i) == 0,
        "flux_msg_unpack object works out of order");
-    ok (i == 43 && s != NULL && !strcmp (s, "smurf"),
+    ok (i == 43 && s != NULL && streq (s, "smurf"),
         "decoded content matches new encoded content");
 
     ok (strlen (flux_msg_last_error (msg)) == 0,
@@ -966,7 +967,7 @@ void check_encode (void)
     free (buf);
     ok (flux_msg_get_type (msg2, &type) == 0 && type == FLUX_MSGTYPE_REQUEST,
         "decoded expected message type");
-    ok (flux_msg_get_topic (msg2, &topic) == 0 && !strcmp (topic, "foo.bar"),
+    ok (flux_msg_get_topic (msg2, &topic) == 0 && streq (topic, "foo.bar"),
         "decoded expected topic string");
     ok (flux_msg_has_payload (msg2) == false,
         "decoded expected (lack of) payload");
@@ -1041,7 +1042,7 @@ void check_copy (void)
              && flux_msg_get_payload (cpy, &cpybuf, &cpylen) == 0
              && cpylen == sizeof (buf) && memcmp (cpybuf, buf, cpylen) == 0
              && flux_msg_route_count (cpy) == 2
-             && flux_msg_get_topic (cpy, &topic) == 0 && !strcmp (topic,"foo"),
+             && flux_msg_get_topic (cpy, &topic) == 0 && streq (topic,"foo"),
         "copy is request: w/routes, topic, and payload");
 
     ok ((s = flux_msg_route_last (cpy)) != NULL,
@@ -1066,7 +1067,7 @@ void check_copy (void)
     ok (flux_msg_get_type (cpy, &type) == 0 && type == FLUX_MSGTYPE_REQUEST
              && !flux_msg_has_payload (cpy)
              && flux_msg_route_count (cpy) == 2
-             && flux_msg_get_topic (cpy, &topic) == 0 && !strcmp (topic,"foo"),
+             && flux_msg_get_topic (cpy, &topic) == 0 && streq (topic,"foo"),
         "copy is request: w/routes, topic, and no payload");
     flux_msg_destroy (cpy);
     flux_msg_destroy (msg);

--- a/src/common/libflux/test/panic.c
+++ b/src/common/libflux/test/panic.c
@@ -14,6 +14,7 @@
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
+#include "ccan/str/str.h"
 
 int main (int argc, char *argv[])
 {
@@ -41,9 +42,9 @@ int main (int argc, char *argv[])
     ok (flux_request_unpack (msg, &topic, "{s:s s:i}",
                              "reason", &reason, "flags", &flags) == 0,
         "flux_request_unpack worked on panic request");
-    ok (topic != NULL && !strcmp (topic, "broker.panic"),
+    ok (topic != NULL && streq (topic, "broker.panic"),
         "topic string is correct");
-    ok (!strcmp (reason, "fubar"),
+    ok (streq (reason, "fubar"),
         "reason is correct");
     ok (flags == 0,
         "flags is correct");

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -13,6 +13,7 @@
 
 #include "src/common/libflux/plugin.h"
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 
 /* function prototype for invalid args testing below */
@@ -281,9 +282,9 @@ int op1 (flux_plugin_t *p, const char *topic,
     int a, b;
     if (flux_plugin_arg_unpack (args, 0, "{s:i s:i}", "a", &a, "b", &b) < 0)
         return -1;
-    if (strcmp (topic, "op.add") == 0)
+    if (streq (topic, "op.add"))
         a += b;
-    else if (strcmp (topic, "op.multiply") == 0)
+    else if (streq (topic, "op.multiply"))
         a *= b;
     else {
         errno = ENOTSUP;
@@ -503,7 +504,7 @@ void test_uuid (void)
         BAIL_OUT ("flux_plugin_create failed");
     uuid = flux_plugin_get_uuid (p);
 
-    ok (uuid != NULL && strcmp (ouuid, uuid) != 0,
+    ok (uuid != NULL && !streq (ouuid, uuid),
         "second plugin instance has different uuid");
     flux_plugin_destroy (p);
     free (ouuid);

--- a/src/common/libflux/test/reactor_loop.c
+++ b/src/common/libflux/test/reactor_loop.c
@@ -20,6 +20,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
+#include "ccan/str/str.h"
 
 static int send_request (flux_t *h, const char *topic)
 {
@@ -41,7 +42,7 @@ static void multmatch1 (flux_t *h, flux_msg_handler_t *mh,
                         const flux_msg_t *msg, void *arg)
 {
     const char *topic;
-    if (flux_msg_get_topic (msg, &topic) < 0 || strcmp (topic, "foo.baz"))
+    if (flux_msg_get_topic (msg, &topic) < 0 || !streq (topic, "foo.baz"))
         flux_reactor_stop_error (flux_get_reactor (h));
     flux_msg_handler_stop (mh);
     multmatch_count++;
@@ -51,7 +52,7 @@ static void multmatch2 (flux_t *h, flux_msg_handler_t *mh,
                         const flux_msg_t *msg, void *arg)
 {
     const char *topic;
-    if (flux_msg_get_topic (msg, &topic) < 0 || strcmp (topic, "foo.bar"))
+    if (flux_msg_get_topic (msg, &topic) < 0 || !streq (topic, "foo.bar"))
         flux_reactor_stop_error (flux_get_reactor (h));
     flux_msg_handler_stop (mh);
     multmatch_count++;

--- a/src/common/libflux/test/request.c
+++ b/src/common/libflux/test/request.c
@@ -15,6 +15,7 @@
 #include "request.h"
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 int main (int argc, char *argv[])
 {
@@ -41,7 +42,7 @@ int main (int argc, char *argv[])
         "flux_request_encode works with NULL payload");
     topic = NULL;
     ok (flux_request_decode (msg, &topic, NULL) == 0
-        && topic != NULL && !strcmp (topic, "foo.bar"),
+        && topic != NULL && streq (topic, "foo.bar"),
         "flux_request_decode returns encoded topic");
     ok (flux_request_decode (msg, NULL, NULL) == 0,
         "flux_request_decode topic is optional");
@@ -56,12 +57,12 @@ int main (int argc, char *argv[])
 
     s = NULL;
     ok (flux_request_decode (msg, NULL, &s) == 0
-        && s != NULL && !strcmp (s, json_str),
+        && s != NULL && streq (s, json_str),
         "flux_request_decode returns encoded payload");
     topic = NULL;
     i = 0;
     ok (flux_request_unpack (msg, &topic, "{s:i}", "a", &i) == 0
-        && i == 42 && topic != NULL && !strcmp (topic, "foo.bar"),
+        && i == 42 && topic != NULL && streq (topic, "foo.bar"),
         "flux_request_unpack returns encoded payload");
 
     errno = 0;
@@ -74,7 +75,7 @@ int main (int argc, char *argv[])
         "flux_request_encode_raw works with NULL payload");
     topic = NULL;
     ok (flux_request_decode_raw (msg, &topic, &d, &l) == 0
-        && topic != NULL && !strcmp (topic, "foo.bar"),
+        && topic != NULL && streq (topic, "foo.bar"),
         "flux_request_decode_raw returns encoded topic");
     ok (flux_request_decode_raw (msg, NULL, &d, &l) == 0,
         "flux_request_decode_raw topic is optional");

--- a/src/common/libflux/test/response.c
+++ b/src/common/libflux/test/response.c
@@ -14,6 +14,7 @@
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
+#include "ccan/str/str.h"
 
 int main (int argc, char *argv[])
 {
@@ -45,7 +46,7 @@ int main (int argc, char *argv[])
 
     topic = NULL;
     ok (flux_response_decode (msg, &topic, NULL) == 0
-        && topic != NULL && !strcmp (topic, "foo.bar"),
+        && topic != NULL && streq (topic, "foo.bar"),
         "flux_response_decode returns encoded topic");
     ok (flux_response_decode (msg, NULL, NULL) == 0,
         "flux_response_decode topic is optional");
@@ -62,7 +63,7 @@ int main (int argc, char *argv[])
 
     topic = NULL;
     ok (flux_response_decode_raw (msg, &topic, &d, &l) == 0
-        && topic != NULL && !strcmp (topic, "foo.bar"),
+        && topic != NULL && streq (topic, "foo.bar"),
         "flux_response_decode_raw returns encoded topic");
     ok (flux_response_decode_raw (msg, NULL, &d, &l) == 0,
         "flux_response_decode_raw topic is optional");
@@ -81,7 +82,7 @@ int main (int argc, char *argv[])
 
     s = NULL;
     ok (flux_response_decode (msg, NULL, &s) == 0
-        && s != NULL && !strcmp (s, json_str),
+        && s != NULL && streq (s, json_str),
         "flux_response_decode returns encoded payload");
     ok (flux_response_decode (msg, NULL, NULL) == 0,
         "flux_response_decode works with payload but don't want the payload");
@@ -125,7 +126,7 @@ int main (int argc, char *argv[])
     ok (flux_response_decode (msg, NULL, NULL) < 0
         && errno == 42,
         "flux_response_decode fails with encoded errnum");
-    ok (flux_response_decode_error (msg, &s) == 0 && !strcmp (s, "My Error"),
+    ok (flux_response_decode_error (msg, &s) == 0 && streq (s, "My Error"),
         "flux_response_decode_error includes error message");
     flux_msg_destroy (msg);
 

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -17,6 +17,7 @@
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
 #include "src/common/libtestutil/util_rpc.h"
+#include "ccan/str/str.h"
 
 /* increment integer and send it back */
 void rpctest_incr_cb (flux_t *h, flux_msg_handler_t *mh,
@@ -307,7 +308,7 @@ void test_service (flux_t *h)
     ok (msg != NULL,
         "flux_recv matched response");
     rc = flux_msg_get_topic (msg, &topic);
-    ok (rc == 0 && !strcmp (topic, "rpctest.hello"),
+    ok (rc == 0 && streq (topic, "rpctest.hello"),
         "response has expected topic %s", topic);
     rc = flux_msg_get_matchtag (msg, &matchtag);
     ok (rc == 0 && matchtag == 1,
@@ -377,7 +378,7 @@ void test_error (flux_t *h)
     ok (flux_rpc_get (f, NULL) < 0 && errno == 69,
         "flux_rpc_get failed with expected errno");
     errstr = flux_future_error_string (f);
-    ok (errstr != NULL && !strcmp (errstr, "Hello world"),
+    ok (errstr != NULL && streq (errstr, "Hello world"),
         "flux_rpc_get_error returned expected error string");
     flux_future_destroy (f);
 
@@ -395,7 +396,7 @@ void test_error (flux_t *h)
     ok (flux_rpc_get (f, NULL) < 0 && errno == ENOTDIR,
         "flux_rpc_get failed with expected errno");
     errstr = flux_future_error_string (f);
-    ok (errstr != NULL && !strcmp (errstr, "Not a directory"),
+    ok (errstr != NULL && streq (errstr, "Not a directory"),
         "flux_future_error_string returned ENOTDIR strerror string");
     flux_future_destroy (f);
 }
@@ -455,7 +456,7 @@ void test_encoding (flux_t *h)
         "flux_rpc with payload when payload is expected works");
     json_str = NULL;
     ok (flux_rpc_get (r, &json_str) == 0
-        && json_str && !strcmp (json_str, "{}"),
+        && json_str && streq (json_str, "{}"),
         "flux_rpc_get works and returned expected payload");
     flux_future_destroy (r);
 
@@ -529,7 +530,7 @@ static void then_cb (flux_future_t *r, void *arg)
         "flux_future_wait_for works (ready) in continuation");
     json_str = NULL;
     ok (flux_rpc_get (r, &json_str) == 0
-        && json_str && !strcmp (json_str, "{}"),
+        && json_str && streq (json_str, "{}"),
         "flux_rpc_get works and returned expected payload in continuation");
     flux_reactor_stop (flux_get_reactor (h));
 }
@@ -553,7 +554,7 @@ void test_then (flux_t *h)
         "flux_rpc with payload when payload is expected works");
     json_str = NULL;
     ok (flux_rpc_get (r, &json_str) == 0
-        && json_str && !strcmp (json_str, "{}"),
+        && json_str && streq (json_str, "{}"),
         "flux_rpc_get works synchronously and returned expected payload");
     ok (flux_future_then (r, -1., then_cb, h) == 0,
         "flux_future_then works");
@@ -900,7 +901,7 @@ static int fake_server (flux_t *h, void *arg)
     while ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL) {
         const char *topic = "unknown";
         (void)flux_msg_get_topic (msg, &topic);
-        if (!strcmp (topic, "shutdown"))
+        if (streq (topic, "shutdown"))
             break;
         flux_msg_destroy (msg);
     }

--- a/src/common/libflux/test/rpc_chained.c
+++ b/src/common/libflux/test/rpc_chained.c
@@ -14,6 +14,7 @@
 #include <flux/core.h>
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
+#include "ccan/str/str.h"
 
 void rpctest_incr_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
@@ -300,7 +301,7 @@ void test_or_then (flux_t *h)
     cmp_ok (rc, "<", 0, "or-then: flux_future_get on composite returns < 0");
     cmp_ok (errno, "==", EPROTO, "or-then: errno is expected");
     errmsg = flux_future_error_string (f2);
-    ok (!strcmp (errmsg, "Protocol error"),
+    ok (streq (errmsg, "Protocol error"),
         "or-then: error string reported correctly");
     flux_future_destroy (f2);
 }
@@ -336,7 +337,7 @@ void test_or_then_error_string (flux_t *h)
     cmp_ok (rc, "<", 0, "or-then: flux_future_get on composite returns < 0");
     cmp_ok (errno, "==", EPROTO, "or-then: errno is expected");
     errmsg = flux_future_error_string (f2);
-    ok (!strcmp (errmsg, "my errstr"),
+    ok (streq (errmsg, "my errstr"),
         "or-then: error string reported correctly");
     flux_future_destroy (f2);
 }

--- a/src/common/libflux/test/version.c
+++ b/src/common/libflux/test/version.c
@@ -10,6 +10,7 @@
 
 #include "src/common/libflux/version.h"
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 #include <string.h>
 
@@ -30,7 +31,7 @@ int main (int argc, char *argv[])
 
     snprintf (vs, sizeof (vs), "%d.%d.%d", a,b,c);
     s = flux_core_version_string ();
-    ok (s != NULL && !strncmp (s, vs, strlen (vs)),
+    ok (s != NULL && strstarts (s, vs),
         "flux_core_version_string returned expected string");
     diag (s);
 

--- a/src/common/libidset/test/idset.c
+++ b/src/common/libidset/test/idset.c
@@ -20,6 +20,7 @@
 #include "src/common/libidset/idset.h"
 #include "src/common/libidset/idset_private.h"
 #include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
 
 struct inout {
     const char *in;
@@ -115,7 +116,7 @@ void test_codec (void)
                 "idset_decode '%s' works", ip->in);
             if (idset != NULL) {
                 char *s = idset_encode (idset, ip->flags);
-                bool match = (s && !strcmp (s, ip->out));
+                bool match = (s && streq (s, ip->out));
                 ok (match == true,
                     "idset_encode flags=0x%x '%s'->'%s' works",
                     ip->flags, ip->in, ip->out);
@@ -690,13 +691,13 @@ void test_format_first (void)
     char buf[64];
 
     ok (format_first (buf, sizeof (buf), "[]xyz", 42) == 0
-        && !strcmp (buf, "42xyz"),
+        && streq (buf, "42xyz"),
         "format_first works with leading idset");
     ok (format_first (buf, sizeof (buf), "abc[]xyz", 42) == 0
-        && !strcmp (buf, "abc42xyz"),
+        && streq (buf, "abc42xyz"),
         "format_first works with mid idset");
     ok (format_first (buf, sizeof (buf), "abc[]", 42) == 0
-        && !strcmp (buf, "abc42"),
+        && streq (buf, "abc42"),
         "format_first works with end idset");
 
     errno = 0;

--- a/src/common/libidset/test/idsetutil.c
+++ b/src/common/libidset/test/idsetutil.c
@@ -21,6 +21,7 @@
 
 #include "src/common/libidset/idset.h"
 #include "src/common/libutil/read_all.h"
+#include "ccan/str/str.h"
 
 
 int expand (int argc, char **argv)
@@ -74,7 +75,7 @@ void usage (void)
 
 int main (int argc, char *argv[])
 {
-    if (argc < 2 || strcmp (argv[1], "expand") != 0) {
+    if (argc < 2 || !streq (argv[1], "expand")) {
         fprintf (stderr, "Usage: isdetutil expand IDSET\n");
         return 1;
     }

--- a/src/common/libioencode/Makefile.am
+++ b/src/common/libioencode/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = \

--- a/src/common/libioencode/ioencode.c
+++ b/src/common/libioencode/ioencode.c
@@ -21,6 +21,7 @@
 
 #include "src/common/libccan/ccan/base64/base64.h"
 #include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
 
 #include "ioencode.h"
 
@@ -167,7 +168,7 @@ int iodecode (json_t *o,
         (*rankp) = rank;
     if (datap || lenp) {
         if (data) {
-            if (encoding && strcmp (encoding, "base64") == 0) {
+            if (encoding && streq (encoding, "base64")) {
                 if (decode_data_base64 (data, len, &bufp, &bin_len) < 0)
                     return -1;
             }

--- a/src/common/libioencode/test/ioencode.c
+++ b/src/common/libioencode/test/ioencode.c
@@ -13,6 +13,7 @@
 #include <jansson.h>
 #include <errno.h>
 
+#include "ccan/str/str.h"
 #include "src/common/libtap/tap.h"
 #include "src/common/libioencode/ioencode.h"
 
@@ -42,8 +43,8 @@ void basic (void)
         "ioencode success (data, eof = false)");
     ok (!iodecode (o, &stream, &rank, &data, &len, &eof),
         "iodecode success");
-    ok (!strcmp (stream, "stdout")
-        && !strcmp (rank, "1")
+    ok (streq (stream, "stdout")
+        && streq (rank, "1")
         && len == 3
         && !strncmp (data, "foo", len)
         && eof == false,
@@ -55,8 +56,8 @@ void basic (void)
         "ioencode success (data, eof = true)");
     ok (!iodecode (o, &stream, &rank, &data, &len, &eof),
         "iodecode success");
-    ok (!strcmp (stream, "stdout")
-        && !strcmp (rank, "[0-8]")
+    ok (streq (stream, "stdout")
+        && streq (rank, "[0-8]")
         && len == 3
         && !strncmp (data, "bar", len)
         && eof == true,
@@ -65,8 +66,8 @@ void basic (void)
 
     ok (iodecode (o, &stream, &rank, NULL, &len, &eof) == 0,
         "iodecode can be passed NULL data to query len");
-    ok (!strcmp (stream, "stdout")
-        && !strcmp (rank, "[0-8]")
+    ok (streq (stream, "stdout")
+        && streq (rank, "[0-8]")
         && len == 3
         && eof == true,
         "iodecode returned correct info");
@@ -76,8 +77,8 @@ void basic (void)
         "ioencode success (no data, eof = true)");
     ok (!iodecode (o, &stream, &rank, &data, &len, &eof),
         "iodecode success");
-    ok (!strcmp (stream, "stderr")
-        && !strcmp (rank, "[4,5]")
+    ok (streq (stream, "stderr")
+        && streq (rank, "[4,5]")
         && data == NULL
         && len == 0
         && eof == true,
@@ -86,8 +87,8 @@ void basic (void)
 
     ok (iodecode (o, &stream, &rank, NULL, &len, &eof) == 0,
         "iodecode can be passed NULL data to query len");
-    ok (!strcmp (stream, "stderr")
-        && !strcmp (rank, "[4,5]")
+    ok (streq (stream, "stderr")
+        && streq (rank, "[4,5]")
         && len == 0
         && eof == true,
         "iodecode returned correct info");

--- a/src/common/libjob/id.c
+++ b/src/common/libjob/id.c
@@ -16,6 +16,7 @@
 
 #include "job.h"
 
+#include "ccan/str/str.h"
 #include "src/common/libutil/fluid.h"
 
 int flux_job_id_parse (const char *s, flux_jobid_t *idp)
@@ -35,7 +36,7 @@ int flux_job_id_parse (const char *s, flux_jobid_t *idp)
     /*  Ignore any `job.` prefix. This allows a "kvs" encoding
      *   created by flux_job_id_encode(3) to properly decode.
      */
-    if (strncmp (p, "job.", 4) == 0)
+    if (strstarts (p, "job."))
         p += 4;
     return fluid_parse (p, idp);
 }

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
 	$(JANSSON_CFLAGS)
 

--- a/src/common/libkvs/kvs_dir.c
+++ b/src/common/libkvs/kvs_dir.c
@@ -18,6 +18,7 @@
 #include <flux/core.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "kvs_dir_private.h"
 #include "treeobj.h"
@@ -203,7 +204,7 @@ char *flux_kvsdir_key_at (const flux_kvsdir_t *dir, const char *name)
     char *s;
     int len;
 
-    if (!strcmp (dir->key, ".")) {
+    if (streq (dir->key, ".")) {
         if (!(s = strdup (name)))
             goto nomem;
     }

--- a/src/common/libkvs/test/kvs_dir.c
+++ b/src/common/libkvs/test/kvs_dir.c
@@ -24,6 +24,7 @@
 #include "src/common/libflux/flux.h"
 #include "kvs_dir.h"
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 void jdiag (json_t *o)
 {
@@ -91,10 +92,10 @@ void test_empty (void)
         "flux_kvsdir_issymlink on nonexistent key returns false");
 
     key = flux_kvsdir_key (dir);
-    ok (key != NULL && !strcmp (key, "foo"),
+    ok (key != NULL && streq (key, "foo"),
         "flux_kvsdir_key returns the key we put in");
     keyat = flux_kvsdir_key_at (dir, "a.b.c");
-    ok (keyat != NULL && !strcmp (keyat, "foo.a.b.c"),
+    ok (keyat != NULL && streq (keyat, "foo.a.b.c"),
         "flux_kvsdir_key_at a.b.c returns foo.a.b.c");
     free (keyat);
     ok (flux_kvsdir_handle (dir) == NULL,

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -21,6 +21,7 @@
 #include "treeobj.h"
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 void jdiag (json_t *o)
 {
@@ -107,7 +108,7 @@ int check_string_value (json_t *dirent, const char *expected)
         json_decref (val);
         return -1;
     }
-    if (strcmp (expected, s) != 0) {
+    if (!streq (expected, s)) {
         diag ("%s: expected %s received %s", __FUNCTION__, expected, s);
         json_decref (val);
         return -1;
@@ -193,7 +194,7 @@ void basic (void)
         "1: retrieved");
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "1: txn_decode_op works");
-    ok (!strcmp (key, "foo.bar.baz")
+    ok (streq (key, "foo.bar.baz")
         && flags == FLUX_KVS_APPEND
         && check_int_value (dirent, 42) == 0,
         "1: put foo.bar.baz = 42");
@@ -203,7 +204,7 @@ void basic (void)
     jdiag (entry);
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "2: txn_decode_op works");
-    ok (!strcmp (key, "foo.bar.bleep")
+    ok (streq (key, "foo.bar.bleep")
         && flags == 0
         && check_string_value (dirent, "foo") == 0,
         "2: put foo.bar.baz = \"foo\"");
@@ -213,7 +214,7 @@ void basic (void)
     jdiag (entry);
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "3: txn_decode_op works");
-    ok (!strcmp (key, "a")
+    ok (streq (key, "a")
         && flags == 0
         && json_is_null (dirent),
         "3: unlink a");
@@ -223,7 +224,7 @@ void basic (void)
     jdiag (entry);
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "4: txn_decode_op works");
-    ok (!strcmp (key, "b.b.b")
+    ok (streq (key, "b.b.b")
         && flags == 0
         && treeobj_is_dir (dirent) && treeobj_get_count (dirent) == 0,
         "4: mkdir b.b.b");
@@ -233,12 +234,12 @@ void basic (void)
     jdiag (entry);
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "5: txn_decode_op works");
-    ok (!strcmp (key, "c.c.c")
+    ok (streq (key, "c.c.c")
         && flags == 0
         && treeobj_is_symlink (dirent)
         && !json_object_get (treeobj_get_data (dirent),
                              "namespace")
-        && !strcmp (json_string_value (json_object_get (treeobj_get_data (dirent),
+        && streq (json_string_value (json_object_get (treeobj_get_data (dirent),
                                                         "target")),
                     "b.b.b"),
         "5: symlink c.c.c b.b.b (no namespace)");
@@ -248,7 +249,7 @@ void basic (void)
     jdiag (entry);
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "6: txn_decode_op works");
-    ok (!strcmp (key, "d.d.d")
+    ok (streq (key, "d.d.d")
         && flags == 0
         && check_int_value (dirent, 43) == 0,
         "6: put foo.bar.baz = 43");
@@ -258,7 +259,7 @@ void basic (void)
     jdiag (entry);
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "7: txn_decode_op works");
-    ok (!strcmp (key, "e")
+    ok (streq (key, "e")
         && flags == 0
         && json_is_null (dirent),
         "7: unlink e");
@@ -268,7 +269,7 @@ void basic (void)
     jdiag (entry);
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "8: txn_decode_op works");
-    ok (!strcmp (key, "nerrrrb")
+    ok (streq (key, "nerrrrb")
         && flags == 0
         && check_null_value (dirent) == 0,
         "8: put nerrrrb = NULL");
@@ -278,14 +279,14 @@ void basic (void)
     jdiag (entry);
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "9: txn_decode_op works");
-    ok (!strcmp (key, "f.f.f")
+    ok (streq (key, "f.f.f")
         && flags == 0
-        && !strcmp (json_string_value (json_object_get (treeobj_get_data (dirent),
-                                                        "namespace")),
-                    "g.g.g")
-        && !strcmp (json_string_value (json_object_get (treeobj_get_data (dirent),
-                                                        "target")),
-                    "h.h.h"),
+        && streq (json_string_value (json_object_get (treeobj_get_data (dirent),
+                                                      "namespace")),
+                  "g.g.g")
+        && streq (json_string_value (json_object_get (treeobj_get_data (dirent),
+                                                      "target")),
+                  "h.h.h"),
         "9: symlink f.f.f g.g.g h.h.h (namespace)");
 
     errno = 0;

--- a/src/common/libkvs/test/kvs_txn_compact.c
+++ b/src/common/libkvs/test/kvs_txn_compact.c
@@ -21,6 +21,7 @@
 #include "treeobj.h"
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 /* Decode a 'val' containing base64 encoded emptiness.
  */
@@ -114,7 +115,7 @@ int main (int argc, char *argv[])
         "1: retrieved");
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "1: txn_decode_op works");
-    ok (!strcmp (key, "foo")
+    ok (streq (key, "foo")
         && flags == FLUX_KVS_APPEND
         && check_raw_value (dirent, "ABC", 3) == 0,
         "1: consolidated foo = ABC");
@@ -152,7 +153,7 @@ int main (int argc, char *argv[])
         "1: retrieved");
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "1: txn_decode_op works");
-    ok (!strcmp (key, "foo")
+    ok (streq (key, "foo")
         && flags == FLUX_KVS_APPEND
         && check_raw_value (dirent, "AC", 2) == 0,
         "1: consolidated foo = AC");
@@ -161,7 +162,7 @@ int main (int argc, char *argv[])
         "2: retrieved");
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "2: txn_decode_op works");
-    ok (!strcmp (key, "bar")
+    ok (streq (key, "bar")
         && flags == FLUX_KVS_APPEND
         && check_raw_value (dirent, "B", 1) == 0,
         "2: bar = B");
@@ -202,7 +203,7 @@ int main (int argc, char *argv[])
         "1: retrieved");
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "1: txn_decode_op works");
-    ok (!strcmp (key, "foo")
+    ok (streq (key, "foo")
         && flags == FLUX_KVS_APPEND
         && check_raw_value (dirent, "AC", 2) == 0,
         "1: consolidated foo = AC");
@@ -211,7 +212,7 @@ int main (int argc, char *argv[])
         "2: retrieved");
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "2: txn_decode_op works");
-    ok (!strcmp (key, "bar")
+    ok (streq (key, "bar")
         && flags == FLUX_KVS_APPEND
         && check_raw_value (dirent, "BD", 2) == 0,
         "2: bar = BD");
@@ -249,7 +250,7 @@ int main (int argc, char *argv[])
         "1: retrieved");
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "1: txn_decode_op works");
-    ok (!strcmp (key, "foo")
+    ok (streq (key, "foo")
         && flags == 0
         && check_raw_value (dirent, "A", 1) == 0,
         "1: consolidated foo = A");
@@ -258,7 +259,7 @@ int main (int argc, char *argv[])
         "2: retrieved");
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "2: txn_decode_op works");
-    ok (!strcmp (key, "foo")
+    ok (streq (key, "foo")
         && flags == FLUX_KVS_APPEND
         && check_raw_value (dirent, "BC", 2) == 0,
         "2: foo = BC");
@@ -315,7 +316,7 @@ int main (int argc, char *argv[])
         "1: retrieved");
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "1: txn_decode_op works");
-    ok (!strcmp (key, "foo")
+    ok (streq (key, "foo")
         && flags == FLUX_KVS_APPEND
         && check_raw_value (dirent, "A", 1) == 0,
         "1: consolidated foo = A");
@@ -353,7 +354,7 @@ int main (int argc, char *argv[])
         "1: retrieved");
     ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
         "1: txn_decode_op works");
-    ok (!strcmp (key, "foo")
+    ok (streq (key, "foo")
         && flags == FLUX_KVS_APPEND
         && check_null_value (dirent) == 0,
         "1: consolidated foo = A");

--- a/src/common/libkvs/test/kvs_util.c
+++ b/src/common/libkvs/test/kvs_util.c
@@ -17,6 +17,7 @@
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libkvs/kvs_util_private.h"
+#include "ccan/str/str.h"
 
 void kvs_util_normalize_key_path_tests (void)
 {
@@ -24,42 +25,42 @@ void kvs_util_normalize_key_path_tests (void)
     bool dirflag;
 
     s = kvs_util_normalize_key ("a.b.c..d.e", &dirflag);
-    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == false,
+    ok (s != NULL && streq (s, "a.b.c.d.e") && dirflag == false,
         "kvs_util_normalize_key transforms consecutive path separators to one");
     free (s);
 
     s = kvs_util_normalize_key (".a.b.c.d.e", &dirflag);
-    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == false,
+    ok (s != NULL && streq (s, "a.b.c.d.e") && dirflag == false,
         "kvs_util_normalize_key drops one leading path separator");
     free (s);
 
     s = kvs_util_normalize_key ("....a.b.c.d.e", &dirflag);
-    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == false,
+    ok (s != NULL && streq (s, "a.b.c.d.e") && dirflag == false,
         "kvs_util_normalize_key drops several leading path separators");
     free (s);
 
     s = kvs_util_normalize_key ("a.b.c.d.e.", &dirflag);
-    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == true,
+    ok (s != NULL && streq (s, "a.b.c.d.e") && dirflag == true,
         "kvs_util_normalize_key drops one trailing path separator");
     free (s);
 
     s = kvs_util_normalize_key ("a.b.c.d.e.....", &dirflag);
-    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == true,
+    ok (s != NULL && streq (s, "a.b.c.d.e") && dirflag == true,
         "kvs_util_normalize_key drops several trailing path separators");
     free (s);
 
     s = kvs_util_normalize_key (".a....b.c.....d..e.....", &dirflag);
-    ok (s != NULL && !strcmp (s, "a.b.c.d.e") && dirflag == true,
+    ok (s != NULL && streq (s, "a.b.c.d.e") && dirflag == true,
         "kvs_util_normalize_key fixes a big mess");
     free (s);
 
     s = kvs_util_normalize_key (".", &dirflag);
-    ok (s != NULL && !strcmp (s, "."),
+    ok (s != NULL && streq (s, "."),
         "kvs_util_normalize_key leaves one standalone separator as is");
     free (s);
 
     s = kvs_util_normalize_key ("....", &dirflag);
-    ok (s != NULL && !strcmp (s, "."),
+    ok (s != NULL && streq (s, "."),
         "kvs_util_normalize_key transforms several standalone separators to one");
     free (s);
 }

--- a/src/common/libkvs/test/treeobj.c
+++ b/src/common/libkvs/test/treeobj.c
@@ -17,6 +17,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/sha1.h"
 #include "src/common/libutil/blobref.h"
+#include "ccan/str/str.h"
 
 const int large_dir_entries = 5000;
 json_t *create_large_dir (void)
@@ -83,7 +84,7 @@ void test_codec (void)
     p = treeobj_encode (cpy1);
     ok (p != NULL,
         "re-encoded %d-entry dir", large_dir_entries);
-    ok (strcmp (p, s) == 0,
+    ok (streq (p, s),
         "and they match");
     free (p);
 
@@ -126,17 +127,17 @@ void test_valref (void)
     ok (treeobj_get_count (valref) == 1,
         "treeobj_get_count returns 1");
     blobref = treeobj_get_blobref (valref, 0);
-    ok (blobref != NULL && !strcmp (blobref, blobrefs[0]),
+    ok (blobref != NULL && streq (blobref, blobrefs[0]),
         "treeobj_get_blobref [0] returns expected blobref");
     ok (treeobj_append_blobref (valref, blobrefs[1]) == 0,
         "treeobj_append_blobref works on 2nd blobref");
     ok (treeobj_get_count (valref) == 2,
         "treeobj_get_count returns 1");
     blobref = treeobj_get_blobref (valref, 0);
-    ok (blobref != NULL && !strcmp (blobref, blobrefs[0]),
+    ok (blobref != NULL && streq (blobref, blobrefs[0]),
         "treeobj_get_blobref [0] still returns expected blobref");
     blobref = treeobj_get_blobref (valref, 1);
-    ok (blobref != NULL && !strcmp (blobref, blobrefs[1]),
+    ok (blobref != NULL && streq (blobref, blobrefs[1]),
         "treeobj_get_blobref [1] returns expected blobref");
     diag_json (valref);
     json_decref (valref);
@@ -148,7 +149,7 @@ void test_valref (void)
     ok (treeobj_get_count (valref) == 1,
         "treeobj_get_count returns 1");
     blobref = treeobj_get_blobref (valref, 0);
-    ok (blobref != NULL && !strcmp (blobref, blobrefs[0]),
+    ok (blobref != NULL && streq (blobref, blobrefs[0]),
         "treeobj_get_blobref [0] returns expected blobref");
     diag_json (valref);
     json_decref (valref);
@@ -165,7 +166,7 @@ void test_valref (void)
     blobref = treeobj_get_blobref (valref, 0);
     for (i = 1; i < 4; i++) {
         blobref2 = treeobj_get_blobref (valref, i);
-        if (!blobref || !blobref2 || strcmp (blobref, blobref2) != 0)
+        if (!blobref || !blobref2 || !streq (blobref, blobref2))
             break;
     }
     ok (i == 4,
@@ -254,17 +255,17 @@ void test_dirref (void)
     ok (treeobj_get_count (dirref) == 1,
         "treeobj_get_count returns 1");
     blobref = treeobj_get_blobref (dirref, 0);
-    ok (blobref != NULL && !strcmp (blobref, blobrefs[0]),
+    ok (blobref != NULL && streq (blobref, blobrefs[0]),
         "treeobj_get_blobref [0] returns expected blobref");
     ok (treeobj_append_blobref (dirref, blobrefs[1]) == 0,
         "treeobj_append_blobref works on 2nd blobref");
     ok (treeobj_get_count (dirref) == 2,
         "treeobj_get_count returns 1");
     blobref = treeobj_get_blobref (dirref, 0);
-    ok (blobref != NULL && !strcmp (blobref, blobrefs[0]),
+    ok (blobref != NULL && streq (blobref, blobrefs[0]),
         "treeobj_get_blobref [0] still returns expected blobref");
     blobref = treeobj_get_blobref (dirref, 1);
-    ok (blobref != NULL && !strcmp (blobref, blobrefs[1]),
+    ok (blobref != NULL && streq (blobref, blobrefs[1]),
         "treeobj_get_blobref [1] returns expected blobref");
     diag_json (dirref);
     json_decref (dirref);
@@ -276,7 +277,7 @@ void test_dirref (void)
     ok (treeobj_get_count (dirref) == 1,
         "treeobj_get_count returns 1");
     blobref = treeobj_get_blobref (dirref, 0);
-    ok (blobref != NULL && !strcmp (blobref, blobrefs[0]),
+    ok (blobref != NULL && streq (blobref, blobrefs[0]),
         "treeobj_get_blobref [0] returns expected blobref");
 
     diag_json (dirref);
@@ -686,7 +687,7 @@ void test_symlink (void)
         "treeobj_get_symlink works on symlink without namespace");
     ok (ns_str == NULL,
         "treeobj_get_symlink returns NULL for namespace");
-    ok (!strcmp (target_str, "a.b.c"),
+    ok (streq (target_str, "a.b.c"),
         "treeobj_get_symlink returns correct string for target");
 
     json_decref (o);
@@ -701,9 +702,9 @@ void test_symlink (void)
         "treeobj_get_data returned string");
     ok (treeobj_get_symlink (o, &ns_str, &target_str) == 0,
         "treeobj_get_symlink works on symlink with namespace");
-    ok (!strcmp (ns_str, "ns"),
+    ok (streq (ns_str, "ns"),
         "treeobj_get_symlink returns correct string for namespace");
-    ok (!strcmp (target_str, "d.e.f"),
+    ok (streq (target_str, "d.e.f"),
         "treeobj_get_symlink returns correct string for target");
 
     json_decref (o);

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -22,6 +22,7 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/fsd.h"
+#include "ccan/str/str.h"
 
 #include "optparse.h"
 #include "getopt.h"
@@ -170,9 +171,9 @@ static int option_info_cmp (void *arg1, void *arg2)
             return (-1);
         else if (y->isdoc)
             return (1);
-        else if (strcmp (o1->name, "help") == 0)
+        else if (streq (o1->name, "help"))
             return -1;
-        else if (strcmp (o2->name, "help") == 0)
+        else if (streq (o2->name, "help"))
             return 1;
         else if (isalnum (o1->key) && isalnum (o2->key))
             return (o1->key - o2->key);
@@ -217,7 +218,7 @@ static struct option_info *find_option_info (optparse_t *p, const char *name)
     o = zlist_first (p->option_list);
     while (o) {
         if (o->p_opt->name != NULL
-            && strcmp (o->p_opt->name, name) == 0)
+            && streq (o->p_opt->name, name))
             return o;
         o = zlist_next (p->option_list);
     }

--- a/src/common/libpmi/pmi2.c
+++ b/src/common/libpmi/pmi2.c
@@ -49,6 +49,8 @@
 #include <sys/types.h>
 #include <string.h>
 
+#include "ccan/str/str.h"
+
 #include "pmi.h"
 #include "pmi2.h"
 #include "pmi_strerror.h"
@@ -341,7 +343,7 @@ int PMI2_Info_GetJobAttr (const char name[],
         result = PMI2_ERR_INVALID_ARG;
         goto error;
     }
-    if (!strcmp (name, "PMI_process_mapping")) {
+    if (streq (name, "PMI_process_mapping")) {
         const char *kvsname;
 
         result = get_cached_kvsname (pmi_global_ctx, &kvsname);
@@ -355,7 +357,7 @@ int PMI2_Info_GetJobAttr (const char name[],
         if (result != PMI2_SUCCESS)
             goto error;
     }
-    else if (!strcmp (name, "universeSize")) {
+    else if (streq (name, "universeSize")) {
         int universe_size;
 
         result = pmi_simple_client_get_universe_size (pmi_global_ctx,

--- a/src/common/libpmi/simple_server.c
+++ b/src/common/libpmi/simple_server.c
@@ -74,6 +74,7 @@
 #include <sys/param.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "simple_server.h"
 #include "keyval.h"
@@ -219,7 +220,7 @@ int pmi_simple_server_request (struct pmi_simple_server *pmi,
 
     /* spawn continuation (unimplemented) */
     if (cli->mcmd_started) {
-        if (strcmp (buf, "endcmd\n") != 0)
+        if (!streq (buf, "endcmd\n"))
             goto out_noresponse; // ignore protocol between mcmd and endcmd
         snprintf (resp, sizeof (resp), "cmd=spawn_result rc=-1\n");
         cli->mcmd_started = false;

--- a/src/common/libpmi/test/canonical.c
+++ b/src/common/libpmi/test/canonical.c
@@ -17,6 +17,7 @@
 #include "src/common/libpmi/dgetline.h"
 #include "src/common/libpmi/pmi.h"
 #include "src/common/libflux/reactor.h"
+#include "ccan/str/str.h"
 
 #include "src/common/libtap/tap.h"
 
@@ -274,7 +275,7 @@ int main (int argc, char *argv[])
         "PMI_KVS_Get length=-1 fails with PMI_ERR_INVALID_ARG");
 
     result = PMI_KVS_Get (kvsname, "foo", val, vallen_max);
-    ok (result == PMI_SUCCESS && !strcmp (val, "bar"),
+    ok (result == PMI_SUCCESS && streq (val, "bar"),
         "PMI_KVS_Get works and got expected value");
 
     /* clique
@@ -377,11 +378,11 @@ int main (int argc, char *argv[])
         "PMI_Get_id_length_max works and set idlen to kvsname_max");
 
     result = PMI_Get_id (buf, sizeof (buf));
-    ok (result == PMI_SUCCESS && !strcmp (buf, kvsname),
+    ok (result == PMI_SUCCESS && streq (buf, kvsname),
         "PMI_Get_id works and set buf to kvsname");
 
     result = PMI_Get_kvs_domain_id (buf, sizeof (buf));
-    ok (result == PMI_SUCCESS && !strcmp (buf, kvsname),
+    ok (result == PMI_SUCCESS && streq (buf, kvsname),
         "PMI_Get_kvs_domain_id works and set buf to kvsname");
 
     /* finalize

--- a/src/common/libpmi/test/canonical2.c
+++ b/src/common/libpmi/test/canonical2.c
@@ -17,6 +17,7 @@
 #include "src/common/libpmi/dgetline.h"
 #include "src/common/libpmi/pmi2.h"
 #include "src/common/libflux/reactor.h"
+#include "ccan/str/str.h"
 
 #include "src/common/libtap/tap.h"
 
@@ -124,13 +125,13 @@ int main (int argc, char *argv[])
                                    val,
                                    sizeof (val),
                                    &found);
-    ok (result == PMI2_SUCCESS && found != 0 && !strcmp (val, "1"),
+    ok (result == PMI2_SUCCESS && found != 0 && streq (val, "1"),
        "PMI2_Info_GetJobAttr PMI_process_mapping works and found != 0");
 
     jobid[0] = '\0';
     result = PMI2_Job_GetId (jobid, sizeof (jobid));
     ok (result == PMI2_SUCCESS
-        && !strcmp (jobid, "bleepgorp"),
+        && streq (jobid, "bleepgorp"),
         "PMI2_Job_GetId works");
 
     /* Exchange node scope data
@@ -143,14 +144,14 @@ int main (int argc, char *argv[])
     result = PMI2_Info_GetNodeAttr ("attr1", val, sizeof (val), &found, 0);
     ok (result == PMI2_SUCCESS
         && found == 1
-        && strcmp (val, "xyz") == 0,
+        && streq (val, "xyz"),
         "PMI2_Info_GetNodeAttr name=attr1 works");
 
     found = 42;
     result = PMI2_Info_GetNodeAttr ("attr1", val, sizeof (val), &found, 1);
     ok (result == PMI2_SUCCESS
         && found == 1
-        && strcmp (val, "xyz") == 0,
+        && streq (val, "xyz"),
         "PMI2_Info_GetNodeAttr name=attr1 waitfor=1 works");
 
     found = 42;
@@ -211,7 +212,7 @@ int main (int argc, char *argv[])
 
     result = PMI2_KVS_Get (jobid, 0, "foo", val, sizeof (val), &vallen);
     ok (result == PMI2_SUCCESS
-        && !strcmp (val, "bar")
+        && streq (val, "bar")
         && vallen == strlen (val),
         "PMI2_KVS_Get works and got expected value");
 

--- a/src/common/libpmi/test/keyval.c
+++ b/src/common/libpmi/test/keyval.c
@@ -10,6 +10,7 @@
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libpmi/keyval.h"
+#include "ccan/str/str.h"
 
 #include <string.h>
 #include <ctype.h>
@@ -88,18 +89,18 @@ int main(int argc, char** argv)
     plan (NO_PLAN);
 
     ok (keyval_parse_word (valid[0], "key1", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "val1"),
+        && streq (val, "val1"),
         "keyval_parse_word parsed the first key");
     ok (keyval_parse_word (valid[1], "key1", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "val1"),
+        && streq (val, "val1"),
         "keyval_parse_word parsed the first word, ignoring trailing space");
     ok (keyval_parse_word (valid[2], "key1", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "val1"),
+        && streq (val, "val1"),
         "keyval_parse_word parsed the first word, ignoring trailing newline");
     ok (keyval_parse_word (valid[2], "noexist", val, sizeof (val)) == EKV_NOKEY,
         "keyval_parse_word failed on nonexistent key");
     ok (keyval_parse_word (valid[3], "key2", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "val2"),
+        && streq (val, "val2"),
         "keyval_parse_word parsed the second key");
     ok (keyval_parse_uint (valid[4], "key3", &ui) == EKV_SUCCESS && ui == 42,
         "keyval_parse_uint worked");
@@ -108,13 +109,13 @@ int main(int argc, char** argv)
     ok (keyval_parse_int (valid[5], "key4", &i) == EKV_SUCCESS && i == -42,
         "keyval_parse_int worked on negative integer");
     ok (keyval_parse_word (valid[6], "key5", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "foo=bar"),
+        && streq (val, "foo=bar"),
         "keyval_parse_word handled value containing an equals");
     ok (keyval_parse_word (valid[6], "key6", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "baz"),
+        && streq (val, "baz"),
         "keyval_parse_word parsed word following value containing an equals");
     ok (keyval_parse_string (valid[7], "key7", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "x y z="),
+        && streq (val, "x y z="),
         "keyval_parse_string parsed string containing space and equals");
     ok (keyval_parse_int (valid[8], "key1", &i) == EKV_SUCCESS && i == 42,
         "keyval_parse_int parsed int not followed by white space");
@@ -125,181 +126,181 @@ int main(int argc, char** argv)
      */
 
     ok (keyval_parse_word (pmi[0], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "init")
+        && streq (val, "init")
         && keyval_parse_uint (pmi[0], "pmi_version", &ui) == EKV_SUCCESS && ui == 1
         && keyval_parse_uint (pmi[0], "pmi_subversion", &ui) == EKV_SUCCESS && ui == 1,
         "parsed pmi-1 init request");
     ok (keyval_parse_word (pmi[1], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "response_to_init")
+        && streq (val, "response_to_init")
         && keyval_parse_int (pmi[1], "rc", &i) == EKV_SUCCESS && i == 0
         && keyval_parse_uint (pmi[1], "pmi_version", &ui) == EKV_SUCCESS && ui == 1
         && keyval_parse_uint (pmi[1], "pmi_subversion", &ui) == EKV_SUCCESS && ui == 1,
         "parsed pmi-1 init response");
     ok (keyval_parse_word (pmi[2], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "get_maxes"),
+        && streq (val, "get_maxes"),
         "parsed pmi-1 maxes request");
     ok (keyval_parse_word (pmi[3], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "maxes")
+        && streq (val, "maxes")
         && keyval_parse_int (pmi[3], "rc", &i) == EKV_SUCCESS && i == 0
         && keyval_parse_uint (pmi[3], "kvsname_max", &ui) == EKV_SUCCESS && ui == 256
         && keyval_parse_uint (pmi[3], "keylen_max", &ui) == EKV_SUCCESS && ui == 256
         && keyval_parse_uint (pmi[3], "vallen_max", &ui) == EKV_SUCCESS && ui == 256,
         "parsed pmi-1 maxes response");
     ok (keyval_parse_word (pmi[4], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "get_universe_size"),
+        && streq (val, "get_universe_size"),
         "parsed pmi-1 universe_size request");
     ok (keyval_parse_word (pmi[5], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "universe_size")
+        && streq (val, "universe_size")
         && keyval_parse_int (pmi[5], "rc", &i) == EKV_SUCCESS && i == 0
         && keyval_parse_uint (pmi[5], "size", &ui) == EKV_SUCCESS && ui == 2,
         "parsed pmi-1 universe_size response");
     ok (keyval_parse_word (pmi[6], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "get_appnum"),
+        && streq (val, "get_appnum"),
         "parsed pmi-1 appnum request");
     ok (keyval_parse_word (pmi[7], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "appnum")
+        && streq (val, "appnum")
         && keyval_parse_int (pmi[7], "rc", &i) == EKV_SUCCESS && i == 0
         && keyval_parse_int (pmi[7], "appnum", &i) == EKV_SUCCESS && i == 0,
         "parsed pmi-1 appnum response");
     ok (keyval_parse_word (pmi[8], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "barrier_in"),
+        && streq (val, "barrier_in"),
         "parsed pmi-1 barrier request");
     ok (keyval_parse_word (pmi[9], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "barrier_out")
+        && streq (val, "barrier_out")
         && keyval_parse_int (pmi[9], "rc", &i) == EKV_SUCCESS && i == 0,
         "parsed pmi-1 barrier response");
     ok (keyval_parse_word (pmi[10], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "finalize"),
+        && streq (val, "finalize"),
         "parsed pmi-1 finalize request");
     ok (keyval_parse_word (pmi[11], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "finalize_ack")
+        && streq (val, "finalize_ack")
         && keyval_parse_int (pmi[11], "rc", &i) == EKV_SUCCESS && i == 0,
         "parsed pmi-1 finalize response");
     ok (keyval_parse_word (pmi[12], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "get_my_kvsname"),
+        && streq (val, "get_my_kvsname"),
         "parsed pmi-1 kvsname request");
     ok (keyval_parse_word (pmi[13], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "my_kvsname")
+        && streq (val, "my_kvsname")
         && keyval_parse_int (pmi[13], "rc", &i) == EKV_SUCCESS && i == 0
         && keyval_parse_word (pmi[13], "kvsname", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "lwj.1.pmi"),
+        && streq (val, "lwj.1.pmi"),
         "parsed pmi-1 kvsname response");
     ok (keyval_parse_word (pmi[14], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "put")
+        && streq (val, "put")
         && keyval_parse_word (pmi[14], "kvsname", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "lwj.1.pmi")
+        && streq (val, "lwj.1.pmi")
         && keyval_parse_word (pmi[14], "key", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "PM")
+        && streq (val, "PM")
         && keyval_parse_string (pmi[14], "value", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "/dev/shm/mpich_shar_tmpYbGKbb"),
+        && streq (val, "/dev/shm/mpich_shar_tmpYbGKbb"),
         "parsed pmi-1 put request");
     ok (keyval_parse_word (pmi[15], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "put_result")
+        && streq (val, "put_result")
         && keyval_parse_int (pmi[15], "rc", &i) == 0 && i == EKV_SUCCESS
         && keyval_parse_string (pmi[15], "msg", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "success"),
+        && streq (val, "success"),
         "parsed pmi-1 put response");
     ok (keyval_parse_word (pmi[16], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "get")
+        && streq (val, "get")
         && keyval_parse_word (pmi[16], "kvsname", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "lwj.1.pmi")
+        && streq (val, "lwj.1.pmi")
         && keyval_parse_word (pmi[16], "key", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "sh"),
+        && streq (val, "sh"),
         "parsed pmi-1 get request");
     ok (keyval_parse_word (pmi[17], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "get_result")
+        && streq (val, "get_result")
         && keyval_parse_int (pmi[17], "rc", &i) == EKV_SUCCESS && i == 0
         && keyval_parse_word (pmi[17], "msg", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "success")
+        && streq (val, "success")
         && keyval_parse_string (pmi[17], "value", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "/dev/shm/mpich_shar_tmpYbGKbb"),
+        && streq (val, "/dev/shm/mpich_shar_tmpYbGKbb"),
         "parsed pmi-1 get response");
     ok (keyval_parse_word (pmi[18], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "publish_name")
+        && streq (val, "publish_name")
         && keyval_parse_word (pmi[18], "service", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "zz")
+        && streq (val, "zz")
         && keyval_parse_word (pmi[18], "port", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "merp42"),
+        && streq (val, "merp42"),
         "parsed pmi-1 publish request");
     ok (keyval_parse_word (pmi[19], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "publish_result")
+        && streq (val, "publish_result")
         && keyval_parse_int (pmi[19], "rc", &i) == EKV_SUCCESS && i == 0
         && keyval_parse_word (pmi[19], "info", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "ok"),
+        && streq (val, "ok"),
         "parsed pmi-1 publish response");
     ok (keyval_parse_word (pmi[20], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "lookup_name")
+        && streq (val, "lookup_name")
         && keyval_parse_word (pmi[20], "service", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "zz"),
+        && streq (val, "zz"),
         "parsed pmi-1 lookup request");
     ok (keyval_parse_word (pmi[21], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "lookup_result")
+        && streq (val, "lookup_result")
         && keyval_parse_int (pmi[21], "rc", &i) == EKV_SUCCESS && i == 0
         && keyval_parse_word (pmi[21], "info", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "ok")
+        && streq (val, "ok")
         && keyval_parse_word (pmi[21], "port", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "merp42"),
+        && streq (val, "merp42"),
         "parsed pmi-1 lookup response");
     ok (keyval_parse_word (pmi[22], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "unpublish_name")
+        && streq (val, "unpublish_name")
         && keyval_parse_word (pmi[22], "service", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "zz"),
+        && streq (val, "zz"),
         "parsed pmi-1 unpublish request");
     ok (keyval_parse_word (pmi[23], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "unpublish_result")
+        && streq (val, "unpublish_result")
         && keyval_parse_int (pmi[23], "rc", &i) == EKV_SUCCESS && i == 0
         && keyval_parse_word (pmi[23], "info", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "ok"),
+        && streq (val, "ok"),
         "parsed pmi-1 unpublish response");
 
     ok (keyval_parse_word (spawn[0], "mcmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "spawn"),
+        && streq (val, "spawn"),
         "parsed pmi-1 spawn mcmd request");
     ok (keyval_parse_uint (spawn[1], "nprocs", &ui) == EKV_SUCCESS && ui == 2,
         "parsed pmi-1 spawn nprocs request");
     ok (keyval_parse_word (spawn[2], "execname", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "workprog"),
+        && streq (val, "workprog"),
         "parsed pmi-1 spawn execname request");
     ok (keyval_parse_uint (spawn[3], "totspawns", &ui) == EKV_SUCCESS && ui == 2,
         "parsed pmi-1 spawn totspawns request");
     ok (keyval_parse_uint (spawn[4], "spawnssofar", &ui) == EKV_SUCCESS && ui == 0,
         "parsed pmi-1 spawn spawnssofar request");
     ok (keyval_parse_word (spawn[5], "arg0", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "workprog"),
+        && streq (val, "workprog"),
         "parsed pmi-1 spawn arg0 request");
     ok (keyval_parse_word (spawn[6], "arg1", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "--do-something=yes"),
+        && streq (val, "--do-something=yes"),
         "parsed pmi-1 spawn arg1 request");
     ok (keyval_parse_word (spawn[7], "arg2", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "-X"),
+        && streq (val, "-X"),
         "parsed pmi-1 spawn arg2 request");
     ok (keyval_parse_word (spawn[8], "arg3", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "inputdeck"),
+        && streq (val, "inputdeck"),
         "parsed pmi-1 spawn arg3 request");
     ok (keyval_parse_uint (spawn[9], "argcnt", &ui) == EKV_SUCCESS && ui == 4,
         "parsed pmi-1 spawn argcnt request");
     ok (keyval_parse_uint (spawn[10], "preput_num", &ui) == EKV_SUCCESS && ui == 1,
         "parsed pmi-1 spawn preput_num request");
     ok (keyval_parse_word (spawn[11], "preput_key_0", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "foo"),
+        && streq (val, "foo"),
         "parsed pmi-1 spawn preput_key_0 request");
     ok (keyval_parse_word (spawn[12], "preput_val_0", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "bar"),
+        && streq (val, "bar"),
         "parsed pmi-1 spawn preput_val_0 request");
     ok (keyval_parse_uint (spawn[13], "info_num", &ui) == EKV_SUCCESS && ui == 1,
         "parsed pmi-1 spawn info_num request");
     ok (keyval_parse_word (spawn[14], "info_key_0", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "baz"),
+        && streq (val, "baz"),
         "parsed pmi-1 spawn info_key_0 request");
     ok (keyval_parse_word (spawn[15], "info_val_0", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "zurn"),
+        && streq (val, "zurn"),
         "parsed pmi-1 spawn info_val_0 request");
-    /* skip endcmd - we'll just strcmp that one */
+    /* skip endcmd - we'll just streq that one */
     ok (keyval_parse_word (spawn[17], "cmd", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "spawn_result")
+        && streq (val, "spawn_result")
         && keyval_parse_int (spawn[17], "rc", &i) == EKV_SUCCESS && i == 0
         && keyval_parse_word (spawn[17], "errcodes", val, sizeof (val)) == EKV_SUCCESS
-        && !strcmp (val, "0,0"),
+        && streq (val, "0,0"),
         "parsed pmi-1 spawn response");
 
     done_testing();

--- a/src/common/libpmi/test/kvstest.c
+++ b/src/common/libpmi/test/kvstest.c
@@ -22,6 +22,7 @@
 #include "src/common/libutil/monotime.h"
 #include "src/common/libpmi/pmi.h"
 #include "src/common/libpmi/pmi_strerror.h"
+#include "ccan/str/str.h"
 
 #define OPTIONS "nN:"
 static const struct option longopts[] = {
@@ -123,7 +124,7 @@ int main(int argc, char *argv[])
                 if (e != PMI_SUCCESS)
                     log_msg_exit ("%d: PMI_KVS_Get: %s", rank, pmi_strerror (e));
                 snprintf (val2, val_len, "sandwich.%d.%d", j, i);
-                if (strcmp (val, val2) != 0)
+                if (!streq (val, val2))
                     log_msg_exit ("%d: PMI_KVS_Get: exp %s got %s\n",
                              rank, val2, val);
             }
@@ -135,7 +136,7 @@ int main(int argc, char *argv[])
                 log_msg_exit ("%d: PMI_KVS_Get: %s", rank, pmi_strerror (e));
             snprintf (val2, val_len, "sandwich.%d.%d",
                       rank > 0 ? rank - 1 : size - 1, i);
-            if (strcmp (val, val2) != 0)
+            if (!streq (val, val2))
                 log_msg_exit ("%d: PMI_KVS_Get: exp %s got %s\n", rank, val2, val);
         }
     }

--- a/src/common/libpmi/test/kvstest2.c
+++ b/src/common/libpmi/test/kvstest2.c
@@ -20,6 +20,7 @@
 #include "src/common/libutil/log.h"
 #include "src/common/libpmi/pmi2.h"
 #include "src/common/libpmi/pmi_strerror.h"
+#include "ccan/str/str.h"
 
 /* We don't have a pmi2_strerror() but the codes are mostly the same as PMI-1
  */
@@ -117,7 +118,7 @@ int main(int argc, char *argv[])
     if (e != PMI2_SUCCESS)
         log_msg_exit ("%d: PMI2_Info_GetNodeAttr %s: %s",
                       rank, key, pmi2_strerror (e));
-    if (strcmp (attr, expected_attr) != 0)
+    if (!streq (attr, expected_attr))
         log_msg_exit ("%d: PMI_Info_GetNodeAttr %s: exp %s got %s\n",
                       rank, key, expected_val, val);
 
@@ -141,7 +142,7 @@ int main(int argc, char *argv[])
             log_msg_exit ("%d: PMI2_KVS_Get: %s", rank, pmi2_strerror (e));
         snprintf (expected_val, sizeof (expected_val), "val-%d.%d",
                   rank > 0 ? rank - 1 : size - 1, i);
-        if (strcmp (val, expected_val) != 0)
+        if (!streq (val, expected_val))
             log_msg_exit ("%d: PMI_KVS_Get: exp %s got %s\n",
                           rank, expected_val, val);
         if (length != strlen (val))

--- a/src/common/libpmi/test/simple.c
+++ b/src/common/libpmi/test/simple.c
@@ -19,6 +19,7 @@
 #include "src/common/libpmi/keyval.h"
 #include "src/common/libpmi/pmi.h"
 #include "src/common/libflux/reactor.h"
+#include "ccan/str/str.h"
 
 #include "src/common/libtap/tap.h"
 
@@ -200,7 +201,7 @@ int main (int argc, char *argv[])
     val = xzmalloc (cli->vallen_max);
     ok (pmi_simple_client_kvs_get (cli, name, "foo",
                                    val, cli->vallen_max) == PMI_SUCCESS
-        && !strcmp (val, "bar"),
+        && streq (val, "bar"),
         "pmi_simple_client_kvs_get foo OK, val=%s", val);
 
     /* put long=... / get long
@@ -213,7 +214,7 @@ int main (int argc, char *argv[])
     ok (pmi_simple_client_kvs_get (cli, name, "long",
                                    val, cli->vallen_max) == PMI_SUCCESS
         && strnlen (val2, cli->vallen_max) < cli->vallen_max
-        && strcmp (val, val2) == 0,
+        && streq (val, val2),
         "pmi_simple_client_kvs_get long OK, val=xxx...");
 
     /* put: value too long

--- a/src/common/libpmi/test/upmi.c
+++ b/src/common/libpmi/test/upmi.c
@@ -15,6 +15,7 @@
 #include <string.h>
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 #include "src/common/libpmi/upmi.h"
 
 void diag_trace (void *arg, const char *text)
@@ -157,7 +158,7 @@ void test_env (void)
                         &error);
     if (!upmi)
         diag ("%s", error.text);
-    ok (upmi != NULL && !strcmp (upmi_describe (upmi), "singlex"),
+    ok (upmi != NULL && streq (upmi_describe (upmi), "singlex"),
         "upmi_create respects FLUX_PMI_CLIENT_METHODS order");
     upmi_destroy (upmi);
 

--- a/src/common/libpmi/upmi.c
+++ b/src/common/libpmi/upmi.c
@@ -201,7 +201,7 @@ static bool match_scheme (const char *scheme, const char *uri)
     size_t slen = strlen (scheme);
     if (slen < strlen (uri)
         && uri[slen] == ':'
-        && strncmp (uri, scheme, slen) == 0)
+        && strstarts (uri, scheme))
             return true;
     return streq (uri, scheme);
 }

--- a/src/common/libpmi/upmi_libpmi2.c
+++ b/src/common/libpmi/upmi_libpmi2.c
@@ -271,9 +271,8 @@ static int op_get (flux_plugin_t *p,
      * employed by Flux to launch Flux.
      */
     else if ((ctx->flags & LIBPMI2_IS_CRAY_CRAY)
-        && (!strncmp (key, "flux.", 5))) {
+        && (strstarts (key, "flux.")))
         result = PMI2_ERR_INVALID_KEY;
-    }
     else {
         result = ctx->kvs_get (NULL,            // this job's key-value space
                                PMI2_ID_NULL,    // no hints for you

--- a/src/common/librlist/match.c
+++ b/src/common/librlist/match.c
@@ -198,7 +198,7 @@ static bool rnode_has (const struct rnode *n, const char *property)
     }
 
     if ((n->properties && zhashx_lookup (n->properties, prop))
-        || strcmp (n->hostname, prop) == 0)
+        || streq (n->hostname, prop))
         match = true;
 
     return negate ? !match : match;

--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -14,6 +14,8 @@
 
 #include <flux/idset.h>
 
+#include "ccan/str/str.h"
+
 #include "rhwloc.h"
 
 /*  Common hwloc_topology_init() and flags for Flux hwloc usage:
@@ -161,9 +163,9 @@ out:
 static bool backend_is_coproc (const char *s)
 {
     /* Only count cudaX, openclX, and rmsiX devices for now */
-    return (strcmp (s, "CUDA") == 0
-            || strcmp (s, "OpenCL") == 0
-            || strcmp (s, "RSMI") == 0);
+    return (streq (s, "CUDA")
+            || streq (s, "OpenCL")
+            || streq (s, "RSMI"));
 }
 
 char * rhwloc_gpu_idset_string (hwloc_topology_t topo)

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -23,6 +23,7 @@
 #include "src/common/libhostlist/hostlist.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/errprintf.h"
+#include "ccan/str/str.h"
 
 #include "rnode.h"
 #include "match.h"
@@ -442,7 +443,7 @@ struct rnode * rlist_find_host (const struct rlist *rl, const char *host)
 {
     struct rnode *n = zlistx_first (rl->nodes);
     while (n) {
-        if (n->hostname && strcmp (n->hostname, host) == 0)
+        if (n->hostname && streq (n->hostname, host))
             return n;
         n = zlistx_next (rl->nodes);
     }
@@ -700,9 +701,9 @@ static int rnode_namecmp (const void *s1, const void *s2)
     const char *a = s1;
     const char *b = s2;
 
-    if (strcmp (a, "core") == 0)
+    if (streq (a, "core"))
         return -1;
-    else if (strcmp (b, "core") == 0)
+    else if (streq (b, "core"))
         return 1;
     else return strcmp (a, b);
 }
@@ -1492,7 +1493,7 @@ static int rlist_idset_set_by_host (const struct rlist *rl,
     int count = 0;
     struct rnode *n = zlistx_first (rl->nodes);
     while (n) {
-        if (n->hostname && strcmp (n->hostname, host) == 0) {
+        if (n->hostname && streq (n->hostname, host)) {
             if (idset_set (ids, n->rank) < 0)
                 return -1;
             count++;
@@ -2046,11 +2047,11 @@ static struct rlist *rlist_try_alloc (struct rlist *rl,
 
     if (ai->nnodes > 0)
         result = rlist_alloc_nnodes (rl, ai);
-    else if (mode == NULL || strcmp (mode, "worst-fit") == 0)
+    else if (mode == NULL || streq (mode, "worst-fit"))
         result = rlist_alloc_worst_fit (rl, ai->slot_size, ai->nslots);
-    else if (mode && strcmp (mode, "best-fit") == 0)
+    else if (mode && streq (mode, "best-fit"))
         result = rlist_alloc_best_fit (rl, ai->slot_size, ai->nslots);
-    else if (mode && strcmp (mode, "first-fit") == 0)
+    else if (mode && streq (mode, "first-fit"))
         result = rlist_alloc_first_fit (rl, ai->slot_size, ai->nslots);
     else
         errno = EINVAL;
@@ -2330,7 +2331,7 @@ static int rlist_mark_state (struct rlist *rl, bool up, const char *ids)
 int rlist_mark_down (struct rlist *rl, const char *ids)
 {
     int count;
-    if (strcmp (ids, "all") == 0)
+    if (streq (ids, "all"))
         count = rlist_mark_all (rl, false);
     else
         count = rlist_mark_state (rl, false, ids);
@@ -2341,7 +2342,7 @@ int rlist_mark_down (struct rlist *rl, const char *ids)
 int rlist_mark_up (struct rlist *rl, const char *ids)
 {
     int count;
-    if (strcmp (ids, "all") == 0)
+    if (streq (ids, "all"))
         count = rlist_mark_all (rl, true);
     else
         count = rlist_mark_state (rl, true, ids);

--- a/src/common/librlist/rnode.c
+++ b/src/common/librlist/rnode.c
@@ -21,7 +21,8 @@
 #include <flux/idset.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
-#include "src/common/libccan/ccan/ptrint/ptrint.h"
+#include "ccan/ptrint/ptrint.h"
+#include "ccan/str/str.h"
 
 #include "rnode.h"
 
@@ -244,7 +245,7 @@ struct rnode *rnode_create_children (const char *name,
         struct rnode_child *c = rnode_add_child (n, key, ids);
         if (c == NULL)
             goto fail;
-        if (strcmp (key, "core") == 0)
+        if (streq (key, "core"))
             n->cores = c;
     }
     return n;
@@ -394,7 +395,7 @@ struct rnode *rnode_copy_cores (const struct rnode *orig)
             goto error;
         name = zlistx_first (keys);
         while (name) {
-            if (strcmp (name, "core") != 0)
+            if (!streq (name, "core"))
                 zhashx_delete (n->children, name);
             name = zlistx_next (keys);
         }
@@ -468,7 +469,7 @@ struct rnode *rnode_diff (const struct rnode *a, const struct rnode *b)
 
             /*  For non-core resources, remove empty sets:
              */
-            if (strcmp (nc->name, "core") != 0
+            if (!streq (nc->name, "core")
                 && idset_count (nc->ids) == 0)
                 zhashx_delete (n->children, nc->name);
         }

--- a/src/common/librouter/router.c
+++ b/src/common/librouter/router.c
@@ -16,6 +16,7 @@
 
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "router.h"
 #include "subhash.h"
@@ -172,19 +173,19 @@ void router_entry_recv (struct router_entry *entry, flux_msg_t *msg)
         return;
     switch (type) {
         case FLUX_MSGTYPE_REQUEST:
-            if (!strcmp (topic, "event.subscribe")) {
+            if (streq (topic, "event.subscribe")) {
                 local_sub_request (entry, msg);
                 break;
             }
-            if (!strcmp (topic, "event.unsubscribe")) {
+            if (streq (topic, "event.unsubscribe")) {
                 local_unsub_request (entry, msg);
                 break;
             }
-            if (!strcmp (topic, "service.add")) {
+            if (streq (topic, "service.add")) {
                 service_add_request (entry, msg);
                 break;
             }
-            if (!strcmp (topic, "service.remove")) {
+            if (streq (topic, "service.remove")) {
                 service_remove_request (entry, msg);
                 break;
             }

--- a/src/common/librouter/servhash.c
+++ b/src/common/librouter/servhash.c
@@ -37,6 +37,7 @@
 
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "servhash.h"
 
@@ -237,7 +238,7 @@ int servhash_remove (struct servhash *sh,
         return -1;
     }
     if (!(entry = zhashx_lookup (sh->services, name))
-            || strcmp (entry->uuid, uuid) != 0
+            || !streq (entry->uuid, uuid)
             || entry->f_remove != NULL) {
         errno = ENOENT;
         return -1;
@@ -267,7 +268,7 @@ void servhash_disconnect (struct servhash *sh, const char *uuid)
         key = zlistx_first (keys);
         while (key) {
             entry = zhashx_lookup (sh->services, key);
-            if (!strcmp (entry->uuid, uuid))
+            if (streq (entry->uuid, uuid))
                 zhashx_delete (sh->services, key);
             key = zlistx_next (keys);
         }

--- a/src/common/librouter/subhash.c
+++ b/src/common/librouter/subhash.c
@@ -40,6 +40,7 @@
 
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "subhash.h"
 
@@ -94,18 +95,6 @@ error:
     return NULL;
 }
 
-/* sub="" matches all
- * sub="foo" matches "foo", "foobar", "foo.bar"
- */
-static bool match_event (const char *sub_topic, const char *msg_topic)
-{
-    int len = strlen (sub_topic);
-
-    if (!strncmp (sub_topic, msg_topic, len))
-        return true;
-    return false;
-}
-
 bool subhash_topic_match (struct subhash *sh, const char *topic)
 {
     struct subhash_entry *entry;
@@ -113,7 +102,10 @@ bool subhash_topic_match (struct subhash *sh, const char *topic)
     if (sh && topic) {
         entry = zhashx_first (sh->subs);
         while (entry) {
-            if (match_event  (entry->topic, topic))
+            /* entry->topic="" matches all
+             * entry->topic="foo" matches "foo", "foobar", "foo.bar"
+             */
+            if (strstarts (topic, entry->topic))
                 return true;
             entry = zhashx_next (sh->subs);
         }

--- a/src/common/librouter/test/disconnect.c
+++ b/src/common/librouter/test/disconnect.c
@@ -14,6 +14,7 @@
 #include <flux/core.h>
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 #include "src/common/librouter/disconnect.h"
 
 /* Used for topic() and hashkeys() subtests */
@@ -58,7 +59,7 @@ void topic (void)
 
     for (i = 0; topics[i].topic != NULL; i++) {
         ok (disconnect_topic (topics[i].topic, buf, sizeof (buf)) >= 0
-            && !strcmp (buf, topics[i].out),
+            && streq (buf, topics[i].out),
             "topic: %s => %s", topics[i].topic, topics[i].out);
     }
 
@@ -107,7 +108,7 @@ void hashkey (void)
             BAIL_OUT ("gen_request failed");
 
         ok (disconnect_hashkey (msg, buf, sizeof (buf)) >= 0
-            && !strcmp (buf, hashkeys[i].out),
+            && streq (buf, hashkeys[i].out),
             "hashkey: %s,%u,%u => %s",
             hashkeys[i].topic,
             (unsigned int)hashkeys[i].nodeid,

--- a/src/common/librouter/test/sendfd.c
+++ b/src/common/librouter/test/sendfd.c
@@ -22,6 +22,7 @@
 #include "src/common/librouter/sendfd.h"
 #include "src/common/libutil/fdutils.h"
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 /* Send a small message over a blocking pipe.
  * We assume that there's enough buffer to do this in one go.
@@ -43,7 +44,7 @@ void test_basic (void)
         "recvfd works");
     ok (flux_request_decode (msg2, &topic, &payload) == 0,
         "received request can be decoded");
-    ok (!strcmp (topic, "foo.bar"),
+    ok (streq (topic, "foo.bar"),
         "decoded request has expected topic string");
     ok (payload == NULL,
         "decoded request has expected (lack of) payload");
@@ -77,7 +78,7 @@ void test_large (void)
         "recvfd works");
     ok (flux_request_decode_raw (msg2, &topic, &buf2, &buf2len) == 0,
         "received request can be decoded");
-    ok (!strcmp (topic, "foo.bar"),
+    ok (streq (topic, "foo.bar"),
         "decoded request has expected topic string");
     ok (buf2 != NULL
         && buf2len == sizeof (buf)
@@ -265,7 +266,7 @@ void test_nonblock (int size, int count)
             errors++;
             goto next;
         }
-        if (strcmp (topic, "foo.bar") != 0) {
+        if (!streq (topic, "foo.bar")) {
             diag ("decoded wrong topic: %s", topic);
             errors++;
             goto next;

--- a/src/common/librouter/test/servhash.c
+++ b/src/common/librouter/test/servhash.c
@@ -16,6 +16,7 @@
 #include "src/common/libtap/tap.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libtestutil/util.h"
+#include "ccan/str/str.h"
 #include "src/common/librouter/servhash.h"
 
 /*
@@ -235,7 +236,7 @@ void test_basic (flux_t *h)
     uuid = NULL;
     ok (servhash_match (sh, req, &uuid) == 0,
         "servhash_match matched request");
-    ok (uuid != NULL && !strcmp (uuid, "basic-uuid"),
+    ok (uuid != NULL && streq (uuid, "basic-uuid"),
         "and matched it to the correct uuid");
     errno = 0;
     ok (servhash_match (sh, req2, &uuid) < 0 && errno == ENOENT,

--- a/src/common/librouter/test/usock_echo.c
+++ b/src/common/librouter/test/usock_echo.c
@@ -18,6 +18,7 @@
 #include "src/common/libutil/unlink_recursive.h"
 #include "src/common/libtestutil/util.h"
 #include "src/common/librouter/usock.h"
+#include "ccan/str/str.h"
 
 #include "usock_util.h"
 
@@ -150,7 +151,7 @@ static bool equal_message (const flux_msg_t *m1, const flux_msg_t *m2)
         return false;
     if (flux_msg_get_topic (m2, &topic2) < 0)
         return false;
-    if (strcmp (topic1, topic2) != 0)
+    if (!streq (topic1, topic2))
         return false;
     if (flux_msg_has_payload (m1) && !flux_msg_has_payload (m2))
         return false;

--- a/src/common/librouter/test/usock_epipe.c
+++ b/src/common/librouter/test/usock_epipe.c
@@ -19,6 +19,7 @@
 #include "src/common/libutil/unlink_recursive.h"
 #include "src/common/libtestutil/util.h"
 #include "src/common/librouter/usock.h"
+#include "ccan/str/str.h"
 
 #include "usock_util.h"
 
@@ -74,7 +75,7 @@ static void server_recv_cb (struct usock_conn *conn, flux_msg_t *msg, void *arg)
     if (flux_request_decode (msg, &topic, NULL) < 0)
         diag ("usock_conn_send failed: %s", flux_strerror (errno));
 
-    if (topic && strcmp (topic, "init") == 0) {
+    if (topic && streq (topic, "init")) {
         if (flux_msg_unpack (msg, "{s:i}", "expected", &tp->expected) < 0)
             diag ("flux_msg_pack: %s", flux_strerror (errno));
         diag ("connection: uuid=%.5s: expect %d messages",

--- a/src/common/libschedutil/Makefile.am
+++ b/src/common/libschedutil/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = \

--- a/src/common/libschedutil/ready.c
+++ b/src/common/libschedutil/ready.c
@@ -14,6 +14,8 @@
 #include <flux/core.h>
 #include <jansson.h>
 
+#include "ccan/str/str.h"
+
 #include "schedutil_private.h"
 #include "init.h"
 #include "ready.h"
@@ -28,7 +30,7 @@ int schedutil_ready (schedutil_t *util, const char *mode, int *queue_depth)
         errno = EINVAL;
         return -1;
     }
-    if (!strncmp (mode, "limited=", 8)) {
+    if (strstarts (mode, "limited=")) {
         char *endptr;
         int n = strtol (mode+8, &endptr, 0);
         if (*endptr != '\0' || n <= 0) {
@@ -38,7 +40,7 @@ int schedutil_ready (schedutil_t *util, const char *mode, int *queue_depth)
         mode = "limited";
         limit = n;
     }
-    else if (strcmp (mode, "unlimited")) {
+    else if (!streq (mode, "unlimited")) {
         errno = EINVAL;
         return -1;
     }

--- a/src/common/libsdprocess/Makefile.am
+++ b/src/common/libsdprocess/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = \

--- a/src/common/libsdprocess/test/sdprocess.c
+++ b/src/common/libsdprocess/test/sdprocess.c
@@ -8,7 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#define _GNU_SOURCE
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -23,6 +25,7 @@
 #include "src/common/libsdprocess/sdprocess_private.h"
 #include "src/common/libsdprocess/strv.h"
 #include "src/common/libutil/fluid.h"
+#include "ccan/str/str.h"
 #include "src/common/libtestutil/util.h"
 
 static struct fluid_generator gen;
@@ -213,7 +216,7 @@ static void test_unitname (flux_t *h)
         "sdprocess_wait success");
 
     unitnameptr = sdprocess_unitname (sdp);
-    ok (unitnameptr && strcmp (unitname, unitnameptr) == 0,
+    ok (unitnameptr && streq (unitname, unitnameptr),
         "sdprocess_unitname returns correct unitname");
 
     sdprocess_systemd_cleanup_wrap (sdp);
@@ -1022,7 +1025,7 @@ static void test_output (flux_t *h,
     ok (ret == 0,
         "sdprocess_wait success");
 
-    ok (strcmp (buf, "foobar\n") == 0,
+    ok (streq (buf, "foobar\n"),
         "%s received the right output", do_stdout ? "stdout" : "stderr");
 
     sdprocess_systemd_cleanup_wrap (sdp);
@@ -1093,7 +1096,7 @@ static void test_stdin (flux_t *h)
     ok (ret == 0,
         "sdprocess_wait success");
 
-    ok (strcmp (buf, "foobar\n") == 0,
+    ok (streq (buf, "foobar\n"),
         "stdout received the right output");
 
     sdprocess_systemd_cleanup_wrap (sdp);
@@ -1144,7 +1147,7 @@ static void test_environment (flux_t *h)
     ok (ret == 0,
         "sdprocess_wait success");
 
-    ok (strcmp (buf, "FOO=BAR\n") == 0,
+    ok (streq (buf, "FOO=BAR\n"),
         "stdout received message indicating environment set correctly");
 
     sdprocess_systemd_cleanup_wrap (sdp);

--- a/src/common/libsdprocess/test/strv.c
+++ b/src/common/libsdprocess/test/strv.c
@@ -8,7 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#define _GNU_SOURCE
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,6 +18,7 @@
 #include <assert.h>
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 #include "src/common/libsdprocess/strv.h"
 
 static void test_corner_case (void)
@@ -60,8 +63,7 @@ static void test_strv_values (char **strv, char **expected_strv)
     char **expected_strv_ptr = expected_strv;
     int index = 0;
     while (*(expected_strv_ptr)) {
-        int ret = strcmp ((*strv_ptr), (*expected_strv_ptr));
-        ok (ret == 0,
+        ok (streq ((*strv_ptr), (*expected_strv_ptr)),
             "strv[%d] matches expected value %s", index, (*expected_strv_ptr));
         strv_ptr++;
         expected_strv_ptr++;

--- a/src/common/libsubprocess/command.c
+++ b/src/common/libsubprocess/command.c
@@ -21,6 +21,7 @@
 #include <jansson.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "command.h"
 
@@ -376,7 +377,7 @@ static const char * z_list_find (zlist_t *l, const char *s)
 {
     const char *v = zlist_first (l);
     while (v != NULL) {
-        if (strcmp (s, v) == 0)
+        if (streq (s, v))
             return (v);
         v = zlist_next (l);
     }

--- a/src/common/libsubprocess/test/cmd.c
+++ b/src/common/libsubprocess/test/cmd.c
@@ -14,6 +14,7 @@
 #include "src/common/libtap/tap.h"
 #include "src/common/libsubprocess/command.h"
 #include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
 
 /*
  *  Check basic flux_cmd_create () with args
@@ -128,15 +129,15 @@ void check_cmd_attributes (flux_cmd_t *cmd)
         "flux_cmd_arg returns EINVAL on bad range");
     arg = flux_cmd_arg (cmd, 0);
     ok (arg != NULL
-        && !strcmp (arg, "command"),
+        && streq (arg, "command"),
         "flux_cmd_arg returns correct argv[0]");
     arg = flux_cmd_arg (cmd, 1);
     ok (arg != NULL
-        && !strcmp (arg, "foo"),
+        && streq (arg, "foo"),
         "flux_cmd_arg returns correct argv[1]");
     arg = flux_cmd_arg (cmd, 2);
     ok (arg != NULL
-        && !strcmp (arg, "bar"),
+        && streq (arg, "bar"),
         "flux_cmd_arg returns correct argv[2]");
 
     is (flux_cmd_getenv (cmd, "PATH"), "/bin:/usr/bin",

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -20,6 +20,7 @@
 #include "src/common/libtap/tap.h"
 #include "src/common/libsubprocess/subprocess.h"
 #include "src/common/libsubprocess/server.h"
+#include "ccan/str/str.h"
 
 extern char **environ;
 
@@ -368,7 +369,7 @@ void output_cb (flux_subprocess_t *p, const char *stream)
 
         sprintf (cmpbuf, "%s:hi\n", stream);
 
-        ok (!strcmp (ptr, cmpbuf),
+        ok (streq (ptr, cmpbuf),
             "flux_subprocess_read_line returned correct data");
         /* 1 + 2 + 1 for ':', "hi", '\n' */
         ok (lenp == (strlen (stream) + 1 + 2 + 1),
@@ -521,7 +522,7 @@ void output_default_stream_cb (flux_subprocess_t *p, const char *stream)
 
         sprintf (cmpbuf, "%s:hi\n", stream);
 
-        ok (!strcmp (ptr, cmpbuf),
+        ok (streq (ptr, cmpbuf),
             "flux_subprocess_read_line returned correct data");
         /* 1 + 2 + 1 for ':', "hi", '\n' */
         ok (lenp == (strlen (stream) + 1 + 2 + 1),
@@ -603,7 +604,7 @@ void output_no_newline_cb (flux_subprocess_t *p, const char *stream)
 
         sprintf (cmpbuf, "%s:hi", stream);
 
-        ok (!strcmp (ptr, cmpbuf),
+        ok (streq (ptr, cmpbuf),
             "flux_subprocess_read returned correct data");
         /* 1 + 2 + 1 for ':', "hi" */
         ok (lenp == (strlen (stream) + 1 + 2),
@@ -677,7 +678,7 @@ void output_trimmed_line_cb (flux_subprocess_t *p, const char *stream)
 
         sprintf (cmpbuf, "%s:hi", stream);
 
-        ok (!strcmp (ptr, cmpbuf),
+        ok (streq (ptr, cmpbuf),
             "flux_subprocess_read_trimmed_line returned correct data");
     }
     else {
@@ -745,7 +746,7 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
             && lenp > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!strcmp (ptr, "foo\n"),
+        ok (streq (ptr, "foo\n"),
             "flux_subprocess_read_line returned correct data");
         ok (lenp == 4,
             "flux_subprocess_read_line returned correct data len");
@@ -756,7 +757,7 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
             && lenp > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!strcmp (ptr, "bar\n"),
+        ok (streq (ptr, "bar\n"),
             "flux_subprocess_read_line returned correct data");
         ok (lenp == 4,
             "flux_subprocess_read_line returned correct data len");
@@ -767,7 +768,7 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
             && lenp > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!strcmp (ptr, "bo\n"),
+        ok (streq (ptr, "bo\n"),
             "flux_subprocess_read_line returned correct data");
         ok (lenp == 3,
             "flux_subprocess_read_line returned correct data len");
@@ -907,7 +908,7 @@ void output_read_line_until_eof_cb (flux_subprocess_t *p, const char *stream)
     if ((*counter) == 0) {
         ok (ptr != NULL,
             "flux_subprocess_getline on %s success", stream);
-        ok (!strcmp (ptr, "foo\n"),
+        ok (streq (ptr, "foo\n"),
             "flux_subprocess_getline returned correct data");
         ok (lenp == 4,
             "flux_subprocess_getline returned correct data len");
@@ -915,7 +916,7 @@ void output_read_line_until_eof_cb (flux_subprocess_t *p, const char *stream)
     else if ((*counter) == 1) {
         ok (ptr != NULL,
             "flux_subprocess_getline on %s success", stream);
-        ok (!strcmp (ptr, "bar"),
+        ok (streq (ptr, "bar"),
             "flux_subprocess_getline returned correct data");
         ok (lenp == 3,
             "flux_subprocess_getline returned correct data len");
@@ -1168,7 +1169,7 @@ void env_passed_cb (flux_subprocess_t *p, const char *stream)
             && lenp > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!strncmp (ptr, "FOOBAR=foobaz", 13),
+        ok (strstarts (ptr, "FOOBAR=foobaz"),
             "environment variable FOOBAR in subprocess");
         ok (lenp == 14,
             "flux_subprocess_read_line returned correct data len");
@@ -1632,7 +1633,7 @@ void channel_fd_env_cb (flux_subprocess_t *p, const char *stream)
             && lenp > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!strncmp (ptr, "FOO=", 4),
+        ok (strstarts (ptr, "FOO="),
             "environment variable FOO created in subprocess");
         /* no length check, can't predict channel FD value */
     }
@@ -1837,7 +1838,7 @@ void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
             && lenp > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!strcmp (ptr, "bob\n"),
+        ok (streq (ptr, "bob\n"),
             "flux_subprocess_read_line returned correct data");
     }
     else if (multiple_lines_channel_cb_count == 1) {
@@ -1846,7 +1847,7 @@ void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
             && lenp > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!strcmp (ptr, "dan\n"),
+        ok (streq (ptr, "dan\n"),
             "flux_subprocess_read_line returned correct data");
     }
     else if (multiple_lines_channel_cb_count == 2) {
@@ -1855,7 +1856,7 @@ void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
             && lenp > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!strcmp (ptr, "jo\n"),
+        ok (streq (ptr, "jo\n"),
             "flux_subprocess_read_line returned correct data");
 
         ok (flux_subprocess_close (p, "TEST_CHANNEL") == 0,
@@ -2282,7 +2283,7 @@ void start_stdout_after_stderr_cb (flux_subprocess_t *p, const char *stream)
     (*len_counter)+= lenp;
 
     if (ptr && lenp && (*len_counter) == 10001) {
-        if (!strcmp (stream, "stderr")) {
+        if (streq (stream, "stderr")) {
             ok (stdout_output_cb_count == 0
                 && stdout_output_cb_len_count == 0,
                 "received all stderr data and stdout output is still 0");

--- a/src/common/libtaskmap/taskmap.c
+++ b/src/common/libtaskmap/taskmap.c
@@ -22,6 +22,7 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/lru_cache.h"
 #include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
 #include "taskmap.h"
 
 struct taskmap_block {
@@ -380,7 +381,7 @@ static struct taskmap *taskmap_decode_pmi (const char *s, flux_error_t *errp)
         while (isspace (*tok))
             tok++;
 
-        if (strncmp (tok, "vector,", 7) == 0)
+        if (strstarts (tok, "vector,"))
             got_sentinel = true;
         else if (!is_empty (tok)) {
             if (!got_sentinel) {

--- a/src/common/libterminus/Makefile.am
+++ b/src/common/libterminus/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
 	$(JANSSON_CFLAGS) \
 	$(FLUX_SECURITY_CFLAGS)

--- a/src/common/libterminus/client.c
+++ b/src/common/libterminus/client.c
@@ -26,6 +26,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/fdutils.h"
 #include "src/common/libutil/llog.h"
+#include "ccan/str/str.h"
 
 #include "pty.h"
 
@@ -356,13 +357,13 @@ static void pty_server_cb (flux_future_t *f, void *arg)
         c->rpc_f = NULL;
         return;
     }
-    if (strcmp (type, "attach") == 0)
+    if (streq (type, "attach"))
         pty_client_attached (c);
-    else if (strcmp (type, "data") == 0)
+    else if (streq (type, "data"))
         pty_client_data (c, f);
-    else if (strcmp (type, "resize") == 0)
+    else if (streq (type, "resize"))
         pty_client_resize (c);
-    else if (strcmp (type, "exit") == 0)
+    else if (streq (type, "exit"))
         pty_client_exit (c, f);
     else {
         llog_error (c, "unknown server response type=%s", type);
@@ -549,7 +550,7 @@ int flux_pty_client_attach (struct flux_pty_client *c,
     if (c->flags & FLUX_PTY_CLIENT_ATTACH_SYNC) {
         const char *type;
         if (flux_rpc_get_unpack (f, "{s:s}", "type", &type) < 0
-            || strcmp (type, "attach") != 0) {
+            || !streq (type, "attach")) {
             flux_future_destroy (f);
             return -1;
         }

--- a/src/common/libterminus/pty.c
+++ b/src/common/libterminus/pty.c
@@ -56,6 +56,7 @@
 #include "src/common/libutil/fdutils.h"
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/aux.h"
+#include "ccan/str/str.h"
 
 #define LLOG_SUBSYSTEM "pty"
 #include "src/common/libutil/llog.h"
@@ -128,7 +129,7 @@ static struct pty_client *pty_client_find (struct flux_pty *pty,
 {
     struct pty_client *c = zlist_first (pty->clients);
     while (c) {
-        if (strcmp (c->uuid, uuid) == 0)
+        if (streq (c->uuid, uuid))
             break;
         c = zlist_next (pty->clients);
     }
@@ -512,11 +513,11 @@ static int pty_client_set_mode (struct flux_pty *pty,
     if (flux_msg_unpack (msg, "{s:s}", "mode", &mode) < 0)
         return -1;
     /*  Valid modes are currently only "ro", "wo", "rw" */
-    if (strcmp (mode, "rw") == 0)
+    if (streq (mode, "rw"))
         c->read_enabled = c->write_enabled = true;
-    else if (strcmp (mode, "wo") == 0)
+    else if (streq (mode, "wo"))
         c->write_enabled = true;
-    else if (strcmp (mode, "ro") == 0)
+    else if (streq (mode, "ro"))
         c->read_enabled = true;
     else {
         llog_error (pty, "client=%s: invalid mode: %s", c->uuid, mode);
@@ -600,7 +601,7 @@ int flux_pty_sendmsg (struct flux_pty *pty, const flux_msg_t *msg)
     llog_debug (pty, "msg: userid=%u type=%s", userid, type);
     c = pty_client_find_sender (pty, msg);
 
-    if (strcmp (type, "attach") == 0) {
+    if (streq (type, "attach")) {
         /* It is an error for the same client to attach more than once */
         if (c != NULL) {
             errno = EEXIST;
@@ -622,17 +623,17 @@ int flux_pty_sendmsg (struct flux_pty *pty, const flux_msg_t *msg)
         errno = ENOENT;
         goto err;
     }
-    else if (strcmp (type, "resize") == 0) {
+    else if (streq (type, "resize")) {
        if (pty_resize (pty, msg) < 0)
             goto err;
     }
-    else if (strcmp (type, "data") == 0) {
+    else if (streq (type, "data")) {
         if (c->write_enabled && pty_write (pty, msg) < 0) {
             llog_error (pty, "pty_write: %s", strerror (errno));
             goto err;
         }
     }
-    else if (strcmp (type, "detach") == 0) {
+    else if (streq (type, "detach")) {
         if (pty_client_detach (pty, c) < 0)
             goto err;
         if (zlist_size (pty->clients) == 0)

--- a/src/common/libtestutil/util.c
+++ b/src/common/libtestutil/util.c
@@ -403,12 +403,12 @@ static int loopback_connector_getopt (void *impl, const char *option,
 {
     struct loopback_connector *lcon = impl;
 
-    if (option && !strcmp (option, FLUX_OPT_TESTING_USERID)) {
+    if (option && streq (option, FLUX_OPT_TESTING_USERID)) {
         if (size != sizeof (lcon->cred.userid))
             goto error;
         memcpy (val, &lcon->cred.userid, size);
     }
-    else if (option && !strcmp (option, FLUX_OPT_TESTING_ROLEMASK)) {
+    else if (option && streq (option, FLUX_OPT_TESTING_ROLEMASK)) {
         if (size != sizeof (lcon->cred.rolemask))
             goto error;
         memcpy (val, &lcon->cred.rolemask, size);
@@ -427,13 +427,13 @@ static int loopback_connector_setopt (void *impl, const char *option,
     struct loopback_connector *lcon = impl;
     size_t val_size;
 
-    if (option && !strcmp (option, FLUX_OPT_TESTING_USERID)) {
+    if (option && streq (option, FLUX_OPT_TESTING_USERID)) {
         val_size = sizeof (lcon->cred.userid);
         if (size != val_size)
             goto error;
         memcpy (&lcon->cred.userid, val, val_size);
     }
-    else if (option && !strcmp (option, FLUX_OPT_TESTING_ROLEMASK)) {
+    else if (option && streq (option, FLUX_OPT_TESTING_ROLEMASK)) {
         val_size = sizeof (lcon->cred.rolemask);
         if (size != val_size)
             goto error;

--- a/src/common/libutil/aux.c
+++ b/src/common/libutil/aux.c
@@ -15,6 +15,8 @@
 #include <errno.h>
 #include <stdlib.h>
 
+#include "ccan/str/str.h"
+
 #include "aux.h"
 
 struct aux_item {
@@ -70,7 +72,7 @@ static void aux_item_delete (struct aux_item **head, const char *key)
         struct aux_item *item;
 
         while ((item = *head) && item->key) {
-            if (!strcmp (item->key, key)) {
+            if (streq (item->key, key)) {
                 *head = item->next;
                 aux_item_destroy (item);
                 break;
@@ -88,7 +90,7 @@ static struct aux_item *aux_item_find (struct aux_item *head, const char *key)
 {
     if (key) {
         while (head && head->key) {
-            if (!strcmp (key, head->key))
+            if (streq (key, head->key))
                 return head;
             head = head->next;
         }

--- a/src/common/libutil/blobref.c
+++ b/src/common/libutil/blobref.c
@@ -18,7 +18,8 @@
 #include <assert.h>
 #include <stdio.h>
 
-#include "src/common/libccan/ccan/str/hex/hex.h"
+#include "ccan/str/str.h"
+#include "ccan/str/hex/hex.h"
 
 #include "blobref.h"
 #include "sha1.h"
@@ -88,12 +89,14 @@ static void sha256_hash (const void *data, int data_len, void *hash, int hash_le
 
 /* true if s1 contains "s2-" prefix
  */
-static int prefixmatch (const char *s1, const char *s2)
+static bool prefixmatch (const char *s1, const char *s2)
 {
-    int len = strlen (s2);
-    if (strlen (s1) < len + 1 || s1[len] != '-')
-        return 0;
-    return !strncmp (s1, s2, len);
+    if (!strstarts (s1, s2))
+        return false;
+    s1 += strlen (s2);
+    if (*s1 != '-')
+        return false;
+    return true;
 }
 
 static struct blobhash *lookup_blobhash (const char *name)
@@ -101,7 +104,7 @@ static struct blobhash *lookup_blobhash (const char *name)
     struct blobhash *bh;
 
     for (bh = &blobtab[0]; bh->name != NULL; bh++)
-        if (!strcmp (name, bh->name) || prefixmatch (name, bh->name))
+        if (streq (name, bh->name) || prefixmatch (name, bh->name))
             return bh;
     return NULL;
 }

--- a/src/common/libutil/cronodate.c
+++ b/src/common/libutil/cronodate.c
@@ -21,6 +21,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libidset/idset.h"
 #include "src/common/libutil/xzmalloc.h"
+#include "ccan/str/str.h"
 
 #include "cronodate.h"
 
@@ -221,7 +222,7 @@ static int tm_string2int (const char *s, tm_unit_t u)
 static int get_range (const char *r, tm_unit_t u, int *lo, int *hi)
 {
     char *p;
-    if (strcmp (r, "*") == 0) {
+    if (streq (r, "*")) {
         *lo = tm_unit_min (u);
         *hi = tm_unit_max (u);
     }

--- a/src/common/libutil/dirwalk.c
+++ b/src/common/libutil/dirwalk.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "dirwalk.h"
 
@@ -186,7 +187,7 @@ int dirwalk_isdir (dirwalk_t *d)
 
 static int is_dotted_dir (struct dirent *dent)
 {
-    if (!strcmp (dent->d_name, ".") || !strcmp (dent->d_name, ".."))
+    if (streq (dent->d_name, ".") || streq (dent->d_name, ".."))
         return 1;
     return 0;
 }

--- a/src/common/libutil/environment.c
+++ b/src/common/libutil/environment.c
@@ -23,6 +23,7 @@
 #include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/iterators.h"
+#include "ccan/str/str.h"
 
 
 #include "environment.h"
@@ -70,7 +71,7 @@ char *find_env_item(struct env_item *i, const char *s)
 {
     char *entry = 0;
     while ((entry = argz_next (i->argz, i->argz_len, entry))) {
-        if (!strcmp(entry, s))
+        if (streq (entry, s))
             return entry;
     }
     return NULL;

--- a/src/common/libutil/fluid.c
+++ b/src/common/libutil/fluid.c
@@ -24,6 +24,7 @@
 #include <langinfo.h>
 #include <locale.h>
 
+#include "ccan/str/str.h"
 #include "fluid.h"
 #include "mnemonic.h"
 
@@ -181,7 +182,7 @@ static inline int is_utf8_locale (void)
      * or similar), but allow ascii encoding to be enforced if
      * FLUX_F58_FORCE_ASCII is set.
      */
-    if (MB_CUR_MAX > 1 && !strcmp (nl_langinfo (CODESET), "UTF-8")
+    if (MB_CUR_MAX > 1 && streq (nl_langinfo (CODESET), "UTF-8")
         && !getenv ("FLUX_F58_FORCE_ASCII"))
         return 1;
     return 0;
@@ -254,15 +255,12 @@ static int b58decode (const char *str, uint64_t *idp)
 
 static int fluid_is_f58 (const char *str)
 {
-    int len = 0;
     if (str == NULL || str[0] == '\0')
         return 0;
-    len = strlen (f58_prefix);
-    if (strncmp (str, f58_prefix, len) == 0)
-        return len;
-    len = strlen (f58_alt_prefix);
-    if (strncmp (str, f58_alt_prefix, len) == 0)
-        return len;
+    if (strstarts (str, f58_prefix))
+        return strlen (f58_prefix);
+    if (strstarts (str, f58_alt_prefix))
+        return strlen (f58_alt_prefix);
     return 0;
 }
 
@@ -448,7 +446,7 @@ int fluid_parse (const char *s, fluid_t *fluidp)
     /* O/w, FLUID encoded as an integer, either base16 (prefix="0x")
      *  or base10 (no prefix).
      */
-    if (strncmp (s, "0x", 2) == 0)
+    if (strstarts (s, "0x"))
         base = 16;
     errno = 0;
     l = strtoull (s, &endptr, base);

--- a/src/common/libutil/fsd.c
+++ b/src/common/libutil/fsd.c
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 
 #include "fsd.h"
-#include "src/common/libccan/ccan/str/str.h"
+#include "ccan/str/str.h"
 
 static int is_invalid_duration (double d)
 {

--- a/src/common/libutil/grudgeset.c
+++ b/src/common/libutil/grudgeset.c
@@ -14,6 +14,8 @@
 #include <string.h>
 #include <errno.h>
 
+#include "ccan/str/str.h"
+
 #include <jansson.h>
 
 struct grudgeset {
@@ -58,7 +60,7 @@ static int json_array_find (json_t *array, const char *val)
     json_t *entry;
     json_array_foreach (array, index, entry) {
         const char *s = json_string_value (entry);
-        if (val && strcmp (val, s) == 0) {
+        if (val && streq (val, s)) {
             return (int) index;
         }
     }

--- a/src/common/libutil/intree.c
+++ b/src/common/libutil/intree.c
@@ -20,6 +20,8 @@
 #include <libgen.h>    /* dirname(3) */
 #include <pthread.h>
 
+#include "ccan/str/str.h"
+
 
 /*  Strip trailing ".libs", otherwise do nothing
  */
@@ -80,7 +82,7 @@ static int is_intree (void)
             return 0;
         return -1;
     }
-    if (strncmp (builddir, selfdir, strlen (builddir)) == 0)
+    if (strstarts (selfdir, builddir))
         ret = 1;
     free (builddir);
     return ret;

--- a/src/common/libutil/ipaddr.c
+++ b/src/common/libutil/ipaddr.c
@@ -23,6 +23,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#include "ccan/str/str.h"
+
 #include "log.h"
 #include "ipaddr.h"
 
@@ -88,7 +90,7 @@ static struct ifaddrs *find_ifaddr (struct ifaddrs *ifaddr,
     struct ifaddrs *ifa;
 
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
-        if (!strcmp (ifa->ifa_name, name)
+        if (streq (ifa->ifa_name, name)
                 && ifa->ifa_addr != NULL
                 && ifa->ifa_addr->sa_family == family
                 && (ifa->ifa_addr->sa_family != AF_INET6

--- a/src/common/libutil/jpath.c
+++ b/src/common/libutil/jpath.c
@@ -16,6 +16,7 @@
 #include <jansson.h>
 
 #include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
 
 #include "jpath.h"
 
@@ -194,7 +195,7 @@ json_t * jpath_set_new (json_t *o, const char *path, json_t *val)
 int jpath_update (json_t *o, const char *path, json_t *val)
 {
     /* Special case, allow "." to update current object */
-    if (strcmp (path, ".") == 0)
+    if (streq (path, "."))
         return update_object_recursive (o, val);
     return jpath_do_set (o, 0, path, val);
 }

--- a/src/common/libutil/test/blobref.c
+++ b/src/common/libutil/test/blobref.c
@@ -14,6 +14,7 @@
 #include "src/common/libutil/blobref.h"
 #include "src/common/libutil/sha1.h"
 #include "src/common/libutil/sha256.h"
+#include "ccan/str/str.h"
 
 const char *badref[] = {
     "nerf-4d4ed591f7d26abd8145650f334d283bdb661765", // unknown hash
@@ -134,7 +135,7 @@ int main(int argc, char** argv)
                            sizeof (ref2)) == 0,
         "blobref_hashtostr back again works");
     diag ("%s", ref2);
-    ok (strcmp (ref, ref2) == 0,
+    ok (streq (ref, ref2),
         "and blobrefs match");
 
     /* sha256 */
@@ -160,7 +161,7 @@ int main(int argc, char** argv)
                            sizeof (ref2)) == 0,
         "blobref_hashtostr back again works");
     diag ("%s", ref2);
-    ok (strcmp (ref, ref2) == 0,
+    ok (streq (ref, ref2),
         "and blobrefs match");
 
     /* blobref_validate */

--- a/src/common/libutil/test/dirwalk.c
+++ b/src/common/libutil/test/dirwalk.c
@@ -8,7 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#define _GNU_SOURCE
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <limits.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -23,6 +25,7 @@
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 #include "src/common/libutil/dirwalk.h"
 
 static int makepath (const char *fmt, ...)
@@ -157,7 +160,6 @@ int check_zlist_order (zlist_t *l, const char *base, char *expected[])
     dir = zlist_first (l);
     while (dir) {
         diag ("zlist_order: %d: %s", i, dir);
-        int result;
         char *exp;
         if (expected[i] == NULL) {
             diag ("check_zlist: more results than expected=%d\n", i-1);
@@ -166,8 +168,7 @@ int check_zlist_order (zlist_t *l, const char *base, char *expected[])
         if (asprintf (&exp, "%s%s", base, expected [i]) < 0)
             BAIL_OUT ("asprintf");
 
-        result = strcmp (exp, dir);
-        if (result != 0) {
+        if (!streq (exp, dir)) {
             diag ("check_zlist: %d: expected %s got %s", i, exp, dir);
             free (exp);
             return 0;
@@ -261,7 +262,7 @@ int main(int argc, char** argv)
     l = dirwalk_find (tmp, 0, "foo", 1, NULL, 0);
     ok (l != NULL, "dirwalk_find");
     ok (l && zlist_size (l) == 1, "dirwalk_find stopped at 1 result");
-    ok (strcmp (basename (zlist_first (l)), "foo") == 0,
+    ok (streq (basename (zlist_first (l)), "foo"),
         "breadth-first search got expected match");
     zlist_destroy (&l);
 

--- a/src/common/libutil/test/fluid.c
+++ b/src/common/libutil/test/fluid.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 #include <string.h>
 #include <locale.h>
@@ -91,6 +94,7 @@ void test_f58 (void)
         tp++;
     }
 
+#if !ASSUME_BROKEN_LOCALE
     if (setenv ("FLUX_F58_FORCE_ASCII", "1", 1) < 0)
         BAIL_OUT ("Failed to setenv FLUX_F58_FORCE_ASCII");
     ok (fluid_encode (buf, sizeof (buf), f58_tests->id, type) == 0,
@@ -99,6 +103,7 @@ void test_f58 (void)
         "fluid_encode with FLUX_F58_FORCE_ASCII used ascii prefix");
     if (unsetenv ("FLUX_F58_FORCE_ASCII") < 0)
         BAIL_OUT ("Failed to unsetenv FLUX_F58_FORCE_ASCII");
+#endif
 
     ok (fluid_encode (buf, 1, 1, type) < 0 && errno == EOVERFLOW,
         "fluid_encode (buf, 1, 1, F58) returns EOVERFLOW");

--- a/src/common/libutil/test/fluid.c
+++ b/src/common/libutil/test/fluid.c
@@ -14,6 +14,7 @@
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/fluid.h"
+#include "ccan/str/str.h"
 
 struct f58_test {
     fluid_t id;
@@ -69,8 +70,8 @@ void test_f58 (void)
     while (tp->f58 != NULL) {
         ok (fluid_encode (buf, sizeof(buf), tp->id, type) == 0,
             "f58_encode (%ju)", tp->id);
-        if (strcmp (buf, tp->f58) == 0
-            || strcmp (buf, tp->f58_alt) == 0)
+        if (streq (buf, tp->f58)
+            || streq (buf, tp->f58_alt))
             pass ("f58_encode %ju -> %s", tp->id, buf);
         else
             fail ("f58_encode %ju: got %s expected %s",

--- a/src/common/libutil/test/jpath.c
+++ b/src/common/libutil/test/jpath.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
 #include "src/common/libtap/tap.h"
 #include "jpath.h"
 
@@ -111,13 +112,13 @@ void basic (void)
     tmp = jpath_get (o, "a.b");
     ok (tmp
         && json_is_string (tmp)
-        && !strcmp (json_string_value (tmp), "foo"),
+        && streq (json_string_value (tmp), "foo"),
         "jpath_get a.b returned expected value");
 
     tmp = jpath_get (o, "a.c.f");
     ok (tmp
         && json_is_string (tmp)
-        && !strcmp (json_string_value (tmp), "bar"),
+        && streq (json_string_value (tmp), "bar"),
         "jpath_get a.c.f returned expected value");
 
     diag_json (o);

--- a/src/common/libutil/test/stdlog.c
+++ b/src/common/libutil/test/stdlog.c
@@ -11,6 +11,7 @@
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/wallclock.h"
 #include "src/common/libutil/stdlog.h"
+#include "ccan/str/str.h"
 
 #include <string.h>
 #include <ctype.h>
@@ -56,7 +57,7 @@ void test_split (void)
     ok (len >= 0,
         "stdlog_encode encoded foo\\nbar\\nbaz");
     xtra = stdlog_split_message (buf, &len, "\r\n");
-    ok (xtra != NULL && !strcmp (xtra, "bar\nbaz"),
+    ok (xtra != NULL && streq (xtra, "bar\nbaz"),
         "stdlog_split_message got bar\\nbaz");
     ok (stdlog_decode (buf, len, &hdr, NULL, NULL, &msg, &msglen) == 0
         && msg != NULL && msglen == 3 && !strncmp (msg, "foo", msglen),
@@ -68,7 +69,7 @@ void test_split (void)
         "stdlog_encode encoded bar\\nbaz");
     free (xtra);
     xtra = stdlog_split_message (buf, &len, "\r\n");
-    ok (xtra != NULL && !strcmp (xtra, "baz"),
+    ok (xtra != NULL && streq (xtra, "baz"),
         "stdlog_split_message got baz");
     diag ("xtra='%s'", xtra);
     ok (stdlog_decode (buf, len, &hdr, NULL, NULL, &msg, &msglen) == 0
@@ -113,15 +114,15 @@ int main(int argc, char** argv)
         "stdlog_decode decoded pri");
     ok (hdr.version == cln.version,
         "stdlog_decode decoded version");
-    ok (strcmp (hdr.timestamp, cln.timestamp) == 0,
+    ok (streq (hdr.timestamp, cln.timestamp),
         "stdlog_decode decoded timestamp");
-    ok (strcmp (hdr.hostname, cln.hostname) == 0,
+    ok (streq (hdr.hostname, cln.hostname),
         "stdlog_decode decoded hostname") ;
-    ok (strcmp (hdr.appname, cln.appname) == 0,
+    ok (streq (hdr.appname, cln.appname),
         "stdlog_decode decoded appname") ;
-    ok (strcmp (hdr.procid, cln.procid) == 0,
+    ok (streq (hdr.procid, cln.procid),
         "stdlog_decode decoded procid") ;
-    ok (strcmp (hdr.msgid, cln.msgid) == 0,
+    ok (streq (hdr.msgid, cln.msgid),
         "stdlog_decode decoded msgid") ;
     ok (sdlen == strlen (STDLOG_NILVALUE) && strncmp (sd, STDLOG_NILVALUE, sdlen) == 0,
         "stdlog_decode decoded structured data");

--- a/src/common/libutil/test/tomltk.c
+++ b/src/common/libutil/test/tomltk.c
@@ -21,6 +21,7 @@
 #include <jansson.h>
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 #include "src/common/libtomlc99/toml.h"
 #include "tomltk.h"
 
@@ -75,7 +76,7 @@ static bool check_ts (json_t *ts, const char *timestr)
     if (strftime (buf, sizeof (buf), "%FT%TZ", &tm) == 0)
         return false;
     diag ("%s: %s ?= %s", __FUNCTION__, buf, timestr);
-    return !strcmp (buf, timestr);
+    return streq (buf, timestr);
 }
 
 void test_json_ts(void)
@@ -126,7 +127,7 @@ void test_tojson_t1 (void)
                      "ts", &ts);
     ok (rc == 0,
         "t1: unpack successful");
-    ok (i == 1 && d == 3.14 && s != NULL && !strcmp (s, "foo") && b != 0
+    ok (i == 1 && d == 3.14 && s != NULL && streq (s, "foo") && b != 0
         && check_ts (ts, "1979-05-27T07:32:00Z"),
         "t1: has expected values");
     json_decref (obj);
@@ -209,7 +210,7 @@ void test_parse_lineno (void)
     ok (error.lineno == 4,
         "bad1: error.lineno is 4");
     const char *msg = "unterminated s-quote";
-    ok (!strcmp (error.errbuf, msg),
+    ok (streq (error.errbuf, msg),
         "bad1: error is \"%s\"", msg); // no "line %d: " prefix
 }
 

--- a/src/common/libutil/tomltk.c
+++ b/src/common/libutil/tomltk.c
@@ -20,6 +20,7 @@
 #include <jansson.h>
 
 #include "src/common/libtomlc99/toml.h"
+#include "ccan/str/str.h"
 #include "timestamp.h"
 #include "tomltk.h"
 
@@ -56,9 +57,9 @@ static void errfromtoml (struct tomltk_error *error,
     if (error) {
         char *msg = errstr;
         int lineno = -1;
-        if (!strncmp (errstr, "line ", 5)) {
+        if (strstarts (errstr, "line ")) {
             lineno = strtoul (errstr + 5, &msg, 10);
-            if (!strncmp (msg, ": ", 2))
+            if (strstarts (msg, ": "))
                 msg += 2;
         }
         return errprintf (error, filename, lineno, "%s", msg);

--- a/src/common/libutil/uri.c
+++ b/src/common/libutil/uri.c
@@ -16,6 +16,7 @@
 #include <string.h>
 
 #include "src/common/libyuarel/yuarel.h"
+#include "ccan/str/str.h"
 #include "errprintf.h"
 #include "popen2.h"
 #include "read_all.h"
@@ -53,7 +54,7 @@ char *uri_remote_get_authority (const char *uri)
     cpy = strdup (uri);
     if (yuarel_parse (&yuri, cpy) == 0
         && yuri.scheme
-        && strcmp (yuri.scheme, "ssh") == 0) {
+        && streq (yuri.scheme, "ssh")) {
         if (asprintf (&result,
                       "%s%s%s",
                       yuri.username ? yuri.username : "",
@@ -78,8 +79,8 @@ char *uri_resolve (const char *uri, flux_error_t *errp)
     if (!cpy)
         return NULL;
     if (yuarel_parse (&yuri, cpy) == 0 && yuri.scheme) {
-        if (strcmp (yuri.scheme, "ssh") == 0
-            || strcmp (yuri.scheme, "local") == 0) {
+        if (streq (yuri.scheme, "ssh")
+            || streq (yuri.scheme, "local")) {
             if (getenv ("FLUX_URI_RESOLVE_LOCAL"))
                 result = uri_to_local (&yuri);
             else

--- a/src/common/libzmqutil/test/msg_zsock.c
+++ b/src/common/libzmqutil/test/msg_zsock.c
@@ -68,7 +68,7 @@ void check_sendzsock (void)
         "zmqutil_msg_recv works");
     ok (flux_msg_get_type (msg2, &type) == 0 && type == FLUX_MSGTYPE_REQUEST
             && flux_msg_get_topic (msg2, &topic) == 0
-            && !strcmp (topic, "foo.bar")
+            && streq (topic, "foo.bar")
             && flux_msg_has_payload (msg2) == false,
         "decoded message looks like what was sent");
     flux_msg_destroy (msg2);
@@ -81,7 +81,7 @@ void check_sendzsock (void)
         "try2: zmqutil_msg_recv works");
     ok (flux_msg_get_type (msg2, &type) == 0 && type == FLUX_MSGTYPE_REQUEST
             && flux_msg_get_topic (msg2, &topic) == 0
-            && !strcmp (topic, "foo.bar")
+            && streq (topic, "foo.bar")
             && flux_msg_has_payload (msg2) == false,
         "try2: decoded message looks like what was sent");
     flux_msg_destroy (msg2);

--- a/src/connectors/local/Makefile.am
+++ b/src/connectors/local/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 fluxconnector_LTLIBRARIES = local.la

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -16,6 +16,7 @@
 
 #include "src/common/librouter/usock.h"
 #include "src/common/libutil/errprintf.h"
+#include "ccan/str/str.h"
 
 struct local_connector {
     struct usock_client *uclient;
@@ -97,7 +98,7 @@ static int op_setopt (void *impl, const char *option,
     size_t val_size;
     int rc = -1;
 
-    if (option && !strcmp (option, FLUX_OPT_TESTING_USERID)) {
+    if (option && streq (option, FLUX_OPT_TESTING_USERID)) {
         val_size = sizeof (ctx->testing_userid);
         if (size != val_size) {
             errno = EINVAL;
@@ -105,7 +106,7 @@ static int op_setopt (void *impl, const char *option,
         }
         memcpy (&ctx->testing_userid, val, val_size);
     }
-    else if (option && !strcmp (option, FLUX_OPT_TESTING_ROLEMASK)) {
+    else if (option && streq (option, FLUX_OPT_TESTING_ROLEMASK)) {
         val_size = sizeof (ctx->testing_rolemask);
         if (size != val_size) {
             errno = EINVAL;
@@ -129,7 +130,7 @@ static int op_getopt (void *impl, const char *option,
     size_t val_size;
     int rc = -1;
 
-    if (option && !strcmp (option, "flux::owner")) {
+    if (option && streq (option, "flux::owner")) {
         val_size = sizeof (ctx->owner);
         if (size != val_size) {
             errno = EINVAL;

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -136,9 +136,9 @@ flux_t *connector_init (const char *path, int flags, flux_error_t *errp)
         goto error;
     }
     while ((item = argz_next (ctx->argz, ctx->argz_len, item))) {
-        if (!strcmp (item, "bind"))
+        if (streq (item, "bind"))
             bind_socket = 1;
-        else if (!strcmp (item, "connect"))
+        else if (streq (item, "connect"))
             bind_socket = 0;
         else {
             errno = EINVAL;

--- a/src/modules/content-files/Makefile.am
+++ b/src/modules/content-files/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = libcontent-files.la

--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -59,6 +59,7 @@
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/dirwalk.h"
 #include "src/common/libutil/unlink_recursive.h"
+#include "ccan/str/str.h"
 
 #include "src/common/libcontent/content-util.h"
 
@@ -358,9 +359,9 @@ static int parse_args (flux_t *h,
 {
     int i;
     for (i = 0; i < argc; i++) {
-        if (!strcmp (argv[i], "testing"))
+        if (streq (argv[i], "testing"))
             *testing = true;
-        else if (!strcmp (argv[i], "truncate"))
+        else if (streq (argv[i], "truncate"))
             *truncate = true;
         else {
             flux_log (h, LOG_ERR, "Unknown module option: %s", argv[i]);

--- a/src/modules/content-files/filedb.c
+++ b/src/modules/content-files/filedb.c
@@ -22,6 +22,7 @@
 
 #include "src/common/libutil/read_all.h"
 #include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
 
 #include "filedb.h"
 
@@ -37,8 +38,8 @@ int filedb_get (const char *dbpath,
     void *data;
     ssize_t size;
 
-    if (strlen (key) == 0 || strchr (key, '/') || !strcmp (key, "..")
-                          || !strcmp (key, ".")) {
+    if (strlen (key) == 0 || strchr (key, '/') || streq (key, "..")
+                          || streq (key, ".")) {
         errno = EINVAL;
         if (errstr)
             *errstr = "invalid key name";
@@ -74,8 +75,8 @@ int filedb_put (const char *dbpath,
     char path[1024];
     int fd;
 
-    if (strlen (key) == 0 || strchr (key, '/') || !strcmp (key, "..")
-                          || !strcmp (key, ".")) {
+    if (strlen (key) == 0 || strchr (key, '/') || streq (key, "..")
+                          || streq (key, ".")) {
         errno = EINVAL;
         if (errstr)
             *errstr = "invalid key";

--- a/src/modules/content-s3/Makefile.am
+++ b/src/modules/content-s3/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = libcontent-s3.la

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -25,6 +25,7 @@
 #include "src/common/libutil/tomltk.h"
 
 #include "src/common/libyuarel/yuarel.h"
+#include "ccan/str/str.h"
 
 #include "s3.h"
 
@@ -186,7 +187,7 @@ static struct s3_config *parse_config (const flux_conf_t *conf,
     if (!(cfg->bucket = strdup (bucket)))
         goto error;
 
-    if (!strncmp (yuri.scheme, "https", 5))
+    if (strstarts (yuri.scheme, "https"))
         cfg->is_secure = 1;
 
     cfg->is_virtual_host = is_virtual_host;
@@ -483,7 +484,7 @@ error:
 static int parse_args (flux_t *h, int argc, char **argv)
 {
     for (int i = 0; i < argc; i++) {
-        if (!strcmp (argv[i], "truncate")) {
+        if (streq (argv[i], "truncate")) {
             flux_log (h,
                       LOG_ERR,
                       "truncate is not implemented.  Use S3 console"

--- a/src/modules/content-s3/s3.c
+++ b/src/modules/content-s3/s3.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 
 #include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
 
 #include "s3.h"
 
@@ -203,8 +204,8 @@ int s3_put (struct s3_config *cfg,
 
     if (strlen (key) == 0
         || strchr (key, '/')
-        || !strcmp (key, "..")
-        || !strcmp (key, ".")) {
+        || streq (key, "..")
+        || streq (key, ".")) {
         errno = EINVAL;
         if (errstr)
             *errstr = "invalid key";
@@ -280,8 +281,8 @@ int s3_get (struct s3_config *cfg,
 
     if (strlen (key) == 0
         || strchr (key, '/')
-        || !strcmp (key, "..")
-        || !strcmp (key, ".")) {
+        || streq (key, "..")
+        || streq (key, ".")) {
         errno = EINVAL;
         if (errstr)
             *errstr = "invalid key";

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -31,6 +31,7 @@
 #include "src/common/libutil/monotime.h"
 
 #include "src/common/libcontent/content-util.h"
+#include "ccan/str/str.h"
 
 const size_t lzo_buf_chunksize = 1024*1024;
 const size_t compression_threshold = 256; /* compress blobs >= this size */
@@ -808,13 +809,13 @@ static int process_args (struct content_sqlite *ctx,
 {
     int i;
     for (i = 0; i < argc; i++) {
-        if (strncmp ("journal_mode=", argv[i], 13) == 0) {
+        if (strstarts (argv[i], "journal_mode=")) {
             ctx->journal_mode = argv[i] + 13;
         }
-        else if (strncmp ("synchronous=", argv[i], 12) == 0) {
+        else if (strstarts (argv[i], "synchronous=")) {
             ctx->synchronous = argv[i] + 12;
         }
-        else if (strcmp ("truncate", argv[i]) == 0) {
+        else if (streq ("truncate", argv[i])) {
             *truncate = true;
         }
         else {

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -35,6 +35,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/fsd.h"
+#include "ccan/str/str.h"
 
 #include "task.h"
 #include "entry.h"
@@ -176,11 +177,11 @@ static void cron_entry_finished_handler (flux_t *h, cron_task_t *t, void *arg)
 {
     cron_entry_t *e = arg;
 
-    if (strcmp (cron_task_state (t), "Exec Failure") == 0) {
+    if (streq (cron_task_state (t), "Exec Failure")) {
         flux_log_error (h, "cron-%ju: failed to run %s", e->id, e->command);
         cron_entry_failure (e);
     }
-    else if (strcmp (cron_task_state (t), "Rexec Failure") == 0) {
+    else if (streq (cron_task_state (t), "Rexec Failure")) {
         flux_log_error (h, "cron-%ju: failure running %s", e->id, e->command);
         cron_entry_failure (e);
     }
@@ -869,9 +870,9 @@ static void process_args (cron_ctx_t *ctx, int ac, char **av)
 {
     int i;
     for (i = 0; i < ac; i++) {
-        if (strncmp (av[i], "sync=", 5) == 0)
+        if (strstarts (av[i], "sync="))
             cron_ctx_sync_event_init (ctx, (av[i])+5);
-        else if (strncmp (av[i], "sync_epsilon=", 13) == 0) {
+        else if (strstarts (av[i], "sync_epsilon=")) {
             char *s = (av[i])+13;
             if (fsd_parse_duration (s, &ctx->sync_epsilon) < 0)
                 flux_log_error (ctx->h, "option %s ignored", av[i]);

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 
 #include "src/common/libutil/log.h"
+#include "ccan/str/str.h"
 
 #include "task.h"
 
@@ -222,7 +223,7 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
 
     assert (t);
 
-    if (!strcmp (stream, "stderr"))
+    if (streq (stream, "stderr"))
         is_stderr = true;
 
     if (!(ptr = flux_subprocess_read_trimmed_line (p, stream, &lenp))) {

--- a/src/modules/cron/types.c
+++ b/src/modules/cron/types.c
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include "entry.h"
+#include "ccan/str/str.h"
 
 /* List of external operations structures defined in
  *  type-specific source files:
@@ -33,7 +34,7 @@ int cron_type_operations_lookup (const char *name,
 {
     struct cron_typeinfo *type = cron_types;
     while (type && type->name) {
-        if (strcmp (name, type->name) == 0) {
+        if (streq (name, type->name)) {
             *ops = *type->ops;
             return (0);
         }

--- a/src/modules/heartbeat/heartbeat.c
+++ b/src/modules/heartbeat/heartbeat.c
@@ -18,6 +18,7 @@
 #include <flux/core.h>
 
 #include <src/common/libutil/fsd.h>
+#include "ccan/str/str.h"
 
 static const double default_period = 2.0;
 
@@ -86,7 +87,7 @@ static int parse_args (int argc, char **argv, struct heartbeat *hb)
     int i;
 
     for (i = 0; i < argc; i++) {
-        if (!strncmp (argv[i], "period=", 7)) {
+        if (strstarts (argv[i], "period=")) {
             if (fsd_parse_duration (argv[i] + 7, &hb->period) < 0) {
                 flux_log_error (hb->h, "error parsing period value");
                 return -1;

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -8,8 +8,8 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
-	-I$(top_builddir)/src/common/libccan \
 	$(JANSSON_CFLAGS)
 
 noinst_LTLIBRARIES = \

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -32,6 +32,8 @@
 
 #include <unistd.h>
 
+#include "ccan/str/str.h"
+
 #include "job-exec.h"
 #include "exec_config.h"
 #include "bulk-exec.h"
@@ -151,8 +153,8 @@ static void output_cb (struct bulk_exec *exec, flux_subprocess_t *p,
     struct jobinfo *job = arg;
     const char *cmd = flux_cmd_arg (flux_subprocess_get_cmd (p), 0);
 
-    if (strcmp (stream, "FLUX_EXEC_PROTOCOL_FD") == 0) {
-        if (strcmp (data, "enter\n") == 0
+    if (streq (stream, "FLUX_EXEC_PROTOCOL_FD")) {
+        if (streq (data, "enter\n")
             && exec_barrier_enter (exec) < 0) {
             jobinfo_fatal_error (job,
                                  errno,
@@ -406,7 +408,7 @@ static int exec_start (struct jobinfo *job)
 {
     struct bulk_exec *exec = job->data;
 
-    if (strcmp (exec_mock_exception (exec), "init") == 0) {
+    if (streq (exec_mock_exception (exec), "init")) {
         /* If creating an "init" mock exception, generate it and
          *  then return to simulate an exception that came in before
          *  we could actually start the job
@@ -414,7 +416,7 @@ static int exec_start (struct jobinfo *job)
         jobinfo_fatal_error (job, 0, "mock init exception generated");
         return 0;
     }
-    else if (strcmp (exec_mock_exception (exec), "starting") == 0) {
+    else if (streq (exec_mock_exception (exec), "starting")) {
         /*  If we're going to mock an exception in "starting" phase, then
          *   set up a check watcher to cancel the job when some shells have
          *   started but (potentially) not all.

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 
 #include "exec_config.h"
+#include "ccan/str/str.h"
 
 static const char *default_cwd = "/tmp";
 static const char *default_job_shell = NULL;
@@ -106,9 +107,9 @@ int config_init (flux_t *h, int argc, char **argv)
     if (argv && argc) {
         /* Finally, override values on cmdline */
         for (int i = 0; i < argc; i++) {
-            if (strncmp (argv[i], "job-shell=", 10) == 0)
+            if (strstarts (argv[i], "job-shell="))
                 default_job_shell = argv[i]+10;
-            else if (strncmp (argv[i], "imp=", 4) == 0)
+            else if (strstarts (argv[i], "imp="))
                 flux_imp_path = argv[i]+4;
         }
     }

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -97,6 +97,7 @@
 #include "src/common/libeventlog/eventlogger.h"
 #include "src/common/libutil/fsd.h"
 #include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
 
 #include "job-exec.h"
 #include "checkpoint.h"
@@ -1319,7 +1320,7 @@ static int job_exec_initialize (flux_t *h, int argc, char **argv)
     }
     /* Override via commandline */
     for (int i = 0; i < argc; i++) {
-        if (strncmp (argv[i], "kill-timeout=", 13) == 0)
+        if (strstarts (argv[i], "kill-timeout="))
             kto = argv[i] + 13;
     }
 

--- a/src/modules/job-exec/test/bulk-exec.c
+++ b/src/modules/job-exec/test/bulk-exec.c
@@ -23,6 +23,7 @@
 
 #include "bulk-exec.h"
 #include "src/common/libutil/log.h"
+#include "ccan/str/str.h"
 
 extern char **environ;
 static int cancel_after = 0;
@@ -64,7 +65,7 @@ void on_output (struct bulk_exec *exec, flux_subprocess_t *p,
                 int data_len, void *arg)
 {
     int rank = flux_subprocess_rank (p);
-    FILE *fp = strcmp (stream, "stdout") == 0 ? stdout : stderr;
+    FILE *fp = streq (stream, "stdout") ? stdout : stderr;
     fprintf (fp, "%d: %s", rank, data);
 }
 
@@ -224,7 +225,7 @@ int main (int ac, char **av)
     if (flux_get_size (h, &size) < 0)
         log_err_exit ("flux_get_size");
 
-    if (strcmp (ranks, "all") == 0) {
+    if (streq (ranks, "all")) {
         if (!(idset = idset_create (size, 0)))
             log_err_exit ("idset_create");
         if (idset_range_set (idset, 0, size - 1) < 0)

--- a/src/modules/job-exec/testexec.c
+++ b/src/modules/job-exec/testexec.c
@@ -50,6 +50,8 @@
 #include "src/common/libjob/job_hash.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
+
 #include "job-exec.h"
 
 struct testexec_ctx {
@@ -147,7 +149,7 @@ static int init_testconf (flux_t *h, struct testconf *conf, json_t *jobspec)
 static bool testconf_mock_exception (struct testconf *conf, const char *where)
 {
     const char *s = conf->mock_exception;
-    return (s && strcmp (s, where) == 0);
+    return (s && streq (s, where));
 }
 
 /* Timer callback, post the "finish" event and notify tasks are complete
@@ -250,7 +252,7 @@ static int testexec_reattach_starttime (struct jobinfo *job,
             jobinfo_fatal_error (job, errno, "eventlog_entry_parse");
             goto cleanup;
         }
-        if (!strcmp (name, "start")) {
+        if (streq (name, "start")) {
             (*startp) = (time_t)timestamp;
             break;
         }
@@ -387,7 +389,7 @@ static void testexec_request_cb (flux_t *h,
         errno = EINVAL;
         goto error;
     }
-    if (strcmp (event, "start") == 0) {
+    if (streq (event, "start")) {
         if (te->job->running) {
             errmsg = "Job already running";
             errno = EINVAL;
@@ -396,7 +398,7 @@ static void testexec_request_cb (flux_t *h,
         if (start_timer (h, te, te->conf.run_duration) < 0)
             goto error;
     }
-    else if (strcmp (event, "finish") == 0) {
+    else if (streq (event, "finish")) {
         if (!te->job->running) {
             errmsg = "Job not running";
             errno = EINVAL;

--- a/src/modules/job-info/allow.c
+++ b/src/modules/job-info/allow.c
@@ -20,6 +20,7 @@
 #include "allow.h"
 
 #include "src/common/libeventlog/eventlog.h"
+#include "ccan/str/str.h"
 
 /* Parse the submit userid from the event log.
  * Assume "submit" is the first event.
@@ -50,7 +51,7 @@ static int eventlog_get_userid (struct info_ctx *ctx, const char *s,
         flux_log_error (ctx->h, "%s: eventlog_decode", __FUNCTION__);
         goto error;
     }
-    if (strcmp (name, "submit") != 0 || !context) {
+    if (!streq (name, "submit") || !context) {
         flux_log (ctx->h, LOG_ERR, "%s: invalid event: %s", __FUNCTION__, name);
         errno = EPROTO;
         goto error;

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -22,6 +22,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libjob/job.h"
 #include "src/common/libeventlog/eventlog.h"
+#include "ccan/str/str.h"
 
 #include "job-info.h"
 #include "watch.h"
@@ -330,13 +331,13 @@ static int check_guest_namespace_status (struct guest_watch_ctx *gw,
         json_t *context = NULL;
         if (eventlog_entry_parse (event, NULL, &name, &context) < 0)
             goto error;
-        if (!strcmp (name, "start"))
+        if (streq (name, "start"))
             gw->guest_started = true;
-        if (!strcmp (name, "release")) {
+        if (streq (name, "release")) {
             void *iter = json_object_iter (context);
             while (iter && !gw->guest_released) {
                 const char *key = json_object_iter_key (iter);
-                if (!strcmp (key, "final")) {
+                if (streq (key, "final")) {
                     json_t *value = json_object_iter_value (iter);
                     if (json_is_boolean (value) && json_is_true (value))
                         gw->guest_released = true;
@@ -465,7 +466,7 @@ static int check_guest_namespace_created (struct guest_watch_ctx *gw,
         goto error;
     }
 
-    if (!strcmp (name, "start"))
+    if (streq (name, "start"))
         gw->guest_started = true;
 
     /* Do not need to check for "clean", if "start" never occurs, will

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -18,6 +18,7 @@
 #include <assert.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "job-info.h"
 #include "lookup.h"
@@ -272,7 +273,7 @@ static int check_keys_for_eventlog (struct lookup_ctx *l)
             errno = EINVAL;
             return -1;
         }
-        if (!strcmp (keystr, "eventlog"))
+        if (streq (keystr, "eventlog"))
             return 0;
     }
 

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -20,6 +20,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libjob/job.h"
 #include "src/common/libeventlog/eventlog.h"
+#include "ccan/str/str.h"
 
 #include "job-info.h"
 #include "watch.h"
@@ -226,7 +227,7 @@ static int check_eventlog_end (struct watch_ctx *w,
         goto error;
     }
 
-    if (!strcmp (name, "clean"))
+    if (streq (name, "clean"))
         rc = 1;
     else
         rc = 0;
@@ -291,7 +292,7 @@ static void watch_continuation (flux_future_t *f, void *arg)
          * An alternate main KVS namespace eventlog does not have a
          * known ruleset, so it will hang.
          */
-        if (!w->guest && !strcmp (w->path, "eventlog")) {
+        if (!w->guest && streq (w->path, "eventlog")) {
             if (check_eventlog_end (w, tok, toklen) > 0) {
                 if (flux_kvs_lookup_cancel (w->watch_f) < 0) {
                     flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
@@ -420,7 +421,7 @@ void watch_cb (flux_t *h, flux_msg_handler_t *mh,
 
     /* if watching a "guest" path, forward to guest watcher for
      * handling */
-    if (!strncmp (path, "guest.", 6)) {
+    if (strstarts (path, "guest.")) {
         if (guest_watch (ctx, msg, id, path + 6, flags) < 0)
             goto error;
     }

--- a/src/modules/job-ingest/Makefile.am
+++ b/src/modules/job-ingest/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
 	$(FLUX_SECURITY_CFLAGS) \
 	$(JANSSON_CFLAGS)

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -25,6 +25,7 @@
 #include "src/common/libutil/jpath.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libjob/job_hash.h"
+#include "ccan/str/str.h"
 
 #include "util.h"
 #include "job.h"
@@ -659,12 +660,12 @@ static int job_ingest_configure (struct job_ingest_ctx *ctx,
         return -1;
     }
     for (int i = 0; i < argc; i++) {
-        if (!strncmp (argv[i], "validator-args=", 15)
-            || !strncmp (argv[i], "validator-plugins=", 18)
-            || !strcmp (argv[i], "disable-validator")) {
+        if (strstarts (argv[i], "validator-args=")
+            || strstarts (argv[i], "validator-plugins=")
+            || streq (argv[i], "disable-validator")) {
             /* handled in pipeline.c */
         }
-        else if (!strncmp (argv[i], "batch-count=", 12)) {
+        else if (strstarts (argv[i], "batch-count=")) {
             char *endptr;
             errno = 0;
             ctx->batch_count = strtol (argv[i]+12, &endptr, 0);

--- a/src/modules/job-ingest/job.c
+++ b/src/modules/job-ingest/job.c
@@ -23,6 +23,7 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libjob/sign_none.h"
+#include "ccan/str/str.h"
 
 #include "job.h"
 
@@ -147,7 +148,7 @@ struct job *job_create_from_request (const flux_msg_t *msg,
         goto error;
     }
     if (!(job->cred.rolemask & FLUX_ROLE_OWNER)
-        && !strcmp (mech_type, "none")) {
+        && streq (mech_type, "none")) {
         errprintf (error, "only instance owner can use sign-type=none");
         errno = EPERM;
         goto error;

--- a/src/modules/job-ingest/pipeline.c
+++ b/src/modules/job-ingest/pipeline.c
@@ -18,6 +18,7 @@
 
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
 
 #include "util.h"
 #include "workcrew.h"
@@ -309,15 +310,15 @@ int pipeline_configure (struct pipeline *pl,
     /* Process module command line
      */
     for (int i = 0; i < argc; i++) {
-        if (!strncmp (argv[i], "validator-args=", 15)) {
+        if (strstarts (argv[i], "validator-args=")) {
             free (validator_args);
             validator_args = strdup (argv[i] + 15);
         }
-        else if (!strncmp (argv[i], "validator-plugins=", 18)) {
+        else if (strstarts (argv[i], "validator-plugins=")) {
             free (validator_plugins);
             validator_plugins = strdup (argv[i] + 18);
         }
-        else if (!strcmp (argv[i], "disable-validator"))
+        else if (streq (argv[i], "disable-validator"))
             pl->validator_bypass = true;
     }
 

--- a/src/modules/job-ingest/test/util.c
+++ b/src/modules/job-ingest/test/util.c
@@ -16,6 +16,7 @@
 #include <errno.h>
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 #include "util.h"
 
@@ -27,7 +28,7 @@ void test_join (void)
     if (!(o = json_pack ("[s]", "foo")))
         BAIL_OUT ("could not create json array");
     s = util_join_arguments (o);
-    ok (s && !strcmp (s, "foo"),
+    ok (s && streq (s, "foo"),
         "util_join_arguments [foo] works");
     free (s);
     json_decref (o);
@@ -35,7 +36,7 @@ void test_join (void)
     if (!(o = json_pack ("[sss]", "foo", "bar", "baz")))
         BAIL_OUT ("could not create json array");
     s = util_join_arguments (o);
-    ok (s && !strcmp (s, "foo,bar,baz"),
+    ok (s && streq (s, "foo,bar,baz"),
         "util_join_arguments [foo,bar,baz] works");
     free (s);
     json_decref (o);
@@ -43,7 +44,7 @@ void test_join (void)
     if (!(o = json_array ()))
         BAIL_OUT ("could not create json array");
     s = util_join_arguments (o);
-    ok (s && !strcmp (s, ""),
+    ok (s && streq (s, ""),
         "util_join_arguments [] works");
     free (s);
     json_decref (o);

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -46,6 +46,7 @@
 #include <flux/core.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "worker.h"
 
@@ -242,12 +243,12 @@ static void worker_output_cb (flux_subprocess_t *p, const char *stream)
          * all output complete.
          */
         if (w->p == p &&
-            !strcmp (stream, "stdout") &&
+            streq (stream, "stdout") &&
             worker_queue_depth (w) > 0)
             worker_unexpected_exit (w);
         return;
     }
-    if (!strcmp (stream, "stdout")) {
+    if (streq (stream, "stdout")) {
         flux_future_t *f;
 
         if (!(f = zlist_pop (w->queue))) {
@@ -260,7 +261,7 @@ static void worker_output_cb (flux_subprocess_t *p, const char *stream)
         if (zlist_size (w->queue) == 0)
             worker_inactive (w);
     }
-    else if (!strcmp (stream, "stderr")) {
+    else if (streq (stream, "stderr")) {
         flux_log (w->h, LOG_DEBUG, "%s: %s", w->name, s ? s : "");
     }
 }

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -624,7 +624,7 @@ static struct job *eventlog_restart_parse (struct job_state_ctx *jsctx,
         else if (streq (name, "flux-restart")) {
             revert_job_state (jsctx, job, timestamp);
         }
-        else if (!strncmp (name, "dependency-", 11)) {
+        else if (strstarts (name, "dependency-")) {
             if (dependency_context_parse (jsctx->h, job, name+11, context) < 0)
                 goto error;
         }
@@ -1378,7 +1378,7 @@ static int journal_process_event (struct job_state_ctx *jsctx, json_t *event)
         if (memo_update (jsctx->h, job, context) < 0)
             return -1;
     }
-    else if (!strncmp (name, "dependency-", 11)) {
+    else if (strstarts (name, "dependency-")) {
         if (journal_dependency_event (jsctx, job, name+11, context) < 0)
             return -1;
     }

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -665,11 +665,11 @@ int event_job_update (struct job *job, json_t *event)
     else if (streq (name, "validate")) {
         job->state = FLUX_JOB_STATE_DEPEND;
     }
-    else if (!strcmp (name, "jobspec-update")) {
+    else if (streq (name, "jobspec-update")) {
         if (event_handle_jobspec_update (job, context) < 0)
             goto inval;
     }
-    else if (!strncmp (name, "dependency-", 11)) {
+    else if (strstarts (name, "dependency-")) {
         if (job->state == FLUX_JOB_STATE_DEPEND
             || job->state == FLUX_JOB_STATE_NEW) {
             if (event_handle_dependency (job, name+11, context) < 0)
@@ -754,13 +754,13 @@ int event_job_update (struct job *job, json_t *event)
             job->t_clean = timestamp;
         }
     }
-    else if (!strncmp (name, "prolog-", 7)) {
+    else if (strstarts (name, "prolog-")) {
         if (!job->start_pending) {
             if (event_handle_perilog (job, name+7, context) < 0)
                 goto error;
         }
     }
-    else if (!strncmp (name, "epilog-", 7)) {
+    else if (strstarts (name, "epilog-")) {
         if (job->state == FLUX_JOB_STATE_CLEANUP) {
             if (event_handle_perilog (job, name+7, context) < 0)
                 goto error;

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -21,6 +21,7 @@
 #include "src/common/libutil/jpath.h"
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "alloc.h"
 #include "job-manager.h"
@@ -631,7 +632,7 @@ static int queue_start (struct queue *queue, const char *name)
 {
     struct job *job = zhashx_first (queue->ctx->active_jobs);
     while (job) {
-        if (!name || (job->queue && !strcmp (job->queue, name))) {
+        if (!name || (job->queue && streq (job->queue, name))) {
             if (!job->alloc_queued
                 && !job->alloc_pending
                 && job->state == FLUX_JOB_STATE_SCHED) {
@@ -652,7 +653,7 @@ static void queue_stop (struct queue *queue, const char *name)
         || alloc_pending_count (queue->ctx->alloc) > 0) {
         struct job *job = zhashx_first (queue->ctx->active_jobs);
         while (job) {
-            if (!name || (job->queue && !strcmp (job->queue, name))) {
+            if (!name || (job->queue && streq (job->queue, name))) {
                 if (job->alloc_queued)
                     alloc_dequeue_alloc_request (queue->ctx->alloc, job);
                 else if (job->alloc_pending)

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -17,6 +17,7 @@
 #include "src/common/libtap/tap.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/modules/job-manager/job.h"
+#include "ccan/str/str.h"
 
 void test_create (void)
 {
@@ -381,7 +382,7 @@ void test_create_from_json (void)
         && job->urgency == 10
         && job->userid == 42
         && job->t_submit == 1.0
-        && job->queue && !strcmp (job->queue, "foo")
+        && job->queue && streq (job->queue, "foo")
         && job->flags == 0,
         "job json object was properly decoded w/ queue");
     json_decref (o);
@@ -540,7 +541,7 @@ static void test_event_queue (void)
     ok (job_event_peek (job, &flags, &entry) == 0,
         "job_event_peek works");
     ok (eventlog_entry_parse (entry, NULL, &name, &context) == 0
-        && !strcmp (name, "foo")
+        && streq (name, "foo")
         && json_unpack (context, "{s:i}", "bar", &i) == 0
         && i == 42,
         "eventlog entry is correct");
@@ -556,7 +557,7 @@ static void test_event_queue (void)
     ok (json_array_size (job->event_queue) == 1,
         "queue size is now 1");
     ok (eventlog_entry_parse (entry, NULL, &name, &context) == 0
-        && !strcmp (name, "foo")
+        && streq (name, "foo")
         && json_unpack (context, "{s:i}", "bar", &i) == 0
         && i == 42,
         "eventlog entry is correct");
@@ -572,7 +573,7 @@ static void test_event_queue (void)
     ok (job_event_peek (job, &flags, &entry) == 0,
         "job_event_peek works");
     ok (eventlog_entry_parse (entry, NULL, &name, &context) == 0
-        && !strcmp (name, "bar")
+        && streq (name, "bar")
         && json_unpack (context, "{s:i}", "baz", &i) == 0
         && i == 43,
         "eventlog entry is correct");

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -625,7 +625,7 @@ static void content_store_completion (flux_future_t *f, void *arg)
      * location we calculated.
      * N.B. perhaps this check is excessive and could be removed
      */
-    if (strcmp (blobref, cache_blobref)) {
+    if (!streq (blobref, cache_blobref)) {
         flux_log (ctx->h, LOG_ERR, "%s: inconsistent blobref returned",
                   __FUNCTION__);
         errno = EPROTO;
@@ -2809,7 +2809,7 @@ static void process_args (struct kvs_ctx *ctx, int ac, char **av)
     int i;
 
     for (i = 0; i < ac; i++) {
-        if (strncmp (av[i], "transaction-merge=", 13) == 0)
+        if (strstarts (av[i], "transaction-merge="))
             ctx->transaction_merge = strtoul (av[i]+13, NULL, 10);
         else
             flux_log (ctx->h, LOG_ERR, "Unknown option `%s'", av[i]);
@@ -2924,7 +2924,7 @@ static int store_initial_rootdir (struct kvs_ctx *ctx, char *ref, int ref_len)
         /* Sanity check that content cache is using the same hash alg as KVS.
          * It should suffice to do this once at startup.
          */
-        if (strcmp (newref, ref) != 0) {
+        if (!streq (newref, ref)) {
             errno = EPROTO;
             flux_log_error (ctx->h, "%s: hash mismatch kvs=%s content=%s",
                             __FUNCTION__, ref, newref);

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -23,6 +23,7 @@
 #include <assert.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "kvsroot.h"
 
@@ -122,7 +123,7 @@ struct kvsroot *kvsroot_mgr_create_root (kvsroot_mgr_t *krm,
         goto error;
     }
 
-    if (!strcmp (root->ns_name, KVS_PRIMARY_NAMESPACE))
+    if (streq (root->ns_name, KVS_PRIMARY_NAMESPACE))
         root->is_primary = true;
 
     if (!(root->ktm = kvstxn_mgr_create (cache,

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -31,6 +31,7 @@
 #include "src/common/libkvs/kvs_commit.h"
 #include "src/common/libkvs/kvs_txn_private.h"
 #include "src/common/libkvs/kvs_util_private.h"
+#include "ccan/str/str.h"
 
 #include "kvstxn.h"
 
@@ -617,7 +618,7 @@ static int kvstxn_link_dirent (kvstxn_t *kt,
 
     /* Special case root
      */
-    if (strcmp (name, ".") == 0) {
+    if (streq (name, ".")) {
         saved_errno = EINVAL;
         goto done;
     }
@@ -709,7 +710,7 @@ static int kvstxn_link_dirent (kvstxn_t *kt,
             assert (target);
 
             /* can't cross into a new namespace */
-            if (ns && strcmp (ns, kt->ktm->ns_name)) {
+            if (ns && !streq (ns, kt->ktm->ns_name)) {
                 saved_errno = EINVAL;
                 goto done;
             }
@@ -860,7 +861,7 @@ kvstxn_process_t kvstxn_process (kvstxn_t *kt,
         if (kt->state == KVSTXN_STATE_INIT) {
             /* Do some initial checks */
             if (kt->flags & FLUX_KVS_SYNC
-                && strcmp (kt->ktm->ns_name, KVS_PRIMARY_NAMESPACE) != 0) {
+                && !streq (kt->ktm->ns_name, KVS_PRIMARY_NAMESPACE)) {
                 kt->errnum = EINVAL;
                 return KVSTXN_PROCESS_ERROR;
             }

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -27,6 +27,7 @@
 #include "src/common/libutil/blobref.h"
 #include "src/common/libkvs/treeobj.h"
 #include "src/common/libkvs/kvs_util_private.h"
+#include "ccan/str/str.h"
 
 #include "cache.h"
 #include "kvsroot.h"
@@ -313,7 +314,7 @@ static lookup_process_t walk_symlink (lookup_t *lh,
         /* if symlink target is root, no need to recurse, just get
          * root_dirent and continue on.
          */
-        if (!strcmp (target, ".")) {
+        if (streq (target, ".")) {
             if (root) {
                 json_decref (wl->tmp_dirent);
                 wl->tmp_dirent = treeobj_create_dirref (root->ref);
@@ -954,7 +955,7 @@ lookup_process_t lookup (lookup_t *lh)
             }
 
             /* special case root */
-            if (!strcmp (lh->path, ".")) {
+            if (streq (lh->path, ".")) {
                 if ((lh->flags & FLUX_KVS_TREEOBJ)) {
                     if (!(lh->val = treeobj_create_dirref (lh->root_ref))) {
                         lh->errnum = errno;

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -19,6 +19,7 @@
 #include "src/common/libtap/tap.h"
 #include "src/modules/kvs/waitqueue.h"
 #include "src/modules/kvs/cache.h"
+#include "ccan/str/str.h"
 
 static int cache_entry_set_treeobj (struct cache_entry *entry, const json_t *o)
 {
@@ -195,7 +196,7 @@ void cache_entry_raw_tests (void)
 
     ok (cache_entry_get_raw (e, (const void **)&datatmp, &len) == 0,
         "raw data retrieved from cache entry");
-    ok (datatmp && strcmp (datatmp, data) == 0,
+    ok (datatmp && streq (datatmp, data),
         "raw data matches expected string");
     ok (datatmp && (len == strlen (data) + 1),
         "raw data length matches expected length");
@@ -471,7 +472,7 @@ void cache_blobref_tests (void)
         "cache_insert works");
     ok ((ref = cache_entry_get_blobref (e)) != NULL,
         "cache_entry_get_blobref success");
-    ok (!strcmp (ref, "abcd"),
+    ok (streq (ref, "abcd"),
         "cache_entry_get_blobref returned correct ref");
 
     cache_destroy (cache);

--- a/src/modules/kvs/test/kvs_wait_version.c
+++ b/src/modules/kvs/test/kvs_wait_version.c
@@ -22,6 +22,7 @@
 #include "src/modules/kvs/kvsroot.h"
 #include "src/modules/kvs/kvs_wait_version.h"
 #include "src/modules/kvs/cache.h"
+#include "ccan/str/str.h"
 
 const char *root_ref = "1234";  /* random string, doesn't matter for tests */
 int count = 0;
@@ -168,11 +169,11 @@ bool msgcmp (const flux_msg_t *msg, void *arg)
     const char *id;
     bool match = false;
     if ((id = flux_msg_route_first (msg))
-        && (!strcmp (id, "1")
-            || !strcmp (id, "2")
-            || !strcmp (id, "3")
-            || !strcmp (id, "4")
-            || !strcmp (id, "5")))
+        && (streq (id, "1")
+            || streq (id, "2")
+            || streq (id, "3")
+            || streq (id, "4")
+            || streq (id, "5")))
         match = true;
     return match;
 }

--- a/src/modules/kvs/test/kvsroot.c
+++ b/src/modules/kvs/test/kvsroot.c
@@ -20,6 +20,7 @@
 #include "src/common/libkvs/kvs.h"
 #include "src/modules/kvs/kvsroot.h"
 #include "src/modules/kvs/treq.h"
+#include "ccan/str/str.h"
 
 int global = 0;
 
@@ -80,7 +81,7 @@ void basic_api_tests (void)
 
     kvsroot_setroot (krm, root, "foobar", 18);
 
-    ok (!strcmp (root->ref, "foobar"),
+    ok (streq (root->ref, "foobar"),
         "kvsroot_setroot set ref correctly");
 
     ok (root->seq == 18,

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -26,6 +26,7 @@
 #include "src/modules/kvs/kvstxn.h"
 #include "src/modules/kvs/kvsroot.h"
 #include "src/modules/kvs/lookup.h"
+#include "ccan/str/str.h"
 
 static int test_global = 5;
 
@@ -350,7 +351,7 @@ bool is_op_key (json_t *ops, const char *key)
     json_array_foreach (ops, index, entry) {
         if ((o = json_object_get (entry, "key"))
                     && (k = json_string_value (o))
-                    && !strcmp (key, k))
+                    && streq (key, k))
             return true;
     }
     return false;
@@ -684,7 +685,7 @@ void kvstxn_basic_tests (void)
     ok ((ns = kvstxn_get_namespace (kt)) != NULL,
         "kvstxn_get_namespace returns non-NULL");
 
-    ok (!strcmp (ns, KVS_PRIMARY_NAMESPACE),
+    ok (streq (ns, KVS_PRIMARY_NAMESPACE),
         "kvstxn_get_namespace returns correct string");
 
     ok (kvstxn_get_aux (kt) == &test_global,
@@ -902,7 +903,7 @@ void kvstxn_basic_kvstxn_process_test_empty_ops (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    ok (strcmp (newroot, rootref) == 0,
+    ok (streq (newroot, rootref),
         "root stays identical when no ops in transaction");
 
     verify_keys_and_ops_standard (kt);
@@ -962,7 +963,7 @@ void kvstxn_basic_kvstxn_process_test_internal_flags (void)
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
         "kvstxn_get_newroot_ref returns != NULL when processing complete");
 
-    ok (strcmp (newroot, rootref) == 0,
+    ok (streq (newroot, rootref),
         "root stays identical when no ops in transaction");
 
     verify_keys_and_ops_standard (kt);
@@ -1331,7 +1332,7 @@ int rootref_cb (kvstxn_t *kt, const char *ref, void *data)
     json_t *rootdir;
     struct cache_entry *entry;
 
-    ok (strcmp (ref, rd->rootref) == 0,
+    ok (streq (ref, rd->rootref),
         "missing root reference is what we expect it to be");
 
     ok ((rootdir = treeobj_create_dir ()) != NULL,

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -25,6 +25,7 @@
 #include "src/modules/kvs/cache.h"
 #include "src/modules/kvs/lookup.h"
 #include "src/common/libutil/blobref.h"
+#include "ccan/str/str.h"
 
 struct flux_msg_cred owner_cred = { .userid = 0, .rolemask = FLUX_ROLE_OWNER };
 struct flux_msg_cred user_cred = { .userid = 0, .rolemask = FLUX_ROLE_USER };
@@ -241,7 +242,7 @@ void basic_api (void)
         "lookup_create works");
     ok ((tmp = lookup_get_namespace (lh)) != NULL,
         "lookup_get_namespace works");
-    ok (!strcmp (tmp, KVS_PRIMARY_NAMESPACE),
+    ok (streq (tmp, KVS_PRIMARY_NAMESPACE),
         "lookup_get_namespace returns correct string");
     ok (lookup_missing_namespace (lh) == NULL,
         "lookup_missing_namespace returned NULL, no missing namespace yet");
@@ -377,7 +378,7 @@ void basic_lookup (void) {
         "lookup process finished");
     ok ((tmp = lookup_get_root_ref (lh)) != NULL,
         "lookup_get_root_ref returns non-NULL");
-    ok (!strcmp (tmp, root_ref),
+    ok (streq (tmp, root_ref),
         "lookup_get_root_ref returned correct root_ref");
     ok (lookup_get_root_seq (lh) >= 0,
         "lookup_get_root_seq returned valid root_seq");
@@ -398,7 +399,7 @@ void basic_lookup (void) {
         "lookup process finished");
     ok ((tmp = lookup_get_root_ref (lh)) != NULL,
         "lookup_get_root_ref returns non-NULL");
-    ok (!strcmp (tmp, root_ref),
+    ok (streq (tmp, root_ref),
         "lookup_get_root_ref returned correct root_ref");
     ok (lookup_get_root_seq (lh) == 18,
         "lookup_get_root_seq returned correct root_seq");
@@ -466,7 +467,7 @@ void check_common (lookup_t *lh,
                 "%s: missing ref returned one missing refs", msg);
 
             if (ld.ref) {
-                ok (strcmp (ld.ref, missing_ref_result) == 0,
+                ok (streq (ld.ref, missing_ref_result),
                     "%s: missing ref returned matched expectation", msg);
             }
             else {
@@ -2334,7 +2335,7 @@ void lookup_stall_namespace (void) {
         "lookup stalled on missing namespace");
     ok ((tmp = lookup_missing_namespace (lh)) != NULL,
         "lookup_missing_namespace returned non-NULL");
-    ok (!strcmp (tmp, KVS_PRIMARY_NAMESPACE),
+    ok (streq (tmp, KVS_PRIMARY_NAMESPACE),
         "lookup_missing_namespace returned correct namespace");
 
     setup_kvsroot (krm, KVS_PRIMARY_NAMESPACE, cache, root_ref1, 0);
@@ -2375,7 +2376,7 @@ void lookup_stall_namespace (void) {
         "lookup stalled on missing namespace");
     ok ((tmp = lookup_missing_namespace (lh)) != NULL,
         "lookup_missing_namespace returned non-NULL");
-    ok (!strcmp (tmp, "foo"),
+    ok (streq (tmp, "foo"),
         "lookup_missing_namespace returned correct namespace");
 
     setup_kvsroot (krm, "foo", cache, root_ref2, 0);
@@ -2416,7 +2417,7 @@ void lookup_stall_namespace (void) {
         "lookup stalled on missing namespace");
     ok ((tmp = lookup_missing_namespace (lh)) != NULL,
         "lookup_missing_namespace returned non-NULL");
-    ok (!strcmp (tmp, "roottest"),
+    ok (streq (tmp, "roottest"),
         "lookup_missing_namespace returned correct namespace");
 
     setup_kvsroot (krm, "roottest", cache, root_ref1, 0);

--- a/src/modules/kvs/test/treq.c
+++ b/src/modules/kvs/test/treq.c
@@ -19,6 +19,7 @@
 #include "src/common/libflux/message.h"
 #include "src/common/libflux/request.h"
 #include "src/modules/kvs/treq.h"
+#include "ccan/str/str.h"
 
 int msg_cb (treq_t *tr, const flux_msg_t *req, void *data)
 {
@@ -26,7 +27,7 @@ int msg_cb (treq_t *tr, const flux_msg_t *req, void *data)
     const char *topic;
 
     if (!flux_msg_get_topic (req, &topic)
-        && !strcmp (topic, "mytopic"))
+        && streq (topic, "mytopic"))
         (*count)++;
 
     return 0;
@@ -58,7 +59,7 @@ void treq_basic_tests (void)
     ok ((name = treq_get_name (tr)) != NULL,
         "treq_get_name works");
 
-    ok (strcmp (name, "foo") == 0,
+    ok (streq (name, "foo"),
         "treq_get_name returns the correct name");
 
     ok (treq_get_nprocs (tr) == 1,

--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -11,6 +11,7 @@
 #include "src/modules/kvs/waitqueue.h"
 #include "src/common/libflux/message.h"
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 void wait_cb (void *arg)
 {
@@ -46,7 +47,7 @@ bool msgcmp (const flux_msg_t *msg, void *arg)
     const char *id;
     bool match = false;
     if ((id = flux_msg_route_first (msg))
-        && (!strcmp (id, "19") || !strcmp (id, "18") || !strcmp (id, "17")))
+        && (streq (id, "19") || streq (id, "18") || streq (id, "17")))
         match = true;
     return match;
 }
@@ -103,7 +104,7 @@ int main (int argc, char *argv[])
     ok (wait_msg_aux_set (w, "aux", "val", NULL) == 0,
         "wait_msg_aux_set works");
     str = wait_msg_aux_get (w, "aux");
-    ok (str && !strcmp (str, "val"),
+    ok (str && streq (str, "val"),
         "wait_msg_aux_get works and returns correct value");
     flux_msg_destroy (msg);
     wait_destroy (w);

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
 	$(JANSSON_CFLAGS) \
 	$(HWLOC_CFLAGS)

--- a/src/modules/resource/acquire.c
+++ b/src/modules/resource/acquire.c
@@ -59,6 +59,7 @@
 #include "src/common/libidset/idset.h"
 #include "src/common/librlist/rlist.h"
 #include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
 
 #include "resource.h"
 #include "reslog.h"
@@ -329,7 +330,7 @@ static void reslog_cb (struct reslog *reslog, const char *name, void *arg)
     while (msg) {
         struct acquire_request *ar = flux_msg_aux_get (msg, "acquire");
 
-        if (!strcmp (name, "resource-define")) {
+        if (streq (name, "resource-define")) {
             if (ar->response_count == 0) {
                 if (!(resobj = inventory_get (ctx->inventory))) {
                     errmsg = "resource discovery failed or interrupted";
@@ -348,9 +349,9 @@ static void reslog_cb (struct reslog *reslog, const char *name, void *arg)
                 }
             }
         }
-        else if (!strcmp (name, "online") || !strcmp (name, "offline")
-                || !strcmp (name, "exclude") || !strcmp (name, "unexclude")
-                || !strcmp (name, "drain") || !strcmp (name, "undrain")) {
+        else if (streq (name, "online") || streq (name, "offline")
+                || streq (name, "exclude") || streq (name, "unexclude")
+                || streq (name, "drain") || streq (name, "undrain")) {
             if (ar->response_count > 0) {
                 struct idset *up, *dn;
                 if (acquire_request_update (ar, acquire, name, &up, &dn) < 0) {

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -44,6 +44,7 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libidset/idset.h"
 #include "src/common/libeventlog/eventlog.h"
+#include "ccan/str/str.h"
 
 #include "resource.h"
 #include "reslog.h"
@@ -385,11 +386,11 @@ static void drain_cb (flux_t *h,
 
     if (mode) {
         errstr = "Invalid mode specified";
-        if (strcmp (mode, "update") == 0)
+        if (streq (mode, "update"))
             update_only = 1;
-        else if (strcmp (mode, "overwrite") == 0)
+        else if (streq (mode, "overwrite"))
             overwrite = 1;
-        else if (strcmp (mode, "force-overwrite") == 0)
+        else if (streq (mode, "force-overwrite"))
             overwrite = 2;
         else {
             errno = EINVAL;
@@ -616,7 +617,7 @@ static int replay_eventlog (struct drain *drain, const json_t *eventlog)
 
             if (eventlog_entry_parse (entry, &timestamp, &name, &context) < 0)
                 return -1;
-            if (!strcmp (name, "resource-init")) {
+            if (streq (name, "resource-init")) {
                 struct drain_init_args args = {
                     .drain = drain,
                     .exclude = exclude
@@ -628,7 +629,7 @@ static int replay_eventlog (struct drain *drain, const json_t *eventlog)
                 if (rutil_idkey_map (draininfo, replay_map, &args) < 0)
                     return -1;
             }
-            else if (!strcmp (name, "drain")) {
+            else if (streq (name, "drain")) {
                 int overwrite = 1;
                 if (json_unpack (context,
                                  "{s:s s?s s?i}",
@@ -653,7 +654,7 @@ static int replay_eventlog (struct drain *drain, const json_t *eventlog)
                 }
                 idset_destroy (idset);
             }
-            else if (!strcmp (name, "undrain")) {
+            else if (streq (name, "undrain")) {
                 if (json_unpack (context, "{s:s}", "idset", &s) < 0) {
                     errno = EPROTO;
                     return -1;

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -23,6 +23,7 @@
 #include "src/common/libidset/idset.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/librlist/rlist.h"
+#include "ccan/str/str.h"
 
 #include "resource.h"
 #include "inventory.h"
@@ -340,7 +341,7 @@ static int prune_eventlog (json_t *eventlog)
 
     json_array_foreach (eventlog, index, entry) {
         if (eventlog_entry_parse (entry, NULL, &name, NULL) == 0
-                && !strcmp (name, "resource-init"))
+                && streq (name, "resource-init"))
             last_entry = index;
     }
     if (last_entry < json_array_size (eventlog)) {
@@ -401,9 +402,9 @@ int parse_args (flux_t *h,
         /* Test option to force all ranks to be marked online in the initial
          * 'restart' event posted to resource.eventlog.
          */
-        if (!strcmp (argv[i], "monitor-force-up"))
+        if (streq (argv[i], "monitor-force-up"))
             *monitor_force_up = true;
-        else if (!strcmp (argv[i], "noverify"))
+        else if (streq (argv[i], "noverify"))
             *noverify = true;
         else  {
             flux_log (h, LOG_ERR, "unknown option: %s", argv[i]);

--- a/src/modules/resource/rutil.c
+++ b/src/modules/resource/rutil.c
@@ -25,6 +25,7 @@
 #include "src/common/libutil/dirwalk.h"
 #include "src/common/libutil/read_all.h"
 #include "src/common/libutil/errprintf.h"
+#include "ccan/str/str.h"
 
 #include "rutil.h"
 
@@ -192,7 +193,7 @@ static int load_xml_file (dirwalk_t *d, void *arg)
         return 0;
     errno = 0;
     rank = strtol (name, &endptr, 10);
-    if (errno > 0 || strcmp (endptr, ".xml") != 0)
+    if (errno > 0 || !streq (endptr, ".xml"))
         return 0;
 
     /* Read the file and encode as JSON string, storing under rank key.

--- a/src/modules/resource/test/rutil.c
+++ b/src/modules/resource/test/rutil.c
@@ -20,6 +20,7 @@
 #include "src/common/libutil/cleanup.h"
 #include "src/common/libutil/read_all.h"
 #include "src/common/libidset/idset.h"
+#include "ccan/str/str.h"
 
 #include "src/modules/resource/rutil.h"
 
@@ -134,12 +135,12 @@ void test_set_json_idset (void)
     ok (rutil_set_json_idset (o, "foo", NULL) == 0
             && (o2 = json_object_get (o, "foo"))
             && (s = json_string_value (o2))
-            && !strcmp (s, ""),
+            && streq (s, ""),
         "rutil_set_json_idset ids=NULL sets empty string value");
     ok (rutil_set_json_idset (o, "bar", ids) == 0
             && (o2 = json_object_get (o, "bar"))
             && (s = json_string_value (o2))
-            && !strcmp (s, "42"),
+            && streq (s, "42"),
         "rutil_set_json_idset ids=[42] sets encoded value");
 
     json_decref (o);
@@ -193,7 +194,7 @@ void test_read_file (void)
     diag ("%s", error.text);
 
     s = rutil_read_file (tmp, &error);
-    ok (s != NULL && !strcmp (s, "XXX"),
+    ok (s != NULL && streq (s, "XXX"),
         "rutil_read_file works");
     free (s);
 

--- a/src/modules/resource/topo.c
+++ b/src/modules/resource/topo.c
@@ -27,6 +27,7 @@
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/librlist/rhwloc.h"
 #include "src/common/librlist/rlist.h"
+#include "ccan/str/str.h"
 
 #include "resource.h"
 #include "inventory.h"
@@ -299,7 +300,7 @@ struct topo *topo_create (struct resource_ctx *ctx,
         const char *method = inventory_get_method (ctx->inventory);
         bool nodrain = false;
 
-        if (method && !strcmp (method, "job-info"))
+        if (method && streq (method, "job-info"))
             nodrain = true;
         if (!no_verify && topo_verify (topo, R, nodrain) < 0)
             goto error;

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -20,6 +20,7 @@
 #include "src/common/libjob/job.h"
 #include "src/common/libjob/jj.h"
 #include "src/common/librlist/rlist.h"
+#include "ccan/str/str.h"
 
 // e.g. flux module debug --setbit 0x1 sched-simple
 // e.g. flux module debug --clearbit 0x1 sched-simple
@@ -798,9 +799,9 @@ out:
 
 static char * get_alloc_mode (flux_t *h, const char *alloc_mode)
 {
-    if (strcmp (alloc_mode, "worst-fit") == 0
-        || strcmp (alloc_mode, "first-fit") == 0
-        || strcmp (alloc_mode, "best-fit") == 0)
+    if (streq (alloc_mode, "worst-fit")
+        || streq (alloc_mode, "first-fit")
+        || streq (alloc_mode, "best-fit"))
         return strdup (alloc_mode);
     flux_log (h, LOG_ERR, "unknown allocation mode: %s", alloc_mode);
     return NULL;
@@ -808,7 +809,7 @@ static char * get_alloc_mode (flux_t *h, const char *alloc_mode)
 
 static void set_mode (struct simple_sched *ss, const char *mode)
 {
-    if (!strncmp (mode, "limited=", 8)) {
+    if (strstarts (mode, "limited=")) {
         char *endptr;
         int n = strtol (mode+8, &endptr, 0);
         if (*endptr != '\0' || n <= 0) {
@@ -842,14 +843,14 @@ static int process_args (flux_t *h, struct simple_sched *ss,
 {
     int i;
     for (i = 0; i < argc; i++) {
-        if (strncmp ("alloc-mode=", argv[i], 11) == 0) {
+        if (strstarts (argv[i], "alloc-mode=")) {
             free (ss->alloc_mode);
             ss->alloc_mode = get_alloc_mode (h, argv[i]+11);
         }
-        else if (strncmp ("mode=", argv[i], 5) == 0) {
+        else if (strstarts (argv[i], "mode=")) {
             set_mode (ss, argv[i]+5);
         }
-        else if (strcmp ("test-free-nolookup", argv[i]) == 0) {
+        else if (streq (argv[i], "test-free-nolookup")) {
             ss->schedutil_flags |= SCHEDUTIL_FREE_NOLOOKUP;
         }
         else {

--- a/src/modules/sdbus/message.c
+++ b/src/modules/sdbus/message.c
@@ -222,9 +222,9 @@ int sdmsg_write (sd_bus_message *m, const char *fmt, json_t *o)
 
         if (!(entry = json_array_get (o, cursor++)))
             return -EPROTO;
-        if (!strncmp (&fmt[i], "a(sasb)", 7))
+        if (strstarts (&fmt[i], "a(sasb)"))
             efmt = strndup (&fmt[i], 7);
-        else if (!strncmp (&fmt[i], "a(sv)", 5))
+        else if (strstarts (&fmt[i], "a(sv)"))
             efmt = strndup (&fmt[i], 5);
         else if (fmt[i] == 'a' && strlen (&fmt[i]) > 1)
             efmt = strndup (&fmt[i], 2);
@@ -457,7 +457,7 @@ int sdmsg_read (sd_bus_message *m, const char *fmt, json_t *o)
         char *efmt = NULL;
         int e;
 
-        if (!strncmp (&fmt[i], "a{sv}", 5))
+        if (strstarts (&fmt[i], "a{sv}"))
             efmt = strndup (&fmt[i], 5);
         else if (fmt[i] == 'a' && strlen (&fmt[i]) > 1)
             efmt = strndup (&fmt[i], 2);

--- a/src/shell/evlog.c
+++ b/src/shell/evlog.c
@@ -38,6 +38,7 @@
 #include <flux/shell.h>
 
 #include "src/common/libeventlog/eventlogger.h"
+#include "ccan/str/str.h"
 
 #include "info.h"
 #include "internal.h"
@@ -177,7 +178,7 @@ static int log_eventlog_setlevel (flux_plugin_t *p,
                          flux_plugin_arg_strerror (args));
         return -1;
     }
-    if (strcmp (name, "any") == 0 || strcmp (name, "eventlog") == 0)
+    if (streq (name, "any") || streq (name, "eventlog"))
         evlog->level = level;
     return 0;
 }

--- a/src/shell/gpubind.c
+++ b/src/shell/gpubind.c
@@ -24,6 +24,8 @@
 #include <flux/shell.h>
 #include <flux/idset.h>
 
+#include "ccan/str/str.h"
+
 #include "builtins.h"
 
 int ngpus_per_task = -1;
@@ -110,7 +112,7 @@ static int gpubind_init (flux_plugin_t *p,
         /* gpu-affinity defaults to "on" */
         opt = "on";
     }
-    if (strcmp (opt, "off") == 0) {
+    if (streq (opt, "off")) {
         shell_debug ("disabling affinity due to gpu-affinity=off");
         return 0;
     }
@@ -133,7 +135,7 @@ static int gpubind_init (flux_plugin_t *p,
 
     flux_shell_setenvf (shell, 0, "CUDA_DEVICE_ORDER", "PCI_BUS_ID");
 
-    if (strcmp (opt, "per-task") == 0) {
+    if (streq (opt, "per-task")) {
         /*  Set global ngpus_per_task to use in task.init callback:
          */
         ngpus_per_task = ngpus / ntasks;

--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -24,6 +24,7 @@
 #include "src/common/libutil/read_all.h"
 #include "src/common/librlist/rhwloc.h"
 #include "src/common/libjob/unwrap.h"
+#include "ccan/str/str.h"
 
 #include "internal.h"
 #include "info.h"
@@ -109,7 +110,7 @@ static char *parse_arg_file (const char *optarg)
     ssize_t size;
     void *buf = NULL;
 
-    if (!strcmp (optarg, "-"))
+    if (streq (optarg, "-"))
         fd = STDIN_FILENO;
     else {
         if ((fd = open (optarg, O_RDONLY)) < 0) {

--- a/src/shell/jobspec.c
+++ b/src/shell/jobspec.c
@@ -13,6 +13,7 @@
 #endif
 #include <flux/core.h>
 #include <jansson.h>
+#include "ccan/str/str.h"
 
 #include "jobspec.h"
 
@@ -95,7 +96,7 @@ static int recursive_parse_helper (struct jobspec *job,
 
         curr_multiplier = with_multiplier * res.count;
 
-        if (!strcmp (res.type, "node")) {
+        if (streq (res.type, "node")) {
             if (job->slot_count > 0) {
                 set_error (error, "node resource encountered after slot resource");
                 return -1;
@@ -110,7 +111,7 @@ static int recursive_parse_helper (struct jobspec *job,
             }
 
             job->node_count = curr_multiplier;
-        } else if (!strcmp (res.type, "slot")) {
+        } else if (streq (res.type, "slot")) {
             if (job->cores_per_slot > 0) {
                 set_error (error, "slot resource encountered after core resource");
                 return -1;
@@ -134,7 +135,7 @@ static int recursive_parse_helper (struct jobspec *job,
                 // (i.e., job->slot_count % job->node_count == 0)
                 job->slots_per_node = job->slot_count / job->node_count;
             }
-        } else if (!strcmp (res.type, "core")) {
+        } else if (streq (res.type, "core")) {
             if (job->slot_count < 1) {
                 set_error (error, "core resource encountered before slot resource");
                 return -1;
@@ -162,13 +163,13 @@ static int recursive_parse_helper (struct jobspec *job,
             }
         }
 
-        if (!strcmp (res.type, "node")) {
+        if (streq (res.type, "node")) {
             if ((job->slot_count <= 0) || (job->cores_per_slot <= 0)) {
                 set_error (error,
                            "node encountered without slot&core below it");
                 return -1;
             }
-        } else if (!strcmp (res.type, "slot")) {
+        } else if (streq (res.type, "slot")) {
             if (job->cores_per_slot <= 0) {
                 set_error (error, "slot encountered without core below it");
                 return -1;

--- a/src/shell/log.c
+++ b/src/shell/log.c
@@ -30,6 +30,8 @@
 #include <flux/core.h>
 #include <flux/shell.h>
 
+#include "ccan/str/str.h"
+
 #include "info.h"
 #include "internal.h"
 #include "log.h"
@@ -348,7 +350,7 @@ int flux_shell_log_setlevel (int level, const char *dest)
      *   the severity level change.
      */
     if (dest != NULL) {
-        if (strcmp (dest, "stderr") == 0)
+        if (streq (dest, "stderr"))
             logger.fp_level = level;
         else
             return log_setlevel (logger.shell, dest, level);

--- a/src/shell/mpir/nodelist.c
+++ b/src/shell/mpir/nodelist.c
@@ -43,6 +43,7 @@
 #include <ctype.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "nodelist.h"
 #include "rangelist.h"
@@ -193,7 +194,7 @@ int nodelist_append (struct nodelist *nl, const char *host)
     strcpy (name, host);
     hostname_split (name, &suffix);
 
-    if (pl && strcmp (name, pl->prefix) == 0)
+    if (pl && streq (name, pl->prefix))
         return rangelist_append (pl->suffixes, suffix);
 
     if (!(pl = prefix_list_create (name, suffix))
@@ -208,7 +209,7 @@ int nodelist_append_list_destroy (struct nodelist *nl1, struct nodelist *nl2)
 {
     struct prefix_list *pl1 = zlist_tail (nl1->list);
     struct prefix_list *pl2 = zlist_pop (nl2->list);
-    if (strcmp (pl1->prefix, pl2->prefix) == 0) {
+    if (streq (pl1->prefix, pl2->prefix)) {
         rangelist_append_list (pl1->suffixes, pl2->suffixes);
         prefix_list_destroy (pl2);
         pl2 = zlist_pop (nl2->list);

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -55,6 +55,7 @@
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libeventlog/eventlogger.h"
 #include "src/common/libioencode/ioencode.h"
+#include "ccan/str/str.h"
 
 #include "task.h"
 #include "svc.h"
@@ -158,7 +159,7 @@ static int shell_output_term (struct shell_output *out)
             shell_log_errno ("eventlog_entry_parse");
             return -1;
         }
-        if (!strcmp (name, "data")) {
+        if (streq (name, "data")) {
             int output_type;
             FILE *f;
             const char *stream = NULL;
@@ -169,7 +170,7 @@ static int shell_output_term (struct shell_output *out)
                 shell_log_errno ("iodecode");
                 return -1;
             }
-            if (!strcmp (stream, "stdout")) {
+            if (streq (stream, "stdout")) {
                 output_type = out->stdout_type;
                 f = stdout;
             }
@@ -321,12 +322,12 @@ static bool entry_output_is_kvs (struct shell_output *out,
         shell_log_errno ("eventlog_entry_parse");
         return 0;
     }
-    if (!strcmp (name, "data")) {
+    if (streq (name, "data")) {
         if (iodecode (context, &stream, NULL, NULL, lenp, eofp) < 0) {
             shell_log_errno ("iodecode");
             return 0;
         }
-        if ((*stdoutp = !strcmp (stream, "stdout")))
+        if ((*stdoutp = streq (stream, "stdout")))
             return (out->stdout_type == FLUX_OUTPUT_TYPE_KVS);
         else
             return (out->stderr_type == FLUX_OUTPUT_TYPE_KVS);
@@ -432,7 +433,7 @@ static int shell_output_data (struct shell_output *out, json_t *context)
         shell_log_errno ("iodecode");
         return -1;
     }
-    if (!strcmp (stream, "stdout")) {
+    if (streq (stream, "stdout")) {
         output_type = out->stdout_type;
         ofp = &out->stdout_file;
     }
@@ -507,13 +508,13 @@ static int shell_output_file (struct shell_output *out)
             shell_log_errno ("eventlog_entry_parse");
             return -1;
         }
-        if (!strcmp (name, "data")) {
+        if (streq (name, "data")) {
             if (shell_output_data (out, context) < 0) {
                 shell_log_errno ("shell_output_data");
                 return -1;
             }
         }
-        else if (!strcmp (name, "log"))
+        else if (streq (name, "log"))
             shell_output_log (out, context);
    }
     return 0;
@@ -544,7 +545,7 @@ static int shell_output_write_leader (struct shell_output *out,
 {
     json_t *entry;
 
-    if (strcmp (type, "eof") == 0) {
+    if (streq (type, "eof")) {
         shell_output_decref (out, mh);
         return 0;
     }
@@ -783,11 +784,11 @@ static int shell_output_parse_type (struct shell_output *out,
                                     const char *typestr,
                                     int *typep)
 {
-    if (out->shell->standalone && !strcmp (typestr, "term"))
+    if (out->shell->standalone && streq (typestr, "term"))
         (*typep) = FLUX_OUTPUT_TYPE_TERM;
-    else if (!strcmp (typestr, "kvs"))
+    else if (streq (typestr, "kvs"))
         (*typep) = FLUX_OUTPUT_TYPE_KVS;
-    else if (!strcmp (typestr, "file"))
+    else if (streq (typestr, "file"))
         (*typep) = FLUX_OUTPUT_TYPE_FILE;
     else
         return shell_log_errn (EINVAL,
@@ -840,7 +841,7 @@ static int shell_output_setup_type (struct shell_output *out,
         struct shell_output_type_file *ofp = NULL;
         struct shell_output_type_file *ofp_copy = NULL;
 
-        if (!strcmp (stream, "stdout"))
+        if (streq (stream, "stdout"))
             ofp = &(out->stdout_file);
         else
             ofp = &(out->stderr_file);

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -206,7 +206,7 @@ static int native_kvs_put (void *arg,
 
     /* Hack to support "node scope" for partial PMI2 impl needed for Cray.
      */
-    if (strncmp (key, "local::", 7) == 0)
+    if (strstarts (key, "local::"))
         return put_dict (pmi->locals, key, val);
     return put_dict (pmi->pending, key, val);
 }
@@ -321,7 +321,7 @@ static int exchange_kvs_put (void *arg,
 
     /* Hack to support "node scope" for partial PMI2 impl needed for Cray.
      */
-    if (strncmp (key, "local::", 7) == 0)
+    if (strstarts (key, "local::"))
         return put_dict (pmi->locals, key, val);
     return put_dict (pmi->pending, key, val);
 }
@@ -514,14 +514,14 @@ static struct shell_pmi *pmi_create (flux_shell_t *shell, json_t *config)
 
     if (parse_args (config, &exchange_k, &kvs, &nomap) < 0)
         goto error;
-    if (!strcmp (kvs, "native")) {
+    if (streq (kvs, "native")) {
         shell_pmi_ops.kvs_put = native_kvs_put;
         shell_pmi_ops.kvs_get = native_kvs_get;
         shell_pmi_ops.barrier_enter = native_barrier_enter;
         if (shell->info->shell_rank == 0)
             shell_warn ("using native Flux kvs implementation");
     }
-    else if (!strcmp (kvs, "exchange")) {
+    else if (streq (kvs, "exchange")) {
         shell_pmi_ops.kvs_put = exchange_kvs_put;
         shell_pmi_ops.kvs_get = exchange_kvs_get;
         shell_pmi_ops.barrier_enter = exchange_barrier_enter;

--- a/src/shell/pty.c
+++ b/src/shell/pty.c
@@ -27,7 +27,8 @@
 
 #include "src/common/libterminus/pty.h"
 #include "src/common/libterminus/terminus.h"
-#include "src/common/libccan/ccan/ptrint/ptrint.h"
+#include "ccan/ptrint/ptrint.h"
+#include "ccan/str/str.h"
 #include "builtins.h"
 #include "log.h"
 
@@ -110,7 +111,7 @@ static struct idset *shell_taskids_intersect (flux_shell_t *shell,
         return NULL;
     if (!(localids = idset_decode (taskids)))
         return NULL;
-    if (strcmp (ids, "all") == 0)
+    if (streq (ids, "all"))
         return localids;
     if (!(idset = idset_decode (ids)))
         goto out;

--- a/src/shell/rc.c
+++ b/src/shell/rc.c
@@ -27,6 +27,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/bindings/lua/jansson-lua.h"
 #include "src/bindings/lua/lutil.h"
+#include "ccan/str/str.h"
 #include "internal.h"
 #include "info.h"
 
@@ -600,15 +601,15 @@ static int l_plugin_index (lua_State *L)
     if (key == NULL)
         return luaL_error (L, "plugin: invalid key");
 
-    if (strcmp (key, "load") == 0) {
+    if (streq (key, "load")) {
         lua_pushcfunction (L, l_plugin_load);
         return 1;
     }
-   if (strcmp (key, "register") == 0) {
+   if (streq (key, "register")) {
         lua_pushcfunction (L, l_plugin_register);
         return 1;
     }
-    else if (strcmp (key, "searchpath") == 0) {
+    else if (streq (key, "searchpath")) {
         lua_pushstring (L, plugstack_get_searchpath (rc_shell->plugstack));
         return 1;
     } else {
@@ -621,7 +622,7 @@ static int l_plugin_index (lua_State *L)
 static int l_plugin_newindex (lua_State *L)
 {
     const char *key = lua_tostring (L, 2);
-    if (strcmp (key, "searchpath") == 0) {
+    if (streq (key, "searchpath")) {
         const char *path = lua_tostring (L, 3);
         plugstack_set_searchpath (rc_shell->plugstack, path);
         return 0;
@@ -636,43 +637,43 @@ static int l_shell_index (lua_State *L)
     if (key == NULL)
         return luaL_error (L, "shell: invalid key");
 
-    if (strcmp (key, "info") == 0)
+    if (streq (key, "info"))
         return l_shell_info (L);
-    else if (strcmp (key, "getenv") == 0) {
+    else if (streq (key, "getenv")) {
         lua_pushcfunction (L, l_shell_getenv);
         return 1;
     }
-    else if (strcmp (key, "setenv") == 0) {
+    else if (streq (key, "setenv")) {
         lua_pushcfunction (L, l_shell_setenv);
         return 1;
     }
-    else if (strcmp (key, "unsetenv") == 0) {
+    else if (streq (key, "unsetenv")) {
         lua_pushcfunction (L, l_shell_unsetenv);
         return 1;
     }
-    else if (strcmp (key, "get_rankinfo") == 0) {
+    else if (streq (key, "get_rankinfo")) {
         lua_pushcfunction (L, l_shell_rankinfo);
         return 1;
     }
-    else if (strcmp (key, "rankinfo") == 0)
+    else if (streq (key, "rankinfo"))
         return l_shell_rankinfo (L);
-    else if (strcmp (key, "verbose") == 0) {
+    else if (streq (key, "verbose")) {
         lua_pushboolean (L, rc_shell->verbose);
         return 1;
     }
-    else if (strcmp (key, "log") == 0) {
+    else if (streq (key, "log")) {
         lua_pushcfunction (L, l_shell_log);
         return 1;
     }
-    else if (strcmp (key, "debug") == 0) {
+    else if (streq (key, "debug")) {
         lua_pushcfunction (L, l_shell_debug);
         return 1;
     }
-    else if (strcmp (key, "log_error") == 0) {
+    else if (streq (key, "log_error")) {
         lua_pushcfunction (L, l_shell_log_error);
         return 1;
     }
-    else if (strcmp (key, "die") == 0) {
+    else if (streq (key, "die")) {
         lua_pushcfunction (L, l_shell_die);
         return 1;
     }
@@ -692,7 +693,7 @@ static int is_shell_method (const char *name)
 {
     const char **sp = &shell_fields [0];
     while (*sp != NULL) {
-        if (strcmp (name, *sp) == 0)
+        if (streq (name, *sp))
             return 1;
         sp++;
     }
@@ -713,7 +714,7 @@ static int l_shell_newindex (lua_State *L)
                                   key);
         }
 
-        if (strcmp (key, "verbose") == 0) {
+        if (streq (key, "verbose")) {
             int level;
             /*  Handle Lua's baffling choice for lua_tonumber(true) == nil
              *  allows shell.verbose = 1 or true to work.
@@ -796,18 +797,18 @@ static int l_task_index (lua_State *L)
 
     if (key == NULL)
         return lua_pusherror (L, "invalid key %s", key);
-    else if (strcmp (key, "info") == 0) {
+    else if (streq (key, "info")) {
         return l_task_info (L, task);
     }
-    else if (strcmp (key, "getenv") == 0) {
+    else if (streq (key, "getenv")) {
         lua_pushcfunction (L, l_task_getenv);
         return 1;
     }
-    else if (strcmp (key, "setenv") == 0) {
+    else if (streq (key, "setenv")) {
         lua_pushcfunction (L, l_task_setenv);
         return 1;
     }
-    else if (strcmp (key, "unsetenv") == 0) {
+    else if (streq (key, "unsetenv")) {
         lua_pushcfunction (L, l_task_unsetenv);
         return 1;
     }

--- a/src/shell/rcalc.c
+++ b/src/shell/rcalc.c
@@ -20,6 +20,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libidset/idset.h"
 #include "src/common/libutil/errprintf.h"
+#include "ccan/str/str.h"
 
 #include "rcalc.h"
 
@@ -353,9 +354,9 @@ int rcalc_distribute_per_resource (rcalc_t *r, const char *name, int ntasks)
     bool by_core = false;
     bool by_node = false;
 
-    if (strcmp (name, "core") == 0)
+    if (streq (name, "core"))
         by_core = true;
-    else if (strcmp (name, "node") == 0)
+    else if (streq (name, "node"))
         by_node = true;
     else {
         errno = EINVAL;

--- a/src/shell/stage-in.c
+++ b/src/shell/stage-in.c
@@ -483,9 +483,9 @@ static int stage_in (flux_shell_t *shell, json_t *config)
         goto error;
     }
     if (destination) {
-        if (strncmp (destination, "local:", 6) == 0)
+        if (strstarts (destination, "local:"))
             ctx.destdir = destination + 6;
-        else if (strncmp (destination, "global:", 7) == 0) {
+        else if (strstarts (destination, "global:")) {
             ctx.destdir = destination + 7;
             leader_only = true;
         }

--- a/src/shell/test/mustache.c
+++ b/src/shell/test/mustache.c
@@ -17,6 +17,7 @@
 #include <flux/core.h>
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 #include "mustache.h"
 
@@ -52,9 +53,9 @@ int cb (FILE *fp, const char *tag, void *arg)
         "cb passed valid tag");
     ok (arg != NULL,
         "cb passed valid arg");
-    if (strcmp (tag, "name") == 0)
+    if (streq (tag, "name"))
         return fputs ("foo", fp);
-    if (strcmp (tag, "number") == 0)
+    if (streq (tag, "number"))
         return fputs ("42", fp);
     errno = ENOENT;
     return -1;

--- a/t/ingest/job-manager.c
+++ b/t/ingest/job-manager.c
@@ -17,6 +17,7 @@
 #include <jansson.h>
 
 #include "src/common/libeventlog/eventlog.h"
+#include "ccan/str/str.h"
 
 const char *eventlog_path = "test.ingest.eventlog";
 static int force_fail = 0;
@@ -173,7 +174,7 @@ int mod_main (flux_t *h, int argc, char *argv[])
     flux_msg_handler_t **handlers = NULL;
     int rc = -1;
 
-    if (argc >= 1 && strcmp (argv[0], "force_fail") == 0)
+    if (argc >= 1 && streq (argv[0], "force_fail"))
         force_fail = 1;
 
     if (flux_msg_handler_addvec (h, htab, NULL, &handlers) < 0) {

--- a/t/ingest/submitbench.c
+++ b/t/ingest/submitbench.c
@@ -29,6 +29,7 @@
 #include "src/common/libutil/fluid.h"
 #include "src/common/libjob/job.h"
 #include "src/common/libutil/read_all.h"
+#include "ccan/str/str.h"
 
 int cmd_submitbench (optparse_t *p, int argc, char **argv);
 
@@ -114,7 +115,7 @@ size_t read_jobspec (const char *name, void **bufp)
     ssize_t size;
     void *buf;
 
-    if (!strcmp (name, "-"))
+    if (streq (name, "-"))
         fd = STDIN_FILENO;
     else {
         if ((fd = open (name, O_RDONLY)) < 0)
@@ -220,7 +221,7 @@ int cmd_submitbench (optparse_t *p, int argc, char **argv)
     if (optparse_hasopt (p, "flags")) {
         const char *name;
         while ((name = optparse_getopt_next (p, "flags"))) {
-            if (!strcmp (name, "debug"))
+            if (streq (name, "debug"))
                 ctx.flags |= FLUX_JOB_DEBUG;
             else
                 log_msg_exit ("unknown flag: %s", name);

--- a/t/job-manager/plugins/args.c
+++ b/t/job-manager/plugins/args.c
@@ -15,6 +15,7 @@
 
 #include <flux/core.h>
 #include <flux/jobtap.h>
+#include "ccan/str/str.h"
 
 static int cb (flux_plugin_t *p,
                const char *topic,
@@ -50,7 +51,7 @@ static int cb (flux_plugin_t *p,
         return -1;
     }
 
-    if (strcmp (topic, "job.new") == 0) {
+    if (streq (topic, "job.new")) {
         /*  Subscribe to events so we get all job.event.* callbacks */
         if (flux_jobtap_job_subscribe (p, FLUX_JOBTAP_CURRENT_JOB) < 0) {
             flux_log (h,
@@ -60,7 +61,7 @@ static int cb (flux_plugin_t *p,
                        strerror (errno));
         }
     }
-    if (strncmp (topic, "job.state.", 10) == 0) {
+    if (strstarts (topic, "job.state.")) {
         if (entry == NULL
             || state == 4096
             || prev_state == 4096) {

--- a/t/job-manager/plugins/jobtap_api.c
+++ b/t/job-manager/plugins/jobtap_api.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <flux/core.h>
 #include <flux/jobtap.h>
+#include "ccan/str/str.h"
 
 static int test_prolog_start_finish (flux_plugin_t *p,
                                      const char *topic,
@@ -39,7 +40,7 @@ static int test_prolog_start_finish (flux_plugin_t *p,
                                      EINVAL);
 
     errno = 0;
-    if (strcmp (topic, "job.state.cleanup") == 0) {
+    if (streq (topic, "job.state.cleanup")) {
         if (flux_jobtap_prolog_start (p, "test") == 0
             || errno != EINVAL)
             flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
@@ -126,7 +127,7 @@ static int test_epilog_start_finish (flux_plugin_t *p,
                                      EINVAL);
 
     errno = 0;
-    if (strcmp (topic, "job.state.run") == 0) {
+    if (streq (topic, "job.state.run")) {
         if (flux_jobtap_epilog_start (p, "test") == 0
             || errno != EINVAL)
             flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
@@ -217,7 +218,7 @@ static int test_event_post_pack (flux_plugin_t *p,
                                      ENOENT);
 
     const char *state;
-    if (strncmp (topic, "job.state.", 10) == 0)
+    if (strstarts (topic, "job.state."))
         state = topic+10;
     else
         state = topic+4;
@@ -290,7 +291,7 @@ static int test_job_flags (flux_plugin_t *p,
                            "p, FLUX_JOBTAP_CURRENT_JOB, foo",
                            EINVAL);
     const char *state;
-    if (strncmp (topic, "job.state.", 10) == 0)
+    if (strstarts (topic, "job.state."))
         state = topic+10;
     else
         state = topic+4;

--- a/t/job-manager/plugins/perilog-test.c
+++ b/t/job-manager/plugins/perilog-test.c
@@ -17,6 +17,7 @@
 
 #include <flux/core.h>
 #include <flux/jobtap.h>
+#include "ccan/str/str.h"
 
 struct perilog_data {
     flux_plugin_t *p;
@@ -90,7 +91,7 @@ static int cb (flux_plugin_t *p,
     flux_jobid_t id;
     struct perilog_data *d;
     int rc;
-    int prolog = strcmp (topic, "job.state.run") == 0;
+    int prolog = streq (topic, "job.state.run");
 
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,

--- a/t/job-manager/plugins/subscribe.c
+++ b/t/job-manager/plugins/subscribe.c
@@ -3,6 +3,7 @@
 
 #include <flux/core.h>
 #include <flux/jobtap.h>
+#include "ccan/str/str.h"
 
 static int cb (flux_plugin_t *p,
                const char *topic,
@@ -11,7 +12,7 @@ static int cb (flux_plugin_t *p,
 {
     flux_t *h = flux_jobtap_get_flux (p);
 
-    if (strcmp (topic, "job.event.start") == 0) {
+    if (streq (topic, "job.event.start")) {
         /*  Test flux_jobtap_job_event_posted(), then unsusbscribe()
          */
         if (flux_jobtap_job_event_posted (NULL, 0, NULL) != -1
@@ -29,7 +30,7 @@ static int cb (flux_plugin_t *p,
                                          "event_count 'start' didn't return 1");
         flux_jobtap_job_unsubscribe (p, FLUX_JOBTAP_CURRENT_JOB);
     }
-    else if (strcmp (topic, "job.event.finish") == 0) {
+    else if (streq (topic, "job.event.finish")) {
         flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
                                      "subscribe-test",
                                      0,
@@ -39,7 +40,7 @@ static int cb (flux_plugin_t *p,
     }
 
     flux_log (h, LOG_INFO, "subscribe-check: %s: OK", topic);
-    if (strcmp (topic, "job.event.start") == 0) {
+    if (streq (topic, "job.event.start")) {
         // Test for nonzero exit from job.event.* callback:
         return -1;
     }

--- a/t/job-manager/plugins/test.c
+++ b/t/job-manager/plugins/test.c
@@ -3,6 +3,7 @@
 
 #include <flux/core.h>
 #include <flux/jobtap.h>
+#include "ccan/str/str.h"
 
 static int cb (flux_plugin_t *p,
                const char *topic,
@@ -29,12 +30,12 @@ static int cb (flux_plugin_t *p,
         return -1;
     }
 
-    if (strcmp (topic, "job.validate") == 0) {
-        if (strcmp (test_mode, "validate failure") == 0)
+    if (streq (topic, "job.validate")) {
+        if (streq (test_mode, "validate failure"))
             return flux_jobtap_reject_job (p, args, "rejected for testing");
-        if (strcmp (test_mode, "validate failure nullmsg") == 0)
+        if (streq (test_mode, "validate failure nullmsg"))
             return flux_jobtap_reject_job (p, args, NULL);
-        if (strcmp (test_mode, "validate failure nomsg") == 0)
+        if (streq (test_mode, "validate failure nomsg"))
             return -1;
         return 0;
     }
@@ -50,12 +51,12 @@ static int cb (flux_plugin_t *p,
                   "arg_pack: %s",
                   flux_plugin_arg_strerror (args));
 
-    if (strcmp (topic, "job.state.priority") == 0) {
-        if (strcmp (test_mode, "priority unset") == 0)
+    if (streq (topic, "job.state.priority")) {
+        if (streq (test_mode, "priority unset"))
             return 0;
-        if (strcmp (test_mode, "callback error") == 0)
+        if (streq (test_mode, "callback error"))
             return -1;
-        if (strcmp (test_mode, "annotations error") == 0) {
+        if (streq (test_mode, "annotations error")) {
             if (flux_plugin_arg_pack (args,
                                       FLUX_PLUGIN_ARG_OUT,
                                       "{s:s}",
@@ -65,33 +66,33 @@ static int cb (flux_plugin_t *p,
                           flux_plugin_arg_strerror (args));
             return 0;
         }
-        if (strcmp (test_mode, "priority type error") == 0) {
+        if (streq (test_mode, "priority type error")) {
             flux_plugin_arg_pack (args,
                                   FLUX_PLUGIN_ARG_OUT,
                                   "{s:s}",
                                   "priority", "foo");
         }
     }
-    else if (strcmp (topic, "job.state.sched") == 0) {
-        if (strcmp (test_mode, "sched: priority unavail") == 0)
+    else if (streq (topic, "job.state.sched")) {
+        if (streq (test_mode, "sched: priority unavail"))
             return flux_jobtap_priority_unavail (p, args);
-        if (strcmp (test_mode, "sched: callback error") == 0)
+        if (streq (test_mode, "sched: callback error"))
             return -1;
-        if (strcmp (test_mode, "sched: update priority") == 0) {
+        if (streq (test_mode, "sched: update priority")) {
             flux_plugin_arg_pack (args,
                                   FLUX_PLUGIN_ARG_OUT,
                                   "{s:i}",
                                   "priority", 42);
         }
-        if (strcmp (test_mode, "sched: dependency-add") == 0) {
+        if (streq (test_mode, "sched: dependency-add")) {
             return flux_jobtap_dependency_add (p, id, "foo");
         }
-        if (strcmp (test_mode, "sched: exception") == 0) {
+        if (streq (test_mode, "sched: exception")) {
             flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
                                         "test", 0,
                                         "sched: test exception");
         }
-        if (strcmp (test_mode, "sched: exception error") == 0) {
+        if (streq (test_mode, "sched: exception error")) {
             if (flux_jobtap_raise_exception (NULL, 0, "test", 0, "") >= 0
                 || errno != EINVAL)
                 flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
@@ -99,12 +100,12 @@ static int cb (flux_plugin_t *p,
                                             "sched: exception error failed");
         }
     }
-    else if (strcmp (topic, "job.priority.get") == 0) {
-        if (strcmp (test_mode, "priority.get: fail") == 0)
+    else if (streq (topic, "job.priority.get")) {
+        if (streq (test_mode, "priority.get: fail"))
             return -1;
-        if (strcmp (test_mode, "priority.get: unavail") == 0)
+        if (streq (test_mode, "priority.get: unavail"))
             return flux_jobtap_priority_unavail (p, args);
-        if (strcmp (test_mode, "priority.get: bad arg") == 0) {
+        if (streq (test_mode, "priority.get: bad arg")) {
             flux_plugin_arg_pack (args,
                                   FLUX_PLUGIN_ARG_OUT,
                                   "{s:s}",

--- a/t/job-manager/print-constants.c
+++ b/t/job-manager/print-constants.c
@@ -13,6 +13,7 @@
 #endif
 #include <stdio.h>
 #include <flux/core.h>
+#include "ccan/str/str.h"
 
 int main (int argc, char *argv[])
 {
@@ -20,7 +21,7 @@ int main (int argc, char *argv[])
         fprintf (stderr, "Usage: print-constants NAME\n");
         return 1;
     }
-    if (!strcmp (argv[1], "FLUX_JOBID_ANY")) {
+    if (streq (argv[1], "FLUX_JOBID_ANY")) {
         printf ("%llx\n", (long long unsigned)FLUX_JOBID_ANY);
     }
     else {

--- a/t/kvs/fence_api.c
+++ b/t/kvs/fence_api.c
@@ -26,6 +26,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/tstat.h"
+#include "ccan/str/str.h"
 
 typedef struct {
     pthread_t t;
@@ -171,10 +172,10 @@ int main (int argc, char *argv[])
      * should all be the same
      */
     for (i = 1; i < count; i++) {
-        if (strcmp (thd[0].treeobj, thd[i].treeobj))
+        if (!streq (thd[0].treeobj, thd[i].treeobj))
             log_msg_exit ("treeobj mismatch: %s != %s\n",
                           thd[0].treeobj, thd[i].treeobj);
-        if (strcmp (thd[0].rootref, thd[i].rootref))
+        if (!streq (thd[0].rootref, thd[i].rootref))
             log_msg_exit ("rootref mismatch: %s != %s\n",
                           thd[0].rootref, thd[i].rootref);
         if (thd[0].sequence != thd[i].sequence)

--- a/t/kvs/torture.c
+++ b/t/kvs/torture.c
@@ -25,6 +25,7 @@
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/oom.h"
+#include "ccan/str/str.h"
 
 
 #define OPTIONS "hc:s:p:qv"
@@ -151,7 +152,7 @@ int main (int argc, char *argv[])
             log_err_exit ("flux_kvs_lookup '%s'", key);
         if (verbose)
             log_msg ("%s = %s", key, s);
-        if (strcmp (s, val) != 0)
+        if (!streq (s, val))
             log_msg_exit ("kvs_lookup: key '%s' wrong value '%s'", key, s);
         free (key);
         flux_future_destroy (f);

--- a/t/module/testmod.c
+++ b/t/module/testmod.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
+#include "ccan/str/str.h"
 
 static void info (flux_t *h,
                   flux_msg_handler_t *mh,
@@ -35,7 +36,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     /* Dynamically register a service name if requested.
      */
     for (int i = 0; i < argc; i++) {
-        if (!strncmp (argv[i], "--service=", 10)) {
+        if (strstarts (argv[i], "--service=")) {
             const char *service = argv[i] + 10;
             flux_future_t *f;
             if (!(f = flux_service_register (h, service))
@@ -45,7 +46,7 @@ int mod_main (flux_t *h, int argc, char **argv)
             }
             flux_future_destroy (f);
         }
-        else if (!strcmp (argv[0], "--init-failure")) {
+        else if (streq (argv[0], "--init-failure")) {
             flux_log (h, LOG_INFO, "aborting during init per test request");
             errno = EIO;
             return -1;

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -19,6 +19,7 @@
 #include "src/common/libutil/oom.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
+#include "ccan/str/str.h"
 
 typedef struct {
     flux_t *h;
@@ -304,7 +305,7 @@ void null_request_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "%s: flux_msg_get_topic", __FUNCTION__);
         goto error;
     }
-    if (strcmp (topic, "req.null") != 0) {
+    if (!streq (topic, "req.null")) {
         flux_log (h, LOG_ERR, "%s: unexpected topic: %s", __FUNCTION__,
                   topic);
         goto error;

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -24,6 +24,7 @@
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
 
 void test_null (flux_t *h, uint32_t nodeid);
 void test_echo (flux_t *h, uint32_t nodeid);
@@ -62,7 +63,7 @@ test_t *test_lookup (const char *name)
 {
     int i;
     for (i = 0; i < ARRAY_SIZE (tests); i++)
-        if (!strcmp (tests[i].name, name))
+        if (streq (tests[i].name, name))
             return &tests[i];
     return NULL;
 }
@@ -139,7 +140,7 @@ void test_echo (flux_t *h, uint32_t nodeid)
                              "{s:s}", "mumble", "burble"))
              || flux_rpc_get_unpack (f, "{s:s}", "mumble", &s) < 0)
         log_err_exit ("%s", __FUNCTION__);
-    if (strcmp (s, "burble") != 0)
+    if (!streq (s, "burble"))
         log_msg_exit ("%s: returned payload wasn't an echo", __FUNCTION__);
     flux_future_destroy (f);
 }

--- a/t/rexec/rexec.c
+++ b/t/rexec/rexec.c
@@ -21,6 +21,7 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/read_all.h"
+#include "ccan/str/str.h"
 
 extern char **environ;
 
@@ -109,7 +110,7 @@ void stdin2stream (flux_subprocess_t *p, const char *stream)
     }
 
     /* do not close for channel, b/c can race w/ data coming back */
-    if (!strcmp (stream, "stdin")) {
+    if (streq (stream, "stdin")) {
         if (flux_subprocess_close (p, stream) < 0)
             log_err_exit ("flux_subprocess_close");
     }
@@ -165,9 +166,9 @@ int main (int argc, char *argv[])
     free (cwd);
 
     if (optparse_getopt (opts, "stdin2stream", &optargp) > 0) {
-        if (strcmp (optargp, "stdin")
-            && strcmp (optargp, "stdout")
-            && strcmp (optargp, "stderr")) {
+        if (!streq (optargp, "stdin")
+            && !streq (optargp, "stdout")
+            && !streq (optargp, "stderr")) {
             if (flux_cmd_add_channel (cmd, optargp) < 0)
                 log_err_exit ("flux_cmd_add_channel");
             ops.on_channel_out = flux_standard_output;

--- a/t/rexec/rexec_count_stdout.c
+++ b/t/rexec/rexec_count_stdout.c
@@ -23,6 +23,7 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/read_all.h"
+#include "ccan/str/str.h"
 
 extern char **environ;
 
@@ -49,7 +50,7 @@ void completion_cb (flux_subprocess_t *p)
 
 void output_cb (flux_subprocess_t *p, const char *stream)
 {
-    FILE *fstream = !strcmp (stream, "stderr") ? stderr : stdout;
+    FILE *fstream = streq (stream, "stderr") ? stderr : stdout;
     const char *ptr;
     int lenp;
 

--- a/t/rexec/rexec_getline.c
+++ b/t/rexec/rexec_getline.c
@@ -20,6 +20,7 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/read_all.h"
+#include "ccan/str/str.h"
 
 extern char **environ;
 
@@ -60,7 +61,7 @@ void stdin2stream (flux_subprocess_t *p, const char *stream)
     }
 
     /* do not close for channel, b/c can race w/ data coming back */
-    if (!strcmp (stream, "stdin")) {
+    if (streq (stream, "stdin")) {
         if (flux_subprocess_close (p, stream) < 0)
             log_err_exit ("flux_subprocess_close");
     }
@@ -70,7 +71,7 @@ void stdin2stream (flux_subprocess_t *p, const char *stream)
 
 void output_cb (flux_subprocess_t *p, const char *stream)
 {
-    FILE *fstream = !strcmp (stream, "stderr") ? stderr : stdout;
+    FILE *fstream = streq (stream, "stderr") ? stderr : stdout;
     const char *ptr;
     int lenp;
 
@@ -127,9 +128,9 @@ int main (int argc, char *argv[])
         log_err_exit ("flux_cmd_setcwd");
 
     if (optparse_getopt (opts, "stdin2stream", &optargp) > 0) {
-        if (strcmp (optargp, "stdin")
-            && strcmp (optargp, "stdout")
-            && strcmp (optargp, "stderr")) {
+        if (!streq (optargp, "stdin")
+            && !streq (optargp, "stdout")
+            && !streq (optargp, "stderr")) {
             if (flux_cmd_add_channel (cmd, optargp) < 0)
                 log_err_exit ("flux_cmd_add_channel");
             ops.on_channel_out = flux_standard_output;

--- a/t/shell/plugins/getopt.c
+++ b/t/shell/plugins/getopt.c
@@ -18,6 +18,7 @@
 #include <flux/shell.h>
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 static int die (const char *fmt, ...)
 {
@@ -73,7 +74,7 @@ static int check_getopt (flux_plugin_t *p,
         && result == 42,
         "setopt worked and set integer value");
 
-    if (strcmp (topic, "shell.exit") == 0 || strcmp (topic, "task.exec") == 0)
+    if (streq (topic, "shell.exit") || streq (topic, "task.exec"))
         return exit_status () == 0 ? 0 : -1;
     return 0;
 }

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -19,6 +19,7 @@
 #include <flux/shell.h>
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 static int die (const char *fmt, ...)
 {
@@ -199,7 +200,7 @@ static int shell_cb (flux_plugin_t *p,
     ok (flux_shell_mustache_render (shell, NULL) == NULL && errno == EINVAL,
         "flux_shell_mustache_render (shell, NULL) returns EINVAL");
 
-    if (strcmp (topic, "shell.init") == 0) {
+    if (streq (topic, "shell.init")) {
         ok (flux_shell_current_task (NULL) == NULL && errno == EINVAL,
             "flux_shell_current_task with NULL shell returns EINVAL");
         errno = 0;
@@ -210,7 +211,7 @@ static int shell_cb (flux_plugin_t *p,
         ok (flux_shell_task_next (shell) == NULL && errno == EAGAIN,
             "flux_shell_task_next (shell) in shell.init returns EAGAIN");
     }
-    if (strcmp (topic, "shell.exit") == 0)
+    if (streq (topic, "shell.exit"))
         return exit_status () == 0 ? 0 : -1;
     return 0;
 }
@@ -247,7 +248,7 @@ static int task_cb (flux_plugin_t *p,
         && errno == EINVAL,
         "flux_shell_task_channel_subscribe with NULL args returns EINVAL");
 
-    if (strcmp (topic, "task.exec") == 0)
+    if (streq (topic, "task.exec"))
         return exit_status () == 0 ? 0 : -1;
     return 0;
 }

--- a/t/shell/plugins/log.c
+++ b/t/shell/plugins/log.c
@@ -19,6 +19,7 @@
 #include <flux/shell.h>
 
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 static int get_shell_rank (flux_shell_t *shell)
 {
@@ -44,7 +45,7 @@ static int check_shell_log (flux_plugin_t *p,
     int shell_rank;
     const char *s = NULL;
 
-    if (strcmp (topic, "shell.log") == 0)
+    if (streq (topic, "shell.log"))
         return 0;
 
     shell_rank = get_shell_rank (shell);
@@ -52,7 +53,7 @@ static int check_shell_log (flux_plugin_t *p,
         shell_die (1, "error parsing log-fatal-error");
 
     if (s) {
-        if (strcmp (s, topic) == 0 && shell_rank == 1)
+        if (streq (s, topic) && shell_rank == 1)
             shell_die (1, "log-fatal-error requested!");
         /* For log-fatal-error test, avoid the remaining log testing
          *  below on the non-fatal ranks
@@ -74,7 +75,7 @@ static int check_shell_log (flux_plugin_t *p,
     ok (shell_log_errno ("%s: log_errno message", topic) == -1,
         "shell_log_errno returns -1");
 
-    if (strcmp (topic, "shell.exit") == 0 || strcmp (topic, "task.exec") == 0)
+    if (streq (topic, "shell.exit") || streq (topic, "task.exec"))
         return exit_status () == 0 ? 0 : -1;
     return 0;
 }

--- a/t/util/handle.c
+++ b/t/util/handle.c
@@ -18,6 +18,7 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
+#include "ccan/str/str.h"
 
 void usage (void)
 {
@@ -27,13 +28,13 @@ void usage (void)
 
 void getopt (flux_t *h, const char *type, const char *name)
 {
-    if (!strcmp (type, "u8")) {
+    if (streq (type, "u8")) {
         uint8_t val;
         if (flux_opt_get (h, name, &val, sizeof (val)) < 0)
             log_err_exit ("%s", name);
         printf ("%u\n", (unsigned int)val);
     }
-    else if (!strcmp (type, "u32")) {
+    else if (streq (type, "u32")) {
         uint32_t val;
         if (flux_opt_get (h, name, &val, sizeof (val)) < 0)
             log_err_exit ("%s", name);
@@ -53,7 +54,7 @@ int main (int argc, char *argv[])
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!strcmp (argv[1], "getopt"))
+    if (streq (argv[1], "getopt"))
         getopt (h, argv[2], argv[3]);
     else
         usage ();


### PR DESCRIPTION
We've been gradually switching from using `strcmp()` to test for string equality to `streq()`.  This converts a chunk of older code.  It's not the whole enchilada but I figured a PR that touches _everything_ is more likely to conflict with pending PRs, so a chunk is OK?