### PR TITLE
broker: avoid spurious overlay peer warning

### DIFF
--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -32,7 +32,6 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/librouter/rpc_track.h"
 #include "src/common/libccan/ccan/ptrint/ptrint.h"
-#include "src/common/libyuarel/yuarel.h"
 
 #include "overlay.h"
 #include "attr.h"
@@ -1264,40 +1263,6 @@ static void parent_monitor_cb (struct zmqutil_monitor *mon, void *arg)
     }
 }
 
-/* Zeromq treats failed hostname resolution as a transient error, and silently
- * retries in the background, which can make config problems hard to diagnose.
- * Parse the URI in advance, and if the host portion is invalid, log it.
- * Ref: flux-framework/flux-core#5009
- */
-static void warn_of_invalid_host (flux_t *h, const char *uri)
-{
-    char *cpy;
-    struct yuarel u = { 0 };
-    struct addrinfo *result;
-    int e;
-
-    if (!(cpy = strdup (uri))
-        || yuarel_parse (&u, cpy) < 0
-        || !u.scheme
-        || !u.host
-        || !streq (u.scheme, "tcp"))
-        goto done;
-    /* N.B. this URI will be used for zmq_connect(), therefore it must
-     * be a valid peer address, not an interface name or wildcard.
-     */
-    if ((e = getaddrinfo (u.host, NULL, NULL, &result)) == 0) {
-        freeaddrinfo (result);
-        goto done;
-    }
-    flux_log (h,
-              LOG_ERR,
-              "Warning: unable to resolve upstream peer %s: %s",
-              u.host,
-              gai_strerror (e));
-done:
-    free (cpy);
-}
-
 int overlay_connect (struct overlay *ov)
 {
     if (ov->rank > 0) {
@@ -1305,7 +1270,6 @@ int overlay_connect (struct overlay *ov)
             errno = EINVAL;
             return -1;
         }
-        warn_of_invalid_host (ov->h, ov->parent.uri);
         if (!(ov->parent.zsock = zsock_new_dealer (NULL)))
             goto nomem;
         /* The socket monitor is only used for logging.


### PR DESCRIPTION
Problem: the broker complains of being unable to resolve its upstream peer when bootstrapped via PMI, but the peer uri is valid.
 ```  
Warning: unable to resolve upstream peer [: Name or service not known
 ```
The URI is generated by 0mq after concretizing a wildcard bind address.  When ipv6 is enabled, 0mq puts the address in a form that cannot be parsed by yuarel, nor can it be looked up by getaddrinfo(3), e.g.
```
tcp://[::ffff:134.9.50.69]:49155
```   
Move the check into boot_config.c so that it is only performed when the URIs come from a config file.
    
Fixes #5273
