### PR TITLE
switch from decimal to f58 jobid encoding in most log messages and shell service name

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -3283,6 +3283,7 @@ void info_usage (void)
 }
 
 struct info_ctx {
+    const char *id_arg;
     flux_jobid_t id;
     json_t *keys;
     bool original;
@@ -3295,7 +3296,7 @@ void info_output (flux_future_t *f, const char *suffix, struct info_ctx *ctx)
     if (flux_rpc_get_unpack (f, "{s:s}", suffix, &s) < 0) {
         if (errno == ENOENT) {
             flux_future_destroy (f);
-            log_msg_exit ("job %ju id or key not found", (uintmax_t)ctx->id);
+            log_msg_exit ("job %s id or key not found", ctx->id_arg);
         }
         else
             log_err_exit ("flux_rpc_get_unpack");
@@ -3340,6 +3341,7 @@ void info_lookup (flux_t *h,
     flux_future_t *f;
     struct info_ctx ctx = {0};
 
+    ctx.id_arg = argv[optindex-1];
     ctx.id = id;
     if (!(ctx.keys = json_array ()))
         log_msg_exit ("json_array");

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -17,6 +17,7 @@
 
 #include "src/common/libutil/uri.h"
 #include "src/common/libutil/errprintf.h"
+#include "src/common/libjob/idf58.h"
 #include "ccan/str/str.h"
 #include "top.h"
 
@@ -224,18 +225,8 @@ static flux_jobid_t get_jobid (flux_t *h)
 
 static char * build_title (struct top *top, const char *title)
 {
-    if (!title) {
-        char jobid [24];
-        title = "";
-        if (top->id != FLUX_JOBID_ANY) {
-            if (flux_job_id_encode (top->id,
-                                    "f58",
-                                    jobid,
-                                    sizeof (jobid)) < 0)
-                fatal (errno, "failed to build jobid");
-            title = jobid;
-        }
-    }
+    if (!title)
+        title = idf58 (top->id);
     return strdup (title);
 }
 

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -39,7 +39,8 @@ libjob_la_SOURCES = \
 	jj.c \
 	jj.h \
 	unwrap.c \
-	unwrap.h
+	unwrap.h \
+	idf58.h
 
 TESTS = \
 	test_job.t \

--- a/src/common/libjob/idf58.h
+++ b/src/common/libjob/idf58.h
@@ -1,0 +1,35 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _IDF58_H
+#define _IDF58_H
+
+#include <flux/core.h>
+
+/*  Convenience function to convert a flux_jobid_t to F58 encoding
+ *  If the encode fails (unlikely), then the decimal encoding is returned.
+ */
+static inline const char *idf58 (flux_jobid_t id)
+{
+    static __thread char buf[21];
+    if (flux_job_id_encode (id, "f58", buf, sizeof (buf)) < 0) {
+        /* 64bit integer is guaranteed to fit in 21 bytes
+         * floor(log(2^64-1)/log(1)) + 1 = 20
+         */
+        (void) sprintf (buf, "%ju", (uintmax_t) id);
+    }
+    return buf;
+}
+
+#endif /* !_IDF58_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -14,6 +14,7 @@
 #include <flux/core.h>
 #include <jansson.h>
 
+#include "src/common/libjob/idf58.h"
 #include "schedutil_private.h"
 #include "init.h"
 #include "hello.h"
@@ -25,14 +26,14 @@ static void raise_exception (flux_t *h, flux_jobid_t id, const char *note)
 
     flux_log (h,
               LOG_INFO,
-              "raising fatal exception on running job id=%ju",
-              (uintmax_t)id);
+              "raising fatal exception on running job id=%s",
+              idf58 (id));
 
     if (!(f = flux_job_raise (h, id, "scheduler-restart", 0, note))
         || flux_future_get (f, NULL) < 0) {
         flux_log_error (h,
-                        "error raising fatal exception on %ju: %s",
-                        (uintmax_t)id,
+                        "error raising fatal exception on %s: %s",
+                        idf58 (id),
                         future_strerror (f, errno));
     }
     flux_future_destroy (f);
@@ -64,8 +65,8 @@ static int schedutil_hello_job (schedutil_t *util,
     flux_future_destroy (f);
     return 0;
 error:
-    flux_log_error (util->h, "hello: error loading R for id=%ju",
-                    (uintmax_t)id);
+    flux_log_error (util->h, "hello: error loading R for id=%s",
+                    idf58 (id));
     flux_future_destroy (f);
     return -1;
 }

--- a/src/modules/job-archive/job-archive.c
+++ b/src/modules/job-archive/job-archive.c
@@ -28,6 +28,7 @@
 #include "src/common/libutil/fsd.h"
 #include "src/common/libutil/tstat.h"
 #include "src/common/libutil/monotime.h"
+#include "src/common/libjob/idf58.h"
 
 #define BUSY_TIMEOUT_DEFAULT 50
 #define BUFSIZE              1024
@@ -298,8 +299,8 @@ void job_info_lookup_continuation (flux_future_t *f, void *arg)
                         "t_run", &t_run,
                         "t_cleanup", &t_cleanup,
                         "t_inactive", &t_inactive) < 0) {
-        flux_log (ctx->h, LOG_ERR, "%s: parse job %ju error: %s",
-                  __FUNCTION__, (uintmax_t)id, error.text);
+        flux_log (ctx->h, LOG_ERR, "%s: parse job %s error: %s",
+                  __FUNCTION__, idf58 (id), error.text);
         goto out;
     }
 

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -20,6 +20,7 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/aux.h"
+#include "src/common/libjob/idf58.h"
 #include "bulk-exec.h"
 
 struct exec_cmd {
@@ -491,8 +492,8 @@ void bulk_exec_kill_log_error (flux_future_t *f, flux_jobid_t id)
         if (flux_future_get (cf, NULL) < 0) {
             uint32_t rank = flux_rpc_get_nodeid (cf);
             flux_log_error (h,
-                            "%ju: exec_kill: %s (rank %lu)",
-                            (uintmax_t) id,
+                            "%s: exec_kill: %s (rank %lu)",
+                            idf58 (id),
                             flux_get_hostbyrank (h, rank),
                             (unsigned long)rank);
         }

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -32,6 +32,7 @@
 
 #include <unistd.h>
 
+#include "src/common/libjob/idf58.h"
 #include "ccan/str/str.h"
 
 #include "job-exec.h"
@@ -462,8 +463,8 @@ static int exec_kill (struct jobinfo *job, int signum)
     }
 
     flux_log (job->h, LOG_DEBUG,
-              "exec_kill: %ju: signal %d",
-              (uintmax_t) job->id,
+              "exec_kill: %s: signal %d",
+              idf58 (job->id),
               signum);
 
     jobinfo_incref (job);

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -458,7 +458,7 @@ static int exec_kill (struct jobinfo *job, int signum)
         f = bulk_exec_kill (exec, signum);
     if (!f) {
         if (errno != ENOENT)
-            flux_log_error (job->h, "%ju: bulk_exec_kill", job->id);
+            flux_log_error (job->h, "%s: bulk_exec_kill", idf58 (job->id));
         return 0;
     }
 
