### PR TITLE
testsuite: fix potential flux-top race

### DIFF
--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -385,6 +385,11 @@ int main (int argc, char *argv[])
                             optparse_get_str (opts, "queue", NULL),
                             &error)))
         fatal (0, "%s", error.text);
+    /* top_create() call above will call initial "draw" routines.  We
+     * do not want those draws to output anything during testing with
+     * the --test-exit-dump option.  Thus we handle --test-exit and
+     * --test-exit-dump setup after the top_create() call.
+     */
     if (optparse_hasopt (opts, "test-exit")) {
         const char *file;
         top->test_exit = 1;

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -20,6 +20,12 @@ job_list_wait_state() {
 	flux job list-ids --wait-state=$2 $1 > /dev/null
 }
 
+# flux-top will redraw panes when a heartbeat is received, which could
+# lead to racy output with tests below.  Remove the heartbeat module to
+# remove this possibility.
+test_expect_success 'set high heartbeat period' '
+	flux module remove heartbeat
+'
 test_expect_success 'flux-top -h prints custom usage' '
 	flux top -h 2>usage &&
 	grep "Usage:.*TARGET" usage


### PR DESCRIPTION
Problem: The flux-top command can redraw output when a heartbeat
is received.  On a slow system, such as during a large parallel
run of the testsuite, its possible the heartbeat could arrive before
a test completes, resulting in unexpected output and a failing test.

Solution: In t2801-top-cmd.t, reload the heartbeat module with a much
longer heartbeat period.

Fixes https://github.com/flux-framework/flux-core/issues/5223