### PR TITLE
sdexec: fix memory leaks

### DIFF
--- a/src/common/libsdexec/parse.c
+++ b/src/common/libsdexec/parse.c
@@ -71,10 +71,10 @@ int sdexec_parse_bitmap (const char *s, uint8_t **bp, size_t *sp)
             BITMAP_BYTE (bitmap, id) |= BITMAP_BIT (id);
             id = idset_next (ids, id);
         }
-        idset_destroy (ids);
     }
     *bp = bitmap;
     *sp = BITMAP_NBYTES (nbits);
+    idset_destroy (ids);
     return 0;
 }
 

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -802,7 +802,7 @@ static void list_cb (flux_t *h,
     }
     if (flux_respond_pack (h,
                            msg,
-                           "{s:i s:o}",
+                           "{s:i s:O}",
                            "rank", ctx->rank,
                            "procs", procs) < 0)
         flux_log_error (h, "error responding to list request");

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -390,6 +390,7 @@ static void sdproc_destroy (struct sdproc *proc)
 {
     if (proc) {
         int saved_errno = errno;
+        sdexec_channel_destroy (proc->in);
         sdexec_channel_destroy (proc->out);
         sdexec_channel_destroy (proc->err);
         if (proc->f_watch) {

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -40,11 +40,18 @@ VALGRIND_WORKLOAD=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind-workload.sh
 
 VALGRIND_NBROKERS=${VALGRIND_NBROKERS:-2}
 
+# Allow jobs to run under sdexec in test, if available
+cat >valgrind.toml <<-EOT
+[exec]
+service-override = true
+EOT
+
 test_expect_success \
   "valgrind reports no new errors on $VALGRIND_NBROKERS broker run" '
 	run_timeout 300 \
 	flux start -s ${VALGRIND_NBROKERS} \
 		--test-exit-timeout=120 \
+		-o,--config-path=valgrind.toml \
 		--wrap=libtool,e,${VALGRIND} \
 		--wrap=--tool=memcheck \
 		--wrap=--leak-check=full \

--- a/t/valgrind/workload.d/job-sdexec
+++ b/t/valgrind/workload.d/job-sdexec
@@ -1,0 +1,27 @@
+if ! flux version | grep systemd; then
+    echo "flux was not built with systemd"
+    exit 0
+fi
+if ! systemctl --user show --property Version; then
+    echo "user systemd is not running"
+    exit 0
+fi
+if ! busctl --user status >/dev/null; then
+    echo "user dbus is not running"
+    exit 0
+fi
+
+flux module load sdbus
+flux module load sdexec
+
+NJOBS=${NJOBS:-10}
+
+for i in `seq 1 ${NJOBS}`
+do
+    flux submit --wait \
+        --setattr system.exec.bulkexec.service=sdexec \
+        ${SHARNESS_TEST_DIRECTORY}/shell/lptest 78 2
+done
+
+flux module remove sdexec
+flux module remove sdbus


### PR DESCRIPTION
This mops up some memory errors found by manually running sdexec and sdbus tests under valgrind and revives @chu11's valgrind "workload" script that runs jobs under sdexec.