### PR TITLE
extend ci-checks timeout for arm64 build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,6 +210,7 @@ jobs:
       if: >
         (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
       run: |
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker manifest create fluxrm/flux-core:bookworm fluxrm/flux-core:bookworm-amd64 fluxrm/flux-core:bookworm-386 fluxrm/flux-core:bookworm-arm64
         docker manifest push fluxrm/flux-core:bookworm
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
       DOCKER_USERNAME: travisflux
       DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TRAVISFLUX_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
       fail-fast: false


### PR DESCRIPTION
It got really, really close, but didn't quite finish in time on the master build.  Give it a bit more of a buffer before canceling.