### PR TITLE
build: require flux-security >= 0.9.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -373,7 +373,7 @@ AS_IF([test x$enable_code_coverage = xyes], [
 AC_ARG_WITH([flux-security], AS_HELP_STRING([--with-flux-security],
              [Build with flux-security]))
 AS_IF([test "x$with_flux_security" = "xyes"], [
-    PKG_CHECK_MODULES([FLUX_SECURITY], [flux-security],
+    PKG_CHECK_MODULES([FLUX_SECURITY], [flux-security >= 0.9.0],
                       [flux_sec_incdir=`$PKG_CONFIG --variable=includedir flux-security`],
                       [flux_sec_incdir=;])
     AS_IF([test "x$flux_sec_incdir" = x],


### PR DESCRIPTION
Problem: job-exec includes code to run the pre-0.9.0 IMP.

Require 0.9.0 so we can drop that code.

This was split from #5267 for improved release notes.

Also: since 0.9.0 is only now starting to roll out in LC (and may be delayed for some time on some platforms), we could elect to delay merging this until deployments catch up a bit, if not being able to build flux-core `--with-flux-security` on those platforms would be inconvenient.  Quickly checking some systems:

- corona: flux-security 0.8.0
- fluke, tioga, rzvernal: flux-security 0.9.0
