### PR TITLE
cache R in the job manager

### DIFF
--- a/src/common/libschedutil/alloc.h
+++ b/src/common/libschedutil/alloc.h
@@ -40,7 +40,8 @@ int schedutil_alloc_respond_annotate_pack (schedutil_t *util,
  * Include human readable error message in 'note'.
  * Return 0 on success, -1 on error with errno set.
  */
-int schedutil_alloc_respond_deny (schedutil_t *util, const flux_msg_t *msg,
+int schedutil_alloc_respond_deny (schedutil_t *util,
+                                  const flux_msg_t *msg,
                                   const char *note);
 
 /* Respond to alloc request message - success, allocate R.
@@ -50,7 +51,8 @@ int schedutil_alloc_respond_deny (schedutil_t *util, const flux_msg_t *msg,
 int schedutil_alloc_respond_success_pack (schedutil_t *util,
                                           const flux_msg_t *msg,
                                           const char *R,
-                                          const char *fmt, ...);
+                                          const char *fmt,
+                                          ...);
 
 /* Respond to an alloc request message - canceled.
  * N.B. 'msg' is the alloc request, not the cancel request.

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -61,11 +61,14 @@ static int schedutil_hello_job (schedutil_t *util,
                           msg,
                           R,
                           util->cb_arg) < 0)
-        raise_exception (util->h, id, "failed to reallocate R for running job");
+        raise_exception (util->h,
+                         id,
+                         "failed to reallocate R for running job");
     flux_future_destroy (f);
     return 0;
 error:
-    flux_log_error (util->h, "hello: error loading R for id=%s",
+    flux_log_error (util->h,
+                    "hello: error loading R for id=%s",
                     idf58 (id));
     flux_future_destroy (f);
     return -1;
@@ -80,8 +83,11 @@ int schedutil_hello (schedutil_t *util)
         errno = EINVAL;
         return -1;
     }
-    if (!(f = flux_rpc (util->h, "job-manager.sched-hello",
-                        NULL, FLUX_NODEID_ANY, FLUX_RPC_STREAMING)))
+    if (!(f = flux_rpc (util->h,
+                        "job-manager.sched-hello",
+                        NULL,
+                        FLUX_NODEID_ANY,
+                        FLUX_RPC_STREAMING)))
         return -1;
     while (1) {
         const flux_msg_t *msg;

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -21,8 +21,10 @@
 #include "init.h"
 #include "ops.h"
 
-static void alloc_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+static void alloc_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     schedutil_t *util = arg;
 
@@ -31,8 +33,10 @@ static void alloc_cb (flux_t *h, flux_msg_handler_t *mh,
     util->ops->alloc (h, msg, util->cb_arg);
 }
 
-static void cancel_cb (flux_t *h, flux_msg_handler_t *mh,
-                       const flux_msg_t *msg, void *arg)
+static void cancel_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
 {
     schedutil_t *util = arg;
 
@@ -64,8 +68,10 @@ error:
     flux_future_destroy (f);
 }
 
-static void free_cb (flux_t *h, flux_msg_handler_t *mh,
-                     const flux_msg_t *msg, void *arg)
+static void free_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
 {
     schedutil_t *util = arg;
     flux_jobid_t id;
@@ -108,8 +114,10 @@ error:
         flux_log_error (h, "sched.free respond_error");
 }
 
-static void prioritize_cb (flux_t *h, flux_msg_handler_t *mh,
-                           const flux_msg_t *msg, void *arg)
+static void prioritize_cb (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
 {
     schedutil_t *util = arg;
 

--- a/src/common/libschedutil/ready.c
+++ b/src/common/libschedutil/ready.c
@@ -45,17 +45,22 @@ int schedutil_ready (schedutil_t *util, const char *mode, int *queue_depth)
         return -1;
     }
     if (limit) {
-        if (!(f = flux_rpc_pack (util->h, "job-manager.sched-ready",
-                                 FLUX_NODEID_ANY, 0,
+        if (!(f = flux_rpc_pack (util->h,
+                                 "job-manager.sched-ready",
+                                 FLUX_NODEID_ANY,
+                                 0,
                                  "{s:s s:i}",
                                  "mode", mode,
                                  "limit", limit)))
             return -1;
     }
     else {
-        if (!(f = flux_rpc_pack (util->h, "job-manager.sched-ready",
-                                 FLUX_NODEID_ANY, 0,
-                                 "{s:s}", "mode", mode)))
+        if (!(f = flux_rpc_pack (util->h,
+                                 "job-manager.sched-ready",
+                                 FLUX_NODEID_ANY,
+                                 0,
+                                 "{s:s}",
+                                 "mode", mode)))
             return -1;
     }
     if (flux_rpc_get_unpack (f, "{s:i}", "count", &count) < 0)

--- a/src/modules/job-exec/rset.c
+++ b/src/modules/job-exec/rset.c
@@ -97,6 +97,10 @@ struct resource_set * resource_set_create (const char *R, json_error_t *errp)
 {
     int version = 0;
     struct resource_set *r = calloc (1, sizeof (*r));
+    if (!r) {
+        snprintf (errp->text, sizeof (errp->text), "out of memory");
+        goto err;
+    }
     if (!(r->R = json_loads (R, 0, errp)))
         goto err;
     if (json_unpack_ex (r->R, errp, 0, "{s:i s:{s:o}}",

--- a/src/modules/job-exec/rset.h
+++ b/src/modules/job-exec/rset.h
@@ -18,7 +18,12 @@ struct resource_set;
 
 struct resource_set *resource_set_create (const char *R, json_error_t *errp);
 
+struct resource_set *resource_set_create_fromjson (json_t *R,
+		                                   json_error_t *errp);
+
 void resource_set_destroy (struct resource_set *rset);
+
+json_t *resource_set_get_json (struct resource_set *rset);
 
 const struct idset * resource_set_ranks (struct resource_set *rset);
 

--- a/src/modules/job-manager/getattr.c
+++ b/src/modules/job-manager/getattr.c
@@ -61,6 +61,15 @@ static json_t *make_dict (struct job *job,
             if (json_object_set (dict, key, job->jobspec_redacted) < 0)
                 goto nomem;
         }
+        else if (streq (key, "R")) {
+            if (!job->R_redacted) {
+                errprintf (errp, "R is NULL");
+                errno = ENOENT;
+                goto error;
+            }
+            if (json_object_set (dict, key, job->R_redacted) < 0)
+                goto nomem;
+        }
         else {
             errprintf (errp, "unknown attr %s", key);
             errno = ENOENT;

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -38,6 +38,7 @@ void job_decref (struct job *job)
         json_decref (job->end_event);
         flux_msg_decref (job->waiter);
         json_decref (job->jobspec_redacted);
+        json_decref (job->R);
         json_decref (job->annotations);
         grudgeset_destroy (job->dependencies);
         subscribers_destroy (job);

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -29,6 +29,7 @@ struct job {
     const char *queue;
     int flags;
     json_t *jobspec_redacted;
+    json_t *R;
     int eventlog_seq;           // eventlog count / sequence number
     flux_job_state_t state;
     json_t *event_queue;

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -29,7 +29,7 @@ struct job {
     const char *queue;
     int flags;
     json_t *jobspec_redacted;
-    json_t *R;
+    json_t *R_redacted;
     int eventlog_seq;           // eventlog count / sequence number
     flux_job_state_t state;
     json_t *event_queue;
@@ -73,6 +73,7 @@ struct job *job_create (void);
 struct job *job_create_from_eventlog (flux_jobid_t id,
                                       const char *eventlog,
                                       const char *jobspec,
+                                      const char *R,
                                       flux_error_t *error);
 struct job *job_create_from_json (json_t *o);
 

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1156,12 +1156,12 @@ int jobtap_call (struct jobtap *jobtap,
          *   annotation event published to the journal before the first
          *   job state event may confuse consumers (i.e. job-info).
          */
-        int rc;
+        int ret;
         if (streq (topic, "job.new"))
-            rc = annotations_update (job, ".", note);
+            ret = annotations_update (job, ".", note);
         else
-            rc = annotations_update_and_publish (jobtap->ctx, job, note);
-        if (rc < 0)
+            ret = annotations_update_and_publish (jobtap->ctx, job, note);
+        if (ret < 0)
             flux_log_error (jobtap->ctx->h,
                             "jobtap: %s: %s: annotations_update",
                             topic,

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -188,6 +188,13 @@ static flux_plugin_arg_t *jobtap_args_create (struct jobtap *jobtap,
                               "priority", job->priority,
                               "t_submit", job->t_submit) < 0)
         goto error;
+    if (job->R_redacted) {
+        if (flux_plugin_arg_pack (args,
+                                  FLUX_PLUGIN_ARG_IN,
+                                  "{s:O}",
+                                  "R", job->R_redacted) < 0)
+            goto error;
+    }
     /*
      *  Always start with empty OUT args. This allows unpack of OUT
      *   args to work without error, even if plugin does not set any

--- a/src/modules/job-manager/plugins/alloc-bypass.c
+++ b/src/modules/job-manager/plugins/alloc-bypass.c
@@ -145,6 +145,9 @@ static int sched_cb (flux_plugin_t *p,
     if (alloc_start (p, id, R) < 0)
         flux_jobtap_raise_exception (p, id, "alloc", 0,
                                      "failed to commit R to kvs");
+    if (flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT, "{s:O}", "R", R) < 0)
+        return -1;
+
     return 0;
 }
 

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -80,7 +80,11 @@ static struct job *lookup_job (flux_t *h,
         *fatal = false;
         goto done;
     }
-    if (!(job = job_create_from_eventlog (id, eventlog, jobspec, &e))) {
+    if (!(job = job_create_from_eventlog (id,
+                                          eventlog,
+                                          jobspec,
+                                          NULL,
+                                          &e))) {
         errprintf (error, "replay %s: %s", k1, e.text);
         *fatal = true;
     }

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -100,8 +100,10 @@ struct start {
     char *topic;
 };
 
-static void hello_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+static void hello_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     struct job_manager *ctx = arg;
     struct start *start = ctx->start;
@@ -154,8 +156,11 @@ static void interface_teardown (struct start *start, char *s, int errnum)
         struct job_manager *ctx = start->ctx;
         struct job *job;
 
-        flux_log (ctx->h, LOG_DEBUG, "start: stop due to %s: %s",
-                  s, flux_strerror (errnum));
+        flux_log (ctx->h,
+                  LOG_DEBUG,
+                  "start: stop due to %s: %s",
+                  s,
+                  flux_strerror (errnum));
 
         free (start->topic);
         start->topic = NULL;
@@ -177,8 +182,10 @@ static void interface_teardown (struct start *start, char *s, int errnum)
     }
 }
 
-static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
-                               const flux_msg_t *msg, void *arg)
+static void start_response_cb (flux_t *h,
+                               flux_msg_handler_t *mh,
+                               const flux_msg_t *msg,
+                               void *arg)
 {
     struct job_manager *ctx = arg;
     struct start *start = ctx->start;
@@ -203,7 +210,9 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        flux_log (h, LOG_ERR, "start response: id=%s not active",
+        flux_log (h,
+                  LOG_ERR,
+                  "start response: id=%s not active",
                   idf58 (id));
         errno = EINVAL;
         goto error;

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -325,11 +325,12 @@ int start_send_request (struct start *start, struct job *job)
         if (!(msg = flux_request_encode (start->topic, NULL)))
             return -1;
         if (flux_msg_pack (msg,
-                           "{s:I s:I s:O s:b}",
+                           "{s:I s:I s:O s:b s:O}",
                            "id", job->id,
                            "userid", (json_int_t) job->userid,
                            "jobspec", job->jobspec_redacted,
-                           "reattach", job->reattach) < 0)
+                           "reattach", job->reattach,
+                           "R", job->R_redacted) < 0)
             goto error;
         if (flux_send (ctx->h, msg, 0) < 0)
             goto error;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -140,6 +140,7 @@ TESTSCRIPTS = \
 	t2217-job-manager-priority-order-limited.t \
 	t2218-job-manager-priority-order-unlimited.t \
 	t2219-job-manager-restart.t \
+	t2220-job-manager-R.t \
 	t2221-job-manager-limit-duration.t \
 	t2222-job-manager-limit-job-size.t \
 	t2223-job-manager-queue-priority-order-limited.t \

--- a/t/t2220-job-manager-R.t
+++ b/t/t2220-job-manager-R.t
@@ -1,0 +1,45 @@
+#!/bin/sh
+test_description='Test job manager internal copy of R'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1
+
+# Usage: job_manager_getattr ID ATTR
+job_manager_getattr() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"job-manager.getattr\",{\"id\":$1,\"attrs\":[\"$2\"]}).get_str())"
+}
+
+# Diff two json files
+# https://stackoverflow.com/questions/31930041/using-jq-or-alternative-command-line-tools-to-compare-json-files
+json_diff() {
+	jq --sort-keys . $1 >difftmp1 &&
+	jq --sort-keys . $2 >difftmp2 &&
+	diff difftmp1 difftmp2
+}
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'submit job' '
+	flux submit -t 10s --wait-event=clean /bin/true | flux job id >jobid
+'
+test_expect_success 'job-manager getattr of R works' '
+	job_manager_getattr $(cat jobid) R  >R.out
+'
+test_expect_success 'R contains expiration' '
+	jq -e .R.execution.expiration R.out
+'
+test_expect_success 'reload job manager' '
+	flux module remove job-list &&
+	flux module remove sched-simple &&
+	flux module reload job-manager &&
+	flux module load sched-simple &&
+	flux module load job-list
+'
+test_expect_success 'job-manager getattr of R still works' '
+	job_manager_getattr $(cat jobid) R  >R2.out
+'
+test_expect_success 'R is unchanged after restart' '
+	json_diff R.out R2.out
+'
+test_done

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -72,15 +72,6 @@ test_expect_success 'job-exec: mock exception during run' '
 	flux job eventlog ${jobid} > eventlog.${jobid}.out &&
 	grep "finish status=15" eventlog.${jobid}.out
 '
-test_expect_success 'job-exec: R with invalid expiration raises exception' '
-	flux module unload job-exec &&
-	jobid=$(flux job submit basic.json) &&
-	key=$(flux job id --to=kvs $jobid).R &&
-	R=$(flux kvs get --wait $key | jq -c ".execution.expiration = -1.") &&
-	flux kvs put ${key}=${R} &&
-	flux module load job-exec &&
-	flux job wait-event -v $jobid exception
-'
 test_expect_success 'start request with empty payload fails with EPROTO(71)' '
 	${RPC} job-exec.start 71 </dev/null
 '


### PR DESCRIPTION
Problem: jobtap plugins might need convenient access to R per #5471 

Per discussion, this prototypes keeping a copy of R in the job manager so that it could potentially be offered to jobtap plugins.  Some notes/caveats:
- R is not deleted after the job becomes inactive, which could be a potential optimization to conserve memory on JGF systems
- jobtap interfaces are unchanged (I thought @grondo might already have a good idea of how he wants to do that)
- if this is acceptable, RFC 27 will need updates to `sched.alloc` and  `job-manager.sched-hello` responses.
- this is set up so that job manager restart could replay `resource-update` events on top of the original _R_ loaded from the KVS
- R could be passed to `job-exec.start` to save a lookup (would require an update to RFC 32).  (Edit: oops I included a couple of commits that started this - maybe I'll just finish it and tack it on)