### PR TITLE
testsuite: fix race in t0005-exec.t signal test

### DIFF
--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -188,9 +188,11 @@ test_expect_success 'signal forwarding works' '
 	cat >test_signal.sh <<-EOF &&
 	#!/bin/bash
 	sig=\${1-INT}
+	mkfifo input.fifo
 	stdbuf --output=L \
-	    flux exec -n sh -c "echo hi; sleep 100" >sleepready.out 2>&1 &
-	$waitfile -t 20 -p ^hi -c ${SIZE} sleepready.out &&
+	    flux exec -v -n awk "BEGIN {print \"hi\"} {print}" input.fifo \
+	        >sleepready.out &
+	$waitfile -vt 20 -p ^hi -c ${SIZE} sleepready.out &&
 	kill -\$sig %1 &&
 	wait %1
 	exit \$?


### PR DESCRIPTION
Problem: If the signal in the signal forwarding test in t0005-exec.t is delivered after the "hi" sentinel is printed but before sleep(1) is executed, then bash ignores the signal and the test will timeout and fail.

To prevent the race use awk instead of a bash script, so that there is no point where the delivered signal will not be handled.  The awk script prints the sentinel then reads from a fifo in order to block indefinitely (stdin in sharness may be closed), so there are no extra subprocesses involved.

Fixes #5382