### PR TITLE
job-ingest: fix cleanup when a pipeline worker process fails

### DIFF
--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -69,7 +69,7 @@ struct worker {
 
 static int worker_start (struct worker *w);
 static void worker_stop (struct worker *w);
-
+static void worker_unexpected_exit (struct worker *w);
 
 static void worker_cleanup_process (struct worker *w, flux_subprocess_t *p)
 {
@@ -125,6 +125,7 @@ static void worker_state_cb (flux_subprocess_t *p,
                       "%s: %s: %s", w->name,
                       flux_subprocess_state_string (state),
                       strerror (flux_subprocess_fail_errno (p)));
+            worker_unexpected_exit (w);
             worker_cleanup_process (w, p);
             break;
         case FLUX_SUBPROCESS_EXITED:

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -120,7 +120,9 @@ static void worker_state_cb (flux_subprocess_t *p,
         case FLUX_SUBPROCESS_RUNNING:
             break;
         case FLUX_SUBPROCESS_FAILED:
-            flux_log (w->h, LOG_ERR, "%s: %s: %s", w->name,
+            flux_log (w->h,
+                      LOG_ERR,
+                      "%s: %s: %s", w->name,
                       flux_subprocess_state_string (state),
                       strerror (flux_subprocess_fail_errno (p)));
             worker_cleanup_process (w, p);
@@ -173,9 +175,11 @@ static void worker_fulfill_future (struct worker *w, flux_future_t *f, const cha
         errnum = EINVAL;
         goto error;
     }
-    if (json_unpack (o, "{s:i s?s s?o}", "errnum", &errnum,
-                                         "errstr", &errstr,
-                                         "data", &data) < 0) {
+    if (json_unpack (o,
+                     "{s:i s?s s?o}",
+                     "errnum", &errnum,
+                     "errstr", &errstr,
+                     "data", &data) < 0) {
         flux_log (w->h, LOG_ERR, "%s: json_unpack '%s' failed", w->name, s);
         errnum = EINVAL;
         goto error;
@@ -346,7 +350,8 @@ flux_future_t *worker_kill (struct worker *w, int signo)
 {
     flux_future_t *f = NULL;
     if (w->p) {
-        flux_log (w->h, LOG_DEBUG,
+        flux_log (w->h,
+                  LOG_DEBUG,
                   "killing %s (pid=%ld)",
                   w->name,
                   (long) flux_subprocess_pid (w->p));
@@ -360,7 +365,8 @@ static int worker_start (struct worker *w)
     if (!w->p) {
         if (!(w->p = flux_rexec_ex (w->h,
                                     "rexec",
-                                    FLUX_NODEID_ANY, 0,
+                                    FLUX_NODEID_ANY,
+                                    0,
                                     w->cmd,
                                     &worker_ops,
                                     flux_llog,
@@ -443,8 +449,11 @@ struct worker *worker_create (flux_t *h, double inactivity_timeout,
         return NULL;
     w->h = h;
     w->inactivity_timeout = inactivity_timeout;
-    if (!(w->timer = flux_timer_watcher_create (r, inactivity_timeout,
-                                                0., worker_timeout, w)))
+    if (!(w->timer = flux_timer_watcher_create (r,
+                                                inactivity_timeout,
+                                                0.,
+                                                worker_timeout,
+                                                w)))
         goto error;
     if (!(w->trash = zlist_new()))
         goto error;


### PR DESCRIPTION
This PR is another piece of the workaround for #5518.

If the buffer for a subprocess on the _server_ side becomes full and therefore a write fails, libsubprocess currently treats this as fatal error, kills the subprocess and returns `FLUX_SUBPROCESS_FAILED` as subprocess state.

If this occurs for a job-ingest worker, then any futures still in the queue will never be fulfilled and job submissions will appear to hang.

This PR just adds a call to `worker_unexpected_exit()` for failed worker subprocesses so that any pending futures are fulfilled with error.