### PR TITLE
add `--conf` option for registering instance config in `flux-batch` and `flux-alloc`

### DIFF
--- a/doc/man1/common/submit-other-options.rst
+++ b/doc/man1/common/submit-other-options.rst
@@ -48,6 +48,32 @@ OTHER OPTIONS
    encode multiple files.  Note: As documented in RFC 14, the file names
    ``script`` and ``conf.json`` are both reserved.
 
+**--conf=FILE|KEY=VAL|STRING**
+   The ``--conf`` option allows configuration for a Flux instance started
+   via ``flux-batch(1)`` or ``flux-alloc(1)`` to be iteratively built on
+   the command line. On first use, a ``conf.json`` entry is added to the
+   internal jobspec file archive, and ``-c{{tmpdir}}/conf.json`` is added
+   to the flux broker command line. Each subsequent use of the ``--conf``
+   option updates this configuration.
+
+   The argument to ``--conf`` may be in one of several forms:
+
+   * A multiline string, e.g. from a batch directive. In this case the string
+     is parsed as JSON or TOML::
+
+      # flux: --conf="""
+      # flux: [resource]
+      # flux: exclude = "0"
+      # flux: """
+
+   * A string containing a ``=`` character, in which case the argument is
+     parsed as ``KEY=VAL``, where ``VAL`` is parsed as JSON, e.g.::
+
+      --conf=resource.exclude=\"0\"
+
+   * A string ending in ``.json`` or ``.toml``, in which case configuration
+     is loaded from a JSON or TOML file.
+
 **--begin-time=+FSD|DATETIME**
    Convenience option for setting a ``begin-time`` dependency for a job.
    The job is guaranteed to start after the specified date and time.

--- a/doc/man1/common/submit-other-options.rst
+++ b/doc/man1/common/submit-other-options.rst
@@ -48,7 +48,7 @@ OTHER OPTIONS
    encode multiple files.  Note: As documented in RFC 14, the file names
    ``script`` and ``conf.json`` are both reserved.
 
-**--conf=FILE|KEY=VAL|STRING**
+**--conf=FILE|KEY=VAL|STRING|NAME**
    The ``--conf`` option allows configuration for a Flux instance started
    via ``flux-batch(1)`` or ``flux-alloc(1)`` to be iteratively built on
    the command line. On first use, a ``conf.json`` entry is added to the
@@ -73,6 +73,17 @@ OTHER OPTIONS
 
    * A string ending in ``.json`` or ``.toml``, in which case configuration
      is loaded from a JSON or TOML file.
+
+   * If none of the above conditions match, then the argument ``NAME`` is
+     assumed to refer to a "named" config file ``NAME.toml`` or ``NAME.json``
+     within the following search path, in order of precedence:
+
+     - ``XDG_CONFIG_HOME/flux/config`` or ``$HOME/.config/flux/config`` if
+       ``XDG_CONFIG_HOME`` is not set
+
+     - ``$XDG_CONFIG_DIRS/flux/config`` or ``/etc/xdg/flux/config`` if
+       ``XDG_CONFIG_DIRS`` is not set. Note that ``XDG_CONFIG_DIRS`` may
+       be a colon-separated path.
 
 **--begin-time=+FSD|DATETIME**
    Convenience option for setting a ``begin-time`` dependency for a job.

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -470,7 +470,7 @@ The ``flux-jobs`` command supports registration of named output formats
 in configuration files. The command loads configuration files from
 ``flux-jobs.EXT`` from the following paths in order of increasing precedence:
 
- * ``$XDG_CONFIG_DIRS/flux`` or ``/etc/flux/xdg`` if ``XDG_CONFIG_DIRS`` is
+ * ``$XDG_CONFIG_DIRS/flux`` or ``/etc/xdg/flux`` if ``XDG_CONFIG_DIRS`` is
    not set. Note that ``XDG_CONFIG_DIRS`` is traversed in reverse order
    such that entries first in the colon separated path are highest priority.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -706,3 +706,5 @@ unbuffered
 statex
 pmix
 SIGUSR
