### PR TITLE
testsuite: handle job signal race in more tests

### DIFF
--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -140,6 +140,9 @@ test_expect_success 'submit jobs for job list testing' '
 	#
 	#  Submit a job and cancel it
 	#
+	# N.B. no need to handle issue #5210 here, the job will not
+	# run due to lack of resources.
+	#
 	jobid=`flux submit --job-name=canceledjob sleep 30` &&
 	fj_wait_event $jobid depend &&
 	flux cancel -m "mecanceled" $jobid &&


### PR DESCRIPTION
Problem: In commit

c851ecbb34d7a741030c25fd12a38e0c11f84b4c

a job signal race was worked around in t2800-jobs-cmd.t.  The same fix should have been applied to t2260-job-list.t but was not.

Solution: Carry over the same fixes to t2260-job-list.t.  Also add a small comment in t2800-jobs-cmd.t for why the signal race workaround isn't needed in one location.

Fixes #5399