### PR TITLE
do not suppress job shell and broker errors with `flux alloc`

### DIFF
--- a/src/shell/pty.c
+++ b/src/shell/pty.c
@@ -342,6 +342,21 @@ static int pty_init (flux_plugin_t *p,
                 shell_log_errno ("flux_shell_add_event_context (pty)");
                 goto error;
             }
+            if (capture) {
+                /*
+                 * If also capturing the pty output for an interactive
+                 *  pty, note this in the shell.init event context. This
+                 *  will hint to the pty reader that the terminal output
+                 *  is duplicated for rank 0.
+                 */
+                if (flux_shell_add_event_context (shell,
+                                                  "shell.init",
+                                                  0,
+                                                  "{s:i}",
+                                                  "capture", 1) < 0) {
+                    shell_log_errno ("flux_shell_add_event_context (capture)");
+                }
+            }
             /*  Ensure that rank 0 pty waits for client to attach
              *   in pty.interactive mode, even if pty.capture is also
              *   specified.

--- a/src/shell/pty.c
+++ b/src/shell/pty.c
@@ -339,7 +339,7 @@ static int pty_init (flux_plugin_t *p,
                                               0,
                                               "{s:s}",
                                               "pty", "terminus.0") < 0) {
-                shell_log_errno ("flux_shell_service_register");
+                shell_log_errno ("flux_shell_add_event_context (pty)");
                 goto error;
             }
             /*  Ensure that rank 0 pty waits for client to attach

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -143,5 +143,13 @@ test_expect_success 'flux alloc: --dump=FILE works with mustache' '
 	flux job wait-event $jobid clean &&
         tar tvf testdump-${jobid}.tgz
 '
+test_expect_success 'flux alloc: does not suppress log messages' '
+	$runpty -o logmsgs.out flux alloc -n1 --cwd=/noexist pwd &&
+	grep -i "going to /tmp instead" logmsgs.out
+'
+test_expect_success 'flux alloc: no duplication of output with pty.capture' '
+	$runpty -o duplicates.out flux alloc -o pty.capture -n1 echo testing &&
+	test $(grep -c testing duplicates.out) -eq 1
+'
 
 test_done


### PR DESCRIPTION
Currently `flux job attach` skips watching the output eventlog when attaching to an interactive pty because all job output is presumed to go through the pty. However, this means error messages posted as `log` events to the eventlog are ignored, which can result in confusing behavior as described in #5272. It would also be valuable to see regular output from tasks, since brokers in a flux-alloc instance may also issue errors or warnings that would otherwise be suppressed.

This PR changes `flux job attach` so it always watches the output eventlog. Special handling for the pty case is required:
 - add missing `\r` for output and log messages since the terminal is assumed to be in raw mode
 - skip output for rank 0 when the pty is being captured to avoid duplication

Otherwise, the code is largely the same as the non pty case.

A fix for #5273 is also included since otherwise this error would now be seen for every `flux alloc` invocation.

A side benefit is that you can now enable shell and/or broker debugging in flux-alloc and actually see the log messages:
```console
$ flux alloc -o verbose --broker-opts=-Slog-stderr-mode=local,-Slog-stderr-level=7 -N2 --cwd=/foo
0.066s: flux-shell[1]: ERROR: host corona211: Could not change dir to /foo: No such file or directory. Going to /tmp instead
0.066s: flux-shell[1]: DEBUG: Loading /g/g0/grondo/git/flux-core.git/src/shell/initrc.lua
0.068s: flux-shell[1]: DEBUG: pmi-simple: simple wire protocol is enabled
0.073s: flux-shell[1]: DEBUG: 1: task 1 on cores 0-47                    
0.058s: flux-shell[0]: ERROR: host corona211: Could not change dir to /foo: No such file or directory. Going to /tmp instead
0.058s: flux-shell[0]: DEBUG: Loading /g/g0/grondo/git/flux-core.git/src/shell/initrc.lua
0.061s: flux-shell[0]: DEBUG: pmi-simple: simple wire protocol is enabled
0.062s: flux-shell[0]: DEBUG: output: batch timeout = 0.500s             
0.067s: flux-shell[0]: DEBUG: 0: task_count=2 slot_count=2 cores_per_slot=1 slots_per_node=1
0.067s: flux-shell[0]: DEBUG: 0: task 0 on cores 0-47
broker.debug[0]: insmod connector-local              
broker.info[0]: start: none->join 3.4426ms
broker.debug[0]: overlay auth cert-name=1 OK
broker.info[0]: parent-none: join->init 0.071131ms
broker.debug[0]: accepting connection from corona211 (rank 1) status full
connector-local.debug[0]: allow-guest-user=false
connector-local.debug[0]: allow-root-owner=false
broker.debug[0]: insmod barrier
broker.debug[0]: insmod content-sqlite
content-sqlite.debug[0]: /var/tmp/grondo/flux-hrz4nD/content.sqlite (0 objects) journal_mode=OFF synchronous=OFF
broker.debug[0]: content backing store: enabled content-sqlite
broker.debug[0]: insmod kvs
broker.debug[0]: insmod kvs-watch
broker.debug[0]: insmod resource
broker.debug[1]: insmod connector-local
broker.info[1]: start: none->join 0.953008ms
broker.debug[1]: hello parent 0 027bc907-e7aa-4dae-95de-021a18c14104
connector-local.debug[1]: allow-guest-user=false                    
connector-local.debug[1]: allow-root-owner=false
resource.debug[0]: reslog_cb: resource-init event posted
resource.debug[0]: reslog_cb: resource-define event posted
broker.debug[0]: insmod cron
cron.info[0]: synchronizing cron tasks to event heartbeat.pulse
broker.debug[0]: insmod job-manager
job-manager.debug[0]: jobtap plugin .history registered method job-manager.history.get
job-manager.info[0]: restart: 0 jobs
job-manager.info[0]: restart: 0 running jobs
job-manager.info[0]: restart: checkpoint.job-manager not found
job-manager.debug[0]: restart: max_jobid=f1
job-manager.debug[0]: duration-validator: updated expiration to 0.00
broker.debug[0]: insmod job-info
broker.debug[0]: insmod job-list
job-list.debug[0]: job_state_init_from_kvs: read 0 jobs
broker.debug[0]: insmod job-ingest
job-ingest.debug[0]: configuring validator with plugins=(null), args=(null) (enabled)
job-ingest.debug[0]: fluid ts=1ms
broker.debug[0]: insmod job-exec
job-exec.debug[0]: using default shell path /g/g0/grondo/git/flux-core.git/src/shell/flux-shell
broker.debug[0]: insmod heartbeat
broker.info[0]: rc1.0: running /g/g0/grondo/git/flux-core.git/etc/rc1.d/02-cron
broker.debug[0]: insmod sched-simple
sched-simple.debug[0]: service_register
sched-simple.debug[0]: resource update: {"resources":{"version":1,"execution":{"R_lite":[{"rank":"0-1","children":{"core":"0-47"}}],"starttime":0.0,"expiration":0.0,"nodelist":["corona[211,211]"]}},"up":""}
job-manager.debug[0]: scheduler: hello
job-manager.debug[0]: scheduler: ready limited
sched-simple.debug[0]: ready: 0 of 96 cores: 
broker.info[0]: rc1.0: /g/g0/grondo/git/flux-core.git/etc/rc1 Exited (rc=0) 1.4s
broker.info[0]: rc1-success: init->quorum 1.40196s
broker.debug[0]: groups: broker.online=0
broker.info[0]: online: corona211 (ranks 0)
resource.debug[0]: reslog_cb: online event posted
sched-simple.debug[0]: resource update: {"up":"0"}
broker.info[1]: parent-ready: join->init 1.40421s
connector-local.debug[1]: allow-guest-user=false 
connector-local.debug[1]: allow-root-owner=false
broker.info[1]: configuration updated           
broker.debug[1]: insmod barrier      
broker.debug[1]: insmod kvs    
broker.debug[1]: insmod kvs-watch
broker.debug[1]: insmod resource 
broker.debug[0]: groups: broker.online=0-1
broker.info[0]: online: corona[211,211] (ranks 0-1)
broker.info[0]: quorum-full: quorum->run 0.945057s
resource.debug[0]: reslog_cb: online event posted
sched-simple.debug[0]: resource update: {"up":"1"}
broker.debug[1]: insmod job-info
broker.debug[1]: insmod job-ingest
job-ingest.debug[1]: configuring validator with plugins=(null), args=(null) (enabled)
job-ingest.debug[1]: fluid ts=1083ms
broker.info[1]: rc1.0: running /g/g0/grondo/git/flux-core.git/etc/rc1.d/02-cron
broker.info[1]: rc1.0: /g/g0/grondo/git/flux-core.git/etc/rc1 Exited (rc=0) 0.7s
broker.info[1]: rc1-success: init->quorum 0.743966s                            
broker.info[1]: quorum-full: quorum->run 0.201652s 
$ flux run hostname
sched-simple.debug[0]: req: f4hmLxkF: spec={0,1,1} duration=0.0
sched-simple.debug[0]: alloc: f4hmLxkF: rank0/core0
corona211
sched-simple.debug[0]: free: rank0/core0
$

```