### PR TITLE
port to Alpine linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,7 +205,8 @@ AC_CHECK_FUNCS( \
 )
 # See src/common/libmissing/Makefile.am
 AC_REPLACE_FUNCS( \
-  strlcpy
+  strlcpy \
+  argz_add \
 )
 X_AC_CHECK_PTHREADS
 X_AC_CHECK_COND_LIB(rt, clock_gettime)

--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,7 @@ AC_CHECK_FUNCS( \
 AC_REPLACE_FUNCS( \
   strlcpy \
   argz_add \
+  envz_add \
 )
 X_AC_CHECK_PTHREADS
 X_AC_CHECK_COND_LIB(rt, clock_gettime)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -22,7 +22,11 @@
 #include <sys/un.h>
 #include <sys/types.h>
 #include <sys/syscall.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <flux/core.h>
 #include <jansson.h>
 #if HAVE_CALIPER

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -12,7 +12,11 @@
 #include "config.h"
 #endif
 #include <dlfcn.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/syscall.h>

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -22,7 +22,11 @@
 #include <unistd.h>
 #include <signal.h>
 #include <assert.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <jansson.h>
 #if HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -25,7 +25,11 @@
 #include <errno.h>
 #include <libgen.h>
 #include <stdbool.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <glob.h>
 #include <inttypes.h>
 #include <termios.h>

--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -17,7 +17,11 @@
 #include <time.h>
 #include <archive.h>
 #include <archive_entry.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libkvs/treeobj.h"

--- a/src/cmd/builtin/startlog.c
+++ b/src/cmd/builtin/startlog.c
@@ -144,7 +144,7 @@ static int format_timestamp (char *buf, size_t size, time_t t)
     struct tm tm;
     if (t < 0 || !localtime_r (&t, &tm))
         return -1;
-    if (strftime (buf, size, "%F %R", &tm) == 0)
+    if (strftime (buf, size, "%Y-%m-%d %R", &tm) == 0)
         return -1;
     return 0;
 }

--- a/src/cmd/cmdhelp.c
+++ b/src/cmd/cmdhelp.c
@@ -13,7 +13,11 @@
 #endif
 #include <glob.h>
 #include <string.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <jansson.h>
 
 #include "src/common/libutil/log.h"

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -13,7 +13,11 @@
 #endif
 #include <stdio.h>
 #include <libgen.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <ctype.h>
 #include <flux/core.h>
 #include <flux/optparse.h>

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -26,7 +26,11 @@
 #include <assert.h>
 #include <locale.h>
 #include <jansson.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <sys/ioctl.h>
 #include <signal.h>
 #include <flux/core.h>

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -3060,7 +3060,7 @@ static int event_timestr (struct entry_format *e, double timestamp,
         struct tm tm;
         if (!gmtime_r (&sec, &tm))
             return -1;
-        if (strftime (buf, size, "%FT%T", &tm) == 0)
+        if (strftime (buf, size, "%Y-%m-%dT%T", &tm) == 0)
             return -1;
         size -= strlen (buf);
         buf += strlen (buf);

--- a/src/cmd/flux-keygen.c
+++ b/src/cmd/flux-keygen.c
@@ -41,7 +41,7 @@ static char * ctime_iso8601_now (char *buf, size_t sz)
 
     if (!localtime_r (&now, &tm))
         return (NULL);
-    strftime (buf, sz, "%FT%T", &tm);
+    strftime (buf, sz, "%Y-%m-%dT%T", &tm);
 
     return (buf);
 }

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -16,7 +16,11 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <jansson.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <ctype.h>
 #include <sys/ioctl.h>
 

--- a/src/cmd/flux-logger.c
+++ b/src/cmd/flux-logger.c
@@ -14,7 +14,11 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <getopt.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <flux/core.h>
 
 #include "src/common/libutil/xzmalloc.h"

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -20,7 +20,11 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <assert.h>
 
 #include "src/common/libutil/xzmalloc.h"

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -21,7 +21,11 @@
 #include <sys/resource.h>
 #include <libgen.h>
 #include <signal.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <sys/ioctl.h>
 #include <jansson.h>
 #include <flux/core.h>

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -111,6 +111,7 @@ libflux_optparse_la_LIBADD = \
 	$(builddir)/liblsd/liblsd.la \
 	$(builddir)/libutil/fsd.lo \
 	$(builddir)/libutil/parse_size.lo \
+	$(builddir)/libmissing/libmissing.la \
 	$(LIBPTHREAD)
 libflux_optparse_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-optparse.map \

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -482,7 +482,7 @@ void test_load_rtld_now ()
         "flux_plugin_set_flags (p, RTLD_NOW) == 0");
     ok (flux_plugin_load_dso (p, "test/.libs/plugin_bar.so") < 0,
         "load of plugin with invalid symbol fails immediately");
