### PR TITLE
support multiplicative suffixes in command options that take a bytes argument

### DIFF
--- a/doc/man1/flux-filemap.rst
+++ b/doc/man1/flux-filemap.rst
@@ -68,15 +68,17 @@ OPTIONS
 
 **--small-file-threshold=N**
    Set the threshold in bytes over which a regular file is mapped through
-   the distributed content cache.  Set to 0 to always use the content cache.
-   The default is 4096 (*map* subcommand only).
+   the distributed content cache. Set to 0 to always use the content cache.
+   N may be specified using an optional multiplicative suffix (See SIZE
+   OPTION section below). The default is 4K (*map* subcommand only).
 
 **--disable-mmap**
    Never map a regular file through the distributed content cache.
 
 **--chunksize=N**
    Limit the content mapped blob size to N bytes.  Set to 0 for unlimited.
-   The default is 1048576 (*map* subcommand only).
+   N may be specified using an optional multiplicative suffix (See SIZE
+   OPTION section below). The default is 1M. (*map* subcommand only).
 
 **--direct**
    Avoid indirection through the content cache when fetching the top level
@@ -89,6 +91,15 @@ OPTIONS
 
 **--raw**
    List RFC 37 file system objects (*list* subcommand only).
+
+SIZE OPTION
+===========
+
+SIZE arguments may be specified as a floating-point number followed by
+an optional multiplicative suffix 'k' or 'K' for kibibytes (KiB, units
+of 1024 bytes), 'M' for mebibytes (MiB, units of 1024 * 1024 bytes), 'G'
+for gibibytes (GiB, units of 1024 * 1024 * 1024 bytes), and so on for
+'T' (TiB), 'P' (PiB), and 'E' (EiB).
 
 EXAMPLE
 =======

--- a/doc/man1/flux-ping.rst
+++ b/doc/man1/flux-ping.rst
@@ -40,9 +40,11 @@ OPTIONS
    respectively. Default: send to “*any*”.
 
 **-p, --pad**\ *=N*
-   Include in the payload a string of length *N* bytes. The payload will be
-   echoed back in the response. This option can be used to explore the
-   effect of message size on latency. Default: no padding.
+   Include in the payload a string of length *N* bytes. The payload will
+   be echoed back in the response. This option can be used to explore
+   the effect of message size on latency. Default: no padding. *N* may be
+   specified as a floating point number with optional multiplicative suffix
+   'k' or 'K' for KiB, 'M' for MiB, and so on.
 
 **-i, --interval**\ *=N*
    Specify the delay, in seconds, between successive requests.

--- a/doc/man1/flux-restore.rst
+++ b/doc/man1/flux-restore.rst
@@ -54,7 +54,11 @@ OPTIONS
    store.  Performance will vary depending on the content of the archive.
 
 **--size-limit**\ =\ *SIZE*
-   Skip restoring keys that exceed SIZE bytes (default: no limit).
+   Skip restoring keys that exceed SIZE bytes (default: no limit). SIZE may
+   be a floating point number with an optional multiplicative suffix 'k'
+   or 'K' for for kibibytes (KiB, units of 1024 bytes), 'M' for mebibytes
+   (MiB, units of 1024 * 1024 bytes), 'G' for gibibytes (GiB, units of
+   1024 * 1024 * 1024 bytes), and so on for 'T', 'P', and 'E'.
 
 RESOURCES
 =========

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -708,3 +708,15 @@ pmix
 SIGUSR
 iteratively
 noverify
+KiB
+kibibytes
+MiB
+mebibytes
+GiB
+gibibytes
+TiB
+tebibytes
+PiB
+pebibytes
+EiB
+exbibytes

--- a/etc/rc1
+++ b/etc/rc1
@@ -47,7 +47,7 @@ if test $RANK -eq 0; then
             flux module load ${backingmod} truncate
         fi
         echo "restoring content from ${dumpfile}"
-        flux restore --quiet --checkpoint --size-limit=104857600 ${dumpfile}
+        flux restore --quiet --checkpoint --size-limit=100M ${dumpfile}
         if test -n "${dumplink}"; then
             rm -f ${dumplink}
         fi

--- a/src/cmd/builtin/filemap.c
+++ b/src/cmd/builtin/filemap.c
@@ -29,8 +29,8 @@
 #include "src/common/libfilemap/filemap.h"
 #include "src/common/libutil/fileref.h"
 
-static const int default_chunksize = 1048576;
-static const int default_small_file_threshold = 4096;
+static const char *default_chunksize = "1M";
+static const char *default_small_file_threshold = "4K";
 
 static json_t *get_list_option (optparse_t *p,
                                 const char *name,
@@ -175,8 +175,8 @@ static int subcmd_map (optparse_t *p, int ac, char *av[])
     }
     ctx.p = p;
     ctx.verbose = optparse_get_int (p, "verbose", 0);
