### PR TITLE
build: reduce minimum jansson version to 2.9

### DIFF
--- a/config/x_ac_jansson.m4
+++ b/config/x_ac_jansson.m4
@@ -1,6 +1,17 @@
+# Versions of jansson shipped by distros:
+# sles15-sp5    ships 2.9  (flux-framework/flux-core#5544)
+# centos7/TOSS3 ships 2.10 (flux-framework/flux-core#3239)
+# centos8/TOSS4 ships 2.11
+# Ubuntu 18.04  ships 2.11
+# Ubuntu 20.04  ships 2.12
+#
+# Some modern jansson features used in flux-core:
+# - json_pack ("O?")     from 2.8
+# - json_string_length() from 2.7
+#
 AC_DEFUN([X_AC_JANSSON], [
 
-    PKG_CHECK_MODULES([JANSSON], [jansson >= 2.10], [], [])
+    PKG_CHECK_MODULES([JANSSON], [jansson >= 2.9], [], [])
 
     ac_save_LIBS="$LIBS"
     LIBS="$LIBS $JANSSON_LIBS"

--- a/doc/man3/common/json_pack.rst
+++ b/doc/man3/common/json_pack.rst
@@ -72,6 +72,6 @@ the corresponding argument or arguments.
 
 Whitespace, **:** (colon) and **,** (comma) are ignored.
 
-These descriptions came from the Jansson 2.10 manual.
+These descriptions came from the Jansson 2.9 manual.
 
-See also: Jansson API: Building Values: http://jansson.readthedocs.io/en/2.10/apiref.html#building-values
+See also: Jansson API: Building Values: http://jansson.readthedocs.io/en/2.9/apiref.html#building-values

--- a/doc/man3/common/json_unpack.rst
+++ b/doc/man3/common/json_unpack.rst
@@ -66,6 +66,6 @@ the corresponding argument or arguments.
 
 Whitespace, **:** (colon) and **,** (comma) are ignored.
 
-These descriptions came from the Jansson 2.10 manual.
+These descriptions came from the Jansson 2.9 manual.
 
-See also: Jansson API: Parsing and Validating Values: http://jansson.readthedocs.io/en/2.10/apiref.html#parsing-and-validating-values
+See also: Jansson API: Parsing and Validating Values: http://jansson.readthedocs.io/en/2.9/apiref.html#parsing-and-validating-values

--- a/doc/man3/flux_shell_get_hwloc_xml.rst
+++ b/doc/man3/flux_shell_get_hwloc_xml.rst
@@ -44,5 +44,3 @@ RESOURCES
 =========
 
 Flux: http://flux-framework.org
-
-Jansson: https://jansson.readthedocs.io/en/2.10/apiref.html

--- a/doc/man3/flux_shell_get_info.rst
+++ b/doc/man3/flux_shell_get_info.rst
@@ -87,4 +87,4 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-Jansson: https://jansson.readthedocs.io/en/2.10/apiref.html
+Jansson: https://jansson.readthedocs.io/en/2.9/apiref.html

--- a/doc/man3/flux_shell_get_jobspec_info.rst
+++ b/doc/man3/flux_shell_get_jobspec_info.rst
@@ -70,4 +70,4 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-Jansson: https://jansson.readthedocs.io/en/2.10/apiref.html
+Jansson: https://jansson.readthedocs.io/en/2.9/apiref.html


### PR DESCRIPTION
Problem: the version of jansson shipped with SLES, reportedly jansson 2.9 on frontier at ORNL and same on sles15-sp5, is too old to build Flux.

It seems that 2.9 is just as good as the current minimum of 2.10 for Flux so reduce the minimum version to 2.9.

Fixes #5544