### PR TITLE
resource: fix problem with exclusions when R is dynamically discovered

### DIFF
--- a/t/t2312-resource-exclude.t
+++ b/t/t2312-resource-exclude.t
@@ -109,5 +109,23 @@ test_expect_success 'flux resource status shows zero nodes excluded' '
 test_expect_success 'unexclude event was posted' '
 	test $(has_resource_event unexclude | wc -l) -eq 1
 '
+# See flux-framework/flux-core#5337
+test_expect_success 'test instance can exclude ranks' '
+	cat >exclude.toml <<-EOT &&
+	[resource]
+	exclude = "1"
+	EOT
+	test $(flux start -s2 -o,--config-path=exclude.toml \
+	    flux resource status -s exclude -no {nnodes}) -eq 1
+'
+test_expect_success 'test instance fails to exclude hostnames' '
+	cat >exclude2.toml <<-EOT &&
+	[resource]
+	exclude = "$(hostname -s)"
+	EOT
+	test_must_fail flux start -s2 -o,--config-path=exclude2.toml \
+	    /bin/true 2>exclude2.err &&
+	grep "R is unavailable" exclude2.err
+'
 
 test_done


### PR DESCRIPTION
Problem: when _R_ is acquired dynamically, the resource module refuses to process exclusions.
    
`inventory_targets_to_ranks()` fails if _R_ is not set, but _R_ is only used if the input fails to parse as an idset.
    
 Move the check for NULL R into the hostnames to ranks mapping block where it is used.  This allows an exclusion set specified as an idset  to be decoded when R is dynamically discovered.
    
Fixes #5337
