### PR TITLE
shell/pmi: accept pmi1 and pmi2 as aliases for "simple" pmi

### DIFF
--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -20,6 +20,12 @@ test_expect_success 'flux run sets PMI_FD' '
 test_expect_success 'flux run -o pmi=simple sets PMI_FD' '
 	flux run -o pmi=simple printenv PMI_FD
 '
+test_expect_success 'flux run -o pmi=pmi1 sets PMI_FD' '
+	flux run -o pmi=pmi1 printenv PMI_FD
+'
+test_expect_success 'flux run -o pmi=pmi2 sets PMI_FD' '
+	flux run -o pmi=pmi2 printenv PMI_FD
+'
 test_expect_success 'flux run -o pmi=simple,unknown sets PMI_FD' '
 	flux run -o pmi=simple,unknown printenv PMI_FD
 '


### PR DESCRIPTION
Problem: when a user specifies `-o pmi=pmi2`, the effect is the same as `-o pmi=off`.

Make `pmi2` and `pmi1` aliases for `-o pmi=simple`.

This is not too outlandish since the flux `libpmi2.so` only speaks the simple wire protocol anyway.
