### PR TITLE
shell: support `-o gpu-affinity=map:LIST`

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -267,9 +267,11 @@ options are supported by the builtin plugins of ``flux-shell``:
   If *OPT* starts with ``map:``, then the rest of the option is taken
   as a semicolon-delimited list of cpus to allocate to each task. Each
   entry in the list can be in one of the :linux:man7:`hwloc` list,
-  bitmask, or taskset formats (See :linux:man3:`hwloc_cpuset_t`).
-  The default is ``on``, which binds all tasks to the assigned set
-  of cores in the job.
+  bitmask, or taskset formats (See
+  `hwlocality_bitmap(3) <https://www.open-mpi.org/projects/hwloc/doc/v2.9.0/a00181.php>`_,
+  especially the ``hwloc_bitmap_list_snprintf()``, ``hwloc_bitmap_snprintf()``
+  and ``hwloc_bitmap_taskset_snprintf()`` functions).  The default is ``on``,
+  which binds all tasks to the assigned set of cores in the job.
 
 **gpu-affinity**\ =\ *OPT*
   Adjust operation of the builtin shell ``gpubind`` plugin, which simply

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -276,7 +276,10 @@ options are supported by the builtin plugins of ``flux-shell``:
   sets ``CUDA_VISIBLE_DEVICES`` to the GPU IDs allocated to the job.
   *OPT* may be set to ``off`` to disable the plugin, or ``per-task``
   to divide allocated GPUs among tasks launched by the shell (sets a
-  different GPU ID or IDs for each launched task)
+  different GPU ID or IDs for each launched task). If *OPT* starts with
+  ``map:``, then the rest of the option is a semicolon-delimited list
+  of GPUs to assign to each task. See **cpu-affinity** documentation
+  for a description of the ``map:`` list format.
 
 **stop-tasks-in-exec**
   Stops tasks in ``exec()`` using ``PTRACE_TRACEME``. Used for debugging

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -711,3 +711,5 @@ noverify
 sdbus
 sdexec
 NONINTERACTIVE
+hwlocality
+snprintf

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -76,6 +76,7 @@ flux_shell_SOURCES = \
 	kill.c \
 	signals.c \
 	affinity.c \
+	affinity.h \
 	gpubind.c \
 	evlog.c \
 	pty.c \

--- a/src/shell/affinity.c
+++ b/src/shell/affinity.c
@@ -32,7 +32,7 @@ struct shell_affinity {
     hwloc_cpuset_t *pertask;
 };
 