-    ctx.chunksize = optparse_get_int (p, "chunksize", default_chunksize);
-    ctx.threshold = optparse_get_int (p,
+    ctx.chunksize = optparse_get_size (p, "chunksize", default_chunksize);
+    ctx.threshold = optparse_get_size (p,
                                       "small-file-threshold",
                                       default_small_file_threshold);
     ctx.disable_mmap = optparse_hasopt (p, "disable-mmap");
@@ -375,9 +375,9 @@ static struct optparse_option map_opts[] = {
       .usage = "Change to DIR before mapping", },
     { .name = "verbose", .key = 'v', .has_arg = 2, .arginfo = "[LEVEL]",
       .usage = "Increase output detail.", },
-    { .name = "chunksize", .has_arg = 1, .arginfo = "N",
+    { .name = "chunksize", .has_arg = 1, .arginfo = "N[kMG]",
       .usage = "Limit blob size to N bytes with 0=unlimited"
-               " (default 1048576)", },
+               " (default 1M)", },
     { .name = "small-file-threshold", .has_arg = 1, .arginfo = "N",
       .usage = "Adjust the maximum size of a \"small file\" in bytes"
                " (default 4096)", },

--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -366,7 +366,7 @@ static int cmd_restore (optparse_t *p, int ac, char *av[])
         content_flags |= CONTENT_FLAG_CACHE_BYPASS;
         kvs_checkpoint_flags |= KVS_CHECKPOINT_FLAG_CACHE_BYPASS;
     }
-    blob_size_limit = optparse_get_int (p, "size-limit", 0);
+    blob_size_limit = optparse_get_size (p, "size-limit", "0");
 
     h = builtin_get_flux_handle (p);
     ar = restore_create (infile);

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -316,7 +316,7 @@ int main (int argc, char *argv[])
     if (!(target = strdup (argv[optindex])))
         log_msg_exit ("out of memory");
 
-    pad_bytes = optparse_get_int (opts, "pad", 0);
+    pad_bytes = optparse_get_size (opts, "pad", "0");
     if (pad_bytes < 0)
         log_msg_exit ("pad must be >= 0");
 

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -111,6 +111,7 @@ libflux_optparse_la_LIBADD = \
 	$(builddir)/libczmqcontainers/libczmqcontainers.la \
 	$(builddir)/liblsd/liblsd.la \
 	$(builddir)/libutil/fsd.lo \
+	$(builddir)/libutil/parse_size.lo \
 	$(LIBPTHREAD)
 libflux_optparse_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-optparse.map \

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -19,9 +19,11 @@
 #include <ctype.h>
 #include <stdarg.h>
 #include <argz.h>
+#include <math.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/fsd.h"
+#include "src/common/libutil/parse_size.h"
 #include "ccan/str/str.h"
 
 #include "optparse.h"
@@ -948,6 +950,34 @@ double optparse_get_duration (optparse_t *p, const char *name,
         return -1;
     }
     return d;
+}
+
+uint64_t optparse_get_size (optparse_t *p,
+                            const char *name,
+                            const char *default_value)
+{
+    int n;
+    uint64_t result;
+    const char *s = NULL;
+
+    if ((n = optparse_getopt (p, name, &s)) < 0) {
+        optparse_fatalmsg (p, 1,
+                           "%s: optparse error: no such argument '%s'\n",
+                           p->program_name, name);
+        return (uintmax_t) -1;
+    }
+    if (n == 0)
+        s = default_value;
+    if (parse_size (s, &result) < 0) {
+        optparse_fatalmsg (p, 1,
+                          "%s: invalid value for option '%s': %s: %s",
+                          p->program_name,
+                          name,
+                          s,
+                          strerror (errno));
+        return (uintmax_t) -1;
+    }
+    return result;
 }
 
 const char *optparse_get_str (optparse_t *p, const char *name,

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -12,6 +12,7 @@
 #define _UTIL_OPTPARSE_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -381,6 +382,16 @@ int optparse_get_int (optparse_t *p, const char *name, int default_value);
 double optparse_get_duration (optparse_t *p, const char *name,
                               double default_value);
 
+/*   Return the option argument parsed as a file size parameter in
+ *   floating-point 'size[bkMGTPE]', where the optional suffix designates
+ *   'k' or 'K' for kibibytes (KiB), 'M' for mebibytes (MiB) or
+ *   'G' for gibibytes (GiB), 'T' for tebibytes (TiB), P for pebibytes (PiB),
+ *   'E' for exbibytes (EiB). The end result in bytes is truncated and
+ *   returned as uint64_t. If there was an error parsing the size string, then
+ *   the fatal error function is called.
+ */
+uint64_t optparse_get_size (optparse_t *p, const char *name,
+                            const char *default_value);
 /*
  *   Return the option argument as a double if 'name' was used,
  *    'default_value' if not.  If the option is unknown, or the argument


### PR DESCRIPTION
This is the redo of the PR to add support for SI units in several commands:
 * `flux restore --size-limit` option
 * `flux filemap --chunksize` and `--small-file-threshold` options
 * `flux ping --pad` option

This is done by using a new `optparse_get_size()` function that uses the new `parse_size()` function in libutil.

This was a rework of a rebase with much manual fixups, so hopefully not too messy.