### PR TITLE
flux-top: fix title when connected to instances that are not jobs

### DIFF
--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -226,7 +226,7 @@ static flux_jobid_t get_jobid (flux_t *h)
 static char * build_title (struct top *top, const char *title)
 {
     if (!title)
-        title = idf58 (top->id);
+        title = top->id == FLUX_JOBID_ANY ? "" : idf58 (top->id);
     return strdup (title);
 }
 

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -61,6 +61,13 @@ test_expect_success 'flux-top summary shows no jobs initially' '
 	grep "0 running" nojobs.out &&
 	grep "0 failed" nojobs.out
 '
+# Note: jpXCZedGfVQ is the base58 representation of FLUX_JOBID_ANY. We
+# grep for this value without f or ƒ in case build environment influences
+# presence of one of the other.
+#
+test_expect_success 'flux-top does not display FLUX_JOBID_ANY jobid in title' '
+	test_must_fail grep jpXCZedGfVQ nojobs.out
+'
 test_expect_success 'run a test job to completion' '
 	flux submit --wait -n1 flux start /bin/true >jobid &&
 	job_list_wait_state $(cat jobid) INACTIVE


### PR DESCRIPTION
This PR fixes the window title for `flux top` when connected to an instance that is not a job, e.g. a system instance or test instance started with `flux start`, etc.