### PR TITLE
Add missing include of config.h

### DIFF
--- a/src/common/libeventlog/test/eventlog.c
+++ b/src/common/libeventlog/test/eventlog.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 #include <string.h>
 #include <stdarg.h>

--- a/src/common/libflux/ev_buffer_read.c
+++ b/src/common/libflux/ev_buffer_read.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stddef.h>
 #include <stdbool.h>
 

--- a/src/common/libflux/ev_buffer_write.c
+++ b/src/common/libflux/ev_buffer_write.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stddef.h>
 #include <stdbool.h>
 #include <unistd.h>

--- a/src/common/libflux/ev_flux.c
+++ b/src/common/libflux/ev_flux.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stddef.h>
 #include <stdbool.h>
 

--- a/src/common/libflux/test/buffer.c
+++ b/src/common/libflux/test/buffer.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/common/libflux/test/msg_handler.c
+++ b/src/common/libflux/test/msg_handler.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <flux/core.h>
 
 #include "src/common/libflux/msg_handler.h"

--- a/src/common/libflux/test/panic.c
+++ b/src/common/libflux/test/panic.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 #include <string.h>
 #include <flux/core.h>

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <errno.h>
 

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/src/common/libflux/test/request.c
+++ b/src/common/libflux/test/request.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 #include <string.h>
 

--- a/src/common/libflux/test/response.c
+++ b/src/common/libflux/test/response.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <errno.h>
 #include <flux/core.h>

--- a/src/common/libflux/test/rpc_security.c
+++ b/src/common/libflux/test/rpc_security.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 #include <flux/core.h>
 #include <inttypes.h>

--- a/src/common/libflux/test/tagpool.c
+++ b/src/common/libflux/test/tagpool.c
@@ -8,6 +8,10 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "src/common/libflux/message.h"
 #include "src/common/libflux/tagpool.h"
 #include "src/common/libtap/tap.h"

--- a/src/common/libflux/test/version.c
+++ b/src/common/libflux/test/version.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 
 #include "src/common/libflux/version.h"

--- a/src/common/libflux/test/version.c
+++ b/src/common/libflux/test/version.c
@@ -8,11 +8,11 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#include <string.h>
+
 #include "src/common/libflux/version.h"
 #include "src/common/libtap/tap.h"
 #include "ccan/str/str.h"
