### PR TITLE
flux-job: get updated version of R

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -483,6 +483,7 @@ check_LTLIBRARIES = \
 	job-manager/plugins/config.la \
 	job-manager/plugins/jobspec-update.la \
 	job-manager/plugins/jobspec-update-job-list.la \
+	job-manager/plugins/resource-update-expiration.la \
 	job-manager/plugins/update-test.la \
 	job-manager/plugins/project-bank-validate.la \
 	stats/stats-basic.la \
@@ -1003,6 +1004,15 @@ job_manager_plugins_jobspec_update_job_list_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la
 
+job_manager_plugins_resource_update_expiration_la_SOURCES = \
+	job-manager/plugins/resource-update-expiration.c
+job_manager_plugins_resource_update_expiration_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_resource_update_expiration_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+job_manager_plugins_resource_update_expiration_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la
 
 job_manager_plugins_update_test_la_SOURCES = \
 	job-manager/plugins/update-test.c

--- a/t/job-manager/plugins/resource-update-expiration.c
+++ b/t/job-manager/plugins/resource-update-expiration.c
@@ -1,0 +1,69 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* jobspec-update-job-list.c - test jobspec-update event in job-list
+ * module
+ */
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+#include "ccan/str/str.h"
+#include "src/common/libutil/errprintf.h"
+
+static int run_cb (flux_plugin_t *p,
+                   const char *topic,
+                   flux_plugin_arg_t *args,
+                   void *data)
+{
+    double expiration;
+    flux_jobid_t id;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I s:{s:{s:F}}}",
+                                "id", &id,
+                                "R",
+                                 "execution",
+                                  "expiration", &expiration) < 0) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "resource-update", 0,
+                                     "unpack failure");
+        return -1;
+    }
+
+    if (flux_jobtap_event_post_pack (p,
+                                     id,
+                                     "resource-update",
+                                     "{s:f}",
+                                     "expiration", expiration + 3600.) < 0) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "resource-update", 0,
+                                     "update failure");
+        return -1;
+    }
+    return 0;
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.state.run", run_cb, NULL },
+    { 0 },
+};
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    if (flux_plugin_register (p, "resource-update-expiration", tab) < 0)
+        return -1;
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -64,7 +64,7 @@ class TestJob(unittest.TestCase):
 
     def check_R_J_str(self, data, jobid):
         self.assertEqual(data["id"], jobid)
-        self.assertNotIn("jobspec", data, jobid)
+        self.assertNotIn("jobspec", data)
         self.assertIn("R", data)
         self.assertIn("J", data)
         self.assertEqual(type(data["R"]), str)

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -188,24 +188,24 @@ class TestJob(unittest.TestCase):
         self.assertNotIn("jobspec", data)
         self.check_R_J_decoded(data, self.jobid1)
 
-    def test_14_job_kvs_lookup_jobspec_base(self):
+    def test_lookup_11_job_kvs_lookup_jobspec_base(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, base=True)
         self.assertNotIn("eventlog", data)
         self.check_jobspec_base_decoded(data, self.jobid1)
 
-    def test_15_job_kvs_lookup_jobspec_base_nodecode(self):
+    def test_lookup_12_job_kvs_lookup_jobspec_base_nodecode(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, decode=False, base=True)
         self.assertNotIn("eventlog", data)
         self.check_jobspec_base_str(data, self.jobid1)
 
-    def test_16_job_kvs_lookup_jobspec_base_multiple_keys(self):
+    def test_lookup_13_job_kvs_lookup_jobspec_base_multiple_keys(self):
         data = flux.job.job_kvs_lookup(
             self.fh, self.jobid1, keys=["jobspec", "eventlog"], base=True
         )
         self.assertIn("eventlog", data)
         self.check_jobspec_base_decoded(data, self.jobid1)
 
-    def test_17_job_kvs_lookup_base_no_jobspec(self):
+    def test_lookup_14_job_kvs_lookup_base_no_jobspec(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["R", "J"], base=True)
         self.assertNotIn("jobspec", data)
         self.check_R_J_decoded(data, self.jobid1)

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -81,6 +81,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(data["R"]["execution"]["R_lite"][0]["rank"], "0")
 
     def check_jobspec_original_str(self, data, jobid):
+        self.assertEqual(data["id"], jobid)
         self.assertIn("jobspec", data)
         self.assertEqual(type(data["jobspec"]), str)
         jobspec = json.loads(data["jobspec"])
@@ -89,6 +90,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(jobspec["attributes"]["system"]["environment"]["FOO"], "BAR")
 
     def check_jobspec_original_decoded(self, data, jobid):
