### PR TITLE
support `[kKMG]` suffixes in command options that take a bytes argument

### DIFF
--- a/doc/man1/flux-filemap.rst
+++ b/doc/man1/flux-filemap.rst
@@ -68,15 +68,19 @@ OPTIONS
 
 **--small-file-threshold=N**
    Set the threshold in bytes over which a regular file is mapped through
-   the distributed content cache.  Set to 0 to always use the content cache.
-   The default is 4096 (*map* subcommand only).
+   the distributed content cache. Set to 0 to always use the content cache.
+   N may be specified as a floating point number with multiplicative suffix
+   k,K=1024, M=1024\*1024, or G=1024\*1024\*1024 up to ``INT_MAX``.
+   The default is 4K (*map* subcommand only).
 
 **--disable-mmap**
    Never map a regular file through the distributed content cache.
 
 **--chunksize=N**
    Limit the content mapped blob size to N bytes.  Set to 0 for unlimited.
-   The default is 1048576 (*map* subcommand only).
+   N may be specified as a floating point number with multiplicative suffix
+   k,K=1024, M=1024\*1024, or G=1024\*1024\*1024 up to ``INT_MAX``.
+   The default is 1M (*map* subcommand only).
 
 **--direct**
    Avoid indirection through the content cache when fetching the top level

--- a/doc/man1/flux-ping.rst
+++ b/doc/man1/flux-ping.rst
@@ -40,9 +40,11 @@ OPTIONS
    respectively. Default: send to “*any*”.
 
 **-p, --pad**\ *=N*
-   Include in the payload a string of length *N* bytes. The payload will be
-   echoed back in the response. This option can be used to explore the
-   effect of message size on latency. Default: no padding.
+   Include in the payload a string of length *N* bytes. *N* may be a
+   floating point number with optional multiplicative suffix k,K=1024,
+   M=1024\*1024, or G=1024\*1024\*1024. The payload will be echoed back in
+   the response. This option can be used to explore the effect of message
+   size on latency. Default: no padding.
 
 **-i, --interval**\ *=N*
    Specify the delay, in seconds, between successive requests.

--- a/doc/man1/flux-restore.rst
+++ b/doc/man1/flux-restore.rst
@@ -54,7 +54,10 @@ OPTIONS
    store.  Performance will vary depending on the content of the archive.
 
 **--size-limit**\ =\ *SIZE*
-   Skip restoring keys that exceed SIZE bytes (default: no limit).
+   Skip restoring keys that exceed SIZE bytes (default: no limit). SIZE may
+   be specified as a floating point number with an optional multiplicative
+   suffix k or K=1024, M=1024\*1024, or G=1024\*1024\*1024 (up to
+   ``INT_MAX``).
 
 RESOURCES
 =========

--- a/etc/rc1
+++ b/etc/rc1
@@ -47,7 +47,7 @@ if test $RANK -eq 0; then
             flux module load ${backingmod} truncate
         fi
         echo "restoring content from ${dumpfile}"
-        flux restore --quiet --checkpoint --size-limit=104857600 ${dumpfile}
+        flux restore --quiet --checkpoint --size-limit=100M ${dumpfile}
         if test -n "${dumplink}"; then
             rm -f ${dumplink}
         fi

--- a/src/cmd/builtin/filemap.c
+++ b/src/cmd/builtin/filemap.c
@@ -29,8 +29,8 @@
 #include "src/common/libfilemap/filemap.h"
 #include "src/common/libutil/fileref.h"
 
-static const int default_chunksize = 1048576;
-static const int default_small_file_threshold = 4096;
+static const char *default_chunksize = "1M";
+static const char *default_small_file_threshold = "4K";
 
 static json_t *get_list_option (optparse_t *p,
                                 const char *name,
@@ -175,10 +175,12 @@ static int subcmd_map (optparse_t *p, int ac, char *av[])
     }
     ctx.p = p;
     ctx.verbose = optparse_get_int (p, "verbose", 0);
-    ctx.chunksize = optparse_get_int (p, "chunksize", default_chunksize);
-    ctx.threshold = optparse_get_int (p,
-                                      "small-file-threshold",
-                                      default_small_file_threshold);
+    ctx.chunksize = optparse_get_size_int (p,
+                                           "chunksize",
+                                           default_chunksize);
+    ctx.threshold = optparse_get_size_int (p,
+                                           "small-file-threshold",
+                                           default_small_file_threshold);
     ctx.disable_mmap = optparse_hasopt (p, "disable-mmap");
     ctx.tags = get_list_option (p, "tags", "main");
     ctx.h = builtin_get_flux_handle (p);
