### PR TITLE
switch qemu-user-static setup to fix setuid

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,9 +154,9 @@ jobs:
       uses: docker/setup-buildx-action@v2
       if: matrix.needs_buildx
 
-    - uses: dbhi/qus/action@main
-      with:
-        targets: aarch64
+    - name: setup qemu-user-static
+      run: |
+        docker run --rm --privileged aptman/qus -s -- -p --credential aarch64
 
     - name: docker-run-checks
       env: ${{matrix.env}}


### PR DESCRIPTION
This pulls over the fix from the matching flux-sched nosuid issue in case we run into it here at some point.

Problem: flux-sched side ran into issues with setuid binaries in some cases under aarch64 emulation building containers.  It seems to depend on which workers pick up the job, so seems best to bring the solution over.

Solution: Run the docker container with the setup script directly with the appropriate option to handle setuid credentials.