### PR TITLE
flux-kvs(1): improve man page formatting

### DIFF
--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -6,7 +6,30 @@ flux-kvs(1)
 SYNOPSIS
 ========
 
-**flux** **kvs** *COMMAND* [*OPTIONS*]
+| **flux** **kvs** **get** [*--waitcreate*] [*--watch*] [*--raw*] *key...*
+| **flux** **kvs** **put** [*--append*] [*--raw*] *key=value...*
+| **flux** **kvs** **dir** [*-R*] [*-d*] [*key*]
+| **flux** **kvs** **ls** [*-R*] [*-d*] [*-1*] [*-F*]  *key...*
+| **flux** **kvs** **unlink** [*-R*] [*-f*] *key...*
+| **flux** **kvs** **link** *target* *linkname*
+| **flux** **kvs** **readlink** *key...*
+| **flux** **kvs** **mkdir** *key...*
+| **flux** **kvs** **dropcache**
+
+| **flux** **kvs** **copy** *source* *destination*
+| **flux** **kvs** **move** *source* *destination*
+
+| **flux** **kvs** **getroot**
+| **flux** **kvs** **version**
+| **flux** **kvs** **wait** *version*
+
+| **flux** **kvs** **namespace** **create** [*-o owner*] *name...*
+| **flux** **kvs** **namespace** **remove** *name...*
+| **flux** **kvs** **namespace** **list**
+
+| **flux** **kvs** **eventlog** **append** *key* *name* [*context...*]
+| **flux** **kvs** **eventlog** **get** [*--waitcreate*] [*--watch*] [*-u*] *key*
+| **flux** **kvs** **eventlog** **wait-event** [*-v*] [*--waitcreate*] *key* *event*
 
 
 DESCRIPTION

--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -64,170 +64,479 @@ which permits commits in multiple namespaces to complete in parallel.
 COMMANDS
 ========
 
-**namespace create** [-o owner] [-r rootref] *name* [*name* ...]
-   Create a new kvs namespace. User may specify an alternate userid of a
-   user that owns the namespace via *-o*. Specifying an alternate owner
-   would allow a non-instance owner to read/write to a namespace.
-   User may specify an initial root reference for the namespace via
-   *-r*.
+.. program:: flux kvs
 
-**namespace remove** *name* [*name...*]
-   Remove a kvs namespace.
+The :program:`flux kvs` sub-commands and their arguments are described below.
 
-**namespace list**
-   List all current namespaces and info on each namespace.
+The following options are common to most sub-commands:
 
-**get** [-N ns] [-r|-t] [-a treeobj] [-l] [-W] [-w] [-u] [-A] [-f] [-c count] *key* [*key* ...]
-   Retrieve the value stored under *key*. If nothing has been stored
-   under *key*, display an error message. Specify an alternate namespace
-   to retrieve *key* from via *-N*. If no options, value is displayed
-   with a newline appended (if value length is nonzero). If *-l*, a
-   *key=* prefix is added. If *-r*, value is displayed without a newline.
-   If *-t*, the RFC 11 object is displayed. *-a treeobj* causes the
-   lookup to be relative to an RFC 11 snapshot reference. If *-W* is
-   specified and a key does not exist, wait until the key has been
-   created. If *-w*, after the initial value, display the new value each
-   time the key is written to until interrupted, or if *-c count* is
-   specified, until *count* values have been displayed. If *-u* is
-   specified, only writes that change the key value will be displayed.
-   If *-A* is specified, only display appends that occur on a key. By
-   default, only a direct write to a key is monitored, which may miss
-   several unique situations, such as the replacement of an entire parent
-   directory. The *-f* option can be specified to monitor for many of
-   these special situations.
+.. option:: -h, --help
 
-**put** [-N ns] [-O|-b|-s] [-r|-t] [-n] [-A] [-S] *key=value* [*key=value* ...]
-   Store *value* under *key* and commit it. Specify an alternate
-   namespace to commit value(s) via *-N*. If it already has a value,
-   overwrite it. If no options, value is stored directly. If *-r* or
-   *-t*, the value may optionally be read from standard input if
-   specified as "-". If *-r*, the value may include embedded NULL bytes.
-   If *-t*, value is stored as a RFC 11 object. *-n* prevents the commit
-   from being merged with with other contemporaneous commits. *-A*
-   appends the value to a key instead of overwriting the value. Append
-   is incompatible with the -j option. *-S* flushes and checkpoints
-   the primary KVS namespace after the put.  This can be used to
-   ensure critical data has been stored to non-volatile storage.
-   After a successful put, *-O*, *-b*, or *-s* can be specified to
-   output the RFC 11 treeobj, root blobref, or root sequence number of
-   the root containing the put(s).
+  Display help on this sub-command.
 
