### PR TITLE
job-manager: support jobspec update to all fields

### DIFF
--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -597,7 +597,12 @@ bool validate_jobspec_updates (json_t *updates)
     const char *key;
     json_t *entry;
     json_object_foreach (updates, key, entry) {
-        if (!strstarts (key, "attributes."))
+        if (!streq (key, "attributes")
+            && !strstarts (key, "attributes.")
+            && !streq (key, "resources")
+            && !strstarts (key, "resources.")
+            && !streq (key, "tasks")
+            && !strstarts (key, "tasks."))
             return false;
     }
     return true;


### PR DESCRIPTION
Problem: An update to RFC21 allows all jobspec fields to be updated by a jobspec-update event.  However not all fields are allowed to be updated via the validate_jobspec_updates() function.

Solution: Allow all fields in current legal jobspecs to be updated.

-- 

A split off from #5418 