### PR TITLE
flux-job: add missing include of signal.h

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -28,6 +28,7 @@
 #include <jansson.h>
 #include <argz.h>
 #include <sys/ioctl.h>
+#include <signal.h>
 #include <flux/core.h>
 #include <flux/optparse.h>
 #include <flux/hostlist.h>


### PR DESCRIPTION
Problem: flux-job.c is missing a necessary include of signal.h.

Add the missing include.