### PR TITLE
broker: cleanup up attribute initialization code

### DIFF
--- a/doc/man1/flux-config.rst
+++ b/doc/man1/flux-config.rst
@@ -107,7 +107,7 @@ The following configuration keys may be printed with
 
 **shell_initrc**
    The initrc script path used by :man1:`flux-shell`, unless overridden by
-   setting the ``conf.shell_pluginpath`` broker attribute.
+   setting the ``conf.shell_initrc`` broker attribute.
 
 **jobtap_pluginpath**
    The search path used by the job manager to locate

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -120,7 +120,7 @@ broker.rc1_path [Updates: C]
    The path to the broker's rc1 script.  Default: ``${prefix}/etc/flux/rc1``.
 
 broker.rc3_path [Updates: C]
-   The path to the broker's rc3 script.  Default: ``${prefix}/etc/flux/rc1``.
+   The path to the broker's rc3 script.  Default: ``${prefix}/etc/flux/rc3``.
 
 broker.exit-restart [Updates: C, R]
    A numeric exit code that the broker uses to indicate that it should not be


### PR DESCRIPTION
Problem: after #5536 was merged, the broker code for initializing "attributes from the environment" looks over-engineered.

Trim it down.
Also fix some man page typos that were adjacent to the work in #5536.

