### PR TITLE
job-list: allow updates to all of jobspec

### DIFF
--- a/src/modules/job-list/job_data.h
+++ b/src/modules/job-list/job_data.h
@@ -65,7 +65,6 @@ struct job {
 
     /* cache of job information */
     json_t *jobspec;
-    json_t *jobspec_tasks;
     json_t *R;
     json_t *exception_context;
 

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -2111,10 +2111,10 @@ test_expect_success 'run job in the default queue' '
 	wait_id_inactive $(cat update1.id)
 '
 
-# jobspec-update-job-list changes duration to 1000.0, job name to
-# "updatename", and queue to "updatequeue".
+# jobspec-update-job-list changes command to "hostname" (thus job name
+# changes), duration to 1000.0, queue to "updatequeue".
 test_expect_success 'job-list returns expected jobspec changes' '
-	flux job list -s inactive | grep $(cat update1.id) | jq -e ".name == \"updatename\"" &&
+	flux job list -s inactive | grep $(cat update1.id) | jq -e ".name == \"hostname\"" &&
 	flux job list -s inactive | grep $(cat update1.id) | jq -e ".queue == \"updatequeue\"" &&
 	flux job list -s inactive | grep $(cat update1.id) | jq -e ".duration == 1000.0"
 '
@@ -2154,7 +2154,7 @@ test_expect_success 'reload the job-list module' '
 '
 
 test_expect_success 'job-list returns expected jobspec changes after reload' '
-	flux job list -s inactive | grep $(cat update1.id) | jq -e ".name == \"updatename\"" &&
+	flux job list -s inactive | grep $(cat update1.id) | jq -e ".name == \"hostname\"" &&
 	flux job list -s inactive | grep $(cat update1.id) | jq -e ".queue == \"updatequeue\"" &&
 	flux job list -s inactive | grep $(cat update1.id) | jq -e ".duration == 1000.0"
 '


### PR DESCRIPTION
Per a recent update to RFC21, all fields in a jobspec can now be updated via a jobspec-update event.  