### PR TITLE
cmd: add flux-watch(1)

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -52,7 +52,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-uri.1 \
 	man1/flux-resource.1 \
 	man1/flux-pgrep.1 \
-	man1/flux-cancel.1
+	man1/flux-cancel.1 \
+	man1/flux-watch.1
 
 # These files are generated as clones of a primary page.
 # Sphinx handles this automatically if declared in the conf.py

--- a/doc/man1/flux-watch.rst
+++ b/doc/man1/flux-watch.rst
@@ -1,0 +1,92 @@
+.. flux-help-section: jobs
+
+============
+flux-jobs(1)
+============
+
+
+SYNOPSIS
+========
+
+**flux** **watch** [*OPTIONS*] [JOBID ...]
+
+DESCRIPTION
+===========
+
+The flux-watch(1) command is used to monitor the output and state of one
+or more Flux jobs. The command works similarly to the :man1:`flux-submit`
+``--watch`` option, but can be used to monitor even inactive jobs. For
+example, to copy all job output to the terminal after submitting a series
+of jobs with :man1:`flux-submit` or :man1:`flux-bulksubmit`, use
+
+::
+
+  flux watch --all
+
+This command can also be used at the end of a batch script to wait for all
+submitted jobs to complete and copy all output to the same location as the
+batch job.
+
+OPTIONS
+=======
+
+**-a, --active**
+   Watch all active jobs.
+   This is equivalent to  *--filter=pending,running*.
+
+**-A, --all**
+   Watch all jobs. This is equivalent to *--filter=pending,running,inactive*.
+
+**-c, --count**\ *=N*
+   Limit output to N jobs (default 1000). This is a safety measure to
+   protect against watching too many jobs with the ``--all`` option. The
+   limit can be disabled with ``--count=0``.
+
+**--since**\ *=WHEN*
+   Limit output to jobs that have been active since a given timestamp.
+   This option implies ``-a`` if no other ``--filter`` options are specified.
+   If *WHEN* begins with ``-`` character, then the remainder is considered
+   to be a an offset in Flux standard duration (RFC 23). Otherwise,
+   any datetime expression accepted by the Python `parsedatetime
+   <https://github.com/bear/parsedatetime>`_ module is accepted. Examples:
+   "-6h", "-1d", "yesterday", "2021-06-21 6am", "last Monday", etc. It is
+   assumed to be an error if a timestamp in the future is supplied.
+
+**-f, --filter**\ *=STATE|RESULT*
+   Watch jobs with specific job state or result. Multiple states or results
+   can be listed separated by comma. See the JOB STATUS section in the
+   :man1:`flux-jobs` manual for additional information.
+
+**--progress**
+   Display a progress bar showing the completion progress of monitored
+   jobs.  Jobs that are already inactive will immediately have their
+   progress updated in the progress bar, with output later copied to the
+   terminal. The progress bar by default includes a count of pending,
+   running, complete and failed jobs, and an elapsed timer. The elapsed
+   timer is initialized at the submit time of the earliest job, or the
+   starttime of the instance with ``--all``, in order to reflect the real
+   elapsed time for the jobs being monitored.
+
+**--jps**
+   With ``--progress``, display throughput statistics (job/s) in the
+   progress bar instead of an elapsed timer. Note: The throughput will be
+   calculated based on the elapsed time as described in the description
+   of the ``-progress`` option.
+
+EXIT STATUS
+===========
+
+The exit status of ``flux watch`` is 0 if no jobs match the job selection
+options or if all jobs complete with success. Otherwise, the command exits
+with the largest exit status of all monitored jobs, or 2 if there is an
+error during option processing.
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+SEE ALSO
+========
+
+:man1:`flux-jobs`, :man1:`flux-submit`, :man1:`flux-bulksubmit`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -67,6 +67,7 @@ man_pages = [
     ('man1/flux-startlog', 'flux-startlog', 'Show Flux instance start and stop times', [author], 1),
     ('man1/flux', 'flux', 'the Flux resource management framework', [author], 1),
     ('man1/flux-shell', 'flux-shell', 'the Flux job shell', [author], 1),
+    ('man1/flux-watch', 'flux-watch', 'monitor one or more Flux jobs', [author], 1),
     ('man3/flux_attr_get', 'flux_attr_set', 'get/set Flux broker attributes', [author], 3),
     ('man3/flux_attr_get', 'flux_attr_get', 'get/set Flux broker attributes', [author], 3),
     ('man3/flux_aux_set', 'flux_aux_get', 'get/set auxiliary handle data', [author], 3),

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -1042,6 +1042,36 @@ _flux_pstree()
     return 0
 }
 
