### PR TITLE
flux-submit: fix substiution of `{cc}` when cc=0

### DIFF
--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -1546,7 +1546,7 @@ class SubmitBulkCmd(SubmitBaseCmd):
 
         for i in cclist:
             #  substitute any {cc} in args (only if --cc or --bcc):
-            xargs = Xcmd(args, cc=i) if i else args
+            xargs = Xcmd(args, cc=i) if isinstance(i, int) else args
             jobspec = self.jobspec_create(xargs)
 
             #  For now, an idset argument to args.input is not supported

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -259,6 +259,19 @@ test_expect_success 'flux submit --cc works' '
 	EOF
 	test_cmp cc.output.expected cc.output.sorted
 '
+test_expect_success 'flux submit --cc substitutes {cc}' '
+	flux submit --quiet --watch --cc=0-3 echo {cc} \
+	    | sort >substitute-cc.out &&
+	test_debug "cat substitute-cc.out" &&
+	test $(wc -l < substitute-cc.out) -eq 4 &&
+	cat <<-EOF >substitute-cc.expected &&
+	0
+	1
+	2
+	3
+	EOF
+	test_cmp substitute-cc.expected substitute-cc.out
+'
 test_expect_success 'flux submit does not substitute {} without --cc' '
 	flux submit \
 		--env=-* \


### PR DESCRIPTION
This PR fixes substitution of `{cc}` in `flux submit --cc/--bcc` when `cc=0`. (Issue #5539)