### PR TITLE
flux job info: drop multiple key support, clean up code, add man page entry

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -33,6 +33,9 @@ SYNOPSIS
 
 **flux** **job** **purge** [*OPTIONS*] [*id...*]
 
+**flux** **job** **info** [*OPTIONS*] *id* *key*
+
+
 DESCRIPTION
 ===========
 
@@ -298,10 +301,85 @@ Inactive jobs may also be purged automatically if the job manager is
 configured as described in :man5:`flux-config-job-manager`.
 
 
+flux job info
+-------------
+
+.. program:: flux job info
+
+:program:`flux job info` retrieves the selected low level job object
+and displays it on standard output.  Object formats are described in the
+RFCs listed in `RESOURCES`_.
+
+
+Options:
+
+.. option:: -o, --original
+
+  For :option:`jobspec`, return the original submitted jobspec, prior
+  to any modifications made at ingest, such as setting defaults.
+
+.. option:: -b, --base
+
+  For :option:`jobspec` or :option:`R`, return the base version, prior
+  to any updates posted to the job eventlog.
+
+The following keys are valid:
+
+eventlog
+   The primary job eventlog, consisting of timestamped events that drive the
+   job through various states.  For example, a job that is pending resource
+   allocation in SCHED state transitions to RUN state on the *alloc* event.
+
+guest.exec.eventlog
+   The execution eventlog, consisting of timestamped events posted by the
+   execution system while the job is running.
+
+guest.input, guest.output
+   The job input and output eventlogs, consisting of timestamped chunks of
+   input/output data.
+
+jobspec
+   The job specification.  Three versions are available:
+
+   - default: the *current* jobspec, which may reflect updates,
+     for example if the job duration was extended
+
+   - with :option:`--original`: the original jobspec submitted by the user
+
+   - with :option:`--base`: the jobspec as initially ingested to the KVS, after
+     the frobnicator filled in any default values, but before updates
+
+R
+   The resource set allocated to the job.  Two versions are available:
+
+   - default: the *current* R, which may reflect updates, for example if the job
+     expiration time was extended (default)
+
+   - with :option:`--base`: the initial R allocated by the scheduler
+
+
 RESOURCES
 =========
 
 Flux: http://flux-framework.org
 
-RFC 34: Flux Task Map: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_34.html
+:doc:`rfc:spec_14`
+  https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_14.html
 
+:doc:`rfc:spec_18`
+  https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_18.html
+
+:doc:`rfc:spec_20`
+  https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_20.html
+
+:doc:`rfc:spec_21`
+  https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_21.html
+
+:doc:`rfc:spec_24`
+  https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_24.html
+
+:doc:`rfc:spec_25`
+  https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_25.html
+
+:doc:`rfc:spec_34`
+  https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_34.html

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -774,3 +774,4 @@ cwFQ
 uAsjAo
 resched
 func