+# flux-watch(1) completions
+_flux_watch()
+{
+    local cmd=$1
+    local OPTS="\
+        -a --active \
+        -A --all \
+        -c --count= \
+        -f --filter= \
+        -l --label-io \
+        --since= \
+        --progress \
+        --jps \
+        --verbose
+    "
+    if [[ $cur != -* ]]; then
+        #  Attempt to substitute an active jobid
+        compopt +o filenames
+        active_jobs=$(flux jobs -no {id})
+        COMPREPLY=( $(compgen -W "${active_jobs}" -- "$cur") )
+        return 0
+    fi
+    COMPREPLY=( $(compgen -W "${OPTS} -h --help" -- "$cur") )
+    if [[ "${COMPREPLY[@]}" == *= ]]; then
+        # Add space if there is not a '=' in suggestions
+        compopt -o nospace
+    fi
+    return 0
+}
+
 #  flux-dump(1) completions
 _flux_dump()
 {
@@ -1440,6 +1470,9 @@ _flux_core()
         ;;
     start)
         _flux_start $subcmd
+        ;;
+    watch)
+        _flux_watch $subcmd
         ;;
     -*)
         COMPREPLY=( $(compgen -W "${FLUX_OPTS}" -- "$cur") )

--- a/src/bindings/python/flux/progress.py
+++ b/src/bindings/python/flux/progress.py
@@ -175,7 +175,8 @@ class Bottombar:
     def start(self):
         """Start drawing a Bottombar"""
         self._running = True
-        self._t0 = time.time()
+        if self._t0 is None:
+            self._t0 = time.time()
         self.redraw()
         atexit.register(self._reset_terminal)
         return self

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -203,6 +203,65 @@ class TreedictAction(argparse.Action):
             setattr(namespace, self.dest, result)
 
 
+class FilterAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+        setattr(namespace, "filtered", True)
+
+
+class FilterActionSetUpdate(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, "filtered", True)
+        values = values.split(",")
+        getattr(namespace, self.dest).update(values)
+
+
+# pylint: disable=redefined-builtin
+class FilterTrueAction(argparse.Action):
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        const=True,
+        default=False,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
+        super(FilterTrueAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=0,
+            const=const,
+            default=default,
+            help=help,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, self.const)
+        setattr(namespace, "filtered", True)
+
+
+class YesNoAction(argparse.Action):
+    """Simple argparse.Action for options with yes|no arguments"""
+
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        help=None,
+        metavar="[yes|no]",
+    ):
+        super().__init__(
+            option_strings=option_strings, dest=dest, help=help, metavar=metavar
+        )
+
+    def __call__(self, parser, namespace, value, option_string=None):
+        if value not in ["yes", "no"]:
+            raise ValueError(f"{option_string} requires either 'yes' or 'no'")
+        setattr(namespace, self.dest, value == "yes")
+
+
 class CLIMain(object):
     def __init__(self, logger=None):
         if logger is None:

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -114,6 +114,7 @@ dist_fluxcmd_SCRIPTS = \
 	flux-pgrep.py \
 	flux-queue.py \
 	flux-cancel.py \
+	flux-watch.py \
 	flux-imp-exec-helper
 
 fluxcmd_PROGRAMS = \

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -19,7 +19,13 @@ import sys
 import flux.constants
 from flux.job import JobID, JobInfo, JobInfoFormat, JobList, job_fields_to_attrs
 from flux.job.stats import JobStats
