### PR TITLE
Python: Derive FluxExecutor from concurrent.futures.Executor

### DIFF
--- a/src/bindings/python/flux/job/executor.py
+++ b/src/bindings/python/flux/job/executor.py
@@ -414,7 +414,7 @@ class FluxExecutorFuture(concurrent.futures.Future):
                 self._invoke_flux_callback(callback, log_entry)
 
 
-class FluxExecutor:
+class FluxExecutor(concurrent.futures.Executor):
     """Provides a method to submit and monitor Flux jobs asynchronously.
 
     Forks threads to complete futures and fetch event updates in the background.
@@ -605,13 +605,6 @@ class FluxExecutor:
             )
             self._next_thread = (self._next_thread + 1) % len(self._submission_queues)
             return fut
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.shutdown(wait=True)
-        return False
 
     @staticmethod
     def _shutdown_threads(event, threads):


### PR DESCRIPTION
In analogy to the `FluxExecutorFuture` being derived from `concurrent.futures.Future` now also the `FluxExecutor` is derived from `concurrent.futures.Executor` . This has two advantages, on the one hand the `__enter__()` and `__exit__()` functions are already defined and on the other hand frameworks which integrate interfaces for multiple Executors can check for classes derived from the `concurrent.futures.Executor` class.