### PR TITLE
 job-info: support WAITCREATE on eventlog watch 

### DIFF
--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -463,6 +463,7 @@ _flux_job()
         -q --quiet \
         -v --verbose \
         -p --path= \
+        -W --waitcreate \
     "
     local info_OPTS="\
         -o --original \

--- a/src/common/libjob/info.c
+++ b/src/common/libjob/info.c
@@ -21,9 +21,9 @@ flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
     flux_future_t *f;
     const char *topic = "job-info.eventlog-watch";
     int rpc_flags = FLUX_RPC_STREAMING;
+    int valid_flags = FLUX_JOB_EVENT_WATCH_WAITCREATE;
 
-    /* No flags supported yet */
-    if (!h || !path || flags) {
+    if (!h || !path || (flags & ~valid_flags)) {
         errno = EINVAL;
         return NULL;
     }

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -26,6 +26,10 @@ enum job_submit_flags {
     FLUX_JOB_NOVALIDATE = 8,    // don't validate jobspec (instance owner only)
 };
 
+enum job_event_watch_flags {
+    FLUX_JOB_EVENT_WATCH_WAITCREATE = 1, // wait for path to exist
+};
+
 enum job_urgency {
     FLUX_JOB_URGENCY_MIN = 0,
     FLUX_JOB_URGENCY_HOLD = FLUX_JOB_URGENCY_MIN,

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -579,7 +579,7 @@ static int guest_namespace_watch (struct guest_watch_ctx *gw)
                                 "id", gw->id,
                                 "guest", true,
                                 "path", gw->path,
-                                "flags", 0)))
+                                "flags", gw->flags)))
         goto error;
 
     if (!(gw->guest_namespace_watch_f = flux_rpc_message (gw->ctx->h,

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -369,7 +369,7 @@ int watch (struct info_ctx *ctx,
     }
 
     if (path
-        && strcasecmp (path, "eventlog")
+        && !streq (path, "eventlog")
         && !w->allow) {
         if (check_eventlog (w) < 0)
             goto error;

--- a/t/t1007-kvs-lookup-watch.t
+++ b/t/t1007-kvs-lookup-watch.t
@@ -665,4 +665,9 @@ test_expect_success 'flux kvs get --watch allows owner access to guest ns' '
 test_expect_success 'kvs-watch.lookup request with empty payload fails with EPROTO(71)' '
 	${RPC} kvs-watch.lookup 71 </dev/null
 '
+# N.B. FLUX_KVS_WATCH = 4
+test_expect_success 'kvs-watch.lookup request non-streaming fails with EPROTO(71)' '
+	echo "{\"namespace\":"foo", \"key\":\"bar\", \"flags\":4}" \
+		${RPC} kvs-watch.lookup 71
+'
 test_done

--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -235,6 +235,18 @@ test_expect_success 'flux job wait-event -p fails on path "guest."' '
 	test_must_fail fj_wait_event -p "guest." $jobid submit
 '
 
+test_expect_success 'flux job wait-event -p and --waitcreate works (guest.exec.eventlog)' '
+	jobid=$(submit_job) &&
+	fj_wait_event --waitcreate -p "guest.exec.eventlog" $jobid done > wait_event_path4.out &&
+	grep done wait_event_path4.out
+'
+
+test_expect_success 'flux job wait-event -p invalid and --waitcreate fails' '
+	jobid=$(submit_job) &&
+	test_must_fail fj_wait_event --waitcreate -p "guest.invalid" $jobid foobar 2> waitcreate1.err &&
+	grep "not found" waitcreate1.err
+'
+
 test_expect_success 'flux job wait-event -p hangs on non-guest eventlog' '
 	jobid=$(submit_job) &&
 	kvsdir=$(flux job id --to=kvs $jobid) &&
@@ -244,7 +256,7 @@ test_expect_success 'flux job wait-event -p hangs on non-guest eventlog' '
 
 test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog works (live job)' '
 	jobid=$(submit_job_live sleeplong.json)
-	fj_wait_event -p "guest.exec.eventlog" $jobid done > wait_event_path4.out &
+	fj_wait_event -p "guest.exec.eventlog" $jobid done > wait_event_path5.out &
 	waitpid=$! &&
 	wait_watchers_nonzero "watchers" &&
 	wait_watchers_nonzero "guest_watchers" &&
@@ -252,7 +264,35 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
 	wait_watcherscount_nonzero $guestns &&
 	flux cancel $jobid &&
 	wait $waitpid &&
-	grep done wait_event_path4.out
+	grep done wait_event_path5.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.foobar and --waitcreate works (live job)' '
+	jobid=$(submit_job_live sleeplong.json)
+	fj_wait_event --waitcreate -p "guest.foobar" $jobid foobar > wait_event_path6.out &
+	waitpid=$! &&
+	wait_watchers_nonzero "watchers" &&
+	wait_watchers_nonzero "guest_watchers" &&
+	guestns=$(flux job namespace $jobid) &&
+	wait_watcherscount_nonzero $guestns &&
+	flux kvs eventlog append --namespace=${guestns} foobar foobar &&
+	flux cancel $jobid &&
+	wait $waitpid &&
+	grep foobar wait_event_path6.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event -p invalid and --waitcreate fails (live job)' '
+	jobid=$(submit_job_live sleeplong.json)
+	fj_wait_event --waitcreate -p "guest.invalid" $jobid foobar \
+		> wait_event_path6.out 2> wait_event_path6.err &
+	waitpid=$! &&
+	wait_watchers_nonzero "watchers" &&
+	wait_watchers_nonzero "guest_watchers" &&
+	guestns=$(flux job namespace $jobid) &&
+	wait_watcherscount_nonzero $guestns &&
+	flux cancel $jobid &&
+	! wait $waitpid &&
+	grep "not found" wait_event_path6.err
 '
 
 test_expect_success 'flux job wait-event -p times out on no event (live job)' '
@@ -313,7 +353,7 @@ test_expect_success 'job-info: generate jobspec to consume all resources' '
 test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog works (wait job)' '
 	jobidall=$(submit_job_live sleeplong-all-rsrc.json)
 	jobid=$(submit_job_wait)
-	fj_wait_event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path5.out &
+	fj_wait_event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path7.out &
 	waitpid=$! &&
 	wait_watchers_nonzero "watchers" &&
 	wait_watchers_nonzero "guest_watchers" &&
@@ -323,7 +363,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
 	wait_watcherscount_nonzero $guestns &&
 	flux cancel ${jobid} &&
 	wait $waitpid &&
-	grep done wait_event_path5.out
+	grep done wait_event_path7.out
 '
 
 test_expect_success 'flux job wait-event -p times out on no event (wait job)' '
@@ -342,12 +382,60 @@ test_expect_success 'flux job wait-event -p times out on no event (wait job)' '
 test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog works (never start job)' '
 	jobidall=$(submit_job_live sleeplong-all-rsrc.json)
 	jobid=$(submit_job_wait)
-	fj_wait_event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path6.out &
+	fj_wait_event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path8.out &
 	waitpid=$! &&
 	wait_watchers_nonzero "watchers" &&
 	wait_watchers_nonzero "guest_watchers" &&
 	flux cancel ${jobid} &&
 	! wait $waitpid &&
+	flux cancel ${jobidall}
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event -p and --waitcreate works (wait job)' '
+	jobidall=$(submit_job_live sleeplong-all-rsrc.json)
+	jobid=$(submit_job_wait)
+	fj_wait_event -v --waitcreate -p "guest.foobar" ${jobid} foobar > wait_event_path8.out &
+	waitpid=$! &&
+	wait_watchers_nonzero "watchers" &&
+	wait_watchers_nonzero "guest_watchers" &&
+	flux cancel ${jobidall} &&
+	fj_wait_event ${jobid} start &&
+	guestns=$(flux job namespace ${jobid}) &&
+	wait_watcherscount_nonzero $guestns &&
+	flux kvs eventlog append --namespace=${guestns} foobar foobar &&
+	flux cancel ${jobid} &&
+	wait $waitpid &&
+	grep foobar wait_event_path8.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event -p invalid and --waitcreate fails (wait job)' '
+	jobidall=$(submit_job_live sleeplong-all-rsrc.json)
+	jobid=$(submit_job_wait)
+	fj_wait_event -v --waitcreate -p "guest.invalid" ${jobid} invalid \
+		> wait_event_path9.out 2> wait_event_path9.err &
+	waitpid=$! &&
+	wait_watchers_nonzero "watchers" &&
+	wait_watchers_nonzero "guest_watchers" &&
+	flux cancel ${jobidall} &&
+	fj_wait_event ${jobid} start &&
+	guestns=$(flux job namespace ${jobid}) &&
+	wait_watcherscount_nonzero $guestns &&
+	flux cancel ${jobid} &&
+	! wait $waitpid &&
+	grep "not found" wait_event_path9.err
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event -p invalid and --waitcreate works (never start job)' '
+	jobidall=$(submit_job_live sleeplong-all-rsrc.json)
+	jobid=$(submit_job_wait)
+	fj_wait_event -v --waitcreate -p "guest.invalid" ${jobid} invalid \
+		> wait_event_path10.out 2> wait_event_path10.err &
+	waitpid=$! &&
+	wait_watchers_nonzero "watchers" &&
+	wait_watchers_nonzero "guest_watchers" &&
+	flux cancel ${jobid} &&
+	! wait $waitpid &&
+	grep "never received" wait_event_path10.err &&
 	flux cancel ${jobidall}
 '
 
@@ -364,6 +452,10 @@ test_expect_success 'eventlog-watch request with empty payload fails with EPROTO
 	${RPC} job-info.eventlog-watch 71 </dev/null
 '
 
+test_expect_success 'eventlog-watch request invalid flags fails with EPROTO(71)' '
+	echo "{\"id\":42, \"path\":\"foobar\", \"flags\":499}" \
+		${RPC} job-info.eventlog-watch 71
+'
 test_expect_success 'eventlog-watch request non-streaming fails with EPROTO(71)' '
 	echo "{\"id\":42, \"path\":\"foobar\", \"flags\":0}" \
 		${RPC} job-info.eventlog-watch 71

--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -359,4 +359,9 @@ test_expect_success 'eventlog-watch request with empty payload fails with EPROTO
 	${RPC} job-info.eventlog-watch 71 </dev/null
 '
 
+test_expect_success 'eventlog-watch request non-streaming fails with EPROTO(71)' '
+	echo "{\"id\":42, \"path\":\"foobar\", \"flags\":0}" \
+		${RPC} job-info.eventlog-watch 71
+'
+
 test_done

--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -225,6 +225,11 @@ test_expect_success 'flux job wait-event -p fails on invalid path' '
 	test_must_fail fj_wait_event -p "foobar" $jobid submit
 '
 
+test_expect_success 'flux job wait-event -p fails on invalid guest path' '
+	jobid=$(submit_job) &&
+	test_must_fail fj_wait_event -p "guest.foobar" $jobid submit
+'
+
 test_expect_success 'flux job wait-event -p fails on path "guest."' '
 	jobid=$(submit_job) &&
 	test_must_fail fj_wait_event -p "guest." $jobid submit

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -89,8 +89,7 @@ test_expect_success NO_CHAIN_LINT 'flux-shell: no stdin desired in job' '
         id=$(flux submit -n1 sleep 60)
         flux job attach $id < input_stdin_file 2> pipe6A.err &
         pid=$! &&
-        flux job wait-event -p guest.exec.eventlog $id shell.init 2> pipe6B.err &&
-        flux job wait-event -p guest.input -m eof=true $id data 2> pipe6C.err &&
+        flux job wait-event -W -p guest.input -m eof=true $id data 2> pipe6C.err &&
         flux cancel $id 2> pipe6D.err &&
         test_expect_code 143 wait $pid
 '
@@ -119,8 +118,7 @@ test_expect_success NO_CHAIN_LINT 'flux-shell: pipe to stdin twice, second fails
         id=$(flux submit -n1 sleep 60)
         flux job attach $id < input_stdin_file 2> pipe9A.err &
         pid=$!
-        flux job wait-event -p guest.exec.eventlog $id shell.init 2> pipe9B.err &&
-        flux job wait-event -p guest.input -m eof=true $id data 2> pipe9C.err &&
+        flux job wait-event -W -p guest.input -m eof=true $id data 2> pipe9C.err &&
         test_must_fail flux job attach $id < input_stdin_file 2> pipe9D.err &&
         flux cancel $id 2> pipe9E.err &&
         test_expect_code 143 wait $pid

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -95,8 +95,7 @@ test_expect_success 'submit jobs for job list testing' '
 	# rare job startup race.  See #5210
 	#
 	jobid=`flux submit ./sleepinf.sh` &&
-	flux job wait-event -p guest.exec.eventlog $jobid shell.init &&
-	flux job wait-event -p guest.output $jobid data &&
+	flux job wait-event -W -p guest.output $jobid data &&
 	flux job kill $jobid &&
 	fj_wait_event $jobid clean &&
 	echo $jobid >> inactiveids &&
@@ -110,8 +109,7 @@ test_expect_success 'submit jobs for job list testing' '
 	# rare job startup race.  See #5210
 	#
 	jobid=`flux submit ./sleepinf.sh` &&
-	flux job wait-event -p guest.exec.eventlog $jobid shell.init &&
-	flux job wait-event -p guest.output $jobid data &&
+	flux job wait-event -W -p guest.output $jobid data &&
 	flux job raise --type=myexception --severity=0 -m "myexception" $jobid &&
 	fj_wait_event $jobid clean &&
 	echo $jobid >> inactiveids &&


### PR DESCRIPTION
Per #5301

Some comments:

- pondered if this should be the default or if a flag / option was best.  Eventually settled on the latter as there may be scenarios we do not want to "waitcreate"

- the "style" in which tests are written in t2231-job-info-eventlog-watch.t is pretty ancient.  It could be cleaned up.  But for this PR, kept the style as is.   Figured cleanup / update can be for a follow up PR.