### PR TITLE
testsuite: fix t2260-job-list.t with `-d -v` and run inception tests with these args to prevent future similar errors

### DIFF
--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -1863,7 +1863,7 @@ test_expect_success 'verify task count preserved across restart' '
 	jobid1=`cat success1.id` &&
 	jobid2=`cat success2.id` &&
 	obj=$(flux job list -s inactive | grep ${jobid1}) &&
-	test_debug "echo $obj | jq -S ." &&
+	test_debug "echo $obj" &&
 	echo $obj | jq -e ".success == true" &&
 	obj=$(flux job list -s inactive | grep ${jobid2}) &&
 	echo $obj | jq -e ".success == false"
@@ -1876,7 +1876,7 @@ test_expect_success 'flux job list outputs exceptions correctly (no exception)' 
 	echo $jobid > exceptions1.id &&
 	wait_jobid_state $jobid inactive &&
 	obj=$(flux job list -s inactive | grep $jobid) &&
-	test_debug "echo $obj | jq -S ." &&
+	test_debug "echo $obj" &&
 	echo $obj | jq -e ".exception_occurred == false" &&
 	echo $obj | jq -e ".exception_severity == null" &&
 	echo $obj | jq -e ".exception_type == null" &&
@@ -1888,7 +1888,7 @@ test_expect_success 'flux job list outputs exceptions correctly (exception)' '
 	echo $jobid > exceptions2.id &&
 	wait_jobid_state $jobid inactive &&
 	obj=$(flux job list -s inactive | grep $jobid) &&
-	test_debug "echo $obj | jq -S ." &&
+	test_debug "echo $obj" &&
 	echo $obj | jq -e ".exception_occurred == true" &&
 	echo $obj | jq -e ".exception_severity == 0" &&
 	echo $obj | jq -e ".exception_type == \"exec\"" &&
@@ -1904,7 +1904,7 @@ test_expect_success 'flux job list outputs exceptions correctly (exception cance
 	flux cancel $jobid &&
 	wait_jobid_state $jobid inactive &&
 	obj=$(flux job list -s inactive | grep $jobid) &&
-	test_debug "echo $obj | jq -S ." &&
+	test_debug "echo $obj" &&
 	echo $obj | jq -e ".exception_occurred == true" &&
 	echo $obj | jq -e ".exception_severity == 0" &&
 	echo $obj | jq -e ".exception_type == \"cancel\"" &&
@@ -1920,7 +1920,7 @@ test_expect_success 'flux job list outputs exceptions correctly (exception cance
 	flux cancel -m "mecanceled" $jobid &&
 	wait_jobid_state $jobid inactive &&
 	obj=$(flux job list -s inactive | grep $jobid) &&
-	test_debug "echo $obj | jq -S ." &&
+	test_debug "echo $obj" &&
 	echo $obj | jq -e ".exception_occurred == true" &&
 	echo $obj | jq -e ".exception_severity == 0" &&
 	echo $obj | jq -e ".exception_type == \"cancel\"" &&
@@ -1940,7 +1940,7 @@ test_expect_success 'flux job list outputs exceptions correctly (user exception)
 	wait_jobid_state $jobid inactive &&
 	test_debug "flux job list -s inactive | jq" &&
 	obj=$(flux job list -s inactive | grep $jobid) &&
-	test_debug "echo $obj | jq -S ." &&
+	test_debug "echo $obj" &&
 	echo $obj | jq -e ".exception_occurred == true" &&
 	echo $obj | jq -e ".exception_severity == 0" &&
 	echo $obj | jq -e ".exception_type == \"foo\"" &&

--- a/t/test-inception.sh
+++ b/t/test-inception.sh
@@ -14,9 +14,14 @@ stats() {
 stats &
 PID=$!
 export FLUX_TESTS_LOGFILE=t
-flux bulksubmit -o pty --watch --quiet \
-	sh -c './{} --root=$FLUX_JOB_TMPDIR' \
-	::: t[0-9]*.t python/t*.py lua/t*.t
+# run sharness tests with -d -v
+flux bulksubmit -o pty --quiet \
+	sh -c './{} -d -v --root=$FLUX_JOB_TMPDIR' \
+	::: t[0-9]*.t
+# python and lua tests do not support -d, -v, or --root options
+flux bulksubmit -o pty --quiet flux python {} ::: python/t*.py
+flux bulksubmit -o pty --quiet ./{} ::: lua/t*.t
+flux watch --all
 RC=$?
 kill $PID
 wait


### PR DESCRIPTION
Another test had some bad `test_debug` statements that caused the test to fail when run with `-d -v`. This PR fixes that and adds these args to the sharness tests in the inception builder to hopefully catch these silly errors in CI.