### PR TITLE
cron: handle ENOMEM without asserting

### DIFF
--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -188,7 +188,6 @@ test_cronodate_t_LDADD = \
 	$(builddir)/cronodate.lo \
 	$(top_builddir)/src/common/libidset/libidset.la \
 	$(builddir)/veb.lo \
-	$(builddir)/xzmalloc.lo \
 	$(top_builddir)/src/common/libtap/libtap.la
 
 test_wallclock_t_SOURCES = test/wallclock.c

--- a/src/common/libutil/cronodate.c
+++ b/src/common/libutil/cronodate.c
@@ -20,7 +20,6 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libidset/idset.h"
-#include "src/common/libutil/xzmalloc.h"
 #include "ccan/str/str.h"
 
 #include "cronodate.h"
@@ -178,9 +177,11 @@ void cronodate_destroy (cronodate_t *d)
 cronodate_t * cronodate_create ()
 {
     int i;
-    cronodate_t *d = xzmalloc (sizeof (*d));
+    cronodate_t *d;
 
-    memset (d, 0, sizeof (*d));
+    if (!(d = calloc (1, sizeof (*d))))
+        return NULL;
+
     for (i = 0; i < TM_MAX_ITEM; i++) {
         struct idset *n = idset_create (tm_unit_max (i) + 1,
                                         IDSET_FLAG_AUTOGROW);


### PR DESCRIPTION
Problem: `cronodate_create()` calls `xzmalloc()` which asserts on ENOMEM, but cronodate is used in a broker module, so asserting is inappropriate.

Have `cronodate_create()` call `cmalloc()` and return NULL on failure. Ensure the return value is checked all along the call path from the cron broker module:
```
cron_entry_create()
 -> cron_datetime_create()
  -> datetime_entry_from_json()
   -> datetime_entry_create()
    -> cronodate_create()
```
(This was peeled off of #5514)