### PR TITLE
flux-start(1): add more description and troubleshooting info

### DIFF
--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -128,7 +128,8 @@ OPTIONS
 .. option:: -v, --verbose=[LEVEL]
 
    This option may be specified multiple times, or with a value, to
-   set a verbosity level.  See `VERBOSITY LEVELS`_ below.
+   set a verbosity level (1: display commands before executing them,
+   2: trace PMI server requests in `TEST MODE`_ only).
 
 .. option:: -X, --noexec
 
@@ -220,15 +221,6 @@ OPTIONS
    instance configuration directory.  This option is unnecessary if
    :option:`--recovery` is specified without its optional argument.  It may
    be required if recovering a dump from a system instance.
-
-VERBOSITY LEVELS
-================
-
-level 1 and above
-   Display commands before executing them.
-
-level 2 and above
-   Trace PMI server requests (test mode only).
 
 
 EXAMPLES

--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -8,7 +8,9 @@ flux-start(1)
 SYNOPSIS
 ========
 
-**flux** **start** [*OPTIONS*] [initial-program [args...]]
+[**launcher**] **flux** **start** [*OPTIONS*] [initial-program [args...]]
+
+**flux** **start** *--test-size=N* [*OPTIONS*] [initial-program [args...]]
 
 DESCRIPTION
 ===========

--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -223,36 +223,6 @@ OPTIONS
    be required if recovering a dump from a system instance.
 
 
-EXAMPLES
-========
-
-Launch an 8-way local Flux instance with an interactive shell as the
-initial program and all logs output to stderr:
-
-::
-
-   flux start -s8 -o,--setattr=log-stderr-level=7
-
-Launch an 8-way Flux instance within a slurm job, with an interactive
-shell as the initial program:
-
-::
-
-   srun --pty -N8 flux start
-
-Start the system instance rank 0 broker in recovery mode:
-
-::
-
-   sudo -u flux flux start --recovery
-
-Start a non-system instance in recovery mode:
-
-::
-
-   flux start --recovery=/tmp/statedir
-
-
 RESOURCES
 =========
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -786,3 +786,9 @@ ogpu
 opmi
 printenv
 XMLFILE
+initio
+mortem
+natively
+execvp
+gdb
+libtool

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -792,3 +792,4 @@ natively
 execvp
 gdb
 libtool
+prepend


### PR DESCRIPTION
This reworks the flux-start(1) man page to hopefully offer more explanation and troubleshooting tips for problems that repeatedly come up.