### PR TITLE
flux-resource: fix `-i, --include=HOSTS` in `list` command when some hosts are excluded

### DIFF
--- a/src/bindings/python/flux/resource/ResourceSet.py
+++ b/src/bindings/python/flux/resource/ResourceSet.py
@@ -11,6 +11,7 @@
 import json
 from collections.abc import Mapping
 
+from flux.hostlist import Hostlist
 from flux.idset import IDset
 from flux.resource import Rlist
 from flux.resource.ResourceSetImplementation import ResourceSetImplementation
@@ -208,6 +209,25 @@ class ResourceSet:
         #  Preserve current state
         rset.state = self.state
         return rset
+
+    def host_ranks(self, hosts, ignore_nomatch=False):
+        """
+        Translate a set of hostnames to broker ranks using the current
+        ResourceSet.
+
+        Args:
+            ignore_nomatch (bool): If True, then hosts that are not in
+                the current ResourceSet are ignored, and only matching
+                hosts result in a returned rank. O/w, FileNotFound error
+                 is raised.
+        Returns:
+            list of rank ids in order of provided hosts
+        """
+        if not isinstance(hosts, Hostlist):
+            hosts = Hostlist(hosts)
+        ranks = list(self.ranks)
+        index = self.nodelist.index(hosts, ignore_nomatch=ignore_nomatch)
+        return [ranks[i] for i in index]
 
     @property
     def nodelist(self):

--- a/src/bindings/python/flux/resource/list.py
+++ b/src/bindings/python/flux/resource/list.py
@@ -58,8 +58,7 @@ class SchedResourceList:
         try:
             include_ranks = IDset(include)
         except ValueError:
-            nodelist = self["all"].nodelist
-            include_ranks = nodelist.index(include, ignore_nomatch=True)
+            include_ranks = IDset(self["all"].host_ranks(include, ignore_nomatch=True))
         for state in ["all", "down", "allocated"]:
             setattr(self, state, self[state].copy_ranks(include_ranks))
 

