### PR TITLE
deprecate flux job cancel and improve flux-job(1) documentation

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -40,8 +40,13 @@ OPTIONS
    Display a list of :program:`flux job` sub-commands.
 
 
-ATTACH
-======
+COMMANDS
+========
+
+Several subcommands are available to perform various operations on jobs.
+
+attach
+------
 
 .. program:: flux job attach
 
@@ -106,8 +111,8 @@ This status line may be suppressed by setting
 
    Enable parallel debugger attach.
 
-CANCEL
-======
+cancel
+------
 
 .. program:: flux job cancel
 
@@ -121,6 +126,9 @@ the exception message from the jobids when necessary.
 
    Set the optional exception note. It is an error to specify the message
    via this option and on the command line after the jobid list.
+
+cancelall
+---------
 
 .. program:: flux job cancelall
 
@@ -143,8 +151,8 @@ are selected with:
 
    Suppress output if no jobs match
 
-STATUS
-======
+status
+------
 
 .. program:: flux job status
 
@@ -163,8 +171,8 @@ Wait for job(s) to complete and exit with the largest exit code.
 
    Increase verbosity of output.
 
-WAIT
-====
+wait
+----
 
 .. program:: flux job wait
 
@@ -208,8 +216,8 @@ code of zero.  If any jobs have failed, it exits with a code of one.
 
    Emit a line of output for all jobs, not just failing ones.
 
-SIGNAL
-======
+kill
+----
 
 .. program:: flux job kill
 
@@ -219,10 +227,12 @@ One or more running jobs may be signaled by jobid with :program:`flux job kill`.
 
    Send signal SIG (default: SIGTERM).
 
+killall
+-------
+
 .. program:: flux job killall
 
-Running jobs may be signaled in bulk with :program:`flux job killall`.  In
-addition to the option above, target jobs are selected with:
+Running jobs may be signaled in bulk with :program:`flux job killall`.
 
 .. option:: -u, --user=USER
 
@@ -232,8 +242,12 @@ addition to the option above, target jobs are selected with:
 
    Confirm the command.
 
-EXCEPTION
-=========
+.. option:: -s, --signal=SIG
+
+   Send signal SIG (default: SIGTERM).
+
+raise
+-----
 
 .. program:: flux job raise
 
@@ -257,6 +271,9 @@ separate the exception message from the jobids when necessary.
 
    Set exception type (default: cancel).
 
+raiseall
+--------
+
 Exceptions may be raised in bulk with :program:`flux job raiseall`, which
 requires a type (positional argument) and accepts the following options:
 
@@ -279,8 +296,8 @@ requires a type (positional argument) and accepts the following options:
 
    Confirm the command.
 
-TASKMAP
-=======
+taskmap
+-------
 
 .. program:: flux job taskmap
 
@@ -320,8 +337,8 @@ support task mapping formats:
 
 One one of the above options may be used per call.
 
-TIMELEFT
-========
+timeleft
+--------
 
 .. program:: flux job timeleft
 
@@ -340,8 +357,8 @@ Options:
 
   Generate human readable output. Report results in Flux Standard Duration.
 
-PURGE
-=====
+purge
+-----
 
 .. program:: flux job purge
 
@@ -366,15 +383,14 @@ Inactive jobs may also be purged automatically if the job manager is
 configured as described in :man5:`flux-config-job-manager`.
 
 
-flux job info
--------------
+info
+----
 
 .. program:: flux job info
 
 :program:`flux job info` retrieves the selected low level job object
 and displays it on standard output.  Object formats are described in the
 RFCs listed in `RESOURCES`_.
-
 
 Options:
 

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -12,6 +12,7 @@ SYNOPSIS
 | **flux** **job** **attach** [*OPTIONS*] *id*
 | **flux** **job** **status** [*OPTIONS*] *id [*id...*]
 | **flux** **job** **last** [*N* | *SLICE*]
+| **flux** **job** **urgency** [*-v*] *id* *N*
 | **flux** **job** **wait** [*OPTIONS*] [*id*]
 | **flux** **job** **kill** [*--signal=SIG*] *id* [*id...*]
 | **flux** **job** **killall** [*OPTIONS*]
