### PR TITLE
flux-shell(1): improve option descriptions and x-ref

### DIFF
--- a/doc/man1/common/job-shell-options.rst
+++ b/doc/man1/common/job-shell-options.rst
@@ -1,46 +1,38 @@
-.. option:: -o mpi=spectrum
+.. Once we advance to sphinx 5.3+, :option: will x-ref with arguments
+.. e.g. :option:`cpu-affinity=OFF`.  For now, leave options off to get x-ref.
 
-   Load the MPI personality plugin for IBM Spectrum MPI. All other MPI
-   plugins are loaded by default.
+.. list-table::
+   :header-rows: 1
 
-.. option:: -o cpu-affinity=per-task
+   * - Name
+     - Description
 
-   Tasks are distributed across the assigned resources.
+   * - :option:`cpu-affinity`
+     - Set task affinity to cores (:option:`off|per-task|map:LIST|on`)
 
-.. option:: -o cpu-affinity=off
+   * - :option:`gpu-affinity`
+     - Set task affinity to GPUs (:option:`off|per-task|map:LIST|on`)
 
-   Disable task affinity plugin.
+   * - :option:`verbose`
+     - Increase shell log verbosity (1 or 2).
 
-.. option:: -o gpu-affinity=per-task
+   * - :option:`nosetpgrp`
+     - Don't run each task in its own process group.
 
-   GPU devices are distributed evenly among local tasks. Otherwise,
-   GPU device affinity is to the job.
+   * - :option:`pmi`
+     - Set PMI service(s) for launched programs (:option:`off|simple|LIST`)
 
-.. option:: -o gpu-affinity=off
+   * - :option:`stage-in`
+     - Copy files previously mapped with :man1:`flux-filemap` to
+       :envvar:`FLUX_JOB_TMPDIR`.
 
-   Disable GPU affinity for this job.
+   * - :option:`pty.interactive`
+     - Enable a pty on rank 0 for :program:`flux job attach`.
 
-.. option:: -o verbose
+   * - :option:`exit-timeout`
+     - Start fatal job exception timer after first task exits
+       (:option:`none|FSD`)
 
-   Increase verbosity of the job shell log.
-
-.. option:: -o nosetpgrp
-
-   Normally the job shell runs each task in its own process group to
-   facilitate delivering signals to tasks which may call :linux:man2:`fork`.
-   With this option, the shell avoids calling :linux:man2:`setpgrp`, and
-   each task will run in the process group of the shell. This will cause
-   signals to be delivered only to direct children of the shell.
-
-.. option:: -o pmi=off
-
-   Disable the process management interface (PMI-1) which is required for
-   bootstrapping most parallel program environments.  See :man1:`flux-shell`
-   for more pmi options.
-
-.. option:: -o stage-in
-
-   Copy files previously mapped with :man1:`flux-filemap` to the directory
-   referred to by :envvar:`FLUX_JOB_TMPDIR`.  See :man1:`flux-shell` for more
-   *stage-in* options.
-
+   * - :option:`exit-on-error`
+     - Raise a fatal job exception immediately if first task exits with
+       nonzero exit code.

--- a/doc/man1/flux-alloc.rst
+++ b/doc/man1/flux-alloc.rst
@@ -114,10 +114,18 @@ OTHER OPTIONS
 SHELL OPTIONS
 =============
 
-These options are provided by built-in shell plugins that may be
-overridden in some cases:
+Some options that affect the parallel runtime environment of the Flux instance
+started by :program:`flux alloc` are provided by the Flux shell.
+These options are described in detail in the
+:ref:`SHELL OPTIONS <flux_shell_options>` section of :man1:`flux-shell`.
+A list of the most commonly needed options follows.
 
+Usage: :option:`flux alloc -o NAME[=ARG]`.
+
+.. make :option: references in the included table x-ref to flux-shell(1)
+.. program:: flux shell
 .. include:: common/job-shell-options.rst
+.. program:: flux alloc
 
 RESOURCES
 =========

--- a/doc/man1/flux-batch.rst
+++ b/doc/man1/flux-batch.rst
@@ -137,10 +137,18 @@ OTHER OPTIONS
 SHELL OPTIONS
 =============
 
-These options are provided by built-in shell plugins that may be
-overridden in some cases:
+Some options that affect the parallel runtime environment of the Flux instance
+started by :program:`flux batch` are provided by the Flux shell.
+These options are described in detail in the
+:ref:`SHELL OPTIONS <flux_shell_options>` section of :man1:`flux-shell`.
+A list of the most commonly needed options follows.
 
