### PR TITLE
job-list: fix json object mem-leak

### DIFF
--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -372,9 +372,11 @@ void check_id_valid_continuation (flux_future_t *f, void *arg)
                 goto cleanup;
             }
             if (flux_respond_pack (jsctx->h, isd->msg, "{s:O}", "job", o) < 0) {
+                json_decref (o);
                 flux_log_error (jsctx->h, "%s: flux_respond_pack", __FUNCTION__);
                 goto cleanup;
             }
+            json_decref (o);
         }
     }
 


### PR DESCRIPTION
Problem: In the check_id_valid path, there is a potential a mem-leak of a json object.  The path is for a rare race, so it likely has not been hit in production.

Solution: Remove the json object when it is no longer used.