### PR TITLE
add interthread connector that does not require zeromq

### DIFF
--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -96,6 +96,7 @@ libflux_la_SOURCES = \
 	attr.c \
 	handle.c \
 	connector_loop.c \
+	connector_interthread.c \
 	reactor.c \
 	reactor_private.h \
 	msg_handler.c \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -11,7 +11,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir) \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(JANSSON_CFLAGS) \
 	$(LIBUUID_CFLAGS)
 
@@ -182,11 +181,9 @@ TESTS = test_message.t \
 test_ldadd = \
 	$(top_builddir)/src/common/libtestutil/libtestutil.la \
 	$(top_builddir)/src/common/libflux/libflux.la \
-	$(top_builddir)/src/common/libzmqutil/libzmqutil.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
-	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -153,6 +153,7 @@ libmessage_la_LDFLAGS = -avoid-version -module -shared -export-dynamic
 
 TESTS = test_message.t \
 	test_msglist.t \
+	test_interthread.t \
 	test_request.t \
 	test_response.t \
 	test_event.t \
@@ -297,6 +298,10 @@ test_sync_t_LDADD = $(test_ldadd)
 test_disconnect_t_SOURCES = test/disconnect.c
 test_disconnect_t_CPPFLAGS = $(test_cppflags)
 test_disconnect_t_LDADD = $(test_ldadd)
+
+test_interthread_t_SOURCES = test/interthread.c
+test_interthread_t_CPPFLAGS = $(test_cppflags)
+test_interthread_t_LDADD = $(test_ldadd)
 
 test_module_t_SOURCES = test/module.c
 test_module_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libflux/connector_interthread.c
