### PR TITLE
testsuite: trivial test fixes

### DIFF
--- a/src/common/libflux/test/disconnect.c
+++ b/src/common/libflux/test/disconnect.c
@@ -219,6 +219,7 @@ void check_cancel (void)
        && flux_msg_get_matchtag (msg, &matchtag) == 0
        && matchtag == 6,
        "flux_msglist_cancel responded to message");
+    flux_msg_destroy (msg);
 
     flux_msglist_destroy (l);
     flux_close (h);

--- a/t/t2290-job-update.t
+++ b/t/t2290-job-update.t
@@ -98,7 +98,7 @@ test_expect_success 'update affects duration of running job' '
 	flux job urgency $jobid default &&
 	flux job wait-event -t 30 -m type=timeout $jobid exception &&
 	flux job info $jobid R \
-	    | jq  -e "(.execution|(.expiration - .starttime)*10 | round) == 1"
+	 | jq -e "(.execution|(.expiration - .starttime)*10 + 0.5 | floor) == 1"
 '
 test_expect_success 'update fails for running job' '
 	jobid=$(flux submit -t1m --wait-event=start sleep 60) &&


### PR DESCRIPTION
This PR contains a couple trivial fixes for the tests. There wasn't really anywhere else to put these, thus this PR.

 - Avoid use of `round` with `jq` (not supported on `jq` 1.5 which is the version on bionic)
 - Fix a silly leak in a unit test.