@@ -469,7 +469,9 @@ static int exec_kill (struct jobinfo *job, int signum)
 
     jobinfo_incref (job);
     if (flux_future_then (f, 3., exec_kill_cb, job) < 0) {
-        flux_log_error (job->h, "%ju: exec_kill: flux_future_then", job->id);
+        flux_log_error (job->h,
+                        "%s: exec_kill: flux_future_then",
+                        idf58 (job->id));
         flux_future_destroy (f);
         return -1;
     }

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -93,6 +93,7 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libjob/job_hash.h"
+#include "src/common/libjob/idf58.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libeventlog/eventlogger.h"
 #include "src/common/libutil/fsd.h"
@@ -290,8 +291,8 @@ static int jobid_exception (flux_t *h, flux_jobid_t id,
 
     flux_log (h,
               LOG_INFO,
-              "job-exception: id=%ju: %s",
-              (uintmax_t) id,
+              "job-exception: id=%s: %s",
+              idf58 (id),
               note);
     return flux_respond_pack (h, msg, "{s:I s:s s:{s:i s:s s:s}}",
                                       "id", id,
@@ -366,8 +367,8 @@ static void kill_shell_timer_cb (flux_reactor_t  *r,
     struct jobinfo *job = arg;
     flux_log (job->h,
               LOG_DEBUG,
-              "Sending SIGKILL to job shell for job %ju",
-              (uintmax_t) job->id);
+              "Sending SIGKILL to job shell for job %s",
+              idf58 (job->id));
     (*job->impl->kill) (job, SIGKILL);
 }
 
@@ -378,8 +379,8 @@ static void kill_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
     flux_future_t *f;
     flux_log (job->h,
               LOG_DEBUG,
-              "Sending SIGKILL to job %ju",
-              (uintmax_t) job->id);
+              "Sending SIGKILL to job %s",
+              idf58 (job->id));
     if (!(f = flux_job_kill (job->h, job->id, SIGKILL))) {
         flux_log_error (job->h,
                         "flux_job_kill (%ju, SIGKILL)",
@@ -1221,7 +1222,7 @@ static void exception_cb (flux_t *h, flux_msg_handler_t *mh,
          *   doesn't dump a duplicate exception into the eventlog.
          */
         job->exception_in_progress = 1;
-        flux_log (h, LOG_DEBUG, "exec aborted: id=%ju", (uintmax_t)id);
+        flux_log (h, LOG_DEBUG, "exec aborted: id=%s", idf58 (id));
         jobinfo_fatal_error (job, 0, "aborted due to exception type=%s", type);
     }
 }

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -174,9 +174,9 @@ flux_future_t *jobinfo_shell_rpc_pack (struct jobinfo *job,
     uint32_t rank;
 
     if (asprintf (&shell_topic,
-                  "%ju-shell-%ju.%s",
+                  "%ju-shell-%s.%s",
                   (uintmax_t) job->userid,
-                  (uintmax_t) job->id,
+                  idf58 (job->id),
                   topic) < 0
         || ((rank = resource_set_nth_rank (job->R, 0)) == IDSET_INVALID_ID))
         goto out;

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -186,7 +186,7 @@ flux_future_t *jobinfo_shell_rpc_pack (struct jobinfo *job,
     flux_future_aux_set (f, "jobinfo", job, (flux_free_f) jobinfo_decref);
     jobinfo_incref (job);
 out:
-    ERRNO_SAFE_WRAP (free ,shell_topic);
+    ERRNO_SAFE_WRAP (free, shell_topic);
     return f;
 }
 

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -383,8 +383,8 @@ static void kill_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
               idf58 (job->id));
     if (!(f = flux_job_kill (job->h, job->id, SIGKILL))) {
         flux_log_error (job->h,
-                        "flux_job_kill (%ju, SIGKILL)",
-                        job->id);
+                        "flux_job_kill (%s, SIGKILL)",
+                        idf58 (job->id));
         return;
     }
     /* Open loop */
@@ -429,8 +429,8 @@ static void timelimit_cb (flux_reactor_t *r,
     if (jobid_exception (job->h, job->id, job->req, "timeout", 0, 0,
                          "resource allocation expired") < 0)
         flux_log_error (job->h,
-                        "failed to generate timeout exception for %ju",
-                        job->id);
+                        "failed to generate timeout exception for %s",
+                        idf58 (job->id));
     (*job->impl->kill) (job, SIGALRM);
     flux_watcher_stop (w);
     job->exception_in_progress = 1;
