### PR TITLE
expose flux version in python module

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -24,6 +24,7 @@ nobase_fluxpy_PYTHON = \
 	core/inner.py \
 	core/handle.py \
 	core/trampoline.py \
+	core/version.py \
 	job/__init__.py \
 	job/JobID.py \
 	job/Jobspec.py \

--- a/src/bindings/python/flux/__init__.py
+++ b/src/bindings/python/flux/__init__.py
@@ -12,6 +12,7 @@
 python bindings to flux-core, the main core of the flux resource manager
 """
 import flux.core.handle
+from flux.core.version import __version__
 
 
 # Manually lazy
@@ -20,4 +21,4 @@ def Flux(*args, **kwargs):
     return flux.core.handle.Flux(*args, **kwargs)
 
 
-__all__ = ["core", "kvs", "rpc", "constants", "Flux"]
+__all__ = ["core", "kvs", "rpc", "constants", "Flux", "__version__"]

--- a/src/bindings/python/flux/core/version.py
+++ b/src/bindings/python/flux/core/version.py
@@ -1,0 +1,16 @@
+###############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from flux.core.inner import raw
+
+
+def __getattr__(name):
+    if name == "__version__":
+        return raw.flux_core_version_string().decode("utf-8")


### PR DESCRIPTION
Problem: Python tools that use Flux want custom logic based on the version, and we currently do not easily expose it.
Solution: create a flux.__version__ "attribute" that calls into a module to call flux_core_version_string().