### PR TITLE
make flux Python commands more resilient to changes in PYTHONPATH

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -474,6 +474,16 @@ of compiled-in install paths and the environment.
 
    Values may include multiple directories separated by colons.
 
+.. note::
+   Flux commands written in Python further modify Python's
+   `sys.path <https://docs.python.org/3/library/sys.html#sys.path>`_
+   to ensure that interpreter default paths appear before any custom values
+   set in :envvar:`PYTHONPATH`. This is an attempt to  avoid incompatible
+   modules interfering with the operation of Flux commands. If it becomes
+   necessary to force a non-standard module first in the search path (e.g.
+   for testing, instrumentation, etc.) then :envvar:`FLUX_PYTHONPATH_PREPEND`
+   should be used.
+
 .. envvar:: LUA_PATH
             LUA_CPATH
             FLUX_LUA_PATH_PREPEND

--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -421,6 +421,18 @@ SUB-COMMAND ENVIRONMENT
 :man1:`flux` sets up the environment for sub-commands using a combination
 of compiled-in install paths and the environment.
 
+.. note::
+   The PREPEND versions of environment variables below may
+   be necessary when developing and testing a new version
+   of a Flux command (:envvar:`FLUX_EXEC_PATH_PREPEND`),
+   module (:envvar:`FLUX_MODULE_PATH_PREPEND`), connector
+   (:envvar:`FLUX_CONNECTOR_PATH_PREPEND`), or Python module
+   (:envvar:`FLUX_PYTHONPATH_PREPEND`) when an existing version of that
+   component is already installed in the system default paths. Otherwise,
+   the installed component would always be used by the system Flux, since
+   the installed paths are always placed first in the subcommand environment
+   created by :man1:`flux`.
+
 .. envvar:: FLUX_EXEC_PATH
             FLUX_EXEC_PATH_PREPEND
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -798,3 +798,4 @@ param
 perres
 pertask
 mpibind
+sys

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -117,7 +117,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-cancel.py \
 	flux-watch.py \
 	flux-update.py \
-	flux-imp-exec-helper
+	flux-imp-exec-helper \
+	py-runner.py
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -327,13 +327,19 @@ void exec_subcommand_py (bool vopt, const char *dir,
                             prefix ? prefix : "", argv[0]);
 
     if (access (path, R_OK|X_OK) == 0) {
-        char *av [argc+2];
+        const char *wrapper = flux_conf_builtin_get ("python_wrapper",
+                                                     FLUX_CONF_AUTO);
+        char *av [argc+3];
         av[0] = PYTHON_INTERPRETER;
-        av[1] = path;
-        for (int i = 2; i < argc+2; i++)
-            av[i] = argv[i-1];
+        av[1] = (char *) wrapper;
+        av[2] = path;
+        for (int i = 3; i < argc+3; i++)
+            av[i] = argv[i-2];
         if (vopt)
-            log_msg ("trying to exec %s %s", PYTHON_INTERPRETER, path);
+            log_msg ("trying to exec %s %s %s",
+                     PYTHON_INTERPRETER,
+                     wrapper,
+                     path);
         execvp (PYTHON_INTERPRETER, av);
     }
     free (path);

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -189,7 +189,8 @@ int main (int argc, char *argv[])
     }
 
     environment_from_env (env, "FLUX_EXEC_PATH", "", ':');
