### PR TITLE
shell/pmi: warn if application might be using slurm's libpmi2.so

### DIFF
--- a/src/common/libpmi/simple_server.h
+++ b/src/common/libpmi/simple_server.h
@@ -46,6 +46,7 @@ struct pmi_simple_ops {
     void (*debug_trace)(void *client, const char *buf);
     void (*abort) (void *arg, void *cli,
                    int exit_code, const char error_message[]);
+    void (*warn)(void *client, const char *buf);
 };
 
 enum {

--- a/src/common/libpmi/test/server_thread.c
+++ b/src/common/libpmi/test/server_thread.c
@@ -162,6 +162,11 @@ void s_trace (void *arg, const char *buf)
     diag ("%s", buf);
 }
 
+void s_warn (void *arg, const char *buf)
+{
+    diag ("WARN: %s", buf);
+}
+
 struct pmi_server_context *pmi_server_create (int *cfd, int size)
 {
     char pmi_fd[16];
@@ -171,6 +176,7 @@ struct pmi_server_context *pmi_server_create (int *cfd, int size)
         .barrier_enter = s_barrier_enter,
         .response_send = s_send_response,
         .debug_trace = s_trace,
+        .warn = s_warn,
     };
     struct pmi_server_context *ctx;
     int i;

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -81,6 +81,12 @@ struct shell_pmi {
     struct pmi_exchange *exchange;
 };
 
+/* pmi_simple_ops->warn() signature */
+static void shell_pmi_warn (void *client, const char *msg)
+{
+    shell_warn ("%s", msg);
+}
+
 /* pmi_simple_ops->abort() signature */
 static void shell_pmi_abort (void *arg,
                              void *client,
@@ -473,6 +479,7 @@ static struct pmi_simple_ops shell_pmi_ops = {
     .response_send  = shell_pmi_response_send,
     .debug_trace    = shell_pmi_debug_trace,
     .abort          = shell_pmi_abort,
+    .warn           = shell_pmi_warn,
 };
 
 static int parse_args (json_t *config,


### PR DESCRIPTION
Problem: on a slurm system, it's easy to trip over the libpmi2.so that they install in libdir.

To get around that library's quirk of ignoring version negotiation, we already disabled PMI version negotiation in our server.   This converts a hang into a hard failure.  However, we didn't have a way for the protocol engine to warn the user what we suspect may be the cause.

Add a new callback so that the shell pmi plugin can call `shell_warn()` when the protocol engine encounters this situation:

```
$ flux run  -N2 flux pmi --method=libpmi2
flux-pmi: /lib/x86_64-linux-gnu/libpmi2.so: pmi error 14
flux-pmi: /lib/x86_64-linux-gnu/libpmi2.so: pmi error 14
0.047s: flux-shell[0]:  WARN: pmi-simple: is application unintentionally using slurm libpmi2.so?
flux-job: task(s) exited with exit code 1
```

Note: on the :coffee: discussion today I mentioned that I needed a change to subprocess buffering to parse PMI-2 protocol request.  That would be necessary if we wanted to retain the ability to do protocol negotiation.  This PR just adds the warning to the point where we refuse to negotiate, so no such changes needed.