### PR TITLE
python: add KVSTxn class to KVS module

### DIFF
--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -307,6 +307,20 @@ error:
     return -1;
 }
 
+int flux_kvs_txn_clear (flux_kvs_txn_t *txn)
+{
+    if (!txn) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (json_array_clear (txn->ops) < 0) {
+        /* right errno? no obvious best choice */
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
 /* kvs_txn_private.h */
 
 int txn_get_op_count (flux_kvs_txn_t *txn)

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -321,6 +321,13 @@ int flux_kvs_txn_clear (flux_kvs_txn_t *txn)
     return 0;
 }
 
+bool flux_kvs_txn_is_empty (flux_kvs_txn_t *txn)
+{
+    if (!txn)
+        return true;
+    return json_array_size (txn->ops) ? false : true;
+}
+
 /* kvs_txn_private.h */
 
 int txn_get_op_count (flux_kvs_txn_t *txn)

--- a/src/common/libkvs/kvs_txn.h
+++ b/src/common/libkvs/kvs_txn.h
@@ -49,6 +49,8 @@ int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
 
 int flux_kvs_txn_clear (flux_kvs_txn_t *txn);
 
+bool flux_kvs_txn_is_empty (flux_kvs_txn_t *txn);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libkvs/kvs_txn.h
+++ b/src/common/libkvs/kvs_txn.h
@@ -47,6 +47,8 @@ int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
                           const char *key, const char *ns,
                           const char *target);
 
+int flux_kvs_txn_clear (flux_kvs_txn_t *txn);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -179,7 +179,7 @@ void basic (void)
     errno = 0;
     rc = flux_kvs_txn_mkdir (txn, 0xFFFF, "b.b.b");
     ok (rc < 0 && errno == EINVAL,
-        "error: flux_kvs_txn_mkdir works");
+        "error: flux_kvs_txn_mkdir(bad flags) fails with EINVAL");
     errno = 0;
     rc = flux_kvs_txn_put (txn, 0xFFFF, "f", "42");
     ok (rc < 0 && errno == EINVAL,

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -145,6 +145,8 @@ void basic (void)
     txn = flux_kvs_txn_create ();
     ok (txn != NULL,
         "flux_kvs_txn_create works");
+    ok (flux_kvs_txn_is_empty (txn) == true,
+        "flux_kvs_txn_is_empty returns true immediately after create");
     rc = flux_kvs_txn_pack (txn, FLUX_KVS_APPEND, "foo.bar.baz",  "i", 42);
     ok (rc == 0,
         "1: flux_kvs_txn_pack(i) flags=FLUX_KVS_APPEND works");
@@ -175,6 +177,8 @@ void basic (void)
 
     /* Verify transaction contents
      */
+    ok (flux_kvs_txn_is_empty (txn) == false,
+        "flux_kvs_txn_is_empty returns false after transactions added");
     ok (txn_get_op_count (txn) == 9,
         "txn contains 9 ops");
     ok (txn_get_op (txn, 0, &entry) == 0
@@ -286,6 +290,9 @@ void basic (void)
 
     ok (txn_get_op_count (txn) == 0,
         "txn contains 0 ops");
+
+    ok (flux_kvs_txn_is_empty (txn) == true,
+        "flux_kvs_txn_is_empty returns true after clear");
 
     flux_kvs_txn_destroy (txn);
 }
@@ -410,6 +417,9 @@ void test_corner_cases (void)
     rc = flux_kvs_txn_clear (NULL);
     ok (rc < 0 && errno == EINVAL,
         "flux_kvs_txn_clear fails w/ EINVAL on bad input");
+
+    ok (flux_kvs_txn_is_empty (NULL) == true,
+        "flux_kvs_txn_is_empty returns true on NULL input");
 
     errno = 0;
     rc = flux_kvs_txn_put (txn, 0xFFFF, "a", "42");

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -281,6 +281,12 @@ void basic (void)
     ok (txn_get_op (txn, 9, &entry) < 0 && errno == EINVAL,
         "10: invalid (end of transaction)");
 
+    ok (flux_kvs_txn_clear (txn) == 0,
+        "flux_kvs_txn_clear success");
+
+    ok (txn_get_op_count (txn) == 0,
+        "txn contains 0 ops");
+
     flux_kvs_txn_destroy (txn);
 }
 