--- a/t/python/t0022-resource-set.py
+++ b/t/python/t0022-resource-set.py
@@ -41,6 +41,27 @@ class TestRSet(unittest.TestCase):
       }
     }
     """
+    R2 = """
+    {
+      "version": 1,
+      "execution": {
+        "R_lite": [
+          {
+            "rank": "10-13",
+            "children": {
+                "core": "0-3",
+                "gpu": "0"
+             }
+          }
+        ],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": [
+          "fluke[10-13]"
+        ]
+      }
+    }
+    """
 
     def test_init_string(self):
         #  init by string
@@ -49,11 +70,23 @@ class TestRSet(unittest.TestCase):
         self.assertEqual(rset.ncores, 16)
         self.assertEqual(rset.ngpus, 4)
 
+        rset = ResourceSet(self.R2)
+        self.assertEqual(str(rset), "rank[10-13]/core[0-3],gpu0")
+        self.assertEqual(rset.ncores, 16)
+        self.assertEqual(rset.ngpus, 4)
+
     def test_init_dict(self):
         #  init by dict
         rdict = json.loads(self.R_input)
         rset = ResourceSet(rdict)
         self.assertEqual(str(rset), "rank[0-3]/core[0-3],gpu0")
+        self.assertEqual(rset.ncores, 16)
+        self.assertEqual(rset.ngpus, 4)
+        self.assertEqual(rset.nnodes, 4)
+
+        rdict = json.loads(self.R2)
+        rset = ResourceSet(rdict)
+        self.assertEqual(str(rset), "rank[10-13]/core[0-3],gpu0")
         self.assertEqual(rset.ncores, 16)
         self.assertEqual(rset.ngpus, 4)
         self.assertEqual(rset.nnodes, 4)
@@ -126,6 +159,11 @@ class TestRSet(unittest.TestCase):
         rset2 = ResourceSet(rstring)
         self.assertEqual(str(rset), str(rset2))
 
+        rset = ResourceSet(self.R2)
+        rstring = rset.encode()
+        rset2 = ResourceSet(rstring)
+        self.assertEqual(str(rset), str(rset2))
+
     def test_append(self):
         rset = ResourceSet(self.R_input)
         rset2 = ResourceSet(Rlist().add_rank(4, cores="0-3").add_child(4, "gpu", "0"))
@@ -148,17 +186,56 @@ class TestRSet(unittest.TestCase):
         self.assertEqual(rset.nodelist.count(), 4)
         self.assertEqual(str(rset.nodelist), "fluke[0-3]")
 
+        rset = ResourceSet(self.R2)
+        self.assertIsInstance(rset.nodelist, Hostlist)
+        self.assertEqual(rset.nodelist.count(), 4)
+        self.assertEqual(str(rset.nodelist), "fluke[10-13]")
+
     def test_ranks(self):
         rset = ResourceSet(self.R_input)
         self.assertIsInstance(rset.ranks, IDset)
         self.assertEqual(rset.ranks.count(), 4)
         self.assertEqual(str(rset.ranks), "0-3")
 
+        rset = ResourceSet(self.R2)
+        self.assertIsInstance(rset.ranks, IDset)
+        self.assertEqual(rset.ranks.count(), 4)
+        self.assertEqual(str(rset.ranks), "10-13")
+
     def test_state(self):
         rset = ResourceSet(self.R_input)
         self.assertIsNone(rset.state)
         rset.state = "up"
         self.assertEqual(rset.state, "up")
+
+    def test_host_ranks(self):
+        rset = ResourceSet(self.R_input)
+        self.assertIsInstance(rset, ResourceSet)
+        self.assertEqual(rset.host_ranks("fluke0"), [0])
+        self.assertEqual(rset.host_ranks("fluke1"), [1])
+        self.assertEqual(rset.host_ranks("fluke2"), [2])
+        self.assertEqual(rset.host_ranks("fluke3"), [3])
+        self.assertEqual(rset.host_ranks("fluke[0,3]"), [0, 3])
+        self.assertEqual(rset.host_ranks("fluke[0-2]"), [0, 1, 2])
+        self.assertEqual(
+            rset.host_ranks("fluke[0-2,7]", ignore_nomatch=True), [0, 1, 2]
+        )
+        with self.assertRaises(FileNotFoundError):
+            rset.host_ranks("fluke7")
+
+        rset = ResourceSet(self.R2)
+        self.assertIsInstance(rset, ResourceSet)
+        self.assertEqual(rset.host_ranks("fluke10"), [10])
+        self.assertEqual(rset.host_ranks("fluke11"), [11])
+        self.assertEqual(rset.host_ranks("fluke12"), [12])
+        self.assertEqual(rset.host_ranks("fluke13"), [13])
+        self.assertEqual(rset.host_ranks("fluke[10,13]"), [10, 13])
+        self.assertEqual(rset.host_ranks("fluke[10-12]"), [10, 11, 12])
+        self.assertEqual(
+            rset.host_ranks("fluke[0-2,10-12]", ignore_nomatch=True), [10, 11, 12]
+        )
+        with self.assertRaises(FileNotFoundError):
+            rset.host_ranks("fluke[0-3,10-12]")
 
     def test_properties(self):
         rset = ResourceSet(self.R_input)

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -103,6 +103,85 @@ test_expect_success 'flux-resource list: --include works with hostnames' '
 	test_debug "cat include-hosts.out" &&
 	grep "^2 pi\[3,0\]" include-hosts.out
 '
+test_expect_success 'flux-resource list: -i works with excluded hosts #5266' '
+	cat <<-'EOF' >corona.json &&
+	{
+	  "all": {
+	    "execution": {
+	      "R_lite": [
+	        {
+	          "children": {
+	            "core": "0-47",
+	            "gpu": "0-7"
+	          },
+	          "rank": "4-124"
+	        }
+	      ],
+	      "expiration": 0,
+	      "nodelist": [
+	        "corona[171-207,213-296]"
+	      ],
+	      "properties": {
+	        "pbatch": "20-124",
+	        "pdebug": "4-19"
+	      },
+	      "starttime": 0
+	    },
+	    "version": 1
+	  },
+	  "allocated": {
+	    "execution": {
+	      "R_lite": [
+	        {
+	          "children": {
+	            "core": "0-47",
+	            "gpu": "0-7"
+	          },
+	          "rank": "20-27,29-34,36-75,78-84,86-87,90-97,99-111,113-124"
+	        }
+	      ],
+	      "expiration": 0,
+	      "nodelist": [
+	        "corona[187-194,196-201,203-207,213-247,250-256,258-259,262-269,271-283,285-296]"
+	      ],
+	      "properties": {
+	        "pbatch": "20-27,29-34,36-75,78-84,86-87,90-97,99-111,113-124"
+	      },
+	      "starttime": 0
+	    },
+	    "version": 1
+	  },
+	  "down": {
+	    "execution": {
+	      "R_lite": [
+	        {
+	          "children": {
+	            "core": "0-47",
+	            "gpu": "0-7"
+	          },
+	          "rank": "5,9,28,35,76-77,85,88-89,98,112"
+	        }
+	      ],
+	      "expiration": 0,
+	      "nodelist": [
+	        "corona[172,176,195,202,248-249,257,260-261,270,284]"
+	      ],
+	      "properties": {
+	        "pbatch": "28,35,76-77,85,88-89,98,112",
+	        "pdebug": "5,9"
+	      },
+	      "starttime": 0
+	    },
+	    "version": 1
+	  }
+	}
+	EOF
+	NODELIST="corona[176,249,260-261,270,284]" &&
+	flux resource list -s all -o "{nodelist}" -ni $NODELIST \
+		--from-stdin < corona.json >corona.output &&
+	test_debug "cat corona.output" &&
+	test "$(cat corona.output)" = "$NODELIST"
+'
 test_expect_success 'flux-resource list: --include works with invalid host' '
 	flux resource list -s all -o "{nnodes} {nodelist}" -ni pi7 \
 		--from-stdin < $INPUT >include-invalid-hosts.out &&


### PR DESCRIPTION
This PR fixes the issue described #5266, when hosts are excluded by configuration, they do not appear in the `SchedResourceList` "all" resource set, and so an erroneous assumption that the index into the `nodelist` attribute is the node rank causes the wrong hosts to be included.

