### PR TITLE
testsuite: improve reliability of a couple job signal/cancel tests

### DIFF
--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -694,6 +694,7 @@ test_expect_success 'flux-job: load modules for live kill tests' '
 # N.B. SIGTERM == 15
 test_expect_success 'flux-job: kill basic works' '
 	id=$(flux submit --wait-event=start sleep 100) &&
+	flux job wait-event -vt 30 -p guest.exec.eventlog $id shell.start &&
 	flux job kill ${id} &&
 	flux job wait-event -t 30 ${id} finish > kill1.out &&
 	grep status=$((15+128<<8)) kill1.out
@@ -702,6 +703,7 @@ test_expect_success 'flux-job: kill basic works' '
 # N.B. SIGUSR1 == 10
 test_expect_success 'flux-job: kill --signal works' '
 	id=$(flux submit --wait-event=start sleep 100) &&
+	flux job wait-event -vt 30 -p guest.exec.eventlog $id shell.start &&
 	flux job kill --signal=SIGUSR1 ${id} &&
 	flux job wait-event -t 30 ${id} finish > kill2.out &&
 	grep status=$((10+128<<8)) kill2.out

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -47,9 +47,10 @@ test_expect_success 'job-exec: status is maximum job shell exit codes' '
 test_expect_success 'job-exec: job exception kills job shells' '
 	id=$(flux submit -n4 -N4 sleep 300) &&
 	flux job wait-event -vt 5 $id start &&
+	flux job wait-event -vt 5 -p guest.exec.eventlog $id shell.start &&
 	flux cancel $id &&
 	flux job wait-event -vt 5 $id clean &&
-	flux job eventlog $id | grep status=15
+	flux job eventlog $id | grep -E "status=(15|36608)"
 '
 test_expect_success 'job-exec: job exception uses SIGKILL after kill-timeout' '
 	flux module reload job-exec kill-timeout=0.2 &&


### PR DESCRIPTION
This PR fixes a couple race conditions that popped up in job signal/cancel tests. I'm unsure why these races seem to have become more likely to be hit lately. Perhaps after the improvements in broker message handling? Anyway, the workarounds presented here seem to improve things in CI and my test environment.