### PR TITLE
support colorized, human-readable output from eventlog commands

### DIFF
--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -496,6 +496,16 @@ Display the contents of an RFC 18 KVS eventlog referred to by *key*.
 
   Display the eventlog in raw RFC 18 form.
 
+.. option:: -H, --human
+
+  Display the eventlog in human-readable form.
+
+.. option:: -L, --color[=WHEN]
+
+  Control output colorization. The optional argument *WHEN* can be one of
+  'auto', 'never', or 'always'. The default value of *WHEN* if omitted is
+  'always'. The default is 'auto' if the option is unused.
+
 eventlog append
 ---------------
 
@@ -537,6 +547,17 @@ referred to by *key*.
 .. option:: -v, --verbose
 
   Display events prior to the matched event.
+
+.. option:: -H, --human
+
+  Display eventlog events in human-readable form.
+
+.. option:: -L, --color[=WHEN]
+
+  Control output colorization. The optional argument *WHEN* can be one of
+  'auto', 'never', or 'always'. The default value of *WHEN* if omitted is
+  'always'. The default is 'auto' if the option is unused.
+
 
 
 RESOURCES

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -43,12 +43,6 @@ struct dmesg_ctx {
 };
 
 enum {
-    DMESG_COLOR_MODE_AUTO,
-    DMESG_COLOR_MODE_NEVER,
-    DMESG_COLOR_MODE_ALWAYS
-};
-
-enum {
     DMESG_COLOR_NAME,
     DMESG_COLOR_TIME,
     DMESG_COLOR_TIMEBREAK,

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -333,6 +333,10 @@ static struct optparse_option eventlog_opts[] =  {
     { .name = "time-format", .key = 'T', .has_arg = 1, .arginfo = "FORMAT",
       .usage = "Specify time format: raw, iso, offset",
     },
+    { .name = "human", .key = 'H', .has_arg = 0,
+      .usage = "Display human-readable output. See also --color, --format, "
+               "and --time-format.",
+    },
     { .name = "color", .key = 'L', .has_arg = 2, .arginfo = "WHEN",
       .usage = "Colorize output when supported; WHEN can be 'always' "
                "(default if omitted), 'never', or 'auto' (default)."
@@ -350,6 +354,10 @@ static struct optparse_option wait_event_opts[] =  {
     },
     { .name = "time-format", .key = 'T', .has_arg = 1, .arginfo = "FORMAT",
       .usage = "Specify time format: raw, iso, offset",
+    },
+    { .name = "human", .key = 'H', .has_arg = 0,
+      .usage = "Display human-readable output. See also --color, --format, "
+               "and --time-format.",
     },
     { .name = "timeout", .key = 't', .has_arg = 1, .arginfo = "DURATION",
       .usage = "timeout after DURATION",
@@ -551,14 +559,14 @@ static struct optparse_subcommand subcommands[] = {
       id_opts
     },
     { "eventlog",
-      "[-f text|json] [-T raw|iso|offset] [-L] [-p path] id",
+      "[-f text|json] [-T raw|iso|offset] [-HL] [-p path] id",
       "Display eventlog for a job",
       cmd_eventlog,
       0,
       eventlog_opts
     },
     { "wait-event",
-      "[-f text|json] [-T raw|iso|offset] [-L] [-t seconds] [-m key=val] [-c <num>] "
+      "[-f text|json] [-T raw|iso|offset] [-HL] [-t seconds] [-m key=val] [-c <num>] "
       "[-p path] [-W] [-q] [-v] id event",
       "Wait for an event ",
       cmd_wait_event,
@@ -3046,6 +3054,12 @@ void formatter_parse_options (optparse_t *p,
     const char *format = optparse_get_str (p, "format", "text");
     const char *time_format = optparse_get_str (p, "time-format", "raw");
     const char *when = optparse_get_str (p, "color", "auto");
+
+    if (optparse_hasopt (p, "human")) {
+        format = "text",
+        time_format = "human";
+        when = "auto";
+    }
 
     if (eventlog_formatter_set_format (evf, format) < 0)
         log_msg_exit ("invalid format type '%s'", format);

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -333,6 +333,10 @@ static struct optparse_option eventlog_opts[] =  {
     { .name = "time-format", .key = 'T', .has_arg = 1, .arginfo = "FORMAT",
       .usage = "Specify time format: raw, iso, offset",
     },
+    { .name = "color", .key = 'L', .has_arg = 2, .arginfo = "WHEN",
+      .usage = "Colorize output when supported; WHEN can be 'always' "
+               "(default if omitted), 'never', or 'auto' (default)."
+    },
     { .name = "path", .key = 'p', .has_arg = 1, .arginfo = "PATH",
       .usage = "Specify alternate eventlog path suffix "
                "(e.g. \"guest.exec.eventlog\")",
@@ -361,6 +365,10 @@ static struct optparse_option wait_event_opts[] =  {
     },
     { .name = "verbose", .key = 'v', .has_arg = 0,
       .usage = "Output all events before matched event",
+    },
+    { .name = "color", .key = 'L', .has_arg = 2, .arginfo = "WHEN",
+      .usage = "Colorize output when supported; WHEN can be 'always' "
+               "(default if omitted), 'never', or 'auto' (default)."
     },
     { .name = "path", .key = 'p', .has_arg = 1, .arginfo = "PATH",
       .usage = "Specify alternate eventlog path suffix "
@@ -543,14 +551,14 @@ static struct optparse_subcommand subcommands[] = {
       id_opts
     },
     { "eventlog",
-      "[-f text|json] [-T raw|iso|offset] [-p path] id",
+      "[-f text|json] [-T raw|iso|offset] [-L] [-p path] id",
       "Display eventlog for a job",
       cmd_eventlog,
       0,
       eventlog_opts
     },
     { "wait-event",
-      "[-f text|json] [-T raw|iso|offset] [-t seconds] [-m key=val] [-c <num>] "
+      "[-f text|json] [-T raw|iso|offset] [-L] [-t seconds] [-m key=val] [-c <num>] "
       "[-p path] [-W] [-q] [-v] id event",
       "Wait for an event ",
       cmd_wait_event,
@@ -3037,11 +3045,14 @@ void formatter_parse_options (optparse_t *p,
 {
     const char *format = optparse_get_str (p, "format", "text");
     const char *time_format = optparse_get_str (p, "time-format", "raw");
+    const char *when = optparse_get_str (p, "color", "auto");
 
     if (eventlog_formatter_set_format (evf, format) < 0)
         log_msg_exit ("invalid format type '%s'", format);
     if (eventlog_formatter_set_timestamp_format (evf, time_format) < 0)
         log_msg_exit ("invalid time-format type '%s'", time_format);
+    if (eventlog_formatter_colors_init (evf, when ? when : "always") < 0)
+        log_msg_exit ("invalid value: --color=%s", when);
 }
 
 void eventlog_continuation (flux_future_t *f, void *arg)

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -559,15 +559,14 @@ static struct optparse_subcommand subcommands[] = {
       id_opts
     },
     { "eventlog",
-      "[-f text|json] [-T raw|iso|offset] [-HL] [-p path] id",
+      "[OPTIONS] id",
       "Display eventlog for a job",
       cmd_eventlog,
       0,
       eventlog_opts
     },
     { "wait-event",
-      "[-f text|json] [-T raw|iso|offset] [-HL] [-t seconds] [-m key=val] [-c <num>] "
-      "[-p path] [-W] [-q] [-v] id event",
+      "[OPTIONS] id event",
       "Wait for an event ",
       cmd_wait_event,
       0,

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -53,8 +53,10 @@
 #include "src/common/libutil/fdutils.h"
 #include "src/common/libutil/strstrip.h"
 #include "src/common/libutil/sigutil.h"
+#include "src/common/libutil/timestamp.h"
 #include "src/common/libidset/idset.h"
 #include "src/common/libeventlog/eventlog.h"
+#include "src/common/libeventlog/formatter.h"
 #include "src/common/libioencode/ioencode.h"
 #include "src/shell/mpir/proctable.h"
 #include "src/common/libdebugged/debugged.h"
@@ -3022,111 +3024,24 @@ int cmd_namespace (optparse_t *p, int argc, char **argv)
     return 0;
 }
 
-struct entry_format {
-    const char *format;
-    const char *time_format;
-    double initial;
-};
-
-void entry_format_parse_options (optparse_t *p, struct entry_format *e)
-{
-    e->format = optparse_get_str (p, "format", "text");
-    if (strcasecmp (e->format, "text")
-        && strcasecmp (e->format, "json"))
-        log_msg_exit ("invalid format type");
-    e->time_format = optparse_get_str (p, "time-format", "raw");
-    if (strcasecmp (e->time_format, "raw")
-        && strcasecmp (e->time_format, "iso")
-        && strcasecmp (e->time_format, "offset"))
-        log_msg_exit ("invalid time-format type");
-}
-
 struct eventlog_ctx {
     optparse_t *p;
     const char *jobid;
     flux_jobid_t id;
     const char *path;
-    struct entry_format e;
+    struct eventlog_formatter *evf;
 };
 
-/* convert floating point timestamp (UNIX epoch, UTC) to ISO 8601 string,
- * with microsecond precision
- */
-static int event_timestr (struct entry_format *e, double timestamp,
-                          char *buf, size_t size)
+void formatter_parse_options (optparse_t *p,
+                              struct eventlog_formatter *evf)
 {
-    if (!strcasecmp (e->time_format, "raw")) {
-        if (snprintf (buf, size, "%lf", timestamp) >= size)
-            return -1;
-    }
-    else if (!strcasecmp (e->time_format, "iso")) {
-        time_t sec = timestamp;
-        unsigned long usec = (timestamp - sec)*1E6;
-        struct tm tm;
-        if (!gmtime_r (&sec, &tm))
-            return -1;
-        if (strftime (buf, size, "%Y-%m-%dT%T", &tm) == 0)
-            return -1;
-        size -= strlen (buf);
-        buf += strlen (buf);
-        if (snprintf (buf, size, ".%.6luZ", usec) >= size)
-            return -1;
-    }
-    else { /* !strcasecmp (e->time_format, "offset") */
-        if (e->initial == 0.)
-            e->initial = timestamp;
-        timestamp -= e->initial;
-        if (snprintf (buf, size, "%lf", timestamp) >= size)
-            return -1;
-    }
-    return 0;
-}
+    const char *format = optparse_get_str (p, "format", "text");
+    const char *time_format = optparse_get_str (p, "time-format", "raw");
 
-void output_event_text (struct entry_format *e, json_t *event)
-{
-    double timestamp;
-    const char *name;
-    json_t *context = NULL;
-    char buf[128];
-
-    if (eventlog_entry_parse (event, &timestamp, &name, &context) < 0)
-        log_err_exit ("eventlog_entry_parse");
-
-    if (event_timestr (e, timestamp, buf, sizeof (buf)) < 0)
-        log_msg_exit ("error converting timestamp to ISO 8601");
-
-    printf ("%s %s", buf, name);
-
-    if (context) {
-        const char *key;
-        json_t *value;
-        json_object_foreach (context, key, value) {
-            char *sval;
-            sval = json_dumps (value, JSON_ENCODE_ANY|JSON_COMPACT);
-            printf (" %s=%s", key, sval);
-            free (sval);
-        }
-    }
-    printf ("\n");
-    fflush (stdout);
-}
-
-void output_event_json (json_t *event)
-{
-    char *e;
-
-    if (!(e = json_dumps (event, JSON_COMPACT)))
-        log_msg_exit ("json_dumps");
-    printf ("%s\n", e);
-    free (e);
-}
-
-void output_event (struct entry_format *e, json_t *event)
-{
-    if (!strcasecmp (e->format, "text"))
-        output_event_text (e, event);
-    else /* !strcasecmp (e->format, "json") */
-        output_event_json (event);
+    if (eventlog_formatter_set_format (evf, format) < 0)
+        log_msg_exit ("invalid format type '%s'", format);
+    if (eventlog_formatter_set_timestamp_format (evf, time_format) < 0)
+        log_msg_exit ("invalid time-format type '%s'", time_format);
 }
 
 void eventlog_continuation (flux_future_t *f, void *arg)
@@ -3153,7 +3068,9 @@ void eventlog_continuation (flux_future_t *f, void *arg)
         log_err_exit ("eventlog_decode");
 
     json_array_foreach (a, index, value) {
-        output_event (&ctx->e, value);
+        flux_error_t error;
+        if (eventlog_entry_dumpf (ctx->evf, stdout, &error, value) < 0)
+            log_msg ("failed to print eventlog entry: %s", error.text);
     }
 
     fflush (stdout);
@@ -3181,7 +3098,10 @@ int cmd_eventlog (optparse_t *p, int argc, char **argv)
     ctx.id = parse_jobid (ctx.jobid);
     ctx.path = optparse_get_str (p, "path", "eventlog");
     ctx.p = p;
-    entry_format_parse_options (p, &ctx.e);
+
+    if (!(ctx.evf = eventlog_formatter_create ()))
+        log_err_exit ("eventlog_formatter_create");
+    formatter_parse_options (p, ctx.evf);
 
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0,
                              "{s:I s:[s] s:i}",
@@ -3195,6 +3115,7 @@ int cmd_eventlog (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_reactor_run");
 
     flux_close (h);
+    eventlog_formatter_destroy (ctx.evf);
     return (0);
 }
 
@@ -3205,7 +3126,7 @@ struct wait_event_ctx {
     flux_jobid_t id;
     const char *path;
     bool got_event;
-    struct entry_format e;
+    struct eventlog_formatter *evf;
     char *context_key;
     char *context_value;
     int count;
@@ -3250,8 +3171,10 @@ bool wait_event_test (struct wait_event_ctx *ctx, json_t *event)
     if (eventlog_entry_parse (event, &timestamp, &name, &context) < 0)
         log_err_exit ("eventlog_entry_parse");
 
-    if (ctx->e.initial == 0.)
-        ctx->e.initial = timestamp;
+    /*  Ensure that timestamp zero is captured in eventlog formatter
+     *  in case the entry is not processed in wait-event.
+     */
+    eventlog_formatter_update_t0 (ctx->evf, timestamp);
 
     if (streq (name, ctx->wait_event)) {
         if (ctx->context_key) {
@@ -3272,6 +3195,7 @@ void wait_event_continuation (flux_future_t *f, void *arg)
     struct wait_event_ctx *ctx = arg;
     json_t *o = NULL;
     const char *event;
+    flux_error_t error;
 
     if (flux_rpc_get (f, NULL) < 0) {
         if (errno == ENOENT) {
@@ -3304,13 +3228,17 @@ void wait_event_continuation (flux_future_t *f, void *arg)
 
     if (wait_event_test (ctx, o)) {
         ctx->got_event = true;
-        if (!optparse_hasopt (ctx->p, "quiet"))
-            output_event (&ctx->e, o);
+        if (!optparse_hasopt (ctx->p, "quiet")) {
+            if (eventlog_entry_dumpf (ctx->evf, stdout, &error, o) < 0)
+                log_err ("failed to print eventlog entry: %s", error.text);
+        }
         if (flux_job_event_watch_cancel (f) < 0)
             log_err_exit ("flux_job_event_watch_cancel");
     } else if (optparse_hasopt (ctx->p, "verbose")) {
-        if (!ctx->got_event)
-            output_event (&ctx->e, o);
+        if (!ctx->got_event) {
+            if (eventlog_entry_dumpf (ctx->evf, stdout, &error, o) < 0)
+                log_err ("failed to print eventlog entry: %s", error.text);
+        }
     }
 
     json_decref (o);
@@ -3343,7 +3271,10 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
     timeout = optparse_get_duration (p, "timeout", -1.0);
     if (optparse_hasopt (p, "waitcreate"))
         flags |= FLUX_JOB_EVENT_WATCH_WAITCREATE;
-    entry_format_parse_options (p, &ctx.e);
+
+    if (!(ctx.evf = eventlog_formatter_create ()))
+        log_err_exit ("eventlog_formatter_create");
+    formatter_parse_options (p, ctx.evf);
     if ((str = optparse_get_str (p, "match-context", NULL))) {
         ctx.context_key = xstrdup (str);
         ctx.context_value = strchr (ctx.context_key, '=');
@@ -3364,6 +3295,7 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
 
     free (ctx.context_key);
     flux_close (h);
+    eventlog_formatter_destroy (ctx.evf);
     return (0);
 }
 

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -557,7 +557,8 @@ int cmd_namespace_list (optparse_t *p, int argc, char **argv)
         if (!(o = json_array_get (array, i)))
             log_err_exit ("json_array_get");
 
-        if (json_unpack (o, "{ s:s s:i s:i }",
+        if (json_unpack (o,
+                         "{ s:s s:i s:i }",
                          "namespace", &ns,
                          "owner", &owner,
                          "flags", &flags) < 0)
@@ -641,9 +642,11 @@ kv_printf (const char *key, int maxcol, const char *fmt, ...)
     if (rc < 0)
         log_err_exit ("%s", __FUNCTION__);
 
-    if (asprintf (&kv, "%s%s%s", key ? key : "",
-                                 key ? " = " : "",
-                                 val) < 0)
+    if (asprintf (&kv,
+                  "%s%s%s",
+                  key ? key : "",
+                  key ? " = " : "",
+                  val) < 0)
         log_err_exit ("%s", __FUNCTION__);
 
     /* There will be no truncation of output if maxcol = 0.
@@ -670,8 +673,9 @@ kv_printf (const char *key, int maxcol, const char *fmt, ...)
             }
         }
     }
-    printf ("%s%s\n", kv,
-                      overflow ? "..." : "");
+    printf ("%s%s\n",
+            kv,
+            overflow ? "..." : "");
 
     free (val);
     free (kv);
@@ -690,8 +694,9 @@ void lookup_continuation (flux_future_t *f, void *arg)
     struct lookup_ctx *ctx = arg;
     const char *key = flux_kvs_lookup_get_key (f);
 
-    if (optparse_hasopt (ctx->p, "watch") && flux_rpc_get (f, NULL) < 0
-                                          && errno == ENODATA) {
+    if (optparse_hasopt (ctx->p, "watch")
+        && flux_rpc_get (f, NULL) < 0
+        && errno == ENODATA) {
         flux_future_destroy (f);
         return; // EOF
     }
@@ -1421,7 +1426,8 @@ static bool need_newline (int col, int col_width, int win_width)
 /* List the content of 'dir', arranging output in columns that fit 'win_width',
  * and using a custom column width selected based on the longest entry name.
  */
-static void list_kvs_dir_single (const flux_kvsdir_t *dir, int win_width,
+static void list_kvs_dir_single (const flux_kvsdir_t *dir,
+                                 int win_width,
                                  optparse_t *p)
 {
     flux_kvsitr_t *itr;
@@ -1462,8 +1468,12 @@ static void list_kvs_dir_single (const flux_kvsdir_t *dir, int win_width,
 /* List contents of directory pointed to by 'key', descending into subdirs
  * if -R was specified.  First the directory is listed, then its subdirs.
  */
-static void list_kvs_dir (flux_t *h, const char *ns, const char *key,
-                          optparse_t *p, int win_width, bool print_label,
+static void list_kvs_dir (flux_t *h,
+                          const char *ns,
+                          const char *key,
+                          optparse_t *p,
+                          int win_width,
+                          bool print_label,
                           bool print_vspace)
 {
     flux_future_t *f;
@@ -1543,8 +1553,11 @@ static int sort_cmp (void *item1, void *item2)
 /* links are special.  If it points to a value, output the link name.
  * If it points to a dir, output contents of the dir.  If it points to
  * an illegal key, still output the link name. */
-static int categorize_link (flux_t *h, const char *ns, char *nkey,
-                            zlist_t *dirs, zlist_t *singles)
+static int categorize_link (flux_t *h,
+                            const char *ns,
+                            char *nkey,
+                            zlist_t *dirs,
+                            zlist_t *singles)
 {
     flux_future_t *f;
 
@@ -1574,8 +1587,12 @@ static int categorize_link (flux_t *h, const char *ns, char *nkey,
  * its contents are to be listed or not.  If -F is specified,
  * 'singles' key names are decorated based on their type.
  */
-static int categorize_key (flux_t *h, optparse_t *p, const char *ns,
-                           const char *key, zlist_t *dirs, zlist_t *singles)
+static int categorize_key (flux_t *h,
+                           optparse_t *p,
+                           const char *ns,
+                           const char *key,
+                           zlist_t *dirs,
+                           zlist_t *singles)
 {
     flux_future_t *f;
     const char *json_str;
@@ -1950,10 +1967,11 @@ static void eventlog_prettyprint (json_t *event)
             log_msg_exit ("json_dumps");
     }
 
-    printf ("%lf %s%s%s\n", timestamp,
-                            name,
-                            context_str ? " " : "",
-                            context_str ? context_str : "");
+    printf ("%lf %s%s%s\n",
+            timestamp,
+            name,
+            context_str ? " " : "",
+            context_str ? context_str : "");
 
     free (context_str);
     fflush (stdout);
@@ -1980,8 +1998,9 @@ void eventlog_get_continuation (flux_future_t *f, void *arg)
      * Destroy the future and return (reactor will then terminate).
      * Errors other than ENODATA are handled by the flux_kvs_lookup_get().
      */
-    if (optparse_hasopt (ctx->p, "watch") && flux_rpc_get (f, NULL) < 0
-                                          && errno == ENODATA) {
+    if (optparse_hasopt (ctx->p, "watch")
+        && flux_rpc_get (f, NULL) < 0
+        && errno == ENODATA) {
         flux_future_destroy (f);
         return;
     }

--- a/src/common/libeventlog/Makefile.am
+++ b/src/common/libeventlog/Makefile.am
@@ -20,7 +20,9 @@ libeventlog_la_SOURCES = \
 	formatter.h \
 	formatter.c
 
-TESTS = test_eventlog.t
+TESTS = \
+	test_eventlog.t \
+	test_formatter.t
 
 check_PROGRAMS = $(TESTS)
 
@@ -34,5 +36,15 @@ test_eventlog_t_LDADD = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libeventlog/libeventlog.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
+	$(JANSSON_LIBS) \
+	$(LIBRT)
+
+test_formatter_t_SOURCES = test/formatter.c
+test_formatter_t_CPPFLAGS = $(AM_CPPFLAGS)
+test_formatter_t_LDADD = \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/libeventlog/libeventlog.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
+	$(top_builddir)/src/common/libmissing/libmissing.la \
 	$(JANSSON_LIBS) \
 	$(LIBRT)

--- a/src/common/libeventlog/Makefile.am
+++ b/src/common/libeventlog/Makefile.am
@@ -16,7 +16,9 @@ libeventlog_la_SOURCES = \
 	eventlog.h \
 	eventlog.c \
 	eventlogger.h \
-	eventlogger.c
+	eventlogger.c \
+	formatter.h \
+	formatter.c
 
 TESTS = test_eventlog.t
 

--- a/src/common/libeventlog/formatter.c
+++ b/src/common/libeventlog/formatter.c
@@ -1,0 +1,261 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <time.h>
+#include <errno.h>
+
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "src/common/libutil/errprintf.h"
+
+#include "eventlog.h"
+#include "formatter.h"
+
+enum entry_format {
+    EVENTLOG_ENTRY_TEXT,
+    EVENTLOG_ENTRY_JSON
+};
+
+enum timestamp_format {
+    EVENTLOG_TIMESTAMP_RAW,
+    EVENTLOG_TIMESTAMP_ISO,
+    EVENTLOG_TIMESTAMP_OFFSET
+};
+
+struct eventlog_formatter {
+    /*  End of line separator for entries */
+    const char *endl;
+
+    /*  Emit unformatted output (RFC 18 JSON) */
+    unsigned int unformatted:1;
+
+    /*  Timestamp and entry formats for non RFC 18 operation: */
+    enum timestamp_format ts_format;
+    enum entry_format entry_format;
+
+    /*  Initial timestamp */
+    double t0;
+};
+
+void eventlog_formatter_destroy (struct eventlog_formatter *evf)
+{
+    if (evf) {
+        int saved_errno = errno;
+        free (evf);
+        errno = saved_errno;
+    }
+}
+
+struct eventlog_formatter *eventlog_formatter_create ()
+{
+    struct eventlog_formatter *evf;
+
+    if (!(evf = calloc (1, sizeof (*evf))))
+        return NULL;
+    evf->endl = "\n";
+    return evf;
+}
+
+void eventlog_formatter_set_no_newline (struct eventlog_formatter *evf)
+{
+    if (evf) {
+        evf->endl = "";
+    }
+}
+
+void eventlog_formatter_update_t0 (struct eventlog_formatter *evf, double ts)
+{
+    if (evf) {
+        if (evf->t0 == 0.)
+            evf->t0 = ts;
+    }
+}
+
+int eventlog_formatter_set_timestamp_format (struct eventlog_formatter *evf,
+                                             const char *format)
+{
+    if (!evf || !format) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (strcasecmp (format, "raw") == 0)
+        evf->ts_format = EVENTLOG_TIMESTAMP_RAW;
+    else if (strcasecmp (format, "iso") == 0)
+        evf->ts_format = EVENTLOG_TIMESTAMP_ISO;
+    else if (strcasecmp (format, "offset") == 0)
+        evf->ts_format = EVENTLOG_TIMESTAMP_OFFSET;
+    else {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+int eventlog_formatter_set_format (struct eventlog_formatter *evf,
+                                   const char *format)
+{
+    if (!evf || !format) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (strcasecmp (format, "text") == 0)
+        evf->unformatted = false;
+    else if (strcasecmp (format, "json") == 0)
+        evf->unformatted = true;
+    else {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+void eventlog_formatter_reset (struct eventlog_formatter *evf)
+{
+    if (evf) {
+        evf->t0 = 0.;
+    }
+}
+
+static int event_timestamp (struct eventlog_formatter *evf,
+                            flux_error_t *errp,
+                            double timestamp,
+                            char *buf,
+                            size_t size)
+{
+    if (evf->ts_format == EVENTLOG_TIMESTAMP_RAW) {
+        if (snprintf (buf, size, "%lf", timestamp) >= size)
+            return errprintf (errp, "buffer truncated writing timestamp");
+    }
+    else if (evf->ts_format == EVENTLOG_TIMESTAMP_ISO) {
+        time_t sec = timestamp;
+        unsigned long usec = (timestamp - sec)*1E6;
+        struct tm tm;
+        if (!gmtime_r (&sec, &tm))
+            return errprintf (errp,
+                              "gmtime(%lf): %s",
+                              timestamp,
+                              strerror (errno));
+        if (strftime (buf, size, "%Y-%m-%dT%T", &tm) == 0)
+            return errprintf (errp,
+                              "strftime(%lf): %s",
+                              timestamp,
+                              strerror (errno));
+        size -= strlen (buf);
+        buf += strlen (buf);
+        if (snprintf (buf, size, ".%.6luZ", usec) >= size)
+            return errprintf (errp,
+                              "buffer truncated writing ISO 8601 timestamp");
+    }
+    else { /* EVENTLOG_TIMESTAMP_OFFSET */
+        eventlog_formatter_update_t0 (evf, timestamp);
+        timestamp -= evf->t0;
+        if (snprintf (buf, size, "%lf", timestamp) >= size)
+            return errprintf (errp,
+                              "buffer truncated writing timestamp offset");
+    }
+    return 0;
+}
+
+static int entry_format_text (struct eventlog_formatter *evf,
+                              flux_error_t *errp,
+                              json_t *event,
+                              double timestamp,
+                              const char *name,
+                              json_t *context,
+                              FILE *fp)
+{
+    char ts[128];
+
+    if (event_timestamp (evf, errp, timestamp, ts, sizeof (ts)) < 0)
+        return -1;
+
+    if (fprintf (fp, "%s %s", ts, name) < 0)
+        return errprintf (errp, "fprintf: %s", strerror (errno));
+
+    if (context) {
+        const char *key;
+        json_t *value;
+        json_object_foreach (context, key, value) {
+            char *sval;
+            int rc;
+            sval = json_dumps (value, JSON_ENCODE_ANY|JSON_COMPACT);
+            rc = fprintf (fp, " %s=%s", key, sval);
+            free (sval);
+            if (rc < 0)
+                return errprintf (errp, "fprintf: %s", strerror (errno));
+        }
+    }
+    fputs (evf->endl, fp);
+    return 0;
+}
+
+int eventlog_entry_dumpf (struct eventlog_formatter *evf,
+                          FILE *fp,
+                          flux_error_t *errp,
+                          json_t *event)
+{
+    double timestamp;
+    json_t *context;
+    const char *name;
+
+    if (!evf || !event || !fp) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /* Validity check:
+     */
+    if (eventlog_entry_parse (event, &timestamp, &name, &context) < 0)
+        return errprintf (errp, "eventlog_entry_parse: %s", strerror (errno));
+
+    if (evf->unformatted) {
+        if (json_dumpf (event, fp, JSON_COMPACT) < 0)
+            return errprintf (errp, "json_dumpf failed");
+        fputs (evf->endl, fp);
+        return 0;
+    }
+
+    return entry_format_text (evf, errp, event, timestamp, name, context, fp);
+}
+
+char *eventlog_entry_dumps (struct eventlog_formatter *evf,
+                            flux_error_t *errp,
+                            json_t *event)
+{
+    size_t size;
+    char *result = NULL;
+    FILE *fp;
+
+    if (!evf || !event) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(fp = open_memstream (&result, &size))) {
+        errprintf (errp, "open_memstream: %s", strerror (errno));
+        return NULL;
+    }
+    if (eventlog_entry_dumpf (evf, fp, errp, event) < 0) {
+        fclose (fp);
+        free (result);
+        return NULL;
+    }
+    fclose (fp);
+    return result;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libeventlog/formatter.h
+++ b/src/common/libeventlog/formatter.h
@@ -1,0 +1,67 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _EVENTLOG_FORMATTER_H
+#define _EVENTLOG_FORMATTER_H
+
+#include <stdio.h>
+#include <jansson.h>
+
+#include <flux/core.h>
+
+struct eventlog_formatter *eventlog_formatter_create (void);
+void eventlog_formatter_destroy (struct eventlog_formatter *evf);
+
+/*  Reset an eventlog formatter. (Clear t0 timestamp).
+ *  Formatting options remain unchanged.
+ */
+void eventlog_formatter_reset (struct eventlog_formatter *evf);
+
+/*  Update formatter initial timestamp if not currently set.
+ */
+void eventlog_formatter_update_t0 (struct eventlog_formatter *evf, double ts);
+
+/*  Set the timestamp format for output. String 'format' may be one of
+ *  "raw"    - raw double precision timestamp (default)
+ *  "iso"    - ISO 8601
+ *  "offset" - offset from initial timestamp in eventlog.
+ */
+int eventlog_formatter_set_timestamp_format (struct eventlog_formatter *evf,
+                                             const char *format);
+
+/*  Set eventlog entry format by name for formatter 'evf':
+ *  "text" - formatted text (default)
+ *  "json" - unformatted raw JSON output (if set, timestamp format is ignored)
+ */
+int eventlog_formatter_set_format (struct eventlog_formatter *evf,
+                                   const char *format);
+
+/*  Disable newline character after eventlog_entry_dumps/f().
+ */
+void eventlog_formatter_set_no_newline (struct eventlog_formatter *evf);
+
+/*  Dump eventlog entry encoded by formatter 'evf' to a string.
+ *  Caller must free result.
+ *  Returns 0 on success, -1 with errno set and error text in errp->text.
+ */
+char *eventlog_entry_dumps (struct eventlog_formatter *evf,
+                            flux_error_t *errp,
+                            json_t *event);
+
+/*  Dump the eventlog entry encoded by 'evf' to stream 'fp'.
+ *  Returns 0 on success, -1 with errno set and error text in errp->text.
+ */
+int eventlog_entry_dumpf (struct eventlog_formatter *evf,
+                          FILE *fp,
+                          flux_error_t *errp,
+                          json_t *event);
+
+
+#endif /* !_EVENTLOG_FORMATTER_H */

--- a/src/common/libeventlog/formatter.h
+++ b/src/common/libeventlog/formatter.h
@@ -19,6 +19,11 @@
 struct eventlog_formatter *eventlog_formatter_create (void);
 void eventlog_formatter_destroy (struct eventlog_formatter *evf);
 
+/*  Set color: when can be "always", "never", or "auto":
+ */
+int eventlog_formatter_colors_init (struct eventlog_formatter *evf,
+                                    const char *when);
+
 /*  Reset an eventlog formatter. (Clear t0 timestamp).
  *  Formatting options remain unchanged.
  */

--- a/src/common/libeventlog/test/formatter.c
+++ b/src/common/libeventlog/test/formatter.c
@@ -1,0 +1,355 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libeventlog/formatter.h"
+
+struct test_entry {
+    const char *input;
+    const char *raw;
+    const char *iso;
+    const char *offset;
+    const char *human;
+};
+
+/*  This input set was constructed from an real eventlog.
+ *  Events must be kept in sequence so that offsets are calculated
+ *  correctly
+ */
+struct test_entry tests[] = {
+    { "{\"timestamp\":1699995759.5377746,\"name\":\"submit\",\"context\":{\"userid\":1001,\"urgency\":16,\"flags\":0,\"version\":1}}",
+      "1699995759.537775 submit userid=1001 urgency=16 flags=0 version=1",
+      "2023-11-14T21:02:39.537774Z submit userid=1001 urgency=16 flags=0 version=1",
+      "0.000000 submit userid=1001 urgency=16 flags=0 version=1",
+      "\x1b[1m\x1b[32m[Nov14 21:02]\x1b[0m \x1b[33msubmit\x1b[0m \x1b[34muserid\x1b[0m=\x1b[37m1001\x1b[0m \x1b[34murgency\x1b[0m=\x1b[37m16\x1b[0m \x1b[34mflags\x1b[0m=\x1b[37m0\x1b[0m \x1b[34mversion\x1b[0m=\x1b[37m1\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1699995759.5597851,\"name\":\"validate\"}",
+      "1699995759.559785 validate",
+      "2023-11-14T21:02:39.559785Z validate",
+      "0.022011 validate",
+      "\x1b[32m[  +0.022011]\x1b[0m \x1b[33mvalidate\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1699995759.5738351,\"name\":\"depend\"}",
+      "1699995759.573835 depend",
+      "2023-11-14T21:02:39.573835Z depend",
+      "0.036061 depend",
+      "\x1b[32m[  +0.036061]\x1b[0m \x1b[33mdepend\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1699995759.5739679,\"name\":\"priority\",\"context\":{\"priority\":66963}}",
+      "1699995759.573968 priority priority=66963",
+      "2023-11-14T21:02:39.573967Z priority priority=66963",
+      "0.036193 priority priority=66963",
+      "\x1b[32m[  +0.036193]\x1b[0m \x1b[33mpriority\x1b[0m \x1b[34mpriority\x1b[0m=\x1b[37m66963\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1699995759.6047542,\"name\":\"alloc\"}",
+      "1699995759.604754 alloc",
+      "2023-11-14T21:02:39.604754Z alloc",
+      "0.066980 alloc",
+      "\x1b[32m[  +0.066980]\x1b[0m \x1b[33malloc\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1699995759.6055193,\"name\":\"prolog-start\",\"context\":{\"description\":\"job-manager.prolog\"}}",
+      "1699995759.605519 prolog-start description=\"job-manager.prolog\"",
+      "2023-11-14T21:02:39.605519Z prolog-start description=\"job-manager.prolog\"",
+      "0.067745 prolog-start description=\"job-manager.prolog\"",
+      "\x1b[32m[  +0.067745]\x1b[0m \x1b[33mprolog-start\x1b[0m \x1b[34mdescription\x1b[0m=\x1b[35m\"job-manager.prolog\"\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1699995759.6055939,\"name\":\"prolog-start\",\"context\":{\"description\":\"cray-pals-port-distributor\"}}",
+      "1699995759.605594 prolog-start description=\"cray-pals-port-distributor\"",
+      "2023-11-14T21:02:39.605593Z prolog-start description=\"cray-pals-port-distributor\"",
+      "0.067819 prolog-start description=\"cray-pals-port-distributor\"",
+      "\x1b[32m[  +0.067819]\x1b[0m \x1b[33mprolog-start\x1b[0m \x1b[34mdescription\x1b[0m=\x1b[35m\"cray-pals-port-distributor\"\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1699995759.7634473,\"name\":\"prolog-finish\",\"context\":{\"description\":\"cray-pals-port-distributor\",\"status\":0}}",
+      "1699995759.763447 prolog-finish description=\"cray-pals-port-distributor\" status=0",
+      "2023-11-14T21:02:39.763447Z prolog-finish description=\"cray-pals-port-distributor\" status=0",
+      "0.225673 prolog-finish description=\"cray-pals-port-distributor\" status=0",
+      "\x1b[32m[  +0.225673]\x1b[0m \x1b[33mprolog-finish\x1b[0m \x1b[34mdescription\x1b[0m=\x1b[35m\"cray-pals-port-distributor\"\x1b[0m \x1b[34mstatus\x1b[0m=\x1b[37m0\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1699995760.3795953,\"name\":\"prolog-finish\",\"context\":{\"description\":\"job-manager.prolog\",\"status\":0}}",
+      "1699995760.379595 prolog-finish description=\"job-manager.prolog\" status=0",
+      "2023-11-14T21:02:40.379595Z prolog-finish description=\"job-manager.prolog\" status=0",
+      "0.841821 prolog-finish description=\"job-manager.prolog\" status=0",
+      "\x1b[32m[  +0.841821]\x1b[0m \x1b[33mprolog-finish\x1b[0m \x1b[34mdescription\x1b[0m=\x1b[35m\"job-manager.prolog\"\x1b[0m \x1b[34mstatus\x1b[0m=\x1b[37m0\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1699995760.3859105,\"name\":\"start\"}",
+      "1699995760.385911 start",
+      "2023-11-14T21:02:40.385910Z start",
+      "0.848136 start",
+      "\x1b[32m[  +0.848136]\x1b[0m \x1b[33mstart\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1699995760.7054179,\"name\":\"memo\",\"context\":{\"uri\":\"ssh://host/var/tmp/user/flux-0QZyMU/local-0\"}}",
+      "1699995760.705418 memo uri=\"ssh://host/var/tmp/user/flux-0QZyMU/local-0\"",
+      "2023-11-14T21:02:40.705417Z memo uri=\"ssh://host/var/tmp/user/flux-0QZyMU/local-0\"",
+      "1.167643 memo uri=\"ssh://host/var/tmp/user/flux-0QZyMU/local-0\"",
+      "\x1b[32m[  +1.167643]\x1b[0m \x1b[33mmemo\x1b[0m \x1b[34muri\x1b[0m=\x1b[35m\"ssh://host/var/tmp/user/flux-0QZyMU/local-0\"\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1700074161.0240808,\"name\":\"finish\",\"context\":{\"status\":0}}",
+      "1700074161.024081 finish status=0",
+      "2023-11-15T18:49:21.024080Z finish status=0",
+      "78401.486306 finish status=0",
+      "\x1b[1m\x1b[32m[Nov15 18:49]\x1b[0m \x1b[33mfinish\x1b[0m \x1b[34mstatus\x1b[0m=\x1b[37m0\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1700074161.0250554,\"name\":\"epilog-start\",\"context\":{\"description\":\"job-manager.epilog\"}}",
+      "1700074161.025055 epilog-start description=\"job-manager.epilog\"",
+      "2023-11-15T18:49:21.025055Z epilog-start description=\"job-manager.epilog\"",
+      "78401.487281 epilog-start description=\"job-manager.epilog\"",
+      "\x1b[32m[  +0.000975]\x1b[0m \x1b[33mepilog-start\x1b[0m \x1b[34mdescription\x1b[0m=\x1b[35m\"job-manager.epilog\"\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1700074161.1864166,\"name\":\"release\",\"context\":{\"ranks\":\"all\",\"final\":true}}",
+      "1700074161.186417 release ranks=\"all\" final=true",
+      "2023-11-15T18:49:21.186416Z release ranks=\"all\" final=true",
+      "78401.648642 release ranks=\"all\" final=true",
+      "\x1b[32m[  +0.162336]\x1b[0m \x1b[33mrelease\x1b[0m \x1b[34mranks\x1b[0m=\x1b[35m\"all\"\x1b[0m \x1b[34mfinal\x1b[0m=\x1b[35mtrue\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1700074445.1199436,\"name\":\"epilog-finish\",\"context\":{\"description\":\"job-manager.epilog\",\"status\":0}}",
+      "1700074445.119944 epilog-finish description=\"job-manager.epilog\" status=0",
+      "2023-11-15T18:54:05.119943Z epilog-finish description=\"job-manager.epilog\" status=0",
+      "78685.582169 epilog-finish description=\"job-manager.epilog\" status=0",
+      "\x1b[1m\x1b[32m[Nov15 18:54]\x1b[0m \x1b[33mepilog-finish\x1b[0m \x1b[34mdescription\x1b[0m=\x1b[35m\"job-manager.epilog\"\x1b[0m \x1b[34mstatus\x1b[0m=\x1b[37m0\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1700074445.1203697,\"name\":\"free\"}",
+      "1700074445.120370 free",
+      "2023-11-15T18:54:05.120369Z free",
+      "78685.582595 free",
+      "\x1b[32m[  +0.000426]\x1b[0m \x1b[33mfree\x1b[0m",
+    },
+    {
+      "{\"timestamp\":1700074445.120451,\"name\":\"clean\"}",
+      "1700074445.120451 clean",
+      "2023-11-15T18:54:05.120450Z clean",
+      "78685.582676 clean",
+      "\x1b[32m[  +0.000507]\x1b[0m \x1b[33mclean\x1b[0m",
+    },
+    {0},
+};
+
+static void test_basic ()
+{
+    struct test_entry *test;
+    flux_error_t error;
+    struct eventlog_formatter *evf;
+    if (!(evf = eventlog_formatter_create ()))
+        BAIL_OUT ("failed to create eventlog formatter");
+
+    eventlog_formatter_set_no_newline (evf);
+
+    test = tests;
+    while (test->input) {
+        char *result;
+        json_t *entry = json_loads (test->input, 0, NULL);
+        if (!entry)
+            BAIL_OUT ("failed to load JSON input '%s'", test->input);
+
+        /* Disable color for tests */
+        ok (eventlog_formatter_colors_init (evf, "never") == 0,
+            "eventlog_formatter_colors_init (never)");
+
+        /* 1. Test unformatted, should equal input
+         */
+        ok (eventlog_formatter_set_format (evf, "json") == 0,
+            "eventlog_formatter_set_format(json)");
+        ok ((result = eventlog_entry_dumps (evf, &error, entry)) != NULL,
+            "eventlog_entry_dumps");
+        diag (result);
+        is (result, test->input,
+            "json output is expected");
+        free (result);
+        /*  Need to reset unformatted flag for other tests:
+         */
+        ok (eventlog_formatter_set_format (evf, "text") == 0,
+            "eventlog_formatter_set_format (text)");
+
+        /*  2. Test raw timestamp
+         */
+        ok (eventlog_formatter_set_timestamp_format (evf, "raw") == 0,
+            "eventlog_formatter_set_timestamp_format raw works");
+        ok ((result = eventlog_entry_dumps (evf, &error, entry)) != NULL,
+            "eventlog_entry_dumps");
+        diag (result);
+        is (result, test->raw,
+            "raw timestamp output is expected");
+        free (result);
+
+        /* 3. Test ISO timestamp
+         */
+        ok (eventlog_formatter_set_timestamp_format (evf, "iso") == 0,
+            "eventlog_formatter_set_timestamp_format iso works");
+        ok ((result = eventlog_entry_dumps (evf, &error, entry)) != NULL,
+            "eventlog_entry_dumps");
+        diag (result);
+        is (result, test->iso,
+            "iso timestamp output is expected");
+        free (result);
+
+        /* 4. Test offset timestamp
+         */
+        ok (eventlog_formatter_set_timestamp_format (evf, "offset") == 0,
+            "eventlog_formatter_set_timestamp_format offset works");
+        ok ((result = eventlog_entry_dumps (evf, &error, entry)) != NULL,
+            "eventlog_entry_dumps");
+        diag (result);
+        is (result, test->offset,
+            "offset timestamp output is expected");
+        free (result);
+
+        /* 5. Test "reltime"/"human" timestamp with color
+         */
+        ok (eventlog_formatter_colors_init (evf, "always") == 0,
+            "eventlog_formatter_colors_init (always)");
+        ok (eventlog_formatter_set_timestamp_format (evf, "human") == 0,
+            "eventlog_formatter_set_timestamp_format human works");
+        ok ((result = eventlog_entry_dumps (evf, &error, entry)) != NULL,
+            "eventlog_entry_dumps");
+        diag (result);
+        is (result, test->human,
+            "human timestamp output is expected");
+        free (result);
+
+        json_decref (entry);
+        test++;
+    }
+
+    eventlog_formatter_destroy (evf);
+}
+
+static void test_invalid ()
+{
+    struct eventlog_formatter *evf;
+    json_t *good, *bad;
+    flux_error_t error;
+
+    if (!(evf = eventlog_formatter_create ()))
+        BAIL_OUT ("failed to create eventlog formatter");
+
+    lives_ok ({eventlog_formatter_destroy (NULL);});
+    lives_ok ({eventlog_formatter_reset (NULL);});
+    lives_ok ({eventlog_formatter_set_no_newline (NULL);});
+    lives_ok ({eventlog_formatter_update_t0 (NULL, 0.);});
+
+    ok (eventlog_formatter_set_timestamp_format (NULL, "") < 0
+        && errno == EINVAL,
+        "eventlog_formatter_set_timestamp_format (NULL) returns EINVAL");
+    ok (eventlog_formatter_set_timestamp_format (evf, NULL) < 0
+        && errno == EINVAL,
+        "eventlog_formatter_set_timestamp_format (evf, NULL) returns EINVAL");
+    ok (eventlog_formatter_set_timestamp_format (evf, "") < 0
+        && errno == EINVAL,
+        "eventlog_formatter_set_timestamp_format (evf, \"\") returns EINVAL");
+
+    ok (eventlog_formatter_set_format (NULL, "text") < 0 && errno == EINVAL,
+        "eventlog_formatter_set_format (NULL, \"text\") returns EINVAL");
+    ok (eventlog_formatter_set_format (evf, "foo") < 0 && errno == EINVAL,
+        "eventlog_formatter_set_format (evf, \"foo\") returns EINVAL");
+
+    ok (eventlog_formatter_colors_init (NULL, "auto") < 0 && errno == EINVAL,
+        "eventlog_formatter_colors_init (NULL, \"auto\") returns EINVAL");
+    ok (eventlog_formatter_colors_init (evf, NULL) < 0 && errno == EINVAL,
+        "eventlog_formatter_colors_init (evf, NULL) returns EINVAL");
+    ok (eventlog_formatter_colors_init (evf, "foo") < 0 && errno == EINVAL,
+        "eventlog_formatter_colors_init (evf, \"foo\") returns EINVAL");
+
+    if (!(good = json_pack ("{s:f s:s s:{s:s}}",
+                            "timestamp", 1699995759.0,
+                            "name", "good",
+                            "context",
+                             "foo", "bar")))
+        BAIL_OUT ("Failed to create good eventlog event");
+
+    if (!(bad = json_pack ("{s:f s:s s:[s]}",
+                            "timestamp", 1699995759.0,
+                            "name", "bad",
+                            "context",
+                             "foo")))
+        BAIL_OUT ("Failed to create bad eventlog event");
+
+    /*  Check all results with default evf, then json formatted evf
+     */
+    for (int i = 0; i < 2; i++) {
+        ok (eventlog_entry_dumpf (NULL, NULL, NULL, NULL) < 0
+            && errno == EINVAL,
+            "eventlog_entry_dumpf (NULL, ...) returns EINVAL");
+        ok (eventlog_entry_dumpf (evf, NULL, NULL, NULL) < 0
+            && errno == EINVAL,
+            "eventlog_entry_dumpf (evf, NULL, ...) returns EINVAL");
+        ok (eventlog_entry_dumpf (evf, stderr, NULL, NULL) < 0
+            && errno == EINVAL,
+            "eventlog_entry_dumpf (evf, stdout, NULL, ...) returns EINVAL");
+        ok (eventlog_entry_dumpf (evf, NULL, &error, good) < 0
+            && errno == EINVAL,
+            "eventlog_entry_dumpf (evf, NULL, &error, event) returns EINVAL");
+        ok (eventlog_entry_dumpf (evf, stderr, &error, bad) < 0
+            && errno == EINVAL,
+            "eventlog_entry_dumpf bad event returns EINVAL");
+        is (error.text, "eventlog_entry_parse: Invalid argument");
+
+        memset (&error, 0, sizeof (error));
+
+        ok ((eventlog_entry_dumps (NULL, NULL, NULL) == NULL)
+            && errno == EINVAL,
+            "eventlog_entry_dumps (NULL, ...) returns EINVAL");
+        ok ((eventlog_entry_dumps (evf, NULL, NULL) == NULL)
+            && errno == EINVAL,
+            "eventlog_entry_dumps (evf, NULL, ...) returns EINVAL");
+        ok ((eventlog_entry_dumps (NULL, &error, good) == NULL)
+            && errno == EINVAL,
+            "eventlog_entry_dumps (NULL, &error, event) returns EINVAL");
+        ok ((eventlog_entry_dumps (evf, &error, bad) == NULL)
+            && errno == EINVAL,
+            "eventlog_entry_dumps (NULL, &error, event) returns EINVAL");
+        is (error.text, "eventlog_entry_parse: Invalid argument");
+
+        ok (eventlog_formatter_set_format (evf, "json") == 0,
+            "eventlog_formatter_set_format json");
+    }
+
+    json_decref (good);
+    json_decref (bad);
+    eventlog_formatter_destroy (evf);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    /*  Set TZ=UTC for predictable results in human-readable timestamps */
+    setenv ("TZ", "", 1);
+    tzset ();
+
+    test_invalid ();
+    test_basic ();
+
+    done_testing ();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/timestamp.c
+++ b/src/common/libutil/timestamp.c
@@ -82,11 +82,8 @@ int timestamp_parse (const char *s,
         return -1;
     }
 
-    if (tm) {
-        memset (tm, 0, sizeof (*tm));
-        if (!(localtime_r (&t, tm)))
+    if (tm && !(localtime_r (&t, tm)))
             return -1;
-    }
 
     if (tv)
         tv->tv_sec = t;
@@ -109,6 +106,29 @@ int timestamp_parse (const char *s,
          *  allow the truncation to simulate floor(3).
          */
         tv->tv_usec = (d * 1000000) + 0.5;
+    }
+    return 0;
+}
+
+int timestamp_from_double (double ts, struct tm *tm, struct timeval *tv)
+{
+    if (ts < 0. || (!tm && !tv)) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (tm) {
+        time_t t = (time_t) ts;
+        memset (tm, 0, sizeof (*tm));
+        if (!localtime_r (&t, tm))
+            return -1;
+    }
+    if (tv) {
+        tv->tv_sec = ts;
+        /*  Note: cast to integer type truncates. To handle underflow from
+         *  double arithmetic (e.g. result = 1234.999), add 0.5 and then
+         *  allow the truncation to simulate floor(3).
+         */
+        tv->tv_usec = ((ts - tv->tv_sec) * 1000000) + 0.5;
     }
     return 0;
 }

--- a/src/common/libutil/timestamp.h
+++ b/src/common/libutil/timestamp.h
@@ -35,6 +35,11 @@ int timestamp_parse (const char *s,
                      struct timeval *tv);
 
 
+/* Convert a double precision timestamp to struct tm and timeval.
+ * At least one of 'tm' or 'tv' must be provided.
+ */
+int timestamp_from_double (double ts, struct tm *tm, struct timeval *tv);
+
 #endif /* !_UTIL_TIMESTAMP_H */
 
 /*

--- a/t/t1008-kvs-eventlog.t
+++ b/t/t1008-kvs-eventlog.t
@@ -29,7 +29,7 @@ test_expect_success 'flux kvs eventlog append works w/ context' '
 	flux kvs eventlog append test.c foo {\"data\":\"bar\"} &&
 	flux kvs eventlog get test.c >get_c.out &&
 	grep -q foo get_c.out &&
-        grep -q "\"data\":\"bar\"" get_c.out
+        grep -q "data=\"bar\"" get_c.out
 '
 
 test_expect_success 'flux kvs eventlog get --watch --count=N works' '

--- a/t/t2100-job-ingest.t
+++ b/t/t2100-job-ingest.t
@@ -105,9 +105,9 @@ test_expect_success 'job-ingest: KVS jobspec lacks environment' '
 test_expect_success 'job-ingest: job announced to job manager' '
 	jobid=$(flux job submit --urgency=10 basic.json | flux job id) &&
 	flux kvs eventlog get ${DUMMY_EVENTLOG} \
-		| grep "\"id\":${jobid}" >jobman.out &&
-	grep -q "\"urgency\":10" jobman.out &&
-	grep -q "\"userid\":$(id -u)" jobman.out
+		| grep "id=${jobid}" >jobman.out &&
+	grep -q "urgency=10" jobman.out &&
+	grep -q "userid=$(id -u)" jobman.out
 '
 
 test_expect_success 'job-ingest: instance owner can submit urgency=31' '


### PR DESCRIPTION
Many times I've wished for output from `flux job eventlog` that matches the output from `flux dmesg -H`, which in turn was taken from the output of `dmesg -H`:
```
[Nov28 17:33] broker[0]: insmod connector-local
[  +0.000085] broker[0]: start: none->join 3.31617ms
[  +0.000117] broker[0]: overlay auth cert-name=1 OK
[  +0.000157] broker[0]: parent-none: join->init 0.06508ms
```

This format is nice because it presents not only relative timestamps of events, but also gives an absolute timestamp every minute, so you can place the events in time as well as tell how far apart they are occurring. With the current eventlog commands, you can choose either an "offset", "raw" floating-point timestamps, or "iso" ISO 8601 timestamps, none of which have the properties of the above format.

This PR adds `-H, --human` options to all the commands that are used to access eventlogs: `flux job eventlog`, `flux job wait-event`, `flux kvs eventlog get` and `flux kvs eventlog wait-event`.

Since the new formatting is used across multiple commands, the implementation is contained in a new `struct eventlog_formatter` class in `libeventlog`, which also allows the impelementation to have unit tests.

Also following the design of `flux dmesg`, support for colorized eventlog is added to the eventlog formatter class, along with the addition of `-L, --color=WHEN` options to the commands listed above.

Note that this changes the default output of `flux kvs eventlog get`. However, it wasn't really clear why this command had different output than `flux job eventlog`, and using the "text" format by default actually made pattern matching the context in some tests _easier_, but hopefully nobody else is depending on the previous output style.

Examples of the result:

![2023-11-29-142539_551x183_scrot](https://github.com/flux-framework/flux-core/assets/741970/7ad1b25c-612a-48a3-8ee3-5a3f0206f04a)
![2023-11-29-142659_565x90_scrot](https://github.com/flux-framework/flux-core/assets/741970/f6fc36bf-2958-41c4-a529-9922715f2bcc)

