### PR TITLE
job-list: support streaming job-stats RPC

### DIFF
--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -95,6 +95,15 @@ static void purge_cb (flux_t *h,
     flux_log (h, LOG_DEBUG, "purged %d inactive jobs", count);
 }
 
+static void disconnect_cb (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+    struct list_ctx *ctx = arg;
+    job_stats_disconnect (ctx->jsctx->statsctx, msg);
+}
+
 static const struct flux_msg_handler_spec htab[] = {
     { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "job-list.list",
@@ -130,6 +139,11 @@ static const struct flux_msg_handler_spec htab[] = {
       .topic_glob   = "job-purge-inactive",
       .cb           = purge_cb,
       .rolemask     = 0
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-list.disconnect",
+      .cb           = disconnect_cb,
+      .rolemask     = FLUX_ROLE_USER,
     },
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -65,23 +65,6 @@ error:
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
-static void job_stats_cb (flux_t *h, flux_msg_handler_t *mh,
-                          const flux_msg_t *msg, void *arg)
-{
-    struct list_ctx *ctx = arg;
-    json_t *o = job_stats_encode (ctx->jsctx->statsctx);
-    if (o == NULL)
-        goto error;
-    if (flux_respond_pack (h, msg, "o", o) < 0) {
-        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-        goto error;
-    }
-    return;
-error:
-    if (flux_respond_error (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-}
-
 static void purge_cb (flux_t *h,
                       flux_msg_handler_t *mh,
                       const flux_msg_t *msg,
@@ -136,11 +119,6 @@ static const struct flux_msg_handler_spec htab[] = {
     { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "job-list.job-state-unpause",
       .cb           = job_state_unpause_cb,
-      .rolemask     = FLUX_ROLE_USER
-    },
-    { .typemask     = FLUX_MSGTYPE_REQUEST,
-      .topic_glob   = "job-list.job-stats",
-      .cb           = job_stats_cb,
       .rolemask     = FLUX_ROLE_USER
     },
     { .typemask     = FLUX_MSGTYPE_REQUEST,

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -47,14 +47,16 @@ static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
     int inactive = zlistx_size (ctx->jsctx->inactive);
     int idsync_lookups = zlistx_size (ctx->isctx->lookups);
     int idsync_waits = zhashx_size (ctx->isctx->waits);
-    if (flux_respond_pack (h, msg, "{s:{s:i s:i s:i} s:{s:i s:i}}",
+    int stats_watchers = job_stats_watchers (ctx->jsctx->statsctx);
+    if (flux_respond_pack (h, msg, "{s:{s:i s:i s:i} s:{s:i s:i} s:i}",
                            "jobs",
                            "pending", pending,
                            "running", running,
                            "inactive", inactive,
                            "idsync",
                            "lookups", idsync_lookups,
-                           "waits", idsync_waits) < 0) {
+                           "waits", idsync_waits,
+                           "stats_watchers", stats_watchers) < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -351,6 +351,12 @@ static int job_stats_respond (struct job_stats_ctx *statsctx,
     return rc;
 }
 
+void job_stats_disconnect (struct job_stats_ctx *statsctx,
+                           const flux_msg_t *msg)
+{
+    flux_msglist_disconnect (statsctx->watchers, msg);
+}
+
 static void timer_cb (flux_reactor_t *r,
                       flux_watcher_t *w,
                       int revents,

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -357,6 +357,11 @@ void job_stats_disconnect (struct job_stats_ctx *statsctx,
     flux_msglist_disconnect (statsctx->watchers, msg);
 }
 
+int job_stats_watchers (struct job_stats_ctx *statsctx)
+{
+    return flux_msglist_count (statsctx->watchers);
+}
+
 static void timer_cb (flux_reactor_t *r,
                       flux_watcher_t *w,
                       int revents,

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -16,9 +16,16 @@
 #include <flux/core.h>
 
 #include "ccan/str/str.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
 
 #include "stats.h"
 #include "job_data.h"
+
+struct job_stats_ctx {
+    flux_t *h;
+    struct job_stats all;
+    zhashx_t *queue_stats;
+};
 
 static void free_wrapper (void **item)
 {

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -43,8 +43,10 @@ struct job_stats_ctx *job_stats_ctx_create (flux_t *h)
         return NULL;
     statsctx->h = h;
 
-    if (!(statsctx->queue_stats = zhashx_new ()))
+    if (!(statsctx->queue_stats = zhashx_new ())) {
+        errno = ENOMEM;
         goto error;
+    }
     zhashx_set_destructor (statsctx->queue_stats, free_wrapper);
 
     return statsctx;

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -41,8 +41,6 @@ void job_stats_remove_queue (struct job_stats_ctx *statsctx,
 
 void job_stats_purge (struct job_stats_ctx *statsctx, struct job *job);
 
-json_t * job_stats_encode (struct job_stats_ctx *statsctx);
-
 #endif /* ! _FLUX_JOB_LIST_JOB_STATS_H */
 
 // vi: ts=4 sw=4 expandtab

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -14,8 +14,6 @@
 #include <flux/core.h> /* FLUX_JOB_NR_STATES */
 #include <jansson.h>
 
-#include "src/common/libczmqcontainers/czmq_containers.h"
-
 #include "job_data.h"
 
 struct job_stats {
@@ -25,12 +23,6 @@ struct job_stats {
     unsigned int timeout;
     unsigned int canceled;
     unsigned int inactive_purged;
-};
-
-struct job_stats_ctx {
-    flux_t *h;
-    struct job_stats all;
-    zhashx_t *queue_stats;
 };
 
 struct job_stats_ctx *job_stats_ctx_create (flux_t *h);

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -47,6 +47,10 @@ void job_stats_purge (struct job_stats_ctx *statsctx, struct job *job);
 void job_stats_disconnect (struct job_stats_ctx *statsctx,
                            const flux_msg_t *msg);
 
+/* Return the number of job-stats streaming clients.
+ */
+int job_stats_watchers (struct job_stats_ctx *statsctx);
+
 #endif /* ! _FLUX_JOB_LIST_JOB_STATS_H */
 
 // vi: ts=4 sw=4 expandtab

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -41,6 +41,12 @@ void job_stats_remove_queue (struct job_stats_ctx *statsctx,
 
 void job_stats_purge (struct job_stats_ctx *statsctx, struct job *job);
 
+/* A client has disconnected from job-list.
+ * Cancel streaming job-stats request, if any.
+ */
+void job_stats_disconnect (struct job_stats_ctx *statsctx,
+                           const flux_msg_t *msg);
+
 #endif /* ! _FLUX_JOB_LIST_JOB_STATS_H */
 
 // vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -148,6 +148,7 @@ TESTSCRIPTS = \
 	t2250-job-archive.t \
 	t2260-job-list.t \
 	t2261-job-list-update.t \
+	t2262-job-list-stats.t \
 	t2270-job-dependencies.t \
 	t2271-job-dependency-after.t \
 	t2272-job-begin-time.t \

--- a/t/t2262-job-list-stats.t
+++ b/t/t2262-job-list-stats.t
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+test_description='Test streaming flux job statistics RPC'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1
+
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+get_watchers() {
+	flux module stats job-list | jq -r .stats_watchers
+}
+
+test_expect_success 'create streaming job-stats script' '
+	cat >job-stats.py <<-EOT &&
+	import sys
+	import flux
+	handle = flux.Flux()
+	fut = handle.rpc("job-list.job-stats",{},flags=flux.constants.FLUX_RPC_STREAMING)
+	for i in range(int(sys.argv[1])):
+	    print(fut.get())
+	    sys.stdout.flush()
+	    fut.reset()
+	EOT
+	chmod +x job-stats.py
+'
+test_expect_success 'streaming job-stats returns one response immediately' '
+	run_timeout 30 flux python job-stats.py 1
+'
+test_expect_success 'disconnect handling works' '
+	test $(get_watchers) -eq 0
+'
+test_expect_success NO_CHAIN_LINT 'start monitoring job-stats and wait for first response' '
+	flux python job-stats.py 100 >stats.log &
+	echo $! >stats.pid &&
+	$waitfile stats.log
+'
+test_expect_success NO_CHAIN_LINT 'run a job to completion' '
+	flux run /bin/true
+'
+test_expect_success NO_CHAIN_LINT 'wait until job-stats produces at least one more response' '
+	$waitfile --count=2 stats.log
+'
+test_expect_success NO_CHAIN_LINT 'kill job-stats script' '
+	pid=$(cat stats.pid) &&
+	kill -15 $pid
+'
+
+test_done


### PR DESCRIPTION
As discussed in #5400, a streaming version of `job-list.job-stats` would be useful and could let us deprecate the `job-stats` events, reducing job manager complexity and background noise on the overlay network.

This modifies `job-list.job-stats` so if the FLUX_RPC_STREAMING flag is used, responses are sent whenever job stats change (but no more frequently than every 200ms), and switches `flux-top(1)` to use the streaming responses to detect job activity in place of subscribing to `job-stats` events.

Marked as WIP pending the addition of tests and any initial feedback.