### PR TITLE
broker: unset SLURM_* in initial program environment

### DIFF
--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -79,6 +79,7 @@ static const char *env_blocklist[] = {
     "FLUX_KVS_NAMESPACE",
     "FLUX_PROXY_REMOTE",
     "PMI_*",
+    "SLURM_*",  // flux-framework/flux-core#5206
     NULL,
 };
 

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -78,9 +78,7 @@ static const char *env_blocklist[] = {
     "FLUX_URI",
     "FLUX_KVS_NAMESPACE",
     "FLUX_PROXY_REMOTE",
-    "PMI_FD",
-    "PMI_RANK",
-    "PMI_SIZE",
+    "PMI_*",
     NULL,
 };
 

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -196,6 +196,7 @@ int flux_cmd_setenvf (flux_cmd_t *cmd, int overwrite,
 
 /*
  *  Unset environment variable `name` in the command object `cmd`.
+ *   If `name` is a glob pattern, unset all matching variables.
  */
 void flux_cmd_unsetenv (flux_cmd_t *cmd, const char *name);
 

--- a/src/common/libsubprocess/test/cmd.c
+++ b/src/common/libsubprocess/test/cmd.c
@@ -321,31 +321,12 @@ void test_arg_insert_delete (void)
     flux_cmd_destroy (cmd);
 }
 
-int main (int argc, char *argv[])
+void test_env (void)
 {
-    json_t *o;
-    flux_cmd_t *cmd, *copy;
+    flux_cmd_t *cmd;
 
-    plan (NO_PLAN);
-
-    diag ("Basic flux_cmd_create");
-    check_basic_create ();
-
-    diag ("Create a flux_cmd_t and fill it with known values");
-    // Create an empty command then fill it with nonsense:
-    cmd = flux_cmd_create (0, NULL, NULL);
-    ok (cmd != NULL, "flux_cmd_create (0, NULL, NULL)");
-    check_empty_cmd_attributes (cmd);
-    set_cmd_attributes (cmd);
-
-    diag ("Ensure flux_cmd_t contains expected values and test interfaces");
-    // Check the nonsense
-    check_cmd_attributes (cmd);
-
-    set_cmd_attributes2 (cmd);
-
-    diag ("Ensure flux_cmd_t contains expected values again");
-    check_cmd_attributes (cmd);
+    if (!(cmd = flux_cmd_create (0, NULL, NULL)))
+        BAIL_OUT ("failed to create command object");
 
     // Test unsetenv with throwaway var
     diag ("Test setenv/getenv/unsetenv");
@@ -371,6 +352,35 @@ int main (int argc, char *argv[])
     is (flux_cmd_getenv (cmd, "FOO"), "24",
         "flux_cmd_getenv (FOO) == 24");
     flux_cmd_unsetenv (cmd, "FOO");
+
+    flux_cmd_destroy (cmd);
+}
+
+int main (int argc, char *argv[])
+{
+    json_t *o;
+    flux_cmd_t *cmd, *copy;
+
+    plan (NO_PLAN);
+
+    diag ("Basic flux_cmd_create");
+    check_basic_create ();
+
+    diag ("Create a flux_cmd_t and fill it with known values");
+    // Create an empty command then fill it with nonsense:
+    cmd = flux_cmd_create (0, NULL, NULL);
+    ok (cmd != NULL, "flux_cmd_create (0, NULL, NULL)");
+    check_empty_cmd_attributes (cmd);
+    set_cmd_attributes (cmd);
+
+    diag ("Ensure flux_cmd_t contains expected values and test interfaces");
+    // Check the nonsense
+    check_cmd_attributes (cmd);
+
+    set_cmd_attributes2 (cmd);
+
+    diag ("Ensure flux_cmd_t contains expected values again");
+    check_cmd_attributes (cmd);
 
     // Test opt overwrite
     ok (flux_cmd_setopt (cmd, "FOO", "BAR") >= 0,
@@ -404,6 +414,8 @@ int main (int argc, char *argv[])
             diag ("%d:%d: %s", error.line, error.column, error.text);
     }
     flux_cmd_destroy (cmd);
+
+    test_env ();
 
     test_find_opts ();
 

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -116,7 +116,7 @@ test_expect_success 'flux admin cleanup-push (stdin) retains cmd block order' '
 '
 
 test_expect_success 'capture the environment for all three rc scripts' '
-	flux start \
+	SLURM_FOO=42 flux start \
 		-o,-Slog-stderr-level=6 \
 		-o,-Sbroker.rc1_path="bash -c printenv >rc1.env" \
 		-o,-Sbroker.rc3_path="bash -c printenv >rc3.env" \
@@ -143,6 +143,9 @@ test_expect_success 'PMI_FD, PMI_SIZE, PMI_RANK are not set in rc scripts' '
 	var_is_unset PMI_FD *.env &&
 	var_is_unset PMI_RANK *.env &&
 	var_is_unset PMI_SIZE *.env
+'
+test_expect_success 'SLURM_* vars were cleared from env of rc scripts' '
+	var_is_unset SLURM_FOO *.env
 '
 test_expect_success 'FLUX_URI is set in rc scripts' '
 	var_is_set FLUX_URI *.env


### PR DESCRIPTION
Problem: SLURM_ prefixed environment variables that leak through slurm -> flux -> MPI can cause hard to diagnose problems.

Clear all SLURM_ prefixed variables in the environment of the rc scripts spawned by the broker (where rc2 == initial program).