### PR TITLE
support update of job queue

### DIFF
--- a/doc/man1/flux-update.rst
+++ b/doc/man1/flux-update.rst
@@ -73,6 +73,12 @@ SPECIAL KEYS
   is any string or number in RFC 23 Flux Standard Duration. Examples include
   ``60``, ``1m``, ``1.5h``, ``+10m``, ``-1h``.
 
+*attributes.system.queue*, *queue*
+  Updates of a pending job's ``queue`` to another enabled queue may
+  be allowed. The update could be rejected if the new job exceeds the
+  destination queue limits or if the job would not be feasible in the
+  new queue.
+
 *name*
   Alias for job name, i.e. ``attributes.system.job.name``
 

--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -272,6 +272,31 @@ attributes have this flag then this validation step is skipped. This can
 be useful to allow an instance owner to update a job attribute beyond limits
 for example.
 
+Some updates may benefit from a job feasibility check before the updates
+are applied. This prevents a user from inadvertently causing a job that
+was feasible at the time of submission to become infeasible through an
+update.  Because the update plugin is in the best position to determine
+if a feasibility check should be completed for an update, feasibility
+checks are only done if a ``feasibility`` flag in ``FLUX_PLUGIN_OUT_ARGS``
+is set. If any plugin for a set of updates requires a feasibility check,
+then feasibility of the updated jobspec as a whole will be checked. If
+the updated job is determined to be infeasible, then the update is aborted
+and an error returned to the user.
+
+The update of one attribute may require modification of other attributes.
+For example, an update of ``attributes.system.queue`` may require
+modification of ``attributes.system.constraints`` to apply the constraints
+of the new queue. To support this use case, plugins may additionally push
+an ``updates`` object onto ``FLUX_PLUGIN_OUT_ARGS``. This object has the
+same form as the ``jobspec-update`` context defined in RFC 21. For example,
+if a plugin wishes to update ``attributes.system.foo`` to 1, it can set ::
+
+   {"updates": {"attributes.system.foo": 1}}
+
+in the ``FLUX_PLUGIN_OUT_ARGS`` before returning. Updates are applied by
+updating the requested updates, so this method could overwrite other user-
+requested updates and caution is advised.
+
 PLUGIN CALLBACK TOPICS
 ======================
 

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -170,6 +170,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating conf context");
         goto done;
     }