@@ -161,6 +162,30 @@ Examples:
 :command:`flux job last [::-1]`
   List all jobids in submission order
 
+urgency
+-------
+
+.. program:: flux job wait
+
+:program:`flux job urgency` changes a job's urgency value.  The urgency
+may also be specified at job submission time.  The argument *N* has a range
+of 0 to 16 for guest users, or 0 to 31 for instance owners.  In lieu of a
+numerical value, the following special names are also accepted:
+
+hold (0)
+  Hold the job until the urgency is raised with :option:`flux job urgency`.
+
+default (16)
+  The default urgency for all users.
+
+expedite (31)
+  Assign the highest possible priority to the job (restricted to instance
+  owner).
+
+Urgency is one factor used to calculate job priority, which affects the
+order in which the scheduler considers jobs.  For more information, refer
+to :man1:`flux-submit` description of the :option:`flux submit --urgency`
+option.
 
 wait
 ----

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -18,7 +18,7 @@ SYNOPSIS
 | **flux** **job** **killall** [*OPTIONS*]
 | **flux** **job** **raise** [*OPTIONS*] *ids...* [*--*] [*message...*]
 | **flux** **job** **raiseall** [*OPTIONS*] *type* [*message...*]
-| **flux** **job** **taskmap** [*OPTIONS*] *id*|*taskmap*
+| **flux** **job** **taskmap** [*OPTIONS*] *id* | *taskmap*
 | **flux** **job** **timeleft** [*OPTIONS*] [*id*]
 | **flux** **job** **purge** [*OPTIONS*] [*id...*]
 | **flux** **job** **info** [*OPTIONS*] *id* *key*

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -27,7 +27,18 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-flux-job(1) performs various job related housekeeping functions.
+:program:`flux job` performs various job related housekeeping functions.
+
+
+OPTIONS
+=======
+
+.. program:: flux job
+
+.. option:: -h, --help
+
+   Display a list of :program:`flux job` sub-commands.
+
 
 ATTACH
 ======

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -9,31 +9,19 @@ flux-job(1)
 SYNOPSIS
 ========
 
-**flux** **job** **attach** [*OPTIONS*] *id*
-
-**flux** **job** **cancel** [*OPTIONS*] *ids...* [*--*] [*message...*]
-
-**flux** **job** **cancelall** [*OPTIONS*] [*message...*]
-
-**flux** **job** **status** [*OPTIONS*] *id [*id...*]
-
-**flux** **job** **wait** [*OPTIONS*] [*id*]
-
-**flux** **job** **kill** [*--signal=SIG*] *id* [*id...*]
-
-**flux** **job** **killall** [*OPTIONS*]
-
-**flux** **job** **raise** [*OPTIONS*] *ids...* [*--*] [*message...*]
-
-**flux** **job** **raiseall** [*OPTIONS*] *type* [*message...*]
-
-**flux** **job** **taskmap** [*OPTIONS*] *id*|*taskmap*
-
-**flux** **job** **timeleft** [*OPTIONS*] [*id*]
-
-**flux** **job** **purge** [*OPTIONS*] [*id...*]
-
-**flux** **job** **info** [*OPTIONS*] *id* *key*
+| **flux** **job** **attach** [*OPTIONS*] *id*
+| **flux** **job** **cancel** [*OPTIONS*] *ids...* [*--*] [*message...*]
+| **flux** **job** **cancelall** [*OPTIONS*] [*message...*]
+| **flux** **job** **status** [*OPTIONS*] *id [*id...*]
+| **flux** **job** **wait** [*OPTIONS*] [*id*]
+| **flux** **job** **kill** [*--signal=SIG*] *id* [*id...*]
+| **flux** **job** **killall** [*OPTIONS*]
+| **flux** **job** **raise** [*OPTIONS*] *ids...* [*--*] [*message...*]
+| **flux** **job** **raiseall** [*OPTIONS*] *type* [*message...*]
+| **flux** **job** **taskmap** [*OPTIONS*] *id*|*taskmap*
+| **flux** **job** **timeleft** [*OPTIONS*] [*id*]
+| **flux** **job** **purge** [*OPTIONS*] [*id...*]
+| **flux** **job** **info** [*OPTIONS*] *id* *key*
 
 
 DESCRIPTION

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -10,8 +10,6 @@ SYNOPSIS
 ========
 
 | **flux** **job** **attach** [*OPTIONS*] *id*
