### PR TITLE
libflux: make local connector built-in

### DIFF
--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -96,6 +96,7 @@ libflux_la_SOURCES = \
 	handle.c \
 	connector_loop.c \
 	connector_interthread.c \
+	connector_local.c \
 	reactor.c \
 	reactor_private.h \
 	msg_handler.c \

--- a/src/common/libflux/connector_local.c
+++ b/src/common/libflux/connector_local.c
@@ -183,7 +183,7 @@ static int override_retry_count (struct usock_retry_params *retry)
     return 0;
 }
 
-flux_t *connector_init (const char *path, int flags, flux_error_t *errp)
+flux_t *connector_local_init (const char *path, int flags, flux_error_t *errp)
 {
     struct local_connector *ctx;
 

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -97,10 +97,12 @@ flux_t *connector_loop_init (const char *uri, int flags, flux_error_t *errp);
 flux_t *connector_interthread_init (const char *uri,
                                     int flags,
                                     flux_error_t *errp);
+flux_t *connector_local_init (const char *uri, int flags, flux_error_t *errp);
 
 static struct builtin_connector builtin_connectors[] = {
     { "loop", &connector_loop_init },
     { "interthread", &connector_interthread_init },
+    { "local", &connector_local_init },
 };
 
 static void handle_trace (flux_t *h, const char *fmt, ...)

--- a/src/connectors/Makefile.am
+++ b/src/connectors/Makefile.am
@@ -12,19 +12,11 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/common/libccan
 
 fluxconnector_LTLIBRARIES = \
-	local.la \
 	ssh.la
 
 connector_ldflags = -module $(san_ld_zdef_flag) \
 	-export-symbols-regex '^connector_init$$' \
 	--disable-static -avoid-version -shared -export-dynamic
-
-local_la_SOURCES = \
-	local/local.c
-local_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la
-local_la_LDFLAGS = $(connector_ldflags)
 
 ssh_la_SOURCES = \
 	ssh/ssh.c


### PR DESCRIPTION
Problem: it's not very efficient to have to separately dlopen the local connector when we could just build it in.

Build it in.