+iteratively
+noverify

--- a/src/bindings/python/flux/cli/alloc.py
+++ b/src/bindings/python/flux/cli/alloc.py
@@ -70,6 +70,7 @@ class AllocCmd(base.MiniCmd):
             num_nodes=args.nodes,
             broker_opts=base.list_split(args.broker_opts),
             exclusive=args.exclusive,
+            conf=args.conf.config,
         )
 
         #  For --bg, always allocate a pty, but not interactive,

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -18,6 +18,7 @@ import fnmatch
 import json
 import logging
 import os
+import pathlib
 import re
 import resource
 import signal
@@ -28,12 +29,18 @@ from os.path import basename
 from string import Template
 from urllib.parse import parse_qs, urlparse
 
+try:
+    import tomllib  # novermin
+except ModuleNotFoundError:
+    from flux.utils import tomli as tomllib
+
 import flux
 from flux import debugged, job, util
 from flux.constraint.parser import ConstraintParser, ConstraintSyntaxError
 from flux.idset import IDset
 from flux.job import JobspecV1
 from flux.progress import ProgressBar
+from flux.util import dict_merge, set_treedict
 
 LOGGER = logging.getLogger("flux")
 
@@ -373,6 +380,100 @@ class EnvFilterAction(argparse.Action):
             items = []
         items.append("-" + values)
         setattr(namespace, "env", items)
+
+
+class BatchConfig:
+    """Convenience class for handling a --conf=[FILE|KEY=VAL] option
+
+    Iteratively build a "config" dict from successive updates.
+    """
+
+    def __init__(self):
+        self.config = None
+
+    def update_string(self, value):
+        # Update config with JSON or TOML string
+        try:
+            conf = json.loads(value)
+        except json.decoder.JSONDecodeError:
+            # Try TOML
+            try:
+                conf = tomllib.loads(value)
+            except tomllib.TOMLDecodeError:
+                raise ValueError(
+                    "--conf: failed to parse multiline as TOML or JSON"
+                ) from None
+        self.config = dict_merge(self.config, conf)
+        return self
+
+    def update_keyval(self, keyval):
+        # dotted key (e.g. resource.noverify=true)
+        key, _, value = keyval.partition("=")
+        try:
+            value = json.loads(value)
+        except json.decoder.JSONDecodeError:
+            value = str(value)
+        set_treedict(self.config, key, value)
+        return self
+
+    def update_file(self, path, extension=".toml"):
+        # Update from file in the filesystem
+        if extension == ".json":
+            loader = json.load
+        elif extension == ".toml":
+            loader = tomllib.load
+        else:
+            raise ValueError("--conf: {path} must end in .toml or .json")
+        try:
+            with open(path, "rb") as fp:
+                conf = loader(fp)
+        except OSError as exc:
+            raise ValueError(f"--conf: {exc}") from None
+        except (json.decoder.JSONDecodeError, tomllib.TOMLDecodeError) as exc:
+            raise ValueError(f"--conf: parse error: {path}: {exc}") from None
+        self.config = dict_merge(self.config, conf)
+        return self
+
+    def update_named_config(self, name):
+        raise NotImplementedError("--conf: no named config support") from None
+
+    def update(self, value):
+        """
+        Update current config with value using the following rules:
+        - If value contains one or more newlines, parse it as a JSON or
+          TOML string.
+        - Otherwise, if value contains an ``=``, then parse it as a dotted
+          key and value, e.g. ``resource.noverify=true``. The value (part
+          after the ``=``) will be parsed as JSON.
+        - Otherwise, if value ends in ``.toml`` or ``.json`` treat value as
+          a path and attempt to parse contents of file as TOML or JSON.
+        - (Future extension: If path does not exist, read a named config from
+           a configuration repository in the local filesystem)
+
+        Configuration can be updated iteratively. The end result is available
+        in the ``config`` attribute.
+        """
+        if self.config is None:
+            self.config = {}
+        if "\n" in value:
+            return self.update_string(value)
+        if "=" in value:
+            return self.update_keyval(value)
+        extension = pathlib.Path(value).suffix
+        if extension in (".toml", ".json"):
+            return self.update_file(value, extension)
+        return self.update_named_config(value)
+
+
+class ConfAction(argparse.Action):
+    """Handle batch/alloc --conf option"""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        conf = getattr(namespace, "conf", None)
+        if conf is None:
+            conf = BatchConfig()
+            setattr(namespace, "conf", conf)
+        conf.update(values)
 
 
 class Xcmd:
