### PR TITLE
python: fix writes in KVSDir with initial paths

### DIFF
--- a/src/bindings/python/flux/job/kvs.py
+++ b/src/bindings/python/flux/job/kvs.py
@@ -21,7 +21,7 @@ def job_kvs(flux_handle, jobid):
     path_len = 1024
     buf = ffi.new("char[]", path_len)
     RAW.kvs_key(buf, path_len, jobid, "")
-    kvs_key = ffi.string(buf, path_len)
+    kvs_key = ffi.string(buf, path_len).decode("utf-8")
     return flux.kvs.get_dir(flux_handle, kvs_key)
 
 
@@ -34,5 +34,5 @@ def job_kvs_guest(flux_handle, jobid):
     path_len = 1024
     buf = ffi.new("char[]", path_len)
     RAW.kvs_guest_key(buf, path_len, jobid, "")
-    kvs_key = ffi.string(buf, path_len)
+    kvs_key = ffi.string(buf, path_len).decode("utf-8")
     return flux.kvs.get_dir(flux_handle, kvs_key)

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -165,6 +165,8 @@ class KVSDir(WrapperPimpl, abc.MutableMapping):
         super(KVSDir, self).__init__()
         self.fhdl = flux_handle
         self.path = path
+        # Helper var for easier concatenations
+        self._path = "" if path == "." else path if path[-1] == "." else path + "."
         if flux_handle is None and handle is None:
             raise ValueError(
                 "flux_handle must be a valid Flux object or"
@@ -191,7 +193,7 @@ class KVSDir(WrapperPimpl, abc.MutableMapping):
             )
 
     def __setitem__(self, key, value):
-        if put(self.fhdl, key, value) < 0:
+        if put(self.fhdl, self._path + key, value) < 0:
             print("Error setting item in KVS")
 
     def __delitem__(self, key):
