### PR TITLE
job-exec: always use stdio for exec barrier

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -350,12 +350,12 @@ static int exec_init (struct jobinfo *job)
         goto err;
     }
     if (job->multiuser) {
-            if (config_use_imp_helper ()
-                && flux_cmd_setenvf (cmd,
-                                     1,
-                                     "FLUX_IMP_EXEC_HELPER",
-                                     "flux imp-exec-helper %ju",
-                                     (uintmax_t) job->id) < 0) {
+        if (config_use_imp_helper ()
+            && flux_cmd_setenvf (cmd,
+                                 1,
+                                 "FLUX_IMP_EXEC_HELPER",
+                                 "flux imp-exec-helper %ju",
+                                 (uintmax_t) job->id) < 0) {
             flux_log_error (job->h, "exec_init: flux_cmd_setenvf");
             goto err;
         }

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -56,7 +56,11 @@ struct exec_ctx {
 
 static void exec_ctx_destroy (struct exec_ctx *tc)
 {
-    free (tc);
+    if (tc) {
+        int saved_errno = errno;
+        free (tc);
+        errno = saved_errno;
+    }
 }
 
 static struct exec_ctx *exec_ctx_create (json_t *jobspec)
@@ -338,6 +342,7 @@ static int exec_init (struct jobinfo *job)
     }
     if (bulk_exec_aux_set (exec, "ctx", ctx,
                           (flux_free_f) exec_ctx_destroy) < 0) {
+        exec_ctx_destroy (ctx);
         flux_log_error (job->h, "exec_init: bulk_exec_aux_set");
         goto err;
     }

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -27,7 +27,6 @@
 static const char *default_cwd = "/tmp";
 static const char *default_job_shell = NULL;
 static const char *flux_imp_path = NULL;
-static bool use_imp_helper = false;
 
 static const char *jobspec_get_job_shell (json_t *jobspec)
 {
@@ -74,11 +73,6 @@ const char *config_get_imp_path (void)
     return flux_imp_path;
 }
 
-bool config_use_imp_helper (void)
-{
-    return use_imp_helper;
-}
-
 /*  Initialize common configurations for use by job-exec exec modules.
  */
 int config_init (flux_t *h, int argc, char **argv)
@@ -114,14 +108,6 @@ int config_init (flux_t *h, int argc, char **argv)
         return -1;
     }
 
-#if HAVE_FLUX_SECURITY
-    /* Use IMP helper by default for flux-security >= 0.9.0
-     */
-    if (FLUX_SECURITY_VERSION_MAJOR >= 0
-        && FLUX_SECURITY_VERSION_MINOR >= 9)
-        use_imp_helper = true;
-#endif /* HAVE_FLUX_SECURITY */
-
     if (argv && argc) {
         /* Finally, override values on cmdline */
         for (int i = 0; i < argc; i++) {
@@ -129,8 +115,6 @@ int config_init (flux_t *h, int argc, char **argv)
                 default_job_shell = argv[i]+10;
             else if (strstarts (argv[i], "imp="))
                 flux_imp_path = argv[i]+4;
-            else if (streq (argv[i], "no-imp-helper"))
-                use_imp_helper = false;
         }
     }
 
@@ -138,9 +122,8 @@ int config_init (flux_t *h, int argc, char **argv)
     if (flux_imp_path) {
         flux_log (h,
                   LOG_DEBUG,
-                  "using imp path %s (%s helper)",
-                  flux_imp_path,
-                  use_imp_helper ? "with" : "without");
+                  "using imp path %s (with helper)",
+                  flux_imp_path);
     }
     return 0;
 }

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -21,8 +21,6 @@ const char *config_get_cwd (struct jobinfo *job);
 
 const char *config_get_imp_path (void);
 
-bool config_use_imp_helper (void);
-
 int config_init (flux_t *h, int argc, char **argv);
 
 #endif /* !HAVE_JOB_EXEC_CONFIG_EXEC_H */

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -68,7 +68,6 @@ struct jobinfo {
 
     struct resource_set * R;         /* Fetched and parsed resource set R */
     json_t *              jobspec;   /* Fetched jobspec */
-    char *                J;         /* Signed jobspec */
 
     struct idset *        critical_ranks;  /* critical shell ranks */
 


### PR DESCRIPTION
Problem: testing with the (future) "sdexec" remote subprocess exec service is complicated by the fact that stdio is only used for the exec barrier when the IMP is invoked.
    
Use stdio by default, falling back to a subprocess channel only if the IMP is too old.

A couple of very minor fixes are also included.

Peeled off of #5197
