### PR TITLE
broker: refactor broker module loading code and fix minor bugs

### DIFF
--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -28,6 +28,8 @@ libbroker_la_SOURCES = \
 	brokercfg.h \
 	module.c \
 	module.h \
+	modhash.c \
+	modhash.h \
 	modservice.c \
 	modservice.h \
 	overlay.h \

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1223,7 +1223,6 @@ static int load_module (broker_ctx_t *ctx,
                              name,
                              path,
                              ctx->rank,
-                             ctx->attrs,
                              args,
                              error)))
         goto error;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -579,13 +579,12 @@ static void init_attrs_from_environment (attr_t *attrs)
 {
     struct attrmap *m;
     const char *val;
-    int flags = 0;  // XXX possibly these should be immutable?
 
     for (m = &attrmap[0]; m->env != NULL; m++) {
         val = getenv (m->env);
         if (!val && m->required)
             log_msg_exit ("required environment variable %s is not set", m->env);
-        if (attr_add (attrs, m->attr, val, flags) < 0)
+        if (attr_add (attrs, m->attr, val, ATTR_IMMUTABLE) < 0)
             log_err_exit ("attr_add %s", m->attr);
         if (m->sanitize)
             unsetenv (m->env);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1875,7 +1875,7 @@ static int module_insmod_respond (flux_t *h, module_t *p)
     int rc;
     int errnum = 0;
     int status = module_get_status (p);
-    flux_msg_t *msg = module_pop_insmod (p);
+    const flux_msg_t *msg = module_pop_insmod (p);
 
     if (msg == NULL)
         return 0;
@@ -1889,18 +1889,18 @@ static int module_insmod_respond (flux_t *h, module_t *p)
     else
         rc = flux_respond_error (h, msg, errnum, NULL);
 
-    flux_msg_destroy (msg);
+    flux_msg_decref (msg);
     return rc;
 }
 
 static int module_rmmod_respond (flux_t *h, module_t *p)
 {
-    flux_msg_t *msg;
+    const flux_msg_t *msg;
     int rc = 0;
     while ((msg = module_pop_rmmod (p))) {
         if (flux_respond (h, msg, NULL) < 0)
             rc = -1;
-        flux_msg_destroy (msg);
+        flux_msg_decref (msg);
     }
     return rc;
 }

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -39,7 +39,7 @@ struct broker {
     struct service_switch *services;
     struct brokercfg *config;
     double heartbeat_rate;
-    zlist_t *subscriptions;     /* subscripts for internal services */
+    struct subhash *sub;        /* subscriptions for internal services */
     struct content_cache *cache;
     struct publisher *publisher;
     struct groups *groups;

--- a/src/broker/brokercfg.c
+++ b/src/broker/brokercfg.c
@@ -23,7 +23,7 @@
 #include "src/common/libutil/fsd.h"
 
 #include "attr.h"
-#include "module.h"
+#include "modhash.h"
 #include "brokercfg.h"
 
 
@@ -475,7 +475,7 @@ static flux_future_t *reload_module_configs (flux_t *h, struct brokercfg *cfg)
     if (!(cf = flux_future_wait_all_create ()))
         return NULL;
     flux_future_set_flux (cf, h);
-    module = module_first (cfg->modhash);
+    module = modhash_first (cfg->modhash);
     while (module) {
         flux_future_t *f;
         char topic[1024];
@@ -493,7 +493,7 @@ static flux_future_t *reload_module_configs (flux_t *h, struct brokercfg *cfg)
             flux_future_destroy (f);
             goto error;
         }
-        module = module_next (cfg->modhash);
+        module = modhash_next (cfg->modhash);
     }
     return cf;
 error:

--- a/src/broker/brokercfg.h
+++ b/src/broker/brokercfg.h
@@ -11,6 +11,10 @@
 #ifndef _BROKER_BROKERCFG_H
 #define _BROKER_BROKERCFG_H
 
+#include <flux/core.h>
+#include "attr.h"
+#include "modhash.h"
+
 struct brokercfg;
 
 struct brokercfg *brokercfg_create (flux_t *h,

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -1,0 +1,204 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/iterators.h"
+#include "ccan/str/str.h"
+
+#include "module.h"
+#include "modhash.h"
+
+struct modhash {
+    zhash_t *zh_byuuid;
+};
+
+int modhash_response_sendmsg (modhash_t *mh, const flux_msg_t *msg)
+{
+    const char *uuid;
+    module_t *p;
+
+    if (!msg)
+        return 0;
+    if (!(uuid = flux_msg_route_last (msg))) {
+        errno = EPROTO;
+        return -1;
+    }
+    if (!(p = zhash_lookup (mh->zh_byuuid, uuid))) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return module_sendmsg (p, msg);
+}
+
+void modhash_add (modhash_t *mh, module_t *p)
+{
+    int rc;
+
+    rc = zhash_insert (mh->zh_byuuid, module_get_uuid (p), p);
+    assert (rc == 0); /* uuids are by definition unique */
+    zhash_freefn (mh->zh_byuuid,
+                  module_get_uuid (p),
+                  (zhash_free_fn *)module_destroy);
+}
+
+void modhash_remove (modhash_t *mh, module_t *p)
+{
+    zhash_delete (mh->zh_byuuid, module_get_uuid (p));
+}
+
+modhash_t *modhash_create (void)
+{
+    modhash_t *mh = calloc (1, sizeof (*mh));
+    if (!mh)
+        return NULL;
+    if (!(mh->zh_byuuid = zhash_new ())) {
+        errno = ENOMEM;
+        modhash_destroy (mh);
+        return NULL;
+    }
+    return mh;
+}
+
+void modhash_destroy (modhash_t *mh)
+{
+    int saved_errno = errno;
+    const char *uuid;
+    module_t *p;
+
+    if (mh) {
+        if (mh->zh_byuuid) {
+            FOREACH_ZHASH (mh->zh_byuuid, uuid, p) {
+                flux_error_t error;
+                if (module_cancel (p, &error) < 0)
+                    log_msg ("%s: %s", module_get_name (p), error.text);
+            }
+            zhash_destroy (&mh->zh_byuuid);
+        }
+        free (mh);
+    }
+    errno = saved_errno;
+}
+
+static json_t *modhash_entry_tojson (module_t *p,
+                                     double now,
+                                     struct service_switch *sw)
+{
+    json_t *svcs;
+    json_t *entry = NULL;
+
+    if (!(svcs  = service_list_byuuid (sw, module_get_uuid (p))))
+        return NULL;
+    entry = json_pack ("{s:s s:s s:i s:i s:O}",
+                       "name", module_get_name (p),
+                       "path", module_get_path (p),
+                       "idle", (int)(now - module_get_lastseen (p)),
+                       "status", module_get_status (p),
+                       "services", svcs);
+    json_decref (svcs);
+    return entry;
+}
+
+json_t *modhash_get_modlist (modhash_t *mh,
+                             double now,
+                             struct service_switch *sw)
+{
+    json_t *mods = NULL;
+    module_t *p;
+
+    if (!(mods = json_array()))
+        goto nomem;
+    p = zhash_first (mh->zh_byuuid);
+    while (p) {
+        json_t *entry;
+
+        if (!(entry = modhash_entry_tojson (p, now, sw))
+            || json_array_append_new (mods, entry) < 0) {
+            json_decref (entry);
+            goto nomem;
+        }
+        p = zhash_next (mh->zh_byuuid);
+    }
+    return mods;
+nomem:
+    json_decref (mods);
+    errno = ENOMEM;
+    return NULL;
+}
+
+module_t *modhash_lookup (modhash_t *mh, const char *uuid)
+{
+    module_t *m;
+
+    if (!(m = zhash_lookup (mh->zh_byuuid, uuid))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return m;
+}
+
+module_t *modhash_lookup_byname (modhash_t *mh, const char *name)
+{
+    zlist_t *uuids;
+    char *uuid;
+    module_t *result = NULL;
+
+    if (!(uuids = zhash_keys (mh->zh_byuuid))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    uuid = zlist_first (uuids);
+    while (uuid) {
+        module_t *p = zhash_lookup (mh->zh_byuuid, uuid);
+        if (p) {
+            if (streq (module_get_name (p), name)
+                || streq (module_get_path (p), name)) {
+                result = p;
+                break;
+            }
+        }
+        uuid = zlist_next (uuids);
+    }
+    zlist_destroy (&uuids);
+    return result;
+}
+
+int modhash_event_mcast (modhash_t *mh, const flux_msg_t *msg)
+{
+    module_t *p;
+
+    p = zhash_first (mh->zh_byuuid);
+    while (p) {
+        if (module_event_cast (p, msg) < 0)
+            return -1;
+        p = zhash_next (mh->zh_byuuid);
+    }
+    return 0;
+}
+
+module_t *modhash_first (modhash_t *mh)
+{
+    return zhash_first (mh->zh_byuuid);
+}
+
+module_t *modhash_next (modhash_t *mh)
+{
+    return zhash_next (mh->zh_byuuid);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/broker/modhash.h
+++ b/src/broker/modhash.h
@@ -1,0 +1,66 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _BROKER_MODHASH_H
+#define _BROKER_MODHASH_H
+
+#include <jansson.h>
+
+#include "src/common/librouter/disconnect.h"
+
+#include "attr.h"
+#include "service.h"
+#include "module.h"
+
+typedef struct modhash modhash_t;
+
+/* Hash-o-modules, keyed by uuid
+ */
+modhash_t *modhash_create (void);
+void modhash_destroy (modhash_t *mh);
+
+void modhash_add (modhash_t *mh, module_t *p);
+void modhash_remove (modhash_t *mh, module_t *p);
+
+/* Send an event message to all modules that have matching subscription.
+ */
+int modhash_event_mcast (modhash_t *mh, const flux_msg_t *msg);
+
+/* Send a response message to the module whose uuid matches the
+ * next hop in the routing stack.
+ */
+int modhash_response_sendmsg (modhash_t *mh, const flux_msg_t *msg);
+
+/* Find a module matching 'uuid'.
+ */
+module_t *modhash_lookup (modhash_t *mh, const char *uuid);
+
+/* Find a module matching 'name'.
+ * Either the module name or the path given to module_add() works.
+ * N.B. this is a slow linear search - keep out of crit paths
+ */
+module_t *modhash_lookup_byname (modhash_t *mh, const char *name);
+
+/* Prepare RFC 5 'mods' array for lsmod response.
+ */
+json_t *modhash_get_modlist (modhash_t *mh,
+                             double now,
+                             struct service_switch *sw);
+
+/* Iterator
+ */
+module_t *modhash_first (modhash_t *mh);
+module_t *modhash_next (modhash_t *mh);
+
+#endif /* !_BROKER_MODHASH_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -115,7 +115,7 @@ static void *module_thread (void *arg)
     module_t *p = arg;
     sigset_t signal_set;
     int errnum;
-    char *uri = NULL;
+    char uri[UUID_STR_LEN + 16];
     char **av = NULL;
     int ac;
     int mod_main_errno = 0;
@@ -127,10 +127,7 @@ static void *module_thread (void *arg)
 
     /* Connect to broker socket, enable logging, register built-in services
      */
-    if (asprintf (&uri, "shmem://%s", p->uuid_str) < 0) {
-        log_err ("asprintf");
-        goto done;
-    }
+    snprintf (uri, sizeof (uri), "shmem://%s", p->uuid_str);
     if (!(p->h = flux_open (uri, 0))) {
         log_err ("flux_open %s", uri);
         goto done;
@@ -211,7 +208,6 @@ static void *module_thread (void *arg)
     }
     flux_future_destroy (f);
 done:
-    free (uri);
     free (av);
     flux_close (p->h);
     p->h = NULL;

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -12,43 +12,37 @@
 #define _BROKER_MODULE_H
 
 #include <jansson.h>
+#include <czmq.h>
+#include <uuid.h>
+#ifndef UUID_STR_LEN
+#define UUID_STR_LEN 37     // defined in later libuuid headers
+#endif
+#include <flux/core.h>
 
 #include "src/common/librouter/disconnect.h"
 
 #include "attr.h"
-#include "service.h"
 
 typedef struct broker_module module_t;
-typedef struct modhash modhash_t;
 typedef void (*modpoller_cb_f)(module_t *p, void *arg);
 typedef void (*module_status_cb_f)(module_t *p, int prev_status, void *arg);
 
-/* Hash-o-modules, keyed by uuid
- */
-modhash_t *modhash_create (void);
-void modhash_destroy (modhash_t *mh);
+module_t *module_create (flux_t *h,
+                         const char *parent_uuid,
+                         const char *name, // may be NULL
+                         const char *path,
+                         int rank,
+                         attr_t *attrs,
+                         json_t *args,
+                         flux_error_t *error);
+void module_destroy (module_t *p);
 
-void modhash_initialize (modhash_t *mh,
-                         flux_t *h,
-                         const char *uuid,
-                         attr_t *attrs);
-
-/* Prepare module at 'path' for starting.
- */
-module_t *module_add (modhash_t *mh,
-                      const char *name, // may be NULL
-                      const char *path,
-                      json_t *args,
-                      flux_error_t *error);
-void module_remove (modhash_t *mh, module_t *p);
-
-/* Get module name.
+/* accessors
  */
 const char *module_get_name (module_t *p);
-
-/* Get module uuid.
- */
+const char *module_get_path (module_t *p);
 const char *module_get_uuid (module_t *p);
+double module_get_lastseen (module_t *p);
 
 /* The poller callback is called when module socket is ready for
  * reading with module_recvmsg().
@@ -69,15 +63,6 @@ int module_disconnect_arm (module_t *p,
                            disconnect_send_f cb,
                            void *arg);
 
-/* Send an event message to all modules that have matching subscription.
- */
-int module_event_mcast (modhash_t *mh, const flux_msg_t *msg);
-
-/* Subscribe/unsubscribe module by uuid
- */
-int module_subscribe (modhash_t *mh, const char *uuid, const char *topic);
-int module_unsubscribe (modhash_t *mh, const char *uuid, const char *topic);
-
 int module_push_rmmod (module_t *p, const flux_msg_t *msg);
 flux_msg_t *module_pop_rmmod (module_t *p);
 int module_push_insmod (module_t *p, const flux_msg_t *msg);
@@ -92,41 +77,27 @@ void module_set_status_cb (module_t *p, module_status_cb_f cb, void *arg);
 int module_get_errnum (module_t *p);
 void module_set_errnum (module_t *p, int errnum);
 
-/* Send a response message to the module whose uuid matches the
- * next hop in the routing stack.
- */
-int module_response_sendmsg (modhash_t *mh, const flux_msg_t *msg);
-
-/* Find a module matching 'uuid'.
- */
-module_t *module_lookup (modhash_t *mh, const char *uuid);
-
-/* Find a module matching 'name'.
- * Either the module name or the path given to module_add() works.
- * N.B. this is a slow linear search - keep out of crit paths
- */
-module_t *module_lookup_byname (modhash_t *mh, const char *name);
-
 /* Start module thread.
  */
 int module_start (module_t *p);
 
 /* Stop module thread by sending a shutdown request.
  */
-int module_stop (module_t *p);
+int module_stop (module_t *p, flux_t *h);
 
 /*  Mute module. Do not send any more messages.
  */
 void module_mute (module_t *p);
 
-/* Prepare RFC 5 'mods' array for lsmod response.
+/* Call pthread_cancel() on module.
  */
-json_t *module_get_modlist (modhash_t *mh, struct service_switch *sw);
+int module_cancel (module_t *p, flux_error_t *error);
 
-/* Iterator
+/* Manage module subscriptions.
  */
-module_t *module_first (modhash_t *mh);
-module_t *module_next (modhash_t *mh);
+int module_subscribe (module_t *p, const char *topic);
+void module_unsubscribe (module_t *p, const char *topic);
+int module_event_cast (module_t *p, const flux_msg_t *msg);
 
 #endif /* !_BROKER_MODULE_H */
 

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -61,9 +61,9 @@ int module_disconnect_arm (module_t *p,
                            void *arg);
 
 int module_push_rmmod (module_t *p, const flux_msg_t *msg);
-flux_msg_t *module_pop_rmmod (module_t *p);
+const flux_msg_t *module_pop_rmmod (module_t *p);
 int module_push_insmod (module_t *p, const flux_msg_t *msg);
-flux_msg_t *module_pop_insmod (module_t *p);
+const flux_msg_t *module_pop_insmod (module_t *p);
 
 /* Get/set module status.
  */

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -93,7 +93,7 @@ int module_cancel (module_t *p, flux_error_t *error);
 /* Manage module subscriptions.
  */
 int module_subscribe (module_t *p, const char *topic);
-void module_unsubscribe (module_t *p, const char *topic);
+int module_unsubscribe (module_t *p, const char *topic);
 int module_event_cast (module_t *p, const flux_msg_t *msg);
 
 #endif /* !_BROKER_MODULE_H */

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -21,8 +21,6 @@
 
 #include "src/common/librouter/disconnect.h"
 
-#include "attr.h"
-
 typedef struct broker_module module_t;
 typedef void (*modpoller_cb_f)(module_t *p, void *arg);
 typedef void (*module_status_cb_f)(module_t *p, int prev_status, void *arg);
@@ -32,7 +30,6 @@ module_t *module_create (flux_t *h,
                          const char *name, // may be NULL
                          const char *path,
                          int rank,
-                         attr_t *attrs,
                          json_t *args,
                          flux_error_t *error);
 void module_destroy (module_t *p);

--- a/src/broker/publisher.c
+++ b/src/broker/publisher.c
@@ -18,6 +18,7 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libccan/ccan/base64/base64.h"
+#include "src/common/librouter/subhash.h"
 #include "ccan/str/str.h"
 
 #include "modhash.h"
@@ -151,35 +152,6 @@ error_restore_seq:
     return -1;
 }
 
-static int broker_subscribe (struct broker *ctx, const char *topic)
-{
-    char *cpy;
-
-    if (!(cpy = strdup (topic)))
-        return -1;
-    if (zlist_append (ctx->subscriptions, cpy) < 0)
-        goto nomem;
-    zlist_freefn (ctx->subscriptions, cpy, free, true);
-    return 0;
-nomem:
-    free (cpy);
-    errno = ENOMEM;
-    return -1;
-}
-
-static void broker_unsubscribe (struct broker *ctx, const char *topic)
-{
-    char *s = zlist_first (ctx->subscriptions);
-    while (s) {
-        if (streq (s, topic)) {
-            zlist_remove (ctx->subscriptions, s);
-            break;
-        }
-        s = zlist_next (ctx->subscriptions);
-    }
-}
-
-
 static void subscribe_cb (flux_t *h, flux_msg_handler_t *mh,
                           const flux_msg_t *msg, void *arg)
 {
@@ -196,7 +168,7 @@ static void subscribe_cb (flux_t *h, flux_msg_handler_t *mh,
             goto error;
     }
     else {
-        if (broker_subscribe (pub->ctx, topic) < 0)
+        if (subhash_subscribe (pub->ctx->sub, topic) < 0)
             goto error;
     }
     if (!flux_msg_is_noresponse (msg)
@@ -220,12 +192,14 @@ static void unsubscribe_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     if ((uuid = flux_msg_route_first (msg))) {
         module_t *p;
-        if (!(p = modhash_lookup (pub->ctx->modhash, uuid)))
+        if (!(p = modhash_lookup (pub->ctx->modhash, uuid))
+            || module_unsubscribe (p, topic) < 0)
             goto error;
-        module_unsubscribe (p, topic);
     }
-    else
-        broker_unsubscribe (pub->ctx, topic);
+    else {
+        if (subhash_unsubscribe (pub->ctx->sub, topic) < 0)
+            goto error;
+    }
     if (!flux_msg_is_noresponse (msg)
         && flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "error responding to unsubscribe request");

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -46,10 +46,14 @@ const char *flux_attr_get (flux_t *h, const char *name);
  */
 int flux_attr_set (flux_t *h, const char *name, const char *val);
 
-
 /* hotwire flux_attr_get()'s cache for testing */
 int flux_attr_set_cacheonly (flux_t *h, const char *name, const char *val);
 
+/* Iterate over the attribute names that are stored in the local
+ * attribute cache.
+ */
+const char *flux_attr_cache_first (flux_t *h);
+const char *flux_attr_cache_next (flux_t *h);
 
 /* Get "rank" attribute, and convert to an unsigned integer.
  * Returns 0 on success, or -1 on failure with errno set.

--- a/t/module/testmod.c
+++ b/t/module/testmod.c
@@ -33,9 +33,9 @@ int mod_main (flux_t *h, int argc, char **argv)
     flux_msg_handler_t **handlers = NULL;
     int rc;
 
-    /* Dynamically register a service name if requested.
-     */
     for (int i = 0; i < argc; i++) {
+        /* Dynamically register a service name if requested.
+         */
         if (strstarts (argv[i], "--service=")) {
             const char *service = argv[i] + 10;
             flux_future_t *f;
@@ -46,7 +46,7 @@ int mod_main (flux_t *h, int argc, char **argv)
             }
             flux_future_destroy (f);
         }
-        else if (streq (argv[0], "--init-failure")) {
+        else if (streq (argv[i], "--init-failure")) {
             flux_log (h, LOG_INFO, "aborting during init per test request");
             errno = EIO;
             return -1;

--- a/t/module/testmod.c
+++ b/t/module/testmod.c
@@ -66,6 +66,13 @@ int mod_main (flux_t *h, int argc, char **argv)
                 return -1;
             }
         }
+        else if (streq (argv[i], "--config-is-cached")) {
+            if (!flux_get_conf (h)) {
+                flux_log (h, LOG_ERR, "config object is not cached");
+                errno = ENOENT;
+                return -1;
+            }
+        }
     }
     if (flux_msg_handler_addvec_ex (h,
                                     flux_aux_get (h, "flux::name"),

--- a/t/module/testmod.c
+++ b/t/module/testmod.c
@@ -51,6 +51,21 @@ int mod_main (flux_t *h, int argc, char **argv)
             errno = EIO;
             return -1;
         }
+        else if (strstarts (argv[i], "--attr-is-cached=")) {
+            const char *attr = argv[i] + 17;
+            const char *name;
+            name = flux_attr_cache_first (h);
+            while (name) {
+                if (streq (attr, name))
+                    break;
+                name = flux_attr_cache_next (h);
+            }
+            if (name == NULL) {
+                flux_log (h, LOG_ERR, "attr %s is not present in cache", attr);
+                errno = ENOENT;
+                return -1;
+            }
+        }
     }
     if (flux_msg_handler_addvec_ex (h,
                                     flux_aux_get (h, "flux::name"),

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -267,6 +267,9 @@ test_expect_success 'module: log-stderr-level attribute is NOT cached' '
         test_must_fail flux module reload $testmod \
             --attr-is-cached=log-stderr-level
 '
+test_expect_success 'module: configuration object is cached' '
+        flux module reload -f $testmod --config-is-cached
+'
 test_expect_success 'module: remove testmod if loaded' '
         flux module remove -f testmod
 '

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -254,4 +254,22 @@ test_expect_success 'module with version ext can be loaded by name' '
 	grep testmod.so.0.0.0 modlist.out
 '
 
+test_expect_success 'module: rank attribute is cached' '
+        flux module load $testmod --attr-is-cached=rank
+'
+test_expect_success 'module: size attribute is cached' '
+        flux module reload $testmod --attr-is-cached=size
+'
+test_expect_success 'module: security.owner attribute is cached' '
+        flux module reload $testmod --attr-is-cached=security.owner
+'
+test_expect_success 'module: log-stderr-level attribute is NOT cached' '
+        test_must_fail flux module reload $testmod \
+            --attr-is-cached=log-stderr-level
+'
+test_expect_success 'module: remove testmod if loaded' '
+        flux module remove -f testmod
+'
+
+
 test_done

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -68,6 +68,7 @@ test_expect_success 'attach: --show-status properly accounts prolog-start events
 		| tail -1 \
 		| cut -f1 -d:) &&
 	test $first_starting_line -ge $last_prolog_finish_line &&
+	flux job wait-event $jobid2 clean &&
 	flux jobtap remove perilog-test.so
 '
 test_expect_success 'attach: shows output from job' '


### PR DESCRIPTION
This was some broker cleanup that was the beginning of  work to create a "module loader" standalone helper executable that could be used to optionally load broker modules in a separate address space.

I didn't get that done, but this cleanup is progress on its own.