### PR TITLE
drop broker conf.module_path, conf.connector_path, conf.exec_path attributes

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -135,9 +135,6 @@ conf.connector_path
 conf.exec_path
    The value of the broker's :envvar:`FLUX_EXEC_PATH` environment variable.
 
-conf.module_path
-   The value of the broker's :envvar:`FLUX_MODULE_PATH` environment variable.
-
 conf.shell_initrc [Updates: C, R]
    The path to the :man1:`flux-shell` initrc script.  Default:
    ``${prefix}/etc/flux/shell/initrc.lua``.

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -129,9 +129,6 @@ broker.exit-restart [Updates: C, R]
 broker.starttime
    Timestamp of broker startup from :man3:`flux_reactor_now`.
 
-conf.exec_path
-   The value of the broker's :envvar:`FLUX_EXEC_PATH` environment variable.
-
 conf.shell_initrc [Updates: C, R]
    The path to the :man1:`flux-shell` initrc script.  Default:
    ``${prefix}/etc/flux/shell/initrc.lua``.

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -129,9 +129,6 @@ broker.exit-restart [Updates: C, R]
 broker.starttime
    Timestamp of broker startup from :man3:`flux_reactor_now`.
 
-conf.connector_path
-   The value of the broker's :envvar:`FLUX_CONNECTOR_PATH` environment variable.
-
 conf.exec_path
    The value of the broker's :envvar:`FLUX_EXEC_PATH` environment variable.
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -546,7 +546,6 @@ struct attrmap {
 static struct attrmap attrmap[] = {
     { "FLUX_EXEC_PATH",         "conf.exec_path",           1, 0 },
     { "FLUX_CONNECTOR_PATH",    "conf.connector_path",      1, 0 },
-    { "FLUX_MODULE_PATH",       "conf.module_path",         1, 0 },
 
     { "FLUX_URI",               "parent-uri",               0, 1 },
     { "FLUX_KVS_NAMESPACE",     "parent-kvs-namespace",     0, 1 },
@@ -1174,8 +1173,8 @@ static int load_module (broker_ctx_t *ctx,
     module_t *p;
 
     if (!strchr (path, '/')) {
-        if (attr_get (ctx->attrs, "conf.module_path", &searchpath, NULL) < 0) {
-            errprintf (error, "conf.module_path attribute is not set");
+        if (!(searchpath = getenv ("FLUX_MODULE_PATH"))) {
+            errprintf (error, "FLUX_MODULE_PATH is not set in the environment");
             errno = EINVAL;
             return -1;
         }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -544,8 +544,6 @@ struct attrmap {
 };
 
 static struct attrmap attrmap[] = {
-    { "FLUX_EXEC_PATH",         "conf.exec_path",           1, 0 },
-
     { "FLUX_URI",               "parent-uri",               0, 1 },
     { "FLUX_KVS_NAMESPACE",     "parent-kvs-namespace",     0, 1 },
     { NULL, NULL, 0, 0 },

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -545,7 +545,6 @@ struct attrmap {
 
 static struct attrmap attrmap[] = {
     { "FLUX_EXEC_PATH",         "conf.exec_path",           1, 0 },
-    { "FLUX_CONNECTOR_PATH",    "conf.connector_path",      1, 0 },
 
     { "FLUX_URI",               "parent-uri",               0, 1 },
     { "FLUX_KVS_NAMESPACE",     "parent-kvs-namespace",     0, 1 },

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -393,7 +393,6 @@ static void push_parent_environment (optparse_t *p, struct environment *env)
 {
     const char *uri;
     const char *ns;
-    const char *path;
     flux_t *h = flux_open_internal (p, NULL);
 
     if (h == NULL)
@@ -415,14 +414,11 @@ static void push_parent_environment (optparse_t *p, struct environment *env)
     else
         environment_unset (env, "FLUX_KVS_NAMESPACE");
 
-    /*  Now close current handle and connect to parent URI, pushing
-     *   parent exec path onto env
+    /*  Now close current handle and connect to parent URI.
      */
     flux_close_internal (p);
     if (!(h = flux_open_internal (p, uri)))
         log_err_exit ("flux_open (parent)");
-    if ((path = flux_attr_get (h, "conf.exec_path")))
-        environment_push (env, "FLUX_EXEC_PATH", path);
 }
 
 static void print_environment (struct environment *env)

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -416,15 +416,13 @@ static void push_parent_environment (optparse_t *p, struct environment *env)
         environment_unset (env, "FLUX_KVS_NAMESPACE");
 
     /*  Now close current handle and connect to parent URI, pushing
-     *   parent exec and module paths onto env
+     *   parent exec path onto env
      */
     flux_close_internal (p);
     if (!(h = flux_open_internal (p, uri)))
         log_err_exit ("flux_open (parent)");
     if ((path = flux_attr_get (h, "conf.exec_path")))
         environment_push (env, "FLUX_EXEC_PATH", path);
-    if ((path = flux_attr_get (h, "conf.module_path")))
-        environment_push (env, "FLUX_MODULE_PATH", path);
 }
 
 static void print_environment (struct environment *env)


### PR DESCRIPTION
We have some broker environment variables that have a "conf." prefix making them at least a little bit confusingly named since they have nothing to do with the toml configuration, but some also do not seem to have a strong reason for existing.  I whacked the following in this PR:
- `conf.module_path` mirrors broker's environment setting for FLUX_MODULE_PATH.  `flux --parent` uses it to fetch the parent's module path and prepend it in the subcommand environment, but now that the broker does its own search for modules rather than the `flux-module` command, this has no effect that I can see.
- `conf.connector_path` has no users
- `conf.exec_path` is used like `conf.module_path` to push parent's FLUX_EXEC_PATH in front of the local path.  This seems iffy to me as built-in commands will be the local version and non-built-in commands will be the parent version.  I could be completely off base on this one and will happily revert this if so!


These are more modern and have nothing to do with the flux(1) command front end or the environment.  They are for overriding the compiled-in shell paths.   However they appear to have no users outside of one sharness test.  I left them alone for now.
- conf.shell_initrc
- conf.shell_pluginpath

I'll mark this as a WIP and pause here for some feedback. 

p.s. this commit added the `--parent` option ca2b173d08b0def8d2a5e11daf7626db948b91f8. 