-static void cpuset_array_destroy (hwloc_cpuset_t *set, int size)
+void cpuset_array_destroy (hwloc_cpuset_t *set, int size)
 {
     if (set) {
         for (int i = 0; i < size; i++) {
@@ -43,7 +43,7 @@ static void cpuset_array_destroy (hwloc_cpuset_t *set, int size)
     }
 }
 
-static hwloc_cpuset_t *cpuset_array_create (int size)
+hwloc_cpuset_t *cpuset_array_create (int size)
 {
     hwloc_cpuset_t *set = calloc (size, sizeof (hwloc_cpuset_t));
     if (!set)
@@ -74,9 +74,9 @@ static int topology_restrict (hwloc_topology_t topo, hwloc_cpuset_t set)
  *
  *  It is an error if any cpuset does not fall within job_cpuset.
  */
-static hwloc_cpuset_t *parse_cpuset_list (const char *setlist,
-                                          hwloc_cpuset_t job_cpuset,
-                                          int ntasks)
+hwloc_cpuset_t *parse_cpuset_list (const char *setlist,
+                                   hwloc_cpuset_t job_cpuset,
+                                   int ntasks)
 {
     char *copy = NULL;
     char *s, *arg, *sptr = NULL;

--- a/src/shell/affinity.h
+++ b/src/shell/affinity.h
@@ -1,0 +1,41 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SHELL_AFFINITY_H
+#define _SHELL_AFFINITY_H
+
+#include <hwloc.h>
+
+/*  Parse a list of hwloc bitmap strings from `setlist` in list, bitmask,
+ *  or taskset form and return an allocated hwloc_cpuset_t array of size
+ *  `ntasks` filled with the resulting bitmasks. If `ntasks` is greater
+ *  than the number of provided cpusets, then cpusets are reused as
+ *  necessary.
+ *
+ *  It is an error if any cpuset is not contained within the `all` cpuset.
+ */
+hwloc_cpuset_t *parse_cpuset_list (const char *setlist,
+                                   hwloc_cpuset_t *all,
+                                   int ntasks);
+
+/*  Create an empty hwloc_cpuset_t array of size elements
+ */
+hwloc_cpuset_t *cpuset_array_create (int size);
+
+/*  Free memory for hwloc_cpuset_t array returned from cpuset_array_create()
+ *  or parse_cpuset_list().
+ */
+void cpuset_array_destroy (hwloc_cpuset_t *set, int size);
+
+#endif /* !_SHELL_AFFINITY_H */
+
+/* vi: ts=4 sw=4 expandtab
+ */
+

--- a/src/shell/affinity.h
+++ b/src/shell/affinity.h
@@ -18,12 +18,8 @@
  *  `ntasks` filled with the resulting bitmasks. If `ntasks` is greater
  *  than the number of provided cpusets, then cpusets are reused as
  *  necessary.
- *
- *  It is an error if any cpuset is not contained within the `all` cpuset.
  */
-hwloc_cpuset_t *parse_cpuset_list (const char *setlist,
-                                   hwloc_cpuset_t *all,
-                                   int ntasks);
+hwloc_cpuset_t *parse_cpuset_list (const char *setlist, int ntasks);
 
 /*  Create an empty hwloc_cpuset_t array of size elements
  */

--- a/src/shell/gpubind.c
+++ b/src/shell/gpubind.c
@@ -225,6 +225,10 @@ static int gpubind_init (flux_plugin_t *p,
             return shell_log_errno ("failed to distribute %d gpus",
                                     ctx->ngpus);
     }
+    else if (strstarts (opt, "map:")) {
+        if (!(ctx->gpusets = parse_cpuset_list (opt+4, ctx->ntasks)))
+            return shell_log_errno ("failed to parse gpu map %s", opt+4);
+    }
     else if (ctx->ngpus > 0) {
         char *ids = idset_encode (ctx->gpus, 0);
         flux_shell_setenvf (shell, 1, "CUDA_VISIBLE_DEVICES", "%s", ids);

--- a/src/shell/gpubind.c
+++ b/src/shell/gpubind.c
@@ -27,34 +27,49 @@
 #include "ccan/str/str.h"
 
 #include "builtins.h"
+#include "affinity.h"
 
-int ngpus_per_task = -1;
+struct gpu_affinity {
+    int ntasks;
+    int ngpus;
+    struct idset *gpus;
+    hwloc_cpuset_t *gpusets;
+};
 
-int get_shell_gpus (flux_shell_t *shell,
-                    int *ntasks,
-                    struct idset **ids)
+
+static void gpu_affinity_destroy (struct gpu_affinity *ctx)
 {
-    int rc = -1;
-    const char *gpu_list = NULL;
-    struct idset *gpus = NULL;
+    if (ctx) {
+        idset_destroy (ctx->gpus);
+        cpuset_array_destroy (ctx->gpusets, ctx->ntasks);
+        free (ctx);
+    }
+}
 
+static struct gpu_affinity *gpu_affinity_create (flux_shell_t *shell)
+{
+    const char *gpu_list = NULL;
+    struct gpu_affinity *ctx = calloc (1, sizeof (*ctx));
+    if (!ctx)
+        return NULL;
     if (flux_shell_rank_info_unpack (shell,
                                      -1,
                                      "{s:i s:{s?s}}",
-                                     "ntasks", ntasks,
+                                     "ntasks", &ctx->ntasks,
                                      "resources",
                                        "gpus", &gpu_list) < 0) {
         shell_log_errno ("flux_shell_rank_info_unpack");
-        goto out;
+        goto error;
     }
-    if (!(gpus = idset_decode (gpu_list ? gpu_list : ""))) {
+    if (!(ctx->gpus = idset_decode (gpu_list ? gpu_list : ""))) {
         shell_log_errno ("idset_encode (%s)", gpu_list);
-        goto out;
+        goto error;
     }
-    rc = 0;
-out:
-    *ids = gpus;
-    return rc;
+    ctx->ngpus = idset_count (ctx->gpus);
+    return ctx;
+error:
+    gpu_affinity_destroy (ctx);
+    return NULL;
 }
 
 static int plugin_task_setenv (flux_plugin_t *p,
@@ -69,25 +84,84 @@ static int plugin_task_setenv (flux_plugin_t *p,
     return 0;
 }
 
+static int plugin_task_id (flux_plugin_t *p)
+{
+    int taskid = -1;
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    flux_shell_task_t *task = flux_shell_current_task (shell);
+    if (flux_shell_task_info_unpack (task,
+                                     "{s:i}",
+                                     "localid", &taskid) < 0)
+        return shell_log_errno ("failed to unpack task local id");
+    return taskid;
+}
+
+static struct idset *cpuset_to_idset (hwloc_cpuset_t set)
+{
+    int i;
+    struct idset *idset;
+    if (!(idset = idset_create (0, IDSET_FLAG_AUTOGROW))) {
+        shell_log_errno ("failed to create idset");
+        return NULL;
+    }
+    i = -1;
+    while ((i = hwloc_bitmap_next (set, i)) != -1) {
+        if (idset_set (idset, i) < 0) {
+            shell_log_errno ("failed to set %d in idset", i);
+            idset_destroy (idset);
+            return NULL;
+        }
+    }
+    return idset;
+}
+
 static int gpubind_task_init (flux_plugin_t *p,
                               const char *topic,
                               flux_plugin_arg_t *args,
                               void *data)
 {
     char *s;
-    struct idset *gpus = data;
-    struct idset *ids = idset_create (0, IDSET_FLAG_AUTOGROW);
+    struct idset *ids;
+    struct gpu_affinity *ctx = data;
+    int taskid = plugin_task_id (p);
+    if (taskid < 0)
+        return -1;
 
-    for (int i = 0; i < ngpus_per_task; i++) {
-        unsigned id = idset_first (gpus);
-        idset_set (ids, id);
-        idset_clear (gpus, id);
+    /* Need to convert hwloc_cpuset_t to idset since there's no function
+     * to convert a hwloc_cpuset_t to a strict comma-separated list of ids:
+     */
+    if (!(ids = cpuset_to_idset (ctx->gpusets[taskid]))
+        || !(s = idset_encode (ids, 0))) {
+        shell_log_error ("failed to get idset from gpu set for task %d",
+                         taskid);
+        idset_destroy (ids);
+        return -1;
     }
-    s = idset_encode (ids, 0);
     plugin_task_setenv (p, "CUDA_VISIBLE_DEVICES", s);
     free (s);
     idset_destroy (ids);
     return 0;
+}
+
+static hwloc_cpuset_t *distribute_gpus (struct gpu_affinity *ctx)
+{
+    int ngpus_per_task = ctx->ngpus / ctx->ntasks;
+    hwloc_cpuset_t *gpusets = cpuset_array_create (ctx->ntasks);
+    for (int i = 0; i < ctx->ntasks; i++) {
+        for (int j = 0; j < ngpus_per_task; j++) {
+            unsigned id = idset_first (ctx->gpus);
+            if (id == IDSET_INVALID_ID
+                || idset_clear (ctx->gpus, id) < 0) {
+                shell_log_errno ("Failed to get GPU id for task %d", id);
+                goto error;
+            }
+            hwloc_bitmap_set (gpusets[i], id);
+        }
+    }
+    return gpusets;
+error:
+    cpuset_array_destroy (gpusets, ctx->ntasks);
+    return NULL;
 }
 
 static int gpubind_init (flux_plugin_t *p,
@@ -95,9 +169,9 @@ static int gpubind_init (flux_plugin_t *p,
                          flux_plugin_arg_t *args,
                          void *data)
 {
-    int rc, ngpus, ntasks;
-    struct idset *gpus;
+    int rc;
     char *opt;
+    struct gpu_affinity *ctx;
     flux_shell_t *shell = flux_plugin_get_shell (p);
 
     if (!shell)
@@ -123,30 +197,33 @@ static int gpubind_init (flux_plugin_t *p,
      */
     flux_shell_setenvf (shell, 1, "CUDA_VISIBLE_DEVICES", "%d", -1);
 
-    if (get_shell_gpus (shell, &ntasks, &gpus) < 0)
+    if (!(ctx = gpu_affinity_create (shell)))
         return -1;
-    if (flux_plugin_aux_set (p, NULL, gpus, (flux_free_f)idset_destroy) < 0) {
+    if (flux_plugin_aux_set (p,
+                             NULL,
+                             ctx,
+                             (flux_free_f) gpu_affinity_destroy) < 0) {
         shell_log_errno ("flux_plugin_aux_set");
-        idset_destroy (gpus);
+        gpu_affinity_destroy (ctx);
         return -1;
     }
-    if ((ngpus = idset_count (gpus)) <= 0)
+    if (ctx->ngpus <= 0)
         return 0;
 
     flux_shell_setenvf (shell, 0, "CUDA_DEVICE_ORDER", "PCI_BUS_ID");
 
     if (streq (opt, "per-task")) {
-        /*  Set global ngpus_per_task to use in task.init callback:
-         */
-        ngpus_per_task = ngpus / ntasks;
+        if (!(ctx->gpusets = distribute_gpus (ctx)))
+            return shell_log_errno ("failed to distribute %d gpus",
+                                    ctx->ngpus);
         if (flux_plugin_add_handler (p,
                                      "task.init",
                                      gpubind_task_init,
-                                     gpus) < 0)
+                                     ctx) < 0)
             return shell_log_errno ("gpubind: flux_plugin_add_handler");
     }
     else {
-        char *ids = idset_encode (gpus, 0);
+        char *ids = idset_encode (ctx->gpus, 0);
         flux_shell_setenvf (shell, 1, "CUDA_VISIBLE_DEVICES", "%s", ids);
         free (ids);
     }

--- a/src/shell/gpubind.c
+++ b/src/shell/gpubind.c
@@ -211,8 +211,6 @@ static int gpubind_init (flux_plugin_t *p,
         gpu_affinity_destroy (ctx);
         return -1;
     }
-    if (ctx->ngpus <= 0)
-        return 0;
 
     if (flux_plugin_add_handler (p,
                                  "task.init",
@@ -227,7 +225,7 @@ static int gpubind_init (flux_plugin_t *p,
             return shell_log_errno ("failed to distribute %d gpus",
                                     ctx->ngpus);
     }
-    else {
+    else if (ctx->ngpus > 0) {
         char *ids = idset_encode (ctx->gpus, 0);
         flux_shell_setenvf (shell, 1, "CUDA_VISIBLE_DEVICES", "%s", ids);
         free (ids);

--- a/t/t2604-job-shell-affinity.t
+++ b/t/t2604-job-shell-affinity.t
@@ -78,14 +78,11 @@ test_expect_success MULTICORE 'flux-shell: map affinity can use hex bitmasks' '
     test "$(hwloc-calc --taskset $task0set)" = "0x1" &&
     test "$(hwloc-calc --taskset $task1set)" = "0x2"
 '
-# Expected to fail since 0xf,0xf won't be in the job cpuset, we're just
-# testing the parsing of args now
 test_expect_success 'flux-shell: map affinity can use a mix of inputs' '
     id=$(flux submit --label-io -o cpu-affinity="map:0xf,0xf;0-3" -n 2 \
 	hwloc-bind --get) &&
-    test_must_fail flux job attach $id >map4.out 2>&1 &&
-    test_debug "cat map4.out" &&
-    grep "cpuset 0xf,0xf is not included in job cpuset" map4.out
+    flux job attach $id >map4.out 2>&1 &&
+    test_debug "cat map4.out"
 '
 test_expect_success 'flux-shell: invalid cpuset is detected' '
     test_must_fail flux run -o cpu-affinity="map:0x0;1" -n 2 \

--- a/t/t2604-job-shell-affinity.t
+++ b/t/t2604-job-shell-affinity.t
@@ -156,6 +156,19 @@ test_expect_success 'flux-shell: gpu-affinity=per-task' '
 		> ${name}.out 2>${name}.err &&
 	test_cmp ${name}.expected ${name}.out
 '
+test_expect_success 'flux-shell: gpu-affinity=map: works' '
+	name=gpu-map &&
+	flux run -N1 -n2 --dry-run -o gpu-affinity="map:7;4-6" \
+		printenv CUDA_VISIBLE_DEVICES > j.${name} &&
+	cat >${name}.expected <<-EOF  &&
+	0: 7
+	1: 4,5,6
+	EOF
+	${FLUX_SHELL} -s -v -r 0 -j j.${name} -R R.gpu 0 | sort -k1,1n \
+		> ${name}.out 2>${name}.err &&
+	test_cmp ${name}.expected ${name}.out
+
+'
 test_expect_success 'flux-shell: gpu-affinity=off' '
 	name=gpu-off && (
 	  unset CUDA_VISIBLE_DEVICES &&


### PR DESCRIPTION
This PR adds support for `gpu-affinity=map:LIST`. This can come in handy for benchmarking, testing, etc. Also, since `-o cpu-affinity` supports `map:`, it seemed like GPUs should be able to assigned in this way.

As a side effect of the approach, #5352 was also fixed.