### PR TITLE
libflux: refactor internal message queues

### DIFF
--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -94,6 +94,8 @@ libflux_la_SOURCES = \
 	flog.c \
 	attr.c \
 	handle.c \
+	msg_deque.c \
+	msg_deque.h \
 	connector_loop.c \
 	connector_interthread.c \
 	connector_local.c \
@@ -177,7 +179,8 @@ TESTS = test_message.t \
 	test_module.t \
 	test_plugin.t \
 	test_sync.t \
-	test_disconnect.t
+	test_disconnect.t \
+	test_msg_deque.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libtestutil/libtestutil.la \
@@ -300,6 +303,10 @@ test_disconnect_t_LDADD = $(test_ldadd)
 test_interthread_t_SOURCES = test/interthread.c
 test_interthread_t_CPPFLAGS = $(test_cppflags)
 test_interthread_t_LDADD = $(test_ldadd)
+
+test_msg_deque_t_SOURCES = test/msg_deque.c
+test_msg_deque_t_CPPFLAGS = $(test_cppflags)
+test_msg_deque_t_LDADD = $(test_ldadd)
 
 test_module_t_SOURCES = test/module.c
 test_module_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -91,6 +91,7 @@ flux_msg_t *flux_msg_create (int type)
     if (!(msg = calloc (1, sizeof (*msg))))
         return NULL;
     list_head_init (&msg->routes);
+    list_node_init (&msg->list);
     msg->proto.type = type;
     if (msg_type_is_valid (msg))
         msg_setup_type (msg);

--- a/src/common/libflux/message_private.h
+++ b/src/common/libflux/message_private.h
@@ -37,6 +37,7 @@ struct flux_msg {
     char *lasterr;
     struct aux_item *aux;
     int refcount;
+    struct list_node list; // for use by msg_deque container only
 };
 
 #define msgtype_is_valid(tp) \

