### PR TITLE
testsuite: more reliability improvements in tests

### DIFF
--- a/t/t2233-job-info-update.t
+++ b/t/t2233-job-info-update.t
@@ -108,7 +108,7 @@ test_expect_success 'job-info: update watch with no update events works (job ina
 '
 
 test_expect_success NO_CHAIN_LINT 'job-info: update watch with no update events works (job run/canceled)' '
-	jobid=$(flux submit --wait-event=start sleep inf)
+	jobid=$(flux submit --wait-event=exec.shell.init sleep inf)
 	watchers=$(get_update_watchers)
 	${UPDATE_WATCH} $jobid R > watch2.out &
 	watchpid=$! &&
@@ -132,7 +132,7 @@ test_expect_success 'job-info: update watch with update events works (job inacti
 '
 
 test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events works (before watch)' '
-	jobid=$(flux submit --wait-event=start sleep inf) &&
+	jobid=$(flux submit --wait-event=exec.shell.init sleep inf) &&
 	update1=$(expiration_add $jobid 100) &&
 	update2=$(expiration_add $jobid 200) &&
 	watchers=$(get_update_watchers)
@@ -147,7 +147,7 @@ test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events wor
 '
 
 test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events works (after watch)' '
-	jobid=$(flux submit --wait-event=start sleep inf) &&
+	jobid=$(flux submit --wait-event=exec.shell.init sleep inf) &&
 	watchers=$(get_update_watchers)
 	${UPDATE_WATCH} $jobid R > watch5.out &
 	watchpid=$! &&
@@ -165,7 +165,7 @@ test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events wor
 '
 
 test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events works (before/after watch)' '
-	jobid=$(flux submit --wait-event=start sleep inf) &&
+	jobid=$(flux submit --wait-event=exec.shell.init sleep inf) &&
 	update1=$(expiration_add $jobid 100) &&
 	watchers=$(get_update_watchers)
 	${UPDATE_WATCH} $jobid R > watch6.out &
@@ -183,7 +183,7 @@ test_expect_success NO_CHAIN_LINT 'job-info: update watch with update events wor
 
 # signaling the update watch tool with SIGUSR1 will cancel the stream
 test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (single watcher)' '
-	jobid=$(flux submit --wait-event=start sleep inf) &&
+	jobid=$(flux submit --wait-event=exec.shell.init sleep inf) &&
 	watchers=$(get_update_watchers)
 	${UPDATE_WATCH} $jobid R > watch7.out &
 	watchpid=$! &&
