### PR TITLE
job-info: support jobspec in update lookup/watch

### DIFF
--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -159,6 +159,7 @@ class TestJob(unittest.TestCase):
         data = rpc.get()
         self.check_jobspec_str(data, self.jobid1, 0)
         data = rpc.get_decode()
+        self.check_jobspec_decoded(data, self.jobid1, 0)
         self.assertEqual(data["id"], self.jobid1, 0)
 
     def test_info_01_job_info_lookup_keys(self):

--- a/t/t2233-job-info-update.t
+++ b/t/t2233-job-info-update.t
@@ -267,6 +267,58 @@ test_expect_success NO_CHAIN_LINT 'job-info: update lookup returns cached R from
 '
 
 #
+# update-lookup/watch works with jobspec
+#
+
+# Usage: check_duration jobid VALUE
+# Check and wait for duration to reach VALUE.
+#
+check_duration() {
+       local jobid=$1
+       local value=$2
+       local i=0
+       while (! ${UPDATE_LOOKUP} ${jobid} jobspec | jq -e ".attributes.system.duration == ${value}" \
+	       && [ $i -lt 200 ] )
+       do
+	       sleep 0.1
+	       i=$((i + 1))
+       done
+       if [ "$i" -eq "200" ]
+       then
+	       return 1
+       fi
+       return 0
+}
+
+test_expect_success 'job-info: update lookup works with jobspec' '
+	jobid=$(flux submit --urgency=hold true) &&
+	check_duration $jobid 0 &&
+	flux update $jobid duration=100s &&
+	check_duration $jobid 100.0 &&
+	flux update $jobid duration=200s &&
+	check_duration $jobid 200.0 &&
+	flux cancel $jobid
+'
+
+test_expect_success NO_CHAIN_LINT 'job-info: update watch works with jobspec' '
+	jobid=$(flux submit --urgency=hold true) &&
+	flux update $jobid duration=100s &&
+	watchers=$(get_update_watchers)
+	${UPDATE_WATCH} $jobid jobspec > watchjobspec.out &
+	watchpid=$! &&
+	wait_update_watchers $((watchers+1)) &&
+	${WAITFILE} --count=1 --timeout=30 --pattern="duration" watchjobspec.out &&
+	flux update $jobid duration=200s &&
+	${WAITFILE} --count=2 --timeout=30 --pattern="duration" watchjobspec.out &&
+	flux cancel $jobid &&
+	wait $watchpid &&
+	test $(cat watchjobspec.out | wc -l) -eq 2 &&
+	head -n1 watchjobspec.out | jq -e ".attributes.system.duration == 100.0" &&
+	tail -n1 watchjobspec.out | jq -e ".attributes.system.duration == 200.0"
+'
+
+
+#
 # security tests
 #
 
@@ -284,6 +336,7 @@ test_expect_success 'job-info: non job owner cannot lookup key' '
 	jobid=`flux submit --wait-event=start sleep inf` &&
 	set_userid 9999 &&
 	test_must_fail ${UPDATE_LOOKUP} $jobid R &&
+	test_must_fail ${UPDATE_LOOKUP} $jobid jobspec &&
 	unset_userid &&
 	flux cancel $jobid
 '
@@ -292,6 +345,7 @@ test_expect_success 'job-info: non job owner cannot watch key' '
 	jobid=`flux submit --wait-event=start sleep inf` &&
 	set_userid 9999 &&
 	test_must_fail ${UPDATE_WATCH} $jobid R &&
+	test_must_fail ${UPDATE_WATCH} $jobid jobspec &&
 	unset_userid &&
 	flux cancel $jobid
 '


### PR DESCRIPTION
Problem: It is inconvenient that update-lookup and update-watch support reading an updated R but not an updated jobspec.

Support returning an updated jobspec in update-lookup and update-watch.

Notes:

I've separated this out into this own PR because there is a downside to this, although it's probably low.  Dunno if we shouldn't do this.

Pro: it "makes sense" to do this since we're already doing it for `R` and reduce code in other places

Con: unlike an "updated R", this isn't really used by anything else core in flux.  It's just for generic queries ... so we're moving burden of "updated jobspec" into the broker and away from userspace.  So when users do `flux job info jobspec` or `job_info_lookup()` in python, there's more work in the broker now.