### PR TITLE
allow hwloc topology to be loaded from a file with FLUX_HWLOC_XMLFILE

### DIFF
--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -178,7 +178,7 @@ char *rhwloc_local_topology_xml (rhwloc_flags_t rflags)
 
 const char * rhwloc_hostname (hwloc_topology_t topo)
 {
-        int depth = hwloc_get_type_depth (topo, HWLOC_OBJ_MACHINE);
+    int depth = hwloc_get_type_depth (topo, HWLOC_OBJ_MACHINE);
     hwloc_obj_t obj = hwloc_get_obj_by_depth (topo, depth, 0);
     if (obj)
         return hwloc_obj_get_info_by_name(obj, "HostName");

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -52,7 +52,13 @@ LONGTESTSCRIPTS = \
 	t3200-instance-restart.t \
 	t3202-instance-restart-testexec.t \
 	t3203-instance-recovery.t \
-	t4000-issues-test-driver.t
+	t4000-issues-test-driver.t \
+	t2801-top-cmd.t \
+	t2808-shutdown-cmd.t \
+	t2712-python-cli-alloc.t \
+	t2702-mini-alloc.t \
+	t2714-python-cli-batch.t \
+	t2701-mini-batch.t
 
 # This list is included in both TESTS and dist_check_SCRIPTS.
 TESTSCRIPTS = \
@@ -205,28 +211,22 @@ TESTSCRIPTS = \
 	t2617-job-shell-stage-in.t \
 	t2618-job-shell-signal.t \
 	t2700-mini-cmd.t \
-	t2701-mini-batch.t \
-	t2702-mini-alloc.t \
 	t2703-mini-bulksubmit.t \
 	t2710-python-cli-submit.t \
 	t2711-python-cli-run.t \
-	t2712-python-cli-alloc.t \
 	t2713-python-cli-bulksubmit.t \
-	t2714-python-cli-batch.t \
 	t2715-python-cli-cancel.t \
 	t2716-python-cli-batch-conf.t \
 	t2800-jobs-cmd.t \
 	t2800-jobs-recursive.t \
 	t2800-jobs-instance-info.t \
 	t2800-jobs-config.t \
-	t2801-top-cmd.t \
 	t2802-uri-cmd.t \
 	t2803-flux-pstree.t \
 	t2804-uptime-cmd.t \
 	t2805-startlog-cmd.t \
 	t2806-config-cmd.t \
 	t2807-dump-cmd.t \
-	t2808-shutdown-cmd.t \
 	t2809-job-purge.t \
 	t2810-kvs-garbage-collect.t \
 	t2811-flux-pgrep.t \

--- a/t/README.md
+++ b/t/README.md
@@ -27,11 +27,25 @@ Running tests
 
 Tests may be run in as many as 3 different ways, the easiest
 of which is to issue `make check` from this directory or at
-the top-level flux-core build directory. The tests may also
-all be invoked via the `./runtests.sh` script, which runs
-all tests in turn and aggregates results of all tests at completion.
-Finally, since the tests output TAP, they may be run through a TAP
-harness such as the [prove] command, e.g.
+the top-level flux-core build directory.
+
+Some systems may have poor performance running `make -j N check`
+due to hwloc topology discovery occurring in parallel across many
+tests, each of which may start multiple brokers per test. To
+alleviate this issue, Flux may be directed to read topology from
+an XML file with the `FLUX_HWLOC_XMLFILE` environment variable,
+which avoids most dynamic topology discovery for the entire
+testsuite, e.g.
+
+```
+$ hwloc-ls --of xml >machine.xml
+$ FLUX_HWLOC_XMLFILE=$(pwd)/machine.xml make -j 32 check
+```
+
+The tests may also all be invoked via the `./runtests.sh` script,
+which runs all tests in turn and aggregates results of all tests
+at completion.  Finally, since the tests output TAP, they may be run
+through a TAP harness such as the [prove] command, e.g.
 
 ```
 $ prove --timer ./t*.t

--- a/t/python/t0015-job-output.py
+++ b/t/python/t0015-job-output.py
@@ -254,7 +254,7 @@ class TestJobOutput(unittest.TestCase):
 
         future = output_event_watch_async(self.fh, jobid)
         self.assertIsInstance(future, flux.job.output.JobOutputEventWatch)
-        future.then(output_event_watch_cb, result, timeout=15)
+        future.then(output_event_watch_cb, result, timeout=60)
         self.fh.reactor_run()
 
         self.assertEqual(result["stdout"], self.test_stdout)

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -368,6 +368,14 @@ test_expect_success 'flux-start dies gracefully when run from removed dir' '
 	 test_must_fail flux start /bin/true )
 '
 
+command -v hwloc-ls >/dev/null && test_set_prereq HWLOC_LS
+test_expect_success HWLOC_LS 'FLUX_HWLOC_XMLFILE works' '
+	hwloc-ls --of xml -i "numa:2 core:3 pu:1" >test.xml &&
+	FLUX_HWLOC_XMLFILE=test.xml flux start -s 2 flux resource info \
+		>rinfo.out &&
+	test_debug "cat rinfo.out" &&
+	grep "12 Cores" rinfo.out
+'
 
 # too slow under ASAN
 test_expect_success NO_ASAN 'test_under_flux works' '

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -763,11 +763,11 @@ test_expect_success 'flux job: timeleft works under mini alloc (and job)' '
 	flux run flux job timeleft > timeleft4
 	EOF
 	chmod +x test.sh &&
-	flux alloc -n1 -t 1m ./test.sh &&
+	flux alloc -n1 -t 5m ./test.sh &&
 	test_debug "cat timeleft3" &&
-	test $(cat timeleft3) -lt 60 &&
+	test $(cat timeleft3) -lt 300 &&
 	test_debug "cat timeleft4" &&
-	test $(cat timeleft4) -lt 60
+	test $(cat timeleft4) -lt 300
 '
 test_expect_success 'flux job: timeleft works for a jobid' '
 	id=$(flux submit --wait-event=start -t 1m sleep 60) &&

--- a/t/t2800-jobs-instance-info.t
+++ b/t/t2800-jobs-instance-info.t
@@ -22,7 +22,7 @@ waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
 #
 test_expect_success 'start a set of Flux instances' '
 	id=$(flux submit flux start /bin/true) &&
-	id2=$(flux submit -n2 -c1 flux start \
+	id2=$(flux submit -N2 -n2 -c1 flux start \
 		"flux run /bin/false ; \
 		 flux submit --cc=1-4 sleep 300 && \
 		 touch ready && \


### PR DESCRIPTION
Running `make -j N check` where `N` is large can cause random and numerous test failures on systems with a lot of cores due to parallel hwloc topology discovery across many tests, each invoking many brokers. Presumably, some kind of kernel locks in sysfs slow down parallel hwloc discovery so much that tests time out and fail in unexpected ways. It is also disappointing that `make -j 32 check` runs slower on a 64 core system than an 8 core system.

Based on an idea by @wihobbs, I found that hwloc supports a `HWLOC_XMLFILE` environment variable that forces `hwloc_topology_load(3)` to use a file instead of reading the real system topology from scratch. However, in practice this environment variable does not seem reliable, and it is pretty easy to create our own similar environment variable.

So, this PR introduces `FLUX_HWLOC_XMLFILE` which works the same as above. When set to a file, `rhwloc_local_topology()` will read from the file instead of `hwloc_topology_load()`. This can really speed up `flux start -s N` on some systems (especially tioga for some reason) or if you are running `make -j N check` since this will also result in many brokers doing "discovery" simultaneously on a system.

This is meant to be used in situations where there is a known problem. The testsuite can be prefaced with:
```console
$ lstopo --of xml > system.xml
$ export FLUX_HWLOC_XMLFILE=$(pwd)/system.xml
$ make -j 32 check
```
Or this variable can be used if you're having trouble running `flux start` with large `--test-size`.

Additionally, this option could be used to start a test instance using hwloc from a different machine or a fake topology just using the XML.

Also included in this PR are a couple related fixes that seemed to be required to get `make -j 32 check` to work reliably on tioga.