### PR TITLE
build: reduce junk content and false dependencies in DSO modules

### DIFF
--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -44,7 +44,7 @@ luamod_ldflags = \
 
 luamod_libadd = \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-internal.la \
+	$(JANSSON_LIBS) \
 	$(LUA_LIB)
 
 flux_la_LDFLAGS = \

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -115,19 +115,32 @@ _rlist_preproc.h: _rlist_clean.h
 
 dist__core_la_SOURCES = callbacks.h
 nodist__core_la_SOURCES = _core.c
-_core_la_LIBADD = $(common_libs)
+_core_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libdebugged/libdebugged.la \
+	$(PYTHON_LIBS)
 
 nodist__hostlist_la_SOURCES = _hostlist.c
-_hostlist_la_LIBADD = $(common_libs)
+_hostlist_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-hostlist.la \
+	$(PYTHON_LIBS)
 
 nodist__idset_la_SOURCES = _idset.c
-_idset_la_LIBADD = $(common_libs)
+_idset_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-idset.la \
+	$(PYTHON_LIBS)
 
 nodist__rlist_la_SOURCES = _rlist.c
 _rlist_la_LIBADD = \
 	$(top_builddir)/src/common/librlist/librlist.la \
+	$(top_builddir)/src/common/libutil/read_all.lo \
+	$(top_builddir)/src/common/libutil/errprintf.lo \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
+	$(top_builddir)/src/common/libflux-idset.la \
+	$(top_builddir)/src/common/libflux-hostlist.la \
+	$(JANSSON_LIBS) \
 	$(HWLOC_LIBS) \
-	$(common_libs)
+	$(PYTHON_LIBS)
 
 if HAVE_FLUX_SECURITY
 
@@ -155,8 +168,8 @@ _security_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_SECURITY_CFLAGS)
 _security_la_LIBADD = \
-	$(common_libs) \
-	$(FLUX_SECURITY_LIBS)
+	$(FLUX_SECURITY_LIBS) \
+	$(PYTHON_LIBS)
 endif
 
 .PHONY: lib-copy

--- a/src/common/librlist/Makefile.am
+++ b/src/common/librlist/Makefile.am
@@ -23,6 +23,8 @@ librlist_la_SOURCES = \
 	match.c \
 	rlist.c \
 	rlist.h \
+	rlist_private.h \
+	rlist_hwloc.c \
 	rhwloc.c \
 	rhwloc.h
 

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -198,7 +198,7 @@ static int rlist_add_rnode_new (struct rlist *rl, struct rnode *n)
  *   by this function (either the rnode is consumed by the rlist, or
  *   the rnode is destroyed after its resources are applied to 'rl')
  */
