### PR TITLE
cmd: add --with-imp options to flux-exec(1) and flux-perilog-run(1)

### DIFF
--- a/doc/man1/flux-exec.rst
+++ b/doc/man1/flux-exec.rst
@@ -63,6 +63,14 @@ OPTIONS
 **-q, --quiet**
    Suppress extraneous output (e.g. per-rank error exit status).
 
+**--with-imp**
+   Prepend ``/path/to/flux-imp run`` to *COMMANDS*. This option is mostly
+   meant for testing or as a convenience to execute a configured ``prolog``
+   or ``epilog`` command under the IMP. Note: When this option is used,
+   or if ``flux-imp`` is detected as the first argument of *COMMANDS*,
+   flux-exec(1) will use ``flux-imp kill`` to signal remote commands
+   instead of the normal builtin subprocess signaling mechanism.
+
 
 NODESET FORMAT
 ==============

--- a/src/cmd/flux-perilog-run.py
+++ b/src/cmd/flux-perilog-run.py
@@ -81,6 +81,8 @@ def run_per_rank(name, jobid, args):
 
     for rank in ranks:
         cmdv = ["flux", "exec", "-qn", f"-r{rank}"]
+        if args.with_imp:
+            cmdv.append("--with-imp")
         if args.sdexec:
             cmdv.append("--service=sdexec")
             cmdv.append(f"--setopt=SDEXEC_NAME={name}-{rank}-{jobid.f58plain}.service")
