### PR TITLE
broker: stop managing 0MQ sockets with czmq

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -264,7 +264,7 @@ int main (int argc, char *argv[])
      * Disable czmq's internal signal handlers for SIGINT and SIGTERM, since
      * the broker will install its own.
      */
-    if (!zsys_init ()) {
+    if (!(ctx.zctx = zsys_init ())) {
         log_err ("zsys_init");
         goto cleanup;
     }
@@ -1214,6 +1214,7 @@ static int load_module (broker_ctx_t *ctx,
         path = zlist_first (files);
     }
     if (!(p = module_create (ctx->h,
+                             ctx->zctx,
                              overlay_get_uuid (ctx->overlay),
                              name,
                              path,

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -318,6 +318,7 @@ int main (int argc, char *argv[])
 
     if (!(ctx.overlay = overlay_create (ctx.h,
                                         ctx.attrs,
+                                        ctx.zctx,
                                         overlay_recv_cb,
                                         &ctx))) {
         log_err ("overlay_create");

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -16,6 +16,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 
 struct broker {
+    void *zctx;
     flux_t *h;
     flux_reactor_t *reactor;
     optparse_t *opts;

--- a/src/broker/modhash.h
+++ b/src/broker/modhash.h
@@ -22,9 +22,10 @@
 typedef struct modhash modhash_t;
 
 /* Hash-o-modules, keyed by uuid
+ * Destructor returns the number of modules that had to be canceled.
  */
 modhash_t *modhash_create (void);
-void modhash_destroy (modhash_t *mh);
+int modhash_destroy (modhash_t *mh);
 
 void modhash_add (modhash_t *mh, module_t *p);
 void modhash_remove (modhash_t *mh, module_t *p);

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -372,10 +372,11 @@ module_t *module_create (flux_t *h,
     }
     zsock_set_unbounded (p->sock);
     zsock_set_linger (p->sock, 5);
-    snprintf (p->endpoint,
-              sizeof (p->endpoint),
-              "inproc://%s",
-              module_get_uuid (p));
+    // copying 9 + 37 + 1 = 47 bytes into 128 byte buffer cannot fail
+    (void)snprintf (p->endpoint,
+                    sizeof (p->endpoint),
+                    "inproc://%s",
+                    module_get_uuid (p));
     if (zmq_bind (p->sock, p->endpoint) < 0) {
         errprintf (error, "zmq_bind %s: %s", p->endpoint, strerror (errno));
         goto cleanup;

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -363,7 +363,7 @@ module_t *module_create (flux_t *h,
     uuid_generate (p->uuid);
     uuid_unparse (p->uuid, p->uuid_str);
 
-     /* Broker end of PAIR socket is opened here.
+    /* Broker end of PAIR socket is opened here.
      */
     if (!(p->sock = zsock_new_pair (NULL))) {
         errprintf (error, "could not create zsock for %s", p->name);

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -26,6 +26,7 @@ typedef void (*modpoller_cb_f)(module_t *p, void *arg);
 typedef void (*module_status_cb_f)(module_t *p, int prev_status, void *arg);
 
 module_t *module_create (flux_t *h,
+                         void *zctx,
                          const char *parent_uuid,
                          const char *name, // may be NULL
                          const char *path,

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1330,7 +1330,7 @@ int overlay_bind (struct overlay *ov, const char *uri)
     }
 
     assert (ov->zap == NULL);
-    if (!(ov->zap = zmqutil_zap_create (ov->reactor))) {
+    if (!(ov->zap = zmqutil_zap_create (ov->zctx, ov->reactor))) {
         log_err ("error creating ZAP server");
         return -1;
     }

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1276,7 +1276,8 @@ int overlay_connect (struct overlay *ov)
          * Setup may fail if libzmq is too old.
          */
         if (ov->zmqdebug) {
-            ov->parent.monitor = zmqutil_monitor_create (ov->parent.zsock,
+            ov->parent.monitor = zmqutil_monitor_create (ov->zctx,
+                                                         ov->parent.zsock,
                                                          ov->reactor,
                                                          parent_monitor_cb,
                                                          ov);
@@ -1344,7 +1345,8 @@ int overlay_bind (struct overlay *ov, const char *uri)
      * Setup may fail if libzmq is too old.
      */
     if (ov->zmqdebug) {
-        ov->bind_monitor = zmqutil_monitor_create (ov->bind_zsock,
+        ov->bind_monitor = zmqutil_monitor_create (ov->zctx,
+                                                   ov->bind_zsock,
                                                    ov->reactor,
                                                    bind_monitor_cb,
                                                    ov);

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -35,6 +35,7 @@ typedef void (*overlay_recv_f)(const flux_msg_t *msg,
  */
 struct overlay *overlay_create (flux_t *h,
                                 attr_t *attrs,
+                                void *zctx,
                                 overlay_recv_f cb,
                                 void *arg);
 void overlay_destroy (struct overlay *ov);

--- a/src/common/libflux/test/attr.c
+++ b/src/common/libflux/test/attr.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <string.h>
 #include <flux/core.h>
+#include <zmq.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -185,12 +186,13 @@ int main (int argc, char *argv[])
     flux_t *h;
     const char *value;
     const char *value2;
+    void *zctx;
 
     plan (NO_PLAN);
 
-    test_server_environment_init ("attr-test");
-
-    if (!(h = test_server_create (0, test_server, NULL)))
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("could not create zeromq context");
+    if (!(h = test_server_create (zctx, 0, test_server, NULL)))
         BAIL_OUT ("test_server_create failed");
 
     /* get ENOENT */
@@ -404,6 +406,8 @@ int main (int argc, char *argv[])
 
     test_server_stop (h);
     flux_close (h);
+
+    zmq_ctx_term (zctx);
 
     done_testing();
     return (0);

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
+#include <zmq.h>
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
 #include "ccan/str/str.h"
@@ -218,8 +219,12 @@ void test_subscribe_rpc (void)
 {
     flux_t *h;
     flux_future_t *f;
+    void *zctx;
 
-    if (!(h = test_server_create (0, test_server, NULL)))
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("could not create zeromq context");
+
+    if (!(h = test_server_create (zctx, 0, test_server, NULL)))
         BAIL_OUT ("test_server_create: %s", strerror (errno));
 
     ok (flux_event_subscribe (h, "fubar") == 0,
@@ -275,6 +280,8 @@ void test_subscribe_rpc (void)
     if (test_server_stop (h) < 0)
         BAIL_OUT ("error stopping test server: %s", strerror (errno));
     flux_close (h);
+
+    zmq_ctx_term (zctx);
 }
 
 void test_subscribe_nosub (void)

--- a/src/common/libflux/test/log.c
+++ b/src/common/libflux/test/log.c
@@ -13,6 +13,7 @@
 #endif
 #include <errno.h>
 #include <flux/core.h>
+#include <zmq.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
@@ -20,12 +21,14 @@
 int main (int argc, char *argv[])
 {
     flux_t *h;
+    void *zctx;
 
     plan (NO_PLAN);
 
-    test_server_environment_init ("log-test");
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("could not create zeromq context");
 
-    if (!(h = test_server_create (0, NULL, NULL)))
+    if (!(h = test_server_create (zctx, 0, NULL, NULL)))
         BAIL_OUT ("could not create test server");
     if (flux_attr_set_cacheonly (h, "rank", "0") < 0)
         BAIL_OUT ("flux_attr_set_cacheonly failed");
@@ -45,6 +48,7 @@ int main (int argc, char *argv[])
 
     test_server_stop (h);
     flux_close (h);
+    zmq_ctx_term (zctx);
     done_testing();
     return (0);
 }

--- a/src/common/libflux/test/rpc_chained.c
+++ b/src/common/libflux/test/rpc_chained.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
+#include <zmq.h>
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
 #include "ccan/str/str.h"
@@ -345,12 +346,14 @@ void test_or_then_error_string (flux_t *h)
 int main (int argc, char *argv[])
 {
     flux_t *h;
+    void *zctx;
 
     plan (NO_PLAN);
 
-    test_server_environment_init ("rpc-chained-test");
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("could not create zeromq context");
 
-    h = test_server_create (0, test_server, NULL);
+    h = test_server_create (zctx, 0, test_server, NULL);
     ok (h != NULL,
         "created test server thread");
     if (!h)
@@ -369,6 +372,8 @@ int main (int argc, char *argv[])
     ok (test_server_stop (h) == 0,
         "stopped test server thread");
     flux_close (h); // destroys test server
+
+    zmq_ctx_term (zctx);
 
     done_testing();
     return (0);

--- a/src/common/librouter/test/router.c
+++ b/src/common/librouter/test/router.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
+#include <zmq.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
@@ -266,13 +267,16 @@ void test_error (flux_t *h)
 int main (int argc, char *argv[])
 {
     flux_t *h;
+    void *zctx;
 
     plan (NO_PLAN);
 
-    diag ("starting test server");
-    test_server_environment_init ("test_router");
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("could not create zeromq context");
 
-    if (!(h = test_server_create (FLUX_O_TEST_NOSUB, server_cb, NULL)))
+    diag ("starting test server");
+
+    if (!(h = test_server_create (zctx, FLUX_O_TEST_NOSUB, server_cb, NULL)))
         BAIL_OUT ("test_server_create failed");
 
     test_basic (h);
@@ -282,6 +286,8 @@ int main (int argc, char *argv[])
     if (test_server_stop (h) < 0)
         BAIL_OUT ("test_server_stop failed");
     flux_close (h);
+
+    zmq_ctx_term (zctx);
 
     done_testing ();
 

--- a/src/common/librouter/test/usock_epipe.c
+++ b/src/common/librouter/test/usock_epipe.c
@@ -14,6 +14,7 @@
 #include <sys/param.h>
 #include <pthread.h>
 #include <flux/core.h>
+#include <zmq.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/unlink_recursive.h"
@@ -217,17 +218,20 @@ int main (int argc, char *argv[])
 {
     struct test_params tp = {0};
     flux_t *h;
+    void *zctx;
 
     plan (NO_PLAN);
+
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("cannot create zeromq context");
 
     tmpdir_create ();
 
     signal (SIGPIPE, SIG_IGN);
 
     diag ("starting test server");
-    test_server_environment_init ("usock_server");
 
-    if (!(h = test_server_create (0, server_cb, &tp)))
+    if (!(h = test_server_create (zctx, 0, server_cb, &tp)))
         BAIL_OUT ("test_server_create failed");
 
     test_send_and_exit (h, 1);
@@ -252,6 +256,7 @@ int main (int argc, char *argv[])
     flux_close (h);
 
     tmpdir_destroy ();
+    zmq_ctx_term (zctx);
     done_testing ();
 
     return 0;

--- a/src/common/libsubprocess/test/iochan.c
+++ b/src/common/libsubprocess/test/iochan.c
@@ -14,6 +14,7 @@
 #include <unistd.h> // environ def
 #include <jansson.h>
 #include <flux/core.h>
+#include <zmq.h>
 
 #include "ccan/array_size/array_size.h"
 #include "ccan/str/str.h"
@@ -252,10 +253,14 @@ bool iochan_run_check (flux_t *h, const char *name, int count)
 int main (int argc, char *argv[])
 {
     flux_t *h;
+    void *zctx;
 
     plan (NO_PLAN);
 
-    h = rcmdsrv_create ("rexec");
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("could not create zeromq context");
+
+    h = rcmdsrv_create (zctx, "rexec");
 
     ok (iochan_run_check (h, "simple", linesize * 100),
         "simple check worked");
@@ -267,6 +272,7 @@ int main (int argc, char *argv[])
         "refcount check worked");
     test_server_stop (h);
     flux_close (h);
+    zmq_ctx_term (zctx);
 
     done_testing ();
     return 0;

--- a/src/common/libsubprocess/test/iostress.c
+++ b/src/common/libsubprocess/test/iostress.c
@@ -14,6 +14,7 @@
 #include <unistd.h> // environ def
 #include <jansson.h>
 #include <flux/core.h>
+#include <zmq.h>
 
 #include "ccan/array_size/array_size.h"
 #include "ccan/str/str.h"
@@ -278,10 +279,14 @@ bool iostress_run_check (flux_t *h,
 int main (int argc, char *argv[])
 {
     flux_t *h;
+    void *zctx;
 
     plan (NO_PLAN);
 
-    h = rcmdsrv_create ("rexec");
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("could not create zeromq context");
+
+    h = rcmdsrv_create (zctx, "rexec");
 
     ok (iostress_run_check (h, "balanced", false, 0, 0, 8, 8, 80),
         "balanced worked");
@@ -304,6 +309,7 @@ int main (int argc, char *argv[])
 
     test_server_stop (h);
     flux_close (h);
+    zmq_ctx_term (zctx);
     done_testing ();
     return 0;
 }

--- a/src/common/libsubprocess/test/rcmdsrv.c
+++ b/src/common/libsubprocess/test/rcmdsrv.c
@@ -74,7 +74,7 @@ done:
     return rc;
 }
 
-flux_t *rcmdsrv_create (const char *service_name)
+flux_t *rcmdsrv_create (void *zctx, const char *service_name)
 {
     flux_t *h;
 
@@ -83,7 +83,7 @@ flux_t *rcmdsrv_create (const char *service_name)
     signal (SIGPIPE, SIG_IGN);
 
     // N.B. test reactor is created with FLUX_REACTOR_SIGCHLD flag
-    if (!(h = test_server_create (0, test_server, (char *)service_name)))
+    if (!(h = test_server_create (zctx, 0, test_server, (char *)service_name)))
         BAIL_OUT ("test_server_create failed");
 
     return h;

--- a/src/common/libsubprocess/test/rcmdsrv.h
+++ b/src/common/libsubprocess/test/rcmdsrv.h
@@ -14,7 +14,7 @@
 /* Start subprocess server.  Returns one end of back-to-back flux_t test
  * handle.  Call test_server_stop (h) when done to join with server thread.
  */
-flux_t *rcmdsrv_create (const char *service_name);
+flux_t *rcmdsrv_create (void *zctx, const char *service_name);
 
 /* llog-compatible logger
  */

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -14,6 +14,7 @@
 #include <unistd.h> // environ def
 #include <jansson.h>
 #include <flux/core.h>
+#include <zmq.h>
 
 #include "ccan/array_size/array_size.h"
 #include "ccan/str/str.h"
@@ -342,16 +343,22 @@ void sigstop_test (flux_t *h)
 int main (int argc, char *argv[])
 {
     flux_t *h;
+    void *zctx;
 
     plan (NO_PLAN);
 
-    h = rcmdsrv_create (SERVER_NAME);
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("could not create zeromq context");
+
+    h = rcmdsrv_create (zctx, SERVER_NAME);
 
     simple_test (h);
     sigstop_test (h);
 
     test_server_stop (h);
     flux_close (h);
+
+    zmq_ctx_term (zctx);
 
     done_testing ();
     return 0;

--- a/src/common/libterminus/test/pty.c
+++ b/src/common/libterminus/test/pty.c
@@ -17,6 +17,7 @@
 #include <errno.h>
 
 #include <flux/core.h>
+#include <zmq.h>
 #include "src/common/libterminus/pty.h"
 
 #include "src/common/libtap/tap.h"
@@ -174,9 +175,9 @@ out:
     return rc;
 }
 
-static void test_basic_protocol (void)
+static void test_basic_protocol (void *zctx)
 {
-    flux_t *h = test_server_create (0, pty_server, NULL);
+    flux_t *h = test_server_create (zctx, 0, pty_server, NULL);
     flux_future_t *f = NULL;
     flux_future_t *f_attach = NULL;
 
@@ -393,9 +394,9 @@ static void pty_exit_cb (struct flux_pty_client *c, void *arg)
     flux_reactor_stop (flux_get_reactor (h));
 }
 
-static void test_client()
+static void test_client (void *zctx)
 {
-    flux_t *h = test_server_create (0, pty_server, NULL);
+    flux_t *h = test_server_create (zctx, 0, pty_server, NULL);
     flux_future_t *f = NULL;
     int rc;
     int flags = FLUX_PTY_CLIENT_ATTACH_SYNC
@@ -481,14 +482,19 @@ void test_monitor ()
 
 int main (int argc, char *argv[])
 {
+    void *zctx;
+
     plan (NO_PLAN);
 
-    test_server_environment_init ("pty");
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("could not create zeromq context");
+
     test_invalid_args ();
     test_empty_server ();
-    test_basic_protocol ();
-    test_client ();
+    test_basic_protocol (zctx);
+    test_client (zctx);
     test_monitor ();
+    zmq_ctx_term (zctx);
     done_testing ();
     return 0;
 }

--- a/src/common/libtestutil/util.h
+++ b/src/common/libtestutil/util.h
@@ -21,21 +21,17 @@
  * 3) broker attributes (such as rank and size) are unavailable
  * 4) message nodeid is ignored
  *
- * Unit tests that use the test server should call
- * test_server_environment_init() once prior to creating the first server
- * to initialize czmq's runtime.
- *
  * If callback is NULL, a default callback is run that logs each
  * message received with diag().
  */
 typedef int (*test_server_f)(flux_t *h, void *arg);
 
-flux_t *test_server_create (int flags, test_server_f cb, void *arg);
+flux_t *test_server_create (void *zctx,
+		            int flags,
+			    test_server_f cb,
+			    void *arg);
 
 int test_server_stop (flux_t *c);
-
-void test_server_environment_init (const char *test_name);
-
 
 /* Create a loopback connector for testing.
  * The net effect is much the same as flux_open("loop://") except
@@ -44,8 +40,5 @@ void test_server_environment_init (const char *test_name);
  * Like loop://, this support test manipulation of credentials:
  *   flux_opt_set (h, FLUX_OPT_TESTING_USERID, &userid, sizeof (userid);
  *   flux_opt_set (h, FLUX_OPT_TESTING_ROLEMASK, &rolemask, sizeof (rolemask))
- *
- * N.B. No need to call test_server_environment_init() if this is the
- * only component used from this module.
  */
 flux_t *loopback_create (int flags);

--- a/src/common/libzmqutil/monitor.h
+++ b/src/common/libzmqutil/monitor.h
@@ -29,7 +29,8 @@ typedef void (*zmqutil_monitor_f)(struct zmqutil_monitor *mon, void *arg);
  * after close/destroy.
  * N.B. this will fail if an old/buggy version of libzmq is used.
  */
-struct zmqutil_monitor *zmqutil_monitor_create (zsock_t *sock,
+struct zmqutil_monitor *zmqutil_monitor_create (void *zctx,
+                                                void *sock,
                                                 flux_reactor_t *r,
                                                 zmqutil_monitor_f fun,
                                                 void *arg);

--- a/src/common/libzmqutil/test/monitor.c
+++ b/src/common/libzmqutil/test/monitor.c
@@ -22,7 +22,7 @@ void test_badargs (void)
     /* Note: these are stubbed for older libzmq (e.g. centos 7),
      * so checking for errno == EINVAL is not going to happen there.
      */
-    ok (zmqutil_monitor_create (NULL, NULL, NULL, NULL) == NULL,
+    ok (zmqutil_monitor_create (NULL, NULL, NULL, NULL, NULL) == NULL,
         "zmqutil_monitor_create sock=NULL fails");
 
     lives_ok({zmqutil_monitor_destroy (NULL);},

--- a/src/common/libzmqutil/test/zap.c
+++ b/src/common/libzmqutil/test/zap.c
@@ -20,8 +20,8 @@
 void test_badargs (void)
 {
     errno = 0;
-    ok (zmqutil_zap_create (NULL) == NULL && errno == EINVAL,
-        "zmqutil_zap_create reactor=NULL fails with EINVAL");
+    ok (zmqutil_zap_create (NULL, NULL) == NULL && errno == EINVAL,
+        "zmqutil_zap_create zctx=NULL reactor=NULL fails with EINVAL");
 
     lives_ok ({zmqutil_zap_destroy (NULL);},
         "zmqutil_zap_destroy zap=NULL doesn't crash");

--- a/src/common/libzmqutil/zap.h
+++ b/src/common/libzmqutil/zap.h
@@ -23,7 +23,7 @@ int zmqutil_zap_authorize (struct zmqutil_zap *zap,
 void zmqutil_zap_set_logger (struct zmqutil_zap *zap, zaplog_f fun, void *arg);
 
 void zmqutil_zap_destroy (struct zmqutil_zap *zap);
-struct zmqutil_zap *zmqutil_zap_create (flux_reactor_t *r);
+struct zmqutil_zap *zmqutil_zap_create (void *zctx, flux_reactor_t *r);
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -519,9 +519,9 @@ test_cppflags = \
 	$(AM_CPPFLAGS)
 
 shmem_backtoback_t_SOURCES = shmem/backtoback.c
-shmem_backtoback_t_CPPFLAGS = $(test_cppflags)
+shmem_backtoback_t_CPPFLAGS = $(test_cppflags) $(ZMQ_CFLAGS)
 shmem_backtoback_t_LDADD = $(test_ldadd)
-shmem_backtoback_t_LDFLAGS = $(test_ldflags)
+shmem_backtoback_t_LDFLAGS = $(test_ldflags) $(ZMQ_LIBS)
 
 loop_logstderr_SOURCES = loop/logstderr.c
 loop_logstderr_CPPFLAGS = $(test_cppflags)

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -278,6 +278,16 @@ test_expect_success 'module: configuration object is cached' '
 test_expect_success 'module: remove testmod if loaded' '
         flux module remove -f testmod
 '
-
+test_expect_success 'module: load without unload causes broker failure' '
+	test_must_fail flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+	    flux module load content 2>nounload.err
+'
+test_expect_success 'module: socket leak is called out' '
+	grep "socket leak" nounload.err
+'
+test_expect_success 'module: leaked module name is called out' '
+	grep ".content. was not properly shut down" nounload.err
+'
 
 test_done

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -249,7 +249,12 @@ test_expect_success 'module with version ext can be loaded by name' '
 	mkdir -p testmoddir &&
 	cp $testmod testmoddir/testmod.so.0.0.0 &&
 	FLUX_MODULE_PATH_PREPEND=$(pwd)/testmoddir flux start \
-	    bash -c "flux module load testmod && flux module list -l" \
+	    bash -c \
+	    "flux module load testmod; \
+	    rc=\$?; \
+	    flux module list -l; \
+	    flux module remove -f testmod; \
+	    exit \$rc" \
 	    >modlist.out &&
 	grep testmod.so.0.0.0 modlist.out
 '

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -357,8 +357,12 @@ load_module_xfail()
 {
 	flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
 	    -o,-Sstatedir=$(pwd) bash -c \
-	    "flux module load content && \
-	    flux module load content-sqlite"
+	    "flux module load content; \
+	    flux module load content-sqlite; \
+	    rc=\$?; \
+	    flux module remove -f content-sqlite; \
+	    flux module remove -f content; \
+	    exit \$rc"
 }
 
 # FWIW https://www.sqlite.org/fileformat.html


### PR DESCRIPTION
Problem: the czmq `atexit()` handler has gotten in the way for years.

A current example: If I load a module and forget to unload it, the error message is unhelpful and the broker exits with success:
```
$ flux start
ƒ(s=1,d=0) $ flux module load --name foo barrier
ƒ(s=1,d=0) $ 
exit
E: (flux-broker) 23-09-15 21:22:51 [488322]dangling 'PAIR' socket created at shmem/shmem.c:148
$ echo $?
0
```

This PR curtails use of the czmq "socket tracker" throughout flux-core by creating all sockets with `zmq_socket()` rather than the tracked `zsock_new*()` series of functions. Since many czmq classes accept a socket argument in either `zsock_t` (tracked) or raw  form, this change has a smaller footprint than it would have otherwise.

Now we get
```
$ ./flux start
ƒ(s=1,d=0,builddir) $ flux module load --name foo barrier
ƒ(s=1,d=0,builddir) $ 
exit
flux-broker: broker module 'foo' was not properly shut down
flux-broker: skipping 0MQ shutdown due to presumed module socket leak
$ echo $?
1
```