### PR TITLE
flux-perilog-run: support prolog and epilog timeouts (default 30m)

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -2481,6 +2481,7 @@ static void attach_notify (struct attach_ctx *ctx,
     if (!event_name)
         return;
     if (ctx->statusline
+        && !ctx->fatal_exception
         && (msg = job_event_notify_string (event_name))) {
         int dt = ts - ctx->timestamp_zero;
         int width = 80;

--- a/src/cmd/flux-perilog-run.py
+++ b/src/cmd/flux-perilog-run.py
@@ -48,11 +48,6 @@ def unblock_signals():
     signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGTERM, signal.SIGINT})
 
 
-def process_create(cmd, stderr=None):
-    # pylint: disable=subprocess-popen-preexec-fn
-    return subprocess.Popen(cmd, preexec_fn=unblock_signals, stderr=stderr)
-
-
 async def get_children(pid):
     """
     Return a best effort list of pid and all current descendants

--- a/t/system/0002-exec-with-imp.t
+++ b/t/system/0002-exec-with-imp.t
@@ -81,3 +81,16 @@ test_expect_success HAVE_IMP 'flux-perilog-run --with-imp works' '
 	grep id=0 prolog-imp.out &&
 	grep "calling sleep 0" prolog-imp.out
 '
+test_expect_success HAVE_IMP 'flux-perilog-run --with-imp --timeout works' '
+	TEST_ARG=120 FLUX_JOB_ID=$(flux job last) \
+		test_expect_code 143 \
+		run_timeout 60 \
+		sudo -E -u flux \
+		flux perilog-run prolog --with-imp -t 1s -ve test \
+		    > prolog-imp-timeout.out &&
+	test_debug "cat prolog-imp-timeout.out" &&
+	jobid=$(flux job last) &&
+	sudo -u flux flux resource undrain $(flux jobs -no {ranks} $jobid) &&
+	grep id=0 prolog-imp-timeout.out &&
+	grep "calling sleep 120" prolog-imp-timeout.out
+'

--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -64,6 +64,15 @@ test_expect_success 'perilog: perilog-run fails if any local script fails' '
 	) &&
 	rm -f prolog.d/fail.sh
 '
+test_expect_success 'perilog: perilog-run timeout works with local scripts' '
+	printf "#!/bin/sh\nsleep 60" >prolog.d/timeout.sh &&
+	chmod +x prolog.d/timeout.sh &&
+	( export FLUX_JOB_ID=f1 &&
+	  test_expect_code 143 \
+	    flux perilog-run prolog --timeout=0.5s -vv -d prolog.d
+	) &&
+	rm -f prolog.d/timeout.sh
+'
 test_expect_success 'perilog: perilog-run --exec-per-rank works' '
 	jobid=$(flux submit -n4 -N4 true) &&
 	flux job wait-event $jobid alloc &&


### PR DESCRIPTION
This PR switches the `flux-perilog-run.py` script to run local and "per rank" prolog and epilog processes under a timeout. By default the timeout is 30m (maybe should be 1h or unlimited by default?), but a `-t, --timeout=FSD` option is added for timeout customization.

In order to more easily support execution of multiple processes under a timeout in this script, it has pretty much been rewritten to use `asyncio`. This has the added benefit that now all local and per-rank executions are done in parallel. There was a bit of other work necessary to make the signaling of timed out processes more reliable, etc.