### PR TITLE
job-info: support new update-lookup and update-watch service

### DIFF
--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -169,7 +169,9 @@ job_info_la_SOURCES = \
 	job-info/watch.h \
 	job-info/watch.c \
 	job-info/guest_watch.h \
-	job-info/guest_watch.c
+	job-info/guest_watch.c \
+	job-info/util.h \
+	job-info/util.c
 job_info_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_SECURITY_CFLAGS)

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -170,6 +170,8 @@ job_info_la_SOURCES = \
 	job-info/watch.c \
 	job-info/guest_watch.h \
 	job-info/guest_watch.c \
+	job-info/update.h \
+	job-info/update.c \
 	job-info/util.h \
 	job-info/util.c
 job_info_la_CPPFLAGS = \
@@ -178,6 +180,7 @@ job_info_la_CPPFLAGS = \
 job_info_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libjob/libjob.la \
 	$(JANSSON_LIBS) \
 	$(HWLOC_LIBS)
 job_info_la_LDFLAGS = $(fluxmod_ldflags) -module

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -131,6 +131,7 @@ static void guest_watch_ctx_destroy (void *data)
 {
     if (data) {
         struct guest_watch_ctx *gw = data;
+        int save_errno = errno;
         flux_msg_decref (gw->msg);
         free (gw->path);
         flux_future_destroy (gw->get_main_eventlog_f);
@@ -138,6 +139,7 @@ static void guest_watch_ctx_destroy (void *data)
         flux_future_destroy (gw->guest_namespace_watch_f);
         flux_future_destroy (gw->main_namespace_lookup_f);
         free (gw);
+        errno = save_errno;
     }
 }
 
@@ -148,7 +150,6 @@ static struct guest_watch_ctx *guest_watch_ctx_create (struct info_ctx *ctx,
                                                        int flags)
 {
     struct guest_watch_ctx *gw = calloc (1, sizeof (*gw));
-    int saved_errno;
 
     if (!gw)
         return NULL;
@@ -172,9 +173,7 @@ static struct guest_watch_ctx *guest_watch_ctx_create (struct info_ctx *ctx,
     return gw;
 
 error:
-    saved_errno = errno;
     guest_watch_ctx_destroy (gw);
-    errno = saved_errno;
     return NULL;
 }
 

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -708,19 +708,6 @@ error:
     return rv;
 }
 
