### PR TITLE
python: clear KVS txns on commit error

### DIFF
--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -203,9 +203,12 @@ def commit(flux_handle, flags: int = 0):
     if flux_handle.aux_txn is None:
         return
     future = RAW.flux_kvs_commit(flux_handle, None, flags, flux_handle.aux_txn)
-    RAW.flux_future_get(future, None)
-    RAW.flux_kvs_txn_destroy(flux_handle.aux_txn)
-    flux_handle.aux_txn = None
+    try:
+        RAW.flux_future_get(future, None)
+    except OSError:
+        RAW.flux_kvs_txn_destroy(flux_handle.aux_txn)
+        flux_handle.aux_txn = None
+        raise
 
 
 def dropcache(flux_handle):

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -371,8 +371,10 @@ class TestKVS(unittest.TestCase):
             flux.kvs.put(self.f, ".", "foof")
             flux.kvs.commit(self.f)
         self.assertEqual(ctx.exception.errno, errno.EINVAL)
-        # so we don't mess up later tests, issue #5333
-        self.f.aux_txn = None
+
+        # Issue #5333, make sure internal bad transaction cleared and
+        # subsequent commit works
+        flux.kvs.commit(self.f)
 
     # just testing that passing flags work, these are pitiful KVS
     # changes and the flags don't mean much


### PR DESCRIPTION
Problem: When a commit error happens on a KVS transaction, an error is raised.  This means that the internal KVS transaction (created via calls to put(), put_mkdir(), etc.) does not get cleared.  Therefore a subsequent call the commit() would redo the the transaction.  If the transaction is the cause of the commit failure, no subsequent commits can ever work.
    
Solution: If an exeption is raised during the commit, clear the internal transactions before returning the exception to the user.
    
Fixes #5333
