### PR TITLE
use zeromq interfaces directly where possible instead of via czmq

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -17,6 +17,10 @@
 #include <inttypes.h>
 #include <sys/prctl.h>
 #include <sys/resource.h>
+#include <unistd.h>
+#include <sys/un.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
 #include <argz.h>
 #include <flux/core.h>
 #include <zmq.h>

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -13,6 +13,7 @@
 #endif
 #include <flux/core.h>
 #include <jansson.h>
+#include <assert.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/log.h"

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -12,7 +12,6 @@
 #define _BROKER_MODULE_H
 
 #include <jansson.h>
-#include <czmq.h>
 #include <uuid.h>
 #ifndef UUID_STR_LEN
 #define UUID_STR_LEN 37     // defined in later libuuid headers

--- a/src/common/libtestutil/Makefile.am
+++ b/src/common/libtestutil/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
+	-I$(top_srcdir)/src/common/libccan \
 	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS)
 

--- a/src/common/libzmqutil/Makefile.am
+++ b/src/common/libzmqutil/Makefile.am
@@ -26,7 +26,9 @@ libzmqutil_la_SOURCES = \
 	zap.h \
 	zap.c \
 	monitor.h \
-	monitor.c
+	monitor.c \
+	sockopt.h \
+	sockopt.c
 
 TESTS = test_msg_zsock.t \
 	test_reactor.t \

--- a/src/common/libzmqutil/Makefile.am
+++ b/src/common/libzmqutil/Makefile.am
@@ -28,13 +28,16 @@ libzmqutil_la_SOURCES = \
 	monitor.h \
 	monitor.c \
 	sockopt.h \
-	sockopt.c
+	sockopt.c \
+	mpart.h \
+	mpart.c
 
 TESTS = test_msg_zsock.t \
 	test_reactor.t \
 	test_ev.t \
 	test_zap.t \
-	test_monitor.t
+	test_monitor.t \
+	test_mpart.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -82,3 +85,8 @@ test_monitor_t_SOURCES = test/monitor.c
 test_monitor_t_CPPFLAGS = $(test_cppflags)
 test_monitor_t_LDADD = $(test_ldadd)
 test_monitor_t_LDFLAGS = $(test_ldflags)
+
+test_mpart_t_SOURCES = test/mpart.c
+test_mpart_t_CPPFLAGS = $(test_cppflags)
+test_mpart_t_LDADD = $(test_ldadd)
+test_mpart_t_LDFLAGS = $(test_ldflags)

--- a/src/common/libzmqutil/ev_zmq.c
+++ b/src/common/libzmqutil/ev_zmq.c
@@ -31,7 +31,6 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <czmq.h>
 #include <zmq.h>
 #include <stdbool.h>
 
@@ -43,11 +42,13 @@ static void prepare_cb (struct ev_loop *loop, ev_prepare *w, int revents)
     ev_zmq *zw = (ev_zmq *)((char *)w - offsetof (ev_zmq, prepare_w));
     uint32_t zevents = 0;
     size_t zevents_size = sizeof (zevents);
-    void *handle = zsock_resolve (zw->zsock);
 
-    if (handle == NULL)
+    if (zw->zsock == NULL)
         ev_idle_start (loop, &zw->idle_w);
-    else if (zmq_getsockopt (handle, ZMQ_EVENTS, &zevents, &zevents_size) < 0)
+    else if (zmq_getsockopt (zw->zsock,
+                             ZMQ_EVENTS,
+                             &zevents,
+                             &zevents_size) < 0)
         ev_idle_start (loop, &zw->idle_w);
     else if ((revents = ztoe (zevents) & zw->events))
         ev_idle_start (loop, &zw->idle_w);
@@ -60,17 +61,19 @@ static void check_cb (struct ev_loop *loop, ev_check *w, int revents)
     ev_zmq *zw = (ev_zmq *)((char *)w - offsetof (ev_zmq, check_w));
     uint32_t zevents = 0;
     size_t zevents_size = sizeof (zevents);
-    void *handle = zsock_resolve (zw->zsock);
 
     ev_io_stop (loop, &zw->io_w);
     ev_idle_stop (loop, &zw->idle_w);
 