-from flux.util import UtilConfig
+from flux.util import (
+    FilterAction,
+    FilterActionSetUpdate,
+    FilterTrueAction,
+    UtilConfig,
+    help_formatter,
+)
 
 LOGGER = logging.getLogger("flux-jobs")
 
@@ -192,49 +198,8 @@ def fetch_jobs(args, fields):
     return lst
 
 
-class FilterAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, values)
-        setattr(namespace, "filtered", True)
-
-
-class FilterActionSetUpdate(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, "filtered", True)
-        values = values.split(",")
-        getattr(namespace, self.dest).update(values)
-
-
-# pylint: disable=redefined-builtin
-class FilterTrueAction(argparse.Action):
-    def __init__(
-        self,
-        option_strings,
-        dest,
-        const=True,
-        default=False,
-        required=False,
-        help=None,
-        metavar=None,
-    ):
-        super(FilterTrueAction, self).__init__(
-            option_strings=option_strings,
-            dest=dest,
-            nargs=0,
-            const=const,
-            default=default,
-            help=help,
-        )
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, self.const)
-        setattr(namespace, "filtered", True)
-
-
 def parse_args():
-    parser = argparse.ArgumentParser(
-        prog="flux-jobs", formatter_class=flux.util.help_formatter()
-    )
+    parser = argparse.ArgumentParser(prog="flux-jobs", formatter_class=help_formatter())
     # -a equivalent to -s "pending,running,inactive" and -u set to userid
     parser.add_argument("-a", action=FilterTrueAction, help="List jobs in all states")
     # -A equivalent to -s "pending,running,inactive" and -u set to "all"

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -18,7 +18,7 @@ from pathlib import PurePath
 
 import flux
 from flux.job import JobID, JobInfoFormat, JobList
-from flux.util import UtilConfig
+from flux.util import FilterActionSetUpdate, UtilConfig
 
 PROGRAM = PurePath(sys.argv[0]).stem
 LOGGER = logging.getLogger(PROGRAM)
@@ -134,12 +134,6 @@ def fetch_jobs(args, flux_handle=None):
         pass
 
     return jobs
