### PR TITLE
flux-proxy: fix double-free on lost connection

### DIFF
--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -321,7 +321,6 @@ static void proxy_command_destroy_usock_and_router (struct proxy_command *ctx)
     ctx->server = NULL;
     router_destroy (ctx->router);
     ctx->router = NULL;
-    free (ctx->remote_uri_authority);
 }
 
 /* Attempt to reconnect to broker.  If successful, wait for for broker to
@@ -481,6 +480,7 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
     }
 done:
     proxy_command_destroy_usock_and_router (&ctx);
+    free (ctx.remote_uri_authority);
 
     if (ctx.exit_code)
         exit (ctx.exit_code);


### PR DESCRIPTION
Problem: flux-proxy core dumps when It loses its connection to Flux.

`ctx.remote_uri_authority` is `free()`ed twice when `flux_reactor_run(`) returns < 0, as it does when the connection is lost.
Pull that `free()` out of `proxy_command_destroy_usock_and_router()` which is called twice and is otherwise idempotent and place it after the second call.

Fixes #5528