### PR TITLE
job-manager: add flux_jobtap_jobspec_update_pack(3)

### DIFF
--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -74,7 +74,6 @@ struct jobtap {
     zhashx_t *plugins_byuuid;
     zlistx_t *jobstack;
     json_t *jobspec_update;
-    char last_error [128];
     bool configured;
 };
 

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -73,6 +73,7 @@ struct jobtap {
     zlistx_t *plugins;
     zhashx_t *plugins_byuuid;
     zlistx_t *jobstack;
+    json_t *jobspec_update;
     char last_error [128];
     bool configured;
 };
@@ -612,6 +613,26 @@ static int jobtap_topic_match_count (struct jobtap *jobtap,
     return count;
 }
 
+static int jobtap_post_jobspec_updates (struct jobtap *jobtap,
+                                        struct job *job)
+{
+    int rc;
+    int saved_errno;
+    if (!jobtap->jobspec_update)
+        return 0;
+    rc = event_job_post_pack (jobtap->ctx->event,
+                              job,
+                              "jobspec-update",
+                              0,
+                              "O",
+                              jobtap->jobspec_update);
+    saved_errno = errno;
+    json_decref (jobtap->jobspec_update);
+    jobtap->jobspec_update = NULL;
+    errno = saved_errno;
+    return rc;
+}
+
 static int jobtap_stack_call (struct jobtap *jobtap,
                               zlistx_t *plugins,
                               struct job *job,
@@ -638,6 +659,18 @@ static int jobtap_stack_call (struct jobtap *jobtap,
                       jobtap_plugin_name (p),
                       topic,
                       rc);
+            retcode = -1;
+            break;
+        }
+        /*  Post any pending jobspec updates now. This is done after
+         *  the callback returns to avoid rewriting jobspec during a
+         *  plugin callback that modifies it.
+         */
+        if (jobtap_post_jobspec_updates (jobtap, job) < 0) {
+            flux_log_error (jobtap->ctx->h,
+                            "jobtap: %s: %s: failed to apply jobspec updates",
+                            jobtap_plugin_name (p),
+                            topic);
             retcode = -1;
             break;
         }
@@ -2075,6 +2108,58 @@ int flux_jobtap_event_post_pack (flux_plugin_t *p,
     va_start (ap, fmt);
     rc = event_job_post_vpack (jobtap->ctx->event, job, name, 0, fmt, ap);
     va_end (ap);
+    return rc;
+}
+
+/* RFC 21 jobspec-update event keys must start with "attributes."
+ * Reject update events with keys that violate the RFC.
+ */
+static bool validate_jobspec_updates (json_t *o)
+{
+    const char *key;
+    json_t *entry;
+    json_object_foreach (o, key, entry) {
+        if (!strstarts (key, "attributes."))
+            return false;
+    }
+    return true;
+}
+
+int flux_jobtap_jobspec_update_pack (flux_plugin_t *p, const char *fmt, ...)
+{
+    int rc = -1;
+    int saved_errno;
+    va_list ap;
+    struct jobtap *jobtap;
+    json_t *o = NULL;
+    json_error_t error;
+
+    if (!p || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))) {
+        errno = EINVAL;
+        return -1;
+    }
+    va_start (ap, fmt);
+    o = json_vpack_ex (&error, 0, fmt, ap);
+    va_end (ap);
+    if (!o) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!validate_jobspec_updates (o)) {
+        errno = EINVAL;
+        goto out;
+    }
+    if (!jobtap->jobspec_update)
+        jobtap->jobspec_update = json_incref (o);
+    else if (json_object_update (jobtap->jobspec_update, o) < 0) {
+        errno = EINVAL;
+        goto out;
+    }
+    rc = 0;
+out:
+    saved_errno = errno;
+    json_decref (o);
+    errno = saved_errno;
     return rc;
 }
 

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -176,6 +176,21 @@ int flux_jobtap_event_post_pack (flux_plugin_t *p,
                                  const char *fmt,
                                  ...);
 
