### PR TITLE
libjob: fix leak in sign_unwrap()

### DIFF
--- a/src/common/libjob/test/unwrap.c
+++ b/src/common/libjob/test/unwrap.c
@@ -48,6 +48,16 @@ static void test_api (unwrap_f unwrap)
         error.text);
 
     userid = 0;
+    result = (*unwrap) (s, false, NULL, &error);
+    ok (result != NULL && userid == 0,
+        "unwrap_string() works with NULL userid");
+    if (result == NULL)
+        diag ("got error: %s", error.text);
+    is (result, "bar",
+        "got expected result");
+    free (result);
+
+    userid = 0;
     result = (*unwrap) (s, false, NULL, NULL);
     ok (result != NULL && userid == 0,
         "unwrap_string() works with NULL userid and error parameters");

--- a/src/common/libjob/unwrap.c
+++ b/src/common/libjob/unwrap.c
@@ -76,12 +76,16 @@ char *unwrap_string (const char *s,
     int64_t userid64;
     int flags = verify ? 0 : FLUX_SIGN_NOVERIFY;
 
-    if (!(sec = flux_security_create (0))
-        || flux_security_configure (sec, NULL) < 0) {
+    if (!(sec = flux_security_create (0))) {
         errprintf (errp,
-                   "failed to initialize security context: %s",
+                   "failed to create security context: %s",
                    strerror (errno));
-        return NULL;
+    }
+    if (flux_security_configure (sec, NULL) < 0) {
+        errprintf (errp,
+                   "failed to configure security context: %s",
+                   flux_security_last_error (sec));
+        goto done;
     }
     if (flux_sign_unwrap_anymech (sec,
                                   s,


### PR DESCRIPTION
While diagnosing a local issue with libflux-security, I noticed that `sign_unwrap()` was suppressing the error from `flux_security_configure(3)` and also had a potential leak.

Fix the leak and grab the `flux_security_last_error()` so that errors are easier to diagnosis.

Add one extra test to the unit tests so that when these tests fail the user has some idea of the actual error.