### PR TITLE
man3: add Link with... instruction to SYNOPSIS

### DIFF
--- a/doc/man3/flux_attr_get.rst
+++ b/doc/man3/flux_attr_get.rst
@@ -15,6 +15,7 @@ SYNOPSIS
 
    int flux_attr_set (flux_t *h, const char *name, const char *val);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_aux_set.rst
+++ b/doc/man3/flux_aux_set.rst
@@ -20,6 +20,7 @@ SYNOPSIS
                      void *aux,
                      flux_free_f destroy);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_child_watcher_create.rst
+++ b/doc/man3/flux_child_watcher_create.rst
@@ -26,6 +26,7 @@ SYNOPSIS
 
    int flux_child_watcher_get_rstatus (flux_watcher_t *w);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_comms_error_set.rst
+++ b/doc/man3/flux_comms_error_set.rst
@@ -17,6 +17,7 @@ SYNOPSIS
                               flux_comms_error_f fun,
                               void *arg);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_core_version.rst
+++ b/doc/man3/flux_core_version.rst
@@ -15,6 +15,7 @@ SYNOPSIS
 
    const char *flux_core_version_string (void);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_event_decode.rst
+++ b/doc/man3/flux_event_decode.rst
@@ -35,6 +35,7 @@ SYNOPSIS
                                 const char *fmt,
                                 ...);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_event_publish.rst
+++ b/doc/man3/flux_event_publish.rst
@@ -30,6 +30,7 @@ SYNOPSIS
 
    int flux_event_publish_get_seq (flux_future_t *f, int *seq);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_event_subscribe.rst
+++ b/doc/man3/flux_event_subscribe.rst
@@ -15,6 +15,7 @@ SYNOPSIS
 
   int flux_event_unsubscribe (flux_t *h, const char *topic);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_fd_watcher_create.rst
+++ b/doc/man3/flux_fd_watcher_create.rst
@@ -24,6 +24,7 @@ SYNOPSIS
 
    int flux_fd_watcher_get_fd (flux_watcher_t *w);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_flags_set.rst
+++ b/doc/man3/flux_flags_set.rst
@@ -17,6 +17,7 @@ SYNOPSIS
 
   int flux_flags_get (flux_t *h);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_future_and_then.rst
+++ b/doc/man3/flux_future_and_then.rst
@@ -30,6 +30,7 @@ SYNOPSIS
                                  void *result,
                                  flux_free_f free_fn);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_future_create.rst
+++ b/doc/man3/flux_future_create.rst
@@ -46,6 +46,7 @@ SYNOPSIS
 
    flux_t *flux_future_get_flux (flux_future_t *f);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_future_get.rst
+++ b/doc/man3/flux_future_get.rst
@@ -30,6 +30,7 @@ SYNOPSIS
 
    const char *flux_future_error_string (flux_future_t *f);
 
+Link with :command:`-lflux-core`.
 
 OVERVIEW
 ========

--- a/doc/man3/flux_future_wait_all_create.rst
+++ b/doc/man3/flux_future_wait_all_create.rst
@@ -26,6 +26,7 @@ SYNOPSIS
    flux_future_t *flux_future_get_child (flux_future_t *cf,
                                          const char *name);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_get_rank.rst
+++ b/doc/man3/flux_get_rank.rst
@@ -15,6 +15,7 @@ SYNOPSIS
 
   int flux_get_size (flux_t *h, uint32_t *size);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_get_reactor.rst
+++ b/doc/man3/flux_get_reactor.rst
@@ -15,6 +15,7 @@ SYNOPSIS
 
   int flux_set_reactor (flux_t *h, flux_reactor_t *r);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_handle_watcher_create.rst
+++ b/doc/man3/flux_handle_watcher_create.rst
@@ -24,6 +24,7 @@ SYNOPSIS
 
    flux_t *flux_handle_watcher_get_flux (flux_watcher_t *w);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_idle_watcher_create.rst
+++ b/doc/man3/flux_idle_watcher_create.rst
@@ -28,6 +28,7 @@ SYNOPSIS
                                              flux_watcher_f callback,
                                              void *arg);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_job_timeleft.rst
+++ b/doc/man3/flux_job_timeleft.rst
@@ -15,6 +15,8 @@ SYNOPSIS
                           flux_error_t *error,
                           double *timeleft);
 