+/*  Post a request to update jobspec for the current job. Accumulated updates
+ *  will be applied once the current callback returns so that the jobspec is
+ *  not modified while the plugin may have references to it.
+ *
+ *  The update is defined by one or more period-delimited keys and values
+ *  specified by `fmt`, ..., e.g.
+ *
+ *      flux_jobtap_jobspec_update_pack (p,
+ *                                       "{s:i s:s}",
+ *                                       "attributes.system.duration", 3600,
+ *                                       "attributes.system.queue", "batch");
+ *
+ */
+int flux_jobtap_jobspec_update_pack (flux_plugin_t *p, const char *fmt, ...);
+
 /*  Return a flux_plugin_arg_t object for a job.
  *
  *  The result can then be unpacked with flux_plugin_arg_unpack(3) to get

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -482,6 +482,7 @@ check_LTLIBRARIES = \
 	job-manager/plugins/create-reject.la \
 	job-manager/plugins/perilog-test.la \
 	job-manager/plugins/config.la \
+	job-manager/plugins/jobspec-update.la \
 	stats/stats-basic.la \
 	stats/stats-immediate.la
 
@@ -981,6 +982,16 @@ job_manager_plugins_perilog_test_la_CPPFLAGS = \
 job_manager_plugins_perilog_test_la_LDFLAGS = \
 	$(fluxplugin_ldflags) -module -rpath /nowhere
 job_manager_plugins_perilog_test_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+job_manager_plugins_jobspec_update_la_SOURCES = \
+	job-manager/plugins/jobspec-update.c
+job_manager_plugins_jobspec_update_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_jobspec_update_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+job_manager_plugins_jobspec_update_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la
 
 hwloc_hwloc_convert_SOURCES = hwloc/hwloc-convert.c

--- a/t/job-manager/plugins/jobspec-update.c
+++ b/t/job-manager/plugins/jobspec-update.c
@@ -1,0 +1,155 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* jobspec-update.c - test flux_jobtop_jobspec_update_pack(3)
+ */
+
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+#include "ccan/str/str.h"
+#include "src/common/libutil/errprintf.h"
+
+static int get_and_update_jobspec_name (flux_error_t *errp,
+                                        flux_plugin_t *p,
+                                        flux_plugin_arg_t *args,
+                                        const char **cur_namep,
+                                        char *name)
+{
+    const char *current_name = NULL;
+    char *copy = NULL;
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:{s:{s?{s?{s?s}}}}}",
+                                "jobspec",
+                                "attributes",
+                                "system",
+                                "job",
+                                "name",
+                                &current_name) < 0) {
+        errprintf (errp,
+                   "failed to unpack job name: %s",
+                   flux_plugin_arg_strerror (args));
+        return -1;
+    }
+    if (current_name && !(copy = strdup (current_name))) {
+        errprintf (errp, "failed to copy job name");
+        return -1;
+    }
+
+    /*  Update job name in jobspec and ensure it doesn't change in this
+     *  function.
+     */
+    if (flux_jobtap_jobspec_update_pack (p,
+                                         "{s:s}",
+                                         "attributes.system.job.name",
+                                         name) < 0) {
+        errprintf (errp,
+                   "flux_jobtap_jobspec_update_pack: %s",
+                   strerror (errno));
+        goto error;
+    }
+    /*  Ensure name hasn't changed after update is posted.
+     */
+    if (copy && current_name && !(streq (current_name, copy))) {
+        errprintf (errp, "unpacked job name failed to match after update");
+        goto error;
+    }
+    /*  jobspec update with key not starting with attributes. should fail:
+     */
+    if (flux_jobtap_jobspec_update_pack (p, "{s:s}", "foo.bar", "baz") == 0) {
+        errprintf (errp,
+                   "update key not starting with attributes. not rejected");
+        goto error;
+    }
+    /*  Add a second key to update in another call:
+     */
+    if (flux_jobtap_jobspec_update_pack (p,
+                                         "{s:i}",
+                                         "attributes.system.update-test",
+                                         1) < 0) {
+        errprintf (errp,
+                   "flux_jobtap_jobspec_update_pack: %s",
+                   strerror (errno));
+        goto error;
+    }
+    if (cur_namep)
+        *cur_namep = current_name;
+    free (copy);
+    return 0;
+error:
+    free (copy);
+    return -1;
+}
+
+static int validate_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *data)
+{
+    flux_error_t error;
+    if (get_and_update_jobspec_name (&error, p, args, NULL, "validated") < 0)
+        flux_jobtap_reject_job (p, args, "jobspec-update: %s", error.text);
+    return 0;
+}
+
+static int depend_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *data)
+{
+    const char *name;
+    flux_error_t error;
+
+    if (get_and_update_jobspec_name (&error, p, args, &name, "depend") < 0) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "jobspec-update",
+                                     0,
+                                     "get_and_update_name failed: %s",
+                                     error.text);
+        return -1;
+    }
+    /*  Ensure jobspec was updated during validate
+     */
+    if (!name) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "jobspec-update", 0,
+                                     "expected job name was NULL");
+        return -1;
+    }
+    if (!streq (name, "validated")) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "jobspec-update", 0,
+                                     "expected job name 'validated' got %s",
+                                     name);
+        return -1;
+    }
+    return 0;
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.validate", validate_cb, NULL },
+    { "job.state.depend", depend_cb, NULL },
+    { 0 },
+};
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    if (flux_plugin_register (p, "jobspec-update", tab) < 0)
+        return -1;
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -507,6 +507,14 @@ test_expect_success 'job-manager: job.create can reject a job' '
 	grep nope submit.err
 '
 
+test_expect_success 'job-manager: plugins can update jobspec' '
+	flux jobtap load --remove=all ${PLUGINPATH}/jobspec-update.so &&
+	jobid=$(flux submit --job-name=test hostname) &&
+	flux job attach $jobid &&
+	flux job eventlog $jobid | grep jobspec-update &&
+	flux job eventlog $jobid | grep attributes.system.update-test
+'
+
 test_expect_success 'job-manager: plugin fails to load on config.update error' '
 	flux jobtap remove all &&
 	test_must_fail flux jobtap load ${PLUGINPATH}/config.so 2>config.err


### PR DESCRIPTION
This PR adds a convenience function for jobtap plugins that want to post a `jobspec-update` event.

The benefit of this function over using `flux_jobtap_event_post_pack(3)` directly is two-fold:
 - The `jobspec-update` event is delayed until after the callback for the current plugin returns, avoiding an update of the jobspec while the callback may be holding some pointers to it as a result of `flux_plugin_arg_unpack()`.
 - It allows some validation of the keys being updated (e.g. RFC 21 specifies they must start with `attributes.`)

The addition of a basic test here also exercises the processing of the `jobspec-update` event in the job manager, which doesn't seem to be tested at all presently.