### PR TITLE
python: support "original" option in job kvslookup module

### DIFF
--- a/src/bindings/python/flux/job/kvslookup.py
+++ b/src/bindings/python/flux/job/kvslookup.py
@@ -16,12 +16,12 @@ from flux.rpc import RPC
 
 
 # a few keys are special, decode them into dicts if you can
-def decode_special_metadata(metadata):
+def decode_special_data(data):
     for key in ("jobspec", "R"):
-        if key in metadata:
+        if key in data:
             try:
-                tmp = json.loads(metadata[key])
-                metadata[key] = tmp
+                tmp = json.loads(data[key])
+                data[key] = tmp
             except json.decoder.JSONDecodeError:
                 # Ignore if can't be decoded
                 pass
@@ -36,9 +36,9 @@ class JobInfoLookupRPC(RPC):
         return super().get()
 
     def get_decode(self):
-        metadata = super().get()
-        decode_special_metadata(metadata)
-        return metadata
+        data = super().get()
+        decode_special_data(data)
+        return data
 
 
 def job_info_lookup(flux_handle, jobid, keys=["jobspec"]):

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -28,6 +28,8 @@ class TestJob(unittest.TestCase):
         compute_jobreq = JobspecV1.from_command(
             command=command, num_tasks=1, num_nodes=1, cores_per_task=1
         )
+        testenv = {"FOO": "BAR"}
+        compute_jobreq.environment = testenv
         return flux.job.submit(self.fh, compute_jobreq, waitable=True)
 
     @classmethod
@@ -69,6 +71,20 @@ class TestJob(unittest.TestCase):
         self.assertIn("J", data)
         self.assertEqual(type(data["J"]), str)
         self.assertEqual(data["R"]["execution"]["R_lite"][0]["rank"], "0")
+
+    def check_jobspec_original_str(self, data, jobid):
+        self.assertIn("jobspec", data)
+        self.assertEqual(type(data["jobspec"]), str)
+        jobspec = json.loads(data["jobspec"])
+        self.assertEqual(jobspec["tasks"][0]["command"][0], "hostname")
+        self.assertEqual(jobspec["attributes"]["system"]["environment"]["FOO"], "BAR")
+
+    def check_jobspec_original_decoded(self, data, jobid):
+        self.assertIn("jobspec", data)
+        self.assertEqual(data["jobspec"]["tasks"][0]["command"][0], "hostname")
+        self.assertEqual(
+            data["jobspec"]["attributes"]["system"]["environment"]["FOO"], "BAR"
+        )
 
     def test_00_job_info_lookup(self):
         rpc = flux.job.job_info_lookup(self.fh, self.jobid1)
@@ -128,57 +144,115 @@ class TestJob(unittest.TestCase):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["foo"])
         self.assertEqual(data, None)
 
-    def test_10_job_kvs_lookup_list(self):
+    def test_10_job_kvs_lookup_jobspec_original(self):
+        data = flux.job.job_kvs_lookup(self.fh, self.jobid1, original=True)
+        self.assertNotIn("J", data)
+        self.check_jobspec_original_decoded(data, self.jobid1)
+
+    def test_11_job_kvs_lookup_jobspec_original_nodecode(self):
+        data = flux.job.job_kvs_lookup(
+            self.fh, self.jobid1, decode=False, original=True
+        )
+        self.assertNotIn("J", data)
+        self.check_jobspec_original_str(data, self.jobid1)
+
+    def test_12_job_kvs_lookup_jobspec_original_multiple_keys(self):
+        data = flux.job.job_kvs_lookup(
+            self.fh, self.jobid1, keys=["jobspec", "J"], original=True
+        )
+        self.assertIn("J", data)
+        self.check_jobspec_original_decoded(data, self.jobid1)
+
+    def test_13_job_kvs_lookup_original_no_jobspec(self):
+        data = flux.job.job_kvs_lookup(
+            self.fh, self.jobid1, keys=["R", "J"], original=True
+        )
+        self.assertNotIn("jobspec", data)
+        self.check_R_J_decoded(data, self.jobid1)
+
+    def test_14_job_kvs_lookup_list(self):
         ids = [self.jobid1]
         data = flux.job.JobKVSLookup(self.fh, ids).data()
         self.assertEqual(len(data), 1)
         self.check_jobspec_decoded(data[0], self.jobid1)
 
-    def test_11_job_kvs_lookup_list_multiple(self):
+    def test_15_job_kvs_lookup_list_multiple(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids).data()
         self.assertEqual(len(data), 2)
         self.check_jobspec_decoded(data[0], self.jobid1)
         self.check_jobspec_decoded(data[1], self.jobid2)
 
