### PR TITLE
 job-info: ignore duplicate lookup keys

### DIFF
--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -87,6 +87,10 @@ static int lookup_key (struct lookup_ctx *l,
     flux_future_t *f = NULL;
     char path[64];
 
+    /* Check for duplicate key, return if already looked up */
+    if (flux_future_get_child (fall, key) != NULL)
+        return 0;
+
     if (flux_job_kvs_key (path, sizeof (path), l->id, key) < 0) {
         flux_log_error (l->ctx->h, "%s: flux_job_kvs_key", __FUNCTION__);
         goto error;

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -95,11 +95,17 @@ test_expect_success 'flux job info jobspec fails on bad id' '
 # job info lookup tests (multiple info requests)
 #
 
-test_expect_success 'flux job info multiple keys works' '
+test_expect_success 'flux job info multiple keys works (different keys)' '
 	jobid=$(submit_job) &&
 	flux job info $jobid eventlog jobspec J > all_info_a.out &&
 	grep submit all_info_a.out &&
 	grep sleep all_info_a.out
+'
+
+test_expect_success 'flux job info multiple keys works (same key)' '
+	jobid=$(submit_job) &&
+	flux job info $jobid eventlog eventlog eventlog > eventlog_3.out &&
+	test $(grep submit eventlog_3.out | wc -l) -eq 3
 '
 
 test_expect_success 'flux job info multiple keys fails on bad id' '


### PR DESCRIPTION
Per #5303.  Multiple approaches on fixing this, I elected to ignore duplicates.  The main reason is because the lookup result is a json object.  So duplicate keys sort of make no sense on a return (i.e. in a json object you can't put the same key in the object twice).

Could have done a "are there duplicates?" check instead and return EINVAL, but figured it's a costly check for a (hopefully) rare corner case.

Note, issue #5305 is highly related to this, but a little different.  Going to solve that in follow up PR.