@@ -255,7 +257,7 @@ class KVSDir(WrapperPimpl, abc.MutableMapping):
               syntax, sub-dicts will be stored as json values in a single key
         """
 
-        put_mkdir(self.fhdl, key)
+        put_mkdir(self.fhdl, self._path + key)
         self.commit()
         new_kvsdir = KVSDir(self.fhdl, key)
         if contents is not None:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -350,6 +350,7 @@ dist_check_SCRIPTS = \
 	issues/t4771-flux-start-bash.sh \
 	issues/t4852-t_submit-legacy.sh \
 	issues/t5105-signal-propagation.sh \
+	issues/t5308-kvsdir-initial-path.py \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t5308-kvsdir-initial-path.py
+++ b/t/issues/t5308-kvsdir-initial-path.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+#
+#  Modifying a job data via object (KVSDir) returned via job_kvs()
+#    works.
+#
+import sys
+import flux
+import flux.job
+from flux.job import JobspecV1
+
+handle = flux.Flux()
+jobspec = JobspecV1.from_command(command=["/bin/true"], num_tasks=1, num_nodes=1)
+jobid = flux.job.submit(handle, jobspec, waitable=True)
+flux.job.wait(handle, jobid=jobid)
+jobdir = flux.job.job_kvs(handle, jobid)
+jobdir["foo"] = "bar"
+jobdir.commit()
+
+jobdir2 = flux.job.job_kvs(handle, jobid)
+if jobdir2["foo"] != "bar":
+    sys.exit(1)
+

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -114,9 +114,10 @@ class TestKVS(unittest.TestCase):
             kd.fill({"things": 1, "stuff": "strstuff", "dir.other_thing": "dirstuff"})
             kd.commit()
 
-            self.assertEqual(kd["things"], 1)
-            self.assertEqual(kd["stuff"], "strstuff")
-            self.assertEqual(kd["dir"]["other_thing"], "dirstuff")
+        with flux.kvs.get_dir(self.f) as kd2:
+            self.assertEqual(kd2["things"], 1)
+            self.assertEqual(kd2["stuff"], "strstuff")
+            self.assertEqual(kd2["dir"]["other_thing"], "dirstuff")
 
     def test_set_deep(self):
         self.set_and_check_context("a.b.c.e.f.j.k", 5, int)

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -149,6 +149,75 @@ class TestKVS(unittest.TestCase):
         with flux.kvs.get_dir(self.f, "testkeyat") as kd:
             self.assertEqual(kd.key_at("meh"), "testkeyat.meh")
 
+    def test_key_initial_path(self):
+        with flux.kvs.get_dir(self.f) as kd:
+            kd.mkdir("initialpath")
+
+        kd2 = flux.kvs.KVSDir(self.f)
+        kd2["initialpath.a"] = 1
+        kd2["initialpath"]["b"] = 2
+        kd2.commit()
+
+        kd3 = flux.kvs.KVSDir(self.f, "initialpath")
+        kd3["c"] = 3
+        kd3["d.e.f"] = 4
+        kd3.commit()
+
+        kd4 = flux.kvs.KVSDir(self.f)
+        self.assertEqual(kd4["initialpath.a"], 1)
+        self.assertEqual(kd4["initialpath"]["a"], 1)
+        self.assertEqual(kd4["initialpath.b"], 2)
+        self.assertEqual(kd4["initialpath"]["b"], 2)
+        self.assertEqual(kd4["initialpath.c"], 3)
+        self.assertEqual(kd4["initialpath"]["c"], 3)
+        self.assertEqual(kd4["initialpath.d.e.f"], 4)
+        self.assertEqual(kd4["initialpath"]["d.e.f"], 4)
+        self.assertEqual(kd4["initialpath"]["d"]["e"]["f"], 4)
+
+        kd5 = flux.kvs.KVSDir(self.f, "initialpath")
+        self.assertEqual(kd5["a"], 1)
+        self.assertEqual(kd5["b"], 2)
+        self.assertEqual(kd5["c"], 3)
+        self.assertEqual(kd5["d.e.f"], 4)
+        self.assertEqual(kd5["d"]["e"]["f"], 4)
+
+    def test_fill_initial_path(self):
+        with flux.kvs.get_dir(self.f) as kd:
+            kd.mkdir("fillinitialpath")
+
+        with flux.kvs.get_dir(self.f, "fillinitialpath") as kd2:
+            kd2.fill({"g": 1, "h": "bar", "i.j.k": "baz"})
+            kd2.commit()
+
+        with flux.kvs.get_dir(self.f) as kd3:
+            self.assertEqual(kd3["fillinitialpath.g"], 1)
+            self.assertEqual(kd3["fillinitialpath.h"], "bar")
+            self.assertEqual(kd3["fillinitialpath.i.j.k"], "baz")
+            self.assertEqual(kd3["fillinitialpath.i"]["j"]["k"], "baz")
+
+        with flux.kvs.get_dir(self.f, "fillinitialpath") as kd4:
+            self.assertEqual(kd4["g"], 1)
+            self.assertEqual(kd4["h"], "bar")
+            self.assertEqual(kd4["i.j.k"], "baz")
+            self.assertEqual(kd4["i"]["j"]["k"], "baz")
+
+    def test_mkdir_initial_path(self):
+        with flux.kvs.get_dir(self.f) as kd:
+            kd.mkdir("mkdirinitialpath", {"l": 1, "m": "bar", "n.o.p": "baz"})
+            kd.commit()
+
+        with flux.kvs.get_dir(self.f) as kd2:
+            self.assertEqual(kd2["mkdirinitialpath.l"], 1)
+            self.assertEqual(kd2["mkdirinitialpath.m"], "bar")
+            self.assertEqual(kd2["mkdirinitialpath.n.o.p"], "baz")
+            self.assertEqual(kd2["mkdirinitialpath.n"]["o"]["p"], "baz")
+
+        with flux.kvs.get_dir(self.f, "mkdirinitialpath") as kd3:
+            self.assertEqual(kd3["l"], 1)
+            self.assertEqual(kd3["m"], "bar")
+            self.assertEqual(kd3["n.o.p"], "baz")
+            self.assertEqual(kd3["n"]["o"]["p"], "baz")
+
     def test_walk_with_no_handle(self):
         with self.assertRaises(ValueError):
             flux.kvs.walk("dir").next()

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -119,6 +119,23 @@ class TestKVS(unittest.TestCase):
             self.assertEqual(kd2["stuff"], "strstuff")
             self.assertEqual(kd2["dir"]["other_thing"], "dirstuff")
 
+    def test_mkdir_fill(self):
+        with flux.kvs.get_dir(self.f) as kd:
+            kd.mkdir(
+                "mkdirfill",
+                {
+                    "thingies": 1,
+                    "stuffs": "strstuffs",
+                    "dir.other_thingies": "dirstuffs",
+                },
+            )
+            kd.commit()
+
+        with flux.kvs.get_dir(self.f) as kd2:
+            self.assertEqual(kd2["mkdirfill.thingies"], 1)
+            self.assertEqual(kd2["mkdirfill.stuffs"], "strstuffs")
+            self.assertEqual(kd2["mkdirfill"]["dir"]["other_thingies"], "dirstuffs")
+
     def test_set_deep(self):
         self.set_and_check_context("a.b.c.e.f.j.k", 5, int)
 


### PR DESCRIPTION
Per #5308.  Fix and add testing coverage that was missing before.

Nothing too extravagant about this fix.  It seems it was an  oversight since the initial implementation.  But as I note in #5308, this has the potential to break any code that was using it in the "buggy" way prior.  i.e.

```
dir = KVSDir(handle, path="foo.bar")
dir["foo.bar.a"] = 1
dir.commit()
```

before this created "foo.bar.a" and if we change it'll create "foo.bar.foo.bar.a".  Same with any other functions that underneath the covers write to the KVS via KVSDir (e.g. `fill()` object function) or anything that gets a KVSDir, such as `job_kvs()` or `kvs.get_dir()`.

I think it's low probability that this will cause a lot of breakage out there, but any breakage would be quite severe for said users.  Not sure if we want to ping some code teams first?  Or alert code teams in release notes with special note?