+        self.assertEqual(data["id"], jobid)
         self.assertIn("jobspec", data)
         self.assertEqual(data["jobspec"]["tasks"][0]["command"][0], "hostname")
         self.assertEqual(data["jobspec"]["attributes"]["system"]["duration"], 0)
@@ -97,6 +99,7 @@ class TestJob(unittest.TestCase):
         )
 
     def check_jobspec_base_str(self, data, jobid):
+        self.assertEqual(data["id"], jobid)
         self.assertIn("jobspec", data)
         self.assertEqual(type(data["jobspec"]), str)
         jobspec = json.loads(data["jobspec"])
@@ -104,6 +107,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(jobspec["attributes"]["system"]["duration"], 0)
 
     def check_jobspec_base_decoded(self, data, jobid):
+        self.assertEqual(data["id"], jobid)
         self.assertIn("jobspec", data)
         self.assertEqual(data["jobspec"]["tasks"][0]["command"][0], "hostname")
         self.assertEqual(data["jobspec"]["attributes"]["system"]["duration"], 0)

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -62,23 +62,27 @@ class TestJob(unittest.TestCase):
         self.assertEqual(data["jobspec"]["attributes"]["system"]["duration"], duration)
         self.assertNotIn("R", data)
 
-    def check_R_J_str(self, data, jobid):
+    def check_R_str(self, data, jobid):
         self.assertEqual(data["id"], jobid)
-        self.assertNotIn("jobspec", data)
         self.assertIn("R", data)
-        self.assertIn("J", data)
         self.assertEqual(type(data["R"]), str)
-        self.assertEqual(type(data["J"]), str)
         R = json.loads(data["R"])
         self.assertEqual(R["execution"]["R_lite"][0]["rank"], "0")
 
-    def check_R_J_decoded(self, data, jobid):
+    def check_R_decoded(self, data, jobid):
         self.assertEqual(data["id"], jobid)
-        self.assertNotIn("jobspec", data)
         self.assertIn("R", data)
+        self.assertEqual(data["R"]["execution"]["R_lite"][0]["rank"], "0")
+
+    def check_J_str(self, data, jobid):
+        self.assertEqual(data["id"], jobid)
         self.assertIn("J", data)
         self.assertEqual(type(data["J"]), str)
-        self.assertEqual(data["R"]["execution"]["R_lite"][0]["rank"], "0")
+
+    def check_J_decoded(self, data, jobid):
+        self.assertEqual(data["id"], jobid)
+        self.assertIn("J", data)
+        self.assertEqual(type(data["J"]), str)
 
     def check_jobspec_original_str(self, data, jobid):
         self.assertEqual(data["id"], jobid)
@@ -122,9 +126,12 @@ class TestJob(unittest.TestCase):
     def test_info_01_job_info_lookup_keys(self):
         rpc = flux.job.job_info_lookup(self.fh, self.jobid1, keys=["R", "J"])
         data = rpc.get()
-        self.check_R_J_str(data, self.jobid1)
+        self.assertNotIn("jobspec", data)
+        self.check_R_str(data, self.jobid1)
+        self.check_J_str(data, self.jobid1)
         data = rpc.get_decode()
-        self.check_R_J_decoded(data, self.jobid1)
+        self.check_R_decoded(data, self.jobid1)
+        self.check_J_decoded(data, self.jobid1)
 
     def test_info_02_job_info_lookup_badid(self):
         rpc = flux.job.job_info_lookup(self.fh, 123456789)
@@ -146,13 +153,17 @@ class TestJob(unittest.TestCase):
 
     def test_lookup_03_job_kvs_lookup_keys(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["R", "J"])
-        self.check_R_J_decoded(data, self.jobid1)
+        self.assertNotIn("jobspec", data)
+        self.check_R_decoded(data, self.jobid1)
+        self.check_J_decoded(data, self.jobid1)
 
     def test_lookup_04_job_kvs_lookup_keys_nodecode(self):
         data = flux.job.job_kvs_lookup(
             self.fh, self.jobid1, keys=["R", "J"], decode=False
         )
-        self.check_R_J_str(data, self.jobid1)
+        self.assertNotIn("jobspec", data)
+        self.check_R_str(data, self.jobid1)
+        self.check_J_str(data, self.jobid1)
 
     def test_lookup_05_job_kvs_lookup_badid(self):
         data = flux.job.job_kvs_lookup(self.fh, 123456789)