+Link with :command:`-lflux-core`.
+
 DESCRIPTION
 ===========
 

--- a/doc/man3/flux_jobtap_get_flux.rst
+++ b/doc/man3/flux_jobtap_get_flux.rst
@@ -33,6 +33,7 @@ SYNOPSIS
                                const char *fmt,
                                ...);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_kvs_commit.rst
+++ b/doc/man3/flux_kvs_commit.rst
@@ -28,6 +28,7 @@ SYNOPSIS
 
    int flux_kvs_commit_get_sequence (flux_future_t *f, int *seq);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_kvs_copy.rst
+++ b/doc/man3/flux_kvs_copy.rst
@@ -21,6 +21,7 @@ SYNOPSIS
                                  const char *dstkey,
                                  int commit_flags);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_kvs_getroot.rst
+++ b/doc/man3/flux_kvs_getroot.rst
@@ -25,6 +25,7 @@ SYNOPSIS
 
    int flux_kvs_getroot_get_owner (flux_future_t *f, uint32_t *owner);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_kvs_lookup.rst
+++ b/doc/man3/flux_kvs_lookup.rst
@@ -45,6 +45,7 @@ SYNOPSIS
 
    int flux_kvs_lookup_cancel (flux_future_t *f);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_kvs_namespace_create.rst
+++ b/doc/man3/flux_kvs_namespace_create.rst
@@ -25,6 +25,7 @@ SYNOPSIS
    flux_future_t *flux_kvs_namespace_remove (flux_t *h,
                                              const char *namespace);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_kvs_txn_create.rst
+++ b/doc/man3/flux_kvs_txn_create.rst
@@ -57,6 +57,7 @@ SYNOPSIS
                                  const char *key,
                                  const char *treeobj);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_log.rst
+++ b/doc/man3/flux_log.rst
@@ -19,6 +19,7 @@ SYNOPSIS
 
   void flux_log_set_procid (flux_t *h, const char *s);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_msg_cmp.rst
+++ b/doc/man3/flux_msg_cmp.rst
@@ -19,6 +19,7 @@ SYNOPSIS
 
    bool flux_msg_cmp (const flux_msg_t *msg, struct flux_match match);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_msg_encode.rst
+++ b/doc/man3/flux_msg_encode.rst
@@ -17,6 +17,7 @@ SYNOPSIS
 
   flux_msg_t *flux_msg_decode (void *buf, size_t size);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_msg_handler_addvec.rst
+++ b/doc/man3/flux_msg_handler_addvec.rst
@@ -25,6 +25,7 @@ SYNOPSIS
 
    void flux_msg_handler_delvec (flux_msg_handler_t *handlers[]);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_msg_handler_create.rst
+++ b/doc/man3/flux_msg_handler_create.rst
@@ -28,6 +28,7 @@ SYNOPSIS
 
    void flux_msg_handler_stop (flux_msg_handler_t *mh);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_open.rst
+++ b/doc/man3/flux_open.rst
@@ -23,6 +23,7 @@ SYNOPSIS
 
    int flux_reconnect (flux_t *h);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_periodic_watcher_create.rst
+++ b/doc/man3/flux_periodic_watcher_create.rst
@@ -32,6 +32,7 @@ SYNOPSIS
                                      double offset,
                                      double interval);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_pollevents.rst
+++ b/doc/man3/flux_pollevents.rst
@@ -15,6 +15,7 @@ SYNOPSIS
 
   int flux_pollfd (flux_t *h);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_reactor_create.rst
+++ b/doc/man3/flux_reactor_create.rst
@@ -25,6 +25,7 @@ SYNOPSIS
 
   void flux_reactor_active_decref (flux_reactor_t *r);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_reactor_now.rst
+++ b/doc/man3/flux_reactor_now.rst
@@ -15,6 +15,7 @@ SYNOPSIS
 
   double flux_reactor_time (void);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_recv.rst
+++ b/doc/man3/flux_recv.rst
@@ -15,6 +15,7 @@ SYNOPSIS
                          struct flux_match match,
                          int flags);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_request_decode.rst
+++ b/doc/man3/flux_request_decode.rst
@@ -25,6 +25,7 @@ SYNOPSIS
                                 const void **data,
                                 int *len);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_request_encode.rst
