### PR TITLE
add f58plain job encoding

### DIFF
--- a/src/bindings/python/flux/job/JobID.py
+++ b/src/bindings/python/flux/job/JobID.py
@@ -81,6 +81,11 @@ class JobID(int):
         return self.encode("f58")
 
     @property
+    def f58plain(self):
+        """Return RFC19 F58 representation of a JobID with ASCII prefix"""
+        return self.encode("f58plain")
+
+    @property
     def hex(self):
         """Return 0x-prefixed hexadecimal representation of a JobID"""
         return self.encode("hex")

--- a/src/common/libjob/id.c
+++ b/src/common/libjob/id.c
@@ -88,6 +88,8 @@ int flux_job_id_encode (flux_jobid_t id,
         t = FLUID_STRING_MNEMONIC;
     else if (strcasecmp (type, "f58") == 0)
         t = FLUID_STRING_F58;
+    else if (strcasecmp (type, "f58plain") == 0)
+        t = FLUID_STRING_F58_PLAIN;
     else if (strcasecmp (type, "emoji") == 0)
         t = FLUID_STRING_EMOJI;
     else {

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -84,7 +84,7 @@ int flux_job_id_parse (const char *s, flux_jobid_t *id);
 /*  Encode a jobid into encoding "type", writing the result to buffer
  *   buf of size bufsz.
  *  Supported encoding types include:
- *   "dec", "hex", "kvs", "dothex", "words", or "f58".
+ *   "dec", "hex", "kvs", "dothex", "words", "f58", or "f58plain"
  *  Returns 0 on success, -1 on failure with errno set:
  *   EPROTO: Invalid encoding type
  *   EINVAL: Invalid other argument

--- a/src/common/libutil/fluid.c
+++ b/src/common/libutil/fluid.c
@@ -189,7 +189,7 @@ static inline int is_utf8_locale (void)
     return 0;
 }
 
-static int fluid_f58_encode (char *buf, int bufsz, fluid_t id)
+static int fluid_f58_encode (char *buf, int bufsz, fluid_t id, bool plain)
 {
     int count;
     const char *prefix = f58_prefix;
@@ -203,7 +203,7 @@ static int fluid_f58_encode (char *buf, int bufsz, fluid_t id)
 
 #if !ASSUME_BROKEN_LOCALE
     /* Use alternate "f" prefix if locale is not multibyte */
-    if (!is_utf8_locale())
+    if (!is_utf8_locale() || plain)
         prefix = f58_alt_prefix;
 #endif
 
@@ -332,7 +332,11 @@ int fluid_encode (char *buf, int bufsz, fluid_t fluid,
                 return -1;
             break;
         case FLUID_STRING_F58:
-            if (fluid_f58_encode (buf, bufsz, fluid) < 0)
+            if (fluid_f58_encode (buf, bufsz, fluid, false) < 0)
+                return -1;
+            break;
+        case FLUID_STRING_F58_PLAIN:
+            if (fluid_f58_encode (buf, bufsz, fluid, true) < 0)
                 return -1;
             break;
         case FLUID_STRING_EMOJI:

--- a/src/common/libutil/fluid.h
+++ b/src/common/libutil/fluid.h
@@ -24,6 +24,7 @@ typedef enum {
     FLUID_STRING_MNEMONIC = 2,  // mnemonicode x-x-x--x-x-x
     FLUID_STRING_F58 = 3,       // FLUID base58 enc: ƒXXXX or fXXXX
     FLUID_STRING_EMOJI = 4,     // FLUID basemoji enc: 😪🏭🐭🍑👨
+    FLUID_STRING_F58_PLAIN = 5, // FLUID base58 enc: fXXXX
 } fluid_string_type_t;
 
 struct fluid_generator {

--- a/src/common/libutil/test/fluid.c
+++ b/src/common/libutil/test/fluid.c
@@ -103,6 +103,14 @@ void test_f58 (void)
         "fluid_encode with FLUX_F58_FORCE_ASCII used ascii prefix");
     if (unsetenv ("FLUX_F58_FORCE_ASCII") < 0)
         BAIL_OUT ("Failed to unsetenv FLUX_F58_FORCE_ASCII");
+
+    ok (fluid_encode (buf,
+                      sizeof (buf),
+                      f58_tests->id,
+                      FLUID_STRING_F58_PLAIN) == 0,
+        "fluid_encode FLUX_STRING_F58_PLAIN works");
+    is (buf, f58_tests->f58_alt,
+        "fluid_encode FLUID_STRING_F58_PLAIN used ascii prefix");
 #endif
 
     ok (fluid_encode (buf, 1, 1, type) < 0 && errno == EOVERFLOW,

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -171,12 +171,14 @@ flux_future_t *jobinfo_shell_rpc_pack (struct jobinfo *job,
     char *shell_topic = NULL;
     flux_future_t *f = NULL;
     uint32_t rank;
+    char idbuf[21];
 
-    if (asprintf (&shell_topic,
-                  "%ju-shell-%s.%s",
-                  (uintmax_t) job->userid,
-                  idf58 (job->id),
-                  topic) < 0
+    if (flux_job_id_encode (job->id, "f58plain", idbuf, sizeof (idbuf)) < 0
+        || asprintf (&shell_topic,
+                     "%ju-shell-%s.%s",
+                     (uintmax_t) job->userid,
+                     idbuf,
+                     topic) < 0
         || ((rank = resource_set_nth_rank (job->R, 0)) == IDSET_INVALID_ID))
         goto out;
     va_start (ap, fmt);

--- a/src/shell/svc.c
+++ b/src/shell/svc.c
@@ -61,16 +61,25 @@ static int lookup_rank (struct shell_svc *svc, int shell_rank, int *rank)
     return 0;
 }
 
+/* Avoid locale-specific encoding for the shell service name.
+ * See flux-framework/flux-core#5257.
+ */
 static int build_topic (struct shell_svc *svc,
                         const char *method,
                         char *buf,
                         int len)
 {
+    char idbuf[21];
+    if (flux_job_id_encode (svc->shell->info->jobid,
+                            "f58plain",
+                            idbuf,
+                            sizeof (idbuf)) < 0)
+        return -1;
     if (snprintf (buf,
                   len,
                   "%ju-shell-%s%s%s",
                   (uintmax_t)svc->uid,
-                  idf58 (svc->shell->info->jobid),
+                  idbuf,
                   method ? "." : "",
                   method ? method : "") >= len) {
         errno = EINVAL;


### PR DESCRIPTION
Problem: an f58 job encoding that does not change depending on locale configuration is potentially useful and a solution to the problem discussed in #5257.

This PR introduces `f58plain` encoding and uses it in the shell job service name.
