### PR TITLE
python: add extra documentation to kvs.py module

### DIFF
--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -248,8 +248,8 @@ class KVSDir(WrapperPimpl, abc.MutableMapping):
             self.commit()
 
     def mkdir(self, key: str, contents: Mapping[str, Any] = None):
-        """Create a new sub-directory, optionally pre-populated with the
-        contents of ``files`` as would be done with ``fill(contents)``
+        """Create a new sub-directory, optionally pre-populated by
+        contents, as would be done with ``fill(contents)``
 
         Args:
             key: Key of the directory to be created

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -300,14 +300,14 @@ def join(*args):
     return ".".join([a for a in args if len(a) > 0])
 
 
-def inner_walk(kvsdir, curr_dir, topdown=False):
+def _inner_walk(kvsdir, curr_dir, topdown=False):
     if topdown:
         yield (curr_dir, kvsdir.directories(), kvsdir.files())
 
     for directory in kvsdir.directories():
         path = join(curr_dir, directory)
         key = kvsdir.key_at(directory)
-        for entry in inner_walk(get_dir(kvsdir.fhdl, key), path, topdown):
+        for entry in _inner_walk(get_dir(kvsdir.fhdl, key), path, topdown):
             yield entry
 
     if not topdown:
@@ -320,4 +320,4 @@ def walk(directory, topdown=False, flux_handle=None):
         if flux_handle is None:
             raise ValueError("If directory is a key, flux_handle must be specified")
         directory = KVSDir(flux_handle, directory)
-    return inner_walk(directory, "", topdown)
+    return _inner_walk(directory, "", topdown)

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -61,9 +61,8 @@ flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *ns);
 int flux_kvs_get_version (flux_t *h, const char *ns, int *versionp);
 int flux_kvs_wait_version (flux_t *h, const char *ns, int version);
 
-/* Garbage collect the cache.  On the root node, drop all data that
- * doesn't have a reference in the namespace.  On other nodes, the entire
- * cache is dropped and will be reloaded on demand.
+/* Garbage collect the cache.  Drop all data that doesn't have a
+ * reference in the namespace.
  * Returns -1 on error (errno set), 0 on success.
  */
 int flux_kvs_dropcache (flux_t *h);

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -370,6 +370,8 @@ class TestKVS(unittest.TestCase):
             flux.kvs.put(self.f, ".", "foof")
             flux.kvs.commit(self.f)
         self.assertEqual(ctx.exception.errno, errno.EINVAL)
+        # so we don't mess up later tests, issue #5333
+        self.f.aux_txn = None
 
 
 if __name__ == "__main__":

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -15,6 +15,7 @@ import errno
 import unittest
 
 import flux
+import flux.constants
 import flux.kvs
 from subflux import rerun_under_flux
 
@@ -372,6 +373,16 @@ class TestKVS(unittest.TestCase):
         self.assertEqual(ctx.exception.errno, errno.EINVAL)
         # so we don't mess up later tests, issue #5333
         self.f.aux_txn = None
+
+    # just testing that passing flags work, these are pitiful KVS
+    # changes and the flags don't mean much
+    def test_46_commit_flags(self):
+        flux.kvs.put(self.f, "commitflags", "foo")
+        flux.kvs.commit(self.f, flux.constants.FLUX_KVS_NO_MERGE)
+        flux.kvs.put(self.f, "commitflags", "baz")
+        flux.kvs.commit(self.f, flux.constants.FLUX_KVS_TXN_COMPACT)
+        flux.kvs.put(self.f, "commitflags", "bar")
+        flux.kvs.commit(self.f, flux.constants.FLUX_KVS_SYNC)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added a bit more in there.  Didn't add it for everything, sorta picked and choosed, notably not adding docs for the direct access to C-bindings stuffs b/c that stuff is mostly just used by `KVSDir`.  The readthedocs shouldn't be quite so bare now.

