### PR TITLE
flux-resource: add `R` subcommand

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -80,6 +80,21 @@ COMMANDS
    specify ranks or hosts which do not exist, the result will be filtered
    to include only those ranks or hosts that are present in *TARGETS*.
 
+**R** [-s STATE,..] [-i TARGETS]
+   Emit an RFC 20 Resource Set on stdout.
+
+   With *-s,--states=STATE,...*, the set of resource states is restricted
+   to a list of provided states. Valid states include "up", "down",
+   "allocated", "free", and "all". Note that the scheduler represents
+   offline, excluded, and drained resources as "down" due to the simplified
+   interface with the resource service defined by RFC 27.
+
+   With *-i, --include=TARGETS*, the results are filtered to only include
+   resources matching **TARGETS**, which may be specified either as an idset
+   of broker ranks or list of hosts in hostlist form. It is not an error to
+   specify ranks or hosts which do not exist, the result will be filtered
+   to include only those ranks or hosts that are present in *TARGETS*.
+
 **status**  [-n] [-o FORMAT] [-s STATE,...] [-i TARGETS] [--skip-empty]
    Show system view of resources. This command queries both the resource
    service and scheduler to identify resources that are available,

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -288,7 +288,7 @@ _flux_mini()
 # flux-resource(1) completions
 _flux_resource()
 {
-    local subcmds="drain undrain status list info reload"
+    local subcmds="drain undrain status list R info reload"
     local cmd=$1
 
     local reload_OPTS="\
@@ -310,6 +310,11 @@ _flux_resource()
     "
     local status_OPTS="\
         ${list_OPTS} \
+    "
+    local R_OPTS="\
+        -h --help \
+        -s --states= \
+        -i --include= \
     "
     local undrain_OPTS="\
         -h --help \

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -569,6 +569,19 @@ def info(args):
     list_handler(args)
 
 
+def emit_R(args):
+    """Emit R in JSON on stdout for requested set of resources"""
+    resources, config = get_resource_list(args)
+
+    rset = ResourceSet()
+    for state in args.states:
+        try:
+            rset.add(resources[state])
+        except AttributeError:
+            raise ValueError(f"unknown state {state}")
+    print(rset.encode())
+
+
 LOGGER = logging.getLogger("flux-resource")
 
 
@@ -765,6 +778,24 @@ def main():
         default=False,
         help="allow resources to contain invalid ranks",
     )
+
+    R_parser = subparsers.add_parser("R", formatter_class=flux.util.help_formatter())
+    R_parser.set_defaults(func=emit_R)
+    R_parser.add_argument(
+        "-s",
+        "--states",
+        metavar="STATE,...",
+        default="all",
+        help="Emit R for resources in given states",
+    )
+    R_parser.add_argument(
+        "-i",
+        "--include",
+        metavar="TARGETS",
+        help="Include only specified targets in output set. TARGETS may be "
+        + "provided as an idset or hostlist.",
+    )
+    R_parser.add_argument("--from-stdin", action="store_true", help=argparse.SUPPRESS)
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -506,24 +506,15 @@ def resources_uniq_lines(resources, states, formatter, config):
     return lines
 
 
-def list_handler(args):
+def get_resource_list(args):
+    """
+    Common function for list_handler() and emit_R()
+    """
     valid_states = ["up", "down", "allocated", "free", "all"]
-    headings = {
-        "state": "STATE",
-        "queue": "QUEUE",
-        "properties": "PROPERTIES",
-        "propertiesx": "PROPERTIES",
-        "nnodes": "NNODES",
-        "ncores": "NCORES",
-        "ngpus": "NGPUS",
-        "ranks": "RANKS",
-        "nodelist": "NODELIST",
-        "rlist": "LIST",
-    }
     config = None
 
-    states = args.states.split(",")
-    for state in states:
+    args.states = args.states.split(",")
+    for state in args.states:
         if state not in valid_states:
             LOGGER.error("Invalid resource state %s specified", state)
             sys.exit(1)
@@ -544,11 +535,28 @@ def list_handler(args):
             resources.filter(include=args.include)
         except (ValueError, TypeError) as exc:
             raise ValueError(f"--include: {exc}") from None
+    return resources, config
+
+
+def list_handler(args):
+    headings = {
+        "state": "STATE",
+        "queue": "QUEUE",
+        "properties": "PROPERTIES",
+        "propertiesx": "PROPERTIES",
+        "nnodes": "NNODES",
+        "ncores": "NCORES",
+        "ngpus": "NGPUS",
+        "ranks": "RANKS",
+        "nodelist": "NODELIST",
+        "rlist": "LIST",
+    }
+    resources, config = get_resource_list(args)
 
     fmt = FluxResourceConfig("list").load().get_format_string(args.format)
     formatter = flux.util.OutputFormat(fmt, headings=headings)
 
