### PR TITLE
flux-keygen: drop libsodium requirement

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,6 @@ Standards-Version: 4.1.2
 Build-Depends:
   debhelper (>= 10),
   flux-security (>= 0.8.0),
-  libsodium-dev,
   libarchive-dev,
   uuid-dev,
   libzmq3-dev,

--- a/src/cmd/flux-keygen.c
+++ b/src/cmd/flux-keygen.c
@@ -15,7 +15,6 @@
 #include <flux/core.h>
 #include <flux/optparse.h>
 #include <czmq.h>
-#include <sodium.h>
 
 #include "src/common/libutil/log.h"
 
@@ -120,10 +119,6 @@ int main (int argc, char *argv[])
                     CZMQ_VERSION_MAJOR,
                     CZMQ_VERSION_MINOR,
                     CZMQ_VERSION_PATCH);
-    zcert_set_meta (cert,
-                    "keygen.sodium-version",
-                    "%s",
-                    SODIUM_VERSION_STRING);
 
     if (path && zcert_save_secret (cert, path) < 0)
         log_msg_exit ("zcert_save_secret %s: %s", path, strerror (errno));


### PR DESCRIPTION
Problem: libsodium is required by flux-keygen but it is not checked in configure.ac.

All we do with libsodium at this point is add its version to certicate metadata.  This was just "provenance", never actually used for anything, and not worth the extra dependency.  Rather than fix configure.ac, drop the libsodium version from flux-keygen(1) certificates.

Fixes #5445