### PR TITLE
python: allow JobID to take a JobID

### DIFF
--- a/src/bindings/python/flux/job/JobID.py
+++ b/src/bindings/python/flux/job/JobID.py
@@ -53,6 +53,8 @@ class JobID(int):
     """
 
     def __new__(cls, value):
+        if isinstance(value, JobID):
+            return cls(value.orig_str)
         if isinstance(value, int):
             jobid = value
         else:

--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -13,6 +13,7 @@ import pwd
 
 import flux.constants
 from flux.future import WaitAllFuture
+from flux.job import JobID
 from flux.job.info import JobInfo
 from flux.rpc import RPC
 
@@ -211,7 +212,7 @@ class JobList:
         self.since = since
         self.name = name
         self.queue = queue
-        self.ids = ids
+        self.ids = list(map(JobID, ids)) if ids else None
         self.errors = []
         for fname in filters:
             for x in fname.split(","):

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -468,6 +468,12 @@ class TestJob(unittest.TestCase):
                     # Ensure encode back to same type works
                     self.assertEqual(getattr(jobid, key), test[key])
 
+        # JobID can also take a JobID
+        jobid1 = job.JobID(1234)
+        jobid2 = job.JobID(jobid1)
+        self.assertEqual(jobid1, jobid2)
+        self.assertEqual(jobid2.orig, "1234")
+
     def test_25_job_list_attrs(self):
         expected_attrs = [
             "userid",


### PR DESCRIPTION
While working on #5176 I noticed a corner case in the `JobList` class.  It assumes that all ids passed in are of type `JobID`, so that later on `jobid.orig` can be output in an error message.  But a jobid could just be an integer.

There are multiple ways to handle this.  I elected to go for a simple:

```
-                    msg = f"JobID {child.jobid.orig} unknown"
+                    id = JobID(child.jobid)
+                    msg = f"JobID {id.orig} unknown"
```

solution.  This also requires the `JobID` class to take a `JobID` as input.  There of course other ways to skin this cat of course.