+Usage: :option:`flux batch -o NAME[=ARG]`.
+
+.. make :option: references in the included table x-ref to flux-shell(1)
+.. program:: flux shell
 .. include:: common/job-shell-options.rst
+.. program:: flux batch
 
 SUBMISSION DIRECTIVES
 =====================

--- a/doc/man1/flux-bulksubmit.rst
+++ b/doc/man1/flux-bulksubmit.rst
@@ -226,11 +226,17 @@ OTHER OPTIONS
 SHELL OPTIONS
 =============
 
-These options are provided by built-in shell plugins that may be
-overridden in some cases:
+Some options that affect the parallel runtime environment are provided by the
+Flux shell.  These options are described in detail in the
+:ref:`SHELL OPTIONS <flux_shell_options>` section of :man1:`flux-shell`.
+A list of the most commonly needed options follows.
 
+Usage: :option:`flux bulksubmit -o NAME[=ARG]`.
+
+.. make :option: references in the included table x-ref to flux-shell(1)
+.. program:: flux shell
 .. include:: common/job-shell-options.rst
-
+.. program:: flux bulksubmit
 
 RESOURCES
 =========

--- a/doc/man1/flux-run.rst
+++ b/doc/man1/flux-run.rst
@@ -142,11 +142,17 @@ OTHER OPTIONS
 SHELL OPTIONS
 =============
 
-These options are provided by built-in shell plugins that may be
-overridden in some cases:
+Some options that affect the parallel runtime environment are provided by the
+Flux shell.  These options are described in detail in the
+:ref:`SHELL OPTIONS <flux_shell_options>` section of :man1:`flux-shell`.
+A list of the most commonly needed options follows.
 
+Usage: :option:`flux run -o NAME[=ARG]`.
+
+.. make :option: references in the included table x-ref to flux-shell(1)
+.. program:: flux shell
 .. include:: common/job-shell-options.rst
-
+.. program:: flux run
 
 RESOURCES
 =========

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -200,42 +200,49 @@ see the documentation for the specific plugin in question.
 Shell options supported by :program:`flux shell` itself and its built-in
 plugins include:
 
-**verbose**\ =\ *INT*
+.. option:: verbose=INT
+
   Set the shell verbosity to *INT*. A larger value indicates increased
   verbosity, though setting this value larger than 2 currently has no
   effect.
 
-**nosetpgrp**\ =\ *INT*
+.. option:: nosetpgrp=INT
+
   If nonzero, disables the use of :linux:man2:`setpgrp` to launch each
   job task in its own process group. This will cause signals to be
   delivered only to direct children of the shell.
 
-**initrc**\ =\ *FILE*
+.. option:: initrc=FILE
+
   Load :program:`flux shell` initrc.lua file from *FILE* instead of the default
   initrc path. For details of the job shell initrc.lua file format,
   see the `SHELL INITRC`_ section below.
 
-**pty**
+.. option:: pty
+
   Allocate a pty to all task ranks for non-interactive use. Output
   from all ranks will be captured to the same location as ``stdout``.
-  This is the same as setting **pty.ranks=all** and **pty.capture**.
+  This is the same as setting :option:`pty.ranks=all` and :option:`pty.capture`.
   (see below).
 
-**pty.ranks**\ =\ *OPT*
+.. option:: pty.ranks=OPT
+
   Set the task ranks for which to allocate a pty. *OPT* may be either
   an RFC 22 IDset of target ranks, an integer rank, or the string "all"
   to indicate all ranks.
 
-**pty.capture**
-  Enable capture of pty output to the same location as stdout. This is
-  the default unless **pty.interactive** is set.
+.. option:: pty.capture
 
-**pty.interactive**
+  Enable capture of pty output to the same location as stdout. This is
+  the default unless :option:`pty.interactive` is set.
+
+.. option:: pty.interactive
+
   Enable a a pty on rank 0 that is set up for interactive attach by
-  a front-end program (i.e. :program:`flux job attach`). With no other **pty**
-  options, only rank 0 will be assigned a pty and output will not
+  a front-end program (i.e. :program:`flux job attach`). With no other
+  :option:`pty` options, only rank 0 will be assigned a pty and output will not
   be captured. These defaults can be changed by setting other
-  **pty** options after **pty.interactive**, e.g.
+  :option:`pty` options after :option:`pty.interactive`, e.g.
 
   .. code-block:: console
 
