### PR TITLE
drop libzcmq dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -327,7 +327,7 @@ AX_PROG_LUA([5.1],[5.5])
 AX_LUA_HEADERS
 AX_LUA_LIBS
 # N.B oldest in CI are focal=libzmq-4.3.2-2, centos7=zeromq-4.1.4
-PKG_CHECK_MODULES([ZMQ], [libczmq >= 3.0.0 libzmq >= 4.0.4])
+PKG_CHECK_MODULES([ZMQ], [libzmq >= 4.0.4])
 X_AC_JANSSON
 PKG_CHECK_MODULES([LIBSYSTEMD], [libsystemd >= 0.23],
                                 [have_libsystemd=yes], [have_libsystemd=no])

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,6 @@ Build-Depends:
   libarchive-dev,
   uuid-dev,
   libzmq3-dev,
-  libczmq-dev,
   libjansson-dev,
   liblz4-dev,
   libhwloc-dev,

--- a/scripts/install-deps-deb.sh
+++ b/scripts/install-deps-deb.sh
@@ -8,7 +8,6 @@ apt install \
   pkg-config \
   libc6-dev \
   libzmq3-dev \
-  libczmq-dev \
   uuid-dev \
   libjansson-dev \
   liblz4-dev \

--- a/scripts/install-deps-rpm.sh
+++ b/scripts/install-deps-rpm.sh
@@ -8,7 +8,6 @@ yum install \
   pkgconfig \
   glibc-devel \
   zeromq4-devel \
-  czmq-devel \
   libuuid-devel \
   jansson-devel \
   lz4-devel \

--- a/src/test/docker/bookworm/Dockerfile
+++ b/src/test/docker/bookworm/Dockerfile
@@ -80,7 +80,6 @@ RUN apt-get update \
  && apt-get -qq install -y --no-install-recommends \
         libsodium-dev \
         libzmq3-dev \
-        libczmq-dev \
         libjansson-dev \
         libmunge-dev \
         libncursesw5-dev \

--- a/src/test/docker/el7/Dockerfile
+++ b/src/test/docker/el7/Dockerfile
@@ -28,7 +28,6 @@ RUN yum -y update \
       coreutils \
       ccache \
       cppcheck \
-      czmq-devel \
       hwloc \
       hwloc-devel \
       jansson-devel \

--- a/src/test/docker/el8/Dockerfile
+++ b/src/test/docker/el8/Dockerfile
@@ -48,7 +48,6 @@ RUN yum -y update \
 #  Development dependencies
 	libsodium-devel \
 	zeromq-devel \
-	czmq-devel \
 	jansson-devel \
 	munge-devel \
 	ncurses-devel \

--- a/src/test/docker/fedora33/Dockerfile
+++ b/src/test/docker/fedora33/Dockerfile
@@ -45,7 +45,6 @@ RUN yum -y update \
 #  Development dependencies
 	libsodium-devel \
 	zeromq-devel \
-	czmq-devel \
 	jansson-devel \
 	munge-devel \
 	ncurses-devel \

--- a/src/test/docker/fedora34/Dockerfile
+++ b/src/test/docker/fedora34/Dockerfile
@@ -45,7 +45,6 @@ RUN yum -y update \
 #  Development dependencies
 	libsodium-devel \
 	zeromq-devel \
-	czmq-devel \
 	jansson-devel \
 	munge-devel \
 	ncurses-devel \

--- a/src/test/docker/fedora35/Dockerfile
+++ b/src/test/docker/fedora35/Dockerfile
@@ -46,7 +46,6 @@ RUN yum -y update \
 #  Development dependencies
 	libsodium-devel \
 	zeromq-devel \
-	czmq-devel \
 	jansson-devel \
 	munge-devel \
 	ncurses-devel \

--- a/src/test/docker/fedora38/Dockerfile
+++ b/src/test/docker/fedora38/Dockerfile
@@ -44,7 +44,6 @@ RUN yum -y update \
 #  Development dependencies
 	libsodium-devel \
 	zeromq-devel \
-	czmq-devel \
 	jansson-devel \
 	munge-devel \
 	ncurses-devel \

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -79,7 +79,6 @@ RUN apt-get update \
  && apt-get -qq install -y --no-install-recommends \
         libsodium-dev \
         libzmq3-dev \
-        libczmq-dev \
         libjansson-dev \
         libmunge-dev \
         libncurses-dev \

--- a/src/test/docker/jammy/Dockerfile
+++ b/src/test/docker/jammy/Dockerfile
@@ -85,7 +85,6 @@ RUN apt-get update \
  && apt-get -qq install -y --no-install-recommends \
         libsodium-dev \
         libzmq3-dev \
-        libczmq-dev \
         libjansson-dev \
         libmunge-dev \
         libncursesw5-dev \


### PR DESCRIPTION
Problem: libczmq is no longer used by flux-core but it's still required.

Drop it from` configure`, `make deb`, and `Dockerfile`s.