### PR TITLE
job-exec: allow job memory limits to be set

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -34,15 +34,48 @@ service-override
 job-shell
    (optional) Override the compiled-in default job shell path.
 
+sdexec-properties
+   (optional) A table of systemd properties to set for all jobs.  All values
+   must be strings.  See SDEXEC PROPERTIES below.
 
-EXAMPLE
-=======
+
+SDEXEC PROPERTIES
+=================
+
+When the sdexec service is selected, The following systemd unit properties may
+be set by adding them to the ``sdexec-properties`` table:
+
+MemoryMax
+   Specify the absolute limit on memory used by the job, in bytes. The value
+   may be suffixed with K, M, G or T, to multiply by Kilobytes, Megabytes,
+   Gigabytes, or Terabytes (base 1024), respectively. Alternatively, a
+   percentage of physical memory may be specified.  If assigned the special
+   value "infinity", no memory limit is applied.
+
+MemoryHigh
+   Specify the throttling limit on memory used by the job.  Values are
+   formatted as described above.
+
+MemoryMin, MemoryLow
+   Specify the memory usage protection of the job.  Values are formatted as
+   described above.
+
+
+EXAMPLES
+========
 
 ::
 
    [exec]
    imp = "/usr/libexec/flux/flux-imp"
    job-shell = "/usr/libexec/flux/flux-shell-special"
+
+::
+
+   [exec]
+   service = "sdexec"
+   [exec.sdexec-properties]
+   MemoryMax = "90%"
 
 
 RESOURCES
@@ -56,4 +89,5 @@ RFC 15: Flux Security: https://flux-framework.readthedocs.io/projects/flux-rfc/e
 SEE ALSO
 ========
 
-:man5:`flux-config`
+:man5:`flux-config`,
+`systemd.resource-control(5) <https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html>`_

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -713,3 +713,7 @@ sdexec
 NONINTERACTIVE
 hwlocality
 snprintf
+MemoryHigh
+MemoryMax
+MemoryLow
+MemoryMin

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -385,6 +385,22 @@ static int exec_init (struct jobinfo *job)
         flux_log_error (job->h, "exec_init: flux_cmd_create");
         goto err;
     }
