### PR TITLE
libsubprocess: support user friendly error string 

### DIFF
--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -157,12 +157,17 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
     if (state == FLUX_SUBPROCESS_FAILED) {
         flux_cmd_t *cmd = flux_subprocess_get_cmd (p);
         int errnum = flux_subprocess_fail_errno (p);
+        const char *errmsg = flux_subprocess_fail_error (p);
         int ec = 1;
 
+        /* N.B. if no error message available from
+         * flux_subprocess_fail_error(), errmsg is set to strerror of
+         * subprocess errno.
+         */
         log_msg ("Error: rank %d: %s: %s",
                  flux_subprocess_rank (p),
                  flux_cmd_arg (cmd, 0),
-                 strerror (errnum));
+                 errmsg);
 
         /* bash standard, 126 for permission/access denied, 127 for
          * command not found.  68 (EX_NOHOST) for No route to host.

--- a/src/common/libsubprocess/fork.c
+++ b/src/common/libsubprocess/fork.c
@@ -248,7 +248,12 @@ static int local_release_child (flux_subprocess_t *p)
 
 static int local_exec (flux_subprocess_t *p)
 {
-    if ((p->exec_failed_errno = local_release_child (p)) != 0) {
+    int ret;
+    /* N.B. We don't set p->failed_errno here, if locally launched via
+     * flux_local_exec(), will return -1 and errno to caller.  If
+     * called via server, p->failed_errno will be set by remote
+     * handler. */
+    if ((ret = local_release_child (p)) != 0) {
         /*
          *  Reap child immediately. Expectation from caller is that
          *   failure to exec will not require subsequent reaping of
@@ -260,7 +265,7 @@ static int local_exec (flux_subprocess_t *p)
             return -1;
         p->status = status;
 
-        errno = p->exec_failed_errno;
+        errno = ret;
         return -1;
     }
     return 0;

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -1121,6 +1121,17 @@ int flux_subprocess_fail_errno (flux_subprocess_t *p)
     return p->failed_errno;
 }
 
+const char *flux_subprocess_fail_error (flux_subprocess_t *p)
+{
+    if (!p)
+        return "internal error: subprocess is NULL";
+    if (p->state != FLUX_SUBPROCESS_FAILED)
+        return "internal error: subprocess is not in FAILED state";
+    if (p->failed_error.text[0] == '\0')
+        return strerror (p->failed_errno);
+    return p->failed_error.text;
+}
+
 int flux_subprocess_status (flux_subprocess_t *p)
 {
     if (!p) {

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -453,7 +453,7 @@ const char *flux_subprocess_state_string (flux_subprocess_state_t state);
 
 int flux_subprocess_rank (flux_subprocess_t *p);
 
-/* Returns the errno causing the FLUX_SUBPROCESS_FAILED states to be reached.
+/* Returns the errno causing the FLUX_SUBPROCESS_FAILED state to be reached.
  */
 int flux_subprocess_fail_errno (flux_subprocess_t *p);
 

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -457,6 +457,12 @@ int flux_subprocess_rank (flux_subprocess_t *p);
  */
 int flux_subprocess_fail_errno (flux_subprocess_t *p);
 
+/* Returns error message describing why FLUX_SUBPROCESS_FAILED state was
+ * reached.  If error message was not set, will return strerror() of
+ * errno returned from flux_subprocess_fail_errno().
+ */
+const char *flux_subprocess_fail_error (flux_subprocess_t *p);
+
 /* Returns exit status as returned from wait(2).  Works only for
  * FLUX_SUBPROCESS_EXITED state. */
 int flux_subprocess_status (flux_subprocess_t *p);

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -110,6 +110,7 @@ struct flux_subprocess {
     flux_future_t *f;           /* primary future reactor */
     bool remote_completed;      /* if remote has completed */
     int failed_errno;           /* Holds errno if FAILED state reached */
+    flux_error_t failed_error;  /* Holds detailed message for failed_errno */
     int signal_pending;         /* signal sent while starting */
 };
 

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -84,7 +84,6 @@ struct flux_subprocess {
     int channels_eof_sent;          /* counter to avoid loop checks */
 
     int status;      /* Raw status from waitpid(2), valid if exited       */
-    int exec_failed_errno;  /* Holds errno from exec(2) if exec() failed  */
 
     flux_subprocess_state_t state;
     flux_subprocess_state_t state_reported; /* for on_state_change */

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -90,7 +90,7 @@ void test_corner_cases (flux_reactor_t *r)
         "subprocess_server_create fails with NULL pointer inputs");
     ok (subprocess_server_shutdown (NULL, 0) == NULL
         && errno == EINVAL,
-        "subprocess_server_shutdown fails with NULL pointer inputs");
+        "subprocess_server_shutdown fails with NULL pointer input");
 
     ok (flux_local_exec (NULL, 0, NULL, NULL) == NULL
         && errno == EINVAL,
@@ -145,10 +145,10 @@ void test_corner_cases (flux_reactor_t *r)
 
     ok (flux_subprocess_write (NULL, "stdin", "foo", 3) < 0
         && errno == EINVAL,
-        "flux_subprocess_write fails with NULL pointer inputs");
+        "flux_subprocess_write fails with NULL pointer input");
     ok (flux_subprocess_close (NULL, "stdin") < 0
         && errno == EINVAL,
-        "flux_subprocess_close fails with NULL pointer inputs");
+        "flux_subprocess_close fails with NULL pointer input");
     ok (flux_subprocess_read (NULL, "stdout", -1, NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_read fails with NULL pointer inputs");
@@ -160,43 +160,43 @@ void test_corner_cases (flux_reactor_t *r)
         "flux_subprocess_read_trimmed_line fails with NULL pointer inputs");
     ok (flux_subprocess_read_stream_closed (NULL, "stdout") < 0
         && errno == EINVAL,
-        "flux_subprocess_read_stream_closed fails with NULL pointer inputs");
+        "flux_subprocess_read_stream_closed fails with NULL pointer input");
     ok (flux_subprocess_kill (NULL, 0) == NULL
         && errno == EINVAL,
-        "flux_subprocess_kill fails with NULL pointer inputs");
+        "flux_subprocess_kill fails with NULL pointer input");
     ok ((int)flux_subprocess_state (NULL) < 0
         && errno == EINVAL,
-        "flux_subprocess_state fails with NULL pointer inputs");
+        "flux_subprocess_state fails with NULL pointer input");
     ok (flux_subprocess_rank (NULL) < 0
         && errno == EINVAL,
-        "flux_subprocess_rank fails with NULL pointer inputs");
+        "flux_subprocess_rank fails with NULL pointer input");
     ok (flux_subprocess_fail_errno (NULL) < 0
         && errno == EINVAL,
-        "flux_subprocess_fail_errno fails with NULL pointer inputs");
+        "flux_subprocess_fail_errno fails with NULL pointer input");
     ok (flux_subprocess_status (NULL) < 0
         && errno == EINVAL,
-        "flux_subprocess_status fails with NULL pointer inputs");
+        "flux_subprocess_status fails with NULL pointer input");
     ok (flux_subprocess_exit_code (NULL) < 0
         && errno == EINVAL,
-        "flux_subprocess_exit_code fails with NULL pointer inputs");
+        "flux_subprocess_exit_code fails with NULL pointer input");
     ok (flux_subprocess_signaled (NULL) < 0
         && errno == EINVAL,
-        "flux_subprocess_signaled fails with NULL pointer inputs");
+        "flux_subprocess_signaled fails with NULL pointer input");
     ok (flux_subprocess_pid (NULL) < 0
         && errno == EINVAL,
-        "flux_subprocess_pid fails with NULL pointer inputs");
+        "flux_subprocess_pid fails with NULL pointer input");
     ok (flux_subprocess_get_cmd (NULL) == NULL
         && errno == EINVAL,
-        "flux_subprocess_get_cmd fails with NULL pointer inputs");
+        "flux_subprocess_get_cmd fails with NULL pointer input");
     ok (flux_subprocess_get_reactor (NULL) == NULL
         && errno == EINVAL,
-        "flux_subprocess_get_reactor fails with NULL pointer inputs");
+        "flux_subprocess_get_reactor fails with NULL pointer input");
     ok (flux_subprocess_aux_set (NULL, "foo", "bar", NULL) < 0
         && errno == EINVAL,
-        "flux_subprocess_aux_set fails with NULL pointer inputs");
+        "flux_subprocess_aux_set fails with NULL pointer input");
     ok (flux_subprocess_aux_get (NULL, "foo") == NULL
         && errno == EINVAL,
-        "flux_subprocess_aux_get fails with NULL pointer inputs");
+        "flux_subprocess_aux_get fails with NULL pointer input");
 
     flux_close (h);
 }

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -173,6 +173,8 @@ void test_corner_cases (flux_reactor_t *r)
     ok (flux_subprocess_fail_errno (NULL) < 0
         && errno == EINVAL,
         "flux_subprocess_fail_errno fails with NULL pointer input");
