### PR TITLE
content: make the content cache a broker module

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -267,24 +267,8 @@ content.backing-module (Updates: C)
    on rank 0 where the content backing store is active.  Default:
    ``content-sqlite``.
 
-content.blob-size-limit (Updates: C, R)
-   The maximum size of a blob, the basic unit of content storage.
-   Default: ``1073741824``.
-
-content.flush-batch-limit (Updates: C, R)
-   The maximum number of outstanding store requests that will be initiated
-   when handling a flush or backing store load operation.  Default: ``256``.
-
 content.hash (Updates: C)
    The selected hash algorithm.  Default ``sha1``.  Other options: ``sha256``.
-
-content.purge-old-entry (Updates: C, R)
-   When the cache size footprint needs to be reduced, only consider purging
-   entries that are older than this number of seconds.  Default:  ``10``.
-
-content.purge-target-size (Updates: C, R)
-   If possible, the cache size purged periodically so that the total size of
-   the cache stays at or below this value, in bytes.  Default: ``16777216``.
 
 
 RESOURCES

--- a/etc/rc1
+++ b/etc/rc1
@@ -22,6 +22,7 @@ if test $RANK -gt 0; then
     flux config reload
 fi
 
+modload all content
 modload all barrier
 if test "$(flux config get --default=false systemd.enable)" = "true"; then
     modload all sdbus

--- a/etc/rc3
+++ b/etc/rc3
@@ -77,5 +77,6 @@ if test $RANK -eq 0; then
         flux module remove ${backingmod} || exit_rc=1
     fi
 fi
+modrm all content
 
 exit $exit_rc

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -40,12 +40,6 @@ libbroker_la_SOURCES = \
 	attr.c \
 	log.h \
 	log.c \
-	content-cache.h \
-	content-cache.c \
-	content-checkpoint.h \
-	content-checkpoint.c \
-	content-mmap.h \
-	content-mmap.c \
 	runat.h \
 	runat.c \
 	state_machine.h \

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -58,7 +58,6 @@
 #include "service.h"
 #include "attr.h"
 #include "log.h"
-#include "content-cache.h"
 #include "runat.h"
 #include "heaptrace.h"
 #include "exec.h"
@@ -469,15 +468,11 @@ int main (int argc, char *argv[])
         log_err ("broker_add_services");
         goto cleanup;
     }
-    /* These two broker-resident services call flux_sync_create(), thus
-     * require event.subscribe to have a handler before running.
+    /* overlay_control_start() calls flux_sync_create(), thus
+     * requires event.subscribe to have a handler before running.
      */
     if (overlay_control_start (ctx.overlay) < 0) {
         log_err ("error initializing overlay control messages");
-        goto cleanup;
-    }
-    if (!(ctx.cache = content_cache_create (ctx.h, ctx.attrs))) {
-        log_err ("error initializing content cache");
         goto cleanup;
     }
 
@@ -536,7 +531,6 @@ cleanup:
     /* Unregister builtin services
      */
     attr_destroy (ctx.attrs);
-    content_cache_destroy (ctx.cache);
 
     modhash_destroy (ctx.modhash);
     zlist_destroy (&ctx.sigwatchers);
