### PR TITLE
doc: reference flux-environment(7) in job submission cli man pages

### DIFF
--- a/doc/man1/flux-alloc.rst
+++ b/doc/man1/flux-alloc.rst
@@ -136,4 +136,4 @@ SEE ALSO
 ========
 
 :man1:`flux-run`, :man1:`flux-submit`, :man1:`flux-batch`,
-:man1:`flux-bulksubmit`
+:man1:`flux-bulksubmit`, :man7:`flux-environment`

--- a/doc/man1/flux-alloc.rst
+++ b/doc/man1/flux-alloc.rst
@@ -77,9 +77,15 @@ DEPENDENCIES
 ENVIRONMENT
 ===========
 
-By default, these commands duplicate the current environment when submitting
-jobs. However, a set of environment manipulation options are provided to
-give fine control over the requested environment submitted with the job.
+By default, :man1:`flux-alloc` duplicates the current environment when
+submitting jobs. However, a set of environment manipulation options are
+provided to give fine control over the requested environment submitted
+with the job.
+
+.. note::
+   The actual environment of the initial program is subject to the caveats
+   described in the :ref:`initial_program_environment` section of
+   :man7:`flux-environment`.
 
 .. include:: common/job-environment.rst
 

--- a/doc/man1/flux-batch.rst
+++ b/doc/man1/flux-batch.rst
@@ -100,9 +100,15 @@ DEPENDENCIES
 ENVIRONMENT
 ===========
 
-By default, these commands duplicate the current environment when submitting
-jobs. However, a set of environment manipulation options are provided to
-give fine control over the requested environment submitted with the job.
+By default, :man1:`flux-batch` duplicates the current environment when
+submitting jobs. However, a set of environment manipulation options
+are provided to give fine control over the requested environment
+submitted with the job.
+
+.. note::
+   The actual environment of the initial program is subject to the caveats
+   described in the :ref:`initial_program_environment` section of
+   :man7:`flux-environment`.
 
 .. include:: common/job-environment.rst
 

--- a/doc/man1/flux-batch.rst
+++ b/doc/man1/flux-batch.rst
@@ -208,4 +208,4 @@ SEE ALSO
 ========
 
 :man1:`flux-submit`, :man1:`flux-run`, :man1:`flux-alloc`,
-:man1:`flux-bulksubmit`
+:man1:`flux-bulksubmit` :man7:`flux-environment`

--- a/doc/man1/flux-bulksubmit.rst
+++ b/doc/man1/flux-bulksubmit.rst
@@ -248,5 +248,5 @@ SEE ALSO
 ========
 
 :man1:`flux-run`, :man1:`flux-submit`, :man1:`flux-alloc`,
-:man1:`flux-batch`
+:man1:`flux-batch`, :man7:`flux-environment`
 

--- a/doc/man1/flux-run.rst
+++ b/doc/man1/flux-run.rst
@@ -164,4 +164,4 @@ SEE ALSO
 ========
 
 :man1:`flux-submit`, :man1:`flux-alloc`, :man1:`flux-batch`,
-:man1:`flux-bulksubmit`
+:man1:`flux-bulksubmit`, :man7:`flux-environment`

--- a/doc/man1/flux-submit.rst
+++ b/doc/man1/flux-submit.rst
@@ -164,4 +164,4 @@ SEE ALSO
 ========
 
 :man1:`flux-run`, :man1:`flux-alloc`, :man1:`flux-batch`,
-:man1:`flux-bulksubmit`
+:man1:`flux-bulksubmit`, :man7:`flux-environment`

--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -136,6 +136,8 @@ The following are set in the environment of each task spawned by
    environment, it points to the local broker responsible for the job.
 
 
+.. _initial_program_environment:
+
 INITIAL PROGRAM ENVIRONMENT
 ===========================
 


### PR DESCRIPTION
This PR adds a few more references to the useful `flux-environment(7)` man page in the job submission cli manual pages.