@@ -195,6 +197,11 @@ def main():
         + "rank of jobid set in FLUX_JOB_ID environment variable",
     )
     prolog_parser.add_argument(
+        "--with-imp",
+        action="store_true",
+        help="With --exec-per-rank, run CMD under 'flux-imp run'",
+    )
+    prolog_parser.add_argument(
         "-d",
         "--exec-directory",
         metavar="DIRECTORY",
@@ -217,6 +224,11 @@ def main():
         metavar="CMD[,ARGS...]",
         help="Use flux-exec(1) to run CMD and optional ARGS on each target "
         + "rank of jobid set in FLUX_JOB_ID environment variable",
+    )
+    epilog_parser.add_argument(
+        "--with-imp",
+        action="store_true",
+        help="With --exec-per-rank, run CMD under 'flux-imp run'",
     )
     epilog_parser.add_argument(
         "-d",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -317,6 +317,7 @@ EXTRA_DIST= \
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \
 	system/0001-basic.t \
+	system/0002-exec-with-imp.t \
 	system/0004-recovery.t \
 	issues/t0441-kvs-put-get.sh \
 	issues/t0505-msg-handler-reg.lua \

--- a/t/system/0002-exec-with-imp.t
+++ b/t/system/0002-exec-with-imp.t
@@ -1,0 +1,83 @@
+#
+#  flux-exec(1) --with-imp option works
+#
+IMP=$(flux config get exec.imp)
+test -n "$IMP" && test_set_prereq HAVE_IMP
+
+SIZE=$(flux getattr size)
+
+test_expect_success HAVE_IMP 'configure a flux-imp run command' '
+	confdir="/etc/flux/imp/conf.d" &&
+	cat <<-EOF >imp-run-test.toml &&
+	[run.test]
+	allowed-users = ["flux"]
+	allowed-environment = ["FLUX_*", "TEST_ARG"]
+	path = "$confdir/run-test.sh"
+	EOF
+	sudo cp imp-run-test.toml $confdir &&
+	cleanup "sudo rm -f $confdir/imp-run-test.toml" &&
+	sudo chmod 644 $confdir/imp-run-test.toml &&
+	cat <<-EOF >run-test.sh
+	#!/bin/sh
+	echo "calling sleep \$TEST_ARG"
+	echo "id=\$(id -u)"
+	sleep \$TEST_ARG
+	EOF
+	sudo cp run-test.sh $confdir &&
+	cleanup "sudo rm -f $confdr/run-test.sh" &&
+	sudo chmod 755 $confdir/run-test.sh
+'
+test_expect_success HAVE_IMP 'flux exec --with-imp works' '
+	TEST_ARG=0 sudo -u flux -E flux exec -vr 0 --with-imp test \
+		>with-imp.out 2>&1 &&
+	test_debug "cat with-imp.out" &&
+	grep id=0 with-imp.out &&
+	grep "calling sleep 0" with-imp.out
+'
+waitfile=$SHARNESS_TEST_SRCDIR/scripts/waitfile.lua
+
+# Need to create a test output directory writable by flux user and
+# readable by current user
+test_expect_success HAVE_IMP 'create test output directory' '
+	TESTDIR=$(mktemp --tmpdir=${TMPDIR:-/tmp} -d exec-with-impXXXX) &&
+	cleanup "rm -rf $TESTDIR" &&
+	chmod 777 $TESTDIR &&
+	test_debug "echo created test directory $TESTDIR"
+'
+test_expect_success HAVE_IMP 'flux exec --with-imp forwards signals' '
+	cat >test_signal.sh <<-EOF &&
+	#!/bin/bash
+        sig=\${1-INT}
+        TEST_ARG=60 stdbuf --output=L flux exec --with-imp -v -n test \
+                >${TESTDIR}/testready.out &
+        $waitfile -vt 20 -p ^id=0 -c ${SIZE} ${TESTDIR}/testready.out &&
+        kill -\$sig %1 &&
+        wait %1
+        exit \$?
+	EOF
+	chmod +x test_signal.sh &&
+	test_expect_code 130 run_timeout 30 sudo -u flux ./test_signal.sh INT &&
+	test_expect_code 143 run_timeout 30 sudo -u flux ./test_signal.sh TERM
+'
+test_expect_success HAVE_IMP 'flux exec flux-imp run forwards signals' '
+	cat >test_signal.sh <<-EOF &&
+	#!/bin/bash
+        sig=\${1-INT}
+        TEST_ARG=60 stdbuf --output=L flux exec -v -n $IMP run test \
+                >${TESTDIR}/testready2.out &
+        $waitfile -vt 20 -p ^id=0 -c ${SIZE} ${TESTDIR}/testready2.out &&
+        kill -\$sig %1 &&
+        wait %1
+        exit \$?
+	EOF
+	chmod +x test_signal.sh &&
+	test_expect_code 130 run_timeout 30 sudo -u flux ./test_signal.sh INT &&
+	test_expect_code 143 run_timeout 30 sudo -u flux ./test_signal.sh TERM
+'
+test_expect_success HAVE_IMP 'flux-perilog-run --with-imp works' '
+	flux run -vv hostname &&
+	TEST_ARG=0 FLUX_JOB_ID=$(flux job last) sudo -E -u flux \
+		flux perilog-run prolog --with-imp -ve test > prolog-imp.out &&
+	grep id=0 prolog-imp.out &&
+	grep "calling sleep 0" prolog-imp.out
+'

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -140,6 +140,12 @@ test_expect_success NO_ASAN 'flux exec passes non-zero exit status' '
 	test_expect_code 139 flux exec -n sh -c "kill -11 \$\$"
 '
 
+test_expect_success 'flux exec fails with --with-imp if no IMP configured' '
+	test_expect_code 1 flux exec --with-imp hostname 2>exec-no-imp.out &&
+	test_debug "cat exec-no-imp.out" &&
+	grep "exec\.imp path not found in config" exec-no-imp.out
+'
+
 test_expect_success NO_ASAN 'flux exec outputs tasks with errors' '
 	! flux exec -n sh -c "exit 2" > 2.out 2>&1 &&
         grep "\[0-3\]: Exit 2" 2.out &&


### PR DESCRIPTION
As suggested offline by @garlick, add a `--with-imp` convenience option to both `flux exec` and `flux perilog-run` that prepends `/path/to/flux-imp run` (fetched from instance configuration) to the command to be executed. Note this requires that the command be configured in the IMP `run` config. At this time this is mostly for `prolog` and `epilog` scripts.

In `flux-exec(1)`, when the `--with-imp` option is used or if `flux-imp` is the first argument of the command, `flux-imp kill` will be used to forward signals to remote processes instead of `flux_subprocess_kill()`. This allows the signals to actually be delivered to the processes spawned by `flux exec` since they are likely running with privilege.

Tests for this feature are added to the "system" ci tests since the IMP is required for a full functionality test.