-    lines = resources_uniq_lines(resources, states, formatter, config)
+    lines = resources_uniq_lines(resources, args.states, formatter, config)
     formatter.print_items(lines.values(), no_header=args.no_header)
 
 

--- a/t/flux-resource/list/fluxion.R
+++ b/t/flux-resource/list/fluxion.R
@@ -1,0 +1,1 @@
+{"version": 1, "execution": {"R_lite": [{"rank": "0-3", "children": {"core": "0-3"}}], "starttime": 0.0, "expiration": 0.0}}

--- a/t/flux-resource/list/missing.R
+++ b/t/flux-resource/list/missing.R
@@ -1,0 +1,1 @@
+{"version": 1, "execution": {"R_lite": [{"rank": "0-3", "children": {"core": "0-3"}}], "starttime": 0.0, "expiration": 0.0}}

--- a/t/flux-resource/list/normal-input.R
+++ b/t/flux-resource/list/normal-input.R
@@ -1,0 +1,1 @@
+{"version": 1, "execution": {"R_lite": [{"rank": "0-3", "children": {"core": "0-3"}}], "starttime": 0.0, "expiration": 0.0}}

--- a/t/flux-resource/list/normal-new.R
+++ b/t/flux-resource/list/normal-new.R
@@ -1,0 +1,1 @@
+{"version": 1, "execution": {"R_lite": [{"rank": "0-4", "children": {"core": "0-3"}}], "starttime": 0.0, "expiration": 0.0, "nodelist": ["pi[3,0-2,4]"], "properties": {"8g": "0-2"}}}

--- a/t/flux-resource/list/null.R
+++ b/t/flux-resource/list/null.R
@@ -1,0 +1,1 @@
+{"version": 1, "execution": {"R_lite": [{"rank": "0-3", "children": {"core": "0-3"}}], "starttime": 0.0, "expiration": 0.0}}

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -53,6 +53,11 @@ for input in ${SHARNESS_TEST_SRCDIR}/flux-resource/list/*.json; do
         test_debug "cat ${name}-info.output" &&
         test_cmp ${base}-info.expected ${name}-info.output
     '
+    test_expect_success "flux-resource R input check: $testname" '
+        flux resource R --from-stdin < $input > ${name}-R.output 2>&1 &&
+        test_debug "cat ${name}-info.output" &&
+        test_cmp ${base}.R ${name}-R.output
+    '
 done
 
 #  Ensure all tested inputs can also work with --include
@@ -72,6 +77,11 @@ for input in ${SHARNESS_TEST_SRCDIR}/flux-resource/list/*.json; do
             > ${name}-info-include.output 2>&1 &&
         test_debug "cat ${name}-info-include.output" &&
 	grep "1 Node" ${name}-info-include.output
+    '
+    test_expect_success "flux-resource R input ---include check: $testname" '
+        flux resource R --from-stdin -i0 < $input \
+           > ${name}-info-R.output &&
+        test "$(flux R decode --count=node <${name}-info-R.output)" -eq 1
     '
 done
 
@@ -98,6 +108,14 @@ test_expect_success 'flux-resource list: --include works with invalid host' '
 		--from-stdin < $INPUT >include-invalid-hosts.out &&
 	test_debug "cat include-invalid-hosts.out" &&
 	grep "^0" include-invalid-hosts.out
+'
+test_expect_success 'flux-resource R supports --states' '
+	flux resource R --from-stdin -s all <$INPUT >all.R &&
+	test $(flux R decode --count=node <all.R) -eq 5 &&
+	flux resource R --from-stdin -s up <$INPUT >up.R &&
+	test $(flux R decode --count=node <up.R) -eq 5 &&
+	flux resource R --from-stdin -s down <$INPUT >down.R &&
+	test $(flux R decode --count=node <down.R) -eq 0
 '
 test_expect_success 'create test input with properties' '
 	cat <<-EOF >properties-test.in


### PR DESCRIPTION
It seems like a gap that there's no way for a user to access the underlying resource set being used by the scheduler. In fact, in a system instance, users can't access any kind of instance wide R since access to `resource.R` in the KVS is limited to the instance owner.

This PR adds a simple `flux resource R` command that fetches the scheduler resource set and emits Rv1. By default, the R for all resources is emitted, but there are options to get R for any state supported by `flux resource list`.