@@ -375,12 +377,12 @@ static struct optparse_option map_opts[] = {
       .usage = "Change to DIR before mapping", },
     { .name = "verbose", .key = 'v', .has_arg = 2, .arginfo = "[LEVEL]",
       .usage = "Increase output detail.", },
-    { .name = "chunksize", .has_arg = 1, .arginfo = "N",
+    { .name = "chunksize", .has_arg = 1, .arginfo = "N[KMG]",
       .usage = "Limit blob size to N bytes with 0=unlimited"
-               " (default 1048576)", },
-    { .name = "small-file-threshold", .has_arg = 1, .arginfo = "N",
+               " (default 1M)", },
+    { .name = "small-file-threshold", .has_arg = 1, .arginfo = "N[KMG]",
       .usage = "Adjust the maximum size of a \"small file\" in bytes"
-               " (default 4096)", },
+               " (default 4K)", },
     { .name = "disable-mmap", .has_arg = 0,
       .usage = "Never mmap(2) files into the content cache", },
     { .name = "tags", .key = 'T', .has_arg = 1, .arginfo = "NAME,...",

--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -366,7 +366,7 @@ static int cmd_restore (optparse_t *p, int ac, char *av[])
         content_flags |= CONTENT_FLAG_CACHE_BYPASS;
         kvs_checkpoint_flags |= KVS_CHECKPOINT_FLAG_CACHE_BYPASS;
     }
-    blob_size_limit = optparse_get_int (p, "size-limit", 0);
+    blob_size_limit = optparse_get_size_int (p, "size-limit", "0");
 
     h = builtin_get_flux_handle (p);
     ar = restore_create (infile);

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -316,9 +316,7 @@ int main (int argc, char *argv[])
     if (!(target = strdup (argv[optindex])))
         log_msg_exit ("out of memory");
 
-    pad_bytes = optparse_get_int (opts, "pad", 0);
-    if (pad_bytes < 0)
-        log_msg_exit ("pad must be >= 0");
+    pad_bytes = optparse_get_size_int (opts, "pad", "0");
 
     ctx.nodeid = FLUX_NODEID_ANY;
     if (optparse_hasopt (opts, "rank")) {

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -111,6 +111,7 @@ libflux_optparse_la_LIBADD = \
 	$(builddir)/libczmqcontainers/libczmqcontainers.la \
 	$(builddir)/liblsd/liblsd.la \
 	$(builddir)/libutil/fsd.lo \
+	$(builddir)/libutil/parse_size.lo \
 	$(LIBPTHREAD)
 libflux_optparse_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-optparse.map \

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -19,9 +19,11 @@
 #include <ctype.h>
 #include <stdarg.h>
 #include <argz.h>
+#include <math.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/fsd.h"
+#include "src/common/libutil/parse_size.h"
 #include "ccan/str/str.h"
 
 #include "optparse.h"
@@ -948,6 +950,59 @@ double optparse_get_duration (optparse_t *p, const char *name,
         return -1;
     }
     return d;
+}
+
+uint64_t optparse_get_size (optparse_t *p,
+                            const char *name,
+                            const char *default_value)
+{
+    int n;
+    uint64_t result;
+    const char *s = NULL;
+
+    if (default_value == NULL)
+        default_value = "0";
+
+    if ((n = optparse_getopt (p, name, &s)) < 0) {
+        optparse_fatalmsg (p, 1,
+                           "%s: optparse error: no such argument '%s'\n",
+                           p->program_name, name);
+        return (uint64_t) -1;
+    }
+    if (n == 0)
+        s = default_value;
+    if (parse_size (s, &result) < 0) {
+        optparse_fatalmsg (p, 1,
+                          "%s: invalid argument for option '%s': %s: %s\n",
+                          p->program_name,
+                          name,
+                          s,
+                          strerror (errno));
+        return (uint64_t) -1;
+    }
+    return result;
+}
+
+int optparse_get_size_int (optparse_t *p,
+                           const char *name,
+                           const char *default_value)
+{
+    uint64_t val = optparse_get_size (p, name, default_value);
+    if (val == (uint64_t)-1)
+        return -1;
+    if (val > INT_MAX) {
+        const char *s;
+        optparse_getopt (p, name, &s);
+        optparse_fatalmsg (p,
+                           1,
+                           "%s: %s: value %s too large (must be < %s)\n",
+                           p->program_name,
+                           name,
+                           s,
+                           encode_size (INT_MAX+1UL));
+        return -1;
+    }
+    return (int)val;
 }
 
 const char *optparse_get_str (optparse_t *p, const char *name,

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -12,6 +12,7 @@
 #define _UTIL_OPTPARSE_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -380,6 +381,27 @@ int optparse_get_int (optparse_t *p, const char *name, int default_value);
  */
 double optparse_get_duration (optparse_t *p, const char *name,
                               double default_value);
+
+/*
+ *   Return the option argument parsed as a size in bytes (or other unit)
+ *    with optional multiplicative suffix: k or K=1024, M=1024*1024,
+ *    G=1024*1024*1024, and so on for T, P, and E. The end result is
+ *    truncated and returned as uint64_t. If there was an error parsing
+ *    the size string, then the fatal error function is called.
+ *
+ *   Return default value if option was unused. default_value=NULL
+ *    is equivalent to default_value="0".
+ */
+uint64_t optparse_get_size (optparse_t *p, const char *name,
+                            const char *default_value);
+
+/*
+ *  Like optparse_get_size(), but return an int and ensure the provided
+ *   argument does not overflow INT_MAX (calls fatal error function if so).
+ */
+int optparse_get_size_int (optparse_t *p,
+                           const char *name,
+                           const char *default_value);
 
 /*
  *   Return the option argument as a double if 'name' was used,

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -384,11 +384,13 @@ void test_convenience_accessors (void)
     rc = optparse_add_option_table (p, opts);
     ok (rc == OPTPARSE_SUCCESS, "register options");
 
-    ok (optparse_option_index (p) == -1, "optparse_option_index returns -1 before parse");
+    ok (optparse_option_index (p) == -1,
+        "optparse_option_index returns -1 before parse");
     optindex = optparse_parse_args (p, ac, av);
     ok (optindex == ac, "parse options, verify optindex");
 
-    ok (optparse_option_index (p) == optindex, "optparse_option_index works after parse");
+    ok (optparse_option_index (p) == optindex,
+        "optparse_option_index works after parse");
 
     /* hasopt
      */

--- a/src/common/libutil/parse_size.c
+++ b/src/common/libutil/parse_size.c
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
 #include <math.h>
@@ -130,6 +131,31 @@ int parse_size (const char *s, uint64_t *vp)
         && parse_as_double (s, vp) < 0)
         return -1;
     return 0;
