### PR TITLE
job-manager: fix duration limit check for jobs with unset/unlimited duration

### DIFF
--- a/src/modules/job-manager/plugins/limit-duration.c
+++ b/src/modules/job-manager/plugins/limit-duration.c
@@ -191,21 +191,19 @@ static int check_limit (struct limit_duration *ctx,
                         const char *queue,
                         flux_error_t *error)
 {
-    if (duration != DURATION_UNLIMITED) {
-        double limit = ctx->general_limit;
-        double qlimit = queues_lookup (ctx->queues, queue);
+    double limit = ctx->general_limit;
+    double qlimit = queues_lookup (ctx->queues, queue);
 
-        if (qlimit != DURATION_INVALID)
-            limit = qlimit;
-        if (limit != DURATION_INVALID
-            && limit != DURATION_UNLIMITED
-            && duration > limit) {
-            char fsd[64];
-            fsd_format_duration_ex (fsd, sizeof (fsd), limit, 1);
-            return errprintf (error,
-                              "requested duration exceeds policy limit of %s",
-                              fsd);
-        }
+    if (qlimit != DURATION_INVALID)
+        limit = qlimit;
+    if (limit != DURATION_INVALID
+        && limit != DURATION_UNLIMITED
+        && (duration > limit || duration == DURATION_UNLIMITED)) {
+        char fsd[64];
+        fsd_format_duration_ex (fsd, sizeof (fsd), limit, 1);
+        return errprintf (error,
+                          "requested duration exceeds policy limit of %s",
+                          fsd);
     }
     return 0;
 }

--- a/t/t2221-job-manager-limit-duration.t
+++ b/t/t2221-job-manager-limit-duration.t
@@ -24,9 +24,6 @@ test_expect_success 'a job that exceeds policy.limits.duration is rejected' '
 	test_must_fail flux submit -t 1h /bin/true 2>duration.err &&
 	grep "exceeds policy limit of 1m" duration.err
 '
-test_expect_success 'a job that sets no explicit duration is accepted' '
-	flux submit /bin/true
-'
 test_expect_success 'a job that is under policy.limits.duration is accepted' '
 	flux submit -t 30s /bin/true
 '

--- a/t/t2221-job-manager-limit-duration.t
+++ b/t/t2221-job-manager-limit-duration.t
@@ -42,6 +42,9 @@ test_expect_success 'configure policy.limits.duration and queue duration' '
 test_expect_success 'a job that exceeds policy.limits.duration is rejected' '
 	test_must_fail flux submit --queue=debug -t 2h /bin/true
 '
+test_expect_success 'a job with no limit is also rejected' '
+	test_must_fail flux submit --queue=debug -t 0 /bin/true
+'
 test_expect_success 'but is accepted by a queue with higher limit' '
 	flux submit \
 	    --queue=batch \
@@ -52,6 +55,12 @@ test_expect_success 'and is rejected when it exceeds the queue limit' '
 	test_must_fail flux submit \
 	    --queue=batch \
 	    -t 16h \
+	    /bin/true
+'
+test_expect_success 'no limit is also rejected as exceeding the queue limit' '
+	test_must_fail flux submit \
+	    --queue=batch \
+	    -t 0 \
 	    /bin/true
 '
 test_expect_success 'a job that is under policy.limits.duration is accepted' '


### PR DESCRIPTION
This PR fixes an outdated design in the `limit-duration` job manager plugin which explicitly allows jobs with unlimited duration through, even if there is an applicable queue or general limit. This was probably the case so that a default could later be applied to the job, but since default are now applied in the job frobnicator at ingest time, this is no longer necessary and allows jobs with unlimited duration to submitted if there is a limit but no duration default.