### PR TITLE
job-ingest: make worker input buffer configurable with a default of 10MB

### DIFF
--- a/doc/man5/flux-config-ingest.rst
+++ b/doc/man5/flux-config-ingest.rst
@@ -32,6 +32,11 @@ batch-count
    ``batch-count`` key is nonzero then jobs are batched based on a counter
    instead. This is mostly useful for testing.
 
+buffer-size
+   (optional) Set the input buffer size for job-ingest module workers.
+   The value is string indicating the buffer size with optional SI units
+   (e.g. "102400", "4.5M", "1024K") The default value is ``10M``.
+
 FROBNICATOR KEYS
 ================
 

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -246,6 +246,9 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *   - stdout_BUFSIZE - set buffer size on stdout
  *   - stderr_BUFSIZE - set buffer size on stderr
  *
+ *   The BUFSIZE string may be a floating point quantity scaled by
+ *   an optional suffix from the set 'kKMG'.
+ *
  *  "LINE_BUFFER" option
  *
  *    By default, output callbacks such as 'on_stdout' and 'on_stderr'

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -650,7 +650,12 @@ static int job_ingest_configure (struct job_ingest_ctx *ctx,
 
     if (policy_validate (conf, error) < 0)
         return -1;
-    if (pipeline_configure (ctx->pipeline, conf, argc, argv, error) < 0)
+    if (pipeline_configure (ctx->pipeline,
+                            conf,
+                            argc,
+                            argv,
+                            NULL,
+                            error) < 0)
         return -1;
     if (flux_conf_unpack (conf,
                           &conf_error,

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -650,13 +650,6 @@ static int job_ingest_configure (struct job_ingest_ctx *ctx,
 
     if (policy_validate (conf, error) < 0)
         return -1;
-    if (pipeline_configure (ctx->pipeline,
-                            conf,
-                            argc,
-                            argv,
-                            NULL,
-                            error) < 0)
-        return -1;
     if (flux_conf_unpack (conf,
                           &conf_error,
                           "{s?{s?i}}",
@@ -689,7 +682,12 @@ static int job_ingest_configure (struct job_ingest_ctx *ctx,
             return -1;
         }
     }
-    return 0;
+    return pipeline_configure (ctx->pipeline,
+                               conf,
+                               argc,
+                               argv,
+                               NULL,
+                               error);
 }
 
 static void reload_cb (flux_t *h,

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -779,6 +779,9 @@ int job_ingest_ctx_init (struct job_ingest_ctx *ctx,
     ctx->h = h;
     flux_error_t error;
 
+    /*  Default worker input buffer size is 10MB */
+    ctx->buffer_size = "10M";
+
     if (!(ctx->pipeline = pipeline_create (h))) {
         flux_log_error (h, "error initializing job preprocessing pipeline");
         return -1;

--- a/src/modules/job-ingest/pipeline.c
+++ b/src/modules/job-ingest/pipeline.c
@@ -270,6 +270,7 @@ int pipeline_configure (struct pipeline *pl,
                         const flux_conf_t *conf,
                         int argc,
                         char **argv,
+                        const char *bufsize,
                         flux_error_t *error)
 {
     flux_error_t conf_error;
@@ -349,7 +350,7 @@ int pipeline_configure (struct pipeline *pl,
                             cmd_frobnicator,
                             frobnicator_plugins,
                             frobnicator_args,
-                            NULL) < 0) {
+                            bufsize) < 0) {
         errprintf (error,
                    "Error (re-)configuring frobnicator workcrew: %s",
                    strerror (errno));
@@ -367,7 +368,7 @@ int pipeline_configure (struct pipeline *pl,
                             cmd_validator,
                             validator_plugins,
                             validator_args,
-                            NULL) < 0) {
+                            bufsize) < 0) {
         errprintf (error,
                    "Error (re-)configuring validator workcrew: %s",
                    strerror (errno));

--- a/src/modules/job-ingest/pipeline.c
+++ b/src/modules/job-ingest/pipeline.c
@@ -348,7 +348,8 @@ int pipeline_configure (struct pipeline *pl,
     if (workcrew_configure (pl->frobnicate,
                             cmd_frobnicator,
                             frobnicator_plugins,
-                            frobnicator_args) < 0) {
+                            frobnicator_args,
+                            NULL) < 0) {
         errprintf (error,
                    "Error (re-)configuring frobnicator workcrew: %s",
                    strerror (errno));
@@ -365,7 +366,8 @@ int pipeline_configure (struct pipeline *pl,
     if (workcrew_configure (pl->validate,
                             cmd_validator,
                             validator_plugins,
-                            validator_args) < 0) {
+                            validator_args,
+                            NULL) < 0) {
         errprintf (error,
                    "Error (re-)configuring validator workcrew: %s",
                    strerror (errno));
@@ -422,10 +424,18 @@ struct pipeline *pipeline_create (flux_t *h)
                                                           pl)))
         goto error;
     if (!(pl->validate = workcrew_create (pl->h))
-        || workcrew_configure (pl->validate, cmd_validator, NULL, NULL) < 0)
+        || workcrew_configure (pl->validate,
+                               cmd_validator,
+                               NULL,
+                               NULL,
+                               NULL) < 0)
         goto error;
     if (!(pl->frobnicate = workcrew_create (pl->h))
-        || workcrew_configure (pl->frobnicate, cmd_frobnicator, NULL, NULL) < 0)
+        || workcrew_configure (pl->frobnicate,
+                               cmd_frobnicator,
+                               NULL,
+                               NULL,
+                               NULL) < 0)
         goto error;
     return pl;
 error:

--- a/src/modules/job-ingest/pipeline.h
+++ b/src/modules/job-ingest/pipeline.h
@@ -25,6 +25,7 @@ int pipeline_configure (struct pipeline *pl,
                         const flux_conf_t *conf,
                         int argc,
                         char **argv,
+                        const char *bufsize,
                         flux_error_t *error);
 
 int pipeline_process_job (struct pipeline *pl,

--- a/src/modules/job-ingest/workcrew.c
+++ b/src/modules/job-ingest/workcrew.c
@@ -141,7 +141,8 @@ error:
 int workcrew_configure (struct workcrew *crew,
                         const char *cmdname,
                         const char *plugins,
-                        const char *args)
+                        const char *args,
+                        const char *bufsize)
 {
     int rc = -1;
     int argc;
@@ -169,6 +170,8 @@ int workcrew_configure (struct workcrew *crew,
                 goto error;
         }
         if (worker_set_cmdline (crew->worker[i], argc, argv) < 0)
+            goto error;
+        if (bufsize && worker_set_bufsize (crew->worker[i], bufsize) < 0)
             goto error;
     }
     /* Close stdin of current workers and allow them to restart on demand.

--- a/src/modules/job-ingest/workcrew.h
+++ b/src/modules/job-ingest/workcrew.h
@@ -43,11 +43,15 @@ struct workcrew *workcrew_create (flux_t *h);
  *
  * args should be a comma-delimited list of additional arguments, or NULL.
  * The list is split into separate command line arguments.
+ *
+ * bufsize should be a string buffer size represented as a floating point
+ * value with optional scale suffix [kKMG].
  */
 int workcrew_configure (struct workcrew *crew,
                         const char *cmdname,
                         const char *plugins,
-                        const char *args);
+                        const char *args,
+                        const char *bufsize);
 
 void workcrew_destroy (struct workcrew *crew);
 

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -440,6 +440,14 @@ int worker_set_cmdline (struct worker *w, int argc, char **argv)
     return 0;
 }
 
+int worker_set_bufsize (struct worker *w, const char *bufsize)
+{
+    int rc = 0;
+    if (bufsize)
+        rc = flux_cmd_setopt (w->cmd, "stdin_BUFSIZE", bufsize);
+    return rc;
+}
+
 struct worker *worker_create (flux_t *h, double inactivity_timeout,
                               const char *name)
 {

--- a/src/modules/job-ingest/worker.h
+++ b/src/modules/job-ingest/worker.h
@@ -39,6 +39,12 @@ struct worker *worker_create (flux_t *h,
  */
 int worker_set_cmdline (struct worker *w, int argc, char **argv);
 
+/*  (re)set stdin buffer size for worker `w`.
+ *  `bufsize` may be a floating point value with optional scale suffix:
+ *  'kKMG'
+ */
+int worker_set_bufsize (struct worker *w, const char *bufsize);
+
 /* Tell worker to stop.
  * Return a count of running processes.
  * If nonzero, arrange for callback to be called each time a process exits.

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -354,6 +354,7 @@ dist_check_SCRIPTS = \
 	issues/t5105-signal-propagation.sh \
 	issues/t5308-kvsdir-initial-path.py \
 	issues/t5368-kvs-commit-clear.py \
+	issues/t5518-job-validator-hang.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t5518-job-validator-hang.sh
+++ b/t/issues/t5518-job-validator-hang.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Run an instance with a very small job-ingest working buffer size
+# and ensure the worker does not hang after errors are returned
+#
+export FLUX_URI_RESOLVE_LOCAL=t
+
+#  Check if we need to start parent job, if so, reexec under flux-start
+if test "$VALIDATOR_HANG_TEST_ACTIVE" != "t"; then
+    export VALIDATOR_HANG_TEST_ACTIVE=t
+    printf "Re-launching test script under flux-start\n"
+    exec flux start -s1 $0
+fi
+
+id=$(flux alloc -n1 --bg --conf=ingest.buffer-size=8k)
+printf "Launched single core alloc job $id\n"
+
+# Submission of more than 1 job should have some failures, but should not
+# hang:
+flux proxy $id flux submit --cc=1-10 --watch hostname
+rc=$?
+printf "submission of multiple jobs got rc=$rc\n"
+test $rc -ne 0 || exit 1
+
+# Small job to clear errors
+flux proxy $id flux run --env=-* --env=PATH hostname
+
+# Another small job should succeed:
+flux proxy $id flux run --env=-* --env=PATH hostname || exit 1
+printf "submission of single job still works\n"

--- a/t/t2111-job-ingest-config.t
+++ b/t/t2111-job-ingest-config.t
@@ -45,6 +45,30 @@ test_expect_success 'job-ingest: configuration can be reloaded' '
 test_expect_success 'job-ingest: verify that feasibility plugin is in effect' '
 	test_must_fail flux submit -n 1024 hostname
 '
+test_expect_success 'job-ingest: worker buffer size can be set via config' '
+	cat <<-EOF >conf.d/ingest.toml &&
+	[ingest]
+	buffer-size = "10M"
+	[ingest.validator]
+	plugins = [ "feasibility", "jobspec" ]
+	args = [ "--require-version=1" ]
+	EOF
+	flux dmesg -C &&
+	flux config reload &&
+	$dmesg_grep -vt 10 "worker input buffer set to 10M"
+'
+test_expect_success 'job-ingest: invalid buffer size is detected on reload' '
+	cat <<-EOF >conf.d/ingest.toml &&
+	[ingest]
+	buffer-size = "10f"
+	[ingest.validator]
+	plugins = [ "feasibility", "jobspec" ]
+	args = [ "--require-version=1" ]
+	EOF
+	test_must_fail flux config reload >bad-buffer-size.out 2>&1 &&
+	test_debug "cat bad-buffer-size.out" &&
+	grep "Invalid buffer-size" bad-buffer-size.out
+'
 test_expect_success 'job-ingest: invalid config detected on reload' '
 	cat <<-EOF >conf.d/ingest.toml &&
 	[ingest.validator]


### PR DESCRIPTION
This is the final piece of the workaround for #5518.

This PR makes the job-ingest worker input buffer configurable and increases the default size to 10MB.
A reproducer for #5518 is then added to the testsuite using the configurable buffer size to reduce the buffer.

This requires #5549 so is built on top of that.

Fixes #5518.