+++ b/src/common/libflux/connector_interthread.c
@@ -1,0 +1,391 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* connector_interthread.c - bidirectional, inter-thread message channel */
+
+/* Notes:
+ * - Each channel has a unique name and 1-2 attached flux_t handles.
+ * - Channels can be safely opened and closed from multiple threads.
+ * - The channel is created on first open and destroyed on last close.
+ * - There are no active/passive roles.
+ * - Writing is always non-blocking.
+ * - Reading can be either blocking or non-blocking.
+ * - Neither reading nor writing are affected if the other end disconnects.
+ * - Reconnect is allowed (by happenstance, not for any particular use case)
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <sys/poll.h>
+#include <pthread.h>
+
+#include <flux/core.h>
+
+#include "src/common/libutil/errprintf.h"
+#include "ccan/list/list.h"
+#include "ccan/str/str.h"
+
+struct msglist_safe {
+    struct flux_msglist *queue;
+    pthread_mutex_t lock;
+};
+
+struct channel {
+    char *name;
+    struct msglist_safe *pair[2];
+    int refcount; // max of 2
+    struct list_node list;
+};
+
+struct interthread_ctx {
+    flux_t *h;
+    struct flux_msg_cred cred;
+    char *router;
+    struct channel *chan;
+    struct msglist_safe *send; // refers to ctx->chan->pair[x]
+    struct msglist_safe *recv; // refers to ctx->chan->pair[y]
+};
+
+/* Global state.
+ * Threads accessing a channel must share this global in order to "connect".
+ */
+static struct list_head channels = LIST_HEAD_INIT (channels);
+static pthread_mutex_t channels_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static const struct flux_handle_ops handle_ops;
+
+
+static void msglist_safe_destroy (struct msglist_safe *ml)
+{
+    if (ml) {
+        int saved_errno = errno;
+        pthread_mutex_destroy (&ml->lock);
+        flux_msglist_destroy (ml->queue);
+        free (ml);
+        errno = saved_errno;
+    };
+}
+
+static struct msglist_safe *msglist_safe_create (void)
+{
+    struct msglist_safe *ml;
+
+    if (!(ml = calloc (1, sizeof (*ml))))
+        return NULL;
+    pthread_mutex_init (&ml->lock, NULL);
+    if (!(ml->queue = flux_msglist_create ())) {
+        msglist_safe_destroy (ml);
+        return NULL;
+    }
+    return ml;
+}
+
+static int msglist_safe_append (struct msglist_safe *ml, const flux_msg_t *msg)
+{
+    pthread_mutex_lock (&ml->lock);
+    int rc = flux_msglist_append (ml->queue, msg);
+    pthread_mutex_unlock (&ml->lock);
+    return rc;
+}
+
+static flux_msg_t *msglist_safe_pop (struct msglist_safe *ml)
+{
+
+    pthread_mutex_lock (&ml->lock);
+    flux_msg_t *msg = (flux_msg_t *)flux_msglist_pop (ml->queue);
+    pthread_mutex_unlock (&ml->lock);
+    return msg;
+}
+
+static int msglist_safe_pollfd (struct msglist_safe *ml)
+{
+    pthread_mutex_lock (&ml->lock);
+    int rc = flux_msglist_pollfd (ml->queue);
+    pthread_mutex_unlock (&ml->lock);
+    return rc;
+}
+
+static int msglist_safe_pollevents (struct msglist_safe *ml)
+{
+    pthread_mutex_lock (&ml->lock);
+    int rc = flux_msglist_pollevents (ml->queue);
+    pthread_mutex_unlock (&ml->lock);
+    return rc;
+}
+
+static void channel_destroy (struct channel *chan)
+{
+    if (chan) {
+        int saved_errno = errno;
+        msglist_safe_destroy (chan->pair[0]);
+        msglist_safe_destroy (chan->pair[1]);
+        free (chan->name);
+        free (chan);
+        errno = saved_errno;
+    }
+}
+
+static struct channel *channel_create (const char *name)
+{
+    struct channel *chan;
+
+    if (!(chan = calloc (1, sizeof (*chan)))
+        || !(chan->name = strdup (name))
+        || !(chan->pair[0] = msglist_safe_create ())
+        || !(chan->pair[1] = msglist_safe_create ()))
+        goto error;
+    list_node_init (&chan->list);
+    return chan;
+error:
+    channel_destroy (chan);
+    return NULL;
+}
+
+/* Add new channel to global list under lock and take a reference.
+ */
+static void channel_add_safe (struct channel *chan)
+{
+    pthread_mutex_lock (&channels_lock);
+    list_add (&channels, &chan->list);
+    chan->refcount++;
+    pthread_mutex_unlock (&channels_lock);
+}
+
+/* Drop a reference on channel under lock.
+ * If the refcount becomes zero, remove it from the global list and return true.
+ */
+static bool channel_remove_safe (struct channel *chan)
+{
+    bool result = false;
+    if (chan) {
+        pthread_mutex_lock (&channels_lock);
+        if (--chan->refcount == 0) {
+            list_del (&chan->list);
+            result = true;
+        }
+        pthread_mutex_unlock (&channels_lock);
+    }
+    return result;
+}
+
+/* Look up a channel by name under lock, for pairing.
+ * If found but already paired (refcount == 2), fail with EADDRINUSE.
+ * If not found, fail with ENOENT.
+ * Otherwise take a reference under lock and return the channel.
+ */
+static struct channel *channel_pair_safe (const char *name)
+{
+    struct channel *result = NULL;
+    struct channel *chan = NULL;
+
+    pthread_mutex_lock (&channels_lock);
+    list_for_each (&channels, chan, list) {
+        if (streq (name, chan->name)) {
+            if (chan->refcount > 1) {
+                pthread_mutex_unlock (&channels_lock);
+                errno = EADDRINUSE;
+                return NULL;
+            }
+            chan->refcount++;
+            result = chan;
+            break;
+        }
+    }
+    pthread_mutex_unlock (&channels_lock);
+    if (!result)
+        errno = ENOENT;
+    return result;
+}
+
+/**
+ ** Connector interfaces follow
+ **/
+
+static int op_pollevents (void *impl)
+{
+    struct interthread_ctx *ctx = impl;
+    int e, revents = 0;
+
+    e = msglist_safe_pollevents (ctx->recv);
+    if (e & POLLIN)
+        revents |= FLUX_POLLIN;
+    if (e & POLLOUT)
+        revents |= FLUX_POLLOUT;
+    if (e & POLLERR)
+        revents |= FLUX_POLLERR;
+    return revents;
+}
+
+static int op_pollfd (void *impl)
+{
+    struct interthread_ctx *ctx = impl;
+    return msglist_safe_pollfd (ctx->recv);
+}
+
+static int router_process (flux_msg_t *msg, const char *name)
+{
+    int type;
+    if (flux_msg_get_type (msg, &type) < 0)
+        return -1;
+    switch (type) {
+        case FLUX_MSGTYPE_RESPONSE:
+            if (flux_msg_route_delete_last (msg) < 0)
+                return -1;
+            break;
+        case FLUX_MSGTYPE_REQUEST:
+        case FLUX_MSGTYPE_EVENT:
+            flux_msg_route_enable (msg);
+            if (flux_msg_route_push (msg, name) < 0)
+                return -1;
+            break;
+        default:
+            break;
+    }
+    return 0;
+}
+
+static int op_send (void *impl, const flux_msg_t *msg, int flags)
+{
+    struct interthread_ctx *ctx = impl;
+    flux_msg_t *cpy;
+    struct flux_msg_cred cred;
+    int rc = -1;
+
+    if (!(cpy = flux_msg_copy (msg, true)))
+        return -1;
+    if (flux_msg_get_cred (cpy, &cred) < 0)
+        goto done;
+    if (cred.userid == FLUX_USERID_UNKNOWN
+        && cred.rolemask == FLUX_ROLE_NONE) {
+        if (flux_msg_set_cred (cpy, ctx->cred) < 0)
+            goto done;
+    }
+    if (ctx->router) {
+        if (router_process (cpy, ctx->router) < 0)
+            goto done;
+    }
+    rc = msglist_safe_append (ctx->send, cpy);
+done:
+    flux_msg_destroy (cpy);
+    return rc;
+}
+
+static flux_msg_t *op_recv (void *impl, int flags)
+{
+    struct interthread_ctx *ctx = impl;
+    flux_msg_t *msg;
+
+    do {
+        msg = msglist_safe_pop (ctx->recv);
+        if (!msg) {
+            if ((flags & FLUX_O_NONBLOCK)) {
+                errno = EWOULDBLOCK;
+                return NULL;
+            }
+            struct pollfd pfd = {
+                .fd = msglist_safe_pollfd (ctx->recv),
+                .events = POLLIN,
+                .revents = 0,
+            };
+            if (poll (&pfd, 1, -1) < 0)
+                return NULL;
+        }
+    } while (!msg);
+    if (ctx->router) {
+        if (router_process (msg, ctx->chan->name) < 0) {
+            flux_msg_destroy (msg);
+            return NULL;
+        }
+    }
+    return msg;
+}
+
+static int op_setopt (void *impl,
+                      const char *option,
+                      const void *val,
+                      size_t size)
+{
+    struct interthread_ctx *ctx = impl;
+
+    if (streq (option, FLUX_OPT_ROUTER_NAME)) {
+        free (ctx->router);
+        if (!(ctx->router = strndup (val, size)))
+            return -1;
+    }
+    else
+        goto error;
+    return 0;
+error:
+    errno = EINVAL;
+    return -1;
+}
+
+static void op_fini (void *impl)
+{
+    struct interthread_ctx *ctx = impl;
+    if (ctx) {
+        int saved_errno = errno;
+        if (channel_remove_safe (ctx->chan))
+            channel_destroy (ctx->chan);
+        free (ctx->router);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+flux_t *connector_interthread_init (const char *path,
+                                    int flags,
+                                    flux_error_t *errp)
+{
+    struct interthread_ctx *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        goto error_seterrp;
+    ctx->cred.userid = getuid ();
+    ctx->cred.rolemask = FLUX_ROLE_OWNER | FLUX_ROLE_LOCAL;
+    if (!(ctx->chan = channel_pair_safe (path))) {
+        if (errno == EADDRINUSE) {
+            errprintf (errp, "interthread channel %s is already paired", path);
+            goto error;
+        }
+        else if (errno != ENOENT)
+            goto error_seterrp;
+        if (!(ctx->chan = channel_create (path)))
+            goto error_seterrp;
+        channel_add_safe (ctx->chan);
+        ctx->send = ctx->chan->pair[0];
+        ctx->recv = ctx->chan->pair[1];
+    }
+    else {
+        ctx->send = ctx->chan->pair[1];
+        ctx->recv = ctx->chan->pair[0];
+    }
+    if (!(ctx->h = flux_handle_create (ctx, &handle_ops, flags)))
+        goto error_seterrp;
+    return ctx->h;
+error_seterrp:
+    errprintf (errp, "%s", strerror (errno));
+error:
+    op_fini (ctx);
+    return NULL;
+}
+
+static const struct flux_handle_ops handle_ops = {
+    .pollfd = op_pollfd,
+    .pollevents = op_pollevents,
+    .send = op_send,
+    .recv = op_recv,
+    .setopt = op_setopt,
+    .impl_destroy = op_fini,
+};
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libflux/connector_loop.c
+++ b/src/common/libflux/connector_loop.c
@@ -31,8 +31,6 @@ typedef struct {
 
 static const struct flux_handle_ops handle_ops;
 
-const char *fake_uuid = "12345678123456781234567812345678";
-
 static int op_pollevents (void *impl)
 {
     loop_ctx_t *c = impl;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -93,9 +93,13 @@ struct builtin_connector {
 };
 
 flux_t *connector_loop_init (const char *uri, int flags, flux_error_t *errp);
+flux_t *connector_interthread_init (const char *uri,
+                                    int flags,
+                                    flux_error_t *errp);
 
 static struct builtin_connector builtin_connectors[] = {
     { "loop", &connector_loop_init },
+    { "interthread", &connector_interthread_init },
 };
 
 static void handle_trace (flux_t *h, const char *fmt, ...)

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -68,6 +68,7 @@ enum {
  */
 #define FLUX_OPT_TESTING_USERID     "flux::testing_userid"
 #define FLUX_OPT_TESTING_ROLEMASK   "flux::testing_rolemask"
+#define FLUX_OPT_ROUTER_NAME        "flux::router_name"
 
 /* Create/destroy a broker handle.
  * The 'uri' scheme name selects a connector to dynamically load.

--- a/src/common/libflux/test/attr.c
+++ b/src/common/libflux/test/attr.c
@@ -14,7 +14,6 @@
 #include <errno.h>
 #include <string.h>
 #include <flux/core.h>
-#include <zmq.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -186,13 +185,10 @@ int main (int argc, char *argv[])
     flux_t *h;
     const char *value;
     const char *value2;
-    void *zctx;
 
     plan (NO_PLAN);
 
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
-    if (!(h = test_server_create (zctx, 0, test_server, NULL)))
+    if (!(h = test_server_create (0, test_server, NULL)))
         BAIL_OUT ("test_server_create failed");
 
     /* get ENOENT */
@@ -406,8 +402,6 @@ int main (int argc, char *argv[])
 
     test_server_stop (h);
     flux_close (h);
-
-    zmq_ctx_term (zctx);
 
     done_testing();
     return (0);

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -12,7 +12,6 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
-#include <zmq.h>
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
 #include "ccan/str/str.h"
@@ -219,12 +218,8 @@ void test_subscribe_rpc (void)
 {
     flux_t *h;
     flux_future_t *f;
-    void *zctx;
 
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
-
-    if (!(h = test_server_create (zctx, 0, test_server, NULL)))
+    if (!(h = test_server_create (0, test_server, NULL)))
         BAIL_OUT ("test_server_create: %s", strerror (errno));
 
     ok (flux_event_subscribe (h, "fubar") == 0,
@@ -280,8 +275,6 @@ void test_subscribe_rpc (void)
     if (test_server_stop (h) < 0)
         BAIL_OUT ("error stopping test server: %s", strerror (errno));
     flux_close (h);
-
-    zmq_ctx_term (zctx);
 }
 
 void test_subscribe_nosub (void)

--- a/src/common/libflux/test/interthread.c
+++ b/src/common/libflux/test/interthread.c
@@ -1,0 +1,331 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <pthread.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
+#include "ccan/array_size/array_size.h"
+
+void test_basic (void)
+{
+    const char *uri = "interthread://test1";
+    const char *uri2 = "interthread://test2";
+    flux_t *h;
+    flux_t *h2;
+    flux_t *h3;
+    flux_t *h4;
+    flux_error_t error;
+    flux_msg_t *msg;
+    flux_msg_t *req;
+    flux_msg_t *rep;
+    struct flux_msg_cred cred;
+    const char *topic;
+    const char *payload;
+
+    /* create pair to use in test */
+    h = flux_open (uri, 0);
+    ok (h != NULL,
+        "basic: flux_open %s (1) works", uri);
+    h2 = flux_open (uri, 0);
+    ok (h2 != NULL,
+        "basic: flux_open %s (2) works", uri);
+
+    /* cover connecting to a paired channel */
+    errno = 0;
+    ok (flux_open (uri, 0) == NULL && errno == EADDRINUSE,
+        "basic: flux_open %s (3) fails with EADDRINUSE", uri);
+    errno = 0;
+    error.text[0] = '\0';
+    ok (flux_open_ex (uri, 0, &error) == NULL && errno == EADDRINUSE,
+        "basic: flux_open_ex %s also fails with EADDRINUSE", uri);
+    diag ("%s", error.text);
+    like (error.text, "already paired",
+        "basic: and error string contains something useful", uri);
+
+    /* create another pair to exercise channel allocation */
+    h3 = flux_open (uri2, 0);
+    ok (h3 != NULL,
+        "basic: flux_open %s (1) works", uri2);
+    h4 = flux_open (uri2, 0);
+    ok (h4 != NULL,
+        "basic: flux_open %s (2) works", uri2);
+    flux_close (h4);
+    flux_close (h3);
+
+    /* send request h -> h2 */
+    if (!(req = flux_request_encode ("foo.bar", "baz")))
+        BAIL_OUT ("basic: could not create request");
+    ok (flux_send (h, req, 0) == 0,
+       "basic: flux_send on first handle works");
+    msg = flux_recv (h2, FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "basic: flux_recv on second handle works");
+    ok (flux_msg_route_count (msg) == 0,
+        "basic: request has no route stack");
+    ok (flux_request_decode (msg, &topic, &payload) == 0
+        && streq (topic, "foo.bar")
+        && streq (payload, "baz"),
+        "basic: request has expected topic and payload");
+    if (!(rep = flux_response_derive (msg, 0)))
+        BAIL_OUT ("basic: could not create response");
+    ok (flux_msg_get_cred (msg, &cred) == 0
+        && cred.userid == getuid ()
+        && cred.rolemask == (FLUX_ROLE_OWNER | FLUX_ROLE_LOCAL),
+        "basic: message cred has expected values");
+    flux_msg_destroy (msg);
+
+    /* send response h2 -> h */
+    ok (flux_send (h2, rep, 0) == 0,
+       "basic: flux_send on second handle works");
+    msg = flux_recv (h, FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "basic: flux_recv on first handle works");
+    ok (flux_msg_route_count (msg) == 0,
+        "basic: response has no route stack");
+    ok (flux_response_decode (msg, &topic, &payload) == 0
+        && streq (topic, "foo.bar")
+        && payload == NULL,
+        "basic: response has expected topic and payload");
+    flux_msg_destroy (msg);
+    flux_msg_destroy (req);
+    flux_msg_destroy (rep);
+
+    flux_close (h2);
+    flux_close (h);
+}
+
+void test_router (void)
+{
+    const char *uri = "interthread://test1";
+    flux_t *h;
+    flux_t *h2;
+    flux_msg_t *msg;
+    flux_msg_t *req;
+    flux_msg_t *rep;
+
+    /* create pair to use in test */
+    h = flux_open (uri, 0);
+    ok (h != NULL,
+        "router: flux_open %s (1) works", uri);
+    ok (flux_opt_set (h, FLUX_OPT_ROUTER_NAME, "testrouter", 11) == 0,
+        "router: flux_opt_set FLUX_OPT_ROUTER_NAME=testrouter works");
+    h2 = flux_open (uri, 0);
+    ok (h2 != NULL,
+        "router: flux_open %s (2) works", uri);
+
+    /* send request h -> h2 */
+    if (!(req = flux_request_encode ("foo.bar", "baz")))
+        BAIL_OUT ("router: could not create request");
+    ok (flux_send (h, req, 0) == 0,
+       "router: flux_send on first handle works");
+    msg = flux_recv (h2, FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "router: flux_recv on second handle works");
+    ok (flux_msg_route_count (msg) == 1
+        && streq (flux_msg_route_last (msg), "testrouter"),
+        "router: request is from testrouter");
+    if (!(rep = flux_response_derive (msg, 0)))
+        BAIL_OUT ("router: could not create response");
+    flux_msg_destroy (msg);
+
+    /* send response h2 -> h */
+    ok (flux_send (h2, rep, 0) == 0,
+       "router: flux_send on second handle works");
+    msg = flux_recv (h, FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "router: flux_recv on first handle works");
+    ok (flux_msg_route_count (msg) == 0,
+        "router: response has no route stack");
+    flux_msg_destroy (msg);
+    flux_msg_destroy (rep);
+
+    /* send request h2 -> h */
+    ok (flux_send (h2, req, 0) == 0,
+       "router: flux_send on second handle works");
+    msg = flux_recv (h, FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "router: flux_recv on first handle works");
+    ok (flux_msg_route_count (msg) == 1
+        && streq (flux_msg_route_last (msg), "test1"),
+        "router: request is from test1");
+    if (!(rep = flux_response_derive (msg, 0)))
+        BAIL_OUT ("router: could not create response");
+    flux_msg_destroy (msg);
+
+    /* send response h -> h2 */
+    ok (flux_send (h, rep, 0) == 0,
+       "router: flux_send on first handle works");
+    msg = flux_recv (h2, FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "router: flux_recv on second handle works");
+    ok (flux_msg_route_count (msg) == 0,
+        "router: response has no route stack");
+    flux_msg_destroy (msg);
+    flux_msg_destroy (rep);
+
+    flux_msg_destroy (req);
+
+    flux_close (h2);
+    flux_close (h);
+}
+
+struct test_thread {
+    pthread_t t;
+    flux_t *h;
+    flux_watcher_t *w;
+    char uri[64];
+    int total;
+    int count;
+};
+
+static flux_watcher_t *timer;
+static int num_active_threads;
+
+void *test_thread (void *arg)
+{
+    struct test_thread *test = arg;
+    flux_t *h;
+    flux_msg_t *msg;
+
+    if (!(h = flux_open (test->uri, 0)))
+        BAIL_OUT ("%s: flux_open: %s", test->uri, strerror (errno));
+    if (!(msg = flux_request_encode ("foo.bar", NULL)))
+        BAIL_OUT ("%s: flux_request_encode: %s", test->uri, strerror (errno));
+    for (int i = 0; i < test->total; i++) {
+        if (flux_send (h, msg, 0) < 0)
+            BAIL_OUT ("%s: flux_send: %s", test->uri, strerror (errno));
+    }
+    flux_msg_destroy (msg);
+    flux_close (h);
+    return NULL;
+}
+
+void timeout (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    diag ("test timed out");
+    flux_reactor_stop_error (r);
+}
+
+void watcher (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    struct test_thread *test = arg;
+    flux_msg_t *msg;
+
+    if (!(msg = flux_recv (test->h, FLUX_MATCH_ANY, 0))) {
+        diag ("%s: flux_recv: %s", test->uri, strerror (errno));
+        flux_reactor_stop_error (r);
+        return;
+    }
+    if (flux_request_decode (msg, NULL, NULL) < 0) {
+        diag ("%s: flux_request_decode: %s", test->uri, strerror (errno));
+        flux_reactor_stop_error (r);
+    }
+    flux_msg_destroy (msg);
+    if (++test->count == test->total) {
+        flux_watcher_stop (w);
+        if (--num_active_threads == 0)
+            flux_watcher_stop (timer);
+    }
+}
+
+int test_threads_init (struct test_thread *test,
+                       size_t count,
+                       flux_reactor_t *r,
+                       int num_messages)
+{
+    for (int i = 0; i < count; i++) {
+        int e;
+        snprintf (test[i].uri, sizeof (test[i].uri), "interthread://%d", i);
+        test[i].total = num_messages;
+        if (!(test[i].h = flux_open (test[i].uri, 0))) {
+            diag ("flux_open %s failed: %s", test[i].uri, strerror (errno));
+            return -1;
+        }
+        if (!(test[i].w = flux_handle_watcher_create (r,
+                                                      test[i].h,
+                                                      FLUX_POLLIN,
+                                                      watcher,
+                                                      &test[i]))) {
+            diag ("watcher create %s failed: %s", test[i].uri, strerror (errno));
+            return -1;
+        }
+        flux_watcher_start (test[i].w);
+        if ((e = pthread_create (&test[i].t, NULL, test_thread, &test[i]))) {
+            diag ("pthread_create %s failed: %s", test[i].uri, strerror (e));
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int test_threads_join (struct test_thread *test, size_t count)
+{
+    for (int i = 0; i < count; i++) {
+        void *result;
+        int e;
+        if ((e = pthread_join (test[i].t, &result))) {
+            diag ("pthread_join %s failed: %s", test[i].uri, strerror (e));
+            return -1;
+        }
+        flux_watcher_destroy (test[i].w);
+        flux_close (test[i].h);
+    }
+    return 0;
+}
+
+void test_threads (void)
+{
+    const double timeout_s = 30.;
+    const int num_messages = 32;
+    const int num_threads = 16;
+    struct test_thread test[num_threads];
+    flux_reactor_t *r;
+
+    if (!(r = flux_reactor_create (0)))
+        BAIL_OUT ("could not create reactor");
+
+    num_active_threads = num_threads;
+    if (!(timer = flux_timer_watcher_create (r, timeout_s, 0, timeout, NULL)))
+        BAIL_OUT ("could not create timer watcher");
+    flux_watcher_start (timer);
+
+    memset (test, 0, sizeof (test));
+
+    ok (test_threads_init (test, num_threads, r, num_messages) == 0,
+        "started %d threads that will each send %d messages",
+        num_threads,
+        num_messages);
+    ok (flux_reactor_run (r, 0) == 0,
+        "all messages received with no errors");
+    ok (test_threads_join (test, num_threads) == 0,
+        "finalized test threads");
+
+    flux_watcher_destroy (timer);
+    flux_reactor_destroy (r);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_basic ();
+    test_router ();
+    test_threads ();
+
+    done_testing ();
+    return 0;
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libflux/test/log.c
+++ b/src/common/libflux/test/log.c
@@ -13,7 +13,6 @@
 #endif
 #include <errno.h>
 #include <flux/core.h>
-#include <zmq.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
@@ -21,14 +20,10 @@
 int main (int argc, char *argv[])
 {
     flux_t *h;
-    void *zctx;
 
     plan (NO_PLAN);
 
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
-
-    if (!(h = test_server_create (zctx, 0, NULL, NULL)))
+    if (!(h = test_server_create (0, NULL, NULL)))
         BAIL_OUT ("could not create test server");
     if (flux_attr_set_cacheonly (h, "rank", "0") < 0)
         BAIL_OUT ("flux_attr_set_cacheonly failed");
@@ -48,7 +43,6 @@ int main (int argc, char *argv[])
 
     test_server_stop (h);
     flux_close (h);
-    zmq_ctx_term (zctx);
     done_testing();
     return (0);
 }

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -12,7 +12,6 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
-#include <zmq.h>
 #include <jansson.h>
 
 #include "src/common/libtap/tap.h"
@@ -915,18 +914,18 @@ static int fake_server_reactor (flux_t *h, void *arg)
     return flux_reactor_run (flux_get_reactor (h), 0);
 }
 
-void test_fake_server (void *zctx)
+void test_fake_server (void)
 {
     flux_t *h;
 
-    ok ((h = test_server_create (zctx, 0, fake_server, NULL)) != NULL,
+    ok ((h = test_server_create (0, fake_server, NULL)) != NULL,
         "test_server_create (recv loop)");
     ok (test_server_stop (h) == 0,
         "test_server_stop worked");
     flux_close (h);
     diag ("completed test with server recv loop");
 
-    ok ((h = test_server_create (zctx, 0, fake_server_reactor, NULL)) != NULL,
+    ok ((h = test_server_create (0, fake_server_reactor, NULL)) != NULL,
         "test_server_create (reactor)");
     ok ((test_server_stop (h)) == 0,
         "test_server_stop worked");
@@ -961,16 +960,12 @@ static int comms_err (flux_t *h, void *arg)
 int main (int argc, char *argv[])
 {
     flux_t *h;
-    void *zctx;
 
     plan (NO_PLAN);
 
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
+    test_fake_server ();
 
-    test_fake_server (zctx);
-
-    h = test_server_create (zctx, 0, test_server, NULL);
+    h = test_server_create (0, test_server, NULL);
     ok (h != NULL,
         "created test server thread");
     if (!h)
@@ -1000,8 +995,6 @@ int main (int argc, char *argv[])
     ok (test_server_stop (h) == 0,
         "stopped test server thread");
     flux_close (h); // destroys test server
-
-    zmq_ctx_term (zctx);
 
     done_testing();
     return (0);

--- a/src/common/libflux/test/rpc_chained.c
+++ b/src/common/libflux/test/rpc_chained.c
@@ -12,7 +12,6 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
-#include <zmq.h>
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
 #include "ccan/str/str.h"
@@ -346,14 +345,10 @@ void test_or_then_error_string (flux_t *h)
 int main (int argc, char *argv[])
 {
     flux_t *h;
-    void *zctx;
 
     plan (NO_PLAN);
 
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
-
-    h = test_server_create (zctx, 0, test_server, NULL);
+    h = test_server_create (0, test_server, NULL);
     ok (h != NULL,
         "created test server thread");
     if (!h)
@@ -372,8 +367,6 @@ int main (int argc, char *argv[])
     ok (test_server_stop (h) == 0,
         "stopped test server thread");
     flux_close (h); // destroys test server
-
-    zmq_ctx_term (zctx);
 
     done_testing();
     return (0);

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -62,8 +62,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \
-	$(FLUX_SECURITY_LIBS) \
-	$(ZMQ_LIBS)
+	$(FLUX_SECURITY_LIBS)
 
 test_cppflags = \
 	$(AM_CPPFLAGS) \

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -67,8 +67,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(JANSSON_LIBS) \
-	$(LIBPTHREAD) \
-	$(ZMQ_LIBS)
+	$(LIBPTHREAD)
 
 test_cppflags = \
 	$(AM_CPPFLAGS) \

--- a/src/common/librouter/Makefile.am
+++ b/src/common/librouter/Makefile.am
@@ -69,11 +69,9 @@ test_ldadd = \
 	$(builddir)/libtestutil.la \
         $(top_builddir)/src/common/librouter/librouter.la \
         $(top_builddir)/src/common/libtestutil/libtestutil.la \
-        $(top_builddir)/src/common/libzmqutil/libzmqutil.la \
         $(top_builddir)/src/common/libflux-core.la \
         $(top_builddir)/src/common/libflux-internal.la \
-        $(top_builddir)/src/common/libtap/libtap.la \
-        $(ZMQ_LIBS)
+        $(top_builddir)/src/common/libtap/libtap.la
 
 test_cppflags = \
         $(AM_CPPFLAGS) \

--- a/src/common/librouter/test/router.c
+++ b/src/common/librouter/test/router.c
@@ -12,7 +12,6 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
-#include <zmq.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libtestutil/util.h"
@@ -267,16 +266,12 @@ void test_error (flux_t *h)
 int main (int argc, char *argv[])
 {
     flux_t *h;
-    void *zctx;
 
     plan (NO_PLAN);
 
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
-
     diag ("starting test server");
 
-    if (!(h = test_server_create (zctx, FLUX_O_TEST_NOSUB, server_cb, NULL)))
+    if (!(h = test_server_create (FLUX_O_TEST_NOSUB, server_cb, NULL)))
         BAIL_OUT ("test_server_create failed");
 
     test_basic (h);
@@ -286,8 +281,6 @@ int main (int argc, char *argv[])
     if (test_server_stop (h) < 0)
         BAIL_OUT ("test_server_stop failed");
     flux_close (h);
-
-    zmq_ctx_term (zctx);
 
     done_testing ();
 

--- a/src/common/librouter/test/servhash.c
+++ b/src/common/librouter/test/servhash.c
@@ -12,7 +12,6 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
-#include <zmq.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -266,16 +265,12 @@ void test_basic (flux_t *h)
 int main (int argc, char *argv[])
 {
     flux_t *h;
-    void *zctx;
 
     plan (NO_PLAN);
 
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
-
     diag ("starting test server");
 
-    if (!(h = test_server_create (zctx, 0, server_cb, NULL)))
+    if (!(h = test_server_create (0, server_cb, NULL)))
         BAIL_OUT ("test_server_create failed");
 
     test_basic (h);
@@ -285,7 +280,6 @@ int main (int argc, char *argv[])
     if (test_server_stop (h) < 0)
         BAIL_OUT ("test_server_stop failed");
     flux_close (h);
-    zmq_ctx_term (zctx);
     done_testing ();
 
     return 0;

--- a/src/common/librouter/test/usock_echo.c
+++ b/src/common/librouter/test/usock_echo.c
@@ -13,7 +13,6 @@
 #endif
 #include <sys/param.h>
 #include <flux/core.h>
-#include <zmq.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/unlink_recursive.h"
@@ -292,12 +291,8 @@ static void test_async_stream (flux_t *h, int size, int count)
 int main (int argc, char *argv[])
 {
     flux_t *h;
-    void *zctx;
 
     plan (NO_PLAN);
-
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("cannot create zeromq context");
 
     tmpdir_create ();
 
@@ -305,7 +300,7 @@ int main (int argc, char *argv[])
 
     diag ("starting test server");
 
-    if (!(h = test_server_create (zctx, 0, server_cb, NULL)))
+    if (!(h = test_server_create (0, server_cb, NULL)))
         BAIL_OUT ("test_server_create failed");
 
     test_early_disconnect (h);
@@ -321,7 +316,6 @@ int main (int argc, char *argv[])
     flux_close (h);
 
     tmpdir_destroy ();
-    zmq_ctx_term (zctx);
     done_testing ();
 
     return 0;

--- a/src/common/librouter/test/usock_emfile.c
+++ b/src/common/librouter/test/usock_emfile.c
@@ -15,7 +15,6 @@
 #include <sys/resource.h>
 #include <pthread.h>
 #include <flux/core.h>
-#include <zmq.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/unlink_recursive.h"
@@ -259,12 +258,8 @@ int main (int argc, char *argv[])
     struct test_params tp = {0};
     struct client_args cargs[2];
     flux_t *h;
-    void *zctx;
 
     plan (NO_PLAN);
-
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
 
     tmpdir_create ();
     if (snprintf (sockpath,
@@ -277,7 +272,7 @@ int main (int argc, char *argv[])
 
     diag ("starting test server");
 
-    if (!(h = test_server_create (zctx, 0, server_cb, &tp)))
+    if (!(h = test_server_create (0, server_cb, &tp)))
         BAIL_OUT ("test_server_create failed");
 
     wait_for_server ();
@@ -345,7 +340,6 @@ int main (int argc, char *argv[])
     tmpdir_destroy ();
 
     diag ("fds_inuse = %d", fds_inuse ());
-    zmq_ctx_term (zctx);
     done_testing ();
     return 0;
 }

--- a/src/common/librouter/test/usock_epipe.c
+++ b/src/common/librouter/test/usock_epipe.c
@@ -14,7 +14,6 @@
 #include <sys/param.h>
 #include <pthread.h>
 #include <flux/core.h>
-#include <zmq.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/unlink_recursive.h"
@@ -218,12 +217,8 @@ int main (int argc, char *argv[])
 {
     struct test_params tp = {0};
     flux_t *h;
-    void *zctx;
 
     plan (NO_PLAN);
-
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("cannot create zeromq context");
 
     tmpdir_create ();
 
@@ -231,7 +226,7 @@ int main (int argc, char *argv[])
 
     diag ("starting test server");
 
-    if (!(h = test_server_create (zctx, 0, server_cb, &tp)))
+    if (!(h = test_server_create (0, server_cb, &tp)))
         BAIL_OUT ("test_server_create failed");
 
     test_send_and_exit (h, 1);
@@ -256,7 +251,6 @@ int main (int argc, char *argv[])
     flux_close (h);
 
     tmpdir_destroy ();
-    zmq_ctx_term (zctx);
     done_testing ();
 
     return 0;

--- a/src/common/libsdexec/Makefile.am
+++ b/src/common/libsdexec/Makefile.am
@@ -36,12 +36,10 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libsubprocess/libsubprocess.la \
 	$(top_builddir)/src/common/libtestutil/libtestutil.la \
-	$(top_builddir)/src/common/libzmqutil/libzmqutil.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(LIBPTHREAD) \
-	$(JANSSON_LIBS) \
-	$(ZMQ_LIBS)
+	$(JANSSON_LIBS)
 
 test_cppflags = \
 	$(AM_CPPFLAGS)

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -62,12 +62,10 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 test_ldadd = \
 	$(builddir)/test/libutil.la \
         $(top_builddir)/src/common/libtestutil/libtestutil.la \
-        $(top_builddir)/src/common/libzmqutil/libzmqutil.la \
         $(top_builddir)/src/common/libtap/libtap.la \
         $(top_builddir)/src/common/libsubprocess/libsubprocess.la \
         $(top_builddir)/src/common/libflux-core.la \
-        $(top_builddir)/src/common/libflux-internal.la \
-        $(ZMQ_LIBS)
+        $(top_builddir)/src/common/libflux-internal.la
 
 test_ldflags = \
 	-no-install

--- a/src/common/libsubprocess/test/iochan.c
+++ b/src/common/libsubprocess/test/iochan.c
@@ -14,7 +14,6 @@
 #include <unistd.h> // environ def
 #include <jansson.h>
 #include <flux/core.h>
-#include <zmq.h>
 
 #include "ccan/array_size/array_size.h"
 #include "ccan/str/str.h"
@@ -253,14 +252,10 @@ bool iochan_run_check (flux_t *h, const char *name, int count)
 int main (int argc, char *argv[])
 {
     flux_t *h;
-    void *zctx;
 
     plan (NO_PLAN);
 
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
-
-    h = rcmdsrv_create (zctx, "rexec");
+    h = rcmdsrv_create ("rexec");
 
     ok (iochan_run_check (h, "simple", linesize * 100),
         "simple check worked");
@@ -272,7 +267,6 @@ int main (int argc, char *argv[])
         "refcount check worked");
     test_server_stop (h);
     flux_close (h);
-    zmq_ctx_term (zctx);
 
     done_testing ();
     return 0;

--- a/src/common/libsubprocess/test/iostress.c
+++ b/src/common/libsubprocess/test/iostress.c
@@ -14,7 +14,6 @@
 #include <unistd.h> // environ def
 #include <jansson.h>
 #include <flux/core.h>
-#include <zmq.h>
 
 #include "ccan/array_size/array_size.h"
 #include "ccan/str/str.h"
@@ -279,14 +278,10 @@ bool iostress_run_check (flux_t *h,
 int main (int argc, char *argv[])
 {
     flux_t *h;
-    void *zctx;
 
     plan (NO_PLAN);
 
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
-
-    h = rcmdsrv_create (zctx, "rexec");
+    h = rcmdsrv_create ("rexec");
 
     ok (iostress_run_check (h, "balanced", false, 0, 0, 8, 8, 80),
         "balanced worked");
@@ -309,7 +304,6 @@ int main (int argc, char *argv[])
 
     test_server_stop (h);
     flux_close (h);
-    zmq_ctx_term (zctx);
     done_testing ();
     return 0;
 }

--- a/src/common/libsubprocess/test/rcmdsrv.c
+++ b/src/common/libsubprocess/test/rcmdsrv.c
@@ -74,7 +74,7 @@ done:
     return rc;
 }
 
-flux_t *rcmdsrv_create (void *zctx, const char *service_name)
+flux_t *rcmdsrv_create (const char *service_name)
 {
     flux_t *h;
 
@@ -83,7 +83,7 @@ flux_t *rcmdsrv_create (void *zctx, const char *service_name)
     signal (SIGPIPE, SIG_IGN);
 
     // N.B. test reactor is created with FLUX_REACTOR_SIGCHLD flag
-    if (!(h = test_server_create (zctx, 0, test_server, (char *)service_name)))
+    if (!(h = test_server_create (0, test_server, (char *)service_name)))
         BAIL_OUT ("test_server_create failed");
 
     return h;

--- a/src/common/libsubprocess/test/rcmdsrv.h
+++ b/src/common/libsubprocess/test/rcmdsrv.h
@@ -14,7 +14,7 @@
 /* Start subprocess server.  Returns one end of back-to-back flux_t test
  * handle.  Call test_server_stop (h) when done to join with server thread.
  */
-flux_t *rcmdsrv_create (void *zctx, const char *service_name);
+flux_t *rcmdsrv_create (const char *service_name);
 
 /* llog-compatible logger
  */

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -14,7 +14,6 @@
 #include <unistd.h> // environ def
 #include <jansson.h>
 #include <flux/core.h>
-#include <zmq.h>
 
 #include "ccan/array_size/array_size.h"
 #include "ccan/str/str.h"
@@ -343,22 +342,16 @@ void sigstop_test (flux_t *h)
 int main (int argc, char *argv[])
 {
     flux_t *h;
-    void *zctx;
 
     plan (NO_PLAN);
 
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
-
-    h = rcmdsrv_create (zctx, SERVER_NAME);
+    h = rcmdsrv_create (SERVER_NAME);
 
     simple_test (h);
     sigstop_test (h);
 
     test_server_stop (h);
     flux_close (h);
-
-    zmq_ctx_term (zctx);
 
     done_testing ();
     return 0;

--- a/src/common/libterminus/Makefile.am
+++ b/src/common/libterminus/Makefile.am
@@ -37,11 +37,9 @@ test_ldadd = \
 	$(top_builddir)/src/common/libterminus/libterminus.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
 	$(top_builddir)/src/common/libtestutil/libtestutil.la \
-	$(top_builddir)/src/common/libzmqutil/libzmqutil.la \
         $(top_builddir)/src/common/libflux-core.la \
         $(top_builddir)/src/common/libflux-internal.la \
-        $(top_builddir)/src/common/libtap/libtap.la \
-        $(ZMQ_LIBS)
+        $(top_builddir)/src/common/libtap/libtap.la
 
 test_ldflags = \
 	-no-install

--- a/src/common/libterminus/test/pty.c
+++ b/src/common/libterminus/test/pty.c
@@ -17,7 +17,6 @@
 #include <errno.h>
 
 #include <flux/core.h>
-#include <zmq.h>
 #include "src/common/libterminus/pty.h"
 
 #include "src/common/libtap/tap.h"
@@ -175,9 +174,9 @@ out:
     return rc;
 }
 
-static void test_basic_protocol (void *zctx)
+static void test_basic_protocol (void)
 {
-    flux_t *h = test_server_create (zctx, 0, pty_server, NULL);
+    flux_t *h = test_server_create (0, pty_server, NULL);
     flux_future_t *f = NULL;
     flux_future_t *f_attach = NULL;
 
@@ -394,9 +393,9 @@ static void pty_exit_cb (struct flux_pty_client *c, void *arg)
     flux_reactor_stop (flux_get_reactor (h));
 }
 
-static void test_client (void *zctx)
+static void test_client (void)
 {
-    flux_t *h = test_server_create (zctx, 0, pty_server, NULL);
+    flux_t *h = test_server_create (0, pty_server, NULL);
     flux_future_t *f = NULL;
     int rc;
     int flags = FLUX_PTY_CLIENT_ATTACH_SYNC
@@ -482,19 +481,13 @@ void test_monitor ()
 
 int main (int argc, char *argv[])
 {
-    void *zctx;
-
     plan (NO_PLAN);
-
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
 
     test_invalid_args ();
     test_empty_server ();
-    test_basic_protocol (zctx);
-    test_client (zctx);
+    test_basic_protocol ();
+    test_client ();
     test_monitor ();
-    zmq_ctx_term (zctx);
     done_testing ();
     return 0;
 }

--- a/src/common/libterminus/test/terminus.c
+++ b/src/common/libterminus/test/terminus.c
@@ -16,7 +16,6 @@
 #include <string.h>
 #include <errno.h>
 #include <jansson.h>
-#include <zmq.h>
 
 #include <flux/core.h>
 #include "src/common/libterminus/terminus.h"
@@ -87,11 +86,11 @@ static int terminus_server (flux_t *h, void *arg)
     return rc;
 }
 
-static void test_kill_server_empty (void *zctx)
+static void test_kill_server_empty (void)
 {
     int rc;
     flux_future_t *f = NULL;
-    flux_t *h = test_server_create (zctx, 0, terminus_server, NULL);
+    flux_t *h = test_server_create (0, terminus_server, NULL);
 
     /* kill-server
      */
@@ -117,12 +116,12 @@ static void test_kill_server_empty (void *zctx)
     flux_close (h);
 }
 
-static void test_protocol (void *zctx)
+static void test_protocol (void)
 {
     int rc;
     json_t *o = NULL;
     flux_future_t *f = NULL;
-    flux_t *h = test_server_create (zctx, 0, terminus_server, NULL);
+    flux_t *h = test_server_create (0, terminus_server, NULL);
 
     const char *service = NULL;
     const char *name = NULL;
@@ -471,22 +470,16 @@ void test_open_close_session (void)
 
 int main (int argc, char *argv[])
 {
-    void *zctx;
-
     plan (NO_PLAN);
     /* Make sure SHELL is set in environment.
      */
     if (getenv ("SHELL") == NULL)
         setenv ("SHELL", "/bin/sh", 1);
 
-    if (!(zctx = zmq_ctx_new ()))
-        BAIL_OUT ("could not create zeromq context");
-
     test_invalid_args ();
-    test_kill_server_empty (zctx);
-    test_protocol (zctx);
+    test_kill_server_empty ();
+    test_protocol ();
     test_open_close_session ();
-    zmq_ctx_term (zctx);
     done_testing ();
     return 0;
 }

--- a/src/common/libtestutil/Makefile.am
+++ b/src/common/libtestutil/Makefile.am
@@ -10,7 +10,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
 	-I$(top_srcdir)/src/common/libccan \
-	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS)
 
 check_LTLIBRARIES = libtestutil.la

--- a/src/common/libtestutil/util.h
+++ b/src/common/libtestutil/util.h
@@ -26,9 +26,6 @@
  */
 typedef int (*test_server_f)(flux_t *h, void *arg);
 
-flux_t *test_server_create (void *zctx,
-		            int flags,
-			    test_server_f cb,
-			    void *arg);
+flux_t *test_server_create (int flags, test_server_f cb, void *arg);
 
 int test_server_stop (flux_t *c);


### PR DESCRIPTION
This adds a new flux_t connector that provides an alternative to "shmem//" without requiring zeromq.

In this PR, the libtestutil test server is converted to use the new connector.  A follow-on PR will convert the broker module infrastructure to use it.

Since this connector is internally implemented as queues of flux messages, it does not require any encoding/decoding, and in fact could provide the basis for avoiding some message copying in the future.

This connector has to be built-in rather than a dso so that any pair of threads that wish to communicate can access a mutex-protected global data structure.   I thought I could work that out from a dso connector, but couldn't seem to.  This is simpler anyway and lets the libflux tests use it (similar to the rationale in #5486 for making "loop" built-in).