### PR TITLE
testsuite: skip tests that expect COLUMNS to be inherited across calls to flux(1) when that isn't true

### DIFF
--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -292,6 +292,23 @@ test_on_rank() {
     flux exec --rank=${ranks} "$@"
 }
 
+#  Note: Some versions of bash may cause the `flux` libtool wrapper script
+#  to reset the COLUMNS shell variable even if it is explicitly set for
+#  for testing purposes. This causes tests that check for output truncation
+#  based on COLUMNS to erroneously fail. (Note: this only seems to be the
+#  case when tests are run with --debug --verbose for unknown reasons.
+#
+#  Add a script for tests that use COLUMNS to check if the variable will
+#  be preserved across an invovation of flux(1) so they may set a prereq
+#  and skip tests that might erroneous fail if COLUMNS is not preserved.
+#
+test_columns_variable_preserved() {
+	local cols=$(COLUMNS=12 \
+	             flux python -c \
+	             "import shutil; print(shutil.get_terminal_size().columns)")
+	test "$cols" = "12"
+}
+
 #  Export a shorter name for this test
 TEST_NAME=$SHARNESS_TEST_NAME
 export TEST_NAME

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -681,7 +681,8 @@ test_expect_success 'kvs: ls -w40 adjusts output width to 40' '
 	EOF
 	test_cmp expected output
 '
-test_expect_success 'kvs: ls with COLUMNS=20 adjusts output width to 20' '
+test_columns_variable_preserved && test_set_prereq USE_COLUMNS
+test_expect_success USE_COLUMNS 'kvs: ls with COLUMNS=20 adjusts output width to 20' '
 	flux kvs unlink -Rf $DIR &&
 	${FLUX_BUILD_DIR}/t/kvs/dtree -p$DIR -h1 -w50 &&
 	COLUMNS=20 flux kvs ls $DIR | wc -wl >output &&

--- a/t/t2803-flux-pstree.t
+++ b/t/t2803-flux-pstree.t
@@ -149,7 +149,8 @@ test_expect_success 'flux-pstree -a works' '
 	EOF
 	test_cmp ${name}.expected ${name}.output
 '
-test_expect_success 'flux-pstree truncates at COLUMNS' '
+test_columns_variable_preserved && test_set_prereq USE_COLUMNS
+test_expect_success USE_COLUMNS 'flux-pstree truncates at COLUMNS' '
 	name="truncated" &&
 	COLUMNS=16 flux pstree -a > ${name}.output &&
 	test_debug "cat ${name}.output" &&


### PR DESCRIPTION
On some systems, likely those with bash >= 5, tests that make use of a `COLUMNS` environment variable to override the detected terminal width were failing when the test was run with `-d -v`. It isn't obvious why the failures only occur with the
debug and verbose sharness flags, but the cause seems to be invocation of the `flux` libtool wrapper script (which uses `#!/bin/bash`), which then causes the `COLUMNS` variable to be reset.

There isn't a clear workaround for this issue, so instead set a prereq if `COLUMNS` does propagate through a call to `flux`, and use that prereq to skip a couple tests when that isn't true.