### PR TITLE
libflux: fix performance of kvs-watch cancel/disconnect

### DIFF
--- a/src/common/libflux/disconnect.h
+++ b/src/common/libflux/disconnect.h
@@ -17,10 +17,26 @@
 extern "C" {
 #endif
 
+struct flux_msg_match {
+    uint32_t matchtag;
+    const char *route_first;
+    struct flux_msg_cred cred;
+};
+
+/* Initialize a flux_msg_match struct from `msg`.
+ */
+int flux_msg_match_init (struct flux_msg_match *match,
+                         const flux_msg_t *msg);
+
 /* Return true if disconnect request msg1 came from same sender as
  * msg2 and has appropriate authorization
  */
 bool flux_disconnect_match (const flux_msg_t *msg1, const flux_msg_t *msg2);
+
+/* Like the above but with reusable flux_msg_match argument.
+ */
+bool flux_disconnect_match_ex (struct flux_msg_match *match,
+                               const flux_msg_t *msg);
 
 /* Remove all messages in 'l' with the same sender as 'msg'.
  * Return 0 or the number of messages removed.
@@ -31,6 +47,11 @@ int flux_msglist_disconnect (struct flux_msglist *l, const flux_msg_t *msg);
  * has appropriate authorization, and references the matchtag in
  * msg2 */
 bool flux_cancel_match (const flux_msg_t *msg1, const flux_msg_t *msg2);
+
+/* Like the above bu with reusable flux_msg_match argument.
+ */
+bool flux_cancel_match_ex (struct flux_msg_match *match,
+                           const flux_msg_t *msg);
 
 /* Respond to and remove the first message in 'l' that matches 'msg'.
  * The sender must match 'msg', and the matchtag must match the one in


### PR DESCRIPTION
While profiling a throughput test workload, I noticed that at least 7% of the broker's CPU time was spent in kvs-watch `watcher_cancel_all()`.

The problem occurs because pulling data from the disconnect or cancel message is repeated for every member of the target list of the match. When the list is very large, this can add up to quite a bit of wasted time.

Add a "msg_match" structure to store the  data being matched so that the message only needs to processed once, and use this in kvs-watch.

Use this scheme in `flux_msglist_cancel()` and `flux_msglist_disconnect()` so that users of these functions can take advantage of the improvement as well.