### PR TITLE
testsuite: fixes for Lassen

### DIFF
--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -820,3 +820,6 @@ hl
 noresponse
 moldable
 aspirational
+infeasible
+login
+workflow

--- a/t/README.md
+++ b/t/README.md
@@ -128,7 +128,7 @@ to run tests under valgrind.
 Skipping Tests
 --------------
 
-The environment variable `SHARNESS_SKIP_TESTS` is a space separated
+The environment variable `SKIP_TESTS` is a space separated
 list of *patterns* that tells which tests to skip, and can either
 match the test number `t[0-]{4}` to skip an entire test script,
 or have an appended `.$number` to skip test `$number` in the


### PR DESCRIPTION
Problem: Lassen doesn't like the words login, workflow, or infeasible, and it causes our CI spellcheck tests to break on that machine.

Add those words to the exempt word list in the docs.

Looking at previous issues, I thought that #3071 might be at play since `LC_ALL=C` is set on Lassen but not on TOSS 4 machines. Changing that to `LC_ALL=""` didn't solve the issue. 

I also tried using `SHARNESS_SKIP_TESTS=spellcheck` command [listed in the testsuite readme](https://github.com/flux-framework/flux-core/tree/master/t#skipping-tests), but it still ran the test. Do we support that command? When I git grep'd for it in core I couldn't find anywhere in our shell scripts it's used. I did find [`SKIP_TESTS` in `t/sharness.sh`](https://github.com/flux-framework/flux-core/blob/f8558d01cc1b853007a82831d94ddb90c8c71e04/t/sharness.sh#L366) but setting that variable to the same thing also didn't exempt the spellcheck test.

Also, just if anyone was curious ;) according to the [OED](https://www.oed.com/search/dictionary/?scope=Entries&q=login) "log in" or "log-in" are the official words. "workflow" and "infeasible" are also words.