### PR TITLE
python: Add kvs.commit_async()

### DIFF
--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -241,6 +241,8 @@ def commit(flux_handle, flags: int = 0, namespace=None, _kvstxn=None):
           set, the primary namespace will be used.
     """
     if _kvstxn is None:
+        # If _kvstxn is None, use the default txn stored in the flux
+        # handle.  If aux_txn is None, there is nothing to commit.
         if flux_handle.aux_txn is None:
             return
         future = RAW.flux_kvs_commit(flux_handle, namespace, flags, flux_handle.aux_txn)
@@ -253,6 +255,8 @@ def commit(flux_handle, flags: int = 0, namespace=None, _kvstxn=None):
             flux_handle.aux_txn = None
             RAW.flux_future_destroy(future)
     else:
+        # if _kvstxn is type KVSTxn, get the RAW kvs txn stored within
+        # it.  If not type KVSTxn, it is assumed to of type RAW txn.
         if isinstance(_kvstxn, KVSTxn):
             _kvstxn = _kvstxn.txn
         future = RAW.flux_kvs_commit(flux_handle, namespace, flags, _kvstxn)

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -751,6 +751,34 @@ class TestKVS(unittest.TestCase):
 
         self.assertEqual(flux.kvs.get(self.f, "kvstxntestkeepref.dir1.dir2.a"), 1)
 
+    def test_commic_async_01_basic(self):
+        flux.kvs.put(self.f, "commicasync1", "foo")
+        f = flux.kvs.commit_async(self.f)
+        f.get()
+        self.assertEqual(flux.kvs.get(self.f, "commicasync1"), "foo")
+
+    def test_commic_async_02_with_kvstxn(self):
+        txn = flux.kvs.KVSTxn(self.f)
+        txn.put("commitasync2", "bar")
+
+        f = flux.kvs.commit_async(self.f, _kvstxn=txn)
+        f.get()
+        self.assertEqual(flux.kvs.get(self.f, "commitasync2"), "bar")
+
+    def test_commic_async_03_kvstxn(self):
+        txn = flux.kvs.KVSTxn(self.f)
+        txn.put("commitasync3", "baz")
+        f = txn.commit_async()
+        f.get()
+        self.assertEqual(flux.kvs.get(self.f, "commitasync3"), "baz")
+
+    def test_commic_async_04_kvsdir(self):
+        kd = flux.kvs.KVSDir(self.f)
+        kd["commitasync4"] = "qux"
+        f = kd.commit_async()
+        f.get()
+        self.assertEqual(flux.kvs.get(self.f, "commitasync4"), "qux")
+
 
 if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):


### PR DESCRIPTION
Problem: There may be circumstances that a non-synchronous kvs
commit is desired, but there is no way to do that at the moment.

Solution: Add a kvs.commit_async() function to the kvs module.
Also add equivalent commit_async() functions to KVSTxn and KVSDir.

Fixes #5606

--- 

Note will re-work #5389 to use this