### PR TITLE
resource: ignore live resource.exclude changes

### DIFF
--- a/doc/man1/flux-broker.rst
+++ b/doc/man1/flux-broker.rst
@@ -45,7 +45,7 @@ OPTIONS
 **-S, --setattr**\ =\ *ATTR=VAL*
    Set initial value for broker attribute.
 
-**-c, --conf-path=**\ =\ *PATH*
+**-c, --config-path=**\ =\ *PATH*
    Set the PATH to broker configuration. If PATH is a directory, then
    read all TOML files from that directory. If PATH is a file, then load
    configuration as JSON if the file extension is ``.json``, otherwise

--- a/doc/man5/flux-config-resource.rst
+++ b/doc/man5/flux-config-resource.rst
@@ -71,6 +71,9 @@ norestrict
    when the Flux system instance is constrained to a subset of cores,
    but jobs run within this instance should have access to all cores.
 
+noverify
+   (optional) If true, disable the draining of nodes when there is a
+   discrepancy between configured resources and HWLOC-probed resources.
 
 EXAMPLE
 =======

--- a/doc/man5/flux-config-resource.rst
+++ b/doc/man5/flux-config-resource.rst
@@ -57,10 +57,6 @@ config
 exclude
    (optional) A string value that defines one or more nodes to withhold
    from scheduling, either in RFC 22 idset form, or in RFC 29 hostlist form.
-   This value may be changed on a live system by reloading the configuration
-   on the rank 0 broker.  A newly excluded node will appear as "down" to
-   the scheduler, but will still be used to determine satisfiability of job
-   requests until the instance is restarted.
 
    If a drained node is subsequently excluded, the drain state of the node
    is cleared since nodes cannot be both excluded and drained.
@@ -74,6 +70,9 @@ norestrict
 noverify
    (optional) If true, disable the draining of nodes when there is a
    discrepancy between configured resources and HWLOC-probed resources.
+
+Note that updates to the resource table are ignored until the next Flux
+restart.
 
 EXAMPLE
 =======