+++ b/doc/man3/flux_request_encode.rst
@@ -17,6 +17,7 @@ SYNOPSIS
                                         void *data,
                                         int len);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_requeue.rst
+++ b/doc/man3/flux_requeue.rst
@@ -13,6 +13,7 @@ SYNOPSIS
 
   int flux_requeue (flux_t *h, const flux_msg_t *msg, int flags);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_respond.rst
+++ b/doc/man3/flux_respond.rst
@@ -30,6 +30,7 @@ SYNOPSIS
                            int errnum,
                            const char *errmsg);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_response_decode.rst
+++ b/doc/man3/flux_response_decode.rst
@@ -23,6 +23,7 @@ SYNOPSIS
    int flux_response_decode_error (const flux_msg_t *msg,
                                    const char *errstr);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_rpc.rst
+++ b/doc/man3/flux_rpc.rst
@@ -48,6 +48,7 @@ SYNOPSIS
 
    uint32_t flux_rpc_get_nodeid (flux_future_t *f);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_send.rst
+++ b/doc/man3/flux_send.rst
@@ -15,6 +15,7 @@ SYNOPSIS
 
    int flux_send_new (flux_t *h, flux_msg_t **msg, int flags);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_service_register.rst
+++ b/doc/man3/flux_service_register.rst
@@ -15,6 +15,7 @@ SYNOPSIS
 
    flux_future_t *flux_service_unregister (flux_t *h, const char *name);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_add_completion_ref.rst
+++ b/doc/man3/flux_shell_add_completion_ref.rst
@@ -20,6 +20,7 @@ SYNOPSIS
                                          const char *fmt,
                                          ...)
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_add_event_context.rst
+++ b/doc/man3/flux_shell_add_event_context.rst
@@ -17,7 +17,7 @@ SYNOPSIS
                                      int flags,
                                      const char *fmt,
                                      ...);
-
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_add_event_handler.rst
+++ b/doc/man3/flux_shell_add_event_handler.rst
@@ -17,6 +17,7 @@ SYNOPSIS
                                      flux_msg_handler_f cb,
                                      void *arg);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_aux_set.rst
+++ b/doc/man3/flux_shell_aux_set.rst
@@ -22,6 +22,7 @@ SYNOPSIS
    void * flux_shell_aux_get (flux_shell_t *shell,
                               const char *key);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_current_task.rst
+++ b/doc/man3/flux_shell_current_task.rst
@@ -18,6 +18,7 @@ SYNOPSIS
 
    flux_shell_task_t *flux_shell_task_next (flux_shell_t *shell);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_get_flux.rst
+++ b/doc/man3/flux_shell_get_flux.rst
@@ -13,6 +13,7 @@ SYNOPSIS
 
    flux_t *flux_shell_get_flux (flux_shell_t *shell);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_get_hwloc_xml.rst
+++ b/doc/man3/flux_shell_get_hwloc_xml.rst
@@ -15,6 +15,7 @@ SYNOPSIS
    int flux_shell_get_hwloc_xml (flux_shell_t *shell,
                                  const char **hwloc_xml);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_get_info.rst
+++ b/doc/man3/flux_shell_get_info.rst
@@ -28,6 +28,7 @@ SYNOPSIS
                                     const char *fmt,
                                     ...);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_get_jobspec_info.rst
+++ b/doc/man3/flux_shell_get_jobspec_info.rst
@@ -19,6 +19,8 @@ SYNOPSIS
                                        const char *fmt,
                                        ...);
 
+Link with :command:`-lflux-core`.
+
 DESCRIPTION
 ===========
 

--- a/doc/man3/flux_shell_get_taskmap.rst
+++ b/doc/man3/flux_shell_get_taskmap.rst
@@ -14,6 +14,7 @@ SYNOPSIS
 
    const struct taskmap * flux_shell_get_taskmap (flux_shell_t *shell);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_getenv.rst
+++ b/doc/man3/flux_shell_getenv.rst
@@ -27,6 +27,7 @@ SYNOPSIS
    int flux_shell_unsetenv (flux_shell_t *shell,
                             const char *name);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_getopt.rst
+++ b/doc/man3/flux_shell_getopt.rst
@@ -30,6 +30,7 @@ SYNOPSIS
                                const char *fmt,
                                ...);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_killall.rst
