### PR TITLE
testsuite: handle job signal race in more tests

### DIFF
--- a/t/t2601-job-shell-standalone.t
+++ b/t/t2601-job-shell-standalone.t
@@ -5,7 +5,7 @@ test_description='Test flux-shell in --standalone mode'
 . `dirname $0`/sharness.sh
 
 #  Run flux-shell under flux command to get correct paths
-FLUX_SHELL="run_timeout 60 flux ${FLUX_BUILD_DIR}/src/shell/flux-shell"
+FLUX_SHELL="run_timeout 300 flux ${FLUX_BUILD_DIR}/src/shell/flux-shell"
 
 PMI_INFO=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi_info
 KVSTEST=${FLUX_BUILD_DIR}/src/common/libpmi/test_kvstest

--- a/t/t2611-debug-emulate.t
+++ b/t/t2611-debug-emulate.t
@@ -13,7 +13,7 @@ stop_tasks_test()     {
 
 test_under_flux 2
 
-TIMEOUT=10
+TIMEOUT=100
 
 parse_jobid() {
 	outfile=$1 &&
@@ -103,7 +103,7 @@ test_expect_success 'debugger: job attach --debug must not continue target' '
 	flux_job_attach ${jobid} jobid.out3 &&
 	tv_jobid=$(parse_totalview_jobid jobid.out3) &&
 	test ${tv_jobid} = "${jobid}" &&
-	test_must_fail flux job wait-event -vt ${TIMEOUT} ${jobid} finish &&
+	test_must_fail flux job wait-event -vt 2 ${jobid} finish &&
 	flux cancel ${jobid} &&
 	flux job wait-event -vt ${TIMEOUT} ${jobid} finish
 '


### PR DESCRIPTION
Same fix as in #5302 and #5401 

also threw a increased timeout length for a test