--- a/src/common/libflux/msg_deque.c
+++ b/src/common/libflux/msg_deque.c
@@ -1,0 +1,254 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* msg_dequeue.c - reactive, thread-safe, output-restricted message deque */
+
+/* The pollfd/pollevents pattern was borrowed from zeromq's ZMQ_EVENTS/ZMQ_FD,
+ * described in zmq_getsockopt(3).  It is an edge-triggered notification system
+ * in which the pollfd, a special file descriptor created with eventfd(2),
+ * can be watched reactively for a POLLIN event, then the actual event on the
+ * queue is determined by sampling pollevents.  The valid pollevents bits are:
+ *
+ * POLLIN   messages are available to pop
+ * POLLOUT  messages may be pushed (always asserted currently)
+ *
+ * The pollevents should not be confused with pollfd events.  In pollfd, only
+ * POLLIN is expected, signaling that one of the bits is newly set in
+ * pollevents, and used to wake up a reactor loop to service those bits.
+ *
+ * "edge-triggered" means that pollfd does not reassert if the reactor handler
+ * returns with the condition that caused the event still true.  In the case
+ * of msg_deque POLLIN events, a handler must pop all messages before
+ * returning, or if fairness is a concern (one message queue starving out other
+ * reactor handlers), a specialized watcher in the pattern of ev_flux.c or
+ * ev_zmq.c is needed.  ev_zmq.c contains further explanation about that
+ * technique. When msg_deque is used within a connector, the reactive signaling
+ * is encapsulated in the flux_t handle, so flux_handle_watcher_create(3),
+ * based on ev_flux.c, already implements a fair handler.
+ *
+ * In the current implementation, msg_deque size is unlimited, so POLLOUT is
+ * always asserted in pollevents.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/poll.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "ccan/list/list.h"
+
+#include "message.h"
+#include "message_private.h" // for access to msg->list
+
+#include "msg_deque.h"
+
+struct msg_deque {
+    struct list_head messages;
+    int pollevents;
+    int pollfd;
+    uint64_t event;
+    pthread_mutex_t lock;
+    int flags;
+};
+
+void msg_deque_destroy (struct msg_deque *q)
+{
+    if (q) {
+        int saved_errno = errno;
+        flux_msg_t *msg;
+        while ((msg = msg_deque_pop_front (q)))
+            flux_msg_destroy (msg);
+        if (q->pollfd >= 0)
+            (void)close (q->pollfd);
+        if (!(q->flags & MSG_DEQUE_SINGLE_THREAD))
+            pthread_mutex_destroy (&q->lock);
+        free (q);
+        errno = saved_errno;
+    };
+}
+
+struct msg_deque *msg_deque_create (int flags)
+{
+    struct msg_deque *q;
+
+    if (flags != 0 && flags != MSG_DEQUE_SINGLE_THREAD) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(q = calloc (1, sizeof (*q))))
+        return NULL;
+    q->flags = flags;
+    q->pollfd = -1;
+    q->pollevents = POLLOUT;
+    if (!(flags & MSG_DEQUE_SINGLE_THREAD))
+        pthread_mutex_init (&q->lock, NULL);
+    list_head_init (&q->messages);
+    return q;
+}
+
+static inline void msg_deque_lock (struct msg_deque *q)
+{
+    if (!(q->flags & MSG_DEQUE_SINGLE_THREAD))
+        pthread_mutex_lock (&q->lock);
+}
+
+static inline void msg_deque_unlock (struct msg_deque *q)
+{
+    if (!(q->flags & MSG_DEQUE_SINGLE_THREAD))
+        pthread_mutex_unlock (&q->lock);
+}
+
+// See eventfd(2) for an explanation of how signaling on q->pollfd works
+static int msg_deque_raise_event (struct msg_deque *q)
+{
+    if (q->pollfd >= 0 && q->event == 0) {
+        q->event = 1;
+        if (write (q->pollfd, &q->event, sizeof (q->event)) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+static int msg_deque_clear_event (struct msg_deque *q)
+{
+    if (q->pollfd >= 0 && q->event == 1) {
+        if (read (q->pollfd, &q->event, sizeof (q->event)) < 0) {
+            if (errno != EAGAIN  && errno != EWOULDBLOCK)
+                return -1;
+            errno = 0;
+        }
+        q->event = 0;
+    }
+    return 0;
+}
+
+bool check_push_args (struct msg_deque *q, flux_msg_t *msg)
+{
+    if (!q || !msg)
+        return false;
+    /* When deque is used as a transport between threads, retaining a
+     * reference on a message after pushing it might result in both threads
+     * modifying the message simultaneously.  Therefore reject the operation
+     * if references other than the one being transferred are held.
+     */
+    if (!(q->flags & MSG_DEQUE_SINGLE_THREAD) && msg->refcount > 1)
+        return false;
+    /* A message can only be in one msg_deque at a time.  Reject the operation
+     * if the list node is not in the state left by list_node_init() and
+     * list_del_init(), which is n.next == n.prev == n.
+     */
+    if (msg->list.next != &msg->list || msg->list.prev != &msg->list)
+        return false;
+
+    return true;
+}
+
+int msg_deque_push_back (struct msg_deque *q, flux_msg_t *msg)
+{
+    if (!check_push_args (q, msg)) {
+        errno = EINVAL;
+        return -1;
+    }
+    msg_deque_lock (q);
+    if (!(q->pollevents & POLLIN)) {
+        q->pollevents |= POLLIN;
+        if (msg_deque_raise_event (q) < 0) {
+            msg_deque_unlock (q);
+            return -1;
+        }
+    }
+    list_add (&q->messages, &msg->list);
+    msg_deque_unlock (q);
+    return 0;
+}
+
+int msg_deque_push_front (struct msg_deque *q, flux_msg_t *msg)
+{
+    if (!check_push_args (q, msg)) {
+        errno = EINVAL;
+        return -1;
+    }
+    msg_deque_lock (q);
+    if (!(q->pollevents & POLLIN)) {
+        q->pollevents |= POLLIN;
+        if (msg_deque_raise_event (q) < 0) {
+            msg_deque_unlock (q);
+            return -1;
+        }
+    }
+    list_add_tail (&q->messages, &msg->list);
+    msg_deque_unlock (q);
+    return 0;
+}
+
+flux_msg_t *msg_deque_pop_front (struct msg_deque *q)
+{
+    if (!q)
+        return NULL;
+    msg_deque_lock (q);
+    flux_msg_t *msg = list_tail (&q->messages, struct flux_msg, list);
+    if (msg) {
+        list_del_init (&msg->list);
+        if ((q->pollevents & POLLIN) && list_empty (&q->messages))
+            q->pollevents &= ~POLLIN;
+    }
+    msg_deque_unlock (q);
+    return msg;
+}
+
+bool msg_deque_empty (struct msg_deque *q)
+{
+    if (!q)
+        return true;
+    msg_deque_lock (q);
+    bool res = list_empty (&q->messages);
+    msg_deque_unlock (q);
+    return res;
+}
+
+int msg_deque_pollfd (struct msg_deque *q)
+{
+    if (!q) {
+        errno = EINVAL;
+        return -1;
+    }
+    int rc;
+    msg_deque_lock (q);
+    if (q->pollfd < 0) {
+        q->event = q->pollevents ? 1 : 0;
+        q->pollfd = eventfd (q->pollevents, EFD_NONBLOCK);
+    }
+    rc = q->pollfd;
+    msg_deque_unlock (q);
+    return rc;
+}
+
+int msg_deque_pollevents (struct msg_deque *q)
+{
+    if (!q) {
+        errno = EINVAL;
+        return -1;
+    }
+    int rc = -1;
+    msg_deque_lock (q);
+    if (msg_deque_clear_event (q) < 0)
+        goto done;
+    rc = q->pollevents;
+done:
+    msg_deque_unlock (q);
+    return rc;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libflux/msg_deque.h
+++ b/src/common/libflux/msg_deque.h
@@ -1,0 +1,40 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_CORE_MSG_DEQUE_H
+#define _FLUX_CORE_MSG_DEQUE_H
+
+/* If flags contains MSG_DEQUE_SINGLE_THREAD, pthread locking is eliminated
+ * and messages are permitted to be pushed with a reference count > 1.
+ */
+enum {
+    MSG_DEQUE_SINGLE_THREAD = 1,
+};
+
+struct msg_deque *msg_deque_create (int flags);
+void msg_deque_destroy (struct msg_deque *q);
+
+/* msg_deque_push_back() and msg_deque_push_front() steal a reference on
+ * 'msg' on success.  If MSG_DEQUE_SINGLE_THREAD was not specified, then
+ * that is expected to be the *only* reference and further access to the
+ * message by the caller is not permitted.
+ */
+int msg_deque_push_back (struct msg_deque *q, flux_msg_t *msg);
+int msg_deque_push_front (struct msg_deque *q, flux_msg_t *msg);
+flux_msg_t *msg_deque_pop_front (struct msg_deque *q);
+
+int msg_deque_pollfd (struct msg_deque *q);
+int msg_deque_pollevents (struct msg_deque *q);
+
+bool msg_deque_empty (struct msg_deque *q);
+
+#endif // !_FLUX_CORE_MSG_DEQUE_H
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libflux/test/handle.c
+++ b/src/common/libflux/test/handle.c
@@ -62,7 +62,7 @@ void test_handle_invalid_args (flux_t *h)
     ok (flux_send_new (h, &nullmsg, 0) < 0 && errno == EINVAL,
        "flux_send_new *msg=NULL fails with EINVAL");
     ok (flux_send_new (h, &msg, 0x100000) < 0 && errno == EINVAL,
-       "flux_send flags=BOGUS fails with EINVAL");
+       "flux_send_new flags=BOGUS fails with EINVAL");
 
     errno = 0;
     ok (flux_send (NULL, msg, 0) < 0 && errno == EINVAL,

--- a/src/common/libflux/test/msg_deque.c
+++ b/src/common/libflux/test/msg_deque.c
@@ -1,0 +1,274 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/poll.h>
+#include <stdbool.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+
+#include "msg_deque.h"
+
+
+void check_queue (void)
+{
+    struct msg_deque *q;
+    flux_msg_t *msg1;
+    flux_msg_t *msg2;
+    flux_msg_t *msg;
+
+    if (!(msg1 = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        BAIL_OUT ("flux_msg_create failed");
+    if (!(msg2 = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        BAIL_OUT ("flux_msg_create failed");
+
+    q = msg_deque_create (0);
+    ok (q != NULL,
+        "msg_deque_create works");
+    ok (msg_deque_empty (q) == true,
+        "msg_deque_empty is true");
+    ok (msg_deque_push_back (q, msg1) == 0,
+        "msg_deque_push_back msg1 works");
+    ok (msg_deque_empty (q) == false,
+        "msg_deque_empty is false");
+    ok (msg_deque_push_back (q, msg2) == 0,
+        "msg_deque_push_back msg2 works");
+    ok (msg_deque_empty (q) == false,
+        "msg_deque_empty is false");
+    ok ((msg = msg_deque_pop_front (q)) == msg1,
+        "msg_deque_pop_front popped msg1");
+    flux_msg_destroy (msg);
+    ok (msg_deque_empty (q) == false,
+        "msg_deque_empty is false");
+    ok ((msg = msg_deque_pop_front (q)) == msg2,
+        "msg_deque_pop_front popped msg2");
+    flux_msg_destroy (msg);
+    ok (msg_deque_empty (q) == true,
+        "msg_deque_empty is true");
+    ok (msg_deque_pop_front (q) == NULL,
+        "msg_deque_pop_front returned NULL");
+
+    /* Now use push_front and verify messages are popped in opposite order */
+    if (!(msg1 = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        BAIL_OUT ("flux_msg_create failed");
+    if (!(msg2 = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        BAIL_OUT ("flux_msg_create failed");
+    ok (msg_deque_empty (q) == true,
+        "msg_deque_empty is true");
+    ok (msg_deque_push_front (q, msg1) == 0,
+        "msg_deque_push_front msg1 works");
+    ok (msg_deque_empty (q) == false,
+        "msg_deque_empty is false");
+    ok (msg_deque_push_front (q, msg2) == 0,
+        "msg_deque_push_front msg2 works");
+    ok (msg_deque_empty (q) == false,
+        "msg_deque_empty is false");
+    ok ((msg = msg_deque_pop_front (q)) == msg2,
+        "msg_deque_pop_front popped msg2");
+    flux_msg_destroy (msg);
+    ok (msg_deque_empty (q) == false,
+        "msg_deque_empty is false");
+    ok ((msg = msg_deque_pop_front (q)) == msg1,
+        "msg_deque_pop_front popped msg1");
+    flux_msg_destroy (msg);
+    ok (msg_deque_empty (q) == true,
+        "msg_deque_empty is true");
+
+    msg_deque_destroy (q);
+}
+
+void check_poll (void)
+{
+    struct msg_deque *q;
+    flux_msg_t *msg1;
+    flux_msg_t *msg2;
+    flux_msg_t *msg;
+    struct pollfd pfd;
+
+    if (!(msg1 = flux_request_encode ("foo", NULL)))
+        BAIL_OUT ("flux_request_encode failed");
+    if (!(msg2 = flux_request_encode ("foo", NULL)))
+        BAIL_OUT ("flux_request_encode failed");
+
+    ok ((q = msg_deque_create (0)) != NULL,
+        "msg_deque_create works");
+    ok (msg_deque_pollevents (q) == POLLOUT,
+        "msg_deque_pollevents on empty queue returns POLLOUT");
+    ok (msg_deque_push_back (q, msg1) == 0,
+        "msg_deque_push_back msg1 works");
+    ok (msg_deque_pollevents (q) == (POLLOUT | POLLIN),
+        "msg_deque_pollevents on non-empty queue returns POLLOUT|POLLIN");
+    ok (msg_deque_push_back (q, msg2) == 0,
+        "msg_deque_push_back msg2 works");
+    ok (msg_deque_pollevents (q) == (POLLOUT | POLLIN),
+        "msg_deque_pollevents still returns POLLOUT|POLLIN");
+    ok ((msg = msg_deque_pop_front (q)) != NULL,
+        "msg_deque_pop_front returns a message");
+    flux_msg_decref (msg);
+    ok (msg_deque_pollevents (q) == (POLLOUT | POLLIN),
+        "msg_deque_pollevents still returns POLLOUT|POLLIN");
+
+    ok ((msg = msg_deque_pop_front (q)) != NULL,
+        "msg_deque_pop_front returns a message");
+    flux_msg_decref (msg);
+    ok (msg_deque_pollevents (q) == POLLOUT,
+        "msg_deque_pollevents on empty queue returns POLLOUT");
+
+    /* now test pollfd */
+    if (!(msg1 = flux_request_encode ("foo", NULL)))
+        BAIL_OUT ("flux_request_encode failed");
+
+    ok ((pfd.fd = msg_deque_pollfd (q)) >= 0,
+        "msg_deque_pollfd works");
+    pfd.events = POLLIN,
+    pfd.revents = 0,
+    ok (poll (&pfd, 1, 0) == 1 && pfd.revents == POLLIN,
+        "msg_deque_pollfd suggests we read pollevents");
+    ok (msg_deque_pollevents (q) == POLLOUT,
+        "msg_deque_pollevents on empty queue returns POLLOUT");
+    pfd.events = POLLIN,
+    pfd.revents = 0,
+    ok (poll (&pfd, 1, 0) == 0,
+        "pollfd is no longer ready");
+    ok (msg_deque_push_back (q, msg1) == 0,
+        "msg_deque_push_back works");
+    pfd.events = POLLIN,
+    pfd.revents = 0,
+    ok (poll (&pfd, 1, 0) == 1 && pfd.revents == POLLIN,
+        "pollfd suggests we read pollevents");
+    ok (msg_deque_pollevents (q) == (POLLOUT | POLLIN),
+        "msg_deque_pollevents on non-empty queue returns POLLOUT|POLLIN");
+    pfd.events = POLLIN,
+    pfd.revents = 0,
+    ok (poll (&pfd, 1, 0) == 0,
+        "pollfd is no longer ready");
+    ok (msg_deque_pollevents (q) == (POLLOUT | POLLIN),
+        "msg_deque_pollevents still returns POLLOUT|POLLIN");
+
+    msg_deque_destroy (q);
+}
+
+void check_single_thread (void)
+{
+    struct msg_deque *q;
+    flux_msg_t *msg1;
+    flux_msg_t *msg;
+
+    if (!(msg1 = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        BAIL_OUT ("flux_msg_create failed");
+
+    q = msg_deque_create (MSG_DEQUE_SINGLE_THREAD);
+    ok (q != NULL,
+        "msg_deque_create flags=SINGLE_THREAD works");
+    flux_msg_incref (msg1);
+    ok (msg_deque_push_back (q, msg1) == 0,
+        "msg_deque_push_back msg1 works with refcount==2");
+    flux_msg_decref (msg1);
+    ok ((msg = msg_deque_pop_front (q)) == msg1,
+        "msg_deque_pop_front popped msg1");
+    flux_msg_destroy (msg);
+
+    msg_deque_destroy (q);
+}
+
+void check_inval (void)
+{
+    struct msg_deque *q;
+    flux_msg_t *msg1;
+    flux_msg_t *msg;
+
+    if (!(q = msg_deque_create (0)))
+        BAIL_OUT ("could not create msg_deque");
+    if (!(msg1 = flux_request_encode ("foo", NULL)))
+        BAIL_OUT ("flux_request_encode failed");
+
+    errno = 0;
+    ok (msg_deque_create (0x1000) == NULL && errno == EINVAL,
+        "msg_deque_create flags=0x1000 fails with EINVAL");
+
+    ok (msg_deque_empty (NULL) == true,
+        "msg_deque_empty q=NULL is true");
+    errno = 42;
+    lives_ok ({msg_deque_destroy (NULL);},
+        "msg_deque_destroy q=NULL doesn't crash");
+    ok (errno == 42,
+        "msg_deque_destroy doesn't clobber errno");
+
+    // msg_deque_push_back
+    errno = 0;
+    ok (msg_deque_push_back (NULL, msg1) < 0 && errno == EINVAL,
+        "msg_deque_push_back q=NULL fails with EINVAL");
+    errno = 0;
+    ok (msg_deque_push_back (q, NULL) < 0 && errno == EINVAL,
+        "msg_deque_push_back msg=NULL fails with EINVAL");
+    flux_msg_incref (msg1);
+    errno = 0;
+    ok (msg_deque_push_back (q, msg1) < 0 && errno == EINVAL,
+        "msg_deque_push_back msg with ref=2 fails with EINVAL");
+    flux_msg_decref (msg1);
+
+    // msg_deque_push_front
+    errno = 0;
+    ok (msg_deque_push_front (NULL, msg1) < 0 && errno == EINVAL,
+        "msg_deque_push_front q=NULL fails with EINVAL");
+    errno = 0;
+    ok (msg_deque_push_front (q, NULL) < 0 && errno == EINVAL,
+        "msg_deque_push_front msg=NULL fails with EINVAL");
+    errno = 0;
+    msg = NULL;
+    ok (msg_deque_push_front (q, msg) < 0 && errno == EINVAL,
+        "msg_deque_push_front *msg=NULL fails with EINVAL");
+    flux_msg_incref (msg1);
+    errno = 0;
+    ok (msg_deque_push_front (q, msg1) < 0 && errno == EINVAL,
+        "msg_deque_push_front msg with ref=2 fails with EINVAL");
+    flux_msg_decref (msg1);
+
+    ok (msg_deque_pop_front (NULL) == NULL,
+        "msg_deque_pop_front q=NULL returns NULL");
+    ok (msg_deque_empty (NULL) == true,
+        "msg_deque_empty q=NULL returns true");
+    errno = 0;
+    ok (msg_deque_pollfd (NULL) < 0 && errno == EINVAL,
+        "msg_deque_pollfd q=NULL fails with EINVAL");
+    errno = 0;
+    ok (msg_deque_pollevents (NULL) < 0 && errno == EINVAL,
+        "msg_deque_pollevents q=NULL fails with EINVAL");
+
+    msg = msg1;
+    ok (msg_deque_push_back (q, msg1) == 0,
+        "msg_deque_push_back msg1 works");
+    errno = 0;
+    ok (msg_deque_push_back (q, msg) < 0 && errno == EINVAL,
+        "msg_deque_push_back msg1 again fails with EINVAL");
+    // this test ends with msg1 owned by q
+
+    msg_deque_destroy (q);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    check_queue ();
+    check_poll ();
+    check_inval ();
+    check_single_thread ();
+
+    done_testing ();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
Problem: the `flux_msglist` class is used in connector implementations as a message queue, but it's not a great fit for that:
- it isn't thread safe
- its operations are slightly awkward for a queue (enqueue is "append", dequeue is "pop")
- it manipulates message references, making it awkward for no-copy interfaces
- it uses a zlistx internally, so insertions require a memory allocation and connectors are on critical performance path

This PR creates a new internal container class called "mpipe" which
- it is thread safe, with a MPIPE_SINGLE_THREAD option to relax this
- it has only enqeuue, dequeue, and requeue (enqueue to the other end) operations
- it uses a CCAN list internally for low overhead insertion
- it implements the pollfd/pollevents interface for reactor loop integration

Then the `loop` connector, `interthread` connector, and `flux_t` "requeue queue" are converted to use mpipe.

~~Finally, since all users of `flux_msglist_pollfd()` and `flux_msglist_pollevents()` were converted, drop those interfaces from the public `flux_msglist` class.~~