+    if (!(ctx.jobtap = jobtap_create (&ctx))) {
+        flux_log (h, LOG_ERR, "error creating jobtap interface");
+        goto done;
+    }
     if (!(ctx.purge = purge_create (&ctx))) {
         flux_log_error (h, "error creating purge context");
         goto done;
@@ -220,10 +224,6 @@ int mod_main (flux_t *h, int argc, char **argv)
     }
     if (!(ctx.update = update_ctx_create (&ctx))) {
         flux_log_error (h, "error creating job update interface");
-        goto done;
-    }
-    if (!(ctx.jobtap = jobtap_create (&ctx))) {
-        flux_log (h, LOG_ERR, "error creating jobtap interface");
         goto done;
     }
     if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {

--- a/src/modules/job-manager/jobtap-internal.h
+++ b/src/modules/job-manager/jobtap-internal.h
@@ -75,6 +75,10 @@ int jobtap_check_dependencies (struct jobtap *jobtap,
  *  needs_validation will be set nonzero. The caller should be sure to pass
  *  the updated jobspec to `job.validate` before posting updates to the job
  *  eventlog.
+ *
+ *  If the update requires a feasibility check with the scheduler, then
+ *  require_feasibility will be set nonzero. The caller should attempt to
+ *  request a feasibility check before applying updates.
  */
 int jobtap_job_update (struct jobtap *jobtap,
                        struct flux_msg_cred cred,
@@ -82,6 +86,7 @@ int jobtap_job_update (struct jobtap *jobtap,
                        const char *key,
                        json_t *value,
                        int *needs_validation,
+                       int *needs_feasibility,
                        char **errp);
 
 /*  Call the `job.validate` plugin stack, but using an updated jobspec by

--- a/src/modules/job-manager/jobtap-internal.h
+++ b/src/modules/job-manager/jobtap-internal.h
@@ -87,6 +87,7 @@ int jobtap_job_update (struct jobtap *jobtap,
                        json_t *value,
                        int *needs_validation,
                        int *needs_feasibility,
+                       json_t **updates,
                        char **errp);
 
 /*  Call the `job.validate` plugin stack, but using an updated jobspec by

--- a/src/modules/job-manager/jobtap-internal.h
+++ b/src/modules/job-manager/jobtap-internal.h
@@ -109,6 +109,16 @@ flux_plugin_t * jobtap_load (struct jobtap *jobtap,
                              json_t *conf,
                              flux_error_t *errp);
 
+typedef int (*jobtap_builtin_f) (flux_plugin_t *p, void *arg);
+
+/*  Add a new jobtap builtin plugin.
+ *  Allows builtins to be created externally to the jobtap module.
+ */
+int jobtap_register_builtin (struct jobtap *jobtap,
+                             const char *name,
+                             jobtap_builtin_f init_cb,
+                             void *arg);
+
 /*  Job manager RPC handler for loading new jobtap plugins.
  */
 void jobtap_handler (flux_t *h,

--- a/src/modules/job-manager/prioritize.c
+++ b/src/modules/job-manager/prioritize.c
@@ -237,9 +237,11 @@ int reprioritize_all (struct job_manager *ctx)
 
     /*  Reorder alloc queue and pending jobs. Canceled alloc requests
      *   will be reinserted into the queue as the scheduler responds
-     *   to them.
+     *   to them. Note: ctx->alloc may not be initialized if this function
+     *   is called during jobtap initialization.
      */
-    alloc_queue_reprioritize (ctx->alloc);
+    if (ctx->alloc)
+        alloc_queue_reprioritize (ctx->alloc);
 
     /*  Update scheduler with any changed priorities */
     if (sched_prioritize (ctx->h, priorities) < 0) {

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -26,6 +26,8 @@
 
 #include "alloc.h"
 #include "job-manager.h"
+#include "jobtap-internal.h"
+#include "jobtap.h"
 #include "conf.h"
 #include "restart.h"
 #include "queue.h"
@@ -774,6 +776,171 @@ void queue_destroy (struct queue *queue)
     }
 }
 
+/*  Test equality of two constraint objects.
+ *  For now, two constraints are equivalent if:
+ *
+ *  - both are either NULL or empty objects (i.e. size == 0)
+ *    (Note: json_object_size (NULL) == 0)
+ *
+ *  - json_equal(a, b) returns true
+ */
+static bool constraints_equal (json_t *c1, json_t *c2)
+{
+    if ((json_object_size (c1) == 0 && json_object_size (c2) == 0)
+        || json_equal (c1, c2))
+        return true;
+    return false;
+}
+
+static int constraints_match_check (struct queue *queue,
+                                    const char *name,
+                                    json_t *constraints,
+                                    flux_error_t *errp)
+{
+    int rc = -1;
+    json_t *expected = NULL;
+    struct jobq *q;
+
+    /*  Return an error if the job's current queue doesn't exist since we
+     *  can't validate current constraints (This should not happen in normal
+     *  situations).
+     */
+    if (!(q = queue_lookup (queue, name, errp)))
+        return -1;
+
+    /*  If current queue has constraints, then create a constraint object
+     *  for equivalence test below:
+     */
+    if (q->requires
+        && !(expected = json_pack ("{s:O}", "properties", q->requires))) {
+        errprintf (errp, "failed to get constraints for current queue");
+        goto out;
+    }
+
+    /*  Constraints of current job and queue must match exactly or queue
+     *  update will be rejected. This is because the entire constraints
+     *  object will be overwritten on queue update, and we do not want to
+     *  replace any extra constraints provided on the submission commandline
+     *  (and these likely wouldn't make sense in the new queue anyway)
+     */
+    if (!constraints_equal (constraints, expected)) {
+        errprintf (errp,
+                   "job appears to have non-queue constraints, "
+                   "unable to update queue to %s",
+                   name);
+        goto out;
+    }
+    rc = 0;
+out:
+    json_decref (expected);
+    return rc;
+}
+
+static int queue_update_cb (flux_plugin_t *p,
+                            const char *topic,
+                            flux_plugin_arg_t *args,
+                            void *arg)
+{
+    int rc;
+    struct queue *queue = arg;
+    flux_job_state_t state;
+    const char *name;
+    const char *current_queue = NULL;
+    json_t *constraints = NULL;
+    flux_error_t error;
+    struct jobq *newq;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:s s:i s:{s:{s:{s?s s?o}}}}",
+                                "value", &name,
+                                "state", &state,
+                                "jobspec",
+                                 "attributes",
+                                  "system",
+                                   "queue", &current_queue,
+                                   "constraints", &constraints) < 0) {
+        flux_jobtap_error (p, args, "plugin args unpack failed");
+        return -1;
+    }
+    if (state == FLUX_JOB_STATE_RUN
+        || state == FLUX_JOB_STATE_CLEANUP) {
+        flux_jobtap_error (p,
+                           args,
+                           "update of queue for running job not supported");
+        return -1;
+    }
+    if (current_queue && streq (current_queue, name)) {
+        flux_jobtap_error (p,
+                           args,
+                           "job queue is already set to %s",
+                           name);
+        return -1;
+    }
+    if (!(newq = queue_lookup (queue, name, &error))) {
+        flux_jobtap_error (p, args, "%s", error.text);
+        return -1;
+    }
+    if (!newq->enable) {
+        flux_jobtap_error (p,
+                           args,
+                           "queue %s is currently disabled",
+                           name);
+        return -1;
+    }
+    /*  Constraints must match current queue exactly since they will be
+     *  overwritten with new queue constraints after queue is updated:
+     */
+    if (constraints_match_check (queue, current_queue, constraints, &error)) {
+        flux_jobtap_error (p, args, "%s", error.text);
+        return -1;
+    }
+    /*  Request the update service do a feasibility check for this update
+     *  and append an additional update of the job constraints.
+     *
+     *  This is done via two different calls below dependent on whether the
+     *  new queue has any constraints.
+     */
+    if (newq->requires) {
+        /*  Replace current constraints with those of the new queue
+         */
+        rc = flux_plugin_arg_pack (args,
+                                   FLUX_PLUGIN_ARG_OUT,
+                                   "{s:i s:{s:{s:O}}}",
+                                   "feasibility", 1,
+                                   "updates",
+                                    "attributes.system.constraints",
+                                     "properties", newq->requires);
+    }
+    else {
+        /*  New queue has no requirements. Set constraints to empty object.
+         */
+        rc = flux_plugin_arg_pack (args,
+                                   FLUX_PLUGIN_ARG_OUT,
+                                   "{s:i s:{s:{}}}",
+                                   "feasibility", 1,
+                                   "updates",
+                                    "attributes.system.constraints");
+    }
+    /*  If either of the above packs failed then return an error:
+     */
+    if (rc < 0) {
+        flux_jobtap_error (p,
+                           args,
+                           "unable to create jobtap out arguments");
+        return -1;
+    }
+    return 0;
+}
+
+static int update_queue_plugin_init (flux_plugin_t *p, void *arg)
+{
+    return flux_plugin_add_handler (p,
+                                    "job.update.attributes.system.queue",
+                                    queue_update_cb,
+                                    arg);
+}
+
 struct queue *queue_create (struct job_manager *ctx)
 {
     struct queue *queue;
@@ -797,6 +964,16 @@ struct queue *queue_create (struct job_manager *ctx)
                   LOG_ERR,
                   "error parsing queue config: %s",
                   error.text);
