### PR TITLE
python: support non-JSON formatted data in KVS

### DIFF
--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -35,10 +35,13 @@ class TestKVS(unittest.TestCase):
         kd = flux.kvs.KVSDir(self.f)
         kd[key] = value
         kd.commit()
-        nv = kd[key]
+
+        kd2 = flux.kvs.KVSDir(self.f)
+        nv = kd2[key]
         self.assertEqual(value, nv)
         self.assertTrue(isinstance(nv, type))
-        return kd
+
+        return kd2
 
     def test_set_int(self):
         self.set_and_check_context("int", 10, int)

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -38,8 +38,12 @@ class TestKVS(unittest.TestCase):
 
         kd2 = flux.kvs.KVSDir(self.f)
         nv = kd2[key]
-        self.assertEqual(value, nv)
-        self.assertTrue(isinstance(nv, type))
+        if isinstance(value, bytes) and type is str:
+            self.assertEqual(value.decode('utf-8'), nv)
+        else:
+            self.assertEqual(value, nv)
+        if type is not None:
+            self.assertTrue(isinstance(nv, type))
 
         return kd2
 
@@ -52,8 +56,14 @@ class TestKVS(unittest.TestCase):
     def test_set_string(self):
         self.set_and_check_context("string", "stuff", str)
 
+    def test_set_none(self):
+        self.set_and_check_context("none", None, None)
+
     def test_set_unicode(self):
         self.set_and_check_context("unicode", "\u32db \u263a \u32e1", str)
+
+    def test_set_bytes(self):
+        self.set_and_check_context("bytes", bytes.fromhex("deadbeef"), bytes)
 
     def test_set_list(self):
         self.set_and_check_context("list", [1, 2, 3, 4], list)
@@ -62,6 +72,9 @@ class TestKVS(unittest.TestCase):
         self.set_and_check_context(
             "dict", {"thing": "stuff", "other thing": "more stuff"}, dict
         )
+
+    def test_set_not_legal_json(self):
+        self.set_and_check_context("badjson", b"{", str)
 
     def test_exists_dir(self):
         with flux.kvs.get_dir(self.f) as kd:

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -31,33 +31,33 @@ class TestKVS(unittest.TestCase):
         with flux.kvs.get_dir(self.f) as d:
             self.assertIsNotNone(d)
 
-    def set_and_check_context(self, key, value):
+    def set_and_check_context(self, key, value, type):
         kd = flux.kvs.KVSDir(self.f)
         kd[key] = value
         kd.commit()
         nv = kd[key]
         self.assertEqual(value, nv)
-        self.assertFalse(isinstance(nv, bytes))
+        self.assertTrue(isinstance(nv, type))
         return kd
 
     def test_set_int(self):
-        self.set_and_check_context("int", 10)
+        self.set_and_check_context("int", 10, int)
 
     def test_set_float(self):
-        self.set_and_check_context("float", 10.5)
+        self.set_and_check_context("float", 10.5, float)
 
     def test_set_string(self):
-        self.set_and_check_context("string", "stuff")
+        self.set_and_check_context("string", "stuff", str)
 
     def test_set_unicode(self):
-        self.set_and_check_context("unicode", "\u32db \u263a \u32e1")
+        self.set_and_check_context("unicode", "\u32db \u263a \u32e1", str)
 
     def test_set_list(self):
-        self.set_and_check_context("list", [1, 2, 3, 4])
+        self.set_and_check_context("list", [1, 2, 3, 4], list)
 
     def test_set_dict(self):
         self.set_and_check_context(
-            "dict", {"thing": "stuff", "other thing": "more stuff"}
+            "dict", {"thing": "stuff", "other thing": "more stuff"}, dict
         )
 
     def test_exists_dir(self):
@@ -79,7 +79,7 @@ class TestKVS(unittest.TestCase):
         self.assertTrue(flux.kvs.exists(self.f, "flagcheck"))
 
     def test_remove(self):
-        kd = self.set_and_check_context("todel", "things to delete")
+        kd = self.set_and_check_context("todel", "things to delete", str)
         del kd["todel"]
         kd.commit()
         with self.assertRaises(KeyError):
@@ -96,7 +96,7 @@ class TestKVS(unittest.TestCase):
             self.assertEqual(kd["dir"]["other_thing"], "dirstuff")
 
     def test_set_deep(self):
-        self.set_and_check_context("a.b.c.e.f.j.k", 5)
+        self.set_and_check_context("a.b.c.e.f.j.k", 5, int)
 
     def test_bad_init(self):
         with self.assertRaises(ValueError):

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -31,7 +31,7 @@ class TestKVS(unittest.TestCase):
         with flux.kvs.get_dir(self.f) as d:
             self.assertIsNotNone(d)
 
-    def set_and_check_context(self, key, value, msg=""):
+    def set_and_check_context(self, key, value):
         kd = flux.kvs.KVSDir(self.f)
         kd[key] = value
         kd.commit()


### PR DESCRIPTION
Problem: The KVS python interface writes all data to the KVS in JSON and reads all data back assuming it is formatted in JSON.  This appears to be legacy implementation from the days that all data in the KVS was required to be formatted in JSON.

There are still some benefits to doing this, for example Python lists/dicts can be written/read back easily.  However, there are clear
problems with this, most notably data written in non-JSON format cannot be read from the KVS via the Python interface at all.

Solution: With the goal of not breaking current code, support the following compromise.  If data that is read back is not in JSON format, return it as a string if all the data is UTF-8 valid.  If it is not UTF-8 valid, return it in a Python bytes object.  If data cannot be written in JSON, write it as binary data if the data is a bytes object.

Fixes #5198 