### PR TITLE
add capability to run jobs in systemd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -553,6 +553,7 @@ AC_CONFIG_FILES( \
   src/common/libzmqutil/Makefile \
   src/common/libtaskmap/Makefile \
   src/common/libfilemap/Makefile \
+  src/common/libsdexec/Makefile \
   src/bindings/Makefile \
   src/bindings/lua/Makefile \
   src/bindings/python/Makefile \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -303,6 +303,7 @@ MAN5_FILES_PRIMARY = \
 	man5/flux-config-bootstrap.5 \
 	man5/flux-config-tbon.5 \
 	man5/flux-config-exec.5 \
+	man5/flux-config-systemd.5 \
 	man5/flux-config-resource.5 \
 	man5/flux-config-archive.5 \
 	man5/flux-config-job-manager.5 \

--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -22,6 +22,15 @@ imp
    the credentials of the guest user that submitted them.  If unset, only
    jobs submitted by the instance owner may be executed.
 
+service
+   (optional) Set the remote subprocess service name. (Default: ``rexec``).
+   Note that ``systemd.enable`` must be set to ``true`` if ``sdexec`` is
+   configured.  See :man5:`flux-config-systemd`.
+
+service-override
+   (optional) Allow ``service`` to be overridden on a per-job basis with
+   ``--setattr system.exec.bulkexec.service=NAME``.  (Default: ``false``).
+
 method
    (optional) Run job shell under a specific mechanism other than the default
    forked subprocesses.  Potential configurations:

--- a/doc/man5/flux-config-systemd.rst
+++ b/doc/man5/flux-config-systemd.rst
@@ -1,0 +1,46 @@
+======================
+flux-config-systemd(5)
+======================
+
+
+DESCRIPTION
+===========
+
+Flux can optionally launch jobs using systemd when :man5:`flux-config-exec`
+selects the ``sdexec`` service.  The ``systemd`` table must also be configured.
+
+KEYS
+====
+
+enable (optional)
+   Boolean value enables the ``sdbus`` and ``sdexec`` modules to be loaded.
+   (Default: ``false``).
+
+sdbus-debug (optional)
+   Boolean value enables debug logging by the ``sdbus`` module.
+
+sdexec-debug (optional)
+   Boolean value enables debug logging by the ``sdexec`` module.
+
+
+EXAMPLE
+=======
+
+::
+
+   [systemd]
+   enable = true
+   sdbus-debug = true
+   sdexec-debug = true
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+
+SEE ALSO
+========
+
+:man5:`flux-config`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -297,6 +297,7 @@ man_pages = [
     ('man5/flux-config-bootstrap', 'flux-config-bootstrap', 'configure Flux instance bootstrap', [author], 5),
     ('man5/flux-config-tbon', 'flux-config-tbon', 'configure Flux overlay network', [author], 5),
     ('man5/flux-config-exec', 'flux-config-exec', 'configure Flux job execution service', [author], 5),
+    ('man5/flux-config-systemd', 'flux-config-systemd', 'configure Flux systemd support', [author], 5),
     ('man5/flux-config-ingest', 'flux-config-ingest', 'configure Flux job ingest service', [author], 5),
     ('man5/flux-config-resource', 'flux-config-resource', 'configure Flux resource service', [author], 5),
     ('man5/flux-config-archive', 'flux-config-archive', 'configure Flux job archival service', [author], 5),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -708,3 +708,5 @@ pmix
 SIGUSR
 iteratively
 noverify
+sdbus
+sdexec

--- a/etc/rc1
+++ b/etc/rc1
@@ -25,6 +25,7 @@ fi
 modload all barrier
 if test "$(flux config get --default=false systemd.enable)" = "true"; then
     modload all sdbus
+    modload all sdexec
 fi
 
 if test $RANK -eq 0; then

--- a/etc/rc3
+++ b/etc/rc3
@@ -39,6 +39,7 @@ modrm 0 job-manager
 modrm all job-ingest
 
 modrm 0 cron
+modrm all sdexec
 modrm all sdbus
 modrm all barrier
 

--- a/src/cmd/flux-perilog-run.py
+++ b/src/cmd/flux-perilog-run.py
@@ -80,7 +80,12 @@ def run_per_rank(name, jobid, args):
         )
 
     for rank in ranks:
-        cmd = ["flux", "exec", "-qn", f"-r{rank}"] + per_rank_cmd
+        cmdv = ["flux", "exec", "-qn", f"-r{rank}"]
+        if args.sdexec:
+            cmdv.append("--service=sdexec")
+            cmdv.append(f"--setopt=SDEXEC_NAME={name}-{rank}-{jobid.f58plain}.service")
+            cmdv.append(f"--setopt=SDEXEC_PROP_Description=System {name} script")
+        cmd = cmdv + per_rank_cmd
         processes[rank] = process_create(cmd, stderr=subprocess.PIPE)
 
     for rank in ranks:
@@ -180,6 +185,9 @@ def main():
         "-v", "--verbose", help="Log script events", action="store_true"
     )
     prolog_parser.add_argument(
+        "-s", "--sdexec", help="Use sdexec to run prolog", action="store_true"
+    )
+    prolog_parser.add_argument(
         "-e",
         "--exec-per-rank",
         metavar="CMD[,ARGS...]",
@@ -199,6 +207,9 @@ def main():
     )
     epilog_parser.add_argument(
         "-v", "--verbose", help="Log script events", action="store_true"
+    )
+    epilog_parser.add_argument(
+        "-s", "--sdexec", help="Use sdexec to run epilog", action="store_true"
     )
     epilog_parser.add_argument(
         "-e",

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -27,7 +27,8 @@ SUBDIRS = \
 	libccan \
 	libzmqutil \
 	libtaskmap \
-	libfilemap
+	libfilemap \
+	libsdexec
 
 if HAVE_LIBSYSTEMD
 SUBDIRS += libsdprocess

--- a/src/common/libsdexec/Makefile.am
+++ b/src/common/libsdexec/Makefile.am
@@ -1,0 +1,33 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	-I$(top_srcdir)/src/common/libccan \
+	$(JANSSON_CFLAGS)
+
+noinst_LTLIBRARIES = libsdexec.la
+
+libsdexec_la_SOURCES = \
+	state.c \
+	state.h \
+	start.c \
+	start.h \
+	stop.h \
+	stop.c \
+	list.h \
+	list.c \
+	property.h \
+	property.c \
+	channel.h \
+	channel.c \
+	unit.h \
+	unit.c \
+	parse.h \
+	parse.c

--- a/src/common/libsdexec/Makefile.am
+++ b/src/common/libsdexec/Makefile.am
@@ -31,3 +31,73 @@ libsdexec_la_SOURCES = \
 	unit.c \
 	parse.h \
 	parse.c
+
+test_ldadd = \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/libsubprocess/libsubprocess.la \
+	$(top_builddir)/src/common/libtestutil/libtestutil.la \
+	$(top_builddir)/src/common/libzmqutil/libzmqutil.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(LIBPTHREAD) \
+	$(JANSSON_LIBS) \
+	$(ZMQ_LIBS)
+
+test_cppflags = \
+	$(AM_CPPFLAGS)
+
+test_ldflags = \
+	-no-install
+
+TESTS = \
+	test_parse.t \
+	test_channel.t \
+	test_list.t \
+	test_property.t \
+	test_start.t \
+	test_state.t \
+	test_stop.t \
+	test_unit.t
+
+check_PROGRAMS = \
+	$(TESTS)
+
+test_parse_t_SOURCES = test/parse.c
+test_parse_t_CPPFLAGS = $(test_cppflags)
+test_parse_t_LDADD = libsdexec.la $(test_ldadd)
+test_parse_t_LDFLAGS = $(test_ldflags)
+
+test_channel_t_SOURCES = test/channel.c
+test_channel_t_CPPFLAGS = $(test_cppflags)
+test_channel_t_LDADD = libsdexec.la $(test_ldadd)
+test_channel_t_LDFLAGS = $(test_ldflags)
+
+test_list_t_SOURCES = test/list.c
+test_list_t_CPPFLAGS = $(test_cppflags)
+test_list_t_LDADD = libsdexec.la $(test_ldadd)
+test_list_t_LDFLAGS = $(test_ldflags)
+
+test_property_t_SOURCES = test/property.c
+test_property_t_CPPFLAGS = $(test_cppflags)
+test_property_t_LDADD = libsdexec.la $(test_ldadd)
+test_property_t_LDFLAGS = $(test_ldflags)
+
+test_start_t_SOURCES = test/start.c
+test_start_t_CPPFLAGS = $(test_cppflags)
+test_start_t_LDADD = libsdexec.la $(test_ldadd)
+test_start_t_LDFLAGS = $(test_ldflags)
+
+test_state_t_SOURCES = test/state.c
+test_state_t_CPPFLAGS = $(test_cppflags)
+test_state_t_LDADD = libsdexec.la $(test_ldadd)
+test_state_t_LDFLAGS = $(test_ldflags)
+
+test_stop_t_SOURCES = test/stop.c
+test_stop_t_CPPFLAGS = $(test_cppflags)
+test_stop_t_LDADD = libsdexec.la $(test_ldadd)
+test_stop_t_LDFLAGS = $(test_ldflags)
+
+test_unit_t_SOURCES = test/unit.c
+test_unit_t_CPPFLAGS = $(test_cppflags)
+test_unit_t_LDADD = libsdexec.la $(test_ldadd)
+test_unit_t_LDFLAGS = $(test_ldflags)

--- a/src/common/libsdexec/channel.c
+++ b/src/common/libsdexec/channel.c
@@ -1,0 +1,233 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* channel.c - manage stdio
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <flux/core.h>
+
+#include "src/common/libioencode/ioencode.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/fdutils.h"
+
+#include "channel.h"
+
+struct channel {
+    flux_t *h;
+    char rankstr[16];
+    int fd[2];
+    flux_watcher_t *w;
+    char *name;
+    bool writable;
+    channel_output_f output_cb;
+    channel_error_f error_cb;
+    void *arg;
+};
+
+/* fd watcher for read end of channel file descriptor
+ */
+static void channel_output_cb (flux_reactor_t *r,
+                               flux_watcher_t *w,
+                               int revents,
+                               void *arg)
+{
+    struct channel *ch = arg;
+    char buf[1024];
+    ssize_t n;
+    json_t *io;
+
+    if ((n = read (ch->fd[0], buf, sizeof (buf))) < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+            return; // spurious wakeup or revents without POLLIN?
+        if (ch->error_cb) {
+            flux_error_t error;
+            errprintf (&error,
+                       "error reading from %s: %s",
+                       ch->name,
+                       strerror (errno));
+            ch->error_cb (ch, &error, ch->arg);
+            // fall through and generate EOF
+        }
+    }
+    /* Since sdexec.exec clients are not finalized until the channel callback
+     * gets EOF, ensure that it always does, even if there was a read error.
+     */
+    if (n <= 0) {
+        io = ioencode (ch->name, ch->rankstr, NULL, 0, true);
+        flux_watcher_stop (w);
+    }
+    else
+        io = ioencode (ch->name, ch->rankstr, buf, n, false);
+    if (!io) {
+        if (ch->error_cb) {
+            flux_error_t error;
+            errprintf (&error,
+                       "error encoding data from %s: %s",
+                       ch->name,
+                       strerror (errno));
+            ch->error_cb (ch, &error, ch->arg);
+        }
+        return;
+    }
+    if (ch->output_cb)
+        ch->output_cb (ch, io, ch->arg);
+    json_decref (io);
+}
+
+int sdexec_channel_get_fd (struct channel *ch)
+{
+    return ch ? ch->fd[1] : -1;
+}
+
+const char *sdexec_channel_get_name (struct channel *ch)
+{
+    return ch ? ch->name : "unknown";
+}
+
+void sdexec_channel_close_fd (struct channel *ch)
+{
+    if (ch && ch->fd[1] >= 0) {
+        close (ch->fd[1]);
+        ch->fd[1] = -1;
+    }
+}
+
+void sdexec_channel_start_output (struct channel *ch)
+{
+    if (ch)
+        flux_watcher_start (ch->w);
+}
+
+void sdexec_channel_destroy (struct channel *ch)
+{
+    if (ch) {
+        int saved_errno = errno;
+        if (ch->fd[0] >= 0)
+            close (ch->fd[0]);
+        if (ch->fd[1] >= 0)
+            close (ch->fd[1]);
+        flux_watcher_destroy (ch->w);
+        free (ch->name);
+        free (ch);
+        errno = saved_errno;
+    }
+}
+
+static struct channel *sdexec_channel_create (flux_t *h, const char *name)
+{
+    struct channel *ch;
+    uint32_t rank;
+
+    if (!h || !name) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(ch = calloc (1, sizeof (*ch))))
+        return NULL;
+    ch->h = h;
+    ch->fd[0] = -1;
+    ch->fd[1] = -1;
+    if (!(ch->name = strdup (name)))
+        goto error;
+    if (flux_get_rank (h, &rank) < 0)
+        goto error;
+    snprintf (ch->rankstr, sizeof (ch->rankstr), "%u", (unsigned int)rank);
+    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, ch->fd) < 0)
+        goto error;
+    return ch;
+error:
+    sdexec_channel_destroy (ch);
+    return NULL;
+}
+
+struct channel *sdexec_channel_create_output (flux_t *h,
+                                              const char *name,
+                                              channel_output_f output_cb,
+                                              channel_error_f error_cb,
+                                              void *arg)
+{
+    struct channel *ch;
+
+    if (!(ch = sdexec_channel_create (h, name)))
+        return NULL;
+    ch->output_cb = output_cb;
+    ch->error_cb = error_cb;
+    ch->arg = arg;
+    if (fd_set_nonblocking (ch->fd[0]) < 0)
+        goto error;
+    if (!(ch->w = flux_fd_watcher_create (flux_get_reactor (h),
+                                          ch->fd[0],
+                                          FLUX_POLLIN,
+                                          channel_output_cb,
+                                          ch)))
+        goto error;
+    return ch;
+error:
+    sdexec_channel_destroy (ch);
+    return NULL;
+}
+
+struct channel *sdexec_channel_create_input (flux_t *h, const char *name)
+{
+    struct channel *ch;
+
+    if (!(ch = sdexec_channel_create (h, name)))
+        return NULL;
+    ch->writable = true;
+    return ch;
+}
+
+int sdexec_channel_write (struct channel *ch, json_t *io)
+{
+    char *data;
+    int len;
+    bool eof;
+
+    if (!ch || !io) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (iodecode (io, NULL, NULL, &data, &len, &eof) < 0)
+        return -1;
+    if (!ch->writable || ch->fd[0] < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (data && len > 0) {
+        int count = 0;
+        while (count < len) {
+            ssize_t n;
+            if ((n = write (ch->fd[0], data + count, len - count)) < 0) {
+                ERRNO_SAFE_WRAP (free, data);
+                return -1;
+            }
+            count += n;
+        }
+        free (data);
+    }
+    if (eof) {
+        int fd = ch->fd[0];
+
+        ch->fd[0] = -1;
+        if (close (fd) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/channel.h
+++ b/src/common/libsdexec/channel.h
@@ -1,0 +1,75 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _LIBSDEXEC_CHANNEL_H
+#define _LIBSDEXEC_CHANNEL_H
+
+#include <jansson.h>
+#include <flux/core.h>
+
+struct channel;
+
+typedef void (*channel_output_f)(struct channel *ch, json_t *io, void *arg);
+typedef void (*channel_error_f)(struct channel *ch,
+                                flux_error_t *error,
+                                void *arg);
+
+/* Open a channel for output from the systemd unit.  When the unit has written
+ * some data, an internal fd watcher reads from it and invokes output_cb.
+ * If there is a read error, the error_cb is also called for logging, then
+ * output_cb is called with EOF.
+ *
+ * Notes:
+ * - internal watcher is not started until sdexec_channel_start_output()
+ *   is called
+ * - data is not line buffered
+ * - a single callback may not represent all the data available at that moment
+ */
+struct channel *sdexec_channel_create_output (flux_t *h,
+                                              const char *name,
+                                              channel_output_f output_cb,
+                                              channel_error_f error_cb,
+                                              void *arg);
+
+/* Open a channel for input to the systemd unit.
+ * The channel may be written to using sdexec_channel_write().
+ */
+struct channel *sdexec_channel_create_input (flux_t *h, const char *name);
+
+/* Write to channel created with sdexec_channel_create_input ().
+ * The ioencoded object's rank and stream name are ignored.
+ * This is potentially a blocking operation if the socketpair cannot
+ * accept all the data.
+ */
+int sdexec_channel_write (struct channel *ch, json_t *io);
+
+/* Get fd for systemd end of socketpair.  Returns -1 if unset or ch==NULL.
+ */
+int sdexec_channel_get_fd (struct channel *ch);
+
+/* Get name of channel.
+ */
+const char *sdexec_channel_get_name (struct channel *ch);
+
+/* Close fd on systemd end of socketpair.
+ * Call this after systemd has received the fd and duped it - in the response
+ * handler for StartTransientUnit should be correct.
+ */
+void sdexec_channel_close_fd (struct channel *ch);
+
+/* Start watching for channel output.
+ */
+void sdexec_channel_start_output (struct channel *ch);
+
+void sdexec_channel_destroy (struct channel *ch);
+
+#endif /* !_LIBSDEXEC_CHANNEL_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/list.c
+++ b/src/common/libsdexec/list.c
@@ -1,0 +1,84 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* list.c - list units
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "ccan/ptrint/ptrint.h"
+
+#include "list.h"
+
+static int parse_unit (json_t *units, size_t index, struct unit_info *info)
+{
+    json_t *entry;
+
+    if (!units
+        || !info
+        || !(entry = json_array_get (units, index))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (json_unpack (entry,
+                     "[sssssssIss]",
+                     &info->name,
+                     &info->description,
+                     &info->load_state,
+                     &info->active_state,
+                     &info->sub_state,
+                     &info->name_follower,
+                     &info->path,
+                     &info->job_id,
+                     &info->job_type,
+                     &info->job_path) < 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    return 0;
+}
+
+bool sdexec_list_units_next (flux_future_t *f, struct unit_info *infop)
+{
+    json_t *units;
+    struct unit_info info;
+    int index = ptr2int (flux_future_aux_get (f, "index")); // zero if not set
+
+    if (!infop
+        || flux_rpc_get_unpack (f, "{s:[o]}", "params", &units) < 0
+        || parse_unit (units, index, &info) < 0
+        || flux_future_aux_set (f, "index", int2ptr (index + 1), NULL) < 0)
+        return false;
+
+    *infop = info;
+    return true;
+}
+
+/* N.B. Input params:  states=[], patterns=[pattern].
+ */
+flux_future_t *sdexec_list_units (flux_t *h, uint32_t rank, const char *pattern)
+{
+    if (!h || !pattern) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return flux_rpc_pack (h,
+                          "sdbus.call",
+                          rank,
+                          0,
+                          "{s:s s:[[] [s]]}",
+                          "member", "ListUnitsByPatterns",
+                          "params", pattern);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/list.h
+++ b/src/common/libsdexec/list.h
@@ -1,0 +1,46 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _LIBSDEXEC_LIST_H
+#define _LIBSDEXEC_LIST_H
+
+#include <jansson.h>
+#include <flux/core.h>
+
+struct unit_info {
+    const char *name;
+    const char *description;
+    const char *load_state;
+    const char *active_state;
+    const char *sub_state;
+    const char *name_follower;  // "" if no unit whose state follows this one
+    const char *path;
+
+    json_int_t job_id;          // 0 if no job queued for the unit
+    const char *job_type;
+    const char *job_path;
+};
+
+/* Obtain the unit list, filtered by glob pattern.
+ * (E.g. use "*" for all).
+ */
+flux_future_t *sdexec_list_units (flux_t *h,
+                                  uint32_t rank,
+                                  const char *pattern);
+
+/* Iterate over returned list of units.
+ * Fill in 'info' with the next entry and return true,
+ * or return false if there are no more entries.
+ */
+bool sdexec_list_units_next (flux_future_t *f, struct unit_info *info);
+
+#endif /* !_LIBSDEXEC_LIST_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/parse.c
+++ b/src/common/libsdexec/parse.c
@@ -1,0 +1,81 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <flux/idset.h>
+
+#include "ccan/str/str.h"
+#include "parse.h"
+
+int sdexec_parse_percent (const char *s, double *dp)
+{
+    char *endptr;
+    double d;
+
+    if (!s || !dp)
+        return -1;
+    errno = 0;
+    d = strtod (s, &endptr);
+    if (errno != 0 || endptr == s || strlen (endptr) != 1 || endptr[0] != '%')
+        return -1;
+    if (d < 0 || d > 100)
+        return -1;
+    *dp = d * 1E-2;
+    return 0;
+}
+
+/* Borrow some macro ideas from ccan/bitmap/bitmap.h.  It cannot be used here
+ * because it apparently swaps bytes of internal words on little endian for
+ * portability, which isn't compatible with the byte array requirement of
+ * systemd/dbus.
+ */
+#define BITMAP_NBYTES(nb)           (((nb) + 8 - 1) / 8)
+#define BITMAP_BYTE(bm,n)           (bm)[(n) / 8]
+#define BITMAP_BIT(n)               (1 << ((n) % 8))
+
+int sdexec_parse_bitmap (const char *s, uint8_t **bp, size_t *sp)
+{
+    struct idset *ids;
+    unsigned int id;
+    unsigned int nbits = 0;
+    uint8_t *bitmap = NULL;
+
+    if (!s || !bp || !sp)
+        return -1;
+    if (!(ids = idset_decode (s)))
+        return -1;
+
+    // allocate a bitmap large enough to fit idset
+    if ((id = idset_last (ids)) != IDSET_INVALID_ID)
+        nbits = id + 1;
+    if (nbits > 0) {
+        if (!(bitmap = calloc (1, BITMAP_NBYTES (nbits)))) {
+            idset_destroy (ids);
+            return -1;
+        }
+        id = idset_first (ids);
+        while (id != IDSET_INVALID_ID) {
+            BITMAP_BYTE (bitmap, id) |= BITMAP_BIT (id);
+            id = idset_next (ids, id);
+        }
+        idset_destroy (ids);
+    }
+    *bp = bitmap;
+    *sp = BITMAP_NBYTES (nbits);
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/parse.h
+++ b/src/common/libsdexec/parse.h
@@ -1,0 +1,32 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _LIBSDEXEC_PARSE_H
+#define _LIBSDEXEC_PARSE_H
+
+#include <sys/types.h>
+#include <stdint.h>
+
+/* Parse 's' as a percentage between 0 and 100 with % suffix and
+ * assign the result, a 0 <= value <= 1.0, to 'dp'.
+ * Return 0 on success or -1 on failure.  Errno is not set.
+ */
+int sdexec_parse_percent (const char *s, double *dp);
+
+/* Parse 's' as an idset into bitmap assigned to 'bp' (caller must free).
+ * The size of the bitmap (in bytes) is assigned to 'sp'.
+ * N.B. an empty string translates to an empty (*bp=NULL, *sp=0) bitmap.
+ * Return 0 on success or -1 on failure.  Errno is not set.
+ */
+int sdexec_parse_bitmap (const char *s, uint8_t **bp, size_t *sp);
+
+#endif /* !_LIBSDEXEC_PARSE_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/property.c
+++ b/src/common/libsdexec/property.c
@@ -1,0 +1,204 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* property.c - query unit properties
+ *
+ * The Get method-reply includes a single property value, represented as a
+ * D-Bus variant type, which is a (type, value) tuple: [s,o]
+ *
+ * The GetAll method-reply and the PropertiesChanged signal include a
+ * dictionary of property values:
+ * {s:[s,o], s:[s,o], s:[s,o], ...}
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "ccan/str/str.h"
+#include "src/common/libutil/errno_safe.h"
+
+#include "property.h"
+
+static const char *serv_interface = "org.freedesktop.systemd1.Service";
+static const char *prop_interface = "org.freedesktop.DBus.Properties";
+
+flux_future_t *sdexec_property_get_all (flux_t *h,
+                                        uint32_t rank,
+                                        const char *path)
+{
+    flux_future_t *f;
+
+    if (!h || !path) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(f = flux_rpc_pack (h,
+                             "sdbus.call",
+                             rank,
+                             0,
+                             "{s:s s:s s:s s:[s]}",
+                             "path", path,
+                             "interface", prop_interface,
+                             "member", "GetAll",
+                             "params", serv_interface)))
+        return NULL;
+    return f;
+}
+
+flux_future_t *sdexec_property_get (flux_t *h,
+                                    uint32_t rank,
+                                    const char *path,
+                                    const char *name)
+{
+    flux_future_t *f;
+
+    if (!h || !path || !name) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(f = flux_rpc_pack (h,
+                             "sdbus.call",
+                             rank,
+                             0,
+                             "{s:s s:s s:s s:[ss]}",
+                             "path", path,
+                             "interface", prop_interface,
+                             "member", "Get",
+                             "params", serv_interface, name)))
+        return NULL;
+    return f;
+}
+
+flux_future_t *sdexec_property_changed (flux_t *h,
+                                        uint32_t rank,
+                                        const char *path)
+{
+    flux_future_t *f;
+    json_t *o;
+
+    if (!h) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(o = json_pack ("{s:s s:s}",
+                         "interface", prop_interface,
+                         "member", "PropertiesChanged")))
+        goto nomem;
+    if (path) {
+        json_t *val = json_string (path);
+        if (!val || json_object_set_new (o, "path", val) < 0) {
+            json_decref (val);
+            goto nomem;
+        }
+    }
+    if (!(f = flux_rpc_pack (h,
+                             "sdbus.subscribe",
+                             rank,
+                             FLUX_RPC_STREAMING,
+                             "O", o)))
+        goto error;
+    json_decref (o);
+    return f;
+nomem:
+    errno = ENOMEM;
+error:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    return NULL;
+}
+
+int sdexec_property_get_unpack (flux_future_t *f, const char *fmt, ...)
+{
+    const char *type; // ignored
+    json_t *val;
+    va_list ap;
+    int rc;
+
+    if (!f || !fmt) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (flux_rpc_get_unpack (f, "{s:[[so]]}", "params", &type, &val) < 0)
+        return -1;
+    va_start (ap, fmt);
+    rc = json_vunpack_ex (val, NULL, 0, fmt, ap);
+    va_end (ap);
+    if (rc < 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    return rc;
+}
+
+int sdexec_property_dict_unpack (json_t *dict,
+                                 const char *name,
+                                 const char *fmt,
+                                 ...)
+
+{
+    const char *type; // ignored
+    json_t *val;
+    va_list ap;
+    int rc;
+
+    if (!dict || !name || !fmt) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (json_unpack (dict, "{s:[so]}", name, &type, &val) < 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    va_start (ap, fmt);
+    rc = json_vunpack_ex (val, NULL, 0, fmt, ap);
+    va_end (ap);
+    if (rc < 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    return 0;
+}
+
+json_t *sdexec_property_get_all_dict (flux_future_t *f)
+
+{
+    json_t *dict;
+
+    if (flux_rpc_get_unpack (f,
+                             "{s:[o]}",
+                             "params", &dict) < 0)
+        return NULL;
+    return dict;
+}
+
+json_t *sdexec_property_changed_dict (flux_future_t *f)
+{
+    const char *iface;
+    json_t *dict;
+    json_t *inval;
+
+    if (flux_rpc_get_unpack (f,
+                             "{s:[s o o]}",
+                             "params", &iface, &dict, &inval) < 0)
+        return NULL;
+    return dict;
+}
+
+const char *sdexec_property_changed_path (flux_future_t *f)
+{
+    const char *path;
+
+    if (flux_rpc_get_unpack (f, "{s:s}", "path", &path) < 0)
+        return NULL;
+    return path;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/property.h
+++ b/src/common/libsdexec/property.h
@@ -1,0 +1,57 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+j************************************************************/
+
+#ifndef _LIBSDEXEC_PROPERTY_H
+#define _LIBSDEXEC_PROPERTY_H
+
+#include <jansson.h>
+#include <flux/core.h>
+
+/* 'Get' method-call.
+ * Parse the returned value with sdexec_property_get_unpack().
+ */
+flux_future_t *sdexec_property_get (flux_t *h,
+                                    uint32_t rank,
+                                    const char *path,
+                                    const char *name);
+int sdexec_property_get_unpack (flux_future_t *f, const char *fmt, ...);
+
+/* 'GetAll' method-call.
+ * sdexec_property_get_all_dict() accesses the returned property dict,
+ * which can be further parsed with sdexec_property_dict_unpack().
+ */
+flux_future_t *sdexec_property_get_all (flux_t *h,
+                                        uint32_t rank,
+                                        const char *path);
+json_t *sdexec_property_get_all_dict (flux_future_t *f);
+
+/* 'PropertiesChanged' signal.
+ * sdexec_property_changed() subscribes to streaming property updates for the
+ * specified path.  Each response contains a property dict that may be accessed
+ * with sdexec_property_changed_dict().  The dict can be further parsed with
+ * sdexec_property_dict_unpack().  Use path=NULL for no path filter, then
+ * sdexec_property_changed_path() to get the path for each response.
+ */
+flux_future_t *sdexec_property_changed (flux_t *h,
+                                        uint32_t rank,
+                                        const char *path);
+json_t *sdexec_property_changed_dict (flux_future_t *f);
+const char *sdexec_property_changed_path (flux_future_t *f);
+
+/* Parse property 'name' from property dict.
+ */
+int sdexec_property_dict_unpack (json_t *dict,
+                                 const char *name,
+                                 const char *fmt,
+                                 ...);
+
+#endif /* !_LIBSDEXEC_PROPERTY_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/start.c
+++ b/src/common/libsdexec/start.c
@@ -1,0 +1,388 @@
+/************************************************************\
+
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* start.c - start transient service unit from json-encoded flux_cmd_t
+ *
+ * Ref: https://www.freedesktop.org/wiki/Software/systemd/dbus/
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <ctype.h>
+#include <stdio.h>
+#include <jansson.h>
+#include <flux/core.h>
+#include <float.h> // for DBL_MAX
+
+#include "ccan/str/str.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/parse_size.h"
+
+#include "parse.h"
+#include "start.h"
+
+/* This dense JSON format string deserves some explanation!
+ * [s[sO]] is [key,[type,val]] std. form for a StartTransientUnit property.
+ * - key is "ExecStart", the property name
+ * - type is "a(sasb)", the D-Bus signature for value
+ * - val is [[sOb]], an array of command lines
+ * The command line [sOb] consists of
+ * - command name (argv[0])
+ * - argv array (of strings)
+ * - boolean ignore-failure flag (e.g. an ExecStart prefix of "-")
+ * This function assumes one command line, and ignore-failure=false.
+ */
+static int prop_add_execstart (json_t *prop, const char *name, json_t *cmdline)
+{
+    json_t *o = NULL;
+    const char *arg0;
+
+    if (json_unpack (cmdline, "[s]", &arg0) < 0
+        || !(o = json_pack ("[s[s[[sOb]]]]", name, "a(sasb)", arg0, cmdline, 0))
+        || json_array_append_new (prop, o) < 0) {
+        json_decref (o);
+        return -1;
+    }
+    return 0;
+}
+
+/* systemd fails a StartTransientUnit request if environment variable
+ * names start with a digit, or contain characters other than digits,
+ * letters, or '_'.
+ * https://github.com/systemd/systemd/blob/main/src/basic/env-util.c#L28
+ */
+static bool environment_name_ok (const char *name)
+{
+    if (strlen (name) == 0 || isdigit (name[0]))
+        return false;
+    for (int i = 0; i < strlen (name); i++) {
+        if (!isalnum (name[i]) && name[i] != '_')
+            return false;
+    }
+    return true;
+}
+
+/* The Environment property is an array of "key=value" strings, which
+ * is built up from the env dict received as part of the command.
+ */
+static int prop_add_env (json_t *prop, const char *name, json_t *dict)
+{
+    json_t *a;
+    const char *k;
+    json_t *vo;
+    json_t *env;
+    int rc = -1;
+
+    if (!(a = json_array ()))
+        return -1;
+    json_object_foreach (dict, k, vo) {
+        const char *v = json_string_value (vo);
+
+        if (environment_name_ok (k)) {
+            char *kv = NULL;
+            json_t *kvo = NULL;
+            if (asprintf (&kv, "%s=%s", k, v) < 0
+                || !(kvo = json_string (kv))
+                || json_array_append_new (a, kvo) < 0) {
+                json_decref (kvo);
+                free (kv);
+                goto out;
+            }
+            free (kv);
+        }
+    }
+    if (!(env = json_pack ("[s[sO]]", name, "as", a))
+        || json_array_append_new (prop, env) < 0) {
+        json_decref (env);
+        goto out;
+    }
+    rc = 0;
+out:
+    json_decref (a);
+    return rc;
+}
+
+static int prop_add_string (json_t *prop, const char *name, const char *val)
+{
+    json_t *o;
+
+    if (val) {
+        if (!(o = json_pack ("[s[ss]]", name, "s", val))
+            || json_array_append_new (prop, o) < 0) {
+            json_decref (o);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* This assumes message source and destination are in the same process,
+ * as is the case with sdexec => sdbus broker modules.
+ */
+static int prop_add_fd (json_t *prop, const char *name, int val)
+{
+    json_t *o;
+
+    if (val >= 0) {
+        if (!(o = json_pack ("[s[si]]", name, "h", val))
+            || json_array_append_new (prop, o) < 0) {
+            json_decref (o);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int prop_add_bool (json_t *prop, const char *name, int val)
+{
+    json_t *o;
+
+    if (!(o = json_pack ("[s[sb]]", name, "b", val))
+        || json_array_append_new (prop, o) < 0) {
+        json_decref (o);
+        return -1;
+    }
+    return 0;
+}
+
+static int prop_add_u32 (json_t *prop, const char *name, uint32_t val)
+{
+    json_int_t i = val;
+    json_t *o;
+
+    if (!(o = json_pack ("[s[sI]]", name, "u", i))
+        || json_array_append_new (prop, o) < 0) {
+        json_decref (o);
+        return -1;
+    }
+    return 0;
+}
+
+static int prop_add_u64 (json_t *prop, const char *name, uint64_t val)
+{
+    json_int_t i = (json_int_t)val;
+    json_t *o;
+
+    if (!(o = json_pack ("[s[sI]]", name, "t", i))
+        || json_array_append_new (prop, o) < 0) {
+        json_decref (o);
+        return -1;
+    }
+    return 0;
+}
+
+static int prop_add_bytearray (json_t *prop,
+                               const char *name,
+                               uint8_t *bytearray,
+                               size_t size)
+{
+    json_t *o;
+    json_t *a;
+
+    if (!(a = json_array ()))
+        return -1;
+    for (int i = 0; i < size; i++) {
+        json_t *vo;
+        if (!(vo = json_integer (bytearray[i]))
+            || json_array_append_new (a, vo) < 0) {
+            json_decref (vo);
+            json_decref (a);
+            return -1;
+        }
+    }
+    if (!(o = json_pack ("[s[sO]]", name, "ay", a))
+        || json_array_append_new (prop, o) < 0) {
+        json_decref (o);
+        json_decref (a);
+        return -1;
+    }
+    json_decref (a);
+    return 0;
+}
+
+/* Set a property by name. By default, values are strings  Those that are
+ * not require explicit conversion from string.
+ */
+static int prop_add (json_t *prop, const char *name, const char *val)
+{
+    if (strlen (name) == 0 || !val)
+        return 0;
+
+    if (streq (name, "MemoryHigh")
+        || streq (name, "MemoryMax")
+        || streq (name, "MemoryMin")
+        || streq (name, "MemoryLow")) {
+        double d;
+        uint64_t u;
+
+        if (sdexec_parse_percent (val, &d) == 0) {
+            char newname[64];
+            snprintf (newname, sizeof (newname), "%sScale", name);
+            if (prop_add_u32 (prop, newname, (uint32_t)(d * UINT32_MAX)) < 0)
+                return -1;
+        }
+        else if (parse_size (val, &u) == 0) {
+            if (prop_add_u64 (prop, name, u) < 0)
+                return -1;
+        }
+        else if (streq (val, "infinity")) {
+            if (prop_add_u64 (prop, name, UINT64_MAX) < 0)
+                return -1;
+        }
+        else
+            return -1;
+    }
+    else if (streq (name, "AllowedCPUs")) {
+        uint8_t *bitmap;
+        size_t size;
+
+        if (sdexec_parse_bitmap (val, &bitmap, &size) < 0)
+            return -1;
+        if (prop_add_bytearray (prop, name, bitmap, size) < 0) {
+            free (bitmap);
+            return -1;
+        }
+        free (bitmap);
+    }
+    else {
+        if (prop_add_string (prop, name, val) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+static json_t *prop_create (json_t *cmd,
+                            const char *type,
+                            int stdin_fd,
+                            int stdout_fd,
+                            int stderr_fd,
+                            flux_error_t *error)
+{
+    json_t *prop;
+    json_error_t jerror;
+    const char *cwd = NULL;
+    json_t *cmdline;
+    json_t *env;
+    json_t *opts;
+    const char *key;
+    json_t *val;
+
+    // Not unpacked: channels
+    if (json_unpack_ex (cmd,
+                        &jerror,
+                        0,
+                        "{s?s s:o s:o s:o}",
+                        "cwd", &cwd,
+                        "cmdline", &cmdline,
+                        "env", &env,
+                        "opts", &opts) < 0
+        || json_array_size (cmdline) == 0) {
+        errprintf (error, "error parsing command object: %s", jerror.text);
+        errno = EPROTO;
+        return NULL;
+    }
+    if (!(prop = json_array ())) {
+        errprintf (error, "out of memory");
+        errno = ENOMEM;
+        return NULL;
+    }
+    if (prop_add_execstart (prop, "ExecStart", cmdline) < 0
+        || prop_add_string (prop, "Type", type) < 0
+        || prop_add_string (prop, "WorkingDirectory", cwd) < 0
+        || prop_add_bool (prop, "RemainAfterExit", true) < 0
+        || prop_add_env (prop, "Environment", env) < 0
+        || prop_add_fd (prop, "StandardInputFileDescriptor", stdin_fd) < 0
+        || prop_add_fd (prop, "StandardOutputFileDescriptor", stdout_fd) < 0
+        || prop_add_fd (prop, "StandardErrorFileDescriptor", stderr_fd) < 0) {
+        errprintf (error, "error packing StartTransientUnit properties");
+        goto error;
+    }
+    // any subprocess opt prefixed with SDEXEC_PROP_ is taken for a property
+    json_object_foreach (opts, key, val) {
+        if (strstarts (key, "SDEXEC_PROP_")) {
+            if (prop_add (prop, key + 12, json_string_value (val)) < 0) {
+                errprintf (error, "%s: error setting property", key);
+                goto error;
+            }
+        }
+    }
+    return prop;
+error:
+    json_decref (prop);
+    errno = EINVAL;
+    return NULL;
+}
+
+flux_future_t *sdexec_start_transient_unit (flux_t *h,
+                                            uint32_t rank,
+                                            const char *mode,
+                                            const char *type,
+                                            json_t *cmd,
+                                            int stdin_fd,
+                                            int stdout_fd,
+                                            int stderr_fd,
+                                            flux_error_t *error)
+{
+    flux_future_t *f;
+    json_t *prop = NULL;
+    const char *name;
+
+    if (!h || !mode || !type || !cmd) {
+        errprintf (error, "invalid argument");
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(prop = prop_create (cmd,
+                              type,
+                              stdin_fd,
+                              stdout_fd,
+                              stderr_fd,
+                              error)))
+        return NULL;
+    if (json_unpack (cmd, "{s:{s:s}}", "opts", "SDEXEC_NAME", &name) < 0) {
+        errprintf (error, "SDEXEC_NAME subprocess command option is not set");
+        errno = EINVAL;
+        goto error;
+    }
+    /* N.B. the empty array tacked onto the end of the 'params' array below
+     * is the placeholder for aux unit info, unused here.
+     */
+    if (!(f = flux_rpc_pack (h,
+                             "sdbus.call",
+                             rank,
+                             0,
+                             "{s:s s:[ssO[]]}",
+                             "member", "StartTransientUnit",
+                             "params", name, mode, prop))) {
+        errprintf (error, "error sending StartTransientUnit RPC");
+        goto error;
+    }
+    json_decref (prop);
+    return f;
+error:
+    ERRNO_SAFE_WRAP (json_decref, prop);
+    return NULL;
+}
+
+int sdexec_start_transient_unit_get (flux_future_t *f, const char **jobp)
+{
+    const char *job;
+
+    if (flux_rpc_get_unpack (f, "{s:[s]}", "params", &job) < 0)
+        return -1;
+    if (jobp)
+        *jobp = job;
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/start.h
+++ b/src/common/libsdexec/start.h
@@ -1,0 +1,64 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _LIBSDEXEC_START_H
+#define _LIBSDEXEC_START_H
+
+#include <flux/core.h>
+
+/* Call systemd StartTransientUnit with parameters from libsubprocess style
+ * command object. The SDEXEC_NAME command option must be set to the unit
+ * name (with .service suffx).
+ *
+ * See https://www.freedesktop.org/wiki/Software/systemd/dbus/
+ * and systemd.service(5) for more info on mode and type parameters.
+ * mode may be one of:
+     replace, fail, isolate, ignore-dependencies, ignore-requirements
+ * type may be one of:
+ *   simple, exec, forking, oneshot, dbus, notify, notify-reload, idle
+ *
+ * stdin_fd, stdout_fd, and stderr_fd are file descriptors to be duped and
+ * passed to the new unit.  The dup should be complete on first fulfillment
+ * of the future and local copies can be closed at that time.  Set to -1 to
+ * indicate that systemd should manage a particular stdio stream.
+ *
+ * Service unit properties may be set with command options prefixed with
+ * SDEXEC_PROP_.  The following unit properties are explicitly parsed and
+ * converted to their native types:
+ *
+ * MemoryHigh, MemoryMax, MemoryLow, MemoryMin
+ *   Value may be "infinity", a percentage of physical memory ("98%"),
+ *   or a quantity with optional base 1024 K, M, G, or T suffix ("8g").
+ *   See also: systemd.resource-control(5).
+ *
+ * AllowedCPUs
+ *   Restrict execution to specific CPUs. Value is a Flux idset representing
+ *   a list of CPU indices.
+ *   See also: systemd.resource-control(5).
+ *
+ * Other service unit properties are assumed to be of type string and are
+ * set without conversion.  For example, Description may be set to a string
+ * that is shown in list-units output.
+ */
+flux_future_t *sdexec_start_transient_unit (flux_t *h,
+                                            uint32_t rank,
+                                            const char *mode,
+                                            const char *type,
+                                            json_t *cmd,
+                                            int stdin_fd,
+                                            int stdout_fd,
+                                            int stderr_fd,
+                                            flux_error_t *error);
+
+int sdexec_start_transient_unit_get (flux_future_t *f, const char **job);
+
+#endif /* !_LIBSDEXEC_START_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/state.c
+++ b/src/common/libsdexec/state.c
@@ -1,0 +1,88 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* state.c - unit state/substate
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "ccan/str/str.h"
+#include "ccan/array_size/array_size.h"
+
+#include "state.h"
+
+struct state_tab {
+    const char *name;
+    int state;
+};
+
+static struct state_tab states[] = {
+    { "unknown", STATE_UNKNOWN },
+    { "activating", STATE_ACTIVATING },
+    { "active", STATE_ACTIVE },
+    { "deactivating", STATE_DEACTIVATING },
+    { "inactive", STATE_INACTIVE },
+    { "failed", STATE_FAILED },
+};
+
+static struct state_tab substates[] = {
+    { "unknown", SUBSTATE_UNKNOWN },
+    { "dead", SUBSTATE_DEAD },
+    { "start", SUBSTATE_START },
+    { "running", SUBSTATE_RUNNING },
+    { "exited", SUBSTATE_EXITED },
+    { "failed", SUBSTATE_FAILED },
+};
+
+static int strtostate (const char *s,
+                       struct state_tab *tab,
+                       size_t len)
+{
+    if (s) {
+        for (int i = 0; i < len; i++) {
+            if (streq (tab[i].name, s))
+                return tab[i].state;
+        }
+    }
+    return tab[0].state;
+}
+
+sdexec_state_t sdexec_strtostate (const char *s)
+{
+    return strtostate (s, states, ARRAY_SIZE (states));
+}
+
+sdexec_substate_t sdexec_strtosubstate (const char *s)
+{
+    return strtostate (s, substates, ARRAY_SIZE (substates));
+}
+
+static const char *statetostr (int state, struct state_tab *tab, size_t len)
+{
+    for (int i = 0; i < len; i++) {
+        if (tab[i].state == state)
+            return tab[i].name;
+    }
+    return tab[0].name;
+}
+
+const char *sdexec_statetostr (sdexec_state_t state)
+{
+    return statetostr (state, states, ARRAY_SIZE (states));
+}
+
+const char *sdexec_substatetostr (sdexec_substate_t substate)
+{
+    return statetostr (substate, substates, ARRAY_SIZE (substates));
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/state.h
+++ b/src/common/libsdexec/state.h
@@ -1,0 +1,40 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _LIBSDEXEC_STATE_H
+#define _LIBSDEXEC_STATE_H
+
+typedef enum {
+    STATE_UNKNOWN,
+    STATE_INACTIVE,
+    STATE_ACTIVATING,
+    STATE_ACTIVE,
+    STATE_DEACTIVATING,
+    STATE_FAILED,
+} sdexec_state_t;
+
+typedef enum {
+    SUBSTATE_UNKNOWN,
+    SUBSTATE_DEAD,
+    SUBSTATE_START,
+    SUBSTATE_RUNNING,
+    SUBSTATE_EXITED,
+    SUBSTATE_FAILED,
+} sdexec_substate_t;
+
+const char *sdexec_statetostr (sdexec_state_t state);
+const char *sdexec_substatetostr (sdexec_substate_t substate);
+
+sdexec_state_t sdexec_strtostate (const char *s);
+sdexec_substate_t sdexec_strtosubstate (const char *s);
+
+#endif /* !_LIBSDEXEC_STATE_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/stop.c
+++ b/src/common/libsdexec/stop.c
@@ -1,0 +1,76 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* stop.c - reset/stop units
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "stop.h"
+
+flux_future_t *sdexec_stop_unit (flux_t *h,
+                                 uint32_t rank,
+                                 const char *name,
+                                 const char *mode)
+{
+    if (!h || !name || !mode) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return flux_rpc_pack (h,
+                          "sdbus.call",
+                          rank,
+                          0,
+                          "{s:s s:[ss]}",
+                          "member", "StopUnit",
+                          "params", name, mode);
+}
+
+flux_future_t *sdexec_reset_failed_unit (flux_t *h,
+                                         uint32_t rank,
+                                         const char *name)
+{
+    if (!h || !name) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return flux_rpc_pack (h,
+                          "sdbus.call",
+                          rank,
+                          0,
+                          "{s:s s:[s]}",
+                          "member", "ResetFailedUnit",
+                          "params", name);
+}
+
+flux_future_t *sdexec_kill_unit (flux_t *h,
+                                 uint32_t rank,
+                                 const char *name,
+                                 const char *who,
+                                 int signum)
+{
+    if (!h || !name || !who ) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return flux_rpc_pack (h,
+                          "sdbus.call",
+                          rank,
+                          0,
+                          "{s:s s:[ssi]}",
+                          "member", "KillUnit",
+                          "params", name, who, signum);
+
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/stop.h
+++ b/src/common/libsdexec/stop.h
@@ -1,0 +1,37 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _LIBSDEXEC_STOP_H
+#define _LIBSDEXEC_STOP_H
+
+#include <flux/core.h>
+
+/* See https://www.freedesktop.org/wiki/Software/systemd/dbus/
+ * for more info on mode parameter.
+ * mode maybe one of: replace, fail, ignore-dependencies, ignore-requirements.
+ */
+flux_future_t *sdexec_stop_unit (flux_t *h,
+                                 uint32_t rank,
+                                 const char *name,
+                                 const char *mode);
+
+flux_future_t *sdexec_reset_failed_unit (flux_t *h,
+                                         uint32_t rank,
+                                         const char *name);
+
+flux_future_t *sdexec_kill_unit (flux_t *h,
+                                 uint32_t rank,
+                                 const char *name,
+                                 const char *who, // main/control/all
+                                 int signum);
+
+#endif /* !_LIBSDEXEC_STOP_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/test/channel.c
+++ b/src/common/libsdexec/test/channel.c
@@ -1,0 +1,258 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "ccan/array_size/array_size.h"
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+#include "src/common/libioencode/ioencode.h"
+#include "channel.h"
+
+bool input_called;
+bool input_eof_set;
+
+void input_cb (flux_reactor_t *r,
+               flux_watcher_t *w,
+               int revents,
+               void *arg)
+{
+    struct channel *ch = arg;
+    const char *name = sdexec_channel_get_name (ch);
+    int fd = sdexec_channel_get_fd (ch);
+    char buf[64];
+    int n;
+
+    n = read (fd, buf, sizeof (buf));
+    if (n < 0) {
+        diag ("%s: read error: %s", name, strerror (errno));
+    }
+    else if (n == 0) {
+        diag ("%s: EOF", name);
+        input_eof_set = true;
+    }
+    else
+        diag ("%s: read %d chars", name, n);
+    input_called = true;
+}
+
+void test_input (void)
+{
+    flux_t *h;
+    struct channel *ch;
+    flux_watcher_t *w;
+    int fd;
+    json_t *io;
+    json_t *io_eof;
+
+    if (!(h = loopback_create (0)))
+        BAIL_OUT ("could not create loopback flux_t handle for testing");
+    if (flux_attr_set_cacheonly (h, "rank", "0") < 0)
+        BAIL_OUT ("could not set rank for testing");
+    ch = sdexec_channel_create_input (h, "in");
+    ok (ch != NULL,
+        "sdexec_channel_create_input works");
+    fd = sdexec_channel_get_fd (ch);
+    ok (fd >= 0,
+        "sdexec_channel_get_fd works");
+    w = flux_fd_watcher_create (flux_get_reactor (h),
+                                fd,
+                                FLUX_POLLIN,
+                                input_cb,
+                                ch);
+    if (!w)
+        BAIL_OUT ("could not create fd watcher");
+    if (!(io = ioencode ("foo", "0", "hello", 6, false)))
+        BAIL_OUT ("could not create json io object");
+    if (!(io_eof = ioencode ("foo", "0", NULL, 0, true)))
+        BAIL_OUT ("could not create json io_eof object");
+    flux_watcher_start (w);
+
+    input_called = false;
+    input_eof_set = false;
+    ok (sdexec_channel_write (ch, io) == 0,
+        "sdexec_channel_write works");
+    ok (flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE) >= 0,
+        "flux_reactor_run ran ONCE");
+    ok (input_called == true,
+        "input callback was called");
+    ok (input_eof_set == false,
+        "eof was not set");
+
+    input_called = false;
+    input_eof_set = false;
+    ok (sdexec_channel_write (ch, io_eof) == 0,
+        "sdexec_channel_write eof works");
+    ok (flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE) >= 0,
+        "flux_reactor_run ran ONCE");
+    ok (input_called == true,
+        "input callback was called");
+    ok (input_eof_set == true,
+        "eof was set");
+
+    json_decref (io_eof);
+    json_decref (io);
+    flux_watcher_destroy (w);
+    sdexec_channel_destroy (ch);
+    flux_close (h);
+}
+
+bool error_called;
+bool output_called;
+bool output_eof_set;
+
+void output_cb (struct channel *ch, json_t *io, void *arg)
+{
+    const char *stream;
+    int len;
+
+    if (iodecode (io, &stream, NULL, NULL, &len, &output_eof_set) < 0) {
+        diag ("%s: idoecode error: %s",
+              sdexec_channel_get_name (ch),
+              strerror (errno));
+    }
+    else {
+        diag ("%s output: stream=%s len=%d eof=%s",
+              sdexec_channel_get_name (ch),
+              stream,
+              len,
+              output_eof_set ? "true" : "false");
+    }
+    output_called = true;
+}
+
+void error_cb (struct channel *ch, flux_error_t *error, void *arg)
+{
+    diag ("%s error: %s",
+          sdexec_channel_get_name (ch),
+          error->text);
+    error_called = true;
+}
+
+void test_output (void)
+{
+    flux_t *h;
+    struct channel *ch;
+    int fd;
+
+    if (!(h = loopback_create (0)))
+        BAIL_OUT ("could not create loopback flux_t handle for testing");
+    if (flux_attr_set_cacheonly (h, "rank", "0") < 0)
+        BAIL_OUT ("could not set rank for testing");
+    ch = sdexec_channel_create_output (h, "out", output_cb, error_cb, NULL);
+    ok (ch != NULL,
+        "sdexec_channel_crate_output works");
+    sdexec_channel_start_output (ch);
+    ok (true, "sdexec_channel_start_output called");
+
+    fd = sdexec_channel_get_fd (ch);
+    ok (fd >= 0,
+        "sdexec_channel_get_fd works");
+
+    output_called = false;
+    error_called = false;
+    output_eof_set = false;
+    ok (write (fd, "hello", 6) == 6,
+        "wrote 'hello' from unit");
+    ok (flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE) >= 0,
+        "flux_reactor_run ran ONCE");
+    ok (output_called == true,
+        "output callback was called");
+    ok (output_eof_set == false,
+        "eof was not set");
+    ok (error_called == false,
+        "error callback was not called");
+
+    output_called = false;
+    error_called = false;
+    output_eof_set = false;
+    sdexec_channel_close_fd (ch);
+    ok (true, "sdexec_channel_close_fd called");
+    ok (flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE) >= 0,
+        "flux_reactor_run ran ONCE");
+    ok (output_called == true,
+        "output callback was called");
+    ok (output_eof_set == true,
+        "eof was set");
+    ok (error_called == false,
+        "error callback was not called");
+
+    sdexec_channel_destroy (ch);
+    flux_close (h);
+}
+
+void test_inval (void)
+{
+    struct channel *ch;
+    flux_t *h;
+    json_t *io;
+
+    if (!(h = loopback_create (0)))
+        BAIL_OUT ("could not create loopback flux_t handle for testing");
+    if (!(io = ioencode ("foo", "0", NULL, 0, true)))
+        BAIL_OUT ("could not create json io object");
+
+    errno = 0;
+    ch = sdexec_channel_create_output (NULL, "foo", output_cb, error_cb, NULL);
+    ok (ch == NULL && errno == EINVAL,
+        "sdexec_channel_create_output h=NULL fails with EINVAL");
+    errno = 0;
+    ch = sdexec_channel_create_output (h, NULL, output_cb, error_cb, NULL);
+    ok (ch == NULL && errno == EINVAL,
+        "sdexec_channel_create_output name=NULL fails with EINVAL");
+
+    errno = 0;
+    ch = sdexec_channel_create_input (NULL, "foo");
+    ok (ch == NULL && errno == EINVAL,
+        "sdexec_channel_create_input h=NULL fails with EINVAL");
+    errno = 0;
+    ch = sdexec_channel_create_input (h, NULL);
+    ok (ch == NULL && errno == EINVAL,
+        "sdexec_channel_create_input name=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (sdexec_channel_write (NULL, io) < 0 && errno == EINVAL,
+        "sdexec_channel_write ch=NULL fails with EINVAL");
+
+    ok (sdexec_channel_get_fd (NULL) == -1,
+        "sdexec_channel_get_fd ch=NULL returns -1");
+
+    ok (sdexec_channel_get_name (NULL) != NULL,
+        "sdexec_channel_get_name ch=NULL returns non-NULL");
+
+    lives_ok ({sdexec_channel_start_output (NULL);},
+              "sdexec_channel_start_output ch=NULL doesn't crash");
+    lives_ok ({sdexec_channel_close_fd (NULL);},
+              "sdexec_channel_close_fd ch=NULL doesn't crash");
+    lives_ok ({sdexec_channel_destroy (NULL);},
+              "sdexec_channel_destroy ch=NULL doesn't crash");
+
+    json_decref (io);
+    flux_close (h);
+}
+
+int main (int ac, char *av[])
+{
+    plan (NO_PLAN);
+
+    test_input ();
+    test_output ();
+    test_inval ();
+
+    done_testing ();
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsdexec/test/list.c
+++ b/src/common/libsdexec/test/list.c
@@ -1,0 +1,59 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+#include "list.h"
+
+void test_inval (void)
+{
+    flux_t *h;
+    struct unit_info info;
+    flux_future_t *f;
+
+    if (!(h = loopback_create (0)))
+        BAIL_OUT ("could not create loopback flux_t handle for testing");
+    if (!(f = flux_future_create (NULL, 0)))
+        BAIL_OUT ("could not create future for testing");
+
+    errno = 0;
+    ok (sdexec_list_units (NULL, 0, "*") == NULL && errno == EINVAL,
+        "sdexec_list_units h=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_list_units (h, 0, NULL) == NULL && errno == EINVAL,
+        "sdexec_list_units pattern=NULL fails with EINVAL");
+
+    ok (sdexec_list_units_next (NULL, &info) == false,
+        "sdexec_list_units_next f=NULL returns false");
+    ok (sdexec_list_units_next (f, NULL) == false,
+        "sdexec_list_units_next infop=NULL returns false");
+
+    flux_future_destroy (f);
+    flux_close (h);
+}
+
+int main (int ac, char *av[])
+{
+    plan (NO_PLAN);
+
+    test_inval ();
+
+    done_testing ();
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsdexec/test/parse.c
+++ b/src/common/libsdexec/test/parse.c
@@ -1,0 +1,128 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <stdbool.h>
+
+#include "ccan/array_size/array_size.h"
+#include "src/common/libtap/tap.h"
+#include "parse.h"
+
+struct tab_percent {
+    const char *s;
+    double val;
+    bool ok;
+};
+const struct tab_percent ptab[] = {
+    // bad
+    { "10", 0, false },
+    { "10%x", 0, false },
+    { "-10%", 0, false },
+    { "", 0, false },
+    { "%", 0, false },
+    { "x%", 0, false },
+    { "110%", 0, false },
+    // good
+    { "0%", 0, true},
+    { "10%", 0.1, true},
+    { "50%", 0.5, true },
+    { "100%", 1, true },
+};
+
+void test_percent (void)
+{
+    double d;
+    int rc;
+
+    lives_ok ({sdexec_parse_percent (NULL, &d);},
+        "sdexec_parse_percent input=NULL doesn't crash");
+    lives_ok ({sdexec_parse_percent ("x", NULL);},
+        "sdexec_parse_percent value=NULL doesn't crash");
+
+    for (int i = 0; i < ARRAY_SIZE (ptab); i++) {
+        d = 0;
+        rc = sdexec_parse_percent (ptab[i].s, &d);
+        if (ptab[i].ok) {
+            ok (rc == 0 && d == ptab[i].val,
+                "sdexec_parse_percent val=%s works", ptab[i].s);
+        }
+        else {
+            ok (rc == -1,
+                "sdexec_parse_percent val=%s fails", ptab[i].s);
+        }
+    }
+}
+
+struct tab_bitmap {
+    const char *s;
+    uint8_t val[4];
+    size_t val_size;
+    bool ok;
+};
+const struct tab_bitmap btab[] = {
+    // bad
+    { "1-",             { 0, 0, 0, 0 },     0, false },
+    { "x",              { 0, 0, 0, 0 },     0, false },
+    // good
+    { "",               { 0, 0, 0, 0 },     0, true },
+    { "0",              { 1, 0, 0, 0 },     1, true },
+    { "0-2,8",          { 7, 1, 0, 0 },     2, true },
+    { "8-15,16-23",     { 0, 255, 255, 0 }, 3, true },
+};
+
+void test_bitmap (void)
+{
+    uint8_t *bitmap;
+    size_t size;
+    int rc;
+
+    lives_ok ({sdexec_parse_bitmap (NULL, &bitmap, &size);},
+        "sdexec_parse_bitmap input=NULL doesn't crash");
+    lives_ok ({sdexec_parse_bitmap ("0", NULL, &size);},
+        "sdexec_parse_bitmap bitmap=NULL doesn't crash");
+    lives_ok ({sdexec_parse_bitmap ("0", &bitmap, NULL);},
+        "sdexec_parse_bitmap size=NULL doesn't crash");
+
+    for (int i = 0; i < ARRAY_SIZE (btab); i++) {
+        bitmap = NULL;
+        size = 0;
+        rc = sdexec_parse_bitmap (btab[i].s, &bitmap, &size);
+        if (btab[i].ok) {
+            ok (rc == 0
+                && size == btab[i].val_size
+                && (size < 1 || bitmap[0] == btab[i].val[0])
+                && (size < 2 || bitmap[1] == btab[i].val[1])
+                && (size < 3 || bitmap[2] == btab[i].val[2])
+                && (size < 4 || bitmap[3] == btab[i].val[3]),
+                "sdexec_parse_bitmap val=%s works", btab[i].s);
+        }
+        else {
+            ok (rc == -1,
+                "sdexec_parse_bitmap val=%s fails", btab[i].s);
+        }
+        free (bitmap);
+    }
+}
+
+int main (int ac, char *av[])
+{
+    plan (NO_PLAN);
+
+    test_percent ();
+    test_bitmap ();
+
+    done_testing ();
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsdexec/test/property.c
+++ b/src/common/libsdexec/test/property.c
@@ -1,0 +1,121 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+#include "property.h"
+
+void test_dict (void)
+{
+    json_t *dict;
+    int val;
+
+    if (!(dict = json_pack ("{s:[si]}", "foo", "i", 42)))
+        BAIL_OUT ("could not create property dict for testing");
+
+    ok (sdexec_property_dict_unpack (dict, "foo", "i", &val) == 0
+        && val == 42,
+        "sdexec_property_dict_unpack works");
+    errno = 0;
+    ok (sdexec_property_dict_unpack (dict, "unknown", "i", &val) < 0
+        && errno == EPROTO,
+        "sdexec_property_dict_unpack name=unknown fails with EPROTO");
+
+    json_decref (dict);
+}
+
+void test_inval (void)
+{
+    flux_t *h;
+    flux_future_t *f;
+    json_t *dict;
+
+    if (!(h = loopback_create (0)))
+        BAIL_OUT ("could not create loopback flux_t handle for testing");
+    if (!(f = flux_future_create (NULL, 0)))
+        BAIL_OUT ("could not create future for testing");
+    if (!(dict = json_pack ("{s:[si]}", "foo", "i", 42)))
+        BAIL_OUT ("could not create property dict for testing");
+
+    errno = 0;
+    ok (sdexec_property_get (NULL, 0, "foo", "bar") == NULL && errno == EINVAL,
+        "sdexec_property_get h=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_property_get (h, 0, NULL, "bar") == NULL && errno == EINVAL,
+        "sdexec_property_get path=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_property_get (h, 0, "foo", NULL) == NULL && errno == EINVAL,
+        "sdexec_property_get name=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (sdexec_property_get_unpack (NULL, "foo") < 0 && errno == EINVAL,
+        "sdexec_property_get_unpack f=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_property_get_unpack (f, NULL) < 0 && errno == EINVAL,
+        "sdexec_property_get_unpack fmt=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (sdexec_property_get_all (NULL, 0, "foo") == NULL && errno == EINVAL,
+        "sdexec_property_get_all h=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_property_get_all (h, 0, NULL) == NULL && errno == EINVAL,
+        "sdexec_property_get_all path=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (sdexec_property_get_all_dict (NULL) == NULL && errno == EINVAL,
+        "sdexec_property_get_all_dict f=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (sdexec_property_changed (NULL, 0, "foo") == NULL && errno == EINVAL,
+        "sdexec_property_changed h=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (sdexec_property_changed_dict (NULL) == NULL && errno == EINVAL,
+        "sdexec_property_changed_dict f=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_property_changed_path (NULL) == NULL && errno == EINVAL,
+        "sdexec_property_changed_path f=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (sdexec_property_dict_unpack (NULL, "foo", "bar") < 0
+        && errno == EINVAL,
+        "sdexec_property_dict_unpack dict=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_property_dict_unpack (dict, NULL, "bar") < 0
+        && errno == EINVAL,
+        "sdexec_property_dict_unpack name=NULL fails with EINVAL");
+    ok (sdexec_property_dict_unpack (dict, "foo", NULL) < 0
+        && errno == EINVAL,
+        "sdexec_property_dict_unpack fmt=NULL fails with EINVAL");
+
+    json_decref (dict);
+    flux_future_destroy (f);
+    flux_close (h);
+}
+
+int main (int ac, char *av[])
+{
+    plan (NO_PLAN);
+
+    test_dict ();
+    test_inval ();
+
+    done_testing ();
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsdexec/test/start.c
+++ b/src/common/libsdexec/test/start.c
@@ -1,0 +1,153 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libsubprocess/command.h"
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+#include "src/common/libutil/jpath.h"
+#include "start.h"
+
+void test_inval (void)
+{
+    char *av[] = { "/bin/ls", NULL };
+    int ac = 1;
+    flux_t *h;
+    flux_future_t *f;
+    flux_cmd_t *cmd;
+    json_t *cmd_o = NULL;
+    json_t *cmd_o_noname;
+    json_t *cmd_o_badprop;
+    json_t *o;
+    flux_error_t error;
+
+    if (!(h = loopback_create (0)))
+        BAIL_OUT ("could not create loopback flux_t handle for testing");
+    if (!(f = flux_future_create (NULL, 0)))
+        BAIL_OUT ("could not create future for testing");
+    if (!(cmd = flux_cmd_create (ac, av, environ))
+        || flux_cmd_setopt (cmd, "SDEXEC_NAME", "foo") < 0
+        || !(cmd_o = cmd_tojson (cmd)))
+        BAIL_OUT ("could not create command object for testing");
+    if (!(cmd_o_noname = json_deep_copy (cmd_o))
+        || jpath_del (cmd_o_noname, "opts.SDEXEC_NAME") < 0)
+        BAIL_OUT ("error preparing test command without SDEXEC_NAME");
+    if (!(cmd_o_badprop = json_deep_copy (cmd_o))
+        || !(o = json_string ("badvalue"))
+        || jpath_set_new (cmd_o_badprop, "opts.SDEXEC_PROP_MemoryMax", o) < 0)
+        BAIL_OUT ("error preparing test command with bad property");
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (sdexec_start_transient_unit (NULL,      // h
+                                     0,         // rank
+                                     "fail",    // mode
+                                     "simple",  // type
+                                     cmd_o,     // cmd
+                                     -1, -1, -1, // *_fd
+                                     &error) == NULL
+        && errno == EINVAL,
+        "sdexec_start_transient_unit h=NULL fails with EINVAL");
+    diag ("%s", error.text);
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (sdexec_start_transient_unit (h,         // h
+                                     0,         // rank
+                                     NULL,      // mode
+                                     "simple",  // type
+                                     cmd_o,     // cmd
+                                     -1, -1, -1, // *_fd
+                                     &error) == NULL
+        && errno == EINVAL,
+        "sdexec_start_transient_unit mode=NULL fails with EINVAL");
+    diag ("%s", error.text);
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (sdexec_start_transient_unit (h,         // h
+                                     0,         // rank
+                                     "fail",    // mode
+                                     NULL,      // type
+                                     cmd_o,     // cmd
+                                     -1, -1, -1, // *_fd
+                                     &error) == NULL
+        && errno == EINVAL,
+        "sdexec_start_transient_unit type=NULL fails with EINVAL");
+    diag ("%s", error.text);
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (sdexec_start_transient_unit (h,         // h
+                                     0,         // rank
+                                     "fail",    // mode
+                                     "simple",  // type
+                                     NULL,      // cmd
+                                     -1, -1, -1, // *_fd
+                                     &error) == NULL
+        && errno == EINVAL,
+        "sdexec_start_transient_unit cmd=NULL fails with EINVAL");
+    diag ("%s", error.text);
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (sdexec_start_transient_unit (h,         // h
+                                     0,         // rank
+                                     "fail",    // mode
+                                     "simple",  // type
+                                     cmd_o_noname, // cmd
+                                     -1, -1, -1, // *_fd
+                                     &error) == NULL
+        && errno == EINVAL,
+        "sdexec_start_transient_unit missing SDEXEC_NAME fails with EINVAL");
+    diag ("%s", error.text);
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (sdexec_start_transient_unit (h,         // h
+                                     0,         // rank
+                                     "fail",    // mode
+                                     "simple",  // type
+                                     cmd_o_badprop, // cmd
+                                     -1, -1, -1, // *_fd
+                                     &error) == NULL
+        && errno == EINVAL,
+        "sdexec_start_transient_unit with bad property fails with EINVAL");
+    diag ("%s", error.text);
+
+    errno = 0;
+    ok (sdexec_start_transient_unit_get (NULL, NULL) < 0 && errno == EINVAL,
+        "sdexec_start_transient_unit_get f=NULL fails with EINVAL");
+
+    json_decref (cmd_o_badprop);
+    json_decref (cmd_o_noname);
+    json_decref (cmd_o);
+    flux_cmd_destroy (cmd);
+    flux_future_destroy (f);
+    flux_close (h);
+}
+
+int main (int ac, char *av[])
+{
+    plan (NO_PLAN);
+
+    test_inval ();
+
+    done_testing ();
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsdexec/test/state.c
+++ b/src/common/libsdexec/test/state.c
@@ -1,0 +1,74 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdbool.h>
+#include <string.h>
+#include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
+#include "src/common/libtap/tap.h"
+#include "state.h"
+
+struct state_tab {
+    const char *name;
+    int state;
+    bool reverse;
+};
+
+static struct state_tab states[] = {
+    { "unknown", STATE_UNKNOWN, true },
+    { "xyz", STATE_UNKNOWN, false },
+    { NULL, STATE_UNKNOWN, false },
+    { "activating", STATE_ACTIVATING, true },
+    { "active", STATE_ACTIVE, true },
+    { "deactivating", STATE_DEACTIVATING, true },
+    { "inactive", STATE_INACTIVE, true },
+    { "failed", STATE_FAILED, true },
+};
+
+static struct state_tab subs[] = {
+    { "unknown", SUBSTATE_UNKNOWN, true },
+    { "xyz", SUBSTATE_UNKNOWN, false },
+    { NULL, SUBSTATE_UNKNOWN, false },
+    { "dead", SUBSTATE_DEAD, true },
+    { "start", SUBSTATE_START, true },
+    { "running", SUBSTATE_RUNNING, true },
+    { "exited", SUBSTATE_EXITED, true },
+    { "failed", SUBSTATE_FAILED, true },
+};
+
+
+int main (int ac, char *av[])
+{
+    plan (NO_PLAN);
+
+    for (int i = 0; i < ARRAY_SIZE (states); i++) {
+        ok (sdexec_strtostate (states[i].name) == states[i].state,
+            "sdexec_strtostate %s works", states[i].name);
+        if (states[i].reverse) {
+            ok (streq (sdexec_statetostr (states[i].state), states[i].name),
+                "sdexec_statetostr %s works", states[i].name);
+        }
+    }
+    for (int i = 0; i < ARRAY_SIZE (subs); i++) {
+        ok (sdexec_strtosubstate (subs[i].name) == subs[i].state,
+            "sdexec_strtosubstate %s works", subs[i].name);
+        if (subs[i].reverse) {
+            ok (streq (sdexec_substatetostr (subs[i].state), subs[i].name),
+                "sdexec_substatetostr %s works", subs[i].name);
+        }
+    }
+
+    done_testing ();
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsdexec/test/stop.c
+++ b/src/common/libsdexec/test/stop.c
@@ -1,0 +1,69 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+#include "stop.h"
+
+void test_inval (void)
+{
+    flux_t *h;
+
+    if (!(h = loopback_create (0)))
+        BAIL_OUT ("could not create loopback flux_t handle for testing");
+
+    errno = 0;
+    ok (sdexec_stop_unit (NULL, 0, "foo", "bar") == NULL && errno == EINVAL,
+        "sdexec_stop_unit h=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_stop_unit (h, 0, NULL, "bar") == NULL && errno == EINVAL,
+        "sdexec_stop_unit name=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_stop_unit (h, 0, "foo", NULL) == NULL && errno == EINVAL,
+        "sdexec_stop_unit mode=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (sdexec_reset_failed_unit (NULL, 0, "foo") == NULL && errno == EINVAL,
+        "sdexec_reset_failed_unit h=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_reset_failed_unit (h, 0, NULL) == NULL && errno == EINVAL,
+        "sdexec_reset_failed_unit name=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (sdexec_kill_unit (NULL, 0, "foo", "bar", 0) == NULL && errno == EINVAL,
+        "sdexec_kill_unit h=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_kill_unit (h, 0, NULL, "bar", 0) == NULL && errno == EINVAL,
+        "sdexec_kill_unit name=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_kill_unit (h, 0, "foo", NULL, 0) == NULL && errno == EINVAL,
+        "sdexec_kill_unit who=NULL fails with EINVAL");
+
+    flux_close (h);
+}
+
+int main (int ac, char *av[])
+{
+    plan (NO_PLAN);
+
+    test_inval ();
+
+    done_testing ();
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsdexec/test/unit.c
+++ b/src/common/libsdexec/test/unit.c
@@ -1,0 +1,172 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <sys/wait.h>
+#include <string.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
+#include "list.h"
+#include "unit.h"
+
+void test_init (void)
+{
+    struct unit *unit;
+    const char *s;
+
+    unit = sdexec_unit_create ("foo.service");
+    ok (unit != NULL,
+        "sdexec_unit_create works");
+    ok (sdexec_unit_state (unit) == STATE_UNKNOWN,
+        "initial state is UNKNOWN");
+    ok (sdexec_unit_substate (unit) == SUBSTATE_UNKNOWN,
+        "initial substate is UNKNOWN");
+    ok (sdexec_unit_pid (unit) == -1,
+        "initial pid is -1");
+    s = sdexec_unit_name (unit);
+    ok (s && streq (s, "foo.service"),
+        "sdexec_unit_name returns original name");
+    s = sdexec_unit_path (unit);
+    ok (s != NULL && streq (s, "/org/freedesktop/systemd1/unit/foo.service"),
+        "sdexec_unit_path returns expected path");
+    ok (sdexec_unit_has_started (unit) == false,
+        "sdexec_unit_has_started returns false");
+    ok (sdexec_unit_has_finished (unit) == false,
+        "sdexec_unit_has_finished returns false");
+    ok (sdexec_unit_wait_status (unit) == -1,
+        "sdexec_unit_wait_status returns -1");
+    ok (sdexec_unit_systemd_error (unit) == -1,
+        "sdexec_unit_systemd_error returns -1");
+
+    sdexec_unit_destroy (unit);
+    ok (true, "sdexec_unit_destroy called");
+}
+
+void test_update (void)
+{
+    struct unit_info info = {
+        .active_state = "active",
+        .sub_state = "start",
+    };
+    struct unit *unit;
+    json_t *dict_pid;
+    json_t *dict_exit;
+
+    if (!(unit = sdexec_unit_create ("foo.service")))
+        BAIL_OUT ("could not create unit object for testing");
+    if (!(dict_pid = json_pack ("{s:[si]}", "ExecMainPID", "I", 42)))
+        BAIL_OUT ("could not create property dict with MainExitPid");
+    if (!(dict_exit = json_pack ("{s:[si] s:[si]}",
+                                 "ExecMainCode", "I", CLD_EXITED,
+                                 "ExecMainStatus", "I", 0)))
+        BAIL_OUT ("could not create property dict with"
+                  " ExecMainCode, ExecMainStatus for testing");
+
+    ok (sdexec_unit_update (unit, dict_pid) == true,
+        "sdexec_unit_update ExecMainPID=42 returns true");
+    ok (sdexec_unit_pid (unit) == 42,
+        "sdexec_unit_pid returns 42");
+
+    ok (sdexec_unit_update_frominfo (unit, &info) == true,
+        "sdexec_unit_update_frominfo active,start returns true");
+    ok (sdexec_unit_has_started (unit) == true,
+        "sdexec_unit_has_started returns true");
+
+    ok (sdexec_unit_update (unit, dict_exit) == true,
+        "sdexec_unit_update ExecMainCode=CLD_EXITED ExecMainStatus=0"
+        " returns true");
+    ok (sdexec_unit_has_finished (unit) == true,
+        "sdexec_unit_has_finished returns true");
+    ok (sdexec_unit_has_failed (unit) == false,
+        "sdexec_unit_has_finished returns true");
+    ok (sdexec_unit_wait_status (unit) == 0,
+        "sdexec_unit_wait_status returns 0");
+
+    json_decref (dict_exit);
+    json_decref (dict_pid);
+    sdexec_unit_destroy (unit);
+}
+
+void test_inval (void)
+{
+    struct unit *unit;
+    json_t *dict;
+    struct unit_info info = {
+        .active_state = "active",
+        .sub_state = "start",
+    };
+
+    if (!(unit = sdexec_unit_create ("foo.service")))
+        BAIL_OUT ("could not create unit object for testing");
+    if (!(dict = json_pack ("{s:[si]}", "foo", "i", 42)))
+        BAIL_OUT ("could not create property dict for testing");
+
+    errno = 0;
+    ok (sdexec_unit_create (NULL) == NULL && errno == EINVAL,
+        "sdexec_unit_create name=NULL fails with EINVAL");
+
+    ok (sdexec_unit_state (NULL) == STATE_UNKNOWN,
+        "sdexec_unit_state unit=NULL is UNKNOWN");
+    ok (sdexec_unit_substate (NULL) == SUBSTATE_UNKNOWN,
+        "sdexec_unit_substate unit=NULL is UNKNOWN");
+    ok (sdexec_unit_name (NULL) != NULL,
+        "sdexec_unit_name unit=NULL returns non-NULL");
+    ok (sdexec_unit_path (NULL) != NULL,
+        "sdexec_unit_path unit=NULL returns non-NULL");
+    ok (sdexec_unit_has_started (NULL) == false,
+        "sdexec_unit_has_started unit=NULL returns false");
+    ok (sdexec_unit_has_finished (NULL) == false,
+        "sdexec_unit_has_finished unit=NULL returns false");
+    ok (sdexec_unit_wait_status (NULL) == -1,
+        "sdexec_unit_wait_status unit=NULL returns -1");
+    ok (sdexec_unit_systemd_error (NULL) == -1,
+        "sdexec_unit_systemd_error unit=NULL returns -1");
+    ok (sdexec_unit_update (NULL, dict) == false,
+        "sdexec_unit_update unit=NULL returns false");
+    ok (sdexec_unit_update (unit, NULL) == false,
+        "sdexec_unit_update dict=NULL returns false");
+
+    ok (sdexec_unit_update_frominfo (NULL, &info) == false,
+        "sdexec_unit_update_frominfo unit=NULL returns false");
+    ok (sdexec_unit_update_frominfo (unit, NULL) == false,
+        "sdexec_unit_update_frominfo info=NULL returns false");
+
+    errno = 0;
+    ok (sdexec_unit_aux_set (NULL, "foo", "bar", NULL) < 0 && errno == EINVAL,
+        "sdexec_unit_aux_set unit=NULL fails with EINVAL");
+    errno = 0;
+    ok (sdexec_unit_aux_get (NULL, "foo") == NULL && errno == EINVAL,
+        "sdexec_unit_aux_get unit=NULL fails with EINVAL");
+
+    lives_ok ({sdexec_unit_destroy (NULL);},
+              "sdexec_unit_destroy unit=NULL doesn't crash");
+
+    json_decref (dict);
+    sdexec_unit_destroy (unit);
+}
+
+int main (int ac, char *av[])
+{
+    plan (NO_PLAN);
+
+    test_init ();
+    test_update ();
+    test_inval ();
+
+    done_testing ();
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsdexec/unit.c
+++ b/src/common/libsdexec/unit.c
@@ -1,0 +1,260 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* unit.c - translate unit property updates to unit object changes
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/aux.h"
+#include "ccan/str/str.h"
+#include "ccan/array_size/array_size.h"
+
+#include "property.h"
+#include "list.h"
+#include "unit.h"
+
+struct unit {
+    char *path;
+    sdexec_state_t state;
+    sdexec_substate_t substate;
+    pid_t exec_main_pid;
+    int exec_main_code;
+    int exec_main_status;
+    bool exec_main_pid_is_set;
+    bool exec_main_status_is_set;
+
+    struct aux_item *aux;
+};
+
+void sdexec_unit_destroy (struct unit *unit)
+{
+    if (unit) {
+        int saved_errno = errno;
+        aux_destroy (&unit->aux);
+        free (unit->path);
+        free (unit);
+        errno = saved_errno;
+    }
+}
+
+void *sdexec_unit_aux_get (struct unit *unit, const char *name)
+{
+    if (!unit) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return aux_get (unit->aux, name);
+}
+
+int sdexec_unit_aux_set (struct unit *unit,
+                         const char *name,
+                         void *aux,
+                         flux_free_f destroy)
+{
+    if (!unit) {
+        errno = EINVAL;
+        return -1;
+    }
+    return aux_set (&unit->aux, name, aux, destroy);
+}
+
+const char *sdexec_unit_name (struct unit *unit)
+{
+    if (unit) {
+        const char *cp;
+        if ((cp = strrchr (unit->path, '/')))
+            return cp + 1;
+        return unit->path;
+    }
+    return "internal error: unit is null";
+}
+
+const char *sdexec_unit_path (struct unit *unit)
+{
+    if (unit)
+        return unit->path;
+    return "internal error: unit is null";
+}
+
+pid_t sdexec_unit_pid (struct unit *unit)
+{
+    if (unit && unit->exec_main_pid_is_set)
+        return unit->exec_main_pid;
+    return -1;
+}
+
+sdexec_state_t sdexec_unit_state (struct unit *unit)
+{
+    if (unit)
+        return unit->state;
+    return STATE_UNKNOWN;
+}
+
+sdexec_substate_t sdexec_unit_substate (struct unit *unit)
+{
+    if (unit)
+        return unit->substate;
+    return SUBSTATE_UNKNOWN;
+}
+
+int sdexec_unit_wait_status (struct unit *unit)
+{
+    if (sdexec_unit_has_finished (unit)) {
+        if (unit->exec_main_code == CLD_KILLED)
+            return __W_EXITCODE (0, unit->exec_main_status);
+        else
+            return __W_EXITCODE (unit->exec_main_status, 0);
+    }
+    return -1;
+}
+
+int sdexec_unit_systemd_error (struct unit *unit)
+{
+    if (sdexec_unit_has_failed (unit))
+        return unit->exec_main_status;
+    return -1;
+}
+
+bool sdexec_unit_has_finished (struct unit *unit)
+{
+    if (unit) {
+        if (unit->exec_main_status_is_set &&
+            unit->exec_main_status < 200) // systemd errors are [200-243]
+            return true;
+    }
+    return false;
+}
+
+bool sdexec_unit_has_failed (struct unit *unit)
+{
+    if (unit) {
+        if (unit->exec_main_status_is_set &&
+            unit->exec_main_status >= 200) // systemd errors are [200-243]
+            return true;
+    }
+    return false;
+}
+
+bool sdexec_unit_has_started (struct unit *unit)
+{
+    if (unit) {
+        if (!unit->exec_main_pid_is_set)
+            return false;
+        /* Process was started if it's got an exit status,
+         * unless the exit status is a systemd error [200-243].
+         */
+        if ((unit->exec_main_status_is_set
+            && unit->exec_main_status < 200)
+            || unit->substate == SUBSTATE_START) {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct unit *sdexec_unit_create (const char *name)
+{
+    struct unit *unit;
+
+    if (!name) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(unit = calloc (1, sizeof (*unit))))
+        return NULL;
+    if (asprintf (&unit->path, "/org/freedesktop/systemd1/unit/%s", name) < 0)
+        goto error;
+    unit->state = STATE_UNKNOWN;
+    unit->substate = SUBSTATE_UNKNOWN;
+    return unit;
+error:
+    sdexec_unit_destroy (unit);
+    return NULL;
+}
+
+bool sdexec_unit_update (struct unit *unit, json_t *dict)
+{
+    json_int_t i;
+    json_int_t j;
+    const char *s;
+    int changes = 0;
+
+    if (!unit || !dict)
+        return false;
+
+    /* The pid is for the forked child and so its availability does not
+     * necessarily mean the exec has succeeded.
+     */
+    if (sdexec_property_dict_unpack (dict, "ExecMainPID", "I", &i) == 0
+        && !unit->exec_main_pid_is_set) {
+        unit->exec_main_pid = i;
+        unit->exec_main_pid_is_set = true;
+        changes++;
+    }
+    /* These seem to be set as a pair, and appear early with values of zero,
+     * which is a valid status but not CLD_* code.  So don't set either unless
+     * the code is valid.  On exec failure, code=1 (CLD_EXITED), status=203.
+     */
+    if (sdexec_property_dict_unpack (dict, "ExecMainCode", "I", &i) == 0
+        && sdexec_property_dict_unpack (dict, "ExecMainStatus", "I", &j) == 0
+        && !unit->exec_main_status_is_set
+        && i > 0) {
+        unit->exec_main_code = i;
+        unit->exec_main_status = j;
+        unit->exec_main_status_is_set = true;
+        changes++;
+    }
+    if (sdexec_property_dict_unpack (dict, "SubState", "s", &s) == 0) {
+        sdexec_substate_t substate  = sdexec_strtosubstate (s);
+        if (unit->substate != substate) {
+            unit->substate = substate;
+            changes++;
+        }
+    }
+    if (sdexec_property_dict_unpack (dict, "ActiveState", "s", &s) == 0) {
+        sdexec_state_t state = sdexec_strtostate (s);
+        if (unit->state != state) {
+            unit->state = state;
+            changes++;
+        }
+    }
+    return (changes > 0 ? true : false);
+}
+
+bool sdexec_unit_update_frominfo (struct unit *unit, struct unit_info *info)
+{
+    sdexec_state_t state;
+    sdexec_substate_t substate;
+    int changes = 0;
+
+    if (!unit || !info)
+        return false;
+
+    state = sdexec_strtostate (info->active_state);
+    substate = sdexec_strtosubstate (info->sub_state);
+    if (unit->state != state) {
+        unit->state = state;
+        changes++;
+    }
+    if (unit->substate != substate) {
+        unit->substate = substate;
+        changes++;
+    }
+    return (changes > 0 ? true : false);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/unit.h
+++ b/src/common/libsdexec/unit.h
@@ -1,0 +1,64 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _LIBSDEXEC_UNIT_H
+#define _LIBSDEXEC_UNIT_H
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "list.h"
+#include "state.h"
+
+/* Create/destroy a unit object.
+ */
+struct unit *sdexec_unit_create (const char *name);
+void sdexec_unit_destroy (struct unit *unit);
+
+/* Update unit object with property dict from sdexec_property_changed_dict()
+ * or sdexec_property_get_all_dict().  Return true if there was a change,
+ * false if the update was a no-op with respect to the unit object.
+ */
+bool sdexec_unit_update (struct unit *unit, json_t *property_dict);
+
+/* Like above but update unit with info from sdexec_list_units_next()
+ */
+bool sdexec_unit_update_frominfo (struct unit *unit, struct unit_info *info);
+
+/* Attach arbitrary data to unit.
+ */
+void *sdexec_unit_aux_get (struct unit *unit, const char *name);
+int sdexec_unit_aux_set (struct unit *unit,
+                         const char *name,
+                         void *aux,
+                         flux_free_f destroy);
+
+/* accessors */
+sdexec_state_t sdexec_unit_state (struct unit *unit);
+sdexec_substate_t sdexec_unit_substate (struct unit *unit);
+pid_t sdexec_unit_pid (struct unit *unit);
+const char *sdexec_unit_path (struct unit *unit);
+const char *sdexec_unit_name (struct unit *unit);
+
+// returns wait(2) status if unit_has_finished() == true, else -1.
+int sdexec_unit_wait_status (struct unit *unit);
+
+// returns error code if unit_has_failed() == true, else -1
+int sdexec_unit_systemd_error (struct unit *unit);
+
+bool sdexec_unit_has_started (struct unit *unit);
+bool sdexec_unit_has_finished (struct unit *unit);
+bool sdexec_unit_has_failed (struct unit *unit);
+
+#endif /* !_LIBSDEXEC_UNIT_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -43,6 +43,7 @@ fluxmod_LTLIBRARIES = \
 	kvs-watch.la \
 	resource.la \
 	sched-simple.la \
+	sdexec.la \
 	sdbus.la
 
 if ENABLE_CONTENT_S3
@@ -261,6 +262,19 @@ sched_simple_la_LIBADD = \
 	$(JANSSON_LIBS) \
 	$(HWLOC_LIBS)
 sched_simple_la_LDFLAGS = $(fluxmod_ldflags) -module
+
+sdexec_la_SOURCES = \
+	sdexec/sdexec.c
+sdexec_la_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(LIBUUID_CFLAGS)
+sdexec_la_LIBADD = \
+	$(top_builddir)/src/common/libsdexec/libsdexec.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(LIBUUID_LIBS) \
+	$(JANSSON_LIBS)
+sdexec_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 sdbus_la_SOURCES =
 sdbus_la_LIBADD = \

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -477,6 +477,7 @@ int bulk_exec_push_cmd (struct bulk_exec *exec,
 
     if (zlist_append (exec->commands, c) < 0) {
         exec_cmd_destroy (c);
+        errno = ENOMEM;
         return -1;
     }
     zlist_freefn (exec->commands, c, exec_cmd_destroy, true);

--- a/src/modules/job-exec/bulk-exec.h
+++ b/src/modules/job-exec/bulk-exec.h
@@ -41,7 +41,11 @@ struct bulk_exec_ops {
     exec_error_f on_error;    /* called on any fatal error              */
 };
 
-struct bulk_exec * bulk_exec_create (struct bulk_exec_ops *ops, void *arg);
+struct bulk_exec * bulk_exec_create (struct bulk_exec_ops *ops,
+		                     const char *service,
+				     flux_jobid_t id,
+				     const char *name,
+				     void *arg);
 
 void *bulk_exec_aux_get (struct bulk_exec *exec, const char *key);
 
@@ -89,5 +93,8 @@ int bulk_exec_close (struct bulk_exec *exec, const char *stream);
 
 /* Returns total number of processes expected to run */
 int bulk_exec_total (struct bulk_exec *exec);
+
+/* Get subprocess remote exec service name (never returns NULL) */
+const char *bulk_exec_service_name (struct bulk_exec *exec);
 
 #endif /* !HAVE_JOB_EXEC_BULK_EXEC_H */

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -23,7 +23,7 @@
  *    "mock_exception":s       - Generate a mock exception in phase:
  *                               "init", or "starting"
  *    "service":s              - Specify service to use for launching remote
- *                               subprocesses: "rexec".
+ *                               subprocesses: "rexec" or "sdexec".
  * }
  *
  */
@@ -312,7 +312,7 @@ static int parse_service_option (json_t *jobspec,
             return -1;
         }
     }
-    if (!streq (s, "rexec")) {
+    if (!streq (s, "rexec") && !streq (s, "sdexec")) {
         errprintf (error, "unknown bulkexec.service value: %s", s);
         errno = EINVAL;
         return -1;

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -22,6 +22,8 @@
  * {
  *    "mock_exception":s       - Generate a mock exception in phase:
  *                               "init", or "starting"
+ *    "service":s              - Specify service to use for launching remote
+ *                               subprocesses: "rexec".
  * }
  *
  */
@@ -34,6 +36,7 @@
 
 #include "src/common/libjob/idf58.h"
 #include "ccan/str/str.h"
+#include "src/common/libutil/errprintf.h"
 
 #include "job-exec.h"
 #include "exec_config.h"
@@ -213,6 +216,14 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
                                 hostname,
                                 rank);
         }
+        else if (errnum == ENOSYS) {
+            jobinfo_fatal_error (job,
+                                 0,
+                                 "%s service is not loaded on %s (rank %d)",
+                                 bulk_exec_service_name (exec),
+                                 hostname,
+                                 rank);
+        }
         else {
             jobinfo_fatal_error (job,
                                  errnum,
@@ -279,6 +290,37 @@ static void exit_cb (struct bulk_exec *exec,
     }
 }
 
+static int parse_service_option (json_t *jobspec,
+                                 const char **service,
+                                 flux_error_t *error)
+{
+    const char *s = config_get_exec_service (); // default
+    json_error_t e;
+
+    if (jobspec) {
+        if (json_unpack_ex (jobspec,
+                            &e,
+                            0,
+                            "{s:{s?{s?{s?{s?s}}}}}",
+                            "attributes",   // key is required per RFC 14
+                              "system",     // key is optional per RFC 14
+                                "exec",
+                                  "bulkexec",
+                                    "service", &s) < 0) {
+            errprintf (error, "error parsing bulkexec.service: %s", e.text);
+            errno = EINVAL;
+            return -1;
+        }
+    }
+    if (!streq (s, "rexec")) {
+        errprintf (error, "unknown bulkexec.service value: %s", s);
+        errno = EINVAL;
+        return -1;
+    }
+    *service = s;
+    return 0;
+}
+
 static struct bulk_exec_ops exec_ops = {
     .on_start =     start_cb,
     .on_exit =      exit_cb,
@@ -293,6 +335,8 @@ static int exec_init (struct jobinfo *job)
     struct exec_ctx *ctx = NULL;
     struct bulk_exec *exec = NULL;
     const struct idset *ranks = NULL;
+    const char *service;
+    flux_error_t error;
 
     if (job->multiuser && !config_get_imp_path ()) {
         flux_log (job->h,
@@ -305,7 +349,15 @@ static int exec_init (struct jobinfo *job)
         flux_log_error (job->h, "exec_init: resource_set_ranks");
         goto err;
     }
-    if (!(exec = bulk_exec_create (&exec_ops, job))) {
+    if (parse_service_option (job->jobspec, &service, &error) < 0) {
+        flux_log (job->h, LOG_ERR, "exec_init: %s" , error.text);
+        goto err;
+    }
+    if (!(exec = bulk_exec_create (&exec_ops,
+                                   service,
+                                   job->id,
+                                   job->multiuser ? "imp-shell" : "shell",
+                                   job))) {
         flux_log_error (job->h, "exec_init: bulk_exec_create");
         goto err;
     }

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -28,6 +28,7 @@ static const char *default_cwd = "/tmp";
 static const char *default_job_shell = NULL;
 static const char *flux_imp_path = NULL;
 static const char *exec_service = "rexec";
+static int exec_service_override = 0;
 
 static const char *jobspec_get_job_shell (json_t *jobspec)
 {
@@ -79,6 +80,11 @@ const char *config_get_exec_service (void)
     return exec_service;
 }
 
+bool config_get_exec_service_override (void)
+{
+    return exec_service_override;
+}
+
 /*  Initialize common configurations for use by job-exec exec modules.
  */
 int config_init (flux_t *h, int argc, char **argv)
@@ -114,12 +120,13 @@ int config_init (flux_t *h, int argc, char **argv)
         return -1;
     }
 
-    /*  Check configuration for exec.service */
+    /*  Check configuration for exec.service and exec.service-override */
     if (flux_conf_unpack (flux_get_conf (h),
                           &err,
-                          "{s?{s?s}}",
+                          "{s?{s?s s?b}}",
                           "exec",
-                            "service", &exec_service) < 0) {
+                            "service", &exec_service,
+                            "service-override", &exec_service_override) < 0) {
         flux_log (h, LOG_ERR,
                   "error reading config value exec.service: %s",
                   err.text);

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -27,6 +27,7 @@
 static const char *default_cwd = "/tmp";
 static const char *default_job_shell = NULL;
 static const char *flux_imp_path = NULL;
+static const char *exec_service = "rexec";
 
 static const char *jobspec_get_job_shell (json_t *jobspec)
 {
@@ -73,6 +74,11 @@ const char *config_get_imp_path (void)
     return flux_imp_path;
 }
 
+const char *config_get_exec_service (void)
+{
+    return exec_service;
+}
+
 /*  Initialize common configurations for use by job-exec exec modules.
  */
 int config_init (flux_t *h, int argc, char **argv)
@@ -108,6 +114,18 @@ int config_init (flux_t *h, int argc, char **argv)
         return -1;
     }
 
+    /*  Check configuration for exec.service */
+    if (flux_conf_unpack (flux_get_conf (h),
+                          &err,
+                          "{s?{s?s}}",
+                          "exec",
+                            "service", &exec_service) < 0) {
+        flux_log (h, LOG_ERR,
+                  "error reading config value exec.service: %s",
+                  err.text);
+        return -1;
+    }
+
     if (argv && argc) {
         /* Finally, override values on cmdline */
         for (int i = 0; i < argc; i++) {
@@ -115,6 +133,8 @@ int config_init (flux_t *h, int argc, char **argv)
                 default_job_shell = argv[i]+10;
             else if (strstarts (argv[i], "imp="))
                 flux_imp_path = argv[i]+4;
+            else if (strstarts (argv[i], "service="))
+                exec_service = argv[i]+8;
         }
     }
 

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -21,6 +21,8 @@ const char *config_get_cwd (struct jobinfo *job);
 
 const char *config_get_imp_path (void);
 
+const char *config_get_exec_service (void);
+
 int config_init (flux_t *h, int argc, char **argv);
 
 #endif /* !HAVE_JOB_EXEC_CONFIG_EXEC_H */

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -11,6 +11,7 @@
 #ifndef HAVE_JOB_EXEC_CONFIG_H
 #define HAVE_JOB_EXEC_CONFIG_H 1
 
+#include <stdbool.h>
 #include <flux/core.h>
 
 #include "job-exec.h"
@@ -22,6 +23,8 @@ const char *config_get_cwd (struct jobinfo *job);
 const char *config_get_imp_path (void);
 
 const char *config_get_exec_service (void);
+
+bool config_get_exec_service_override (void);
 
 int config_init (flux_t *h, int argc, char **argv);
 

--- a/src/modules/job-exec/test/bulk-exec.c
+++ b/src/modules/job-exec/test/bulk-exec.c
@@ -236,7 +236,7 @@ int main (int ac, char **av)
     else if (!(idset = idset_decode (ranks)))
         log_err_exit ("idset_decode (%s)", ranks);
 
-    if (!(exec = bulk_exec_create (&ops, h)))
+    if (!(exec = bulk_exec_create (&ops, "rexec", 1234, "shell", h)))
         log_err_exit ("bulk_exec_create");
 
     if (bulk_exec_set_max_per_loop (exec, optparse_get_int (p, "mpl", -1)) < 0)

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -1,0 +1,1034 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* sdexec.c - run subprocesses under systemd as transient units
+ *
+ * Configuration:
+ *  [systemd]
+ *  sdexec-debug = true   # enables debug logging
+ *  enable = true         # enables auto loading by rc script
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <jansson.h>
+#include <uuid.h>
+#ifndef UUID_STR_LEN
+#define UUID_STR_LEN 37     // defined in later libuuid headers
+#endif
+#include <flux/core.h>
+
+
+#include "src/common/libsubprocess/client.h"
+#include "src/common/libioencode/ioencode.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/fdutils.h"
+#include "src/common/libutil/jpath.h"
+#include "ccan/str/str.h"
+
+#include "src/common/libsdexec/stop.h"
+#include "src/common/libsdexec/start.h"
+#include "src/common/libsdexec/channel.h"
+#include "src/common/libsdexec/unit.h"
+#include "src/common/libsdexec/property.h"
+
+#define MODULE_NAME "sdexec"
+
+struct sdexec_ctx {
+    flux_t *h;
+    uint32_t rank;
+    char *local_uri;
+    flux_msg_handler_t **handlers;
+    struct flux_msglist *requests; // each exec request "owns" an sdproc
+    struct flux_msglist *kills;
+};
+
+struct sdproc {
+    const flux_msg_t *msg;
+    json_t *cmd;
+    int flags;
+    flux_future_t *f_watch;
+    flux_future_t *f_start;
+    flux_future_t *f_stop;
+    struct unit *unit;
+    struct channel *in;
+    struct channel *out;
+    struct channel *err;
+    uint8_t started_response_sent:1;
+    uint8_t finished_response_sent:1;
+    uint8_t out_eof_sent:1;
+    uint8_t err_eof_sent:1;
+
+    int errnum;
+    const char *errstr;
+    flux_error_t error;
+
+    struct sdexec_ctx *ctx;
+};
+
+static bool sdexec_debug;
+
+static __attribute__ ((format (printf, 2, 3)))
+void sdexec_log_debug (flux_t *h, const char *fmt, ...)
+{
+    if (sdexec_debug) {
+        va_list ap;
+
+        va_start (ap, fmt);
+        flux_vlog (h, LOG_DEBUG, fmt, ap);
+        va_end (ap);
+    }
+}
+
+static void delete_message (struct flux_msglist *msglist,
+                            const flux_msg_t *msg)
+{
+    const flux_msg_t *m;
+
+    m = flux_msglist_first (msglist);
+    while (m) {
+        if (msg == m) {
+            flux_msglist_delete (msglist);
+            return;
+        }
+        m = flux_msglist_next (msglist);
+    }
+}
+
+static const flux_msg_t *lookup_message_bypid (struct flux_msglist *msglist,
+                                               pid_t pid)
+{
+    const flux_msg_t *m;
+
+    m = flux_msglist_first (msglist);
+    while (m) {
+        struct sdproc *proc = flux_msg_aux_get (m, "sdproc");
+        if (sdexec_unit_pid (proc->unit) == pid)
+            return m;
+        m = flux_msglist_next (msglist);
+    }
+    return NULL;
+}
+
+static const flux_msg_t *lookup_message_byaux (struct flux_msglist *msglist,
+                                               const char *name,
+                                               void *value)
+{
+    const flux_msg_t *m;
+
+    m = flux_msglist_first (msglist);
+    while (m) {
+        if (flux_msg_aux_get (m, name) == value)
+            return m;
+        m = flux_msglist_next (msglist);
+    }
+    return NULL;
+}
+
+static void exec_respond_error (struct sdproc *proc,
+                                int errnum,
+                                const char *errstr)
+{
+    if (flux_respond_error (proc->ctx->h, proc->msg, errnum, errstr) < 0)
+        flux_log_error (proc->ctx->h, "error responding to exec request");
+    delete_message (proc->ctx->requests, proc->msg); // destroys proc too
+}
+
+/* Send the streaming response IFF unit cleanup is complete and EOFs have
+ * been sent.  Channel EOF and cleanup might(?) complete out of order so
+ * call this from unit and channel callbacks.
+ */
+static void finalize_exec_request_if_done (struct sdproc *proc)
+{
+    if (sdexec_unit_state (proc->unit) == STATE_INACTIVE
+        && sdexec_unit_substate (proc->unit) == SUBSTATE_DEAD
+        && (!proc->out || proc->out_eof_sent)
+        && (!proc->err || proc->err_eof_sent)) {
+
+        /* If there was an exec error, fail with ENOENT.
+         * N.B. we have no way of discerning which exec(2) error occurred,
+         * so guess ENOENT.  It could actually be EPERM, for example.
+         */
+        if (sdexec_unit_has_failed (proc->unit)) {
+            flux_error_t error;
+            errprintf (&error,
+                       "unit process could not be started (systemd error %d)",
+                       sdexec_unit_systemd_error (proc->unit));
+            exec_respond_error (proc, ENOENT, error.text);
+        }
+        else
+            exec_respond_error (proc, ENODATA, NULL);
+    }
+}
+
+static void stop_continuation (flux_future_t *f, void *arg)
+{
+    struct sdproc *proc = arg;
+
+    if (flux_rpc_get (f, NULL) < 0) {
+        flux_log (proc->ctx->h,
+                  LOG_ERR,
+                  "stop %s: %s",
+                  sdexec_unit_name (proc->unit),
+                  future_strerror (f, errno));
+    }
+}
+
+static void reset_continuation (flux_future_t *f, void *arg)
+{
+    struct sdproc *proc = arg;
+
+    if (flux_rpc_get (f, NULL) < 0) {
+        flux_log (proc->ctx->h,
+                  LOG_ERR,
+                  "reset-failed %s: %s",
+                  sdexec_unit_name (proc->unit),
+                  future_strerror (f, errno));
+    }
+}
+
+/* sdbus.subscribe sent a PropertiesChanged response for a particular unit.
+ * Advance the proc->unit state accordingly and send exec responses as needed.
+ * call finalize_exec_request_if_done() in case this update is the last thing
+ * the exec request was waiting for.
+ */
+static void property_changed_continuation (flux_future_t *f, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f);
+    struct sdproc *proc = arg;
+    json_t *properties;
+
+    if (!(properties = sdexec_property_changed_dict (f))) {
+        exec_respond_error (proc, errno, future_strerror (f, errno));
+        return;
+    }
+    if (!sdexec_unit_update (proc->unit, properties)) {
+        flux_future_reset (f);
+        return;
+    }
+
+    sdexec_log_debug (h,
+                      "%s: %s.%s",
+                      sdexec_unit_name (proc->unit),
+                      sdexec_statetostr (sdexec_unit_state (proc->unit)),
+                      sdexec_substatetostr (sdexec_unit_substate (proc->unit)));
+
+    /* The started response must be the first response to an exec request,
+     * so channel output may begin after this.
+     * If there is an exec error, "started" should not be sent.
+     */
+    if (!proc->started_response_sent) {
+        if (sdexec_unit_has_started (proc->unit)) {
+            if (flux_respond_pack (h,
+                                   proc->msg,
+                                   "{s:s s:I}",
+                                   "type", "started",
+                                   "pid", sdexec_unit_pid (proc->unit)) < 0)
+                flux_log_error (h, "error responding to exec request");
+            proc->started_response_sent = 1;
+            sdexec_channel_start_output (proc->out);
+            sdexec_channel_start_output (proc->err);
+        }
+    }
+    /* The finished response is sent when wait status is available.
+     * If there was an exec error, "finished" should not be sent.
+     */
+    if (!proc->finished_response_sent) {
+        if (sdexec_unit_has_finished (proc->unit)) {
+            if (flux_respond_pack (h,
+                                   proc->msg,
+                                   "{s:s s:i}",
+                                   "type", "finished",
+                                   "status",
+                                   sdexec_unit_wait_status (proc->unit)) < 0)
+                flux_log_error (h, "error responding to exec request");
+            proc->finished_response_sent = 1;
+        }
+    }
+    /* If the unit reaches active.exited call StopUnit to cause stdout
+     * and stderr to reach eof, and the unit to transition to inactive.dead.
+     */
+    if (sdexec_unit_state (proc->unit) == STATE_ACTIVE
+        && sdexec_unit_substate (proc->unit) == SUBSTATE_EXITED
+        && proc->finished_response_sent) {
+
+        if (!proc->f_stop) {
+            flux_future_t *f2;
+            sdexec_log_debug (h, "stop %s", sdexec_unit_name (proc->unit));
+            if (!(f2 = sdexec_stop_unit (h,
+                                         proc->ctx->rank,
+                                         sdexec_unit_name (proc->unit),
+                                         "fail"))
+                || flux_future_then (f2, -1, stop_continuation, proc) < 0) {
+                flux_log_error (h, "error initiating unit stop");
+                flux_future_destroy (f2);
+                f2 = NULL;
+            }
+            proc->f_stop = f2;
+        }
+    }
+    /* If the unit reaches failed.failed call ResetFailedUnit to cause stdout
+     * and stderr to reach eof, and the unit to transition to inactive.dead.
+     * We can land here for both a child failure and an exec failure.
+     * Start channel output here in case of the latter so it can be finalized.
+     */
+    if (sdexec_unit_state (proc->unit) == STATE_FAILED
+        && sdexec_unit_substate (proc->unit) == SUBSTATE_FAILED) {
+
+        sdexec_channel_start_output (proc->out);
+        sdexec_channel_start_output (proc->err);
+
+        if (!proc->f_stop) {
+            flux_future_t *f2;
+            sdexec_log_debug (h,
+                              "reset-failed %s",
+                              sdexec_unit_name (proc->unit));
+            if (!(f2 = sdexec_reset_failed_unit (h,
+                                                 proc->ctx->rank,
+                                                 sdexec_unit_name (proc->unit)))
+                || flux_future_then (f2, -1, reset_continuation, proc) < 0) {
+                flux_log_error (h, "error initiating unit reset");
+                flux_future_destroy (f2);
+                f2 = NULL;
+            }
+            proc->f_stop = f2;
+        }
+    }
+    flux_future_reset (f);
+    /* Conditionally send the final RPC response.
+     */
+    finalize_exec_request_if_done (proc);
+}
+
+/* StartTransientUnit reply does not normally generate a sdexec.exec response,
+ * unless it fails.  Streaming responses continue as property change updates
+ * are received from sdbus.
+ */
+static void start_continuation (flux_future_t *f, void *arg)
+{
+    const flux_msg_t *msg = flux_future_aux_get (f, "request");
+    struct sdproc *proc = flux_msg_aux_get (msg, "sdproc");
+    struct sdexec_ctx *ctx = arg;
+
+    if (sdexec_start_transient_unit_get (f, NULL) < 0)
+        goto error;
+    /* Now that systemd has acknowledged the StartTransientUnit request, close
+     * the systemd end of any channel(s).  The assumption is that systemd has
+     * received its fd and has already called dup(2) on it.
+     */
+    sdexec_channel_close_fd (proc->in);
+    sdexec_channel_close_fd (proc->out);
+    sdexec_channel_close_fd (proc->err);
+    return;
+error:
+    if (flux_respond_error (ctx->h, msg, errno, future_strerror (f, errno)))
+        flux_log_error (ctx->h, "error responding to exec request");
+    delete_message (ctx->requests, msg);
+}
+
+/* Log an error receiving data from unit stdout or stderr.  channel_cb will
+ * be called with an EOF after this callback returns.
+ */
+static void cherror_cb (struct channel *ch, flux_error_t *error, void *arg)
+{
+    struct sdproc *proc = arg;
+    flux_t *h = proc->ctx->h;
+
+    flux_log (h, LOG_ERR, "%s: %s", sdexec_channel_get_name (ch), error->text);
+}
+
+/* Receive some data from unit stdout or stderr and forward it as an
+ * exec response.  In case this was the last thing the exec request was
+ * waiting to receive (e.g. a final EOF), call finalize_exec_request_if_done()
+ * to take care of that if needed.
+ */
+static void channel_cb (struct channel *ch, json_t *io, void *arg)
+{
+    struct sdproc *proc = arg;
+    flux_t *h = proc->ctx->h;
+
+    if (flux_respond_pack (h,
+                           proc->msg,
+                           "{s:s s:i s:O}",
+                           "type", "output",
+                           "pid", sdexec_unit_pid (proc->unit),
+                           "io", io) < 0)
+        flux_log_error (h, "error responding to exec request");
+
+    const char *stream;
+    bool eof;
+    if (iodecode (io, &stream, NULL, NULL, NULL, &eof) == 0 && eof == true) {
+        if (streq (stream, "stdout"))
+            proc->out_eof_sent = true;
+        else if (streq (stream, "stderr"))
+            proc->err_eof_sent = true;
+    }
+    finalize_exec_request_if_done (proc);
+}
+
+/* Since an sdproc is attached to each exec message's aux container, this
+ * destructor is typically called when an exec request is destroyed, e.g.
+ * after unit reaping is complete and the exec client has been sent ENODATA
+ * or another error response.  This ends the sdbus.subscribe request for
+ * property updates on this unit.  The subscribe future is destroyed here;
+ * we do not wait for the ENODATA response.
+ */
+static void sdproc_destroy (struct sdproc *proc)
+{
+    if (proc) {
+        int saved_errno = errno;
+        sdexec_channel_destroy (proc->out);
+        sdexec_channel_destroy (proc->err);
+        if (proc->f_watch) {
+            flux_future_t *f;
+            sdexec_log_debug (proc->ctx->h,
+                              "unwatch %s",
+                              sdexec_unit_name (proc->unit));
+            f = flux_rpc_pack (proc->ctx->h,
+                               "sdbus.subscribe-cancel",
+                               proc->ctx->rank,
+                               FLUX_RPC_NORESPONSE,
+                               "{s:i}",
+                               "matchtag",
+                               flux_rpc_get_matchtag (proc->f_watch));
+            flux_future_destroy (f);
+            flux_future_destroy (proc->f_watch);
+        }
+        flux_future_destroy (proc->f_start);
+        flux_future_destroy (proc->f_stop);
+        sdexec_unit_destroy (proc->unit);
+        json_decref (proc->cmd);
+        free (proc);
+        errno = saved_errno;
+    }
+}
+
+/* Set a key 'k', value 'v' pair in the dictionary named 'name'.
+ * The dictionary is created if it does not exist.
+ * If key is already set, the previous value is overwritten.
+ */
+static int set_dict (json_t *o,
+                     const char *name,
+                     const char *k,
+                     const char *v)
+{
+    json_t *dict;
+    json_t *vo;
+
+    if (!(dict = json_object_get (o, name))) {
+        if (!(dict = json_object ())
+            || json_object_set_new (o, name, dict) < 0) {
+            json_decref (dict);
+            goto nomem;
+        }
+    }
+    if (!(vo = json_string (v))
+        || json_object_set_new (dict, k, vo) < 0) {
+        json_decref (vo);
+        goto nomem;
+    }
+    return 0;
+nomem:
+    errno = ENOMEM;
+    return -1;
+}
+
+/* Look up key 'k' in dictionary named 'name' and assign value to 'vp'.
+ */
+static int get_dict (json_t *o,
+                     const char *name,
+                     const char *k,
+                     const char **vp)
+{
+    const char *v;
+    if (json_unpack (o, "{s:{s:s}}", name, k, &v) < 0) {
+        errno = ENOENT;
+        return -1;
+    }
+    *vp = v;
+    return 0;
+}
+
+static struct sdproc *sdproc_create (struct sdexec_ctx *ctx,
+                                     json_t *cmd,
+                                     int flags)
+{
+    struct sdproc *proc;
+    const int valid_flags = SUBPROCESS_REXEC_STDOUT
+        | SUBPROCESS_REXEC_STDERR
+        | SUBPROCESS_REXEC_CHANNEL;
+    const char *name;
+    char *tmp = NULL;
+
+    if ((flags & ~valid_flags) != 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(proc = calloc (1, sizeof (*proc))))
+        return NULL;
+    proc->ctx = ctx;
+    proc->flags = flags;
+    if (!(proc->cmd = json_deep_copy (cmd))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    /* Set SDEXEC_NAME for sdexec_start_transient_unit().
+     * If unset, use a truncated uuid as the name.
+     */
+    if (get_dict (proc->cmd, "opts", "SDEXEC_NAME", &name) < 0) {
+        uuid_t uuid;
+        char uuid_str[UUID_STR_LEN];
+
+        uuid_generate (uuid);
+        uuid_unparse (uuid, uuid_str);
+        uuid_str[13] = '\0'; // plenty of uniqueness
+        if (asprintf (&tmp, "%s.service", uuid_str) < 0
+            || set_dict (proc->cmd, "opts", "SDEXEC_NAME", tmp) < 0)
+            goto error;
+        name = tmp;
+    }
+    if (!(proc->unit = sdexec_unit_create (name)))
+        goto error;
+    /* Ensure that FLUX_URI refers to the local broker.
+     */
+    if (set_dict (proc->cmd, "env", "FLUX_URI", ctx->local_uri) < 0)
+        goto error;
+    /* Create channels for stdio as required by flags.
+     */
+    if (!(proc->in = sdexec_channel_create_input (ctx->h, "stdin")))
+        goto error;
+    if ((flags & SUBPROCESS_REXEC_STDOUT)) {
+        if (!(proc->out = sdexec_channel_create_output (ctx->h,
+                                                        "stdout",
+                                                        channel_cb,
+                                                        cherror_cb,
+                                                        proc)))
+            goto error;
+    }
+    if ((flags & SUBPROCESS_REXEC_STDERR)) {
+        if (!(proc->err = sdexec_channel_create_output (ctx->h,
+                                                        "stderr",
+                                                        channel_cb,
+                                                        cherror_cb,
+                                                        proc)))
+            goto error;
+    }
+    free (tmp);
+    return proc;
+error:
+    ERRNO_SAFE_WRAP (free, tmp);
+    sdproc_destroy (proc);
+    return NULL;
+}
+
+static int authorize_request (const flux_msg_t *msg,
+                              uint32_t rank,
+                              flux_error_t *error)
+{
+    if (rank != 0 || flux_msg_is_local (msg))
+        return 0;
+    errprintf (error, "Remote sdexec requests are not allowed on rank 0");
+    errno = EPERM;
+    return -1;
+}
+
+/* Start a process as a systemd transient unit.  This is a streaming request.
+ * It triggers two sdbus RPCs:
+ * 1) sdbus.subscribe (streaming) for updates to this unit's properties
+ * 2) sdbus.call StartTransientUnit to launch the transient unit.
+ * Responses to those are handled in property_changed_continuation()
+ * and start_continuation().
+ */
+static void exec_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    struct sdexec_ctx *ctx = arg;
+    json_t *cmd;
+    int flags;
+    flux_error_t error;
+    const char *errstr = NULL;
+    struct sdproc *proc;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:o s:i}",
+                             "cmd", &cmd,
+                             "flags", &flags) < 0)
+        goto error;
+    if (!flux_msg_is_streaming (msg)) {
+        errstr = "exec request is missing STREAMING flag";
+        errno = EPROTO;
+        goto error;
+    }
+    if (authorize_request (msg, ctx->rank, &error) < 0) {
+        errstr = error.text;
+        goto error;
+    }
+    if ((flags & SUBPROCESS_REXEC_CHANNEL)) {
+        errstr = "subprocess auxiliary channels are not supported yet";
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(proc = sdproc_create (ctx, cmd, flags))
+        || flux_msg_aux_set (msg,
+                             "sdproc",
+                             proc,
+                             (flux_free_f)sdproc_destroy) < 0) {
+        sdproc_destroy (proc);
+        goto error;
+    }
+    proc->msg = msg;
+    sdexec_log_debug (h, "watch %s", sdexec_unit_name (proc->unit));
+    if (!(proc->f_watch = sdexec_property_changed (h,
+                                               ctx->rank,
+                                               sdexec_unit_path (proc->unit)))
+        || flux_future_then (proc->f_watch,
+                             -1,
+                             property_changed_continuation,
+                             proc) < 0)
+        goto error;
+    sdexec_log_debug (h, "start %s", sdexec_unit_name (proc->unit));
+    if (!(proc->f_start = sdexec_start_transient_unit (h,
+                                             ctx->rank,
+                                             "fail", // mode
+                                             "exec", // type
+                                             proc->cmd,
+                                             sdexec_channel_get_fd (proc->in),
+                                             sdexec_channel_get_fd (proc->out),
+                                             sdexec_channel_get_fd (proc->err),
+                                             &error))) {
+        errstr = error.text;
+        goto error;
+    }
+    if (flux_future_then (proc->f_start, -1, start_continuation, ctx) < 0
+        || flux_future_aux_set (proc->f_start,
+                                "request",
+                                (void *)msg,
+                                NULL) < 0)
+        goto error;
+    if (flux_msglist_append (ctx->requests, msg) < 0)
+        goto error;
+    return; // response occurs later
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to exec request");
+}
+
+/* Send some data to stdin of a unit started with sdexec.exec.
+ * The unit is looked up by pid. This request is "fire and forget"
+ * (no response) per libsubprocess protocol.
+ */
+static void write_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
+{
+    struct sdexec_ctx *ctx = arg;
+    pid_t pid;
+    json_t *io;
+    const flux_msg_t *exec_request;
+    flux_error_t error;
+    struct sdproc *proc;
+    const char *stream;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:i s:o}",
+                             "pid", &pid,
+                             "io", &io) < 0) {
+        flux_log_error (h, "error decoding write request");
+        return;
+    }
+    if (!flux_msg_is_noresponse (msg)) {
+        flux_log (h, LOG_ERR, "write request is missing NORESPONSE flag");
+        return;
+    }
+    if (authorize_request (msg, ctx->rank, &error) < 0) {
+        flux_log_error (h, "%s", error.text);
+        return;
+    }
+    if (!(exec_request = lookup_message_bypid (ctx->requests, pid))
+        || !(proc = flux_msg_aux_get (exec_request, "sdproc"))) {
+        flux_log (h, LOG_ERR, "write pid=%d: not found", pid);
+        return;
+    }
+    if (iodecode (io, &stream, NULL, NULL, NULL, NULL) == 0
+        && !streq (stream, "stdin")) {
+        flux_log (h,
+                  LOG_ERR,
+                  "write pid=%d stream=%s: invalid stream",
+                  pid,
+                  stream);
+        return;
+    }
+    if (sdexec_channel_write (proc->in, io) < 0) {
+        flux_log_error (h, "write pid=%d", pid);
+        return;
+    }
+}
+
+static void kill_continuation (flux_future_t *f, void *arg)
+{
+    struct sdexec_ctx *ctx = arg;
+    flux_t *h = ctx->h;
+    const flux_msg_t *msg = lookup_message_byaux (ctx->kills, "kill", f);
+    int rc;
+
+    if (flux_rpc_get (f, NULL) < 0)
+        rc = flux_respond_error (h, msg, errno, future_strerror (f, errno));
+    else
+        rc = flux_respond (h, msg, NULL) ;
+    if (rc < 0)
+        flux_log_error (h, "error responding to kill request");
+    flux_msglist_delete (ctx->kills); // destroys msg and f
+}
+
+/* Handle a kill by pid request.  This does not work on arbitrary pids,
+ * only the pids of units started with sdexec.exec since the sdexec module
+ * was loaded.  Since this sends an sdbus RPC, the response is handled in
+ * kill_continuation() when the sdbus response is received.
+ * N.B. in a typical system instance, job-exec would remotely execute
+ * flux-imp kill and this would not be used.
+ */
+static void kill_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    struct sdexec_ctx *ctx = arg;
+    pid_t pid;
+    int signum;
+    const flux_msg_t *exec_request;
+    struct sdproc *proc;
+    flux_error_t error;
+    const char *errstr = NULL;
+    flux_future_t *f;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:i s:i}",
+                             "pid", &pid,
+                             "signum", &signum) < 0)
+        goto error;
+    if (authorize_request (msg, ctx->rank, &error) < 0) {
+        errstr = error.text;
+        goto error;
+    }
+    if (!(exec_request = lookup_message_bypid (ctx->requests, pid))
+        || !(proc = flux_msg_aux_get (exec_request, "sdproc"))) {
+        errprintf (&error, "kill pid=%d not found", pid);
+        errstr = error.text;
+        errno = ESRCH;
+        goto error;
+    }
+    sdexec_log_debug (h,
+                      "kill main %s (signal %d)",
+                      sdexec_unit_name (proc->unit),
+                      signum);
+    if (!(f = sdexec_kill_unit (h,
+                                ctx->rank,
+                                sdexec_unit_name (proc->unit),
+                                "main",
+                                signum))
+        || flux_future_then (f, -1, kill_continuation, ctx) < 0
+        || flux_msg_aux_set (msg,
+                             "kill",
+                             f,
+                             (flux_free_f)flux_future_destroy) < 0) {
+        flux_future_destroy (f);
+        errstr = "error sending KillUnit request";
+        goto error;
+    }
+    // kill_continuation will respond
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to kill request");
+}
+
+/* Handle an sdexec.list request.
+ * At this time, this RPC is only used in test and the returned data
+ * is sparse.  It could be expanded later if needed.
+ */
+static void list_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    struct sdexec_ctx *ctx = arg;
+    flux_error_t error;
+    const char *errstr = NULL;
+    json_t *procs = NULL;
+    const flux_msg_t *req;
+
+    if (authorize_request (msg, ctx->rank, &error) < 0) {
+        errstr = error.text;
+        goto error;
+    }
+    if (!(procs = json_array ()))
+        goto nomem;
+    req = flux_msglist_first (ctx->requests);
+    while (req) {
+        struct sdproc *proc;
+        const char *arg0;
+        json_t *o;
+        if ((proc = flux_msg_aux_get (req, "sdproc"))
+            && json_unpack (proc->cmd, "{s:[s]}", "cmdline", &arg0) == 0
+            && (o = json_pack ("{s:i s:s}",
+                               "pid", sdexec_unit_pid (proc->unit),
+                               "cmd", arg0))) {
+            if (json_array_append_new (procs, o) < 0) {
+                json_decref (o);
+                goto nomem;
+            }
+        }
+        req = flux_msglist_next (ctx->requests);
+    }
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:i s:o}",
+                           "rank", ctx->rank,
+                           "procs", procs) < 0)
+        flux_log_error (h, "error responding to list request");
+    json_decref (procs);
+    return;
+nomem:
+    errno = ENOMEM;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to list request");
+    json_decref (procs);
+}
+
+/* When a client (like flux-exec or job-exec) disconnects, send any running
+ * units that were started by that UUID a SIGKILL to begin cleanup.  Leave
+ * the request in ctx->requests so the unit can be "reaped".  Let normal
+ * cleanup of the request (including generating a response which shouldn't
+ * hurt) to occur when that happens.
+ */
+static void disconnect_cb (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+    struct sdexec_ctx *ctx = arg;
+    const flux_msg_t *request;
+
+    request = flux_msglist_first (ctx->requests);
+    while (request) {
+        if (flux_disconnect_match (msg, request)) {
+            struct sdproc *proc = flux_msg_aux_get (request, "sdproc");
+            if (proc) {
+                flux_future_t *f;
+                f = sdexec_kill_unit (h,
+                                      ctx->rank,
+                                      sdexec_unit_name (proc->unit),
+                                      "main",
+                                       SIGKILL);
+                flux_future_destroy (f);
+            }
+        }
+        request = flux_msglist_next (ctx->requests);
+    }
+}
+
+/* N.B. systemd.enable is checked in rc1 and ignored here since
+ * it should be OK to load the module manually for testing.
+ */
+static int sdexec_configure (struct sdexec_ctx *ctx,
+                             const flux_conf_t *conf,
+                             flux_error_t *error)
+{
+    flux_error_t conf_error;
+    int debug = 0;
+
+    if (flux_conf_unpack (conf,
+                          &conf_error,
+                          "{s?{s?b}}",
+                          "systemd",
+                            "sdexec-debug", &debug) < 0) {
+        errprintf (error,
+                   "error reading [systemd] config table: %s",
+                   conf_error.text);
+        return -1;
+    }
+    sdexec_debug = (debug ? true : false);
+    return 0;
+}
+
+static void config_reload_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
+{
+    struct sdexec_ctx *ctx = arg;
+    const flux_conf_t *conf;
+    flux_error_t error;
+    const char *errstr = NULL;
+
+    if (flux_conf_reload_decode (msg, &conf) < 0) {
+        errstr = "Failed to parse config-reload request";
+        goto error;
+    }
+    if (sdexec_configure (ctx, conf, &error) < 0) {
+        errstr = error.text;
+        goto error;
+    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to config-reload request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to config-reload request");
+}
+
+static struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,
+      "disconnect",
+      disconnect_cb,
+      0
+    },
+    { FLUX_MSGTYPE_REQUEST,
+      "exec",
+      exec_cb,
+      0
+    },
+    { FLUX_MSGTYPE_REQUEST,
+      "write",
+      write_cb,
+      0
+    },
+    { FLUX_MSGTYPE_REQUEST,
+      "kill",
+      kill_cb,
+      0
+    },
+    { FLUX_MSGTYPE_REQUEST,
+      "list",
+      list_cb,
+      0
+    },
+    { FLUX_MSGTYPE_REQUEST,
+      "config-reload",
+      config_reload_cb,
+      0
+    },
+    FLUX_MSGHANDLER_TABLE_END
+};
+
+static void sdexec_ctx_destroy (struct sdexec_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (ctx->handlers);
+        if (ctx->requests) {
+            const flux_msg_t *msg;
+            msg = flux_msglist_first (ctx->requests);
+            while (msg) {
+                const char *errstr = "sdexec module is unloading";
+                if (flux_respond_error (ctx->h, msg, ENOSYS, errstr) < 0)
+                    flux_log_error (ctx->h, "error responding to exec request");
+                msg = flux_msglist_next (ctx->requests);
+            }
+            flux_msglist_destroy (ctx->requests);
+        }
+        flux_msglist_destroy (ctx->kills);
+        free (ctx->local_uri);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct sdexec_ctx *sdexec_ctx_create (flux_t *h)
+{
+    struct sdexec_ctx *ctx;
+    const char *s;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    ctx->h = h;
+    if (flux_get_rank (h, &ctx->rank) < 0)
+        goto error;
+    if (!(s = flux_attr_get (h, "local-uri"))
+        || !(ctx->local_uri = strdup (s)))
+        goto error;
+    if (!(ctx->requests = flux_msglist_create ())
+        || !(ctx->kills = flux_msglist_create ()))
+        goto error;
+    return ctx;
+error:
+    sdexec_ctx_destroy (ctx);
+    return NULL;
+}
+
+/* Check if the sdbus module is loaded on the local rank by pinging its
+ * stats-get method.  N.B. sdbus handles its D-bus connect asynchronously
+ * so stats-get should be responsive even if D-Bus is not.
+ */
+static int sdbus_is_loaded (flux_t *h, uint32_t rank, flux_error_t *error)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_rpc (h, "sdbus.stats-get", NULL, rank, 0))
+        || flux_rpc_get (f, NULL) < 0) {
+        if (errno == ENOSYS)
+            errprintf (error, "sdbus module is not loaded");
+        else
+            errprintf (error, "sdbus: %s", future_strerror (f, errno));
+        flux_future_destroy (f);
+        return -1;
+    }
+    flux_future_destroy (f);
+    return 0;
+}
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    struct sdexec_ctx *ctx;
+    flux_error_t error;
+    int rc = -1;
+
+    if (!(ctx = sdexec_ctx_create (h)))
+        goto error;
+    if (sdexec_configure (ctx, flux_get_conf (h), &error) < 0) {
+        flux_log (h, LOG_ERR, "%s", error.text);
+        goto error;
+    }
+    if (flux_msg_handler_addvec_ex (h,
+                                    MODULE_NAME,
+                                    htab,
+                                    ctx,
+                                    &ctx->handlers) < 0)
+        goto error;
+    if (sdbus_is_loaded (h, ctx->rank, &error) < 0) {
+        flux_log (h, LOG_ERR, "%s", error.text);
+        goto error;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        flux_log_error (h, "reactor exited abnormally");
+        goto error;
+    }
+    rc = 0;
+error:
+    sdexec_ctx_destroy (ctx);
+    return rc;
+}
+
+MOD_NAME (MODULE_NAME);
+
+// vi:ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -180,6 +180,7 @@ TESTSCRIPTS = \
 	t2408-sdbus-recovery.t \
 	t2409-sdexec.t \
 	t2410-exec-systemd.t \
+	t2411-sdexec-job.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \
 	t2600-job-shell-rcalc.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -181,6 +181,7 @@ TESTSCRIPTS = \
 	t2409-sdexec.t \
 	t2410-exec-systemd.t \
 	t2411-sdexec-job.t \
+	t2412-sdexec-perilog.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \
 	t2600-job-shell-rcalc.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -178,6 +178,7 @@ TESTSCRIPTS = \
 	t2406-job-exec-cleanup.t \
 	t2407-sdbus.t \
 	t2408-sdbus-recovery.t \
+	t2409-sdexec.t \
 	t2410-exec-systemd.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \

--- a/t/scripts/rexec.py
+++ b/t/scripts/rexec.py
@@ -21,7 +21,7 @@ def kill(args):
     h = flux.Flux()
     try:
         h.rpc(
-            "rexec.kill",
+            args.service + ".kill",
             nodeid=args.rank,
             payload={"pid": int(args.pid), "signum": int(args.signum)},
         ).get()
@@ -34,7 +34,7 @@ def ps(args):
     h = flux.Flux()
     try:
         resp = h.rpc(
-            "rexec.list",
+            args.service + ".list",
             nodeid=int(args.rank),
         ).get()
     except OSError as exc:
@@ -67,6 +67,13 @@ def main():
         help="Send RPC to specified broker rank",
         default=flux.constants.FLUX_NODEID_ANY,
     )
+    kill_parser.add_argument(
+        "-s",
+        "--service",
+        type=str,
+        help="Send RPC to specified service (default rexec)",
+        default="rexec",
+    )
     kill_parser.add_argument("signum")
     kill_parser.add_argument("pid")
     kill_parser.set_defaults(func=kill)
@@ -82,6 +89,13 @@ def main():
         type=int,
         help="Send RPC to specified broker rank",
         default=flux.constants.FLUX_NODEID_ANY,
+    )
+    ps_parser.add_argument(
+        "-s",
+        "--service",
+        type=str,
+        help="Send RPC to specified service (default rexec)",
+        default="rexec",
     )
     ps_parser.set_defaults(func=ps)
 

--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ci=system
+
+test_description='Test flux systemd execution'
+
+. $(dirname $0)/sharness.sh
+
+if ! flux version | grep systemd; then
+	skip_all="flux was not built with systemd"
+	test_done
+fi
+if ! systemctl --user show --property Version; then
+	skip_all="user systemd is not running"
+	test_done
+fi
+if ! busctl --user status >/dev/null; then
+	skip_all="user dbus is not running"
+	test_done
+fi
+
+test_under_flux 2 minimal
+
+flux setattr log-stderr-level 1
+
+sdexec="flux exec --service sdexec"
+lptest=${FLUX_BUILD_DIR}/t/shell/lptest
+rkill="flux python ${SHARNESS_TEST_SRCDIR}/scripts/rexec.py kill -s sdexec"
+rps="flux python ${SHARNESS_TEST_SRCDIR}/scripts/rexec.py ps -s sdexec"
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+# systemd 239 requires commands to be fully qualified, while 249 does not
+true=$(which true)
+false=$(which false)
+sh=$(which sh)
+cat=$(which cat)
+pwd=$(which pwd)
+printenv=$(which printenv)
+systemctl=$(which systemctl)
+
+test_expect_success 'enable debug logging' '
+	cat >systemd.toml <<-EOF &&
+	[systemd]
+	sdbus-debug = true
+	sdexec-debug = true
+	EOF
+	flux config load <systemd.toml
+'
+test_expect_success 'load sdbus,sdexec modules' '
+	flux exec flux module load sdbus &&
+	flux exec flux module load sdexec
+'
+test_expect_success 'clear broker logs' '
+	flux dmesg -C
+'
+test_expect_success 'sdexec true succeeds' '
+	$sdexec -r 0 $true
+'
+test_expect_success 'sdexec false fails with exit code 1' '
+	test_expect_code 1 $sdexec -r 0 $false
+'
+test_expect_success 'sdexec /notacmd fails with exit code 127' '
+	test_expect_code 127 $sdexec -r 0 /notacmd
+'
+test_expect_success 'capture broker logs' '
+	flux dmesg >dmesg.log
+'
+test_expect_success 'sdexec stdout works' '
+	cat >hello.exp <<-EOT &&
+	Hello world!
+	EOT
+	$sdexec -r 0 $sh -c "echo Hello world!" >hello.out &&
+	test_cmp hello.exp hello.out
+'
+test_expect_success 'sdexec stderr works' '
+	$sdexec -r 0 $sh -c "echo Hello world! >&2" 2>hello.err &&
+	test_cmp hello.exp hello.err
+'
+test_expect_success 'sdexec stdout+stderr works' '
+	$sdexec -r 0 $sh -c "echo Hello world!; echo Hello world! >&2" \
+		>hello2.out 2>hello2.err &&
+	test_cmp hello.exp hello2.out &&
+	test_cmp hello.exp hello2.err
+'
+test_expect_success 'sdexec stdin works' '
+	echo "Hello world!" | $sdexec -r 0 $cat >hello.in &&
+	test_cmp hello.exp hello.in
+'
+test_expect_success 'set up for lptest stdio tests' '
+	$lptest 79 10000 >lptest.exp
+'
+test_expect_success 'sdexec works with 10K lines of stdout' '
+	$sdexec -r 0 $cat lptest.exp >lptest.out &&
+	test_cmp lptest.exp lptest.out
+'
+test_expect_success 'sdexec works with 10K lines of stdin' '
+	$sdexec -r 0 $sh -c "cat >lptest.in" <lptest.exp &&
+	test_cmp lptest.exp lptest.in
+'
+test_expect_success 'sdexec can set working directory' '
+	pwd >dir.exp &&
+	$sdexec -r 0 $pwd >dir.out &&
+	test_cmp dir.exp dir.out
+'
+test_expect_success 'sdexec can set environment' '
+	echo 42 >env.exp &&
+	T2409=42 $sdexec -r 0 $printenv T2409 >env.out &&
+	test_cmp env.exp env.out
+'
+# environment modules sets variables with names like 'BASH_FUNC_ml()'
+# https://bugzilla.redhat.com/show_bug.cgi?id=1912046#c5
+test_expect_success 'sdexec ignores environment containing parens' '
+	env "foo()"=badenv666 $sdexec -r 0 $printenv >badenv.out &&
+	test_must_fail grep -q badenv666 badenv.out
+'
+
+
+# each entry: "TESTVAR_xxxxx=" (14) + val (1009) + delim (1) = 1024 bytes
+make_exports() {
+	local count=$1
+	local val=$(for i in $(seq 1009); do printf x; done)
+	while test $count -gt 0; do
+		printf "export TESTVAR_%.5d=%s\n" $count $val
+		count=$(($count-1))
+	done
+}
+
+# Since the StartTransientUnit request includes the user's environment, the
+# request message size is unpredictable.  Let's be sure a large environment
+# as might be seen with spack or environment modules is handled OK.
+#
+# Note the maximum dbus message size is 128 MiB per spec[1].
+# Tested on debian 11 aarch64:
+# - count=1024 (1MiB) works
+# - count=2048 (2MiB) works
+# - count=4096 (4MiB) works
+# - count=8192 (8MiB) printenv(1) fails with "Argument list too long"
+# But sdexec/dbus holds up just fine.
+#
+# [1] https://dbus.freedesktop.org/doc/dbus-specification.html
+test_expect_success 'sdexec accepts supersize environment' '
+	count=1024 &&
+	make_exports $count >testenv &&
+	sed -e "s/^export //" <testenv | sort >testenv.exp
+	(. $(pwd)/testenv && $sdexec -r 0 $printenv) >testenv.raw &&
+	grep TESTVAR_ testenv.raw | sort >testenv.out &&
+	test_cmp testenv.exp testenv.out
+'
+test_expect_success 'sdexec can set unit name' '
+	$sdexec -r 0 --setopt=SDEXEC_NAME=t2409-funfunfun.service \
+	    $systemctl --user list-units --type=service >name.out &&
+	grep t2409-funfunfun name.out
+'
+test_expect_success 'sdexec can set unit Description property' '
+	cat >desc.exp <<-EOT &&
+	Description=fubar
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME=t2409-desc.service \
+	    --setopt=SDEXEC_PROP_Description=fubar \
+	    $systemctl --user show --property Description \
+	        t2409-desc.service >desc.out &&
+	test_cmp desc.exp desc.out
+'
+# Check that we can set resource control attributes on our transient units,
+# but expect resource control testing to occur elsewhere.
+# See also:
+# https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
+test_expect_success 'sdexec can set unit MemoryHigh property' '
+	cat >memhi.exp <<-EOT &&
+	MemoryHigh=1073741824
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-memhi.service" \
+	    --setopt=SDEXEC_PROP_MemoryHigh=1G \
+	    $systemctl --user show --property MemoryHigh \
+	        t2409-memhi.service >memhi.out &&
+	test_cmp memhi.exp memhi.out
+'
+test_expect_success 'sdexec can set unit MemoryMax property' '
+	cat >memmax.exp <<-EOT &&
+	MemoryMax=infinity
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-memmax.service" \
+	    --setopt=SDEXEC_PROP_MemoryMax=infinity \
+	    $systemctl --user show --property MemoryMax \
+	        t2409-memmax.service >memmax.out &&
+	test_cmp memmax.exp memmax.out
+'
+test_expect_success 'sdexec can set unit MemoryMin property' '
+	cat >memmin.exp <<-EOT &&
+	MemoryMin=1048576
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-memmin.service" \
+	    --setopt=SDEXEC_PROP_MemoryMin=1M \
+	    $systemctl --user show --property MemoryMin \
+	        t2409-memmin.service >memmin.out &&
+	test_cmp memmin.exp memmin.out
+'
+test_expect_success 'sdexec can set unit AllowedCPUs property' '
+	cat >allowedcpus.exp <<-EOT &&
+	AllowedCPUs=0 57-99 127
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-allowedcpus.service" \
+	    --setopt=SDEXEC_PROP_AllowedCPUs="0,57-99,127" \
+	    $systemctl --user show --property AllowedCPUs \
+	        t2409-allowedcpus.service >allowedcpus.out &&
+	test_cmp allowedcpus.exp allowedcpus.out
+'
+test_expect_success 'sdexec can set unit AllowedCPUs to an empty bitmask' '
+	cat >allowedcpus2.exp <<-EOT &&
+	AllowedCPUs=
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-allowedcpus2.service" \
+	    --setopt=SDEXEC_PROP_AllowedCPUs="" \
+	    $systemctl --user show --property AllowedCPUs \
+	        t2409-allowedcpus2.service >allowedcpus2.out &&
+	test_cmp allowedcpus2.exp allowedcpus2.out
+'
+
+memtotal() {
+	local kb=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
+	expr $kb \* 1024
+}
+
+# There's a rounding error in here somewhere because 50% is off by 2048 bytes,
+# but 100% is accurate with respect to /proc/meminfo.  Just use 100% for now.
+test_expect_success 'sdexec can set unit MemoryLow property' '
+	echo MemoryLow=$(memtotal) >memlow.exp &&
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-memlow.service" \
+	    --setopt=SDEXEC_PROP_MemoryLow=100% \
+	    $systemctl --user show --property MemoryLow \
+	        t2409-memlow.service >memlow.out &&
+	test_cmp memlow.exp memlow.out
+'
+test_expect_success 'sdexec fails on bad property' '
+	test_must_fail $sdexec -r 0 --setopt=SDEXEC_PROP_xxx=yyz \
+	    $true 2>setunk.err &&
+	grep "Cannot set property xxx" setunk.err
+'
+test_expect_success 'kill fails on unknown pid' '
+        test_must_fail $rkill -r 0 15 1234 2>killunk.err &&
+	grep "not found" killunk.err
+'
+test_expect_success 'rank 0 sdexec fails if remote' '
+        test_must_fail flux exec -r 1 $sdexec -r 0 $true 2>restrict.err &&
+        grep "not allowed on rank 0" restrict.err
+'
+test_expect_success 'rank 0 kill fails if remote' '
+        test_must_fail flux exec -r 1 $rkill -r 0 15 1234 2>killperm.err &&
+	grep "not allowed on rank 0" killperm.err
+'
+test_expect_success 'rank 0 list fails if remote' '
+        test_must_fail flux exec -r 1 $rps -r 0 2>psperm.err &&
+	grep "not allowed on rank 0" psperm.err
+'
+# N.B. this "kill" test relies on the fact that flux exec forwards
+# signals to the remote process
+test_expect_success NO_CHAIN_LINT 'sdexec remote kill works' '
+	$sdexec -r 0 $sh -c "echo hello >sleep.out && sleep 60" &
+	testpid=$! &&
+	$waitfile -q -t 30 sleep.out &&
+	kill -15 $testpid &&
+	test_expect_code 143 wait $testpid
+'
+test_expect_success NO_CHAIN_LINT 'sdexec.list works' '
+	$sdexec -r 0 $sh -c "echo hello >sleep2.out && sleep 60" &
+	testpid=$! &&
+	$waitfile -q -t 30 sleep2.out &&
+	$rps >list.out &&
+	grep sh list.out &&
+	kill -15 $testpid &&
+	test_expect_code 143 wait $testpid
+'
+test_expect_success 'sdexec sets FLUX_URI to local broker' '
+	echo $FLUX_URI >uri.exp &&
+	$sdexec -r 1 $printenv FLUX_URI >uri.out &&
+	test_must_fail test_cmp uri.exp uri.out
+'
+test_expect_success 'sdexec reconfig fails with bad sdexec-debug value' '
+	test_must_fail flux config load <<-EOT 2>config.err &&
+	[systemd]
+	sdexec-debug = 42
+	EOT
+	grep "Expected true or false" config.err
+'
+test_expect_success 'remove sdexec,sdbus modules' '
+	flux exec flux module remove sdexec &&
+	flux exec flux module remove sdbus
+'
+test_done

--- a/t/t2411-sdexec-job.t
+++ b/t/t2411-sdexec-job.t
@@ -23,6 +23,8 @@ cat >config/config.toml <<EOT
 [systemd]
 sdbus-debug = true
 sdexec-debug = true
+[exec]
+service-override = true
 EOT
 
 test_under_flux 2 full -o,--config-path=$(pwd)/config

--- a/t/t2411-sdexec-job.t
+++ b/t/t2411-sdexec-job.t
@@ -1,0 +1,67 @@
+#!/bin/sh
+# ci=system
+
+test_description='Test sdexec job launch'
+
+. $(dirname $0)/sharness.sh
+
+if ! flux version | grep systemd; then
+	skip_all="flux was not built with systemd"
+	test_done
+fi
+if ! systemctl --user show --property Version; then
+	skip_all="user systemd is not running"
+	test_done
+fi
+if ! busctl --user status >/dev/null; then
+	skip_all="user dbus is not running"
+	test_done
+fi
+
+mkdir -p config
+cat >config/config.toml <<EOT
+[systemd]
+sdbus-debug = true
+sdexec-debug = true
+EOT
+
+test_under_flux 2 full -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+sdexec="flux exec --service sdexec"
+lptest=${FLUX_BUILD_DIR}/t/shell/lptest
+rkill="flux python ${SHARNESS_TEST_SRCDIR}/scripts/rexec.py kill -s sdexec"
+
+test_expect_success 'job gets exception if sdexec requested but not loaded' '
+	test_must_fail flux run --setattr system.exec.bulkexec.service=sdexec \
+	    -N1 /bin/true 2>except.err &&
+	grep "sdexec service is not loaded" except.err
+'
+test_expect_success 'load sdbus,sdexec modules' '
+	flux exec flux module load sdbus &&
+	flux exec flux module load sdexec
+'
+test_expect_success 'clear broker logs' '
+        flux dmesg -C
+'
+test_expect_success 'incorrect bulkexec.service fails' '
+	test_must_fail flux run --setattr system.exec.bulkexec.service=zzz \
+	    -N1 /bin/true
+'
+test_expect_success '1-node job works' '
+	flux run --setattr system.exec.bulkexec.service=sdexec \
+	    -N1 /bin/true
+'
+test_expect_success 'dump broker logs' '
+        flux dmesg >dmesg.out
+'
+test_expect_success '2-node job works' '
+	flux run --setattr system.exec.bulkexec.service=sdexec \
+	    -N2 /bin/true
+'
+test_expect_success 'remove sdexec,sdbus modules' '
+	flux exec flux module remove sdexec &&
+	flux exec flux module remove sdbus
+'
+test_done

--- a/t/t2412-sdexec-perilog.t
+++ b/t/t2412-sdexec-perilog.t
@@ -68,4 +68,14 @@ test_expect_success 'prolog was run under systemd' '
 test_expect_success 'epilog was run under systemd' '
 	grep "System epilog script" dmesg.out
 '
+test_expect_success 'configured exec service cannot be overridden' '
+	test_must_fail flux run \
+	    --setattr system.exec.bulkexec.service=rexec \
+	    /bin/true
+'
+test_expect_success 'but the default can be over-specified' '
+	flux run \
+	    --setattr system.exec.bulkexec.service=sdexec \
+	    /bin/true
+'
 test_done

--- a/t/t2412-sdexec-perilog.t
+++ b/t/t2412-sdexec-perilog.t
@@ -1,0 +1,71 @@
+#!/bin/sh
+# ci=system
+
+test_description='Test that prolog and epilog can be run under systemd'
+
+. $(dirname $0)/sharness.sh
+
+if ! flux version | grep systemd; then
+	skip_all="flux was not built with systemd"
+	test_done
+fi
+if ! systemctl --user show --property Version; then
+	skip_all="user systemd is not running"
+	test_done
+fi
+if ! busctl --user status >/dev/null; then
+	skip_all="user dbus is not running"
+	test_done
+fi
+
+mkdir -p config
+cat >config/config.toml <<EOT
+[systemd]
+enable = true
+sdbus-debug = true
+sdexec-debug = true
+
+[exec]
+service = "sdexec"
+
+[job-manager]
+plugins = [
+    { load = "perilog.so" }
+]
+prolog.command = [
+   "flux", "perilog-run", "prolog", "--sdexec", "-e", "$(pwd)/flist.sh"
+]
+epilog.command = [
+   "flux", "perilog-run", "epilog", "--sdexec", "-e", "$(pwd)/flist.sh"
+]
+EOT
+
+test_under_flux 1 full -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'create flist.sh script' '
+	cat >flist.sh<<-EOT &&
+	#!/bin/sh
+	systemctl --user list-units --type=service | grep "active running"
+	EOT
+	chmod +x flist.sh
+'
+test_expect_success 'run a single node job and capture broker logs' '
+	flux dmesg -C &&
+	flux run --wait-event=clean -vvv -N1 ./flist.sh >run.out &&
+	flux dmesg >dmesg.out
+'
+# Search for unit descriptions in list-units output as an indication that
+# the task ran under systemd.  These unit descriptions must match what is set
+# in job-exec and flux-perilog.py.
+test_expect_success 'shell was run under systemd' '
+	grep "User workload" run.out
+'
+test_expect_success 'prolog was run under systemd' '
+	grep "System prolog script" dmesg.out
+'
+test_expect_success 'epilog was run under systemd' '
+	grep "System epilog script" dmesg.out
+'
+test_done


### PR DESCRIPTION
This is another step towards enabling jobs to run in systemd so that we can limit their resource consumption and eventually be able to restart the flux system instance without killing the workload.  It adds:
- `sdexec` module which adds a subprocess server, compatible with `libsubprocess`, that runs processes as systemd transient units via the `sdbus` module added in #5070 
- `job-exec` support for running jobs with `--setattr system.exec.bulkexec.service=sdexec` to optionally start job shells in systemd

An internal convenience library `libsdexec` is added which hides some of the gory details of managing transient units via the `sdbus` module.  This simplifies the `sdexec` module a bit.  Even though I'm not sure if there will be other users of it, it seemed helpful to me to think of those interfaces as possibly usable elsewhere and to minimize `sdexec` and `libsubprocess` quirks creeping in.

Testing on this has a way to go and due to taking breaks on this several times I can't remember if there are any gaps I've forgotten about!  But anyway, this is a checkpoint that seems to work.

TODO:

- [x] test on actual cluster
- [x] test job kill, with and without imp
- [x] append broker rank to transient unit name prefix to avoid the unit tracker claiming units of other brokers in test
- [x] libsdexec unit tests to at least cover invalid arguments
- [x] verify/document behavior when systemd and/or dbus restarts (audit code for that in sdbus/sdexec)
- [x] test job with large/complex environment (e.g. when env modules present)
- [x] implement `sdexec.list` and use in tests with `rexec.py` test program
- [x] add ability to configure jobs and perilog to use sdexec
- [x] add some method to control debug logging (also in `sdbus`)
- [x] add containment support as prototyped in #4255