### PR TITLE
build: reduce junk content in DSOs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -515,13 +515,13 @@ AC_SUBST(fluxbindingincludedir)
 ##
 # Macros to avoid repetition in Makefiles.am's
 ##
-fluxmod_ldflags="$san_ld_zdef_flag -avoid-version -export-symbols-regex '^mod_(main|name)\$\$' --disable-static -shared -export-dynamic"
+fluxmod_ldflags="$san_ld_zdef_flag -avoid-version -export-symbols-regex '^mod_(main|name)\$\$' --disable-static -shared -export-dynamic -Wl,--gc-sections"
 AC_SUBST(fluxmod_ldflags)
 
-fluxplugin_ldflags="-avoid-version -export-symbols-regex '^flux_plugin_init\$\$' --disable-static -shared -export-dynamic"
+fluxplugin_ldflags="-avoid-version -export-symbols-regex '^flux_plugin_init\$\$' --disable-static -shared -export-dynamic -Wl,--gc-sections"
 AC_SUBST(fluxplugin_ldflags)
 
-fluxlib_ldflags="-shared -export-dynamic --disable-static $san_ld_zdef_flag"
+fluxlib_ldflags="-shared -export-dynamic --disable-static $san_ld_zdef_flag -Wl,--gc-sections"
 AC_SUBST(fluxlib_ldflags)
 
 ##

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -40,6 +40,7 @@ noinst_LTLIBRARIES = \
 
 luamod_ldflags = \
 	-avoid-version -module -shared --disable-static \
+	-Wl,--gc-sections \
 	$(san_ld_zdef_flag)
 
 luamod_libadd = \

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -12,6 +12,7 @@ AM_LDFLAGS = \
 	-module \
 	$(san_ld_zdef_flag) \
 	-Wl,-rpath,$(PYTHON_PREFIX)/lib \
+	-Wl,--gc-sections \
 	$(CODE_COVERAGE_LIBS)
 
 common_libs = \

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -99,6 +99,7 @@ libflux_core_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-core.map \
 	-version-info @LIBFLUX_CORE_VERSION_INFO@ \
 	-shared -export-dynamic --disable-static \
+	-Wl,--gc-sections \
 	$(san_ld_zdef_flag)
 
 libflux_optparse_la_SOURCES =
@@ -113,6 +114,7 @@ libflux_optparse_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-optparse.map \
 	-version-info @LIBFLUX_OPTPARSE_VERSION_INFO@ \
 	-shared -export-dynamic --disable-static \
+	-Wl,--gc-sections \
 	$(san_ld_zdef_flag)
 
 libflux_idset_la_SOURCES =
@@ -123,6 +125,7 @@ libflux_idset_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-idset.map \
 	-version-info @LIBFLUX_IDSET_VERSION_INFO@ \
 	-shared -export-dynamic --disable-static \
+	-Wl,--gc-sections \
 	$(san_ld_zdef_flag)
 
 libflux_schedutil_la_SOURCES =
@@ -135,6 +138,7 @@ libflux_schedutil_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-schedutil.map \
 	-version-info @LIBFLUX_SCHEDUTIL_VERSION_INFO@ \
 	-shared -export-dynamic --disable-static \
+	-Wl,--gc-sections \
 	$(san_ld_zdef_flag)
 
 libflux_hostlist_la_SOURCES =
@@ -144,6 +148,7 @@ libflux_hostlist_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-hostlist.map \
 	-version-info @LIBFLUX_HOSTLIST_VERSION_INFO@ \
 	-shared -export-dynamic --disable-static \
+	-Wl,--gc-sections \
 	$(san_ld_zdef_flag)
 
 libflux_taskmap_la_SOURCES =
@@ -161,6 +166,7 @@ libflux_taskmap_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-taskmap.map \
 	-version-info @LIBFLUX_TASKMAP_VERSION_INFO@ \
 	-shared -export-dynamic --disable-static \
+	-Wl,--gc-sections \
 	$(san_ld_zdef_flag)
 
 flux_libpmi_la_SOURCES =
@@ -177,6 +183,7 @@ flux_libpmi_la_LDFLAGS = \
 	-version-info 0:0:0 \
 	-Wl,--defsym=flux_pmi_library=1 \
 	-shared -export-dynamic --disable-static \
+	-Wl,--gc-sections \
 	$(san_ld_zdef_flag)
 
 flux_libpmi2_la_SOURCES =
@@ -192,6 +199,7 @@ flux_libpmi2_la_LDFLAGS = \
 	-version-info 0:0:0 \
 	-Wl,--defsym=flux_pmi_library=1 \
 	-shared -export-dynamic --disable-static \
+	-Wl,--gc-sections \
 	$(san_ld_zdef_flag)
 
 EXTRA_DIST = \

--- a/src/connectors/Makefile.am
+++ b/src/connectors/Makefile.am
@@ -16,7 +16,8 @@ fluxconnector_LTLIBRARIES = \
 
 connector_ldflags = -module $(san_ld_zdef_flag) \
 	-export-symbols-regex '^connector_init$$' \
-	--disable-static -avoid-version -shared -export-dynamic
+	--disable-static -avoid-version -shared -export-dynamic \
+	-Wl,--gc-sections
 
 ssh_la_SOURCES = \
 	ssh/ssh.c


### PR DESCRIPTION
New try at #5514 - this just adds the `--gc-sections` linker options in places where we build DSOs.

Overall, this reduces the size of DSO text and bss sections by about 50%.  It seems the debuginfo sections are not removed though, so the `.so` size is not reduced that much  :shrug:

Anyway, this makes the linker work the way I thought it was supposed to(!) so that's progress IMHO.