### PR TITLE
ci: add flux-pmix, flux-pam builds to CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,9 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
     - name: Install ubuntu dependencies
-      run: sudo scripts/install-deps-deb.sh
+      run: |
+        sudo apt update
+        sudo scripts/install-deps-deb.sh
     - name: Install python dependencies
       run: |
         python3 -m pip install --upgrade pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,26 @@ jobs:
         --build-arg OMPI_BRANCH=v5.0.0rc12
         --build-arg OPENPMIX_BRANCH=v4.2.3
 
+  check-pam:
+    needs: [python-lint]
+    name: flux-pam check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - run: >
+        src/test/docker/docker-run-checks.sh
+        --image=el8
+        --install-only
+        --tag=fluxrm/flux-core:el8
+    - run: >
+        cd .. &&
+        git clone https://github.com/flux-framework/flux-pam &&
+        cd flux-pam &&
+        src/test/docker/docker-run-checks.sh -j 4 -i el8
+
   generate-matrix:
     # https://stackoverflow.com/questions/59977364
     name: Generate build matrix

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,29 @@ jobs:
           --tag=fluxrm/flux-core:el8
     - run: >
         cd .. && git clone https://github.com/flux-framework/flux-accounting &&
-        cd flux-accounting && src/test/docker/docker-run-checks.sh -j 4 
+        cd flux-accounting && src/test/docker/docker-run-checks.sh -j 4
+
+  check-pmix:
+    needs: [python-lint]
+    name: flux-pmix check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - run: >
+        src/test/docker/docker-run-checks.sh
+        --image=el8
+        --install-only
+        --tag=fluxrm/flux-core:el8
+    - run: >
+        cd .. &&
+        git clone https://github.com/flux-framework/flux-pmix &&
+        cd flux-pmix &&
+        src/test/docker/docker-run-checks.sh -j 4 -i el8
+        --build-arg OMPI_BRANCH=v5.0.0rc12
+        --build-arg OPENPMIX_BRANCH=v4.2.3
 
   generate-matrix:
     # https://stackoverflow.com/questions/59977364

--- a/codecov.yml
+++ b/codecov.yml
@@ -27,3 +27,7 @@ comment:
  layout: "header, diff, changes, tree"
  behavior: new
  after_n_builds: 2
+
+codecov:
+ notify:
+  after_n_builds: 2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
-sphinx==3.4.3
+sphinx<6.0.0
 sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18
 urllib3<2
+jinja2<3.1.0

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -16,7 +16,7 @@ JOBS=2
 MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
 
 if test "$PROJECT" = "flux-core"; then
-  FLUX_SECURITY_VERSION=0.9.0
+  FLUX_SECURITY_VERSION=0.10.0
   POISON=t
 fi
 


### PR DESCRIPTION
This PR adds the flux-pmix and flux-pam builds to CI to ensure PRs do not break the build/test of these projects.
flux-pam is probably less useful, but it is so quick to build I threw it in there.

This also fixes the `after_n_builds` support for codecov which might hopefully reduce the extra reporting we get for coverage.