### PR TITLE
actions: add merge_group trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [pull_request, push]
+on: [pull_request, push, merge_group]
 name: ci
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Add the marge_group trigger in case we want to test out the github native merge queue functionality.  Just add that in, has no effect until and unless we enable the merge queue branch protection.