### PR TITLE
allow guests to use flux module list, flux module stats

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1573,7 +1573,7 @@ static const struct flux_msg_handler_spec htab[] = {
         FLUX_MSGTYPE_REQUEST,
         "broker.rusage",
         method_rusage_cb,
-        0
+        FLUX_ROLE_USER
     },
     {
         FLUX_MSGTYPE_REQUEST,

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1597,7 +1597,7 @@ static const struct flux_msg_handler_spec htab[] = {
         FLUX_MSGTYPE_REQUEST,
         "broker.lsmod",
         broker_lsmod_cb,
-        0
+        FLUX_ROLE_USER,
     },
     {
         FLUX_MSGTYPE_REQUEST,

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -137,7 +137,7 @@ static struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,
       "rusage",
       method_rusage_cb,
-      0,
+      FLUX_ROLE_USER,
     },
     { FLUX_MSGTYPE_REQUEST,
       "ping",

--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -300,7 +300,8 @@ static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "content-backing.store",   store_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "content-backing.checkpoint-get", checkpoint_get_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "content-backing.checkpoint-put", checkpoint_put_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content-files.stats-get", stats_get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "content-files.stats-get",
+      stats_get_cb, FLUX_ROLE_USER },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -738,7 +738,8 @@ static const struct flux_msg_handler_spec htab[] = {
                             checkpoint_get_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "content-backing.checkpoint-put",
                             checkpoint_put_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content-sqlite.stats-get", stats_get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "content-sqlite.stats-get",
+                            stats_get_cb, FLUX_ROLE_USER },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/job-archive/job-archive.c
+++ b/src/modules/job-archive/job-archive.c
@@ -604,7 +604,8 @@ static int process_config (struct job_archive_ctx *ctx)
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST, "job-archive.stats-get", stats_get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "job-archive.stats-get",
+      stats_get_cb, FLUX_ROLE_USER },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -739,7 +739,8 @@ static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,  "job-ingest.submit", submit_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST,  "job-ingest.shutdown", shutdown_cb, 0 },
     { FLUX_MSGTYPE_REQUEST,  "job-ingest.config-reload", reload_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST,  "job-ingest.stats-get",  stats_get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "job-ingest.stats-get",
+      stats_get_cb, FLUX_ROLE_USER },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -146,7 +146,7 @@ static const struct flux_msg_handler_spec htab[] = {
     { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "job-list.stats-get",
       .cb           = stats_cb,
-      .rolemask     = 0
+      .rolemask     = FLUX_ROLE_USER,
     },
     { .typemask     = FLUX_MSGTYPE_EVENT,
       .topic_glob   = "job-purge-inactive",

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -140,7 +140,7 @@ static const struct flux_msg_handler_spec htab[] = {
         FLUX_MSGTYPE_REQUEST,
         "job-manager.stats-get",
         stats_cb,
-        0
+        FLUX_ROLE_USER,
     },
 
     FLUX_MSGHANDLER_TABLE_END,

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -1075,7 +1075,7 @@ static const struct flux_msg_handler_spec htab[] = {
     { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "kvs-watch.stats-get",
       .cb           = stats_cb,
-      .rolemask     = 0
+      .rolemask     = FLUX_ROLE_USER
     },
     { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "kvs-watch.lookup",

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2754,7 +2754,7 @@ static void config_reload_cb (flux_t *h,
 /* see comments above in event_subscribe() regarding event
  * subscriptions to kvs.namespace */
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST, "kvs.stats-get",  stats_get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs.stats-get",  stats_get_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST, "kvs.stats-clear",stats_clear_request_cb, 0 },
     { FLUX_MSGTYPE_EVENT,   "kvs.stats-clear",stats_clear_event_cb, 0 },
     { FLUX_MSGTYPE_EVENT,   "kvs.namespace-*-setroot",  setroot_event_cb, 0 },

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -373,6 +373,11 @@ test_expect_success 'full instance start fails corrupt database' '
 	test_must_fail flux start -o,-Sstatedir=$(pwd) /bin/true
 '
 
+test_expect_success 'flux module stats content-sqlite is open to guests' '
+	FLUX_HANDLE_ROLEMASK=0x2 \
+	    flux module stats content-sqlite >/dev/null
+'
+
 test_expect_success 'remove content-sqlite module on rank 0' '
 	flux module remove content-sqlite
 '

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -345,5 +345,13 @@ test_expect_success 'flux content store not allowed for guest user' '
 test_expect_success 'flux module list is open to guests' '
 	FLUX_HANDLE_ROLEMASK=0x2 flux module list >/dev/null
 '
+test_expect_success 'flux module stats --rusage is open to guests (broker)' '
+	FLUX_HANDLE_ROLEMASK=0x2 \
+	    flux module stats --rusage broker >/dev/null
+'
+test_expect_success 'flux module stats --rusage is open to guests (module)' '
+	FLUX_HANDLE_ROLEMASK=0x2 \
+	    flux module stats --rusage connector-local >/dev/null
+'
 
 test_done

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -342,4 +342,8 @@ test_expect_success 'flux content store not allowed for guest user' '
 	    grep "Request requires owner credentials" content-store.err
 '
 
+test_expect_success 'flux module list is open to guests' '
+	FLUX_HANDLE_ROLEMASK=0x2 flux module list >/dev/null
+'
+
 test_done

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -287,6 +287,11 @@ test_expect_success 'checkpoint-backing-get foo returns spoon' '
        wait_checkpoint_flush spoon
 '
 
+test_expect_success 'flux module stats content-files is open to guests' '
+	FLUX_HANDLE_ROLEMASK=0x2 \
+	    flux module stats content-files >/dev/null
+'
+
 test_expect_success 'remove content-files module on rank 0' '
        flux content flush &&
        flux module remove content-files

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -292,9 +292,9 @@ test_expect_success 'kvs: dropcache fails (user)' '
         unset_userid
 '
 
-test_expect_success 'kvs: stats fails (user)' '
+test_expect_success 'kvs: stats works (user)' '
         set_userid 9999 &&
-        ! flux module stats kvs &&
+        flux module stats kvs >/dev/null &&
         unset_userid
 '
 

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -298,6 +298,12 @@ test_expect_success 'kvs: stats works (user)' '
         unset_userid
 '
 
+test_expect_success 'kvs-watch: stats works (user)' '
+        set_userid 9999 &&
+        flux module stats kvs-watch >/dev/null &&
+        unset_userid
+'
+
 test_expect_success 'kvs: stats clear fails (user)' '
         set_userid 9999 &&
         ! flux module stats -c kvs &&

--- a/t/t2100-job-ingest.t
+++ b/t/t2100-job-ingest.t
@@ -164,6 +164,11 @@ test_expect_success 'job-ingest: handle total batch failure in job-ingest' '
 	test_must_fail flux submit --cc=1-4 hostname
 '
 
+test_expect_success 'flux module stats job-ingest is open to guests' '
+	FLUX_HANDLE_ROLEMASK=0x2 \
+	    flux module stats job-ingest >/dev/null
+'
+
 test_expect_success 'job-ingest: remove modules' '
 	flux module remove job-manager &&
 	flux exec -r all flux module remove job-ingest

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -377,6 +377,11 @@ test_expect_success 'job-manager stats works' '
 	cat stats.out | $jq -e .journal.listeners
 '
 
+test_expect_success 'flux module stats job-manager is open to guests' '
+	FLUX_HANDLE_ROLEMASK=0x2 \
+	    flux module stats job-manager >/dev/null
+'
+
 test_expect_success 'job-manager: remove job-info, job-manager, job-ingest' '
 	flux module remove job-info &&
 	flux module remove job-manager &&

--- a/t/t2250-job-archive.t
+++ b/t/t2250-job-archive.t
@@ -280,6 +280,11 @@ test_expect_success 'job-archive: get module stats' '
         flux module stats job-archive
 '
 
+test_expect_success 'flux module stats job-archive is open to guests' '
+	FLUX_HANDLE_ROLEMASK=0x2 \
+	    flux module stats job-archive >/dev/null
+'
+
 test_expect_success 'job-archive: unload module' '
         flux module unload job-archive
 '

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -358,6 +358,11 @@ test_expect_success 'flux job list all jobs works' '
 	test_cmp all.ids list_all_jobids.out
 '
 
+test_expect_success 'flux module stats job-list is open to guests' '
+	FLUX_HANDLE_ROLEMASK=0x2 \
+	    flux module stats job-list >/dev/null
+'
+
 # with single anonymous queue, queues arrays should be zero length
 test_expect_success 'job stats lists jobs in correct state (mix)' '
 	flux job stats | jq -e ".job_states.depend == 0" &&


### PR DESCRIPTION
Problem: the  `flux module list` and `flux module stats` sub-commands are unnecessarily restricted to instance owner.

Open them to guests.

Fixes #5244