### PR TITLE
improve ssh connector reliability with different installation paths

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -206,6 +206,7 @@ AC_CHECK_FUNCS( \
 # See src/common/libmissing/Makefile.am
 AC_REPLACE_FUNCS( \
   strlcpy \
+  strlcat \
   argz_add \
   envz_add \
 )

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
+	-DABS_TOP_BUILDDIR=\"${abs_top_builddir}\" \
 	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
 	$(JANSSON_CFLAGS) \

--- a/src/common/libmissing/Makefile.am
+++ b/src/common/libmissing/Makefile.am
@@ -42,6 +42,7 @@ libmissing_la_SOURCES =
 
 EXTRA_libmissing_la_SOURCES = \
 	strlcpy.h \
+	strlcat.h \
 	argz.h \
 	argz.c \
 	envz.h \

--- a/src/common/libmissing/strlcat.c
+++ b/src/common/libmissing/strlcat.c
@@ -1,0 +1,59 @@
+/*	$OpenBSD: strlcat.c,v 1.11 2003/06/17 21:56:24 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#if defined(LIBC_SCCS) && !defined(lint)
+static char *rcsid = "$OpenBSD: strlcat.c,v 1.11 2003/06/17 21:56:24 millert Exp $";
+#endif /* LIBC_SCCS and not lint */
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Appends src to string dst of size siz (unlike strncat, siz is the
+ * full size of dst, not space left).  At most siz-1 characters
+ * will be copied.  Always NUL terminates (unless siz <= strlen(dst)).
+ * Returns strlen(src) + MIN(siz, strlen(initial dst)).
+ * If retval >= siz, truncation occurred.
+ */
+size_t
+strlcat(char *dst, const char *src, size_t siz)
+{
+	register char *d = dst;
+	register const char *s = src;
+	register size_t n = siz;
+	size_t dlen;
+
+	/* Find the end of dst and adjust bytes left but don't go past end */
+	while (n-- != 0 && *d != '\0')
+		d++;
+	dlen = d - dst;
+	n = siz - dlen;
+
+	if (n == 0)
+		return(dlen + strlen(s));
+	while (*s != '\0') {
+		if (n != 1) {
+			*d++ = *s;
+			n--;
+		}
+		s++;
+	}
+	*d = '\0';
+
+	return(dlen + (s - src));	/* count does not include NUL */
+}

--- a/src/common/libmissing/strlcat.h
+++ b/src/common/libmissing/strlcat.h
@@ -1,0 +1,17 @@
+#if HAVE_CONFIG_H
+#  include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#if !_MISSING_STRLCAT_H
+#define _MISSING_STRLCAT_H
+
+size_t strlcat(char *dst, const char *src, size_t siz);
+/*
+ *  Appends src to string dst of size siz (unlike strncat, siz is the
+ *    full size of dst, not space left).  At most siz-1 characters
+ *    will be copied.  Always NUL terminates (unless siz <= strlen(dst)).
+ *  Returns strlen(src) + MIN(siz, strlen(initial dst)).
+ *  If retval >= siz, truncation occurred.
+ */
+
+#endif // !_MISSING_STRLCAT

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -274,10 +274,10 @@ flux_t *connector_init (const char *path, int flags, flux_error_t *errp)
      * inside flux_open() rather than in some less obvious context later.
      */
     if (!(ctx->uclient = usock_client_create (popen2_get_fd (ctx->p)))) {
-        char *buf = NULL;
-        if (read_all (popen2_get_stderr_fd (ctx->p), (void **) &buf) > 0)
-            errprintf (errp, "%s", strstrip (buf));
-        free (buf);
+        char *data = NULL;
+        if (read_all (popen2_get_stderr_fd (ctx->p), (void **) &data) > 0)
+            errprintf (errp, "%s", strstrip (data));
+        free (data);
         goto error;
     }
     if (!(ctx->h = flux_handle_create (ctx, &handle_ops, flags)))

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -18,6 +18,7 @@
 #else
 #include "src/common/libmissing/argz.h"
 #endif
+#include <libgen.h>
 #include <flux/core.h>
 
 #include "src/common/libutil/popen2.h"
@@ -26,6 +27,12 @@
 #include "src/common/libutil/read_all.h"
 #include "src/common/libutil/strstrip.h"
 #include "src/common/libyuarel/yuarel.h"
+#ifndef HAVE_STRLCPY
+#include "src/common/libmissing/strlcpy.h"
+#endif
+#ifndef HAVE_STRLCAT
+#include "src/common/libmissing/strlcat.h"
+#endif
 #include "src/common/librouter/usock.h"
 
 struct ssh_connector {
@@ -77,7 +84,7 @@ static void op_fini (void *impl)
     }
 }
 