@@ -186,7 +197,8 @@ class TestJob(unittest.TestCase):
             self.fh, self.jobid1, keys=["R", "J"], original=True
         )
         self.assertNotIn("jobspec", data)
-        self.check_R_J_decoded(data, self.jobid1)
+        self.check_R_decoded(data, self.jobid1)
+        self.check_J_decoded(data, self.jobid1)
 
     def test_lookup_11_job_kvs_lookup_jobspec_base(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, base=True)
@@ -208,7 +220,8 @@ class TestJob(unittest.TestCase):
     def test_lookup_14_job_kvs_lookup_base_no_jobspec(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["R", "J"], base=True)
         self.assertNotIn("jobspec", data)
-        self.check_R_J_decoded(data, self.jobid1)
+        self.check_R_decoded(data, self.jobid1)
+        self.check_J_decoded(data, self.jobid1)
 
     def test_list_00_job_kvs_lookup_list(self):
         ids = [self.jobid1]
@@ -233,16 +246,22 @@ class TestJob(unittest.TestCase):
     def test_list_03_job_kvs_lookup_list_multiple_keys(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"]).data()
+        self.assertNotIn("jobspec", data)
         self.assertEqual(len(data), 2)
-        self.check_R_J_decoded(data[0], self.jobid1)
-        self.check_R_J_decoded(data[1], self.jobid2)
+        self.check_R_decoded(data[0], self.jobid1)
+        self.check_J_decoded(data[0], self.jobid1)
+        self.check_R_decoded(data[1], self.jobid2)
+        self.check_J_decoded(data[1], self.jobid2)
 
     def test_list_04_job_kvs_lookup_list_multiple_keys_nodecode(self):
         ids = [self.jobid1, self.jobid2]
         data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"], decode=False).data()
+        self.assertNotIn("jobspec", data)
         self.assertEqual(len(data), 2)
-        self.check_R_J_str(data[0], self.jobid1)
-        self.check_R_J_str(data[1], self.jobid2)
+        self.check_R_str(data[0], self.jobid1)
+        self.check_J_str(data[0], self.jobid1)
+        self.check_R_str(data[1], self.jobid2)
+        self.check_J_str(data[1], self.jobid2)
 
     def test_list_05_job_kvs_lookup_list_none(self):
         data = flux.job.JobKVSLookup(self.fh).data()
@@ -292,7 +311,8 @@ class TestJob(unittest.TestCase):
         ).data()
         self.assertEqual(len(data), 1)
         self.assertNotIn("jobspec", data[0])
-        self.check_R_J_decoded(data[0], self.jobid1)
+        self.check_R_decoded(data[0], self.jobid1)
+        self.check_J_decoded(data[0], self.jobid1)
 
     def test_list_12_job_kvs_lookup_list_jobspec_base(self):
         ids = [self.jobid1]
@@ -322,7 +342,8 @@ class TestJob(unittest.TestCase):
         data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"], base=True).data()
         self.assertEqual(len(data), 1)
         self.assertNotIn("jobspec", data[0])
-        self.check_R_J_decoded(data[0], self.jobid1)
+        self.check_R_decoded(data[0], self.jobid1)
+        self.check_J_decoded(data[0], self.jobid1)
 
 
 if __name__ == "__main__":

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -11,6 +11,7 @@
 ###############################################################
 
 import json
+import os
 import unittest
 
 import flux