@@ -245,7 +252,8 @@ plugins include:
   pty session to the KVS (so it can be displayed after the job exits
   with ``flux job attach``).
 
-**cpu-affinity**\ =\ *OPT*
+.. option:: cpu-affinity=OPT
+
   Adjust the operation of the builtin shell ``affinity`` plugin.
   *OPT* may be set to ``off`` to disable the affinity plugin, or
   ``per-task`` to have available CPUs distributed to tasks.
@@ -258,21 +266,24 @@ plugins include:
   and ``hwloc_bitmap_taskset_snprintf()`` functions).  The default is ``on``,
   which binds all tasks to the assigned set of cores in the job.
 
-**gpu-affinity**\ =\ *OPT*
+.. option:: gpu-affinity=OPT
+
   Adjust operation of the builtin shell ``gpubind`` plugin, which simply
   sets :envvar:`CUDA_VISIBLE_DEVICES` to the GPU IDs allocated to the job.
   *OPT* may be set to ``off`` to disable the plugin, or ``per-task``
   to divide allocated GPUs among tasks launched by the shell (sets a
   different GPU ID or IDs for each launched task). If *OPT* starts with
   ``map:``, then the rest of the option is a semicolon-delimited list
-  of GPUs to assign to each task. See **cpu-affinity** documentation
+  of GPUs to assign to each task. See :option:`cpu-affinity` documentation
   for a description of the ``map:`` list format.
 
-**stop-tasks-in-exec**
+.. option:: stop-tasks-in-exec
+
   Stops tasks in ``exec()`` using ``PTRACE_TRACEME``. Used for debugging
   parallel jobs. Users should not need to set this option directly.
 
-**output.{stdout,stderr}.type**\ =\ *TYPE*
+.. option:: output.{stdout,stderr}.type=TYPE
+
   Set job output to for **stderr** or **stdout** to *TYPE*. *TYPE* may
   be one of ``term``, ``kvs`` or ``file`` (Default: ``kvs``). If only
   ``output.stdout.type`` is set, then this option applies to both
@@ -281,71 +292,87 @@ plugins include:
   this option directly, as it will be set automatically by options
   of higher level commands such as :man1:`flux-submit`.
 
-**output.{stdout,stderr}.path**\ =\ *PATH*
+.. option:: output.{stdout,stderr}.path=PATH
+
   Set job stderr/out file output to PATH.
 
-**input.stdin.type**\ =\ *TYPE*
+.. option:: input.stdin.type=TYPE
+
   Set job input for **stdin** to *TYPE*. *TYPE* may be either ``service``
   or ``file``. Users should not need to set this option directly as it
   will be handled by options of higher level commands like :man1:`flux-submit`.
 
-**exit-timeout**\ =\ *VALUE*
+.. option:: exit-timeout=VALUE
+
   A fatal exception is raised on the job 30s after the first task exits.
   The timeout period may be altered by providing a different value in
   Flux Standard Duration form.  A value of ``none`` disables generation of
   the exception.
 
-**exit-on-error**
+.. option:: exit-on-error
+
   If the first task to exit was signaled or exited with a nonzero status,
   raise a fatal exception on the job immediately.
 
-**rlimit**
+.. option:: rlimit
+
   A dictionary of soft process resource limits to apply to the job before
   starting tasks. Resource limits are set to integer values by lowercase
   name without the ``RLIMIT_`` prefix, e.g. ``core`` or ``nofile``. Users
   should not need to set this shell option as it is handled by commands
   like :man1:`flux-submit`.
 
-**taskmap**
+.. option:: taskmap
+
   Request an alternate job task mapping. This option is an object
   consisting of required key ``scheme`` and optional key ``value``. The
   shell will attempt to call a ``taskmap.scheme`` plugin callback in the
   shell to invoke the alternate requested mapping. If ``value`` is set,
   this will also be passed to the invoked plugin. Normally, this option will
-  be set by the :man1:`flux-submit` and related commands --taskmap`` option.
+  be set by the :man1:`flux-submit` and related commands :option:`--taskmap`
+  option.
 
-**pmi=off**
+.. option:: pmi=off
+
   Disable the process management interface for parallel jobs (see below).
 
-**pmi=LIST**
+.. option:: pmi=LIST
+
   Specify a comma-separated list of PMI implementations to enable.  If the
   option is unspecified, the ``simple`` PMI-1 wire protocol implementation
   is enabled.  Other options such as ``cray-pals`` or ``pmix`` may be
   installed on your system.
 
