### PR TITLE
python: fix exists in KVSDir with initial paths

### DIFF
--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -182,7 +182,7 @@ class KVSDir(WrapperPimpl, abc.MutableMapping):
         return p_str.decode("utf-8")
 
     def exists(self, name):
-        return exists(self.fhdl, name)
+        return exists(self.fhdl, self._path + name)
 
     def __getitem__(self, key):
         try:

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -149,6 +149,20 @@ class TestKVS(unittest.TestCase):
         with flux.kvs.get_dir(self.f, "testkeyat") as kd:
             self.assertEqual(kd.key_at("meh"), "testkeyat.meh")
 
+    def test_exists_initial_path(self):
+        with flux.kvs.get_dir(self.f) as kd:
+            kd["exists1"] = 1
+            kd.mkdir("existssubdir")
+            kd["existssubdir.exists2"] = 2
+
+        with flux.kvs.get_dir(self.f) as kd2:
+            self.assertTrue(kd2.exists("exists1"))
+            self.assertTrue(kd2.exists("existssubdir.exists2"))
+
+        with flux.kvs.get_dir(self.f, "existssubdir") as kd3:
+            self.assertFalse(kd3.exists("exists1"))
+            self.assertTrue(kd3.exists("exists2"))
+
     def test_key_initial_path(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("initialpath")


### PR DESCRIPTION
Problem: KVSDir can be passed an initial path when initialized.  This
path is utilized as a contextual path for reads and writes.  However,
it was not used for the exists() class function.

Solution: Use the initial path when checking a key in exists().

---

Notes: this was simply missed in #5322 b/c it wasn't a "write" thingie.  Looked through all the KVSDir functions and I think everything else works as intended.