### PR TITLE
job-manager: publish event on jobtap exception

### DIFF
--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -33,6 +33,7 @@
 #include "event.h"
 #include "drain.h"
 #include "annotate.h"
+#include "raise.h"
 #include "queue.h"
 
 struct alloc {
@@ -286,12 +287,12 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
                                 __FUNCTION__,
                                 idf58 (id));
         }
-        if (event_job_post_pack (ctx->event, job, "exception", 0,
-                                 "{ s:s s:i s:I s:s }",
-                                 "type", "alloc",
-                                 "severity", 0,
-                                 "userid", (json_int_t) FLUX_USERID_UNKNOWN,
-                                 "note", note ? note : "") < 0)
+        if (raise_job_exception (ctx,
+                                 job,
+                                 "alloc",
+                                 0,
+                                 FLUX_USERID_UNKNOWN,
+                                 note) < 0)
             goto teardown;
         break;
     case FLUX_SCHED_ALLOC_CANCEL:

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -37,6 +37,7 @@
 #include "prioritize.h"
 #include "conf.h"
 #include "event.h"
+#include "raise.h"
 #include "jobtap.h"
 #include "jobtap-internal.h"
 
@@ -1931,13 +1932,12 @@ static int jobtap_job_vraise (struct jobtap *jobtap,
     char note [1024];
     if (vsnprintf (note, sizeof (note), fmt, ap) >= sizeof (note))
         note[sizeof(note) - 2] = '+';
-    return event_job_post_pack (jobtap->ctx->event,
-                                job, "exception", 0,
-                                "{ s:s s:i s:i s:s }",
-                                "type", type,
-                                "severity", severity,
-                                "userid", FLUX_USERID_UNKNOWN,
-                                "note", note);
+    return raise_job_exception (jobtap->ctx,
+                                job,
+                                type,
+                                severity,
+                                FLUX_USERID_UNKNOWN,
+                                note);
 }
 
 static int jobtap_job_raise (struct jobtap *jobtap,

--- a/src/modules/job-manager/raise.h
+++ b/src/modules/job-manager/raise.h
@@ -22,6 +22,22 @@ void raise_ctx_destroy (struct raise *raise);
 int raise_check_type (const char *type);
 int raise_check_severity (int severity);
 
+/* Raise a job exception: post to job eventlog and publish job-exception
+ * message.
+ *
+ * N.B. job object may be destroyed in event_job_post_pack().
+ * Do not reference the object after calling this function.
+ * Do not call this function and continue to iterate on the job hash
+ * with zhash_next().
+ */
+int raise_job_exception (struct job_manager *ctx,
+                         struct job *job,
+                         const char *type,
+                         int severity,
+                         uint32_t userid,   // skip if FLUX_USERID_NONE
+                         const char *note); // skip if NULL
+
+
 #endif /* ! _FLUX_JOB_MANAGER_RAISE_H */
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
Problem: the job manager publishes a job-exception event message when an exception is raised via the job-manager.raise RPC, but not when a jobtap plugin calls flux_jobtap_raise_exception().

Publish the job-exception event when a jobtap plugin calls flux_jobtap_raise_exception().

Fixes #5306