+rfc

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -552,7 +552,7 @@ static struct optparse_subcommand subcommands[] = {
       wait_event_opts
     },
     { "info",
-      "id key ...",
+      "id key",
       "Display info for a job",
       cmd_info,
       0,
@@ -3361,14 +3361,17 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
 void info_usage (void)
 {
     fprintf (stderr,
-             "Missing lookup key(s), common keys:\n"
-             "J\n"
-             "R\n"
-             "eventlog\n"
-             "jobspec\n"
-             "guest.exec.eventlog\n"
-             "guest.input\n"
-             "guest.output\n");
+             "Usage: flux job info id key\n"
+             "some useful keys are:\n"
+             "  J                    - signed jobspec\n"
+             "  R                    - allocated resources\n"
+             "  eventlog             - primary job eventlog\n"
+             "  jobspec              - job specification\n"
+             "  guest.exec.eventlog  - execution eventlog\n"
+             "  guest.input          - job input log\n"
+             "  guest.output         - job output log\n"
+             "Use flux job info -h to list available options\n");
+
 }
 
 struct info_ctx {
@@ -3562,6 +3565,9 @@ void info_lookup (flux_t *h,
     flux_future_t *f;
     struct info_ctx ctx = {0};
 
+    if (argc - optindex != 1)
+        log_msg_exit ("only one key may be looked up");
+
     ctx.id_arg = argv[optindex-1];
     ctx.id = id;
     if (!(ctx.keys_input = json_array ()))
@@ -3642,13 +3648,13 @@ int cmd_info (optparse_t *p, int argc, char **argv)
     int optindex = optparse_option_index (p);
     flux_jobid_t id;
 
-    if (!(h = flux_open (NULL, 0)))
-        log_err_exit ("flux_open");
-
-    if ((argc - optindex) < 1) {
-        optparse_print_usage (p);
+    // Usage: flux job info id key
+    if (optindex - argc != 3) {
+        info_usage ();
         exit (1);
     }
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
 
     id = parse_jobid (argv[optindex++]);
 

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -50,15 +50,14 @@ test_expect_success 'flux job info fails without jobid' '
 '
 
 test_expect_success 'flux job info listing of keys works' '
-	jobid=$(submit_job) &&
-	flux job info $jobid > list_keys.err 2>&1 &&
-	grep "^J" list_keys.err &&
-	grep "^R" list_keys.err &&
-	grep "^eventlog" list_keys.err &&
-	grep "^jobspec" list_keys.err &&
-	grep "^guest.exec.eventlog" list_keys.err &&
-	grep "^guest.input" list_keys.err &&
-	grep "^guest.output" list_keys.err
+	test_must_fail flux job info 2>list_keys.err &&
+	grep J list_keys.err &&
+	grep R list_keys.err &&
+	grep eventlog list_keys.err &&
+	grep jobspec list_keys.err &&
+	grep guest.exec.eventlog list_keys.err &&
+	grep guest.input list_keys.err &&
+	grep guest.output list_keys.err
 '
 
 #

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -124,49 +124,6 @@ test_expect_success 'flux job info --base R works' '
 '
 
 #
-# job info lookup tests (multiple info requests)
-#
-
-test_expect_success 'flux job info multiple keys works (different keys)' '
-	jobid=$(submit_job) &&
-	flux job info $jobid eventlog jobspec J > all_info_a.out &&
-	grep submit all_info_a.out &&
-	grep sleep all_info_a.out
-'
-
-test_expect_success 'flux job info multiple keys works (same key)' '
-	jobid=$(submit_job) &&
-	flux job info $jobid eventlog eventlog eventlog > eventlog_3.out &&
-	test $(grep submit eventlog_3.out | wc -l) -eq 3
-'
-
-test_expect_success 'flux job info multiple keys fails on bad id' '
-	test_must_fail flux job info 12345 eventlog jobspec J
-'
-
-test_expect_success 'flux job info multiple keys fails on 1 bad entry (include eventlog)' '
-	jobid=$(submit_job) &&
-	kvsdir=$(flux job id --to=kvs $jobid) &&
-	flux kvs unlink ${kvsdir}.jobspec &&
-	test_must_fail flux job info $jobid eventlog jobspec J > all_info_b.out
-'
-
-test_expect_success 'flux job info multiple keys fails on 1 bad entry (no eventlog)' '
-	jobid=$(submit_job) &&
-	kvsdir=$(flux job id --to=kvs $jobid) &&
-	flux kvs unlink ${kvsdir}.jobspec &&
-	test_must_fail flux job info $jobid jobspec J > all_info_b.out
-'
-
-# N.B. Issue #5305, jobspec would be output twice, so we check for one
-# output of jobspec
-test_expect_success 'flux job info --original jobspec and J works' '
-	jobid=$(flux submit --env=ORIGINALTHING=t true) &&
-	flux job info --original $jobid J jobspec > J_jobspec_original.out &&
-	test $(grep ORIGINALTHING J_jobspec_original.out | wc -l) -eq 1
-'
-
-#
 # job info lookup tests (via eventlog)
 #
 

--- a/t/t2232-job-info-security.t
+++ b/t/t2232-job-info-security.t
@@ -158,44 +158,6 @@ test_expect_success 'flux job info jobspec fails (wrong user)' '
 	unset_userid
 '
 
-test_expect_success 'flux job info multiple keys works (owner, include eventlog)' '
-	jobid=$(submit_job) &&
-	flux job info $jobid eventlog jobspec J
-'
-
-test_expect_success 'flux job info multiple keys works (user, include eventlog)' '
-	jobid=$(submit_job 9000) &&
-	set_userid 9000 &&
-	flux job info $jobid eventlog jobspec J &&
-	unset_userid
-'
-
-test_expect_success 'flux job info multiple keys fails (wrong user, include eventlog)' '
-	jobid=$(submit_job 9000) &&
-	set_userid 9999 &&
-	! flux job info $jobid eventlog jobspec J &&
-	unset_userid
-'
-
-test_expect_success 'flux job info multiple keys works (owner, no eventlog)' '
-	jobid=$(submit_job) &&
-	flux job info $jobid jobspec J
-'
-
-test_expect_success 'flux job info multiple keys works (user, no eventlog)' '
-	jobid=$(submit_job 9000) &&
-	set_userid 9000 &&
-	flux job info $jobid jobspec J &&
-	unset_userid
-'
-
-test_expect_success 'flux job info multiple keys fails (wrong user, no eventlog)' '
-	jobid=$(submit_job 9000) &&
-	set_userid 9999 &&
-	! flux job info $jobid jobspec J &&
-	unset_userid
-'
-
 test_expect_success 'flux job info foobar fails (owner)' '
 	jobid=$(submit_job) &&
 	! flux job info $jobid foobar

--- a/t/valgrind/workload.d/job-info
+++ b/t/valgrind/workload.d/job-info
@@ -7,4 +7,6 @@ set -x
 id=$(flux submit -n 1 /bin/true)
 flux job attach ${id}
 
-flux job info ${id} eventlog jobspec R >/dev/null
+flux job info ${id} eventlog >/dev/null
+flux job info ${id} jobspec >/dev/null
+flux job info ${id} R >/dev/null


### PR DESCRIPTION
Following up on #5464, this tries to simplify`flux job info`.  For a start, it uses `job-info.update-lookup` to fetch the current R instead of replaying the eventlog on the original R.  It also cleans up the `flux-job(1)` man page and adds an entry for `flux job info` with descriptions of each available key.