### PR TITLE
python: fix handling of JobInfo properties and `to_dict()` method with missing attributes

### DIFF
--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -541,7 +541,10 @@ class JobInfo:
         """
         result = {}
         for attr in chain(self.defaults.keys(), self.properties):
-            val = getattr(self, attr)
+            try:
+                val = getattr(self, attr)
+            except AttributeError:
+                val = None
             if val is not None:
                 result[attr] = val
 

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -406,10 +406,14 @@ class JobInfo:
         return runtime
 
     def get_remaining_time(self):
-        status = str(self.status)
-        if status != "RUN":
+        try:
+            status = str(self.status)
+            if status != "RUN":
+                return 0.0
+            tleft = self.expiration - time.time()
+        except (KeyError, AttributeError):
+            # expiration and/or status attributes may not exist, return 0.0
             return 0.0
-        tleft = self.expiration - time.time()
         if tleft < 0.0:
             return 0.0
         return tleft

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -629,6 +629,18 @@ class TestJob(unittest.TestCase):
                 }
             ),
         )
+
+        # t_remaining returns 0 from JobInfo returned from result():
+        self.assertEqual(result[ids[0]].get_info().t_remaining, 0.0)
+
+        # Ensure to_dict() works for a JobInfo returned from result():
+        job_dict = result[ids[0]].get_info().to_dict()
+        self.assertIsInstance(job_dict, dict)
+        self.assertEqual(job_dict["id"], ids[0])
+        self.assertEqual(job_dict["result"], "COMPLETED")
+        self.assertEqual(job_dict["returncode"], 0)
+        self.assertEqual(job_dict["duration"], 0.0)
+
         self.assertEqual(
             result[ids[1]].get_info(),
             JobInfo(
@@ -643,6 +655,14 @@ class TestJob(unittest.TestCase):
                 }
             ),
         )
+        # Ensure to_dict() works for a JobInfo returned from result():
+        job_dict = result[ids[1]].get_info().to_dict()
+        self.assertIsInstance(job_dict, dict)
+        self.assertEqual(job_dict["id"], ids[1])
+        self.assertEqual(job_dict["result"], "FAILED")
+        self.assertEqual(job_dict["returncode"], 1)
+        self.assertEqual(job_dict["duration"], 0.0)
+
         self.assertEqual(
             result[ids[2]].get_info(),
             JobInfo(


### PR DESCRIPTION
This PR fixes #5491, however it does it in two ways

 - fix handling of the `t_remaining` `JobInfo` attribute when `expiration` and/or `status` attrs are missing
 - skip attributes that raise an exception in `to_dict()`

This allows `to_dict()` to work with `JobInfo` objects returned from `flux.job.result()`.