+    ok (flux_subprocess_fail_error (NULL) != NULL,
+        "flux_subprocess_fail_error works with NULL pointer input");
     ok (flux_subprocess_status (NULL) < 0
         && errno == EINVAL,
         "flux_subprocess_status fails with NULL pointer input");
@@ -258,6 +260,8 @@ void test_post_exec_errors (flux_reactor_t *r)
         "flux_subprocess_rank fails b/c subprocess is local");
     ok (flux_subprocess_fail_errno (p) < 0,
         "subprocess fail errno fails b/c subprocess not failed");
+    ok (flux_subprocess_fail_error (p) != NULL,
+        "subprocess fail error works when subprocess not failed");
     ok (flux_subprocess_status (p) < 0,
         "subprocess status fails b/c subprocess not yet exited");
     ok (flux_subprocess_exit_code (p) < 0,

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -121,11 +121,14 @@ test_expect_success 'flux exec exits with code 127 for file not found' '
 
 test_expect_success 'flux exec outputs appropriate error message for file not found' '
 	test_expect_code 127 flux exec -n ./nosuchprocess 2> exec.stderr &&
-        grep "No such file or directory" exec.stderr
+	grep "error launching process" exec.stderr &&
+	grep "No such file or directory" exec.stderr
 '
 
 test_expect_success 'flux exec exits with code 126 for non executable' '
-	test_expect_code 126 flux exec -n /dev/null
+	test_expect_code 126 flux exec -n /dev/null 2> exec.stderr2 &&
+	grep "error launching process" exec.stderr2 &&
+	grep "Permission denied" exec.stderr2
 '
 
 test_expect_success 'flux exec exits with code 68 (EX_NOHOST) for rank not found' '


### PR DESCRIPTION
Problem: When a subprocess fails the "failed_errno" value is set and can be returned in `flux_subprocess_fail_errno()`.  It would
be convenient if there was an error message to describe the error in more detail.

Solution: Internally support a new "failed_error" field which can store a text message describing the error in more detail.  Generally speaking, always fill this with a text message when "failed_errno" is also set.

Set user friendly error string in many cases throughout libsubprocess.

Support a new `flux_subprocess_fail_error()` to retrieve this error message.

Add corner case unit tests.

Fixes https://github.com/flux-framework/flux-core/issues/5233

----

Extra notes:

I think the biggest review question in this PR will be my choice of "error message" throughout.  And if I should add it in more places.  We capture the big ones of EACCESS / EPERM on a remotely executed process. e.g.

```
flux-exec: Error: rank 0: ./nosuchprocess: error launching process: No such file or directory
```