-**ls** [-N ns] [-R] [-d] [-F] [-w COLS] [-1] [*key* ...]
-   Display directory referred to by *key*, or "." (root) if unspecified.
-   Specify an alternate namespace to display via *-N*. Remaining options are
-   roughly equivalent to a subset of :linux:man1:`ls` options. *-R*
-   lists directory recursively. *-d* displays directory not its
-   contents. *-F* classifies files with one character suffix (. is
-   directory, @ is symlink). *-w COLS* sets the terminal width in
-   characters. *-1* causes output to be displayed in one column.
+.. option:: -N, --namespace=NAME
 
-**dir** [-N ns] [-R] [-d] [-w COLS] [-a treeobj] [*key*]
-   Display all keys and their values under the directory *key*. Specify
-   an alternate namespace to display via *-N*. If *key* does not exist
-   or is not a directory, display an error message. If *key* is not
-   provided, "." (root of the namespace) is assumed. If *-R* is
-   specified, recursively display keys under subdirectories. If *-d* is
-   specified, do not output key values. Output is truncated to fit the
-   terminal width. *-w COLS* sets the terminal width (0=unlimited). *-a
-   treeobj* causes the lookup to be relative to an RFC 11 snapshot
-   reference.
+  Specify an alternate namespace.  By default, the primary KVS namespace
+  or the value of :envvar:`FLUX_KVS_NAMESPACE` is used.
 
-**unlink** [-N ns] [-O|-b|-s] [-R] [-f] *key* [*key* ...]
-   Remove *key* from the KVS and commit the change. Specify an alternate
-   namespace to commit to via *-N*. If *key* represents a directory,
-   specify *-R* to remove all keys underneath it. If *-f* is specified,
-   ignore nonexistent files. After a successful unlink, *-O*, *-b*, or
-   *-s* can be specified to output the RFC 11 treeobj, root blobref,
-   or root sequence number of the root containing the unlink(s).
+get
+---
 
-**link** [-N ns] [-T ns] [-O|-b|-s] *target* *linkname*
-   Create a new name for *target*, similar to a symbolic link, and commit
-   the change. *target* does not have to exist. If *linkname* exists,
-   it is overwritten. Specify an alternate namespace to commit linkname
-   to via *-N*. Specify the target's namespace via *-T*. After a
-   successfully created link, *-O*, *-b*, or *-s* can be specified to
-   output the RFC 11 treeobj, root blobref, or root sequence number of
-   the root containing the link.
+.. program:: flux kvs get
 
-**readlink** [-N ns] [-a treeobj] [ -o \| -k ] *key* [*key* ...]
-   Retrieve the key a link refers to rather than its value, as would be
-   returned by **get**. Specify an alternate namespace to retrieve from
-   via *-N*. *-a treeobj* causes the lookup to be relative to an RFC 11
-   snapshot reference. If the link points to a namespace, the namespace
-   and key will be output in the format *<namespace>::<key>*. The *-o*
-   can be used to only output namespaces and the *-k* can be used to only
-   output keys.
+Retrieve the value stored under *key* and print it on standard output.
+It is an error if *key* does not exist, unless :option:``--waitcreate`` is
+specified.  It is an error if *key* is a directory.
 
-**mkdir** [-N ns] [-O|-b|-s] *key* [*key* ...]
-   Create an empty directory and commit the change. If *key* exists,
-   it is overwritten. Specify an alternate namespace to commit to via
-   *-N*. After a successful mkdir, *-O*, *-b*, or *-s* can be
-   specified to output the RFC 11 treeobj, root blobref, or root
-   sequence number of the root containing the new directory.
+If multiple *key* arguments are specified, their values are concatenated.
+A newline is appended to each value, unless :option:`--raw` is specified or
+the value is zero length.
 
