### PR TITLE
job-exec: provide IMP exec helper when possible and use stdin/out for shell exec protocol

### DIFF
--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -112,7 +112,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-pstree.py \
 	flux-pgrep.py \
 	flux-queue.py \
-	flux-cancel.py
+	flux-cancel.py \
+	flux-imp-exec-helper
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux-imp-exec-helper
+++ b/src/cmd/flux-imp-exec-helper
@@ -1,0 +1,20 @@
+#!/bin/sh
+##############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+#
+# Helper for flux-imp exec functionality.
+# Emit input to IMP for jobid on stdout given jobid in $1
+#
+JOBID=${1:-$FLUX_JOB_ID}
+if test -z "$JOBID"; then
+    echo "flux-imp-exec-helper: Unable to determine jobid" >&2
+    exit 1
+fi
+printf '{"J": "%s"}' $(flux job info --orig $JOBID J)

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -34,8 +34,7 @@ installed_conf_cppflags = \
 	-DINSTALLED_UPMI_PLUGINPATH=\"$(fluxlibdir)/upmi/plugins\" \
 	-DINSTALLED_CMDHELP_PATTERN=\"${datadir}/flux/help.d/*.json\" \
 	-DINSTALLED_NO_DOCS_PATH=\"${datadir}/flux/.nodocs\" \
-	-DINSTALLED_RUNDIR=\"${runstatedir}/flux\" \
-	-DINSTALLED_BINDIR=\"$(fluxcmddir)\"
+	-DINSTALLED_RUNDIR=\"${runstatedir}/flux\"
 
 intree_conf_cppflags = \
 	-DINTREE_MODULE_PATH=\"$(abs_top_builddir)/src/modules/.libs\" \
@@ -55,8 +54,7 @@ intree_conf_cppflags = \
 	-DINTREE_JOBTAP_PLUGINPATH=\"$(abs_top_builddir)/src/modules/job-manager/plugins/.libs\" \
 	-DINTREE_UPMI_PLUGINPATH=\"$(abs_top_builddir)/src/common/libpmi/plugins/.libs\" \
 	-DINTREE_CMDHELP_PATTERN=\"${abs_top_builddir}/etc/flux/help.d/*.json\" \
-	-DINTREE_NO_DOCS_PATH=\"${abs_top_builddir}/etc/flux/.nodocs\" \
-	-DINTREE_BINDIR=\"${abs_top_builddir}/src/cmd\"
+	-DINTREE_NO_DOCS_PATH=\"${abs_top_builddir}/etc/flux/.nodocs\"
 
 
 fluxcoreinclude_HEADERS = \

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -66,7 +66,6 @@ static struct builtin builtin_tab[] = {
     { "upmi_pluginpath",INSTALLED_UPMI_PLUGINPATH,  INTREE_UPMI_PLUGINPATH },
     { "no_docs_path",   INSTALLED_NO_DOCS_PATH,     INTREE_NO_DOCS_PATH },
     { "rundir",         INSTALLED_RUNDIR,           NULL },
-    { "bindir",         INSTALLED_BINDIR,           INTREE_BINDIR },
     { NULL, NULL, NULL },
 };
 

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -21,6 +21,8 @@ const char *config_get_cwd (struct jobinfo *job);
 
 const char *config_get_imp_path (void);
 
+bool config_use_imp_helper (void);
+
 int config_init (flux_t *h, int argc, char **argv);
 
 #endif /* !HAVE_JOB_EXEC_CONFIG_EXEC_H */

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -101,6 +101,7 @@
 
 #include "job-exec.h"
 #include "checkpoint.h"
+#include "exec_config.h"
 
 static double kill_timeout=5.0;
 
@@ -890,7 +891,7 @@ static void jobinfo_start_continue (flux_future_t *f, void *arg)
         jobinfo_fatal_error (job, errno, "initializing critical ranks");
         goto done;
     }
