### PR TITLE
job-manager: prevent jobspec-update events after a job has resources

### DIFF
--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -556,7 +556,9 @@ static int event_handle_jobspec_update (struct job *job, json_t *context)
     const char *path;
     json_t *val;
 
-    if (!job->jobspec_redacted)
+    if (!job->jobspec_redacted
+        || job->state == FLUX_JOB_STATE_RUN
+        || job->state == FLUX_JOB_STATE_CLEANUP)
         return -1;
     json_object_foreach (context, path, val) {
         if (jpath_set (job->jobspec_redacted, path, val) < 0)

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -492,6 +492,10 @@ int job_event_enqueue (struct job *job, int flags, json_t *entry)
 {
     json_t *wrap;
 
+    if (job->eventlog_readonly) {
+        errno = EROFS;
+        return -1;
+    }
     if (!(wrap = json_pack ("{s:i s:O}",
                             "flags", flags,
                             "entry", entry))

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -2130,10 +2130,16 @@ int flux_jobtap_jobspec_update_pack (flux_plugin_t *p, const char *fmt, ...)
     int saved_errno;
     va_list ap;
     struct jobtap *jobtap;
+    struct job * job;
     json_t *o = NULL;
     json_error_t error;
 
-    if (!p || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))) {
+    if (!p
+        || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))
+        || !(job = current_job (jobtap))
+        || job->state == FLUX_JOB_STATE_RUN
+        || job->state == FLUX_JOB_STATE_CLEANUP
+        || job->eventlog_readonly) {
         errno = EINVAL;
         return -1;
     }

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -188,6 +188,9 @@ int flux_jobtap_event_post_pack (flux_plugin_t *p,
  *                                       "attributes.system.duration", 3600,
  *                                       "attributes.system.queue", "batch");
  *
+ *  Returns -1 with errno set to EINVAL for invalid arguments, if there is
+ *  no current job, or if the current job is in RUN, CLEANUP, or INACTIVE
+ *  states.
  */
 int flux_jobtap_jobspec_update_pack (flux_plugin_t *p, const char *fmt, ...);
 

--- a/t/job-manager/plugins/jobspec-update.c
+++ b/t/job-manager/plugins/jobspec-update.c
@@ -139,9 +139,30 @@ static int depend_cb (flux_plugin_t *p,
     return 0;
 }
 
+static int run_cb (flux_plugin_t *p,
+                   const char *topic,
+                   flux_plugin_arg_t *args,
+                   void *data)
+{
+    /*  Jobspec update after RUN is expected to fail
+     */
+    if (flux_jobtap_jobspec_update_pack (p,
+                                         "{s:i}",
+                                         "attributes.system.run-update",
+                                         1) == 0) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "jobspec-update", 0,
+                                     "expected update failure, got success");
+    }
+    return 0;
+}
+
+
 static const struct flux_plugin_handler tab[] = {
     { "job.validate", validate_cb, NULL },
     { "job.state.depend", depend_cb, NULL },
+    { "job.state.run", run_cb, NULL },
     { 0 },
 };
 

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -512,7 +512,9 @@ test_expect_success 'job-manager: plugins can update jobspec' '
 	jobid=$(flux submit --job-name=test hostname) &&
 	flux job attach $jobid &&
 	flux job eventlog $jobid | grep jobspec-update &&
-	flux job eventlog $jobid | grep attributes.system.update-test
+	flux job eventlog $jobid | grep attributes.system.update-test &&
+	flux job eventlog $jobid | \
+		test_must_fail grep attributes.system.run-update
 '
 
 test_expect_success 'job-manager: plugin fails to load on config.update error' '


### PR DESCRIPTION
Almost all jobspec updates don't make any sense after the job has been allocated resources and the job starts running, but as noted by @chu11, there is currently nothing the job manager that prevents a `jobspec-update` event in job state from modifying the redacted jobspec.

This PR makes it an error if a `jobspec-update` event occurs in `RUN`, `CLEANUP` or `INACTIVE` states (actually, any event is prevented if the job is inactive now by checking the `eventlog_inactive` flag)

There is also one commit that adds missing support for bumping a job in `SCHED` back to `PRIORITY` on a `jobspec-update` event so that the priority can be recalculated and the `alloc` request restarted, but now I'm wondering if that commit belongs here or in a future PR that adds support for a job manager update service.