### PR TITLE
python: support convenience API for `job-info.lookup` RPC / "flux job info"

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -31,6 +31,7 @@ nobase_fluxpy_PYTHON = \
 	job/kill.py \
 	job/kvs.py \
 	job/list.py \
+	job/kvslookup.py \
 	job/info.py \
 	job/wait.py \
 	job/submit.py \

--- a/src/bindings/python/flux/job/__init__.py
+++ b/src/bindings/python/flux/job/__init__.py
@@ -15,6 +15,7 @@ from flux.job.kill import kill_async, kill, cancel_async, cancel
 from flux.job.submit import submit_async, submit, submit_get_id
 from flux.job.info import JobInfo, JobInfoFormat, job_fields_to_attrs
 from flux.job.list import job_list, job_list_inactive, job_list_id, JobList, get_job
+from flux.job.kvslookup import job_info_lookup, JobKVSLookup, job_kvs_lookup
 from flux.job.wait import wait_async, wait, wait_get_status, result_async, result
 from flux.job.event import (
     event_watch_async,

--- a/src/bindings/python/flux/job/kvslookup.py
+++ b/src/bindings/python/flux/job/kvslookup.py
@@ -1,0 +1,171 @@
+###############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import errno
+import json
+
+from flux.future import WaitAllFuture
+from flux.job import JobID
+from flux.rpc import RPC
+
+
+# a few keys are special, decode them into dicts if you can
+def decode_special_metadata(metadata):
+    for key in ("jobspec", "R"):
+        if key in metadata:
+            try:
+                tmp = json.loads(metadata[key])
+                metadata[key] = tmp
+            except json.decoder.JSONDecodeError:
+                # Ignore if can't be decoded
+                pass
+
+
+class JobInfoLookupRPC(RPC):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.jobid = None
+
+    def get(self):
+        return super().get()
+
+    def get_decode(self):
+        metadata = super().get()
+        decode_special_metadata(metadata)
+        return metadata
+
+
+def job_info_lookup(flux_handle, jobid, keys=["jobspec"]):
+    payload = {"id": int(jobid), "keys": keys, "flags": 0}
+    rpc = JobInfoLookupRPC(flux_handle, "job-info.lookup", payload)
+    rpc.jobid = jobid
+    return rpc
+
+
+# jobs_kvs_lookup simple variant for one jobid
+def job_kvs_lookup(flux_handle, jobid, keys=["jobspec"], decode=True):
+    """
+    Lookup job kvs data based on a jobid
+
+    :flux_handle: A Flux handle obtained from flux.Flux()
+    :jobid: jobid to lookup info for
+    :keys: Optional list of keys to fetch. (default is "jobspec")
+    :decode: Optional flag to decode special data into Python data structures
+             currently decodes "jobspec" and "R" into dicts
+             (default True)
+    """
+    payload = {"id": int(jobid), "keys": keys, "flags": 0}
+    rpc = JobInfoLookupRPC(flux_handle, "job-info.lookup", payload)
+    try:
+        if decode:
+            rsp = rpc.get_decode()
+        else:
+            rsp = rpc.get()
+    # The job does not exist!
+    except FileNotFoundError:
+        return None
+    return rsp
+
+
+class JobKVSLookupFuture(WaitAllFuture):
+    """Wrapper Future for multiple jobids"""
+
+    def __init__(self):
+        super(JobKVSLookupFuture, self).__init__()
+        self.errors = []
+
+    def _get(self, decode=True):
+        jobs = []
+        #  Wait for all RPCs to complete
+        self.wait_for()
+
+        #  Get all successful jobs, accumulate errors in self.errors
+        for child in self.children:
+            try:
+                if decode:
+                    rsp = child.get_decode()
+                else:
+                    rsp = child.get()
+                jobs.append(rsp)
+            except EnvironmentError as err:
+                if err.errno == errno.ENOENT:
+                    msg = f"JobID {child.jobid.orig} unknown"
+                else:
+                    msg = f"rpc: {err.strerror}"
+                self.errors.append(msg)
+        return jobs
+
+    def get(self):
+        """get all successful results, appending errors into self.errors"""
+        return self._get(False)
+
+    def get_decode(self):
+        """
+        get all successful results, appending errors into self.errors.  Decode
+        special data into Python data structures
+        """
+        return self._get(True)
+
+
+class JobKVSLookup:
+    """User friendly class to lookup job KVS data
+
+    :flux_handle: A Flux handle obtained from flux.Flux()
+    :ids: List of jobids to get data for
+    :keys: Optional list of keys to fetch. (default is "jobspec")
+    :decode: Optional flag to decode special data into Python data structures
+             currently decodes "jobspec" and "R" into dicts
+             (default True)
+    """
+
+    def __init__(
+        self,
+        flux_handle,
+        ids=[],
+        keys=["jobspec"],
+        decode=True,
+    ):
+        self.handle = flux_handle
+        self.keys = list(keys)
+        self.ids = list(map(JobID, ids)) if ids else []
+        self.decode = decode
+        self.errors = []
+
+    def fetch_data(self):
+        """Initiate the job info lookup to the Flux job-info module
+
+        JobKVSLookup.fetch_data() returns a JobKVSLookupFuture,
+        which will be fulfilled when the job data is available.
+
+        Once the Future has been fulfilled, a list of objects
+        can be obtained via JobKVSLookup.data(). If
+        JobKVSLookupFuture.errors is non-empty, then it will contain a
+        list of errors returned via the query.
+        """
+        listids = JobKVSLookupFuture()
+        for jobid in self.ids:
+            listids.push(job_info_lookup(self.handle, jobid, self.keys))
+        return listids
+
+    def data(self):
+        """Synchronously fetch a list of data responses
+
+        If the Future object returned by JobKVSLookup.fetch_data has
+        not yet been fulfilled (e.g. is_ready() returns False), then this call
+        may block.  Otherwise, returns a list of responses for all job ids
+        returned.
+        """
+        rpc = self.fetch_data()
+        if self.decode:
+            data = rpc.get_decode()
+        else:
+            data = rpc.get()
+        if hasattr(rpc, "errors"):
+            self.errors = rpc.errors
+        return data

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -160,6 +160,7 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
     size_t index;
     json_t *key;
     json_t *o = NULL;
+    json_t *tmp = NULL;
     char *data = NULL;
 
     if (!l->allow) {
@@ -183,6 +184,12 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
 
     if (!(o = json_object ()))
         goto enomem;
+
+    tmp = json_integer (l->id);
+    if (json_object_set_new (o, "id", tmp) < 0) {
+        json_decref (tmp);
+        goto enomem;
+    }
 
     json_array_foreach(l->keys, index, key) {
         flux_future_t *f;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -260,6 +260,7 @@ TESTSCRIPTS = \
 	python/t0010-job.py \
 	python/t0012-futures.py \
 	python/t0013-job-list.py \
+	python/t0014-job-kvslookup.py \
 	python/t0020-hostlist.py \
 	python/t0021-idset.py \
 	python/t0022-resource-set.py \

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -689,8 +689,8 @@ class TestJob(unittest.TestCase):
     def test_33_get_job(self):
         self.sleep_jobspec = JobspecV1.from_command(["sleep", "5"])
         jobid = job.submit(self.fh, self.sleep_jobspec)
-        meta = job.get_job(self.fh, jobid)
-        self.assertIsInstance(meta, dict)
+        info = job.get_job(self.fh, jobid)
+        self.assertIsInstance(info, dict)
         for key in [
             "id",
             "userid",
@@ -712,17 +712,17 @@ class TestJob(unittest.TestCase):
             "nodelist",
             "exception",
         ]:
-            self.assertIn(key, meta)
+            self.assertIn(key, info)
 
-        self.assertEqual(meta["id"], jobid)
-        self.assertEqual(meta["name"], "sleep")
-        self.assertTrue(meta["state"] in ["SCHED", "DEPEND", "RUN"])
-        self.assertEqual(meta["ntasks"], 1)
-        self.assertEqual(meta["ncores"], 1)
+        self.assertEqual(info["id"], jobid)
+        self.assertEqual(info["name"], "sleep")
+        self.assertTrue(info["state"] in ["SCHED", "DEPEND", "RUN"])
+        self.assertEqual(info["ntasks"], 1)
+        self.assertEqual(info["ncores"], 1)
 
         # Test a job that does not exist
-        meta = job.get_job(self.fh, 123456)
-        self.assertIsNone(meta)
+        info = job.get_job(self.fh, 123456)
+        self.assertIsNone(info)
 
     def test_34_timeleft(self):
         spec = JobspecV1.from_command(

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import json
+import unittest
+
+import flux
+import subflux  # noqa: F401 - for PYTHONPATH
+from flux.job import JobspecV1
+
+
+def __flux_size():
+    return 1
+
+
+class TestJob(unittest.TestCase):
+    @classmethod
+    def submitJob(self, command):
+        compute_jobreq = JobspecV1.from_command(
+            command=command, num_tasks=1, num_nodes=1, cores_per_task=1
+        )
+        return flux.job.submit(self.fh, compute_jobreq, waitable=True)
+
+    @classmethod
+    def setUpClass(self):
+        self.fh = flux.Flux()
+        self.jobid1 = self.submitJob(["hostname"])
+        flux.job.event_wait(self.fh, self.jobid1, name="start")
+        self.jobid2 = self.submitJob(["hostname"])
+        flux.job.event_wait(self.fh, self.jobid2, name="start")
+
+    def check_jobspec_str(self, data, jobid):
+        self.assertEqual(data["id"], jobid)
+        self.assertIn("jobspec", data)
+        self.assertEqual(type(data["jobspec"]), str)
+        jobspec = json.loads(data["jobspec"])
+        self.assertEqual(jobspec["tasks"][0]["command"][0], "hostname")
+        self.assertNotIn("R", data)
+
+    def check_jobspec_decoded(self, data, jobid):
+        self.assertEqual(data["id"], jobid)
+        self.assertIn("jobspec", data)
+        self.assertEqual(data["jobspec"]["tasks"][0]["command"][0], "hostname")
+        self.assertNotIn("R", data)
+
+    def check_R_J_str(self, data, jobid):
+        self.assertEqual(data["id"], jobid)
+        self.assertNotIn("jobspec", data, jobid)
+        self.assertIn("R", data)
+        self.assertIn("J", data)
+        self.assertEqual(type(data["R"]), str)
+        self.assertEqual(type(data["J"]), str)
+        R = json.loads(data["R"])
+        self.assertEqual(R["execution"]["R_lite"][0]["rank"], "0")
+
+    def check_R_J_decoded(self, data, jobid):
+        self.assertEqual(data["id"], jobid)
+        self.assertNotIn("jobspec", data)
+        self.assertIn("R", data)
+        self.assertIn("J", data)
+        self.assertEqual(type(data["J"]), str)
+        self.assertEqual(data["R"]["execution"]["R_lite"][0]["rank"], "0")
+
+    def test_00_job_info_lookup(self):
+        rpc = flux.job.job_info_lookup(self.fh, self.jobid1)
+        data = rpc.get()
+        self.check_jobspec_str(data, self.jobid1)
+        data = rpc.get_decode()
+        self.assertEqual(data["id"], self.jobid1)
+
+    def test_01_job_info_lookup_keys(self):
+        rpc = flux.job.job_info_lookup(self.fh, self.jobid1, keys=["R", "J"])
+        data = rpc.get()
+        self.check_R_J_str(data, self.jobid1)
+        data = rpc.get_decode()
+        self.check_R_J_decoded(data, self.jobid1)
+
+    def test_02_job_info_lookup_badid(self):
+        rpc = flux.job.job_info_lookup(self.fh, 123456789)
+        notfound = False
+        try:
+            rpc.get()
+        except FileNotFoundError:
+            notfound = True
+        self.assertEqual(notfound, True)
+
+    def test_03_job_info_lookup_badkey(self):
+        rpc = flux.job.job_info_lookup(self.fh, self.jobid1, keys=["foo"])
+        notfound = False
+        try:
+            rpc.get()
+        except FileNotFoundError:
+            notfound = True
+        self.assertEqual(notfound, True)
+
+    def test_04_job_kvs_lookup(self):
+        data = flux.job.job_kvs_lookup(self.fh, self.jobid1)
+        self.check_jobspec_decoded(data, self.jobid1)
+
+    def test_05_job_kvs_lookup_nodecode(self):
+        data = flux.job.job_kvs_lookup(self.fh, self.jobid1, decode=False)
+        self.check_jobspec_str(data, self.jobid1)
+
+    def test_06_job_kvs_lookup_keys(self):
+        data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["R", "J"])
+        self.check_R_J_decoded(data, self.jobid1)
+
+    def test_07_job_kvs_lookup_keys_nodecode(self):
+        data = flux.job.job_kvs_lookup(
+            self.fh, self.jobid1, keys=["R", "J"], decode=False
+        )
+        self.check_R_J_str(data, self.jobid1)
+
+    def test_08_job_kvs_lookup_badid(self):
+        data = flux.job.job_kvs_lookup(self.fh, 123456789)
+        self.assertEqual(data, None)
+
+    def test_09_job_kvs_lookup_badkey(self):
+        data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["foo"])
+        self.assertEqual(data, None)
+
+    def test_10_job_kvs_lookup_list(self):
+        ids = [self.jobid1]
+        data = flux.job.JobKVSLookup(self.fh, ids).data()
+        self.assertEqual(len(data), 1)
+        self.check_jobspec_decoded(data[0], self.jobid1)
+
+    def test_11_job_kvs_lookup_list_multiple(self):
+        ids = [self.jobid1, self.jobid2]
+        data = flux.job.JobKVSLookup(self.fh, ids).data()
+        self.assertEqual(len(data), 2)
+        self.check_jobspec_decoded(data[0], self.jobid1)
+        self.check_jobspec_decoded(data[1], self.jobid2)
+
+    def test_12_job_kvs_lookup_list_multiple_nodecode(self):
+        ids = [self.jobid1, self.jobid2]
+        data = flux.job.JobKVSLookup(self.fh, ids, decode=False).data()
+        self.assertEqual(len(data), 2)
+        self.check_jobspec_str(data[0], self.jobid1)
+        self.check_jobspec_str(data[1], self.jobid2)
+
+    def test_13_job_kvs_lookup_list_multiple_keys(self):
+        ids = [self.jobid1, self.jobid2]
+        data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"]).data()
+        self.assertEqual(len(data), 2)
+        self.check_R_J_decoded(data[0], self.jobid1)
+        self.check_R_J_decoded(data[1], self.jobid2)
+
+    def test_14_job_kvs_lookup_list_multiple_keys_nodecode(self):
+        ids = [self.jobid1, self.jobid2]
+        data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"], decode=False).data()
+        self.assertEqual(len(data), 2)
+        self.check_R_J_str(data[0], self.jobid1)
+        self.check_R_J_str(data[1], self.jobid2)
+
+    def test_15_job_kvs_lookup_list_none(self):
+        data = flux.job.JobKVSLookup(self.fh).data()
+        self.assertEqual(len(data), 0)
+
+    def test_16_job_kvs_lookup_list_badid(self):
+        ids = [123456789]
+        datalookup = flux.job.JobKVSLookup(self.fh, ids)
+        data = datalookup.data()
+        self.assertEqual(len(data), 0)
+        self.assertEqual(len(datalookup.errors), 1)
+
+    def test_17_job_kvs_lookup_list_badkey(self):
+        ids = [self.jobid1]
+        datalookup = flux.job.JobKVSLookup(self.fh, ids, keys=["foo"])
+        data = datalookup.data()
+        self.assertEqual(len(data), 0)
+        self.assertEqual(len(datalookup.errors), 1)
+
+
+if __name__ == "__main__":
+    from subflux import rerun_under_flux
+
+    if rerun_under_flux(size=__flux_size(), personality="job"):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner())

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -33,6 +33,14 @@ test_expect_success 'job-info: generate jobspec for simple test job' '
 	flux run --dry-run -n1 -N1 sleep 300 > sleeplong.json
 '
 
+test_expect_success 'job-info.lookup returns jobid in response' '
+	jobid=$(submit_job) &&
+	id=$(flux job id --to=dec ${jobid}) &&
+        $jq -j -c -n  "{id:${id}, keys:[\"jobspec\"], flags:0}" \
+          | $RPC job-info.lookup > job_info_lookup.out &&
+        cat job_info_lookup.out | $jq -e ".id == ${id}"
+'
+
 #
 # job info lookup list w/o jobid & keys
 #


### PR DESCRIPTION
Per #5176, it'd be nice to have a convenience API for `job-info.lookup` as doing the rpcs and parsing out the results can be inconvenient, especially when you want to do multiple lookups.

On the command line this is `flux job info` b/c of the `job-info` module, but we created the "JobInfo" class for the data coming back from `job-list` module in the Python bindings.  In hindsight perhaps an unfortunate naming.

So ... I eventually settled on calling this getting "job metadata".  The naming of this can be debated of course.  I think it's a good name for things like "jobspec", "eventlog", "R".  It's sort of a meh name for "guest.input/output".  But presumably we'll someday have the solution for https://github.com/flux-framework/flux-core/issues/4854, so maybe it doesn't matter as much on that front?

It has an API similar to `list.py` module and the `JobList` class, where you can get metadata for one jobid (`get_metadata()`) or a list of metadata for multiple jobids (`JobMetaDataLookup`).  Some differences:

- we want to return the "raw" metadata back to the user, not a "friendly" representation.  So there is no new equivalent to the "JobInfo" class, I just return the RPC 'dict' from the call.  Function names and call style adjusted as a result.

- I special case process "jobspec" and "R" w/ `json.loads()`, so that users get a `dict` instead of a string representing a JSON object.  That way it removes that extra step that many people will do which is to `json.loads()` the `metadata["jobspec"]` in the response.  I elected to make this the default and an optional `decode` parameter will turn it off.  It could be argued the default should be the other way around since some (such as `flux-accounting` and other projects) will likely want to store the jobspec as well.  Any strong opinions on this?  I think it's a bit of a tossup on which direction the default should be.

- `JobList` returns "all" joblist data by default, but we don't want to do that for `JobMetaData` b/c of the "infinite" maximum amount of data that can exist in several fields (i.e. "guest.input/output").  I default to just "jobspec" since I think that's the 90% use case.  The 96% case is probably "jobspec" and "R" and the 99% case would probably be "jobspec" and "R" and "eventlog"/"guest.exec.eventlog".  I debated which to do but settled on just "jobspec" b/c I think a default of "several things" is weird.

Other notes

- As we can return multiple metadata results in one list, it would be hard to figure out which data belongs to which jobs.  So I added a "id" key into each response, so that the data can be associated with the appropriate job.

- Because I'm anal ... I renamed "flux job info" to "flux job metadata" in the last commit ... maybe that was dumb.  It does serve a small purpose.  IIRC, some folks saw "flux job info" and thought it served a function similar to "flux job list" or "flux jobs", which it doesn't.  I think "flux job metadata" does imply a bit more that this is "extra stuffs".  But no issues if folks disagree, we can drop the commit.