-**copy** [-S src-ns] [-D dst-ns] *source* *destination*
-   Copy *source* key to *destination* key. Optionally, specify a source
-   and/or destination namespace for the *source* and/or *destination*
-   respectively. If a directory is copied, a new reference is created;
-   it is unnecessary for **copy** to recurse into *source*.
+.. option:: -r, --raw
 
-**move** [-S src-ns] [-D dst-ns] *source* *destination*
-   Like **copy**, but *source* is unlinked after the copy.
+  Display value without a newline.
 
-**dropcache** [--all]
-   Tell the local KVS to drop any cache it is holding. If *--all* is
-   specified, send an event across the Flux instance instructing all KVS
-   modules to drop their caches.
+.. option:: -t, --treeobj
 
-**version** [-N ns]
-   Display the current KVS version, an integer value. The version starts
-   at zero and is incremented on each KVS commit. Note that some commits
-   may be aggregated for performance and the version will be incremented
-   once for the aggregation, so it cannot be used as a direct count of
-   commit requests. Specify an alternate namespace to retrieve the
-   version from via *-N*.
+  Display RFC 11 tree object.
 
-**wait** [-N ns] *version*
-   Block until the KVS version reaches *version* or greater. A simple form
-   of synchronization between peers is: node A puts a value, commits it,
-   reads version, sends version to node B. Node B waits for version, gets
-   value.
+.. option:: -a, --at=TREEOBJ
 
-**getroot** [-N ns] [-s \| -o \| -b]
-   Retrieve the current KVS root, displaying it as an RFC 11 dirref object.
-   Specify an alternate namespace to retrieve from via *-N*. If *-o* is
-   specified, display the namespace owner. If *-s* is specified, display
-   the root sequence number.  If *-b* is specified, display the root blobref.
+  Perform the lookup relative to a directory reference in RFC 11 tree object
+  format.
 
-**eventlog get** [-N ns] [-W] [-w] [-c count] [-u] *key*
-   Display the contents of an RFC 18 KVS eventlog referred to by *key*.
-   If *-u* is specified, display the log in raw form. If *-W* is
-   specified and the eventlog does not exist, wait until it has been
-   created. If *-w* is specified, after the existing contents have
-   been displayed, the eventlog is monitored and updates are displayed
-   as they are committed.  This runs until the program is interrupted
-   or an error occurs, unless the number of events is limited with the
-   *-c* option. Specify an alternate namespace to display from via
-   *-N*.
+.. option:: -l, --label
 
-**eventlog append** [-N ns] [-t SECONDS] *key* *name* [*context* ...]
-   Append an event to an RFC 18 KVS eventlog referred to by *key*.
-   The event *name* and optional *context* are specified on the command line.
-   The timestamp may optionally be specified with *-t* as decimal seconds since
-   the UNIX epoch (UTC), otherwise the current wall clock is used.
-   Specify an alternate namespace to append to via *-N*.
+  Add *key=* prefix to output.
 
