### PR TITLE
testsuite: fix occasional broker kill error

### DIFF
--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -32,7 +32,7 @@ test_expect_success 'rc1 bad path handled same as failure' '
 '
 
 test_expect_success 'default initial program is $SHELL' '
-	run_timeout --env=SHELL=/bin/sh 15 \
+	run_timeout --env=SHELL=/bin/sh 60 \
 		flux $SHARNESS_TEST_SRCDIR/scripts/runpty.py -i none \
 		flux start -o,-Slog-stderr-level=6 \
 		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \

--- a/t/t3203-instance-recovery.t
+++ b/t/t3203-instance-recovery.t
@@ -9,9 +9,12 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 
 runpty="flux ${SHARNESS_TEST_SRCDIR}/scripts/runpty.py"
 
+# N.B. Increase test-exit-timeout from default of 20s, on slower / busy
+# systems timeout can trigger and kill broker.
 test_expect_success 'start a persistent instance of size 4' '
 	mkdir -p test1 &&
-	flux start --test-size=4 -o,-Sstatedir=$(pwd)/test1 /bin/true
+	flux start --test-size=4 --test-exit-timeout=300s \
+		-o,-Sstatedir=$(pwd)/test1 /bin/true
 '
 test_expect_success 'expected broker attributes are set in recovery mode' '
 	cat >recov_attrs.exp <<-EOT &&


### PR DESCRIPTION
Problem: flux-start will kill all brokers after the first broker exits.  By default the timeout to kill all the other brokers
is 20s.  A broker in a test in t3203-instance-recovery.t would sometimes be killed due to a slow running rc3 cleanup.  This would
lead to a invalid test error.

Solution: Increase the kill timeout to 300s with the--test-exit-timeout option.

Fixes https://github.com/flux-framework/flux-core/issues/5290

Also increase the timeout in one other test that timed out.