### PR TITLE
libflux: add flux_send_new()

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -166,6 +166,7 @@ MAN3_FILES_SECONDARY = \
 	man3/flux_shell_task_info_unpack.3 \
 	man3/flux_shell_task_cmd.3 \
 	man3/flux_service_unregister.3 \
+	man3/flux_send_new.3 \
 	man3/flux_clone.3 \
 	man3/flux_close.3 \
 	man3/flux_reconnect.3 \

--- a/doc/man3/flux_send.rst
+++ b/doc/man3/flux_send.rst
@@ -6,9 +6,13 @@ flux_send(3)
 SYNOPSIS
 ========
 
-#include <flux/core.h>
+::
 
-int flux_send (flux_t \*h, const flux_msg_t \*msg, int flags);
+   #include <flux/core.h>
+
+   int flux_send (flux_t *h, const flux_msg_t *msg, int flags);
+
+   int flux_send_new (flux_t *h, flux_msg_t **msg, int flags);
 
 
 DESCRIPTION
@@ -30,6 +34,11 @@ to ``flux_open()`` when the handle was created.
 
 The message type, topic string, and nodeid affect how the message
 will be routed by the broker. These attributes are pre-set in the message.
+
+``flux_send_new()`` is the same, except message ownership is transferred
+to the handle *h*.  The double pointer *msg* points to a NULL value if
+the message is successfully transferred.  The send fails if the message
+reference count is greater than one.
 
 
 RETURN VALUE

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -215,6 +215,7 @@ man_pages = [
     ('man3/flux_rpc', 'flux_rpc_get_matchtag', 'perform a remote procedure call to a Flux service', [author], 3),
     ('man3/flux_rpc', 'flux_rpc_get_nodeid', 'perform a remote procedure call to a Flux service', [author], 3),
     ('man3/flux_send', 'flux_send', 'send message using Flux Message Broker', [author], 3),
+    ('man3/flux_send', 'flux_send_new', 'send message using Flux Message Broker', [author], 3),
     ('man3/flux_service_register', 'flux_service_register', 'Register service with flux broker', [author], 3),
     ('man3/flux_service_register', 'flux_service_unregister', 'Unregister service with flux broker', [author], 3),
     ('man3/flux_shell_add_completion_ref', 'flux_shell_remove_completion_ref', 'Manipulate conditions for job completion.', [author], 3),

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -46,7 +46,6 @@ struct broker_module {
 
     flux_t *h_broker;       /* broker end of interthread channel */
     char uri[128];
-    struct flux_msg_cred cred; /* cred of connection */
 
     uuid_t uuid;            /* uuid for unique request sender identity */
     char uuid_str[UUID_STR_LEN];
@@ -372,13 +371,6 @@ module_t *module_create (flux_t *h,
         errprintf (error, "could not create %s flux handle watcher", p->name);
         goto cleanup;
     }
-    /* Set creds for connection.
-     * Since this is a point to point connection between broker threads,
-     * credentials are always those of the instance owner.
-     */
-    p->cred.userid = getuid ();
-    p->cred.rolemask = FLUX_ROLE_OWNER | FLUX_ROLE_LOCAL;
-
     /* Optimization: create attribute cache to be primed in the module's
      * flux_t handle.  Priming the cache avoids a synchronous RPC from
      * flux_attr_get(3) for common attrs like rank, etc.

--- a/src/common/libflux/connector.h
+++ b/src/common/libflux/connector.h
@@ -35,6 +35,7 @@ struct flux_handle_ops {
     int         (*pollfd)(void *impl);
     int         (*pollevents)(void *impl);
     int         (*send)(void *impl, const flux_msg_t *msg, int flags);
+    int         (*send_new)(void *impl, flux_msg_t **msg, int flags);
     flux_msg_t* (*recv)(void *impl, int flags);
     int         (*reconnect)(void *impl);
 

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -107,13 +107,13 @@ const char *flux_strerror (int errnum)
 static int log_rpc (flux_t *h, const char *buf, int len)
 {
     flux_msg_t *msg;
-    int rc;
 
-    if (!(msg = flux_request_encode_raw ("log.append", buf, len)))
+    if (!(msg = flux_request_encode_raw ("log.append", buf, len))
+        || flux_send_new (h, &msg, 0) < 0) {
+        flux_msg_destroy (msg);
         return -1;
-    rc = flux_send (h, msg, 0);
-    flux_msg_destroy (msg);
-    return rc;
+    }
+    return 0;
 }
 
 int flux_vlog (flux_t *h, int level, const char *fmt, va_list ap)

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -143,6 +143,11 @@ uint32_t flux_matchtag_avail (flux_t *h);
  */
 int flux_send (flux_t *h, const flux_msg_t *msg, int flags);
 
+/* Send a message - same as above but '*msg' ownership is transferred to 'h'.
+ * N.B. this fails with EINVAL if '*msg' reference count is greater than 1.
+ */
+int flux_send_new (flux_t *h, flux_msg_t **msg, int flags);
+
 /* Receive a message
  * flags may be 0 or FLUX_O_TRACE or FLUX_O_NONBLOCK (FLUX_O_COPROC is ignored)
  * flux_recv reads messages from the handle until 'match' is matched,

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -47,7 +47,8 @@ done:
     return rc;
 }
 
-int flux_response_decode (const flux_msg_t *msg, const char **topicp,
+int flux_response_decode (const flux_msg_t *msg,
+                          const char **topicp,
                           const char **sp)
 {
     const char *topic, *s;
@@ -67,8 +68,10 @@ done:
     return rc;
 }
 
-int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
-                              const void **data, int *len)
+int flux_response_decode_raw (const flux_msg_t *msg,
+                              const char **topic,
+                              const void **data,
+                              int *len)
 {
     const char *ts;
     const void *d = NULL;
@@ -163,7 +166,8 @@ error:
 }
 
 flux_msg_t *flux_response_encode_raw (const char *topic,
-                                      const void *data, int len)
+                                      const void *data,
+                                      int len)
 {
     flux_msg_t *msg;
 
@@ -177,7 +181,8 @@ error:
     return NULL;
 }
 
-flux_msg_t *flux_response_encode_error (const char *topic, int errnum,
+flux_msg_t *flux_response_encode_error (const char *topic,
+                                        int errnum,
                                         const char *errstr)
 {
     flux_msg_t *msg;
@@ -244,8 +249,10 @@ error:
     return -1;
 }
 
-static int flux_respond_vpack (flux_t *h, const flux_msg_t *request,
-                               const char *fmt, va_list ap)
+static int flux_respond_vpack (flux_t *h,
+                               const flux_msg_t *request,
+                               const char *fmt,
+                               va_list ap)
 {
     flux_msg_t *msg = NULL;
 
@@ -269,8 +276,10 @@ error:
     return -1;
 }
 
-int flux_respond_pack (flux_t *h, const flux_msg_t *request,
-                       const char *fmt, ...)
+int flux_respond_pack (flux_t *h,
+                       const flux_msg_t *request,
+                       const char *fmt,
+                       ...)
 {
     int rc;
     va_list ap;
@@ -285,8 +294,10 @@ int flux_respond_pack (flux_t *h, const flux_msg_t *request,
     return rc;
 }
 
-int flux_respond_raw (flux_t *h, const flux_msg_t *request,
-                      const void *data, int len)
+int flux_respond_raw (flux_t *h,
+                      const flux_msg_t *request,
+                      const void *data,
+                      int len)
 {
     flux_msg_t *msg = NULL;
 
@@ -310,8 +321,10 @@ error:
     return -1;
 }
 
-int flux_respond_error (flux_t *h, const flux_msg_t *request,
-                        int errnum, const char *errstr)
+int flux_respond_error (flux_t *h,
+                        const flux_msg_t *request,
+                        int errnum,
+                        const char *errstr)
 {
     flux_msg_t *msg = NULL;
 

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -26,7 +26,8 @@ extern "C" {
  * to topic or s.  Returns 0 on success, or -1 on failure with
  * errno set.
  */
-int flux_response_decode (const flux_msg_t *msg, const char **topic,
+int flux_response_decode (const flux_msg_t *msg,
+                          const char **topic,
                           const char **s);
 
 /* Decode a response message, with optional raw payload.
@@ -37,8 +38,10 @@ int flux_response_decode (const flux_msg_t *msg, const char **topic,
  * and -1 is returned with no assignments to topic, data, or len.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_response_decode_raw (const flux_msg_t *msg, const char **topic,
-                              const void **data, int *len);
+int flux_response_decode_raw (const flux_msg_t *msg,
+                              const char **topic,
+                              const void **data,
+                              int *len);
 
 /* If failed response includes an error string payload, assign to 'errstr',
  * otherwise fail.
@@ -54,12 +57,14 @@ flux_msg_t *flux_response_encode (const char *topic, const char *s);
 /* Encode a response message with optional raw payload.
  */
 flux_msg_t *flux_response_encode_raw (const char *topic,
-                                      const void *data, int len);
+                                      const void *data,
+                                      int len);
 
 /* Encode an error response with 'errnum' (must be nonzero) and
  * if non-NULL, an error string payload.
  */
-flux_msg_t *flux_response_encode_error (const char *topic, int errnum,
+flux_msg_t *flux_response_encode_error (const char *topic,
+                                        int errnum,
                                         const char *errstr);
 
 /* Derive a response message from a request message, setting 'errnum' to
@@ -76,21 +81,27 @@ int flux_respond (flux_t *h, const flux_msg_t *request, const char *s);
  * jansson pack style variable arguments for encoding the JSON object
  * payload directly.
  */
-int flux_respond_pack (flux_t *h, const flux_msg_t *request,
-                       const char *fmt, ...);
+int flux_respond_pack (flux_t *h,
+                       const flux_msg_t *request,
+                       const char *fmt,
+                       ...);
 
 
 /* Create a response to the provided request message with optional raw payload.
  */
-int flux_respond_raw (flux_t *h, const flux_msg_t *request,
-                      const void *data, int len);
+int flux_respond_raw (flux_t *h,
+                      const flux_msg_t *request,
+                      const void *data,
+                      int len);
 
 /* Create an error response to the provided request message with optional
  * error string payload (if errstr is non-NULL).  If errnum is zero, EINVAL
  * is substituted.
  */
-int flux_respond_error (flux_t *h, const flux_msg_t *request,
-                        int errnum, const char *errstr);
+int flux_respond_error (flux_t *h,
+                        const flux_msg_t *request,
+                        int errnum,
+                        const char *errstr);
 
 
 #ifdef __cplusplus

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -243,10 +243,10 @@ error:
     flux_future_fulfill_error (f, errno, NULL);
 }
 
-static flux_future_t *flux_rpc_message_nocopy (flux_t *h,
-                                               flux_msg_t *msg,
-                                               uint32_t nodeid,
-                                               int flags)
+static flux_future_t *flux_rpc_message_send_new (flux_t *h,
+                                                 flux_msg_t **msg,
+                                                 uint32_t nodeid,
+                                                 int flags)
 {
     struct flux_rpc *rpc = NULL;
     flux_future_t *f;
@@ -261,9 +261,9 @@ static flux_future_t *flux_rpc_message_nocopy (flux_t *h,
         rpc_destroy (rpc);
         goto error;
     }
-    if (flux_msg_set_matchtag (msg, rpc->matchtag) < 0)
+    if (flux_msg_set_matchtag (*msg, rpc->matchtag) < 0)
         goto error;
-    if (flux_msg_get_flags (msg, &msgflags) < 0)
+    if (flux_msg_get_flags (*msg, &msgflags) < 0)
         goto error;
     if (nodeid == FLUX_NODEID_UPSTREAM) {
         msgflags |= FLUX_MSGFLAG_UPSTREAM;
@@ -274,9 +274,9 @@ static flux_future_t *flux_rpc_message_nocopy (flux_t *h,
         msgflags |= FLUX_MSGFLAG_STREAMING;
     if ((flags & FLUX_RPC_NORESPONSE))
         msgflags |= FLUX_MSGFLAG_NORESPONSE;
-    if (flux_msg_set_flags (msg, msgflags) < 0)
+    if (flux_msg_set_flags (*msg, msgflags) < 0)
         goto error;
-    if (flux_msg_set_nodeid (msg, nodeid) < 0)
+    if (flux_msg_set_nodeid (*msg, nodeid) < 0)
         goto error;
 #if HAVE_CALIPER
     cali_begin_string_byname ("flux.message.rpc", "single");
@@ -284,7 +284,7 @@ static flux_future_t *flux_rpc_message_nocopy (flux_t *h,
     cali_begin_int_byname ("flux.message.response_expected",
                            !(flags & FLUX_RPC_NORESPONSE));
 #endif
-    int rc = flux_send (h, msg, 0);
+    int rc = flux_send_new (h, msg, 0);
 #if HAVE_CALIPER
     cali_end_byname ("flux.message.response_expected");
     cali_end_byname ("flux.message.rpc.nodeid");
@@ -327,15 +327,12 @@ flux_future_t *flux_rpc_message (flux_t *h,
         errno = EINVAL;
         return NULL;
     }
-    if (!(cpy = flux_msg_copy (msg, true)))
+    if (!(cpy = flux_msg_copy (msg, true))
+        || !(f = flux_rpc_message_send_new (h, &cpy, nodeid, flags))) {
+        flux_msg_destroy (cpy);
         return NULL;
-    if (!(f = flux_rpc_message_nocopy (h, cpy, nodeid, flags)))
-        goto error;
-    flux_msg_destroy (cpy);
+    }
     return f;
-error:
-    flux_msg_destroy (cpy);
-    return NULL;
 }
 
 flux_future_t *flux_rpc (flux_t *h,
@@ -344,20 +341,19 @@ flux_future_t *flux_rpc (flux_t *h,
                          uint32_t nodeid,
                          int flags)
 {
-    flux_msg_t *msg = NULL;
-    flux_future_t *f = NULL;
+    flux_msg_t *msg;
+    flux_future_t *f;
 
     if (validate_flags (flags, FLUX_RPC_NORESPONSE | FLUX_RPC_STREAMING) < 0
         || !h) {
         errno = EINVAL;
         return NULL;
     }
-    if (!(msg = flux_request_encode (topic, s)))
-        goto done;
-    if (!(f = flux_rpc_message_nocopy (h, msg, nodeid, flags)))
-        goto done;
-done:
-    flux_msg_destroy (msg);
+    if (!(msg = flux_request_encode (topic, s))
+        || !(f = flux_rpc_message_send_new (h, &msg, nodeid, flags))) {
+        flux_msg_destroy (msg);
+        return NULL;
+    }
     return f;
 }
 
@@ -369,19 +365,18 @@ flux_future_t *flux_rpc_raw (flux_t *h,
                              int flags)
 {
     flux_msg_t *msg;
-    flux_future_t *f = NULL;
+    flux_future_t *f;
 
     if (validate_flags (flags, FLUX_RPC_NORESPONSE | FLUX_RPC_STREAMING) < 0
         || !h) {
         errno = EINVAL;
         return NULL;
     }
-    if (!(msg = flux_request_encode_raw (topic, data, len)))
-        goto done;
-    if (!(f = flux_rpc_message_nocopy (h, msg, nodeid, flags)))
-        goto done;
-done:
-    flux_msg_destroy (msg);
+    if (!(msg = flux_request_encode_raw (topic, data, len))
+        || !(f = flux_rpc_message_send_new (h, &msg, nodeid, flags))) {
+        flux_msg_destroy (msg);
+        return NULL;
+    }
     return f;
 }
 
@@ -393,20 +388,19 @@ flux_future_t *flux_rpc_vpack (flux_t *h,
                                va_list ap)
 {
     flux_msg_t *msg;
-    flux_future_t *f = NULL;
+    flux_future_t *f;
 
     if (validate_flags (flags, FLUX_RPC_NORESPONSE | FLUX_RPC_STREAMING) < 0
         || !h) {
         errno = EINVAL;
         return NULL;
     }
-    if (!(msg = flux_request_encode (topic, NULL)))
-        goto done;
-    if (flux_msg_vpack (msg, fmt, ap) < 0)
-        goto done;
-    f = flux_rpc_message_nocopy (h, msg, nodeid, flags);
-done:
-    flux_msg_destroy (msg);
+    if (!(msg = flux_request_encode (topic, NULL))
+        || flux_msg_vpack (msg, fmt, ap) < 0
+        || !(f = flux_rpc_message_send_new (h, &msg, nodeid, flags))) {
+        flux_msg_destroy (msg);
+        return NULL;
+    }
     return f;
 }
 

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -180,8 +180,10 @@ int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...)
  * instead of flux_rpc_get() to test result of RPC with no response payload.
  * Fulfill future.
 */
-static void response_cb (flux_t *h, flux_msg_handler_t *mh,
-                         const flux_msg_t *msg, void *arg)
+static void response_cb (flux_t *h,
+                         flux_msg_handler_t *mh,
+                         const flux_msg_t *msg,
+                         void *arg)
 {
     flux_future_t *f = arg;
     struct flux_rpc *rpc = flux_future_aux_get (f, "flux::rpc");
@@ -318,8 +320,10 @@ flux_future_t *flux_rpc_message (flux_t *h,
     flux_msg_t *cpy;
     flux_future_t *f;
 
-    if (!h || !msg || validate_flags (flags, FLUX_RPC_NORESPONSE
-                                           | FLUX_RPC_STREAMING)) {
+    if (!h
+        || !msg
+        || validate_flags (flags,
+                           FLUX_RPC_NORESPONSE | FLUX_RPC_STREAMING) < 0) {
         errno = EINVAL;
         return NULL;
     }
@@ -343,8 +347,8 @@ flux_future_t *flux_rpc (flux_t *h,
     flux_msg_t *msg = NULL;
     flux_future_t *f = NULL;
 
-    if (!h || validate_flags (flags, FLUX_RPC_NORESPONSE
-                                   | FLUX_RPC_STREAMING)) {
+    if (validate_flags (flags, FLUX_RPC_NORESPONSE | FLUX_RPC_STREAMING) < 0
+        || !h) {
         errno = EINVAL;
         return NULL;
     }
@@ -367,8 +371,8 @@ flux_future_t *flux_rpc_raw (flux_t *h,
     flux_msg_t *msg;
     flux_future_t *f = NULL;
 
-    if (!h || validate_flags (flags, FLUX_RPC_NORESPONSE
-                                   | FLUX_RPC_STREAMING)) {
+    if (validate_flags (flags, FLUX_RPC_NORESPONSE | FLUX_RPC_STREAMING) < 0
+        || !h) {
         errno = EINVAL;
         return NULL;
     }
@@ -385,13 +389,14 @@ flux_future_t *flux_rpc_vpack (flux_t *h,
                                const char *topic,
                                uint32_t nodeid,
                                int flags,
-                               const char *fmt, va_list ap)
+                               const char *fmt,
+                               va_list ap)
 {
     flux_msg_t *msg;
     flux_future_t *f = NULL;
 
-    if (!h || validate_flags (flags, FLUX_RPC_NORESPONSE
-                                   | FLUX_RPC_STREAMING)) {
+    if (validate_flags (flags, FLUX_RPC_NORESPONSE | FLUX_RPC_STREAMING) < 0
+        || !h) {
         errno = EINVAL;
         return NULL;
     }
@@ -405,8 +410,12 @@ done:
     return f;
 }
 
-flux_future_t *flux_rpc_pack (flux_t *h, const char *topic, uint32_t nodeid,
-                              int flags, const char *fmt, ...)
+flux_future_t *flux_rpc_pack (flux_t *h,
+                              const char *topic,
+                              uint32_t nodeid,
+                              int flags,
+                              const char *fmt,
+                              ...)
 {
     va_list ap;
     flux_future_t *f;

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -23,24 +23,37 @@ enum {
     FLUX_RPC_STREAMING = 2,
 };
 
-flux_future_t *flux_rpc (flux_t *h, const char *topic, const char *s,
-                         uint32_t nodeid, int flags);
+flux_future_t *flux_rpc (flux_t *h,
+                         const char *topic,
+                         const char *s,
+                         uint32_t nodeid,
+                         int flags);
 
-flux_future_t *flux_rpc_pack (flux_t *h, const char *topic, uint32_t nodeid,
-                              int flags, const char *fmt, ...);
+flux_future_t *flux_rpc_pack (flux_t *h,
+                              const char *topic,
+                              uint32_t nodeid,
+                              int flags,
+                              const char *fmt,
+                              ...);
 
 flux_future_t *flux_rpc_vpack (flux_t *h,
                                const char *topic,
                                uint32_t nodeid,
                                int flags,
-                               const char *fmt, va_list ap);
+                               const char *fmt,
+                               va_list ap);
 
-flux_future_t *flux_rpc_raw (flux_t *h, const char *topic,
-                             const void *data, int len,
-                             uint32_t nodeid, int flags);
+flux_future_t *flux_rpc_raw (flux_t *h,
+                             const char *topic,
+                             const void *data,
+                             int len,
+                             uint32_t nodeid,
+                             int flags);
 
-flux_future_t *flux_rpc_message (flux_t *h, const flux_msg_t *msg,
-                                 uint32_t nodeid, int flags);
+flux_future_t *flux_rpc_message (flux_t *h,
+                                 const flux_msg_t *msg,
+                                 uint32_t nodeid,
+                                 int flags);
 
 int flux_rpc_get (flux_future_t *f, const char **s);
 


### PR DESCRIPTION
Problem: it's a common pattern to create a message, send it with with `flux_send()`, then destroy it; however, there is no interface to allow the message ownership to be transferred rather than copied.
    
Add `flux_send_new()` which accepts a non-const `flux_msg_t **` and implement it in the interthread connector.  Now messages can pass from one end to the other without costly duplication.

Use this function in the common `flux_rpc()` and `flux_respond()` family of functions.

This is marked WIP for now while I consider whether it's possible to use this in the broker along the message path.  It would be neat if rpcs between broker modules could transit the broker without copying!

Even just this change does seem to have a positive impact on job throughput.
