### PR TITLE
flux-job: get updated version of jobspec

### DIFF
--- a/src/bindings/python/flux/job/kvslookup.py
+++ b/src/bindings/python/flux/job/kvslookup.py
@@ -12,7 +12,8 @@ import json
 
 from _flux._core import ffi, lib
 from flux.future import WaitAllFuture
-from flux.job import JobID
+from flux.job import JobID, JobspecV1
+from flux.job.event import EventLogEvent
 from flux.rpc import RPC
 
 
@@ -53,11 +54,15 @@ def job_info_lookup(flux_handle, jobid, keys=["jobspec"]):
     return rpc
 
 
-def _setup_lookup_keys(keys, original):
-    if original and "jobspec" in keys:
-        keys.remove("jobspec")
-        if "J" not in keys:
-            keys.append("J")
+def _setup_lookup_keys(keys, original, base):
+    if "jobspec" in keys:
+        if original:
+            keys.remove("jobspec")
+            if "J" not in keys:
+                keys.append("J")
+        elif not base:
+            if "eventlog" not in keys:
+                keys.append("eventlog")
 
 
 def _get_original_jobspec(job_data):
@@ -68,19 +73,46 @@ def _get_original_jobspec(job_data):
     return result.decode("utf-8")
 
 
-def _update_keys(job_data, decode, keys, original):
-    if original and "jobspec" in keys:
-        job_data["jobspec"] = _get_original_jobspec(job_data)
-        if decode:
-            _decode_field(job_data, "jobspec")
-        if "J" not in keys:
-            job_data.pop("J")
+def _get_updated_jobspec(job_data):
+    if isinstance(job_data["jobspec"], str):
+        data = json.loads(job_data["jobspec"])
+    else:
+        data = job_data["jobspec"]
+    jobspec = JobspecV1(**data)
+    for entry in job_data["eventlog"].splitlines():
+        event = EventLogEvent(entry)
+        if event.name == "jobspec-update":
+            for key, value in event.context.items():
+                jobspec.setattr(key, value)
+    return jobspec.dumps()
+
+
+def _update_keys(job_data, decode, keys, original, base):
+    if "jobspec" in keys:
+        if original:
+            job_data["jobspec"] = _get_original_jobspec(job_data)
+            if decode:
+                _decode_field(job_data, "jobspec")
+            if "J" not in keys:
+                job_data.pop("J")
+        elif not base:
+            job_data["jobspec"] = _get_updated_jobspec(job_data)
+            if decode:
+                _decode_field(job_data, "jobspec")
+            if "eventlog" not in keys:
+                job_data.pop("eventlog")
 
 
 # jobs_kvs_lookup simple variant for one jobid
-def job_kvs_lookup(flux_handle, jobid, keys=["jobspec"], decode=True, original=False):
+def job_kvs_lookup(
+    flux_handle, jobid, keys=["jobspec"], decode=True, original=False, base=False
+):
     """
     Lookup job kvs data based on a jobid
+
+    Some keys such as "jobspec" may be altered based on update events
+    in the eventlog.  Set 'base' to True to skip these updates and
+    read exactly what is in the KVS.
 
     :flux_handle: A Flux handle obtained from flux.Flux()
     :jobid: jobid to lookup info for
@@ -89,9 +121,10 @@ def job_kvs_lookup(flux_handle, jobid, keys=["jobspec"], decode=True, original=F
              currently decodes "jobspec" and "R" into dicts
              (default True)
     :original: For 'jobspec', return the original submitted jobspec
+    :base: For 'jobspec', get base value, do not apply updates from eventlog
     """
     keyslookup = list(keys)
-    _setup_lookup_keys(keyslookup, original)
+    _setup_lookup_keys(keyslookup, original, base)
     payload = {"id": int(jobid), "keys": keyslookup, "flags": 0}
     rpc = JobInfoLookupRPC(flux_handle, "job-info.lookup", payload)
     try:
