### PR TITLE
modules: consistently return error on invalid module arguments

### DIFF
--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -366,6 +366,7 @@ static int parse_args (flux_t *h,
             *truncate = true;
         else {
             flux_log (h, LOG_ERR, "Unknown module option: %s", argv[i]);
+            errno = EINVAL;
             return -1;
         }
     }

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -493,6 +493,7 @@ static int parse_args (flux_t *h, int argc, char **argv)
         }
         else {
             flux_log (h, LOG_ERR, "Unknown module option: %s", argv[i]);
+            errno = EINVAL;
             return -1;
         }
     }

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -821,6 +821,7 @@ static int process_args (struct content_sqlite *ctx,
         }
         else {
             flux_log (ctx->h, LOG_ERR, "Unknown module option: '%s'", argv[i]);
+            errno = EINVAL;
             return -1;
         }
     }

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -856,6 +856,7 @@ static int process_args (flux_t *h, struct simple_sched *ss,
         }
         else {
             flux_log_error (h, "Unknown module option: '%s'", argv[i]);
+            errno = EINVAL;
             return -1;
         }
     }

--- a/t/t0015-cron.t
+++ b/t/t0015-cron.t
@@ -43,6 +43,9 @@ contains() {
     fi
 }
 
+test_expect_success 'module fails to load with unknown option' '
+	test_must_fail flux module load cron badopt
+'
 test_expect_success 'load cron module' '
     flux module load cron
 '

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -1272,4 +1272,14 @@ test_expect_success 'setroot-pause request with empty payload fails with EPROTO(
 test_expect_success 'setroot-unpause request with empty payload fails with EPROTO(71)' '
 	${RPC} kvs.setroot-unpause 71 </dev/null
 '
+
+#
+# module corner cases
+#
+
+test_expect_success 'module fails to load with unknown option' '
+	flux module remove kvs &&
+	test_must_fail flux module load kvs badopt
+'
+
 test_done


### PR DESCRIPTION
Per #5440, noticed there was inconsistency where some modules returned error on invalid module args, while others ignored invalid args.

Also noticed a few modules did not set errno = EINVAL when an invalid arg was specified.