### PR TITLE
job-manager: update: cleanup, small fixes, and documentation

### DIFF
--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -227,6 +227,10 @@ job.inactive-add
 job.inactive-remove
   The job has been purged from the inactive hash.
 
+job.update
+  The job has been updated with an RFC 21 ``jobspec-update`` event.
+
+
 CONFIGURATION CALLBACK TOPIC
 ============================
 
@@ -244,6 +248,29 @@ The callback should return 0 on success, and -1 on failure.  On failure,
 it may optionally set a human readable error string in the ``errstr`` output
 argument.  The ``flux_jobtap_error()`` convenience function may be useful here.
 
+JOB UPDATE CALLBACKS
+====================
+
+The job manager allows updates of select job attributes through a
+plugin-based scheme. Plugins may register a callback topic matching
+``job.update.KEY``, where ``KEY`` is a period-delimited jobspec attribute,
+e.g. ``job.update.attributes.system.duration``. The requested updates are
+passed as an additional argument to the plugin in the ``updates`` key.
+
+The purpose of ``job.update.*`` callbacks to enable plugins to allow or
+deny the update of specific job attributes. Updates are denied by default
+unless a callback exists for the updated attribute and the plugin returns 0
+from the callback. Plugins deny an attribute update by returning -1 from
+the callback, and may optionally set an error message to return to the
+user with ``flux_jobtap_error(3)``.
+
+After all updates in a request are allowed by plugins, then the updated
+jobspec is passed through the ``job.validate`` plugin stack to ensure the
+result is valid. Plugins can note that an update is already validated by
+setting a ``validated`` flag in the ``FLUX_PLUGIN_OUT_ARGS``. If all updated
+attributes have this flag then this validation step is skipped. This can
+be useful to allow an instance owner to update a job attribute beyond limits
+for example.
 
 PLUGIN CALLBACK TOPICS
 ======================

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -2352,6 +2352,7 @@ int jobtap_job_update (struct jobtap *jobtap,
          */
         error_asprintf (jobtap, job, errp, "update of %s not supported", key);
         rc = -1;
+        errno = EINVAL;
     }
     else if (rc < 0) {
         /* Callback failed, check for provided errmsg */
@@ -2363,7 +2364,7 @@ int jobtap_job_update (struct jobtap *jobtap,
             errmsg = "update rejected by job-manager plugin";
         }
         error_asprintf (jobtap, job, errp, "%s", errmsg);
-        errno = EPERM;
+        errno = EINVAL;
     }
     else if (rc > 0 && needs_validation != NULL) {
         /*  Default is to require further validation by calling job.validate
@@ -2438,6 +2439,7 @@ int jobtap_validate_updates (struct jobtap *jobtap,
         if ((*errp = strdup (errmsg)) == NULL)
             flux_log (jobtap->ctx->h, LOG_ERR,
                       "jobtap: validate failed to capture errmsg");
+        errno = EINVAL;
     }
 error:
     ERRNO_SAFE_WRAP (json_decref, jobspec_updated);

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -763,12 +763,14 @@ static void error_asprintf (struct jobtap *jobtap,
                             const char *fmt, ...)
 {
     va_list ap;
+    int saved_errno = errno;
     va_start (ap, fmt);
     if (vasprintf (errp, fmt, ap) < 0)
         flux_log_error (jobtap->ctx->h,
                         "id=%s: failed to create error string: fmt=%s",
                         idf58 (job->id), fmt);
     va_end (ap);
+    errno = saved_errno;
 }
 
 /* Common function for job.create and job.validate.

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -2379,8 +2379,6 @@ int jobtap_job_update (struct jobtap *jobtap,
                             job,
                             errp,
                             "failed to unpack validated flag");
-            fprintf (stderr, "arg unpack failed: %s\n",
-                             flux_plugin_arg_strerror (args));
             return -1;
         }
         *needs_validation = !validated;

--- a/src/modules/job-manager/update.c
+++ b/src/modules/job-manager/update.c
@@ -216,6 +216,7 @@ static void update_handle_request (flux_t *h,
     }
     if (job->immutable && !(cred.rolemask & FLUX_ROLE_OWNER)) {
         errstr = "job is immutable due to previous instance owner update";
+        errno = EPERM;
         goto error;
     }
     /*  Process the update request

--- a/src/modules/job-manager/update.c
+++ b/src/modules/job-manager/update.c
@@ -196,11 +196,14 @@ static void update_handle_request (flux_t *h,
     /*  Verify jobid exists and is not inactive
      */
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        if (!(job = zhashx_lookup (ctx->inactive_jobs, &id)))
+        if (!(job = zhashx_lookup (ctx->inactive_jobs, &id))) {
             errstr = "unknown job id";
-        else
+            errno = ENOENT;
+        }
+        else {
             errstr = "job is inactive";
-        errno = EINVAL;
+            errno = EINVAL;
+        }
         goto error;
     }
     /*  Fetch the credential from this message and ensure the user

--- a/t/t2290-job-update.t
+++ b/t/t2290-job-update.t
@@ -63,7 +63,7 @@ test_expect_success 'update request for negative duration fails' '
 	echo "{\"id\": $(flux job id $jobid),\
 	       \"updates\": {\"attributes.system.duration\": -1.0}\
               }" \
-	    | ${FLUX_BUILD_DIR}/t/request/rpc job-manager.update 1 # EPERM
+	    | ${FLUX_BUILD_DIR}/t/request/rpc job-manager.update 22 # EINVAL
 '
 test_expect_success 'update request with invalid duration type fails' '
 	echo "{\"id\": $(flux job id $jobid),\


### PR DESCRIPTION
This PR is some minor cleanup for the job-manager update service.

Also, add missing documentation in `flux-jobtap-plugins(7)`.