### PR TITLE
zhash_insert()/zhashx_insert() return EEXIST 

### DIFF
--- a/src/broker/groups.c
+++ b/src/broker/groups.c
@@ -121,11 +121,7 @@ static struct group *group_lookup (struct groups *g,
         }
         if (!(group = group_create (name)))
             return NULL;
-        if (zhashx_insert (g->groups, group->name, group) < 0) {
-            group_destroy (group);
-            errno = ENOMEM;
-            return NULL;
-        }
+        (void)zhashx_insert (g->groups, group->name, group);
     }
     return group;
 }

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -432,10 +432,7 @@ static int runat_push (struct runat *r,
     if (!(entry = zhashx_lookup (r->entries, name))) {
         if (!(entry = runat_entry_create (name)))
             return -1;
-        if (zhashx_insert (r->entries, name, entry) < 0) {
-            runat_entry_destroy (entry);
-            return -1;
-        }
+        (void)zhashx_insert (r->entries, name, entry);
     }
     if (zlist_push (entry->commands, cmd) < 0) {
         if (zlist_size (entry->commands) == 0)

--- a/src/broker/service.c
+++ b/src/broker/service.c
@@ -160,10 +160,7 @@ int service_add (struct service_switch *sh, const char *name,
     svc = service_create (uuid);
     svc->cb = cb;
     svc->cb_arg = arg;
-    if (zhash_insert (sh->services, name, svc) < 0) {
-        errno = ENOMEM;
-        goto error;
-    }
+    (void)zhash_insert (sh->services, name, svc);
     zhash_freefn (sh->services, name, (zhash_free_fn *)service_destroy);
     return 0;
 error:

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -117,8 +117,7 @@ void completion_cb (flux_subprocess_t *p)
             if (!(idset = idset_create (rank_range, 0)))
                 log_err_exit ("idset_create");
             (void)zhashx_insert (exitsets, buf, idset);
-            if (!zhashx_freefn (exitsets, buf, idset_destroy_wrapper))
-                log_err_exit ("zhashx_freefn");
+            (void)zhashx_freefn (exitsets, buf, idset_destroy_wrapper);
         }
 
         if (idset_set (idset, rank) < 0)

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -116,8 +116,7 @@ void completion_cb (flux_subprocess_t *p)
         if (!(idset = zhashx_lookup (exitsets, buf))) {
             if (!(idset = idset_create (rank_range, 0)))
                 log_err_exit ("idset_create");
-            if (zhashx_insert (exitsets, buf, idset) < 0)
-                log_err_exit ("zhashx_insert");
+            (void)zhashx_insert (exitsets, buf, idset);
             if (!zhashx_freefn (exitsets, buf, idset_destroy_wrapper))
                 log_err_exit ("zhashx_freefn");
         }

--- a/src/common/libflux/composite_future.c
+++ b/src/common/libflux/composite_future.c
@@ -204,8 +204,10 @@ int flux_future_push (flux_future_t *f, const char *name, flux_future_t *child)
             return -1;
         name = anon;
     }
-    if (zhash_insert (cf->children, name, child) < 0)
+    if (zhash_insert (cf->children, name, child) < 0) {
+        errno = EEXIST;
         goto done;
+    }
     zhash_freefn (cf->children, name, (flux_free_f) flux_future_destroy);
     if (flux_future_aux_set (child, "flux::parent", f, NULL) < 0) {
         zhash_delete (cf->children, name);

--- a/src/common/libkvs/kvs_txn_compact.c
+++ b/src/common/libkvs/kvs_txn_compact.c
@@ -275,7 +275,7 @@ int txn_compact (flux_kvs_txn_t *txn)
                     goto error;
                 }
                 if (zhash_insert (append_keys, key, ck) < 0) {
-                    errno = ENOMEM;
+                    errno = EEXIST;
                     goto error;
                 }
                 zhash_freefn (append_keys, key, compact_key_destroy);

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -1605,16 +1605,7 @@ static zhashx_t *rlist_properties (struct rlist *rl)
                         errno = ENOMEM;
                         goto error;
                     }