-    if (handle == NULL)
+    if (zw->zsock == NULL)
         zw->cb (loop, zw, EV_ERROR);
     else if (ev_is_pending (&zw->io_w)
             && ev_clear_pending (loop, &zw->io_w) & EV_ERROR)
         zw->cb (loop, zw, EV_ERROR);
-    else if (zmq_getsockopt (handle, ZMQ_EVENTS, &zevents, &zevents_size) < 0)
+    else if (zmq_getsockopt (zw->zsock,
+                             ZMQ_EVENTS,
+                             &zevents,
+                             &zevents_size) < 0)
         zw->cb (loop, zw, EV_ERROR);
     else if ((revents = ztoe (zevents) & zw->events))
         zw->cb (loop, zw, revents);
@@ -82,11 +85,10 @@ int ev_zmq_init (ev_zmq *w, ev_zmq_cb cb, void *zsock, int events)
     w->zsock = zsock;
     w->events = events;
     size_t fd_size = sizeof (w->fd);
-    void *handle = zsock_resolve (zsock);
 
-    if (handle == NULL)
+    if (zsock == NULL)
         return -1;
-    if (zmq_getsockopt (handle, ZMQ_FD, &w->fd, &fd_size) < 0)
+    if (zmq_getsockopt (zsock, ZMQ_FD, &w->fd, &fd_size) < 0)
         return -1;
 
     ev_prepare_init (&w->prepare_w, prepare_cb);

