### PR TITLE
job-manager: prevent jobs with outstanding epilog-start events from becoming inactive

### DIFF
--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -423,7 +423,9 @@ int event_job_action (struct event *event, struct job *job)
                 && !job->alloc_pending
                 && !job->free_pending
                 && !job->start_pending
-                && !job->has_resources) {
+                && !job->has_resources
+                && !job_event_is_queued (job, "epilog-start")
+                && !job->perilog_active) {
 
                 if (event_job_post_pack (event, job, "clean", 0, NULL) < 0)
                     return -1;

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -482,6 +482,16 @@ test_expect_success 'job-manager: epilog works after exception during prolog' '
 	n_free=$(lineno job.free perilog-exception-test.out) &&
 	test $n_epilog -lt $n_free
 '
+test_expect_success 'job-manager: epilog prevents clean event' '
+	flux jobtap load --remove=all ${PLUGINPATH}/perilog-test.so &&
+	jobid=$(flux submit --urgency=hold hostname) &&
+	flux cancel $jobid &&
+	flux job attach --wait-event clean -vE $jobid 2>&1 \
+	    | tee perilog-epilog-clean-test.out &&
+	n_epilog=$(lineno job.epilog-finish perilog-epilog-clean-test.out) &&
+	n_clean=$(lineno job.clean perilog-epilog-clean-test.out) &&
+	test $n_epilog -lt $n_clean
+'
 test_expect_success 'job-manager: job.create posts events before validation' '
 	flux jobtap load --remove=all ${PLUGINPATH}/create-event.so &&
 	jobid=$(flux submit hostname) &&


### PR DESCRIPTION
This PR fixes #5345, where a job that is canceled before an `alloc` event could become inactive (have a `clean` event posted) even while an epilog action was in progress (outstanding `epilog-start` event).

This PR simply checks for an enqueued `epilog-start` event or `perilog_active` count before allowing the `clean` event to be emitted. Also adds a test that reproduces the original issue.