@@ -498,8 +498,8 @@ void jobinfo_started (struct jobinfo *job)
     if (h && job->req) {
         if (jobinfo_set_expiration (job) < 0)
             flux_log_error (h,
-                            "failed to set expiration for %ju",
-                            (uintmax_t) job->id);
+                            "failed to set expiration for %s",
+                            idf58 (job->id));
         job->running = 1;
         if (jobinfo_respond (h, job, "start") < 0)
             flux_log_error (h, "jobinfo_started: flux_respond");
@@ -641,8 +641,8 @@ void jobinfo_log_output (struct jobinfo *job,
                                  "rank", buf,
                                  "data", data, len) < 0)
         flux_log_error (job->h,
-                        "eventlog_append failed: %ju: message=%s",
-                        (uintmax_t) job->id,
+                        "eventlog_append failed: %s: message=%s",
+                        idf58 (job->id),
                         data);
 }
 
@@ -1009,8 +1009,8 @@ static void get_rootref_cb (flux_future_t *fprev, void *arg)
                                                   job->userid)))
         flux_log (job->h,
                   LOG_DEBUG,
-                  "checkpoint rootref not found: %ju",
-                  (uintmax_t)job->id);
+                  "checkpoint rootref not found: %s",
+                  idf58 (job->id));
 
     /* if rootref not found, still create namespace */
     if (!(f = ns_create_and_link (h, job, 0)))
@@ -1084,8 +1084,8 @@ static void evlog_err (struct eventlogger *ev, void *arg, int err, json_t *e)
     struct jobinfo *job = arg;
     char *s = json_dumps (e, JSON_COMPACT);
     flux_log_error (job->h,
-                    "eventlog error: job=%ju: entry=%s",
-                    (uintmax_t) job->id,
+                    "eventlog error: %s: entry=%s",
+                    idf58 (job->id),
                     s);
     free (s);
 }
@@ -1151,8 +1151,8 @@ static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
     job->ev = eventlogger_create (job->h, 0.01, &ev_ops, job);
     if (!job->ev || eventlogger_setns (job->ev, job->ns) < 0) {
         flux_log_error (job->h,
-                        "eventlogger_create/setns for job %ju failed",
-                        (uintmax_t) job->id);
+                        "eventlogger_create/setns for job %s failed",
+                        idf58 (job->id));
         jobinfo_decref (job);
         return -1;
     }

--- a/src/modules/job-list/job_data.c
+++ b/src/modules/job-list/job_data.c
@@ -22,6 +22,7 @@
 #include "src/common/librlist/rnode.h"
 #include "src/common/libccan/ccan/str/str.h"
 #include "src/common/libjob/jj.h"
+#include "src/common/libjob/idf58.h"
 
 #include "job_data.h"
 
@@ -104,8 +105,8 @@ static int parse_jobspec_job_name (struct job *job,
                             "{s?:s}",
                             "name", &job->name) < 0) {
             flux_log (job->h, LOG_ERR,
-                      "%s: job %ju invalid job dictionary: %s",
-                      __FUNCTION__, (uintmax_t)job->id, error.text);
+                      "%s: job %s invalid job dictionary: %s",
+                      __FUNCTION__, idf58 (job->id), error.text);
             return -1;
         }
     }
@@ -120,23 +121,23 @@ static int parse_jobspec_job_name (struct job *job,
                             "[{s:o}]",
                             "command", &command) < 0) {
             flux_log (job->h, LOG_ERR,
-                      "%s: job %ju invalid jobspec: %s",
-                      __FUNCTION__, (uintmax_t)job->id, error.text);
+                      "%s: job %s invalid jobspec: %s",
+                      __FUNCTION__, idf58 (job->id), error.text);
             return -1;
         }
 
         if (!json_is_array (command)) {
             flux_log (job->h, LOG_ERR,
-                      "%s: job %ju invalid jobspec",
-                      __FUNCTION__, (uintmax_t)job->id);
+                      "%s: job %s invalid jobspec",
+                      __FUNCTION__, idf58 (job->id));
             return -1;
         }
 
         arg0 = json_array_get (command, 0);
         if (!arg0 || !json_is_string (arg0)) {
             flux_log (job->h, LOG_ERR,
-                      "%s: job %ju invalid job command",
-                      __FUNCTION__, (uintmax_t)job->id);
+                      "%s: job %s invalid job command",
+                      __FUNCTION__, idf58 (job->id));
             return -1;
         }
         job->name = parse_job_name (json_string_value (arg0));
@@ -181,8 +182,8 @@ static int parse_per_resource (struct job *job,
                               "options",
                                 "per-resource", &o) < 0) {
         flux_log (job->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
+                  "%s: job %s invalid jobspec: %s",
+                  __FUNCTION__, idf58 (job->id), error.text);
         return -1;
     }
 
@@ -193,8 +194,8 @@ static int parse_per_resource (struct job *job,
                             "type", type,
                             "count", count) < 0) {
             flux_log (job->h, LOG_ERR,
-                      "%s: job %ju invalid per-resource spec: %s",
-                      __FUNCTION__, (uintmax_t)job->id, error.text);
+                      "%s: job %s invalid per-resource spec: %s",
+                      __FUNCTION__, idf58 (job->id), error.text);
             return -1;
         }
     }
@@ -269,8 +270,8 @@ static int parse_jobspec (struct job *job, const char *s, bool allow_nonfatal)
 
     if (!(job->jobspec = json_loads (s, 0, &error))) {
         flux_log (job->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
+                  "%s: job %s invalid jobspec: %s",
+                  __FUNCTION__, idf58 (job->id), error.text);
         goto error;
     }
 