-    environment_push (env, "FLUX_EXEC_PATH",
+    environment_push (env,
+                      "FLUX_EXEC_PATH",
                       flux_conf_builtin_get ("exec_path", flags));
     environment_push (env, "FLUX_EXEC_PATH", getenv ("FLUX_EXEC_PATH_PREPEND"));
 
@@ -197,14 +198,16 @@ int main (int argc, char *argv[])
     environment_push (env,
                       "FLUX_CONNECTOR_PATH",
                       flux_conf_builtin_get ("connector_path", flags));
-    environment_push (env, "FLUX_CONNECTOR_PATH",
+    environment_push (env,
+                      "FLUX_CONNECTOR_PATH",
                       getenv ("FLUX_CONNECTOR_PATH_PREPEND"));
 
     environment_from_env (env, "FLUX_MODULE_PATH", "", ':');
     environment_push (env,
                       "FLUX_MODULE_PATH",
                       flux_conf_builtin_get ("module_path", flags));
-    environment_push (env, "FLUX_MODULE_PATH",
+    environment_push (env,
+                      "FLUX_MODULE_PATH",
                       getenv ("FLUX_MODULE_PATH_PREPEND"));
 
     if (getenv ("FLUX_URI"))
@@ -319,9 +322,10 @@ void exec_subcommand_py (bool vopt, const char *dir,
 	                     const char *prefix)
 {
     char *path = xasprintf ("%s%s%s%s.py",
-            dir ? dir : "",
-            dir ? "/" : "",
-            prefix ? prefix : "", argv[0]);
+                            dir ? dir : "",
+                            dir ? "/" : "",
+                            prefix ? prefix : "", argv[0]);
+
     if (access (path, R_OK|X_OK) == 0) {
         char *av [argc+2];
         av[0] = PYTHON_INTERPRETER;
@@ -339,9 +343,9 @@ void exec_subcommand_dir (bool vopt, const char *dir, char *argv[],
         const char *prefix)
 {
     char *path = xasprintf ("%s%s%s%s",
-            dir ? dir : "",
-            dir ? "/" : "",
-            prefix ? prefix : "", argv[0]);
+                            dir ? dir : "",
+                            dir ? "/" : "",
+                            prefix ? prefix : "", argv[0]);
     if (vopt)
         log_msg ("trying to exec %s", path);
     execvp (path, argv); /* no return if successful */
@@ -366,7 +370,8 @@ void exec_subcommand (const char *searchpath, bool vopt, int argc, char *argv[])
             a1 = NULL;
         }
         free (cpy);
-        log_msg_exit ("`%s' is not a flux command.  See 'flux --help'", argv[0]);
+        log_msg_exit ("`%s' is not a flux command.  See 'flux --help'",
+                      argv[0]);
     }
 }
 

--- a/src/cmd/py-runner.py
+++ b/src/cmd/py-runner.py
@@ -1,0 +1,97 @@
+##############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import os
+import runpy
+import sys
+import sysconfig
+
+from _flux._core import ffi, lib
+
+
+def split_path(path):
+    return filter(None, path.split(":"))
+
+
+def builtin_python_path():
+    """
+    Get the path to this module and assume this is the builtin
+    Python path.
+    """
+    #  We can't use FLUX_CONF_AUTO since the executable in this context is
+    #  just python or python3, therefore determine which builtin conf flag to
+    #  use dynamically from the path to the current file.
+    #
+    #  Note: We need to avoid importing 'flux' here, since that might trigger
+    #  the problem this module is trying to solve (user modified PYTHONPATH
+    #  bringing incompatible modules first). So we copy the definitions of
+    #  FLUX_CONF_INTREE and FLUX_CONF_INSTALLED directly from `lib` here.
+    #
+    flag = lib.FLUX_CONF_INSTALLED
+    if "src/cmd" in __file__:
+        flag = lib.FLUX_CONF_INTREE
+
+    return split_path(
+        ffi.string(lib.flux_conf_builtin_get(b"python_path", flag)).decode("utf-8")
+    )
+
+
+def flux_python_path_prepend():
+    """
+    Get the value of FLUX_PYTHONPATH_PREPEND as a list. An empty list is
+    returned if the environment variable is not set.
+    """
+    return split_path(os.environ.get("FLUX_PYTHONPATH_PREPEND", ""))
+
+
+def prepend_standard_python_paths(patharray):
+    """
+    Prepend standard interpreter and Flux python module paths to the
+    input array `patharray`.
+
+    Paths that will be prepended include, in order:
+    - FLUX_PYTHONPATH_PREPEND
+    - The Flux builtin path to its own modules
+    - The Python interpreter configured values for
+      - stdlib
+      - platform specific stdlib
+      - platform modules
+      - pure python modules
+    """
+    #  Set of paths to append, in order, to sys.path after builtin path:
+    std_paths = ("stdlib", "platstdlib", "platlib", "purelib")
+
+    prepend_paths = [
+        *flux_python_path_prepend(),
+        *builtin_python_path(),
+        *[sysconfig.get_path(name) for name in std_paths],
+    ]
+
+    for path in prepend_paths:
+        try:
+            sys.path.remove(path)
+        except ValueError:
+            pass  # ignore missing path in sys.path
+
+    # Prepend list to sys.path:
+    sys.path[0:0] = prepend_paths
+
+
+if __name__ == "__main__":
+    #  Pop first argument which is this script, modify sys.path as noted
+    #  above, then invoke target script in this interpreter using
+    #  runpy.run_path():
+    #
+    sys.argv.pop(0)
+    prepend_standard_python_paths(sys.path)
+    runpy.run_path(sys.argv[0], run_name="__main__")
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -63,6 +63,11 @@ static struct builtin builtin_tab[] = {
                       ABS_TOP_SRCDIR "/src/bindings/python",
     },
     {
+        .key = "python_wrapper",
+        .val_installed = FLUXCMDDIR "/py-runner.py",
+        .val_intree = ABS_TOP_SRCDIR "/src/cmd/py-runner.py",
+    },
+    {
         .key = "man_path",
         .val_installed = X_MANDIR,
         .val_intree =  ABS_TOP_BUILDDIR "/doc",


### PR DESCRIPTION
This is stab at fixing #5547 with a new module `fixsyspath` which can be imported first in all Python utilities to move the standard and Flux Python module paths back to the front of `sys.path`.  This works around possible changes to `PYTHONPATH` that put incompatible Python modules before the system modules.

Still need to add some automated tests here, but I did verify this works around the specific case documented in the issue:

On current master:
```console
$ module load omniperf
$ flux alloc -n1 flux run hostname
flux-run: ERROR: Unrecoverable error: worker unexpectedly exited
Nov 10 16:58:58.347767 broker.err[0]: rc2.0: flux run hostname Exited (rc=1) 0.4s
Nov 10 16:58:58.348470 job-ingest.err[0]: job-validator[0]: exited with rc=1
[detached: session exiting]
```

On this branch:
```console
$ module load omniperf
$ flux alloc -N1 flux run hostnametioga10
[detached: session exiting]
```

It should be simple to add a test for this, but thought I'd post it as is to get any comments about the general approach.


