### PR TITLE
flux-terminus: fix potential hang in terminus client commands

### DIFF
--- a/src/common/libterminus/terminus.c
+++ b/src/common/libterminus/terminus.c
@@ -864,6 +864,12 @@ error:
     return -1;
 }
 
+flux_future_t *
+flux_terminus_server_unregister (struct flux_terminus_server *ts)
+{
+    return flux_service_unregister (ts->h, ts->service);
+}
+
 struct flux_terminus_server *
 flux_terminus_server_create (flux_t *h, const char *service)
 {

--- a/src/common/libterminus/terminus.h
+++ b/src/common/libterminus/terminus.h
@@ -71,6 +71,14 @@ flux_terminus_server_session_open (struct flux_terminus_server *ts,
 int flux_terminus_server_session_close (struct flux_terminus_server *ts,
                                         struct flux_pty *pty,
                                         int status);
+
+/*  Unregister the terminus server service.
+ *  Returns a future that will be fulfilled when the service is successfully
+ *  unregistered.
+ */
+flux_future_t *
+flux_terminus_server_unregister (struct flux_terminus_server *ts);
+
 #endif /* !FLUX_TERMINUS_H */
 
 /*


### PR DESCRIPTION
Looking into why `t0020-terminus.t` has been hanging (#5595) revealed a potential race in the flux-terminus server. When the server shuts down, it relies on the disconnect handler to unregister the service with the broker. This leaves a small race between when the server leaves the flux reactor and when the service is unregistered where a client request could be left without a response. This could cause a client hang and thus the hangs in `t0020-terminus.t`.

I did observe the hang several times in the alpine docker container while attempting to debug this, and no hangs after 100s of runs on this branch. So while there's no definitive proof that this issue was the cause of the hang, I'm hopeful this will fix it.