### PR TITLE
rc: avoid startup problems when BASH_ENV is set

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -1,7 +1,15 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # Allow connector-local more time to start listening on socket
 RANK=$(FLUX_LOCAL_CONNECTOR_RETRY_COUNT=30 flux getattr rank)
+
+listfiles() {
+    local glob="$1"
+    for file in $glob; do
+        [ $file = "$glob" ] && continue
+        echo $file
+    done
+}
 
 # Usage: modload {all|<rank>} modname [args ...]
 modload() {
@@ -92,14 +100,12 @@ modload 0 heartbeat
 core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}
 IFS=:
-shopt -s nullglob
 for rcdir in $all_dirs; do
-    for rcfile in $rcdir/rc1.d/*; do
+    for rcfile in $(listfiles "$rcdir/rc1.d/*"); do
 	echo running $rcfile
         $rcfile
     done
 done
-shopt -u nullglob
 
 # Print module that has registered 'sched' service, if any
 lookup_sched_module() {

--- a/etc/rc3
+++ b/etc/rc3
@@ -1,7 +1,15 @@
-#!/bin/bash
+#!/bin/sh
 
 RANK=$(flux getattr rank)
 exit_rc=0
+
+listfiles() {
+    local glob="$1"
+    for file in $glob; do
+        [ $file = "$glob" ] && continue
+        echo $file
+    done
+}
 
 # Usage: modrm {all|<rank>} modname
 modrm() {
@@ -19,14 +27,12 @@ backing_module() {
 core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}
 IFS=:
-shopt -s nullglob
 for rcdir in $all_dirs; do
-    for rcfile in $rcdir/rc3.d/*; do
+    for rcfile in $(listfiles "$rcdir/rc3.d/*"); do
         echo running $rcfile
         $rcfile || exit_rc=1
     done
 done
-shopt -u nullglob
 
 modrm 0 heartbeat
 modrm 0 sched-simple

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -311,6 +311,19 @@ test_expect_success 'flux-start in subprocess/pmi mode works as initial program'
 	flux start ${ARGS} -s2 flux start ${ARGS} -s1 flux getattr size | grep -x 1
 "
 
+# See issue #5447: rc1 can fail if the shell sources a script that reactivates
+# errexit mode and has an unchecked error.  'command' apparently reactivates
+# errexit mode in older versions of bash.
+#
+test_expect_success 'flux-start works with non-errexit clean BASH_ENV' '
+	cat >testbashrc <<-EOT &&
+	command -v ls >/dev/null || :
+	/bin/false
+	/bin/true
+	EOT
+	BASH_ENV=testbashrc flux start /bin/true
+'
+
 test_expect_success 'flux-start --wrap option works' '
 	broker_path=$(flux start ${ARGS} -vX 2>&1 | sed "s/^flux-start: *//g") &&
 	echo broker_path=${broker_path} &&


### PR DESCRIPTION
Problem: If BASH_ENV is set to a script that is not "-e clean", flux's rc1 script exits immediately.

Drop -e from the shebang and add a "set -e" afterwards.

Fixes #5447