-
-
-class FilterActionSetUpdate(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        values = values.split(",")
-        getattr(namespace, self.dest).update(values)
 
 
 def parse_args():

--- a/src/cmd/flux-pstree.py
+++ b/src/cmd/flux-pstree.py
@@ -16,7 +16,7 @@ import sys
 import flux
 import flux.uri
 from flux.job import JobID, JobInfo, JobInfoFormat, JobList
-from flux.util import Tree
+from flux.util import FilterAction, FilterTrueAction, Tree, YesNoAction
 
 DETAILS_FORMAT = {
     "default": (
@@ -204,58 +204,6 @@ def load_tree(
         tree.append_tree(future.result())
 
     return tree
-
-
-class FilterAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, values)
-        setattr(namespace, "filtered", True)
-
-
-# pylint: disable=redefined-builtin
-class FilterTrueAction(argparse.Action):
-    def __init__(
-        self,
-        option_strings,
-        dest,
-        const=True,
-        default=False,
-        required=False,
-        help=None,
-        metavar=None,
-    ):
-        super(FilterTrueAction, self).__init__(
-            option_strings=option_strings,
-            dest=dest,
-            nargs=0,
-            const=const,
-            default=default,
-            help=help,
-        )
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, self.const)
-        setattr(namespace, "filtered", True)
-
-
-class YesNoAction(argparse.Action):
-    """Simple argparse.Action for options with yes|no arguments"""
-
-    def __init__(
-        self,
-        option_strings,
-        dest,
-        help=None,
-        metavar="[yes|no]",
-    ):
-        super().__init__(
-            option_strings=option_strings, dest=dest, help=help, metavar=metavar
-        )
-
-    def __call__(self, parser, namespace, value, option_string=None):
-        if value not in ["yes", "no"]:
-            raise ValueError(f"{option_string} requires either 'yes' or 'no'")
-        setattr(namespace, self.dest, value == "yes")
 
 
 def parse_args():

--- a/src/cmd/flux-watch.py
+++ b/src/cmd/flux-watch.py
@@ -1,0 +1,208 @@
+##############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import argparse
+import logging
+import os
+import sys
+
+import flux
+from flux.job import JobID, JobList
+from flux.job.watcher import JobWatcher
+from flux.util import (
+    FilterAction,
+    FilterActionSetUpdate,
+    FilterTrueAction,
+    help_formatter,
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="flux-watch", formatter_class=help_formatter()
+    )
+    parser.add_argument(
+        "-a",
+        "--active",
+        action=FilterTrueAction,
+        help="Watch all active jobs for current user",
+    )
+    parser.add_argument(
+        "-A",
+        "--all",
+        action=FilterTrueAction,
+        help="Watch all jobs for current user in all states including inactive",
+    )
+    parser.add_argument(
+        "-c",
+        "--count",
+        action=FilterAction,
+        type=int,
+        metavar="N",
+        default=0,
+        help="Limit to N jobs (default 1000)",
+    )
+    parser.add_argument(
+        "-f",
+        "--filter",
+        action=FilterActionSetUpdate,
+        metavar="STATE|RESULT",
+        default=set(),
+        help="Watch jobs with specific job state or result",
+    )
+    parser.add_argument(
+        "--since",
+        action=FilterAction,
+        type=str,
+        metavar="WHEN",
+        default=0.0,
+        help="Include only jobs that have been inactive since WHEN. "
+        + "(implies -a if no other --filter option is specified)",
+    )
+    parser.add_argument(
+        "--progress",
+        action="store_true",
+        default=False,
+        help="Show progress bar",
+    )
+    parser.add_argument(
+        "--jps",
+        action="store_true",
+        default=False,
+        help="Display jobs/s instead of elapsed time ",
+    )
+    parser.add_argument(
+        "-l",
+        "--label-io",
+        action="store_true",
+        default=False,
+        help="label lines of output with task id",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity",
+    )
+    parser.add_argument(
+        "jobids",
+        metavar="JOBID",
+        type=JobID,
+        nargs="*",
+        help="Watch specific jobids",
+    )
+    parser.set_defaults(filtered=False)
+    return parser.parse_args()
+
+
+LOGGER = logging.getLogger("flux-watch")
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+
+    sys.stdout = open(
+        sys.stdout.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+    sys.stderr = open(
+        sys.stderr.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+
+    starttime = None
+    since = 0.0
+
+    args = parse_args()
+
+    if args.jobids and args.filtered:
+        LOGGER.warning("Filtering options ignored with jobid list")
+
+    fh = flux.Flux()
+    instance_starttime = float(fh.attr_get("broker.starttime"))
+
+    if args.since:
+        #  Implies --all unless any other filter option is already in effect.
+        if not args.filter:
+            args.all = True
+        try:
+            since = flux.util.parse_datetime(args.since).timestamp()
+        except ValueError:
+            try:
+                since = float(args.since)
+            except ValueError:
+                LOGGER.error(f"--since: invalid value '{args.since}'")
+                sys.exit(2)
+
+        # Ensure args.since is in the past
+        if since > flux.util.parse_datetime("now").timestamp():
+            LOGGER.error("--since=%s appears to be in the future", args.since)
+            sys.exit(2)
+
+        #  With since, start elapsed timer at maximum of since time or
+        #  instance starttime
+        starttime = max(since, instance_starttime)
+
+    if args.active:
+        args.filter.update(("pending", "running"))
+
+    if args.all:
+        args.filter.update(("pending", "running", "inactive"))
+        if not starttime:
+            starttime = instance_starttime
+
+    if not args.filter and not args.jobids:
+        LOGGER.error("At least one job selection option is required")
+        print("Try 'flux watch --help' for more information.", file=sys.stderr)
+        sys.exit(1)
+
+    joblist = JobList(
+        fh,
+        ids=args.jobids,
+        attrs=["state", "result", "t_submit"],
+        filters=args.filter,
+        since=since,
+        user=str(os.getuid()),
+        max_entries=args.count,
+    )
+    jobs = list(joblist.jobs())
+    for errmsg in joblist.errors:
+        LOGGER.error(errmsg)
+
+    if not jobs:
+        LOGGER.info("No matching jobs")
+        sys.exit(0)
+
+    if args.verbose:
+        LOGGER.info(f"Watching {len(jobs)} jobs")
+
+    if args.progress and not sys.stdout.isatty():
+        LOGGER.warning("stdout is not a tty. Ignoring --progress option")
+        args.progress = False
+
+    watcher = JobWatcher(
+        fh,
+        jobs=jobs,
+        progress=args.progress,
+        jps=args.jps,
+        log_events=(args.verbose > 1),
+        log_status=(args.verbose > 0),
+        labelio=args.label_io,
+        starttime=starttime,
+    ).start()
+
+    fh.reactor_run()
+
+    sys.exit(watcher.exitcode)
+
+
+if __name__ == "__main__":
+    main()
+
+# vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -228,6 +228,7 @@ TESTSCRIPTS = \
 	t2810-kvs-garbage-collect.t \
 	t2811-flux-pgrep.t \
 	t2812-flux-job-last.t \
+	t2813-flux-watch.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2813-flux-watch.t
+++ b/t/t2813-flux-watch.t
@@ -1,0 +1,133 @@
+#!/bin/sh
+
+test_description='Test the flux-watch command'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 2 job
+
+export FLUX_PYCLI_LOGLEVEL=10
+export SHELL=/bin/sh
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast --line-buffer"
+
+test_expect_success 'flux-watch: does nothing with no args' '
+	test_expect_code 1 flux watch >no-args.log 2>&1 &&
+	test_debug "cat no-args.log" &&
+	grep "one job selection option is required" no-args.log
+'
+test_expect_success 'flux-watch: start some active jobs to watch' '
+	cat <<-EOF >test.sh &&
+	#!/bin/sh
+	echo \$TEST_OUTPUT
+	EOF
+	chmod +x test.sh &&
+	flux submit --urgency=hold --cc=1-2 --env=TEST_OUTPUT=test{cc} \
+	    ./test.sh >active.ids
+'
+test_expect_success NO_CHAIN_LINT 'flux-watch: --active watches all active jobs' '
+	flux watch -vv --active >active.log 2>&1 &
+	$waitfile -t 30 -v -p "Watching 2 jobs" active.log &&
+	for id in $(cat active.ids); do
+	    flux job urgency $id default
+	done &&
+	wait &&
+	test_debug "cat active.log" &&
+	grep test1 active.log &&
+	grep test2 active.log
+'
+test_expect_success 'flux-watch: ensure previous jobs are inactive (in case of chain-lint)' '
+	for id in $(cat active.ids); do
+            flux job urgency $id default || true
+        done &&
+	flux watch $(cat active.ids)
+'
+test_expect_success 'flux-watch: --all watches inactive jobs' '
+	flux watch --all  >all.log 2>&1 &&
+	test_debug "cat all.log" &&
+	grep test1 all.log &&
+	grep test2 all.log
+'
+test_expect_success 'flux-watch: run some failed jobs' '
+	id=$(flux submit sh -c "echo test3; exit 2") &&
+	id2=$(flux submit --urgency hold true) &&
+	flux job cancel $id2
+'
+test_expect_success 'flux-watch: exits with highest job exit code' '
+	test_expect_code 2 flux watch --all
+'
+test_expect_success 'flux-watch: can specify multiple jobids' '
+	flux watch $(cat active.ids) >by-jobid.out 2>&1 &&
+	test_debug "cat by-jobid.out" &&
+	grep test1 by-jobid.out &&
+	grep test2 by-jobid.out
+'
+test_expect_success 'flux-watch: emits errors for invalid jobs' '
+	flux watch f123 2>invalid-jobid.err &&
+	grep "JobID f123 unknown" invalid-jobid.err
+'
+test_expect_success 'flux-watch: issues warning with jobids and filtering option' '
+	flux watch -v --all $(cat active.ids) >all-error.out 2>&1 &&
+	test_debug "cat all-error.out" &&
+	grep "Filtering options ignored with jobid list" all-error.out
+'
+# Note: test with --since by using the t_submit of the last submitted job.
+# This should only match up to the last two jobs, which were failed and
+# canceled respectively, so the test must fail and the tool should output
+# it watched only 1 or 2 jobs (we can't guarantee when the first failed
+# job finished relative to submission of the second)
+test_expect_success 'flux-watch: works with --since' '
+	t_since=$(flux jobs -ac 1 -no {t_submit}) &&
+	test_must_fail flux watch -v --since=$t_since >since.out 2>&1 &&
+	test_debug "cat since.out" &&
+	grep "Watching [12] job" since.out
+'
+# -1h should get us all 4 jobs
+test_expect_success 'flux-watch: --since takes negative offset' '
+	test_must_fail flux watch -v --since=-1h >since1h.out 2>&1 &&
+	test_debug "cat since1h.out" &&
+	grep "Watching 4 job" since1h.out
+'
+test_expect_success 'flux-watch: invalid --since fails' '
+	test_expect_code 2 flux watch --since=-1g 2>since.err &&
+	grep "invalid value" since.err
+'
+test_expect_success 'flux-watch: --since in future fails' '
+	test_expect_code 2 flux watch --since=+1d 2>since2.err &&
+	grep "appears to be in the future" since2.err
+'
+test_expect_success 'flux-watch: --count works' '
+	test_might_fail flux watch -v --all --count=1 >count.out 2>&1 &&
+	grep "Watching 1 job" count.out
+'
+test_expect_success 'flux-watch: --progress works' '
+	test_might_fail $runpty flux watch --all --progress >progress.out &&
+	test_debug "cat progress.out" &&
+	grep "PD:0 *R:0 *CD:2 *F:2 .*100.0%" progress.out
+'
+test_expect_success 'flux-watch: --progress --jps works' '
+	test_might_fail $runpty flux watch --all --progress --jps >jps.out &&
+	test_debug "cat jps.out" &&
+	grep "PD:0 *R:0 *CD:2 *F:2 .*job/s" jps.out
+'
+
+test_expect_success 'flux-watch: --progress is ignored with no tty' '
+	test_might_fail flux watch --all --progress >progress-nopty.out 2>&1 &&
+	test_debug "cat progress-nopty.out" &&
+	grep "Ignoring --progress" progress-nopty.out
+'
+test_expect_success 'flux-watch: --label-io works' '
+	test_might_fail flux watch --all --label-io >labelio.out 2>&1 &&
+	test_debug "cat labelio.out" &&
+	grep "0: test3" labelio.out &&
+	grep "0: test2" labelio.out &&
+	grep "0: test1" labelio.out
+'
+test_expect_success 'flux-watch: --filter works' '
+	nfailed=$(flux jobs -no {id} -f failed,canceled | wc -l) &&
+	test_expect_code 2 flux watch -v --filter=failed,canceled \
+	    >failed.out 2>&1 &&
+	test_debug "cat failed.out" &&
+	grep "Watching ${nfailed} job" failed.out
+'
+test_done


### PR DESCRIPTION
Putting this up as a WIP, in case others have suggestions or comments on this added command.

This PR adds a new command, `flux watch` for lack of a better name (I asked ChatGPT and one of its suggestions was `flux gazemancer` but that was just a bit too outlandish). This command basically does the same thing as `flux submit --watch` but can monitor all running jobs, all inactive jobs, or a specific set of jobs. (It has a similar set of options as `flux jobs`, `flux pstree` etc.).

This allows users to submit many jobs then watch then with `flux watch`, e.g. at the end of a batch script, or if you need to run multiple `submit` or `bulksubmit` commands to submit a set of jobs and then want to monitor them all, e.g. `flux watch --all --progress`...

I still need to think more about the set of options here, write tests, etc. But that should go fairly quickly since this is actually a pretty simple command.