@@ -1595,6 +1696,16 @@ def add_batch_alloc_args(parser):
     Add "batch"-specific resource allocation arguments to parser object
     which deal in slots instead of tasks.
     """
+    parser.add_argument(
+        "--conf",
+        metavar="CONF",
+        default=BatchConfig(),
+        action=ConfAction,
+        help="Set configuration for a child Flux instance. CONF may be a "
+        + "multiline string in JSON or TOML, a configuration key=value, or a "
+        + "path to a JSON or TOML file. This option may specified multiple "
+        + "times, in which case the config is iteratively updated.",
+    )
     parser.add_argument(
         "--broker-opts",
         metavar="OPTS",

--- a/src/bindings/python/flux/cli/batch.py
+++ b/src/bindings/python/flux/cli/batch.py
@@ -116,6 +116,7 @@ class BatchCmd(base.MiniCmd):
             num_nodes=args.nodes,
             broker_opts=base.list_split(args.broker_opts),
             exclusive=args.exclusive,
+            conf=args.conf.config,
         )
 
         # Default output is flux-{{jobid}}.out

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -987,6 +987,23 @@ def dict_merge(src, new):
     return src
 
 
+def xdg_searchpath(subdir=""):
+    """
+    Build standard Flux config search path based on XDG specification
+    """
+    #  Start with XDG_CONFIG_HOME (or ~/.config) since it is the
+    #  highest precedence:
+    confdirs = [os.getenv("XDG_CONFIG_HOME") or f"{Path.home()}/.config"]
+
+    #  Append XDG_CONFIG_DIRS as colon separated path (or /etc/xdg)
+    #  Note: colon separated paths are in order of precedence.
+    confdirs += (os.getenv("XDG_CONFIG_DIRS") or "/etc/xdg").split(":")
+
+    #  Append "/flux" (with optional subdir) to all members of
+    #  confdirs to build searchpath:
+    return [Path(directory, "flux", subdir) for directory in confdirs]
+
+
 class UtilConfig:
     """
     Very simple class for loading hierarchical configuration for Flux
@@ -1032,17 +1049,7 @@ class UtilConfig:
         #  specification. Later this will be reversed since we want
         #  to traverse the paths in _reverse_ precedence order in this
         #  implementation.
-        #
-        #  Start with XDG_CONFIG_HOME (or ~/.config) since it is the
-        #  highest precedence:
-        confdirs = [os.getenv("XDG_CONFIG_HOME") or f"{Path.home()}/.config"]
-
-        #  Append XDG_CONFIG_DIRS as colon separated path (or /etc/xdg)
-        #  Note: colon separated paths are in order of precedence.
-        confdirs += (os.getenv("XDG_CONFIG_DIRS") or "/etc/xdg").split(":")
-
-        #  Append "/flux" to all members of confdirs to build searchpath:
-        self.searchpath = [Path(directory, "flux") for directory in confdirs]
+        self.searchpath = xdg_searchpath()
 
         #  Reorder searchpath into reverse precedence order
         self.searchpath.reverse()

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -209,6 +209,7 @@ TESTSCRIPTS = \
 	t2713-python-cli-bulksubmit.t \
 	t2714-python-cli-batch.t \
 	t2715-python-cli-cancel.t \
