### PR TITLE
fix improper include directives in source files impacting portability

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -13,6 +13,7 @@
 #endif
 #include <assert.h>
 #include <libgen.h>
+#include <signal.h>
 #include <locale.h>
 #include <inttypes.h>
 #include <sys/prctl.h>

--- a/src/common/libeventlog/eventlog.c
+++ b/src/common/libeventlog/eventlog.c
@@ -13,7 +13,6 @@
 #endif
 #include <flux/core.h>
 #include <jansson.h>
-#include <argz.h>
 #include <time.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"

--- a/src/common/libflux/connector_interthread.c
+++ b/src/common/libflux/connector_interthread.c
@@ -25,7 +25,7 @@
 #include "config.h"
 #endif
 #include <unistd.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <pthread.h>
 
 #include <flux/core.h>

--- a/src/common/libflux/connector_loop.c
+++ b/src/common/libflux/connector_loop.c
@@ -14,7 +14,7 @@
 #include "config.h"
 #endif
 #include <unistd.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 #include <flux/core.h>
 

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -12,7 +12,6 @@
 #include "config.h"
 #endif
 #include <dlfcn.h>
-#include <argz.h>
 #include <dirent.h>
 #include <sys/stat.h>
 #include <jansson.h>

--- a/src/common/libflux/msg_deque.c
+++ b/src/common/libflux/msg_deque.c
@@ -40,7 +40,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
 #include <pthread.h>

--- a/src/common/libflux/test/interthread.c
+++ b/src/common/libflux/test/interthread.c
@@ -11,7 +11,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <sys/poll.h>
+#include <poll.h>
 #include <pthread.h>
 #include <flux/core.h>
 

--- a/src/common/libflux/test/msg_deque.c
+++ b/src/common/libflux/test/msg_deque.c
@@ -11,7 +11,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <sys/poll.h>
+#include <poll.h>
 #include <stdbool.h>
 #include <flux/core.h>
 

--- a/src/common/libflux/test/msglist.c
+++ b/src/common/libflux/test/msglist.c
@@ -14,7 +14,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <sys/poll.h>
+#include <poll.h>
 #include <flux/core.h>
 
 #include "src/common/libtap/tap.h"

--- a/src/common/liboptparse/getopt.c
+++ b/src/common/liboptparse/getopt.c
@@ -59,6 +59,8 @@
    contain conflicting prototypes for getopt.  */
 # include <stdlib.h>
 # include <unistd.h>
+#else
+# include <alloca.h>
 #endif	/* GNU C library.  */
 
 #include <string.h>

--- a/src/common/libsubprocess/fork.c
+++ b/src/common/libsubprocess/fork.c
@@ -12,7 +12,7 @@
 # include "config.h"
 #endif
 
-#include <wait.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <errno.h>
 

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -14,7 +14,6 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <wait.h>
 #include <unistd.h>
 #include <errno.h>
 

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -13,7 +13,7 @@
 #endif
 
 #include <sys/types.h>
-#include <wait.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <stdarg.h>
 #include <errno.h>

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -14,7 +14,7 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <wait.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <errno.h>
 #include <assert.h>

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -13,7 +13,6 @@
 #endif
 
 #include <sys/types.h>
-#include <wait.h>
 #include <unistd.h>
 #include <errno.h>
 

--- a/src/common/libtestutil/util.c
+++ b/src/common/libtestutil/util.c
@@ -14,7 +14,6 @@
 #include <flux/core.h>
 #include <uuid.h>
 #include <pthread.h>
-#include <sys/poll.h>
 
 #include "ccan/str/str.h"
 #include "src/common/libtap/tap.h"

--- a/src/common/libutil/timestamp.h
+++ b/src/common/libutil/timestamp.h
@@ -11,6 +11,7 @@
 #ifndef _UTIL_TIMESTAMP_H
 #define _UTIL_TIMESTAMP_H
 
+#include <sys/time.h>
 #include <time.h>
 
 /* Convert time_t (GMT) to ISO 8601 timestamp string,

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -89,6 +89,7 @@
 #endif
 #include <assert.h>
 #include <unistd.h>
+#include <signal.h>
 #include <flux/core.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"


### PR DESCRIPTION
Problem: a few non-standard headers are included in place of the standard ones, impacting portability.  Other headers are included for no reason, likely left over from cut and paste or previous versions of the code.  Cleanup is in order.

Use the standard headers and drop some needless includes.

This was peeled off of #5564. 