### PR TITLE
broker: eliminate some message copies

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -88,8 +88,10 @@ static void overlay_recv_cb (const flux_msg_t *msg,
                              void *arg);
 static void module_cb (module_t *p, void *arg);
 static void module_status_cb (module_t *p, int prev_state, void *arg);
-static void signal_cb (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg);
+static void signal_cb (flux_reactor_t *r,
+                       flux_watcher_t *w,
+                       int revents,
+                       void *arg);
 static int broker_handle_signals (broker_ctx_t *ctx);
 
 static flux_msg_handler_t **broker_add_services (broker_ctx_t *ctx);
@@ -162,7 +164,8 @@ void parse_command_line_arguments (int argc, char *argv[], broker_ctx_t *ctx)
 
     if (optindex < argc) {
         int e;
-        if ((e = argz_create (argv + optindex, &ctx->init_shell_cmd,
+        if ((e = argz_create (argv + optindex,
+                              &ctx->init_shell_cmd,
                               &ctx->init_shell_cmd_len)) != 0)
             log_errn_exit (e, "argz_create");
     }
@@ -1215,7 +1218,8 @@ error:
     return -1;
 }
 
-static int unload_module (broker_ctx_t *ctx, const char *name,
+static int unload_module (broker_ctx_t *ctx,
+                          const char *name,
                           const flux_msg_t *request)
 {
     module_t *p;
@@ -1274,8 +1278,10 @@ static int broker_handle_signals (broker_ctx_t *ctx)
  * N.B. unload_module() handles response, unless it fails early
  * and returns -1.
  */
-static void broker_rmmod_cb (flux_t *h, flux_msg_handler_t *mh,
-                             const flux_msg_t *msg, void *arg)
+static void broker_rmmod_cb (flux_t *h,
+                             flux_msg_handler_t *mh,
+                             const flux_msg_t *msg,
+                             void *arg)
 {
     broker_ctx_t *ctx = arg;
     const char *name;
@@ -1293,8 +1299,10 @@ error:
 /* Load a module, asynchronously.
  * N.B. load_module() handles response, unless it returns -1.
  */
-static void broker_insmod_cb (flux_t *h, flux_msg_handler_t *mh,
-                              const flux_msg_t *msg, void *arg)
+static void broker_insmod_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
 {
     broker_ctx_t *ctx = arg;
     const char *name = NULL;
@@ -1322,8 +1330,10 @@ error:
 
 /* List loaded modules
  */
-static void broker_lsmod_cb (flux_t *h, flux_msg_handler_t *mh,
-                             const flux_msg_t *msg, void *arg)
+static void broker_lsmod_cb (flux_t *h,
+                             flux_msg_handler_t *mh,
+                             const flux_msg_t *msg,
+                             void *arg)
 {
     broker_ctx_t *ctx = arg;
     json_t *mods = NULL;
@@ -1400,8 +1410,10 @@ void __gcov_dump (void);
 void __gcov_reset (void);
 #endif
 
-static void broker_disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
-                               const flux_msg_t *msg, void *arg)
+static void broker_disconnect_cb (flux_t *h,
+                                  flux_msg_handler_t *mh,
+                                  const flux_msg_t *msg,
+                                  void *arg)
 {
 }
 
@@ -1433,8 +1445,10 @@ static int service_allow (struct flux_msg_cred cred, const char *name)
  * These handlers need to appear in broker.c so that they have
  *  access to broker internals like modhash
  */
-static void service_add_cb (flux_t *h, flux_msg_handler_t *w,
-                            const flux_msg_t *msg, void *arg)
+static void service_add_cb (flux_t *h,
+                            flux_msg_handler_t *w,
+                            const flux_msg_t *msg,
+                            void *arg)
 {
     broker_ctx_t *ctx = arg;
     const char *name = NULL;
@@ -1443,7 +1457,7 @@ static void service_add_cb (flux_t *h, flux_msg_handler_t *w,
     struct flux_msg_cred cred;
 
     if (flux_request_unpack (msg, NULL, "{ s:s }", "service", &name) < 0
-            || flux_msg_get_cred (msg, &cred) < 0)
+        || flux_msg_get_cred (msg, &cred) < 0)
         goto error;
     if (service_allow (cred, name) < 0)
         goto error;
@@ -1465,8 +1479,10 @@ error:
         flux_log_error (h, "service_add: flux_respond_error");
 }
 
-static void service_remove_cb (flux_t *h, flux_msg_handler_t *w,
-                               const flux_msg_t *msg, void *arg)
+static void service_remove_cb (flux_t *h,
+                               flux_msg_handler_t *w,
+                               const flux_msg_t *msg,
+                               void *arg)
 {
     broker_ctx_t *ctx = arg;
     const char *name;
@@ -1475,7 +1491,7 @@ static void service_remove_cb (flux_t *h, flux_msg_handler_t *w,
     struct flux_msg_cred cred;
 
     if (flux_request_unpack (msg, NULL, "{ s:s }", "service", &name) < 0
-            || flux_msg_get_cred (msg, &cred) < 0)
+        || flux_msg_get_cred (msg, &cred) < 0)
         goto error;
     if (service_allow (cred, name) < 0)
         goto error;
@@ -1592,8 +1608,10 @@ static flux_msg_handler_t **broker_add_services (broker_ctx_t *ctx)
     for (svc = &services[0]; svc->name != NULL; svc++) {
         if (!nodeset_member (svc->nodeset, ctx->rank))
             continue;
-        if (service_add (ctx->services, svc->name, NULL,
-                         route_to_handle, ctx) < 0) {
+        if (service_add (ctx->services,
+                         svc->name, NULL,
+                         route_to_handle,
+                         ctx) < 0) {
             log_err ("error registering service for %s", svc->name);
             return NULL;
         }
@@ -1660,7 +1678,8 @@ static void overlay_recv_cb (const flux_msg_t *msg,
     if (dropped && (type != FLUX_MSGTYPE_RESPONSE || errno != ENOSYS)) {
         const char *topic = "unknown";
         (void)flux_msg_get_topic (msg, &topic);
-        flux_log_error (ctx->h, "DROP %s %s topic=%s",
+        flux_log_error (ctx->h,
+                        "DROP %s %s topic=%s",
                         where == OVERLAY_UPSTREAM ? "upstream" : "downstream",
                         flux_msg_typestr (type),
                         topic);
@@ -1782,14 +1801,19 @@ static void module_cb (module_t *p, void *arg)
             break;
         case FLUX_MSGTYPE_EVENT:
             if (broker_event_sendmsg (ctx, msg) < 0) {
-                flux_log_error (ctx->h, "%s(%s): broker_event_sendmsg %s",
-                                __FUNCTION__, module_get_name (p),
+                flux_log_error (ctx->h,
+                                "%s(%s): broker_event_sendmsg %s",
+                                __FUNCTION__,
+                                module_get_name (p),
                                 flux_msg_typestr (type));
             }
             break;
         default:
-            flux_log (ctx->h, LOG_ERR, "%s(%s): unexpected %s",
-                      __FUNCTION__, module_get_name (p),
+            flux_log (ctx->h,
+                      LOG_ERR,
+                      "%s(%s): unexpected %s",
+                      __FUNCTION__,
+                      module_get_name (p),
                       flux_msg_typestr (type));
             break;
     }
@@ -1908,16 +1932,18 @@ static int killall_jobs (broker_ctx_t *ctx, int signum)
                              "userid", FLUX_USERID_UNKNOWN,
                              "signum", signum))
         || flux_future_then (f, -1., killall_cb, ctx) < 0) {
-            flux_future_destroy (f);
-            return -1;
+        flux_future_destroy (f);
+        return -1;
     }
     if (flux_future_aux_set (f, "signum", int2ptr (signum), NULL) < 0)
         flux_log_error (ctx->h, "killall: future_aux_set");
     return 0;
 }
 
-static void signal_cb (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg)
+static void signal_cb (flux_reactor_t *r,
+                       flux_watcher_t *w,
+                       int revents,
+                       void *arg)
 {
     broker_ctx_t *ctx = arg;
     int signum = flux_signal_watcher_get_signum (w);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1155,11 +1155,10 @@ static bool nodeset_member (const char *s, uint32_t rank)
     return member;
 }
 
-static int mod_svc_cb (const flux_msg_t *msg, void *arg)
+static int mod_svc_cb (flux_msg_t **msg, void *arg)
 {
     module_t *p = arg;
-    int rc = module_sendmsg (p, msg);
-    return rc;
+    return module_sendmsg_new (p, msg);
 }
 
 /* Load broker module.
@@ -1441,10 +1440,10 @@ static void broker_disconnect_cb (flux_t *h,
 {
 }
 
-static int route_to_handle (const flux_msg_t *msg, void *arg)
+static int route_to_handle (flux_msg_t **msg, void *arg)
 {
     broker_ctx_t *ctx = arg;
-    if (flux_send (ctx->h_internal, msg, 0) < 0) {
+    if (flux_send_new (ctx->h_internal, msg, 0) < 0) {
         flux_log_error (ctx->h, "send failed on internal broker handle");
         return -1;
     }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -2096,10 +2096,8 @@ static int broker_response_sendmsg_new (broker_ctx_t *ctx,
             return -1;
     }
     else {
-        if (modhash_response_sendmsg (ctx->modhash, *msg) < 0)
+        if (modhash_response_sendmsg_new (ctx->modhash, msg) < 0)
             return -1;
-        flux_msg_decref (*msg);
-        *msg = NULL;
     }
     return 0;
 }

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -18,6 +18,8 @@
 struct broker {
     void *zctx;
     flux_t *h;
+    flux_t *h_internal;
+    flux_watcher_t *w_internal;
     flux_reactor_t *reactor;
     optparse_t *opts;
 

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -27,14 +27,14 @@ struct modhash {
     zhash_t *zh_byuuid;
 };
 
-int modhash_response_sendmsg (modhash_t *mh, const flux_msg_t *msg)
+int modhash_response_sendmsg_new (modhash_t *mh, flux_msg_t **msg)
 {
     const char *uuid;
     module_t *p;
 
-    if (!msg)
+    if (!*msg)
         return 0;
-    if (!(uuid = flux_msg_route_last (msg))) {
+    if (!(uuid = flux_msg_route_last (*msg))) {
         errno = EPROTO;
         return -1;
     }
@@ -42,7 +42,7 @@ int modhash_response_sendmsg (modhash_t *mh, const flux_msg_t *msg)
         errno = ENOSYS;
         return -1;
     }
-    return module_sendmsg (p, msg);
+    return module_sendmsg_new (p, msg);
 }
 
 void modhash_add (modhash_t *mh, module_t *p)

--- a/src/broker/modhash.h
+++ b/src/broker/modhash.h
@@ -37,7 +37,7 @@ int modhash_event_mcast (modhash_t *mh, const flux_msg_t *msg);
 /* Send a response message to the module whose uuid matches the
  * next hop in the routing stack.
  */
-int modhash_response_sendmsg (modhash_t *mh, const flux_msg_t *msg);
+int modhash_response_sendmsg_new (modhash_t *mh, flux_msg_t **msg);
 
 /* Find a module matching 'uuid'.
  */

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -420,15 +420,15 @@ flux_msg_t *module_recvmsg (module_t *p)
     return flux_recv (p->h_broker, FLUX_MATCH_ANY, FLUX_O_NONBLOCK);
 }
 
-int module_sendmsg (module_t *p, const flux_msg_t *msg)
+int module_sendmsg_new (module_t *p, flux_msg_t **msg)
 {
     int type;
     const char *topic;
 
-    if (!msg)
+    if (!msg || !*msg)
         return 0;
-    if (flux_msg_get_type (msg, &type) < 0
-        || flux_msg_get_topic (msg, &topic) < 0)
+    if (flux_msg_get_type (*msg, &type) < 0
+        || flux_msg_get_topic (*msg, &topic) < 0)
         return -1;
     /* Muted modules only accept response to broker.module-status
      */
@@ -439,7 +439,21 @@ int module_sendmsg (module_t *p, const flux_msg_t *msg)
             return -1;
         }
     }
-    return flux_send (p->h_broker, msg, 0);
+    return flux_send_new (p->h_broker, msg, 0);
+}
+
+int module_sendmsg (module_t *p, const flux_msg_t *msg)
+{
+    flux_msg_t *cpy;
+
+    if (!msg)
+        return 0;
+    if (!(cpy = flux_msg_copy (msg, true))
+        || module_sendmsg_new (p, &cpy) < 0) {
+        flux_msg_decref (cpy);
+        return -1;
+    }
+    return 0;
 }
 
 int module_disconnect_arm (module_t *p,

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -44,7 +44,6 @@ void module_set_poller_cb (module_t *p, modpoller_cb_f cb, void *arg);
 /* Send/recv a message for to/from a specific module.
  */
 flux_msg_t *module_recvmsg (module_t *p);
-int module_sendmsg (module_t *p, const flux_msg_t *msg);
 int module_sendmsg_new (module_t *p, flux_msg_t **msg);
 
 /* Pass module's requests through this function to enable disconnect

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -45,6 +45,7 @@ void module_set_poller_cb (module_t *p, modpoller_cb_f cb, void *arg);
  */
 flux_msg_t *module_recvmsg (module_t *p);
 int module_sendmsg (module_t *p, const flux_msg_t *msg);
+int module_sendmsg_new (module_t *p, flux_msg_t **msg);
 
 /* Pass module's requests through this function to enable disconnect
  * messages to be sent when the module is unloaded.  The callback will

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -841,7 +841,8 @@ static void overlay_mcast_child (struct overlay *ov, const flux_msg_t *msg)
 static void logdrop (struct overlay *ov,
                      overlay_where_t where,
                      const flux_msg_t *msg,
-                     const char *fmt, ...)
+                     const char *fmt,
+                     ...)
 {
     char reason[128];
     va_list ap;
@@ -883,8 +884,10 @@ static int clear_msg_role (flux_msg_t *msg, uint32_t role)
 
 /* Handle a message received from TBON child (downstream).
  */
-static void child_cb (flux_reactor_t *r, flux_watcher_t *w,
-                      int revents, void *arg)
+static void child_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
 {
     struct overlay *ov = arg;
     flux_msg_t *msg;
@@ -991,8 +994,10 @@ static void fail_parent_rpc (const flux_msg_t *msg, void *arg)
         log_tracker_error (ov->h, msg, errno);
 }
 
-static void parent_cb (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg)
+static void parent_cb (flux_reactor_t *r,
+                       flux_watcher_t *w,
+                       int revents,
+                       void *arg)
 {
     struct overlay *ov = arg;
     flux_msg_t *msg;
@@ -1203,8 +1208,11 @@ static void hello_response_handler (struct overlay *ov, const flux_msg_t *msg)
         errno = saved_errno;
         goto error;
     }
-    flux_log (ov->h, LOG_DEBUG, "hello parent %lu %s",
-              (unsigned long)ov->parent.rank, uuid);
+    flux_log (ov->h,
+              LOG_DEBUG,
+              "hello parent %lu %s",
+              (unsigned long)ov->parent.rank,
+              uuid);
     snprintf (ov->parent.uuid, sizeof (ov->parent.uuid), "%s", uuid);
     ov->parent.hello_responded = true;
     ov->parent.hello_error = false;

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -975,7 +975,9 @@ static void child_cb (flux_reactor_t *r,
         case FLUX_MSGTYPE_EVENT:
             break;
     }
-    ov->recv_cb (msg, OVERLAY_DOWNSTREAM, ov->recv_arg);
+    if (ov->recv_cb (&msg, OVERLAY_DOWNSTREAM, ov->recv_arg) < 0)
+        goto done;
+    return;
 done:
     flux_msg_decref (msg);
 }
@@ -1061,7 +1063,9 @@ static void parent_cb (flux_reactor_t *r,
         default:
             break;
     }
-    ov->recv_cb (msg, OVERLAY_UPSTREAM, ov->recv_arg);
+    if (ov->recv_cb (&msg, OVERLAY_UPSTREAM, ov->recv_arg) < 0)
+        goto done;
+    return;
 done:
     flux_msg_destroy (msg);
 }

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -188,7 +188,7 @@ struct overlay {
     struct flux_msglist *health_requests;
 };
 
-static void overlay_mcast_child (struct overlay *ov, const flux_msg_t *msg);
+static void overlay_mcast_child (struct overlay *ov, flux_msg_t *msg);
 static int overlay_sendmsg_child (struct overlay *ov, const flux_msg_t *msg);
 static int overlay_sendmsg_parent (struct overlay *ov, const flux_msg_t *msg);
 static void hello_response_handler (struct overlay *ov, const flux_msg_t *msg);
@@ -572,20 +572,18 @@ error:
     return -1;
 }
 
-int overlay_sendmsg (struct overlay *ov,
-                     const flux_msg_t *msg,
-                     overlay_where_t where)
+int overlay_sendmsg_new (struct overlay *ov,
+                         flux_msg_t **msg,
+                         overlay_where_t where)
 {
     int type;
     uint8_t flags;
-    flux_msg_t *cpy = NULL;
     const char *uuid;
     uint32_t nodeid;
     struct child *child = NULL;
-    int rc;
 
-    if (flux_msg_get_type (msg, &type) < 0
-        || flux_msg_get_flags (msg, &flags) < 0)
+    if (flux_msg_get_type (*msg, &type) < 0
+        || flux_msg_get_flags (*msg, &flags) < 0)
         return -1;
     switch (type) {
         case FLUX_MSGTYPE_REQUEST:
@@ -595,23 +593,19 @@ int overlay_sendmsg (struct overlay *ov,
              * select the peer, and our uuid remains as part of the source addr.
              */
             if (where == OVERLAY_ANY) {
-                if (flux_msg_get_nodeid (msg, &nodeid) < 0)
-                    goto error;
+                if (flux_msg_get_nodeid (*msg, &nodeid) < 0)
+                    return -1;
                 if ((flags & FLUX_MSGFLAG_UPSTREAM) && nodeid == ov->rank)
                     where = OVERLAY_UPSTREAM;
                 else {
                     if ((child = child_lookup_route (ov, nodeid))) {
                         if (!subtree_is_online (child->status)) {
                             errno = EHOSTUNREACH;
-                            goto error;
+                            return -1;
                         }
-                        if (!(cpy = flux_msg_copy (msg, true)))
-                            goto error;
-                        if (flux_msg_route_push (cpy, ov->uuid) < 0)
-                            goto error;
-                        if (flux_msg_route_push (cpy, child->uuid) < 0)
-                            goto error;
-                        msg = cpy;
+                        if (flux_msg_route_push (*msg, ov->uuid) < 0
+                            || flux_msg_route_push (*msg, child->uuid) < 0)
+                            return -1;
                         where = OVERLAY_DOWNSTREAM;
                     }
                     else
@@ -619,23 +613,20 @@ int overlay_sendmsg (struct overlay *ov,
                 }
             }
             if (where == OVERLAY_UPSTREAM) {
-                rc = overlay_sendmsg_parent (ov, msg);
-                if (rc == 0)
-                    rpc_track_update (ov->parent.tracker, msg);
+                if (overlay_sendmsg_parent (ov, *msg) < 0)
+                    return -1;
+                rpc_track_update (ov->parent.tracker, *msg);
             }
             else {
-                rc = overlay_sendmsg_child (ov, msg);
-                if (rc == 0) {
-                    if (!child) {
-                        if ((uuid = flux_msg_route_last (msg)))
-                            child = child_lookup_online (ov, ov->uuid);
-                    }
-                    if (child)
-                        rpc_track_update (child->tracker, msg);
+                if (overlay_sendmsg_child (ov, *msg) < 0)
+                    return -1;
+                if (!child) {
+                    if ((uuid = flux_msg_route_last (*msg)))
+                        child = child_lookup_online (ov, ov->uuid);
                 }
+                if (child)
+                    rpc_track_update (child->tracker, *msg);
             }
-            if (rc < 0)
-                goto error;
             break;
         case FLUX_MSGTYPE_RESPONSE:
             /* Assume if next route matches parent, the message goes upstream;
@@ -644,46 +635,57 @@ int overlay_sendmsg (struct overlay *ov,
              */
             if (where == OVERLAY_ANY) {
                 if (ov->rank > 0
-                    && (uuid = flux_msg_route_last (msg)) != NULL
+                    && (uuid = flux_msg_route_last (*msg)) != NULL
                     && streq (uuid, ov->parent.uuid))
                     where = OVERLAY_UPSTREAM;
                 else
                     where = OVERLAY_DOWNSTREAM;
             }
-            if (where == OVERLAY_UPSTREAM)
-                rc = overlay_sendmsg_parent (ov, msg);
-            else
-                rc = overlay_sendmsg_child (ov, msg);
-            if (rc < 0)
-                goto error;
+            if (where == OVERLAY_UPSTREAM) {
+                if (overlay_sendmsg_parent (ov, *msg) < 0)
+                    return -1;
+            }
+            else {
+                if (overlay_sendmsg_child (ov, *msg) < 0)
+                    return -1;
+            }
             break;
         case FLUX_MSGTYPE_EVENT:
             if (where == OVERLAY_DOWNSTREAM || where == OVERLAY_ANY)
-                overlay_mcast_child (ov, msg);
+                overlay_mcast_child (ov, *msg);
             else {
                 /* N.B. add route delimiter if needed to pass unpublished
                  * event message upstream through router socket.
                  */
                 if (!(flags & FLUX_MSGFLAG_ROUTE)) {
-                    if (!(cpy = flux_msg_copy (msg, true)))
-                        goto error;
-                    flux_msg_route_enable (cpy);
-                    msg = cpy;
+                    flux_msg_route_enable (*msg);
                 }
-                if (overlay_sendmsg_parent (ov, msg) < 0)
-                    goto error;
+                if (overlay_sendmsg_parent (ov, *msg) < 0)
+                    return -1;
             }
             break;
         default:
-            goto inval;
+            errno = EINVAL;
+            return -1;
     }
-    flux_msg_decref (cpy);
+    flux_msg_decref (*msg);
+    *msg = NULL;
     return 0;
-inval:
-    errno = EINVAL;
-error:
-    flux_msg_decref (cpy);
-    return -1;
+}
+
+int overlay_sendmsg (struct overlay *ov,
+                     const flux_msg_t *msg,
+                     overlay_where_t where)
+{
+    flux_msg_t *cpy;
+
+    if (!(cpy = flux_msg_copy (msg, true)))
+        return -1;
+    if (overlay_sendmsg_new (ov, &cpy, where) < 0) {
+        flux_msg_destroy (cpy);
+        return -1;
+    }
+    return 0;
 }
 
 static void sync_cb (flux_future_t *f, void *arg)
@@ -801,29 +803,24 @@ done:
     return rc;
 }
 
+/* Push child->uuid onto the message, then pop it off again after sending.
+ */
 static int overlay_mcast_child_one (struct overlay *ov,
-                                    const flux_msg_t *msg,
+                                    flux_msg_t *msg,
                                     struct child *child)
 {
-    flux_msg_t *cpy;
-    int rc = -1;
-
-    if (!(cpy = flux_msg_copy (msg, true)))
+    if (flux_msg_route_push (msg, child->uuid) < 0)
         return -1;
-    flux_msg_route_enable (cpy);
-    if (flux_msg_route_push (cpy, child->uuid) < 0)
-        goto done;
-    if (overlay_sendmsg_child (ov, cpy) < 0)
-        goto done;
-    rc = 0;
-done:
-    flux_msg_destroy (cpy);
+    int rc = overlay_sendmsg_child (ov, msg);
+    (void)flux_msg_route_delete_last (msg);
     return rc;
 }
 
-static void overlay_mcast_child (struct overlay *ov, const flux_msg_t *msg)
+static void overlay_mcast_child (struct overlay *ov, flux_msg_t *msg)
 {
     struct child *child;
+
+    flux_msg_route_enable (msg);
 
     foreach_overlay_child (ov, child) {
         if (subtree_is_online (child->status)) {

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -26,9 +26,9 @@ typedef enum {
 struct overlay;
 
 typedef void (*overlay_monitor_f)(struct overlay *ov, uint32_t rank, void *arg);
-typedef void (*overlay_recv_f)(const flux_msg_t *msg,
-                               overlay_where_t from,
-                               void *arg);
+typedef int (*overlay_recv_f)(flux_msg_t **msg,
+                              overlay_where_t from,
+                              void *arg);
 
 /* Create overlay network, registering 'cb' to be called with each
  * received message.

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -57,6 +57,11 @@ int overlay_set_topology (struct overlay *ov, struct topology *topo);
 int overlay_sendmsg (struct overlay *ov,
                      const flux_msg_t *msg,
                      overlay_where_t where);
+/* same as above but steals reference to 'msg' on success.
+ */
+int overlay_sendmsg_new (struct overlay *ov,
+                         flux_msg_t **msg,
+                         overlay_where_t where);
 
 /* Each broker has a public, private CURVE key-pair.  Call overlay_authorize()
  * with the public key of each downstream peer to authorize it to connect,

--- a/src/broker/service.c
+++ b/src/broker/service.c
@@ -144,8 +144,11 @@ void service_remove_byuuid (struct service_switch *sw, const char *uuid)
     }
 }
 
-int service_add (struct service_switch *sh, const char *name,
-                 const char *uuid, service_send_f cb, void *arg)
+int service_add (struct service_switch *sh,
+                 const char *name,
+                 const char *uuid,
+                 service_send_f cb,
+                 void *arg)
 {
     struct service *svc = NULL;
 
@@ -172,7 +175,8 @@ error:
  * Avoid an extra malloc here if the substring is short.
  */
 static struct service *service_lookup_subtopic (struct service_switch *sw,
-                                                const char *topic, int length)
+                                                const char *topic,
+                                                int length)
 {
     char buf[16];
     char *cpy = NULL;

--- a/src/broker/service.c
+++ b/src/broker/service.c
@@ -224,17 +224,6 @@ int service_send_new (struct service_switch *sw, flux_msg_t **msg)
     return svc->cb (msg, svc->cb_arg);
 }
 
-int service_send (struct service_switch *sw, const flux_msg_t *msg)
-{
-    flux_msg_t *cpy;
-    if (!(cpy = flux_msg_copy (msg, true))
-        || service_send_new (sw, &cpy) < 0) {
-        flux_msg_destroy (cpy);
-        return -1;
-    }
-    return 0;
-}
-
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/broker/service.h
+++ b/src/broker/service.h
@@ -18,8 +18,11 @@ typedef int (*service_send_f)(const flux_msg_t *msg, void *arg);
 struct service_switch *service_switch_create (void);
 void service_switch_destroy (struct service_switch *sw);
 
-int service_add (struct service_switch *sw, const char *name,
-                 const char *uuid, service_send_f cb, void *arg);
+int service_add (struct service_switch *sw,
+                 const char *name,
+                 const char *uuid,
+                 service_send_f cb,
+                 void *arg);
 
 void service_remove (struct service_switch *sw, const char *name);
 

--- a/src/broker/service.h
+++ b/src/broker/service.h
@@ -28,7 +28,6 @@ void service_remove (struct service_switch *sw, const char *name);
 
 void service_remove_byuuid (struct service_switch *sw, const char *uuid);
 
-int service_send (struct service_switch *sw, const flux_msg_t *msg);
 int service_send_new (struct service_switch *sw, flux_msg_t **msg);
 
 /* Return the UUID currently registered for service `name` */

--- a/src/broker/service.h
+++ b/src/broker/service.h
@@ -13,7 +13,7 @@
 
 #include <jansson.h>
 
-typedef int (*service_send_f)(const flux_msg_t *msg, void *arg);
+typedef int (*service_send_f)(flux_msg_t **msg, void *arg);
 
 struct service_switch *service_switch_create (void);
 void service_switch_destroy (struct service_switch *sw);
@@ -29,6 +29,7 @@ void service_remove (struct service_switch *sw, const char *name);
 void service_remove_byuuid (struct service_switch *sw, const char *uuid);
 
 int service_send (struct service_switch *sw, const flux_msg_t *msg);
+int service_send_new (struct service_switch *sw, flux_msg_t **msg);
 
 /* Return the UUID currently registered for service `name` */
 const char *service_get_uuid (struct service_switch *sw, const char *name);

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -224,14 +224,16 @@ void single (flux_t *h)
     ctx_destroy (ctx);
 }
 
-void recv_cb (const flux_msg_t *msg, overlay_where_t from, void *arg)
+int recv_cb (flux_msg_t **msg, overlay_where_t from, void *arg)
 {
     struct context *ctx = arg;
 
     diag ("%s message received",
           from == OVERLAY_UPSTREAM ? "upstream" : "downstream");
-    ctx->msg = flux_msg_incref (msg);
+    ctx->msg = *msg;
+    *msg = NULL;
     flux_reactor_stop (flux_get_reactor (ctx->h));
+    return 0;
 }
 
 void timeout_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)

--- a/src/broker/test/service.c
+++ b/src/broker/test/service.c
@@ -20,20 +20,25 @@
 
 #include "src/common/libtap/tap.h"
 
-const flux_msg_t *foo_cb_msg;
+flux_msg_t *foo_cb_msg;
 void *foo_cb_arg;
 int foo_cb_called;
 int foo_cb_rc;
 int foo_cb_errno;
 
-static int foo_cb (const flux_msg_t *msg, void *arg)
+static int foo_cb (flux_msg_t **msg, void *arg)
 {
-    foo_cb_msg = msg;
+    foo_cb_msg = *msg;
     foo_cb_arg = arg;
     foo_cb_called++;
 
     if (foo_cb_rc != 0)
         errno = foo_cb_errno;
+
+    if (foo_cb_rc == 0) {
+        flux_msg_decref (*msg);
+        *msg = NULL;
+    }
 
     return foo_cb_rc;
 }
@@ -43,6 +48,7 @@ int main (int argc, char **argv)
 {
     struct service_switch *sw;
     flux_msg_t *msg, *msg2, *msg3;
+    void *msg_ptr;
 
     plan (NO_PLAN);
 
@@ -50,12 +56,15 @@ int main (int argc, char **argv)
     ok (sw != NULL,
         "service_switch_create works");
 
-    msg = flux_request_encode ("foo", NULL);
+    msg_ptr = msg = flux_request_encode ("foo", NULL);
     if (!msg)
         BAIL_OUT ("flux_request_encode: %s", flux_strerror (errno));
     errno = 0;
-    ok (service_send (sw, msg) < 0 && errno == ENOSYS,
-        "service_send to 'foo' fails with ENOSYS");
+    ok (service_send_new (sw, &msg) < 0 && errno == ENOSYS,
+        "service_send_new to 'foo' fails with ENOSYS");
+    ok (msg != NULL,
+        "and message as not set to NULL");
+    msg = msg_ptr; // just in case that test failed
 
     ok (service_add (sw, "foo", NULL, foo_cb, NULL) == 0,
         "service_add foo works");
@@ -64,16 +73,25 @@ int main (int argc, char **argv)
     foo_cb_arg = (void *)(uintptr_t)1;
     foo_cb_called = 0;
     foo_cb_rc = 0;
-    ok (service_send (sw, msg) == 0,
-        "service_send to 'foo' works");
-    ok (foo_cb_called == 1 && foo_cb_arg == NULL && foo_cb_msg == msg,
+    ok (service_send_new (sw, &msg) == 0,
+        "service_send_new to 'foo' works");
+    ok (msg == NULL,
+        "and msg was set to NULL");
+    ok (foo_cb_called == 1 && foo_cb_arg == NULL && foo_cb_msg == msg_ptr,
         "and callback was called with expected arguments");
 
-    foo_cb_rc = 42;
+    // msg was destroyed above so recreate
+    msg_ptr = msg = flux_request_encode ("foo", NULL);
+    if (!msg)
+        BAIL_OUT ("flux_request_encode: %s", flux_strerror (errno));
+
+    foo_cb_rc = -1;
     foo_cb_errno = ENXIO;
     errno = 0;
-    ok (service_send (sw, msg) == 42 && errno == ENXIO,
-        "service_send returns callback's return code and preserves errno");
+    ok (service_send (sw, msg) == -1,
+        "service_send returns callback's return code");
+    ok (errno == ENXIO,
+        "and callback's errno was set");
 
     service_remove (sw, "foo");
     errno = 0;


### PR DESCRIPTION
Problem: the broker copies messages when it doesn't have to.

This PR eliminates some places in the broker where messages are needlessly copied.  I had hoped that by making the local paths between ingest -> kvs, ingest -> job manager, kvs -> content cache effectively zero copy, there would be a measurable effect on the job throughput test.  Well, not really.

I'll mark this WIP for now and revisit tomorrow to make sure I'm not missing something.

The other thing here is I replaced the strange half-constructed connector with back-to-back interthread handles.  It should make the broker code a little easier to understand.