-static bool eventlog_parse_next (const char **pp, const char **tok,
-                                 size_t *toklen)
-{
-    char *term;
-
-    if (!(term = strchr (*pp, '\n')))
-        return false;
-    *tok = *pp;
-    *toklen = term - *pp + 1;
-    *pp = term + 1;
-    return true;
-}
-
 static void main_namespace_lookup_continuation (flux_future_t *f, void *arg)
 {
     struct guest_watch_ctx *gw = arg;

--- a/src/modules/job-info/guest_watch.h
+++ b/src/modules/job-info/guest_watch.h
@@ -31,7 +31,7 @@ void guest_watchers_cancel (struct info_ctx *ctx,
 
 void guest_watch_cleanup (struct info_ctx *ctx);
 
-#endif /* ! _FLUX_JOB_INFO_EVENTLOG_GUEST_WATCH_H */
+#endif /* ! _FLUX_JOB_INFO_GUEST_WATCH_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/job-info/job-info.h
+++ b/src/modules/job-info/job-info.h
@@ -14,6 +14,7 @@
 #include <flux/core.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libjob/job_hash.h"
 #include "src/common/libutil/lru_cache.h"
 
 #define OWNER_LRU_MAXSIZE 1000
@@ -25,6 +26,9 @@ struct info_ctx {
     zlist_t *lookups;
     zlist_t *watchers;
     zlist_t *guest_watchers;
+    zlist_t *update_lookups;
+    zlist_t *update_watchers;
+    zhashx_t *index_uw;        /* update_watchers lookup */
 };
 
 #endif /* _FLUX_JOB_INFO_H */

--- a/src/modules/job-info/update.c
+++ b/src/modules/job-info/update.c
@@ -1,0 +1,720 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* update.c - handle job-info.update-watch &
+ * job-info.eventlog-update-cancel for job-info */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libjob/job.h"
+#include "src/common/libjob/idf58.h"
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libutil/jpath.h"
+#include "ccan/str/str.h"
+
+#include "job-info.h"
+#include "update.h"
+#include "util.h"
+
+typedef enum {
+    UPDATE_TYPE_LOOKUP,
+    UPDATE_TYPE_WATCH,
+} update_type_t;
+
+struct update_ctx {
+    struct info_ctx *ctx;
+    update_type_t type;
+    struct flux_msglist *msglist;
+    uint32_t userid;
+    flux_jobid_t id;
+    char *key;
+    int flags;
+    const char *update_name;
+    flux_future_t *lookup_f;
+    flux_future_t *eventlog_watch_f;
+    bool eventlog_watch_canceled;
+    json_t *update_object;
+    int initial_update_count;
+    int watch_update_count;
+    char *index_key;            /* for watch */
+};
+
+static void update_ctx_destroy (void *data)
+{
+    if (data) {
+        struct update_ctx *uc = data;
+        int save_errno = errno;
+        flux_msglist_destroy (uc->msglist);
+        free (uc->key);
+        flux_future_destroy (uc->lookup_f);
+        flux_future_destroy (uc->eventlog_watch_f);
+        json_decref (uc->update_object);
+        free (uc->index_key);
+        free (uc);
+        errno = save_errno;
+    }
+}
+
+static char *get_index_key (flux_jobid_t id, const char *key)
+{
+    char *s;
+    if (asprintf (&s, "%ju-%s", id, key) < 0)
+        return NULL;
+    return s;
+}
+
+static struct update_ctx *update_ctx_create (struct info_ctx *ctx,
+                                             update_type_t type,
+                                             const flux_msg_t *msg,
+                                             flux_jobid_t id,
+                                             const char *key,
+                                             int flags)
+{
+    struct update_ctx *uc = calloc (1, sizeof (*uc));
+
+    if (!uc)
+        return NULL;
+
+    uc->ctx = ctx;
+    uc->type = type;
+    uc->id = id;
+    if (!(uc->key = strdup (key))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (streq (key, "R"))
+        uc->update_name = "resource-update";
+    else {
+        errno = EINVAL;
+        goto error;
+    }
+    uc->flags = flags;
+
+    /* for lookups, the msglist will never be > 1 in length */
+    if (!(uc->msglist = flux_msglist_create ()))
+        goto error;
+    flux_msglist_append (uc->msglist, msg);
+
+    if (uc->type == UPDATE_TYPE_WATCH) {
+        /* use jobid + key as lookup key, in future we may support other
+         * keys other than R
+         */
+        if (!(uc->index_key = get_index_key (uc->id, uc->key)))
+            goto error;
+    }
+
+    return uc;
+
+error:
+    update_ctx_destroy (uc);
+    return NULL;
+}
+
+static void eventlog_watch_cancel (struct update_ctx *uc)
+{
+    flux_future_t *f;
+    int matchtag;
+
+    /* in some cases, possible eventlog watch hasn't started yet */
+    if (!uc->eventlog_watch_f || uc->eventlog_watch_canceled)
+        return;
+
+    matchtag = (int)flux_rpc_get_matchtag (uc->eventlog_watch_f);
+
+    if (!(f = flux_rpc_pack (uc->ctx->h,
+                             "job-info.eventlog-watch-cancel",
+                             FLUX_NODEID_ANY,
+                             FLUX_RPC_NORESPONSE,
+                             "{s:i}",
+                             "matchtag", matchtag))) {
+        flux_log_error (uc->ctx->h, "%s: flux_rpc_pack", __FUNCTION__);
+        return;
+    }
+    flux_future_destroy (f);
+    uc->eventlog_watch_canceled = true;
+}
+
+static void apply_updates_R (struct update_ctx *uc,
+                             json_t *context)
+{
+    const char *key;
+    json_t *value;
+
+    json_object_foreach (context, key, value) {
+        /* RFC 21 resource-update event only allows update
+         * to:
+         * - expiration
+         */
+        if (streq (key, "expiration"))
+            if (jpath_set (uc->update_object,
+                           "execution.expiration",
+                           value) < 0)
+                flux_log (uc->ctx->h, LOG_INFO,
+                          "%s: failed to update job %s %s",
+                          __FUNCTION__, idf58 (uc->id), uc->key);
+    }
+}
+
+static void eventlog_continuation (flux_future_t *f, void *arg)
+{
+    struct update_ctx *uc = arg;
+    struct info_ctx *ctx = uc->ctx;
+    const char *s;
+    json_t *event = NULL;
+    const char *name;
+    json_t *context = NULL;
+    const char *errmsg = NULL;
+    const flux_msg_t *msg;
+
+    if (flux_rpc_get (f, NULL) < 0) {
+        /* ENODATA is normal when job finishes or we've sent cancel */
+        if (errno != ENODATA)
+            flux_log_error (ctx->h, "%s: job-info.eventlog-watch", __FUNCTION__);
+        goto error;
+    }
+
+    /* if count == 0, all callers canceled streams */
+    if (flux_msglist_count (uc->msglist) == 0)
+        goto cleanup;
+
+    if (flux_job_event_watch_get (f, &s) < 0) {
+        flux_log_error (ctx->h, "%s: flux_job_event_watch_get", __FUNCTION__);
+        goto error_cancel;
+    }
+
+    if (!(event = eventlog_entry_decode (s))) {
+        flux_log_error (uc->ctx->h, "%s: eventlog_entry_decode", __FUNCTION__);
+        goto error_cancel;
+    }
+
+    if (eventlog_entry_parse (event, NULL, &name, &context) < 0) {
+        flux_log_error (uc->ctx->h, "%s: eventlog_entry_decode", __FUNCTION__);
+        goto error_cancel;
+    }
+
+    if (context && streq (name, uc->update_name)) {
+        uc->watch_update_count++;
+
+        /* don't apply update events that we've already applied from
+         * initial lookup */
+        if (uc->watch_update_count > uc->initial_update_count) {
+            if (streq (uc->key, "R"))
+                apply_updates_R (uc, context);
+
+            msg = flux_msglist_first (uc->msglist);
+            while (msg) {
+                if (flux_respond_pack (uc->ctx->h, msg, "{s:O}",
+                                       uc->key, uc->update_object) < 0) {
+                    flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
+                    goto error_cancel;
+                }
+                msg = flux_msglist_next (uc->msglist);
+            }
+        }
+    }
+
+    flux_future_reset (f);
+    json_decref (event);
+    return;
+
+error_cancel:
+    /* Must do so so that the future's matchtag will eventually be
+     * freed */
+    eventlog_watch_cancel (uc);
+
+error:
+    msg = flux_msglist_first (uc->msglist);
+    while (msg) {
+        if (flux_respond_error (ctx->h, msg, errno, errmsg) < 0)
+            flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+        msg = flux_msglist_next (uc->msglist);
+    }
+
+cleanup:
+    /* flux future destroyed in update_ctx_destroy, which is
+     * called via zlist_remove() */
+    zhashx_delete (ctx->index_uw, uc->index_key);
+    zlist_remove (ctx->update_watchers, uc);
+}
+
+static int eventlog_watch (struct update_ctx *uc)
+{
+    const char *topic = "job-info.eventlog-watch";
+    int rpc_flags = FLUX_RPC_STREAMING;
+    flux_msg_t *msg = NULL;
+    int save_errno, rc = -1;
+
+    if (!(uc->eventlog_watch_f = flux_rpc_pack (uc->ctx->h,
+                                                topic,
+                                                FLUX_NODEID_ANY,
+                                                rpc_flags,
+                                                "{s:I s:s s:i}",
+                                                "id", uc->id,
+                                                "path", "eventlog",
+                                                "flags", 0))) {
+        flux_log_error (uc->ctx->h, "%s: flux_rpc_pack", __FUNCTION__);
+        goto error;
+    }
+
+    if (flux_future_then (uc->eventlog_watch_f,
+                          -1,
+                          eventlog_continuation,
+                          uc) < 0) {
+        /* future cleanup handled with context destruction */
+        flux_log_error (uc->ctx->h, "%s: flux_future_then", __FUNCTION__);
+        goto error;
+    }
+
+    rc = 0;
+error:
+    save_errno = errno;
+    flux_msg_destroy (msg);
+    errno = save_errno;
+    return rc;
+}
+
+static void lookup_continuation (flux_future_t *f, void *arg)
+{
+    struct update_ctx *uc = arg;
+    struct info_ctx *ctx = uc->ctx;
+    const char *key_str;
+    const char *eventlog_str;
+    const char *input;
+    const char *tok;
+    size_t toklen;
+    const char *errmsg = NULL;
+    bool job_ended = false;
+    bool submit_parsed = false;
+    const flux_msg_t *msg;
+
+    if (flux_rpc_get_unpack (f, "{s:s s:s}",
+                             uc->key, &key_str,
+                             "eventlog", &eventlog_str) < 0) {
+        if (errno != ENOENT && errno != EPERM)
+            flux_log_error (ctx->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+        goto error;
+    }
+
+    /* if count == 0, all callers canceled streams */
+    if (flux_msglist_count (uc->msglist) == 0)
+        goto cleanup;
+
+    if (!(uc->update_object = json_loads (key_str, 0, NULL))) {
+        errno = EINVAL;
+        errmsg = "lookup value cannot be parsed";
+        goto error;
+    }
+
+    input = eventlog_str;
+    while (eventlog_parse_next (&input, &tok, &toklen)) {
+        json_t *entry = NULL;
+        const char *name;
+        json_t *context = NULL;
+        if (eventlog_parse_entry_chunk (uc->ctx->h,
+                                        tok,
+                                        toklen,
+                                        &entry,
+                                        &name,
+                                        &context) < 0) {
+            errmsg = "error parsing eventlog";
+            goto error;
+        }
+        if (streq (name, "submit")) {
+            if (!context) {
+                errno = EPROTO;
+                goto error;
+            }
+            if (json_unpack (context, "{ s:i }", "userid", &uc->userid) < 0) {
+                errno = EPROTO;
+                goto error;
+            }
+            submit_parsed = true;
+        }
+        else if (streq (name, uc->update_name)) {
+            if (streq (uc->key, "R"))
+                apply_updates_R (uc, context);
+            uc->initial_update_count++;
+        }
+        else if (streq (name, "clean"))
+            job_ended = true;
+        json_decref (entry);
+    }
+
+    /* double check, generally speaking should be impossible */
+    if (!submit_parsed) {
+        errno = EPROTO;
+        goto error;
+    }
+
+    msg = flux_msglist_first (uc->msglist);
+    while (msg) {
+        /* caller can't access this data, this is not a "fatal" error,
+         * so send error to this one message and continue on the
+         * msglist
+         */
+        if (flux_msg_authorize (msg, uc->userid) < 0) {
+            if (flux_respond_error (ctx->h, msg, errno, NULL) < 0)
+                flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+            flux_msglist_delete (uc->msglist);
+            goto next;
+        }
+
+        if (flux_respond_pack (uc->ctx->h, msg, "{s:O}",
+                               uc->key, uc->update_object) < 0) {
+            flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
+            goto error;
+        }
+
+    next:
+        msg = flux_msglist_next (uc->msglist);
+    }
+
+    /* due to security check above, possible no more messages in this
+     * watcher */
+    if (flux_msglist_count (uc->msglist) == 0)
+        goto cleanup;
+
+    /* If this is a lookup, we're done, only continue on if this is a
+     * watcher */
+    if (uc->type == UPDATE_TYPE_LOOKUP)
+        goto cleanup;
+
+    /* this job has ended, no need to watch the eventlog for future
+     * updates */
+    if (job_ended) {
+        errno = ENODATA;
+        goto error;
+    }
+
+    /* we've confirmed key is readable and sent to caller, now watch
+     * eventlog for future changes */
+    if (eventlog_watch (uc) < 0)
+        goto error;
+
+    return;
+
+error:
+    msg = flux_msglist_first (uc->msglist);
+    while (msg) {
+        if (flux_respond_error (ctx->h, msg, errno, errmsg) < 0)
+            flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
+        msg = flux_msglist_next (uc->msglist);
+    }
+
+cleanup:
+    /* flux future destroyed in update_ctx_destroy, which is called
+     * via zlist_remove() */
+    if (uc->type == UPDATE_TYPE_WATCH) {
+        zhashx_delete (ctx->index_uw, uc->index_key);
+        zlist_remove (ctx->update_watchers, uc);
+    }
+    else
+        zlist_remove (ctx->update_lookups, uc);
+}
+
+static int update_lookup (struct info_ctx *ctx,
+                          update_type_t type,
+                          const flux_msg_t *msg,
+                          flux_jobid_t id,
+                          const char *key,
+                          int flags)
+{
+    struct update_ctx *uc = NULL;
+    const char *topic = "job-info.lookup";
+
+    if (!(uc = update_ctx_create (ctx,
+                                  type,
+                                  msg,
+                                  id,
+                                  key,
+                                  flags)))
+        goto error;
+
+    if (!(uc->lookup_f = flux_rpc_pack (uc->ctx->h,
+                                        topic,
+                                        FLUX_NODEID_ANY,
+                                        0,
+                                        "{s:I s:[ss] s:i}",
+                                        "id", uc->id,
+                                        "keys", uc->key, "eventlog",
+                                        "flags", 0))) {
+        flux_log_error (uc->ctx->h, "%s: flux_rpc_pack", __FUNCTION__);
+        goto error;
+    }
+
+    if (flux_future_then (uc->lookup_f,
+                          -1,
+                          lookup_continuation,
+                          uc) < 0) {
+        /* future cleanup handled with context destruction */
+        flux_log_error (uc->ctx->h, "%s: flux_future_then", __FUNCTION__);
+        goto error;
+    }
+
+    if (type == UPDATE_TYPE_WATCH) {
+        if (zlist_append (ctx->update_watchers, uc) < 0) {
+            flux_log_error (ctx->h, "%s: zlist_append", __FUNCTION__);
+            goto error;
+        }
+        zlist_freefn (ctx->update_watchers, uc, update_ctx_destroy, true);
+
+        if (zhashx_insert (ctx->index_uw, uc->index_key, uc) < 0) {
+            flux_log_error (ctx->h, "%s: zhashx_insert", __FUNCTION__);
+            goto error_list;
+        }
+    }
+    else {
+        if (zlist_append (ctx->update_lookups, uc) < 0) {
+            flux_log_error (ctx->h, "%s: zlist_append", __FUNCTION__);
+            goto error;
+        }
+        zlist_freefn (ctx->update_lookups, uc, update_ctx_destroy, true);
+    }
+
+    return 0;
+
+error_list:
+    zlist_remove (ctx->update_watchers, uc);
+    return -1;
+
+error:
+    update_ctx_destroy (uc);
+    return -1;
+}
+
+void update_lookup_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    struct update_ctx *uc = NULL;
+    flux_jobid_t id;
+    const char *key = NULL;
+    int flags;
+    int valid_flags = 0;
+    const char *errmsg = NULL;
+    char *index_key = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:I s:s s:i}",
+                             "id", &id,
+                             "key", &key,
+                             "flags", &flags) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+        goto error;
+    }
+    if ((flags & ~valid_flags)) {
+        errno = EPROTO;
+        errmsg = "update-lookup request rejected with invalid flag";
+        goto error;
+    }
+    if (!streq (key, "R")) {
+        errno = EINVAL;
+        errmsg = "update-lookup unsupported key specified";
+        goto error;
+    }
+
+    if (!(index_key = get_index_key (id, key)))
+        goto error;
+
+    /* is somebody watching this jobid + key already, return the
+     * cached result */
+
+    if ((uc = zhashx_lookup (ctx->index_uw, index_key))
+        && uc->update_object) {
+        if (flux_msg_authorize (msg, uc->userid) < 0)
+            goto error;
+        if (flux_respond_pack (uc->ctx->h, msg, "{s:O}",
+                               uc->key, uc->update_object) < 0) {
+            flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
+            goto error;
+        }
+    }
+    else {
+        if (update_lookup (ctx,
+                           UPDATE_TYPE_LOOKUP,
+                           msg,
+                           id,
+                           key,
+                           flags) < 0)
+            goto error;
+    }
+
+    free (index_key);
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    free (index_key);
+}
+
+void update_watch_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    struct update_ctx *uc = NULL;
+    flux_jobid_t id;
+    const char *key = NULL;
+    int flags;
+    int valid_flags = 0;
+    const char *errmsg = NULL;
+    char *index_key = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:I s:s s:i}",
+                             "id", &id,
+                             "key", &key,
+                             "flags", &flags) < 0) {
+        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+        goto error;
+    }
+    if ((flags & ~valid_flags)) {
+        errno = EPROTO;
+        errmsg = "update-watch request rejected with invalid flag";
+        goto error;
+    }
+    if (!flux_msg_is_streaming (msg)) {
+        errno = EPROTO;
+        errmsg = "update-watch request rejected without streaming RPC flag";
+        goto error;
+    }
+    if (!streq (key, "R")) {
+        errno = EINVAL;
+        errmsg = "update-watch unsupported key specified";
+        goto error;
+    }
+
+    if (!(index_key = get_index_key (id, key)))
+        goto error;
+
+    /* if no watchers for this jobid yet, start it */
+    if (!(uc = zhashx_lookup (ctx->index_uw, index_key))) {
+        if (update_lookup (ctx,
+                           UPDATE_TYPE_WATCH,
+                           msg,
+                           id,
+                           key,
+                           flags) < 0)
+            goto error;
+    }
+    else {
+        if (uc->update_object) {
+            if (flux_msg_authorize (msg, uc->userid) < 0)
+                goto error;
+            if (flux_respond_pack (uc->ctx->h, msg, "{s:O}",
+                                   uc->key, uc->update_object) < 0) {
+                flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
+                goto error;
+            }
+        }
+        /* if uc->update_object has not been set, the initial lookup
+         * has not completed.  The security check will be done in
+         * watch_lookup_continuation when the initial lookup completes.
+         */
+        flux_msglist_append (uc->msglist, msg);
+    }
+
+    free (index_key);
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    free (index_key);
+}
+
+/* Cancel update_watch if it matches message.
+ */
+static void update_watch_cancel (struct update_ctx *uc,
+                                 const flux_msg_t *msg,
+                                 bool cancel)
+{
+    const flux_msg_t *cmpmsg;
+
+    cmpmsg = flux_msglist_first (uc->msglist);
+    while (cmpmsg) {
+        bool match;
+
+        if (cancel)
+            match = flux_cancel_match (msg, cmpmsg);
+        else
+            match = flux_disconnect_match (msg, cmpmsg);
+
+        if (match) {
+            if (flux_respond_error (uc->ctx->h, cmpmsg, ENODATA, NULL) < 0)
+                flux_log_error (uc->ctx->h,
+                                "%s: flux_respond_error",
+                                __FUNCTION__);
+            /* deletes at cursor */
+            flux_msglist_delete (uc->msglist);
+        }
+
+        cmpmsg = flux_msglist_next (uc->msglist);
+    }
+
+    if (flux_msglist_count (uc->msglist) == 0)
+        eventlog_watch_cancel (uc);
+}
+
+void update_watchers_cancel (struct info_ctx *ctx, const flux_msg_t *msg, bool cancel)
+{
+    struct update_ctx *uc;
+
+    uc = zlist_first (ctx->update_watchers);
+    while (uc) {
+        update_watch_cancel (uc, msg, cancel);
+        uc = zlist_next (ctx->update_watchers);
+    }
+}
+
+void update_watch_cancel_cb (flux_t *h, flux_msg_handler_t *mh,
+                             const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    update_watchers_cancel (ctx, msg, true);
+}
+
+void update_watch_cleanup (struct info_ctx *ctx)
+{
+    struct update_ctx *uc;
+
+    while ((uc = zlist_pop (ctx->update_watchers))) {
+        const flux_msg_t *msg;
+        eventlog_watch_cancel (uc);
+        msg = flux_msglist_first (uc->msglist);
+        while (msg) {
+            if (flux_respond_error (ctx->h, msg, ENOSYS, NULL) < 0)
+                flux_log_error (ctx->h, "%s: flux_respond_error",
+                                __FUNCTION__);
+            msg = flux_msglist_next (uc->msglist);
+        }
+        update_ctx_destroy (uc);
+    }
+}
+
+int update_watch_count (struct info_ctx *ctx)
+{
+    struct update_ctx *uc;
+    int count = 0;
+
+    uc = zlist_first (ctx->update_watchers);
+    while (uc) {
+        count += flux_msglist_count (uc->msglist);
+        uc = zlist_next (ctx->update_watchers);
+    }
+    return count;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-info/update.h
+++ b/src/modules/job-info/update.h
@@ -1,0 +1,41 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_INFO_UPDATE_H
+#define _FLUX_JOB_INFO_UPDATE_H
+
+#include <flux/core.h>
+
+void update_lookup_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg);
+
+void update_watch_cb (flux_t *h, flux_msg_handler_t *mh,
+                      const flux_msg_t *msg, void *arg);
+
+void update_watch_cancel_cb (flux_t *h, flux_msg_handler_t *mh,
+                             const flux_msg_t *msg, void *arg);
+
+/* Cancel all update watches that match msg.
+ * match credentials & matchtag if cancel true
+ * match credentials if cancel false
+ */
+void update_watchers_cancel (struct info_ctx *ctx,
+                             const flux_msg_t *msg,
+                             bool cancel);
+
+void update_watch_cleanup (struct info_ctx *ctx);
+
+int update_watch_count (struct info_ctx *ctx);
+
+#endif /* ! _FLUX_JOB_INFO_UPDATE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-info/util.c
+++ b/src/modules/job-info/util.c
@@ -1,0 +1,58 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+flux_msg_t *cred_msg_pack (const char *topic,
+                           struct flux_msg_cred cred,
+                           const char *fmt,
+                           ...)
+{
+    flux_msg_t *newmsg = NULL;
+    json_t *payload = NULL;
+    char *payloadstr = NULL;
+    flux_msg_t *rv = NULL;
+    int save_errno;
+    va_list ap;
+
+    va_start (ap, fmt);
+
+    if (!(newmsg = flux_request_encode (topic, NULL)))
+        goto error;
+    if (flux_msg_set_cred (newmsg, cred) < 0)
+        goto error;
+    if (!(payload = json_vpack_ex (NULL, 0, fmt, ap)))
+        goto error;
+    if (!(payloadstr = json_dumps (payload, JSON_COMPACT))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (flux_msg_set_string (newmsg, payloadstr) < 0)
+        goto error;
+
+    rv = newmsg;
+error:
+    save_errno = errno;
+    if (!rv)
+        flux_msg_destroy (newmsg);
+    json_decref (payload);
+    free (payloadstr);
+    va_end (ap);
+    errno = save_errno;
+    return rv;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-info/util.c
+++ b/src/modules/job-info/util.c
@@ -11,8 +11,11 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <string.h>
 #include <jansson.h>
 #include <flux/core.h>
+
+#include "src/common/libeventlog/eventlog.h"
 
 flux_msg_t *cred_msg_pack (const char *topic,
                            struct flux_msg_cred cred,
@@ -51,6 +54,58 @@ error:
     va_end (ap);
     errno = save_errno;
     return rv;
+}
+
+bool eventlog_parse_next (const char **pp,
+                          const char **tok,
+                          size_t *toklen)
+{
+    char *term;
+
+    if (!(term = strchr (*pp, '\n')))
+        return false;
+    *tok = *pp;
+    *toklen = term - *pp + 1;
+    *pp = term + 1;
+    return true;
+}
+
+int eventlog_parse_entry_chunk (flux_t *h,
+                                const char *tok,
+                                size_t toklen,
+                                json_t **entry,
+                                const char **name,
+                                json_t **context)
+{
+    char *str = NULL;
+    json_t *o = NULL;
+    int saved_errno, rc = -1;
+
+    if (!(str = strndup (tok, toklen))) {
+        flux_log_error (h, "%s: strndup", __FUNCTION__);
+        goto error;
+    }
+
+    if (!(o = eventlog_entry_decode (str))) {
+        flux_log_error (h, "%s: eventlog_entry_decode", __FUNCTION__);
+        goto error;
+    }
+
+    if (eventlog_entry_parse (o, NULL, name, context) < 0) {
+        flux_log_error (h, "%s: eventlog_entry_parse", __FUNCTION__);
+        goto error;
+    }
+
+    (*entry) = o;
+    free (str);
+    return 0;
+
+error:
+    saved_errno = errno;
+    free (str);
+    json_decref (o);
+    errno = saved_errno;
+    return rc;
 }
 
 /*

--- a/src/modules/job-info/util.h
+++ b/src/modules/job-info/util.h
@@ -11,6 +11,7 @@
 #ifndef _FLUX_JOB_INFO_UTIL_H
 #define _FLUX_JOB_INFO_UTIL_H
 
+#include <jansson.h>
 #include <flux/core.h>
 
 /* we want to copy credentials, etc. from the original
@@ -20,6 +21,19 @@ flux_msg_t *cred_msg_pack (const char *topic,
                            struct flux_msg_cred cred,
                            const char *fmt,
                            ...);
+
+/* helper to parse next eventlog entry when whole eventlog is read */
+bool eventlog_parse_next (const char **pp, const char **tok,
+                          size_t *toklen);
+
+/* parse chunk from eventlog_parse_next, 'entry' is required and
+ * should be json_decref'ed after use */
+int eventlog_parse_entry_chunk (flux_t *h,
+                                const char *tok,
+                                size_t toklen,
+                                json_t **entry,
+                                const char **name,
+                                json_t **context);
 
 #endif /* ! _FLUX_JOB_INFO_UTIL_H */
 

--- a/src/modules/job-info/util.h
+++ b/src/modules/job-info/util.h
@@ -1,0 +1,28 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_INFO_UTIL_H
+#define _FLUX_JOB_INFO_UTIL_H
+
+#include <flux/core.h>
+
+/* we want to copy credentials, etc. from the original
+ * message when we send RPCs to other job-info targets.
+ */
+flux_msg_t *cred_msg_pack (const char *topic,
+                           struct flux_msg_cred cred,
+                           const char *fmt,
+                           ...);
+
+#endif /* ! _FLUX_JOB_INFO_UTIL_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -47,11 +47,13 @@ static void watch_ctx_destroy (void *data)
 {
     if (data) {
         struct watch_ctx *ctx = data;
+        int save_errno = errno;
         flux_msg_decref (ctx->msg);
         free (ctx->path);
         flux_future_destroy (ctx->check_f);
         flux_future_destroy (ctx->watch_f);
         free (ctx);
+        errno = save_errno;
     }
 }
 
@@ -63,7 +65,6 @@ static struct watch_ctx *watch_ctx_create (struct info_ctx *ctx,
                                            int flags)
 {
     struct watch_ctx *w = calloc (1, sizeof (*w));
-    int saved_errno;
 
     if (!w)
         return NULL;
@@ -82,9 +83,7 @@ static struct watch_ctx *watch_ctx_create (struct info_ctx *ctx,
     return w;
 
 error:
-    saved_errno = errno;
     watch_ctx_destroy (w);
-    errno = saved_errno;
     return NULL;
 }
 

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -333,12 +333,12 @@ error:
     zlist_remove (ctx->watchers, w);
 }
 
-int watch (struct info_ctx *ctx,
-           const flux_msg_t *msg,
-           flux_jobid_t id,
-           const char *path,
-           int flags,
-           bool guest)
+static int watch (struct info_ctx *ctx,
+                  const flux_msg_t *msg,
+                  flux_jobid_t id,
+                  const char *path,
+                  int flags,
+                  bool guest)
 {
     struct watch_ctx *w = NULL;
     uint32_t rolemask;

--- a/src/modules/job-info/watch.h
+++ b/src/modules/job-info/watch.h
@@ -29,7 +29,7 @@ void watchers_cancel (struct info_ctx *ctx,
 
 void watch_cleanup (struct info_ctx *ctx);
 
-#endif /* ! _FLUX_JOB_INFO_EVENTLOG_WATCH_H */
+#endif /* ! _FLUX_JOB_INFO_WATCH_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -147,6 +147,7 @@ TESTSCRIPTS = \
 	t2230-job-info-lookup.t \
 	t2231-job-info-eventlog-watch.t \
 	t2232-job-info-security.t \
+	t2233-job-info-update.t \
 	t2240-queue-cmd.t \
 	t2241-queue-cmd-list.t \
 	t2245-policy-config.t \
@@ -421,6 +422,8 @@ check_PROGRAMS = \
 	job-manager/list-jobs \
 	job-manager/print-constants \
 	job-manager/events_journal_stream \
+	job-info/update_lookup \
+	job-info/update_watch_stream \
 	ingest/submitbench \
 	sched-simple/jj-reader \
 	shell/rcalc \
@@ -764,6 +767,16 @@ job_manager_events_journal_stream_SOURCES = job-manager/events_journal_stream.c
 job_manager_events_journal_stream_CPPFLAGS = $(test_cppflags)
 job_manager_events_journal_stream_LDADD = $(test_ldadd)
 job_manager_events_journal_stream_LDFLAGS = $(test_ldflags)
+
+job_info_update_lookup_SOURCES = job-info/update_lookup.c
+job_info_update_lookup_CPPFLAGS = $(test_cppflags)
+job_info_update_lookup_LDADD = $(test_ldadd)
+job_info_update_lookup_LDFLAGS = $(test_ldflags)
+
+job_info_update_watch_stream_SOURCES = job-info/update_watch_stream.c
+job_info_update_watch_stream_CPPFLAGS = $(test_cppflags)
+job_info_update_watch_stream_LDADD = $(test_ldadd)
+job_info_update_watch_stream_LDFLAGS = $(test_ldflags)
 
 disconnect_watcher_la_SOURCES = disconnect/watcher.c
 disconnect_watcher_la_CPPFLAGS = $(test_cppflags)

--- a/t/job-info/update_lookup.c
+++ b/t/job-info/update_lookup.c
@@ -1,0 +1,69 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <jansson.h>
+#include <stdio.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    flux_future_t *f;
+    flux_jobid_t id;
+    const char *key;
+    json_t *value;
+    char *s;
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (argc != 3) {
+        fprintf (stderr, "Usage: update_lookup <jobid> <key>\n");
+        exit (1);
+    }
+
+    if (flux_job_id_parse (argv[1], &id) < 0)
+        log_msg_exit ("error parsing jobid: %s", argv[1]);
+
+    key = argv[2];
+
+    if (!(f = flux_rpc_pack (h,
+                             "job-info.update-lookup",
+                             FLUX_NODEID_ANY,
+                             0,
+                             "{s:I s:s s:i}",
+                             "id", id,
+                             "key", key,
+                             "flags", 0)))
+        log_err_exit ("flux_rpc_pack");
+
+    if (flux_rpc_get_unpack (f, "{s:o}", key, &value) < 0)
+        log_msg_exit ("job-info.update-lookup: %s",
+                      future_strerror (f, errno));
+    if (!(s = json_dumps (value, 0)))
+        log_msg_exit ("invalid json result");
+    printf ("%s\n", s);
+    fflush (stdout);
+    free (s);
+
+    flux_future_destroy (f);
+    flux_close (h);
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/job-info/update_watch_stream.c
+++ b/t/job-info/update_watch_stream.c
@@ -1,0 +1,92 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <jansson.h>
+#include <signal.h>
+#include <stdio.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+
+flux_t *h;
+flux_future_t *f;
+
+void cancel_cb (int sig)
+{
+    flux_future_t *f2;
+    if (!(f2 = flux_rpc_pack (h,
+                              "job-info.update-watch-cancel",
+                              FLUX_NODEID_ANY,
+                              FLUX_RPC_NORESPONSE,
+                              "{s:i}",
+                              "matchtag", (int)flux_rpc_get_matchtag (f))))
+        log_err_exit ("flux_rpc_pack");
+    flux_future_destroy (f2);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_jobid_t id;
+    const char *key;
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (argc != 3) {
+        fprintf (stderr, "Usage: update_watch_stream <jobid> <key>\n");
+        exit (1);
+    }
+
+    if (flux_job_id_parse (argv[1], &id) < 0)
+        log_msg_exit ("error parsing jobid: %s", argv[1]);
+
+    key = argv[2];
+
+    if (!(f = flux_rpc_pack (h,
+                             "job-info.update-watch",
+                             FLUX_NODEID_ANY,
+                             FLUX_RPC_STREAMING,
+                             "{s:I s:s s:i}",
+                             "id", id,
+                             "key", key,
+                             "flags", 0)))
+        log_err_exit ("flux_rpc_pack");
+
+    if (signal (SIGUSR1, cancel_cb) == SIG_ERR)
+        log_err_exit ("signal");
+
+    while (1) {
+        json_t *value;
+        char *s;
+        if (flux_rpc_get_unpack (f, "{s:o}", key, &value) < 0) {
+            if (errno == ENODATA)
+                break;
+            log_msg_exit ("job-info.update-watch: %s",
+                          future_strerror (f, errno));
+        }
+        if (!(s = json_dumps (value, 0)))
+            log_msg_exit ("invalid json result");
+        printf ("%s\n", s);
+        fflush (stdout);
+        free (s);
+        flux_future_reset (f);
+    }
+    flux_future_destroy (f);
+    flux_close (h);
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -9,6 +9,7 @@ test_description='Test flux job info service eventlog watch'
 test_under_flux 4 job
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
+RPC_STREAM=${FLUX_BUILD_DIR}/t/request/rpc_stream
 
 fj_wait_event() {
 	flux job wait-event --timeout=20 "$@"
@@ -452,9 +453,10 @@ test_expect_success 'eventlog-watch request with empty payload fails with EPROTO
 	${RPC} job-info.eventlog-watch 71 </dev/null
 '
 
-test_expect_success 'eventlog-watch request invalid flags fails with EPROTO(71)' '
+test_expect_success 'eventlog-watch request invalid flags fails' '
 	echo "{\"id\":42, \"path\":\"foobar\", \"flags\":499}" \
-		| ${RPC} job-info.eventlog-watch 71
+		| test_must_fail ${RPC_STREAM} job-info.eventlog-watch 2> invalidflags.err &&
+	grep "invalid flag" invalidflags.err
 '
 test_expect_success 'eventlog-watch request non-streaming fails with EPROTO(71)' '
 	echo "{\"id\":42, \"path\":\"foobar\", \"flags\":0}" \

--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -454,11 +454,11 @@ test_expect_success 'eventlog-watch request with empty payload fails with EPROTO
 
 test_expect_success 'eventlog-watch request invalid flags fails with EPROTO(71)' '
 	echo "{\"id\":42, \"path\":\"foobar\", \"flags\":499}" \
-		${RPC} job-info.eventlog-watch 71
+		| ${RPC} job-info.eventlog-watch 71
 '
 test_expect_success 'eventlog-watch request non-streaming fails with EPROTO(71)' '
 	echo "{\"id\":42, \"path\":\"foobar\", \"flags\":0}" \
-		${RPC} job-info.eventlog-watch 71
+		| ${RPC} job-info.eventlog-watch 71
 '
 
 test_done

--- a/t/t2233-job-info-update.t
+++ b/t/t2233-job-info-update.t
@@ -1,0 +1,346 @@
+#!/bin/sh
+
+test_description='Test flux job info service update lookup/watch'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+RPC_STREAM=${FLUX_BUILD_DIR}/t/request/rpc_stream
+UPDATE_LOOKUP=${FLUX_BUILD_DIR}/t/job-info/update_lookup
+UPDATE_WATCH=${FLUX_BUILD_DIR}/t/job-info/update_watch_stream
+WAITFILE="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+fj_wait_event() {
+	flux job wait-event --timeout=20 "$@"
+}
+
+wait_update_watchers() {
+	local count=$1
+	local i=0
+	while (! flux module stats --parse "update_watchers" job-info > /dev/null 2>&1 \
+		|| [ "$(flux module stats --parse "update_watchers" job-info 2> /dev/null)" != "${count}" ]) \
+		&& [ $i -lt 50 ]
+	do
+		sleep 0.1
+		i=$((i + 1))
+	done
+	if [ "$i" -eq "50" ]
+	then
+		return 1
+	fi
+	return 0
+}
+
+test_expect_success 'job-info: update lookup with no update events works (job active)' '
+	flux submit --wait-event=start sleep 300 > lookup1.id &&
+	${UPDATE_LOOKUP} $(cat lookup1.id) R > lookup1.out &&
+	flux cancel $(cat lookup1.id) &&
+	cat lookup1.out | jq -e ".execution.expiration == 0.0"
+'
+
+test_expect_success 'job-info: update lookup with no update events works (job inactive)' '
+	flux submit --wait-event=clean hostname > lookup2.id &&
+	${UPDATE_LOOKUP} $(cat lookup2.id) R > lookup2.out &&
+	cat lookup2.out | jq -e ".execution.expiration == 0.0"
+'
+
+test_expect_success 'job-info: update lookup with update events works (job active)' '
+	flux submit --wait-event=start sleep 300 > lookup3.id &&
+	kvspath=`flux job id --to=kvs $(cat lookup3.id)` &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
+	${UPDATE_LOOKUP} $(cat lookup3.id) R > lookup3A.out &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
+	${UPDATE_LOOKUP} $(cat lookup3.id) R > lookup3B.out &&
+	flux cancel $(cat lookup3.id) &&
+	cat lookup3A.out | jq -e ".execution.expiration == 100.0" &&
+	cat lookup3B.out | jq -e ".execution.expiration == 200.0"
+'
+
+test_expect_success 'job-info: update lookup with update events works (job inactive)' '
+	flux submit --wait-event=start sleep 300 > lookup4.id &&
+	kvspath=`flux job id --to=kvs $(cat lookup4.id)` &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
+	flux cancel $(cat lookup4.id) &&
+	${UPDATE_LOOKUP} $(cat lookup4.id) R > lookup4.out &&
+	cat lookup4.out | jq -e ".execution.expiration == 200.0"
+'
+
+test_expect_success 'job-info: update watch with no update events works (job inactive)' '
+	flux submit --wait-event=clean hostname > watch1.id &&
+	${UPDATE_WATCH} $(cat watch1.id) R > watch1.out &&
+	test $(cat watch1.out | wc -l) -eq 1 &&
+	cat watch1.out | jq -e ".execution.expiration == 0.0"
+'
+
+test_expect_success NO_CHAIN_LINT 'job-info: update watch with no update events works (job run/canceled)' '
+	flux submit --wait-event=start sleep inf > watch2.id
+	${UPDATE_WATCH} $(cat watch2.id) R > watch2.out &
+	watchpid=$! &&
+	wait_update_watchers 1 &&
+	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch2.out &&
+	flux cancel $(cat watch2.id) &&
+	wait $watchpid &&
+	test $(cat watch2.out | wc -l) -eq 1 &&
+	cat watch2.out | jq -e ".execution.expiration == 0.0"
+'
+
+test_expect_success 'job-info: update watch with update events works (job inactive)' '
+	flux submit --wait-event=start sleep inf > watch3.id &&
+	kvspath=`flux job id --to=kvs $(cat watch3.id)` &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
+	flux cancel $(cat watch3.id) &&
+	${UPDATE_WATCH} $(cat watch3.id) R > watch3.out &&
+	test $(cat watch3.out | wc -l) -eq 1 &&
+	cat watch3.out | jq -e ".execution.expiration == 200.0"
+'
+
+test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events works (before watch)' '
+	flux submit --wait-event=start sleep inf > watch4.id &&
+	kvspath=`flux job id --to=kvs $(cat watch4.id)` &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}"
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}"
+	${UPDATE_WATCH} $(cat watch4.id) R > watch4.out &
+	watchpid=$! &&
+	wait_update_watchers 1 &&
+	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch4.out &&
+	flux cancel $(cat watch4.id) &&
+	wait $watchpid &&
+	test $(cat watch4.out | wc -l) -eq 1 &&
+	cat watch4.out | jq -e ".execution.expiration == 200.0"
+'
+
+test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events works (after watch)' '
+	flux submit --wait-event=start sleep inf > watch5.id
+	${UPDATE_WATCH} $(cat watch5.id) R > watch5.out &
+	watchpid=$! &&
+	wait_update_watchers 1 &&
+	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch5.out &&
+	kvspath=`flux job id --to=kvs $(cat watch5.id)` &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
+	${WAITFILE} --count=3 --timeout=30 --pattern="expiration" watch5.out &&
+	flux cancel $(cat watch5.id) &&
+	wait $watchpid &&
+	test $(cat watch5.out | wc -l) -eq 3 &&
+	head -n1 watch5.out | jq -e ".execution.expiration == 0.0" &&
+	head -n2 watch5.out | tail -n1 | jq -e ".execution.expiration == 100.0" &&
+	tail -n1 watch5.out | jq -e ".execution.expiration == 200.0"
+'
+
+test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events works (before/after watch)' '
+	flux submit --wait-event=start sleep inf > watch6.id &&
+	kvspath=`flux job id --to=kvs $(cat watch6.id)` &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}"
+	${UPDATE_WATCH} $(cat watch6.id) R > watch6.out &
+	watchpid=$! &&
+	wait_update_watchers 1 &&
+	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch6.out &&
+	kvspath=`flux job id --to=kvs $(cat watch6.id)` &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
+	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch6.out &&
+	flux cancel $(cat watch6.id) &&
+	wait $watchpid &&
+	test $(cat watch6.out | wc -l) -eq 2 &&
+	head -n1 watch6.out | jq -e ".execution.expiration == 100.0" &&
+	tail -n1 watch6.out | jq -e ".execution.expiration == 200.0"
+'
+
+# signaling the update watch tool with SIGUSR1 will cancel the stream
+test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (single watcher)' '
+	flux submit --wait-event=start sleep inf > watch7.id
+	${UPDATE_WATCH} $(cat watch7.id) R > watch7.out &
+	watchpid=$! &&
+	wait_update_watchers 1 &&
+	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch7.out &&
+	kill -s USR1 $watchpid &&
+	wait $watchpid &&
+	flux cancel $(cat watch7.id) &&
+	test $(cat watch7.out | wc -l) -eq 1 &&
+	cat watch7.out | jq -e ".execution.expiration == 0.0"
+'
+
+# This test may look tricky.  Basically we are updating the eventlog
+# with resource-update events once in awhile and starting watchers at
+# different point in times in the eventlog's parsing.
+#
+# At the end, the first watcher should see 3 R versions, the second
+# one 2, and the last one only 1.
+test_expect_success NO_CHAIN_LINT 'job-info: update watch with multiple watchers works' '
+	flux submit --wait-event=start sleep inf > watch8.id
+	${UPDATE_WATCH} $(cat watch8.id) R > watch8A.out &
+	watchpidA=$! &&
+	wait_update_watchers 1 &&
+	kvspath=`flux job id --to=kvs $(cat watch8.id)` &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
+	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch8A.out
+	${UPDATE_WATCH} $(cat watch8.id) R > watch8B.out &
+	watchpidB=$! &&
+	wait_update_watchers 2 &&
+	kvspath=`flux job id --to=kvs $(cat watch8.id)` &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
+	${WAITFILE} --count=3 --timeout=30 --pattern="expiration" watch8A.out &&
+	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch8B.out
+	${UPDATE_WATCH} $(cat watch8.id) R > watch8C.out &
+	watchpidC=$! &&
+	wait_update_watchers 3 &&
+	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch8C.out &&
+	flux cancel $(cat watch8.id) &&
+	wait $watchpidA &&
+	wait $watchpidB &&
+	wait $watchpidC &&
+	test $(cat watch8A.out | wc -l) -eq 3 &&
+	test $(cat watch8B.out | wc -l) -eq 2 &&
+	test $(cat watch8C.out | wc -l) -eq 1 &&
+	head -n1 watch8A.out | jq -e ".execution.expiration == 0.0" &&
+	head -n2 watch8A.out | tail -n1 | jq -e ".execution.expiration == 100.0" &&
+	tail -n1 watch8A.out | jq -e ".execution.expiration == 200.0" &&
+	head -n1 watch8B.out | jq -e ".execution.expiration == 100.0" &&
+	tail -n1 watch8B.out | jq -e ".execution.expiration == 200.0" &&
+	tail -n1 watch8C.out | jq -e ".execution.expiration == 200.0"
+'
+
+# signaling the update watch tool with SIGUSR1 will cancel the stream
+test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (multiple watchers)' '
+	flux submit --wait-event=start sleep inf > watch10.id
+	${UPDATE_WATCH} $(cat watch10.id) R > watch10A.out &
+	watchpidA=$! &&
+	wait_update_watchers 1 &&
+	kvspath=`flux job id --to=kvs $(cat watch10.id)` &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}"
+	${UPDATE_WATCH} $(cat watch10.id) R > watch10B.out &
+	watchpidB=$! &&
+	wait_update_watchers 2 &&
+	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch10A.out &&
+	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch10B.out &&
+	kill -s USR1 $watchpidA &&
+	wait $watchpidA &&
+	kill -s USR1 $watchpidB &&
+	wait $watchpidB &&
+	flux cancel $(cat watch10.id) &&
+	test $(cat watch10A.out | wc -l) -eq 2 &&
+	test $(cat watch10B.out | wc -l) -eq 1 &&
+	head -n1 watch10A.out | jq -e ".execution.expiration == 0.0" &&
+	tail -n1 watch10B.out | jq -e ".execution.expiration == 100.0" &&
+	cat watch10B.out | jq -e ".execution.expiration == 100.0"
+'
+
+# If someone is already doing an update-watch on a jobid/key, update-lookup can
+# return the cached info
+test_expect_success NO_CHAIN_LINT 'job-info: update lookup returns cached R from update watch' '
+	flux submit --wait-event=start sleep inf > watch9.id
+	${UPDATE_WATCH} $(cat watch9.id) R > watch9.out &
+	watchpid=$! &&
+	wait_update_watchers 1 &&
+	kvspath=`flux job id --to=kvs $(cat watch9.id)` &&
+	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
+	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch9.out &&
+        ${UPDATE_LOOKUP} $(cat watch9.id) R > lookup9.out &&
+	flux cancel $(cat watch9.id) &&
+	wait $watchpid &&
+	test $(cat watch9.out | wc -l) -eq 2 &&
+	head -n1 watch9.out | jq -e ".execution.expiration == 0.0" &&
+	tail -n1 watch9.out | jq -e ".execution.expiration == 100.0" &&
+	cat lookup9.out | jq -e ".execution.expiration == 100.0"
+'
+
+#
+# security tests
+#
+
+set_userid() {
+	export FLUX_HANDLE_USERID=$1
+	export FLUX_HANDLE_ROLEMASK=0x2
+}
+
+unset_userid() {
+	unset FLUX_HANDLE_USERID
+	unset FLUX_HANDLE_ROLEMASK
+}
+
+test_expect_success 'job-info: non job owner cannot lookup key' '
+	jobid=`flux submit --wait-event=start sleep inf` &&
+	set_userid 9999 &&
+	test_must_fail ${UPDATE_LOOKUP} $jobid R &&
+	unset_userid &&
+	flux cancel $jobid
+'
+
+test_expect_success 'job-info: non job owner cannot watch key' '
+	jobid=`flux submit --wait-event=start sleep inf` &&
+	set_userid 9999 &&
+	test_must_fail ${UPDATE_WATCH} $jobid R &&
+	unset_userid &&
+	flux cancel $jobid
+'
+
+# this test checks security on a second watcher, which is trying to
+# access cached info
+test_expect_success NO_CHAIN_LINT 'job-info: non job owner cannot watch key (second watcher)' '
+	jobid=`flux submit --wait-event=start sleep inf`
+	${UPDATE_WATCH} $jobid R > watchsecurity.out &
+	watchpid=$! &&
+	wait_update_watchers 1 &&
+	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watchsecurity.out &&
+	set_userid 9999 &&
+	test_must_fail ${UPDATE_WATCH} $jobid R &&
+	unset_userid &&
+	flux cancel $jobid &&
+	wait $watchpid
+'
+
+# update-lookup cannot read cached watch data
+test_expect_success NO_CHAIN_LINT 'job-info: non job owner cannot lookup key (piggy backed)' '
+	jobid=`flux submit --wait-event=start sleep inf`
+	${UPDATE_WATCH} $jobid R > lookupsecurity.out &
+	watchpid=$! &&
+	wait_update_watchers 1 &&
+	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" lookupsecurity.out &&
+	set_userid 9999 &&
+	test_must_fail ${UPDATE_LOOKUP} $jobid R &&
+	unset_userid &&
+	flux cancel $jobid &&
+	wait $watchpid
+'
+
+#
+# stats & corner cases
+#
+
+test_expect_success 'job-info stats works' '
+	flux module stats --parse update_lookups job-info &&
+	flux module stats --parse update_watchers job-info
+'
+test_expect_success 'update-lookup request with empty payload fails with EPROTO(71)' '
+	${RPC} job-info.update-watch 71 </dev/null
+'
+test_expect_success 'update-watch request with empty payload fails with EPROTO(71)' '
+	${RPC} job-info.update-watch 71 </dev/null
+'
+test_expect_success 'update-lookup request with invalid key fails with EINVAL(22))' '
+	echo "{\"id\":42, \"key\":\"foobar\", \"flags\":0}" \
+		| ${RPC} job-info.update-lookup 22
+'
+test_expect_success 'update-watch request invalid key fails' '
+	echo "{\"id\":42, \"key\":\"foobar\", \"flags\":0}" \
+		| test_must_fail ${RPC_STREAM} job-info.update-watch 2> invalidkey.err && \
+	grep "unsupported key" invalidkey.err
+'
+test_expect_success 'update-lookup request with invalid flags fails with EPROTO(71))' '
+	echo "{\"id\":42, \"key\":\"R\", \"flags\":499}" \
+		| ${RPC} job-info.update-lookup 71
+'
+test_expect_success 'update-watch request invalid flags fails' '
+	echo "{\"id\":42, \"key\":\"R\", \"flags\":499}" \
+		| test_must_fail ${RPC_STREAM} job-info.update-watch 2> invalidflags.err &&
+	grep "invalid flag" invalidflags.err
+'
+test_expect_success 'update-watch request non-streaming fails with EPROTO(71)' '
+	echo "{\"id\":42, \"key\":\"R\", \"flags\":0}" \
+		| ${RPC} job-info.update-watch 71
+'
+
+test_done


### PR DESCRIPTION
per discussion in #5451

Problem: In the future, several services will need to know a job's resources and know the updates that would apply to them.
This would currently require users to read R, watch the eventlog, and then apply `resource-update` events as they happen.  It would be nice if a service did this as there will be multiple users.

Solution: Support a new job-info.update-watch streaming service.  It currently supports only the key "R", but can be extended to other keys in the future.

The service will read R and the eventlog for a job and apply all resource-update changes as needed.  This initial "R" will sent back to the caller.  If the job has completed, the RPC streaming service ends.  If not, the eventlog will be watched for future resource-update events.  On each new resource-update event, a new R will be streamed back to the caller.  This continues until the job ends or the caller cancels the stream.

----

Notes:

- It might be wise to add some type of "caching" of sorts as multiple callers may want to watch the same job's R value.  I didn't do that at the moment.  I figured that could be an optimization for the future.

- per discussion in #5451 future options could include a "uniq" option as a "full history" option.