### PR TITLE
job-manager: make exception note a requirement

### DIFF
--- a/src/bindings/python/flux/job/event.py
+++ b/src/bindings/python/flux/job/event.py
@@ -191,7 +191,7 @@ class JobException(Exception):
     def __init__(self, event):
         self.timestamp = event.timestamp
         self.type = event.context["type"]
-        self.note = event.context.get("note", "no explanation given")
+        self.note = event.context["note"]
         self.severity = event.context["severity"]
         super().__init__(self)
 

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -2550,9 +2550,9 @@ void attach_event_continuation (flux_future_t *f, void *arg)
     if (streq (name, "exception")) {
         const char *type;
         int severity;
-        const char *note = NULL;
+        const char *note;
 
-        if (json_unpack (context, "{s:s s:i s?s}",
+        if (json_unpack (context, "{s:s s:i s:s}",
                          "type", &type,
                          "severity", &severity,
                          "note", &note) < 0)
@@ -2561,7 +2561,7 @@ void attach_event_continuation (flux_future_t *f, void *arg)
                          timestamp - ctx->timestamp_zero,
                          type,
                          severity,
-                         note ? note : "");
+                         note);
 
         /*  If this job has an interactive pty and the pty is not yet attached,
          *   destroy the pty to avoid a potential hang attempting to connect

--- a/src/common/libjob/result.c
+++ b/src/common/libjob/result.c
@@ -175,8 +175,10 @@ static void result_eventlog_cb (flux_future_t *f, void *arg)
             || json_object_set (res, "waitstatus", wstatus) < 0)
             goto error;
     }
-    else if (streq (name, "exception"))
-        job_result_handle_exception (res, context);
+    else if (streq (name, "exception")) {
+        if (job_result_handle_exception (res, context) < 0)
+            goto error;
+    }
 
     json_decref (o);
 

--- a/src/common/libjob/result.c
+++ b/src/common/libjob/result.c
@@ -112,10 +112,10 @@ static int job_result_handle_exception (json_t *res,
 {
     json_t *type;
     json_t *severity;
-    json_t *note = NULL;
+    json_t *note;
 
     if (json_unpack (context,
-                     "{s:o s:o s?o}",
+                     "{s:o s:o s:o}",
                      "type", &type,
                      "severity", &severity,
                      "note", &note) < 0) {

--- a/src/common/libjob/result.c
+++ b/src/common/libjob/result.c
@@ -11,6 +11,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <assert.h>
 #include <flux/core.h>
 
 #include "ccan/array_size/array_size.h"
@@ -88,7 +89,7 @@ static void result_eventlog_error_cb (flux_future_t *f, void *arg)
     if (!(o = json_integer (result))
         || json_object_set_new (res, "result", o) < 0
         || !(s = json_dumps (res, JSON_COMPACT))) {
-        flux_future_continue_error (f, errno, NULL);
+        flux_future_continue_error (f, ENOMEM, NULL);
         goto out;
     }
     flux_future_fulfill_next (f, s, free);
@@ -112,19 +113,17 @@ static int job_result_handle_exception (json_t *res,
     json_t *type;
     json_t *severity;
     json_t *note = NULL;
-    json_t *exception_occurred = json_object_get (res, "exception_occurred");
-
-    if (!exception_occurred)
-        return -1;
 
     if (json_unpack (context,
                      "{s:o s:o s?o}",
                      "type", &type,
                      "severity", &severity,
-                     "note", &note) < 0)
+                     "note", &note) < 0) {
+        errno = EPROTO;
         return -1;
+    }
 
-    if (json_is_true (exception_occurred)) {
+    if (json_is_true (json_object_get (res, "exception_occurred"))) {
         /* Only overwrite previous exception if the latest
          *  is of greater severity.
          */
@@ -136,8 +135,10 @@ static int job_result_handle_exception (json_t *res,
     if (json_object_set (res, "exception_occurred", json_true ()) < 0
         || json_object_set (res, "exception_type", type) < 0
         || json_object_set (res, "exception_note", note) < 0
-        || json_object_set (res, "exception_severity", severity) < 0)
-            return -1;
+        || json_object_set (res, "exception_severity", severity) < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
     return 0;
 }
 
@@ -155,25 +156,33 @@ static void result_eventlog_cb (flux_future_t *f, void *arg)
          */
         goto error;
     }
