### PR TITLE
improve begin-time representation in `flux-jobs(1)` output

### DIFF
--- a/t/t2272-job-begin-time.t
+++ b/t/t2272-job-begin-time.t
@@ -43,8 +43,23 @@ test_expect_success 'begin-time: job with begin-time=+1h is still in depend' '
 	flux jobs &&
 	test $(flux jobs -no {state} $DELAYED) = "DEPEND"
 '
+test_expect_success 'begin-time: dependency is displayed in flux-jobs output' '
+	flux jobs | grep begin@
+'
 test_expect_success 'begin-time: job with begin-time can be safely canceled' '
 	flux cancel $DELAYED &&
 	flux job wait-event -vt 15 $DELAYED clean
+'
+test_expect_success 'begin-time: begin-time=8pm drops trailing :00' '
+	jobid=$(flux submit --begin-time="8pm tomorrow" hostname) &&
+	flux jobs &&
+	flux jobs ${jobid} | grep -- "-20:00$" &&
+	flux cancel $jobid
+'
+test_expect_success 'begin-time: begin-time=8:00:21 keeps trailing seconds' '
+	jobid=$(flux submit --begin-time="8:00:21 tomorrow" hostname) &&
+	flux jobs &&
+	flux jobs ${jobid} | grep -- "-08:00:21$" &&
+	flux cancel $jobid
 '
 test_done


### PR DESCRIPTION
This proposes a fix for #5465 (the easy way). This adds special case handling of the `begin-time` dependencies in the `JobInfo` class. Other special cases could be added in the future, perhaps with a way to register plugins so that out-of-tree dependency modules could register their own post-processing of raw dependencies (though honestly I doubt this would ever be necessary)

Edit: Oh, I guess it would help to describe the method used here: `begin-time=<timestamp>` is replaced with `begin@<datetime>` where `datetime` is 
 - The time if `datetime` is today
 - The datetime as MMMDD-HH:MM (e.g. `Sep26-17:00`) if `datetime` is tomorrow or later
 - Seconds are only displayed if they are nonzero. 