### PR TITLE
matrix: add arm64 install-only builder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,3 +195,21 @@ jobs:
         files: flux-core*.tar.gz
         body: |
           View [Release Notes](https://github.com/${{ github.repository }}/blob/${{ matrix.tag }}/NEWS.md) for flux-core ${{ matrix.tag }}
+
+  generate-manifest:
+    name: Generate docker manifest
+    runs-on: ubuntu-latest
+    needs: [ci-checks]
+    env:
+      DOCKER_REPO: fluxrm/flux-core
+      DOCKER_USERNAME: travisflux
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TRAVISFLUX_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - name: make and push manifest as fluxrm/flux-core
+      if: >
+        (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
+      run: |
+        docker manifest create fluxrm/flux-core:bookworm fluxrm/flux-core:bookworm-amd64 fluxrm/flux-core:bookworm-386 fluxrm/flux-core:bookworm-arm64
+        docker manifest push fluxrm/flux-core:bookworm
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,6 +154,10 @@ jobs:
       uses: docker/setup-buildx-action@v2
       if: matrix.needs_buildx
 
+    - uses: dbhi/qus/action@main
+      with:
+        targets: aarch64
+
     - name: docker-run-checks
       env: ${{matrix.env}}
       run: ${{matrix.command}}

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -210,6 +210,7 @@ matrix.add_build(
     env=dict(
         TEST_INSTALL="t",
     ),
+    platform="linux/amd64",
     docker_tag=True,
 )
 

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -149,6 +149,16 @@ matrix.add_build(
     docker_tag=True,
 )
 
+# Debian: arm64, expensive, only on master and tags, only install
+if matrix.branch == 'master' or matrix.tag:
+    matrix.add_build(
+        name="bookworm - arm64",
+        image="bookworm",
+        platform="linux/arm64",
+        docker_tag=True,
+        command_args="--install-only ",
+    )
+
 # Debian: gcc-12, content-s3, distcheck
 matrix.add_build(
     name="bookworm - gcc-12,content-s3,distcheck",


### PR DESCRIPTION
This is a step-1 to supporting arm64 a bit better in CI.  If this is
fast enough, maybe we can get some occasional smoke tests on top of it
or something but it should make getting dev containers going easier at
the least.
