### PR TITLE
actions: update typo checker version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Check Spelling
-      uses: crate-ci/typos@7ad296c72fa8265059cc03d1eda562fbdfcd6df2 # v1.9.0
+      uses: crate-ci/typos@e477391cc0243daaeeb154a7bfa67cb7d6fc5831 # v1.16.8
 
   python-lint:
     name: python linting

--- a/.typos.toml
+++ b/.typos.toml
@@ -8,6 +8,7 @@ extend-exclude = [
   "src/common/libccan/*",
   "src/common/liblsd/*",
   "src/common/libtomlc99/*",
+  "src/common/libczmqcontainers/*",
   "src/bindings/python/flux/utils/parsedatetime/*",
   "t/sharness.sh",
   "src/common/libutil/sha1.c",
@@ -25,3 +26,7 @@ inout = "inout"
 trun = "trun"
 fullset = "fullset"
 mone = "mone"
+requestor = "requestor"
+requestors = "requestors"
+clen = "clen"
+WRONLY = "WRONLY"

--- a/NEWS.md
+++ b/NEWS.md
@@ -587,7 +587,7 @@ Other highlights include:
  * configure.ac: fix error message when running autogen.sh (#4590)
  * job-manager: print better errors on inactive move (#4586)
  * broker: fix use-after-free segfault (#4570)
- * python: uri: use path to current flux executable in lsf resovler (#4559)
+ * python: uri: use path to current flux executable in lsf resolver (#4559)
  * spack: add flux-core container build (#4561)
  * improve signal/noise ratio in systemd journal logs (#4560)
  * flux-mini: improve an error message and documentation for per-resource

--- a/src/broker/test/topology.c
+++ b/src/broker/test/topology.c
@@ -436,7 +436,7 @@ void test_custom (void)
     if (!topo)
         diag ("%s", error.text);
     ok (topo == NULL,
-        "topology_create custom failed with mistmatched topo and host size");
+        "topology_create custom failed with mismatched topo and host size");
 
     topo = topology_create ("custom:", 256, &error);
     topology_hosts_set (NULL);

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -2385,7 +2385,7 @@ void attach_exec_event_continuation (flux_future_t *f, void *arg)
 
     /*  If job is complete, and we haven't started watching
      *   output eventlog, then start now in case shell.init event
-     *   was never emitted (failure in iniitialization)
+     *   was never emitted (failure in initialization)
      */
     if (streq (name, "complete") && !ctx->output_f)
         attach_output_start (ctx);

--- a/src/common/libflux/fripp.h
+++ b/src/common/libflux/fripp.h
@@ -58,7 +58,7 @@ void fripp_set_agg_period (struct fripp_ctx *ctx, double period);
  */
 bool fripp_enabled (struct fripp_ctx *ctx);
 
-/* Set the prefix to be preprended to all metrics sent from the handle.
+/* Set the prefix to be prepended to all metrics sent from the handle.
  * The prefix has a max limit of 127 characters. The default prefix is
  * flux.{{rank}}.
  */

--- a/src/common/libflux/stats.h
+++ b/src/common/libflux/stats.h
@@ -64,7 +64,7 @@ void flux_stats_timing (flux_t *h, const char *name, double ms);
  */
 void flux_stats_set_period (flux_t *h, double period);
 
-/* Set the prefix to be preprended to all metrics sent from the handle.
+/* Set the prefix to be prepended to all metrics sent from the handle.
  * The prefix has a max limit of 127 characters. The default prefix is
  * flux.{{rank}}.
  */

--- a/src/common/libutil/test/dirwalk.c
+++ b/src/common/libutil/test/dirwalk.c
@@ -314,7 +314,7 @@ int main(int argc, char** argv)
                       find_dir,
                       NULL);
     ok (l != NULL && zlist_size (l) == 2,
-        "dirwalk_find FIND_DIR|NORECURSE vists top level directories");
+        "dirwalk_find FIND_DIR|NORECURSE visits top level directories");
     zlist_destroy (&l);
 
     flags = DIRWALK_FIND_DIR;

--- a/src/modules/content-s3/s3.c
+++ b/src/modules/content-s3/s3.c
@@ -224,7 +224,7 @@ int s3_put (struct s3_config *cfg,
         S3_put_object (&bucket_ctx,
                        key,
                        size,
-                       NULL, // putPorperties (NULL for none)
+                       NULL, // putProperties (NULL for none)
                        NULL, // requestContext (NULL for synchronous operation)
                        &put_obj_hndl,
                        &ctx);

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -649,11 +649,11 @@ static void watcher_respond (struct ns_monitor *nsm, struct watcher *w)
      * of w->lookups until an unfulfilled future is encountered, so that
      * responses are always returned to the watcher in commit order.
      *
-     * Security note: although the requestor has already been authenticated
+     * Security note: although the requester has already been authenticated
      * to access the namespace by check_authorization() above, we make the
-     * kvs.lookupat request with the requestor's creds, in case the key lookup
+     * kvs.lookupat request with the requester's creds, in case the key lookup
      * traverses to a new namespace.  Leave it up to the KVS module to ensure
-     * the requestor is permitted to access *that* namespace.
+     * the requester is permitted to access *that* namespace.
      *
      * Note on FLUX_KVS_WATCH_FULL: A lookup / comparison is done on every
      * change.

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -96,7 +96,7 @@ const char *lookup_get_namespace (lookup_t *lh);
  * root_ref will be the root_ref passed in via lookup_create() or the
  * root_ref used from the namespace.  The root_seq is only if the
  * root_ref was from a namespace.  Note that the values are not valid
- * unless the lookup completes (LOOKUP_PROCESS_FINISED).
+ * unless the lookup completes (LOOKUP_PROCESS_FINISHED).
  */
 const char *lookup_get_root_ref (lookup_t *lh);
 int lookup_get_root_seq (lookup_t *lh);

--- a/src/modules/kvs/test/kvsroot.c
+++ b/src/modules/kvs/test/kvsroot.c
@@ -228,7 +228,7 @@ void basic_iter_tests (void)
 
     count = 0;
     ok (kvsroot_mgr_iter_roots (krm, count_roots_early_exit_cb, &count) == 0,
-        "kvsroot_mgr_iter_roots works if exitting midway");
+        "kvsroot_mgr_iter_roots works if exiting midway");
 
     ok (count == 1,
         "kvsroot_mgr_iter_roots called callback correct number of times");


### PR DESCRIPTION
nothing fancy here, except I chose to add the british "requestor" to the false positives list, instead of change to use the american "requester".  Could fix of course ... we did away with the british "cancelled" awhile back.

Update: FWIW

```
>git grep -i "requestor" | wc -l
13
>git grep -i "requester" | wc -l
2
```

Edit:

Ok, googling more, I guess in computer programming circles "requestor" is liked more.  But I guess it doesn't really matter.
