### PR TITLE
shell: document signal race

### DIFF
--- a/src/shell/log.c
+++ b/src/shell/log.c
@@ -364,6 +364,7 @@ int shell_log_init (flux_shell_t *shell, const char *progname)
     logger.level = FLUX_SHELL_NOTICE;
     logger.fp_level = FLUX_SHELL_NOTICE;
     logger.active = 0;
+    logger.exception_logged = 0;
     logger.fp = stderr;
     logger.rank = -1;
     if (progname && !(logger.prog = strdup (progname)))

--- a/src/shell/signals.c
+++ b/src/shell/signals.c
@@ -17,6 +17,25 @@
  * SIGTERM - forward
  * SIGALRM - forward
  *
+ * Notes:
+ *
+ * By setting up the signal watchers during "shell.init", there is the
+ * potential for inconsistent exit codes if a signal is received before all
+ * tasks have started.  For example, this could be seen with something
+ * like:
+ *
+ * jobid=`flux submit -n1000 foo.sh`
+ * flux job raise --type=foo --severity=0 $jobid
+ *
+ * i.e. raise sends SIGTERM to job/shell immediately after starting,
+ * but due to the large task count of 1000, the signal is received
+ * before tasks are all setup.  Some tasks could receive SIGTERM while
+ * some (to be created ones) do not.
+ *
+ * Note that the shell should always return an error, but the error
+ * may not be consistent.  This situation is extremely rare and only
+ * seen is testing situations such as the above.  So we elect to not
+ * fix this race.
  */
 #define FLUX_SHELL_PLUGIN_NAME "signals"
 

--- a/src/shell/signals.c
+++ b/src/shell/signals.c
@@ -15,6 +15,7 @@
  *
  * SIGINT  - forward to all local tasks
  * SIGTERM - forward
+ * SIGALRM - forward
  *
  */
 #define FLUX_SHELL_PLUGIN_NAME "signals"


### PR DESCRIPTION
Per discussion in #5210, but I'm not 100% sure this completely fixes #5210, but it is a fix nonetheless.

Problem: If a trapped signal (SIGTERM, SIGINT, SIGALRM) is caught before all shell tasks have been launched, unexpected behavior could happen.  For example, some tasks could be run without being sent the signal.  The signal can also interrupt initial setup and cause other problems.

Solution: In this unlikely situation, kill current tasks via SIGKILL and exit.  If this situation is hit outside of testing conditions, it is assumed the job was messed up and we want to just kill it.