--- a/src/modules/resource/acquire.c
+++ b/src/modules/resource/acquire.c
@@ -350,7 +350,6 @@ static void reslog_cb (struct reslog *reslog, const char *name, void *arg)
             }
         }
         else if (streq (name, "online") || streq (name, "offline")
-                || streq (name, "exclude") || streq (name, "unexclude")
                 || streq (name, "drain") || streq (name, "undrain")) {
             if (ar->response_count > 0) {
                 struct idset *up, *dn;

--- a/src/modules/resource/exclude.h
+++ b/src/modules/resource/exclude.h
@@ -14,10 +14,6 @@
 struct exclude *exclude_create (struct resource_ctx *ctx, const char *idset);
 void exclude_destroy (struct exclude *exclude);
 
-int exclude_update (struct exclude *exclude,
-                    const char *idset,
-                    flux_error_t *errp);
-
 const struct idset *exclude_get (struct exclude *exclude);
 
 #endif /* !_FLUX_RESOURCE_EXCLUDE_H */

--- a/t/t2303-sched-hello.t
+++ b/t/t2303-sched-hello.t
@@ -16,7 +16,8 @@ test_expect_success 'start a long-running job' '
 	jobid=$(flux submit -n1 -t1h sleep 3600)
 '
 test_expect_success 'unload scheduler' '
-	flux module remove sched-simple
+	flux module remove sched-simple &&
+	flux module remove resource
 '
 test_expect_success 'exclude the job node from configuration' '
 	flux config load <<-EOT
@@ -28,6 +29,7 @@ test_expect_success 'increase broker stderr log level' '
 	flux setattr log-stderr-level 6
 '
 test_expect_success 'load scheduler' '
+	flux module load resource &&
 	flux module load sched-simple
 '
 test_expect_success 'job receives exception' '

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -174,9 +174,13 @@ test_expect_success 'no nodes remain drained after restart' '
 test_expect_success 'drain one node' '
 	flux resource drain 0 testing
 '
-
-test_expect_success 'exclude one node via configuration' '
-	echo "resource.exclude = \"0\"" | flux config load
+test_expect_success 'reload resource module with one node excluded' '
+	flux module remove sched-simple &&
+	flux module remove resource &&
+	echo "resource.exclude = \"0\"" | flux config load &&
+	flux module load resource &&
+	waitdown 0 &&
+	flux module load sched-simple
 '
 
 test_expect_success 'excluded node is no longer drained' '
@@ -194,9 +198,16 @@ test_expect_success 'drain of idset with excluded and drained nodes fails' '
 	grep "drained or excluded" multi.err
 '
 
-test_expect_success 'undrain/unexclude ranks' '
-	flux resource undrain 1 &&
-	echo "resource.exclude = \"\"" | flux config load
+test_expect_success 'undrain ranks' '
+	flux resource undrain 1
+'
+test_expect_success 'reload resource module with no nodes excluded' '
+	flux module remove sched-simple &&
+	flux module remove resource &&
+	echo "resource.exclude = \"\"" | flux config load &&
+	flux module load resource &&
+	waitdown 0 &&
+	flux module load sched-simple
 '
 
 test_expect_success 'no nodes remain drained or excluded' '
@@ -217,17 +228,18 @@ test_expect_success 'drained rank subsequently excluded is ignored' '
 	flux resource list
 '
 
-test_expect_success 'unexclude ranks' '
-	echo "resource.exclude = \"\"" | flux config load
+test_expect_success 'reload resource module with no nodes excluded' '
+	flux module remove sched-simple &&
+	flux module remove resource &&
+	echo "resource.exclude = \"\"" | flux config load &&
+	flux module load resource &&
+	waitdown 0 &&
+	flux module load sched-simple
 '
 
 test_expect_success 'no nodes remain drained or excluded' '
 	test $(flux resource status -s drain -no {nnodes}) -eq 0 &&
 	test $(flux resource status -s exclude -no {nnodes}) -eq 0
-'
-
-test_expect_success 'reload scheduler so it seems all ranks' '
-	flux module reload sched-simple
 '
 
 test_expect_success 'undrain fails if rank not drained' '

--- a/t/t2312-resource-exclude.t
+++ b/t/t2312-resource-exclude.t
@@ -4,12 +4,13 @@ test_description='Test resource exclusion'
 
 . `dirname $0`/sharness.sh
 
-# Start out with empty config object
-# Then we will reload after adding TOML to cwd
-export FLUX_CONF_DIR=$(pwd)
+cat >exclude.toml <<-EOT
+[resource]
+exclude = "0"
+EOT
 
 SIZE=4
-test_under_flux $SIZE
+test_under_flux $SIZE full -o,--config-path=$(pwd)/exclude.toml
 
 # Usage: waitup N
 #   where N is a count of online ranks
@@ -27,16 +28,9 @@ has_resource_event () {
 test_expect_success 'wait for monitor to declare all nodes are up' '
     waitdown 0
 '
-test_expect_success 'reconfigure with rank 0 exclusion' '
-	cat >resource.toml <<-EOT &&
-	[resource]
-	exclude = "0"
-	EOT
-	flux config reload
-'
 
-test_expect_success 'flux resource list shows one node down' '
-	test $(flux resource list -n -s down -o {nnodes}) -eq 1
+test_expect_success 'flux resource list shows no nodes down' '
+	test $(flux resource list -n -s down -o {nnodes}) -eq 0
 '
 
 test_expect_success 'flux resource status shows one node excluded' '
@@ -57,58 +51,22 @@ test_expect_success 'but monitor still says all nodes are up' '
 	waitdown 0
 '
 
-test_expect_success 'exclude event was posted' '
-	test $(has_resource_event exclude | wc -l) -eq 1
-'
-
-test_expect_success 'reconfig with bad exclude idset fails' '
+test_expect_success 'config with bad exclude idset fails' '
 	cat >resource.toml <<-EOT &&
 	[resource]
 	exclude = "xxzz"
 	EOT
-	test_must_fail flux config reload
+	test_must_fail flux start -o,--config-path=resource.toml
 '
 
-test_expect_success 'flux resource list still shows one node down' '
-	test $(flux resource list -n -s down -o {nnodes}) -eq 1
-'
-
-test_expect_success 'reconfig with out of range exclude idset fails' '
+test_expect_success 'config with out of range exclude idset fails' '
 	cat >resource.toml <<-EOT &&
 	[resource]
-	exclude = "0-$SIZE"
+	exclude = "1"
 	EOT
-	test_must_fail flux config reload
+	test_must_fail flux start -o,--config-path=resource.toml
 '
 
-test_expect_success 'reconfig with hostnames in exclude set works' '
-	cat >resource.toml <<-EOT &&
-	[resource]
-	exclude = "$(hostname)"
-	EOT
-	flux config reload &&
-	test_debug "flux dmesg | grep resource" &&
-	test $(flux resource list -n -s down -o {nnodes}) -eq ${SIZE}
-'
-
-test_expect_success 'reconfig with no exclude idset' '
-	cat >resource.toml <<-EOT &&
-	[resource]
-	EOT
-	flux config reload
-'
-
-test_expect_success 'flux resource list shows zero nodes down' '
-	test $(flux resource list -n -s down -o {nnodes}) -eq 0
-'
-
-test_expect_success 'flux resource status shows zero nodes excluded' '
-	test $(flux resource status -s exclude -no {nnodes}) -eq 0
-'
-
-test_expect_success 'unexclude event was posted' '
-	test $(has_resource_event unexclude | wc -l) -eq 1
-'
 # See flux-framework/flux-core#5337
 test_expect_success 'test instance can exclude ranks' '
 	cat >exclude.toml <<-EOT &&
@@ -126,6 +84,18 @@ test_expect_success 'test instance fails to exclude hostnames' '
 	test_must_fail flux start -s2 -o,--config-path=exclude2.toml \
 	    /bin/true 2>exclude2.err &&
 	grep "R is unavailable" exclude2.err
+'
+test_expect_success 'instance with configured R can exclude hostnames' '
+	cat >exclude3.toml <<-EOT &&
+	[resource]
+	exclude = "$(hostname -s)"
+	noverify = true
+	[[resource.config]]
+	hosts = "$(hostname -s)"
+	cores = "0"
+	EOT
+	test $(flux start -s1 -o,--config-path=exclude3.toml \
+	    flux resource status -s exclude -no {nnodes}) -eq 1
 '
 
 test_done


### PR DESCRIPTION
 Problem: the resource module contains code to process live changes to the configured exclude set, but as discussed in flux-framework/rfc#383, there is no longer much of a use case now that flux-batch(1) et al have a `--conf` option that can configure exclusions on the command line for subinstances.
    
The extra code includes posting `exclude`/`unexclude` events to the KVS resource.eventlog _synchronously_ by calling the internal function `reslog_sync()`.  This makes the resource module unresponsive while the KVS commit completes.
    
This extra complexity is no longer justified.  Remove.

Update tests.

There are also a couple of incidental man page updates here which could be split off to a separate pr if desired.
