### PR TITLE
split flux_requeue() into two functions

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -167,6 +167,7 @@ MAN3_FILES_SECONDARY = \
 	man3/flux_shell_task_cmd.3 \
 	man3/flux_service_unregister.3 \
 	man3/flux_send_new.3 \
+	man3/flux_enqueue.3 \
 	man3/flux_clone.3 \
 	man3/flux_close.3 \
 	man3/flux_reconnect.3 \

--- a/doc/man3/flux_requeue.rst
+++ b/doc/man3/flux_requeue.rst
@@ -10,29 +10,31 @@ SYNOPSIS
 
   #include <flux/core.h>
 
-  int flux_requeue (flux_t *h, const flux_msg_t *msg, int flags);
+  cc $(pkg-config --cflags --libs flux-core)
 
 
 DESCRIPTION
 ===========
 
-``flux_requeue()`` requeues a *msg* in handle *h*. The message
-can be received with ``flux_recv()`` as though it arrived from the broker.
+.. function:: int flux_requeue(flux_t *h, const flux_msg_t *msg)
 
-*flags* must be set to one of the following values:
+Enqueue :c:var:`msg` on the head of the handle :c:var:`h`'s receive queue,
+placing it in front of any messages already in the queue.  If successful, a
+reference is taken on :c:var:`msg` and the handle :c:var:`h` becomes
+ready for reading just as if the message were received from the broker.
+Available messages may be read by calling :man3:`flux_recv`.
 
-FLUX_RQ_TAIL
-   *msg* is placed at the tail of the message queue.
+.. function:: int flux_enqueue(flux_t *h, const flux_msg_t *msg)
 
-FLUX_RQ_TAIL
-   *msg* is placed at the head of the message queue.
+Like :func:`flux_requeue` except the message is enqueued on the tail of the
+receive queue, placing it behind any messages already in the queue.
 
 
 RETURN VALUE
 ============
 