@@ -399,6 +405,11 @@ void test_corner_cases (void)
     rc = flux_kvs_txn_symlink (NULL, 0, NULL, NULL, NULL);
     ok (rc < 0 && errno == EINVAL,
         "flux_kvs_txn_symlink fails w/ EINVAL on bad inputs");
+
+    errno = 0;
+    rc = flux_kvs_txn_clear (NULL);
+    ok (rc < 0 && errno == EINVAL,
+        "flux_kvs_txn_clear fails w/ EINVAL on bad input");
 
     errno = 0;
     rc = flux_kvs_txn_put (txn, 0xFFFF, "a", "42");


### PR DESCRIPTION
Built on top of the prior #5373.  Unlike the namespace support, this ones a little ehhh ... 

Support a new "KVSTxn" class that semi-mirrors the "kvs transactions" we do in `libkvs`.  This allows users to do:

```
with KVSTxn(handle, "basedir", namespace="foobar") as txn:
     txn.put("a", 1)
```

and, most notably, not all changes to the KVS are placed into a single transaction.  For example, under the old code something like:

```
dir1 = get_dir("mydir")
dir1["a"] = 1

dir2 = get_dir("mydir")
dir2["a"] = 2

dir1.commit()
```

Would not give you the effect one would expect.

Notes:

- All of the "put*()" functions don't need a `flux_handle`, just a transaction object.  But because of the old "aux_txn" and backwards compatibility, we have to leave it there.  Unless we decide to just break things.

- I went back and forth on whether or not the main `put*()` and `commit()` functions should take a `KVSTxn` object as an argument.  For the time being I went with yes, it can take a KVSTxn object (internally it'll get the `flux_kvs_txn_t *` stored within the `KVSTxn` class).

- I also debated, should this optional parameter be publicly known / documented.  I elected no, and prefix the parameter with an underscore to illustrate this point.  It should only be used by internally knowledgeable stuffs.  This would be altered if we removed the `flux_handle` argument and `aux_txn` stuff per first bullet comment above.

- I don't think there's much that will surprise people in the implementation.  I suppose some of the "don't create object until you need it" makes some code a little more complex then I would have liked.  Had to handle those corner cases.  Maybe the "don't create object until you need it" was overkill and not necessary for any significant performance gain.

- BUT ... there's one implementation subtlety which surprised me and would probably surprise a reviewer:

```
kvsdir["mydir"]["mysubdir"]["mysubdir2"] = 2
kvsdir.commit()
```

each access to a directory returns another `KVSDir` object.  This happens to work under the old implementation because there was a single global kvs transaction object (the `aux_txn` one), so that final `commit()` at the end worked.  But if we add per-KVSDir-transaction-objects, this stops working.

So to get it working I did this:

```
+    def __del__(self):
+        # Necessary because of recursive KVSDir settings, e.g.
+        # kvsdir["mydir"]["mysubdir"]["mysubdir2"] = 2
+        if self.kvstxn:
+            self.commit()
```

i.e. when the reference to the object is gone, do a final commit on the KVSDir object.

I don't know if this is Python kosher.  There's of course fears that user could keep reference around like

```
kvsdir["mydir"]["mysubdir"]["mysubdir2"] = "foo"
myvar = kvsdir["mydir"]["mysubdir"]["mysubdir2"]
```

and so my change wouldn't work.  Gonna experiment to see if I can "give" my transaction object to retrieved directory and see where that goes.  But figured I'd park this for now if there's any overarching comments .... 


