### PR TITLE
libsubprocess: do not allow short writes with `flux_subprocess_write()`

### DIFF
--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -416,10 +416,6 @@ static void server_write_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (data && len) {
         int rc = flux_subprocess_write (p, stream, data, len);
-        if (rc >= 0 && rc < len) { // short write is promoted to fatal error
-            errno = ENOSPC;
-            rc = -1;
-        }
         if (rc < 0) {
             llog_error (s,
                         "Error writing %d bytes to subprocess pid %d %s",

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -790,7 +790,10 @@ int flux_subprocess_write (flux_subprocess_t *p, const char *stream,
             log_err ("flux_buffer_write_watcher_get_buffer");
             return -1;
         }
-
+        if (flux_buffer_space (fb) < len) {
+            errno = ENOSPC;
+            return -1;
+        }
         if ((ret = flux_buffer_write (fb, buf, len)) < 0) {
             log_err ("flux_buffer_write");
             return -1;
@@ -800,6 +803,10 @@ int flux_subprocess_write (flux_subprocess_t *p, const char *stream,
         if (p->state != FLUX_SUBPROCESS_INIT
             && p->state != FLUX_SUBPROCESS_RUNNING) {
             errno = EPIPE;
+            return -1;
+        }
+        if (flux_buffer_space (c->write_buffer) < len) {
+            errno = ENOSPC;
             return -1;
         }
         if ((ret = flux_buffer_write (c->write_buffer, buf, len)) < 0) {

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -341,7 +341,10 @@ int flux_subprocess_stream_status (flux_subprocess_t *p, const char *stream);
  *  Write data to "stream" stream of subprocess `p`.  'stream' can be
  *  "stdin" or the name of a stream specified with flux_cmd_add_channel().
  *
- *  Returns the total amount of data successfully buffered.
+ *  Returns the total amount of data successfully buffered or -1 on error
+ *  with errno set. Note: this function will not return a short write. If
+ *  all `len` bytes cannot fit in the destination buffer, then no bytes
+ *  will be written and -1 will be returned with errno=ENOSPC.
  */
 int flux_subprocess_write (flux_subprocess_t *p, const char *stream,
                            const char *buf, size_t len);

--- a/t/rexec/rexec.c
+++ b/t/rexec/rexec.c
@@ -96,17 +96,14 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 void stdin2stream (flux_subprocess_t *p, const char *stream)
 {
     char *buf = NULL;
-    int tmp, len;
+    int len;
 
     if ((len = read_all (STDIN_FILENO, (void **)&buf)) < 0)
         log_err_exit ("read_all");
 
     if (len) {
-        if ((tmp = flux_subprocess_write (p, stream, buf, len)) < 0)
+        if (flux_subprocess_write (p, stream, buf, len) < 0)
             log_err_exit ("flux_subprocess_write");
-
-        if (tmp != len)
-            log_err_exit ("overflow in write");
     }
 
     /* do not close for channel, b/c can race w/ data coming back */

--- a/t/rexec/rexec_getline.c
+++ b/t/rexec/rexec_getline.c
@@ -47,17 +47,14 @@ void completion_cb (flux_subprocess_t *p)
 void stdin2stream (flux_subprocess_t *p, const char *stream)
 {
     char *buf = NULL;
-    int tmp, len;
+    int len;
 
     if ((len = read_all (STDIN_FILENO, (void **)&buf)) < 0)
         log_err_exit ("read_all");
 
     if (len) {
-        if ((tmp = flux_subprocess_write (p, stream, buf, len)) < 0)
+        if (flux_subprocess_write (p, stream, buf, len) < 0)
             log_err_exit ("flux_subprocess_write");
-
-        if (tmp != len)
-            log_err_exit ("overflow in write");
     }
 
     /* do not close for channel, b/c can race w/ data coming back */


### PR DESCRIPTION
This was pulled off some other work.

Currently, `flux_subprocess_write()` writes any bytes it can to the destination buffer, which could result in a short write (return code < `len`). However, a check for a short write is not done is most places (a check for `rc < 0` seems to be the common case), and where it is checked it is immediately promoted to a fatal error. In some cases (such as the job-ingest pipeline) a short write can be dangerous since it isn't recovered and writing only part of a line "hangs" the protocol.

In the interest of simplicity, add a check for the available buffer space in `flux_subprocess_write()` and return immediately with return code `-1` and `errno` set to `ENOSPC` if there is not enough space for all the data. Update any callers that attempt to handle a short write as a special case.

In the future we'll need a more sophisticated buffered write function anyway that can handle flow control and/or a chain of buffers instead of adding short-write handling at each caller (e.g. see #5542)