-    def test_12_job_kvs_lookup_list_multiple_nodecode(self):
+    def test_16_job_kvs_lookup_list_multiple_nodecode(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids, decode=False).data()
         self.assertEqual(len(data), 2)
         self.check_jobspec_str(data[0], self.jobid1)
         self.check_jobspec_str(data[1], self.jobid2)
 
-    def test_13_job_kvs_lookup_list_multiple_keys(self):
+    def test_17_job_kvs_lookup_list_multiple_keys(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"]).data()
         self.assertEqual(len(data), 2)
         self.check_R_J_decoded(data[0], self.jobid1)
         self.check_R_J_decoded(data[1], self.jobid2)
 
-    def test_14_job_kvs_lookup_list_multiple_keys_nodecode(self):
+    def test_18_job_kvs_lookup_list_multiple_keys_nodecode(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"], decode=False).data()
         self.assertEqual(len(data), 2)
         self.check_R_J_str(data[0], self.jobid1)
         self.check_R_J_str(data[1], self.jobid2)
 
-    def test_15_job_kvs_lookup_list_none(self):
+    def test_19_job_kvs_lookup_list_none(self):
         data = flux.job.JobKVSLookup(self.fh).data()
         self.assertEqual(len(data), 0)
 
-    def test_16_job_kvs_lookup_list_badid(self):
+    def test_20_job_kvs_lookup_list_badid(self):
         ids = [123456789]
         datalookup = flux.job.JobKVSLookup(self.fh, ids)
         data = datalookup.data()
         self.assertEqual(len(data), 0)
         self.assertEqual(len(datalookup.errors), 1)
 
-    def test_17_job_kvs_lookup_list_badkey(self):
+    def test_21_job_kvs_lookup_list_badkey(self):
         ids = [self.jobid1]
         datalookup = flux.job.JobKVSLookup(self.fh, ids, keys=["foo"])
         data = datalookup.data()
         self.assertEqual(len(data), 0)
         self.assertEqual(len(datalookup.errors), 1)
+
+    def test_22_job_kvs_lookup_list_jobspec_original(self):
+        ids = [self.jobid1]
+        data = flux.job.JobKVSLookup(self.fh, ids, original=True).data()
+        self.assertEqual(len(data), 1)
+        self.assertNotIn("J", data[0])
+        self.check_jobspec_original_decoded(data[0], self.jobid1)
+
+    def test_23_job_kvs_lookup_list_jobspec_original_nodecode(self):
+        ids = [self.jobid1]
+        data = flux.job.JobKVSLookup(self.fh, ids, decode=False, original=True).data()
+        self.assertEqual(len(data), 1)
+        self.assertNotIn("J", data[0])
+        self.check_jobspec_original_str(data[0], self.jobid1)
+
+    def test_24_job_kvs_lookup_list_jobspec_original_multiple_keys(self):
+        ids = [self.jobid1]
+        data = flux.job.JobKVSLookup(
+            self.fh, ids, keys=["jobspec", "J"], original=True
+        ).data()
+        self.assertEqual(len(data), 1)
+        self.assertIn("J", data[0])
+        self.check_jobspec_original_decoded(data[0], self.jobid1)
+
+    def test_25_job_kvs_lookup_list_original_no_jobspec(self):
+        ids = [self.jobid1]
+        data = flux.job.JobKVSLookup(
+            self.fh, ids, keys=["R", "J"], original=True
+        ).data()
+        self.assertEqual(len(data), 1)
+        self.assertNotIn("jobspec", data[0])
+        self.check_R_J_decoded(data[0], self.jobid1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Support something similar to the `--original` option in `flux job info`

There are multiple approaches and I went with the approach of make the `libjob` `unwrap_string()` function public.  Hopefully not a unpopular decision.

There were several reasons:

0) `libjob`'s `unwrap_string()` function easily handles the `flux-core` built w/ and w/o `flux-security` case.

1) while possible to implement the `unwrap_string()`'s `flux-security` code in python via the security module, in `libjob` there is an implementation of the function `sign_none_unwrap()` for the "no flux security" case, which would probably be hard to re-do in python (and minimally annoying to re-do).

2) I realized `unwrap_string()` is used in the job shell, it made me think there may be users of `unwrap_string()` in the future outside of `flux-core`.

So ... I made `unwrap_string()` public and re-named it `flux_unwrap_string()`.  I declare it in a new `job_util.h` header.  I state in the comments in the header that it is mostly for internal use or associated libraries/tools.

Then adding it into the python job `kvslookup.py` module.  Wasn't too hard logically, although unsure I made the code "Pythonic" enough.
