### PR TITLE
flux-resource: support new "watch" subcommand

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -21,6 +21,8 @@ SYNOPSIS
 
 | **flux** **resource** **reload** [-f] [--xml] *path*
 
+| **flux** **resource** **watch** [-a] [-r]
+
 DESCRIPTION
 ===========
 
@@ -290,6 +292,23 @@ This command is primarily used in test.
 .. option:: -f, --force
 
   Do not fail if resource contain invalid ranks.
+
+watch
+-----
+
+.. program:: flux resource watch
+
+Output changes in resources from the *resource.eventlog* log as they
+occur.  May be useful when needing to see resource changes in real
+time.
+
+.. option:: -a, --all
+
+  Output all historical changes, not just new ones
+
+.. option:: -r, --ranks
+
+  Output ranks instead of hosts
 
 
 OUTPUT FORMAT

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -762,7 +762,6 @@ def main():
     reload_parser = subparsers.add_parser(
         "reload", formatter_class=flux.util.help_formatter()
     )
-    reload_parser.set_defaults(func=reload)
     reload_parser.add_argument("path", help="path to R or hwloc <rank>.xml dir")
     reload_parser.add_argument(
         "-x",
@@ -778,9 +777,9 @@ def main():
         default=False,
         help="allow resources to contain invalid ranks",
     )
+    reload_parser.set_defaults(func=reload)
 
     R_parser = subparsers.add_parser("R", formatter_class=flux.util.help_formatter())
-    R_parser.set_defaults(func=emit_R)
     R_parser.add_argument(
         "-s",
         "--states",
@@ -796,6 +795,7 @@ def main():
         + "provided as an idset or hostlist.",
     )
     R_parser.add_argument("--from-stdin", action="store_true", help=argparse.SUPPRESS)
+    R_parser.set_defaults(func=emit_R)
 
     args = parser.parse_args()
     args.func(args)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -176,6 +176,7 @@ TESTSCRIPTS = \
 	t2350-resource-list.t \
 	t2351-resource-status-input.t \
 	t2352-resource-cmd-config.t \
+	t2353-resource-cmd-watch.t \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
 	t2402-job-exec-dummy.t \

--- a/t/t2353-resource-cmd-watch.t
+++ b/t/t2353-resource-cmd-watch.t
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+test_description='flux-resource watch tests'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+# below, we will kill a broker in tests.  So we want to use system
+# personality.  System personality sets exit mode = leader, ensuring
+# flux start does not exit with error
+test_under_flux 4 system
+
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+# wait for count of 2 for all.out, we can't be guaranteed exact number
+# of lines, but we know atleast 2 because of rank 0 and rank > 0.
+test_expect_success NO_CHAIN_LINT 'flux-resource watch initial setup works' '
+        flux resource watch > watch.out &
+        pid=$!
+        echo $pid > watch.pid
+        flux resource watch --all > all.out &
+        pid=$!
+        echo $pid > all.pid
+        flux resource watch --ranks > ranks.out &
+        pid=$!
+        echo $pid > ranks.pid
+        $waitfile --count=2 --timeout=60 --pattern=online all.out &&
+        test_must_fail grep online watch.out &&
+        test_must_fail grep offline watch.out &&
+        test_must_fail grep drain watch.out &&
+        test_must_fail grep offline all.out &&
+        test_must_fail grep drain all.out &&
+        test_must_fail grep online ranks.out &&
+        test_must_fail grep offline ranks.out &&
+        test_must_fail grep drain ranks.out
+'
+test_expect_success 'take down a broker' '
+        flux overlay disconnect 3
+'
+test_expect_success NO_CHAIN_LINT 'flux-resource watch for offline' '
+        $waitfile --count=1 --timeout=60 --pattern=offline watch.out &&
+        $waitfile --count=1 --timeout=60 --pattern=offline all.out &&
+        $waitfile --count=1 --timeout=60 --pattern="offline 3" ranks.out
+'
+test_expect_success 'drain a rank' '
+        flux resource drain 2
+'
+test_expect_success NO_CHAIN_LINT 'flux-resource watch for drain' '
+        $waitfile --count=1 --timeout=60 --pattern=drain watch.out &&
+        $waitfile --count=1 --timeout=60 --pattern=drain all.out &&
+        $waitfile --count=1 --timeout=60 --pattern="drain   2" ranks.out
+'
+test_expect_success 'undrain a rank' '
+        flux resource undrain 2
+'
+test_expect_success NO_CHAIN_LINT 'flux-resource watch for undrain' '
+        $waitfile --count=1 --timeout=60 --pattern=undrain watch.out &&
+        $waitfile --count=1 --timeout=60 --pattern=undrain all.out &&
+        $waitfile --count=1 --timeout=60 --pattern="undrain 2" ranks.out
+'
+test_expect_success NO_CHAIN_LINT 'cleanup watches' '
+        kill $(cat watch.pid) &&
+        kill $(cat all.pid) &&
+        kill $(cat ranks.pid) &&
+        ! wait $(cat watch.pid) &&
+        ! wait $(cat all.pid) &&
+        ! wait $(cat ranks.pid)
+'
+test_done


### PR DESCRIPTION
Built on top of #5389.  Per a random idea I once had in #4792, support a `flux resource watch` command that watches and outputs resource changes as they occur by watching `resource.eventlog`.  The idea is to type it in your terminal when you leave work, and see what changed in your terminal when you get back in the next day.  Sample output:

```
2023-08-16T03:51:53 offline fake3
2023-08-16T03:51:53 drain   fake2
```

This was largely an exercise to make sure the recently added KVSWatch support in the Python kvs module is sorta useful.  And for the most part it works as intended.  Admittedly this is sort of just "neat" rather than a "must have" or "important".  But went ahead and add tests/documentation just in case people like it.

Some thoughts:

- should `job.EventLogEvent` be moved outside of `job/event.py` to a more general location?  I didn't do that here, but for consideration.

- I only support the options `--all` and `--ranks` for now.  An infinite number of output possibilities exist, but I think this is ok for now.
