### PR TITLE
rc: fix `flux start` failure when multiple scripts are present in `rc1.d`

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -3,14 +3,6 @@
 # Allow connector-local more time to start listening on socket
 RANK=$(FLUX_LOCAL_CONNECTOR_RETRY_COUNT=30 flux getattr rank)
 
-listfiles() {
-    local glob="$1"
-    for file in $glob; do
-        [ $file = "$glob" ] && continue
-        echo $file
-    done
-}
-
 # Usage: modload {all|<rank>} modname [args ...]
 modload() {
     local where=$1; shift
@@ -101,7 +93,8 @@ core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}
 IFS=:
 for rcdir in $all_dirs; do
-    for rcfile in $(listfiles "$rcdir/rc1.d/*"); do
+    for rcfile in $rcdir/rc1.d/*; do
+	[ -e $rcfile ] || continue
 	echo running $rcfile
         $rcfile
     done

--- a/etc/rc3
+++ b/etc/rc3
@@ -3,14 +3,6 @@
 RANK=$(flux getattr rank)
 exit_rc=0
 
-listfiles() {
-    local glob="$1"
-    for file in $glob; do
-        [ $file = "$glob" ] && continue
-        echo $file
-    done
-}
-
 # Usage: modrm {all|<rank>} modname
 modrm() {
     local where=$1; shift
@@ -28,7 +20,8 @@ core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}
 IFS=:
 for rcdir in $all_dirs; do
-    for rcfile in $(listfiles "$rcdir/rc3.d/*"); do
+    for rcfile in $rcdir/rc3.d/*; do
+	[ -e $rcfile ] || continue
         echo running $rcfile
         $rcfile || exit_rc=1
     done

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -324,6 +324,19 @@ test_expect_success 'flux-start works with non-errexit clean BASH_ENV' '
 	BASH_ENV=testbashrc flux start /bin/true
 '
 
+test_expect_success 'flux-start works with multiple files in rc1.d' '
+	mkdir -p rc1.d &&
+	printf "echo rc-one\n" >rc1.d/one &&
+	printf "echo rc-two\n" >rc1.d/two &&
+	chmod +x rc1.d/* &&
+	FLUX_RC_EXTRA=$(pwd) flux start -o-Slog-stderr-level=6 \
+		echo rc-three >rc-multi.out 2>&1 &&
+	test_debug "cat rc-multi.out" &&
+	grep rc-one rc-multi.out &&
+	grep rc-two rc-multi.out &&
+	grep rc-three rc-multi.out
+'
+
 test_expect_success 'flux-start --wrap option works' '
 	broker_path=$(flux start ${ARGS} -vX 2>&1 | sed "s/^flux-start: *//g") &&
 	echo broker_path=${broker_path} &&


### PR DESCRIPTION
This is a potential fix for #5452.
