### PR TITLE
flux-resource: add `-i, --include=TARGETS` option to `list`  and `info` subcommands

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -47,7 +47,7 @@ RESOURCE INVENTORY section below.
 COMMANDS
 ========
 
-**list** [-n] [-o FORMAT] [-s STATE,...]
+**list** [-n] [-o FORMAT] [-s STATE,...] [-i TARGETS]
    Show scheduler view of resources.
 
    With *-s,--states=STATE,...*, the set of resource states is restricted
@@ -56,17 +56,29 @@ COMMANDS
    offline, excluded, and drained resources as "down" due to the simplified
    interface with the resource service defined by RFC 27.
 
+   With *-i, --include=TARGETS*, the results are filtered to only include
+   resources matching **TARGETS**, which may be specified either as an idset
+   of broker ranks or list of hosts in hostlist form. It is not an error to
+   specify ranks or hosts which do not exist, the result will be filtered
+   to include only those ranks or hosts that are present in *TARGETS*.
+
    The *-o,--format=FORMAT* option may be used to customize the output
    format (See OUTPUT FORMAT section below).
 
    The *-n,--no-header* option suppresses header from output,
 
-**info** [-s STATE,...]
+**info** [-s STATE,...] [-i TARGETS]
    Show a brief, single line summary of scheduler view of resources.
 
    With *-s, --states=STATE,...*, limit the output to specified resource
    states as with ``flux resource list``. By default, the *STATE* reported
    by ``flux resource info`` is "all".
+
+   With *-i, --include=TARGETS*, the results are filtered to only include
+   resources matching **TARGETS**, which may be specified either as an idset
+   of broker ranks or list of hosts in hostlist form. It is not an error to
+   specify ranks or hosts which do not exist, the result will be filtered
+   to include only those ranks or hosts that are present in *TARGETS*.
 
 **status**  [-n] [-o FORMAT] [-s STATE,...] [-i TARGETS] [--skip-empty]
    Show system view of resources. This command queries both the resource

--- a/src/bindings/python/flux/resource/ResourceSet.py
+++ b/src/bindings/python/flux/resource/ResourceSet.py
@@ -189,7 +189,7 @@ class ResourceSet:
                       to remove
         """
         if not isinstance(ranks, IDset):
-            ranks = IDset(str(ranks))
+            ranks = IDset(ranks)
         self.impl.remove_ranks(ranks)
         return self
 
@@ -202,7 +202,7 @@ class ResourceSet:
                       to copy
         """
         if not isinstance(ranks, IDset):
-            ranks = IDset(str(ranks))
+            ranks = IDset(ranks)
         rset = ResourceSet(self.impl.copy_ranks(ranks))
 
         #  Preserve current state

--- a/src/bindings/python/flux/resource/Rlist.py
+++ b/src/bindings/python/flux/resource/Rlist.py
@@ -112,7 +112,7 @@ class Rlist(WrapperPimpl):
 
     def remove_ranks(self, ranks):
         if not isinstance(ranks, IDset):
-            ranks = IDset(str(ranks))
+            ranks = IDset(ranks)
         self.pimpl.remove_ranks(ranks)
         return self
 

--- a/src/bindings/python/flux/resource/list.py
+++ b/src/bindings/python/flux/resource/list.py
@@ -8,6 +8,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+from flux.idset import IDset
 from flux.memoized_property import memoized_property
 from flux.resource import ResourceSet
 from flux.rpc import RPC
@@ -46,6 +47,21 @@ class SchedResourceList:
     #  Make class subscriptable, e.g. resources[state]
     def __getitem__(self, item):
         return getattr(self, item)
+
+    def filter(self, include):
+        """
+        Filter the reported resources in a ResourceList object
+        Args:
+            include(str, IDset, Hostlist): restrict the current set of
+                reported ranks to the given ranks or hosts.
+        """
+        try:
+            include_ranks = IDset(include)
+        except ValueError:
+            nodelist = self["all"].nodelist
+            include_ranks = nodelist.index(include, ignore_nomatch=True)
+        for state in ["all", "down", "allocated"]:
+            setattr(self, state, self[state].copy_ranks(include_ranks))
 
     @memoized_property
     # pylint: disable=invalid-name

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -539,6 +539,12 @@ def list_handler(args):
         except Exception as e:
             LOGGER.warning("Could not get flux config: " + str(e))
 
+    if args.include:
+        try:
+            resources.filter(include=args.include)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"--include: {exc}") from None
+
     fmt = FluxResourceConfig("list").load().get_format_string(args.format)
     formatter = flux.util.OutputFormat(fmt, headings=headings)
 
@@ -696,6 +702,13 @@ def main():
         help="Output resources in given states",
     )
     list_parser.add_argument(
+        "-i",
+        "--include",
+        metavar="TARGETS",
+        help="Include only specified targets in output set. TARGETS may be "
+        + "provided as an idset or hostlist.",
+    )
+    list_parser.add_argument(
         "-n", "--no-header", action="store_true", help="Suppress header output"
     )
     list_parser.add_argument(
@@ -712,6 +725,13 @@ def main():
         "--states",
         metavar="STATE,...",
         help="Show output only for resources in given states",
+    )
+    info_parser.add_argument(
+        "-i",
+        "--include",
+        metavar="TARGETS",
+        help="Include only specified targets in output set. TARGETS may be "
+        + "provided as an idset or hostlist.",
     )
     info_parser.add_argument(
         "--from-stdin", action="store_true", help=argparse.SUPPRESS

--- a/t/flux-resource/list/normal-new-info.expected
+++ b/t/flux-resource/list/normal-new-info.expected
@@ -1,0 +1,1 @@
+5 Nodes, 20 Cores, 0 GPUs

--- a/t/flux-resource/list/normal-new.expected
+++ b/t/flux-resource/list/normal-new.expected
@@ -1,0 +1,5 @@
+     STATE PROPERTIES NNODES   NCORES    NGPUS
+      free 8g              3       12        0
+      free                 2        8        0
+ allocated                 0        0        0
+      down                 0        0        0

--- a/t/flux-resource/list/normal-new.json
+++ b/t/flux-resource/list/normal-new.json
@@ -1,0 +1,25 @@
+{
+  "all": {
+    "execution": {
+      "R_lite": [
+        {
+          "children": {
+            "core": "0-3"
+          },
+          "rank": "0-4"
+        }
+      ],
+      "expiration": 0,
+      "nodelist": [
+        "pi[3,0-2,4]"
+      ],
+      "properties": {
+        "8g": "0-2"
+      },
+      "starttime": 0
+    },
+    "version": 1
+  },
+  "allocated": null,
+  "down": null
+}


### PR DESCRIPTION
Recently, a `-i, --include=TARGETS` option was added to `flux resource drain` and `flux resource status`, but not to `flux resource list`. It turns out this would be useful, and it is simple, so add it.
