### PR TITLE
python: add FutureExt class for extensible futures from python

### DIFF
--- a/src/bindings/python/_flux/callbacks.h
+++ b/src/bindings/python/_flux/callbacks.h
@@ -8,3 +8,6 @@ extern "Python" void signal_handler_wrapper(flux_reactor_t *, flux_watcher_t *, 
 
 //flux_continuation_f
 extern "Python" void continuation_callback(flux_future_t *, void *);
+
+//flux_future_init_f
+extern "Python" void init_callback(flux_future_t *, void *);

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -286,8 +286,7 @@ class Flux(Wrapper):
         #
         if threading.current_thread() != threading.main_thread():
             rc = self.flux_reactor_run(reactor, flags)
-            if rc < 0:
-                Flux.raise_if_exception()
+            Flux.raise_if_exception()
             return rc
 
         reactor_interrupted = False
@@ -312,8 +311,7 @@ class Flux(Wrapper):
                 self.reactor_active_incref(reactor)
             if reactor_interrupted:
                 raise KeyboardInterrupt
-            if rc < 0:
-                Flux.raise_if_exception()
+            Flux.raise_if_exception()
 
         # If rc > 0, we need to subtract our added SIGINT watcher, which
         # will now be destroyed since it has left scope

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -124,7 +124,12 @@ class Flux(Wrapper):
         The exception is raised ``from None`` to preserve the original
         stack trace.
         """
-        if cls.tls.exception is not None:
+        #  Note: for unknown reason, an AttributeError is occasionally raised
+        #  here: '_thread._local' object has no attribute 'exception'
+        #  This should not be possible since the attribute is initialized
+        #  in the class, but workaround it anyway through use of getattr():
+        #
+        if getattr(cls.tls, "exception", None) is not None:
             raise cls.set_exception(None) from None
 
     # pylint: disable=no-self-use

--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -131,6 +131,9 @@ class Future(WrapperPimpl):
         handle.incref()
         return handle
 
+    def set_flux(self, flux_handle):
+        self.pimpl.set_flux(flux_handle)
+
     def get_reactor(self):
         return self.pimpl.get_reactor()
 
@@ -156,6 +159,9 @@ class Future(WrapperPimpl):
         # return self to enable further chaining of the future.
         # For example `f.rpc('topic').then(cb).wait_for(-1)
         return self
+
+    def fulfill_error(self, errnum=2, errstr=ffi.NULL):
+        self.pimpl.fulfill_error(errnum, errstr)
 
     def reset(self):
         self.pimpl.reset()

--- a/src/bindings/python/flux/job/event.py
+++ b/src/bindings/python/flux/job/event.py
@@ -104,6 +104,8 @@ class JobEventWatchFuture(Future):
             if exc.errno == errno.ENODATA:
                 self.needs_cancel = False
                 return None
+            # raise handle exception if there is one
+            self.raise_if_handle_exception()
             # re-raise all other exceptions
             raise
         event = EventLogEvent(ffi.string(result[0]).decode("utf-8"))

--- a/src/bindings/python/flux/job/wait.py
+++ b/src/bindings/python/flux/job/wait.py
@@ -112,8 +112,12 @@ class JobResultFuture(Future):
         Return the underlying "result" payload from ``flux_job_result(3)``
         as a dictionary.
         """
-        result_str = ffi.new("char *[1]")
-        RAW.result_get(self.handle, result_str)
+        try:
+            result_str = ffi.new("char *[1]")
+            RAW.result_get(self.handle, result_str)
+        except OSError:
+            self.raise_if_handle_exception()
+            raise
         if result_str[0] == ffi.NULL:
             return None
         return json.loads(ffi.string(result_str[0]).decode("utf-8"))

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -68,7 +68,11 @@ class RPC(Future):
     @interruptible
     def get_str(self):
         payload_str = ffi.new("char *[1]")
-        self.pimpl.flux_rpc_get(payload_str)
+        try:
+            self.pimpl.flux_rpc_get(payload_str)
+        except OSError:
+            self.raise_if_handle_exception()
+            raise
         if payload_str[0] == ffi.NULL:
             return None
         return ffi.string(payload_str[0]).decode("utf-8")

--- a/src/common/libflux/composite_future.c
+++ b/src/common/libflux/composite_future.c
@@ -356,6 +356,12 @@ static void chained_continuation (flux_future_t *prev, void *arg)
         ran_callback = true;
     }
 
+    /*  Check if prev future was reset. If so return and allow this
+     *   continuation to run again.
+     */
+    if (!flux_future_is_ready (prev))
+        return;
+
     /*  If future prev was not continued with flux_future_continue()
      *   or flux_future_continue_error(), then fallback to continue
      *   cf->next using prev directly.


### PR DESCRIPTION
Problem: There is no current support for easily building extensible Future objects in the Python API, e.g. to return a Future that may be composed of a series of multiple RPCs or other actions with a single result.

Add a `FutureExt` class, which is derived from `Future`, but takes an initialization callback like `flux_future_t` which can be used to initiate the composite series of actions that should result in fulfillment of the returned `Future`. The `FutureExt` class also support fulfilling a Future with any Python object that is JSON serializable, and the `FutureExt.get()` method is overloaded to return the fulfilled value. This makes it simple to return a result from Python to Python using `FutureExt`.

A simple example is used in testing and copied here for demonstration purposes: a `Ping5` future which is fulfilled after 5 successful pings, used in both synchronous and async contexts:

```python
import flux
from flux.future import FutureExt


class Ping5(FutureExt):
    def __init__(self, flux_handle):
        super().__init__(init_cb=self.init_cb, flux_handle=flux_handle)

    def ping_cb(self, future):
        seq = future.get()["seq"]
        if seq == 5:
            try:
                self.fulfill(future.get())
            except Exception as exc:
                print(exc)
            return
        h = future.get_flux()
        h.rpc("broker.ping", {"seq": seq + 1}).then(self.ping_cb)

    def init_cb(self, future):
        h = future.get_flux()
        h.rpc("broker.ping", {"seq": 1}).then(self.ping_cb)


print(Ping5(flux.Flux()).get())

h = flux.Flux()
Ping5(h).then(lambda future: print(future.get()))
h.reactor_run()
```

```console
$ python3 ping5.py
{'seq': 5, 'route': '7240baa1!c201314c!a2da1fa8', 'userid': 1000, 'rolemask': 5, 'rank': 0}
{'seq': 5, 'route': '12776d3e!c201314c!a2da1fa8', 'userid': 1000, 'rolemask': 5, 'rank': 0}
```

The main use of this class for now though will be to handle an API for job output, which will be forthcoming in a future PR.