### PR TITLE
testsuite: fix test corner case on stderr

### DIFF
--- a/t/t2716-python-cli-batch-conf.t
+++ b/t/t2716-python-cli-batch-conf.t
@@ -206,7 +206,7 @@ test_expect_success 'flux-batch multiline --conf + --conf=KEY=VAL override works
 '
 test_expect_success 'flux-batch --conf end-to-end test' '
 	jobid=$(flux batch --conf=resource.exclude=\"0\" \
-		--output=batchtest.out batch.sh) &&
+		--output=batchtest.out --error=batchtest.err batch.sh) &&
 	flux job wait-event $jobid clean &&
 	jq -e ".resource.noverify" <batchtest.out &&
 	jq -e ".resource.exclude == \"0\"" <batchtest.out


### PR DESCRIPTION
Problem: A test in t2716-python-cli-batch-conf.t can fail if some errant stderr ends up in the json output file.

Solution: Redirect stderr to a separate file.