### PR TITLE
python: fix __delitem__ in KVSDir with initial paths

### DIFF
--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -327,7 +327,7 @@ class KVSDir(WrapperPimpl, abc.MutableMapping):
         put(self.fhdl, self._path + key, value)
 
     def __delitem__(self, key):
-        put_unlink(self.fhdl, key)
+        put_unlink(self.fhdl, self._path + key)
 
     class KVSDirIterator(abc.Iterator):
         def __init__(self, kvsdir):

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -140,9 +140,8 @@ def put(flux_handle, key, value):
         RAW.flux_kvs_txn_put(flux_handle.aux_txn, 0, key, json_str)
     except TypeError:
         if isinstance(value, bytes):
-            return RAW.flux_kvs_txn_put_raw(
-                flux_handle.aux_txn, 0, key, value, len(value)
-            )
+            RAW.flux_kvs_txn_put_raw(flux_handle.aux_txn, 0, key, value, len(value))
+            return
         raise TypeError
 
 

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -291,7 +291,23 @@ class TestKVS(unittest.TestCase):
         self.assertEqual(kd5["d.e.f"], 4)
         self.assertEqual(kd5["d"]["e"]["f"], 4)
 
-    def test_kvsdir_10_fill_initial_path(self):
+    def test_kvsdir_10_unlink_initial_path(self):
+        with flux.kvs.get_dir(self.f) as kd:
+            kd.mkdir("unlinkinitialpath")
+            kd["unlinkinitialpath"]["a"] = 1
+
+        kd2 = flux.kvs.KVSDir(self.f)
+        self.assertEqual(kd2["unlinkinitialpath.a"], 1)
+
+        kd3 = flux.kvs.KVSDir(self.f, "unlinkinitialpath")
+        del kd3["a"]
+        kd3.commit()
+
+        kd4 = flux.kvs.KVSDir(self.f)
+        with self.assertRaises(KeyError):
+            kd4["unlinkinitialpath.a"]
+
+    def test_kvsdir_11_fill_initial_path(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("fillinitialpath")
 
@@ -311,7 +327,7 @@ class TestKVS(unittest.TestCase):
             self.assertEqual(kd4["i.j.k"], "baz")
             self.assertEqual(kd4["i"]["j"]["k"], "baz")
 
-    def test_kvsdir_11_mkdir_initial_path(self):
+    def test_kvsdir_12_mkdir_initial_path(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("mkdirinitialpath", {"l": 1, "m": "bar", "n.o.p": "baz"})
             kd.commit()
@@ -328,7 +344,7 @@ class TestKVS(unittest.TestCase):
             self.assertEqual(kd3["n.o.p"], "baz")
             self.assertEqual(kd3["n"]["o"]["p"], "baz")
 
-    def test_kvsdir_12_iterator(self):
+    def test_kvsdir_13_iterator(self):
         keys = ["testdir1a." + str(x) for x in range(1, 15)]
         with flux.kvs.get_dir(self.f) as kd:
             for k in keys:
@@ -340,7 +356,7 @@ class TestKVS(unittest.TestCase):
                 self.assertEqual(v, "bar")
                 print("passed {}".format(k))
 
-    def test_kvsdir_13_files(self):
+    def test_kvsdir_14_files(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("filestest", {"somefile": 1, "somefile2": 2})
             kd.mkdir("filestest.subdir")
@@ -352,7 +368,7 @@ class TestKVS(unittest.TestCase):
             self.assertIn("somefile", files)
             self.assertIn("somefile2", files)
 
-    def test_kvsdir_14_directories(self):
+    def test_kvsdir_15_directories(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("directoriestest", {"somefile": 1, "somefile2": 2})
             kd.mkdir("directoriestest.subdir")
@@ -363,7 +379,7 @@ class TestKVS(unittest.TestCase):
             self.assertEqual(len(directories), 1)
             self.assertIn("subdir", directories)
 
-    def test_kvsdir_15_list_all(self):
+    def test_kvsdir_16_list_all(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("listalltest", {"somefile": 1, "somefile2": 2})
             kd.mkdir("listalltest.subdir")

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -29,7 +29,7 @@ class TestKVS(unittest.TestCase):
     def setUpClass(self):
         self.f = flux.Flux()
 
-    def test_01_kvs_dir_open(self):
+    def test_basic_01_kvs_dir_open(self):
         with flux.kvs.get_dir(self.f) as d:
             self.assertIsNotNone(d)
 
@@ -53,68 +53,158 @@ class TestKVS(unittest.TestCase):
 
         return kd2
 
-    def test_02_set_int(self):
+    def test_basic_02_set_int(self):
         self.set_and_check_context("int", 10, int)
 
-    def test_03_set_float(self):
+    def test_basic_03_set_float(self):
         self.set_and_check_context("float", 10.5, float)
 
-    def test_04_set_string(self):
+    def test_basic_04_set_string(self):
         self.set_and_check_context("string", "stuff", str)
 
-    def test_05_set_none(self):
+    def test_basic_05_set_none(self):
         self.set_and_check_context("none", None, None)
 
-    def test_06_set_unicode(self):
+    def test_basic_06_set_unicode(self):
         self.set_and_check_context("unicode", "\u32db \u263a \u32e1", str)
 
-    def test_07_set_bytes(self):
+    def test_basic_07_set_bytes(self):
         self.set_and_check_context("bytes", bytes.fromhex("deadbeef"), bytes)
 
-    def test_08_set_list(self):
+    def test_basic_08_set_list(self):
         self.set_and_check_context("list", [1, 2, 3, 4], list)
 
-    def test_09_set_dict(self):
+    def test_basic_09_set_dict(self):
         self.set_and_check_context(
             "dict", {"thing": "stuff", "other thing": "more stuff"}, dict
         )
 
-    def test_10_set_legal_json(self):
+    def test_basic_10_set_legal_json(self):
         self.set_and_check_context("badjson", b"{}", dict)
 
-    def test_11_set_not_legal_json(self):
+    def test_basic_11_set_not_legal_json(self):
         self.set_and_check_context("badjson", b"{", str)
 
-    def test_12_exists_dir(self):
+    def test_basic_12_set_deep(self):
+        self.set_and_check_context("a.b.c.e.f.j.k", 5, int)
+
+    def test_api_01_exists_dir(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("pytestdir")
         self.assertTrue(flux.kvs.exists(self.f, "pytestdir"))
 
-    def test_13_exists_true(self):
+    def test_api_02_exists_true(self):
         flux.kvs.put(self.f, "thing", 15)
         flux.kvs.commit(self.f)
         self.assertTrue(flux.kvs.exists(self.f, "thing"))
 
-    def test_14_exists_false(self):
+    def test_api_03_exists_false(self):
         self.assertFalse(flux.kvs.exists(self.f, "argbah"))
 
-    def test_15_isdir_true(self):
+    def test_api_04_isdir_true(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("testisdir")
         self.assertTrue(flux.kvs.isdir(self.f, "testisdir"))
 
-    def test_16_isdir_false(self):
+    def test_api_05_isdir_false(self):
         flux.kvs.put(self.f, "testisdirkey", 15)
         flux.kvs.commit(self.f)
         self.assertFalse(flux.kvs.isdir(self.f, "testisdirkey"))
         self.assertFalse(flux.kvs.isdir(self.f, "not_a_key_i_made"))
 
-    def test_17_commit_flags(self):
+    def test_api_06_put_mkdir(self):
+        flux.kvs.put_mkdir(self.f, "txn_mkdir")
+        flux.kvs.commit(self.f)
+        self.assertTrue(flux.kvs.exists(self.f, "txn_mkdir"))
+
+    def test_api_07_put_unlink(self):
+        flux.kvs.put(self.f, "txn_unlink", 1)
+        flux.kvs.commit(self.f)
+        flux.kvs.put_unlink(self.f, "txn_unlink")
+        flux.kvs.commit(self.f)
+        self.assertFalse(flux.kvs.exists(self.f, "txn_unlink"))
+
+    def test_api_08_put_symlink(self):
+        flux.kvs.put_symlink(self.f, "txn_symlink", "txn_target")
+        flux.kvs.commit(self.f)
+        self.assertFalse(flux.kvs.exists(self.f, "txn_symlink"))
+
+    def test_api_09_commit_flags(self):
         flux.kvs.put(self.f, "flagcheck", 42)
         flux.kvs.commit(self.f, 1)
         self.assertTrue(flux.kvs.exists(self.f, "flagcheck"))
 
-    def test_18_remove(self):
+    # just testing that passing flags work, these are pitiful KVS
+    # changes and the flags don't mean much
+    def test_api_10_commit_flags(self):
+        flux.kvs.put(self.f, "commitflags", "foo")
+        flux.kvs.commit(self.f, flux.constants.FLUX_KVS_NO_MERGE)
+        flux.kvs.put(self.f, "commitflags", "baz")
+        flux.kvs.commit(self.f, flux.constants.FLUX_KVS_TXN_COMPACT)
+        flux.kvs.put(self.f, "commitflags", "bar")
+        flux.kvs.commit(self.f, flux.constants.FLUX_KVS_SYNC)
+
+    # try to overwrite root dir, will fail on commit
+    def test_api_11_commit_fail(self):
+        with self.assertRaises(OSError) as ctx:
+            flux.kvs.put(self.f, ".", "foof")
+            flux.kvs.commit(self.f)
+        self.assertEqual(ctx.exception.errno, errno.EINVAL)
+
+        # Issue #5333, make sure internal bad transaction cleared and
+        # subsequent commit works
+        flux.kvs.commit(self.f)
+
+    def bad_input(self, func, *args):
+        with self.assertRaises(OSError) as ctx:
+            func(*args)
+        self.assertEqual(ctx.exception.errno, errno.EINVAL)
+
+    def test_bad_input_01_exists(self):
+        self.bad_input(flux.kvs.exists, self.f, "")
+
+    def test_bad_input_02_isdir(self):
+        self.bad_input(flux.kvs.isdir, self.f, "")
+
+    def test_bad_input_03_get(self):
+        self.bad_input(flux.kvs.get, self.f, "")
+
+    def test_bad_input_04_get_dir(self):
+        self.bad_input(flux.kvs.get_dir, self.f, "")
+
+    def test_bad_input_05_put_exception(self):
+        self.bad_input(flux.kvs.put, self.f, "", "")
+
+    def test_bad_input_06_put_mkdir_exception(self):
+        self.bad_input(flux.kvs.put_mkdir, self.f, "")
+
+    def test_bad_input_07_put_unlink(self):
+        self.bad_input(flux.kvs.put_unlink, self.f, "")
+
+    def test_bad_input_08_put_symlink(self):
+        self.bad_input(flux.kvs.put_symlink, self.f, "", "")
+
+    def test_kvsdir_01_bad_init(self):
+        with self.assertRaises(ValueError):
+            flux.kvs.KVSDir()
+
+    def test_kvsdir_02_read_non_existent(self):
+        with self.assertRaises(KeyError):
+            print(
+                flux.kvs.KVSDir(self.f)[
+                    "crazykeythatclearlydoesntexistandneverwillinanyuniverse"
+                ]
+            )
+
+    def test_kvsdir_03_read_non_existent_basedir(self):
+        with self.assertRaisesRegex(EnvironmentError, "No such file"):
+            print(
+                flux.kvs.KVSDir(
+                    self.f, "crazykeythatclearlydoesntexistandneverwillinanyuniverse"
+                )
+            )
+
+    def test_kvsdir_04_remove(self):
         kd = self.set_and_check_context("todel", "things to delete", str)
         del kd["todel"]
         kd.commit()
@@ -122,7 +212,7 @@ class TestKVS(unittest.TestCase):
             stuff = kd["todel"]
             print(stuff)
 
-    def test_19_fill(self):
+    def test_kvsdir_05_fill(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.fill({"things": 1, "stuff": "strstuff", "dir.other_thing": "dirstuff"})
             kd.commit()
@@ -132,7 +222,7 @@ class TestKVS(unittest.TestCase):
             self.assertEqual(kd2["stuff"], "strstuff")
             self.assertEqual(kd2["dir"]["other_thing"], "dirstuff")
 
-    def test_20_mkdir_fill(self):
+    def test_kvsdir_06_mkdir_fill(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir(
                 "mkdirfill",
@@ -149,20 +239,13 @@ class TestKVS(unittest.TestCase):
             self.assertEqual(kd2["mkdirfill.stuffs"], "strstuffs")
             self.assertEqual(kd2["mkdirfill"]["dir"]["other_thingies"], "dirstuffs")
 
-    def test_21_set_deep(self):
-        self.set_and_check_context("a.b.c.e.f.j.k", 5, int)
-
-    def test_22_bad_init(self):
-        with self.assertRaises(ValueError):
-            flux.kvs.KVSDir()
-
-    def test_23_key_at(self):
+    def test_kvsdir_07_key_at(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("testkeyat")
         with flux.kvs.get_dir(self.f, "testkeyat") as kd:
             self.assertEqual(kd.key_at("meh"), "testkeyat.meh")
 
-    def test_24_exists_initial_path(self):
+    def test_kvsdir_08_exists_initial_path(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd["exists1"] = 1
             kd.mkdir("existssubdir")
@@ -176,7 +259,7 @@ class TestKVS(unittest.TestCase):
             self.assertFalse(kd3.exists("exists1"))
             self.assertTrue(kd3.exists("exists2"))
 
-    def test_25_key_initial_path(self):
+    def test_kvsdir_09_key_initial_path(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("initialpath")
 
@@ -208,7 +291,7 @@ class TestKVS(unittest.TestCase):
         self.assertEqual(kd5["d.e.f"], 4)
         self.assertEqual(kd5["d"]["e"]["f"], 4)
 
-    def test_26_fill_initial_path(self):
+    def test_kvsdir_10_fill_initial_path(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("fillinitialpath")
 
@@ -228,7 +311,7 @@ class TestKVS(unittest.TestCase):
             self.assertEqual(kd4["i.j.k"], "baz")
             self.assertEqual(kd4["i"]["j"]["k"], "baz")
 
-    def test_27_mkdir_initial_path(self):
+    def test_kvsdir_11_mkdir_initial_path(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("mkdirinitialpath", {"l": 1, "m": "bar", "n.o.p": "baz"})
             kd.commit()
@@ -245,7 +328,19 @@ class TestKVS(unittest.TestCase):
             self.assertEqual(kd3["n.o.p"], "baz")
             self.assertEqual(kd3["n"]["o"]["p"], "baz")
 
-    def test_28_files(self):
+    def test_kvsdir_12_iterator(self):
+        keys = ["testdir1a." + str(x) for x in range(1, 15)]
+        with flux.kvs.get_dir(self.f) as kd:
+            for k in keys:
+                kd[k] = "bar"
+
+        with flux.kvs.get_dir(self.f, "testdir1a") as kd:
+            print(kd.keys())
+            for k, v in kd.items():
+                self.assertEqual(v, "bar")
+                print("passed {}".format(k))
+
+    def test_kvsdir_13_files(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("filestest", {"somefile": 1, "somefile2": 2})
             kd.mkdir("filestest.subdir")
@@ -257,7 +352,7 @@ class TestKVS(unittest.TestCase):
             self.assertIn("somefile", files)
             self.assertIn("somefile2", files)
 
-    def test_29_directories(self):
+    def test_kvsdir_14_directories(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("directoriestest", {"somefile": 1, "somefile2": 2})
             kd.mkdir("directoriestest.subdir")
@@ -268,7 +363,7 @@ class TestKVS(unittest.TestCase):
             self.assertEqual(len(directories), 1)
             self.assertIn("subdir", directories)
 
-    def test_30_list_all(self):
+    def test_kvsdir_15_list_all(self):
         with flux.kvs.get_dir(self.f) as kd:
             kd.mkdir("listalltest", {"somefile": 1, "somefile2": 2})
             kd.mkdir("listalltest.subdir")
@@ -282,35 +377,7 @@ class TestKVS(unittest.TestCase):
             self.assertIn("somefile2", files)
             self.assertIn("subdir", directories)
 
-    def test_31_read_non_existent(self):
-        with self.assertRaises(KeyError):
-            print(
-                flux.kvs.KVSDir(self.f)[
-                    "crazykeythatclearlydoesntexistandneverwillinanyuniverse"
-                ]
-            )
-
-    def test_32_read_non_existent_basedir(self):
-        with self.assertRaisesRegex(EnvironmentError, "No such file"):
-            print(
-                flux.kvs.KVSDir(
-                    self.f, "crazykeythatclearlydoesntexistandneverwillinanyuniverse"
-                )
-            )
-
-    def test_33_iterator(self):
-        keys = ["testdir1a." + str(x) for x in range(1, 15)]
-        with flux.kvs.get_dir(self.f) as kd:
-            for k in keys:
-                kd[k] = "bar"
-
-        with flux.kvs.get_dir(self.f, "testdir1a") as kd:
-            print(kd.keys())
-            for k, v in kd.items():
-                self.assertEqual(v, "bar")
-                print("passed {}".format(k))
-
-    def test_34_walk(self):
+    def test_misc_01_walk(self):
         keys = ["testwalk." + str(x) for x in range(1, 15)]
         with flux.kvs.get_dir(self.f) as kd:
             for k in keys:
@@ -326,76 +393,9 @@ class TestKVS(unittest.TestCase):
         for r, ds, fs in walk_gen:
             pass
 
-    def test_35_walk_with_no_handle(self):
+    def test_misc_02_walk_with_no_handle(self):
         with self.assertRaises(ValueError):
             flux.kvs.walk("dir").next()
-
-    def test_36_put_mkdir(self):
-        flux.kvs.put_mkdir(self.f, "txn_mkdir")
-        flux.kvs.commit(self.f)
-        self.assertTrue(flux.kvs.exists(self.f, "txn_mkdir"))
-
-    def test_37_put_unlink(self):
-        flux.kvs.put(self.f, "txn_unlink", 1)
-        flux.kvs.commit(self.f)
-        flux.kvs.put_unlink(self.f, "txn_unlink")
-        flux.kvs.commit(self.f)
-        self.assertFalse(flux.kvs.exists(self.f, "txn_unlink"))
-
-    def test_38_put_symlink(self):
-        flux.kvs.put_symlink(self.f, "txn_symlink", "txn_target")
-        flux.kvs.commit(self.f)
-        self.assertFalse(flux.kvs.exists(self.f, "txn_symlink"))
-
-    def bad_input(self, func, *args):
-        with self.assertRaises(OSError) as ctx:
-            func(*args)
-        self.assertEqual(ctx.exception.errno, errno.EINVAL)
-
-    def test_39_exists_bad_input(self):
-        self.bad_input(flux.kvs.exists, self.f, "")
-
-    def test_40_isdir_bad_input(self):
-        self.bad_input(flux.kvs.isdir, self.f, "")
-
-    def test_41_get_bad_input(self):
-        self.bad_input(flux.kvs.get, self.f, "")
-
-    def test_42_get_dir_bad_input(self):
-        self.bad_input(flux.kvs.get_dir, self.f, "")
-
-    def test_43_put_exception_bad_input(self):
-        self.bad_input(flux.kvs.put, self.f, "", "")
-
-    def test_44_put_mkdir_exception_bad_input(self):
-        self.bad_input(flux.kvs.put_mkdir, self.f, "")
-
-    def test_45_put_unlink_bad_input(self):
-        self.bad_input(flux.kvs.put_unlink, self.f, "")
-
-    def test_46_put_symlink_bad_input(self):
-        self.bad_input(flux.kvs.put_symlink, self.f, "", "")
-
-    # try to overwrite root dir, will fail on commit
-    def test_47_commit_fail(self):
-        with self.assertRaises(OSError) as ctx:
-            flux.kvs.put(self.f, ".", "foof")
-            flux.kvs.commit(self.f)
-        self.assertEqual(ctx.exception.errno, errno.EINVAL)
-
-        # Issue #5333, make sure internal bad transaction cleared and
-        # subsequent commit works
-        flux.kvs.commit(self.f)
-
-    # just testing that passing flags work, these are pitiful KVS
-    # changes and the flags don't mean much
-    def test_48_commit_flags(self):
-        flux.kvs.put(self.f, "commitflags", "foo")
-        flux.kvs.commit(self.f, flux.constants.FLUX_KVS_NO_MERGE)
-        flux.kvs.put(self.f, "commitflags", "baz")
-        flux.kvs.commit(self.f, flux.constants.FLUX_KVS_TXN_COMPACT)
-        flux.kvs.put(self.f, "commitflags", "bar")
-        flux.kvs.commit(self.f, flux.constants.FLUX_KVS_SYNC)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
GAH, another "initial path" bug in KVSDir.  I missed this one in the `__delitem__` item accessor.

I stole some cleanup from PR #5373 to put at the beginning of this PR since it would make the test numbering update easier.  This one now comes first in the chain of PRs.