### PR TITLE
libzmqutil: fix portability to libzmq-4.1.5

### DIFF
--- a/src/common/libzmqutil/cert.c
+++ b/src/common/libzmqutil/cert.c
@@ -103,11 +103,13 @@ error:
 // assumes both keys are valid
 static bool valid_keypair (struct cert *cert)
 {
+#if (ZMQ_VERSION >= ZMQ_MAKE_VERSION(4,2,1))
     char pub[TXTSIZE];
-    if (zmq_curve_public (pub, cert->secret_txt) == 0
-        && streq (pub, cert->public_txt))
-        return true;
-    return false;
+    if (zmq_curve_public (pub, cert->secret_txt) < 0
+        || !streq (pub, cert->public_txt))
+        return false;
+#endif
+    return true;
 }
 
 struct cert *cert_create_from (const char *public_txt, const char *secret_txt)

--- a/src/common/libzmqutil/test/cert.c
+++ b/src/common/libzmqutil/test/cert.c
@@ -13,6 +13,7 @@
 #endif
 #include <stdbool.h>
 #include <errno.h>
+#include <zmq.h>
 
 #include "tap.h"
 #include "ccan/str/str.h"
@@ -160,6 +161,7 @@ static struct test_vec badvec[] = {
     " public-key = \"" PAIR1_PUB PAIR1_PUB "\"\n"
     " secret-key = \"" PAIR1_SEC "\"\n"
     },
+#if (ZMQ_VERSION >= ZMQ_MAKE_VERSION(4,2,1))
     {
         .name = "cert with mismatched keypair",
         .input =
@@ -168,6 +170,7 @@ static struct test_vec badvec[] = {
     " public-key = \"" "YYFE.@650VuUqRGygAtG.RC$A<cid63q(WEnR+&y" "\"\n"
     " secret-key = \"" PAIR1_SEC "\"\n"
     },
+#endif
 };
 
 void test_basic (void)

--- a/src/common/libzmqutil/test/cert.c
+++ b/src/common/libzmqutil/test/cert.c
@@ -353,8 +353,7 @@ void test_inval (void)
 
     if (!(cert = cert_create ()))
         BAIL_OUT ("could not create cert");
-    if (!(cpub = cert_create_from (cert_public_txt (cert),
-                                           NULL)))
+    if (!(cpub = cert_create_from (cert_public_txt (cert), NULL)))
         BAIL_OUT ("could not create cert");
 
     errno = 0;


### PR DESCRIPTION
Problem: the cert class uses some newer 0MQ functionality that isn't available in libzmq-4.1.5, which is the packaged version on the lassen (IBM coral) system.

Simple fixes.