+}
+
+const char *encode_size (uint64_t size)
+{
+    /* Allocate a thread-local buffer to make this function easy to use
+     * in output formats (its intended use case).
+     *
+     * Note: The maximum printable digits for a double is 15 (DBL_DIG).
+     *  We also account for an optional decimal point, suffix, and required
+     *  space for NUL to get a buffer size of 18. (We ignore the fact that
+     *  a precision is specified in the %g format below for safety).
+     */
+    static __thread char buf[18];
+    const char* suffix[] = {"", "K", "M", "G", "T", "P", "E"};
+    int i = 0;
+    double value = size;
+    while (value >= 1024) {
+        value /= 1024;
+        i++;
+    }
+    /* Note: UINT64_MAX is 16E so there is no possibility that 'i' will
+     * overflow the suffix array.
+     */
+    (void) snprintf (buf, sizeof (buf), "%.8g%s", value, suffix[i]);
+    return buf;
 }
 
 // vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/parse_size.h
+++ b/src/common/libutil/parse_size.h
@@ -22,7 +22,7 @@
  *  P     2^50
  *  E     2^60
  *
- * The numeric part is parsed with first strtoull(3) then strtod(3), so
+ * The numeric part is parsed with first strtoull(3) then strtod(3),
  * so all input supported by those functions should work including
  * decimal (255), hex (0xf), octal (0377 prefix), exponent (2.55E2), etc.
  *

--- a/src/common/libutil/parse_size.h
+++ b/src/common/libutil/parse_size.h
@@ -31,6 +31,17 @@
  */
 int parse_size (const char *s, uint64_t *vp);
 
+/* Format 'size' as a human readable string using suffixes documented
+ * above for parse_size(). Note that due to use of double precision
+ * arithmetic and because the result is rounded to 8 significant figures
+ * the returned string may be imprecise. Passing the result of encode_size()
+ * to parse_size() may not result in the same value for 'size'.
+ *
+ * The result is only good until the next call to encode_size() from the
+ * current thread.
+ */
+const char *encode_size (uint64_t size);
+
 #endif /* !_UTIL_PARSE_SIZE_H */
 
 // vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/test/parse_size.c
