### PR TITLE
flux-job: suppress the `attach` status line in more situations

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -45,6 +45,17 @@ A job can be interactively attached to via ``flux job attach``.  This is
 typically used to watch stdout/stderr while a job is running or after it has
 completed.  It can also be used to feed stdin to a job.
 
+When ``flux job attach`` is run interactively -- that is all of ``stdout``,
+``stderr`` and ``stdin`` are attached to a tty -- the command may display
+a status line while the job is pending, e.g
+
+::
+
+    flux-job: ƒJqUHUCzX9 waiting for resources                 00:00:08
+
+This status line may be suppressed by setting ``FLUX_ATTACH_NONINTERACTIVE``
+in the environment.
+
 **-l, --label-io**
    Label output by rank
 

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -68,6 +68,30 @@ in the environment.
    for tasks not in **RANKS** will be closed. The default is to broadcast
    stdin to all ranks.
 
+**--read-only**
+   Operate in read-only mode. Disable reading of stdin and capturing of
+   signals.
+
+**-v, --verbose**
+   Increase verbosity.
+
+**-w, --wait-event=EVENT**
+   Wait for event *EVENT* before detaching from eventlog. The default is
+   ``finish``.
+
+**-E, --show-events**
+   Show job events on stderr. This option also suppresses the status line
+   if enabled.
+
+**-X, --show-exec**
+   Show exec eventlog events on stderr.
+
+**--show-status**
+   Force immediate display of the status line.
+
+**--debug***
+   Enable parallel debugger attach.
+
 CANCEL
 ======
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -710,3 +710,4 @@ iteratively
 noverify
 sdbus
 sdexec
+NONINTERACTIVE

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -40,6 +40,17 @@ test_expect_success 'attach: --show-status shows job status line' '
 	grep "starting" jobid1.status &&
 	grep "started" jobid1.status
 '
+test_expect_success 'attach: no status is shown with FLUX_ATTACH_NONINTERACTIVE' '
+	(export FLUX_ATTACH_NONINTERACTIVE=t &&
+	 run_timeout 5 flux job attach \
+		--show-status $(cat jobid1) 2>jobid1.status2
+	) &&
+	test_must_fail grep "resolving dependencies" jobid1.status2 &&
+	test_must_fail grep "waiting for resources" jobid1.status2 &&
+	test_must_fail grep "starting" jobid1.status2 &&
+	test_must_fail grep "started" jobid1.status2
+
+'
 test_expect_success 'attach: --show-status properly accounts prolog-start events' '
 	flux jobtap load ${FLUX_BUILD_DIR}/t/job-manager/plugins/.libs/perilog-test.so prolog-count=4 &&
 	jobid2=$(flux submit hostname) &&


### PR DESCRIPTION
This PR makes it a little more likely that the `flux job attach` status line will be suppressed if its output is not desirable.

Since we really only want to display the status line if `flux job attach` is actually being run interactively, only enable it if all of `stdout`, `stderr`, and `stdin` are attached to a tty. Also add a `FLUX_ATTACH_NONINTERACTIVE` environment variable that always suppresses the status line for environments like ATS where a pty is used to run jobs but the output is logged. In this case the status line generates a lot of output since theres a timer updated every second.
