### PR TITLE
flux-environment(7): add new man page

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -319,7 +319,8 @@ MAN7_FILES = $(MAN7_FILES_PRIMARY)
 
 MAN7_FILES_PRIMARY = \
 	man7/flux-broker-attributes.7 \
-	man7/flux-jobtap-plugins.7
+	man7/flux-jobtap-plugins.7 \
+	man7/flux-environment.7
 
 
 RST_FILES  = \

--- a/doc/man1/common/submit-environment.rst
+++ b/doc/man1/common/submit-environment.rst
@@ -54,9 +54,9 @@ via a set of *RULE* expressions. The currently supported rules are
    simple substitution supports the following syntax:
 
      * ``$$`` is an escape; it is replaced with ``$``
-     * ``$var`` will substitute ``var`` from the current environment,
+     * ``$var`` will substitute :envvar:`var` from the current environment,
        falling back to the process environment. An error will be thrown
-       if environment variable ``var`` is not set.
+       if environment variable :envvar:`var` is not set.
      * ``${var}`` is equivalent to ``$var``
      * Advanced parameter substitution is not allowed, e.g. ``${var:-foo}``
        will raise an error.
@@ -66,12 +66,12 @@ via a set of *RULE* expressions. The currently supported rules are
 
  * Otherwise, the rule is considered a pattern from which to match
    variables from the process environment if they do not exist in
-   the generated environment. E.g. ``PATH`` will export ``PATH`` from the
+   the generated environment. E.g. ``PATH`` will export :envvar:`PATH` from the
    current environment (if it has not already been set in the generated
    environment), and ``OMP*`` would copy all environment variables that
-   start with ``OMP`` and are not already set in the generated environment.
-   It is important to note that if the pattern does not match any variables,
-   then the rule is a no-op, i.e. an error is *not* generated.
+   start with :envvar:`OMP` and are not already set in the generated
+   environment.  It is important to note that if the pattern does not match
+   any variables, then the rule is a no-op, i.e. an error is *not* generated.
 
    Examples:
        ``PATH``, ``FLUX_*_PATH``, ``/^OMP.*/``
@@ -80,7 +80,7 @@ Since we always starts with a copy of the current environment,
 the default implicit rule is ``*`` (or :option:`--env=*`). To start with an
 empty environment instead, the ``-*`` rule or :option:`--env-remove=*` option
 should be used. For example, the following will only export the current
-``PATH`` to a job:
+:envvar:`PATH` to a job:
 
 ::
 
@@ -111,6 +111,6 @@ This works particularly well when specifying rules in a file:
     BAR=${FOO}/baz
 
 The above file would first clear the environment, then copy all variables
-starting with ``OMP`` from the current environment, set ``FOO=bar``,
+starting with :envvar:`OMP` from the current environment, set ``FOO=bar``,
 and then set ``BAR=bar/baz``.
 

--- a/doc/man1/common/submit-job-environment-variables.rst
+++ b/doc/man1/common/submit-job-environment-variables.rst
@@ -1,29 +1,33 @@
 JOB ENVIRONMENT VARIABLES
 =========================
 
-Flux creates several environment variables for every job task.  They are as follows:
+The job environment is described in more detail in the :man7:`flux-environment`
+:ref:`job_environment` section.  A summary of the most commonly used variables
+is provided below:
 
-**FLUX_JOB_ID**
-    The jobid for this job
+.. list-table::
+   :header-rows: 1
 
-**FLUX_URI**
-    The URI of the enclosing Flux instance
+   * - Name
+     - Description
 
-**FLUX_JOB_TMPDIR**
-    Path to temporary directory created for job
+   * - :envvar:`FLUX_JOB_ID`
+     - the current jobid
 
-**FLUX_TASK_LOCAL_ID**
-    The task id local to the node
+   * - :envvar:`FLUX_JOB_SIZE`
+     - the number of tasks in the current job
 
-**FLUX_TASK_RANK**
-    The global rank for this task
+   * - :envvar:`FLUX_JOB_NNODES`
+     - the total number of nodes hosting tasks on behalf of the job
 
-**FLUX_JOB_NNODES**
-    The total number of nodes in the job
+   * - :envvar:`FLUX_TASK_RANK`
+     - the global task rank (zero origin)
 
-**FLUX_JOB_SIZE**
-    The count of job shells in the job, typical the same value as FLUX_JOB_NNODES
+   * - :envvar:`FLUX_TASK_LOCAL_ID`
+     - the local task rank (zero origin)
 
-**FLUX_KVS_NAMESPACE**
-    The identifier of the KVS guest namespace of the job. This redirects KVS command and
-    API calls to the job guest namespace instead of the root namespace.
+   * - :envvar:`FLUX_JOB_TMPDIR`
+     - path to temporary, per-job directory, usually in ``/tmp``
+
+   * - :envvar:`FLUX_URI`
+     - the URI of the enclosing Flux instance

--- a/doc/man1/common/submit-other-options.rst
+++ b/doc/man1/common/submit-other-options.rst
@@ -92,11 +92,11 @@ OTHER OPTIONS
      within the following search path, in order of precedence:
 
      - ``XDG_CONFIG_HOME/flux/config`` or ``$HOME/.config/flux/config`` if
-       ``XDG_CONFIG_HOME`` is not set
+       :envvar:`XDG_CONFIG_HOME` is not set
 
      - ``$XDG_CONFIG_DIRS/flux/config`` or ``/etc/xdg/flux/config`` if
-       ``XDG_CONFIG_DIRS`` is not set. Note that ``XDG_CONFIG_DIRS`` may
-       be a colon-separated path.
+       :envvar:`XDG_CONFIG_DIRS` is not set. Note that :envvar:`XDG_CONFIG_DIRS`
+       may be a colon-separated path.
 
 .. option:: --begin-time=+FSD|DATETIME
 
@@ -184,16 +184,16 @@ OTHER OPTIONS
 .. option:: --cc=IDSET
 
    *(submit,bulksubmit)* Replicate the job for each ``id`` in ``IDSET``.
-   ``FLUX_JOB_CC=id`` will be set in the environment of each submitted job
-   to allow the job to alter its execution based on the submission index.
-   (e.g. for reading from a different input file). When using :option:`--cc`,
-   the substitution string ``{cc}`` may be used in options and commands
-   and will be replaced by the current ``id``.
+   :envvar:`FLUX_JOB_CC` will be set to ``id`` in the environment of each
+   submitted job to allow the job to alter its execution based on the
+   submission index.  (e.g. for reading from a different input file). When
+   using :option:`--cc`, the substitution string ``{cc}`` may be used in
+   options and commands and will be replaced by the current ``id``.
 
 .. option:: --bcc=IDSET
 
    *(submit,bulksubmit)* Identical to :option:`--cc`, but do not set