@@ -99,7 +132,7 @@ def job_kvs_lookup(flux_handle, jobid, keys=["jobspec"], decode=True, original=F
             rsp = rpc.get_decode()
         else:
             rsp = rpc.get()
-        _update_keys(rsp, decode, keys, original)
+        _update_keys(rsp, decode, keys, original, base)
     # The job does not exist!
     except FileNotFoundError:
         return None
@@ -149,6 +182,10 @@ class JobKVSLookupFuture(WaitAllFuture):
 class JobKVSLookup:
     """User friendly class to lookup job KVS data
 
+    Some keys such as "jobspec" may be altered based on update events
+    in the eventlog.  Set 'base' to True to skip these updates and
+    read exactly what is in the KVS.
+
     :flux_handle: A Flux handle obtained from flux.Flux()
     :ids: List of jobids to get data for
     :keys: Optional list of keys to fetch. (default is "jobspec")
@@ -156,6 +193,7 @@ class JobKVSLookup:
              currently decodes "jobspec" and "R" into dicts
              (default True)
     :original: For 'jobspec', return the original submitted jobspec
+    :base: For 'jobspec', get base value, do not apply updates from eventlog
     """
 
     def __init__(
@@ -165,6 +203,7 @@ class JobKVSLookup:
         keys=["jobspec"],
         decode=True,
         original=False,
+        base=False,
     ):
         self.handle = flux_handle
         self.keys = list(keys)
@@ -172,8 +211,9 @@ class JobKVSLookup:
         self.ids = list(map(JobID, ids)) if ids else []
         self.decode = decode
         self.original = original
+        self.base = base
         self.errors = []
-        _setup_lookup_keys(self.keyslookup, self.original)
+        _setup_lookup_keys(self.keyslookup, self.original, self.base)
 
     def fetch_data(self):
         """Initiate the job info lookup to the Flux job-info module
@@ -207,5 +247,5 @@ class JobKVSLookup:
         if hasattr(rpc, "errors"):
             self.errors = rpc.errors
         for job_data in data:
-            _update_keys(job_data, self.decode, self.keys, self.original)
+            _update_keys(job_data, self.decode, self.keys, self.original, self.base)
         return data

--- a/src/cmd/flux-update.py
+++ b/src/cmd/flux-update.py
@@ -49,27 +49,17 @@ class JobspecUpdates:
             self._flux_handle = flux.Flux()
         return self._flux_handle
 
-    def _apply_jobspec_updates(self, eventlog):
-        """
-        Apply jobspec updates from eventlog to internal jobspec:
-        """
-        for entry in eventlog.splitlines():
-            event = flux.job.EventLogEvent(entry)
-            if event.name == "jobspec-update":
-                for key, value in event.context.items():
-                    self.jobspec.setattr(key, value)
-
     def _fetch_jobspec(self, key):
         """
-        Fetch dotted key 'key' in jobspec for this job, fetching jobspec
-        and eventlog (to apply jobspec-updates) if necessary.
+        Fetch dotted key 'key' in jobspec for this job.  Note that
+        job_kvs_lookup() will apply `jobspec-update` events from the
+        eventlog in the returned jobspec.
         """
         if self.jobspec is None:
             lookup = flux.job.job_kvs_lookup(
-                self.flux_handle, jobid=self.jobid, keys=["jobspec", "eventlog"]
+                self.flux_handle, jobid=self.jobid, keys=["jobspec"]
             )
             self.jobspec = flux.job.JobspecV1(**lookup["jobspec"])
-            self._apply_jobspec_updates(lookup["eventlog"])
 
         return self.jobspec.getattr(key)
 

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -86,149 +86,149 @@ class TestJob(unittest.TestCase):
             data["jobspec"]["attributes"]["system"]["environment"]["FOO"], "BAR"
         )
 
-    def test_00_job_info_lookup(self):
+    def test_info_00_job_info_lookup(self):
         rpc = flux.job.job_info_lookup(self.fh, self.jobid1)
         data = rpc.get()
         self.check_jobspec_str(data, self.jobid1)
         data = rpc.get_decode()
         self.assertEqual(data["id"], self.jobid1)
 
-    def test_01_job_info_lookup_keys(self):
+    def test_info_01_job_info_lookup_keys(self):
         rpc = flux.job.job_info_lookup(self.fh, self.jobid1, keys=["R", "J"])
         data = rpc.get()
         self.check_R_J_str(data, self.jobid1)
         data = rpc.get_decode()
         self.check_R_J_decoded(data, self.jobid1)
 
-    def test_02_job_info_lookup_badid(self):
+    def test_info_02_job_info_lookup_badid(self):
         rpc = flux.job.job_info_lookup(self.fh, 123456789)
         with self.assertRaises(FileNotFoundError):
             rpc.get()
 
-    def test_03_job_info_lookup_badkey(self):
+    def test_info_03_job_info_lookup_badkey(self):
         rpc = flux.job.job_info_lookup(self.fh, self.jobid1, keys=["foo"])
         with self.assertRaises(FileNotFoundError):
             rpc.get()
 
-    def test_04_job_kvs_lookup(self):
+    def test_lookup_01_job_kvs_lookup(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1)
         self.check_jobspec_decoded(data, self.jobid1)
 
-    def test_05_job_kvs_lookup_nodecode(self):
+    def test_lookup_02_job_kvs_lookup_nodecode(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, decode=False)
         self.check_jobspec_str(data, self.jobid1)
 
-    def test_06_job_kvs_lookup_keys(self):
+    def test_lookup_03_job_kvs_lookup_keys(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["R", "J"])
         self.check_R_J_decoded(data, self.jobid1)
 
-    def test_07_job_kvs_lookup_keys_nodecode(self):
+    def test_lookup_04_job_kvs_lookup_keys_nodecode(self):
         data = flux.job.job_kvs_lookup(
             self.fh, self.jobid1, keys=["R", "J"], decode=False
         )
         self.check_R_J_str(data, self.jobid1)
 
-    def test_08_job_kvs_lookup_badid(self):
+    def test_lookup_05_job_kvs_lookup_badid(self):
         data = flux.job.job_kvs_lookup(self.fh, 123456789)
         self.assertEqual(data, None)
 
-    def test_09_job_kvs_lookup_badkey(self):
+    def test_lookup_06_job_kvs_lookup_badkey(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["foo"])
         self.assertEqual(data, None)
 
-    def test_10_job_kvs_lookup_jobspec_original(self):
+    def test_lookup_07_job_kvs_lookup_jobspec_original(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, original=True)
         self.assertNotIn("J", data)
         self.check_jobspec_original_decoded(data, self.jobid1)
 
-    def test_11_job_kvs_lookup_jobspec_original_nodecode(self):
+    def test_lookup_08_job_kvs_lookup_jobspec_original_nodecode(self):
         data = flux.job.job_kvs_lookup(
             self.fh, self.jobid1, decode=False, original=True
         )
         self.assertNotIn("J", data)
         self.check_jobspec_original_str(data, self.jobid1)
 
-    def test_12_job_kvs_lookup_jobspec_original_multiple_keys(self):
+    def test_lookup_09_job_kvs_lookup_jobspec_original_multiple_keys(self):
         data = flux.job.job_kvs_lookup(
             self.fh, self.jobid1, keys=["jobspec", "J"], original=True
         )
         self.assertIn("J", data)
         self.check_jobspec_original_decoded(data, self.jobid1)
 
-    def test_13_job_kvs_lookup_original_no_jobspec(self):
+    def test_lookup_10_job_kvs_lookup_original_no_jobspec(self):
         data = flux.job.job_kvs_lookup(
             self.fh, self.jobid1, keys=["R", "J"], original=True
         )
         self.assertNotIn("jobspec", data)
         self.check_R_J_decoded(data, self.jobid1)
 
-    def test_14_job_kvs_lookup_list(self):
+    def test_list_00_job_kvs_lookup_list(self):
         ids = [self.jobid1]
         data = flux.job.JobKVSLookup(self.fh, ids).data()
         self.assertEqual(len(data), 1)
         self.check_jobspec_decoded(data[0], self.jobid1)
 
-    def test_15_job_kvs_lookup_list_multiple(self):
+    def test_list_01_job_kvs_lookup_list_multiple(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids).data()
         self.assertEqual(len(data), 2)
         self.check_jobspec_decoded(data[0], self.jobid1)
         self.check_jobspec_decoded(data[1], self.jobid2)
 
-    def test_16_job_kvs_lookup_list_multiple_nodecode(self):
+    def test_list_02_job_kvs_lookup_list_multiple_nodecode(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids, decode=False).data()
         self.assertEqual(len(data), 2)
         self.check_jobspec_str(data[0], self.jobid1)
         self.check_jobspec_str(data[1], self.jobid2)
 
-    def test_17_job_kvs_lookup_list_multiple_keys(self):
+    def test_list_03_job_kvs_lookup_list_multiple_keys(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"]).data()
         self.assertEqual(len(data), 2)
         self.check_R_J_decoded(data[0], self.jobid1)
         self.check_R_J_decoded(data[1], self.jobid2)
 
-    def test_18_job_kvs_lookup_list_multiple_keys_nodecode(self):
+    def test_list_04_job_kvs_lookup_list_multiple_keys_nodecode(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"], decode=False).data()
         self.assertEqual(len(data), 2)
         self.check_R_J_str(data[0], self.jobid1)
         self.check_R_J_str(data[1], self.jobid2)
 
-    def test_19_job_kvs_lookup_list_none(self):
+    def test_list_05_job_kvs_lookup_list_none(self):
         data = flux.job.JobKVSLookup(self.fh).data()
         self.assertEqual(len(data), 0)
 
-    def test_20_job_kvs_lookup_list_badid(self):
+    def test_list_06_job_kvs_lookup_list_badid(self):
         ids = [123456789]
         datalookup = flux.job.JobKVSLookup(self.fh, ids)
         data = datalookup.data()
         self.assertEqual(len(data), 0)
         self.assertEqual(len(datalookup.errors), 1)
 
-    def test_21_job_kvs_lookup_list_badkey(self):
+    def test_list_07_job_kvs_lookup_list_badkey(self):
         ids = [self.jobid1]
         datalookup = flux.job.JobKVSLookup(self.fh, ids, keys=["foo"])
         data = datalookup.data()
         self.assertEqual(len(data), 0)
         self.assertEqual(len(datalookup.errors), 1)
 
-    def test_22_job_kvs_lookup_list_jobspec_original(self):
+    def test_list_08_job_kvs_lookup_list_jobspec_original(self):
         ids = [self.jobid1]
         data = flux.job.JobKVSLookup(self.fh, ids, original=True).data()
         self.assertEqual(len(data), 1)
         self.assertNotIn("J", data[0])
         self.check_jobspec_original_decoded(data[0], self.jobid1)
 
-    def test_23_job_kvs_lookup_list_jobspec_original_nodecode(self):
+    def test_list_09_job_kvs_lookup_list_jobspec_original_nodecode(self):
         ids = [self.jobid1]
         data = flux.job.JobKVSLookup(self.fh, ids, decode=False, original=True).data()
         self.assertEqual(len(data), 1)
         self.assertNotIn("J", data[0])
         self.check_jobspec_original_str(data[0], self.jobid1)
 
-    def test_24_job_kvs_lookup_list_jobspec_original_multiple_keys(self):
+    def test_list_10_job_kvs_lookup_list_jobspec_original_multiple_keys(self):
         ids = [self.jobid1]
         data = flux.job.JobKVSLookup(
             self.fh, ids, keys=["jobspec", "J"], original=True
@@ -237,7 +237,7 @@ class TestJob(unittest.TestCase):
         self.assertIn("J", data[0])
         self.check_jobspec_original_decoded(data[0], self.jobid1)
 
-    def test_25_job_kvs_lookup_list_original_no_jobspec(self):
+    def test_list_11_job_kvs_lookup_list_original_no_jobspec(self):
         ids = [self.jobid1]
         data = flux.job.JobKVSLookup(
             self.fh, ids, keys=["R", "J"], original=True

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -24,34 +24,42 @@ def __flux_size():
 
 class TestJob(unittest.TestCase):
     @classmethod
-    def submitJob(self, command):
+    def submitJob(self, command, urgency):
         compute_jobreq = JobspecV1.from_command(
             command=command, num_tasks=1, num_nodes=1, cores_per_task=1
         )
         testenv = {"FOO": "BAR"}
         compute_jobreq.environment = testenv
-        return flux.job.submit(self.fh, compute_jobreq, waitable=True)
+        return flux.job.submit(self.fh, compute_jobreq, urgency=urgency, waitable=True)
 
     @classmethod
     def setUpClass(self):
         self.fh = flux.Flux()
-        self.jobid1 = self.submitJob(["hostname"])
-        flux.job.event_wait(self.fh, self.jobid1, name="start")
-        self.jobid2 = self.submitJob(["hostname"])
-        flux.job.event_wait(self.fh, self.jobid2, name="start")
+        self.jobid1 = self.submitJob(["hostname"], 0)
+        flux.job.event_wait(self.fh, self.jobid1, name="priority")
+        update = {"attributes.system.duration": 100.0}
+        payload = {"id": self.jobid1, "updates": update}
+        self.fh.rpc("job-manager.update", payload).get()
+        payload = {"id": self.jobid1, "urgency": 16}
+        self.fh.rpc("job-manager.urgency", payload).get()
+        flux.job.event_wait(self.fh, self.jobid1, name="clean")
+        self.jobid2 = self.submitJob(["hostname"], 16)
+        flux.job.event_wait(self.fh, self.jobid2, name="clean")
 
-    def check_jobspec_str(self, data, jobid):
+    def check_jobspec_str(self, data, jobid, duration):
         self.assertEqual(data["id"], jobid)
         self.assertIn("jobspec", data)
         self.assertEqual(type(data["jobspec"]), str)
         jobspec = json.loads(data["jobspec"])
         self.assertEqual(jobspec["tasks"][0]["command"][0], "hostname")
+        self.assertEqual(jobspec["attributes"]["system"]["duration"], duration)
         self.assertNotIn("R", data)
 
-    def check_jobspec_decoded(self, data, jobid):
+    def check_jobspec_decoded(self, data, jobid, duration):
         self.assertEqual(data["id"], jobid)
         self.assertIn("jobspec", data)
         self.assertEqual(data["jobspec"]["tasks"][0]["command"][0], "hostname")
+        self.assertEqual(data["jobspec"]["attributes"]["system"]["duration"], duration)
         self.assertNotIn("R", data)
 
     def check_R_J_str(self, data, jobid):
@@ -77,21 +85,35 @@ class TestJob(unittest.TestCase):
         self.assertEqual(type(data["jobspec"]), str)
         jobspec = json.loads(data["jobspec"])
         self.assertEqual(jobspec["tasks"][0]["command"][0], "hostname")
+        self.assertEqual(jobspec["attributes"]["system"]["duration"], 0)
         self.assertEqual(jobspec["attributes"]["system"]["environment"]["FOO"], "BAR")
 
     def check_jobspec_original_decoded(self, data, jobid):
         self.assertIn("jobspec", data)
         self.assertEqual(data["jobspec"]["tasks"][0]["command"][0], "hostname")
+        self.assertEqual(data["jobspec"]["attributes"]["system"]["duration"], 0)
         self.assertEqual(
             data["jobspec"]["attributes"]["system"]["environment"]["FOO"], "BAR"
         )
 
+    def check_jobspec_base_str(self, data, jobid):
+        self.assertIn("jobspec", data)
+        self.assertEqual(type(data["jobspec"]), str)
+        jobspec = json.loads(data["jobspec"])
+        self.assertEqual(jobspec["tasks"][0]["command"][0], "hostname")
+        self.assertEqual(jobspec["attributes"]["system"]["duration"], 0)
+
+    def check_jobspec_base_decoded(self, data, jobid):
+        self.assertIn("jobspec", data)
+        self.assertEqual(data["jobspec"]["tasks"][0]["command"][0], "hostname")
+        self.assertEqual(data["jobspec"]["attributes"]["system"]["duration"], 0)
+
     def test_info_00_job_info_lookup(self):
         rpc = flux.job.job_info_lookup(self.fh, self.jobid1)
         data = rpc.get()
-        self.check_jobspec_str(data, self.jobid1)
+        self.check_jobspec_str(data, self.jobid1, 0)
         data = rpc.get_decode()
-        self.assertEqual(data["id"], self.jobid1)
+        self.assertEqual(data["id"], self.jobid1, 0)
 
     def test_info_01_job_info_lookup_keys(self):
         rpc = flux.job.job_info_lookup(self.fh, self.jobid1, keys=["R", "J"])
@@ -112,11 +134,11 @@ class TestJob(unittest.TestCase):
 
     def test_lookup_01_job_kvs_lookup(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1)
-        self.check_jobspec_decoded(data, self.jobid1)
+        self.check_jobspec_decoded(data, self.jobid1, 100.0)
 
     def test_lookup_02_job_kvs_lookup_nodecode(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, decode=False)
-        self.check_jobspec_str(data, self.jobid1)
+        self.check_jobspec_str(data, self.jobid1, 100.0)
 
     def test_lookup_03_job_kvs_lookup_keys(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["R", "J"])
@@ -162,25 +184,47 @@ class TestJob(unittest.TestCase):
         self.assertNotIn("jobspec", data)
         self.check_R_J_decoded(data, self.jobid1)
 
+    def test_14_job_kvs_lookup_jobspec_base(self):
+        data = flux.job.job_kvs_lookup(self.fh, self.jobid1, base=True)
+        self.assertNotIn("eventlog", data)
+        self.check_jobspec_base_decoded(data, self.jobid1)
+
+    def test_15_job_kvs_lookup_jobspec_base_nodecode(self):
+        data = flux.job.job_kvs_lookup(self.fh, self.jobid1, decode=False, base=True)
+        self.assertNotIn("eventlog", data)
+        self.check_jobspec_base_str(data, self.jobid1)
+
+    def test_16_job_kvs_lookup_jobspec_base_multiple_keys(self):
+        data = flux.job.job_kvs_lookup(
+            self.fh, self.jobid1, keys=["jobspec", "eventlog"], base=True
+        )
+        self.assertIn("eventlog", data)
+        self.check_jobspec_base_decoded(data, self.jobid1)
+
+    def test_17_job_kvs_lookup_base_no_jobspec(self):
+        data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["R", "J"], base=True)
+        self.assertNotIn("jobspec", data)
+        self.check_R_J_decoded(data, self.jobid1)
+
     def test_list_00_job_kvs_lookup_list(self):
         ids = [self.jobid1]
         data = flux.job.JobKVSLookup(self.fh, ids).data()
         self.assertEqual(len(data), 1)
-        self.check_jobspec_decoded(data[0], self.jobid1)
+        self.check_jobspec_decoded(data[0], self.jobid1, 100.0)
 
     def test_list_01_job_kvs_lookup_list_multiple(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids).data()
         self.assertEqual(len(data), 2)
-        self.check_jobspec_decoded(data[0], self.jobid1)
-        self.check_jobspec_decoded(data[1], self.jobid2)
+        self.check_jobspec_decoded(data[0], self.jobid1, 100.0)
+        self.check_jobspec_decoded(data[1], self.jobid2, 0)
 
     def test_list_02_job_kvs_lookup_list_multiple_nodecode(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids, decode=False).data()
         self.assertEqual(len(data), 2)
-        self.check_jobspec_str(data[0], self.jobid1)
-        self.check_jobspec_str(data[1], self.jobid2)
+        self.check_jobspec_str(data[0], self.jobid1, 100.0)
+        self.check_jobspec_str(data[1], self.jobid2, 0)
 
     def test_list_03_job_kvs_lookup_list_multiple_keys(self):
         ids = [self.jobid1, self.jobid2]
@@ -242,6 +286,36 @@ class TestJob(unittest.TestCase):
         data = flux.job.JobKVSLookup(
             self.fh, ids, keys=["R", "J"], original=True
         ).data()
+        self.assertEqual(len(data), 1)
+        self.assertNotIn("jobspec", data[0])
+        self.check_R_J_decoded(data[0], self.jobid1)
+
+    def test_list_12_job_kvs_lookup_list_jobspec_base(self):
+        ids = [self.jobid1]
+        data = flux.job.JobKVSLookup(self.fh, ids, base=True).data()
+        self.assertEqual(len(data), 1)
+        self.assertNotIn("J", data[0])
+        self.check_jobspec_base_decoded(data[0], self.jobid1)
+
+    def test_list_13_job_kvs_lookup_list_jobspec_base_nodecode(self):
+        ids = [self.jobid1]
+        data = flux.job.JobKVSLookup(self.fh, ids, decode=False, base=True).data()
+        self.assertEqual(len(data), 1)
+        self.assertNotIn("J", data[0])
+        self.check_jobspec_base_str(data[0], self.jobid1)
+
+    def test_list_14_job_kvs_lookup_list_jobspec_base_multiple_keys(self):
+        ids = [self.jobid1]
+        data = flux.job.JobKVSLookup(
+            self.fh, ids, keys=["jobspec", "J"], base=True
+        ).data()
+        self.assertEqual(len(data), 1)
+        self.assertIn("J", data[0])
+        self.check_jobspec_base_decoded(data[0], self.jobid1)
+
+    def test_list_15_job_kvs_lookup_list_base_no_jobspec(self):
+        ids = [self.jobid1]
+        data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"], base=True).data()
         self.assertEqual(len(data), 1)
         self.assertNotIn("jobspec", data[0])
         self.check_R_J_decoded(data[0], self.jobid1)

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -87,6 +87,20 @@ test_expect_success 'flux job info --original jobspec works' '
 	grep ORIGINALTHING jobspec_original.out
 '
 
+test_expect_success 'flux job info applies jobspec updates' '
+	jobid=$(flux submit --urgency=hold true) &&
+	echo $jobid > updated_jobspec.id &&
+	flux job info $jobid jobspec | jq -e ".attributes.system.duration == 0" &&
+	flux update $jobid duration=100s &&
+	flux job info $jobid jobspec | jq -e ".attributes.system.duration == 100.0" &&
+	flux cancel $jobid
+'
+
+test_expect_success 'flux job info --base jobspec works' '
+	flux job info --base $(cat updated_jobspec.id) jobspec \
+	     | jq -e ".attributes.system.duration == 0"
+'
+
 test_expect_success 'flux job info jobspec fails on bad id' '
 	test_must_fail flux job info 12345 jobspec
 '


### PR DESCRIPTION
The jobspec returned by `flux job info` is the one stored in the KVS, which may differ from what is internally "viewed" by flux components due to `jobspec-update` events.  Notably, the jobspec returned may not be consistent to what is returned via `flux jobs`.

This PR will make `flux job info` return an updated jobspec by default.

Added a `--noupdate` option to get the version stored in the KVS.  I'm not super in love with this option name.  I considered `--kvs`, but that was confusing give Python binding function names like ("job_kvs_lookup()").  `--stored` seemed dumb too.  Ehhh ... any better ideas?  I didn't want the option to be `--update` b/c I wanted the default to be the updated one.

Also added support in the Python bindings.

Update `flux-update`, as it no longer needs to apply `jobspec-update` events manually.
