### PR TITLE
configure: use distutils if available to avoid extra python module dependency

### DIFF
--- a/config/am_check_pymod.m4
+++ b/config/am_check_pymod.m4
@@ -15,7 +15,10 @@ except:
         sys.exit(0)
 sys.exit(0)"], [prog="
 import sys
-from packaging.version import Version
+try:
+    from distutils.version import StrictVersion as Version
+except ModuleNotFoundError:
+    from packaging.version import Version
 import $1
 if not $2:
     sys.exit(1)


### PR DESCRIPTION
Problem: The Python packaging module is not standard, but configure uses it to compare versions, leading to an implicit new dependency.

Since distutils is not removed until Python 3.12, try distutils first then fall back to the packaging package. This will allow configure to continue to work on existing systems while also not breaking on Python 3.12.

Note: this is a proposed workaround for #5457. It will keep our current systems working without a new dependency, but will require Python 3.12 users to install the `packaging` module. :shrug: 