@@ -281,16 +282,16 @@ static int parse_jobspec (struct job *job, const char *s, bool allow_nonfatal)
                         "job",
                         &jobspec_job) < 0) {
         flux_log (job->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
+                  "%s: job %s invalid jobspec: %s",
+                  __FUNCTION__, idf58 (job->id), error.text);
         goto nonfatal_error;
     }
 
     if (jobspec_job) {
         if (!json_is_object (jobspec_job)) {
             flux_log (job->h, LOG_ERR,
-                      "%s: job %ju invalid jobspec",
-                      __FUNCTION__, (uintmax_t)job->id);
+                      "%s: job %s invalid jobspec",
+                      __FUNCTION__, idf58 (job->id));
             goto nonfatal_error;
         }
     }
@@ -299,8 +300,8 @@ static int parse_jobspec (struct job *job, const char *s, bool allow_nonfatal)
                         "{s:o}",
                         "tasks", &tasks) < 0) {
         flux_log (job->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
+                  "%s: job %s invalid jobspec: %s",
+                  __FUNCTION__, idf58 (job->id), error.text);
         goto nonfatal_error;
     }
 
@@ -314,15 +315,15 @@ static int parse_jobspec (struct job *job, const char *s, bool allow_nonfatal)
                         "cwd", &job->cwd,
                         "queue", &job->queue) < 0) {
         flux_log (job->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
+                  "%s: job %s invalid jobspec: %s",
+                  __FUNCTION__, idf58 (job->id), error.text);
         goto nonfatal_error;
     }
 
     if (jj_get_counts_json (job->jobspec, &jj) < 0) {
         flux_log (job->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec; %s",
-                  __FUNCTION__, (uintmax_t)job->id, jj.error);
+                  "%s: job %s invalid jobspec; %s",
+                  __FUNCTION__, idf58 (job->id), jj.error);
         goto nonfatal_error;
     }
 
@@ -371,8 +372,8 @@ static int parse_R (struct job *job, const char *s, bool allow_nonfatal)
 
     if (!(job->R = json_loads (s, 0, &error))) {
         flux_log (job->h, LOG_ERR,
-                  "%s: job %ju invalid R: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
+                  "%s: job %s invalid R: %s",
+                  __FUNCTION__, idf58 (job->id), error.text);
         goto nonfatal_error;
     }
 

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -44,6 +44,7 @@
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/jpath.h"
+#include "src/common/libjob/idf58.h"
 #include "ccan/ptrint/ptrint.h"
 #include "ccan/str/str.h"
 
@@ -212,8 +213,8 @@ static void event_batch_destroy (struct event_batch *batch)
                 job->hold_events = 0;
                 if (event_job_post_deferred (batch->event, job) < 0)
                     flux_log_error (batch->event->ctx->h,
-                                    "%ju: error posting deferred events",
-                                    (uintmax_t) job->id);
+                                    "%s: error posting deferred events",
+                                    idf58 (job->id));
             }
             zlist_destroy (&batch->jobs);
         }
@@ -440,8 +441,8 @@ int event_job_action (struct event *event, struct job *job)
                 if (purge_enqueue_job (ctx->purge, job) < 0) {
                     flux_log (event->ctx->h,
                               LOG_ERR,
-                              "%ju: error adding inactive job to purge queue",
-                               (uintmax_t)job->id);
+                              "%s: error adding inactive job to purge queue",
+                               idf58 (job->id));
                 }
             }
             (void) jobtap_call (ctx->jobtap, job, "job.destroy", NULL);