+	t2716-python-cli-batch-conf.t \
 	t2800-jobs-cmd.t \
 	t2800-jobs-recursive.t \
 	t2800-jobs-instance-info.t \

--- a/t/t2716-python-cli-batch-conf.t
+++ b/t/t2716-python-cli-batch-conf.t
@@ -1,0 +1,161 @@
+#!/bin/sh
+
+test_description='flux batch --conf tests'
+
+. $(dirname $0)/sharness.sh
+
+
+# Start an instance with 16 cores across 4 ranks
+export TEST_UNDER_FLUX_CORES_PER_RANK=4
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+
+NCORES=$(flux kvs get resource.R | flux R decode --count=core)
+test ${NCORES} -gt 4 && test_set_prereq MULTICORE
+
+test_expect_success 'flux-batch: create test configs' '
+	cat <<-EOF >conf.json &&
+	{"resource": {"noverify": true}}
+	EOF
+	cat <<-EOF >conf.toml
+	[resource]
+	noverify = true
+	EOF
+'
+test_expect_success 'flux-batch --conf=FILE works with TOML file' '
+	flux batch --conf=conf.toml -n1 --dry-run --wrap hostname \
+		>conf1.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.noverify" \
+		<conf1.json
+'
+test_expect_success 'flux-batch --conf=FILE works with JSON file' '
+	flux batch --conf=conf.json -n1 --dry-run --wrap hostname \
+		>conf2.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.noverify" \
+		<conf2.json
+'
+test_expect_success 'flux-batch --conf=FILE errors if FILE does not exist' '
+	test_must_fail flux batch --conf=/nofile.json -n1 --dry-run \
+		--wrap hostname
+'
+test_expect_success 'flux-batch --conf=FILE detects invalid TOML syntax' '
+	cat <<-EOF >conf-bad.toml &&
+	[resource]
+	noverify = foo
+	EOF
+	test_must_fail flux batch --conf=conf-bad.toml -n1 --dry-run \
+		--wrap hostname >parse-error.out 2>&1 &&
+	test_debug "cat parse-error.out" &&
+	grep "parse error" parse-error.out
+'
+test_expect_success 'flux-batch --conf=FILE detects invalid JSON syntax' '
+	cat <<-EOF >conf-bad.json &&
+	{"resource": {"noverify": foo}}
+	EOF
+	test_must_fail flux batch --conf=conf-bad.json -n1 --dry-run \
+		--wrap hostname >parse-error2.out 2>&1 &&
+	test_debug "cat parse-error2.out" &&
+	grep "parse error" parse-error2.out
+'
+test_expect_success 'flux-batch --conf=NAME raises NotImplemented' '
+	test_must_fail flux batch --conf=named -n1 --dry-run \
+		--wrap hostname >named.out 2>&1 &&
+	test_debug "cat named.out" &&
+	grep "no named config support" named.out
+'
+test_expect_success 'flux-batch --conf=KEY=VAL works' '
+	flux batch --conf=resource.noverify=true -n1 --dry-run \
+		--wrap hostname >conf3.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.noverify" \
+		<conf3.json
+'
+test_expect_success 'flux-batch --conf=KEY=VAL multiple use is merged' '
+	flux batch --conf=resource.noverify=true \
+		--conf=resource.exclude=0 -n1 --dry-run \
+		--wrap hostname >conf4.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.noverify" \
+		<conf4.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.exclude == 0" \
+		<conf4.json
+'
+test_expect_success 'flux-batch --conf=KEY=VAL VAL can be JSON' '
+	flux batch --conf=foo={} \
+		--conf=resource.exclude=0 -n1 --dry-run \
+		--wrap hostname >conf4.1.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.foo == {}" \
+		<conf4.1.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.exclude == 0" \
+		<conf4.1.json
+'
+test_expect_success 'flux-batch --conf=FILE --conf=KEY=VAL works' '
+	flux batch --conf=conf.toml \
+		--conf=resource.exclude=0 -n1 --dry-run \
+		--wrap hostname >conf5.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.noverify" \
+		<conf5.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.exclude == 0" \
+		<conf5.json
+'
+test_expect_success 'flux-batch multiline --conf directive works' '
+	cat <<-EOF >batch.sh &&
+	#!/bin/sh
+	# flux: -n1
+	# flux: --conf="""
+	# flux: [resource]
+	# flux: noverify = true
+	# flux: """
+	flux config get
+	EOF
+	flux batch --dry-run batch.sh >conf6.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.noverify" \
+		<conf6.json
+'
+test_expect_success 'flux-batch multiline --conf directive in JSON works' '
+	cat <<-EOF >batch2.sh &&
+	#!/bin/sh
+	# flux: -n1
+	# flux: --conf="""
+	# flux: {"resource": {"noverify": true}}
+	# flux: """
+	flux config get
+	EOF
+	flux batch --dry-run batch.sh >conf7.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.noverify" \
+		<conf7.json
+'
+test_expect_success 'flux-batch --conf directive syntax error detected' '
+	cat <<-EOF >bad-batch.sh &&
+	#!/bin/sh
+	# flux: -n1
+	# flux: --conf="""
+	# flux: [resource]
+	# flux: noverify = foo
+	# flux: """
+	flux config get
+	EOF
+	test_must_fail flux batch --dry-run bad-batch.sh >ml-syntax.out 2>&1 &&
+	test_debug "cat ml-syntax.out" &&
+	grep "failed to parse" ml-syntax.out
+'
+test_expect_success 'flux-batch multiline --conf + --conf=KEY=VAL works' '
+	flux batch --conf=resource.exclude=0 --dry-run batch.sh >conf8.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.noverify" \
+		<conf8.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.exclude == 0" \
+		<conf8.json
+'
+test_expect_success 'flux-batch multiline --conf + --conf=KEY=VAL override works' '
+	flux batch --conf=resource.noverify=false --dry-run batch.sh \
+		>conf9.json &&
+	jq -e ".attributes.system.files[\"conf.json\"].data.resource.noverify == false" \
+		<conf9.json
+'
+test_expect_success 'flux-batch --conf end-to-end test' '
+	jobid=$(flux batch --conf=resource.exclude=\"0\" \
+		--output=batchtest.out batch.sh) &&
+	flux job wait-event $jobid clean &&
+	jq -e ".resource.noverify" <batchtest.out &&
+	jq -e ".resource.exclude == \"0\"" <batchtest.out
+'
+test_done


### PR DESCRIPTION
This PR adds a `--conf` option to `flux-alloc` and `flux-batch` which allows users to iteratively build a JSON config file in the jobspec file archive (i.e. `.attributes.system.files["conf.json"].data`). If this option is used once, then `-c{{tmpdir}}/conf.json` is appended to the broker options so that the config becomes the child instance config. The `--conf=ARG` option takes several possible types of arguments:

 * If `ARG` contains a newline, then it is assume to be a multiline configuration and is parsed as JSON or TOML. This allows config to be embedded directly in a batch directive
 * O/w, if `ARG` contains a `=`, the argument is assumed to be `key=value` where `key` can be dotted to set hierarchical values, and value is parsed as JSON -- e.g. `--conf=resource.noverify=true`
 * O/w, if `ARG` ends in `.json` or `.toml` then the argument is assumed to be a path to a file in JSON or TOML.
 * O/w, an error is raised, but eventually the argument may refer to a "named config" file registered in the system or user Flux config hierarchy. (This is planned as future work).
 
The `--conf` option may be used multiple times to iteratively build a config on the command line.

I'm actually tempted to add the `--conf` option to all submission commands, e.g. it could be useful with `flux run OPTIONS.. flux start -o,-c{{tmpdir}}/conf.json`.

I also wonder if might be useful to add an argument that initializes a job's config from the enclosing instance config.