### PR TITLE
broker: foward nonfatal signals to all running jobs

### DIFF
--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -465,9 +465,9 @@ int runat_push_shell_command (struct runat *r,
 
     /*   For shell commands run the target cmdline in a separate process
      *   group so that any processes spawned by the shell will be signaled
-     *   in runat_abort(). This is probably unnecessary for single commands,
-     *   and does not work for an interactive shell (seems to disable access
-     *   to the pty), so we set the flag only here for now.
+     *   in runat_abort(). This does not work for an interactive shell
+     *   (seems to disable access to the pty), so this flag is not set in
+     *   runat_push_shell().
      */
     cmd->flags |= FLUX_SUBPROCESS_FLAGS_SETPGRP;
 
@@ -522,6 +522,13 @@ int runat_push_command (struct runat *r,
     }
     if (!(cmd = runat_command_create (environ, flags)))
         return -1;
+
+    /*   Run the target cmdline in a separate process group so that any
+     *   processes spawned by the new process are also signaled in
+     *   runat_abort().
+     */
+    cmd->flags |= FLUX_SUBPROCESS_FLAGS_SETPGRP;
+
     if (runat_command_set_argz (cmd, argz, argz_len) < 0)
         goto error;
     if (runat_command_modenv (cmd, env_blocklist, r->local_uri) < 0)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -344,6 +344,7 @@ dist_check_SCRIPTS = \
 	issues/t4711-job-list-purge-inactive.sh \
 	issues/t4771-flux-start-bash.sh \
 	issues/t4852-t_submit-legacy.sh \
+	issues/t5105-signal-propagation.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t5105-signal-propagation.sh
+++ b/t/issues/t5105-signal-propagation.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Run an 3 level nested instance, with a test job at the final level
+
+waitfile=$SHARNESS_TEST_SRCDIR/scripts/waitfile.lua
+
+cat <<EOF >test.py
+import signal
+import time
+import flux
+import os
+
+h = flux.Flux()
+level = h.attr_get("instance-level")
+jobid = os.getenv("FLUX_JOB_ID")
+signal.signal(
+    signal.SIGUSR1,
+    lambda x, y: print(f"job {jobid} in level {level} got SIGUSR1", flush=True),
+)
+open("ready", 'a').close()
+signal.pause()
+EOF
+
+id=$(flux submit --output=log flux start \
+     flux run flux start \
+     flux run flux python ./test.py)
+
+$waitfile -t 30 -v ready
+
+flux job kill -s SIGUSR1 $id
+
+$waitfile -t 30 -v -p "got SIGUSR1" log
+
+flux job status --json -v $id
+
+# vi: ts=4 sw=4 expandtab
+


### PR DESCRIPTION
This PR changes the behavior of the broker when handling nonfatal symbols `SIGUSR1`, `SIGUSR2`.

Currently, the broker ignores `SIGUSR1` and `SIGUSR2`, so a user attempting to signal a batch job with `SIGUSR1` to achieve some effect will be disappointed - the signal is ignored.

This PR changes the handling of these signals so that they are forwarded to all active jobs. If there is an error forwarding signals (e.g. the job-manager module is not loaded), then the broker falls back to calling `state_machine_kill()`.

This allows the `SIGUSR` and `SIGUSR2` signals to be propagated to jobs -- i.e. the expected behavior. If one or more jobs are subinstances, then the signal is forwarded to the jobs in that instance, and so on. The test added here ensures that a `SIGUSR1` delivered to a batch job makes it all the way down to a job running at depth 3 in a hierarchy.

Edit: removed references to `SIGALRM`, the handling of this signal is unchanged here.