@@ -802,9 +803,9 @@ static int event_jobtap_call (struct event *event,
                                    "{s:O}",
                                    "entry", entry) < 0)
             flux_log (event->ctx->h, LOG_ERR,
-                      "jobtap: event.%s callback failed for job %ju",
+                      "jobtap: event.%s callback failed for job %s",
                       name,
-                      (uintmax_t) job->id);
+                      idf58 (job->id));
 
     if (job->state != old_state) {
         /*

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -30,6 +30,7 @@
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/aux.h"
+#include "src/common/libjob/idf58.h"
 #include "ccan/str/str.h"
 
 #include "annotate.h"
@@ -190,8 +191,8 @@ static int plugin_check_dependencies (struct jobtap *jobtap,
     if (dependencies_unpack (jobtap, job, &error, &dependencies) < 0) {
         flux_log (jobtap->ctx->h,
                   LOG_ERR,
-                  "id=%ju: plugin_register_dependencies: %s",
-                  (uintmax_t) job->id,
+                  "id=%s: plugin_register_dependencies: %s",
+                  idf58 (job->id),
                   error);
         free (error);
         return -1;
@@ -280,8 +281,8 @@ static flux_plugin_t * jobtap_load_plugin (struct jobtap *jobtap,
         if (job->state == FLUX_JOB_STATE_DEPEND) {
             if (plugin_check_dependencies (jobtap, p, job, args) < 0)
                 errprintf (errp,
-                           "failed to check dependencies for job %ju",
-                           job->id);
+                           "failed to check dependencies for job %s",
+                           idf58 (job->id));
             (void) flux_plugin_call (p, "job.state.depend", args);
         }
 
@@ -696,8 +697,8 @@ int jobtap_get_priority (struct jobtap *jobtap,
              */
             if (job->state == FLUX_JOB_STATE_SCHED)
                 flux_log (jobtap->ctx->h, LOG_ERR,
-                          "jobtap: %ju: BUG: plugin didn't return priority",
-                          (uintmax_t) job->id);
+                          "jobtap: %s: BUG: plugin didn't return priority",
+                          idf58 (job->id));
         }
         /*
          *   O/w, plugin provided a new priority.
@@ -727,8 +728,8 @@ static void error_asprintf (struct jobtap *jobtap,
     va_start (ap, fmt);
     if (vasprintf (errp, fmt, ap) < 0)
         flux_log_error (jobtap->ctx->h,
-                        "id=%ju: failed to create error string: fmt=%s",
-                        (uintmax_t) job->id, fmt);
+                        "id=%s: failed to create error string: fmt=%s",
+                        idf58 (job->id), fmt);
     va_end (ap);
 }
 
@@ -955,8 +956,8 @@ int jobtap_check_dependencies (struct jobtap *jobtap,
                                   "%s (job may be stuck in DEPEND state)",
                                   *errp) < 0)
                 flux_log_error (jobtap->ctx->h,
-                                "id=%ju: failed to raise dependency exception",
-                                (uintmax_t) job->id);
+                                "id=%s: failed to raise dependency exception",
+                                idf58 (job->id));
             free (*errp);
             *errp = NULL;
         }
@@ -984,9 +985,9 @@ int jobtap_notify_subscribers (struct jobtap *jobtap,
 
     if (snprintf (topic, topiclen, "job.event.%s", name) >= topiclen) {
         flux_log (jobtap->ctx->h, LOG_ERR,
-                  "jobtap: %s: %ju: event topic name too long",
+                  "jobtap: %s: %s: event topic name too long",
                   name,
-                  (uintmax_t) job->id);
+                  idf58 (job->id));
         return -1;
     }
 
@@ -995,9 +996,9 @@ int jobtap_notify_subscribers (struct jobtap *jobtap,
     va_end (ap);
     if (!args) {
         flux_log (jobtap->ctx->h, LOG_ERR,
-                  "jobtap: %s: %ju: failed to create plugin args",
+                  "jobtap: %s: %s: failed to create plugin args",
                   topic,
-                  (uintmax_t) job->id);
+                  idf58 (job->id));
         return -1;
     }
 
@@ -1024,9 +1025,9 @@ int jobtap_call (struct jobtap *jobtap,
     va_start (ap, fmt);
     if (!(args = jobtap_args_vcreate (jobtap, job, fmt, ap))) {
         flux_log (jobtap->ctx->h, LOG_ERR,
-                  "jobtap: %s: %ju: failed to create plugin args",
+                  "jobtap: %s: %s: failed to create plugin args",
                   topic,
-                  (uintmax_t) job->id);
+                  idf58 (job->id));
     }
     va_end (ap);
 
@@ -1071,9 +1072,9 @@ int jobtap_call (struct jobtap *jobtap,
             rc = annotations_update_and_publish (jobtap->ctx, job, note);
         if (rc < 0)
             flux_log_error (jobtap->ctx->h,
-                            "jobtap: %s: %ju: annotations_update",
+                            "jobtap: %s: %s: annotations_update",
                             topic,
-                            (uintmax_t) job->id);
+                            idf58 (job->id));
     }
     if (priority >= FLUX_JOB_PRIORITY_MIN) {
         /*

--- a/src/modules/job-manager/plugins/alloc-bypass.c
+++ b/src/modules/job-manager/plugins/alloc-bypass.c
@@ -24,6 +24,7 @@
 #include <flux/jobtap.h>
 
 #include "src/common/librlist/rlist.h"
+#include "src/common/libjob/idf58.h"
 
 static void alloc_continuation (flux_future_t *f, void *arg)
 {
@@ -56,8 +57,8 @@ static void alloc_continuation (flux_future_t *f, void *arg)
      */
     if (flux_jobtap_job_aux_set (p, *idptr, "alloc-bypass::free", p, NULL) < 0)
         flux_log_error (flux_jobtap_get_flux (p),
-                        "id=%ju: Failed to set alloc-bypass::free",
-                        *idptr);
+                        "id=%s: Failed to set alloc-bypass::free",
+                        idf58 (*idptr));
 
 done:
     flux_future_destroy (f);

--- a/src/modules/job-manager/plugins/begin-time.c
+++ b/src/modules/job-manager/plugins/begin-time.c
@@ -20,6 +20,8 @@
 #include <flux/core.h>
 #include <flux/jobtap.h>
 
+#include "src/common/libjob/idf58.h"
+
 struct begin_time_arg {
     flux_plugin_t *p;
     flux_watcher_t *w;
@@ -94,7 +96,7 @@ static int add_begin_time (flux_plugin_t *p,
     flux_watcher_start (arg->w);
 
     if (flux_jobtap_dependency_add (p, id, arg->desc) < 0) {
-        flux_log_error (h, "%ju: flux_jobtap_dependency_add", (uintmax_t) id);
+        flux_log_error (h, "%s: flux_jobtap_dependency_add", idf58 (id));
         goto error;
     }
 

--- a/src/modules/job-manager/plugins/dependency-after.c
+++ b/src/modules/job-manager/plugins/dependency-after.c
@@ -20,6 +20,7 @@
 #include <flux/jobtap.h>
 
 #include "src/common/libutil/iterators.h"
+#include "src/common/libjob/idf58.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "ccan/str/str.h"
 
@@ -413,8 +414,8 @@ static int dependency_after_cb (flux_plugin_t *p,
         && flux_jobtap_job_subscribe (p, afterid) < 0) {
         after_info_destroy (after);
         after_ref_destroy (ref);
-        return flux_jobtap_reject_job (p, args, "failed to subscribe to %ju",
-                                       (uintmax_t) id);
+        return flux_jobtap_reject_job (p, args, "failed to subscribe to %s",
+                                       idf58 (id));
     }
 
     return 0;
@@ -437,8 +438,8 @@ static void remove_jobid_dependency (flux_plugin_t *p,
                                          "Failed to remove dependency %s",
                                          after->description) < 0) {
             flux_log_error (flux_jobtap_get_flux (p),
-                            "flux_jobtap_raise_exception: id=%ju",
-                            (uintmax_t) after->depid);
+                            "flux_jobtap_raise_exception: id=%s",
+                            idf58 (after->depid));
         }
     }
 }