-**eventlog wait-event** [-N ns] [-t SECONDS] [-u] [-W] [-q] [-v] *key* *event*
-   Wait for a specific *event* to occur in an RFC 18 KVS eventlog
-   referred to by *key*.  If *-t* is specified, timeout after
-   *SECONDS* if the event has not occurred.  If *-u* is specified,
-   display the log in raw form. If *-W* is specified and the eventlog
-   does not exist, wait until it has been created. If *-q* is
-   specified, not output the matched event.  If *-v* is specified,
-   output all events prior to the matched event.  This runs until the
-   program is interrupted, the event occurs, or a timeout occurs if
-   *-t* is specified.  Specify an alternate namespace to display from
-   via *-N*.
+.. option:: -W, --waitcreate
+
+  If the key does not exist, wait until it does, then return its value.
+
+.. option:: -w, --watch
+
+  Display the initial value for *key*, then watch for changes and display
+  each new value until interrupted or :option:`--count=N` is reached.
+
+.. option:: -c, --count=N
+
+  With :option:`--watch`, display *N* values then exit.
+
+.. option:: -u, --uniq
+
+  With :option:`--watch`, suppress output when value is the same, even
+  if the watched key was the target of a KVS commit.
+
+.. option:: -A, --append
+
+  With :option:`--watch`, display only the new data when the watched
+  value is appended to.
+
+.. option:: -f, --full
+
+  With :option:`--watch`, monitor key changes with more complete accuracy.
+
+  By default, only a direct write to a key is monitored, thus changes that
+  occur indirectly could be missed, such as when the parent directory is
+  replaced.  The :option:`--full` option ensures these changes are reported
+  as well, at greater overhead.
+
+put
+---
+
+.. program:: flux kvs put
+
+Set *key* to *value*.  If *key* exists, the current value is overwritten.
+If multiple *key=value* pairs are specified, they are sent as one
+commit and succeed or fail atomically.
+
+.. option:: -O, --treeobj-root
+
+   After the commit has completed, display the new root directory reference
+   in RFC 11 tree object format.
+
+.. option:: -b, --blobref
+
+   After the commit has completed, display the new root directory reference
+   as a single blobref.
+
+.. option:: -s, --sequence
+
+   After the commit has completed, display the new root sequence number
+   or "version".
+
+.. option:: -r, --raw
+
+   Store *value* as-is, without adding NUL termination.
+   If *value* is ``-``, read it from standard input.
+   *value* may include embedded NUL bytes.
+
+.. option:: -t, --treeobj
+
+   Interpret *value* as an RFC 11 tree object to be stored directly.
+   If *value* is ``-``, read it from standard input.
+
+.. option:: -n, --no-merge
+
+   Set the ``NO_MERGE`` flag on the commit to ensure it is not combined with
+   other commits.  The KVS normally combines contemporaneous commits to save
+   work, but since commits succeed or fail atomically, this a commit could
+   fail due to collateral damage.  This option prevents that from happening.
+
+.. option:: -A, --append
+
+   Append *value* to key's existing value, if any, instead of overwriting it.
+
+.. option:: -S, --sync
+
+   After the commit has completed, flush pending content and checkpoints
+   to disk.  Commits normally complete with data in memory, which ensures a
+   subsequent :command:`flux kvs get` would receive the updated value, but
+   does not ensure it persists across a Flux instance crash.  This can be
+   used to ensure critical data has been written to non-volatile storage.
+
+dir
+---
+
+.. program:: flux kvs dir
+
+Display all keys and their values under the directory *key*.  Values that
+are too long to fit the terminal width are truncated with "..." appended.
+This command fails if *key* does not exist or is not a directory.
+If *key* is not provided, ``.`` (root of the namespace) is assumed.
+
+.. option:: -R, --recursive
+
+  Recursively display keys under subdirectories.
+
+.. option:: -d, --directory
+
+  List directory entries but not values.
+
+.. option:: -w, --width=N
+
+  Truncate values to fit in *N* columns instead of the terminal width.
+  Specify 0 to avoid truncation entirely.
+
+.. option:: -a, --at=TREEOBJ
+
+  Perform the directory lookup relative to a directory reference in
+  RFC 11 tree object format.
+
+ls
+--
+
+.. program:: flux kvs ls
+
+Display directory referred to by *key*, or "." (root) if unspecified.  This
+sub-command is intended to mimic :linux:man1:`ls` behavior in a limited way.
+
+.. option:: -R, --recursive
+
+  List directory recursively.
+
+.. option:: -d, --directory
+
+  List directory instead of contents.
+
+.. option:: -w, --width=N
+
+  Limit output width to *N* columns.  Specify 0 for unlimited output width.
+
+.. option:: -1, --1
+
+  Force one entry per line.
+
+.. option:: -F, --classify
+
+  Append key type indicator to key: ``.`` for directory.  ``@`` for
+  symbolic link.
+
+unlink
+------
+
+.. program:: flux kvs unlink
+
+Remove key from the KVS.
+
+.. option:: -O, --treeobj-root
+
+   After the commit has completed, display the new root directory reference
+   in RFC 11 tree object format.
+
+.. option:: -b, --blobref
+
+   After the commit has completed, display the new root directory reference
+   as a single blobref.
+
+.. option:: -s, --sequence
+
+   After the commit has completed, display the new root sequence number
+   or "version".
+
+.. option:: -R, --recursive
+
+   Specify recursive removal of a directory.
+
+.. option:: -f, --force
+
+   Ignore nonexistent keys.
+
+link
+----
+
+.. program:: flux kvs link
+
+Create a new name for *target*, similar to a symbolic link.  *target* does not
+have to exist.  If *linkname* exists, it is overwritten.
+
+.. option:: -T, --target-namespace=NAME
+
+  Specify an alternate namespace for *target*.  By default, *target* is
+  in the same namespace as *linkname*.
+
+.. option:: -O, --treeobj-root
+
+   After the commit has completed, display the new root directory reference
+   in RFC 11 tree object format.
+
+.. option:: -b, --blobref
+
+   After the commit has completed, display the new root directory reference
+   as a single blobref.
+
+.. option:: -s, --sequence
+
+   After the commit has completed, display the new root sequence number
+   or "version".
+
+readlink
+---------
+
+.. program:: flux kvs readlink
+
+Print the symbolic link target of *key*.  The target may be another key name,
+or a :option:`namespace::key` tuple.  It is an error if *key* is not a
+symbolic link.
+
+.. option:: -a, --at=TREEOBJ
+
+  Perform the lookup relative to a directory reference in RFC 11 tree object
+  format.
+
+.. option:: -o, --namespace-only
+
+  Print only the namespace name if the target has a namespace prefix.
+
+.. option:: -k, --key-only
+
+  Print only the key if the target has a namespace prefix.
+
+mkdir
+-----
+
+.. program:: flux kvs mkdir
+
+Create an empty directory. If *key* exists, it is overwritten.
+
+.. option:: -O, --treeobj-root
+
+   After the commit has completed, display the new root directory reference
+   in RFC 11 tree object format.
+
+.. option:: -b, --blobref
+
+   After the commit has completed, display the new root directory reference
+   as a single blobref.
+
+.. option:: -s, --sequence
+
+   After the commit has completed, display the new root sequence number
+   or "version".
+
+dropcache
+---------
+
+.. program:: flux kvs dropcache
+
+Tell the local KVS to drop any cache it is holding.
+
+.. option:: -a, --all
+
+  Publish an event across the Flux instance instructing the KVS module on
+  all ranks to drop their caches.
+
+copy
+----
+
+.. program:: flux kvs copy
+
+Copy *source* key to *destination* key.  If a directory is copied, a new
+reference is created.
+
+.. option:: -S, --src-namespace=NAME
+
+  Specify the source namespace.  By default, the primary KVS namespace
+  or the value of :envvar:`FLUX_KVS_NAMESPACE` is used.
+
+.. option:: -D, --dst-namespace=NAME
+
+  Specify the destination namespace.  By default, the primary KVS namespace
+  or the value of :envvar:`FLUX_KVS_NAMESPACE` is used.
+
+move
+----
+
+.. program:: flux kvs move
+
+Copy *source* key to *destination* key and unlink *source*.
+
+.. option:: -S, --src-namespace=NAME
+
+  Specify the source namespace.  By default, the primary KVS namespace
+  or the value of :envvar:`FLUX_KVS_NAMESPACE` is used.
+
+.. option:: -D, --dst-namespace=NAME
+
+  Specify the destination namespace.  By default, the primary KVS namespace
+  or the value of :envvar:`FLUX_KVS_NAMESPACE` is used.
+
+getroot
+-------
+
+.. program:: flux kvs getroot
+
+Retrieve the current KVS root directory reference, displaying it as an
+RFC 11 dirref object unless otherwise specified.
+
+.. option:: -o, --owner
+
+   Display the numerical user ID that owns the target namespace.
+
+.. option:: -b, --blobref
+
+   Display the root directory reference as a single blobref.
+
+.. option:: -s, --sequence
+
+   Display the root sequence number or "version".
+
+version
+-------
+
+.. program:: flux kvs version
+
+Display the current KVS version, an integer value. The version starts
+at zero and is incremented on each KVS commit. Note that some commits
+may be aggregated for performance and the version will be incremented
+once for the aggregation, so it cannot be used as a direct count of
+commit requests.
+
+wait
+----
+
+.. program:: flux kvs wait
+
+Block until the KVS version reaches *version* or greater. A simple form
+of synchronization between peers is: node A puts a value, commits it,
+reads version, sends version to node B. Node B waits for version, gets value.
+
+namespace create
+----------------
+
+.. program:: flux kvs namespace create
+
+Create a new KVS namespace.
+
+.. option:: -o, --owner=UID
+
+  Set the owner of the namespace to *UID*.  If unspecified, the owner is
+  set to the Flux instance owner.
+
+.. option:: -r, --rootref=TREEOBJ
+
+  Initialize namespace with specific root directory reference
+  If unspecified, an empty directory is referenced.
+
+namespace remove
+----------------
+
+.. program:: flux kvs namespace remove
+
+Remove a KVS namespace.  Removal is not guaranteed to be complete when
+the command returns.
+
+namespace list
+--------------
+
+.. program:: flux kvs namespace list
+
+List all current namespaces, with owner and flags.
+
+eventlog get
+------------
+
+.. program:: flux kvs eventlog get
+
+Display the contents of an RFC 18 KVS eventlog referred to by *key*.
+
+.. option:: -W, --waitcreate
+
+  If the key does not exist, wait until it does.
+
+.. option:: -w, --watch
+
+  Monitor the eventlog, displaying new events as they are appended.
+
+.. option:: -c, --count=N
+
+  With :option:`--watch`, exit once *N* events have been displayed.
+
+.. option:: -u, --unformatted
+
+  Display the eventlog in raw RFC 18 form.
+
+eventlog append
+---------------
+
+.. program:: flux kvs eventlog append
+
+Append an event to an RFC 18 KVS eventlog referred to by *key*.
+The event *name* and optional *context* are specified on the command line.
+
+.. option:: -t, --timestamp=SEC
+
+  Specify timestamp in decimal seconds since the UNIX epoch (UTC), otherwise
+  the current wall clock is used.
+
+
+eventlog wait-event
+-------------------
+
+.. program:: flux kvs eventlog wait-event
+
+Wait for a specific *event* to occur in an RFC 18 KVS eventlog
+referred to by *key*.
+
+.. option:: -W, --waitcreate
+
+  If the key does not exist, wait until it does.
+
+.. option:: -t, --timeout=SEC
+
+   Timeout after *SEC* if the specified event has not occurred by then.
+
+.. option:: -u, --unformatted
+
+  Display the event(s) in raw RFC 18 form.
+
+.. option:: -q, --quiet
+
+  Do not display the matched event.
+
+.. option:: -v, --verbose
+
+  Display events prior to the matched event.
 
 
 RESOURCES

