### PR TITLE
flux-config-bootstrap(5): fix TOML error

### DIFF
--- a/doc/man5/flux-config-bootstrap.rst
+++ b/doc/man5/flux-config-bootstrap.rst
@@ -159,14 +159,8 @@ The following example is a simple, two node cluster with a fully specified
    curve_cert = "/etc/flux/system/curve.cert"
 
    hosts = [
-       {
-           host="foo",
-           bind="tcp://eth0:9001",
-           connect="tcp://10.0.1.1:9001"
-       },
-       {
-           host = "bar"
-       },
+       { host="foo", bind="tcp://eth0:9001", connect="tcp://10.0.1.1:9001" },
+       { host = "bar" },
    ]
 
 
@@ -188,14 +182,11 @@ a different network interface configuration compared to its peers.
    default_connect = "tcp://e%h:%p"
 
    hosts = [
-       {   # Management requires non-default config
-           host="test0",
-           bind="tcp://en4:9001",
-           connect="tcp://test-mgmt:9001"
-       },
-       {   # Other nodes use defaults
-           host = "test[1-255]"
-       },
+       # Management requires non-default config
+       { host="test0", bind="tcp://en4:9001", connect="tcp://test-mgmt:9001" },
+
+       # Other nodes use defaults
+       { host = "test[1-255]" },
    ]
 
 The following example is a 256 node cluster that uses the ``parent`` key to


### PR DESCRIPTION
Problem: two of the examples in flux-config-bootstrap(5) split inline tables across lines, but TOML 1.0.0 forbids newlines bewteen the curly braces unless they are valid within a value.

Inline tables are described here:
  https://toml.io/en/v1.0.0#inline-table

Change the formatting of the examples to be valid TOML 1.0.0.

Note that the last example demonstrates using the "arrays of tables" syntax which may be more readable when inline tables become too long. Arrays of tables are described here:
  https://toml.io/en/v1.0.0#array-of-tables

All the bootstrap examples were successfully run through https://www.toml-lint.com/.

Fixes #5249