@@ -486,8 +487,8 @@ static void raise_exceptions (flux_plugin_t *p, zlistx_t *l)
                                              "dependency",
                                              after->description) < 0)
                 flux_log_error (flux_jobtap_get_flux (p),
-                                "id=%ju: unable to raise exception for %s",
-                                (uintmax_t) after->depid,
+                                "id=%s: unable to raise exception for %s",
+                                idf58 (after->depid),
                                 after->description);
         }
         /*  N.B. = entry will be deleted at list destruction */

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -161,8 +161,8 @@ static void emit_finish_event (struct perilog_proc *proc, int status)
                                        "job-manager.prolog",
                                        status) < 0)
             flux_log_error (flux_jobtap_get_flux (proc->p),
-                            "flux_jobtap_prolog_finish: id=%ju status=%d",
-                            proc->id,
+                            "flux_jobtap_prolog_finish: id=%s status=%d",
+                            idf58 (proc->id),
                             status);
     }
     else {
@@ -233,8 +233,8 @@ static void io_cb (flux_subprocess_t *sp, const char *stream)
     int len;
 
     if (!(s = flux_subprocess_getline (sp, stream, &len))) {
-        flux_log_error (h, "%ju: %s: %s: flux_subprocess_getline",
-                        (uintmax_t) proc->id,
+        flux_log_error (h, "%s: %s: %s: flux_subprocess_getline",
+                        idf58 (proc->id),
                         proc->prolog ? "prolog": "epilog",
                         stream);
         return;
@@ -245,8 +245,8 @@ static void io_cb (flux_subprocess_t *sp, const char *stream)
             level = LOG_ERR;
         flux_log (h,
                   level,
-                  "%ju: %s: %s: %s",
-                  (uintmax_t) proc->id,
+                  "%s: %s: %s: %s",
+                  idf58 (proc->id),
                   proc->prolog ? "prolog" : "epilog",
                   stream,
                   s);
@@ -380,8 +380,8 @@ static void prolog_kill_cb (flux_future_t *f, void *arg)
 
     if (flux_future_get (f, NULL) < 0) {
         flux_log_error (h,
-                        "%ju: Failed to signal job prolog",
-                        (uintmax_t) proc->id);
+                        "%s: Failed to signal job prolog",
+                        idf58 (proc->id));
     }
 }
 
@@ -419,8 +419,8 @@ static void prolog_kill_timer_cb (flux_reactor_t *r,
 
     if (!(f = flux_subprocess_kill (proc->sp, SIGKILL))) {
         flux_log_error (h,
-                        "%ju: failed to send SIGKILL to prolog",
-                        (uintmax_t) proc->id);
+                        "%s: failed to send SIGKILL to prolog",
+                        idf58 (proc->id));
         return;
     }
     /* Do not wait for any response */
@@ -439,8 +439,8 @@ static int prolog_kill_timer_start (struct perilog_proc *proc, double timeout)
                                                       proc);
         if (!proc->kill_timer) {
             flux_log_error (h,
-                            "%ju: failed to start prolog kill timer",
-                            (uintmax_t) proc->id);
+                            "%s: failed to start prolog kill timer",
+                            idf58 (proc->id));
             return -1;
         }
         flux_watcher_start (proc->kill_timer);

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -52,6 +52,7 @@
 #include <flux/jobtap.h>
 
 #include "src/common/libjob/job_hash.h"
+#include "src/common/libjob/idf58.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "ccan/str/str.h"
 
@@ -269,7 +270,6 @@ static int run_command (flux_plugin_t *p,
         .on_stderr = io_cb
     };
     char path[PATH_MAX + 1];
-    char jobid[128];
 
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
@@ -280,13 +280,8 @@ static int run_command (flux_plugin_t *p,
         return -1;
     }
 
-    if (flux_job_id_encode (id, "f58", jobid, sizeof (jobid)) < 0) {
-        flux_log_error (h, "flux_job_id_encode");
-        return -1;
-    }
-
     if (flux_cmd_setcwd (cmd, getcwd (path, sizeof (path))) < 0
-        || flux_cmd_setenvf (cmd, 1, "FLUX_JOB_ID", "%s", jobid) < 0
+        || flux_cmd_setenvf (cmd, 1, "FLUX_JOB_ID", "%s", idf58 (id)) < 0
         || flux_cmd_setenvf (cmd, 1, "FLUX_JOB_USERID", "%u", userid) < 0) {
         flux_log_error (h, "%s: flux_cmd_create", prolog ? "prolog" : "epilog");
         return -1;

--- a/src/modules/job-manager/prioritize.c
+++ b/src/modules/job-manager/prioritize.c
@@ -17,6 +17,7 @@
 #endif
 #include <flux/core.h>
 
+#include "src/common/libjob/idf58.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 
 #include "job.h"
@@ -53,7 +54,9 @@ static int sched_prioritize_one (struct job_manager *ctx, struct job *job)
         return -1;
     }
     if (sched_prioritize (ctx->h, priorities) < 0) {
-        flux_log_error (ctx->h, "rpc: sched.priority: id=%ju", job->id);
+        flux_log_error (ctx->h,
+                        "rpc: sched.priority: id=%s",
+                        idf58 (job->id));
         json_decref (priorities);
         return -1;
     }
@@ -189,8 +192,8 @@ int reprioritize_all (struct job_manager *ctx)
         /*  Call plugin to get immediate priority calculation
          */
         if (jobtap_get_priority (ctx->jobtap, job, &priority) < 0) {
-            flux_log_error (h, "jobtap_get_priority: %ju",
-                            (uintmax_t) job->id);
+            flux_log_error (h, "jobtap_get_priority: %s",
+                            idf58 (job->id));
             continue;
         }
 