-    like (flux_plugin_strerror (p), "^dlopen: .*: undefined symbol",
+    like (flux_plugin_strerror (p), "^dlopen: .*: (undefined symbol|symbol not found)",
         "got expected error message: %s", flux_plugin_strerror (p));
 
     flux_plugin_destroy (p);

--- a/src/common/libhostlist/hostlist.c
+++ b/src/common/libhostlist/hostlist.c
@@ -22,6 +22,8 @@
 #include <sys/param.h>
 #include <unistd.h>
 
+#include "src/common/libutil/errno_safe.h"
+
 #include "hostlist.h"
 #include "hostrange.h"
 #include "util.h"
@@ -502,7 +504,7 @@ static struct hostlist * hostlist_create_bracketed (const char *hostlist,
     if (!(orig = str = strdup (hostlist))
         || !(ctx = calloc (1, sizeof (*ctx)))) {
         hostlist_destroy (new);
-        free (orig);
+        ERRNO_SAFE_WRAP (free, orig);
         return NULL;
     }
 
@@ -550,8 +552,8 @@ static struct hostlist * hostlist_create_bracketed (const char *hostlist,
     errno = EINVAL;
   error:
     hostlist_destroy (new);
-    free (orig);
-    free (ctx);
+    ERRNO_SAFE_WRAP (free, orig);
+    ERRNO_SAFE_WRAP (free, ctx);
     return NULL;
 }
 

--- a/src/common/libhostlist/hostlist.c
+++ b/src/common/libhostlist/hostlist.c
@@ -491,6 +491,9 @@ static struct hostlist * hostlist_create_bracketed (const char *hostlist,
     char *p, *tok, *str, *orig;
     char cur_tok[1024];
 
+    if (!new)
+        return NULL;
+
     if (hostlist == NULL)
         return new;
 

--- a/src/common/libjob/sign_none.c
+++ b/src/common/libjob/sign_none.c
@@ -16,7 +16,11 @@
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 
 #include "ccan/base64/base64.h"
 #include "ccan/str/str.h"

--- a/src/common/libmissing/Makefile.am
+++ b/src/common/libmissing/Makefile.am
@@ -29,6 +29,12 @@
 # https://www.gnu.org/software/automake/manual/html_node/LIBOBJS.html
 # https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.71/html_node/Generic-Functions.html
 #
+AM_CFLAGS = \
+        $(WARNING_CFLAGS) \
+        $(CODE_COVERAGE_CFLAGS)
+
+AM_CPPFLAGS =
+
 noinst_LTLIBRARIES = libmissing.la
 
 libmissing_la_LIBADD = $(LTLIBOBJS)
@@ -37,4 +43,6 @@ libmissing_la_SOURCES =
 EXTRA_libmissing_la_SOURCES = \
 	strlcpy.h \
 	argz.h \
-	argz.c
+	argz.c \
+	envz.h \
+	envz.c

--- a/src/common/libmissing/Makefile.am
+++ b/src/common/libmissing/Makefile.am
@@ -35,4 +35,6 @@ libmissing_la_LIBADD = $(LTLIBOBJS)
 libmissing_la_SOURCES =
 
 EXTRA_libmissing_la_SOURCES = \
-	strlcpy.h
+	strlcpy.h \
+	argz.h \
+	argz.c

--- a/src/common/libmissing/Makefile.am
+++ b/src/common/libmissing/Makefile.am
@@ -45,4 +45,5 @@ EXTRA_libmissing_la_SOURCES = \
 	argz.h \
 	argz.c \
 	envz.h \
-	envz.c
+	envz.c \
+	macros.h

--- a/src/common/libmissing/argz.c
+++ b/src/common/libmissing/argz.c
@@ -1,0 +1,406 @@
+/* Functions for dealing with '\0' separated arg vectors.
+   Copyright (C) 1995-1998, 2000-2002, 2006, 2008-2023 Free Software
+   Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   This file is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This file is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+#include <config.h>
+
+#include <argz.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+
+/* Add BUF, of length BUF_LEN to the argz vector in ARGZ & ARGZ_LEN.  */
+error_t
+argz_append (char **argz, size_t *argz_len, const char *buf, size_t buf_len)
+{
+  size_t new_argz_len = *argz_len + buf_len;
+  char *new_argz = realloc (*argz, new_argz_len);
+  if (new_argz)
+    {
+      memcpy (new_argz + *argz_len, buf, buf_len);
+      *argz = new_argz;
+      *argz_len = new_argz_len;
+      return 0;
+    }
+  else
+    return ENOMEM;
+}
+
+/* Add STR to the argz vector in ARGZ & ARGZ_LEN.  This should be moved into
+   argz.c in libshouldbelibc.  */
+error_t
+argz_add (char **argz, size_t *argz_len, const char *str)
+{
+  return argz_append (argz, argz_len, str, strlen (str) + 1);
+}
+
+
+
+error_t
+argz_add_sep (char **argz, size_t *argz_len, const char *string, int delim)
+{
+  size_t nlen = strlen (string) + 1;
+
+  if (nlen > 1)
+    {
+      const char *rp;
+      char *wp;
+
+      *argz = (char *) realloc (*argz, *argz_len + nlen);
+      if (*argz == NULL)
+        return ENOMEM;
+
+      wp = *argz + *argz_len;
+      rp = string;
+      do
+        if (*rp == delim)
+          {
+            if (wp > *argz && wp[-1] != '\0')
+              *wp++ = '\0';
+            else
+              --nlen;
+          }
+        else
+          *wp++ = *rp;
+      while (*rp++ != '\0');
+
+      *argz_len += nlen;
+    }
+
+  return 0;
+}
+
+
+
+error_t
+argz_create_sep (const char *string, int delim, char **argz, size_t *len)
+{
+  size_t nlen = strlen (string) + 1;
+
+  if (nlen > 1)
+    {
+      const char *rp;
+      char *wp;
+
+      *argz = (char *) malloc (nlen);
+      if (*argz == NULL)
+        return ENOMEM;
+
+      rp = string;
+      wp = *argz;
+      do
+        if (*rp == delim)
+          {
+            if (wp > *argz && wp[-1] != '\0')
+              *wp++ = '\0';
+            else
+              --nlen;
+          }
+        else
+          *wp++ = *rp;
+      while (*rp++ != '\0');
+
+      if (nlen == 0)
+        {
+          free (*argz);
+          *argz = NULL;
+          *len = 0;
+        }
+
+      *len = nlen;
+    }
+  else
+    {
+      *argz = NULL;
+      *len = 0;
+    }
+
+  return 0;
+}
+
+
+/* Insert ENTRY into ARGZ & ARGZ_LEN before BEFORE, which should be an
+   existing entry in ARGZ; if BEFORE is NULL, ENTRY is appended to the end.
+   Since ARGZ's first entry is the same as ARGZ, argz_insert (ARGZ, ARGZ_LEN,
+   ARGZ, ENTRY) will insert ENTRY at the beginning of ARGZ.  If BEFORE is not
+   in ARGZ, EINVAL is returned, else if memory can't be allocated for the new
+   ARGZ, ENOMEM is returned, else 0.  */
+error_t
+argz_insert (char **argz, size_t *argz_len, char *before, const char *entry)
+{
+  if (! before)
+    return argz_add (argz, argz_len, entry);
+
+  if (before < *argz || before >= *argz + *argz_len)
+    return EINVAL;
+
+  if (before > *argz)
+    /* Make sure before is actually the beginning of an entry.  */
+    while (before[-1])
+      before--;
+
+  {
+    size_t after_before = *argz_len - (before - *argz);
+    size_t entry_len = strlen  (entry) + 1;
+    size_t new_argz_len = *argz_len + entry_len;
+    char *new_argz = realloc (*argz, new_argz_len);
+
+    if (new_argz)
+      {
+        before = new_argz + (before - *argz);
+        memmove (before + entry_len, before, after_before);
+        memmove (before, entry, entry_len);
+        *argz = new_argz;
+        *argz_len = new_argz_len;
+        return 0;
+      }
+    else
+      return ENOMEM;
+  }
+}
+
+
+char *
+argz_next (const char *argz, size_t argz_len, const char *entry)
+{
+  if (entry)
+    {
+      if (entry < argz + argz_len)
+        entry = strchr (entry, '\0') + 1;
+
+      return entry >= argz + argz_len ? NULL : (char *) entry;
+    }
+  else
+    if (argz_len > 0)
+      return (char *) argz;
+    else
+      return NULL;
+}
+
+
+/* Make '\0' separated arg vector ARGZ printable by converting all the '\0's
+   except the last into the character SEP.  */
+void
+argz_stringify (char *argz, size_t len, int sep)
+{
+  if (len > 0)
+    while (1)
+      {
+        size_t part_len = strnlen (argz, len);
+        argz += part_len;
+        len -= part_len;
+        if (len-- <= 1)         /* includes final '\0' we want to stop at */
+          break;
+        *argz++ = sep;
+      }
+}
+
+
+/* Returns the number of strings in ARGZ.  */
+size_t
+argz_count (const char *argz, size_t len)
+{
+  size_t count = 0;
+  while (len > 0)
+    {
+      size_t part_len = strlen (argz);
+      argz += part_len + 1;
+      len -= part_len + 1;
+      count++;
+    }
+  return count;
+}
+
+
+/* Puts pointers to each string in ARGZ, plus a terminating 0 element, into
+   ARGV, which must be large enough to hold them all.  */
+void
+argz_extract (const char *argz, size_t len, char **argv)
+{
+  while (len > 0)
+    {
+      size_t part_len = strlen (argz);
+      *argv++ = (char *) argz;
+      argz += part_len + 1;
+      len -= part_len + 1;
+    }
+  *argv = 0;
+}
+
+
+/* Make a '\0' separated arg vector from a unix argv vector, returning it in
+   ARGZ, and the total length in LEN.  If a memory allocation error occurs,
+   ENOMEM is returned, otherwise 0.  */
+error_t
+argz_create (char *const argv[], char **argz, size_t *len)
+{
+  int argc;
+  size_t tlen = 0;
+  char *const *ap;
+  char *p;
+
+  for (argc = 0; argv[argc] != NULL; ++argc)
+    tlen += strlen (argv[argc]) + 1;
+
+  if (tlen == 0)
+    *argz = NULL;
+  else
+    {
+      *argz = malloc (tlen);
+      if (*argz == NULL)
+        return ENOMEM;
+
+      for (p = *argz, ap = argv; *ap; ++ap, ++p)
+        p = stpcpy (p, *ap);
+    }
+  *len = tlen;
+
+  return 0;
+}
+
+
+/* Delete ENTRY from ARGZ & ARGZ_LEN, if any.  */
+void
+argz_delete (char **argz, size_t *argz_len, char *entry)
+{
+  if (entry)
+    /* Get rid of the old value for NAME.  */
+    {
+      size_t entry_len = strlen (entry) + 1;
+      *argz_len -= entry_len;
+      memmove (entry, entry + entry_len, *argz_len - (entry - *argz));
+      if (*argz_len == 0)
+        {
+          free (*argz);
+          *argz = 0;
+        }
+    }
+}
+
+
+/* Append BUF, of length BUF_LEN to *TO, of length *TO_LEN, reallocating and
+   updating *TO & *TO_LEN appropriately.  If an allocation error occurs,
+   *TO's old value is freed, and *TO is set to 0.  */
+static void
+str_append (char **to, size_t *to_len, const char *buf, const size_t buf_len)
+{
+  size_t new_len = *to_len + buf_len;
+  char *new_to = realloc (*to, new_len + 1);
+
+  if (new_to)
+    {
+      *((char *) mempcpy (new_to + *to_len, buf, buf_len)) = '\0';
+      *to = new_to;
+      *to_len = new_len;
+    }
+  else
+    {
+      free (*to);
+      *to = 0;
+    }
+}
+
+/* Replace any occurrences of the string STR in ARGZ with WITH, reallocating
+   ARGZ as necessary.  If REPLACE_COUNT is non-zero, *REPLACE_COUNT will be
+   incremented by number of replacements performed.  */
+error_t
+argz_replace (char **argz, size_t *argz_len, const char *str, const char *with,
+                unsigned *replace_count)
+{
+  error_t err = 0;
+
+  if (str && *str)
+    {
+      char *arg = 0;
+      char *src = *argz;
+      size_t src_len = *argz_len;
+      char *dst = 0;
+      size_t dst_len = 0;
+      int delayed_copy = 1;     /* True while we've avoided copying anything.  */
+      size_t str_len = strlen (str), with_len = strlen (with);
+
+      while (!err && (arg = argz_next (src, src_len, arg)))
+        {
+          char *match = strstr (arg, str);
+          if (match)
+            {
+              char *from = match + str_len;
+              size_t to_len = match - arg;
+              char *to = strndup (arg, to_len);
+
+              while (to && from)
+                {
+                  str_append (&to, &to_len, with, with_len);
+                  if (to)
+                    {
+                      match = strstr (from, str);
+                      if (match)
+                        {
+                          str_append (&to, &to_len, from, match - from);
+                          from = match + str_len;
+                        }
+                      else
+                        {
+                          str_append (&to, &to_len, from, strlen (from));
+                          from = 0;
+                        }
+                    }
+                }
+
+              if (to)
+                {
+                  if (delayed_copy)
+                    /* We avoided copying SRC to DST until we found a match;
+                       now that we've done so, copy everything from the start
+                       of SRC.  */
+                    {
+                      if (arg > src)
+                        err = argz_append (&dst, &dst_len, src, (arg - src));
+                      delayed_copy = 0;
+                    }
+                  if (! err)
+                    err = argz_add (&dst, &dst_len, to);
+                  free (to);
+                }
+              else
+                err = ENOMEM;
+
+              if (replace_count)
+                (*replace_count)++;
+            }
+          else if (! delayed_copy)
+            err = argz_add (&dst, &dst_len, arg);
+        }
+
+      if (! err)
+        {
+          if (! delayed_copy)
+            /* We never found any instances of str.  */
+            {
+              free (src);
+              *argz = dst;
+              *argz_len = dst_len;
+            }
+        }
+      else if (dst_len > 0)
+        free (dst);
+    }
+
+  return err;
+}

--- a/src/common/libmissing/argz.h
+++ b/src/common/libmissing/argz.h
@@ -1,0 +1,130 @@
+/* Routines for dealing with '\0' separated arg vectors.
+   Copyright (C) 1995-2000, 2004, 2007, 2009-2023 Free Software Foundation,
+   Inc.
+   This file is part of the GNU C Library.
+
+   This file is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This file is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+#ifndef _ARGZ_H
+#define _ARGZ_H 1
+
+
+#define __need_error_t
+#include <errno.h>
+#include <string.h>             /* Need size_t.  */
+
+#ifndef __error_t_defined
+typedef int error_t;
+#endif
+
+
+
+/* Make a '\0' separated arg vector from a unix argv vector, returning it in
+   ARGZ, and the total length in LEN.  If a memory allocation error occurs,
+   ENOMEM is returned, otherwise 0.  The result can be destroyed using free.  */
+
+extern error_t argz_create (char *const /*argv*/[], char **restrict /*argz*/,
+                            size_t *restrict /*len*/);
+
+/* Make a '\0' separated arg vector from a SEP separated list in
+   STRING, returning it in ARGZ, and the total length in LEN.  If a
+   memory allocation error occurs, ENOMEM is returned, otherwise 0.
+   The result can be destroyed using free.  */
+
+extern error_t argz_create_sep (const char *restrict /*string*/,
+                                int /*sep*/, char **restrict /*argz*/,
+                                size_t *restrict /*len*/);
+
+/* Returns the number of strings in ARGZ.  */
+
+extern size_t argz_count (const char * /*argz*/, size_t /*len*/);
+
+/* Puts pointers to each string in ARGZ into ARGV, which must be large enough
+   to hold them all.  */
+
+extern void argz_extract (const char *restrict /*argz*/, size_t /*len*/,
+                          char **restrict /*argv*/);
+
+/* Make '\0' separated arg vector ARGZ printable by converting all the '\0's
+   except the last into the character SEP.  */
+
+extern void argz_stringify (char * /*argz*/, size_t /*len*/, int /*sep*/);
+
+/* Append BUF, of length BUF_LEN to the argz vector in ARGZ & ARGZ_LEN.  */
+
+extern error_t argz_append (char **restrict /*argz*/,
+                            size_t *restrict /*argz_len*/,
+                            const char *restrict /*buf*/, size_t /*buf_len*/);
+
+/* Append STR to the argz vector in ARGZ & ARGZ_LEN.  */
+
+extern error_t argz_add (char **restrict /*argz*/,
+                         size_t *restrict /*argz_len*/,
+                         const char *restrict str);
+
+/* Append SEP separated list in STRING to the argz vector in ARGZ &
+   ARGZ_LEN.  */
+
+extern error_t argz_add_sep (char **restrict /*argz*/,
+                             size_t *restrict /*argz_len*/,
+                             const char *restrict /*string*/, int /*delim*/);
+
+/* Delete ENTRY from ARGZ & ARGZ_LEN, if it appears there.  */
+
+extern void argz_delete (char **restrict /*argz*/,
+                         size_t *restrict /*argz_len*/,
+                         char *restrict /*entry*/);
+
+/* Insert ENTRY into ARGZ & ARGZ_LEN before BEFORE, which should be an
+   existing entry in ARGZ; if BEFORE is NULL, ENTRY is appended to the end.
+   Since ARGZ's first entry is the same as ARGZ, argz_insert (ARGZ, ARGZ_LEN,
+   ARGZ, ENTRY) will insert ENTRY at the beginning of ARGZ.  If BEFORE is not
+   in ARGZ, EINVAL is returned, else if memory can't be allocated for the new
+   ARGZ, ENOMEM is returned, else 0.  */
+
+extern error_t argz_insert (char **restrict /*argz*/,
+                            size_t *restrict /*argz_len*/,
+                            char *restrict /*before*/,
+                            const char *restrict /*entry*/);
+
+/* Replace any occurrences of the string STR in ARGZ with WITH, reallocating
+   ARGZ as necessary.  If REPLACE_COUNT is non-zero, *REPLACE_COUNT will be
+   incremented by number of replacements performed.  */
+
+extern error_t argz_replace (char **restrict /*argz*/,
+                             size_t *restrict /*argz_len*/,
+                             const char *restrict /*str*/,
+                             const char *restrict /*with*/,
+                             unsigned int *restrict /*replace_count*/);
+
+/* Returns the next entry in ARGZ & ARGZ_LEN after ENTRY, or NULL if there
+   are no more.  If entry is NULL, then the first entry is returned.  This
+   behavior allows two convenient iteration styles:
+
+    char *entry = 0;
+    while ((entry = argz_next (argz, argz_len, entry)))
+      ...;
+
+   or
+
+    char *entry;
+    for (entry = argz; entry; entry = argz_next (argz, argz_len, entry))
+      ...;
+*/
+
+extern char *argz_next (const char *restrict /*argz*/, size_t /*argz_len*/,
+                        const char *restrict /*entry*/);
+
+
+#endif /* argz.h */

--- a/src/common/libmissing/argz_add.c
+++ b/src/common/libmissing/argz_add.c
@@ -1,0 +1,2 @@
+// build all of argz.c if argz_add() is detected missing by autotools
+#include "argz.c"

--- a/src/common/libmissing/envz.c
+++ b/src/common/libmissing/envz.c
@@ -1,0 +1,169 @@
+/* Routines for dealing with '\0' separated environment vectors
+   Copyright (C) 1995-2023 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <malloc.h>
+#include <string.h>
+
+#include <envz.h>
+
+/* The character separating names from values in an envz.  */
+#define SEP '='
+
+/* Returns a pointer to the entry in ENVZ for NAME, or 0 if there is none.
+   If NAME contains the separator character, only the portion before it is
+   used in the comparison.  */
+char *
+envz_entry (const char *envz, size_t envz_len, const char *name)
+{
+  while (envz_len)
+    {
+      const char *p = name;
+      const char *entry = envz;	/* Start of this entry. */
+
+      /* See how far NAME and ENTRY match.  */
+      while (envz_len && *p == *envz && *p && *p != SEP)
+	p++, envz++, envz_len--;
+
+      if ((*envz == '\0' || *envz == SEP) && (*p == '\0' || *p == SEP))
+	/* Bingo! */
+	return (char *) entry;
+
+      /* No match, skip to the next entry.  */
+      while (envz_len && *envz)
+	envz++, envz_len--;
+      if (envz_len)
+	envz++, envz_len--;	/* skip '\0' */
+    }
+
+  return 0;
+}
+
+/* Returns a pointer to the value portion of the entry in ENVZ for NAME, or 0
+   if there is none.  */
+char *
+envz_get (const char *envz, size_t envz_len, const char *name)
+{
+  char *entry = envz_entry (envz, envz_len, name);
+  if (entry)
+    {
+      while (*entry && *entry != SEP)
+	entry++;
+      if (*entry)
+	entry++;
+      else
+	entry = 0;		/* A null entry.  */
+    }
+  return entry;
+}
+
+/* Remove the entry for NAME from ENVZ & ENVZ_LEN, if any.  */
+void
+envz_remove (char **envz, size_t *envz_len, const char *name)
+{
+  char *entry = envz_entry (*envz, *envz_len, name);
+  if (entry)
+    argz_delete (envz, envz_len, entry);
+}
+
+/* Adds an entry for NAME with value VALUE to ENVZ & ENVZ_LEN.  If an entry
+   with the same name already exists in ENVZ, it is removed.  If VALUE is
+   NULL, then the new entry will a special null one, for which envz_get will
+   return NULL, although envz_entry will still return an entry; this is handy
+   because when merging with another envz, the null entry can override an
+   entry in the other one.  Null entries can be removed with envz_strip ().  */
+error_t
+envz_add (char **envz, size_t *envz_len, const char *name, const char *value)
+{
+  envz_remove (envz, envz_len, name);
+
+  if (value)
+    /* Add the new value, if there is one.  */
+    {
+      size_t name_len = strlen (name);
+      size_t value_len = strlen (value);
+      size_t old_envz_len = *envz_len;
+      size_t new_envz_len = old_envz_len + name_len + 1 + value_len + 1;
+      char *new_envz = realloc (*envz, new_envz_len);
+
+      if (new_envz)
+	{
+	  memcpy (new_envz + old_envz_len, name, name_len);
+	  new_envz[old_envz_len + name_len] = SEP;
+	  memcpy (new_envz + old_envz_len + name_len + 1, value, value_len);
+	  new_envz[new_envz_len - 1] = 0;
+
+	  *envz = new_envz;
+	  *envz_len = new_envz_len;
+
+	  return 0;
+	}
+      else
+	return ENOMEM;
+    }
+  else
+    /* Add a null entry.  */
+    return argz_add (envz, envz_len, name);
+}
+
+/* Adds each entry in ENVZ2 to ENVZ & ENVZ_LEN, as if with envz_add().  If
+   OVERRIDE is true, then values in ENVZ2 will supersede those with the same
+   name in ENV, otherwise not.  */
+error_t
+envz_merge (char **envz, size_t *envz_len, const char *envz2,
+	    size_t envz2_len, int override)
+{
+  error_t err = 0;
+
+  while (envz2_len && ! err)
+    {
+      char *old = envz_entry (*envz, *envz_len, envz2);
+      size_t new_len = strlen (envz2) + 1;
+
+      if (! old)
+	err = argz_append (envz, envz_len, envz2, new_len);
+      else if (override)
+	{
+	  argz_delete (envz, envz_len, old);
+	  err = argz_append (envz, envz_len, envz2, new_len);
+	}
+
+      envz2 += new_len;
+      envz2_len -= new_len;
+    }
+
+  return err;
+}
+
+/* Remove null entries.  */
+void
+envz_strip (char **envz, size_t *envz_len)
+{
+  char *entry = *envz;
+  size_t left = *envz_len;
+  while (left)
+    {
+      size_t entry_len = strlen (entry) + 1;
+      left -= entry_len;
+      if (! strchr (entry, SEP))
+	/* Null entry. */
+	memmove (entry, entry + entry_len, left);
+      else
+	entry += entry_len;
+    }
+  *envz_len = entry - *envz;
+}

--- a/src/common/libmissing/envz.h
+++ b/src/common/libmissing/envz.h
@@ -1,0 +1,98 @@
+/* Routines for dealing with '\0' separated environment vectors
+   Copyright (C) 1995-2023 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#ifndef _ENVZ_H
+#define _ENVZ_H	1
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <features.h>
+
+#include <errno.h>
+
+/* Envz's are argz's too, and should be created etc., using the same
+   routines.  */
+#if HAVE_ARGZ_ADD
+#include <argz.h>
+#else
+#include "argz.h"
+#endif
+
+#ifndef __BEGIN_DECLS
+#define __BEGIN_DECLS
+#endif
+#ifndef __END_DECLS
+#define __END_DECLS
+#endif
+#ifndef __THROW
+#define __THROW
+#endif
+#ifndef __CATCH
+#define __CATCH
+#endif
+#ifndef __attribute_pure__
+#define __attribute_pure__
+#endif
+
+
+__BEGIN_DECLS
+
+/* Returns a pointer to the entry in ENVZ for NAME, or 0 if there is none.  */
+extern char *envz_entry (const char *__restrict __envz, size_t __envz_len,
+			 const char *__restrict __name)
+     __THROW __attribute_pure__;
+
+/* Returns a pointer to the value portion of the entry in ENVZ for NAME, or 0
+   if there is none.  */
+extern char *envz_get (const char *__restrict __envz, size_t __envz_len,
+		       const char *__restrict __name)
+     __THROW __attribute_pure__;
+
+/* Adds an entry for NAME with value VALUE to ENVZ & ENVZ_LEN.  If an entry
+   with the same name already exists in ENVZ, it is removed.  If VALUE is
+   NULL, then the new entry will a special null one, for which envz_get will
+   return NULL, although envz_entry will still return an entry; this is handy
+   because when merging with another envz, the null entry can override an
+   entry in the other one.  Null entries can be removed with envz_strip ().  */
+extern error_t envz_add (char **__restrict __envz,
+			 size_t *__restrict __envz_len,
+			 const char *__restrict __name,
+			 const char *__restrict __value) __THROW;
+
+/* Adds each entry in ENVZ2 to ENVZ & ENVZ_LEN, as if with envz_add().  If
+   OVERRIDE is true, then values in ENVZ2 will supersede those with the same
+   name in ENV, otherwise not.  */
+extern error_t envz_merge (char **__restrict __envz,
+			   size_t *__restrict __envz_len,
+			   const char *__restrict __envz2,
+			   size_t __envz2_len, int __override) __THROW;
+
+/* Remove the entry for NAME from ENVZ & ENVZ_LEN, if any.  */
+extern void envz_remove (char **__restrict __envz,
+			 size_t *__restrict __envz_len,
+			 const char *__restrict __name) __THROW;
+
+/* Remove null entries.  */
+extern void envz_strip (char **__restrict __envz,
+			size_t *__restrict __envz_len) __THROW;
+
+__END_DECLS
+
+#endif /* envz.h */

--- a/src/common/libmissing/envz_add.c
+++ b/src/common/libmissing/envz_add.c
@@ -1,0 +1,2 @@
+// build all of envz.c if envz_add() is detected missing by autotools
+#include "envz.c"

--- a/src/common/libmissing/macros.h
+++ b/src/common/libmissing/macros.h
@@ -1,0 +1,19 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef LIBMISSING_MACROS_H
+#define LIBMISSING_MACROS_H 1
+
+// borrowed from glibc-2.38.9000-255-g323f367cc4
+#ifndef __W_EXITCODE
+#define __W_EXITCODE(ret, sig)  ((ret) << 8 | (sig))
+#endif
+
+#endif

--- a/src/common/liboptparse/Makefile.am
+++ b/src/common/liboptparse/Makefile.am
@@ -30,4 +30,5 @@ test_optparse_t_LDADD = \
 	$(top_builddir)/src/common/liboptparse/liboptparse.la \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
+	$(top_builddir)/src/common/libmissing/libmissing.la \
 	$(LIBPTHREAD)

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -18,7 +18,11 @@
 #include <sys/param.h>
 #include <ctype.h>
 #include <stdarg.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <math.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"

--- a/src/common/libpmi/upmi.c
+++ b/src/common/libpmi/upmi.c
@@ -16,7 +16,11 @@
 #include <jansson.h>
 #include <flux/core.h>
 #include <assert.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <glob.h>
 
 #include "ccan/array_size/array_size.h"

--- a/src/common/libsdexec/unit.c
+++ b/src/common/libsdexec/unit.c
@@ -18,6 +18,7 @@
 #include <sys/wait.h>
 #include <flux/core.h>
 
+#include "src/common/libmissing/macros.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/aux.h"
 #include "ccan/str/str.h"

--- a/src/common/libsubprocess/command.c
+++ b/src/common/libsubprocess/command.c
@@ -14,7 +14,11 @@
 
 #include <stdlib.h>
 #include <sys/types.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <envz.h>
 #include <assert.h>
 #include <fnmatch.h>

--- a/src/common/libsubprocess/command.c
+++ b/src/common/libsubprocess/command.c
@@ -19,7 +19,11 @@
 #else
 #include "src/common/libmissing/argz.h"
 #endif
+#ifdef HAVE_ENVZ_ADD
 #include <envz.h>
+#else
+#include "src/common/libmissing/envz.h"
+#endif
 #include <assert.h>
 #include <fnmatch.h>
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -150,6 +150,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtomlc99/libtomlc99.la \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libccan/libccan.la \
+	$(top_builddir)/src/common/libmissing/libmissing.la \
 	$(LIBPTHREAD) \
 	$(LIBRT) \
 	$(JANSSON_LIBS)

--- a/src/common/libutil/environment.c
+++ b/src/common/libutil/environment.c
@@ -16,7 +16,11 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <stdlib.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/log.h"

--- a/src/common/libutil/slice.c
+++ b/src/common/libutil/slice.c
@@ -44,7 +44,8 @@ static int parse_int (char **cp, int def, char sep, int *value)
 
     errno = 0;
     v = strtol (*cp, &endptr, 10);
-    if (errno != 0)
+    // standard says EINVAL may be set if zero is returned for nothing parsed
+    if (v != 0 && errno != 0)
         return -1;
     if (endptr == *cp) {    // no digits
         if ((*cp)[0] == sep)

--- a/src/common/libutil/test/popen2.c
+++ b/src/common/libutil/test/popen2.c
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
         "popen2 /noexist failed with ENOENT");
 
     /* open/close (child exit error) */
-    ok ((p = popen2 ("/bin/false", av, 0)) != NULL,
+    ok ((p = popen2 ("/bin/false", (char*[]){ "/bin/false", NULL }, 0)) != NULL,
         "popen2 /bin/false OK");
     ok (pclose2 (p) == 0x100,
         "pclose2 returns child exit code 1");

--- a/src/common/libutil/test/tomltk.c
+++ b/src/common/libutil/test/tomltk.c
@@ -73,7 +73,7 @@ static bool check_ts (json_t *ts, const char *timestr)
         return false;
     if (!gmtime_r (&t, &tm))
         return false;
-    if (strftime (buf, sizeof (buf), "%FT%TZ", &tm) == 0)
+    if (strftime (buf, sizeof (buf), "%Y-%m-%dT%TZ", &tm) == 0)
         return false;
     diag ("%s: %s ?= %s", __FUNCTION__, buf, timestr);
     return streq (buf, timestr);

--- a/src/common/libutil/timestamp.c
+++ b/src/common/libutil/timestamp.c
@@ -45,7 +45,7 @@ int timestamp_tostr (time_t t, char *buf, int size)
     struct tm tm;
     if (t < 0 || !gmtime_r (&t, &tm))
         return -1;
-    if (strftime (buf, size, "%FT%TZ", &tm) == 0)
+    if (strftime (buf, size, "%Y-%m-%dT%TZ", &tm) == 0)
         return -1;
     return 0;
 }
@@ -54,7 +54,7 @@ int timestamp_fromstr (const char *s, time_t *tp)
 {
     struct tm tm;
     time_t t;
-    if (!strptime (s, "%FT%TZ", &tm))
+    if (!strptime (s, "%Y-%m-%dT%TZ", &tm))
         return -1;
     if ((t = portable_timegm (&tm)) < 0)
         return -1;
@@ -76,7 +76,7 @@ int timestamp_parse (const char *s,
         return -1;
     }
 
-    if (!(extra = strptime (s, "%FT%T", &gm_tm))
+    if (!(extra = strptime (s, "%Y-%m-%dT%T", &gm_tm))
         || (t = portable_timegm (&gm_tm)) < (time_t) -1) {
         errno = EINVAL;
         return -1;

--- a/src/common/libutil/wallclock.c
+++ b/src/common/libutil/wallclock.c
@@ -44,7 +44,7 @@ int wallclock_get_zulu (char *buf, size_t len)
         errno = EINVAL;
         return -1;
     }
-    if (strftime (buf, len, "%FT%T", &tm) == 0) {
+    if (strftime (buf, len, "%Y-%m-%dT%T", &tm) == 0) {
         errno = EINVAL;
         return -1;
     }

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -13,7 +13,11 @@
 #endif
 #include <sys/param.h>
 #include <unistd.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <flux/core.h>
 
 #include "src/common/libutil/popen2.h"

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -13,6 +13,7 @@
 #endif
 
 #include <sys/wait.h>
+#include "src/common/libmissing/macros.h"
 #define EXIT_CODE(x) __W_EXITCODE(x,0)
 
 #include <flux/core.h>

--- a/src/modules/job-ingest/workcrew.c
+++ b/src/modules/job-ingest/workcrew.c
@@ -25,7 +25,11 @@
 #include "config.h"
 #endif
 #include <unistd.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <jansson.h>
 #include <assert.h>
 #include <signal.h>

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -45,6 +45,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include "src/common/libmissing/macros.h"
 #define EXIT_CODE(x) __W_EXITCODE(x,0)
 
 #include <jansson.h>

--- a/src/shell/oom.c
+++ b/src/shell/oom.c
@@ -25,7 +25,11 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <unistd.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <flux/core.h>
 #include <jansson.h>
 #include <assert.h>

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -58,7 +58,11 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <assert.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <flux/core.h>
 #include <jansson.h>
 

--- a/src/shell/rlimit.c
+++ b/src/shell/rlimit.c
@@ -42,10 +42,8 @@ static int rlimit_name_to_string (const char *name)
         return RLIMIT_STACK;
     if (streq (name, "core"))
         return RLIMIT_CORE;
-    if (streq (name, "nofile"))
+    if (streq (name, "nofile") || streq (name, "ofile"))
         return RLIMIT_NOFILE;
-    if (streq (name, "ofile"))
-        return RLIMIT_OFILE;
     if (streq (name, "as"))
         return RLIMIT_AS;
     if (streq (name, "rss"))

--- a/src/shell/stage-in.c
+++ b/src/shell/stage-in.c
@@ -20,7 +20,11 @@
 #include <stdlib.h>
 #include <libgen.h>
 #include <jansson.h>
+#ifdef HAVE_ARGZ_ADD
 #include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
 #include <archive.h>
 #include <archive_entry.h>
 #include <flux/core.h>


### PR DESCRIPTION
Problem: flux-core does not build on Alpine linux.

This addresses several issues that came up when trying to build on Alpine, primarily where we have used non-standard interfaces of glibc.  This PR is sufficient to build flux-core and run its unit tests.  A number of sharness tests are still failing.  Those are being worked in #5564.

I verified that we can run `make check-prep` in  Alpine with this PR applied.