-static char *which (const char *prog, char *buf, size_t size)
+static const char *which_dir (const char *prog, char *buf, size_t size)
 {
     char *path = getenv ("PATH");
     char *cpy = path ? strdup (path) : NULL;
@@ -91,7 +98,7 @@ static char *which (const char *prog, char *buf, size_t size)
             if (stat (buf, &sb) == 0
                 && S_ISREG (sb.st_mode)
                 && access (buf, X_OK) == 0) {
-                result = buf;
+                result = dirname (buf);
                 break;
             }
             a1 = NULL;
@@ -99,6 +106,46 @@ static char *which (const char *prog, char *buf, size_t size)
     }
     free (cpy);
     return result;
+}
+
+static int make_path (char *path, size_t size, const char *sockpath)
+{
+    char *sockpath_cpy;
+    char buf[1024];
+    const char *rundir;
+    const char *bindir;
+    int rc = -1;
+
+    if (strlcpy (path, "PATH=", size) >= size
+        || !(sockpath_cpy = strdup (sockpath)))
+        return -1;
+
+    // append rundir/bin
+    rundir = dirname (sockpath_cpy);
+    if (rundir[0] != '/') {
+        if (strlcat (path, "/", size) >= size)
+            goto error;
+    }
+    if (strlcat (path, rundir, size) >= size)
+        goto error;
+    if (strlcat (path, "/bin", size) >= size)
+        goto error;
+
+    // append directory in which flux(1) was found locally
+    if ((bindir = which_dir ("flux", buf, sizeof (buf)))) {
+        if (strlcat (path, ":", size) >= size)
+            goto error;
+        if (strlcat (path, bindir, size) >= size)
+            goto error;
+    }
+
+    // append system bin so libtool wrappers can work if necessary
+    if (strlcat (path, ":/bin:/usr/bin", size) >= size)
+        goto error;
+    rc = 0;
+error:
+    free (sockpath_cpy);
+    return rc;
 }
 
 /* uri_path is interpreted as:
@@ -155,10 +202,21 @@ int build_ssh_command (const char *uri_path,
             goto nomem;
     }
 
-    /* LD_LIBRARY_PATH */
-    if (ld_lib_path) {
+    /* [env] */
+    if (ld_lib_path || !flux_cmd) {
         if (argz_add (&argz, &argz_len, "env") != 0)
             goto nomem;
+    }
+    /* [PATH=remote_path] */
+    if (!flux_cmd) {
+        if (make_path (buf, sizeof (buf), yuri.path) == 0) {
+            if (argz_add (&argz, &argz_len, buf) != 0)
+                goto nomem;
+        }
+        flux_cmd = "flux";
+    }
+    /* [LD_LIBRARY_PATH=ld_lib_path] */
+    if (ld_lib_path) {
         (void)snprintf (buf, sizeof (buf), "LD_LIBRARY_PATH=%s", ld_lib_path);
         if (argz_add (&argz, &argz_len, buf) != 0)
             goto nomem;
@@ -199,7 +257,6 @@ error:
 flux_t *connector_init (const char *path, int flags, flux_error_t *errp)
 {
     struct ssh_connector *ctx;
-    char buf[PATH_MAX + 1];
     const char *ssh_cmd;
     const char *flux_cmd;
     const char *ld_lib_path;
@@ -215,15 +272,10 @@ flux_t *connector_init (const char *path, int flags, flux_error_t *errp)
      */
     if (!(ssh_cmd = getenv ("FLUX_SSH")))
         ssh_cmd = PATH_SSH;
-    /* FLUX_SSH_RCMD may be used to select a different path to the flux
-     * command front end than the default.  The default is to use the one
-     * from the client's PATH.
+    /* FLUX_SSH_RCMD may be used to force a specific path to the flux
+     * command front end.
      */
     flux_cmd = getenv ("FLUX_SSH_RCMD");
-    if (!flux_cmd)
-        flux_cmd = which ("flux", buf, sizeof (buf));
-    if (!flux_cmd)
-        flux_cmd = "flux"; // maybe this will work for installed version
 
     /* ssh and rsh do not forward environment variables, thus LD_LIBRARY_PATH
      * is not guaranteed to be set on the remote node where the flux command is

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -87,7 +87,7 @@ test_expect_success 'flux-proxy forwards LD_LIBRARY_PATH' '
 		export FLUX_SSH=./proxinator.sh &&
 		test_must_fail flux proxy ssh://hostname/baz/local) &&
 	test_debug "cat ./proxinator.log" &&
-	grep -E "ssh.* LD_LIBRARY_PATH=[^ ]*:?/foo .*/flux relay" ./proxinator.log
+	grep -E "ssh.* LD_LIBRARY_PATH=[^ ]*:?/foo .*flux relay" ./proxinator.log
 '
 
 test_expect_success 'set bogus broker version' '

--- a/t/t1106-ssh-connector.t
+++ b/t/t1106-ssh-connector.t
@@ -90,26 +90,35 @@ test_expect_success 'ssh:// cannot shadow a broker service (EEXIST)' "
 "
 
 test_expect_success 'ssh:// with bad query option fails in flux_open()' '
-	! FLUX_URI=ssh://localhost$TEST_SOCKDIR?badarg=bar FLUX_SSH=$TEST_SSH \
-	  flux getattr size 2>badarg.out &&
+	test_must_fail env \
+	    FLUX_URI=ssh://localhost$TEST_SOCKDIR?badarg=bar \
+	    FLUX_SSH=$TEST_SSH \
+	    flux getattr size 2>badarg.out &&
 	grep -q "flux_open:" badarg.out
 '
 
 test_expect_success 'ssh:// with bad FLUX_SSH value fails in flux_open()' '
-	! FLUX_URI=ssh://localhost$TEST_SOCKDIR FLUX_SSH=/noexist \
-	  flux getattr size 2>noexist.out &&
+	test_must_fail env \
+	    FLUX_URI=ssh://localhost$TEST_SOCKDIR \
+	    FLUX_SSH=/noexist \
+	    flux getattr size 2>noexist.out &&
 	grep -q "flux_open:" noexist.out
 '
 
 test_expect_success 'ssh:// with bad FLUX_SSH_RCMD value fails in flux_open()' '
-	! FLUX_URI=ssh://localhost$TEST_SOCKDIR FLUX_SSH=$TEST_SSH \
-	  FLUX_SSH_RCMD=/nocmd flux getattr size 2>nocmd.out &&
+	test_must_fail env \
+	    FLUX_URI=ssh://localhost$TEST_SOCKDIR \
+	    FLUX_SSH=$TEST_SSH \
+	    FLUX_SSH_RCMD=/nocmd \
+	    flux getattr size 2>nocmd.out &&
 	grep -q "flux_open:" nocmd.out
 '
 
 test_expect_success 'ssh:// with missing path component fails in flux_open()' '
-	! FLUX_URI=ssh://localhost FLUX_SSH=$TEST_SSH \
-	  flux getattr size 2>nopath.out &&
+	test_must_fail env \
+	    FLUX_URI=ssh://localhost \
+	    FLUX_SSH=$TEST_SSH \
+	    flux getattr size 2>nopath.out &&
 	grep -q "flux_open:" nopath.out
 '
 

--- a/t/t1106-ssh-connector.t
+++ b/t/t1106-ssh-connector.t
@@ -12,6 +12,22 @@ export TEST_SOCKDIR=$(echo $FLUX_URI | sed -e "s!local://!!") &&
 export TEST_SSH=${SHARNESS_TEST_SRCDIR}/scripts/tssh
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
+extract_env_command() {
+	grep cmd= \
+	    | sed s/cmd=\"env\ // \
+	    | sed s/\ flux\ relay.*// \
+	    | xargs -n1
+}
+
+test_expect_success 'rundir/bin directory exists' '
+	test -d $(dirname $TEST_SOCKDIR)/bin
+'
+test_expect_success 'rundir/bin/flux symlink exists' '
+	test -h $(dirname $TEST_SOCKDIR)/bin/flux
+'
+test_expect_success 'rundir/bin/flux points to an executable' '
+	test -x $(dirname $TEST_SOCKDIR)/bin/flux
+'
 test_expect_success 'load heartbeat module with fast rate' '
         flux module load heartbeat period=0.1s
 '
@@ -20,6 +36,31 @@ test_expect_success 'ssh:// with local sockdir works' '
 	  flux getattr size 2>basic.err &&
 	  grep hostname=localhost basic.err &&
 	  grep cmd= basic.err | grep "flux relay $TEST_SOCKDIR"
+'
+test_expect_success 'remote PATH is set' '
+	extract_env_command <basic.err >basic.env &&
+	grep -q "^PATH=" basic.env
+'
+test_expect_success 'remote PATH has rundir/bin first' '
+	grep -q "^PATH=$(dirname $TEST_SOCKDIR)/bin:" basic.env
+'
+test_expect_success 'remote PATH includes local flux bindir' '
+	fbindir=$(dirname $(which flux)) &&
+	grep -q "^PATH=.*:$fbindir" basic.env
+'
+test_expect_success 'remote PATH includes system bindirs' '
+	grep -q "^PATH=.*:/bin:/usr/bin" basic.env
+'
+# N.B. ensure LD_LIBRARY_PATH is set so env(1) is used when PATH is not set
+# For in tree testing it is set by libtool wrappers
+test_expect_success 'ssh:// with FLUX_SSH_RCMD does not set remote PATH' '
+	env FLUX_URI=ssh://localhost$TEST_SOCKDIR \
+	    FLUX_SSH=$TEST_SSH \
+	    FLUX_SSH_RCMD=flux \
+	    LD_LIBRARY_PATH=${LD_LIBRARY_PATH=-/foo/bar} \
+	    flux getattr size 2>basic_rcmd.err &&
+	extract_env_command <basic_rcmd.err >basic_rcmd.env &&
+	test_must_fail grep "^PATH=" basic_rcmd.env
 '
 test -x /bin/tcsh && test_set_prereq HAVE_TCSH
 test_expect_success HAVE_TCSH 'ssh:// with local sockdir and SHELL=tcsh works' '

--- a/t/t1106-ssh-connector.t
+++ b/t/t1106-ssh-connector.t
@@ -57,7 +57,7 @@ test_expect_success 'ssh:// with local sockdir, user, and port works' '
 
 test_expect_success 'ssh:// can handle nontrivial message load' '
 	FLUX_URI=ssh://localhost$TEST_SOCKDIR FLUX_SSH=$TEST_SSH \
-	  flux ping --count=100 -i 0.001 broker
+	  flux ping --count=100 -i 0.001 broker >/dev/null
 '
 
 test_expect_success 'ssh:// can work with events' '

--- a/t/t1106-ssh-connector.t
+++ b/t/t1106-ssh-connector.t
@@ -26,9 +26,9 @@ test_expect_success HAVE_TCSH 'ssh:// with local sockdir and SHELL=tcsh works' '
 	FLUX_URI=ssh://localhost${TEST_SOCKDIR} \
 	FLUX_SSH=$TEST_SSH \
 	SHELL=/bin/tcsh \
-	  flux getattr size 2>basic.err &&
-	  grep hostname=localhost basic.err &&
-	  grep cmd= basic.err | grep "flux relay $TEST_SOCKDIR"
+	  flux getattr size 2>basic_tcsh.err &&
+	  grep hostname=localhost basic_tcsh.err &&
+	  grep cmd= basic_tcsh.err | grep "flux relay $TEST_SOCKDIR"
 '
 
 test_expect_success 'ssh:// with local sockdir and port works' '


### PR DESCRIPTION
Problem: the ssh connector tries to remotely execute `flux-relay` using a path derived from the local flux installation.  This tends not to work well when the remote flux is installed to a different path, as was encountered in #5582.

This  PR improves the odds of getting it right with the following changes:
1. the broker places a symlink to its bindir in `rundir/bin`
2. the ssh connector derives `rundir` from the `ssh://` URI and places `rundir/bin` first in the remote PATH

The local directory that contains `flux(1)` is appended to the remote PATH, so that there should be no change in behavior when using `flux proxy` to an older version of flux that doesn't have this feature.  `/usr/bin:/bin` is also appended so `flux(1)` can be a libtool wrapper (the wrapper scripts need to run some basic commands).

The remote command path can still be overridden by setting `FLUX_SSH_RCMD`.

Fixes #5583

(Marking WIP as tests are needed, but feedback welcome)