@@ -203,8 +206,8 @@ int reprioritize_all (struct job_manager *ctx)
              *   post a priority event if the priority changes
              */
             if (reprioritize_one (ctx, job, priority, false) < 0) {
-                flux_log_error (h, "reprioritize_one: %ju",
-                                (uintmax_t) job->id);
+                flux_log_error (h, "reprioritize_one: %s",
+                                idf58 (job->id));
                 goto error;
             }
 

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -20,6 +20,7 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/jpath.h"
 #include "src/common/libutil/errno_safe.h"
+#include "src/common/libjob/idf58.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "ccan/str/str.h"
 
@@ -404,8 +405,8 @@ bool queue_started (struct queue *queue, struct job *job)
             return false;
         if (!(q = zhashx_lookup (queue->named, job->queue))) {
             flux_log (queue->ctx->h, LOG_ERR,
-                      "%s: job %ju invalid queue: %s",
-                      __FUNCTION__, (uintmax_t)job->id, job->queue);
+                      "%s: job %s invalid queue: %s",
+                      __FUNCTION__, idf58 (job->id), job->queue);
             return false;
         }
         return q->start;

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -31,6 +31,7 @@
 #include <ctype.h>
 #include <flux/core.h>
 
+#include "src/common/libjob/idf58.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 
 #include "job.h"
