### PR TITLE
pre-commit: increase vermin version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         types: [python]
         entry: ./scripts/run_mypy.sh
   - repo: https://github.com/netromdk/vermin
-    rev: v1.4.2
+    rev: v1.5.1
     hooks:
       - id: vermin
         args: ['-t=3.6-', '--violations']

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -30,8 +30,10 @@ from typing import Mapping
 
 import yaml
 
+# tomllib added to standard library in Python 3.11
+# flux-core minimum is Python 3.6.
 try:
-    import tomllib
+    import tomllib  # novermin
 except ModuleNotFoundError:
     from flux.utils import tomli as tomllib
 


### PR DESCRIPTION
In #5055 some code that was only supported in Python 3.11 did not get caught by the vermin check, which surprised me.  It ended up it was caught in a newer version of vermin.

So lets increase the version and add a `novermin` comment for one place that needs it.  Also add a comment to the place that needs the novermin override. 