-static int rlist_add_rnode (struct rlist *rl, struct rnode *n)
+int rlist_add_rnode (struct rlist *rl, struct rnode *n)
 {
     struct rnode *found = rlist_find_rank (rl, n->rank);
     if (found) {
@@ -2339,49 +2339,6 @@ int rlist_mark_up (struct rlist *rl, const char *ids)
         count = rlist_mark_state (rl, true, ids);
     rl->avail += count;
     return 0;
-}
-
-
-struct rlist *rlist_from_hwloc (int rank, const char *xml)
-{
-    char *ids = NULL;
-    struct rnode *n = NULL;
-    hwloc_topology_t topo = NULL;
-    const char *name;
-    struct rlist *rl = rlist_create ();
-
-    if (!rl)
-        return NULL;
-
-    if (xml)
-        topo = rhwloc_xml_topology_load (xml);
-    else
-        topo = rhwloc_local_topology_load (0);
-    if (!topo)
-        goto fail;
-    if (!(ids = rhwloc_core_idset_string (topo))
-        || !(name = rhwloc_hostname (topo)))
-        goto fail;
-
-    if (!(n = rnode_create (name, rank, ids))
-        || rlist_add_rnode (rl, n) < 0)
-        goto fail;
-
-    free (ids);
-
-    if ((ids = rhwloc_gpu_idset_string (topo))
-        && rnode_add_child (n, "gpu", ids) < 0)
-        goto fail;
-
-    hwloc_topology_destroy (topo);
-    free (ids);
-    return rl;
-fail:
-    rlist_destroy (rl);
-    rnode_destroy (n);
-    free (ids);
-    hwloc_topology_destroy (topo);
-    return NULL;
 }
 
 /*  Check if a resource set provided by configuration is valid.

--- a/src/common/librlist/rlist_hwloc.c
+++ b/src/common/librlist/rlist_hwloc.c
@@ -1,0 +1,67 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* N.B. This was split from rlist.c that rlist.o can be used in a limited
+ * fashion by sched-simple and job-list without inheriting a hwloc dependency.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "rnode.h"
+#include "rlist.h"
+#include "rlist_private.h"
+#include "rhwloc.h"
+
+struct rlist *rlist_from_hwloc (int rank, const char *xml)
+{
+    char *ids = NULL;
+    struct rnode *n = NULL;
+    hwloc_topology_t topo = NULL;
+    const char *name;
+    struct rlist *rl = rlist_create ();
+
+    if (!rl)
+        return NULL;
+
+    if (xml)
+        topo = rhwloc_xml_topology_load (xml);
+    else
+        topo = rhwloc_local_topology_load (0);
+    if (!topo)
+        goto fail;
+    if (!(ids = rhwloc_core_idset_string (topo))
+        || !(name = rhwloc_hostname (topo)))
+        goto fail;
+
+    if (!(n = rnode_create (name, rank, ids))
+        || rlist_add_rnode (rl, n) < 0)
+        goto fail;
+
+    free (ids);
+
+    if ((ids = rhwloc_gpu_idset_string (topo))
+        && rnode_add_child (n, "gpu", ids) < 0)
+        goto fail;
+
+    hwloc_topology_destroy (topo);
+    free (ids);
+    return rl;
+fail:
+    rlist_destroy (rl);
+    rnode_destroy (n);
+    free (ids);
+    hwloc_topology_destroy (topo);
+    return NULL;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/librlist/rlist_private.h
+++ b/src/common/librlist/rlist_private.h
@@ -1,0 +1,17 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_SCHED_RLIST_PRIVATE_H
+#define HAVE_SCHED_RLIST_PRIVATE_H 1
+
+// needed by rlist_hwloc.c
+int rlist_add_rnode (struct rlist *rl, struct rnode *n);
+
+#endif /* !HAVE_SCHED_RLIST_H */

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -188,7 +188,6 @@ test_cronodate_t_LDADD = \
 	$(builddir)/cronodate.lo \
 	$(top_builddir)/src/common/libidset/libidset.la \
 	$(builddir)/veb.lo \
-	$(builddir)/xzmalloc.lo \
 	$(top_builddir)/src/common/libtap/libtap.la
 
 test_wallclock_t_SOURCES = test/wallclock.c

--- a/src/common/libutil/cronodate.c
+++ b/src/common/libutil/cronodate.c
@@ -20,7 +20,6 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libidset/idset.h"
-#include "src/common/libutil/xzmalloc.h"
 #include "ccan/str/str.h"
 
 #include "cronodate.h"
@@ -178,9 +177,11 @@ void cronodate_destroy (cronodate_t *d)
 cronodate_t * cronodate_create ()
 {
     int i;
-    cronodate_t *d = xzmalloc (sizeof (*d));
+    cronodate_t *d;
 
-    memset (d, 0, sizeof (*d));
+    if (!(d = calloc (1, sizeof (*d))))
+        return NULL;
+
     for (i = 0; i < TM_MAX_ITEM; i++) {
         struct idset *n = idset_create (tm_unit_max (i) + 1,
                                         IDSET_FLAG_AUTOGROW);

--- a/src/connectors/Makefile.am
+++ b/src/connectors/Makefile.am
@@ -21,6 +21,18 @@ connector_ldflags = -module $(san_ld_zdef_flag) \
 ssh_la_SOURCES = \
 	ssh/ssh.c
 ssh_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la
+       	$(top_builddir)/src/common/librouter/librouter.la \
+	$(top_builddir)/src/common/libutil/log.lo \
+	$(top_builddir)/src/common/libutil/aux.lo \
+	$(top_builddir)/src/common/libutil/errprintf.lo \
+	$(top_builddir)/src/common/libutil/fdutils.lo \
+	$(top_builddir)/src/common/libutil/popen2.lo \
+	$(top_builddir)/src/common/libutil/fdwalk.lo \
+	$(top_builddir)/src/common/libutil/strstrip.lo \
+	$(top_builddir)/src/common/libutil/read_all.lo \
+	$(top_builddir)/src/common/libyuarel/libyuarel.la \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(LIBUUID_LIBS)
+
 ssh_la_LDFLAGS = $(connector_ldflags)

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -176,7 +176,6 @@ cron_la_SOURCES = \
 	cron/datetime.c
 cron_la_LIBADD = \
 	$(top_builddir)/src/common/libutil/cronodate.lo \
-	$(top_builddir)/src/common/libutil/xzmalloc.lo \
 	$(top_builddir)/src/common/libutil/fsd.lo \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -51,6 +51,43 @@ if ENABLE_CONTENT_S3
 fluxmod_LTLIBRARIES += content-s3.la
 endif
 
+# dependencies common to kvs and content modules
+content_libadd = \
+	$(top_builddir)/src/common/libcontent/libcontent.la \
+	$(top_builddir)/src/common/libutil/blobref.lo \
+	$(top_builddir)/src/common/libutil/sha1.lo \
+	$(top_builddir)/src/common/libutil/sha256.lo \
+	$(top_builddir)/src/common/libutil/errprintf.lo \
+	$(top_builddir)/src/common/libutil/monotime.lo \
+	$(top_builddir)/src/common/libutil/tstat.lo \
+	$(top_builddir)/src/common/libccan/libccan.la \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(JANSSON_LIBS)
+
+# dependencies common to job related modules
+job_libadd = \
+	$(top_builddir)/src/common/libjob/libjob.la \
+	$(top_builddir)/src/common/libeventlog/libeventlog.la \
+	$(top_builddir)/src/common/libutil/errprintf.lo \
+	$(top_builddir)/src/common/libutil/jpath.lo \
+	$(top_builddir)/src/common/libutil/fluid.lo \
+	$(top_builddir)/src/common/libutil/mnemonic.lo \
+	$(top_builddir)/src/common/libutil/mn_wordlist.lo \
+	$(top_builddir)/src/common/libutil/basemoji.lo \
+	$(top_builddir)/src/common/libutil/fsd.lo \
+	$(top_builddir)/src/common/libccan/libccan.la \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(FLUX_SECURITY_LIBS) \
+	$(JANSSON_LIBS)
+
+# non-hwloc dependent portion of librlist
+rlist_libadd = \
+	$(top_builddir)/src/common/librlist/rlist.lo \
+	$(top_builddir)/src/common/librlist/rnode.lo \
+	$(top_builddir)/src/common/librlist/match.lo
+
 # N.B. SOURCES should be empty when module subdir is listed in
 # SUBDIRS above.  This avoids distcheck problems with older automake.
 # Hint: build convenience library in subdir and reference that in LIBADD.
@@ -58,15 +95,24 @@ endif
 barrier_la_SOURCES = \
 	barrier/barrier.c
 barrier_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libflux-core.la
 barrier_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 connector_local_la_SOURCES = \
 	connector-local/local.c
 connector_local_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la
+	$(top_builddir)/src/common/librouter/librouter.la \
+	$(top_builddir)/src/common/libutil/log.lo \
+	$(top_builddir)/src/common/libutil/aux.lo \
+	$(top_builddir)/src/common/libutil/errprintf.lo \
+	$(top_builddir)/src/common/libutil/fdutils.lo \
+	$(top_builddir)/src/common/libutil/cleanup.lo \
+	$(top_builddir)/src/common/libutil/unlink_recursive.lo \
+	$(top_builddir)/src/common/libutil/dirwalk.lo \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(LIBUUID_LIBS)
 connector_local_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 content_la_SOURCES = \
@@ -78,23 +124,30 @@ content_la_SOURCES = \
 	content/checkpoint.c \
 	content/checkpoint.h
 content_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la
+	$(top_builddir)/src/common/libutil/fileref.lo \
+	$(top_builddir)/src/common/libutil/hola.lo \
+	$(top_builddir)/src/common/libutil/read_all.lo \
+	$(content_libadd)
 content_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 content_files_la_SOURCES =
 content_files_la_LIBADD = \
 	$(builddir)/content-files/libcontent-files.la \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la
+	$(top_builddir)/src/common/libutil/unlink_recursive.lo \
+	$(top_builddir)/src/common/libutil/dirwalk.lo \
+	$(top_builddir)/src/common/libutil/read_all.lo \
+	$(content_libadd)
 content_files_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 if ENABLE_CONTENT_S3
 content_s3_la_SOURCES =
 content_s3_la_LIBADD = \
 	$(builddir)/content-s3/libcontent-s3.la \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libutil/tomltk.lo \
+	$(top_builddir)/src/common/libutil/timestamp.lo \
+	$(top_builddir)/src/common/libtomlc99/libtomlc99.la \
+	$(top_builddir)/src/common/libyuarel/libyuarel.la \
+	$(content_libadd) \
 	$(LIBS3)
 content_s3_la_LDFLAGS = $(fluxmod_ldflags) -module
 endif
@@ -106,8 +159,7 @@ content_sqlite_la_CPPFLAGS = \
 	$(SQLITE_CFLAGS) \
 	$(LZ4_CFLAGS)
 content_sqlite_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
+	$(content_libadd) \
 	$(SQLITE_LIBS) \
 	$(LZ4_LIBS)
 content_sqlite_la_LDFLAGS = $(fluxmod_ldflags) -module
@@ -123,15 +175,19 @@ cron_la_SOURCES = \
 	cron/event.c \
 	cron/datetime.c
 cron_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libutil/cronodate.lo \
+	$(top_builddir)/src/common/libutil/xzmalloc.lo \
+	$(top_builddir)/src/common/libutil/fsd.lo \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-idset.la \
 	$(JANSSON_LIBS)
 cron_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 heartbeat_la_SOURCES = \
 	heartbeat/heartbeat.c
 heartbeat_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libutil/fsd.lo \
 	$(top_builddir)/src/common/libflux-core.la
 heartbeat_la_LDFLAGS = $(fluxmod_ldflags) -module
 
@@ -142,7 +198,9 @@ job_archive_la_CPPFLAGS = \
 	$(SQLITE_CFLAGS) \
 	$(FLUX_SECURITY_CFLAGS)
 job_archive_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libutil/fsd.lo \
+	$(top_builddir)/src/common/libutil/tstat.lo \
+	$(top_builddir)/src/common/libutil/monotime.lo \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(JANSSON_LIBS) \
 	$(SQLITE_LIBS)
@@ -152,11 +210,9 @@ job_exec_la_SOURCES =
 job_exec_la_LIBADD = \
 	$(builddir)/job-exec/libjob-exec.la \
 	$(builddir)/job-exec/libbulk-exec.la \
-	$(top_builddir)/src/common/libjob/libjob.la \
-	$(top_builddir)/src/common/libsubprocess/libsubprocess.la \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
-	$(JANSSON_LIBS)
+	$(top_builddir)/src/common/libutil/aux.lo \
+	$(top_builddir)/src/common/libflux-idset.la \
+	$(job_libadd)
 job_exec_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 job_info_la_SOURCES = \
@@ -174,50 +230,45 @@ job_info_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(FLUX_SECURITY_CFLAGS)
 job_info_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libeventlog/libeventlog.la \
+	$(top_builddir)/src/common/libutil/lru_cache.lo \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(JANSSON_LIBS) \
-	$(HWLOC_LIBS)
+	$(JANSSON_LIBS)
 job_info_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 job_list_la_SOURCES =
 job_list_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
-	$(FLUX_SECURITY_CFLAGS) \
-	$(HWLOC_CFLAGS)
+	$(FLUX_SECURITY_CFLAGS)
 job_list_la_LIBADD = \
 	$(builddir)/job-list/libjob-list.la \
-	$(top_builddir)/src/common/libjob/libjob.la \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-optparse.la \
-	$(top_builddir)/src/common/librlist/librlist.la \
-	$(JANSSON_LIBS) \
-	$(HWLOC_LIBS)
+	$(rlist_libadd) \
+	$(top_builddir)/src/common/libutil/read_all.lo \
+	$(top_builddir)/src/common/libutil/grudgeset.lo \
+	$(top_builddir)/src/common/libflux-idset.la \
+	$(top_builddir)/src/common/libflux-hostlist.la \
+	$(job_libadd)
 job_list_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 job_ingest_la_SOURCES =
 job_ingest_la_CPPFLAGS = \
-	$(AM_CPPFLAGS) \
-	$(HWLOC_CFLAGS)
+	$(AM_CPPFLAGS)
 job_ingest_la_LIBADD = \
 	$(builddir)/job-ingest/libingest.la \
-	$(top_builddir)/src/common/libjob/libjob.la \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-optparse.la \
-	$(JANSSON_LIBS) \
-	$(FLUX_SECURITY_LIBS)
+	$(top_builddir)/src/common/libfluxutil/libfluxutil.la \
+	$(job_libadd)
 job_ingest_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 job_manager_la_SOURCES =
 job_manager_la_LIBADD = \
 	$(builddir)/job-manager/libjob-manager.la \
-	$(top_builddir)/src/common/libjob/libjob.la \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-optparse.la \
-	$(JANSSON_LIBS)
+	$(top_builddir)/src/common/libfluxutil/libfluxutil.la \
+	$(top_builddir)/src/common/libutil/hola.lo \
+	$(top_builddir)/src/common/libutil/slice.lo \
+	$(top_builddir)/src/common/libutil/aux.lo \
+	$(top_builddir)/src/common/libutil/grudgeset.lo \
+	$(job_libadd)
 job_manager_la_LDFLAGS = \
 	$(fluxlib_ldflags) \
 	-avoid-version \
@@ -229,7 +280,9 @@ kvs_la_SOURCES =
 kvs_la_LIBADD = \
 	$(builddir)/kvs/libkvs.la \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
-	$(top_builddir)/src/common/libflux-internal.la \
+	$(content_libadd) \
+	$(top_builddir)/src/common/libutil/fsd.lo \
+	$(top_builddir)/src/common/libutil/timestamp.lo \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(JANSSON_LIBS)
 kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
@@ -238,21 +291,25 @@ kvs_watch_la_SOURCES = \
 	kvs-watch/kvs-watch.c
 kvs_watch_la_LIBADD = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
-	$(top_builddir)/src/common/libflux-internal.la \
+	$(content_libadd) \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-optparse.la \
 	$(JANSSON_LIBS)
 kvs_watch_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 resource_la_SOURCES =
 resource_la_CPPFLAGS = \
-	$(AM_CPPFLAGS) \
-	$(HWLOC_CFLAGS)
+	$(AM_CPPFLAGS)
 resource_la_LIBADD = \
 	$(builddir)/resource/libresource.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
-	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libutil/errprintf.lo \
+	$(top_builddir)/src/common/libutil/dirwalk.lo \
+	$(top_builddir)/src/common/libutil/read_all.lo \
+	$(top_builddir)/src/common/libeventlog/libeventlog.la \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-idset.la \
+	$(top_builddir)/src/common/libflux-hostlist.la \
 	$(JANSSON_LIBS) \
 	$(HWLOC_LIBS)
 resource_la_LDFLAGS = $(fluxmod_ldflags) -module
@@ -260,17 +317,14 @@ resource_la_LDFLAGS = $(fluxmod_ldflags) -module
 sched_simple_la_SOURCES = \
 	sched-simple/sched.c
 sched_simple_la_CPPFLAGS = \
-	$(AM_CPPFLAGS) \
-	$(HWLOC_CFLAGS)
+	$(AM_CPPFLAGS)
 sched_simple_la_LIBADD = \
-	$(top_builddir)/src/common/librlist/librlist.la \
+	$(rlist_libadd) \
 	$(top_builddir)/src/common/libschedutil/libschedutil.la \
-	$(top_builddir)/src/common/libjob/libjob.la \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-optparse.la \
-	$(JANSSON_LIBS) \
-	$(HWLOC_LIBS)
+	$(top_builddir)/src/common/libutil/read_all.lo \
+	$(top_builddir)/src/common/libflux-idset.la \
+	$(top_builddir)/src/common/libflux-hostlist.la \
+	$(job_libadd)
 sched_simple_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 sdexec_la_SOURCES = \
@@ -280,8 +334,14 @@ sdexec_la_CPPFLAGS = \
 	$(LIBUUID_CFLAGS)
 sdexec_la_LIBADD = \
 	$(top_builddir)/src/common/libsdexec/libsdexec.la \
+	$(top_builddir)/src/common/libutil/aux.lo \
+	$(top_builddir)/src/common/libutil/errprintf.lo \
+	$(top_builddir)/src/common/libutil/fdutils.lo \
+	$(top_builddir)/src/common/libutil/parse_size.lo \
+	$(top_builddir)/src/common/libioencode/libioencode.la \
+	$(top_builddir)/src/common/libccan/libccan.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-idset.la \
 	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS)
 sdexec_la_LDFLAGS = $(fluxmod_ldflags) -module
@@ -289,8 +349,8 @@ sdexec_la_LDFLAGS = $(fluxmod_ldflags) -module
 sdbus_la_SOURCES =
 sdbus_la_LIBADD = \
 	$(builddir)/sdbus/libsdbus.la \
+	$(top_builddir)/src/common/libutil/errprintf.lo \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(JANSSON_LIBS)
 if HAVE_LIBSYSTEMD
 sdbus_la_LIBADD += $(LIBSYSTEMD_LIBS)

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -76,6 +76,19 @@ libjob_manager_la_SOURCES = \
 	plugins/validate-duration.c \
 	plugins/history.c
 
+job_libadd = \
+	$(top_builddir)/src/common/libjob/libjob.la \
+	$(top_builddir)/src/common/libeventlog/libeventlog.la \
+	$(top_builddir)/src/common/libutil/errprintf.lo \
+	$(top_builddir)/src/common/libutil/jpath.lo \
+	$(top_builddir)/src/common/libutil/fluid.lo \
+	$(top_builddir)/src/common/libutil/mnemonic.lo \
+	$(top_builddir)/src/common/libutil/mn_wordlist.lo \
+	$(top_builddir)/src/common/libutil/basemoji.lo \
+	$(top_builddir)/src/common/libutil/fsd.lo \
+	$(top_builddir)/src/common/libccan/libccan.la \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la
+
 fluxinclude_HEADERS = \
 	jobtap.h
 
@@ -88,8 +101,10 @@ plugins_submit_hold_la_LDFLAGS = \
 plugins_alloc_bypass_la_SOURCES = \
 	plugins/alloc-bypass.c
 plugins_alloc_bypass_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/librlist/librlist.la
+	$(top_builddir)/src/common/librlist/librlist.la \
+	$(top_builddir)/src/common/libutil/errprintf.lo \
+	$(top_builddir)/src/common/libutil/read_all.lo \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la
 plugins_alloc_bypass_la_LDFLAGS = \
 	$(fluxplugin_ldflags) \
 	-module
@@ -97,8 +112,10 @@ plugins_alloc_bypass_la_LDFLAGS = \
 plugins_alloc_check_la_SOURCES = \
 	plugins/alloc-check.c
 plugins_alloc_check_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/librlist/librlist.la
+	$(top_builddir)/src/common/librlist/librlist.la \
+	$(top_builddir)/src/common/libutil/errprintf.lo \
+	$(top_builddir)/src/common/libutil/read_all.lo \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la
 plugins_alloc_check_la_LDFLAGS = \
 	$(fluxplugin_ldflags) \
 	-module
@@ -106,9 +123,9 @@ plugins_alloc_check_la_LDFLAGS = \
 plugins_perilog_la_SOURCES = \
 	plugins/perilog.c
 plugins_perilog_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
-	$(top_builddir)/src/common/libjob/libjob.la
+	$(top_builddir)/src/common/libutil/read_all.lo \
+	$(job_libadd)
 plugins_perilog_la_LDFLAGS = \
 	$(fluxplugin_ldflags) \
 	-module
@@ -128,6 +145,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux/libflux.la \
 	$(LIBPTHREAD) $(JANSSON_LIBS)
 
 test_cppflags = \


### PR DESCRIPTION
Problem: various DSO plugins  include large convenience libraries such as `libflux-internal.la` in `_la_LIBADD`.  This instructs the linker to include all the objects in the convenience library in the shared object, which bloats its size and potentially adds inappropriate dependencies.

Work through broker modules, (installed) jobtap plugins, and bindings DSOs to ensure `_la_LIBADD` includes something close to the minimum object set required to get the job done.

This was peeled off of #5513 and improved to cover the bindings DSOs.