### PR TITLE
python: fix potential gc of Future ffi handle before Future destruction

### DIFF
--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -46,6 +46,14 @@ def continuation_callback(c_future, opaque_handle):
         flux_handle = py_future.get_flux()
         type(flux_handle).set_exception(exc)
         flux_handle.reactor_stop_error()
+        #
+        # Reset this future so it doesn't immediately call the callback
+        # again (and fail) if the reactor is restarted. (and bypass
+        # future.reset() to avoid unnecessarily incrementing _THEN_HANDLES
+        # count).
+        #
+        py_future.pimpl.reset()
+        py_future.stop()
 
     finally:
         if py_future in _THEN_HANDLES:


### PR DESCRIPTION
This PR fixes a frustrating issue I was hitting while working on #5332 which uses the `FutureExt` class.

The crux of the issue is that a Python `Future` ffi handle for the `then_cb` (`future.cb_handle`) can be garbage collected before the `Future` itself is. If the C `flux_future_t` can be fufilled multiple times, or if the future was not reset, then the reactor may try to invoke the Python `continuation_callback()` again, and Python throws a little fit and aborts since the ffi handle is no longer valid.

Thanks to help from @trws, the problem was narrowed down to the `finally` block in `continuation_callback()`:
https://github.com/flux-framework/flux-core/blob/837104c07ee7400bb2f3413c9bd0b04b971143bd/src/bindings/python/flux/future.py#L46-L52

Since `py_future.cb_handle` is set to `None`,  the ffi handle could be garbage collected at this point. This works fine for futures that only call the `then_cb` a single time. But Futures with multiple fulfillment could end up calling the `then_cb()` again until the `Future` itself is GC'd (at which point `flux_future_destroy()` is called by the destructor).

The solution as suggested by @trws is to just avoid setting `cb_handle = None` and let the ffi handle lifetime match that of the `Future` object. This should completely eliminate the chances of a Python abort due to this problem. (And I probably spent many hours tracking down various ways this can happen and working around it while working on the job output code)

The other issue resolved here is that if an exception is raised in a callback, there is now a chance that the future is still active and fulfilled with an error (e.g. if the Future still has a reference and is not collected by gc). If the caller restarts the reactor, then the future callback will be called again, the same error raised, etc. Therefore, after stashing the exception in the handle, reset and stop the affected future to avoid this issue. 