-                    /* This zhashx_insert() cannot fail since we are
-                     *  guaranteed that `name` is not set in properties
-                     *  hash. However, check for error return in case
-                     *  zhashx_insert() returns -1 on ENOMEM in the future.
-                     */
-                    if (zhashx_insert (properties, name, ids) < 0) {
-                        idset_destroy (ids);
-                        errno = ENOMEM;
-                        goto error;
-                    }
+                    (void)zhashx_insert (properties, name, ids);
                 }
                 if (idset_set (ids, n->rank) < 0)
                     goto error;

--- a/src/common/librouter/disconnect.c
+++ b/src/common/librouter/disconnect.c
@@ -173,10 +173,7 @@ int disconnect_arm (struct disconnect *dcon, const flux_msg_t *msg)
         flux_msg_t *dmsg;
         if (!(dmsg = disconnect_msg (msg)))
             return -1;
-        if (zhashx_insert (dcon->hash, key, dmsg) < 0) {
-            flux_msg_destroy (dmsg);
-            return -1;
-        }
+        (void)zhashx_insert (dcon->hash, key, dmsg);
     }
     return 0;
 }

--- a/src/common/libsubprocess/command.c
+++ b/src/common/libsubprocess/command.c
@@ -309,7 +309,7 @@ static zhash_t *zhash_fromjson (json_t *o)
             goto fail;
         if (zhash_insert (h, key, (char *) json_string_value (val)) < 0) {
             /* Duplicate key. This can't happen unless json object is
-             *  corrupt, so give up and return error (EINVAL)
+             *  corrupt, so give up and return error (EPROTO)
              */
             goto fail;
         }

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -271,6 +271,7 @@ static int channel_local_setup (flux_subprocess_t *p,
 
     if (zhash_insert (p->channels, name, c) < 0) {
         llog_debug (p, "zhash_insert failed");
+        errno = EEXIST;
         goto error;
     }
     if (!zhash_freefn (p->channels, name, channel_destroy)) {

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -414,6 +414,7 @@ static int remote_channel_setup (flux_subprocess_t *p,
 
     if (zhash_insert (p->channels, name, c) < 0) {
         llog_debug (p, "zhash_insert failed");
+        errno = EEXIST;
         goto error;
     }
     if (!zhash_freefn (p->channels, name, channel_destroy)) {

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1157,6 +1157,7 @@ static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
     }
 
     if (zhashx_insert (ctx->jobs, &job->id, job) < 0) {
+        errno = EEXIST;
         flux_log_error (ctx->h, "zhashx_insert");
         jobinfo_fatal_error (job, errno, "failed to hash job");
         return -1;

--- a/src/modules/job-list/idsync.c
+++ b/src/modules/job-list/idsync.c
@@ -202,8 +202,7 @@ static int idsync_add_waiter (struct idsync_ctx *isctx,
         zlistx_set_destructor (iwl->l, idsync_data_destroy_wrapper);
         iwl->id = isd->id;
 
-        if (zhashx_insert (isctx->waits, &iwl->id, iwl) < 0)
-            goto enomem;
+        (void)zhashx_insert (isctx->waits, &iwl->id, iwl);
     }
 
     if (!zlistx_add_end (iwl->l, isd))

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -729,8 +729,10 @@ static int depthfirst_map_one (struct job_state_ctx *jsctx,
     if (job->states_mask & FLUX_JOB_STATE_INACTIVE)
         eventlog_inactive_complete (job);
 
-    if (zhashx_insert (jsctx->index, &job->id, job) < 0)
+    if (zhashx_insert (jsctx->index, &job->id, job) < 0) {
+        errno = EEXIST;
         goto done;
+    }
 
     if (job_insert_list (jsctx, job, job->state) < 0)
         goto done;
@@ -934,7 +936,7 @@ static int journal_submit_event (struct job_state_ctx *jsctx,
             return -1;
         if (zhashx_insert (jsctx->index, &job->id, job) < 0) {
             job_destroy (job);
-            errno = ENOMEM;
+            errno = EEXIST;
             return -1;
         }
         /* job always starts off on processing list */

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -69,14 +69,7 @@ static struct job_stats *queue_stats_lookup (struct job_stats_ctx *statsctx,
     if (!stats) {
         if (!(stats = calloc (1, sizeof (*stats))))
             return NULL;
-        if (zhashx_insert (statsctx->queue_stats, job->queue, stats) < 0) {
-            flux_log (statsctx->h,
-                      LOG_ERR,
-                      "%s: zhashx_insert: out of memory",
-                      __FUNCTION__);
-            free (stats);
-            return NULL;
-        }
+        (void)zhashx_insert (statsctx->queue_stats, job->queue, stats);
     }
     return stats;
 }

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -1084,16 +1084,7 @@ int event_index (struct event *event, const char *name)
     void *entry = zhashx_lookup (event->evindex, name);
     if (!entry) {
         entry = int2ptr (((int) zhashx_size (event->evindex) + 1));
-        if (zhashx_insert (event->evindex, name, entry) < 0) {
-            /*
-             *  insertion only fails on duplicate entry, which we know
-             *   is not possible in this case. However, cover ENOMEM
-             *   case here in case assert-on-malloc failure is fixed
-             *   in the future for zhashx.
-             */
-            errno = ENOMEM;
-            return -1;
-        }
+        (void)zhashx_insert (event->evindex, name, entry);
     }
     return ptr2int (entry);
 }

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1298,8 +1298,12 @@ flux_plugin_t * jobtap_load (struct jobtap *jobtap,
         goto error;
 
     char *uuid = (char *)flux_plugin_get_uuid (p);
-    if (zhashx_insert (jobtap->plugins_byuuid, uuid, p) < 0
-        || !zlistx_add_end (jobtap->plugins, p)) {
+    if (zhashx_insert (jobtap->plugins_byuuid, uuid, p) < 0) {
+        errprintf (errp, "Error adding plugin to list");
+        errno = EEXIST;
+        goto error;
+    }
+    if (!zlistx_add_end (jobtap->plugins, p)) {
         zhashx_delete (jobtap->plugins_byuuid, uuid);
         errprintf (errp, "Out of memory adding plugin to list");
         errno = ENOMEM;

--- a/src/modules/job-manager/plugins/limit-duration.c
+++ b/src/modules/job-manager/plugins/limit-duration.c
@@ -91,13 +91,9 @@ static double queues_lookup (zhashx_t *queues, const char *name)
     return DURATION_INVALID;
 }
 
-static int queues_insert (zhashx_t *queues, const char *name, double duration)
+static void queues_insert (zhashx_t *queues, const char *name, double duration)
 {
-    if (zhashx_insert (queues, name, &duration) < 0) { // dups duration
-        errno = ENOMEM;
-        return -1;
-    }
-    return 0;
+    (void)zhashx_insert (queues, name, &duration); // dups duration
 }
 
 static void limit_duration_destroy (struct limit_duration *ctx)
@@ -180,10 +176,7 @@ static int queues_parse (zhashx_t **zhp,
                 errprintf (error, "queues.%s.%s", name, e.text);
                 goto error;
             }
-            if (queues_insert (zh, name, duration) < 0) {
-                errprintf (error, "out of memory parsing [queues]");
-                goto error;
-            }
+            queues_insert (zh, name, duration);
         }
     }
     *zhp = zh;

--- a/src/modules/job-manager/plugins/limit-job-size.c
+++ b/src/modules/job-manager/plugins/limit-job-size.c
@@ -160,15 +160,11 @@ static zhashx_t *queues_create (void)
     return queues;
 }
 
-static int queues_insert (zhashx_t *queues,
-                          const char *name,
-                          struct limits *limits)
+static void queues_insert (zhashx_t *queues,
+                           const char *name,
+                           struct limits *limits)
 {
-    if (zhashx_insert (queues, name, limits) < 0) { // dups limits
-        errno = ENOMEM;
-        return -1;
-    }
-    return 0;
+    (void)zhashx_insert (queues, name, limits); // dups limits
 }
 
 static struct limits *queues_lookup (zhashx_t *queues, const char *name)
@@ -291,10 +287,7 @@ static int queues_parse (zhashx_t **zhp,
                 errprintf (error, "queues.%s.%s", name, e.text);
                 goto error;
             }
-            if (queues_insert (zh, name, &limits) < 0) {
-                errprintf (error, "out of memory parsing [queues]");
-                goto error;
-            }
+            queues_insert (zh, name, &limits);
         }
     }
     *zhp = zh;

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -92,6 +92,7 @@ static struct perilog_proc * perilog_proc_create (flux_plugin_t *p,
     proc->sp = sp;
     if (zhashx_insert (perilog_config.processes, &proc->id, proc) < 0) {
         free (proc);
+        errno = EEXIST;
         return NULL;
     }
     return proc;

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -458,11 +458,9 @@ static int queue_configure (const flux_conf_t *conf,
          */
         json_object_foreach (queues, name, value) {
             if (!zhashx_lookup (queue->named, name)) {
-                if (!(q = jobq_create (name))
-                    || zhashx_insert (queue->named, name, q) < 0) {
-                    jobq_destroy (q);
+                if (!(q = jobq_create (name)))
                     goto nomem;
-                }
+                (void)zhashx_insert (queue->named, name, q);
             }
         }
     }

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -926,10 +926,7 @@ struct ns_monitor *namespace_monitor (struct watch_ctx *ctx,
     if (!(nsm = zhash_lookup (ctx->namespaces, ns))) {
         if (!(nsm = namespace_create (ctx, ns)))
             return NULL;
-        if (zhash_insert (ctx->namespaces, ns, nsm) < 0) {
-            namespace_destroy (nsm);
-            return NULL;
-        }
+        (void)zhash_insert (ctx->namespaces, ns, nsm);
         zhash_freefn (ctx->namespaces, ns,
                       (zhash_free_fn *)namespace_destroy);
         /* store future in namespace, so namespace can be destroyed

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -150,6 +150,7 @@ struct kvsroot *kvsroot_mgr_create_root (kvsroot_mgr_t *krm,
     root->remove = false;
 
     if (zhash_insert (krm->roothash, ns, root) < 0) {
+        errno = EEXIST;
         flux_log_error (krm->h, "zhash_insert");
         goto error;
     }

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -995,7 +995,7 @@ static int shell_output_type_file_setup (struct shell_output *out,
         goto error;
 
     if (zhash_insert (out->fds, ofp->path, fdp) < 0) {
-        errno = ENOMEM;
+        errno = EEXIST;
         goto error;
     }
     zhash_freefn (out->fds, ofp->path, shell_output_fd_destroy);


### PR DESCRIPTION
Problem: zhash_insert() and zhashx_insert() return -1 when a duplicate entry exists, NOT when the process is out of memory.  However, a number of locations assume it returns when out of memory and set errno = ENOMEM as a result.

Do not assume zhash_insert()/zhashx_insert() fail on memory allocation errors.  Always ssume duplicate entry.  When necessary set/return errno = EEXIST instead of ENOMEM.

Fixes https://github.com/flux-framework/flux-core/issues/5216

Notes:

My initial reason for doing this was just to make things consistent b/c there was inconsistency in `flux-core`.   Don't know how necessary this is ... Maybe this was just a pointless excercise ... but since I did it, here's the PR :P

There were obviously borderline cases.  Maybe another approach would be to set errno = ENOMEM when a `zhash_insert()` is done directly after a `zhash_lookup()`?
                                                                                                                                            
                                                                                