+++ b/src/common/libutil/test/parse_size.c
@@ -7,7 +7,6 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
-
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -60,12 +59,10 @@ const struct entry testvec[] = {
     { "0.5E", 576460752303423488, 0 },
 };
 
-int main (int argc, char **argv)
+static void test_parse (void)
 {
     uint64_t val;
     int rc;
-
-    plan (NO_PLAN);
 
     lives_ok ({parse_size (NULL, &val);},
         "parse_size input=NULL doesn't crash");
@@ -89,9 +86,13 @@ int main (int argc, char **argv)
                 testvec[i].errnum);
         }
     }
+}
 
+int main (int argc, char **argv)
+{
+    plan (NO_PLAN);
+    test_parse ();
     done_testing ();
-
     return 0;
 }
 

--- a/src/common/libutil/test/parse_size.c
+++ b/src/common/libutil/test/parse_size.c
@@ -88,10 +88,40 @@ static void test_parse (void)
     }
 }
 
+const struct entry encode_tests[] = {
+    { "0", 0, 0 },
+    { "1K", 1024, 0 },
+    { "1.5K", 1024*1.5, 0 },
+    { "4K", 4096, 0 },
+    { "1M", 1048576, 0 },
+    { "1.000001M", 1048577, 0 },
+    { "8.75M", 1024*1024*8.75, 0 },
+    { "2G", 2147483648, 0 },
+    { "512", 512, 0 },
+    { "1.22G", 1024*1024*1024*1.22, 0 },
+    { "4T", 4398046511104, 0 },
+    { "4.04T", 4398046511104*1.01, 0 },
+    { "8.5P", 1125899906842624UL * 8.5, 0 },
+    { "16E", UINT64_MAX, 0 },
+};
+
+static void test_encode (void)
+{
+    for (int i = 0; i < ARRAY_SIZE (encode_tests); i++) {
+        const struct entry *te = &encode_tests[i];
+        const char *result = encode_size (te->val);
+        is (result, te->s,
+            "encode_size (%ju) = %s",
+            (uintmax_t) te->val,
+            result);
+    }
+}
+
 int main (int argc, char **argv)
 {
     plan (NO_PLAN);
     test_parse ();
+    test_encode ();
     done_testing ();
     return 0;
 }

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -17,23 +17,23 @@ test_expect_success 'ping: 10K 1K byte echo requests' '
 '
 
 test_expect_success 'ping: 1K 10K byte echo requests' '
-	run_timeout 15 flux ping --pad 10240 --count 1024 --interval 0 0
+	run_timeout 15 flux ping --pad 10K --count 1024 --interval 0 0
 '
 
 test_expect_success 'ping: 100 100K byte echo requests' '
-	run_timeout 15 flux ping --pad 102400 --count 100 --interval 0 0
+	run_timeout 15 flux ping --pad 100K --count 100 --interval 0 0
 '
 
 test_expect_success 'ping: 10 1M byte echo requests' '
-	run_timeout 15 flux ping --pad 1048576 --count 10 --interval 0 0
+	run_timeout 15 flux ping --pad 1M --count 10 --interval 0 0
 '
 
 test_expect_success 'ping: 10 1M byte echo requests (batched)' '
-	run_timeout 15 flux ping --pad 1048576 --count 10 --batch --interval 0 0
+	run_timeout 15 flux ping --pad 1M --count 10 --batch --interval 0 0
 '
 
 test_expect_success 'ping: 1K 10K byte echo requests (batched)' '
-	run_timeout 20 flux ping --pad 10240 --count 1024 --batch --interval 0 0
+	run_timeout 20 flux ping --pad 10K --count 1024 --batch --interval 0 0
 '
 
 test_expect_success 'ping --rank 1 works' '


### PR DESCRIPTION
Ok, attempt 3 here. I think we now know what this all about.

Differences in this version:
 - as suggested, add a `optparse_get_size_int()` helper function that calls the optparse fatal error function if the supplied argument overflows `MAX_INT`.
 - add an `encode_size()` function (with unit tests) to `parse_size.c` that creates a human readable string from a `size` argument using the same suffixes supported by `parse_size()`. This is only used to encode `MAX_INT` for help output for now, but could be useful in the future.
 - Use `optparse_get_size_int()` in the affected flux utilities.
 - Simplify documentation
 