-
-#include <string.h>
 
 int main (int argc, char *argv[])
 {

--- a/src/common/libioencode/test/ioencode.c
+++ b/src/common/libioencode/test/ioencode.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <jansson.h>

--- a/src/common/libkvs/test/treeobj.c
+++ b/src/common/libkvs/test/treeobj.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <errno.h>
 

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/common/libpmi/test/keyval.c
+++ b/src/common/libpmi/test/keyval.c
@@ -8,12 +8,12 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#include <string.h>
+#include <ctype.h>
+
 #include "src/common/libtap/tap.h"
 #include "src/common/libpmi/keyval.h"
 #include "ccan/str/str.h"
-
-#include <string.h>
-#include <ctype.h>
 
 static char *valid[] = {
     "key1=val1",

--- a/src/common/libpmi/test/keyval.c
+++ b/src/common/libpmi/test/keyval.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <ctype.h>
 

--- a/src/common/libpmi/test/kvstest.c
+++ b/src/common/libpmi/test/kvstest.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/common/libpmi/test/kvstest2.c
+++ b/src/common/libpmi/test/kvstest2.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/common/libpmi/test/pmi2_info.c
+++ b/src/common/libpmi/test/pmi2_info.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/common/libpmi/test/pmi_info.c
+++ b/src/common/libpmi/test/pmi_info.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/common/librlist/test/match.c
+++ b/src/common/librlist/test/match.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 
 #include "src/common/libtap/tap.h"

--- a/src/common/librlist/test/rhwloc.c
+++ b/src/common/librlist/test/rhwloc.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <flux/hostlist.h>
 
 #include "src/common/libtap/tap.h"

--- a/src/common/librlist/test/rlist.c
+++ b/src/common/librlist/test/rlist.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <unistd.h>
 #include <errno.h>
 #include <jansson.h>

--- a/src/common/librlist/test/rnode.c
+++ b/src/common/librlist/test/rnode.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 
 #include "src/common/libtap/tap.h"

--- a/src/common/libsubprocess/test/cmd.c
+++ b/src/common/libsubprocess/test/cmd.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <assert.h>
 #include <jansson.h>
 

--- a/src/common/libsubprocess/test/rcmdsrv.h
+++ b/src/common/libsubprocess/test/rcmdsrv.h
@@ -8,10 +8,6 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#if HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #ifndef _SUBPROCESS_TEST_RCMDSRV_H
 #define _SUBPROCESS_TEST_RCMDSRV_H
 

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -8,8 +8,10 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <assert.h>
-
 #include <flux/core.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/src/common/libterminus/terminus.c
+++ b/src/common/libterminus/terminus.c
@@ -45,6 +45,9 @@
  * in pty.c.
  */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/src/common/libutil/test/aux.c
+++ b/src/common/libutil/test/aux.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <errno.h>
 

--- a/src/common/libutil/test/blobref.c
+++ b/src/common/libutil/test/blobref.c
@@ -8,8 +8,12 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <errno.h>
+
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/blobref.h"
 #include "src/common/libutil/sha1.h"

--- a/src/common/libutil/test/cronodate.c
+++ b/src/common/libutil/test/cronodate.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #define _XOPEN_SOURCE 700
 #include <stdlib.h>
 #include <time.h>

--- a/src/common/libutil/test/environment.c
+++ b/src/common/libutil/test/environment.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 
 #include "ccan/str/str.h"

--- a/src/common/libutil/test/fdutils.c
+++ b/src/common/libutil/test/fdutils.c
@@ -8,10 +8,14 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
 #include <fcntl.h>
+
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/fdutils.h"
 

--- a/src/common/libutil/test/fdwalk.c
+++ b/src/common/libutil/test/fdwalk.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>

--- a/src/common/libutil/test/fsd.c
+++ b/src/common/libutil/test/fsd.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <math.h>
 #include <string.h>
 #include <errno.h>

--- a/src/common/libutil/test/grudgeset.c
+++ b/src/common/libutil/test/grudgeset.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <errno.h>
 #include <jansson.h>

--- a/src/common/libutil/test/hola.c
+++ b/src/common/libutil/test/hola.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 
 #include "src/common/libtap/tap.h"

--- a/src/common/libutil/test/intree.c
+++ b/src/common/libutil/test/intree.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <errno.h>
 #include <pthread.h>

--- a/src/common/libutil/test/ipaddr.c
+++ b/src/common/libutil/test/ipaddr.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <sys/param.h>
 
 #include "src/common/libtap/tap.h"

--- a/src/common/libutil/test/kary.c
+++ b/src/common/libutil/test/kary.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/kary.h"
 

--- a/src/common/libutil/test/popen2.c
+++ b/src/common/libutil/test/popen2.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <errno.h>
 #include <stdint.h>

--- a/src/common/libutil/test/stdlog.c
+++ b/src/common/libutil/test/stdlog.c
@@ -8,13 +8,13 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#include <string.h>
+#include <ctype.h>
+
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/wallclock.h"
 #include "src/common/libutil/stdlog.h"
 #include "ccan/str/str.h"
-
-#include <string.h>
-#include <ctype.h>
 
 static char *valid[] = {
     "<1>1 - - - - - - message",

--- a/src/common/libutil/test/stdlog.c
+++ b/src/common/libutil/test/stdlog.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <ctype.h>
 

--- a/src/common/libutil/test/strstrip.c
+++ b/src/common/libutil/test/strstrip.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 #include <string.h>
 

--- a/src/common/libutil/test/unlink.c
+++ b/src/common/libutil/test/unlink.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <limits.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/common/libutil/test/veb.c
+++ b/src/common/libutil/test/veb.c
@@ -8,8 +8,12 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <stdlib.h>
+
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/veb.h"
 

--- a/src/common/libutil/test/wallclock.c
+++ b/src/common/libutil/test/wallclock.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include <ctype.h>
 

--- a/src/common/libutil/test/wallclock.c
+++ b/src/common/libutil/test/wallclock.c
@@ -8,12 +8,12 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#include <string.h>
+#include <ctype.h>
+
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/wallclock.h"
 #include "src/common/libutil/stdlog.h"
-
-#include <string.h>
-#include <ctype.h>
 
 int main(int argc, char** argv)
 {

--- a/src/common/libzmqutil/test/reactor.c
+++ b/src/common/libzmqutil/test/reactor.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 #include <czmq.h>
 #include <sys/types.h>

--- a/src/modules/cron/types.c
+++ b/src/modules/cron/types.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <string.h>
 #include "entry.h"
 #include "ccan/str/str.h"

--- a/src/modules/job-exec/rset.c
+++ b/src/modules/job-exec/rset.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 #include "rset.h"
 

--- a/src/modules/job-exec/test/bulk-exec.c
+++ b/src/modules/job-exec/test/bulk-exec.c
@@ -12,7 +12,9 @@
  *   execution API.
  */
 
-#define _GNU_SOURCE 1
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <unistd.h>
 #include <assert.h>
 #include <signal.h>

--- a/src/modules/job-exec/test/rset.c
+++ b/src/modules/job-exec/test/rset.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <errno.h>
 #include <string.h>
 

--- a/src/modules/job-manager/plugins/alloc-bypass.c
+++ b/src/modules/job-manager/plugins/alloc-bypass.c
@@ -13,7 +13,9 @@
  *  owner use only)
  */
 
-
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <unistd.h>
 #include <sys/types.h>
 

--- a/src/modules/job-manager/plugins/begin-time.c
+++ b/src/modules/job-manager/plugins/begin-time.c
@@ -10,6 +10,9 @@
 
 /*  begin-time: Builtin job-manager begin-time dependency plugin */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <time.h>
 #include <math.h>
 #include <jansson.h>

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -38,6 +38,9 @@
  *     event in the job's eventlog.
  */
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <limits.h>
 #include <unistd.h>
 #include <sys/types.h>

--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -8,6 +8,10 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "src/modules/kvs/waitqueue.h"
 #include "src/common/libflux/message.h"
 #include "src/common/libtap/tap.h"

--- a/t/kvs/issue1876.c
+++ b/t/kvs/issue1876.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <flux/core.h>
 #include "src/common/libutil/log.h"
 

--- a/t/kvs/waitcreate_cancel.c
+++ b/t/kvs/waitcreate_cancel.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <flux/core.h>
 #include "src/common/libutil/log.h"
 

--- a/t/module/legacy.c
+++ b/t/module/legacy.c
@@ -8,9 +8,8 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#if HAVE_CONFIG_H
-#include "config.h"
-#endif
+/* Do not include project config.h, we are testing public module
+ * interface */
 #include <flux/core.h>
 
 int mod_main (flux_t *h, int argc, char **argv)

--- a/t/sched-simple/jj-reader.c
+++ b/t/sched-simple/jj-reader.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>

--- a/t/stats/stats-basic.c
+++ b/t/stats/stats-basic.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <flux/core.h>
 #include <flux/jobtap.h>
 #include <time.h>

--- a/t/stats/stats-immediate.c
+++ b/t/stats/stats-immediate.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <flux/core.h>
 #include <flux/jobtap.h>
 #include <time.h>


### PR DESCRIPTION
Problem: A number of C files did not include config.h.

Globally add it when it is missing and the file is not a vendored file.  Update some formatting in some locations. Most notably move include of system headers before local code headers.

Fixes #5167

Edit: I re-read the PR title and didn't like it, adjusted it and the commit message.