-    if (job->multiuser) {
+    if (job->multiuser && !config_use_imp_helper ()) {
         const char *J = jobinfo_kvs_lookup_get (f, "J");
         if (!J || !(job->J = strdup (J))) {
             jobinfo_fatal_error (job, errno, "reading J: %s", error.text);
@@ -1056,6 +1057,7 @@ static flux_future_t *jobinfo_start_init (struct jobinfo *job)
         || flux_future_push (f, "R", f_kvs) < 0)
         goto err;
     if (job->multiuser
+        && !config_use_imp_helper ()
         && (!(f_kvs = flux_jobid_kvs_lookup (h, job->id, 0, "J"))
         || flux_future_push (f, "J", f_kvs) < 0)) {
         goto err;

--- a/src/modules/job-exec/sdexec.c
+++ b/src/modules/job-exec/sdexec.c
@@ -86,11 +86,6 @@ struct sdexec
     bool jobinfo_tasks_complete_called;
 };
 
-static int sdexec_config (flux_t *h, int argc, char **argv)
-{
-    return config_init (h, argc, argv);
-}
-
 static void sdexec_destroy (void *data)
 {
     struct sdexec *se = data;
@@ -788,7 +783,6 @@ static int sdexec_cancel (struct jobinfo *job)
 
 struct exec_implementation sdexec = {
     .name =     "sdexec",
-    .config =   sdexec_config,
     .init =     sdexec_init,
     .exit =     sdexec_exit,
     .start =    sdexec_start,

--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -27,7 +27,7 @@ struct flux_shell {
     flux_jobid_t jobid;
     int broker_rank;
     char hostname [MAXHOSTNAMELEN + 1];
-    int protocol_fd;
+    int protocol_fd[2];
 
     optparse_t *p;
     flux_t *h;

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -16,7 +16,7 @@ JOBS=2
 MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
 
 if test "$PROJECT" = "flux-core"; then
-  FLUX_SECURITY_VERSION=0.8.0
+  FLUX_SECURITY_VERSION=0.9.0
   POISON=t
 fi
 

--- a/t/job-exec/imp.sh
+++ b/t/job-exec/imp.sh
@@ -9,7 +9,7 @@ case "$cmd" in
     exec)
         shift; 
         #  Copy IMP's input to a file so tests can check result:
-        cat - >imp-$(flux job id $2).input
+        ${FLUX_IMP_EXEC_HELPER:-cat} >imp-$(flux job id $2).input
         printf "test-imp: Running $* \n" >&2
         exec "$@" ;;
     kill)

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -55,7 +55,7 @@ test_expect_success 'job-exec: job exception uses SIGKILL after kill-timeout' '
 	flux module reload job-exec kill-timeout=0.2 &&
 	cat <<-EOF >trap-sigterm.sh &&
 	#!/bin/sh
-	trap "echo trap-sigterm got SIGTERM" 15
+	trap "echo trap-sigterm got SIGTERM >&2" 15
 	flux kvs put trap-ready=1
 	sleep 60 &
 	pid=\$!

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -328,23 +328,10 @@ test_expect_success 'job-shell: restore rundir writability' '
 	chmod 700 $(flux getattr rundir)
 '
 
-test_expect_success 'job-shell: fails if FLUX_EXEC_PROTOCOL_FD not set' '
-	cat <<-EOF >shell.sh &&
-	#!/bin/sh
-	unset FLUX_EXEC_PROTOCOL_FD
-	exec ${FLUX_BUILD_DIR}/src/shell/flux-shell "\$@"
-	EOF
-	chmod +x shell.sh &&
-	test_must_fail flux run \
-		--setattr=system.exec.job_shell=$(pwd)/shell.sh \
-		-n2 -N2 hostname 2>protocol_fd_missing.err &&
-	grep FLUX_EXEC_PROTOCOL_FD protocol_fd_missing.err
-'
-
 test_expect_success 'job-shell: fails if FLUX_EXEC_PROTOCOL_FD incorrect' '
 	cat <<-EOF >shell2.sh &&
 	#!/bin/sh
-	FLUX_EXEC_PROTOCOL_FD=foo
+	export FLUX_EXEC_PROTOCOL_FD=foo
 	exec ${FLUX_BUILD_DIR}/src/shell/flux-shell "\$@"
 	EOF
 	chmod +x shell2.sh &&

--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -82,9 +82,9 @@
    Memcheck:Leak
    match-leak-kinds: definite
    fun:malloc
-   obj:/usr/lib64/libhwloc.so.15.4.0
-   obj:/usr/lib64/libhwloc.so.15.4.0
-   obj:/usr/lib64/libhwloc.so.15.4.0
+   ...
+   obj:*libhwloc.so.15.4.*
+   obj:*libhwloc.so.15.4.*
    fun:hwloc_topology_load
    ...
 }


### PR DESCRIPTION
This PR adds an IMP exec helper utility that lets the IMP fetch its input from the enclosing instance instead of requiring the input on stdin. This becomes the default behavior if flux-security >= 0.9.0 is detected (the version in which support for an IMP helper was introduced). 

This should improve scalability of mulituser job launch somewhat, but the main purpose is to free up stdin/out of the job shell to be used to implement the exec barrier protocol instead of a separate socketpair. This will be necessary to support launching multi-node jobs under systemd, under which we can't provide a separate set of fds for the protocol.

Thus, when the IMP helper is used, use stdin/out fds for the exec protocol.

Closes #4220 