@@ -35,6 +36,17 @@ class TestJob(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.fh = flux.Flux()
+
+        # in future use more standard update mechanism instead of
+        # jobtap plugin.  This jobtap plugin will simply increase the
+        # job expiration by 60 minutes.
+        pluginpath = (
+            os.environ["FLUX_BUILD_DIR"]
+            + "/t/job-manager/plugins/.libs/resource-update-expiration.so"
+        )
+        payload = {"load": pluginpath}
+        self.fh.rpc("job-manager.jobtap", payload).get()
+
         self.jobid1 = self.submitJob(["hostname"], 0)
         flux.job.event_wait(self.fh, self.jobid1, name="priority")
         update = {"attributes.system.duration": 100.0}
@@ -43,6 +55,10 @@ class TestJob(unittest.TestCase):
         payload = {"id": self.jobid1, "urgency": 16}
         self.fh.rpc("job-manager.urgency", payload).get()
         flux.job.event_wait(self.fh, self.jobid1, name="clean")
+
+        payload = {"remove": "all"}
+        self.fh.rpc("job-manager.jobtap", payload).get()
+
         self.jobid2 = self.submitJob(["hostname"], 16)
         flux.job.event_wait(self.fh, self.jobid2, name="clean")
 
@@ -115,6 +131,28 @@ class TestJob(unittest.TestCase):
         self.assertIn("jobspec", data)
         self.assertEqual(data["jobspec"]["tasks"][0]["command"][0], "hostname")
         self.assertEqual(data["jobspec"]["attributes"]["system"]["duration"], 0)
+
+    def check_R_base_str(self, jobid, base, data):
+        self.assertEqual(base["id"], jobid)
+        self.assertEqual(data["id"], jobid)
+        self.assertIn("R", base)
+        self.assertIn("R", data)
+        self.assertEqual(type(base["R"]), str)
+        self.assertEqual(type(data["R"]), str)
+        R_base = json.loads(base["R"])
+        R_data = json.loads(data["R"])
+        base_expiration = R_base["execution"]["expiration"]
+        data_expiration = R_data["execution"]["expiration"]
+        self.assertGreater(data_expiration, base_expiration)
+
+    def check_R_base_decoded(self, jobid, base, data):
+        self.assertEqual(base["id"], jobid)
+        self.assertEqual(data["id"], jobid)
+        self.assertIn("R", base)
+        self.assertIn("R", data)
+        base_expiration = base["R"]["execution"]["expiration"]
+        data_expiration = data["R"]["execution"]["expiration"]
+        self.assertGreater(data_expiration, base_expiration)
 
     def test_info_00_job_info_lookup(self):
         rpc = flux.job.job_info_lookup(self.fh, self.jobid1)
@@ -217,10 +255,37 @@ class TestJob(unittest.TestCase):
         self.assertIn("eventlog", data)
         self.check_jobspec_base_decoded(data, self.jobid1)
 
-    def test_lookup_14_job_kvs_lookup_base_no_jobspec(self):
-        data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["R", "J"], base=True)
+    def test_lookup_14_job_kvs_lookup_R_base(self):
+        base = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["R"], base=True)
+        data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["R"])
+        self.assertNotIn("eventlog", base)
+        self.assertNotIn("eventlog", data)
+        self.check_R_base_decoded(self.jobid1, base, data)
+
+    def test_lookup_15_job_kvs_lookup_R_base_nodecode(self):
+        base = flux.job.job_kvs_lookup(
+            self.fh, self.jobid1, keys=["R"], decode=False, base=True
+        )
+        data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["R"], decode=False)
+        self.assertNotIn("eventlog", base)
+        self.assertNotIn("eventlog", data)
+        self.check_R_base_str(self.jobid1, base, data)
+
+    def test_lookup_16_job_kvs_lookup_R_base_multiple_keys(self):
+        base = flux.job.job_kvs_lookup(
+            self.fh, self.jobid1, keys=["R", "eventlog"], decode=False, base=True
+        )
+        data = flux.job.job_kvs_lookup(
+            self.fh, self.jobid1, keys=["R", "eventlog"], decode=False
+        )
+        self.assertIn("eventlog", base)
+        self.assertIn("eventlog", data)
+        self.check_R_base_str(self.jobid1, base, data)
+
+    def test_lookup_17_job_kvs_lookup_base_no_jobspec_R(self):
+        data = flux.job.job_kvs_lookup(self.fh, self.jobid1, keys=["J"], base=True)
         self.assertNotIn("jobspec", data)
-        self.check_R_decoded(data, self.jobid1)
+        self.assertNotIn("R", data)
         self.check_J_decoded(data, self.jobid1)
 
     def test_list_00_job_kvs_lookup_list(self):
@@ -337,12 +402,38 @@ class TestJob(unittest.TestCase):
         self.assertIn("J", data[0])
         self.check_jobspec_base_decoded(data[0], self.jobid1)
 
-    def test_list_15_job_kvs_lookup_list_base_no_jobspec(self):
+    def test_list_15_job_kvs_lookup_list_R_base(self):
         ids = [self.jobid1]
