### PR TITLE
optparse: add `optparse_get_size()` accessor and use it in `flux restore` and `flux filemap`

### DIFF
--- a/doc/man1/flux-filemap.rst
+++ b/doc/man1/flux-filemap.rst
@@ -76,7 +76,10 @@ OPTIONS
 
 **--chunksize=N**
    Limit the content mapped blob size to N bytes.  Set to 0 for unlimited.
-   The default is 1048576 (*map* subcommand only).
+   N may be a floating-point number with optional suffix 'b' for bytes (the
+   default), 'k' for kibibytes (KiB, units of 1024 bytes), 'M' for mebibytes
+   (MiB, units of 1024 * 1024 bytes), or 'G' for gibibytes (units of 1024 *
+   1024 * 1024 bytes). The default is 1M (*map* subcommand only).
 
 **--direct**
    Avoid indirection through the content cache when fetching the top level

--- a/doc/man1/flux-restore.rst
+++ b/doc/man1/flux-restore.rst
@@ -54,7 +54,11 @@ OPTIONS
    store.  Performance will vary depending on the content of the archive.
 
 **--size-limit**\ =\ *SIZE*
-   Skip restoring keys that exceed SIZE bytes (default: no limit).
+   Skip restoring keys that exceed SIZE bytes (default: no limit). SIZE is
+   a floating point number with an optional suffix of 'b' for bytes (the
+   default), 'k' for kibibytes (KiB, units of 1024 bytes), 'M' for mebibytes
+   (MiB, unites of 1024 * 1024 bytes), or 'G' for gibibytes (GiB, units of
+   1024 * 1024 * 1024 bytes).
 
 RESOURCES
 =========

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -708,3 +708,9 @@ pmix
 SIGUSR
 iteratively
 noverify
+KiB
+kibibytes
+MiB
+mebibytes
+GiB
+gibibytes

--- a/etc/rc1
+++ b/etc/rc1
@@ -47,7 +47,7 @@ if test $RANK -eq 0; then
             flux module load ${backingmod} truncate
         fi
         echo "restoring content from ${dumpfile}"
-        flux restore --quiet --checkpoint --size-limit=104857600 ${dumpfile}
+        flux restore --quiet --checkpoint --size-limit=100M ${dumpfile}
         if test -n "${dumplink}"; then
             rm -f ${dumplink}
         fi

--- a/src/cmd/builtin/filemap.c
+++ b/src/cmd/builtin/filemap.c
@@ -29,7 +29,7 @@
 #include "src/common/libfilemap/filemap.h"
 #include "src/common/libutil/fileref.h"
 
-static const int default_chunksize = 1048576;
+static const char *default_chunksize = "1M";
 static const int default_small_file_threshold = 4096;
 
 static json_t *get_list_option (optparse_t *p,
@@ -175,7 +175,7 @@ static int subcmd_map (optparse_t *p, int ac, char *av[])
     }
     ctx.p = p;
     ctx.verbose = optparse_get_int (p, "verbose", 0);
-    ctx.chunksize = optparse_get_int (p, "chunksize", default_chunksize);
+    ctx.chunksize = optparse_get_size (p, "chunksize", default_chunksize);
     ctx.threshold = optparse_get_int (p,
                                       "small-file-threshold",
                                       default_small_file_threshold);
@@ -375,9 +375,9 @@ static struct optparse_option map_opts[] = {
       .usage = "Change to DIR before mapping", },
     { .name = "verbose", .key = 'v', .has_arg = 2, .arginfo = "[LEVEL]",
       .usage = "Increase output detail.", },
-    { .name = "chunksize", .has_arg = 1, .arginfo = "N",
+    { .name = "chunksize", .has_arg = 1, .arginfo = "N[kMG]",
       .usage = "Limit blob size to N bytes with 0=unlimited"
-               " (default 1048576)", },
+               " (default 1M)", },
     { .name = "small-file-threshold", .has_arg = 1, .arginfo = "N",
       .usage = "Adjust the maximum size of a \"small file\" in bytes"
                " (default 4096)", },

--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -366,7 +366,7 @@ static int cmd_restore (optparse_t *p, int ac, char *av[])
         content_flags |= CONTENT_FLAG_CACHE_BYPASS;
         kvs_checkpoint_flags |= KVS_CHECKPOINT_FLAG_CACHE_BYPASS;
     }
-    blob_size_limit = optparse_get_int (p, "size-limit", 0);
+    blob_size_limit = optparse_get_size (p, "size-limit", "0");
 
     h = builtin_get_flux_handle (p);
     ar = restore_create (infile);

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -381,6 +381,15 @@ int optparse_get_int (optparse_t *p, const char *name, int default_value);
 double optparse_get_duration (optparse_t *p, const char *name,
                               double default_value);
 
+/*   Return the option argument parsed as a file size parameter in
+ *   floating-point 'size[bkMG]', where the optional suffix designates
+ *   'b' for bytes, 'k' for kibibytes (KiB), 'M' for mebibytes (MiB) or
+ *   'G' for gibibytes (GiB). The end result in bytes is truncated
+ *   and returned as off_t. If there was an error parsing the size string,
+ *   then the fatal error function is called.
+ */
+off_t optparse_get_size (optparse_t *p, const char *name,
+                         const char *default_value);
 /*
  *   Return the option argument as a double if 'name' was used,
  *    'default_value' if not.  If the option is unknown, or the argument


### PR DESCRIPTION
I couldn't help myself and added an `optparse_get_size()` accessor that takes a string argument of the form `N[bkMG]` to specify a size value. `N` can be a floating-point value with optional suffix `b` (the default) for bytes, `k` for KiB (1024 bytes), `M` for MiB (1024*1024 bytes), and `G` for GiB.

Then a couple commands that take a size argument are updated with this accessor so they can take human readable arguments.