### PR TITLE
connectors: avoid future ABI issues with _pad[]

### DIFF
--- a/src/common/libflux/connector.h
+++ b/src/common/libflux/connector.h
@@ -35,11 +35,16 @@ struct flux_handle_ops {
     int         (*pollfd)(void *impl);
     int         (*pollevents)(void *impl);
     int         (*send)(void *impl, const flux_msg_t *msg, int flags);
-    int         (*send_new)(void *impl, flux_msg_t **msg, int flags);
     flux_msg_t* (*recv)(void *impl, int flags);
     int         (*reconnect)(void *impl);
 
     void        (*impl_destroy)(void *impl);
+
+    // added in v0.56.0
+    int         (*send_new)(void *impl, flux_msg_t **msg, int flags);
+
+    // added in v0.56.0
+    void        *_pad[4]; // reserved for future use
 };
 
 flux_t *flux_handle_create (void *impl,


### PR DESCRIPTION
Problem: when connector operations are added, ABI compatibility between flux versions is broken.

Move the new `op->send_new()` to the end of the struct so that old libflux can operate with new connectors.

Add padding so in the future, new ops can replace padding and new libflux can operate wtih old connectors.