### PR TITLE
flux-job: fix `flux job status` handling of nonfatal exceptions

### DIFF
--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -1966,7 +1966,7 @@ test_expect_success 'job-list can handle events with superfluous context data' '
 {"timestamp":1014.0,"name":"free","context":{"etc":1}}
 {"timestamp":1015.0,"name":"clean","context":{"etc":1}}
 EOF
-	jobid=`flux submit --wait --urgency 16 hostname` &&
+	jobid=`flux submit --wait --urgency=default hostname` &&
 	kvspath=`flux job id --to=kvs ${jobid}` &&
 	flux kvs put -r ${kvspath}.eventlog=- < eventlog_superfluous_context.out &&
 	flux module reload job-list &&

--- a/t/t2501-job-status.t
+++ b/t/t2501-job-status.t
@@ -53,7 +53,7 @@ test_expect_success 'status: flux-job status --json works' '
 		jq -e ".waitstatus == 256"
 '
 test_expect_success 'status: returns most severe exception' '
-	jobid=$(flux submit --urgency=0 sleep 20) &&
+	jobid=$(flux submit --urgency=hold sleep 20) &&
 	flux job raise --severity=1 -t test $jobid &&
 	flux job raise --severity=0 -t cancel $jobid &&
 	flux job wait-event -v $jobid clean &&
@@ -62,10 +62,10 @@ test_expect_success 'status: returns most severe exception' '
 		jq -e ".exception_severity == 0"
 '
 test_expect_success 'status: returns most severe exception' '
-	jobid=$(flux submit --urgency=0 sleep 0) &&
+	jobid=$(flux submit --urgency=hold sleep 0) &&
 	flux job raise --severity=1 -t test $jobid &&
 	flux job raise --severity=2 -t test2 $jobid &&
-	flux job urgency ${jobid} 16 &&
+	flux job urgency ${jobid} default &&
 	flux job wait-event -v $jobid clean &&
 	flux job status --exception-exit-code=0 --json ${jobid} &&
 	flux job status --exception-exit-code=0 --json ${jobid} | \
@@ -74,7 +74,7 @@ test_expect_success 'status: returns most severe exception' '
 		jq -e ".exception_type == \"test\""
 '
 test_expect_success 'status: exit code ignores nonfatal exceptions' '
-	jobid=$(flux submit --urgency=0 sleep 0) &&
+	jobid=$(flux submit --urgency=hold sleep 0) &&
 	flux job raise --severity=1 -t test $jobid &&
 	flux job raise --severity=2 -t test2 $jobid &&
 	flux job urgency ${jobid} 16 &&

--- a/t/t2501-job-status.t
+++ b/t/t2501-job-status.t
@@ -73,6 +73,14 @@ test_expect_success 'status: returns most severe exception' '
 	flux job status --exception-exit-code=0 --json ${jobid} | \
 		jq -e ".exception_type == \"test\""
 '
+test_expect_success 'status: exit code ignores nonfatal exceptions' '
+	jobid=$(flux submit --urgency=0 sleep 0) &&
+	flux job raise --severity=1 -t test $jobid &&
+	flux job raise --severity=2 -t test2 $jobid &&
+	flux job urgency ${jobid} 16 &&
+	flux job wait-event -v $jobid clean &&
+	flux job status -vvv $jobid
+'
 test_expect_success 'status: returns 143 (SIGTERM) for canceled running job' '
 	flux job wait-event -p guest.exec.eventlog ${killed} shell.start &&
 	flux cancel ${killed} &&


### PR DESCRIPTION
I noticed that `flux job status` treats all job exceptions as fatal. This is incorrect behavior since a job can get an exception with severity > 0 and still be "successful" i.e. exit with a 0 status.

This PR fixes the behavior and adds a simple test.