### PR TITLE
Ignore errors when starting flux from a restart dump containing giant blobs

### DIFF
--- a/doc/man1/flux-restore.rst
+++ b/doc/man1/flux-restore.rst
@@ -53,6 +53,8 @@ OPTIONS
    Bypass the broker content cache and interact directly with the backing
    store.  Performance will vary depending on the content of the archive.
 
+**--size-limit**\ =\ *SIZE*
+   Skip restoring keys that exceed SIZE bytes (default: no limit).
 
 RESOURCES
 =========

--- a/etc/rc1
+++ b/etc/rc1
@@ -47,7 +47,7 @@ if test $RANK -eq 0; then
             flux module load ${backingmod} truncate
         fi
         echo "restoring content from ${dumpfile}"
-        flux restore --quiet --checkpoint ${dumpfile}
+        flux restore --quiet --checkpoint --size-limit=104857600 ${dumpfile}
         if test -n "${dumplink}"; then
             rm -f ${dumplink}
         fi

--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -37,6 +37,7 @@ static int content_flags;
 static time_t restore_timestamp;
 static int blobcount;
 static int keycount;
+static int blob_size_limit;
 
 static void progress (int delta_blob, int delta_keys)
 {
@@ -270,6 +271,17 @@ static json_t *restore_snapshot (struct archive *ar, flux_t *h)
         else if (type == AE_IFREG) {
             int size = archive_entry_size (entry);
 
+            if (blob_size_limit > 0 && size > blob_size_limit) {
+                fprintf (stderr,
+                         "%s%s size %d exceeds %d limit, skipping\n",
+                         (!quiet && !verbose) ? "\r" : "",
+                         path,
+                         size,
+                         blob_size_limit);
+                // N.B.  archive_read_next_header() skips unconsumed data
+                //   automatically so it is safe to "continue" here.
+                continue;
+            }
             if (size > bufsize) {
                 void *newbuf;
                 if (!(newbuf = realloc (buf, size)))
@@ -354,6 +366,7 @@ static int cmd_restore (optparse_t *p, int ac, char *av[])
         content_flags |= CONTENT_FLAG_CACHE_BYPASS;
         kvs_checkpoint_flags |= KVS_CHECKPOINT_FLAG_CACHE_BYPASS;
     }
+    blob_size_limit = optparse_get_int (p, "size-limit", 0);
 
     h = builtin_get_flux_handle (p);
     ar = restore_create (infile);
@@ -457,6 +470,9 @@ static struct optparse_option restore_opts[] = {
     },
     { .name = "no-cache", .has_arg = 0,
       .usage = "Bypass the broker content cache",
+    },
+    { .name = "size-limit", .has_arg = 1, .arginfo = "SIZE",
+      .usage = "Do not restore blobs greater than SIZE bytes",
     },
     OPTPARSE_TABLE_END
 };


### PR DESCRIPTION
Problem: flux could not be restarted on a system after `flux shutdown --gc` due to EFBIG errors from `flux-restore(1)`.

This was more fallout from the earlier lack of any limit on the amount of stdio a job can write to the KVS.   Some large stdio keys were apparently still around and were added to the dump file when flux was shut down.  When flux was brought back, up the  keys could not be restored because they exceed the maximum content cache blob size and manual recovery was necessary.

As discussed in #5245, this adds a new option `--ignore-store-error=LIST` to flux-restore(1) that allows certain store errors to be treated as warnings rather than fatal.  rc1 is modified to call `flux restore --ignore-store-error=EFBIG`.