### PR TITLE
testsuite: fix tests when run in debug mode

### DIFF
--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -140,9 +140,9 @@ test_expect_success 'submit jobs for job list testing' '
 	#  the job-manager queue.  To ensure no raciness in tests, ensure
 	#  jobs above have reached expected states in job-list before continuing.
 	#
-	flux job list-ids --wait-state=sched $(job_list_state_ids pending) &&
-	flux job list-ids --wait-state=run $(job_list_state_ids running) &&
-	flux job list-ids --wait-state=inactive $(job_list_state_ids inactive)
+	flux job list-ids --wait-state=sched $(job_list_state_ids pending) > /dev/null &&
+	flux job list-ids --wait-state=run $(job_list_state_ids running) > /dev/null &&
+	flux job list-ids --wait-state=inactive $(job_list_state_ids inactive) > /dev/null
 '
 
 # Note: "running" = "run" | "cleanup", we also test just "run" state

--- a/t/t2261-job-list-update.t
+++ b/t/t2261-job-list-update.t
@@ -85,9 +85,9 @@ test_expect_success 'submit jobs for job list testing' '
         #  the job-manager queue.  To ensure no raciness in tests, ensure
         #  jobs above have reached expected states in job-list before continuing.
         #
-        flux job list-ids --wait-state=sched $(job_list_state_ids pending) &&
-        flux job list-ids --wait-state=run $(job_list_state_ids running) &&
-        flux job list-ids --wait-state=inactive $(job_list_state_ids inactive)
+        flux job list-ids --wait-state=sched $(job_list_state_ids pending) > /dev/null &&
+        flux job list-ids --wait-state=run $(job_list_state_ids running) > /dev/null &&
+        flux job list-ids --wait-state=inactive $(job_list_state_ids inactive) > /dev/null
 '
 
 # Note: "running" = "run" | "cleanup", we also test just "run" state

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -137,9 +137,9 @@ test_expect_success 'submit jobs for job list testing' '
 	#  the job-manager queue.  To ensure no raciness in tests, ensure
 	#  jobs above have reached expected states in job-list before continuing.
 	#
-	flux job list-ids --wait-state=sched $(job_list_state_ids sched) &&
-	flux job list-ids --wait-state=run $(job_list_state_ids run) &&
-	flux job list-ids --wait-state=inactive $(job_list_state_ids inactive)
+	flux job list-ids --wait-state=sched $(job_list_state_ids sched) > /dev/null &&
+	flux job list-ids --wait-state=run $(job_list_state_ids run) > /dev/null &&
+	flux job list-ids --wait-state=inactive $(job_list_state_ids inactive) > /dev/null
 '
 
 #


### PR DESCRIPTION
Problem: flux job list-ids will error out when output is to stdout instead of a file.  Recent testsuite cleanup did not consider this fact when tests are run in debug mode.

Solution: When using flux job list-ids always redirect to a file. Fix offending cases in t2260-job-list.t, t2261-job-list-update.t, and t2800-jobs-cmd.t by redirecting to /dev/null.

Fixes #5230