### PR TITLE
docker-deploy: only push latest when arch is 64-bit

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ queue_rules:
       - status-success="flux-sched check"
       - status-success="flux-accounting check"
       - status-success="python linting"
-      - status-success="jammy"
+      - status-success="jammy - test-install"
       - status-success="bookworm"
       - status-success="bookworm - 32 bit"
       - status-success="bookworm - gcc-12,content-s3,distcheck"

--- a/src/test/docker-deploy.sh
+++ b/src/test/docker-deploy.sh
@@ -21,7 +21,7 @@ log "docker push ${DOCKER_TAG}"
 docker push ${DOCKER_TAG}
 
 #  If this is the bookworm build, then also tag without image name:
-if echo "$DOCKER_TAG" | grep -q "bookworm"; then
+if echo "$DOCKER_TAG" | grep "bookworm" | grep -qv "386"; then
     t="${DOCKER_REPO}:${GITHUB_TAG:-latest}"
     log "docker push ${t}"
     docker tag "$DOCKER_TAG" ${t} && docker push ${t}


### PR DESCRIPTION
Apparently had a mistake in there.  On merge to master, the new default bookworm containers all went up, but the 386 version got tagged latest rather than the amd64 version.  This should fix that.