@@ -1612,7 +1606,6 @@ struct internal_service {
 static struct internal_service services[] = {
     { "broker",             NULL }, // kind of a catch-all, slowly deprecating
     { "log",                NULL },
-    { "content",            NULL },
     { "attr",               NULL },
     { "heaptrace",          NULL },
     { "event",              NULL },

--- a/src/common/libcontent/content.c
+++ b/src/common/libcontent/content.c
@@ -87,14 +87,14 @@ int content_store_get_hash (flux_future_t *f, const void **hash, int *hash_size)
     return 0;
 }
 
-int content_store_get_blobref (flux_future_t *f, const char **blobref)
+int content_store_get_blobref (flux_future_t *f,
+                               const char *hash_name,
+                               const char **blobref)
 {
-    flux_t *h = flux_future_get_flux (f);
     const char *auxkey = "flux::blobref";
     const char *result;
 
     if (!(result = flux_future_aux_get (f, auxkey))) {
-        const char *hash_name = flux_attr_get (h, "content.hash");
         const void *hash;
         int hash_len;
         char buf[BLOBREF_MAX_STRING_SIZE];

--- a/src/common/libcontent/content.h
+++ b/src/common/libcontent/content.h
@@ -43,7 +43,9 @@ flux_future_t *content_store (flux_t *h, const void *buf, int len, int flags);
  * Returns 0 on success, -1 on failure with errno set.
  */
 int content_store_get_hash (flux_future_t *f, const void **hash, int *hash_len);
-int content_store_get_blobref (flux_future_t *f, const char **blobref);
+int content_store_get_blobref (flux_future_t *f,
+                               const char *hash_name,
+                               const char **blobref);
 
 #endif /* !_FLUX_CONTENT_H */
 

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -29,6 +29,7 @@ endif
 fluxmod_LTLIBRARIES = \
 	barrier.la \
 	connector-local.la \
+	content.la \
 	content-files.la \
 	content-sqlite.la \
 	cron.la \
@@ -67,6 +68,19 @@ connector_local_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la
 connector_local_la_LDFLAGS = $(fluxmod_ldflags) -module
+
+content_la_SOURCES = \
+	content/main.c \
+	content/cache.c \
+	content/cache.h \
+	content/mmap.c \
+	content/mmap.h \
+	content/checkpoint.c \
+	content/checkpoint.h
+content_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la
+content_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 content_files_la_SOURCES =
 content_files_la_LIBADD = \

--- a/src/modules/content/cache.c
+++ b/src/modules/content/cache.c
@@ -26,10 +26,9 @@
 #include "src/common/libcontent/content.h"
 #include "ccan/str/str.h"
 
-#include "attr.h"
-#include "content-cache.h"
-#include "content-checkpoint.h"
-#include "content-mmap.h"
+#include "cache.h"
+#include "checkpoint.h"
+#include "mmap.h"
 
 /* A periodic callback purges the cache of least recently used entries.
  * The callback is synchronized with the instance heartbeat, with a
@@ -996,6 +995,7 @@ static const struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
+#if 0
 static int content_cache_getattr (const char *name, const char **val, void *arg)
 {
     struct content_cache *cache = arg;
@@ -1006,9 +1006,11 @@ static int content_cache_getattr (const char *name, const char **val, void *arg)
         return -1;
     return 0;
 }
+#endif
 
-static int register_attrs (struct content_cache *cache, attr_t *attr)
+static int register_attrs (struct content_cache *cache)
 {
+#if 0
     const char *s;
 
     /* Take initial value of content->backing_name from content.backing-module
@@ -1061,7 +1063,7 @@ static int register_attrs (struct content_cache *cache, attr_t *attr)
     if (attr_add_active (attr, "content.backing-module", 0,
                  content_cache_getattr, NULL, cache) < 0)
         return -1;
-
+#endif
     return 0;
 }
 
@@ -1081,7 +1083,7 @@ void content_cache_destroy (struct content_cache *cache)
     }
 }
 
-struct content_cache *content_cache_create (flux_t *h, attr_t *attrs)
+struct content_cache *content_cache_create (flux_t *h)
 {
     struct content_cache *cache;
 
@@ -1109,7 +1111,7 @@ struct content_cache *content_cache_create (flux_t *h, attr_t *attrs)
     list_head_init (&cache->lru);
     list_head_init (&cache->flush);
 
-    if (register_attrs (cache, attrs) < 0)
+    if (register_attrs (cache) < 0)
         goto error;
     assert (content_hash_size >= sizeof (size_t)); // hasher assumes this
 

--- a/src/modules/content/cache.c
+++ b/src/modules/content/cache.c
@@ -88,7 +88,7 @@ struct content_cache {
     zhashx_t *entries;
     uint8_t backing:1;              // 'content.backing' service available
     char *backing_name;
-    const char *hash_name;
+    char *hash_name;
     struct msgstack *flush_requests;
 
     struct list_head lru;           // LRU is for valid, clean entries only
@@ -745,7 +745,10 @@ static void content_register_backing_request (flux_t *h,
      * be changed.
      */
     if (!cache->backing_name) {
-        if (!(cache->backing_name = strdup (name)))
+        if (!(cache->backing_name = strdup (name))
+            || flux_attr_set (h,
+                              "content.backing-module",
+                              cache->backing_name) < 0)
             goto error;
     }
     if (!streq (cache->backing_name, name)) {
@@ -995,75 +998,75 @@ static const struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
-#if 0
-static int content_cache_getattr (const char *name, const char **val, void *arg)
+static int get_hash_name (struct content_cache *cache)
 {
-    struct content_cache *cache = arg;
-
-    if (streq (name, "content.backing-module"))
-        *val = cache->backing_name;
-    else
-        return -1;
-    return 0;
-}
-#endif
-
-static int register_attrs (struct content_cache *cache)
-{
-#if 0
     const char *s;
 
-    /* Take initial value of content->backing_name from content.backing-module
-     * attribute, if set.  The attribute is re-added below.
-     */
-    if (attr_get (attr, "content.backing-module", &s, NULL) == 0) {
-        if (!(cache->backing_name = strdup (s)))
-            return -1;
-        if (attr_delete (attr, "content.backing-module", 1) < 0)
-            return -1;
+    if (!(s = flux_attr_get (cache->h, "content.hash")))
+        s = default_hash;
+    if ((content_hash_size = blobref_validate_hashtype (s)) < 0
+        || !(cache->hash_name = strdup (s))) {
+        flux_log_error (cache->h, "%s: unknown hash type", s);
+        return -1;
     }
+    if (flux_attr_set (cache->h, "content.hash", cache->hash_name) < 0) {
+        flux_log_error (cache->h, "setattr content.hash");
+        return -1;
+    }
+    return 0;
+}
 
-    /* content.hash may be set on the command line.
-     */
-    if (attr_get (attr, "content.hash", &s, NULL) < 0) {
-        if (attr_add (attr,
-                      "content.hash",
-                      cache->hash_name,
-                      ATTR_IMMUTABLE) < 0)
-            return -1;
-    }
-    else {
-        int hash_size;
-        if ((hash_size = blobref_validate_hashtype (s)) < 0) {
-            log_msg ("%s: unknown hash type", s);
+static int parse_u32 (const char *s, uint32_t *val)
+{
+    unsigned long u;
+    char *endptr;
+
+    errno = 0;
+    u = strtoul (s, &endptr, 10);
+    if (errno != 0 || *endptr != '\0' || u > UINT32_MAX)
+        return -1;
+    *val = u;
+    return 0;
+}
+
+int parse_args (struct content_cache *cache, int argc, char **argv)
+{
+    uint32_t val;
+
+    for (int i = 0; i < argc; i++) {
+        if (strstarts (argv[i], "purge-target-size=")) {
+            if (parse_u32 (argv[i] + 18, &val) < 0) {
+                flux_log (cache->h, LOG_ERR, "error parsing %s", argv[i]);
+                return -1;
+            }
+            cache->purge_target_size = val;
+        }
+        else if (strstarts (argv[i], "purge-old-entry=")) {
+            if (parse_u32 (argv[i] + 16, &val) < 0) {
+                flux_log (cache->h, LOG_ERR, "error parsing %s", argv[i]);
+                return -1;
+            }
+            cache->purge_old_entry = val;
+        }
+        else if (strstarts (argv[i], "flush-batch-limit=")) {
+            if (parse_u32 (argv[i] + 18, &val) < 0) {
+                flux_log (cache->h, LOG_ERR, "error parsing %s", argv[i]);
+                return -1;
+            }
+            cache->purge_old_entry = val;
+        }
+        else if (strstarts (argv[i], "blob-size-limit=")) {
+            if (parse_u32 (argv[i] + 16, &val) < 0) {
+                flux_log (cache->h, LOG_ERR, "error parsing %s", argv[i]);
+                return -1;
+            }
+            cache->blob_size_limit = val;
+        }
+        else {
+            flux_log (cache->h, LOG_ERR, "unknown module option: %s", argv[i]);
             return -1;
         }
-        if (attr_set_flags (attr, "content.hash", ATTR_IMMUTABLE) < 0)
-            return -1;
-        cache->hash_name = s;
-        content_hash_size = hash_size;
     }
-
-    /* Purge tunables
-     */
-    if (attr_add_active_uint32 (attr, "content.purge-target-size",
-                &cache->purge_target_size, 0) < 0)
-        return -1;
-    if (attr_add_active_uint32 (attr, "content.purge-old-entry",
-                &cache->purge_old_entry, 0) < 0)
-        return -1;
-    /* Misc
-     */
-    if (attr_add_active_uint32 (attr, "content.flush-batch-limit",
-                &cache->flush_batch_limit, 0) < 0)
-        return -1;
-    if (attr_add_active_uint32 (attr, "content.blob-size-limit",
-                &cache->blob_size_limit, ATTR_IMMUTABLE) < 0)
-        return -1;
-    if (attr_add_active (attr, "content.backing-module", 0,
-                 content_cache_getattr, NULL, cache) < 0)
-        return -1;
-#endif
     return 0;
 }
 
@@ -1078,12 +1081,13 @@ void content_cache_destroy (struct content_cache *cache)
         msgstack_destroy (&cache->flush_requests);
         content_checkpoint_destroy (cache->checkpoint);
         content_mmap_destroy (cache->mmap);
+        free (cache->hash_name);
         free (cache);
         errno = saved_errno;
     }
 }
 
-struct content_cache *content_cache_create (flux_t *h)
+struct content_cache *content_cache_create (flux_t *h, int argc, char **argv)
 {
     struct content_cache *cache;
 
@@ -1091,6 +1095,8 @@ struct content_cache *content_cache_create (flux_t *h)
         return NULL;
     if (!(cache->entries = zhashx_new ()))
         goto nomem;
+    cache->h = h;
+    cache->reactor = flux_get_reactor (h);
 
     zhashx_set_destructor (cache->entries, cache_entry_destructor);
     zhashx_set_key_hasher (cache->entries, cache_entry_hasher);
@@ -1103,17 +1109,17 @@ struct content_cache *content_cache_create (flux_t *h)
     cache->flush_batch_limit = default_flush_batch_limit;
     cache->purge_target_size = default_cache_purge_target_size;
     cache->purge_old_entry = default_cache_purge_old_entry;
-    cache->hash_name = default_hash;
-    if ((content_hash_size = blobref_validate_hashtype (default_hash)) < 0)
+    /* Some tunables may be set on the module command line (mainly for test).
+     */
+    if (parse_args (cache, argc, argv) < 0) {
+        errno = EINVAL;
         goto error;
-    cache->h = h;
-    cache->reactor = flux_get_reactor (h);
+    }
+    if (get_hash_name (cache) < 0)
+        goto error;
+
     list_head_init (&cache->lru);
     list_head_init (&cache->flush);
-
-    if (register_attrs (cache) < 0)
-        goto error;
-    assert (content_hash_size >= sizeof (size_t)); // hasher assumes this
 
     if (flux_get_rank (h, &cache->rank) < 0)
         goto error;

--- a/src/modules/content/cache.h
+++ b/src/modules/content/cache.h
@@ -13,7 +13,7 @@
 
 struct content_cache;
 
-struct content_cache *content_cache_create (flux_t *h);
+struct content_cache *content_cache_create (flux_t *h, int argc, char **argv);
 void content_cache_destroy (struct content_cache *cache);
 bool content_cache_backing_loaded (struct content_cache *cache);
 

--- a/src/modules/content/cache.h
+++ b/src/modules/content/cache.h
@@ -8,18 +8,16 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef HAVE_BROKER_CONTENT_CACHE_H
-#define HAVE_BROKER_CONTENT_CACHE_H 1
-
-#include "attr.h"
+#ifndef _CONTENT_CACHE_H
+#define _CONTENT_CACHE_H 1
 
 struct content_cache;
 
-struct content_cache *content_cache_create (flux_t *h, attr_t *attr);
+struct content_cache *content_cache_create (flux_t *h);
 void content_cache_destroy (struct content_cache *cache);
 bool content_cache_backing_loaded (struct content_cache *cache);
 
-#endif /* !HAVE_BROKER_CONTENT_CACHE_H */
+#endif /* !_CONTENT_CACHE_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/content/checkpoint.c
+++ b/src/modules/content/checkpoint.c
@@ -20,8 +20,8 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 
-#include "content-checkpoint.h"
-#include "content-cache.h"
+#include "checkpoint.h"
+#include "cache.h"
 
 struct content_checkpoint {
     flux_t *h;

--- a/src/modules/content/checkpoint.h
+++ b/src/modules/content/checkpoint.h
@@ -8,10 +8,10 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef HAVE_BROKER_CONTENT_CHECKPOINT_H
-#define HAVE_BROKER_CONTENT_CHECKPOINT_H 1
+#ifndef _CONTENT_CHECKPOINT_H
+#define _CONTENT_CHECKPOINT_H 1
 
-#include "content-cache.h"
+#include "cache.h"
 
 struct content_checkpoint *content_checkpoint_create (
     flux_t *h,
@@ -21,7 +21,7 @@ void content_checkpoint_destroy (struct content_checkpoint *checkpoint);
 
 int checkpoints_flush (struct content_checkpoint *checkpoint);
 
-#endif /* !HAVE_BROKER_CONTENT_CHECKPOINT_H */
+#endif /* !_CONTENT_CHECKPOINT_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/content/main.c
+++ b/src/modules/content/main.c
@@ -23,7 +23,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     struct content_cache *cache;
     int rc = -1;
 
-    if (!(cache = content_cache_create (h))) {
+    if (!(cache = content_cache_create (h, argc, argv))) {
         flux_log_error (h, "error initializing content cache");
         goto done;
     }

--- a/src/modules/content/main.c
+++ b/src/modules/content/main.c
@@ -1,0 +1,42 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* main.c - module main() for content module
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "cache.h"
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    struct content_cache *cache;
+    int rc = -1;
+
+    if (!(cache = content_cache_create (h))) {
+        flux_log_error (h, "error initializing content cache");
+        goto done;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        flux_log_error (h, "reactor exited abnormally");
+        goto done;
+    }
+    rc = 0;
+done:
+    content_cache_destroy (cache);
+    return rc;
+}
+
+MOD_NAME ("content");
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/content/mmap.c
+++ b/src/modules/content/mmap.c
@@ -90,7 +90,7 @@
 #include "ccan/ptrint/ptrint.h"
 #include "ccan/str/str.h"
 
-#include "content-mmap.h"
+#include "mmap.h"
 
 struct cache_entry {
     struct content_region *reg;

--- a/src/modules/content/mmap.h
+++ b/src/modules/content/mmap.h
@@ -8,12 +8,12 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef BROKER_CONTENT_MMAP_H
-#define BROKER_CONTENT_MMAP_H 1
+#ifndef _CONTENT_MMAP_H
+#define _CONTENT_MMAP_H 1
 
 #include <stdbool.h>
 
-#include "content-cache.h"
+#include "cache.h"
 
 struct content_mmap *content_mmap_create (flux_t *h,
                                           const char *hash_name,
@@ -35,6 +35,6 @@ bool content_mmap_validate (struct content_region *reg,
 void content_mmap_region_decref (struct content_region *reg);
 struct content_region *content_mmap_region_incref (struct content_region *reg);
 
-#endif /* !BROKER_CONTENT_MMAP_H */
+#endif /* !_CONTENT_MMAP_H */
 
 // vi:ts=4 sw=4 expandtab

--- a/t/issues/t4482-flush-list-corruption.sh
+++ b/t/issues/t4482-flush-list-corruption.sh
@@ -15,6 +15,8 @@
 cat <<-EOF >t4482.sh
 #!/bin/sh -e
 
+flux module load content
+
 echo "abcde" | flux content store
 echo "fghij" | flux content store
 echo "klmno" | flux content store
@@ -29,6 +31,7 @@ flux module load content-sqlite
 flux content flush
 
 flux module remove content-sqlite
+flux module remove content
 
 EOF
 

--- a/t/kvs/content-spam.c
+++ b/t/kvs/content-spam.c
@@ -29,8 +29,9 @@ static void store_completion (flux_future_t *f, void *arg)
 {
     flux_t *h = arg;
     const char *blobref;
+    const char *hash_type = flux_aux_get (h, "hash_type");
 
-    if (content_store_get_blobref (f, &blobref) < 0)
+    if (content_store_get_blobref (f, hash_type, &blobref) < 0)
         log_err_exit ("store");
     printf ("%s\n", blobref);
     flux_future_destroy (f);
@@ -45,6 +46,8 @@ int main (int ac, char *av[])
     flux_t *h;
     char data[256];
     int size = 256;
+    const char *s;
+    char *hash_type;
 
     if (ac != 2 && ac != 3) {
         fprintf (stderr, "Usage: content-spam N [M]\n");
@@ -58,6 +61,10 @@ int main (int ac, char *av[])
 
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
+    if (!(s = flux_attr_get (h, "content.hash"))
+        || !(hash_type = strdup (s))
+        || flux_aux_set (h, "hash_type", hash_type, (flux_free_f)free) < 0)
+        log_err_exit ("getattr content.hash");
 
     spam_cur_inflight = 0;
     i = 0;

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -28,6 +28,7 @@ modload() {
 }
 
 
+modload all content
 modload 0 content-sqlite
 modload all kvs
 modload all kvs-watch

--- a/t/rc/rc1-kvs
+++ b/t/rc/rc1-kvs
@@ -10,6 +10,7 @@ modload() {
     fi
 }
 
+modload all content blob-size-limit=1048576
 modload 0 content-sqlite
 modload all kvs
 modload all kvs-watch

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -29,3 +29,4 @@ modrm all kvs
 flux content flush
 
 modrm 0 content-sqlite
+modrm all content

--- a/t/rc/rc3-kvs
+++ b/t/rc/rc3-kvs
@@ -17,3 +17,4 @@ modrm all kvs
 
 flux content flush
 modrm 0 content-sqlite
+modrm all content

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -220,5 +220,8 @@ test_expect_success 'content load with no blobrefs fails' '
 test_expect_success 'remove content module' '
 	flux exec flux module remove content
 '
+test_expect_success 'module fails to load with unknown option' '
+	test_must_fail flux module load content badopt
+'
 
 test_done

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -281,6 +281,9 @@ test_expect_success 'guests may not add non-userid-prefixed services' '
 
 # kvs.namespace-<NS>-setroot is a "private" event
 
+test_expect_success 'loaded content module' '
+	flux module load content
+'
 test_expect_success 'loaded kvs module' '
 	flux module load kvs
 '
@@ -340,6 +343,10 @@ test_expect_success 'flux content store not allowed for guest user' '
 	test_must_fail bash -c "FLUX_HANDLE_ROLEMASK=0x2 \
 	    flux content store <content.blob 2>content-store.err" &&
 	    grep "Request requires owner credentials" content-store.err
+'
+
+test_expect_success 'unloaded content module' '
+	flux module remove content
 '
 
 test_expect_success 'flux module list is open to guests' '

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -58,6 +58,10 @@ recheck_cache_blob() {
 	test_cmp blob.$1 blob.$1.cachecheck
 }
 
+test_expect_success 'load content module' '
+	flux module load content
+'
+
 ##
 # Tests of the module by itself (no content cache)
 ##
@@ -295,6 +299,10 @@ test_expect_success 'flux module stats content-files is open to guests' '
 test_expect_success 'remove content-files module on rank 0' '
        flux content flush &&
        flux module remove content-files
+'
+
+test_expect_success 'remove content module' '
+	flux module remove content
 '
 
 test_done

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -63,6 +63,10 @@ recheck_cache_blob() {
 	test_cmp blob.$1 blob.$1.cachecheck
 }
 
+test_expect_success 'load content module' '
+	flux module load content
+'
+
 ##
 # Tests of the module by itself (no content cache)
 ##
@@ -328,6 +332,7 @@ test_expect_success 'remove content-s3 module' '
 test_expect_success 'generate rc1/rc3 for content-s3 backing' '
 	cat >rc1-content-s3 <<EOF &&
 #!/bin/bash -e
+flux module load content
 flux module load content-s3
 flux module load kvs
 EOF
@@ -335,6 +340,7 @@ EOF
 #!/bin/bash -e
 flux module remove kvs
 flux module remove content-s3
+flux module remove content
 EOF
         chmod +x rc1-content-s3 &&
         chmod +x rc3-content-s3
@@ -367,6 +373,10 @@ test_expect_success 're-run instance, verify checkpoint date saved (s3)' '
 test_expect_success 'verify date in flux logs (s3)' '
 	today=`date --iso-8601` &&
 	grep checkpoint dmesgs3.out | grep ${today}
+'
+
+test_expect_success 'remove content module' '
+	flux module remove content
 '
 
 test_done

--- a/t/t0028-content-backing-none.t
+++ b/t/t0028-content-backing-none.t
@@ -11,6 +11,10 @@ echo "# $0: flux session size will be ${SIZE}"
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
+test_expect_success 'loaded content module' '
+	flux exec flux module load content
+'
+
 test_expect_success 'checkpoint-get fails, no checkpoints yet' '
         checkpoint_put foo bar
 '
@@ -82,6 +86,10 @@ test_expect_success 'unload kvs' '
 
 test_expect_success 'content.backing-module input of none works' '
         flux start -o,-Scontent.backing-module=none /bin/true
+'
+
+test_expect_success 'removedcontent module' '
+	flux exec flux module remove content
 '
 
 test_done

--- a/t/t0029-filemap-cmd.t
+++ b/t/t0029-filemap-cmd.t
@@ -40,6 +40,10 @@ test_under_flux 2 minimal
 # these tests.
 umask 022
 
+test_expect_success 'load content module' '
+	flux exec flux module load content
+'
+
 test_expect_success 'create copy directory' '
 	mkdir -p copydir
 '
@@ -299,6 +303,10 @@ test_expect_success 'size reduction should cause an error' '
 	rm -f copydir/testfile &&
 	test_must_fail flux filemap get -C copydir 2>reduced.err &&
 	grep changed reduced.err
+'
+
+test_expect_success 'remove content module' '
+	flux exec flux module remove content
 '
 
 test_done

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -290,16 +290,10 @@ test_expect_success 'kvs: invalid dirref write wont hang' '
         ! flux kvs put $DIR.bad_dirref.b=1
 '
 
-test_expect_success NO_ASAN "kvs: failure to store blob that exceeds max size does not hang" '
-        dd if=/dev/zero count=$((1048576/4096+1)) bs=4096 \
-                        skip=$((1048576/4096)) >toobig 2>/dev/null &&
-        test_must_fail flux start -s4 -o,--setattr=content.blob-size-limit=1048576 \
-                       flux kvs put -r $DIR.bad_toobig=- <toobig
-'
+# N.B. kvs test personality loads content module with blob-size-limit=1048576
+MAXBLOB=1048576
 
-MAXBLOB=`flux getattr content.blob-size-limit`
-
-test_expect_success LONGTEST "kvs: failure to store blob that exceeds max size default does not hang" '
+test_expect_success "kvs: failure to store blob that exceeds max size does not hang" '
 	dd if=/dev/zero count=$(($MAXBLOB/4096+1)) bs=4096 \
 			skip=$(($MAXBLOB/4096)) >toobig_long 2>/dev/null &&
 	test_must_fail flux kvs put -r $DIR.bad_toobig_long=- < toobig_long

--- a/t/t1003-kvs-stress.t
+++ b/t/t1003-kvs-stress.t
@@ -97,16 +97,8 @@ test_expect_success 'kvs: 8 threads/rank each doing 100 put,fence in a loop, mix
 
 # large dirs
 
-test_expect_success 'kvs: store value exceeding RFC 10 max blob size of 1m' '
-	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $DIR.tortureval --count 1 --size=1048577
-'
-
 test_expect_success 'kvs: store 10,000 keys in one dir' '
 	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $DIR.bigdir --count 10000
-'
-
-test_expect_success LONGTEST 'kvs: store 100,000 keys in one dir' '
-	${FLUX_BUILD_DIR}/t/kvs/torture --prefix $DIR.bigdir2 --count 100000
 '
 
 # kvs merging tests

--- a/t/t1010-kvs-commit-sync.t
+++ b/t/t1010-kvs-commit-sync.t
@@ -18,6 +18,10 @@ checkpoint_get() {
         jq -j -c -n  "{key:\"$1\"}" | $RPC content.checkpoint-get
 }
 
+test_expect_success 'load content module' '
+	flux module load content
+'
+
 test_expect_success 'load content-sqlite and kvs and add some data' '
         flux module load content-sqlite &&
         flux module load kvs &&
@@ -75,6 +79,10 @@ test_expect_success 'kvs: sync without backing store fails' '
 
 test_expect_success 'kvs: unload kvs' '
 	flux module remove kvs
+'
+
+test_expect_success 'remove content module' '
+	flux module remove content
 '
 
 test_done

--- a/t/t1011-kvs-checkpoint-period.t
+++ b/t/t1011-kvs-checkpoint-period.t
@@ -53,6 +53,7 @@ test_expect_success 'configure checkpoint-period, place initial value' '
 	checkpoint-period = "200ms"
 	EOF
 	flux config reload &&
+	flux module load content &&
 	flux module load content-sqlite &&
 	flux module load kvs &&
 	flux kvs put --blobref --sync a=1 > blob1.out
@@ -157,7 +158,8 @@ test_expect_success 'kvs: checkpoint of kvs-primary should change in time (4)' '
 
 test_expect_success 'kvs: remove modules' '
 	flux module remove kvs &&
-	flux module remove content-sqlite
+	flux module remove content-sqlite &&
+	flux module remove content
 '
 
 test_done

--- a/t/t2010-kvs-snapshot-restore.t
+++ b/t/t2010-kvs-snapshot-restore.t
@@ -99,6 +99,7 @@ test_expect_success 'verify checkpoint loaded with no date (sqlite)' '
 test_expect_success 'generate rc1/rc3 for content-files backing' '
 	cat >rc1-content-files <<EOF &&
 #!/bin/bash -e
+flux module load content
 flux module load content-files
 flux module load kvs
 EOF
@@ -106,6 +107,7 @@ EOF
 #!/bin/bash -e
 flux module remove kvs
 flux module remove content-files
+flux module remove content
 EOF
 	chmod +x rc1-content-files &&
 	chmod +x rc3-content-files

--- a/t/t2807-dump-cmd.t
+++ b/t/t2807-dump-cmd.t
@@ -13,6 +13,10 @@ countblobs() {
 		"select count(*) from objects;" | sed -e 's/.*= //'
 }
 
+test_expect_success 'load content module' '
+	flux module load content
+'
+
 test_expect_success 'flux-dump with no args prints Usage message' '
 	test_must_fail flux dump 2>dump-noargs.out &&
 	grep "Usage" dump-noargs.out
@@ -198,9 +202,11 @@ reader() {
                 -o,-Sbroker.rc3_path=\
                 -o,-Sstatedir=$dbdir\
                 bash -c "\
+                        flux module load content && \
                         flux module load content-sqlite && \
                         flux dump --no-cache -q --checkpoint - &&\
-                        flux module remove content-sqlite
+                        flux module remove content-sqlite && \
+                        flux module remove content
                 "
 }
 
@@ -210,9 +216,11 @@ writer() {
                 -o,-Sbroker.rc3_path= \
                 -o,-Sstatedir=$dbdir \
                 bash -c "\
+                        flux module load content && \
                         flux module load content-sqlite && \
                         flux restore --checkpoint - && \
-                        flux module remove content-sqlite
+                        flux module remove content-sqlite && \
+                        flux module remove content
                 "
 }
 
@@ -255,6 +263,10 @@ test_expect_success 'rc1 skips blob that exceeds 100M limit' '
 	flux start -o,-Scontent.restore=bigdump2.tar \
 		/bin/true 2>bigdump3.err &&
 	grep "exceeds" bigdump3.err
+'
+
+test_expect_success 'remove content module' '
+	flux module remove content
 '
 
 test_done

--- a/t/test-under-flux/expected.modcheck
+++ b/t/test-under-flux/expected.modcheck
@@ -1,4 +1,4 @@
-ok 1 - flux module load kvs
+ok 1 - flux module load heartbeat
 # passed all 1 test(s)
 1..1
-error: manually loaded module(s) not unloaded: kvs
+error: manually loaded module(s) not unloaded: heartbeat

--- a/t/test-under-flux/t_modcheck.t
+++ b/t/test-under-flux/t_modcheck.t
@@ -2,7 +2,7 @@
 test_description="test_under_flux with module loaded, but not unloaded"
 . "$SHARNESS_TEST_SRCDIR"/sharness.sh
 test_under_flux 2 minimal
-test_expect_success "flux module load kvs" "
-flux module load kvs
+test_expect_success "flux module load heartbeat" "
+flux module load heartbeat
 "
 test_done


### PR DESCRIPTION
Problem: the content service embedded in the broker is resource-intensive under load, potentially impacting broker performance.  Furthermore, it is a complex, optional service rather than an integral broker component.
    
Move the content service to a broker module where it is less tightly coupled to the broker and has a private reactor thread.

I didn't see any obvious impact on performance when running the throughput test.

**This branch**
```
$ src/test/throughput.py -n 10000
number of jobs: 10000
submit time:    2.964 s (3373.6 job/s)
script runtime: 45.773s
job runtime:    45.616s
throughput:     219.2 job/s (script: 218.5 job/s)

$ src/test/throughput.py -n 10000 -x
number of jobs: 10000
submit time:    3.216 s (3109.4 job/s)
script runtime: 449.663s
job runtime:    103.558s
throughput:     96.6 job/s (script:  22.2 job/s)
```

**Master (v0.54.0-32-g9d9216681)**
```
$ src/test/throughput.py -n 10000
number of jobs: 10000
submit time:    3.008 s (3324.5 job/s)
script runtime: 46.227s
job runtime:    46.054s
throughput:     217.1 job/s (script: 216.3 job/s)

$ src/test/throughput.py -n 10000 -x
number of jobs: 10000
submit time:    2.850 s (3509.2 job/s)
script runtime: 460.330s
job runtime:    93.438s
throughput:     107.0 job/s (script:  21.7 job/s)
```