### PR TITLE
libsubprocess: fail with ESRCH when pid cannot be found

### DIFF
--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -601,7 +601,7 @@ int remote_exec (flux_subprocess_t *p)
     flux_future_t *f;
     int flags = 0;
 
-    if (p->ops.on_channel_out)
+    if (zlist_size (cmd_channel_list (p->cmd)) > 0)
         flags |= SUBPROCESS_REXEC_CHANNEL;
     if (p->ops.on_stdout)
         flags |= SUBPROCESS_REXEC_STDOUT;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -102,7 +102,7 @@ static flux_subprocess_t *proc_find_bypid (subprocess_server_t *s, pid_t pid)
             return p;
         p = zlistx_next (s->subprocesses);
     }
-    errno = ENOENT;
+    errno = ESRCH;
     return NULL;
 }
 

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -278,4 +278,9 @@ test_expect_success NO_CHAIN_LINT 'ps, kill fail remotely on rank 0' '
 	wait_rexec_process_count 0 0
 '
 
+test_expect_success NO_CHAIN_LINT 'kill fails with ESRCH when pid is unknown' '
+	test_must_fail $rexec_script kill 15 12345678 2>kill.err &&
+	grep "No such process" kill.err
+'
+
 test_done


### PR DESCRIPTION
Problem: when `rexec.kill` cannot look up a pid, it fails with ENOENT (No such file or directory).

Fail with ESRCH (No such process) instead.

Also, don't set the SUBPROCESS_REXEC_CHANNEL flag for a remote subprocess if an `on_channel_out` callback is registered, but no channels are configured.

This was peeled off of #5197.