### PR TITLE
python: clear kvs txn after all commits

### DIFF
--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -206,10 +206,10 @@ def commit(flux_handle, flags: int = 0):
     try:
         RAW.flux_future_get(future, None)
     except OSError:
-        RAW.flux_kvs_txn_destroy(flux_handle.aux_txn)
-        flux_handle.aux_txn = None
         raise
     finally:
+        RAW.flux_kvs_txn_destroy(flux_handle.aux_txn)
+        flux_handle.aux_txn = None
         RAW.flux_future_destroy(future)
 
 

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -209,6 +209,8 @@ def commit(flux_handle, flags: int = 0):
         RAW.flux_kvs_txn_destroy(flux_handle.aux_txn)
         flux_handle.aux_txn = None
         raise
+    finally:
+        RAW.flux_future_destroy(future)
 
 
 def dropcache(flux_handle):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -354,6 +354,7 @@ dist_check_SCRIPTS = \
 	issues/t4852-t_submit-legacy.sh \
 	issues/t5105-signal-propagation.sh \
 	issues/t5308-kvsdir-initial-path.py \
+	issues/t5368-kvs-commit-clear.py \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t5368-kvs-commit-clear.py
+++ b/t/issues/t5368-kvs-commit-clear.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+#
+#  Internal KVS txn cleared between commits.
+#
+import sys
+import flux
+import flux.kvs
+import os
+import errno
+
+handle = flux.Flux()
+
+flux.kvs.put(handle, "issue5368A", 1)
+flux.kvs.commit(handle)
+val = flux.kvs.get(handle, "issue5368A")
+if val != 1:
+    print("could not write issue5368A")
+    sys.exit(1)
+
+# delete key outside of this test's flux handle
+os.system("flux kvs unlink issue5368A")
+
+flux.kvs.put(handle, "issue5368B", 1)
+flux.kvs.commit(handle)
+
+# If the internal KVS transaction is not cleared, then the key
+# "issue5368A" will be rewritten.  We want ENOENT to occur.
+try:
+    val = flux.kvs.get(handle, "issue5368A")
+    print("key issue5368A retrieved successfully")
+except OSError as e:
+    if e.errno == errno.ENOENT:
+        sys.exit(0)
+    print("unexpected errno " + e.errno)
+
+sys.exit(1)


### PR DESCRIPTION
Problem: The internal KVS transaction is only cleared when commit()
causes an error.  It should be cleared after every call to commit().

Clear the internal KVS transaction after every call to commit().

Also fixed up a corner case I saw, I think the future needs to be destroyed too.