-| **flux** **job** **cancel** [*OPTIONS*] *ids...* [*--*] [*message...*]
-| **flux** **job** **cancelall** [*OPTIONS*] [*message...*]
 | **flux** **job** **status** [*OPTIONS*] *id [*id...*]
 | **flux** **job** **wait** [*OPTIONS*] [*id*]
 | **flux** **job** **kill** [*--signal=SIG*] *id* [*id...*]
@@ -110,46 +108,6 @@ This status line may be suppressed by setting
 .. option:: --debug
 
    Enable parallel debugger attach.
-
-cancel
-------
-
-.. program:: flux job cancel
-
-One or more jobs by may be canceled with :program:`flux job cancel`.  An
-optional message included with the cancel exception may be provided via the
-:option:`--message=NOTE` option or after the list of jobids. The special
-argument *"--"* forces the end of jobid processing and can be used to separate
-the exception message from the jobids when necessary.
-
-.. option:: -m, --message=NOTE
-
-   Set the optional exception note. It is an error to specify the message
-   via this option and on the command line after the jobid list.
-
-cancelall
----------
-
-.. program:: flux job cancelall
-
-Jobs may be canceled in bulk with :program:`flux job cancelall`.  Target jobs
-are selected with:
-
-.. option:: -u, --user=USER
-
-   Set target user.  The instance owner may specify *all* for all users.
-
-.. option:: -S, --states=STATES
-
-   Set target job states (default: ACTIVE).
-
-.. option:: -f, --force
-
-   Confirm the command
-
-.. option:: -q, --quiet
-
-   Suppress output if no jobs match
 
 status
 ------

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -11,6 +11,7 @@ SYNOPSIS
 
 | **flux** **job** **attach** [*OPTIONS*] *id*
 | **flux** **job** **status** [*OPTIONS*] *id [*id...*]
+| **flux** **job** **last** [*N* | *SLICE*]
 | **flux** **job** **wait** [*OPTIONS*] [*id*]
 | **flux** **job** **kill** [*--signal=SIG*] *id* [*id...*]
 | **flux** **job** **killall** [*OPTIONS*]
@@ -128,6 +129,38 @@ Wait for job(s) to complete and exit with the largest exit code.
 .. option:: -v, --verbose
 
    Increase verbosity of output.
+
+last
+-----
+
+.. program:: flux job last
+
+Print the most recently submitted jobid for the current user.
+
+If the optional argument is specified as a number *N*, print the *N* most
+recently submitted jobids in reverse submission order, one per line.  If it
+is enclosed in brackets, the argument is interpreted as a `python-style slice
+<https://python-reference.readthedocs.io/en/latest/docs/brackets/slicing.html>`_
+in :option:`[start:stop[:step]]` form which slices the job history array,
+where index 0 is the most recently submitted job.
+
+Examples:
+
+:command:`flux job last 4`
+  List the last four jobids in reverse submission order
+
+:command:`flux job last [0:4]`
+  Same as above
+
+:command:`flux job last [-1:]`
+  List the least recently submitted jobid
+
+:command:`flux job last [:]`
+  List all jobids in reverse submission order
+
+:command:`flux job last [::-1]`
+  List all jobids in submission order
+
 
 wait
 ----

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -9,19 +9,19 @@ flux-job(1)
 SYNOPSIS
 ========
 
-| **flux** **job** **attach** [*OPTIONS*] *id*
-| **flux** **job** **status** [*OPTIONS*] *id [*id...*]
+| **flux** **job** **attach** [*--label-io*] [*-E*] [*--wait-event=EVENT*] *id*
+| **flux** **job** **status** [*-v*] [*--json*] [-e CODE] *id [*id...*]
 | **flux** **job** **last** [*N* | *SLICE*]
 | **flux** **job** **urgency** [*-v*] *id* *N*
