### PR TITLE
testsuite: increase test expiration

### DIFF
--- a/t/issues/t4184-sched-simple-restart.sh
+++ b/t/issues/t4184-sched-simple-restart.sh
@@ -31,13 +31,13 @@ flux job wait-event \$id clean
 
 echo "t4184: waiting for \$id2 to start..."
 
-flux job wait-event -t 15 \$id2 start
+flux job wait-event -t 100 \$id2 start
 
 echo "t4184: canceling \$id2..."
 flux cancel \$id2
 
 echo "t4184: waiting for \$id2 to end..."
-flux job wait-event -t 15 \$id2 clean
+flux job wait-event -t 100 \$id2 clean
 
 EOF
 

--- a/t/issues/t4227-test.sh
+++ b/t/issues/t4227-test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
-flux run -vvv hostname 
+flux run -vvv hostname
 flux submit -vvv --wait hostname

--- a/t/issues/t4331-job-manager-purged-events.sh
+++ b/t/issues/t4331-job-manager-purged-events.sh
@@ -8,7 +8,7 @@ EVENTS_JOURNAL_STREAM=${FLUX_BUILD_DIR}/t/job-manager/events_journal_stream
 wait_jobid_event() {
     local file=$1
     local jobid=$2
-    for i in `seq 1 30`
+    for i in `seq 1 100`
     do
         if grep -q ${jobid} ${file}
         then
@@ -16,7 +16,7 @@ wait_jobid_event() {
         fi
         sleep 1
     done
-    if [ "${i}" -eq "30" ]
+    if [ "${i}" -eq "100" ]
     then
         return 1
     fi

--- a/t/issues/t4583-free-range-test.sh
+++ b/t/issues/t4583-free-range-test.sh
@@ -57,10 +57,10 @@ log "Killing rank 3 (pid %d) and all children\n" $broker_pid
 kill -9 $(list_descendants $broker_pid) $broker_pid
 
 log "Wait for exception event in $jobid\n"
-flux job wait-event -t 5 $jobid exception
+flux job wait-event -t 100 $jobid exception
 
 log "But running a 3 node job in $jobid still works:\n"
-flux proxy $jobid flux run -t 5s -N3 hostname
+flux proxy $jobid flux run -t 100s -N3 hostname
 
 log "Overlay status of $jobid should show rank offline:\n"
 flux proxy $jobid flux overlay status
@@ -69,7 +69,7 @@ log "Call flux shutdown on $jobid\n"
 flux shutdown --quiet $jobid
 
 log "job $jobid should exit cleanly (no hang) and a zero exit code:\n"
-flux job wait-event -t 2 $jobid finish
+flux job wait-event -t 100 $jobid finish
 
 log "dump output from job:\n\n"
 flux job attach $jobid

--- a/t/issues/t4583-free-range-test.sh
+++ b/t/issues/t4583-free-range-test.sh
@@ -42,7 +42,7 @@ log "Started job $jobid\n"
 
 #  Run a job on all ranks of child job
 log "Current overlay status of $jobid:\n"
-flux proxy $jobid flux overlay status 
+flux proxy $jobid flux overlay status
 
 log "Launch a sleep job within $jobid:\n"
 flux proxy $jobid flux submit -N4 sleep inf
@@ -63,7 +63,7 @@ log "But running a 3 node job in $jobid still works:\n"
 flux proxy $jobid flux run -t 5s -N3 hostname
 
 log "Overlay status of $jobid should show rank offline:\n"
-flux proxy $jobid flux overlay status 
+flux proxy $jobid flux overlay status
 
 log "Call flux shutdown on $jobid\n"
 flux shutdown --quiet $jobid

--- a/t/issues/t4612-eventlog-overwrite-crash.sh
+++ b/t/issues/t4612-eventlog-overwrite-crash.sh
@@ -14,7 +14,7 @@ kvsdir=$(flux job id --to=kvs $jobid)
 flux job attach $jobid > t4612.out &
 
 # ensure backgrounded process has started to monitor eventlog
-$waitfile --count=1 --timeout=30 --pattern=foo t4612.out
+$waitfile --count=1 --timeout=100 --pattern=foo t4612.out
 
 # now overwrite the eventlog without changing its length
 flux kvs get --raw ${kvsdir}.eventlog \

--- a/t/issues/t5105-signal-propagation.sh
+++ b/t/issues/t5105-signal-propagation.sh
@@ -24,11 +24,11 @@ id=$(flux submit --output=log flux start \
      flux run flux start \
      flux run flux python ./test.py)
 
-$waitfile -t 30 -v ready
+$waitfile -t 100 -v ready
 
 flux job kill -s SIGUSR1 $id
 
-$waitfile -t 30 -v -p "got SIGUSR1" log
+$waitfile -t 100 -v -p "got SIGUSR1" log
 
 flux job status --json -v $id
 

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -79,7 +79,7 @@ test_expect_success 'instance functions with late-joiner' '
 	echo "0" >late.exp &&
 	rm -f fifo &&
 	mkfifo fifo &&
-	run_timeout 10 \
+	run_timeout 60 \
 		flux start -s2 \
 		-o,-Slog-stderr-level=6 \
 		-o,-Sbroker.rc1_path="$(pwd)/rc1_block" \

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -12,7 +12,7 @@ echo "# $0: flux session size will be ${SIZE}"
 
 ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
 test_expect_success "flux can run flux instance as a job" '
-	run_timeout 10 flux run -n1 -N1 \
+	run_timeout 60 flux run -n1 -N1 \
 		flux start ${ARGS} flux getattr size >size.out &&
 	echo 1 >size.exp &&
 	test_cmp size.exp size.out

--- a/t/t4000-issues-test-driver.t
+++ b/t/t4000-issues-test-driver.t
@@ -18,7 +18,7 @@ if test -z "$T4000_ISSUES_GLOB"; then
     T4000_ISSUES_GLOB="*"
 fi
 
-flux bulksubmit -n1 -o pty --job-name={./%} -t 2m \
+flux bulksubmit -n1 -o pty --job-name={./%} -t 10m \
 	--flags=waitable \
 	--quiet --watch  \
 	flux start {} \


### PR DESCRIPTION
Problem: The regression tests in t/issues are now run in parallel, which can increase the chance of test timeouts / failures when a large parallel run of the test suite is done.

Increase the timelimit of each issue to 10m from 2m.  For extra good measure, increase the timeouts of several waits / etc. in several tests under t/issues.