-        data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"], base=True).data()
+        base = flux.job.JobKVSLookup(self.fh, ids, keys=["R"], base=True).data()
+        data = flux.job.JobKVSLookup(self.fh, ids, keys=["R"]).data()
+        self.assertEqual(len(base), 1)
+        self.assertEqual(len(data), 1)
+        self.check_R_base_decoded(self.jobid1, base[0], data[0])
+
+    def test_list_16_job_kvs_lookup_list_R_base_nodecode(self):
+        ids = [self.jobid1]
+        base = flux.job.JobKVSLookup(
+            self.fh, ids, keys=["R"], decode=False, base=True
+        ).data()
+        data = flux.job.JobKVSLookup(self.fh, ids, keys=["R"], decode=False).data()
+        self.assertEqual(len(base), 1)
+        self.assertEqual(len(data), 1)
+        self.check_R_base_str(self.jobid1, base[0], data[0])
+
+    def test_list_17_job_kvs_lookup_list_R_base_multiple_keys(self):
+        ids = [self.jobid1]
+        base = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"], base=True).data()
+        data = flux.job.JobKVSLookup(self.fh, ids, keys=["R", "J"]).data()
+        self.assertEqual(len(data), 1)
+        self.assertIn("J", data[0])
+        self.check_R_base_decoded(self.jobid1, base[0], data[0])
+
+    def test_list_18_job_kvs_lookup_list_base_no_jobspec_R(self):
+        ids = [self.jobid1]
+        data = flux.job.JobKVSLookup(self.fh, ids, keys=["J"], base=True).data()
         self.assertEqual(len(data), 1)
         self.assertNotIn("jobspec", data[0])
-        self.check_R_decoded(data[0], self.jobid1)
+        self.assertNotIn("R", data[0])
         self.check_J_decoded(data[0], self.jobid1)
 
 

--- a/t/t2232-job-info-security.t
+++ b/t/t2232-job-info-security.t
@@ -285,20 +285,21 @@ test_expect_success 'flux job wait-event guest.exec.eventlog fails via -p (live 
 
 # for these tests we need to create a fake job eventlog in the KVS
 
-# value of R irrelevant here, just need to lookup something
+# value of "dummy" irrelevant here, just need to lookup something
+
 test_expect_success 'create empty eventlog for job' '
 	jobpath=`flux job id --to=kvs 123456789` &&
 	flux kvs put "${jobpath}.eventlog"="" &&
-	flux kvs put "${jobpath}.R"="foobar"
+	flux kvs put "${jobpath}.dummy"="foobar"
 '
 
-test_expect_success 'flux job info R works (owner)' '
-	flux job info $jobpath R
+test_expect_success 'flux job info dummy works (owner)' '
+	flux job info $jobpath dummy
 '
 
-test_expect_success 'flux job info R fails (user)' '
+test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 R 2>&1 | grep "Protocol error" &&
+        flux job info 123456789 dummy 2>&1 | grep "Protocol error" &&
 	unset_userid
 '
 
@@ -307,9 +308,9 @@ test_expect_success 'create eventlog with invalid data / not JSON' '
 	flux kvs put "${jobpath}.eventlog"="foobar"
 '
 
-test_expect_success 'flux job info R fails (user)' '
+test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 R 2>&1 | grep "Protocol error" &&
+        flux job info 123456789 dummy 2>&1 | grep "Protocol error" &&
 	unset_userid
 '
 
@@ -319,9 +320,9 @@ test_expect_success 'create eventlog without submit context' '
 	echo $submitstr | flux kvs put --raw "${jobpath}.eventlog"=-
 '
 
-test_expect_success 'flux job info R fails (user)' '
+test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 R 2>&1 | grep "Protocol error" &&
+        flux job info 123456789 dummy 2>&1 | grep "Protocol error" &&
 	unset_userid
 '
 
@@ -331,9 +332,9 @@ test_expect_success 'create eventlog without submit userid' '
 	echo $submitstr | flux kvs put --raw "${jobpath}.eventlog"=-
 '
 
-test_expect_success 'flux job info R fails (user)' '
+test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 R 2>&1 | grep "Protocol error" &&
+        flux job info 123456789 dummy 2>&1 | grep "Protocol error" &&
 	unset_userid
 '
 
@@ -343,9 +344,9 @@ test_expect_success 'create eventlog that is binary garbage' '
 	flux kvs put --raw "${jobpath}.eventlog"=- < binary.out
 '
 
-test_expect_success 'flux job info R fails (user)' '
+test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 R 2>&1 | grep "Protocol error" &&
+        flux job info 123456789 dummy 2>&1 | grep "Protocol error" &&
 	unset_userid
 '
 


### PR DESCRIPTION
similar to https://github.com/flux-framework/flux-core/pull/5428 this supports `resource-update` events in `flux job info` and the equivalent python bindings to look up the "viewed" R and not the "base" one stored in the KVS.

Just like #5463, the commits with new tests do not work and have XXX tagged to be filled in later when an actual way to update the R of a job exists.

I should also note that this does not use any solution from #5451 as A) I implemented this first :P, B) copied the implementation from the jobspec side, and C) I wanted to keep this processing out of broker.  We could of course change the approach.