-| **flux** **job** **wait** [*OPTIONS*] [*id*]
-| **flux** **job** **kill** [*--signal=SIG*] *id* [*id...*]
-| **flux** **job** **killall** [*OPTIONS*]
-| **flux** **job** **raise** [*OPTIONS*] *ids...* [*--*] [*message...*]
-| **flux** **job** **raiseall** [*OPTIONS*] *type* [*message...*]
+| **flux** **job** **wait** [*-v*] [*--all*] [*id*]
+| **flux** **job** **kill** [*--signal=SIG*] *ids...*
+| **flux** **job** **killall** [*-f*] [*--user=USER*] [*--signal=SIG*]
+| **flux** **job** **raise** [*-severity=N*] [*--type=TYPE*] *ids...* [*--*] [*message...*]
+| **flux** **job** **raiseall** [*--severity=N*] [*--user=USER*] [*--states=STATES*] *type* [ [*--*] [*message...*]
 | **flux** **job** **taskmap** [*OPTIONS*] *id* | *taskmap*
-| **flux** **job** **timeleft** [*OPTIONS*] [*id*]
-| **flux** **job** **purge** [*OPTIONS*] [*id...*]
-| **flux** **job** **info** [*OPTIONS*] *id* *key*
+| **flux** **job** **timeleft** [*-H*] [*id*]
+| **flux** **job** **purge** [*-f*] [*--age-limit=FSD*] [*--num-limit=N*] [*ids...*]
+| **flux** **job** **info** [*--original*] [*--base*] *id* *key*
 
 
 DESCRIPTION

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -474,14 +474,14 @@ static struct optparse_subcommand subcommands[] = {
       "[OPTIONS] ids... [--] [message ...]",
       "Cancel one or more jobs",
       cmd_cancel,
-      0,
+      OPTPARSE_SUBCMD_HIDDEN,
       cancel_opts,
     },
     { "cancelall",
       "[OPTIONS] [message ...]",
       "Cancel multiple jobs",
       cmd_cancelall,
-      0,
+      OPTPARSE_SUBCMD_HIDDEN,
       cancelall_opts,
     },
     { "raise",
@@ -1192,6 +1192,9 @@ int cmd_cancel (optparse_t *p, int argc, char **argv)
 
     parse_jobids_and_note (p, argv + optindex, &args, &note);
 
+    fprintf (stderr,
+             "WARNING: this command is deprecated.  Use flux-cancel(1).\n");
+
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
@@ -1241,6 +1244,8 @@ int cmd_cancelall (optparse_t *p, int argc, char **argv)
         userid = getuid ();
     if (optparse_hasopt (p, "force"))
         dry_run = 0;
+    fprintf (stderr,
+             "WARNING: this command is deprecated.  Use flux-cancel(1).\n");
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
     count = raiseall (h,

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -149,7 +149,7 @@ test_expect_success 'cancel test job' '
 test_expect_success NO_CHAIN_LINT 'flux-proxy attempts to restore terminal on error' '
 	cat <<-EOF >test.sh &&
 	#!/bin/bash
-	flux --parent job cancel \$(flux getattr jobid)
+	flux --parent cancel \$(flux getattr jobid)
 	while flux getattr jobid; do sleep 0.1; done
 	EOF
 	chmod +x test.sh
@@ -163,7 +163,7 @@ test_expect_success NO_CHAIN_LINT 'flux-proxy sends SIGHUP to children without -
 	SHELL=/bin/sh &&
 	cat <<-EOF >test.sh &&
 	#!/bin/bash
-	flux --parent job cancel \$(flux getattr jobid)
+	flux --parent cancel \$(flux getattr jobid)
 	while true; do sleep 0.1; done
 	EOF
 	chmod +x test.sh

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -490,7 +490,8 @@ test_expect_success 'flux job: the queue contains active jobs' '
 
 test_expect_success 'flux job: cancelall with no args works' '
 	count=$(flux job list | wc -l) &&
-	flux job cancelall 2>cancelall.err &&
+	flux job cancelall 2>cancelall.tmp &&
+	grep -v WARNING cancelall.tmp >cancelall.err &&
 	cat <<-EOT >cancelall.exp &&
 	flux-job: Command matched ${count} jobs (-f to confirm)
 	EOT
@@ -502,13 +503,15 @@ test_expect_success 'flux-job: cancelall with bad broker connection fails' '
 '
 
 test_expect_success 'flux job: cancelall with reason works' '
-	flux job cancelall this is a reason 2>cancelall_reason.err &&
+	flux job cancelall this is a reason 2>cancelall_reason.tmp &&
+	grep -v WARNING cancelall_reason.tmp >cancelall_reason.err &&
 	test_cmp cancelall.exp cancelall_reason.err
 '
 
 test_expect_success 'flux job: cancelall --force works' '
 	count=$(flux job list | wc -l) &&
-	flux job cancelall --force 2>cancelall_f.err &&
+	flux job cancelall --force 2>cancelall_f.tmp &&
+	grep -v WARNING cancelall_f.tmp >cancelall_f.err &&
 	cat <<-EOT >cancelall_f.exp &&
 	flux-job: Canceled ${count} jobs (0 errors)
 	EOT
@@ -522,7 +525,8 @@ test_expect_success 'flux job: the queue is empty' '
 test_expect_success 'flux-job: cancelall --user all fails for guest' '
 	id=$(($(id -u)+1)) &&
 	test_must_fail runas ${id} \
-		flux job cancelall --user all 2> cancelall_all_guest.err &&
+		flux job cancelall --user all 2> cancelall_all_guest.tmp &&
+	grep -v WARNING cancelall_all_guest.tmp >cancelall_all_guest.err &&
 	cat <<-EOF >cancelall_all_guest.exp &&
 	flux-job: raiseall: guests can only raise exceptions on their own jobs
 	EOF
@@ -653,7 +657,8 @@ test_expect_success 'flux-job: raiseall -f returns correct count' '
 '
 
 test_expect_success 'flux-job: cancelall -f returns correct count' '
-	flux job cancelall -f 2>cancelall_testf.err &&
+	flux job cancelall -f 2>cancelall_testf.tmp &&
+	grep -v WARNING cancelall_testf.tmp >cancelall_testf.err &&
 	cat <<-EOT >cancelall_testf.exp &&
 	flux-job: Canceled 3 jobs (0 errors)
 	EOT

--- a/t/t2292-job-update-running.t
+++ b/t/t2292-job-update-running.t
@@ -68,7 +68,7 @@ test_expect_success 'duration update is processed by execution system' '
 	flux update $jobid duration=+1m &&
 	$SHARNESS_TEST_SRCDIR/scripts/dmesg-grep.py \
 		-vt 30 "job-exec.*updated expiration of $jobid" &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	flux job wait-event $jobid clean
 '
 #  Test that the job shell correctly processes an expiration update.

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -47,7 +47,7 @@ test_expect_success 'job-exec: status is maximum job shell exit codes' '
 test_expect_success 'job-exec: job exception kills job shells' '
 	id=$(flux submit -n4 -N4 sleep 300) &&
 	flux job wait-event -vt 5 $id start &&
-	flux job cancel $id &&
+	flux cancel $id &&
 	flux job wait-event -vt 5 $id clean &&
 	flux job eventlog $id | grep status=15
 '

--- a/t/t2813-flux-watch.t
+++ b/t/t2813-flux-watch.t
@@ -51,7 +51,7 @@ test_expect_success 'flux-watch: --all watches inactive jobs' '
 test_expect_success 'flux-watch: run some failed jobs' '
 	id=$(flux submit sh -c "echo test3; exit 2") &&
 	id2=$(flux submit --urgency hold true) &&
-	flux job cancel $id2
+	flux cancel $id2
 '
 test_expect_success 'flux-watch: exits with highest job exit code' '
 	test_expect_code 2 flux watch --all


### PR DESCRIPTION
Problem: flux job cancel still is documented but we want people to use `flux-cancel(1)` now.

Hide the `cancel` and `cancelall` sub-commands of `flux-job(1)`  and print a deprecation warning if they are used.

Drop those sub-commands from the `flux-job(1)` man page and make various improvements to the page, including documenting some user-facing commands that were not listed such as `flux job urgency` and `flux job last`.