### PR TITLE
cli: avoid KeyError when PATH isn't set in environment

### DIFF
--- a/src/bindings/python/flux/cli/alloc.py
+++ b/src/bindings/python/flux/cli/alloc.py
@@ -169,5 +169,9 @@ class AllocCmd(base.MiniCmd):
         attach_args.append(jobid.f58.encode("utf-8", errors="surrogateescape"))
 
         # Exec flux-job attach, searching for it in FLUX_EXEC_PATH.
-        os.environ["PATH"] = os.environ["FLUX_EXEC_PATH"] + ":" + os.environ["PATH"]
+        old_path = os.environ.get("PATH")
+        os.environ["PATH"] = os.environ["FLUX_EXEC_PATH"]
+        if old_path:
+            os.environ["PATH"] += f":{old_path}"
+
         os.execvp("flux-job", attach_args)

--- a/src/bindings/python/flux/cli/run.py
+++ b/src/bindings/python/flux/cli/run.py
@@ -72,5 +72,9 @@ class RunCmd(base.SubmitBaseCmd):
         attach_args.append(jobid.f58.encode("utf-8", errors="surrogateescape"))
 
         # Exec flux-job attach, searching for it in FLUX_EXEC_PATH.
-        os.environ["PATH"] = os.environ["FLUX_EXEC_PATH"] + ":" + os.environ["PATH"]
+        old_path = os.environ.get("PATH")
+        os.environ["PATH"] = os.environ["FLUX_EXEC_PATH"]
+        if old_path:
+            os.environ["PATH"] += f":{old_path}"
+
         os.execvp("flux-job", attach_args)


### PR DESCRIPTION
Problem: If PATH is not set in the environment of the flux-run(1) and flux-alloc(1) job submission commands, they raise an unhelpful KeyError and fail to invoke `flux job attach`, leaving the job running without the interactive attach.

Do not assume PATH is set in these commands when prepending FLUX_EXEC_PATH.

Fixes #5562