### PR TITLE
python: remove manual jobspec/R updates

### DIFF
--- a/src/bindings/python/flux/job/__init__.py
+++ b/src/bindings/python/flux/job/__init__.py
@@ -15,7 +15,12 @@ from flux.job.kill import kill_async, kill, cancel_async, cancel
 from flux.job.submit import submit_async, submit, submit_get_id
 from flux.job.info import JobInfo, JobInfoFormat, job_fields_to_attrs
 from flux.job.list import job_list, job_list_inactive, job_list_id, JobList, get_job
-from flux.job.kvslookup import job_info_lookup, JobKVSLookup, job_kvs_lookup
+from flux.job.kvslookup import (
+    job_info_lookup,
+    job_info_update_lookup,
+    JobKVSLookup,
+    job_kvs_lookup,
+)
 from flux.job.wait import wait_async, wait, wait_get_status, result_async, result
 from flux.job.event import (
     event_watch_async,

--- a/src/bindings/python/flux/job/kvslookup.py
+++ b/src/bindings/python/flux/job/kvslookup.py
@@ -12,10 +12,8 @@ import json
 
 from _flux._core import ffi, lib
 from flux.future import WaitAllFuture
-from flux.job import JobID, JobspecV1
-from flux.job.event import EventLogEvent
+from flux.job import JobID
 from flux.rpc import RPC
-from flux.util import set_treedict
 
 
 def _decode_field(data, key):
@@ -87,19 +85,61 @@ def job_info_update_lookup(flux_handle, jobid, key="jobspec"):
     return rpc
 
 
-def _setup_lookup_keys(keys, original, base):
+# Convenience class, wraps JobInfoLookupRPC and JobInfoUpdateLookupRPC RPCs.
+class JobInfoWrapLookupRPC(WaitAllFuture):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.jobid = None
+
+    def _get(self, decode):
+        data = {}
+        #  Wait for all RPCs to complete
+        self.wait_for()
+        for child in self.children:
+            if decode:
+                childdata = child.get_decode()
+            else:
+                childdata = child.get()
+            data.update(childdata)
+        return data
+
+    def get(self):
+        return self._get(decode=False)
+
+    def get_decode(self):
+        return self._get(decode=True)
+
+
+# Convenience class, wraps calls to job_info_lookup() and
+# job_info_update_lookup() dependent on input keys and base value.
+def job_info_wrap_lookup(flux_handle, jobid, keys=["jobspec"], base=False):
+    tmpkeys = list(keys)
+    wraprpc = JobInfoWrapLookupRPC()
+    wraprpc.jobid = jobid
+    if not base:
+        if "jobspec" in tmpkeys:
+            payload = {"id": int(jobid), "key": "jobspec", "flags": 0}
+            rpc = JobInfoUpdateLookupRPC(flux_handle, "job-info.update-lookup", payload)
+            wraprpc.push(rpc)
+            tmpkeys.remove("jobspec")
+        if "R" in tmpkeys:
+            payload = {"id": int(jobid), "key": "R", "flags": 0}
+            rpc = JobInfoUpdateLookupRPC(flux_handle, "job-info.update-lookup", payload)
+            wraprpc.push(rpc)
+            tmpkeys.remove("R")
+    if tmpkeys:
+        payload = {"id": int(jobid), "keys": tmpkeys, "flags": 0}
+        rpc = JobInfoLookupRPC(flux_handle, "job-info.lookup", payload)
+        wraprpc.push(rpc)
+    return wraprpc
+
+
+def _setup_lookup_keys(keys, original):
     if "jobspec" in keys:
         if original:
             keys.remove("jobspec")
             if "J" not in keys:
                 keys.append("J")
-        elif not base:
-            if "eventlog" not in keys:
-                keys.append("eventlog")
-    if "R" in keys:
-        if not base:
-            if "eventlog" not in keys:
-                keys.append("eventlog")
 
 
 def _get_original_jobspec(job_data):
@@ -110,36 +150,7 @@ def _get_original_jobspec(job_data):
     return result.decode("utf-8")
 
 
-def _get_updated_jobspec(job_data):
-    if isinstance(job_data["jobspec"], str):
-        data = json.loads(job_data["jobspec"])
-    else:
-        data = job_data["jobspec"]
-    jobspec = JobspecV1(**data)
-    for entry in job_data["eventlog"].splitlines():
-        event = EventLogEvent(entry)
-        if event.name == "jobspec-update":
-            for key, value in event.context.items():
-                jobspec.setattr(key, value)
-    return jobspec.dumps()
-
-
-def _get_updated_R(job_data):
-    if isinstance(job_data["R"], str):
-        R = json.loads(job_data["R"])
-    else:
-        R = job_data["R"]
-    for entry in job_data["eventlog"].splitlines():
-        event = EventLogEvent(entry)
-        if event.name == "resource-update":
-            for key, value in event.context.items():
-                if key == "expiration":
-                    set_treedict(R, "execution.expiration", value)
-    return json.dumps(R, ensure_ascii=False)
-
-
-def _update_keys(job_data, decode, keys, original, base):
-    remove_eventlog = False
+def _update_keys(job_data, decode, keys, original):
     if "jobspec" in keys:
         if original:
             job_data["jobspec"] = _get_original_jobspec(job_data)
@@ -147,21 +158,6 @@ def _update_keys(job_data, decode, keys, original, base):
                 _decode_field(job_data, "jobspec")
             if "J" not in keys:
                 job_data.pop("J")
-        elif not base:
-            job_data["jobspec"] = _get_updated_jobspec(job_data)
-            if decode:
-                _decode_field(job_data, "jobspec")
-            if "eventlog" not in keys:
-                remove_eventlog = True
-    if "R" in keys:
-        if not base:
-            job_data["R"] = _get_updated_R(job_data)
-            if decode:
-                _decode_field(job_data, "R")
-            if "eventlog" not in keys:
-                remove_eventlog = True
-    if remove_eventlog:
-        job_data.pop("eventlog")
 
 
 # jobs_kvs_lookup simple variant for one jobid
@@ -185,15 +181,14 @@ def job_kvs_lookup(
     :base: For 'jobspec' or 'R', get base value, do not apply updates from eventlog
     """
     keyslookup = list(keys)
-    _setup_lookup_keys(keyslookup, original, base)
-    payload = {"id": int(jobid), "keys": keyslookup, "flags": 0}
-    rpc = JobInfoLookupRPC(flux_handle, "job-info.lookup", payload)
+    _setup_lookup_keys(keyslookup, original)
+    rpc = job_info_wrap_lookup(flux_handle, jobid, keyslookup, base)
     try:
         if decode:
             rsp = rpc.get_decode()
         else:
             rsp = rpc.get()
-        _update_keys(rsp, decode, keys, original, base)
+        _update_keys(rsp, decode, keys, original)
     # The job does not exist!
     except FileNotFoundError:
         return None
@@ -274,7 +269,7 @@ class JobKVSLookup:
         self.original = original
         self.base = base
         self.errors = []
-        _setup_lookup_keys(self.keyslookup, self.original, self.base)
+        _setup_lookup_keys(self.keyslookup, self.original)
 
     def fetch_data(self):
         """Initiate the job info lookup to the Flux job-info module
@@ -289,7 +284,9 @@ class JobKVSLookup:
         """
         listids = JobKVSLookupFuture()
         for jobid in self.ids:
-            listids.push(job_info_lookup(self.handle, jobid, self.keyslookup))
+            listids.push(
+                job_info_wrap_lookup(self.handle, jobid, self.keyslookup, self.base)
+            )
         return listids
 
     def data(self):
@@ -308,5 +305,5 @@ class JobKVSLookup:
         if hasattr(rpc, "errors"):
             self.errors = rpc.errors
         for job_data in data:
-            _update_keys(job_data, self.decode, self.keys, self.original, self.base)
+            _update_keys(job_data, self.decode, self.keys, self.original)
         return data

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -3362,42 +3362,6 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
     return (0);
 }
 
-char *reconstruct_current_jobspec (const char *jobspec_str,
-                                   const char *eventlog_str)
-{
-    json_t *jobspec;
-    json_t *eventlog;
-    size_t index;
-    json_t *entry;
-    char *result;
-
-    if (!(jobspec = json_loads (jobspec_str, 0, NULL)))
-        log_msg_exit ("error decoding jobspec");
-    if (!(eventlog = eventlog_decode (eventlog_str)))
-        log_msg_exit ("error decoding eventlog");
-    json_array_foreach (eventlog, index, entry) {
-        const char *name;
-        json_t *context;
-
-        if (eventlog_entry_parse (entry, NULL, &name, &context) < 0)
-            log_msg_exit ("error decoding eventlog entry");
-        if (streq (name, "jobspec-update")) {
-            const char *path;
-            json_t *value;
-
-            json_object_foreach (context, path, value) {
-                if (jpath_set (jobspec, path, value) < 0)
-                    log_err_exit ("failed to update jobspec");
-            }
-        }
-    }
-    if (!(result = json_dumps (jobspec, JSON_COMPACT)))
-        log_msg_exit ("failed to encode jobspec object");
-    json_decref (jobspec);
-    json_decref (eventlog);
-    return result;
-}
-
 void info_usage (void)
 {
     fprintf (stderr,
@@ -3457,33 +3421,11 @@ int cmd_info (optparse_t *p, int argc, char **argv)
             log_msg_exit ("Failed to unwrap J to get jobspec: %s", error.text);
         val = new_val;
     }
-    /* The current (non --base) jobspec has to be reconstructed by fetching
-     * the jobspec and the eventlog and updating the former with the latter.
-     */
-    else if (!optparse_hasopt (p, "base") && streq (key, "jobspec")) {
-        const char *jobspec;
-        const char *eventlog;
-
-        // fetch the two keys in parallel
-        if (!(f = flux_rpc_pack (h,
-                                 "job-info.lookup",
-                                 FLUX_NODEID_ANY,
-                                 0,
-                                 "{s:I s:[ss] s:i}",
-                                 "id", id,
-                                 "keys", "jobspec", "eventlog",
-                                 "flags", 0))
-            || flux_rpc_get_unpack (f,
-                                    "{s:s s:s}",
-                                    "jobspec", &jobspec,
-                                    "eventlog", &eventlog) < 0)
-            log_msg_exit ("%s", future_strerror (f, errno ));
-        val = new_val = reconstruct_current_jobspec (jobspec, eventlog);
-    }
-    /* The current (non --base) R is obtained through the
+    /* The current (non --base) R and jobspec are obtained through the
      * job-info.update-lookup RPC, not the normal job-info.lookup.
      */
-    else if (!optparse_hasopt (p, "base") && streq (key, "R")) {
+    else if (!optparse_hasopt (p, "base")
+             && (streq (key, "R") || streq (key, "jobspec"))) {
         json_t *o;
         if (!(f = flux_rpc_pack (h,
                                  "job-info.update-lookup",

--- a/src/modules/job-info/update.c
+++ b/src/modules/job-info/update.c
@@ -233,7 +233,8 @@ static void eventlog_continuation (flux_future_t *f, void *arg)
 
             msg = flux_msglist_first (uc->msglist);
             while (msg) {
-                if (flux_respond_pack (uc->ctx->h, msg, "{s:O}",
+                if (flux_respond_pack (uc->ctx->h, msg, "{s:I s:O}",
+                                       "id", uc->id,
                                        uc->key, uc->update_object) < 0) {
                     flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
                     goto error_cancel;
@@ -388,7 +389,8 @@ static void lookup_continuation (flux_future_t *f, void *arg)
             goto next;
         }
 
-        if (flux_respond_pack (uc->ctx->h, msg, "{s:O}",
+        if (flux_respond_pack (uc->ctx->h, msg, "{s:I s:O}",
+                               "id", uc->id,
                                uc->key, uc->update_object) < 0) {
             flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
             goto error;
@@ -553,7 +555,8 @@ void update_lookup_cb (flux_t *h, flux_msg_handler_t *mh,
         && uc->update_object) {
         if (flux_msg_authorize (msg, uc->userid) < 0)
             goto error;
-        if (flux_respond_pack (uc->ctx->h, msg, "{s:O}",
+        if (flux_respond_pack (uc->ctx->h, msg, "{s:I s:O}",
+                               "id", uc->id,
                                uc->key, uc->update_object) < 0) {
             flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
             goto error;
@@ -630,7 +633,8 @@ void update_watch_cb (flux_t *h, flux_msg_handler_t *mh,
         if (uc->update_object) {
             if (flux_msg_authorize (msg, uc->userid) < 0)
                 goto error;
-            if (flux_respond_pack (uc->ctx->h, msg, "{s:O}",
+            if (flux_respond_pack (uc->ctx->h, msg, "{s:I s:O}",
+                                   "id", uc->id,
                                    uc->key, uc->update_object) < 0) {
                 flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
                 goto error;

--- a/t/job-info/update_watch_stream.c
+++ b/t/job-info/update_watch_stream.c
@@ -67,14 +67,23 @@ int main (int argc, char *argv[])
         log_err_exit ("signal");
 
     while (1) {
+        flux_jobid_t check_id;
         json_t *value;
         char *s;
-        if (flux_rpc_get_unpack (f, "{s:o}", key, &value) < 0) {
+
+        if (flux_rpc_get_unpack (f, "{s:I}", "id", &check_id) < 0) {
             if (errno == ENODATA)
                 break;
-            log_msg_exit ("job-info.update-watch: %s",
-                          future_strerror (f, errno));
+            log_msg_exit ("job-info.update-watch: id: %s",
+                      future_strerror (f, errno));
         }
+
+        if (id != check_id)
+            log_msg_exit ("job-info.update-watch returned invalid jobid");
+
+        if (flux_rpc_get_unpack (f, "{s:o}", key, &value) < 0)
+            log_msg_exit ("job-info.update-watch: %s: %s",
+                          key, future_strerror (f, errno));
         if (!(s = json_dumps (value, 0)))
             log_msg_exit ("invalid json result");
         printf ("%s\n", s);

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -10,6 +10,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import errno
 import json
 import os
 import unittest
@@ -181,6 +182,25 @@ class TestJob(unittest.TestCase):
         rpc = flux.job.job_info_lookup(self.fh, self.jobid1, keys=["foo"])
         with self.assertRaises(FileNotFoundError):
             rpc.get()
+
+    def test_info_00_job_info_update_lookup(self):
+        rpc = flux.job.job_info_update_lookup(self.fh, self.jobid1)
+        data = rpc.get()
+        self.check_jobspec_str(data, self.jobid1, 100.0)
+        data = rpc.get_decode()
+        self.check_jobspec_decoded(data, self.jobid1, 100.0)
+        self.assertEqual(data["id"], self.jobid1)
+
+    def test_info_01_job_info_update_lookup_badid(self):
+        rpc = flux.job.job_info_update_lookup(self.fh, 123456789)
+        with self.assertRaises(FileNotFoundError):
+            rpc.get()
+
+    def test_info_02_job_info_update_lookup_badkey(self):
+        rpc = flux.job.job_info_update_lookup(self.fh, self.jobid1, key="foo")
+        with self.assertRaises(OSError) as e:
+            rpc.get()
+        self.assertEqual(e.exception.errno, errno.EINVAL)
 
     def test_lookup_01_job_kvs_lookup(self):
         data = flux.job.job_kvs_lookup(self.fh, self.jobid1)

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -159,6 +159,7 @@ class TestJob(unittest.TestCase):
         data = rpc.get()
         self.check_jobspec_str(data, self.jobid1, 0)
         data = rpc.get_decode()
+        self.check_jobspec_decoded(data, self.jobid1, 0)
         self.assertEqual(data["id"], self.jobid1, 0)
 
     def test_info_01_job_info_lookup_keys(self):


### PR DESCRIPTION
Built on top of #5592.  Would adjust changes if we decided #5592 shouldn't go in.

Python code still manually calculated "updated jobspec" and "updated R" in code, rather than use the `job-info` "update" service.  So tried to remove that stuff.

Notes:

To my surprise, `job-info.lookup` returns encoded jobspec/R to the caller (i.e. it returns `{s:s}, "jobspec", json.dumps(jobspec)`) while `job-info.update-lookup` returns decoded data (i.e. returns `{s:o}, "jobspec", jobspec`).  This may have been an oversight in the original design.  But I elected not to change this bc the `updated-lookup/update-watch` serves a different purpose ... and there's code out there that depends on this already.  But making them consistent could be considered a wise choice.  Could be for a follow up PR.

To deal with this inconsistency I did some stuff to make `job-info.lookup` and `job-info.update-lookup` look the same in some code.

Minor note, I could technically split up the addition of the `job_info_update_lookup()` function into the Python kvslookup module.  It's a semi-independent addition, but since it's so tiny I didn't.