--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -38,7 +38,6 @@ DESCRIPTION
 The Flux key-value store (KVS) is a simple, distributed data storage
 service used a building block by other Flux components.
 :program:`flux kvs` is a command line utility that operates on the KVS.
-It is a very thin layer on top of a C API.
 
 The Flux KVS stores values under string keys. The keys are
 hierarchical, using "." as a path separator, analogous to "/"
@@ -49,21 +48,17 @@ The KVS is distributed among the broker ranks of a Flux instance. Rank 0
 is the leader, and other ranks are caching followers. All writes are flushed
 to the leader during a commit operation. Data is stored in a hash tree
 such that every commit results in a new root hash. Each new root hash
-is multicast across the session. When followers update their root hash,
+is multicast across the Flux instance. When followers update their root hash,
 they atomically update their view to match the leader. There may be a
 delay after a commit while old data is served on a follower that has not yet
-updated its root hash, thus the Flux KVS consistency model is "eventually
-consistent". Followers cache data temporally and fault in new data through
-their parent in the overlay network.
+updated its root hash, thus the Flux KVS cache is "eventually consistent".
+Followers expire cache data after a period of disuse, and fault in new data
+through their parent in the overlay network.
 
-Different KVS namespaces can be created in which kvs values can be
-read from/written to. By default, all KVS operations operate on the
-default KVS namespace "primary". An alternate namespace can be
-specified in most kvs commands via the *--namespace* option, or by
-setting the namespace in the environment variable :envvar:`FLUX_KVS_NAMESPACE`.
-
-:program:`flux kvs` runs a KVS *COMMAND*. The possible commands and their
-arguments are described below.
+The primary KVS namespace is only accessible to the Flux instance owner.
+Other namespaces may be created and assigned to guest users.  Although the
+cache is shared across namespaces, each has an independent root directory,
+which permits commits in multiple namespaces to complete in parallel.
 
 
 COMMANDS

--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -549,3 +549,5 @@ FLUX RFC
 ========
 
 :doc:`rfc:spec_11`
+
+:doc:`rfc:spec_18`

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -806,3 +806,4 @@ maxid
 unallocated
 NUL
 ssize
+waitcreate

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -807,3 +807,5 @@ unallocated
 NUL
 ssize
 waitcreate
+unformatted
+uniq


### PR DESCRIPTION
Problem: flux-kvs(1) is hard to use as a reference.

Improve the synopsis, description, and break out sub-commands into sub-sections with properly declared options.