+        goto error;
+    }
+    if (jobtap_register_builtin (ctx->jobtap,
+                                 ".update-queue",
+                                 update_queue_plugin_init,
+                                 queue) < 0
+        || !jobtap_load (ctx->jobtap, ".update-queue", NULL, NULL)) {
+        flux_log (ctx->h,
+                  LOG_ERR,
+                  "Failed to register and load update-queue plugin");
         goto error;
     }
     return queue;

--- a/src/modules/job-manager/update.c
+++ b/src/modules/job-manager/update.c
@@ -40,17 +40,15 @@
  * `job.update.*` callback. The `job.validate` step will only be skipped
  * all keys in an update have the validated flag set.
  *
+ * Plugins may also request a job feasibility check (sched.feasibility RPC)
+ * by setting a 'feasibility' flag to 1 in the FLUX_PLUGIN_OUT_ARGS. If any
+ * plugin requests a feasibility check, then feasibility is run for the
+ * proposed jobspec as a whole.
+ *
  * If all steps above are successful, then a `jobspec-update`event is
  * posted for the job and a success response sent to the caller.
  *
  * FUTURE WORK
- *
- * - Some job updates may require feasibility checks on the resulting
- *   jobspec. There should be a flag for a plugin to require that the
- *   result be passed to the scheduler feasibility RPC.
- *
- * - The above change will require some asynchronous handling be added
- *   to this service
  *
  * - Plugins should also somehow be able to initiate asynchronous work
  *   before validating an update. There is no support for async plugin
