### PR TITLE
libflux: don't accept FLUX_MSGTYPE_ANY  in flux_msg_create()

### DIFF
--- a/src/common/libflux/message_iovec.h
+++ b/src/common/libflux/message_iovec.h
@@ -23,9 +23,7 @@ struct msg_iovec {
     void *transport_data;
 };
 
-int iovec_to_msg (flux_msg_t *msg,
-                  struct msg_iovec *iov,
-                  int iovcnt);
+flux_msg_t *iovec_to_msg (struct msg_iovec *iov, int iovcnt);
 
 int msg_to_iovec (const flux_msg_t *msg,
                   uint8_t *proto,

--- a/src/common/libflux/message_private.h
+++ b/src/common/libflux/message_private.h
@@ -40,6 +40,8 @@ struct flux_msg {
     struct list_node list; // for use by msg_deque container only
 };
 
+flux_msg_t *msg_create (void);
+
 #define msgtype_is_valid(tp) \
     ((tp) == FLUX_MSGTYPE_REQUEST || (tp) == FLUX_MSGTYPE_RESPONSE \
      || (tp) == FLUX_MSGTYPE_EVENT || (tp) == FLUX_MSGTYPE_CONTROL)

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -30,7 +30,7 @@ static bool verbose = false;
 void check_cornercase (void)
 {
     flux_msg_t *msg;
-    flux_msg_t *req, *rsp, *evt, *any;
+    flux_msg_t *req, *rsp, *evt;
     struct flux_msg_cred cred;
     uint32_t seq, nodeid;
     uint8_t encodebuf[64];
@@ -52,8 +52,6 @@ void check_cornercase (void)
     if (!(rsp = flux_msg_create (FLUX_MSGTYPE_RESPONSE)))
         BAIL_OUT ("flux_msg_create failed");
     if (!(evt = flux_msg_create (FLUX_MSGTYPE_EVENT)))
-        BAIL_OUT ("flux_msg_create failed");
-    if (!(any = flux_msg_create (FLUX_MSGTYPE_ANY)))
         BAIL_OUT ("flux_msg_create failed");
 
     lives_ok ({flux_msg_destroy (NULL);},
@@ -82,9 +80,6 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_encode (NULL, encodebuf, encodesize) < 0 && errno == EINVAL,
         "flux_msg_encode fails on EINVAL with msg=NULL");
-    errno = 0;
-    ok (flux_msg_encode (any, encodebuf, encodesize) < 0 && errno == EPROTO,
-        "flux_msg_encode fails on EPROTO with msg type ANY");
     errno = 0;
     ok (flux_msg_frames (NULL) < 0 && errno == EINVAL,
         "flux_msg_frames returns -1 errno EINVAL on msg = NULL");
@@ -729,12 +724,6 @@ void check_proto (void)
     uint32_t nodeid;
     int errnum;
     int type;
-
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_ANY)) != NULL,
-        "flux_msg_create works");
-    ok (flux_msg_get_type (msg, &type) == 0 && type == FLUX_MSGTYPE_ANY,
-        "flux_msg_get_type works with type FLUX_MSGTYPE_ANY");
-    flux_msg_destroy (msg);
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_RESPONSE)) != NULL,
         "flux_msg_create works");

--- a/src/common/libzmqutil/msg_zsock.c
+++ b/src/common/libzmqutil/msg_zsock.c
@@ -116,9 +116,7 @@ flux_msg_t *zmqutil_msg_recv (void *sock)
             break;
     }
 
-    if (!(msg = flux_msg_create (FLUX_MSGTYPE_ANY)))
-        goto error;
-    if (iovec_to_msg (msg, iov, iovcnt) < 0)
+    if (!(msg = iovec_to_msg (iov, iovcnt)))
         goto error;
     rv = msg;
 error:

--- a/src/common/libzmqutil/test/msg_zsock.c
+++ b/src/common/libzmqutil/test/msg_zsock.c
@@ -28,7 +28,7 @@ static void *zctx;
 void check_sendzsock (void)
 {
     void *zsock[2] = { NULL, NULL };
-    flux_msg_t *any, *msg, *msg2;
+    flux_msg_t *msg, *msg2;
     const char *topic;
     int type;
     const char *uri = "inproc://test";
@@ -43,9 +43,6 @@ void check_sendzsock (void)
         || zsetsockopt_int (zsock[1], ZMQ_LINGER, 5) < 0)
         BAIL_OUT ("could not set ZMQ_LINGER socket option");
 
-    if (!(any = flux_msg_create (FLUX_MSGTYPE_ANY)))
-        BAIL_OUT ("flux_msg_create failed");
-
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL
             && flux_msg_set_topic (msg, "foo.bar") == 0,
         "created test message");
@@ -53,12 +50,8 @@ void check_sendzsock (void)
     /* corner case tests */
     ok (zmqutil_msg_send (NULL, msg) < 0 && errno == EINVAL,
         "zmqutil_msg_send returns < 0 and EINVAL on dest = NULL");
-    ok (zmqutil_msg_send (zsock[1], any) < 0 && errno == EPROTO,
-        "zmqutil_msg_send returns < 0 and EPROTO on msg w/ type = ANY");
     ok (zmqutil_msg_send_ex (NULL, msg, true) < 0 && errno == EINVAL,
         "zmqutil_msg_send_ex returns < 0 and EINVAL on dest = NULL");
-    ok (zmqutil_msg_send_ex (zsock[1], any, true) < 0 && errno == EPROTO,
-        "zmqutil_msg_send_ex returns < 0 and EPROTO on msg w/ type = ANY");
     ok (zmqutil_msg_recv (NULL) == NULL && errno == EINVAL,
         "zmqutil_msg_recv returns NULL and EINVAL on dest = NULL");
 
@@ -85,7 +78,6 @@ void check_sendzsock (void)
             && flux_msg_has_payload (msg2) == false,
         "try2: decoded message looks like what was sent");
     flux_msg_destroy (msg2);
-    flux_msg_destroy (any);
     flux_msg_destroy (msg);
 
     zmq_close (zsock[0]);


### PR DESCRIPTION
Problem: `flux_msg_create()` accepts FLUX_MSGTYPE_ANY as a type argument, but this is confusing and is not required by users.

Factor out a `msg_create()` internal constructor that can be used by internal functions instead.

Update libflux and libzmqutil users.
Update unit tests.

This was split off of #5630