+    /* Set any configured exec.sdexec-properties.
+     */
+    json_t *props;
+    if (streq (service, "sdexec")
+        && (props = config_get_sdexec_properties ())) {
+        const char *k;
+        json_t *v;
+        json_object_foreach (props, k, v) {
+            char name[128];
+            snprintf (name, sizeof (name), "SDEXEC_PROP_%s", k);
+            if (flux_cmd_setopt (cmd, name, json_string_value (v)) < 0) {
+                flux_log_error (job->h, "Unable to set sdexec options");
+                return -1;
+            }
+        }
+    }
     if (flux_cmd_setenvf (cmd, 1, "FLUX_KVS_NAMESPACE", "%s", job->ns) < 0) {
         flux_log_error (job->h, "exec_init: flux_cmd_setenvf");
         goto err;

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -11,6 +11,7 @@
 #ifndef HAVE_JOB_EXEC_CONFIG_H
 #define HAVE_JOB_EXEC_CONFIG_H 1
 
+#include <jansson.h>
 #include <stdbool.h>
 #include <flux/core.h>
 
@@ -23,6 +24,8 @@ const char *config_get_cwd (struct jobinfo *job);
 const char *config_get_imp_path (void);
 
 const char *config_get_exec_service (void);
+
+json_t *config_get_sdexec_properties (void);
 
 bool config_get_exec_service_override (void);
 

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -92,7 +92,8 @@ flux_shell_SOURCES = \
 	rlimit.c \
 	cyclic.c \
 	signal.c \
-	files.c
+	files.c \
+	oom.c
 
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -50,6 +50,7 @@ extern struct shell_builtin builtin_exception;
 extern struct shell_builtin builtin_rlimit;
 extern struct shell_builtin builtin_cyclic;
 extern struct shell_builtin builtin_signal;
+extern struct shell_builtin builtin_oom;
 
 static struct shell_builtin * builtins [] = {
     &builtin_tmpdir,
@@ -72,6 +73,7 @@ static struct shell_builtin * builtins [] = {
     &builtin_rlimit,
     &builtin_cyclic,
     &builtin_signal,
+    &builtin_oom,
     &builtin_list_end,
 };
 

--- a/src/shell/oom.c
+++ b/src/shell/oom.c
@@ -1,0 +1,249 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* oom.c - log kernel oom kill events
+ *
+ * This is an no-op if the cgroup v2 memory controller is not set up.
+ */
+
+#define FLUX_SHELL_PLUGIN_NAME "oom"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/inotify.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <argz.h>
+#include <flux/core.h>
+#include <jansson.h>
+#include <assert.h>
+
+#include "src/common/libutil/read_all.h"
+#include "src/common/libutil/strstrip.h"
+#include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
+
+#include "builtins.h"
+#include "internal.h"
+
+struct shell_oom {
+    flux_shell_t *shell;
+    char *memory_events_path;
+    int inotify_fd;
+    int watch_id;
+    flux_watcher_t *w;
+    unsigned long oom_kill;
+};
+
+/* Read the contents of 'path' into NULL terminated buffer.
+ * Caller must free.
+ */
+static char *read_file (const char *path)
+{
+    int fd;
+    char *buf;
+    if ((fd = open (path, O_RDONLY)) < 0)
+        return NULL;
+    if (read_all (fd, (void **)&buf) < 0) {
+        ERRNO_SAFE_WRAP (close, fd);
+        return NULL;
+    }
+    close (fd);
+    return buf;
+}
+
+/* Determine the cgroup v2 path to 'name' for for pid.
+ * Check access(2) to the file according to 'mode' mask.
+ * Caller must free.
+ */
+static char *get_cgroup_path (pid_t pid, const char *name, int mode)
+{
+    char tmp[1024];
+    char *cg;
+    char *path;
+
+    snprintf (tmp, sizeof (tmp), "/proc/%d/cgroup", (int)pid);
+    if (!(cg = read_file (tmp)))
+        return NULL;
+    if (!strstarts (cg, "0::")) // v2 always begins with 0::
+        goto eproto;
+    snprintf (tmp,
+              sizeof (tmp),
+              "/sys/fs/cgroup/%s/%s",
+              strstrip (cg + 3),
+              name);
+    if (!(path = realpath (tmp, NULL)))
+        goto error;
+    if (access (path, mode) < 0) {
+        ERRNO_SAFE_WRAP (free, path);
+        goto error;
+    }
+    free (cg);
+    return path;
+eproto:
+    errno = EPROTO;
+error:
+    ERRNO_SAFE_WRAP (free, cg);
+    return NULL;
+}
+
+/* Parse 'name' from memory.events file.  Example content:
+ *   low 0
+ *   high 0
+ *   max 0
+ *   oom 0
+ *   oom_kill 0
+ *   oom_group_kill 0
+ */
+static int parse_memory_events (const char *s,
+                                const char *name,
+                                unsigned long *valp)
+{
+    char *argz = NULL;
+    size_t argz_len = 0;
+    int e;
+
+    if ((e = argz_create_sep (s, '\n', &argz, &argz_len)) != 0) {
+        errno = e;
+        return -1;
+    }
+    char *entry = NULL;
+    while ((entry = argz_next (argz, argz_len, entry))) {
+        if (strstarts (entry, name) && isblank (entry[strlen (name)])) {
+            unsigned long val;
+            char *endptr;
+            errno = 0;
+            val = strtoul (&entry[strlen (name) + 1], &endptr, 10);
+            if (errno == 0 && *endptr == '\0') {
+                *valp = val;
+                free (argz);
+                return 0;
+            }
+        }
+    }
+    free (argz);
+    errno = EPROTO;
+    return -1;
+}
+
+static void watch_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
+{
+    struct shell_oom *oom = arg;
+    char evbuf[sizeof (struct inotify_event) + NAME_MAX + 1];
+    char *me;
+    unsigned long count;
+
+    /* Consume an event from inotify file descriptor.
+     * Ignore event contents since there is only one watch registered.
+     */
+    if (read (oom->inotify_fd, &evbuf, sizeof (evbuf)) < 0) {
+        shell_log_error ("error reading from inotify fd");
+        return;
+    }
+    /* Read memory.events.
+     */
+    if (!(me = read_file (oom->memory_events_path))
+        || parse_memory_events (me, "oom_kill", &count) < 0) {
+        shell_log_error ("error reading %s", oom->memory_events_path);
+        goto out;
+    }
+    /* If any new oom events have been recorded, log them.
+     */
+    if (oom->oom_kill < count) {
+        shell_log_error ("Memory cgroup out of memory: killed %lu task%s.",
+                         count - oom->oom_kill,
+                         count - oom->oom_kill > 1 ? "s" : "");
+        oom->oom_kill = count;
+    }
+out:
+    free (me);
+}
+
+static void oom_destroy (struct shell_oom *oom)
+{
+    if (oom) {
+        int saved_errno = errno;
+        flux_watcher_destroy (oom->w);
+        if (oom->watch_id >= 0)
+            inotify_rm_watch (oom->inotify_fd, oom->watch_id);
+        if (oom->inotify_fd >= 0)
+            close (oom->inotify_fd);
+        free (oom->memory_events_path);
+        free (oom);
+        errno = saved_errno;
+    }
+}
+
+static struct shell_oom *oom_create (flux_shell_t *shell, char *path)
+{
+    struct shell_oom *oom;
+
+    if (!(oom = calloc (1, sizeof (*oom))))
+        return NULL;
+    oom->inotify_fd = -1;
+    oom->watch_id = -1;
+    oom->shell = shell;
+    if ((oom->inotify_fd = inotify_init1 (IN_NONBLOCK | IN_CLOEXEC)) < 0
+        || (oom->watch_id = inotify_add_watch (oom->inotify_fd,
+                                               path,
+                                               IN_MODIFY)) < 0)
+        goto error;
+    if (!(oom->w = flux_fd_watcher_create (shell->r,
+                                           oom->inotify_fd,
+                                           FLUX_POLLIN,
+                                           watch_cb,
+                                           oom)))
+        goto error;
+    flux_watcher_start (oom->w);
+    oom->memory_events_path = path; // takes ownership
+    return oom;
+error:
+    oom_destroy (oom);
+    return NULL;
+}
+
+static int oom_init (flux_plugin_t *p,
+                      const char *topic,
+                      flux_plugin_arg_t *arg,
+                      void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct shell_oom *oom;
+    char *path;
+
+    // assume cgroup is not configured or not v2
+    if (!(path = get_cgroup_path (getpid (), "memory.events", R_OK)))
+        return 0;
+    if (!shell || !(oom = oom_create (shell, path))) {
+        ERRNO_SAFE_WRAP (free, path);
+        return -1;
+    }
+    if (flux_plugin_aux_set (p, "oom", oom, (flux_free_f)oom_destroy) < 0) {
+        oom_destroy (oom);
+        return -1;
+    }
+    shell_debug ("monitoring %s", path);
+    return 0;
+}
+
+struct shell_builtin builtin_oom = {
+    .name = FLUX_SHELL_PLUGIN_NAME,
+    .init = oom_init,
+};
+
+// vi:ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -178,6 +178,7 @@ TESTSCRIPTS = \
 	t2407-sdbus.t \
 	t2408-sdbus-recovery.t \
 	t2409-sdexec.t \
+	t2410-sdexec-memlimit.t \
 	t2411-sdexec-job.t \
 	t2412-sdexec-perilog.t \
 	t2500-job-attach.t \

--- a/t/shell/plugins/setopt.c
+++ b/t/shell/plugins/setopt.c
@@ -49,8 +49,8 @@ static int check_setopt (flux_plugin_t *p,
                                 "attributes",
                                 "system",
                                 "shell",
-                                "options", &options) < 0 && errno == ENOENT,
-        "flux_shell_info_unpack shell options returns ENOENT");
+                                "options", &options) < 0,
+        "flux_shell_info_unpack shell options fails");
 
     /*  A shell plugin should be able to call setopt even though
      *   no shell options were currently set in jobspec.

--- a/t/t2410-sdexec-memlimit.t
+++ b/t/t2410-sdexec-memlimit.t
@@ -1,0 +1,154 @@
+#!/bin/sh
+# ci=system
+test_description='Test sdexec cgroups memory controller manipulation
+
+Test whether Flux can affect the cgroups memory controller for processes
+spawned via sdexec, and the capability to configure basic limits for jobs.
+
+See also:
+https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
+https://docs.kernel.org/admin-guide/cgroup-v2.html#memory
+cgroups(7) /proc/[pid]/cgroup
+'
+
+. $(dirname $0)/sharness.sh
+
+if ! flux version | grep systemd; then
+	skip_all="flux was not built with systemd"
+	test_done
+fi
+if ! systemctl --user show --property Version; then
+	skip_all="user systemd is not running"
+	test_done
+fi
+if ! busctl --user status >/dev/null; then
+	skip_all="user dbus is not running"
+	test_done
+fi
+if ! systemctl show user@$(id -u) -p DelegateControllers | grep memory; then
+	skip_all="cgroups memory controller is not delegated"
+	test_done
+fi
+if stress=$(which stress); then
+	test_set_prereq STRESS
+fi
+
+mkdir -p config
+cat >config/config.toml <<EOT
+[systemd]
+enable = true
+sdbus-debug = true
+sdexec-debug = true
+[exec]
+service = "sdexec"
+[exec.sdexec-properties]
+MemoryHigh = "200M"
+MemoryMax = "100M"
+EOT
+
+cat >getcg.sh <<EOT2
+#!/bin/sh
+CGDIR=/sys/fs/cgroup/\$(cat /proc/\$\$/cgroup | cut -d: -f3)
+cat \$CGDIR/\$1
+EOT2
+chmod +x getcg.sh
+
+if ! $(pwd)/getcg.sh cgroup.controllers | grep memory; then
+	skip_all="cgroups memory controller is not enabled"
+	test_done
+fi
+
+test_under_flux 1 full -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+sdexec="flux exec --service sdexec"
+getcg=$(pwd)/getcg.sh
+
+#
+# memory.high: the throttling limit on memory usage
+#
+test_expect_success 'memory.high exists' '
+	$sdexec $getcg memory.high
+'
+test_expect_success 'memory.high can be set to 200M' '
+	cat >200M.exp <<-EOT &&
+	209715200
+	EOT
+	$sdexec \
+	    --setopt=SDEXEC_PROP_MemoryHigh=200M \
+	    $getcg memory.high >high.out &&
+	test_cmp 200M.exp high.out
+'
+test_expect_success 'memory.high can be set to infinity' '
+	cat >inf.exp <<-EOT &&
+	max
+	EOT
+	$sdexec \
+	    --setopt=SDEXEC_PROP_MemoryHigh=infinity \
+	    $getcg memory.high >high2.out &&
+	test_cmp inf.exp high2.out
+'
+test_expect_success 'memory.high can be configured for jobs' '
+	flux run $getcg memory.high >high3.out &&
+	test_cmp 200M.exp high3.out
+'
+
+#
+# memory.max: the absolute limit on memory usage
+#
+test_expect_success 'memory.max exists' '
+	$sdexec $getcg memory.max
+'
+test_expect_success 'memory.max can be set to 100M' '
+	cat >100M.exp <<-EOT &&
+	104857600
+	EOT
+	$sdexec \
+	    --setopt=SDEXEC_PROP_MemoryMax=100M \
+	    $getcg memory.max >max.out &&
+	test_cmp 100M.exp max.out
+'
+test_expect_success 'memory.max can be set to infinity' '
+	cat >inf.exp <<-EOT &&
+	max
+	EOT
+	$sdexec \
+	    --setopt=SDEXEC_PROP_MemoryMax=infinity \
+	    $getcg memory.max >max2.out &&
+	test_cmp inf.exp max2.out
+'
+test_expect_success 'memory.max can be configured for jobs' '
+	flux run $getcg memory.max >max3.out &&
+	test_cmp 100M.exp max3.out
+'
+test_expect_success STRESS 'remaining within memory.max works' '
+	$sdexec \
+	    --setopt=SDEXEC_PROP_MemoryMax=200M \
+	    $stress --timeout 3 --vm-keep --vm 1 --vm-bytes 100M
+'
+
+# Like test_expect_code() except 143/SIGKILL (oom kill) is also acceptable
+test_expect_code_or_killed() {
+	local want_code=$1
+	shift
+	"$@"
+	exit_code=$?
+	if test $exit_code = $want_code || test $exit_code = 143; then
+	    return 0
+	fi
+	echo >&2 "test_expect_code_or_killed: command exited with $exit_code, we wanted $want_code or 143/SIGKILL $*"
+	return 1
+}
+
+test_expect_success STRESS 'exceeding memory.max causes exec failure' '
+	test_expect_code_or_killed 1 $sdexec \
+	    --setopt=SDEXEC_PROP_MemoryMax=100M \
+	    $stress --timeout 60 --vm-keep --vm 1 --vm-bytes 200M
+'
+test_expect_success STRESS 'exceeding memory.max causes job failure' '
+	test_expect_code_or_killed 1 flux run \
+	    $stress --timeout 60 --vm-keep --vm 1 --vm-bytes 200M
+'
+
+test_done

--- a/t/t2411-sdexec-job.t
+++ b/t/t2411-sdexec-job.t
@@ -29,7 +29,7 @@ EOT
 
 test_under_flux 2 full -o,--config-path=$(pwd)/config
 
-flux setattr log-stderr-level 1
+flux setattr log-stderr-level 3
 
 sdexec="flux exec --service sdexec"
 lptest=${FLUX_BUILD_DIR}/t/shell/lptest
@@ -66,4 +66,25 @@ test_expect_success 'remove sdexec,sdbus modules' '
 	flux exec flux module remove sdexec &&
 	flux exec flux module remove sdbus
 '
+test_expect_success 'remove job-exec module' '
+	flux module remove job-exec
+'
+test_expect_success 'reconfigure with exec.sdexec-properties not a table' '
+	flux config load <<-EOT
+	exec.sdexec-properties = 42
+	EOT
+'
+test_expect_success 'cannot load job-exec module' '
+	test_must_fail flux module load job-exec
+'
+test_expect_success 'reconfigure with exec.sdexec-properties.key not a string' '
+	flux config load <<-EOT
+	[exec.sdexec-properties]
+	foo = 24
+	EOT
+'
+test_expect_success 'cannot load job-exec module' '
+	test_must_fail flux module load job-exec
+'
+
 test_done


### PR DESCRIPTION
This adds some configuration that allows cgroups MemoryMax to be set for jobs.  For example, on my test system I am setting
```toml
[systemd]
enable = true

[exec]
imp = "/usr/lib/aarch64-linux-gnu/flux/flux-imp"
service = "sdexec"

[exec.sdexec-properties]
MemoryMax = "80%"
```

When I run a  sleep job on a 2g node, systemd neatly displays
```
 garlick@picl1:~$ fsystemctl status imp-shell-1-fUdKSFCzEes.service
● imp-shell-1-fUdKSFCzEes.service - User workload
     Loaded: loaded (/run/user/500/systemd/transient/imp-shell-1-fUdKSFCzEes.se>
  Transient: yes
     Active: active (running) since Fri 2023-07-28 14:01:23 PDT; 14s ago
   Main PID: 407340 (flux-imp)
      Tasks: 3 (limit: 1599)
     Memory: 2.2M (max: 1.4G)
        CPU: 127ms
     CGroup: /user.slice/user-500.slice/user@500.service/app.slice/imp-shell-1->
             ├─407340 
             ├─407346 
             └─407360 
```