@@ -70,50 +68,69 @@
 struct update {
     struct job_manager *ctx;
     flux_msg_handler_t **handlers;
+    zlistx_t *pending_requests;
 };
 
-static void update_job (struct job_manager *ctx,
+struct update_request {
+    void *handle;                 /* zlistx_t handle                       */
+    flux_future_t *feasibility_f; /* feasibility request future            */
+    struct update *update;        /* pointer back to update struct         */
+    const flux_msg_t *msg;        /* original update request msg           */
+    struct flux_msg_cred cred;    /* update request credentials            */
+    struct job *job;              /* target job                            */
+    json_t *updates;              /* requested updates object              */
+    unsigned int validate:1;      /* 1: validate updates, 0: no validation */
+};
+
+static void update_request_destroy (struct update_request *req)
+{
+    if (req) {
+        int saved_errno = errno;
+        flux_future_destroy (req->feasibility_f);
+        flux_msg_decref (req->msg);
+        job_decref (req->job);
+        free (req);
+        errno = saved_errno;
+    }
+}
+
+/* zlistx_t destructor_fn */
+static void update_request_destructor (void **item)
+{
+    if (item) {
+        struct update_request *req = *item;
+        update_request_destroy (req);
+        *item = NULL;
+    }
+}
+
+static struct update_request *
+update_request_create (struct update *update,
                        const flux_msg_t *msg,
                        struct flux_msg_cred cred,
                        struct job *job,
                        json_t *updates)
 {
+    struct update_request *req;
+
+    if (!(req = calloc (1, sizeof (*req))))
+        return NULL;
+    req->update = update;
+    req->msg = flux_msg_incref (msg);
+    req->job = job_incref (job);
+    req->cred = cred;
+    req->updates = updates;
+    return req;
+}
+
+static void post_job_updates (struct job_manager *ctx,
+                              const flux_msg_t *msg,
+                              struct flux_msg_cred cred,
+                              struct job *job,
+                              json_t *updates,
+                              int validate)
+{
     const char *errstr = NULL;
-    char *error = NULL;
-    const char *key;
-    json_t *value;
-    int validate = 0; /* validation of result necessary */
-
-    /*  Loop through one or more proposed updates in `updates` object
-     *  and call `job.update.<key>` job plugin(s) to validate each
-     *  update.
-     */
-    json_object_foreach (updates, key, value) {
-        int needs_validation = 1;
-        if (jobtap_job_update (ctx->jobtap,
-                               cred,
-                               job,
-                               key,
-                               value,
-                               &needs_validation,
-                               &error) < 0)
-            goto error;
-        /*  If any jobspec key needs further validation, then all
-         *  keys will be validated at the same time. This means a key
-         *  that might not need further validation when updated alone
-         *  may need to be validated when paired with other keys in a
-         *  single update:
-         */
-        if (needs_validation)
-            validate = 1;
-    }
-    if (validate
-        && jobtap_validate_updates (ctx->jobtap,
-                                    job,
-                                    updates,
-                                    &error) < 0)
-        goto error;
-
 
     /*  If this update was requested by the instance owner, and the
      *  job owner is not the instance owner, and job validation was
@@ -163,7 +180,147 @@ static void update_job (struct job_manager *ctx,
         flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
     return;
 error:
-    if (flux_respond_error (ctx->h, msg, errno, error ? error : errstr) < 0)
+    if (flux_respond_error (ctx->h, msg, errno, errstr) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+static void feasibility_cb (flux_future_t *f, void *arg)
+{
+    struct update_request *req = arg;
+    if (flux_future_get (f, NULL) < 0) {
+        if (flux_respond_error (req->update->ctx->h,
+                                req->msg,
+                                errno,
+                                future_strerror (f, errno)) < 0)
+            flux_log_error (req->update->ctx->h,
+                            "%s: flux_respond_error",
+                            __FUNCTION__);
+    }
+    else {
+        post_job_updates (req->update->ctx,
+                          req->msg,
+                          req->cred,
+                          req->job,
+                          req->updates,
+                          req->validate);
+    }
+    zlistx_delete (req->update->pending_requests, req->handle);
+}
+
+static struct update_request *
+pending_request_create (struct update *update,
+                        const flux_msg_t *msg,
+                        struct flux_msg_cred cred,
+                        struct job *job,
+                        json_t *updates,
+                        int validate)
+{
+    struct update_request *req = NULL;
+    if (!(req = update_request_create (update, msg, cred, job, updates))
+        || !(req->handle = zlistx_add_end (update->pending_requests, req)))
+        goto error;
+    req->validate = validate;
+    return req;
+error:
+    update_request_destroy (req);
+    errno = ENOMEM;
+    return NULL;
+}
+
+static int update_feasibility_check (struct update *update,
+                                     const flux_msg_t *msg,
+                                     struct flux_msg_cred cred,
+                                     struct job *job,
+                                     json_t *updates,
+                                     int validate)
+{
+    json_t *jobspec = NULL;
+    struct update_request *req = NULL;
+    flux_future_t *f = NULL;
+
+    if (!(jobspec = job_jobspec_with_updates (job, updates))
+        || !(req = pending_request_create (update,
+                                           msg,
+                                           cred,
+                                           job,
+                                           updates,
+                                           validate))
+        || !(f = flux_rpc_pack (update->ctx->h,
+                                "sched.feasibility",
+                                0,
+                                0,
+                                "{s:O}",
+                                "jobspec", jobspec))
+        || flux_future_then (f, -1., feasibility_cb, req) < 0)
+        goto error;
+    req->feasibility_f = f;
+    json_decref (jobspec);
+    return 0;
+error:
+    json_decref (jobspec);
+    update_request_destroy (req);
+    flux_future_destroy (f);
+    return -1;
+
+}
+
+static void update_job (struct update *update,
+                        const flux_msg_t *msg,
+                        struct flux_msg_cred cred,
+                        struct job *job,
+                        json_t *updates)
+{
+    char *error = NULL;
+    const char *key;
+    json_t *value;
+    int validate = 0; /* validation of result necessary */
+    int feasibility = 0; /* feasibilty check necessary */
+    struct job_manager *ctx = update->ctx;
+
+    /*  Loop through one or more proposed updates in `updates` object
+     *  and call `job.update.<key>` job plugin(s) to validate each
+     *  update.
+     */
+    json_object_foreach (updates, key, value) {
+        int needs_validation = 1;
+        int require_feasibility = 0;
+        if (jobtap_job_update (ctx->jobtap,
+                               cred,
+                               job,
+                               key,
+                               value,
+                               &needs_validation,
+                               &require_feasibility,
+                               &error) < 0)
+            goto error;
+        /*  If any jobspec key needs further validation, then all
+         *  keys will be validated at the same time. This means a key
+         *  that might not need further validation when updated alone
+         *  may need to be validated when paired with other keys in a
+         *  single update:
+         */
+        if (needs_validation)
+            validate = 1;
+        /*  Similarly, if any key requires a feasibility check, then
+         *  request feasibilty on the update as a whole.
+         */
+        if (require_feasibility)
+            feasibility = 1;
+    }
+    if (validate
+        && jobtap_validate_updates (ctx->jobtap,
+                                    job,
+                                    updates,
+                                    &error) < 0)
+        goto error;
+
+    if (feasibility)
+        update_feasibility_check (update, msg, cred, job, updates, validate);
+    else
+        post_job_updates (ctx, msg, cred, job, updates, validate);
+    return;
+error:
+    if (flux_respond_error (ctx->h, msg, EINVAL, error) < 0)
         flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
     free (error);
 }
@@ -224,18 +381,36 @@ static void update_handle_request (flux_t *h,
     }
     /*  Process the update request. Response will be handled in update_job().
      */
-    update_job (ctx, msg, cred, job, updates);
+    update_job (update, msg, cred, job, updates);
     return;
 error:
     if (flux_respond_error (h, msg, errno, errstr) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
+static void send_error_responses (struct update *update)
+{
+    struct update_request *req = zlistx_first (update->pending_requests);
+    while (req) {
+        if (flux_respond_error (update->ctx->h,
+                                req->msg,
+                                EAGAIN,
+                                "job manager is shutting down") < 0)
+            flux_log_error (update->ctx->h,
+                            "%s: error responding to "
+                            "job-manager.update request",
+                            __FUNCTION__);
+        req = zlistx_next (update->pending_requests);
+    }
+}
+
 void update_ctx_destroy (struct update *update)
 {
     if (update) {
         int saved_errno = errno;
+        send_error_responses (update);
         flux_msg_handler_delvec (update->handlers);
+        zlistx_destroy (&update->pending_requests);
         free (update);
         errno = saved_errno;
     }
@@ -260,6 +435,12 @@ struct update *update_ctx_create (struct job_manager *ctx)
     update->ctx = ctx;
     if (flux_msg_handler_addvec (ctx->h, htab, update, &update->handlers) < 0)
         goto error;
+    if (!(update->pending_requests = zlistx_new ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    zlistx_set_destructor (update->pending_requests,
+                           update_request_destructor);
     return update;
 error:
     update_ctx_destroy (update);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -157,6 +157,7 @@ TESTSCRIPTS = \
 	t2276-job-requires.t \
 	t2280-job-memo.t \
 	t2290-job-update.t \
+	t2291-job-update-queue.t \
 	t2300-sched-simple.t \
 	t2302-sched-simple-up-down.t \
 	t2303-sched-hello.t \

--- a/t/t2291-job-update-queue.t
+++ b/t/t2291-job-update-queue.t
@@ -1,0 +1,167 @@
+#!/bin/sh
+test_description='Test update of job queue'
+
+. $(dirname $0)/sharness.sh
+
+if flux job submit --help 2>&1 | grep -q sign-type; then
+	test_set_prereq HAVE_FLUX_SECURITY
+fi
+
+test_under_flux 4 full
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'config queues and resources' '
+	flux R encode -r 0-3 -p batch:0-2 -p debug:3 \
+	   | tr -d "\n" \
+	   | flux kvs put -r resource.R=- &&
+	flux config load <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	policy.limits.duration = "1h"
+	policy.jobspec.defaults.system.duration = "1h"
+
+	[queues.debug]
+	requires = [ "debug" ]
+	policy.limits.duration = "1m"
+	policy.jobspec.defaults.system.duration = "1m"
+
+	[queues.other]
+
+	[policy.jobspec.defaults.system]
+	queue = "batch"
+	EOT
+	flux queue start --all &&
+	flux module unload sched-simple &&
+	flux module reload resource &&
+	flux module load sched-simple &&
+	flux queue list &&
+	flux resource list -o rlist
+'
+test_expect_success 'invalid queue update RPC fails' '
+	jobid=$(flux submit --urgency=hold -n1 hostname) &&
+	echo "{\"id\": $(flux job id $jobid),\
+	       \"updates\": {\"attributes.system.queue\": 42}\
+	      }" \
+            | ${FLUX_BUILD_DIR}/t/request/rpc job-manager.update 22 && # EINVAL
+	flux cancel $jobid &&
+	flux job wait-event $jobid clean
+'
+test_expect_success 'update of invalid job fails' '
+	test_must_fail flux update f1234 queue=batch
+'
+test_expect_success 'update queue of running job fails' '
+	jobid=$(flux submit --wait-event=start -n1 sleep 300) &&
+	test_must_fail flux update $jobid queue=debug 2>running.err &&
+	flux cancel $jobid &&
+	flux job wait-event $jobid clean &&
+	grep "update of queue for running job not supported" running.err
+'
+test_expect_success 'update to invalid queue fails' '
+	jobid=$(flux submit -q debug --urgency=hold hostname) &&
+	test_must_fail flux update $jobid queue=foo
+'
+test_expect_success 'update to same queue fails' '
+	test_must_fail flux update $jobid queue=debug
+'
+test_expect_success 'update to batch queue works' '
+	flux update $jobid queue=batch &&
+	test_debug "flux job eventlog $jobid" &&
+	flux job eventlog $jobid \
+	  | grep jobspec-update \
+	  | grep attributes.system.queue=\"batch\"
+'
+test_expect_success 'job runs on batch resources' '
+	flux job urgency $jobid default &&
+	flux job wait-event $jobid clean &&
+	test "$(flux jobs -no {queue} $jobid)" = "batch" &&
+	test $(flux jobs -no {ranks} $jobid) = "0"
+'
+test_expect_success 'update to queue with lower duration limit fails' '
+	jobid=$(flux submit -q batch --urgency=hold hostname) &&
+	test_must_fail flux update $jobid queue=debug 2>queue.err &&
+	grep "duration exceeds policy limit" queue.err
+'
+test_expect_success 'update of duration allows queue update' '
+	flux update $jobid queue=debug duration=1m  &&
+	test_debug "flux job eventlog $jobid" &&
+	flux job eventlog $jobid \
+	  | grep jobspec-update \
+	  | grep attributes.system.queue=\"debug\"
+'
+test_expect_success 'job runs on debug resources' '
+	flux job urgency $jobid default &&
+	flux job wait-event $jobid clean &&
+	test "$(flux jobs -no {queue} $jobid)" = "debug" &&
+	test $(flux jobs -no {ranks} $jobid) = "3"
+'
+test_expect_success 'update of infeasible job to queue fails' '
+	jobid=$(flux submit -q batch -N2 --urgency=hold hostname) &&
+	test_debug "flux jobs -a" &&
+	test_must_fail flux update $jobid duration=1m queue=debug \
+		2>infeasible.err &&
+	test_debug "cat infeasible.err" &&
+	flux cancel $jobid
+'
+test_expect_success 'update of queue for job with other constraints fails' '
+	jobid=$(flux submit --urgency=hold \
+		-q batch -N1 -t 1m --requires=rank:0 hostname) &&
+	test_must_fail flux update $jobid queue=debug \
+		2>constraints.err &&
+	test_debug "cat constraints.err" &&
+	grep "unable to update queue" constraints.err &&
+	flux cancel $jobid &&
+	flux job wait-event $jobid clean
+'
+test_expect_success 'update from queue with no constraints works' '
+	jobid=$(flux submit -t 1m --urgency=hold -q other hostname) &&
+	flux update $jobid queue=debug &&
+	test_debug "flux job eventlog $jobid" &&
+	flux job eventlog $jobid \
+	  | grep jobspec-update \
+	  | grep attributes.system.queue=\"debug\" &&
+	flux cancel $jobid &&
+	flux job wait-event $jobid clean
+'
+test_expect_success 'update to queue with no constraints works' '
+	jobid=$(flux submit --urgency=hold -q debug hostname) &&
+	flux update $jobid queue=other &&
+	test_debug "flux job eventlog $jobid" &&
+	flux job eventlog $jobid \
+	  | grep jobspec-update \
+	  | grep attributes.system.queue=\"other\"
+'
+test_expect_success 'job can still run' '
+	flux job urgency $jobid default &&
+	flux job attach $jobid
+'
+test_expect_success "job with constraints in a queue without can't be updated" '
+	jobid=$(flux submit -t 1m --urgency=hold -q other \
+		--requires=rank:0 hostname) &&
+	test_must_fail flux update $jobid queue=debug &&
+	flux cancel $jobid &&
+	flux job wait-event $jobid clean
+'
+test_expect_success 'update-queue plugin can be unloaded' '
+	flux jobtap remove .update-queue &&
+	flux jobtap list -a >jobtap-list.out &&
+	test_must_fail grep update-queue jobtap-list.out
+'
+test_expect_success 'updates are now disabled' '
+	jobid=$(flux submit -q debug --urgency=hold hostname) &&
+	test_must_fail flux update $jobid queue=batch
+'
+test_expect_success 'update-queue plugin can be reloaded' '
+	flux jobtap load .update-queue &&
+	flux jobtap list -a >jobtap-list2.out &&
+	grep update-queue jobtap-list2.out
+'
+test_expect_success 'updates are reenabled' '
+	flux update $jobid queue=batch &&
+	flux cancel $jobid &&
+	flux job wait-event $jobid clean &&
+	flux job eventlog $jobid \
+	  | grep jobspec-update \
+	  | grep attributes.system.queue=\"batch\"
+'
+test_done


### PR DESCRIPTION
This is an experimental WIP that allows users to move a pending job to a new queue.

The list of valid queues and their current status (enabled/disabled) is currently private to `job-manager/queue.c`, so it isn't straightforward to add an `update-queue` plugin. The plugin would have to send an RPC back to the job-manager itself to query the list of queues and their states (and there's currently no way to do asynchronous work in one of these plugins), or a `jobtap` API call to "unpack" the queues or otherwise query them would be required.

Instead, this PR proposes a way for job manager components to register builtins directly from within their initialization routines, and pass some opaque data along that can be passed to all jobtap callbacks. This seems a little backwards, since it exposes internals to jobtap plugins, which slightly breaks the design, but it happens to be very useful for the specific case of allowing updates for an attribute of jobspec which is managed by a private job manager component.

This allows the `.update-queue` plugin to easily access queue-specific data without RPCs or ad-hoc jobtap functions that expose some internals of the queue module. It also keeps all the queue related code in one place, and reduces the amount of boiler plate code to a minimum, while still allowing the "plugin" to be unloaded to prevent queue updates, or reloaded to re-enable them. If other queue restrictions are added in the future (e.g. access controls) these can easily be supported in the `.update-queue` plugin since it is internal to `job-manager/queue.c`.

Of course the drawback is that someone could never write a truly external queue-update plugin since we've not exposed those internals for general jobtap use. Since that is a pretty big caveat, I'm just proposing this PR as an experimental WIP at this time to get feedback on this particular design choice.

Either way, the next step here is to add a way for the plugin to request that a feasibility check be issued after the update has been allowed and before it is applied. This will require changes to `job-manager/update.c` itself, since the feasibility check requires an RPC to the scheduler.

Example:
```console
$ jobid=$(flux submit --urgency=hold -q batch hostname)
$ flux jobs -no {queue} $jobid
batch
$ flux update $jobid queue=debug
$ flux jobs -no {queue} $jobid
debug
$ flux update $jobid queue=foo
flux-update: ERROR: 'foo' is not a valid queue
$ flux queue disable -q batch testing update of disabled queue
batch: Job submission is disabled: testing update of disabled queue
$ flux update $jobid queue=batch
flux-update: ERROR: job submission to batch is disabled: testing update of disabled queue
``` 