-**pmi-simple.nomap**
+.. option:: pmi-simple.nomap
+
   Skip populating the PMI ``flux.taskmap`` and ``PMI_process_mapping`` keys.
 
-**pmi-simple.kvs=native**
+.. option:: pmi-simple.kvs=native
+
   Use the native Flux KVS instead of the PMI plugin's built-in key exchange
   algorithm.
 
-**pmi-simple.exchange.k=N**
+.. option:: pmi-simple.exchange.k=N
+
   Configure the PMI plugin's built-in key exchange algorithm to use a
   virtual tree fanout of ``N`` for key gather/broadcast.  The default is 2.
 
-**stage-in**
+.. option:: stage-in
+
   Copy files to the directory referenced by :envvar:`FLUX_JOB_TMPDIR` that
   were previously mapped using :man1:`flux-filemap`.
 
-**stage-in.tags**\ =\ *LIST*
+.. option:: stage-in.tags=LIST
+
   Select files to copy by specifying a comma-separated list of tags.
   If no tags are specified, the ``main`` tag is assumed.
 
-**stage-in.pattern**\ =\ *PATTERN*
+.. option:: stage-in.pattern=PATTERN
+
   Further filter the selected files to copy using a :man7:`glob` pattern.
 
-**stage-in.destination**\ =\ *[SCOPE:]PATH*
+.. option:: stage-in.destination=[SCOPE:]PATH
+
   Copy files to the specified destination instead of the directory referenced
   by :envvar:`FLUX_JOB_TMPDIR`.  The argument is a directory with optional
   *scope* prefix.  A scope of ``local`` denotes a local file system (the
@@ -353,18 +380,21 @@ plugins include:
   takes place on all the job's nodes if the scope is local, versus only the
   first node of the job if the scope is global.
 
-**signal=OPTION**
+.. option:: signal=OPTION
+
   Deliver signal ``SIGUSR1`` to the job 60s before job expiration.
   To customize the signal number or amount of time before expiration to
   deliver the signal, the ``signal`` option may be an object with one
   or both of the keys ``signum`` or ``timeleft``. (See below)
 
-**signal.signum**\ =\ *NUMBER*
-  Send signal *NUMBER* to the job ``signal.timeleft`` seconds before
+.. option:: signal.signum=NUMBER
+
+  Send signal *NUMBER* to the job :option:`signal.timeleft` seconds before
   the time limit.
 
-**signal.timeleft**\ =\ *TIME*
-  Send signal ``signal.signum`` *TIME* seconds before job expiration.
+.. option:: signal.timeleft=TIME
+
+  Send signal :option:`signal.signum` *TIME* seconds before job expiration.
 
 .. warning::
   The directory referenced by :envvar:`FLUX_JOB_TMPDIR` is cleaned up when the

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -254,28 +254,49 @@ plugins include:
 
 .. option:: cpu-affinity=OPT
 
-  Adjust the operation of the builtin shell ``affinity`` plugin.
-  *OPT* may be set to ``off`` to disable the affinity plugin, or
-  ``per-task`` to have available CPUs distributed to tasks.
-  If *OPT* starts with ``map:``, then the rest of the option is taken
-  as a semicolon-delimited list of cpus to allocate to each task. Each
-  entry in the list can be in one of the :linux:man7:`hwloc` list,
-  bitmask, or taskset formats (See
-  `hwlocality_bitmap(3) <https://www.open-mpi.org/projects/hwloc/doc/v2.9.0/a00181.php>`_,
-  especially the ``hwloc_bitmap_list_snprintf()``, ``hwloc_bitmap_snprintf()``
-  and ``hwloc_bitmap_taskset_snprintf()`` functions).  The default is ``on``,
-  which binds all tasks to the assigned set of cores in the job.
+  Adjust the operation of the builtin shell ``affinity`` plugin.  If the
+  option is unspecified, ``on`` is assumed.  *OPT* may be set to:
+
+  on
+    Bind each task to the full set of cores allocated to the job.
+
+  off
+    Disable the affinity plugin.  This may be useful if using another plugin
+    such as `mpibind <https://github.com/LLNL/mpibind>`_ to manage CPU
+    affinity.
+
+  per-task
+    Bind each task to an evenly populated subset of the cores allocated to
+    the job.  Tasks share cores only if there are more tasks than cores.
+
+  map:LIST
+    Bind each task to *LIST*, a semicolon-delimited list of cores.
+    Each entry in the list can be in one of the :linux:man7:`hwloc`
+    *list*, *bitmask*, or *taskset* formats. See `hwlocality_bitmap(3)
+    <https://www.open-mpi.org/projects/hwloc/doc/v2.9.0/a00181.php>`_,
+    especially the :func:`hwloc_bitmap_list_snprintf`,
+    :func:`hwloc_bitmap_snprintf` and :func:`hwloc_bitmap_taskset_snprintf`
+    functions.
 
 .. option:: gpu-affinity=OPT
 
-  Adjust operation of the builtin shell ``gpubind`` plugin, which simply
+  Adjust operation of the builtin shell ``gpubind`` plugin.  This plugin
   sets :envvar:`CUDA_VISIBLE_DEVICES` to the GPU IDs allocated to the job.
-  *OPT* may be set to ``off`` to disable the plugin, or ``per-task``
-  to divide allocated GPUs among tasks launched by the shell (sets a
-  different GPU ID or IDs for each launched task). If *OPT* starts with
-  ``map:``, then the rest of the option is a semicolon-delimited list
-  of GPUs to assign to each task. See :option:`cpu-affinity` documentation
-  for a description of the ``map:`` list format.
+  If the option is unspecified, ``on`` is assumed.  *OPT* may be set to:
+
+  on
+    Constrain each task to the full set of GPUs allocated to the job.
+
+  off
+    Disable the gpu-affinity plugin.
+
+  per-task
+    Constrain each task to an evenly populated subset of the GPUs allocated
+    to the job.  Tasks share GPUs only if there are more tasks than GPUs.
+
+  map:LIST
+    Constrain each task to *LIST*, a semicolon-delimited list of GPUs.
+    See :option:`cpu-affinity` above for a description of *LIST* format.
 
 .. option:: stop-tasks-in-exec
 

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -200,7 +200,7 @@ see the documentation for the specific plugin in question.
 Shell options supported by :program:`flux shell` itself and its built-in
 plugins include:
 
-.. option:: verbose=INT
+.. option:: verbose[=INT]
 
   Set the shell verbosity to *INT*. A larger value indicates increased
   verbosity, though setting this value larger than 2 currently has no

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -332,30 +332,46 @@ plugins include:
   be set by the :man1:`flux-submit` and related commands :option:`--taskmap`
   option.
 
-.. option:: pmi=off
-
-  Disable the process management interface for parallel jobs (see below).
-
 .. option:: pmi=LIST
 
   Specify a comma-separated list of PMI implementations to enable.  If the
-  option is unspecified, the ``simple`` PMI-1 wire protocol implementation
-  is enabled.  Other options such as ``cray-pals`` or ``pmix`` may be
-  installed on your system.
+  option is unspecified, ``simple`` is assumed.  To disable, set *LIST* to
+  ``off``.  Available implementations include
+
+  simple
+    The simple PMI-1 wire protocol.  This implementation works by passing an
+    open file descriptor to clients via the :envvar:`PMI_FD` environment
+    variable.  It must be enabled when Flux's ``libpmi.so`` or ``libpmi2.so``
+    libraries are used, and is preferred by :man1:`flux-broker`
+    when Flux launches Flux, e.g. by means of :man1:`flux-batch` or
+    :man1:`flux-alloc`.
+
+  pmi1, pmi2
+    Aliases for ``simple``.
+
+  cray-pals
+    Provided via external plugin from the
+    `flux-coral2 <https://github.com/flux-framework/flux-coral2>`_ project.
+
+  pmix
+    Provided via external plugin from the
+    `flux-pmix <https://github.com/flux-framework/flux-pmix>`_ project.
 
 .. option:: pmi-simple.nomap
 
-  Skip populating the PMI ``flux.taskmap`` and ``PMI_process_mapping`` keys.
+  Skip pre-populating the ``flux.taskmap`` and ``PMI_process_mapping`` keys
+  in the ``simple`` implementation.
 
 .. option:: pmi-simple.kvs=native
 
   Use the native Flux KVS instead of the PMI plugin's built-in key exchange
-  algorithm.
+  algorithm in the ``simple`` implementation.
 
 .. option:: pmi-simple.exchange.k=N
 
   Configure the PMI plugin's built-in key exchange algorithm to use a
-  virtual tree fanout of ``N`` for key gather/broadcast.  The default is 2.
+  virtual tree fanout of ``N`` for key gather/broadcast in the ``simple``
+  implementation.  The default is 2.
 
 .. option:: stage-in
 

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -206,9 +206,9 @@ plugins include:
   verbosity, though setting this value larger than 2 currently has no
   effect.
 
-.. option:: nosetpgrp=INT
+.. option:: nosetpgrp
 
-  If nonzero, disables the use of :linux:man2:`setpgrp` to launch each
+  Disable the use of :linux:man2:`setpgrp` to launch each
   job task in its own process group. This will cause signals to be
   delivered only to direct children of the shell.
 

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -66,7 +66,7 @@ execution of the job:
    typically ``<userid>-shell-<jobid>``
  * load the system default ``initrc.lua``
    (``$sysconfdir/flux/shell/initrc.lua``), unless overridden by
-   configuration (See `JOBSPEC OPTIONS`_ and `SHELL INITRC`_ sections below)
+   configuration (See `SHELL OPTIONS`_ and `SHELL INITRC`_ sections below)
  * call ``shell.init`` plugin callbacks
  * change working directory to the cwd of the job
  * enter a barrier to ensure shell initialization is complete on all shells
@@ -175,9 +175,10 @@ Note however, that plugins may also call into the plugin stack to create
 new callbacks at runtime, so more topics than those listed above may be
 available in a given shell instance.
 
+.. _flux_shell_options:
 
-JOBSPEC OPTIONS
-===============
+SHELL OPTIONS
+=============
 
 On startup, :program:`flux shell` will examine the jobspec for any shell
 specific options under the ``attributes.system.shell.options`` key.  These
@@ -192,7 +193,12 @@ of optional job shell behavior. In the list below, if an option doesn't
 include a ``=``, then it is a simple boolean option or switch and may be
 specified simply with :option:`flux submit -o OPTION`.
 
-Options supported by :program:`flux shell` proper include:
+Job shell plugins may also support configuration via shell options in
+the jobspec. For specific information about runtime-loaded plugins,
+see the documentation for the specific plugin in question.
+
+Shell options supported by :program:`flux shell` itself and its built-in
+plugins include:
 
 **verbose**\ =\ *INT*
   Set the shell verbosity to *INT*. A larger value indicates increased
@@ -208,11 +214,6 @@ Options supported by :program:`flux shell` proper include:
   Load :program:`flux shell` initrc.lua file from *FILE* instead of the default
   initrc path. For details of the job shell initrc.lua file format,
   see the `SHELL INITRC`_ section below.
-
-Job shell plugins may also support configuration via shell options in
-the jobspec. For specific information about runtime-loaded plugins,
-see the documentation for the specific plugin in question. The following
-options are supported by the builtin plugins of :program:`flux shell`:
 
 **pty**
   Allocate a pty to all task ranks for non-interactive use. Output
@@ -371,6 +372,8 @@ options are supported by the builtin plugins of :program:`flux shell`:
   such as a *tmpfs*.  If a destination is explicitly specified, use the
   ``global:`` prefix where appropriate to avoid overwhelming a shared file
   system, and be sure to clean up.
+
+.. _flux_shell_initrc:
 
 SHELL INITRC
 ============

--- a/doc/man1/flux-submit.rst
+++ b/doc/man1/flux-submit.rst
@@ -142,11 +142,17 @@ OTHER OPTIONS
 SHELL OPTIONS
 =============
 
-These options are provided by built-in shell plugins that may be
-overridden in some cases:
+Some options that affect the parallel runtime environment are provided by the
+Flux shell.  These options are described in detail in the
+:ref:`SHELL OPTIONS <flux_shell_options>` section of :man1:`flux-shell`.
+A list of the most commonly needed options follows.
 
+Usage: :option:`flux submit -o NAME[=ARG]`.
+
+.. make :option: references in the included table x-ref to flux-shell(1)
+.. program:: flux shell
 .. include:: common/job-shell-options.rst
-
+.. program:: flux submit
 
 RESOURCES
 =========

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -797,3 +797,4 @@ noflux
 param
 perres
 pertask
+mpibind


### PR DESCRIPTION
Problem: the job submission commands duplicate shell plugin information in `flux-shell(1)`.

Improve the way options are formatted for HTML presentation in `flux-shell(1)`, adding x-ref capability and reworking some dense/terse descriptions.  Then change the duplicate option descriptions in the submission commands into a short table that cross-references commonly needed options to `flux-shell(1)`.

Improve the descriptions of pmi and affinity options as they were a bit terse IMHO.