### PR TITLE
ensure flux utilities agree that a job with a fatal exception has failed

### DIFF
--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -1471,6 +1471,14 @@ class SubmitBulkCmd(SubmitBaseCmd):
                 jobinfo["state"] = "failed"
                 if self.exitcode == 0:
                     self.exitcode = 1
+            elif event.context["severity"] == 0:
+                #
+                #  A fatal job exception should cause the command to
+                #  to fail under any circumstances, even if the job
+                #  ends up finishing with status=0.
+                #
+                if self.exitcode == 0:
+                    self.exitcode = 1
 
             #  Print a human readable error:
             exception_type = event.context["type"]

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1595,6 +1595,7 @@ struct attach_ctx {
     int eventlog_watch_count;
     bool statusline;
     char *last_event;
+    bool fatal_exception;
 };
 
 void attach_completed_check (struct attach_ctx *ctx)
@@ -2570,6 +2571,8 @@ void attach_event_continuation (flux_future_t *f, void *arg)
                          severity,
                          note);
 
+        ctx->fatal_exception = (severity == 0);
+
         /*  If this job has an interactive pty and the pty is not yet attached,
          *   destroy the pty to avoid a potential hang attempting to connect
          *   to job pty that will never exist.
@@ -2799,6 +2802,10 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
     free (totalview_jobid);
     free (ctx.last_event);
     free (ctx.stdin_ranks);
+
+    if (ctx.fatal_exception && ctx.exit_code == 0)
+        ctx.exit_code = 1;
+
     return ctx.exit_code;
 }
 

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -1010,11 +1010,12 @@ static int finish_context_parse (flux_t *h,
         return -1;
     }
 
-    /* There is no need to check for "exception" events for the
-     * "success" attribute.  "success" is always false unless the
-     * job completes ("finish") without error.
+    /*
+     *  A job is successful only if it finished with status == 0
+     *  *and* there were no fatal job exceptions:
      */
-    if (!job->wait_status)
+    if (job->wait_status == 0
+        && !(job->exception_occurred && job->exception_severity == 0))
         job->success = true;
 
     return 0;

--- a/t/t2304-sched-simple-alloc-check.t
+++ b/t/t2304-sched-simple-alloc-check.t
@@ -30,6 +30,18 @@ test_expect_success 'a regular job fails with an alloc-check exception' '
 test_expect_success 'flux job wait says the job failed' '
 	test_must_fail flux job wait -v $(cat bypass.jobid)
 '
+test_expect_success 'flux job attach says the job failed' '
+	test_must_fail flux job attach -vE $(cat bypass.jobid)
+'
+test_expect_success 'flux job status says the job failed' '
+	test_must_fail flux job status -v $(cat bypass.jobid)
+'
+test_expect_success 'flux jobs says the job failed' '
+	flux job list-ids --wait-state=inactive $(cat bypass.jobid) >/dev/null &&
+	flux jobs -no {result} $(cat bypass.jobid) > bypass.result &&
+	test_debug "cat bypass.result" &&
+	test "$(cat bypass.result)" = "FAILED"
+'
 test_expect_success 'clean up jobs' '
 	flux cancel --all &&
 	flux queue drain

--- a/t/t2304-sched-simple-alloc-check.t
+++ b/t/t2304-sched-simple-alloc-check.t
@@ -22,7 +22,8 @@ test_expect_success 'run an alloc-bypass sleep job' '
 	    sleep inf
 '
 test_expect_success 'a regular job fails with an alloc-check exception' '
-	run_timeout 30 flux submit --flags=waitable -vvv \
+	test_expect_code 1 \
+	    run_timeout 30 flux submit --flags=waitable -vvv \
 	    --wait-event=exception \
 	    -N1 /bin/true >bypass.jobid
 '


### PR DESCRIPTION
As pointed out in #5307, `flux job attach` and `flux jobs` ignore fatal job exceptions if the job has a `finish` event with exit status `0`. This doesn't agree with `flux job wait` and `flux job status`, which exit with failure for any fatal job exception.

Given that a fatal exception by definition probably indicates that the job has failed in some way regardless if the job tasks finished successfully, update the behavior of these commands (as well as `flux submit` and `flux bulksubmit`) to exit with failure for any fatal job exception. Additionally, `flux jobs` now only reports a successful job if the job finished with `status=0` _and_ there were no fatal job exceptions.

Because the "alloc check" tests already generated the failing case here (job with fatal job exception but all tasks finish successfully with `status=0`) add checks to this test to ensure that the various utilities now agree that the job with the alloc-check exception has "failed".

Fixes #5307