@@ -203,7 +203,7 @@ test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (singl
 # At the end, the first watcher should see 3 R versions, the second
 # one 2, and the last one only 1.
 test_expect_success NO_CHAIN_LINT 'job-info: update watch with multiple watchers works' '
-	jobid=$(flux submit --wait-event=start sleep inf)
+	jobid=$(flux submit --wait-event=exec.shell.init sleep inf)
 	watchers=$(get_update_watchers)
 	${UPDATE_WATCH} $jobid R > watch8A.out &
 	watchpidA=$! &&
@@ -237,7 +237,7 @@ test_expect_success NO_CHAIN_LINT 'job-info: update watch with multiple watchers
 
 # signaling the update watch tool with SIGUSR1 will cancel the stream
 test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (multiple watchers)' '
-	jobid=$(flux submit --wait-event=start sleep inf)
+	jobid=$(flux submit --wait-event=exec.shell.init sleep inf)
 	watchers=$(get_update_watchers)
 	${UPDATE_WATCH} $jobid R > watch10A.out &
 	watchpidA=$! &&
@@ -265,7 +265,7 @@ test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (multi
 # If someone is already doing an update-watch on a jobid/key, update-lookup can
 # return the cached info
 test_expect_success NO_CHAIN_LINT 'job-info: update lookup returns cached R from update watch' '
-	jobid=$(flux submit --wait-event=start sleep inf) &&
+	jobid=$(flux submit --wait-event=exec.shell.init sleep inf) &&
 	watchers=$(get_update_watchers)
 	${UPDATE_WATCH} $jobid R > watch9.out &
 	watchpid=$! &&
@@ -314,7 +314,7 @@ test_expect_success 'job-info: non job owner cannot watch key' '
 # this test checks security on a second watcher, which is trying to
 # access cached info
 test_expect_success NO_CHAIN_LINT 'job-info: non job owner cannot watch key (second watcher)' '
-	jobid=`flux submit --wait-event=start sleep inf`
+	jobid=`flux submit --wait-event=exec.shell.init sleep inf`
 	watchers=$(get_update_watchers)
 	${UPDATE_WATCH} $jobid R > watchsecurity.out &
 	watchpid=$! &&
@@ -329,7 +329,7 @@ test_expect_success NO_CHAIN_LINT 'job-info: non job owner cannot watch key (sec
 
 # update-lookup cannot read cached watch data
 test_expect_success NO_CHAIN_LINT 'job-info: non job owner cannot lookup key (piggy backed)' '
-	jobid=`flux submit --wait-event=start sleep inf`
+	jobid=`flux submit --wait-event=exec.shell.init sleep inf`
 	watchers=$(get_update_watchers)
 	${UPDATE_WATCH} $jobid R > lookupsecurity.out &
 	watchpid=$! &&

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -171,9 +171,9 @@ test_expect_success 'attach: cannot attach to interactive pty when --read-only s
 		flux job attach $jobid
 '
 test_expect_success 'attach: --stdin-ranks works' '
-	id=$(flux submit -N4 -t60s cat) &&
+	id=$(flux submit -N4 -o exit-timeout=none -t60s cat) &&
 	echo hello from 0 \
-		| flux job attach --label-io -i0 $id >stdin-ranks.out &&
+		| flux job attach -vEX --label-io -i0 $id >stdin-ranks.out &&
 	flux job eventlog -p guest.input $id &&
 	cat <<-EOF >stdin-ranks.expected &&
 	0: hello from 0

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -171,7 +171,7 @@ test_expect_success 'attach: cannot attach to interactive pty when --read-only s
 		flux job attach $jobid
 '
 test_expect_success 'attach: --stdin-ranks works' '
-	id=$(flux submit -N4 -t20s cat) &&
+	id=$(flux submit -N4 -t60s cat) &&
 	echo hello from 0 \
 		| flux job attach --label-io -i0 $id >stdin-ranks.out &&
 	flux job eventlog -p guest.input $id &&
@@ -181,24 +181,24 @@ test_expect_success 'attach: --stdin-ranks works' '
 	test_cmp stdin-ranks.expected stdin-ranks.out
 '
 test_expect_success 'attach: --stdin-ranks with invalid idset errors' '
-	id=$(flux submit -t20s cat) &&
+	id=$(flux submit -t60s cat) &&
 	test_must_fail flux job attach -i 5-0 $id &&
 	flux cancel $id
 '
 test_expect_success 'attach: --stdin-ranks is adjusted to intersection' '
-	id=$(flux submit -n2 -t20s cat) &&
+	id=$(flux submit -n2 -t60s cat) &&
 	echo foo | flux job attach --label-io -i1-2 $id >adjusted.out 2>&1 &&
 	test_debug "cat adjusted.out" &&
 	grep "warning: adjusting --stdin-ranks" adjusted.out
 '
 test_expect_success 'attach: --stdin-ranks cannot be used with --read-only' '
-	id=$(flux submit -n2 -t20s cat) &&
+	id=$(flux submit -n2 -t60s cat) &&
 	test_must_fail flux job attach -i all --read-only $id &&
 	flux cancel $id
 '
 jobpipe=$SHARNESS_TEST_SRCDIR/scripts/pipe.py
 test_expect_success 'attach: writing to stdin of closed tasks returns EPIPE' '
-	id=$(flux submit -N4 -t20s cat) &&
+	id=$(flux submit -N4 -t60s cat) &&
 	$jobpipe $id 0 </dev/null &&
 	test_must_fail $jobpipe $id 0 </dev/null >pipe.out 2>&1 &&
 	$jobpipe $id all </dev/null &&


### PR DESCRIPTION
This PR includes a few more fixes for unreliable tests in ci. There are still more flaky tests, but they are now somewhat rare instead of annoyingly common.