### PR TITLE
sdbus: make debug logging configurable

### DIFF
--- a/t/t2407-sdbus.t
+++ b/t/t2407-sdbus.t
@@ -299,7 +299,7 @@ test_expect_success 'create list script' '
 test_expect_success 'list from rank 0 is allowed' '
 	flux python ./list.py >/dev/null
 '
-test_expect_success 'list-units-leader from rank 1 is restricted' '
+test_expect_success 'list from rank 1 is restricted' '
 	test_must_fail flux exec -r 1 flux python ./list.py 2>list1.err &&
 	grep "not allowed" list1.err
 '

--- a/t/t2407-sdbus.t
+++ b/t/t2407-sdbus.t
@@ -111,8 +111,21 @@ bus_subscribe_cancel () {
     flux python -c "import flux; flux.Flux().rpc(\"sdbus.subscribe-cancel\",{\"matchtag\":$1},flags=flux.constants.FLUX_RPC_NORESPONSE)"
 }
 
+test_expect_success 'enable sdbus-debug in configuration' '
+	flux config load <<-EOT
+	[systemd]
+	sdbus-debug = true
+	EOT
+'
 test_expect_success 'load sdbus module' '
 	flux module load sdbus
+'
+test_expect_success 'sdbus reconfig fails with bad sdbus-debug value' '
+	test_must_fail flux config load <<-EOT 2>config.err &&
+	[systemd]
+	sdbus-debug = 42
+	EOT
+	grep "Expected true or false" config.err
 '
 
 test_expect_success 'sdbus list-units works' '

--- a/t/t2408-sdbus-recovery.t
+++ b/t/t2408-sdbus-recovery.t
@@ -18,7 +18,13 @@ if ! busctl --user status >/dev/null; then
 	test_done
 fi
 
-test_under_flux 1 minimal
+mkdir -p config
+cat >config/config.toml <<EOF
+[systemd]
+sdbus-debug = true
+EOF
+
+test_under_flux 1 minimal -o,--config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 


### PR DESCRIPTION
Problem: sdbus is prolific in its output to the flux circular log buffer.
    
Disable debug logging by default, and allow it to be enabled by config:
```toml
[systemd]
sdbus-debug = true
````

(This was peeled off of #5197)