--- a/src/common/libzmqutil/monitor.c
+++ b/src/common/libzmqutil/monitor.c
@@ -274,7 +274,7 @@ struct zmqutil_monitor *zmqutil_monitor_create (void *zctx,
     /* Arrange for local callback to run on each monitor event.
      * It will call the user's callback.
      */
-    if (zmq_socket_monitor (zsock_resolve (sock),
+    if (zmq_socket_monitor (sock,
                             mon->endpoint,
                             ZMQ_EVENT_ALL) < 0
         || !(mon->sock = zmq_socket (zctx, ZMQ_PAIR))

--- a/src/common/libzmqutil/monitor.c
+++ b/src/common/libzmqutil/monitor.c
@@ -18,6 +18,7 @@
 #include "ccan/array_size/array_size.h"
 
 #include "reactor.h"
+#include "sockopt.h"
 #include "monitor.h"
 
 #ifndef UUID_STR_LEN
@@ -284,8 +285,10 @@ struct zmqutil_monitor *zmqutil_monitor_create (void *zctx,
                                               monitor_callback,
                                               mon)))
         goto error;
-    zsock_set_linger (mon->sock, 0);
-    zsock_set_unbounded (mon->sock);
+    if (zsetsockopt_int (mon->sock, ZMQ_LINGER, 0) < 0
+        || zsetsockopt_int (mon->sock, ZMQ_RCVHWM, 0) < 0
+        || zsetsockopt_int (mon->sock, ZMQ_SNDHWM, 0) < 0)
+        goto error;
     flux_watcher_start (mon->w);
     return mon;
 error:

--- a/src/common/libzmqutil/monitor.h
+++ b/src/common/libzmqutil/monitor.h
@@ -8,9 +8,10 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#ifndef _ZMQUTIL_MONITOR_H
+#define _ZMQUTIL_MONITOR_H
+
 #include <flux/core.h>
-#include <czmq.h>
-#include <zmq.h>
 
 struct monitor_event {
     uint16_t event;
@@ -45,5 +46,7 @@ int zmqutil_monitor_get (struct zmqutil_monitor *mon,
 /* Returns true if the socket event likely should be logged at error severity.
  */
 bool zmqutil_monitor_iserror (struct monitor_event *mevent);
+
+#endif // !_ZMQUTIL_MONITOR
 
 // vi:ts=4 sw=4 expandtab

--- a/src/common/libzmqutil/mpart.c
+++ b/src/common/libzmqutil/mpart.c
@@ -1,0 +1,201 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <zmq.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+#include "sockopt.h"
+#include "mpart.h"
+
+static void part_destroy (zmq_msg_t *part)
+{
+    if (part) {
+        int saved_errno = errno;
+        zmq_msg_close (part);
+        free (part);
+        errno = saved_errno;
+    }
+}
+
+static zmq_msg_t *part_create (const void *data, size_t size)
+{
+    zmq_msg_t *part;
+
+    if (!(part = calloc (1, sizeof (*part))))
+        return NULL;
+    if (size > 0) {
+        if (zmq_msg_init_size (part, size) < 0)
+            goto error;
+        if (data)
+            memcpy (zmq_msg_data (part), data, size);
+    }
+    else
+        (void)zmq_msg_init (part); // documented as always returning 0
+    return part;
+error:
+    part_destroy (part);
+    return NULL;
+}
+
+static zmq_msg_t *part_recv (void *sock)
+{
+    zmq_msg_t *part;
+
+    if (!(part = part_create (NULL, 0)))
+        return NULL;
+    if (zmq_msg_recv (part, sock, 0) < 0) {
+        part_destroy (part);
+        return NULL;
+    }
+    return part;
+}
+
+static bool part_streq (zmq_msg_t *part, const char *s)
+{
+    if (part
+        && s
+        && zmq_msg_size (part) == strlen (s)
+        && memcmp (zmq_msg_data (part), s, zmq_msg_size (part)) == 0)
+        return true;
+    return false;
+}
+
+void mpart_destroy (zlist_t *mpart)
+{
+    if (mpart) {
+        int saved_errno = errno;
+        zlist_destroy (&mpart);
+        errno = saved_errno;
+    }
+}
+
+zlist_t *mpart_create (void)
+{
+    zlist_t *mpart;
+
+    if (!(mpart = zlist_new ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return mpart;
+}
+
+static int mpart_append (zlist_t *mpart, zmq_msg_t *part)
+{
+    if (zlist_append (mpart, part) < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    zlist_freefn (mpart, part, (zlist_free_fn *)part_destroy, true);
+    return 0;
+}
+
+int mpart_addmem (zlist_t *mpart, const void *buf, int size)
+{
+    zmq_msg_t *part;
+
+    if (!mpart) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(part = part_create (buf, size)))
+        return -1;
+    if (mpart_append (mpart, part) < 0) {
+        part_destroy (part);
+        return -1;
+    }
+    return 0;
+}
+
+int mpart_addstr (zlist_t *mpart, const char *s)
+{
+    if (!mpart || !s) {
+        errno = EINVAL;
+        return -1;
+    }
+    return mpart_addmem (mpart, s, strlen (s));
+}
+
+zlist_t *mpart_recv (void *sock)
+{
+    zlist_t *mpart;
+    int more;
+
+    if (!(mpart = mpart_create ()))
+        return NULL;
+    do {
+        zmq_msg_t *part;
+        if (!(part = part_recv (sock)))
+            goto error;
+        if (mpart_append (mpart, part) < 0) {
+            part_destroy (part);
+            goto error;
+        }
+        if (zgetsockopt_int (sock, ZMQ_RCVMORE, &more) < 0)
+            goto error;
+    } while (more);
+    return mpart;
+error:
+    mpart_destroy (mpart);
+    return NULL;
+}
+
+int mpart_send (void *sock, zlist_t *mpart)
+{
+    if (!mpart) {
+        errno = EINVAL;
+        return -1;
+    }
+    int count = 0;
+    int parts = zlist_size (mpart);
+    zmq_msg_t *part = zlist_first (mpart);
+    while (part) {
+        int flags = 0;
+        if (++count < parts)
+            flags |= ZMQ_SNDMORE;
+        if (zmq_msg_send (part, sock, flags) < 0)
+            return -1;
+        part = zlist_next (mpart);
+    }
+    return 0;
+}
+
+zmq_msg_t *mpart_get (zlist_t *mpart, int index)
+{
+    if (mpart) {
+        zmq_msg_t *part;
+        int count = 0;
+
+        part = zlist_first (mpart);
+        while (part) {
+            if (count++ == index)
+                return part;
+            part = zlist_next (mpart);
+        }
+    }
+    return NULL;
+}
+
+bool mpart_streq (zlist_t *mpart, int index, const char *s)
+{
+    if (mpart && s) {
+        zmq_msg_t *part = mpart_get (mpart, index);
+        if (part && part_streq (part, s))
+            return true;
+    }
+    return false;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libzmqutil/mpart.h
+++ b/src/common/libzmqutil/mpart.h
@@ -1,0 +1,32 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _ZMQUTIL_MPART_H
+#define _ZMQUTIL_MPART_H
+
+#include <stdbool.h>
+#include <zmq.h>
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+/* helpers for multi-part messages as zlist of zmq_msg_t
+ * (like stripped down zmsg_t)
+ */
+void mpart_destroy (zlist_t *mpart);
+zlist_t *mpart_create (void);
+int mpart_addmem (zlist_t *mpart, const void *buf, int size);
+int mpart_addstr (zlist_t *mpart, const char *s);
+zlist_t *mpart_recv (void *sock);
+int mpart_send (void *sock, zlist_t *mpart);
+zmq_msg_t *mpart_get (zlist_t *mpart, int index);
+bool mpart_streq (zlist_t *mpart, int index, const char *s);
+
+#endif // !_ZMQUTIL_MPART_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libzmqutil/msg_zsock.c
+++ b/src/common/libzmqutil/msg_zsock.c
@@ -23,6 +23,7 @@
 #include "src/common/libflux/message_proto.h"
 #include "src/common/libutil/errno_safe.h"
 
+#include "sockopt.h"
 #include "msg_zsock.h"
 
 int zmqutil_msg_send_ex (void *sock, const flux_msg_t *msg, bool nonblock)
@@ -111,7 +112,11 @@ flux_msg_t *zmqutil_msg_recv (void *sock)
         iov[iovcnt].data = zmq_msg_data (msgdata);
         iov[iovcnt].size = zmq_msg_size (msgdata);
         iovcnt++;
-        if (!zsock_rcvmore (handle))
+
+        int rcvmore;
+        if (zgetsockopt_int (handle, ZMQ_RCVMORE, &rcvmore) < 0)
+            goto error;
+        if (!rcvmore)
             break;
     }
 

--- a/src/common/libzmqutil/reactor.c
+++ b/src/common/libzmqutil/reactor.c
@@ -15,7 +15,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <assert.h>
-#include <czmq.h>
+#include <zmq.h>
 
 #include "src/common/libev/ev.h"
 #include "src/common/libflux/reactor_private.h"

--- a/src/common/libzmqutil/sockopt.c
+++ b/src/common/libzmqutil/sockopt.c
@@ -1,0 +1,53 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <zmq.h>
+#include <string.h>
+
+#include "sockopt.h"
+
+int zsetsockopt_int (void *sock, int option_name, int value)
+{
+    return zmq_setsockopt (sock, option_name, &value, sizeof (value));
+}
+
+int zgetsockopt_int (void *sock, int option_name, int *value)
+{
+    int val;
+    size_t size = sizeof (val);
+    if (zmq_getsockopt (sock, option_name, &val, &size) < 0)
+        return -1;
+    *value = val;
+    return 0;
+}
+
+int zgetsockopt_str (void *sock, int option_name, char **value)
+{
+    char val[1024];
+    size_t size = sizeof (val);
+    char *cpy;
+
+    if (zmq_getsockopt (sock, option_name, &val, &size) < 0)
+        return -1;
+    if (!(cpy = strdup (val)))
+        return -1;
+    *value = cpy;
+    return 0;
+}
+
+int zsetsockopt_str (void *sock, int option_name, const char *value)
+{
+    return zmq_setsockopt (sock, option_name, value, strlen (value));
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libzmqutil/sockopt.h
+++ b/src/common/libzmqutil/sockopt.h
@@ -1,0 +1,22 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _ZMQUTIL_SOCKOPT_H
+#define _ZMQUTIL_SOCKOPT_H
+
+int zsetsockopt_int (void *sock, int option_name, int value);
+int zgetsockopt_int (void *sock, int option_name, int *value);
+
+int zsetsockopt_str (void *sock, int option_name, const char *value);
+int zgetsockopt_str (void *sock, int option_name, char **value);
+
+#endif /* !_ZMQUTIL_SOCKOPT_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libzmqutil/test/ev.c
+++ b/src/common/libzmqutil/test/ev.c
@@ -8,182 +8,29 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+/* ev.c - standalone test of libev ev_zmq watcher (no flux) */
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
 #include <poll.h>
-#include <czmq.h>
+#include <zmq.h>
+#include <stdio.h>
 
 #include "src/common/libzmqutil/ev_zmq.h"
-#include "src/common/libczmqcontainers/czmq_containers.h"
-#include "src/common/libutil/oom.h"
 #include "src/common/libtap/tap.h"
 
-void timer_arg_cb (struct ev_loop *loop, ev_timer *w, int revents)
-{
-    int *i = w->data;
-    if (i && ++(*i) == 100)
-        ev_break (loop, EVBREAK_ALL);
-}
-
-void timer_cb (struct ev_loop *loop, ev_timer *w, int revents)
-{
-}
-
-void test_libev_timer (void)
-{
-    struct ev_loop *loop;
-    ev_timer w;
-    int i;
-
-    ok ((loop = ev_loop_new (EVFLAG_AUTO)) != NULL,
-        "ev_loop_new works");
-    ok (ev_run (loop, 0) == 0,
-        "ev_run returns 0 with no watchers configured");
-
-    ev_timer_init (&w, timer_cb, 1E-1, 0.);
-    ev_timer_start (loop, &w);
-    ok (ev_run (loop, 0) == 0,
-        "ev_run returns 0 after no-repeat timer fires once");
-    ev_timer_stop (loop, &w);
-
-    i = 0;
-    ev_timer_init (&w, timer_arg_cb, 1E-1, 0.);
-    w.data = &i;
-    ev_timer_start (loop, &w);
-    ok (ev_run (loop, 0) == 0 && i == 1,
-        "passing arbitrary data using w->data works");
-    ev_timer_stop (loop, &w);
-
-    i = 0;
-    ev_timer_init (&w, timer_arg_cb, 1E-3, 1E-3);
-    w.data = &i;
-    ev_timer_start (loop, &w);
-    ok (ev_run (loop, 0) != 0 && i == 100,
-        "ev_break causes ev_run to return nonzero");
-    ev_timer_stop (loop, &w);
-
-    ev_loop_destroy (loop);
-}
-
-void zero_cb (struct ev_loop *loop, ev_io *w, int revents)
-{
-    int *i = w->data;
-    ssize_t n;
-    char buf[1024];
-
-    if ((n = read (w->fd, buf, sizeof (buf))) < 0) {
-        fprintf (stderr, "read error on /dev/zero: %s\n", strerror (errno));
-        return;
-    }
-    if (n < sizeof (buf)) {
-        fprintf (stderr, "short read on /dev/zero\n");
-        return;
-    }
-    if (i && ++(*i) == 100)
-        ev_break (loop, EVBREAK_ALL);
-}
-
-void test_libev_io (void)
-{
-    struct ev_loop *loop;
-    ev_io w, w2;
-    int i, fd, fd2;
-
-    ok ((loop = ev_loop_new (EVFLAG_AUTO)) != NULL,
-        "ev_loop_new works");
-
-    /* handle 100 read events from /dev/zero with two workers */
-    fd = open ("/dev/zero", O_RDONLY);
-    fd2 = open ("/dev/zero", O_RDONLY);
-    ok (fd >= 0 && fd2 >= 0,
-        "opened /dev/zero twice");
-
-    i = 0;
-    ev_io_init (&w, zero_cb, fd, EV_READ);
-    w.data = &i;
-    ev_io_init (&w2, zero_cb, fd2, EV_READ);
-    w2.data = &i;
-    ev_io_start (loop, &w);
-    ev_io_start (loop, &w2);
-    ok (ev_run (loop, 0) != 0 && i == 100,
-        "ev_run ran two /dev/zero readers a total of 100 times");
-    ev_io_stop (loop, &w);
-    ev_io_stop (loop, &w2);
-
-    close (fd);
-    close (fd2);
-
-    ev_loop_destroy (loop);
-}
-
-/* test that zmq arcana we built ev_zmq on functions as advertised,
- * mainly the ZMQ_FD and ZMQ_EVENTS socket options that zmq_poll uses.
- */
-void test_zmq_events (void)
-{
-    void *zctx;
-    void *zin, *zout;
-    int fd;
-    char *s = NULL;
-
-    ok ((zctx = zmq_init (1)) != NULL,
-        "initialized zmq context");
-    ok ((zout = zmq_socket (zctx, ZMQ_PAIR)) != NULL
-        && zmq_bind (zout, "inproc://eventloop_test") == 0,
-        "PAIR socket bind ok");
-    ok ((zin = zmq_socket (zctx, ZMQ_PAIR)) != NULL
-        && zmq_connect (zin, "inproc://eventloop_test") == 0,
-        "PAIR socket connect ok");
-    size_t fd_size = sizeof (fd);
-    ok (zmq_getsockopt (zin, ZMQ_FD, &fd, &fd_size) == 0 && fd >= 0,
-        "zmq_getsockopt ZMQ_FD returned valid file descriptor");
-    /* ZMQ_EVENTS must be called after ZMQ_FD and before each poll()
-     * to "reset" event trigger.  For more details see Issue #524.
-     */
-    uint32_t zevents;
-    size_t zevents_size = sizeof (zevents);
-    ok (zmq_getsockopt (zin, ZMQ_EVENTS, &zevents, &zevents_size) == 0
-        && !(zevents & ZMQ_POLLIN),
-        "zmq_getsockopt ZMQ_EVENTS says PAIR socket not ready to recv");
-    // this test is somewhat questionable as there may be false positives
-    struct pollfd pfd = { .fd = fd, .events = POLLIN };
-    ok (poll (&pfd, 1, 10) == 0,
-        "poll says edge triggered mailbox descriptor is not ready");
-    ok (zstr_send (zout, "TEST") == 0,
-        "sent a message over PAIR sockets");
-    ok (poll (&pfd, 1, 10) == 1
-        && (pfd.revents & POLLIN),
-        "poll says edge triggered mailbox descriptor is ready");
-    ok (zmq_getsockopt (zin, ZMQ_EVENTS, &zevents, &zevents_size) == 0
-        && (zevents & ZMQ_POLLIN),
-        "zmq_getsockopt ZMQ_EVENTS says PAIR socket ready to recv");
-    zmq_pollitem_t zp = { .socket = zin, .events = ZMQ_POLLIN };
-    ok (zmq_poll (&zp, 1, 10) == 1 && zp.revents == ZMQ_POLLIN,
-        "zmq_poll says PAIR socket ready to recv");
-    ok ((s = zstr_recv (zin)) != NULL,
-        "received message over PAIR sockets");
-    ok (zmq_getsockopt (zin, ZMQ_EVENTS, &zevents, &zevents_size) == 0
-        && !(zevents & ZMQ_POLLIN),
-        "zmq_getsockopt ZMQ_EVENTS says PAIR socket not ready to recv");
-    ok (zmq_poll (&zp, 1, 10) == 0,
-        "zmq_poll says PAIR socket not ready to recv");
-    if (s)
-        free (s);
-    zmq_close (zin);
-    zmq_close (zout);
-    zmq_ctx_destroy (zctx);
-}
+static void *zctx;
 
 void zsock_tx_cb (struct ev_loop *loop, ev_zmq *w, int revents)
 {
     static int count = 50; /* send two per invocation */
 
     if ((revents & EV_WRITE)) {
-        if (zstr_send (w->zsock, "PING") < 0)
-            fprintf (stderr, "zstr_send: %s", strerror (errno));
-        if (zstr_send (w->zsock, "PING") < 0)
-            fprintf (stderr, "zstr_send: %s", strerror (errno));
+        if (zmq_send (w->zsock, "PING", 4, 0) < 0)
+            fprintf (stderr, "zmq_send: %s", strerror (errno));
+        if (zmq_send (w->zsock, "PING", 4, 0) < 0)
+            fprintf (stderr, "zmq_send: %s", strerror (errno));
         if (--count == 0)
             ev_zmq_stop (loop, w);
     }
@@ -194,15 +41,13 @@ void zsock_tx_cb (struct ev_loop *loop, ev_zmq *w, int revents)
 void zsock_rx_cb (struct ev_loop *loop, ev_zmq *w, int revents)
 {
     int *iter = w->data;
-    char *s;
+    char buf[128];
     static int count = 100;
 
     if ((revents & EV_READ)) {
         (*iter)++;
-        if (!(s = zstr_recv (w->zsock)))
+        if (zmq_recv (w->zsock, buf, sizeof (buf), 0) < 0)
             fprintf (stderr, "zstr_recv: %s", strerror (errno));
-        else
-            free (s);
         if (--count == 0)
             ev_zmq_stop (loop, w);
     }
@@ -252,30 +97,18 @@ void test_ev_zmq (void)
 
     zmq_close (zin);
     zmq_close (zout);
-    zmq_ctx_destroy (zctx);
-}
-
-void list_timer_cb (struct ev_loop *loop, ev_timer *w, int revents)
-{
-    static int i = 100;
-    zlist_t *l = w->data;
-    if (--i == 0) {
-        ev_break (loop, EVBREAK_ALL);
-    } else {
-        zmsg_t *zmsg;
-        if (!(zmsg = zmsg_new ()) || zlist_append (l, zmsg) < 0)
-            oom ();
-    }
 }
 
 int main (int argc, char *argv[])
 {
-    plan (27);
+    plan (NO_PLAN);
 
-    test_libev_timer (); // 5
-    test_libev_io (); // 3
-    test_zmq_events (); // 13
-    test_ev_zmq (); // 6
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("could not create zeromq context");
+
+    test_ev_zmq ();
+
+    zmq_ctx_term (zctx);
 
     done_testing ();
 }

--- a/src/common/libzmqutil/test/mpart.c
+++ b/src/common/libzmqutil/test/mpart.c
@@ -1,0 +1,136 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+#include <zmq.h>
+#include "mpart.h"
+
+#include "src/common/libtap/tap.h"
+
+static void *zctx;
+
+static void zsocketpair (void **sock, const char *uri)
+{
+    sock[0] = zmq_socket (zctx, ZMQ_PAIR);
+    sock[1] = zmq_socket (zctx, ZMQ_PAIR);
+    if (!sock[0]
+        || !sock[1]
+        || zmq_bind (sock[0], uri) < 0
+        || zmq_connect (sock[1], uri) < 0)
+        BAIL_OUT ("could not create 0MQ socketpair");
+}
+
+void test_mpart (void)
+{
+    void *sock[2];
+    zlist_t *mpart_snd;
+    zlist_t *mpart_rcv;
+
+    zsocketpair (sock, "inproc://test_mpart");
+
+    mpart_snd = mpart_create ();
+    ok (mpart_snd != NULL,
+        "mpart_create works");
+    ok (mpart_addstr (mpart_snd, "foo") == 0
+        && zlist_size (mpart_snd) == 1,
+        "mpart_addstr works");
+    ok (mpart_addmem (mpart_snd, "bar", 3) == 0
+        && zlist_size (mpart_snd) == 2,
+        "mpart_addmem works");
+    ok (mpart_addmem (mpart_snd, NULL, 0) == 0
+        && zlist_size (mpart_snd) == 3,
+        "mpart_addmem buf=NULL size=0 works");
+    ok (mpart_send (sock[1], mpart_snd) == 0,
+        "mpart_send works");
+    mpart_rcv = mpart_recv (sock[0]);
+    ok (mpart_rcv != NULL,
+        "mpart_recv works");
+    ok (zlist_size (mpart_rcv) == 3
+        && mpart_streq (mpart_rcv, 0, "foo")
+        && mpart_streq (mpart_rcv, 1, "bar")
+        && zmq_msg_size (mpart_get (mpart_rcv, 2)) == 0,
+        "send and recv messages are identical");
+
+    errno = 42;
+    mpart_destroy (mpart_snd);
+    mpart_destroy (mpart_rcv);
+    ok (errno == 42,
+        "mpart_destroy doesn't clobber errno");
+
+    zmq_close (sock[0]);
+    zmq_close (sock[1]);
+}
+
+void test_mpart_inval (void)
+{
+    zlist_t *mpart;
+    void *sock[2];
+
+    zsocketpair (sock, "inproc://test_mpart_inval");
+
+    if (!(mpart = mpart_create ())
+        || mpart_addstr (mpart, "x"))
+        BAIL_OUT ("mpart_create failed");
+
+    errno = 0;
+    ok (mpart_addmem (NULL, NULL, 0) < 0 && errno == EINVAL,
+        "mpart_addmem mpart=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (mpart_addstr (NULL, "foo") < 0 && errno == EINVAL,
+        "mpart_addstr mpart=NULL fails with EINVAL");
+    errno = 0;
+    ok (mpart_addstr (mpart, NULL) < 0 && errno == EINVAL,
+        "mpart_addstr s=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (mpart_recv (NULL) == NULL && errno == ENOTSOCK,
+        "mpart_recv sock=NULL fails with ENOTSOCK");
+
+    errno = 0;
+    ok (mpart_send (NULL, mpart) < 0 && errno == ENOTSOCK,
+        "mpart_send sock=NULL fails with ENOTSOCK");
+
+    errno = 0;
+    ok (mpart_send (sock[1], NULL) < 0 && errno == EINVAL,
+        "mpart_send mpart=NULL fails with EINVAL");
+
+    ok (mpart_get (NULL, 0) == NULL,
+        "mpart_get mpart=NULL returns NULL");
+    ok (mpart_streq (NULL, 0, "foo") == false,
+        "mpart_streq mpart=NULL returns false");
+
+    mpart_destroy (mpart);
+
+    zmq_close (sock[0]);
+    zmq_close (sock[1]);
+
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("could not create zeromq context");
+
+    test_mpart ();
+    test_mpart_inval ();
+
+    zmq_ctx_term (zctx);
+
+    done_testing ();
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libzmqutil/test/msg_zsock.c
+++ b/src/common/libzmqutil/test/msg_zsock.c
@@ -85,6 +85,7 @@ void check_sendzsock (void)
             && flux_msg_has_payload (msg2) == false,
         "try2: decoded message looks like what was sent");
     flux_msg_destroy (msg2);
+    flux_msg_destroy (any);
     flux_msg_destroy (msg);
 
     zmq_close (zsock[0]);

--- a/src/common/libzmqutil/test/msg_zsock.c
+++ b/src/common/libzmqutil/test/msg_zsock.c
@@ -12,13 +12,14 @@
 #include "config.h"
 #endif
 #include <stdbool.h>
-#include <czmq.h>
+#include <zmq.h>
 #include <errno.h>
 #include <stdio.h>
 
 #include "src/common/libflux/message.h"
 #include "src/common/libzmqutil/msg_zsock.h"
 #include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
 
 #include "sockopt.h"
 

--- a/src/common/libzmqutil/test/msg_zsock.c
+++ b/src/common/libzmqutil/test/msg_zsock.c
@@ -20,6 +20,8 @@
 #include "src/common/libzmqutil/msg_zsock.h"
 #include "src/common/libtap/tap.h"
 
+#include "sockopt.h"
+
 static void *zctx;
 
 void check_sendzsock (void)
@@ -36,8 +38,9 @@ void check_sendzsock (void)
         && zmq_connect( zsock[1], uri) == 0,
         "got inproc socket pair");
 
-    zsock_set_linger (zsock[0], 5);
-    zsock_set_linger (zsock[1], 5);
+    if (zsetsockopt_int (zsock[0], ZMQ_LINGER, 5) < 0
+        || zsetsockopt_int (zsock[1], ZMQ_LINGER, 5) < 0)
+        BAIL_OUT ("could not set ZMQ_LINGER socket option");
 
     if (!(any = flux_msg_create (FLUX_MSGTYPE_ANY)))
         BAIL_OUT ("flux_msg_create failed");

--- a/src/common/libzmqutil/zap.h
+++ b/src/common/libzmqutil/zap.h
@@ -8,9 +8,10 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#ifndef _ZMQUTIL_ZAP_H
+#define _ZMQUTIL_ZAP_H
+
 #include <flux/core.h>
-#include <czmq.h>
-#include <zmq.h>
 
 struct zmqutil_zap;
 
@@ -24,6 +25,8 @@ void zmqutil_zap_set_logger (struct zmqutil_zap *zap, zaplog_f fun, void *arg);
 
 void zmqutil_zap_destroy (struct zmqutil_zap *zap);
 struct zmqutil_zap *zmqutil_zap_create (void *zctx, flux_reactor_t *r);
+
+#endif // !_ZMQUTIL_ZAP_H
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
Problem: libczmq is handy for prototyping 0MQ code in C but Flux is beyond prototyping now and we've outgrown it.  It is cleaner for us to use the libzmq API directly, since it is better documented and its error handling is more aligned with flux's (sets `errno` for example).

This PR migrates flux-core off of czmq classes, except for the `zcert`  (CURVE certificate handling) which will be handled in another PR.  Once that's in, we can drop the external czmq dependency.