-``flux_requeue()`` return zero on success.
-On error, -1 is returned, and errno is set appropriately.
+These functions return zero on success.  On error, -1 is returned with errno
+set.
 
 
 ERRORS

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -198,6 +198,7 @@ man_pages = [
     ('man3/flux_request_encode', 'flux_request_encode_raw', 'encode a Flux request message', [author], 3),
     ('man3/flux_request_encode', 'flux_request_encode', 'encode a Flux request message', [author], 3),
     ('man3/flux_requeue', 'flux_requeue', 'requeue a message', [author], 3),
+    ('man3/flux_requeue', 'flux_enqueue', 'requeue a message', [author], 3),
     ('man3/flux_respond', 'flux_respond_pack', 'respond to a request', [author], 3),
     ('man3/flux_respond', 'flux_respond_raw', 'respond to a request', [author], 3),
     ('man3/flux_respond', 'flux_respond_error', 'respond to a request', [author], 3),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -773,3 +773,5 @@ cumQnK
 cwFQ
 uAsjAo
 resched
+func
+cflags

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1431,8 +1431,8 @@ static void broker_disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
 static int route_to_handle (const flux_msg_t *msg, void *arg)
 {
     broker_ctx_t *ctx = arg;
-    if (flux_requeue (ctx->h, msg, FLUX_RQ_TAIL) < 0)
-        flux_log_error (ctx->h, "%s: flux_requeue\n", __FUNCTION__);
+    if (flux_enqueue (ctx->h, msg) < 0)
+        flux_log_error (ctx->h, "%s: flux_enqueue\n", __FUNCTION__);
     return 0;
 }
 
@@ -1724,8 +1724,8 @@ static int handle_event (broker_ctx_t *ctx, const flux_msg_t *msg)
     /* Internal services may install message handlers for events.
      */
     if (subhash_topic_match (ctx->sub, topic)) {
-        if (flux_requeue (ctx->h, msg, FLUX_RQ_TAIL) < 0)
-            flux_log_error (ctx->h, "%s: flux_requeue\n", __FUNCTION__);
+        if (flux_enqueue (ctx->h, msg) < 0)
+            flux_log_error (ctx->h, "%s: flux_enqueue\n", __FUNCTION__);
     }
     /* Finally, route to local module subscribers.
      */
@@ -2049,7 +2049,7 @@ static int broker_response_sendmsg (broker_ctx_t *ctx, const flux_msg_t *msg)
     const char *uuid;
 
     if (!(uuid = flux_msg_route_last (msg)))
-        rc = flux_requeue (ctx->h, msg, FLUX_RQ_TAIL);
+        rc = flux_enqueue (ctx->h, msg);
     else if (overlay_uuid_is_parent (ctx->overlay, uuid))
         rc = overlay_sendmsg (ctx->overlay, msg, OVERLAY_UPSTREAM);
     else if (overlay_uuid_is_child (ctx->overlay, uuid))

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -49,13 +49,6 @@ enum {
     FLUX_O_NOREQUEUE = 64,  /* disable flux_requeue() to save file descr. */
 };
 
-/* Flags for flux_requeue().
- */
-enum {
-    FLUX_RQ_HEAD = 1,   /* requeue message at head of queue */
-    FLUX_RQ_TAIL = 2,   /* requeue message at tail of queue */
-};
-
 /* Flags for flux_pollevents().
  */
 enum {
@@ -158,11 +151,11 @@ int flux_send_new (flux_t *h, flux_msg_t **msg, int flags);
 flux_msg_t *flux_recv (flux_t *h, struct flux_match match, int flags);
 
 /* Requeue a message
- * flags must be either FLUX_RQ_HEAD or FLUX_RQ_TAIL.
  * A message that is requeued will be seen again by flux_recv() and will
  * cause FLUX_POLLIN to be raised in flux_pollevents().
  */
-int flux_requeue (flux_t *h, const flux_msg_t *msg, int flags);
+int flux_requeue (flux_t *h, const flux_msg_t *msg); // add to head of queue
+int flux_enqueue (flux_t *h, const flux_msg_t *msg); // add to tail of queue
 
 /* Obtain a bitmask of FLUX_POLL* bits for the flux handle.
  * Returns bitmask on success, -1 on error with errno set.

--- a/src/common/libflux/msg_handler.c
+++ b/src/common/libflux/msg_handler.c
@@ -196,7 +196,7 @@ static void dispatch_requeue (struct dispatch *d)
     if (d->unmatched) {
         flux_msg_t *msg;
         while ((msg = zlist_pop (d->unmatched))) {
-            if (flux_requeue (d->h, msg, FLUX_RQ_HEAD) < 0)
+            if (flux_requeue (d->h, msg) < 0)
                 flux_log_error (d->h, "%s: flux_requeue", __FUNCTION__);
             flux_msg_destroy (msg);
         }

--- a/src/common/libflux/test/handle.c
+++ b/src/common/libflux/test/handle.c
@@ -268,24 +268,20 @@ int main (int argc, char *argv[])
     ok ((flux_pollevents (h) & FLUX_POLLIN) == 0,
        "flux_pollevents shows FLUX_POLLIN clear after queue is emptied");
 
-    /* flux_requeue bad args */
+    /* flux_requeue, flux_enqueue bad args */
     errno = 0;
-    ok (flux_requeue (NULL, msg, FLUX_RQ_HEAD) < 0 && errno == EINVAL,
+    ok (flux_requeue (NULL, msg) < 0 && errno == EINVAL,
         "flux_requeue h=NULL fails with EINVAL");
     errno = 0;
-    ok (flux_requeue (h, NULL, FLUX_RQ_HEAD) < 0 && errno == EINVAL,
+    ok (flux_requeue (h, NULL) < 0 && errno == EINVAL,
         "flux_requeue msg=NULL fails with EINVAL");
-    errno = 0;
-    ok (flux_requeue (h, msg, 0) < 0 && errno == EINVAL,
-        "flux_requeue fails with EINVAL if HEAD|TAIL unspecified");
-    flux_msg_destroy (msg);
 
     /* requeue preserves aux container (kvs needs this) */
     if (!(msg = flux_request_encode ("foo", NULL)))
         BAIL_OUT ("couldn't encode request");
     if (flux_msg_aux_set (msg, "fubar", "xyz", NULL) < 0)
         BAIL_OUT ("couldn't attach something to message aux container");
-    ok (flux_requeue (h, msg, FLUX_RQ_HEAD) == 0,
+    ok (flux_requeue (h, msg) == 0,
         "flux_requeue works");
     msg2 = flux_recv (h, FLUX_MATCH_ANY, 0);
     ok (msg2 == msg,
@@ -298,12 +294,12 @@ int main (int argc, char *argv[])
     /* flux_requeue: add foo, bar to HEAD; then receive bar, foo */
     if (!(msg = flux_request_encode ("foo", NULL)))
         BAIL_OUT ("couldn't encode request");
-    ok (flux_requeue (h, msg, FLUX_RQ_HEAD) == 0,
+    ok (flux_requeue (h, msg) == 0,
         "flux_requeue foo HEAD works");
     flux_msg_destroy (msg);
     if (!(msg = flux_request_encode ("bar", NULL)))
         BAIL_OUT ("couldn't encode request");
-    ok (flux_requeue (h, msg, FLUX_RQ_HEAD) == 0,
+    ok (flux_requeue (h, msg) == 0,
         "flux_requeue bar HEAD works");
     flux_msg_destroy (msg);
     ok ((flux_pollevents (h) & FLUX_POLLIN) != 0,
@@ -324,13 +320,13 @@ int main (int argc, char *argv[])
     /* flux_requeue: add foo, bar to TAIL; then receive foo, bar */
     if (!(msg = flux_request_encode ("foo", NULL)))
         BAIL_OUT ("couldn't encode request");
-    ok (flux_requeue (h, msg, FLUX_RQ_TAIL) == 0,
-        "flux_requeue foo TAIL works");
+    ok (flux_enqueue (h, msg) == 0,
+        "flux_enqueue foo works");
     flux_msg_destroy (msg);
     if (!(msg = flux_request_encode ("bar", NULL)))
         BAIL_OUT ("couldn't encode request");
-    ok (flux_requeue (h, msg, FLUX_RQ_TAIL) == 0,
-        "flux_requeue bar TAIL works");
+    ok (flux_enqueue (h, msg) == 0,
+        "flux_enqueue bar works");
     flux_msg_destroy (msg);
     ok ((flux_pollevents (h) & FLUX_POLLIN) != 0,
        "flux_pollevents shows FLUX_POLLIN set after requeue");

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -326,7 +326,7 @@ void test_service (flux_t *h)
     ok (flux_matchtag_avail (h) == count - 1,
         "flux_future_destroy did not free matchtag");
     // requeue "lost" response so matchtag can be reclaimed
-    ok (flux_requeue (h, msg, FLUX_RQ_HEAD) == 0,
+    ok (flux_requeue (h, msg) == 0,
         "flux_requeue response worked");
     flux_msg_destroy (msg);
 

--- a/src/common/librouter/usock_service.c
+++ b/src/common/librouter/usock_service.c
@@ -58,7 +58,7 @@ static void notify_disconnect (struct service *ss, const char *uuid)
         || (flux_msg_route_enable (msg), false)
         || flux_msg_set_cred (msg, ss->cred) < 0
         || flux_msg_route_push (msg, uuid) < 0
-        || flux_requeue (ss->h, msg, FLUX_RQ_TAIL) < 0) {
+        || flux_enqueue (ss->h, msg) < 0) {
         if (ss->verbose)
             log_msg ("error notifying server of %.5s disconnect", uuid);
     }
@@ -100,7 +100,7 @@ static void service_recv (struct usock_conn *uconn, flux_msg_t *msg, void *arg)
         || (flux_msg_route_enable (msg), false)
         || flux_msg_set_cred (msg, ss->cred) < 0
         || flux_msg_route_push (msg, uuid) < 0
-        || flux_requeue (ss->h, msg, FLUX_RQ_TAIL) < 0)
+        || flux_enqueue (ss->h, msg) < 0)
         goto drop;
     return;
 drop:

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -357,7 +357,7 @@ static void getroot_completion (flux_future_t *f, void *arg)
     if (!root->remove)
         setroot (ctx, root, ref, rootseq);
 
-    if (flux_requeue (ctx->h, msg, FLUX_RQ_HEAD) < 0) {
+    if (flux_requeue (ctx->h, msg) < 0) {
         flux_log_error (ctx->h, "%s: flux_requeue", __FUNCTION__);
         goto error;
     }

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -251,8 +251,8 @@ void test_putmsg (flux_t *h, uint32_t nodeid)
                 oom ();
             if (seq == defer_start + defer_count - 1) {
                 while ((z = zlist_pop (defer))) {
-                    if (flux_requeue (h, z, FLUX_RQ_TAIL) < 0)
-                        log_err_exit ("%s: flux_requeue", __FUNCTION__);
+                    if (flux_enqueue (h, z) < 0)
+                        log_err_exit ("%s: flux_enqueue", __FUNCTION__);
                     flux_msg_destroy (z);
                 }
                 popped = true;


### PR DESCRIPTION
In working on other stuff, I got annoyed with the `flux_requeue()` interface.  I know we shouldn't be in the habit of making gratuitous changes to public functions, but I didn't find this used in any of our primary repos so maybe OK?

The old prototype was
```c
/* Flags for flux_requeue().
 */
enum {
    FLUX_RQ_HEAD = 1,   /* requeue message at head of queue */
    FLUX_RQ_TAIL = 2,   /* requeue message at tail of queue */
};

/* Requeue a message
 * flags must be either FLUX_RQ_HEAD or FLUX_RQ_TAIL.
 * A message that is requeued will be seen again by flux_recv() and will
 * cause FLUX_POLLIN to be raised in flux_pollevents().
 */
int flux_requeue (flux_t *h, const flux_msg_t *msg, int flags);
```
It just seems like there ought to be two functions:
```c
/* Requeue a message
 * A message that is requeued will be seen again by flux_recv() and will
 * cause FLUX_POLLIN to be raised in flux_pollevents().
 */
int flux_requeue (flux_t *h, const flux_msg_t *msg); // add to head of queue
int flux_enqueue (flux_t *h, const flux_msg_t *msg); // add to tail of queue
```
So this makes that change.  I can easily withdraw this PR if we decide it's not advisable.

Edit: oh and how about this man page style for APIs?
https://flux-framework--5509.org.readthedocs.build/projects/flux-core/en/5509/man3/flux_requeue.html