### PR TITLE
testsuite: fix t2233-job-info-update.t with debug=t

### DIFF
--- a/t/t2233-job-info-update.t
+++ b/t/t2233-job-info-update.t
@@ -252,8 +252,8 @@ test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (multi
 	wait $watchpidA &&
 	kill -s USR1 $watchpidB &&
 	wait $watchpidB &&
-	test_debug "echo watch10A: $(cat watch10A.out)" &&
-	test_debug "echo watch10B: $(cat watch10B.out)" &&
+	test_debug "echo watch10A: \"$(cat watch10A.out)\"" &&
+	test_debug "echo watch10B: \"$(cat watch10B.out)\"" &&
 	flux cancel $jobid &&
 	test $(cat watch10A.out | wc -l) -eq 2 &&
 	test $(cat watch10B.out | wc -l) -eq 1 &&


### PR DESCRIPTION
Problem: A quoting issue in one of the tests in t2233-job-info-update.t causes the test to fail when run with -d -v or debug=t.

Fix the quoting issue.

This was caught by gitlab-ci. Not sure why it doesn't surface in our normal CI.