### PR TITLE
flux-job: submit: strip unnecessary whitespace from pre-signed jobspec

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1574,9 +1574,7 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
 #endif
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
-    jobspecsz = read_jobspec (input, &jobspec);
-    assert (((char *)jobspec)[jobspecsz] == '\0');
-    if (jobspecsz == 0)
+    if ((jobspecsz = read_jobspec (input, &jobspec)) == 0)
         log_msg_exit ("required jobspec is empty");
     urgency = optparse_get_int (p, "urgency", FLUX_JOB_URGENCY_DEFAULT);
 

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1563,7 +1563,7 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
      * context so jobspec can be pre-signed before submission.
      */
     if (optparse_hasopt (p, "security-config")
-                            || optparse_hasopt (p, "sign-type")) {
+        || optparse_hasopt (p, "sign-type")) {
         sec_config = optparse_get_str (p, "security-config", NULL);
         if (!(sec = flux_security_create (0)))
             log_err_exit ("security");
@@ -1583,7 +1583,8 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
 #if HAVE_FLUX_SECURITY
     if (sec) {
         if (!(J = flux_sign_wrap (sec, jobspec, jobspecsz, sign_type, 0)))
-            log_err_exit ("flux_sign_wrap: %s", flux_security_last_error (sec));
+            log_err_exit ("flux_sign_wrap: %s",
+                          flux_security_last_error (sec));
         flags |= FLUX_JOB_PRE_SIGNED;
     }
 #endif

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1526,7 +1526,7 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
 #if HAVE_FLUX_SECURITY
     flux_security_t *sec = NULL;
     const char *sec_config;
-    const char *sign_type;
+    const char *sign_type = NULL;
 #endif
     int flags = 0;
     void *jobspec;

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1565,12 +1565,17 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
      */
     if (optparse_hasopt (p, "security-config")
         || optparse_hasopt (p, "sign-type")) {
-        sec_config = optparse_get_str (p, "security-config", NULL);
-        if (!(sec = flux_security_create (0)))
-            log_err_exit ("security");
-        if (flux_security_configure (sec, sec_config) < 0)
-            log_err_exit ("security config %s", flux_security_last_error (sec));
-        sign_type = optparse_get_str (p, "sign-type", NULL);
+        if (flags & FLUX_JOB_PRE_SIGNED)
+            log_msg ("Ignoring security config with --flags=pre-signed");
+        else {
+            sec_config = optparse_get_str (p, "security-config", NULL);
+            if (!(sec = flux_security_create (0)))
+                log_err_exit ("security");
+            if (flux_security_configure (sec, sec_config) < 0)
+                log_err_exit ("security config %s",
+                              flux_security_last_error (sec));
+            sign_type = optparse_get_str (p, "sign-type", NULL);
+        }
     }
 #endif
     if (!(h = flux_open (NULL, 0)))

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -47,6 +47,7 @@
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/fsd.h"
 #include "src/common/libutil/fdutils.h"
+#include "src/common/libutil/strstrip.h"
 #include "src/common/libidset/idset.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libioencode/ioencode.h"
@@ -1576,6 +1577,13 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_open");
     if ((jobspecsz = read_jobspec (input, &jobspec)) == 0)
         log_msg_exit ("required jobspec is empty");
+
+    /* If jobspec was pre-signed, then assign J to to jobspec after
+     * stripping surrounding whitespace.
+     */
+    if (flags & FLUX_JOB_PRE_SIGNED)
+        J = strstrip (jobspec);
+
     urgency = optparse_get_int (p, "urgency", FLUX_JOB_URGENCY_DEFAULT);
 
 #if HAVE_FLUX_SECURITY

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -87,7 +87,14 @@ test_expect_success HAVE_FLUX_SECURITY 'flux-job: submit with bad sign type fail
 		--sign-type=notvalid \
 		basic.json
 '
-
+test_expect_success HAVE_FLUX_SECURITY 'flux-job: submit ignores security-config with --flags=signed' '
+	flux run --dry-run -n1 hostnane | \
+	    flux python \
+	    ${SHARNESS_TEST_SRCDIR}/scripts/sign-as.py $(id -u) >signed.json &&
+	flux job submit --security-config=/nonexist --flags=signed \
+		signed.json >submit-signed.out 2>&1 &&
+	grep "Ignoring security config" submit-signed.out
+'
 test_expect_success 'flux-job: can submit jobspec on stdin with -' '
 	flux job submit - <basic.json
 '

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -65,7 +65,7 @@ test_expect_success 'job-exec: large jobspec does not get truncated' '
 		actual=imp-$(flux job id $id).input &&
 		test_debug "echo expecting J of size $(wc -c < job.signed)B" &&
 		test_debug "echo input to IMP was $(wc -c < $actual)B" &&
-		jq -j .J ${actual} > J.input &&
+		jq -r .J ${actual} > J.input &&
 		test_cmp job.signed J.input
 	)
 '


### PR DESCRIPTION
This is a small change required for some other work, but which seemed more appropriate as its own PR.

The main goal is to simply strip leading and trailing whitespace from J when submitted with `flux job submit --flags=signed`, however there was some other very minor cleanup along the way.