-    if (!(o = eventlog_entry_decode (entry))
-        || !(timestamp = json_object_get (o, "timestamp"))
-        || eventlog_entry_parse (o, NULL, &name, &context) < 0)
+    if (!(o = eventlog_entry_decode (entry)))
+        goto error;
+    if (!(timestamp = json_object_get (o, "timestamp"))) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (eventlog_entry_parse (o, NULL, &name, &context) < 0)
         goto error;
 
     if (streq (name, "submit")) {
         if (json_object_set (res, "t_submit", timestamp) < 0)
-            goto error;
+            goto enomem;
     }
     else if (streq (name, "alloc")) {
         if (json_object_set (res, "t_run", timestamp) < 0)
-            goto error;
+            goto enomem;
     }
     else if (streq (name, "finish")) {
         json_t *wstatus = NULL;
-        if (json_object_set (res, "t_cleanup", timestamp) < 0
-            || !(wstatus = json_object_get (context, "status"))
-            || json_object_set (res, "waitstatus", wstatus) < 0)
+        if (json_object_set (res, "t_cleanup", timestamp) < 0)
+            goto enomem;
+        if (!(wstatus = json_object_get (context, "status"))) {
+            errno = EPROTO;
             goto error;
+        }
+        if (json_object_set (res, "waitstatus", wstatus) < 0)
+            goto enomem;
     }
     else if (streq (name, "exception")) {
         if (job_result_handle_exception (res, context) < 0)
@@ -189,6 +198,8 @@ static void result_eventlog_cb (flux_future_t *f, void *arg)
     flux_future_continue (f, NULL);
     flux_future_reset (f);
     return;
+enomem:
+    errno = ENOMEM;
 error:
     flux_future_continue_error (f, errno, NULL);
     flux_future_destroy (f);

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -1070,11 +1070,11 @@ static int exception_context_parse (flux_t *h,
 {
     const char *type;
     int severity;
-    const char *note = NULL;
+    const char *note;
 
     if (!context
         || json_unpack (context,
-                        "{s:s s:i s?s}",
+                        "{s:s s:i s:s}",
                         "type", &type,
                         "severity", &severity,
                         "note", &note) < 0) {

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -76,26 +76,20 @@ int raise_job_exception (struct job_manager *ctx,
     flux_future_t *f;
     json_t *evctx;
 
-    // create exception event context with the required keys per RFC 21
-    if (!(evctx = json_pack ("{s:s s:i}", "type", type, "severity", severity)))
-        goto nomem;
-    // work around flux-framework/flux-core#5314
+    // if no note specified, set to empty string per RFC21
     if (!note)
         note = "";
+    // create exception event context with the required keys per RFC 21
+    if (!(evctx = json_pack ("{s:s s:i s:s}",
+                             "type", type,
+                             "severity", severity,
+                             "note", note)))
+        goto nomem;
     // add optional userid key
     if (userid != FLUX_USERID_UNKNOWN) {
         json_t *val;
         if (!(val = json_integer (userid))
             || json_object_set_new (evctx, "userid", val) < 0) {
-            json_decref (val);
-            goto nomem;
-        }
-    }
-    // add optional note key
-    if (note) {
-        json_t *val;
-        if (!(val = json_string (note))
-            || json_object_set_new (evctx, "note", val) < 0) {
             json_decref (val);
             goto nomem;
         }

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -43,7 +43,7 @@
  *             data: {"ranks":s "final":b}
  *
  * "exception" - raise an exception (0 is fatal)
- *               data: {"severity":i "type":s "note"?:s}
+ *               data: {"severity":i "type":s "note":s}
  *
  * "finish" - data: {"status":i}
  *
@@ -272,7 +272,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
                                  "type", xtype,
                                  "severity", xseverity,
                                  "userid", (json_int_t) FLUX_USERID_UNKNOWN,
-                                 "note", xnote ? xnote : "")  < 0)
+                                 "note", xnote)  < 0)
             goto error_post;
     }
     else if (streq (type, "finish")) {

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -89,17 +89,17 @@ static int decode_job_result (struct job *job,
      */
     if (streq (name, "exception")) {
         const char *type;
-        const char *note = NULL;
+        const char *note;
 
         if (json_unpack (context,
-                         "{s:s s?s}",
+                         "{s:s s:s}",
                          "type", &type,
                          "note", &note) < 0)
             return -1;
         errprintf (errp,
                    "Fatal exception type=%s %s",
                    type,
-                   note ? note : "");
+                   note);
         *success = false;
     }
     /* Shells exited - set errbuf=decoded status byte,

--- a/t/python/t0023-executor.py
+++ b/t/python/t0023-executor.py
@@ -304,7 +304,7 @@ class TestFluxExecutorThread(unittest.TestCase):
                     {
                         "name": "exception",
                         "timestamp": 0,
-                        "context": {"severity": 1, "type": "foobar"},
+                        "context": {"severity": 1, "type": "foobar", "note": ""},
                     }
                 )
             ),
@@ -317,7 +317,7 @@ class TestFluxExecutorThread(unittest.TestCase):
                     {
                         "name": "exception",
                         "timestamp": 0,
-                        "context": {"severity": 0, "type": "foobar"},
+                        "context": {"severity": 0, "type": "foobar", "note": ""},
                     }
                 )
             ),

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -1919,28 +1919,6 @@ EOF
 	flux job list-ids ${jobid} > empty_alloc.out &&
 	cat empty_alloc.out | jq -e ".annotations == null"
 '
-test_expect_success 'job-list can handle events missing optional data (exception)' '
-	userid=`id -u` &&
-	cat <<EOF >eventlog_no_exception_note.out &&
-{"timestamp":1000.0,"name":"submit","context":{"userid":${userid},"urgency":16,"flags":0,"version":1}}
-{"timestamp":1001.0,"name":"validate"}
-{"timestamp":1002.0,"name":"depend"}
-{"timestamp":1003.0,"name":"priority","context":{"priority":8}}
-{"timestamp":1004.0,"name":"alloc","context":{"annotations":{"sched":{"resource_summary":"rank0/core0"}}}}
-{"timestamp":1005.0,"name":"start"}
-{"timestamp":1006.0,"name":"exception","context":{"type":"exec","severity":0}}
-{"timestamp":1007.0,"name":"finish","context":{"status":0}}
-{"timestamp":1008.0,"name":"release","context":{"ranks":"all","final":true}}
-{"timestamp":1009.0,"name":"free"}
-{"timestamp":1010.0,"name":"clean"}
-EOF
-	jobid=`flux submit notacommand` &&
-	kvspath=`flux job id --to=kvs ${jobid}` &&
-	flux kvs put -r ${kvspath}.eventlog=- < eventlog_no_exception_note.out &&
-	flux module reload job-list &&
-	flux job list-ids ${jobid} > no_exception_note.out &&
-	cat no_exception_note.out | jq -e ".exception_note == null"
-'
 # N.B. Note the original job was submitted with urgency 16, but we
 # hard code 8 in the fake eventlog.	 This is just to make sure the fake
 # eventlog was loaded correctly at the end of the test.


### PR DESCRIPTION
Per #5314, the job-manager would output an empty string "note" for an exception when a note is not specified.  But RFC21 says that the note is optional.  So do not output this empty string "note".

Two test fallouts from this.  The job result code in `libjob` always assumed a note would be there.  And some job-list tests would sometimes assume a note would be empty string instead of "null".

Doing an audit on the code, I think there is one more place where there could be a problem but it wasn't covered in tests.  It's in the Python cli base code.

Also some misc cleanup in `libjob` when I was looking at the code and trying to figure why it failed the way it did.