### PR TITLE
testsuite: relax systemctl output parsing

### DIFF
--- a/t/t2412-sdexec-perilog.t
+++ b/t/t2412-sdexec-perilog.t
@@ -47,7 +47,7 @@ flux setattr log-stderr-level 1
 test_expect_success 'create flist.sh script' '
 	cat >flist.sh<<-EOT &&
 	#!/bin/sh
-	systemctl --user list-units --type=service | grep "active running"
+	systemctl --user list-units --type=service | grep "active[[:space:]]*running"
 	EOT
 	chmod +x flist.sh
 '


### PR DESCRIPTION
Problem: the t2412-sdexec-perilog.t test script expects exactly one space between output columns but this fails in some environments.

The failing environment is a Ubuntu 22.04 LTS system running systemd 249.11-0ubuntu3.9.

Allow any number of spaces between the columns.