+++ b/doc/man3/flux_shell_killall.rst
@@ -13,6 +13,7 @@ SYNOPSIS
 
    void flux_shell_killall (flux_shell_t *shell, int sig);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_log.rst
+++ b/doc/man3/flux_shell_log.rst
@@ -41,6 +41,7 @@ SYNOPSIS
 
    int flux_shell_log_setlevel (int level, const char *dest);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_plugstack_call.rst
+++ b/doc/man3/flux_shell_plugstack_call.rst
@@ -15,6 +15,7 @@ SYNOPSIS
                                   const char *topic,
                                   flux_plugin_arg_t *args);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_rpc_pack.rst
+++ b/doc/man3/flux_shell_rpc_pack.rst
@@ -19,6 +19,7 @@ SYNOPSIS
                                        const char *fmt,
                                        ...);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_service_register.rst
+++ b/doc/man3/flux_shell_service_register.rst
@@ -16,6 +16,7 @@ SYNOPSIS
                                     flux_msg_handler_f cb,
                                     void *arg);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_task_channel_subscribe.rst
+++ b/doc/man3/flux_shell_task_channel_subscribe.rst
@@ -16,6 +16,7 @@ SYNOPSIS
                                           flux_shell_task_io_f cb,
                                           void *arg);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_task_get_info.rst
+++ b/doc/man3/flux_shell_task_get_info.rst
@@ -18,6 +18,7 @@ SYNOPSIS
                                     const char *fmt,
                                     ...);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_shell_task_subprocess.rst
+++ b/doc/man3/flux_shell_task_subprocess.rst
@@ -15,6 +15,7 @@ SYNOPSIS
 
    flux_cmd_t *flux_shell_task_cmd (flux_shell_task_t *task);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_signal_watcher_create.rst
+++ b/doc/man3/flux_signal_watcher_create.rst
@@ -23,6 +23,7 @@ SYNOPSIS
 
    int flux_signal_watcher_get_signum (flux_watcher_t *w);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_stat_watcher_create.rst
+++ b/doc/man3/flux_stat_watcher_create.rst
@@ -26,6 +26,7 @@ SYNOPSIS
                                      struct stat *stat,
                                      struct stat *prev);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_sync_create.rst
+++ b/doc/man3/flux_sync_create.rst
@@ -13,6 +13,7 @@ SYNOPSIS
 
    flux_future_t *flux_sync_create (flux_t *h, double minimum);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_timer_watcher_create.rst
+++ b/doc/man3/flux_timer_watcher_create.rst
@@ -26,6 +26,7 @@ SYNOPSIS
                                   double after,
                                   double repeat);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/flux_watcher_start.rst
+++ b/doc/man3/flux_watcher_start.rst
@@ -17,6 +17,7 @@ SYNOPSIS
 
   double flux_watcher_next_wakeup (flux_watcher_t *w);
 
+Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/idset_add.rst
+++ b/doc/man3/idset_add.rst
@@ -29,12 +29,7 @@ SYNOPSIS
 
    #define idset_clear_all (x) idset_subtract (x, x)
 
-
-USAGE
-=====
-
-cc [flags] files -lflux-idset [libraries]
-
+Link with :command:`-lflux-idset`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/idset_create.rst
+++ b/doc/man3/idset_create.rst
@@ -43,12 +43,7 @@ SYNOPSIS
    bool idset_equal (const struct idset *set1,
                      const struct idset *set2);
 
-
-USAGE
-=====
-
-cc [flags] files -lflux-idset [libraries]
-
+Link with :command:`-lflux-idset`.
 
 DESCRIPTION
 ===========

--- a/doc/man3/idset_encode.rst
+++ b/doc/man3/idset_encode.rst
@@ -17,12 +17,7 @@ SYNOPSIS
 
    struct idset *idset_ndecode (const char *s, size_t len);
 
-
-USAGE
-=====
-
-cc [flags] files -lflux-idset [libraries]
-
+Link with :command:`-lflux-idset`.
 
 DESCRIPTION
 ===========


### PR DESCRIPTION
Problem: most section 3 pages do not include link instructions.

Follow the pattern of the math functions (e.g. floor(3)) and add a "Link with -lflux-core" or "Linux with -lflux-idset" note at the end of SYNOPSIS.