### PR TITLE
libjob: return on error in unwrap_string()

### DIFF
--- a/src/common/libjob/unwrap.c
+++ b/src/common/libjob/unwrap.c
@@ -80,6 +80,7 @@ char *unwrap_string (const char *s,
         errprintf (errp,
                    "failed to create security context: %s",
                    strerror (errno));
+        return NULL;
     }
     if (flux_security_configure (sec, NULL) < 0) {
         errprintf (errp,


### PR DESCRIPTION
Problem: if the Flux security context cannot be allocated, `unwrap_string()` falls through to `flux_security_configure()` instead of returning.

Add missing return.