### PR TITLE
doc: add usage note for --add-file submission cli option

### DIFF
--- a/doc/man1/common/submit-other-options.rst
+++ b/doc/man1/common/submit-other-options.rst
@@ -48,6 +48,12 @@ OTHER OPTIONS
    encode multiple files.  Note: As documented in RFC 14, the file names
    ``script`` and ``conf.json`` are both reserved.
 
+   .. note::
+      This option should only be used for small files such as program input
+      parameters, configuration, scripts, and so on. For broadcast of large
+      files, binaries, and directories, the :man1:`flux-shell` ``stage-in``
+      plugin will be more appropriate.
+
 **--conf=FILE|KEY=VAL|STRING|NAME**
    The ``--conf`` option allows configuration for a Flux instance started
    via ``flux-batch(1)`` or ``flux-alloc(1)`` to be iteratively built on


### PR DESCRIPTION
Problem: It may be tempting for users to use the --add-file=PATH job submission cli option to broadcast large files to their job, a use which would be inappropriate.

Add a note to this option explaining when --add-file should be used vs the shell stage-in plugin.