### PR TITLE
shell: set correct HOSTNAME in job environment if necessary

### DIFF
--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1668,7 +1668,7 @@ int main (int argc, char *argv[])
     while (taskid != IDSET_INVALID_ID) {
         struct shell_task *task;
 
-        if (!(task = shell_task_create (shell.info, i, taskid)))
+        if (!(task = shell_task_create (&shell, i, taskid)))
             shell_die (1, "shell_task_create index=%d", i);
 
         task->pre_exec_cb = shell_task_exec;

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -91,10 +91,11 @@ error:
     return NULL;
 }
 
-struct shell_task *shell_task_create (struct shell_info *info,
+struct shell_task *shell_task_create (flux_shell_t *shell,
                                       int index,
                                       int taskid)
 {
+    struct shell_info *info = shell->info;
     struct shell_task *task;
     const char *key;
     json_t *entry;

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -22,6 +22,7 @@
  *    . FLUX_JOB_NNODES
  *    . FLUX_JOB_ID
  *    . FLUX_URI (if not running standalone)
+ *    . correct HOSTNAME if set in job environment
  *
  * Current working directory
  *    Ignore - shell should already be in it.
@@ -154,6 +155,17 @@ struct shell_task *shell_task_create (flux_shell_t *shell,
                               getenv ("FLUX_KVS_NAMESPACE")) < 0)
             goto error;
     }
+
+    /* If HOSTNAME is set in job environment it is almost certain to be
+     * incorrect. Overwrite with the correct hostname.
+     */
+    if (flux_cmd_getenv (task->cmd, "HOSTNAME")
+        && flux_cmd_setenvf (task->cmd,
+                             1,
+                             "HOSTNAME",
+                             "%s",
+                             shell->hostname) < 0)
+        goto error;
     return task;
 error:
     shell_task_destroy (task);

--- a/src/shell/task.h
+++ b/src/shell/task.h
@@ -54,7 +54,7 @@ struct shell_task {
 
 void shell_task_destroy (struct shell_task *task);
 
-struct shell_task *shell_task_create (struct shell_info *info,
+struct shell_task *shell_task_create (flux_shell_t *shell,
                                       int index,
                                       int taskid);
 

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -340,7 +340,18 @@ test_expect_success 'job-shell: fails if FLUX_EXEC_PROTOCOL_FD incorrect' '
 		-n2 -N2 hostname 2>protocol_fd_invalid.err &&
 	grep FLUX_EXEC_PROTOCOL_FD protocol_fd_invalid.err
 '
-
+test_expect_success 'job-shell: corrects HOSTNAME environment variable' '
+	HOSTNAME=incorrect \
+		flux run -n1 printenv HOSTNAME >hostname.out &&
+	test_debug "cat hostname.out" &&
+	test "$(hostname)" = "$(cat hostname.out)"
+'
+test_expect_success 'job-shell: leaves HOSTNAME unset if not set' '
+	( unset HOSTNAME &&
+	  test_expect_code 1 flux run -n1 printenv HOSTNAME >hostname.out2
+	) &&
+	test_must_be_empty hostname.out2
+'
 #  Note: in below tests, os.exit(True) returns with nonzero exit code,
 #   so the sense of the tests is reversed so the tasks exit with zero exit
 #   code for success.


### PR DESCRIPTION
This PR fixes #5258 by overwriting HOSTNAME in the job environment when it is set.