@@ -254,8 +255,8 @@ void raiseall_handle_request (flux_t *h,
         while (job) {
             if (raise_job (ctx, type, severity, cred.userid, note, job) < 0) {
                 flux_log_error (h,
-                                "error raising exception on id=%ju",
-                                (uintmax_t)job->id);
+                                "error raising exception on id=%s",
+                                idf58 (job->id));
                 error_count++;
             }
             job = zlistx_next (target_jobs);

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -85,6 +85,7 @@
 #include <flux/core.h>
 #include <assert.h>
 
+#include "src/common/libjob/idf58.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "ccan/str/str.h"
 
@@ -134,8 +135,10 @@ static void hello_cb (flux_t *h, flux_msg_handler_t *mh,
     while (job) {
         if (job->state == FLUX_JOB_STATE_RUN) {
             if (event_job_action (ctx->event, job) < 0)
-                flux_log_error (h, "%s: event_job_action id=%ju", __FUNCTION__,
-                                (uintmax_t)job->id);
+                flux_log_error (h,
+                                "%s: event_job_action id=%s",
+                                __FUNCTION__,
+                                idf58 (job->id));
         }
         job = zhashx_next (ctx->active_jobs);
     }
@@ -195,8 +198,8 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        flux_log (h, LOG_ERR, "start response: id=%ju not active",
-                  (uintmax_t)id);
+        flux_log (h, LOG_ERR, "start response: id=%s not active",
+                  idf58 (id));
         errno = EINVAL;
         goto error;
     }
@@ -204,8 +207,8 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
         if (job->reattach)
             flux_log (h,
                       LOG_ERR,
-                      "start response: id=%ju should not get start event",
-                      (uintmax_t)id);
+                      "start response: id=%s should not get start event",
+                      idf58 (id));
         else {
             if (event_job_post_pack (ctx->event, job, "start", 0, NULL) < 0)
                 goto error_post;

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -57,6 +57,7 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libjob/job_hash.h"
+#include "src/common/libjob/idf58.h"
 #include "ccan/str/str.h"
 
 #include "drain.h"
@@ -148,8 +149,8 @@ static void wait_respond (struct waitjob *wait,
     if (decode_job_result (job, &success, &error) < 0) {
         flux_log (h,
                   LOG_ERR,
-                  "wait_respond id=%ju: result decode failure",
-                  (uintmax_t)job->id);
+                  "wait_respond id=%s: result decode failure",
+                  idf58 (job->id));
         goto error;
     }
     if (flux_respond_pack (h,
@@ -161,11 +162,11 @@ static void wait_respond (struct waitjob *wait,
                            success ? 1 : 0,
                            "errstr",
                            error.text) < 0)
-        flux_log_error (h, "wait_respond id=%ju", (uintmax_t)job->id);
+        flux_log_error (h, "wait_respond id=%s", idf58 (job->id));
     return;
 error:
     if (flux_respond_error (h, msg, errno, "Flux job wait internal error") < 0)
-        flux_log_error (h, "wait_respond id=%ju", (uintmax_t)job->id);
+        flux_log_error (h, "wait_respond id=%s", idf58 (job->id));
 }
 
 /* Callback from event_job_action().  The 'job' has entered INACTIVE state.

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -19,6 +19,7 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libjob/job.h"
 #include "src/common/libjob/jj.h"
+#include "src/common/libjob/idf58.h"
 #include "src/common/librlist/rlist.h"
 #include "ccan/str/str.h"
 
@@ -272,7 +273,7 @@ static int try_alloc (flux_t *h, struct simple_sched *ss)
                                               "jobs_ahead") < 0)
         flux_log_error (h, "schedutil_alloc_respond_success_pack");
 
-    flux_log (h, LOG_DEBUG, "alloc: %ju: %s", (uintmax_t) job->id, s);
+    flux_log (h, LOG_DEBUG, "alloc: %s: %s", idf58 (job->id), s);
     rc = 0;
 
 out:
@@ -402,8 +403,8 @@ static void alloc_cb (flux_t *h, const flux_msg_t *msg, void *arg)
         jobreq_destroy (job);
         return;
     }
-    flux_log (h, LOG_DEBUG, "req: %ju: spec={%d,%d,%d} duration=%.1f",
-                            (uintmax_t) job->id, job->jj.nnodes,
+    flux_log (h, LOG_DEBUG, "req: %s: spec={%d,%d,%d} duration=%.1f",
+                            idf58 (job->id), job->jj.nnodes,
                             job->jj.nslots, job->jj.slot_size,
                             job->jj.duration);
     search_dir = job->priority > FLUX_JOB_URGENCY_DEFAULT;
@@ -521,8 +522,8 @@ static int hello_cb (flux_t *h,
     }
 
     flux_log (h, LOG_DEBUG,
-              "hello: id=%ju priority=%u userid=%u t_submit=%0.1f",
-              (uintmax_t)id,
+              "hello: id=%s priority=%u userid=%u t_submit=%0.1f",
+              idf58 (id),
               priority,
               (unsigned int)userid,
               t_submit);

--- a/src/shell/svc.c
+++ b/src/shell/svc.c
@@ -35,6 +35,8 @@
 #include <unistd.h>
 #include <flux/core.h>
 
+#include "src/common/libjob/idf58.h"
+
 #include "internal.h"
 #include "task.h"
 #include "svc.h"
@@ -66,9 +68,9 @@ static int build_topic (struct shell_svc *svc,
 {
     if (snprintf (buf,
                   len,
-                  "%ju-shell-%ju%s%s",
+                  "%ju-shell-%s%s%s",
                   (uintmax_t)svc->uid,
-                  (uintmax_t)svc->shell->info->jobid,
+                  idf58 (svc->shell->info->jobid),
                   method ? "." : "",
                   method ? method : "") >= len) {
         errno = EINVAL;

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -42,6 +42,7 @@
 #include <flux/core.h>
 #include <flux/shell.h>
 
+#include "src/common/libjob/idf58.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 
 #include "internal.h"
@@ -98,7 +99,6 @@ struct shell_task *shell_task_create (struct shell_info *info,
     const char *key;
     json_t *entry;
     size_t i;
-    char buf[64];
 
     if (!(task = shell_task_new ()))
         return NULL;
@@ -130,10 +130,11 @@ struct shell_task *shell_task_create (struct shell_info *info,
                           info->shell_size) < 0)
         goto error;
 
-    /* Attempt to encode jobid as F58 by default */
-    if (flux_job_id_encode (info->jobid, "f58", buf, sizeof (buf)) < 0)
-       snprintf (buf, sizeof (buf), "%ju", (uintmax_t)info->jobid);
-    if (flux_cmd_setenvf (task->cmd, 1, "FLUX_JOB_ID", "%s", buf) < 0)
+    if (flux_cmd_setenvf (task->cmd,
+                          1,
+                          "FLUX_JOB_ID",
+                          "%s",
+                          idf58 (info->jobid)) < 0)
         goto error;
 
     /* Always unset FLUX_PROXY_REMOTE since this never makes sense

--- a/src/shell/tmpdir.c
+++ b/src/shell/tmpdir.c
@@ -15,6 +15,7 @@
 #endif
 
 #include "src/common/libutil/cleanup.h"
+#include "src/common/libjob/idf58.h"
 
 #include "builtins.h"
 #include "internal.h"
@@ -39,13 +40,16 @@ static int make_job_path (flux_shell_t *shell,
 {
     size_t n;
 
-    n = snprintf (buf, size, "%s/jobtmp-%d-", parent, shell->info->shell_rank);
+    n = snprintf (buf,
+                  size,
+                  "%s/jobtmp-%d-%s",
+                  parent,
+                  shell->info->shell_rank,
+                  idf58 (shell->jobid));
     if (n >= size) {
         errno = EOVERFLOW;
         return -1;
     }
-    if (flux_job_id_encode (shell->jobid, "f58", buf + n, size - n) < 0)
-        return -1;
     return 0;
 }
 

--- a/t/t2203-job-manager-single.t
+++ b/t/t2203-job-manager-single.t
@@ -125,8 +125,8 @@ test_expect_success 'job-manager: reload sched-simple w/ 2 ranks, 2 cores/rank' 
 '
 
 test_expect_success 'job-manager: hello handshake found jobs 1 3' '
-        grep id=$(flux job id < job1.id) hello.dmesg &&
-        grep id=$(flux job id < job3.id) hello.dmesg
+        grep id=$(flux job id --to=f58 < job1.id) hello.dmesg &&
+        grep id=$(flux job id --to=f58 < job3.id) hello.dmesg
 '
 
 test_expect_success 'job-manager: hello handshake priority is default urgency' '

--- a/t/t2207-job-manager-bulk-state.t
+++ b/t/t2207-job-manager-bulk-state.t
@@ -11,11 +11,11 @@ flux setattr log-stderr-level 1
 BULK_STATE="flux python ${FLUX_SOURCE_DIR}/t/job-manager/bulk-state.py"
 
 test_expect_success 'job-manager: all state events received (5 jobs from rank 0)' '
-	run_timeout 10 ${BULK_STATE} 5
+	run_timeout 30 ${BULK_STATE} 5
 '
 
 test_expect_success 'job-manager: all state events received (2 jobs from 4 ranks)' '
-	run_timeout 10 flux exec -r all ${BULK_STATE} 2
+	run_timeout 30 flux exec -r all ${BULK_STATE} 2
 '
 
 test_done

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -83,7 +83,7 @@ test_expect_success 'job-exec: job shell eventually killed by SIGKILL' '
 		ready &&
 	flux cancel $id &&
 	flux job wait-event -vt 15 $id clean &&
-	flux dmesg | grep $(flux job id $id) &&
+	flux dmesg | grep $(flux job id --to=f58 $id) &&
 	test_expect_code 137 flux job status $id &&
 	flux module reload job-exec
 '


### PR DESCRIPTION
This PR adds an `idf58()` convenience function which uses TLS for the buffer so it is safe to use in broker modules. This function is meant to replace similar local functions used in a few other places in the code base, and also to easily convert jobids to an f58 string in logging functions.

This function is then used to replace common code in a couple places, to render the jobid as f58 in the shell service name, and to update most logging of jobids from decimal to f58.

I put this as a WIP becase I'm not sure if others will agree with the approach, and I may have gone too far converting log messages. Also, maybe there's a better way...

Fixes #5243