### PR TITLE
support duration update for running jobs

### DIFF
--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -106,6 +106,8 @@
 
 static double kill_timeout=5.0;
 
+#define DEBUG_FAIL_EXPIRATION 1
+
 extern struct exec_implementation testexec;
 extern struct exec_implementation bulkexec;
 
@@ -1228,6 +1230,12 @@ static void expiration_cb (flux_t *h,
     double expiration;
     struct jobinfo *job;
 
+    /*  Respond with error if module debug flag set for testing purposes
+     */
+    if (flux_module_debug_test (h, DEBUG_FAIL_EXPIRATION, false)) {
+        errno = EINVAL;
+        goto error;
+    }
     if (flux_request_unpack (msg,
                              NULL,
                              "{s:I s:F}",

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -89,6 +89,8 @@ struct jobinfo {
     flux_watcher_t       *kill_shell_timer;
     flux_watcher_t       *expiration_timer;
 
+    double                t0;        /* timestamp we initially saw this job */
+
     /* Exec implementation for this job */
     struct exec_implementation *impl;
     void *                      data;

--- a/src/modules/job-exec/rset.c
+++ b/src/modules/job-exec/rset.c
@@ -89,7 +89,7 @@ static int rset_read_time_window (struct resource_set *r, json_error_t *errp)
     /*  Default values: 0. indicates "unset"
      */
     r->expiration = 0.;
-    r-> starttime = 0.;
+    r->starttime = 0.;
     if (json_unpack_ex (r->R, errp, 0,
                         "{s:{s?F s?F}}",
                         "execution",
@@ -109,21 +109,27 @@ struct resource_set *resource_set_create_fromjson (json_t *R,
         goto err;
     }
     r->R = json_incref (R);
-    if (json_unpack_ex (r->R, errp, 0, "{s:i s:{s:o}}",
-                                       "version", &version,
-                                       "execution",
-                                       "R_lite", &r->R_lite) < 0)
+    if (json_unpack_ex (r->R,
+                        errp,
+                        0,
+                        "{s:i s:{s:o}}",
+                        "version", &version,
+                        "execution",
+                        "R_lite", &r->R_lite) < 0)
         goto err;
     if (version != 1) {
         if (errp)
-            snprintf (errp->text, sizeof (errp->text),
-                    "invalid version: %d", version);
+            snprintf (errp->text,
+                      sizeof (errp->text),
+                      "invalid version: %d",
+                      version);
         goto err;
     }
     if (!(r->ranks = rset_ranks (r))) {
         if (errp)
-            snprintf (errp->text, sizeof (errp->text),
-                    "R_lite: failed to read target rank list");
+            snprintf (errp->text,
+                      sizeof (errp->text),
+                      "R_lite: failed to read target rank list");
         goto err;
     }
     if (rset_read_time_window (r, errp) < 0)
@@ -146,7 +152,7 @@ struct resource_set *resource_set_create (const char *R, json_error_t *errp)
     return rset;
 }
 
-const struct idset * resource_set_ranks (struct resource_set *r)
+const struct idset *resource_set_ranks (struct resource_set *r)
 {
     return r->ranks;
 }

--- a/src/modules/job-exec/rset.c
+++ b/src/modules/job-exec/rset.c
@@ -167,6 +167,12 @@ double resource_set_expiration (struct resource_set *r)
     return r->expiration;
 }
 
+void resource_set_update_expiration (struct resource_set *r,
+                                     double expiration)
+{
+    r->expiration = expiration;
+}
+
 uint32_t resource_set_nth_rank (struct resource_set *r, int n)
 {
     uint32_t rank;

--- a/src/modules/job-exec/rset.h
+++ b/src/modules/job-exec/rset.h
@@ -25,7 +25,7 @@ void resource_set_destroy (struct resource_set *rset);
 
 json_t *resource_set_get_json (struct resource_set *rset);
 
-const struct idset * resource_set_ranks (struct resource_set *rset);
+const struct idset *resource_set_ranks (struct resource_set *rset);
 
 uint32_t resource_set_nth_rank (struct resource_set *r, int n);
 

--- a/src/modules/job-exec/rset.h
+++ b/src/modules/job-exec/rset.h
@@ -35,6 +35,9 @@ double resource_set_starttime (struct resource_set *rset);
 
 double resource_set_expiration (struct resource_set *rset);
 
+void resource_set_update_expiration (struct resource_set *rset,
+                                     double expiration);
+
 #endif /* !HAVE_JOB_EXEC_RSET_H */
 
 

--- a/src/modules/job-exec/test/rset.c
+++ b/src/modules/job-exec/test/rset.c
@@ -179,6 +179,10 @@ int main (int ac, char *av[])
                 ok (expiration == e->expiration,
                     "%s: expect expiration %.2f (got %.2f)", e->descr,
                     e->expiration, expiration);
+                resource_set_update_expiration (r, 120.);
+                ok (resource_set_expiration (r) == 120.,
+                    "%s: resource_set_update_expiration() works",
+                    e->descr);
             }
             else {
                 fail ("%s: %d:[%s]",

--- a/src/modules/job-list/job_data.c
+++ b/src/modules/job-list/job_data.c
@@ -409,6 +409,7 @@ static int parse_R (struct job *job, bool allow_nonfatal)
     int core_count = 0;
     struct rnode *rnode;
     int saved_errno, rc = -1;
+    char *tmp;
 
     if (!(rl = rlist_from_json (job->R, &error))) {
         flux_log_error (job->h, "rlist_from_json: %s", error.text);
@@ -421,8 +422,10 @@ static int parse_R (struct job *job, bool allow_nonfatal)
         goto nonfatal_error;
 
     job->nnodes = idset_count (idset);
-    if (!(job->ranks = idset_encode (idset, flags)))
+    if (!(tmp = idset_encode (idset, flags)))
         goto nonfatal_error;
+    free (job->ranks);
+    job->ranks = tmp;
 
     /* reading nodelist from R directly would avoid the creation /
      * destruction of a hostlist.  However, we get a hostlist to
@@ -432,8 +435,10 @@ static int parse_R (struct job *job, bool allow_nonfatal)
     if (!(hl = rlist_nodelist (rl)))
         goto nonfatal_error;
 
-    if (!(job->nodelist = hostlist_encode (hl)))
+    if (!(tmp = hostlist_encode (hl)))
         goto nonfatal_error;
+    free (job->nodelist);
+    job->nodelist = tmp;
 
     rnode = zlistx_first (rl->nodes);
     while (rnode) {

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -592,6 +592,10 @@ int event_job_update (struct job *job, json_t *event)
         if (job->state == FLUX_JOB_STATE_SCHED)
             job->state = FLUX_JOB_STATE_PRIORITY;
     }
+    else if (streq (name, "resource-update")) {
+        if (job_apply_resource_updates (job, context) < 0)
+            goto inval;
+    }
     else if (strstarts (name, "dependency-")) {
         if (job->state == FLUX_JOB_STATE_DEPEND
             || job->state == FLUX_JOB_STATE_NEW) {

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -469,8 +469,6 @@ static int event_handle_dependency (struct job *job,
 static int event_handle_jobspec_update (struct job *job, json_t *context)
 {
     if (!job->jobspec_redacted
-        || job->state == FLUX_JOB_STATE_RUN
-        || job->state == FLUX_JOB_STATE_CLEANUP
         || job_apply_jobspec_updates (job, context) < 0)
         return -1;
     return 0;

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -853,6 +853,16 @@ int event_job_process_entry (struct event *event,
      */
     (void) event_jobtap_call (event, job, name, entry, old_state);
 
+    /*  After processing a resource-update event, send the updated
+     *  expiration to the job execution service.
+     */
+    if (streq (name, "resource-update")
+        && start_send_expiration_update (event->ctx->start, job, context) < 0)
+        flux_log (event->ctx->h,
+                  LOG_ERR,
+                  "%s: failed to send expiration update to exec service",
+                  idf58 (job->id));
+
     return event_job_action (event, job);
 }
 

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -142,6 +142,10 @@ int job_apply_jobspec_updates (struct job *job, json_t *updates);
  */
 json_t *job_jobspec_with_updates (struct job *job, json_t *updates);
 
+/* Apply resource updates to redacted copy of R
+ */
+int job_apply_resource_updates (struct job *job, json_t *updates);
+
 #endif /* _FLUX_JOB_MANAGER_JOB_H */
 
 /*

--- a/src/modules/job-manager/plugins/update-duration.c
+++ b/src/modules/job-manager/plugins/update-duration.c
@@ -56,10 +56,16 @@ static int duration_update_cb (flux_plugin_t *p,
     }
     if (state == FLUX_JOB_STATE_RUN
         || state == FLUX_JOB_STATE_CLEANUP) {
-        flux_jobtap_error (p,
-                           args,
-                           "update of duration for running job not supported");
-        return -1;
+        /*  Allow update of duration of running job for instance owner
+         *  only:
+         */
+        if (!(cred.rolemask & FLUX_ROLE_OWNER) || !owner_allow_any) {
+            flux_jobtap_error (p,
+                               args,
+                               "duration update of running job requires"
+                               " instance owner privileges");
+            return -1;
+        }
     }
     if ((cred.rolemask & FLUX_ROLE_OWNER) && owner_allow_any) {
         /* If owner is allowed to make any duration adjustment, then

--- a/src/modules/job-manager/start.h
+++ b/src/modules/job-manager/start.h
@@ -20,6 +20,10 @@ void start_ctx_destroy (struct start *start);
 
 int start_send_request (struct start *start, struct job *job);
 
+int start_send_expiration_update (struct start *start,
+                                  struct job *job,
+                                  json_t *context);
+
 #endif /* ! _FLUX_JOB_MANAGER_START_H */
 
 /*

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -736,6 +736,7 @@ static void test_jobspec_update (void)
 
     cpy = job_jobspec_with_updates (job, o);
     ok (cpy != NULL, "job_jobspec_with_updates success");
+    json_decref (o);
 
     ret = json_unpack (cpy,
                        "{s:{s:{s:s}}}",

--- a/src/modules/resource/acquire.c
+++ b/src/modules/resource/acquire.c
@@ -352,6 +352,29 @@ static void reslog_cb (struct reslog *reslog,
                 }
             }
         }
+        else if (streq (name, "resource-update")) {
+            double expiration = -1.;
+
+            /*  Handle resource-update event. Currently the only supported
+             *  context of such an event is an expiration update
+             */
+            if (json_unpack (context,
+                             "{s?F}",
+                             "expiration", &expiration) < 0) {
+                errmsg = "error preparing resource.acquire update response";
+                goto error;
+            }
+            if (expiration >= 0.
+                && flux_respond_pack (h,
+                                      msg,
+                                      "{s:f}",
+                                      "expiration", expiration) < 0) {
+                    flux_log_error (h,
+                                    "error responding to resource.acquire (%s)",
+                                    name);
+                    goto error;
+            }
+        }
         else if (streq (name, "online")
                  || streq (name, "offline")
                  || streq (name, "drain")

--- a/src/modules/resource/acquire.c
+++ b/src/modules/resource/acquire.c
@@ -315,7 +315,10 @@ void acquire_disconnect (struct acquire *acquire, const flux_msg_t *msg)
  * FWIW, this function is not called until after the eventlog KVS
  * commit completes.
  */
-static void reslog_cb (struct reslog *reslog, const char *name, void *arg)
+static void reslog_cb (struct reslog *reslog,
+                       const char *name,
+                       json_t *context,
+                       void *arg)
 {
     struct acquire *acquire = arg;
     struct resource_ctx *ctx = acquire->ctx;

--- a/src/modules/resource/acquire.c
+++ b/src/modules/resource/acquire.c
@@ -349,16 +349,25 @@ static void reslog_cb (struct reslog *reslog, const char *name, void *arg)
                 }
             }
         }
-        else if (streq (name, "online") || streq (name, "offline")
-                || streq (name, "drain") || streq (name, "undrain")) {
+        else if (streq (name, "online")
+                 || streq (name, "offline")
+                 || streq (name, "drain")
+                 || streq (name, "undrain")) {
             if (ar->response_count > 0) {
                 struct idset *up, *dn;
-                if (acquire_request_update (ar, acquire, name, &up, &dn) < 0) {
+                if (acquire_request_update (ar,
+                                            acquire,
+                                            name,
+                                            &up,
+                                            &dn) < 0) {
                     errmsg = "error preparing resource.acquire update response";
                     goto error;
                 }
                 if (up || dn) {
-                    if (acquire_respond_next (h, msg, up, dn) < 0) {
+                    if (acquire_respond_next (h,
+                                              msg,
+                                              up,
+                                              dn) < 0) {
                         flux_log_error (h,
                                     "error responding to resource.acquire (%s)",
                                     name);
@@ -403,7 +412,9 @@ void acquire_destroy (struct acquire *acquire)
 
             msg = flux_msglist_first (acquire->requests);
             while (msg) {
-                if (flux_respond_error (h, msg, ECANCELED,
+                if (flux_respond_error (h,
+                                        msg,
+                                        ECANCELED,
                                         "the resource module was unloaded") < 0)
                     flux_log_error (h, "error responding to acquire request");
                 flux_msglist_delete (acquire->requests);
@@ -425,7 +436,10 @@ struct acquire *acquire_create (struct resource_ctx *ctx)
     acquire->ctx = ctx;
     if (!(acquire->requests = flux_msglist_create ()))
         goto error;
-    if (flux_msg_handler_addvec (ctx->h, htab, acquire, &acquire->handlers) < 0)
+    if (flux_msg_handler_addvec (ctx->h,
+                                 htab,
+                                 acquire,
+                                 &acquire->handlers) < 0)
         goto error;
     reslog_set_callback (ctx->reslog, reslog_cb, acquire);
     return acquire;

--- a/src/modules/resource/reslog.c
+++ b/src/modules/resource/reslog.c
@@ -39,12 +39,16 @@ static void notify_callback (struct reslog *reslog, json_t *event)
 {
     if (reslog->cb) {
         const char *name;
+        json_t *context;
 
-        if (json_unpack (event, "{s:s}", "name", &name) < 0) {
+        if (json_unpack (event,
+                         "{s:s s:o}",
+                         "name", &name,
+                         "context", &context) < 0) {
             flux_log (reslog->h, LOG_ERR, "error unpacking event for callback");
             return;
         }
-        reslog->cb (reslog, name, reslog->cb_arg);
+        reslog->cb (reslog, name, context, reslog->cb_arg);
     }
 }
 

--- a/src/modules/resource/reslog.h
+++ b/src/modules/resource/reslog.h
@@ -15,6 +15,7 @@ struct reslog;
 
 typedef void (*reslog_cb_f)(struct reslog *reslog,
                             const char *name,
+                            json_t *context,
                             void *arg);
 
 struct reslog *reslog_create (flux_t *h);

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -189,12 +189,12 @@ static char *Rstring_create (struct simple_sched *ss,
 {
     char *s = NULL;
     json_t *R = NULL;
+    l->starttime = now;
+    l->expiration = 0.;
     if (timelimit > 0.) {
-        l->starttime = now;
         l->expiration = now + timelimit;
     }
     else if (ss->rlist->expiration > 0.) {
-        l->starttime = now;
         l->expiration = ss->rlist->expiration;
     }
     if ((R = rlist_to_R (l))) {

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -28,6 +28,7 @@
 enum module_debug_flags {
     DEBUG_FAIL_ALLOC = 1, // while set, alloc requests fail
     DEBUG_ANNOTATE_REASON_PENDING = 2, // add reason_pending annotation
+    DEBUG_EXPIRATION_UPDATE_DENY = 4,  // deny sched.expiration RPCs
 };
 
 struct jobreq {
@@ -670,6 +671,43 @@ err:
         flux_log_error (h, "feasibility_cb: flux_respond_error");
 }
 
+/* For testing purposes, support the sched.expiration RPC even though
+ * sched-simple is not a planning scheduler.
+ */
+static void expiration_cb (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+    struct simple_sched *ss = arg;
+    flux_jobid_t id;
+    double expiration;
+    const char *errmsg = NULL;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:I s:F}",
+                             "id", &id,
+                             "expiration", &expiration) < 0)
+        goto err;
+    if (expiration < 0.) {
+        errno = EINVAL;
+        goto err;
+    }
+    if (flux_module_debug_test (ss->h,
+                                DEBUG_EXPIRATION_UPDATE_DENY,
+                                false)) {
+        errmsg = "Rejecting expiration update for testing";
+        goto err;
+    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "feasibility_cb: flux_respond_pack");
+    return;
+err:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "expiration_cb: flux_respond_error");
+}
+
 static int ss_resource_update (struct simple_sched *ss, flux_future_t *f)
 {
     const char *up = NULL;
@@ -863,9 +901,12 @@ static int process_args (flux_t *h, struct simple_sched *ss,
     return 0;
 }
 
+
+
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "*.resource-status", status_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST, "*.feasibility", feasibility_cb, FLUX_ROLE_USER },
+    { FLUX_MSGTYPE_REQUEST, "*.expiration", expiration_cb, FLUX_ROLE_OWNER },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -29,13 +29,11 @@
 #include "info.h"
 #include "jobspec.h"
 
-/* Get R and jobspec from job-info.lookup future and assign.
+/* Get jobspec from job-info.lookup future and assign.
  * Return 0 on success, -1 on failure (and log error).
  * N.B. assigned values remain valid until future is destroyed.
  */
-static int lookup_job_info_get (flux_future_t *f,
-                                char **jobspec,
-                                const char **R)
+static int lookup_jobspec_get (flux_future_t *f, char **jobspec)
 {
     flux_error_t error;
     const char *J;
@@ -45,31 +43,80 @@ static int lookup_job_info_get (flux_future_t *f,
         shell_log_error ("failed to unwrap J: %s", error.text);
         return -1;
     }
-    if (flux_rpc_get_unpack (f, "{s:s}", "R", R) < 0)
-        goto error;
     return 0;
 error:
     shell_log_error ("job-info: %s", future_strerror (f, errno));
     return -1;
 }
 
-/* Fetch R and J from the job-info service.
+/* Fetch J from the job-info service.
  * Return future on success or NULL on failure (and log error).
  */
-static flux_future_t *lookup_job_info (flux_t *h, flux_jobid_t jobid)
+static flux_future_t *lookup_jobspec (flux_t *h, flux_jobid_t jobid)
 {
     flux_future_t *f;
     f = flux_rpc_pack (h,
                        "job-info.lookup",
                        FLUX_NODEID_ANY,
                        0,
-                       "{s:I s:[ss] s:i}",
+                       "{s:I s:[s] s:i}",
                        "id", jobid,
-                       "keys", "R", "J",
+                       "keys", "J",
                        "flags", 0);
     if (!f)
         shell_log_error ("error sending job-info request");
     return f;
+}
+
+/*  Unpack R from a job-info.update-watch response and update the
+ *  shell's internal info->R and info->rcalc. If a response can't be
+ *  unpacked or rcalc_create_json() fails, just ignore this response
+ *  and let caller decide if the error is fatal.
+ */
+static int resource_watch_update (struct shell_info *info)
+{
+    int rc = -1;
+    flux_future_t *f = info->R_watch_future;
+    json_t *R = NULL;
+    rcalc_t *rcalc = NULL;
+
+    if (flux_rpc_get_unpack (f, "{s:o}", "R", &R) < 0) {
+        shell_log_errno ("error getting R from job-info watch response");
+        goto out;
+    }
+    if (!(rcalc = rcalc_create_json (R))) {
+        shell_log_error ("error decoding R");
+        goto out;
+    }
+    /*  Swap previous and updated R, rcalc:
+     */
+    json_decref (info->R);
+    info->R = json_incref (R);
+    rcalc_destroy (info->rcalc);
+    info->rcalc = rcalc;
+    rc = 0;
+out:
+    flux_future_reset (f);
+    return rc;
+}
+
+static void R_update_cb (flux_future_t *f, void *arg)
+{
+    flux_shell_t *shell = arg;
+
+    if (resource_watch_update (shell->info) < 0)
+        return;
+
+    /*  Destroy cached shell "info" JSON object otherwise plugins will
+     *  not see the updated R
+     */
+    (void) flux_shell_aux_set (shell, "shell::info", NULL, NULL);
+
+    /* Notify plugins that resources have been updated.
+     * (Assume plugins will emit appropriate error messages, so ignore
+     *  error from flux_shell_plugstack_call()).
+     */
+    (void) flux_shell_plugstack_call (shell, "shell.resource-update", NULL);
 }
 
 /*  Fetch jobinfo (jobspec, R) from job-info service if not provided on
@@ -82,7 +129,6 @@ static int shell_init_jobinfo (flux_shell_t *shell, struct shell_info *info)
     flux_future_t *f_hwloc = NULL;
     const char *xml;
     char *jobspec = NULL;
-    const char *R;
     json_error_t error;
 
     /*  fetch hwloc topology from resource module to avoid having to
@@ -96,9 +142,21 @@ static int shell_init_jobinfo (flux_shell_t *shell, struct shell_info *info)
                               0)))
         goto out;
 
-    /*  fetch jobspec (via J) and R for this job
+    /*  fetch R from job-info service
      */
-    if (!(f_info = lookup_job_info (shell->h, shell->jobid)))
+    if (!(info->R_watch_future = flux_rpc_pack (shell->h,
+                                                "job-info.update-watch",
+                                                FLUX_NODEID_ANY,
+                                                FLUX_RPC_STREAMING,
+                                                "{s:I s:s s:i}",
+                                                "id", shell->jobid,
+                                                "key", "R",
+                                                "flags", 0)))
+        goto out;
+
+    /*  fetch jobspec (via J) for this job
+     */
+    if (!(f_info = lookup_jobspec (shell->h, shell->jobid)))
         goto out;
 
     if (flux_rpc_get (f_hwloc, &xml) < 0
@@ -109,20 +167,28 @@ static int shell_init_jobinfo (flux_shell_t *shell, struct shell_info *info)
             goto out;
         }
     }
-    if (lookup_job_info_get (f_info, &jobspec, &R) < 0) {
-        shell_log_error ("error fetching jobspec,R");
+    if (lookup_jobspec_get (f_info, &jobspec) < 0) {
+        shell_log_error ("error fetching jobspec");
         goto out;
     }
     if (!(info->jobspec = jobspec_parse (jobspec, &error))) {
         shell_log_error ("error parsing jobspec: %s", error.text);
         goto out;
     }
-    if (!(info->R = json_loads (R, 0, &error))) {
-        shell_log_error ("error parsing R: %s", error.text);
+
+    /*  Synchronously get initial version of R from first job-info
+     *  watch response:
+     */
+    if (resource_watch_update (info) < 0)
         goto out;
-    }
-    if (!(info->rcalc = rcalc_create_json (info->R))) {
-        shell_log_error ("error decoding R");
+
+    /*  Register callback for future R updates:
+     */
+    if (flux_future_then (info->R_watch_future,
+                          -1.,
+                          R_update_cb,
+                          shell) < 0) {
+        shell_log_errno ("error registering R watch callback");
         goto out;
     }
     rc = 0;
@@ -262,6 +328,7 @@ void shell_info_destroy (struct shell_info *info)
 {
     if (info) {
         int saved_errno = errno;
+        flux_future_destroy (info->R_watch_future);
         json_decref (info->R);
         jobspec_destroy (info->jobspec);
         rcalc_destroy (info->rcalc);

--- a/src/shell/info.h
+++ b/src/shell/info.h
@@ -34,6 +34,7 @@ struct shell_info {
     struct taskmap *taskmap;
     struct idset *taskids;
     char *hwloc_xml;
+    flux_future_t *R_watch_future;
 };
 
 /* Create shell_info.

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -166,6 +166,7 @@ TESTSCRIPTS = \
 	t2280-job-memo.t \
 	t2290-job-update.t \
 	t2291-job-update-queue.t \
+	t2292-job-update-running.t \
 	t2300-sched-simple.t \
 	t2302-sched-simple-up-down.t \
 	t2303-sched-hello.t \

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -110,9 +110,8 @@ test_expect_success 'flux job info applies resource updates' '
 	jobid=$(flux submit --wait-event=start sleep 300) &&
 	echo $jobid > updated_R.id &&
 	flux job info $jobid R | jq -e ".execution.expiration == 0.0" &&
-	kvspath=`flux job id --to=kvs ${jobid}` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 1000.0}" &&
-	flux job info $jobid R | jq -e ".execution.expiration == 1000.0" &&
+	flux update $jobid duration=300 &&
+	flux job info $jobid R | jq -e ".execution.expiration > 0.0" &&
 	flux job info $jobid eventlog &&
 	flux cancel $jobid
 '

--- a/t/t2233-job-info-update.t
+++ b/t/t2233-job-info-update.t
@@ -16,10 +16,15 @@ fj_wait_event() {
 	flux job wait-event --timeout=20 "$@"
 }
 
+get_update_watchers() {
+	flux module stats --parse "update_watchers" job-info
+}
+
 wait_update_watchers() {
 	local count=$1
 	local i=0
-	while (! flux module stats --parse "update_watchers" job-info > /dev/null 2>&1 \
+	echo "waiting for $count watchers"
+	while (! flux module stats --parse "update_watchers" job-info \
 		|| [ "$(flux module stats --parse "update_watchers" job-info 2> /dev/null)" != "${count}" ]) \
 		&& [ $i -lt 50 ]
 	do
@@ -33,132 +38,147 @@ wait_update_watchers() {
 	return 0
 }
 
+# Usage: expiration_add JOBID N
+# Set expiration of job with JOBID to now + N seconds
+#
+expiration_add() {
+	local id=$1
+	local amount=$2
+	local kvsdir=$(flux job id --to=kvs $id)
+	local new=$(($(date +%s) + $amount))
+	flux kvs eventlog append \
+	    ${kvsdir}.eventlog resource-update "{\"expiration\": $new}"
+	echo $new
+}
+
 test_expect_success 'job-info: update lookup with no update events works (job active)' '
-	flux submit --wait-event=start sleep 300 > lookup1.id &&
-	${UPDATE_LOOKUP} $(cat lookup1.id) R > lookup1.out &&
-	flux cancel $(cat lookup1.id) &&
+	jobid=$(flux submit --wait-event=start sleep 300) &&
+	${UPDATE_LOOKUP} $jobid R > lookup1.out &&
+	flux cancel $jobid &&
+	test_debug "cat lookup1.out" &&
 	cat lookup1.out | jq -e ".execution.expiration == 0.0"
 '
 
 test_expect_success 'job-info: update lookup with no update events works (job inactive)' '
-	flux submit --wait-event=clean hostname > lookup2.id &&
-	${UPDATE_LOOKUP} $(cat lookup2.id) R > lookup2.out &&
+	jobid=$(flux submit --wait-event=clean hostname) &&
+	${UPDATE_LOOKUP} $jobid R > lookup2.out &&
+	test_debug "cat lookup2.out" &&
 	cat lookup2.out | jq -e ".execution.expiration == 0.0"
 '
 
 test_expect_success 'job-info: update lookup with update events works (job active)' '
-	flux submit --wait-event=start sleep 300 > lookup3.id &&
-	kvspath=`flux job id --to=kvs $(cat lookup3.id)` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
-	${UPDATE_LOOKUP} $(cat lookup3.id) R > lookup3A.out &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
-	${UPDATE_LOOKUP} $(cat lookup3.id) R > lookup3B.out &&
-	flux cancel $(cat lookup3.id) &&
-	cat lookup3A.out | jq -e ".execution.expiration == 100.0" &&
-	cat lookup3B.out | jq -e ".execution.expiration == 200.0"
+	jobid=$(flux submit --wait-event=start sleep 300) &&
+	update1=$(expiration_add $jobid 100) &&
+	flux job eventlog $jobid &&
+	${UPDATE_LOOKUP} $jobid R > lookup3A.out &&
+	update2=$(expiration_add $jobid 200) &&
+	${UPDATE_LOOKUP} $jobid R > lookup3B.out &&
+	flux cancel $jobid &&
+	cat lookup3A.out | jq -e ".execution.expiration == ${update1}" &&
+	cat lookup3B.out | jq -e ".execution.expiration == ${update2}"
 '
 
 test_expect_success 'job-info: update lookup with update events works (job inactive)' '
-	flux submit --wait-event=start sleep 300 > lookup4.id &&
-	kvspath=`flux job id --to=kvs $(cat lookup4.id)` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
-	flux cancel $(cat lookup4.id) &&
-	${UPDATE_LOOKUP} $(cat lookup4.id) R > lookup4.out &&
-	cat lookup4.out | jq -e ".execution.expiration == 200.0"
+	jobid=$(flux submit --wait-event=start sleep 300) &&
+	update1=$(expiration_add $jobid 100) &&
+	update2=$(expiration_add $jobid 100) &&
+	flux cancel $jobid &&
+	${UPDATE_LOOKUP} $jobid R > lookup4.out &&
+	cat lookup4.out | jq -e ".execution.expiration == ${update2}"
 '
 
 test_expect_success 'job-info: update watch with no update events works (job inactive)' '
-	flux submit --wait-event=clean hostname > watch1.id &&
-	${UPDATE_WATCH} $(cat watch1.id) R > watch1.out &&
+	jobid=$(flux submit --wait-event=clean hostname) &&
+	${UPDATE_WATCH} $jobid R > watch1.out &&
 	test $(cat watch1.out | wc -l) -eq 1 &&
 	cat watch1.out | jq -e ".execution.expiration == 0.0"
 '
 
 test_expect_success NO_CHAIN_LINT 'job-info: update watch with no update events works (job run/canceled)' '
-	flux submit --wait-event=start sleep inf > watch2.id
-	${UPDATE_WATCH} $(cat watch2.id) R > watch2.out &
+	jobid=$(flux submit --wait-event=start sleep inf)
+	watchers=$(get_update_watchers)
+	${UPDATE_WATCH} $jobid R > watch2.out &
 	watchpid=$! &&
-	wait_update_watchers 1 &&
-	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch2.out &&
-	flux cancel $(cat watch2.id) &&
+	wait_update_watchers $((watchers+1)) &&
+	${WAITFILE} -v --count=1 --timeout=30 --pattern="expiration" watch2.out &&
+	flux cancel $jobid &&
 	wait $watchpid &&
+	test_debug "cat watch2.out" &&
 	test $(cat watch2.out | wc -l) -eq 1 &&
 	cat watch2.out | jq -e ".execution.expiration == 0.0"
 '
 
 test_expect_success 'job-info: update watch with update events works (job inactive)' '
-	flux submit --wait-event=start sleep inf > watch3.id &&
-	kvspath=`flux job id --to=kvs $(cat watch3.id)` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
-	flux cancel $(cat watch3.id) &&
-	${UPDATE_WATCH} $(cat watch3.id) R > watch3.out &&
+	jobid=$(flux submit --wait-event=start sleep inf) &&
+	update1=$(expiration_add $jobid 100) &&
+	update2=$(expiration_add $jobid 200) &&
+	flux cancel $jobid &&
+	${UPDATE_WATCH} $jobid R > watch3.out &&
 	test $(cat watch3.out | wc -l) -eq 1 &&
-	cat watch3.out | jq -e ".execution.expiration == 200.0"
+	cat watch3.out | jq -e ".execution.expiration == ${update2}"
 '
 
 test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events works (before watch)' '
-	flux submit --wait-event=start sleep inf > watch4.id &&
-	kvspath=`flux job id --to=kvs $(cat watch4.id)` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}"
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}"
-	${UPDATE_WATCH} $(cat watch4.id) R > watch4.out &
+	jobid=$(flux submit --wait-event=start sleep inf) &&
+	update1=$(expiration_add $jobid 100) &&
+	update2=$(expiration_add $jobid 200) &&
+	watchers=$(get_update_watchers)
+	${UPDATE_WATCH} $jobid R > watch4.out &
 	watchpid=$! &&
-	wait_update_watchers 1 &&
+	wait_update_watchers $((watchers+1)) &&
 	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch4.out &&
-	flux cancel $(cat watch4.id) &&
+	flux cancel $jobid &&
 	wait $watchpid &&
 	test $(cat watch4.out | wc -l) -eq 1 &&
-	cat watch4.out | jq -e ".execution.expiration == 200.0"
+	cat watch4.out | jq -e ".execution.expiration == ${update2}"
 '
 
 test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events works (after watch)' '
-	flux submit --wait-event=start sleep inf > watch5.id
-	${UPDATE_WATCH} $(cat watch5.id) R > watch5.out &
+	jobid=$(flux submit --wait-event=start sleep inf) &&
+	watchers=$(get_update_watchers)
+	${UPDATE_WATCH} $jobid R > watch5.out &
 	watchpid=$! &&
-	wait_update_watchers 1 &&
+	wait_update_watchers $((watchers+1)) &&
 	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch5.out &&
-	kvspath=`flux job id --to=kvs $(cat watch5.id)` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
+	update1=$(expiration_add $jobid 100) &&
+	update2=$(expiration_add $jobid 200) &&
 	${WAITFILE} --count=3 --timeout=30 --pattern="expiration" watch5.out &&
-	flux cancel $(cat watch5.id) &&
+	flux cancel $jobid &&
 	wait $watchpid &&
 	test $(cat watch5.out | wc -l) -eq 3 &&
 	head -n1 watch5.out | jq -e ".execution.expiration == 0.0" &&
-	head -n2 watch5.out | tail -n1 | jq -e ".execution.expiration == 100.0" &&
-	tail -n1 watch5.out | jq -e ".execution.expiration == 200.0"
+	head -n2 watch5.out | tail -n1 | jq -e ".execution.expiration == ${update1}" &&
+	tail -n1 watch5.out | jq -e ".execution.expiration == ${update2}"
 '
 
 test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events works (before/after watch)' '
-	flux submit --wait-event=start sleep inf > watch6.id &&
-	kvspath=`flux job id --to=kvs $(cat watch6.id)` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}"
-	${UPDATE_WATCH} $(cat watch6.id) R > watch6.out &
+	jobid=$(flux submit --wait-event=start sleep inf) &&
+	update1=$(expiration_add $jobid 100) &&
+	watchers=$(get_update_watchers)
+	${UPDATE_WATCH} $jobid R > watch6.out &
 	watchpid=$! &&
-	wait_update_watchers 1 &&
+	wait_update_watchers $((watchers+1)) &&
 	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch6.out &&
-	kvspath=`flux job id --to=kvs $(cat watch6.id)` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
+	update2=$(expiration_add $jobid 200) &&
 	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch6.out &&
-	flux cancel $(cat watch6.id) &&
+	flux cancel $jobid &&
 	wait $watchpid &&
 	test $(cat watch6.out | wc -l) -eq 2 &&
-	head -n1 watch6.out | jq -e ".execution.expiration == 100.0" &&
-	tail -n1 watch6.out | jq -e ".execution.expiration == 200.0"
+	head -n1 watch6.out | jq -e ".execution.expiration == ${update1}" &&
+	tail -n1 watch6.out | jq -e ".execution.expiration == ${update2}"
 '
 
 # signaling the update watch tool with SIGUSR1 will cancel the stream
 test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (single watcher)' '
-	flux submit --wait-event=start sleep inf > watch7.id
-	${UPDATE_WATCH} $(cat watch7.id) R > watch7.out &
+	jobid=$(flux submit --wait-event=start sleep inf) &&
+	watchers=$(get_update_watchers)
+	${UPDATE_WATCH} $jobid R > watch7.out &
 	watchpid=$! &&
-	wait_update_watchers 1 &&
+	wait_update_watchers $((watchers+1)) &&
 	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch7.out &&
 	kill -s USR1 $watchpid &&
 	wait $watchpid &&
-	flux cancel $(cat watch7.id) &&
+	flux cancel $jobid &&
 	test $(cat watch7.out | wc -l) -eq 1 &&
 	cat watch7.out | jq -e ".execution.expiration == 0.0"
 '
@@ -170,25 +190,24 @@ test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (singl
 # At the end, the first watcher should see 3 R versions, the second
 # one 2, and the last one only 1.
 test_expect_success NO_CHAIN_LINT 'job-info: update watch with multiple watchers works' '
-	flux submit --wait-event=start sleep inf > watch8.id
-	${UPDATE_WATCH} $(cat watch8.id) R > watch8A.out &
+	jobid=$(flux submit --wait-event=start sleep inf)
+	watchers=$(get_update_watchers)
+	${UPDATE_WATCH} $jobid R > watch8A.out &
 	watchpidA=$! &&
-	wait_update_watchers 1 &&
-	kvspath=`flux job id --to=kvs $(cat watch8.id)` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
+	wait_update_watchers $((watchers+1)) &&
+	update1=$(expiration_add $jobid 100) &&
 	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch8A.out
-	${UPDATE_WATCH} $(cat watch8.id) R > watch8B.out &
+	${UPDATE_WATCH} $jobid R > watch8B.out &
 	watchpidB=$! &&
-	wait_update_watchers 2 &&
-	kvspath=`flux job id --to=kvs $(cat watch8.id)` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 200.0}" &&
+	wait_update_watchers $((watchers+2)) &&
+	update2=$(expiration_add $jobid 200) &&
 	${WAITFILE} --count=3 --timeout=30 --pattern="expiration" watch8A.out &&
 	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch8B.out
-	${UPDATE_WATCH} $(cat watch8.id) R > watch8C.out &
+	${UPDATE_WATCH} $jobid R > watch8C.out &
 	watchpidC=$! &&
-	wait_update_watchers 3 &&
+	wait_update_watchers $((watchers+3)) &&
 	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch8C.out &&
-	flux cancel $(cat watch8.id) &&
+	flux cancel $jobid &&
 	wait $watchpidA &&
 	wait $watchpidB &&
 	wait $watchpidC &&
@@ -196,55 +215,55 @@ test_expect_success NO_CHAIN_LINT 'job-info: update watch with multiple watchers
 	test $(cat watch8B.out | wc -l) -eq 2 &&
 	test $(cat watch8C.out | wc -l) -eq 1 &&
 	head -n1 watch8A.out | jq -e ".execution.expiration == 0.0" &&
-	head -n2 watch8A.out | tail -n1 | jq -e ".execution.expiration == 100.0" &&
-	tail -n1 watch8A.out | jq -e ".execution.expiration == 200.0" &&
-	head -n1 watch8B.out | jq -e ".execution.expiration == 100.0" &&
-	tail -n1 watch8B.out | jq -e ".execution.expiration == 200.0" &&
-	tail -n1 watch8C.out | jq -e ".execution.expiration == 200.0"
+	head -n2 watch8A.out | tail -n1 | jq -e ".execution.expiration == ${update1}" &&
+	tail -n1 watch8A.out | jq -e ".execution.expiration == ${update2}" &&
+	head -n1 watch8B.out | jq -e ".execution.expiration == ${update1}" &&
+	tail -n1 watch8B.out | jq -e ".execution.expiration == ${update2}" &&
+	tail -n1 watch8C.out | jq -e ".execution.expiration == ${update2}"
 '
 
 # signaling the update watch tool with SIGUSR1 will cancel the stream
 test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (multiple watchers)' '
-	flux submit --wait-event=start sleep inf > watch10.id
-	${UPDATE_WATCH} $(cat watch10.id) R > watch10A.out &
+	jobid=$(flux submit --wait-event=start sleep inf)
+	watchers=$(get_update_watchers)
+	${UPDATE_WATCH} $jobid R > watch10A.out &
 	watchpidA=$! &&
-	wait_update_watchers 1 &&
-	kvspath=`flux job id --to=kvs $(cat watch10.id)` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}"
-	${UPDATE_WATCH} $(cat watch10.id) R > watch10B.out &
+	wait_update_watchers $((watchers+1)) &&
+	update1=$(expiration_add $jobid 100)
+	${UPDATE_WATCH} $jobid R > watch10B.out &
 	watchpidB=$! &&
-	wait_update_watchers 2 &&
+	wait_update_watchers $((watchers+2)) &&
 	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch10A.out &&
 	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch10B.out &&
 	kill -s USR1 $watchpidA &&
 	wait $watchpidA &&
 	kill -s USR1 $watchpidB &&
 	wait $watchpidB &&
-	flux cancel $(cat watch10.id) &&
+	flux cancel $jobid &&
 	test $(cat watch10A.out | wc -l) -eq 2 &&
 	test $(cat watch10B.out | wc -l) -eq 1 &&
 	head -n1 watch10A.out | jq -e ".execution.expiration == 0.0" &&
-	tail -n1 watch10B.out | jq -e ".execution.expiration == 100.0" &&
-	cat watch10B.out | jq -e ".execution.expiration == 100.0"
+	tail -n1 watch10B.out | jq -e ".execution.expiration == ${update1}" &&
+	cat watch10B.out | jq -e ".execution.expiration == ${update1}"
 '
 
 # If someone is already doing an update-watch on a jobid/key, update-lookup can
 # return the cached info
 test_expect_success NO_CHAIN_LINT 'job-info: update lookup returns cached R from update watch' '
-	flux submit --wait-event=start sleep inf > watch9.id
-	${UPDATE_WATCH} $(cat watch9.id) R > watch9.out &
+	jobid=$(flux submit --wait-event=start sleep inf) &&
+	watchers=$(get_update_watchers)
+	${UPDATE_WATCH} $jobid R > watch9.out &
 	watchpid=$! &&
-	wait_update_watchers 1 &&
-	kvspath=`flux job id --to=kvs $(cat watch9.id)` &&
-	flux kvs eventlog append ${kvspath}.eventlog resource-update "{\"expiration\": 100.0}" &&
+	wait_update_watchers $((watchers+1)) &&
+	update1=$(expiration_add $jobid 100) &&
 	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch9.out &&
-        ${UPDATE_LOOKUP} $(cat watch9.id) R > lookup9.out &&
-	flux cancel $(cat watch9.id) &&
+        ${UPDATE_LOOKUP} $jobid R > lookup9.out &&
+	flux cancel $jobid &&
 	wait $watchpid &&
 	test $(cat watch9.out | wc -l) -eq 2 &&
 	head -n1 watch9.out | jq -e ".execution.expiration == 0.0" &&
-	tail -n1 watch9.out | jq -e ".execution.expiration == 100.0" &&
-	cat lookup9.out | jq -e ".execution.expiration == 100.0"
+	tail -n1 watch9.out | jq -e ".execution.expiration == ${update1}" &&
+	cat lookup9.out | jq -e ".execution.expiration == ${update1}"
 '
 
 #
@@ -281,9 +300,10 @@ test_expect_success 'job-info: non job owner cannot watch key' '
 # access cached info
 test_expect_success NO_CHAIN_LINT 'job-info: non job owner cannot watch key (second watcher)' '
 	jobid=`flux submit --wait-event=start sleep inf`
+	watchers=$(get_update_watchers)
 	${UPDATE_WATCH} $jobid R > watchsecurity.out &
 	watchpid=$! &&
-	wait_update_watchers 1 &&
+	wait_update_watchers $((watchers+1)) &&
 	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watchsecurity.out &&
 	set_userid 9999 &&
 	test_must_fail ${UPDATE_WATCH} $jobid R &&
@@ -295,9 +315,10 @@ test_expect_success NO_CHAIN_LINT 'job-info: non job owner cannot watch key (sec
 # update-lookup cannot read cached watch data
 test_expect_success NO_CHAIN_LINT 'job-info: non job owner cannot lookup key (piggy backed)' '
 	jobid=`flux submit --wait-event=start sleep inf`
+	watchers=$(get_update_watchers)
 	${UPDATE_WATCH} $jobid R > lookupsecurity.out &
 	watchpid=$! &&
-	wait_update_watchers 1 &&
+	wait_update_watchers $((watchers+1)) &&
 	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" lookupsecurity.out &&
 	set_userid 9999 &&
 	test_must_fail ${UPDATE_LOOKUP} $jobid R &&

--- a/t/t2290-job-update.t
+++ b/t/t2290-job-update.t
@@ -155,7 +155,7 @@ test_expect_success 'update fails for running job' '
 	jobid=$(flux submit -t1m --wait-event=start sleep 60) &&
 	test_expect_code 1 flux update $jobid duration=90s 2>run.err &&
 	test_debug "cat run.err" &&
-	grep "update of duration for running job not supported" run.err
+	grep "duration update of running job requires instance owner" run.err
 '
 test_expect_success 'update of attributes.system.test fails' '
 	test_expect_code 1 flux update $jobid test=foo

--- a/t/t2292-job-update-running.t
+++ b/t/t2292-job-update-running.t
@@ -1,0 +1,275 @@
+#!/bin/sh
+test_description='Test update of running jobs'
+
+. $(dirname $0)/sharness.sh
+
+if flux job submit --help 2>&1 | grep -q sign-type; then
+	test_set_prereq HAVE_FLUX_SECURITY
+fi
+
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+export FLUX_URI_RESOLVE_LOCAL=t
+runas_guest() {
+	local userid=$(($(id -u)+1))
+        FLUX_HANDLE_USERID=$userid FLUX_HANDLE_ROLEMASK=0x2 "$@"
+}
+
+submit_job_as_guest()
+{
+	local duration=$1
+	local userid=$(($(id -u)+1))
+        flux run --dry-run -t $duration \
+	  --setattr=exec.test.run_duration=\"600\" \
+	  sleep inf | \
+          flux python ${SHARNESS_TEST_SRCDIR}/scripts/sign-as.py $userid \
+            >job.signed
+        FLUX_HANDLE_USERID=$userid \
+          flux job submit --flags=signed job.signed
+}
+
+# Usage: job_manager_get_R ID
+# This needs to be a shell script since it will be run under flux-proxy(1):
+cat <<'EOF' >job_manager_get_R
+#!/bin/sh
+flux python -c \
+"import flux; \
+ payload = {\"id\":$(flux job id $1),\"attrs\":[\"R\"]}; \
+ print(flux.Flux().rpc(\"job-manager.getattr\", payload).get_str()) \
+"
+EOF
+chmod +x job_manager_get_R
+
+export PATH=$(pwd):$PATH
+
+job_manager_get_expiration() {
+	job_manager_get_R $1 | jq .R.execution.expiration
+}
+job_manager_get_starttime() {
+	job_manager_get_R $1 | jq .R.execution.starttime
+}
+
+test_expect_success 'instance owner can adjust expiration of their own job' '
+	jobid=$(flux submit --wait-event=start -t5m sleep 300) &&
+	expiration=$(job_manager_get_expiration $jobid) &&
+	test_debug "echo expiration=$expiration" &&
+	flux update $jobid duration=+1m &&
+	job_manager_get_expiration $jobid | jq -e ". == $expiration + 60"
+'
+test_expect_success 'duration update with expiration in past fails' '
+	test_must_fail flux update $jobid duration=10ms 2>err.log &&
+	grep past err.log
+'
+#  Test that job execution systems sees an expiration update by
+#  waiting for an expected log message from the job-exec module
+#
+test_expect_success 'duration update is processed by execution system' '
+	flux update $jobid duration=+1m &&
+	$SHARNESS_TEST_SRCDIR/scripts/dmesg-grep.py \
+		-vt 30 "job-exec.*updated expiration of $jobid" &&
+	flux job cancel $jobid &&
+	flux job wait-event $jobid clean
+'
+#  Test that the job shell correctly processes an expiration update.
+#  Set up the job shell to send SIGTERM to the job 60s before expiration.
+#  for a job with a 5m duration. Then adjust duration such that expiration
+#  will occur 30s from now, and ensure the job shell picks up the update and
+#  sends SIGTERM immediately.
+#
+test_expect_success 'duration update is processed by job shell' '
+	jobid=$(flux submit --wait-event start \
+		-o verbose --signal=SIGTERM@60 -t5 sleep 300) &&
+	duration=$(job_manager_get_starttime $jobid | jq "now - . + 30") &&
+	flux update $jobid duration=$duration &&
+	test_must_fail_or_be_terminated \
+		flux job attach $jobid >shell.log 2>&1 &&
+	test_debug "cat shell.log" &&
+	grep "Will send SIGTERM to job in 0\.0" shell.log &&
+	grep "sending SIGTERM" shell.log
+'
+test_expect_success 'duration can be set to unlimited for a running job' '
+	jobid=$(flux submit --wait-event=start -t5m sleep 300) &&
+	expiration=$(job_manager_get_expiration $jobid) &&
+	test_debug "echo expiration=$expiration" &&
+	flux update $jobid duration=0 &&
+	job_manager_get_expiration $jobid | jq -e ". == 0." &&
+	flux cancel $jobid &&
+	flux job wait-event $jobid clean
+'
+test_expect_success HAVE_FLUX_SECURITY 'duration update of running job is denied for guest' '
+	jobid=$(submit_job_as_guest 5m) &&
+	flux job wait-event -vt 30 $jobid start &&
+	test_must_fail runas_guest flux update $jobid duration=+1m &&
+	flux cancel $jobid
+'
+test_expect_success HAVE_FLUX_SECURITY 'duration update of running guest job is allowed for owner' '
+	jobid=$(submit_job_as_guest 5m) &&
+	flux job wait-event -vt 30 $jobid start &&
+	expiration=$(job_manager_get_expiration $jobid) &&
+	flux update $jobid duration=+1m &&
+	job_manager_get_expiration $jobid | jq -e ". == $expiration + 60" &&
+	flux cancel $jobid
+'
+#  Set module debug flag 0x4 on sched-simple so it will deny sched.expiration
+#  RPCs:
+test_expect_success 'expiration update can be denied by scheduler' '
+	flux module debug --set 4 sched-simple &&
+	jobid=$(flux submit --wait-event=start -t 5m sleep 300) &&
+	test_must_fail flux update $jobid duration=+10m >sched-deny.out 2>&1 &&
+	test_debug "cat sched-deny.out" &&
+	grep "scheduler refused" sched-deny.out &&
+	flux cancel $jobid &&
+	flux module debug --clear sched-simple
+'
+#  Set module debug flag on job-exec so it will respond with error to the
+#  exec.expiration RPC from job manager:
+test_expect_success 'failure in exec.expiration RPC results in nonfatal job exception' '
+	flux module debug --set 1 job-exec &&
+	jobid=$(flux submit --wait-event=start -t 5m sleep 300) &&
+	flux update $jobid duration=1m &&
+	flux job wait-event -vt 30 -m severity=1 $jobid exception &&
+	flux cancel $jobid
+'
+subinstance_get_R() {
+	flux proxy $1 flux kvs get resource.R
+}
+subinstance_get_expiration() {
+	subinstance_get_R $1 | jq .execution.expiration
+}
+# Usage: subinstance_get_duration ID JOBID
+subinstance_get_job_duration() {
+	flux proxy $1 job_manager_get_R $2 |
+		jq '.R.execution | .expiration - .starttime'
+}
+subinstance_get_job_expiration() {
+	flux proxy $1 job_manager_get_R $2 | jq '.R.execution.expiration'
+}
+
+#
+#  The following tests ensure that an expiration modification of a job
+#  is propagated to child jobs when appropriate. The tests may be somewhat
+#  difficult to follow, so are summarized in comments:
+#
+# 1. submit an instance with 5m time limit
+# 2. submit a job in that instance with no duration - its expiration should
+#    be set to that of the instance. (duration <5m)
+# 3. Submit a job with a set duration for testing (duration 4m)
+# 4. update duration of instance to 10m (+5m)
+# 5. wait for instance resource module to post resource-update event
+#    which indicates the expiration update is reflected in resource.R.
+# 6. wait for sched-simple to register expiration update by checking
+#    for expected log message
+# 7. Ensure subinstance now reflects updated expiration in resource.R.
+# 8. Ensure new expiration is 300s greater than old expiration
+#
+test_expect_success 'expiration update is detected by subinstance' '
+	id=$(flux alloc --bg -t5m -n4) &&
+	exp1=$(subinstance_get_expiration $id) &&
+	test_debug "echo instance expiration is $exp1" &&
+	id1=$(flux proxy $id flux submit sleep 300) &&
+	id2=$(flux proxy $id flux submit -t4m sleep 300) &&
+	tleft1=$(flux proxy $id flux job timeleft $id1) &&
+	duration1=$(subinstance_get_job_duration $id $id1) &&
+	duration2=$(subinstance_get_job_duration $id $id2) &&
+	test_debug "echo initial duration of job1 is $duration1" &&
+	test_debug "echo initial timeleft of job1 is $tleft1" &&
+	echo $duration1 | jq -e ". < 300" &&
+	echo $duration2 | jq -e ". == 240" &&
+	test_debug "echo updating duration of alloc job +5m" &&
+	flux update $id duration=+5m &&
+	test_debug "echo waiting for resource-update event" &&
+	flux proxy $id flux kvs eventlog wait-event -vt 30 \
+		resource.eventlog resource-update &&
+	test_debug "echo waiting for scheduler to see updated expiration" &&
+	flux proxy $id $SHARNESS_TEST_SRCDIR/scripts/dmesg-grep.py \
+		-vt 30 \"sched-simple.*expiration updated\" &&
+	exp2=$(subinstance_get_expiration $id) &&
+	subinstance_get_R $id &&
+	test_debug "echo expiration updated from $exp1 to $exp2" &&
+	echo $exp2 | jq -e ". == $exp1 + 300"
+'
+#
+#  9. Submit job to previous instance and ensure its expiration matches
+#     the updated value
+# 10. Ensure flux-job timeleft returns > 5m for the new job
+# 11. Wait for expected resource-update event to be propagated to the first job
+# 12. Ensure the timeleft of the first job is now > 5m
+#
+test_expect_success 'instance expiration update propagates to jobs' '
+	id3=$(flux proxy $id flux submit --wait-event=start sleep 300) &&
+	tleft3=$(flux proxy $id flux job timeleft $id3) &&
+	duration3=$(subinstance_get_job_duration $id $id3) &&
+	test_debug "echo timeleft of job submitted after update is $tleft3" &&
+	test_debug "echo duration of job submitted after update is $duration3" &&
+	echo $duration3 | jq -e ". > 300" &&
+	flux proxy $id flux job wait-event -vt 20 \
+		$id1 resource-update &&
+	tleft1=$(flux proxy $id flux job timeleft $id1) &&
+	duration1=$(subinstance_get_job_duration $id $id1) &&
+	test_debug "echo timeleft of job submitted extended to $tleft1" &&
+	test_debug "echo duration of job submitted extended to $duration1" &&
+	echo $duration1 | jq -e ". > 300"
+'
+#
+# 13. Check that expiration of job submitted with a duration is untouched.
+#
+test_expect_success 'instance expiration is not propagated to jobs with duration' '
+	tleft2=$(flux proxy $id flux job timeleft $id2) &&
+	duration2=$(subinstance_get_job_duration $id $id2) &&
+	test_debug "echo timeleft of job with duration is now $tleft2" &&
+	test_debug "echo duration of same job is now $duration2" &&
+	echo $duration2 | jq -e ". == 240"
+'
+#
+# 14. Now update job expiration to unlimited and ensure jobs have unlimited
+#     duration as well:
+#
+test_expect_success 'instance expiration can be updated to unlimited' '
+	test_debug "echo updating instance duration to inf" &&
+	flux update $id duration=inf &&
+	test_debug "echo waiting for second job resource-update event" &&
+	flux proxy $id flux job wait-event -c 2 -vt 20 \
+		$id1 resource-update &&
+	exp=$(subinstance_get_job_expiration $id $id1) &&
+	test_debug "echo job1 expiration is now $exp" &&
+	echo $exp | jq -e ". == 0" &&
+	flux proxy $id $SHARNESS_TEST_SRCDIR/scripts/dmesg-grep.py \
+		-vt 30 \"job-exec.*updated expiration of $id1 to 0\.0\"
+'
+#
+# 15. Now update job expiration to 1h and ensure job expiration is reduced
+#
+test_expect_success 'instance expiration can be decreased from unlimited' '
+	test_debug "echo updating instance duration to 1h" &&
+	flux update $id duration=1h &&
+	test_debug "echo waiting for third job resource-update event" &&
+	flux proxy $id flux job wait-event -c 3 -vt 20 \
+		$id1 resource-update &&
+	duration=$(subinstance_get_job_duration $id $id1) &&
+	test_debug "echo job1 duration is now $duration" &&
+	echo $duration | jq -e ". < 3600 and . > 0" &&
+	flux proxy $id $SHARNESS_TEST_SRCDIR/scripts/dmesg-grep.py \
+		-vt 30 \"job-manager.*expiration of $id1.*-inf\"
+'
+#
+# 16. Now update job expiration to 30m. Job expiration should be reduced again.
+#
+test_expect_success 'instance expiration can be decreased again' '
+	test_debug "echo updating instance duration to 30m" &&
+	flux update $id duration=-.5h &&
+	test_debug "echo waiting for fourth job resource-update event" &&
+	flux proxy $id flux job wait-event -c 4 -vt 20 \
+		$id1 resource-update &&
+	duration=$(subinstance_get_job_duration $id $id1) &&
+	test_debug "echo job1 duration is now $duration" &&
+	echo $duration | jq -e ". < 1800 and . > 0" &&
+	flux proxy $id $SHARNESS_TEST_SRCDIR/scripts/dmesg-grep.py \
+		-vt 30 \"job-manager.*expiration of $id1.*-1800\"
+'
+test_expect_success 'shutdown test instance' '
+	flux proxy $id flux cancel --all &&
+	flux shutdown --quiet $id &&
+	flux job wait-event $id clean
+'
+test_done


### PR DESCRIPTION
This PR adds full support for updating the duration/expiration of running jobs.

Updates to duration of running jobs are permitted by the update-duration plugin when made by the instance owner only. Running job duration updates are then handled as a special case in the job-manager update service. The update service sends the RFC 27 `sched.expiration` RPC and defers posting of `jobspec-update` and `duration-update` events until the RPC returns successfully.

The job execution system (which handles signaling jobs at their expiration) and the job shell (which uses the expiration for support of the `--signal` option) are updated to watch R instead of fetching it once at the beginning of the job. On updates, the expiration 

Additionally, the resource module is switched from `job-info.lookup` to `job-info.update-watch` so that it can register updates to the instance expiration. When an update in R occurs, if the new expiration does not equal the old expiration, then the resource module posts a `resource-update` event to the `resource-eventlog` after committing the new R to the KVS, and sends a response to the `sched.acquire` RPC containing the new expiration. Finally, sched-simple is extended to set the updated expiration on its internal resource set (This is used to set a default expiration for newly submitted jobs).

The job-manager update service is also extended to watch the `resource.R` KVS key. When R is updated, and the expiration has changed, then the list of running jobs is traversed and any job with an expiration matching the previous expiration has a `resource-update` event automatically applied to adjust to the new instance expiration. This allows updates in the expiration of running instance to propagate to all jobs (recursively applied if any running jobs are also instance)

This is a WIP while I think about if more testing is needed and work out any kinks found by CodeQL or other CI tests, but I thought it would be useful to post this early since there is a lot of stuff being tied together here (and perhaps some poor choices were made when trying to get this done). 

Perhaps this also could be split into multiple PRs, but leaving anything out may result in only a partial solution.

TODO before removing WIP:
- [x] resolve racy tests in `t2292-job-update-running.t`. Specifically the job-exec expiration test.
- [x] test with Fluxion