### PR TITLE
python: return more precise result from `flux.util.parse_datetime("now")`

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -346,6 +346,9 @@ def parse_datetime(string, now=None):
     if now is None:
         now = datetime.now().astimezone()
 
+    if string == "now":
+        return now
+
     if string.startswith("+"):
         timestamp = now.timestamp() + parse_fsd(string[1:])
         return datetime.fromtimestamp(timestamp).astimezone()

--- a/t/python/t0024-util.py
+++ b/t/python/t0024-util.py
@@ -34,6 +34,13 @@ class TestParseDatetime(unittest.TestCase):
     def parsedt(self, string):
         return parse_datetime(string).astimezone()
 
+    def test_now(self):
+        # "now" returns parse_datetime(now=) when set
+        self.assertEqual(self.parse("now"), self.ts)
+        # "now" has better than second precision
+        now = parse_datetime("now").timestamp()
+        self.assertNotEqual(now % 1, 0)
+
     def test_fsd(self):
         self.assertEqual(self.parse("+1"), self.ts + 1)
         self.assertEqual(self.parse("-1"), self.ts - 1)


### PR DESCRIPTION
This PR fixes #5501 by adding a special case for `parse_datetime("now")`. Instead of parsing `"now"` with the `parsedatetime` module, just use `datetime.now()` which internally uses `gettimeofday(2)` and thus has sub-second precision, unlike `parsedatetime` `Calendar.parse()` which returns only second precision by default.