-   ``FLUX_JOB_CC`` in each job. All jobs will be identical copies.
+   :envvar:`FLUX_JOB_CC` in each job. All jobs will be identical copies.
    As with :option:`--cc`, ``{cc}`` in option arguments and commands will be
    replaced with the current ``id``.
 

--- a/doc/man1/common/submit-shell-options.rst
+++ b/doc/man1/common/submit-shell-options.rst
@@ -46,6 +46,7 @@ overridden in some cases:
 
 .. option:: -o stage-in
 
-   Copy files previously mapped with :man1:`flux-filemap` to $FLUX_JOB_TMPDIR.
-   See :man1:`flux-shell` for more *stage-in* options.
+   Copy files previously mapped with :man1:`flux-filemap` to the directory
+   referred to by :envvar:`FLUX_JOB_TMPDIR`.  See :man1:`flux-shell` for more
+   *stage-in* options.
 

--- a/doc/man1/flux-config.rst
+++ b/doc/man1/flux-config.rst
@@ -120,32 +120,36 @@ The following configuration keys may be printed with
    The configured ``${libexecdir/flux/cmd`` directory.
 
 **lua_cpath_add**
-   Consulted by :man1:`flux` when setting the LUA_CPATH environment variable.
+   Consulted by :man1:`flux` when setting the :envvar:`LUA_CPATH` environment
+   variable.
 
 **lua_path_add**
-   Consulted by :man1:`flux` when setting the LUA_PATH environment variable.
+   Consulted by :man1:`flux` when setting the :envvar:`LUA_PATH` environment
+   variable.
 
 **python_path**
-   Consulted by :man1:`flux` when setting the PYTHONPATH environment variable.
+   Consulted by :man1:`flux` when setting the :envvar:`PYTHONPATH` environment
+   variable.
 
 **man_path**
-   Consulted by :man1:`flux` when setting the MANPATH environment variable.
+   Consulted by :man1:`flux` when setting the :envvar:`MANPATH` environment
+   variable.
 
 **exec_path**
-   Consulted by :man1:`flux` when setting the FLUX_EXEC_PATH environment
-   variable.
+   Consulted by :man1:`flux` when setting the :envvar:`FLUX_EXEC_PATH`
+   environment variable.
 
 **connector_path**
-   Consulted by :man1:`flux` when setting the FLUX_CONNECTOR_PATH environment
-   variable.
+   Consulted by :man1:`flux` when setting the :envvar:`FLUX_CONNECTOR_PATH`
+   environment variable.
 
 **module_path**
-   Consulted by :man1:`flux` when setting the FLUX_MODULE_PATH environment
-   variable.
+   Consulted by :man1:`flux` when setting the :envvar:`FLUX_MODULE_PATH`
+   environment variable.
 
 **pmi_library_path**
-   Consulted by :man1:`flux` when setting the FLUX_PMI_LIBRARY_PATH environment
-   variable.
+   Consulted by :man1:`flux` when setting the :envvar:`FLUX_PMI_LIBRARY_PATH`
+   environment variable.
 
 **cmdhelp_pattern**
    Used by :man1:`flux` to generate a list of common commands when run without

--- a/doc/man1/flux-filemap.rst
+++ b/doc/man1/flux-filemap.rst
@@ -47,7 +47,8 @@ is not on a network file system without considering the ramifications.
 :option:`flux filemap unmap` unmaps mapped files.
 
 The ``stage-in`` shell plugin described in :man1:`flux-shell` may be used to
-extract previously mapped files into $FLUX_JOB_TMPDIR or another directory.
+extract previously mapped files into the directory referred to by
+:envvar:`FLUX_JOB_TMPDIR` or another directory.
 
 OPTIONS
 =======
@@ -132,7 +133,7 @@ by multiple jobs.
   flux filemap unmap
 
 Example 2: a batch script that maps two data sets with tags, then uses the
-``stage-in`` shell plugin to selectively copy them to $FLUX_JOB_TMPDIR,
+``stage-in`` shell plugin to selectively copy them to :envvar:`FLUX_JOB_TMPDIR`
 which is automatically cleaned up after each job.
 
 .. code-block:: console

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -58,8 +58,8 @@ display a status line while the job is pending, e.g
 
     flux-job: ƒJqUHUCzX9 waiting for resources                 00:00:08
 
-This status line may be suppressed by setting ``FLUX_ATTACH_NONINTERACTIVE``
-in the environment.
+This status line may be suppressed by setting
+:envvar:`FLUX_ATTACH_NONINTERACTIVE` in the environment.
 
 .. option:: -l, --label-io
 

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -78,10 +78,10 @@ OPTIONS
    Specify a named output format *NAME* or a format string using Python's
    format syntax. See `OUTPUT FORMAT`_ below for field names. Named formats
    may be listed via :option:`--format=help`.  An alternate default format can
-   be set via the FLUX_JOBS_FORMAT_DEFAULT environment variable.  Additional
-   named formats may be registered with :program:`flux jobs` via configuration.
-   See the `CONFIGURATION`_ section for more details. A configuration snippet
-   for an existing named format may be generated with
+   be set via the :envvar:`FLUX_JOBS_FORMAT_DEFAULT` environment variable.
+   Additional named formats may be registered with :program:`flux jobs` via
+   configuration.  See the `CONFIGURATION`_ section for more details. A
+   configuration snippet for an existing named format may be generated with
    :option:`--format=get-config=NAME`.
 
 .. option:: --json
@@ -503,12 +503,13 @@ The :program:`flux jobs` command supports registration of named output formats
 in configuration files. The command loads configuration files from
 ``flux-jobs.EXT`` from the following paths in order of increasing precedence:
 
- * ``$XDG_CONFIG_DIRS/flux`` or ``/etc/xdg/flux`` if ``XDG_CONFIG_DIRS`` is
-   not set. Note that ``XDG_CONFIG_DIRS`` is traversed in reverse order
-   such that entries first in the colon separated path are highest priority.
+ * ``$XDG_CONFIG_DIRS/flux`` or ``/etc/xdg/flux`` if :envvar:`XDG_CONFIG_DIRS`
+   is not set. Note that :envvar:`XDG_CONFIG_DIRS` is traversed in reverse
+   order such that entries first in the colon separated path are highest
+   priority.
 
- * ``XDG_CONFIG_HOME/flux`` or ``$HOME/.config/flux`` if ``XDG_CONFIG_HOME``
-   is not set
+ * ``$XDG_CONFIG_HOME/flux`` or ``$HOME/.config/flux`` if
+   :envvar:`XDG_CONFIG_HOME` is not set
 
 where ``EXT`` can be one of ``toml``, ``yaml``, or ``json``.
 

--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -37,7 +37,7 @@ Different KVS namespaces can be created in which kvs values can be
 read from/written to. By default, all KVS operations operate on the
 default KVS namespace "primary". An alternate namespace can be
 specified in most kvs commands via the *--namespace* option, or by
-setting the namespace in the environment variable FLUX_KVS_NAMESPACE.
+setting the namespace in the environment variable :envvar:`FLUX_KVS_NAMESPACE`.
 
 :program:`flux kvs` runs a KVS *COMMAND*. The possible commands and their
 arguments are described below.

--- a/doc/man1/flux-pgrep.rst
+++ b/doc/man1/flux-pgrep.rst
@@ -72,12 +72,12 @@ OPTIONS
 
    Specify a named output format *NAME* or a format string using Python's
    format syntax.  An alternate default format can be set via the
-   FLUX_PGREP_FORMAT_DEFAULT environment variable.  For full documentation of
-   this option, including supported field names and format configuration
-   options, see :man1:flux-jobs. This command shares configured named formats
-   with *flux-jobs* by reading *flux-jobs* configuration files. Supported
-   builtin named formats include *default*, *full*, *long*, and *deps*. The
-   default format emits the matched jobids only. (pgrep only)
+   :envvar:`FLUX_PGREP_FORMAT_DEFAULT` environment variable.  For full
+   documentation of this option, including supported field names and format
+   configuration options, see :man1:flux-jobs. This command shares configured
+   named formats with *flux-jobs* by reading *flux-jobs* configuration files.
+   Supported builtin named formats include *default*, *full*, *long*, and
+   *deps*. The default format emits the matched jobids only. (pgrep only)
 
 .. option:: -n, --no-header
 

--- a/doc/man1/flux-proxy.rst
+++ b/doc/man1/flux-proxy.rst
@@ -18,7 +18,7 @@ DESCRIPTION
 .. program:: flux proxy
 
 :program:`flux proxy` connects to the Flux instance identified by *TARGET*,
-then spawns a shell with FLUX_URI pointing to a local:// socket
+then spawns a shell with :envvar:`FLUX_URI` pointing to a local:// socket
 managed by the proxy program. As long as the shell is running,
 the proxy program routes messages between the instance and the
 local:// socket. Once the shell terminates, the proxy program
@@ -72,7 +72,7 @@ OPTIONS
 EXAMPLES
 ========
 
-Connect to a job running on the localhost which has a FLUX_URI
+Connect to a job running on the localhost which has a :envvar:`FLUX_URI`
 of ``local:///tmp/flux-123456-abcdef/0/local`` and spawn an interactive
 shell:
 

--- a/doc/man1/flux-queue.rst
+++ b/doc/man1/flux-queue.rst
@@ -130,10 +130,10 @@ OUTPUT FORMAT
 The :option:`--format` option can be used to specify an output format using
 Python's string format syntax or a defined format by name. For a list of
 built-in and configured formats use :option:`-o help`.  An alternate default
-format can be set via the FLUX_QUEUE_LIST_FORMAT_DEFAULT environment variable.
-A configuration snippet for an existing named format may be generated with
-:option:`--format=get-config=NAME`.  See :man1:`flux-jobs` *OUTPUT FORMAT*
-section for a detailed description of this syntax.
+format can be set via the :envvar:`FLUX_QUEUE_LIST_FORMAT_DEFAULT` environment
+variable.  A configuration snippet for an existing named format may be
+generated with :option:`--format=get-config=NAME`.  See :man1:`flux-jobs`
+*OUTPUT FORMAT* section for a detailed description of this syntax.
 
 The following field names can be specified:
 

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -175,15 +175,14 @@ OUTPUT FORMAT
 The :option:`--format` option can be used to specify an output format using
 Python's string format syntax or a defined format by name. For a list of
 built-in and configured formats use :option:`-o help`.  An alternate default
-<<<<<<< HEAD
-format can be set via the FLUX_RESOURCE_STATUS_FORMAT_DEFAULT,
-FLUX_RESOURCE_DRAIN_FORMAT_DEFAULT, and FLUX_RESOURCE_LIST_FORMAT_DEFAULT
-environment variables (for :program:`flux resource status`,
-:program:`flux resource drain`, and :program:`flux resource list`
-respectively).  A configuration snippet for an existing named format may be
-generated with :option:`--format=get-config=NAME`.  See :man1:`flux-jobs`
-:ref:`flux_jobs_output_format` section for a detailed description of this
-syntax.
+format can be set via the :envvar:`FLUX_RESOURCE_STATUS_FORMAT_DEFAULT`,
+:envvar:`FLUX_RESOURCE_DRAIN_FORMAT_DEFAULT`, and
+:envvar:`FLUX_RESOURCE_LIST_FORMAT_DEFAULT` environment variables (for
+:program:`flux resource status`, :program:`flux resource drain`, and
+:program:`flux resource list` respectively).  A configuration snippet for an
+existing named format may be generated with :option:`--format=get-config=NAME`.
+See :man1:`flux-jobs` :ref:`flux_jobs_output_format` section for a detailed
+description of this syntax.
 
 Resources are combined into a single line of output when possible depending on
 the supplied output format.  Resource counts are not included in the

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -51,7 +51,7 @@ OPERATION
 When a job has been granted resources by a Flux instance, a
 :program:`flux shell` process is invoked on each broker rank involved in the
 job. The job shell runs as the job user, and will always have
-``FLUX_KVS_NAMESPACE`` set such that the root of the job shell's
+:envvar:`FLUX_KVS_NAMESPACE` set such that the root of the job shell's
 KVS accesses will be the guest namespace for the job.
 
 Each :program:`flux shell` connects to the local broker, fetches the jobspec
@@ -259,7 +259,7 @@ options are supported by the builtin plugins of :program:`flux shell`:
 
 **gpu-affinity**\ =\ *OPT*
   Adjust operation of the builtin shell ``gpubind`` plugin, which simply
-  sets ``CUDA_VISIBLE_DEVICES`` to the GPU IDs allocated to the job.
+  sets :envvar:`CUDA_VISIBLE_DEVICES` to the GPU IDs allocated to the job.
   *OPT* may be set to ``off`` to disable the plugin, or ``per-task``
   to divide allocated GPUs among tasks launched by the shell (sets a
   different GPU ID or IDs for each launched task). If *OPT* starts with
@@ -334,8 +334,8 @@ options are supported by the builtin plugins of :program:`flux shell`:
   virtual tree fanout of ``N`` for key gather/broadcast.  The default is 2.
 
 **stage-in**
-  Copy files to $FLUX_JOB_TMPDIR that were previously mapped using
-  :man1:`flux-filemap`.
+  Copy files to the directory referenced by :envvar:`FLUX_JOB_TMPDIR` that
+  were previously mapped using :man1:`flux-filemap`.
 
 **stage-in.tags**\ =\ *LIST*
   Select files to copy by specifying a comma-separated list of tags.
@@ -345,12 +345,12 @@ options are supported by the builtin plugins of :program:`flux shell`:
   Further filter the selected files to copy using a :man7:`glob` pattern.
 
 **stage-in.destination**\ =\ *[SCOPE:]PATH*
-  Copy files to the specified destination instead of $FLUX_JOB_TMPDIR.
-  The argument is a directory with optional *scope* prefix.  A scope of
-  ``local`` denotes a local file system (the default), and a scope of
-  ``global`` denotes a global file system.  The copy takes place on all the
-  job's nodes if the scope is local, versus only the first node of the
-  job if the scope is global.
+  Copy files to the specified destination instead of the directory referenced
+  by :envvar:`FLUX_JOB_TMPDIR`.  The argument is a directory with optional
+  *scope* prefix.  A scope of ``local`` denotes a local file system (the
+  default), and a scope of ``global`` denotes a global file system.  The copy
+  takes place on all the job's nodes if the scope is local, versus only the
+  first node of the job if the scope is global.
 
 **signal=OPTION**
   Deliver signal ``SIGUSR1`` to the job 60s before job expiration.
@@ -366,11 +366,11 @@ options are supported by the builtin plugins of :program:`flux shell`:
   Send signal ``signal.signum`` *TIME* seconds before job expiration.
 
 .. warning::
-  The $FLUX_JOB_TMPDIR is cleaned up when the job ends, is guaranteed to
-  be unique, and is generally on fast local storage such as a *tmpfs*.
-  If a destination is explicitly specified, use the ``global:`` prefix
-  where appropriate to avoid overwhelming a shared file system, and be sure
-  to clean up.
+  The directory referenced by :envvar:`FLUX_JOB_TMPDIR` is cleaned up when the
+  job ends, is guaranteed to be unique, and is generally on fast local storage
+  such as a *tmpfs*.  If a destination is explicitly specified, use the
+  ``global:`` prefix where appropriate to avoid overwhelming a shared file
+  system, and be sure to clean up.
 
 SHELL INITRC
 ============

--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -46,8 +46,8 @@ OPTIONS
 
    Run brokers with Caliper profiling enabled, using a Caliper
    configuration profile named *PROFILE*. Requires a version of Flux
-   built with :option:`--enable-caliper`. Unless CALI_LOG_VERBOSITY is already
-   set in the environment, it will default to 0 for all brokers.
+   built with :option:`--enable-caliper`. Unless :envvar:`CALI_LOG_VERBOSITY`
+   is already set in the environment, it will default to 0 for all brokers.
 
 .. option:: --rundir=DIR
 
@@ -69,8 +69,8 @@ OPTIONS
 
 .. option:: --test-hosts=HOSTLIST
 
-   Set FLUX_FAKE_HOSTNAME in the environment of each broker so that the
-   broker can bootstrap from a config file instead of PMI.  HOSTLIST is
+   Set :envvar:`FLUX_FAKE_HOSTNAME` in the environment of each broker so that
+   the broker can bootstrap from a config file instead of PMI.  HOSTLIST is
    assumed to be in rank order.  The broker will use the fake hostname to
    find its entry in the configured bootstrap host array.
 

--- a/doc/man1/flux-uri.rst
+++ b/doc/man1/flux-uri.rst
@@ -20,7 +20,7 @@ connection, and are typically either *local*, with a  ``local`` URI
 scheme, or *remote*, with a ``ssh`` URI scheme. These URIs are considered
 fully-resolved, native Flux URIs.
 
-Processes running within a Flux instance will have the ``FLUX_URI``
+Processes running within a Flux instance will have the :envvar:`FLUX_URI`
 environment variable set to a native URI which :man3:`flux_open` will
 use by default, with fallback to a compiled-in native URI for the system
 instance of Flux. Therefore, there is usually no need to specify a URI when
@@ -54,7 +54,7 @@ all *TARGET* URIs support the special query arguments ``local`` or
 
 would return the ``local://`` URI for *JOBID* (if the URI can be resolved).
 
-A special environment variable FLUX_URI_RESOLVE_LOCAL will force
+A special environment variable :envvar:`FLUX_URI_RESOLVE_LOCAL` will force
 :program:`flux uri` to always resolve URIs to local form.  This is often useful
 if the local connector is known to be on the local system (i.e. within a test
 Flux instance), and ssh to localhost does not work.
@@ -92,10 +92,10 @@ jobid:ID[/ID...]
    if the target job is not running.
 
 pid:PID
-  This scheme attempts to read the ``FLUX_URI`` value from the process id
+  This scheme attempts to read the :envvar:`FLUX_URI` value from the process id
   *PID* using ``/proc/PID/environ``. If *PID* refers to a ``flux-broker``,
-  then the scheme reads ``FLUX_URI`` from the broker's initial program or
-  another child process since ``FLUX_URI`` in the broker's environment
+  then the scheme reads :envvar:`FLUX_URI` from the broker's initial program or
+  another child process since :envvar:`FLUX_URI` in the broker's environment
   would refer to *its* parent (or may not be set at all in the case of a
   test instance started with :option:`flux start --test-size=N`).
 
@@ -103,7 +103,7 @@ slurm:JOBID
   This scheme makes a best-effort to resolve the URI of a Flux instance
   launched under Slurm. It invokes ``srun`` to run ``scontrol listpids``
   on the first node of the job, and then uses the ``pid`` resolver until
-  it finds a valid ``FLUX_URI``.
+  it finds a valid :envvar:`FLUX_URI`.
 
 
 EXAMPLES

--- a/doc/man1/flux-version.rst
+++ b/doc/man1/flux-version.rst
@@ -17,7 +17,7 @@ DESCRIPTION
 :program:`flux version` prints version information for flux components.
 At a minimum, the version of flux commands and the currently linked
 libflux-core.so library is displayed. If running within an instance,
-the version of the flux-broker found and FLUX_URI are also included.
+the version of the flux-broker found and :envvar:`FLUX_URI` are also included.
 Finally, if flux is compiled against flux-security, then the version
 of the currently linked libflux-security is included.
 

--- a/doc/man1/flux.rst
+++ b/doc/man1/flux.rst
@@ -34,8 +34,8 @@ OPTIONS
 .. option:: -p, --parent
 
    If current instance is a child, connect to parent instead. Also sets
-   *FLUX_KVS_NAMESPACE* if current instance is confined to a KVS namespace
-   in the parent. This option may be specified multiple times.
+   :envvar:`FLUX_KVS_NAMESPACE` if current instance is confined to a KVS
+   namespace in the parent. This option may be specified multiple times.
 
 .. option:: -v, --verbose
 
@@ -50,50 +50,33 @@ SUB-COMMAND ENVIRONMENT
 =======================
 
 :program:`flux` uses compiled-in install paths and its environment
-to construct the environment for sub-commands.
+to construct the environment for sub-commands.  More detail is available in the
+:man7:`flux-environment` :ref:`sub_command_environment` section.  A summary
+is provided below:
 
-Sub-command search path
-   Look for "flux-*CMD*" executable by searching a path constructed
-   with the following prototype:
+.. list-table::
+   :header-rows: 1
 
-   ::
+   * - Name
+     - Description
 
-      [getenv FLUX_EXEC_PATH_PREPEND]:install-path:\
-        [getenv FLUX_EXEC_PATH]
+   * - :envvar:`FLUX_EXEC_PATH`
+     - where to look for "flux-*CMD*" executables
 
-setenv FLUX_MODULE_PATH
-   Set up broker module search path according to:
+   * - :envvar:`FLUX_MODULE_PATH`
+     - directories to look for broker modules
 
-   ::
+   * - :envvar:`FLUX_CONNECTOR_PATH`
+     - directories to search for connector modules
 
-      [getenv FLUX_MODULE_PATH_PREPEND]:install-path:\
-        [getenv FLUX_MODULE_PATH]
+   * - :envvar:`LUA_PATH`
+     - Lua module search path
 
-setenv FLUX_CONNECTOR_PATH
-   Set up search path for connector modules used by libflux to open a connection
-   to the broker
+   * - :envvar:`LUA_CPATH`
+     - Lua binary module search path
 
-   ::
-
-      [getenv FLUX_CONNECTOR_PATH_PREPEND]:install-path:\
-        [getenv FLUX_CONNECTOR_PATH]
-
-setenv LUA_PATH
-   Set Lua module search path:
-
-   [getenv FLUX_LUA_PATH_PREPEND];[getenv LUA_PATH];install-path;
-
-setenv LUA_CPATH
-   Set Lua binary module search path:
-
-   [getenv FLUX_LUA_CPATH_PREPEND];[getenv LUA_CPATH];install-path;
-
-setenv PYTHONPATH
-   Set Python module search path:
-
-   ::
-
-      [getenv FLUX_PYTHONPATH_PREPEND]:[getenv PYTHONPATH];install-path
+   * - :envvar:`PYTHONPATH`
+     - Python module search path:
 
 
 RESOURCES

--- a/doc/man3/flux_kvs_lookup.rst
+++ b/doc/man3/flux_kvs_lookup.rst
@@ -57,8 +57,8 @@ service used by Flux services.
 which acts as handle for synchronization and container for the result. The
 namespace :var:`ns` is optional. If set to NULL, :func:`flux_kvs_lookup` uses
 the default namespace, or if set, the namespace from the
-FLUX_KVS_NAMESPACE environment variable. :var:`flags` modifies the request
-as described below.
+:envvar:`FLUX_KVS_NAMESPACE` environment variable. :var:`flags` modifies the
+request as described below.
 
 :func:`flux_kvs_lookupat` is identical to :func:`flux_kvs_lookup` except
 :var:`treeobj` is a serialized RFC 11 object that references a particular

--- a/doc/man3/flux_open.rst
+++ b/doc/man3/flux_open.rst
@@ -34,8 +34,8 @@ be used to store any errors which may have otherwise gone to :var:`stderr`.
 
 The :var:`uri` scheme (before "://") specifies the "connector" that will be used
 to establish the connection. The :var:`uri` path (after "://") is parsed by the
-connector. If :var:`uri` is NULL, the value of $FLUX_URI is used.  If
-$FLUX_URI is not set, a compiled-in default URI is used.
+connector. If :var:`uri` is NULL, the value of :envvar:`FLUX_URI` is used.  If
+:envvar:`FLUX_URI` is not set, a compiled-in default URI is used.
 
 *flags* is the logical "or" of zero or more of the following flags:
 

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -8,9 +8,10 @@ DESCRIPTION
 Flux normally operates without configuration files.  If configuration is
 needed, the :man1:`flux-broker` **--config-path=PATH** option may be used
 to instruct Flux to parse a config file or, if **PATH** is a directory, all
-files matching the glob **PATH/*.toml**.  Alternatively, the FLUX_CONF_DIR
-environment variable may be used to set the configuration file or directory
-path. If both are set, the command line argument takes precedence.
+files matching the glob **PATH/*.toml**.  Alternatively, the
+:envvar:`FLUX_CONF_DIR` environment variable may be used to set the
+configuration file or directory path. If both are set, the command line
+argument takes precedence.
 
 The Flux systemd unit file starts the system instance broker with
 ``--config-path=${sysconfdir}/flux/system/conf.d``.  Further discussion of the

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -61,9 +61,9 @@ local-uri [Updates: C]
    existing directory.
 
 parent-uri
-   The value of the broker's ``FLUX_URI`` environment variable.  This is the
-   URI that should be passed to :man3:`flux_open` to establish a connection to
-   the enclosing instance.
+   The value of the broker's :envvar:`FLUX_URI` environment variable.  This is
+   the URI that should be passed to :man3:`flux_open` to establish a connection
+   to the enclosing instance.
 
 instance-level
    The nesting level of this Flux instance, or ``0`` if there is no enclosing
@@ -75,7 +75,7 @@ jobid
    other than a Flux job ID if Flux was started by another means.
 
 parent-kvs-namespace
-   The value of the broker's ``FLUX_KVS_NAMESPACE`` environment variable.
+   The value of the broker's :envvar:`FLUX_KVS_NAMESPACE` environment variable.
    This is the KVS namespace assigned to this Flux instance by its enclosing
    instance, if it was launched by Flux as a job.
 
@@ -130,16 +130,17 @@ broker.starttime
    Timestamp of broker startup from :man3:`flux_reactor_now`.
 
 conf.connector_path
-   The value of the broker's ``FLUX_CONNECTOR_PATH`` environment variable.
+   The value of the broker's :envvar:`FLUX_CONNECTOR_PATH` environment variable.
 
 conf.exec_path
-   The value of the broker's ``FLUX_EXEC_PATH`` environment variable.
+   The value of the broker's :envvar:`FLUX_EXEC_PATH` environment variable.
 
 conf.module_path
-   The value of the broker's ``FLUX_MODULE_PATH`` environment variable.
+   The value of the broker's :envvar:`FLUX_MODULE_PATH` environment variable.
 
 conf.pmi_library_path
-   The value of the broker's ``FLUX_PMI_LIBRARY_PATH`` environment variable.
+   The value of the broker's :envvar:`FLUX_PMI_LIBRARY_PATH` environment
+   variable.
 
 conf.shell_initrc [Updates: C, R]
    The path to the :man1:`flux-shell` initrc script.  Default:
@@ -151,7 +152,7 @@ conf.shell_pluginpath [Updates: C, R]
 
 config.path [Updates: see below]
    A config file or directory (containing ``*.toml`` config files) for
-   this Flux instance. This attribute may be set via the FLUX_CONF_DIR
+   this Flux instance. This attribute may be set via the :envvar:`FLUX_CONF_DIR`
    environment variable, or the :man1:`flux-broker` ``--config-path``
    command line argument.  Default: none.  See also :man5:`flux-config`.
 

--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -1,0 +1,474 @@
+===================
+flux-environment(7)
+===================
+
+
+DESCRIPTION
+===========
+
+The following environment variables are set by Flux or influence Flux.
+
+.. _job_environment:
+
+JOB ENVIRONMENT
+===============
+
+The following are set in the environment of each task spawned by
+:man1:`flux-shell` as part of a Flux job.
+
+.. envvar:: FLUX_JOB_ID
+
+   The current jobid in F58 form.  F58 is a compact, non-numeric representation
+   of Flux's 64-bit integer jobid.  If the numeric form is required, use e.g.:
+
+   .. code-block:: shell
+
+      NUMERIC_JOB_ID=$(flux job id $FLUX_JOB_ID)
+
+.. envvar:: FLUX_JOB_SIZE
+
+   The number of tasks in the current job.
+
+.. envvar:: FLUX_JOB_NNODES
+
+   The total number of nodes hosting tasks on behalf of the current job.
+
+.. note::
+
+   :envvar:`FLUX_JOB_NNODES` is more precisely defined as the total number of
+   :man1:`flux-shell` processes running tasks on behalf of the current job.
+   Normally one shell is started per broker, and one broker is started per
+   node.  However, in rare test setups, a large Flux instance is mocked by
+   running multiple brokers per node.  In that case, this variable may not
+   represent the physical node count.
+
+.. envvar:: FLUX_TASK_RANK
+
+   The zero-origin, global rank for this task.  Tasks are assigned ranks using
+   a "block" algorithm by default, although :option:`flux submit --taskmap` may
+   select other mapping algorithms.
+
+   Example: 8 tasks on 2 nodes with block and cyclic task mapping:
+
+   .. list-table::
+
+      * - Mapping
+        - Node 0
+        - Node 1
+
+      * - block
+        - 0, 1, 2, 3
+	- 4, 5, 6, 7
+
+      * - cyclic
+        - 0, 2, 4, 6
+	- 1, 3, 5, 7
+
+
+.. envvar:: FLUX_TASK_LOCAL_ID
+
+   The zero-origin, local (to the node) rank for this task.
+
+   Example: 8 tasks on 2 nodes:
+
+   .. list-table::
+
+      * - Node 0
+        - Node 1
+
+      * - 0, 1, 2, 3
+	- 0, 1, 2, 3
+
+.. envvar:: FLUX_JOB_CC
+
+   When :option:`flux submit --cc` or :option:`flux bulksubmit --cc` is used
+   to submit a set of jobs, :envvar:`FLUX_JOB_CC` is set to the the integer
+   id of the current job in the set.
+
+.. envvar:: FLUX_JOB_TMPDIR
+
+   The path of a per-job temporary directory that is created on each host node
+   before any tasks are started, and cleaned up after all tasks have exited.
+   All a job's tasks on a given node share the same directory.
+
+.. envvar:: FLUX_KVS_NAMESPACE
+
+   Each job is assigned a unique, job-owner-writable Flux KVS key space that
+   is independent of the default (primary) one and persists as such while the
+   job is in the RUNNING state.  This environment variable is interpreted by
+   the Flux KVS API and therefore :man1:`flux-kvs` as a directive to treat
+   all operations as rooted in that space.  The job exec service and the job
+   shell record the job's input, output, and a log of events in this space.
+
+   After the job completes, the job's namespace is added to the primary
+   namespace and becomes part of the read-only job record.
+
+.. envvar:: PMI_RANK
+	    PMI_SIZE
+	    PMI_FD
+	    PMI_SPAWNED
+
+   The ``pmi`` shell plugin sets these variables in the job environment to
+   aid in the bootstrap of parallel programs.  They are not set when the simple
+   PMI server is disabled, e.g.  with :option:`flux run -opmi=none`.
+
+.. envvar:: CUDA_VISIBLE_DEVICES
+            CUDA_DEVICE_ORDER
+
+   The ``gpubind`` shell plugin sets these variables in the job environment
+   to assign GPU devices to tasks.  They are not set when GPU affinity is
+   disabled with :option:`flux run -ogpu-affinity=off`.
+
+.. envvar:: FLUX_URI
+
+   :envvar:`FLUX_URI` overrides the default, compiled-in broker socket path
+   in the Flux API, and by extension all the Flux commands.  In the job
+   environment, it points to the local broker responsible for the job.
+
+.. envvar:: FLUX_PMI_LIBRARY_PATH
+
+   The full path of Flux's ``libpmi.so`` shared library, which is normally not
+   installed to standard system paths.  This exists as an aid to the old
+   OpenMPI Flux MCA plugins (now defunct) so that an MPI program running
+   under Flux knows where to :func:`dlopen` the library for bootstrap.
+
+INITIAL PROGRAM ENVIRONMENT
+===========================
+
+The :man1:`flux-alloc` interactive shell and the :man1:`flux-batch` batch
+script are examples of Flux initial programs.  Flux does not set many
+environment variables for the initial program.  In fact, the following
+are actively unset to avoid confusion when they are set by the *enclosing
+instance*:
+
+ - :envvar:`FLUX_JOB_ID`
+ - :envvar:`FLUX_JOB_SIZE`
+ - :envvar:`FLUX_JOB_NNODES`
+ - :envvar:`FLUX_JOB_TMPDIR`
+ - :envvar:`FLUX_TASK_RANK`
+ - :envvar:`FLUX_TASK_LOCAL_ID`
+ - :envvar:`FLUX_KVS_NAMESPACE`
+ - :envvar:`FLUX_PROXY_REMOTE`
+ - :envvar:`PMI_*`
+ - :envvar:`SLURM_*`
+
+The :envvar:`FLUX_URI` variable is set, however, so Flux commands can be used
+as needed from the initial program to obtain information they might get via the
+environment in other workload managers, for example:
+
+.. code-block:: shell
+
+   BATCH_NNODES=$(flux resource list -n -o {nnodes})
+   BATCH_NCORES=$(flux resource list -n -o {ncores})
+   BATCH_NGPUS=$(flux resource list -n -o {ngpus})
+   BATCH_HOSTLIST=$(flux getattr hostlist)
+   BATCH_JOBID=$(flux getattr jobid)
+
+
+PMI CLIENT
+==========
+
+The :man1:`flux-broker` is capable of bootstrapping from configuration or
+using a PMI client, similar to the way an MPI program bootstraps.  The broker's
+PMI *client* is separate from the :man1:`flux-shell` PMI *server* offered to
+parallel programs launched by Flux.  The following environment variables
+affect the broker's PMI client.
+
+.. envvar:: FLUX_PMI_DEBUG
+
+   When set (to any value) in the broker's environment, PMI client tracing
+   is enabled, causing PMI operations that occur during broker bootstrap to
+   be logged to standard error.
+
+.. envvar:: FLUX_PMI_CLIENT_METHODS
+
+   Flux iterates through a list of PMI client implementations to find one that
+   works.  By default the list is ``simple libpmi2 libpmi single``.  The
+   sequence can be altered by setting this variable to a space-delimited list
+   of client implementations.  The built-in ones are:
+
+   simple
+      Use the PMI-1 simple wire protocol.
+
+   libpmi2
+      :func:`dlopen` ``libpmi2.so`` and use the PMI-2 API.
+
+   libpmi
+      :func:`dlopen` ``libpmi.so`` and use the PMI-1 API.
+
+   single
+      Become a singleton.  This always succeeds so should be the last method.
+
+.. envvar:: FLUX_PMI_CLIENT_SEARCHPATH
+
+   A colon-separated list of directories to search for PMI client plugins.
+   Client plugins can be packaged separately from flux-core.
+
+.. envvar:: FLUX_IPADDR_HOSTNAME
+
+   When bootstrapping with PMI, the broker dynamically selects an TCP address
+   to bind to for overlay network communication, which it then exchanges with
+   peers using PMI.  By default, it tries to use the address associated with
+   the default route.  Setting this variable to any value in the broker's
+   environment directs it to prefer the address associated with the system
+   :linux:man1:`hostname` instead.
+
+.. envvar:: FLUX_IPADDR_V6
+
+   When dynamically selecting an address to use with PMI, the broker prefers IP
+   version 4 addresses.  Setting this variable to any value in the broker's
+   environment causes it to prefer version 6 addresses.
+
+
+CUSTOM OUTPUT FORMATS
+=====================
+
+Sites and individual users may create custom output formats for some Flux
+commands.  The formats are expressed in configuration files with a base name
+of the command name plus a ``.toml``, ``.yaml``, or ``.json`` extension,
+stored in directories that follow the `XDG Base Directory Specification
+<https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_.
+
+Named formats are merged and/or overridden in the following order:
+
+   #. internal defaults
+   #. config files found in a ``flux`` sub-directory of the
+      :envvar:`XDG_CONFIG_DIRS` directories
+   #. config files found in a ``flux`` sub-directory of
+      :envvar:`XDG_CONFIG_HOME`
+
+For more information on named formats see the individual command documentation
+and the :ref:`flux_jobs_configuration` section of :man1:`flux-jobs`.
+
+.. envvar:: XDG_CONFIG_DIRS
+
+   A colon-separated, preference-ordered list of base directories to search for
+   configuration files in addition to the :envvar:`XDG_CONFIG_HOME` base
+   directory.  If unset, ``/etc/xdg`` is used.
+
+.. envvar:: XDG_CONFIG_HOME
+
+   The base directory for user-specific configuration files.  If unset,
+   ``$HOME/.config`` is used.
+
+.. envvar:: FLUX_JOBS_FORMAT_DEFAULT
+            FLUX_RESOURCE_STATUS_FORMAT
+            FLUX_RESOURCE_LIST_FORMAT_DEFAULT
+            FLUX_QUEUE_LIST_FORMAT_DEFAULT
+            FLUX_PGREP_FORMAT_DEFAULT
+
+   In addition to registering custom named formats, users and sites can change
+   the default output format to one of the named formats by setting an
+   environment variable to the format name.  The above variables affect the
+   default output of :man1:`flux-jobs`, :man1:`flux-resource`,
+   :man1:`flux-queue`, and :man1:`flux-pgrep`.
+
+
+TESTING
+=======
+
+The following environment variables are primarily useful when debugging Flux
+components or writing tests.
+
+.. envvar:: FLUX_HANDLE_TRACE
+
+   If set in the environment of a Flux component, the ``FLUX_O_TRACE`` flag
+   is automatically set in any call to :man3:`flux_open`.  This causes decoded
+   messages passed over the :c:type:`flux_t` handle to be decoded and printed
+   on standard error.
+
+.. envvar:: FLUX_HANDLE_MATCHDEBUG
+
+   If set in the environment of a Flux component, the ``FLUX_O_MATCHDEBUG``
+   flag is automatically set in any call to :man3:`flux_open`.  This causes a
+   diagnostic to be printed to standard error if any matchtags are leaked when
+   the broker connection is closed.
+
+.. envvar:: FLUX_HANDLE_USERID
+
+   Mock a user.  If set to a numerical user ID in the environment of a Flux
+   component, all messages sent by the component appear to have been sent by
+   this user.  This is useful for testing code that authorizes actions based on
+   the identity of the requesting user.  This is restricted to the instance
+   owner.
+
+.. envvar:: FLUX_HANDLE_ROLEMASK
+
+   Mock a rolemask (capability set).  If set to a decimal or hex (``0x``
+   prefixed) value in the environment of a Flux component, all messages sent
+   by the component are stamped with this rolemask. This is useful for testing
+   code that authorizes actions based on the possession of particular roles.
+   This is restricted to the instance owner.
+
+.. envvar:: FLUX_FAKE_HOSTNAME
+
+   When Flux bootstraps from a configuration file as described in
+   :man5:`flux-config-bootstrap`, a :man1:`flux-broker` determines its rank
+   by looking up its own hostname in a ``hosts`` array and using the array
+   index as its rank.  To allow this to be tested on a single node,
+   :envvar:`FLUX_FAKE_HOSTNAME` may be set in the broker's environment to use
+   the specified name instead of the result of :linux:man3:`gethostname`.  Use
+   of this capability in test is simplified by the
+   :option:`flux start --test-hosts` option.
+
+.. envvar:: FLUX_HWLOC_XMLFILE
+
+   Flux discovers available resources dynamically using `HWLOC
+   <https://www.open-mpi.org/projects/hwloc/>`_.  In some cases dynamic
+   discovery is not desired, such as when it causes poor performance in
+   parallel testing.  Flux may be directed to read topology from an XML file
+   instead by setting :envvar:`FLUX_HWLOC_XMLFILE` to the file path.
+
+   :program:`flux resource reload` offers a related mechanism for loading a
+   set of HWLOC xml files directly into the instance resource inventory
+   for test scenarios.
+
+.. envvar:: FLUX_URI_RESOLVE_LOCAL
+
+   If set, force :man1:`flux-uri` and the URI resolver embedded in other
+   commands to resolve URIs to local form.  This is useful in test environments
+   where the remote connector does not work.
+
+
+MISCELLANEOUS
+=============
+
+.. envvar:: FLUX_F58_FORCE_ASCII
+
+   A locale or terminal misconfiguration can cause the ``ƒ`` character used in
+   Flux jobids to be rendered incorrectly.  As a workaround, set this variable
+   and ASCII ``f`` is used instead.
+
+.. envvar:: FLUX_CONF_DIR
+
+   If set in in the :man1:`flux-broker` environment, configuration files
+   matching ``*.toml`` are loaded from the specified directory.  The
+   :option:`flux broker --config-path` option does that too, and is more
+   flexible in that it can also load single files in TOML or JSON format.
+
+.. envvar:: FLUX_ATTACH_NONINTERACTIVE
+
+   If set, never show the status line in :program:`flux job attach` output.
+
+.. envvar:: FLUX_PROXY_REMOTE
+
+   When :man1:`flux-proxy` connects to a remote instance, it sets this variable
+   to the authority part of the remote URI.  This serves as a hint to
+   :man3:`flux_attr_get` to transform the value of the ``parent-uri`` broker
+   attribute into a remote URI so it can work from the remote proxy environment.
+   For example:
+
+   .. code-block:: shell
+
+      $ flux alloc -N1
+      f(s=1,d=1) $ flux getattr parent-uri
+      local:///run/flux/local
+
+   .. code-block:: shell
+
+      $ flux proxy $(flux job last)
+      ƒ(s=1,d=1) $ printenv FLUX_PROXY_REMOTE
+      test0
+      ƒ(s=1,d=1) $ flux getattr parent-uri
+      ssh://test0/run/flux/local
+
+.. envvar:: FLUX_TERMINUS_SESSION
+
+   The current terminus session ID.  A terminus session is started when the
+   job has an interactive pseudo-terminal, which occurs when a job is run with
+   :option:`flux run -o pty.interactive`, or when a Flux instance is started
+   with :man1:`flux-alloc`.
+
+.. envvar:: FLUX_RC_EXTRA
+
+   If set to a colon-separated list of directories, the installed
+   :man1:`flux-broker` rc scripts search these directories for additional
+   scripts to run during broker initialization and finalization.
+
+   Specifically the ``rc1`` script runs ``rc1.d/*`` in each directory
+   and the ``rc3`` script runs ``rc3.d/*`` in each directory.
+
+.. envvar:: FLUX_SHELL_RC_PATH
+
+   Set to a colon-separated list of directories to be added to the directories
+   that :man1:`flux-shell` searches for lua scripts to extend its initrc.
+
+.. envvar:: FLUX_SSH
+
+   Override the compiled-in path to the :program:`ssh` executable used by the
+   ssh connector.  The ssh connector is invoked when attempting to open a
+   connection to Flux with a URI that begins with ``ssh://``.
+
+.. envvar:: FLUX_SSH_RCMD
+
+   Override the heuristically-determined remote path to the :man1:`flux`
+   command front end executable used by the ssh connector to start
+   :program:`flux relay` on the remote system.
+
+.. _sub_command_environment:
+
+SUB-COMMAND ENVIRONMENT
+=======================
+
+:man1:`flux` sets up the environment for sub-commands using a combination
+of compiled-in install paths and the environment.
+
+.. envvar:: FLUX_EXEC_PATH
+            FLUX_EXEC_PATH_PREPEND
+
+   :man1:`flux` finds sub-command executables by searching:
+
+      $FLUX_EXEC_PATH_PREPEND : install-path : $FLUX_EXEC_PATH
+
+   Values may include multiple directories separated by colons.
+
+.. envvar:: FLUX_MODULE_PATH
+            FLUX_MODULE_PATH_PREPEND
+
+   :envvar:`FLUX_MODULE_PATH` is set in the environment of the broker
+   so that broker modules can be found and loaded when requested by
+   :man1:`flux-module`:
+
+      $FLUX_MODULE_PATH_PREPEND : install-path : $FLUX_MODULE_PATH
+
+   Values may include multiple directories separated by colons.
+
+.. envvar:: FLUX_CONNECTOR_PATH
+            FLUX_CONNECTOR_PATH_PREPEND
+
+   :envvar:`FLUX_CONNECTOR_PATH` is set in the environment of sub-commands so
+   that :man3:`flux_open` can find the connector corresponding to the URI
+   scheme:
+
+      $FLUX_CONNECTOR_PATH_PREPEND : install-path : $FLUX_CONNECTOR_PATH
+
+   Values may include multiple directories separated by colons.
+
+.. envvar:: PYTHONPATH
+            FLUX_PYTHONPATH_PREPEND
+
+   :envvar:`PYTHONPATH` is set so that sub-commands can find required Python
+   libraries:
+
+      $FLUX_PYTHONPATH_PREPEND : install-path : $PYTHONPATH
+
+   Values may include multiple directories separated by colons.
+
+.. envvar:: LUA_PATH
+            LUA_CPATH
+            FLUX_LUA_PATH_PREPEND
+            FLUX_LUA_CPATH_PREPEND
+
+   :envvar:`LUA_PATH` and :envvar:`LUA_CPATH` are set so that sub-commands can
+   find required Lua libraries.  They are set, respectively, to
+
+      $FLUX_LUA_PATH_PREPEND ; install-path ; $LUA_PATH ;;
+
+      $FLUX_LUA_CPATH_PREPEND ; install-path ; $LUA_CPATH ;;
+
+   Values may include multiple directories separated by semicolons.
+
+SEE ALSO
+========
+
+:man1:`flux-env`

--- a/doc/man7/index.rst
+++ b/doc/man7/index.rst
@@ -3,6 +3,6 @@ Section 7 - Flux Miscellany
 
 .. toctree::
    :maxdepth: 1
+   :glob:
 
-   flux-broker-attributes
-   flux-jobtap-plugins
+   *

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -309,4 +309,5 @@ man_pages = [
     ('man5/flux-config-kvs', 'flux-config-kvs', 'configure Flux kvs service', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),
+    ('man7/flux-environment', 'flux-environment', 'Flux environment overview', [author], 7),
 ]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -775,3 +775,14 @@ uAsjAo
 resched
 func
 rfc
+envvar
+dlopen
+executables
+gethostname
+IPADDR
+MCA
+misconfiguration
+ogpu
+opmi
+printenv
+XMLFILE


### PR DESCRIPTION
This adds flux-environment(7), an attempt at "one stop shopping" for the environment variables that flux sets or that influence flux.  The environment variable references scattered throughout other pages are then formatted with the `:envvar:` markup that creates a cross-reference to the new entries in the HTML.  Some content in other pages like flux(1) and flux-run(1) was reduced to a summary table with references.

I spent some time researching each variable so I think the descriptions are of a fairly high quality but it would be good to check them over to be sure.
