### PR TITLE
libkvs: fix test failure in aarch64 CI

### DIFF
--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -21,8 +21,10 @@
 #include "treeobj.h"
 #include "kvs_util_private.h"
 
-flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *ns,
-                                          uint32_t owner, int flags)
+flux_future_t *flux_kvs_namespace_create (flux_t *h,
+                                          const char *ns,
+                                          uint32_t owner,
+                                          int flags)
 {
     flux_future_t *rv = NULL;
     const char *hash_name;
@@ -53,21 +55,26 @@ flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *ns,
         goto cleanup;
 
     /* N.B. owner cast to int */
-    rv = flux_rpc_pack (h, "kvs.namespace-create", 0, 0,
-                           "{ s:s s:s s:i s:i }",
-                           "namespace", ns,
-                           "rootref", rootref,
-                           "owner", owner,
-                           "flags", flags);
+    rv = flux_rpc_pack (h,
+                        "kvs.namespace-create",
+                        0,
+                        0,
+                        "{ s:s s:s s:i s:i }",
+                        "namespace", ns,
+                        "rootref", rootref,
+                        "owner", owner,
+                        "flags", flags);
 cleanup:
     json_decref (rootdir);
     free (data);
     return rv;
 }
 
-flux_future_t *flux_kvs_namespace_create_with (flux_t *h, const char *ns,
+flux_future_t *flux_kvs_namespace_create_with (flux_t *h,
+                                               const char *ns,
                                                const char *rootref,
-                                               uint32_t owner, int flags)
+                                               uint32_t owner,
+                                               int flags)
 {
     if (!ns || !rootref || flags) {
         errno = EINVAL;
@@ -75,7 +82,10 @@ flux_future_t *flux_kvs_namespace_create_with (flux_t *h, const char *ns,
     }
 
     /* N.B. owner cast to int */
-    return flux_rpc_pack (h, "kvs.namespace-create", 0, 0,
+    return flux_rpc_pack (h,
+                          "kvs.namespace-create",
+                          0,
+                          0,
                           "{ s:s s:s s:i s:i }",
                           "namespace", ns,
                           "rootref", rootref,
@@ -90,7 +100,10 @@ flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *ns)
         return NULL;
     }
 
-    return flux_rpc_pack (h, "kvs.namespace-remove", 0, 0,
+    return flux_rpc_pack (h,
+                          "kvs.namespace-remove",
+                          0,
+                          0,
                           "{ s:s }",
                           "namespace", ns);
 }
@@ -105,7 +118,11 @@ int flux_kvs_get_version (flux_t *h, const char *ns, int *versionp)
         if (!(ns = kvs_get_namespace ()))
             return -1;
     }
-    if (!(f = flux_rpc_pack (h, "kvs.getroot", FLUX_NODEID_ANY, 0, "{ s:s }",
+    if (!(f = flux_rpc_pack (h,
+                             "kvs.getroot",
+                             FLUX_NODEID_ANY,
+                             0,
+                             "{ s:s }",
                              "namespace", ns)))
         goto done;
     if (flux_rpc_get_unpack (f, "{ s:i }", "rootseq", &version) < 0)
@@ -127,7 +144,10 @@ int flux_kvs_wait_version (flux_t *h, const char *ns, int version)
         if (!(ns = kvs_get_namespace ()))
             return -1;
     }
-    if (!(f = flux_rpc_pack (h, "kvs.wait-version", FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (h,
+                             "kvs.wait-version",
+                             FLUX_NODEID_ANY,
+                             0,
                              "{ s:i s:s }",
                              "rootseq", version,
                              "namespace", ns)))

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -47,11 +47,15 @@ enum kvs_op {
  *   namespace will official be removed.  The removal is "eventually
  *   consistent".
  */
-flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *ns,
-                                          uint32_t owner, int flags);
-flux_future_t *flux_kvs_namespace_create_with (flux_t *h, const char *ns,
+flux_future_t *flux_kvs_namespace_create (flux_t *h,
+                                          const char *ns,
+                                          uint32_t owner,
+                                          int flags);
+flux_future_t *flux_kvs_namespace_create_with (flux_t *h,
+                                               const char *ns,
                                                const char *rootref,
-                                               uint32_t owner, int flags);
+                                               uint32_t owner,
+                                               int flags);
 flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *ns);
 
 /* Synchronization:

--- a/src/common/libkvs/kvs_checkpoint.c
+++ b/src/common/libkvs/kvs_checkpoint.c
@@ -92,10 +92,11 @@ int kvs_checkpoint_lookup_get_rootref (flux_future_t *f, const char **rootref)
         return -1;
     }
 
-    if (flux_rpc_get_unpack (f, "{s:{s:i s:s}}",
-                                "value",
-                                "version", &version,
-                                "rootref", &tmp_rootref) < 0)
+    if (flux_rpc_get_unpack (f,
+                             "{s:{s:i s:s}}",
+                             "value",
+                               "version", &version,
+                               "rootref", &tmp_rootref) < 0)
         return -1;
 
     if (version != 0 && version != 1) {
@@ -116,10 +117,11 @@ int kvs_checkpoint_lookup_get_timestamp (flux_future_t *f, double *timestamp)
         errno = EINVAL;
         return -1;
     }
-    if (flux_rpc_get_unpack (f, "{s:{s:i s?f}}",
-                                "value",
-                                "version", &version,
-                                "timestamp", &ts) < 0)
+    if (flux_rpc_get_unpack (f,
+                             "{s:{s:i s?f}}",
+                             "value",
+                               "version", &version,
+                               "timestamp", &ts) < 0)
         return -1;
     if (version != 0 && version != 1) {
         errno = EINVAL;
@@ -138,10 +140,11 @@ int kvs_checkpoint_lookup_get_sequence (flux_future_t *f, int *sequence)
         errno = EINVAL;
         return -1;
     }
-    if (flux_rpc_get_unpack (f, "{s:{s:i s?i}}",
-                                "value",
-                                "version", &version,
-                                "sequence", &seq) < 0)
+    if (flux_rpc_get_unpack (f,
+                             "{s:{s:i s?i}}",
+                             "value",
+                               "version", &version,
+                               "sequence", &seq) < 0)
         return -1;
     if (version != 0 && version != 1) {
         errno = EINVAL;

--- a/src/common/libkvs/kvs_commit.c
+++ b/src/common/libkvs/kvs_commit.c
@@ -43,8 +43,11 @@ static struct commit_ctx *alloc_ctx (void)
     return ctx;
 }
 
-flux_future_t *flux_kvs_fence (flux_t *h, const char *ns, int flags,
-                               const char *name, int nprocs,
+flux_future_t *flux_kvs_fence (flux_t *h,
+                               const char *ns,
+                               int flags,
+                               const char *name,
+                               int nprocs,
                                flux_kvs_txn_t *txn)
 {
     flux_future_t *f;
@@ -75,7 +78,10 @@ flux_future_t *flux_kvs_fence (flux_t *h, const char *ns, int flags,
     if (!(ctx = alloc_ctx ()))
         return NULL;
 
-    if (!(f = flux_rpc_pack (h, "kvs.fence", FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (h,
+                             "kvs.fence",
+                             FLUX_NODEID_ANY,
+                             0,
                              "{s:s s:i s:s s:i s:O}",
                              "name", name,
                              "nprocs", nprocs,
@@ -96,7 +102,9 @@ error:
     return NULL;
 }
 
-flux_future_t *flux_kvs_commit (flux_t *h, const char *ns, int flags,
+flux_future_t *flux_kvs_commit (flux_t *h,
+                                const char *ns,
+                                int flags,
                                 flux_kvs_txn_t *txn)
 {
     flux_future_t *f;
@@ -127,7 +135,10 @@ flux_future_t *flux_kvs_commit (flux_t *h, const char *ns, int flags,
     if (!(ctx = alloc_ctx ()))
         return NULL;
 
-    if (!(f = flux_rpc_pack (h, "kvs.commit", FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (h,
+                             "kvs.commit",
+                             FLUX_NODEID_ANY,
+                             0,
                              "{s:s s:i s:O}",
                              "namespace", ns,
                              "flags", flags,
@@ -146,13 +157,15 @@ error:
     return NULL;
 }
 
-static int decode_response (flux_future_t *f, const char **rootrefp,
+static int decode_response (flux_future_t *f,
+                            const char **rootrefp,
                             int *rootseqp)
 {
     const char *rootref;
     int rootseq;
 
-    if (flux_rpc_get_unpack (f, "{s:s s:i}",
+    if (flux_rpc_get_unpack (f,
+                             "{s:s s:i}",
                              "rootref", &rootref,
                              "rootseq", &rootseq) < 0)
         return -1;

--- a/src/common/libkvs/kvs_commit.h
+++ b/src/common/libkvs/kvs_commit.h
@@ -43,11 +43,16 @@ enum kvs_commit_flags {
     FLUX_KVS_SYNC = 4, /* flush and checkpoint after commit is done */
 };
 
-flux_future_t *flux_kvs_commit (flux_t *h, const char *ns, int flags,
+flux_future_t *flux_kvs_commit (flux_t *h,
+                                const char *ns,
+                                int flags,
                                 flux_kvs_txn_t *txn);
 
-flux_future_t *flux_kvs_fence (flux_t *h, const char *ns, int flags,
-                               const char *name, int nprocs,
+flux_future_t *flux_kvs_fence (flux_t *h,
+                               const char *ns,
+                               int flags,
+                               const char *name,
+                               int nprocs,
                                flux_kvs_txn_t *txn);
 
 /* accessors can be used for commit or fence futures */

--- a/src/common/libkvs/kvs_dir.c
+++ b/src/common/libkvs/kvs_dir.c
@@ -63,8 +63,10 @@ flux_kvsdir_t *flux_kvsdir_copy (const flux_kvsdir_t *dir)
  * so that subsequent flux_kvsdir_get_* accesses can be relative to that
  * snapshot.  Otherwise, they are relative to the current root.
  */
-flux_kvsdir_t *flux_kvsdir_create (flux_t *h, const char *rootref,
-                                   const char *key, const char *json_str)
+flux_kvsdir_t *flux_kvsdir_create (flux_t *h,
+                                   const char *rootref,
+                                   const char *key,
+                                   const char *json_str)
 {
     flux_kvsdir_t *dir = NULL;
     json_t *dirobj = NULL;
@@ -227,8 +229,10 @@ nomem:
 
 /* kvs_txn_private.h */
 
-flux_kvsdir_t *kvsdir_create_fromobj (flux_t *handle, const char *rootref,
-                                      const char *key, json_t *treeobj)
+flux_kvsdir_t *kvsdir_create_fromobj (flux_t *handle,
+                                      const char *rootref,
+                                      const char *key,
+                                      json_t *treeobj)
 {
     flux_kvsdir_t *dir = NULL;
 

--- a/src/common/libkvs/kvs_dir.h
+++ b/src/common/libkvs/kvs_dir.h
@@ -35,8 +35,10 @@ typedef struct flux_kvsitr flux_kvsitr_t;
  * are not freed until the reference count reaches zero.  The object is
  * initially created with a reference count of one.
  */
-flux_kvsdir_t *flux_kvsdir_create (flux_t *handle, const char *rootref,
-                                   const char *key, const char *json_str);
+flux_kvsdir_t *flux_kvsdir_create (flux_t *handle,
+                                   const char *rootref,
+                                   const char *key,
+                                   const char *json_str);
 void flux_kvsdir_destroy (flux_kvsdir_t *dir);
 
 flux_kvsdir_t *flux_kvsdir_copy (const flux_kvsdir_t *dir);

--- a/src/common/libkvs/kvs_dir_private.h
+++ b/src/common/libkvs/kvs_dir_private.h
@@ -11,8 +11,10 @@
 #ifndef _KVS_DIR_PRIVATE_H
 #define _KVS_DIR_PRIVATE_H
 
-flux_kvsdir_t *kvsdir_create_fromobj (flux_t *handle, const char *rootref,
-                                      const char *key, json_t *treeobj);
+flux_kvsdir_t *kvsdir_create_fromobj (flux_t *handle,
+                                      const char *rootref,
+                                      const char *key,
+                                      json_t *treeobj);
 
 json_t *kvsdir_get_obj (flux_kvsdir_t *dir);
 

--- a/src/common/libkvs/kvs_getroot.c
+++ b/src/common/libkvs/kvs_getroot.c
@@ -58,7 +58,10 @@ flux_future_t *flux_kvs_getroot (flux_t *h, const char *ns, int flags)
         return NULL;
     if (!ns && !(ns = kvs_get_namespace ()))
         goto error;
-    if (!(f = flux_rpc_pack (h, "kvs.getroot", FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (h,
+                             "kvs.getroot",
+                             FLUX_NODEID_ANY,
+                             0,
                              "{s:s s:i}",
                              "namespace", ns,
                              "flags", flags)))
@@ -74,15 +77,18 @@ error:
     return NULL;
 }
 
-static int decode_response (flux_future_t *f, const char **rootrefp,
-                            int *rootseqp, uint32_t *ownerp)
+static int decode_response (flux_future_t *f,
+                            const char **rootrefp,
+                            int *rootseqp,
+                            uint32_t *ownerp)
 {
     const char *rootref;
     int rootseq;
     int owner;
     int flags;
 
-    if (flux_rpc_get_unpack (f, "{s:s s:i s:i s:i}",
+    if (flux_rpc_get_unpack (f,
+                             "{s:s s:i s:i s:i}",
                              "rootref", &rootref,
                              "rootseq", &rootseq,
                              "owner", &owner,

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -115,7 +115,9 @@ flux_future_t *flux_kvs_lookup (flux_t *h,
     const char *topic = "kvs.lookup";
     int rpc_flags = 0;
 
-    if (!h || !key || strlen (key) == 0
+    if (!h
+        || !key
+        || strlen (key) == 0
         || validate_lookup_flags (flags, true) < 0) {
         errno = EINVAL;
         return NULL;
@@ -131,7 +133,10 @@ flux_future_t *flux_kvs_lookup (flux_t *h,
         topic = "kvs-watch.lookup"; // redirect to kvs-watch module
     if ((flags & FLUX_KVS_WATCH))
         rpc_flags |= FLUX_RPC_STREAMING;
-    if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, rpc_flags,
+    if (!(f = flux_rpc_pack (h,
+                             topic,
+                             FLUX_NODEID_ANY,
+                             rpc_flags,
                              "{s:s s:s s:i}",
                              "key", key,
                              "namespace", ns,
@@ -147,7 +152,9 @@ flux_future_t *flux_kvs_lookup (flux_t *h,
     return f;
 }
 
-flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
+flux_future_t *flux_kvs_lookupat (flux_t *h,
+                                  int flags,
+                                  const char *key,
                                   const char *treeobj)
 {
     flux_future_t *f;
@@ -156,7 +163,10 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
 
     /* N.B. FLUX_KVS_WATCH is not valid for lookupat (r/o snapshot).
      */
-    if (!h || !key || strlen (key) == 0 || !treeobj
+    if (!h
+        || !key
+        || strlen (key) == 0
+        || !treeobj
         || validate_lookup_flags (flags, false) < 0) {
         errno = EINVAL;
         return NULL;
@@ -169,7 +179,10 @@ flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
         errno = EINVAL;
         return NULL;
     }
-    if (!(f = flux_rpc_pack (h, "kvs.lookup", FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (h,
+                             "kvs.lookup",
+                             FLUX_NODEID_ANY,
+                             0,
                              "{s:s s:i s:O}",
                              "key", key,
                              "flags", flags,
@@ -257,8 +270,9 @@ int flux_kvs_lookup_get (flux_future_t *f, const char **value)
     if (parse_response (f, ctx) < 0)
         return -1;
     if (!ctx->val_valid) {
-        if (treeobj_decode_val (ctx->treeobj, &ctx->val_data,
-                                              &ctx->val_len) < 0)
+        if (treeobj_decode_val (ctx->treeobj,
+                                &ctx->val_data,
+                                &ctx->val_len) < 0)
             return -1;
         ctx->val_valid = true;
         // N.B. val_data includes xtra 0 byte term not reflected in val_len
@@ -296,14 +310,17 @@ int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...)
     if (parse_response (f, ctx) < 0)
         return -1;
     if (!ctx->val_valid) {
-        if (treeobj_decode_val (ctx->treeobj, &ctx->val_data,
-                                              &ctx->val_len) < 0)
+        if (treeobj_decode_val (ctx->treeobj,
+                                &ctx->val_data,
+                                &ctx->val_len) < 0)
             return -1;
         ctx->val_valid = true;
     }
     if (!ctx->val_obj) {
-        if (!(ctx->val_obj = json_loadb (ctx->val_data, ctx->val_len,
-                                         JSON_DECODE_ANY, NULL))) {
+        if (!(ctx->val_obj = json_loadb (ctx->val_data,
+                                         ctx->val_len,
+                                         JSON_DECODE_ANY,
+                                         NULL))) {
             errno = EINVAL;
             return -1;
         }
@@ -325,8 +342,9 @@ int flux_kvs_lookup_get_raw (flux_future_t *f, const void **data, int *len)
     if (parse_response (f, ctx) < 0)
         return -1;
     if (!ctx->val_valid) {
-        if (treeobj_decode_val (ctx->treeobj, &ctx->val_data,
-                                              &ctx->val_len) < 0)
+        if (treeobj_decode_val (ctx->treeobj,
+                                &ctx->val_data,
+                                &ctx->val_len) < 0)
             return -1;
         ctx->val_valid = true;
     }
@@ -346,8 +364,10 @@ int flux_kvs_lookup_get_dir (flux_future_t *f, const flux_kvsdir_t **dirp)
     if (parse_response (f, ctx) < 0)
         return -1;
     if (!ctx->dir) {
-        if (!(ctx->dir = kvsdir_create_fromobj (ctx->h, ctx->atref,
-                                                ctx->key, ctx->treeobj)))
+        if (!(ctx->dir = kvsdir_create_fromobj (ctx->h,
+                                                ctx->atref,
+                                                ctx->key,
+                                                ctx->treeobj)))
             return -1;
     }
     if (dirp)

--- a/src/common/libkvs/kvs_lookup.h
+++ b/src/common/libkvs/kvs_lookup.h
@@ -15,9 +15,13 @@
 extern "C" {
 #endif
 
-flux_future_t *flux_kvs_lookup (flux_t *h, const char *ns, int flags,
+flux_future_t *flux_kvs_lookup (flux_t *h,
+                                const char *ns,
+                                int flags,
                                 const char *key);
-flux_future_t *flux_kvs_lookupat (flux_t *h, int flags, const char *key,
+flux_future_t *flux_kvs_lookupat (flux_t *h,
+                                  int flags,
+                                  const char *key,
                                   const char *treeobj);
 
 int flux_kvs_lookup_get (flux_future_t *f, const char **value);

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -75,8 +75,10 @@ static int validate_flags (int flags, int allowed)
 /* Add an operation on dirent to the transaction.
  * Takes a reference on dirent so caller retains ownership.
  */
-static int append_op_to_txn (flux_kvs_txn_t *txn, int flags,
-                             const char *key, json_t *dirent)
+static int append_op_to_txn (flux_kvs_txn_t *txn,
+                             int flags,
+                             const char *key,
+                             json_t *dirent)
 {
     json_t *op = NULL;
     int saved_errno;
@@ -95,8 +97,11 @@ error:
     return -1;
 }
 
-int flux_kvs_txn_put_raw (flux_kvs_txn_t *txn, int flags,
-                          const char *key, const void *data, int len)
+int flux_kvs_txn_put_raw (flux_kvs_txn_t *txn,
+                          int flags,
+                          const char *key,
+                          const void *data,
+                          int len)
 {
     json_t *dirent = NULL;
     int saved_errno;
@@ -121,8 +126,10 @@ error:
     return -1;
 }
 
-int flux_kvs_txn_put_treeobj (flux_kvs_txn_t *txn, int flags,
-                              const char *key, const char *treeobj)
+int flux_kvs_txn_put_treeobj (flux_kvs_txn_t *txn,
+                              int flags,
+                              const char *key,
+                              const char *treeobj)
 {
     json_t *dirent = NULL;
     int saved_errno;
@@ -147,8 +154,10 @@ error:
     return -1;
 }
 
-int flux_kvs_txn_put (flux_kvs_txn_t *txn, int flags,
-                      const char *key, const char *value)
+int flux_kvs_txn_put (flux_kvs_txn_t *txn,
+                      int flags,
+                      const char *key,
+                      const char *value)
 {
     json_t *dirent = NULL;
     int saved_errno;
@@ -173,8 +182,11 @@ error:
     return -1;
 }
 
-int flux_kvs_txn_vpack (flux_kvs_txn_t *txn, int flags,
-                        const char *key, const char *fmt, va_list ap)
+int flux_kvs_txn_vpack (flux_kvs_txn_t *txn,
+                        int flags,
+                        const char *key,
+                        const char *fmt,
+                        va_list ap)
 {
     json_t *val, *dirent = NULL;
     int saved_errno;
@@ -214,8 +226,11 @@ error:
     return -1;
 }
 
-int flux_kvs_txn_pack (flux_kvs_txn_t *txn, int flags,
-                       const char *key, const char *fmt, ...)
+int flux_kvs_txn_pack (flux_kvs_txn_t *txn,
+                       int flags,
+                       const char *key,
+                       const char *fmt,
+                       ...)
 {
     va_list ap;
     int rc;
@@ -230,7 +245,8 @@ int flux_kvs_txn_pack (flux_kvs_txn_t *txn, int flags,
     return rc;
 }
 
-int flux_kvs_txn_mkdir (flux_kvs_txn_t *txn, int flags,
+int flux_kvs_txn_mkdir (flux_kvs_txn_t *txn,
+                        int flags,
                         const char *key)
 {
     json_t *dirent = NULL;
@@ -256,7 +272,8 @@ error:
     return -1;
 }
 
-int flux_kvs_txn_unlink (flux_kvs_txn_t *txn, int flags,
+int flux_kvs_txn_unlink (flux_kvs_txn_t *txn,
+                         int flags,
                          const char *key)
 {
     json_t *dirent = NULL;
@@ -281,8 +298,10 @@ error:
     return -1;
 }
 
-int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
-                          const char *key, const char *ns,
+int flux_kvs_txn_symlink (flux_kvs_txn_t *txn,
+                          int flags,
+                          const char *key,
+                          const char *ns,
                           const char *target)
 {
     json_t *dirent = NULL;
@@ -358,10 +377,11 @@ int txn_decode_op (json_t *op, const char **keyp, int *flagsp, json_t **direntp)
     int flags;
     json_t *dirent;
 
-    if (json_unpack (op, "{s:s s:i s:o !}",
-                         "key", &key,
-                         "flags", &flags,
-                         "dirent", &dirent) < 0) {
+    if (json_unpack (op,
+                     "{s:s s:i s:o !}",
+                     "key", &key,
+                     "flags", &flags,
+                     "dirent", &dirent) < 0) {
         errno = EPROTO;
         return -1;
     }
@@ -378,8 +398,10 @@ int txn_encode_op (const char *key, int flags, json_t *dirent, json_t **opp)
 {
     json_t *op;
 
-    if (!key || strlen (key) == 0 || !dirent
-             || (!json_is_null (dirent) && treeobj_validate (dirent) < 0)) {
+    if (!key
+        || strlen (key) == 0
+        || !dirent
+        || (!json_is_null (dirent) && treeobj_validate (dirent) < 0)) {
         errno = EINVAL;
         return -1;
     }

--- a/src/common/libkvs/kvs_txn.h
+++ b/src/common/libkvs/kvs_txn.h
@@ -22,29 +22,46 @@ typedef struct flux_kvs_txn flux_kvs_txn_t;
 flux_kvs_txn_t *flux_kvs_txn_create (void);
 void flux_kvs_txn_destroy (flux_kvs_txn_t *txn);
 
-int flux_kvs_txn_put (flux_kvs_txn_t *txn, int flags,
-                      const char *key, const char *value);
+int flux_kvs_txn_put (flux_kvs_txn_t *txn,
+                      int flags,
+                      const char *key,
+                      const char *value);
 
-int flux_kvs_txn_vpack (flux_kvs_txn_t *txn, int flags, const char *key,
-                        const char *fmt, va_list ap);
+int flux_kvs_txn_vpack (flux_kvs_txn_t *txn,
+                        int flags,
+                        const char *key,
+                        const char *fmt,
+                        va_list ap);
 
-int flux_kvs_txn_pack (flux_kvs_txn_t *txn, int flags, const char *key,
-                       const char *fmt, ...);
+int flux_kvs_txn_pack (flux_kvs_txn_t *txn,
+                       int flags,
+                       const char *key,
+                       const char *fmt,
+                       ...);
 
-int flux_kvs_txn_put_raw (flux_kvs_txn_t *txn, int flags,
-                          const char *key, const void *data, int len);
+int flux_kvs_txn_put_raw (flux_kvs_txn_t *txn,
+                          int flags,
+                          const char *key,
+                          const void *data,
+                          int len);
 
-int flux_kvs_txn_put_treeobj (flux_kvs_txn_t *txn, int flags,
-                              const char *key, const char *treeobj);
+int flux_kvs_txn_put_treeobj (flux_kvs_txn_t *txn,
+                              int flags,
+                              const char *key,
+                              const char *treeobj);
 
-int flux_kvs_txn_mkdir (flux_kvs_txn_t *txn, int flags,
+int flux_kvs_txn_mkdir (flux_kvs_txn_t *txn,
+                        int flags,
                         const char *key);
 
-int flux_kvs_txn_unlink (flux_kvs_txn_t *txn, int flags,
+int flux_kvs_txn_unlink (flux_kvs_txn_t *txn,
+                         int flags,
                          const char *key);
 
-int flux_kvs_txn_symlink (flux_kvs_txn_t *txn, int flags,
-                          const char *key, const char *ns,
+int flux_kvs_txn_symlink (flux_kvs_txn_t *txn,
+                          int flags,
+                          const char *key,
+                          const char *ns,
                           const char *target);
 
 int flux_kvs_txn_clear (flux_kvs_txn_t *txn);

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -379,7 +379,7 @@ void test_corner_cases (void)
         "flux_kvs_txn_put fails w/ EINVAL on bad inputs");
 
     errno = 0;
-    rc = flux_kvs_txn_vpack (NULL, 0, NULL, NULL, NULL);
+    rc = flux_kvs_txn_vpack (NULL, 0, NULL, NULL, (va_list){0});
     ok (rc < 0 && errno == EINVAL,
         "flux_kvs_txn_vpack fails w/ EINVAL on bad inputs");
 

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -32,11 +32,13 @@ static int treeobj_unpack (json_t *obj, const char **typep, json_t **datap)
     json_t *data;
     int version;
     const char *type;
-    if (!obj || json_unpack (obj, "{s:i s:s s:o !}",
-                                  "ver", &version,
-                                  "type", &type,
-                                  "data", &data) < 0
-             || version != treeobj_version) {
+    if (!obj
+        || json_unpack (obj,
+                        "{s:i s:s s:o !}",
+                        "ver", &version,
+                        "type", &type,
+                        "data", &data) < 0
+        || version != treeobj_version) {
         errno = EINVAL;
         return -1;
     }
@@ -47,7 +49,8 @@ static int treeobj_unpack (json_t *obj, const char **typep, json_t **datap)
     return 0;
 }
 
-static int treeobj_peek (const json_t *obj, const char **typep,
+static int treeobj_peek (const json_t *obj,
+                         const char **typep,
                          const json_t **datap)
 {
     json_t *data;
@@ -57,11 +60,13 @@ static int treeobj_peek (const json_t *obj, const char **typep,
     /* N.B. it should be safe to cast away const on 'obj' as long as 'data'
      * parameter is not modified.  We make 'data' const to ensure that.
      */
-    if (!obj || json_unpack ((json_t *)obj, "{s:i s:s s:o !}",
-                                  "ver", &version,
-                                  "type", &type,
-                                  "data", &data) < 0
-             || version != treeobj_version) {
+    if (!obj
+        || json_unpack ((json_t *)obj,
+                        "{s:i s:s s:o !}",
+                        "ver", &version,
+                        "type", &type,
+                        "data", &data) < 0
+        || version != treeobj_version) {
         errno = EINVAL;
         return -1;
     }
@@ -282,7 +287,7 @@ json_t *treeobj_get_entry (json_t *obj, const char *name)
     json_t *data, *obj2;
 
     if (treeobj_unpack (obj, &type, &data) < 0
-            || !streq (type, "dir")) {
+        || !streq (type, "dir")) {
         errno = EINVAL;
         return NULL;
     }
@@ -299,7 +304,7 @@ int treeobj_delete_entry (json_t *obj, const char *name)
     json_t *data;
 
     if (treeobj_unpack (obj, &type, &data) < 0
-            || !streq (type, "dir")) {
+        || !streq (type, "dir")) {
         errno = EINVAL;
         return -1;
     }
@@ -315,9 +320,11 @@ int treeobj_insert_entry (json_t *obj, const char *name, json_t *obj2)
     const char *type;
     json_t *data;
 
-    if (!name || !obj2 || treeobj_unpack (obj, &type, &data) < 0
-            || !streq (type, "dir")
-            || treeobj_validate (obj2) < 0) {
+    if (!name
+        || !obj2
+        || treeobj_unpack (obj, &type, &data) < 0
+        || !streq (type, "dir")
+        || treeobj_validate (obj2) < 0) {
         errno = EINVAL;
         return -1;
     }
@@ -337,9 +344,10 @@ int treeobj_insert_entry_novalidate (json_t *obj,
     const char *type;
     json_t *data;
 
-    if (!name || !obj2 || treeobj_unpack (obj, &type, &data) < 0
-            || !streq (type, "dir")
-            || treeobj_peek (obj2, NULL, NULL) < 0) {
+    if (!name
+        || !obj2 || treeobj_unpack (obj, &type, &data) < 0
+        || !streq (type, "dir")
+        || treeobj_peek (obj2, NULL, NULL) < 0) {
         errno = EINVAL;
         return -1;
     }
@@ -356,7 +364,7 @@ const json_t *treeobj_peek_entry (const json_t *obj, const char *name)
     const json_t *data, *obj2;
 
     if (treeobj_peek (obj, &type, &data) < 0
-            || !streq (type, "dir")) {
+        || !streq (type, "dir")) {
         errno = EINVAL;
         return NULL;
     }
@@ -417,10 +425,10 @@ int treeobj_append_blobref (json_t *obj, const char *blobref)
     json_t *data, *o;
     int rc = -1;
 
-    if (!blobref || blobref_validate (blobref) < 0
-                 || treeobj_unpack (obj, &type, &data) < 0
-                 || (!streq (type, "dirref")
-                    && !streq (type, "valref"))) {
+    if (!blobref
+        || blobref_validate (blobref) < 0
+        || treeobj_unpack (obj, &type, &data) < 0
+        || (!streq (type, "dirref") && !streq (type, "valref"))) {
         errno = EINVAL;
         goto done;
     }
@@ -445,8 +453,7 @@ const char *treeobj_get_blobref (const json_t *obj, int index)
     const char *type, *blobref = NULL;
 
     if (treeobj_peek (obj, &type, &data) < 0
-            || (!streq (type, "dirref")
-                && !streq (type, "valref"))) {
+        || (!streq (type, "dirref") && !streq (type, "valref"))) {
         errno = EINVAL;
         goto done;
     }
@@ -463,9 +470,10 @@ json_t *treeobj_create_dir (void)
 {
     json_t *obj;
 
-    if (!(obj = json_pack ("{s:i s:s s:{}}", "ver", treeobj_version,
-                                            "type", "dir",
-                                            "data"))) {
+    if (!(obj = json_pack ("{s:i s:s s:{}}",
+                           "ver", treeobj_version,
+                           "type", "dir",
+                           "data"))) {
         errno = ENOMEM;
         return NULL;
     }
@@ -488,7 +496,8 @@ json_t *treeobj_create_symlink (const char *ns, const char *target)
         }
     }
     else {
-        if (!(data = json_pack ("{s:s s:s}", "namespace", ns,
+        if (!(data = json_pack ("{s:s s:s}",
+                                "namespace", ns,
                                 "target", target))) {
             errno = ENOMEM;
             return NULL;
@@ -496,9 +505,10 @@ json_t *treeobj_create_symlink (const char *ns, const char *target)
     }
 
     /* obj takes reference to "data" */
-    if (!(obj = json_pack ("{s:i s:s s:o}", "ver", treeobj_version,
-                                            "type", "symlink",
-                                            "data", data))) {
+    if (!(obj = json_pack ("{s:i s:s s:o}",
+                           "ver", treeobj_version,
+                           "type", "symlink",
+                           "data", data))) {
         json_decref (data);
         errno = ENOMEM;
         return NULL;
@@ -518,9 +528,10 @@ json_t *treeobj_create_val (const void *data, int len)
         goto done;
     if (base64_encode (xdata, xlen, (char *)data, len) < 0)
         goto done;
-    if (!(obj = json_pack ("{s:i s:s s:s}", "ver", treeobj_version,
-                                            "type", "val",
-                                            "data", xdata))) {
+    if (!(obj = json_pack ("{s:i s:s s:s}",
+                           "ver", treeobj_version,
+                           "type", "val",
+                           "data", xdata))) {
         errno = ENOMEM;
         goto done;
     }
@@ -533,14 +544,18 @@ json_t *treeobj_create_valref (const char *blobref)
 {
     json_t *obj;
 
-    if (blobref)
-        obj = json_pack ("{s:i s:s s:[s]}", "ver", treeobj_version,
-                                            "type", "valref",
-                                            "data", blobref);
-    else
-        obj = json_pack ("{s:i s:s s:[]}", "ver", treeobj_version,
-                                            "type", "valref",
-                                            "data");
+    if (blobref) {
+        obj = json_pack ("{s:i s:s s:[s]}",
+                         "ver", treeobj_version,
+                         "type", "valref",
+                         "data", blobref);
+    }
+    else {
+        obj = json_pack ("{s:i s:s s:[]}",
+                         "ver", treeobj_version,
+                         "type", "valref",
+                         "data");
+    }
     if (!obj) {
         errno = ENOMEM;
         return NULL;
@@ -552,14 +567,18 @@ json_t *treeobj_create_dirref (const char *blobref)
 {
     json_t *obj;
 
-    if (blobref)
-        obj = json_pack ("{s:i s:s s:[s]}", "ver", treeobj_version,
-                                            "type", "dirref",
-                                            "data", blobref);
-    else
-        obj = json_pack ("{s:i s:s s:[]}", "ver", treeobj_version,
-                                            "type", "dirref",
-                                            "data");
+    if (blobref) {
+        obj = json_pack ("{s:i s:s s:[s]}",
+                         "ver", treeobj_version,
+                         "type", "dirref",
+                         "data", blobref);
+    }
+    else {
+        obj = json_pack ("{s:i s:s s:[]}",
+                         "ver", treeobj_version,
+                         "type", "dirref",
+                         "data");
+    }
     if (!obj) {
         errno = ENOMEM;
         return NULL;
@@ -567,8 +586,10 @@ json_t *treeobj_create_dirref (const char *blobref)
     return obj;
 }
 
-json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob,
-                                   void *data, int len)
+json_t *treeobj_create_valref_buf (const char *hashtype,
+                                   int maxblob,
+                                   void *data,
+                                   int len)
 {
     json_t *valref = NULL;
     char blobref[BLOBREF_MAX_STRING_SIZE];
@@ -580,7 +601,10 @@ json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob,
         blob_len = len;
         if (maxblob > 0 && len > maxblob)
             blob_len = maxblob;
-        if (blobref_hash (hashtype, data, blob_len, blobref,
+        if (blobref_hash (hashtype,
+                          data,
+                          blob_len,
+                          blobref,
                           sizeof (blobref)) < 0)
             goto error;
         if (treeobj_append_blobref (valref, blobref) < 0)
@@ -609,7 +633,7 @@ json_t *treeobj_decodeb (const char *buf, size_t buflen)
 {
     json_t *obj = NULL;
     if (!(obj = json_loadb (buf, buflen, 0, NULL))
-            || treeobj_validate (obj) < 0) {
+        || treeobj_validate (obj) < 0) {
         errno = EPROTO;
         goto error;
     }

--- a/src/common/libkvs/treeobj.h
+++ b/src/common/libkvs/treeobj.h
@@ -125,8 +125,10 @@ const char *treeobj_get_blobref (const json_t *obj, int index);
  * 'hashtype' hash algorithm (e.g. "sha1").  If 'maxblob' > 0, split the
  * blob into maxblob size chunks.
  */
-json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob,
-                                   void *data, int len);
+json_t *treeobj_create_valref_buf (const char *hashtype,
+                                   int maxblob,
+                                   void *data,
+                                   int len);
 
 /* Convert a treeobj to/from string.
  * The return value of treeobj_decode must be destroyed with json_decref().


### PR DESCRIPTION
This fixes a bad parameter that was caught in RHEL 8 aarch64 CI.  I also tacked on some libkvs whitespace cleanup.