### PR TITLE
job-info: add JSON_DECODE & CURRENT flags, deprecate job-info.update-lookup

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -3398,7 +3398,7 @@ int cmd_info (optparse_t *p, int argc, char **argv)
                                  "keys", "J",
                                  "flags", 0))
             || flux_rpc_get_unpack (f, "{s:s}", "J", &val) < 0)
-            log_msg_exit ("%s", future_strerror (f, errno ));
+            log_msg_exit ("%s", future_strerror (f, errno));
         if (!(new_val = flux_unwrap_string (val, false, NULL, &error)))
             log_msg_exit ("Failed to unwrap J to get jobspec: %s", error.text);
         val = new_val;
@@ -3423,7 +3423,7 @@ int cmd_info (optparse_t *p, int argc, char **argv)
                                     "{s:s s:s}",
                                     "jobspec", &jobspec,
                                     "eventlog", &eventlog) < 0)
-            log_msg_exit ("%s", future_strerror (f, errno ));
+            log_msg_exit ("%s", future_strerror (f, errno));
         val = new_val = reconstruct_current_jobspec (jobspec, eventlog);
     }
     /* The current (non --base) R is obtained through the
@@ -3440,7 +3440,7 @@ int cmd_info (optparse_t *p, int argc, char **argv)
                                  "key", key,
                                  "flags", 0))
             || flux_rpc_get_unpack (f, "{s:o}", key, &o) < 0)
-            log_msg_exit ("%s", future_strerror (f, errno ));
+            log_msg_exit ("%s", future_strerror (f, errno));
         if (!(new_val = json_dumps (o, JSON_COMPACT)))
             log_msg_exit ("error encoding R object");
         val = new_val;
@@ -3457,7 +3457,7 @@ int cmd_info (optparse_t *p, int argc, char **argv)
                                  "keys", key,
                                  "flags", 0))
             || flux_rpc_get_unpack (f, "{s:s}", key, &val) < 0)
-            log_msg_exit ("%s", future_strerror (f, errno ));
+            log_msg_exit ("%s", future_strerror (f, errno));
     }
 
     printf ("%s\n", val);

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -3427,23 +3427,19 @@ int cmd_info (optparse_t *p, int argc, char **argv)
         val = new_val = reconstruct_current_jobspec (jobspec, eventlog);
     }
     /* The current (non --base) R is obtained through the
-     * job-info.update-lookup RPC, not the normal job-info.lookup.
+     * job-info.lookup RPC w/ the CURRENT flag.
      */
     else if (!optparse_hasopt (p, "base") && streq (key, "R")) {
-        json_t *o;
         if (!(f = flux_rpc_pack (h,
-                                 "job-info.update-lookup",
+                                 "job-info.lookup",
                                  FLUX_NODEID_ANY,
                                  0,
-                                 "{s:I s:s s:i}",
+                                 "{s:I s:[s] s:i}",
                                  "id", id,
-                                 "key", key,
-                                 "flags", 0))
-            || flux_rpc_get_unpack (f, "{s:o}", key, &o) < 0)
+                                 "keys", key,
+                                 "flags", FLUX_JOB_LOOKUP_CURRENT))
+            || flux_rpc_get_unpack (f, "{s:s}", key, &val) < 0)
             log_msg_exit ("%s", future_strerror (f, errno));
-        if (!(new_val = json_dumps (o, JSON_COMPACT)))
-            log_msg_exit ("error encoding R object");
-        val = new_val;
     }
     /* All other keys are obtained this way.
      */

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -35,6 +35,11 @@ enum job_lookup_flags {
      * - currently works for jobspec and R
      */
     FLUX_JOB_LOOKUP_JSON_DECODE = 1,
+    /* get current value of special fields by applying eventlog
+     * updates for those fields
+     * - currently works for R
+     */
+    FLUX_JOB_LOOKUP_CURRENT = 2,
 };
 
 enum job_urgency {

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -30,6 +30,13 @@ enum job_event_watch_flags {
     FLUX_JOB_EVENT_WATCH_WAITCREATE = 1, // wait for path to exist
 };
 
+enum job_lookup_flags {
+    /* return special fields as decoded JSON objects instead of strings
+     * - currently works for jobspec and R
+     */
+    FLUX_JOB_LOOKUP_JSON_DECODE = 1,
+};
+
 enum job_urgency {
     FLUX_JOB_URGENCY_MIN = 0,
     FLUX_JOB_URGENCY_HOLD = FLUX_JOB_URGENCY_MIN,

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -38,7 +38,7 @@ static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
     int lookups = zlist_size (ctx->lookups);
     int watchers = zlist_size (ctx->watchers);
     int guest_watchers = zlist_size (ctx->guest_watchers);
-    int update_lookups = zlist_size (ctx->update_lookups);
+    int update_lookups = 0;     /* no longer supported */
     int update_watchers = update_watch_count (ctx);
     if (flux_respond_pack (h, msg, "{s:i s:i s:i s:i s:i}",
                            "lookups", lookups,
@@ -117,10 +117,6 @@ static void info_ctx_destroy (struct info_ctx *ctx)
             guest_watch_cleanup (ctx);
             zlist_destroy (&ctx->guest_watchers);
         }
-        if (ctx->update_lookups) {
-            update_lookup_cleanup (ctx);
-            zlist_destroy (&ctx->update_lookups);
-        }
         if (ctx->update_watchers) {
             update_watch_cleanup (ctx);
             zlist_destroy (&ctx->update_watchers);
@@ -148,8 +144,6 @@ static struct info_ctx *info_ctx_create (flux_t *h)
     if (!(ctx->watchers = zlist_new ()))
         goto error;
     if (!(ctx->guest_watchers = zlist_new ()))
-        goto error;
-    if (!(ctx->update_lookups = zlist_new ()))
         goto error;
     if (!(ctx->update_watchers = zlist_new ()))
         goto error;

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -117,8 +117,10 @@ static void info_ctx_destroy (struct info_ctx *ctx)
             guest_watch_cleanup (ctx);
             zlist_destroy (&ctx->guest_watchers);
         }
-        if (ctx->update_lookups)
+        if (ctx->update_lookups) {
+            update_lookup_cleanup (ctx);
             zlist_destroy (&ctx->update_lookups);
+        }
         if (ctx->update_watchers) {
             update_watch_cleanup (ctx);
             zlist_destroy (&ctx->update_watchers);

--- a/src/modules/job-info/job-info.h
+++ b/src/modules/job-info/job-info.h
@@ -26,7 +26,6 @@ struct info_ctx {
     zlist_t *lookups;
     zlist_t *watchers;
     zlist_t *guest_watchers;
-    zlist_t *update_lookups;
     zlist_t *update_watchers;
     zhashx_t *index_uw;        /* update_watchers lookup */
 };

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -29,7 +29,7 @@ struct lookup_ctx {
     const flux_msg_t *msg;
     flux_jobid_t id;
     json_t *keys;
-    bool check_eventlog;
+    bool lookup_eventlog;
     int flags;
     flux_future_t *f;
     bool allow;
@@ -125,7 +125,7 @@ static int lookup_keys (struct lookup_ctx *l)
     }
     flux_future_set_flux (fall, l->ctx->h);
 
-    if (l->check_eventlog) {
+    if (l->lookup_eventlog) {
         if (lookup_key (l, fall, "eventlog") < 0)
             goto error;
     }
@@ -288,7 +288,7 @@ static int check_keys_for_eventlog (struct lookup_ctx *l)
             return 0;
     }
 
-    l->check_eventlog = true;
+    l->lookup_eventlog = true;
     return 0;
 }
 

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -130,7 +130,7 @@ static int lookup_keys (struct lookup_ctx *l)
             goto error;
     }
 
-    json_array_foreach(l->keys, index, key) {
+    json_array_foreach (l->keys, index, key) {
         const char *keystr;
         if (!(keystr = json_string_value (key))) {
             errno = EINVAL;
@@ -195,7 +195,7 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
         goto enomem;
     }
 
-    json_array_foreach(l->keys, index, key) {
+    json_array_foreach (l->keys, index, key) {
         flux_future_t *f;
         const char *keystr;
         json_t *str = NULL;
@@ -278,7 +278,7 @@ static int check_keys_for_eventlog (struct lookup_ctx *l)
         return 0;
     }
 
-    json_array_foreach(l->keys, index, key) {
+    json_array_foreach (l->keys, index, key) {
         const char *keystr;
         if (!(keystr = json_string_value (key))) {
             errno = EINVAL;

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -18,6 +18,9 @@
 #include <assert.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libjob/idf58.h"
+#include "src/common/libutil/jpath.h"
 #include "ccan/str/str.h"
 
 #include "job-info.h"
@@ -151,11 +154,105 @@ error:
     return -1;
 }
 
+static void apply_updates_R (struct lookup_ctx *l,
+                             const char *key,
+                             json_t *update_object,
+                             json_t *context)
+{
+    const char *context_key;
+    json_t *value;
+
+    json_object_foreach (context, context_key, value) {
+        /* RFC 21 resource-update event only allows update
+         * to:
+         * - expiration
+         */
+        if (streq (context_key, "expiration"))
+            if (jpath_set (update_object,
+                           "execution.expiration",
+                           value) < 0)
+                flux_log (l->ctx->h, LOG_INFO,
+                          "%s: failed to update job %s %s",
+                          __FUNCTION__, idf58 (l->id), key);
+    }
+}
+
+static int lookup_current (struct lookup_ctx *l,
+                           flux_future_t *fall,
+                           const char *key,
+                           const char *value,
+                           char **current_value)
+{
+    flux_future_t *f_eventlog;
+    const char *s_eventlog;
+    json_t *value_object = NULL;
+    json_t *eventlog = NULL;
+    size_t index;
+    json_t *entry;
+    const char *update_event_name = NULL;
+    char *value_object_str = NULL;
+    int save_errno;
+
+    if (streq (key, "R"))
+        update_event_name = "resource-update";
+
+    if (!(value_object = json_loads (value, 0, NULL))) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    if (!(f_eventlog = flux_future_get_child (fall, "eventlog"))) {
+        flux_log_error (l->ctx->h, "%s: flux_future_get_child",
+                        __FUNCTION__);
+        goto error;
+    }
+
+    if (flux_kvs_lookup_get (f_eventlog, &s_eventlog) < 0) {
+        if (errno != ENOENT)
+            flux_log_error (l->ctx->h, "%s: flux_kvs_lookup_get",
+                            __FUNCTION__);
+        goto error;
+    }
+
+    if (!(eventlog = eventlog_decode (s_eventlog))) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    json_array_foreach (eventlog, index, entry) {
+        const char *name;
+        json_t *context = NULL;
+        if (eventlog_entry_parse (entry, NULL, &name, &context) < 0)
+            goto error;
+        if (streq (name, update_event_name)) {
+            if (streq (key, "R"))
+                apply_updates_R (l, key, value_object, context);
+        }
+    }
+
+    if (!(value_object_str = json_dumps (value_object, 0)))
+        goto error;
+
+    (*current_value) = value_object_str;
+    json_decref (eventlog);
+    json_decref (value_object);
+    return 0;
+
+error:
+    save_errno = errno;
+    json_decref (eventlog);
+    json_decref (value_object);
+    free (value_object_str);
+    errno = save_errno;
+    return -1;
+}
+
 static void info_lookup_continuation (flux_future_t *fall, void *arg)
 {
     struct lookup_ctx *l = arg;
     struct info_ctx *ctx = l->ctx;
     const char *s;
+    char *current_value = NULL;
     size_t index;
     json_t *key;
     json_t *o = NULL;
@@ -212,6 +309,15 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
             goto error;
         }
 
+        if ((l->flags & FLUX_JOB_LOOKUP_CURRENT)
+            && streq (keystr, "R")) {
+            if (lookup_current (l, fall, keystr, s, &current_value) < 0)
+                goto error;
+            s = current_value;
+        }
+
+        /* check for JSON_DECODE flag last, as changes above could affect
+         * desired value */
         if ((l->flags & FLUX_JOB_LOOKUP_JSON_DECODE)
             && (streq (keystr, "jobspec")
                 || streq (keystr, "R"))) {
@@ -229,6 +335,9 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
             json_decref (val);
             goto enomem;
         }
+
+        free (current_value);
+        current_value = NULL;
     }
 
     /* must have been allowed earlier or above, otherwise should have
@@ -256,17 +365,22 @@ done:
      * via zlist_remove() */
     json_decref (o);
     free (data);
+    free (current_value);
     zlist_remove (ctx->lookups, l);
 }
 
-/* If keys array doesn't contain eventlog, flag that we'll need to do
- * an eventlog check.
+/* Check if lookup allowed, either b/c message is from instance owner
+ * or previous lookup verified it's ok.
  */
-static int check_keys_for_eventlog (struct lookup_ctx *l)
+static int check_allow (struct lookup_ctx *l)
 {
-    size_t index;
-    json_t *key;
     int ret;
+
+    /* if rpc from owner, no need to do guest access check */
+    if (flux_msg_authorize (l->msg, FLUX_USERID_UNKNOWN) == 0) {
+        l->allow = true;
+        return 0;
+    }
 
     if ((ret = eventlog_allow_lru (l->ctx,
                                    l->msg,
@@ -278,12 +392,24 @@ static int check_keys_for_eventlog (struct lookup_ctx *l)
         return 0;
     }
 
-    json_array_foreach (l->keys, index, key) {
-        if (streq (json_string_value (key), "eventlog"))
-            return 0;
+    return 0;
+}
+
+/* If we need the eventlog for an allow check or for update-lookup
+ * we need to add it to the key lookup list.
+ */
+static int check_to_lookup_eventlog (struct lookup_ctx *l)
+{
+    if (!l->allow || (l->flags & FLUX_JOB_LOOKUP_CURRENT)) {
+        size_t index;
+        json_t *key;
+        json_array_foreach (l->keys, index, key) {
+            if (streq (json_string_value (key), "eventlog"))
+                return 0;
+        }
+        l->lookup_eventlog = true;
     }
 
-    l->lookup_eventlog = true;
     return 0;
 }
 
@@ -296,9 +422,8 @@ void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
     json_t *key;
     json_t *keys;
     flux_jobid_t id;
-    uint32_t rolemask;
     int flags;
-    int valid_flags = FLUX_JOB_LOOKUP_JSON_DECODE;
+    int valid_flags = FLUX_JOB_LOOKUP_JSON_DECODE | FLUX_JOB_LOOKUP_CURRENT;
     const char *errmsg = NULL;
 
     if (flux_request_unpack (msg, NULL, "{s:I s:o s:i}",
@@ -331,16 +456,11 @@ void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
     if (!(l = lookup_ctx_create (ctx, msg, id, keys, flags)))
         goto error;
 
-    if (flux_msg_get_rolemask (msg, &rolemask) < 0)
+    if (check_allow (l) < 0)
         goto error;
 
-    /* if rpc from owner, no need to do guest access check */
-    if ((rolemask & FLUX_ROLE_OWNER))
-        l->allow = true;
-    else {
-        if (check_keys_for_eventlog (l) < 0)
-            goto error;
-    }
+    if (check_to_lookup_eventlog (l) < 0)
+        goto error;
 
     if (lookup_keys (l) < 0)
         goto error;

--- a/src/modules/job-info/lookup.h
+++ b/src/modules/job-info/lookup.h
@@ -16,6 +16,10 @@
 void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
                 const flux_msg_t *msg, void *arg);
 
+/* legacy rpc target */
+void update_lookup_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg);
+
 #endif /* ! _FLUX_JOB_INFO_LOOKUP_H */
 
 /*

--- a/src/modules/job-info/update.c
+++ b/src/modules/job-info/update.c
@@ -689,6 +689,23 @@ void update_watch_cleanup (struct info_ctx *ctx)
     }
 }
 
+void update_lookup_cleanup (struct info_ctx *ctx)
+{
+    struct update_ctx *uc;
+
+    while ((uc = zlist_pop (ctx->update_lookups))) {
+        const flux_msg_t *msg;
+        msg = flux_msglist_first (uc->msglist);
+        while (msg) {
+            if (flux_respond_error (ctx->h, msg, ENOSYS, NULL) < 0)
+                flux_log_error (ctx->h, "%s: flux_respond_error",
+                                __FUNCTION__);
+            msg = flux_msglist_next (uc->msglist);
+        }
+        update_ctx_destroy (uc);
+    }
+}
+
 int update_watch_count (struct info_ctx *ctx)
 {
     struct update_ctx *uc;

--- a/src/modules/job-info/update.c
+++ b/src/modules/job-info/update.c
@@ -8,8 +8,7 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-/* update.c - handle job-info.update-watch &
- * job-info.eventlog-update-cancel for job-info */
+/* update.c - handle job-info.update-watch for job-info */
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -19,23 +18,15 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libjob/job.h"
-#include "src/common/libjob/idf58.h"
 #include "src/common/libeventlog/eventlog.h"
-#include "src/common/libutil/jpath.h"
 #include "ccan/str/str.h"
 
 #include "job-info.h"
 #include "update.h"
 #include "util.h"
 
-typedef enum {
-    UPDATE_TYPE_LOOKUP,
-    UPDATE_TYPE_WATCH,
-} update_type_t;
-
 struct update_ctx {
     struct info_ctx *ctx;
-    update_type_t type;
     struct flux_msglist *msglist;
     uint32_t userid;
     flux_jobid_t id;
@@ -48,7 +39,7 @@ struct update_ctx {
     json_t *update_object;
     int initial_update_count;
     int watch_update_count;
-    char *index_key;            /* for watch */
+    char *index_key;
 };
 
 static void update_ctx_destroy (void *data)
@@ -76,7 +67,6 @@ static char *get_index_key (flux_jobid_t id, const char *key)
 }
 
 static struct update_ctx *update_ctx_create (struct info_ctx *ctx,
-                                             update_type_t type,
                                              const flux_msg_t *msg,
                                              flux_jobid_t id,
                                              const char *key,
@@ -88,7 +78,6 @@ static struct update_ctx *update_ctx_create (struct info_ctx *ctx,
         return NULL;
 
     uc->ctx = ctx;
-    uc->type = type;
     uc->id = id;
     if (!(uc->key = strdup (key)))
         goto error;
@@ -105,13 +94,11 @@ static struct update_ctx *update_ctx_create (struct info_ctx *ctx,
         goto error;
     flux_msglist_append (uc->msglist, msg);
 
-    if (uc->type == UPDATE_TYPE_WATCH) {
-        /* use jobid + key as lookup key, in future we may support other
-         * keys other than R
-         */
-        if (!(uc->index_key = get_index_key (uc->id, uc->key)))
-            goto error;
-    }
+    /* use jobid + key as lookup key, in future we may support other
+     * keys other than R
+     */
+    if (!(uc->index_key = get_index_key (uc->id, uc->key)))
+        goto error;
 
     return uc;
 
@@ -142,27 +129,6 @@ static void eventlog_watch_cancel (struct update_ctx *uc)
     }
     flux_future_destroy (f);
     uc->eventlog_watch_canceled = true;
-}
-
-static void apply_updates_R (struct update_ctx *uc,
-                             json_t *context)
-{
-    const char *key;
-    json_t *value;
-
-    json_object_foreach (context, key, value) {
-        /* RFC 21 resource-update event only allows update
-         * to:
-         * - expiration
-         */
-        if (streq (key, "expiration"))
-            if (jpath_set (uc->update_object,
-                           "execution.expiration",
-                           value) < 0)
-                flux_log (uc->ctx->h, LOG_INFO,
-                          "%s: failed to update job %s %s",
-                          __FUNCTION__, idf58 (uc->id), uc->key);
-    }
 }
 
 static void eventlog_continuation (flux_future_t *f, void *arg)
@@ -209,7 +175,11 @@ static void eventlog_continuation (flux_future_t *f, void *arg)
          * initial lookup */
         if (uc->watch_update_count > uc->initial_update_count) {
             if (streq (uc->key, "R"))
-                apply_updates_R (uc, context);
+                apply_updates_R (uc->ctx->h,
+                                 uc->id,
+                                 uc->key,
+                                 uc->update_object,
+                                 context);
 
             msg = flux_msglist_first (uc->msglist);
             while (msg) {
@@ -340,7 +310,11 @@ static void lookup_continuation (flux_future_t *f, void *arg)
         }
         else if (streq (name, uc->update_name)) {
             if (streq (uc->key, "R"))
-                apply_updates_R (uc, context);
+                apply_updates_R (uc->ctx->h,
+                                 uc->id,
+                                 uc->key,
+                                 uc->update_object,
+                                 context);
             uc->initial_update_count++;
         }
         else if (streq (name, "clean"))
@@ -381,11 +355,6 @@ static void lookup_continuation (flux_future_t *f, void *arg)
     if (flux_msglist_count (uc->msglist) == 0)
         goto cleanup;
 
-    /* If this is a lookup, we're done, only continue on if this is a
-     * watcher */
-    if (uc->type == UPDATE_TYPE_LOOKUP)
-        goto cleanup;
-
     /* this job has ended, no need to watch the eventlog for future
      * updates */
     if (job_ended) {
@@ -412,17 +381,12 @@ error:
 cleanup:
     /* flux future destroyed in update_ctx_destroy, which is called
      * via zlist_remove() */
-    if (uc->type == UPDATE_TYPE_WATCH) {
-        zhashx_delete (ctx->index_uw, uc->index_key);
-        zlist_remove (ctx->update_watchers, uc);
-    }
-    else
-        zlist_remove (ctx->update_lookups, uc);
+    zhashx_delete (ctx->index_uw, uc->index_key);
+    zlist_remove (ctx->update_watchers, uc);
     json_decref (eventlog);
 }
 
 static int update_lookup (struct info_ctx *ctx,
-                          update_type_t type,
                           const flux_msg_t *msg,
                           flux_jobid_t id,
                           const char *key,
@@ -432,7 +396,6 @@ static int update_lookup (struct info_ctx *ctx,
     const char *topic = "job-info.lookup";
 
     if (!(uc = update_ctx_create (ctx,
-                                  type,
                                   msg,
                                   id,
                                   key,
@@ -460,24 +423,15 @@ static int update_lookup (struct info_ctx *ctx,
         goto error;
     }
 
-    if (type == UPDATE_TYPE_WATCH) {
-        if (zlist_append (ctx->update_watchers, uc) < 0) {
-            flux_log_error (ctx->h, "%s: zlist_append", __FUNCTION__);
-            goto error;
-        }
-        zlist_freefn (ctx->update_watchers, uc, update_ctx_destroy, true);
-
-        if (zhashx_insert (ctx->index_uw, uc->index_key, uc) < 0) {
-            flux_log_error (ctx->h, "%s: zhashx_insert", __FUNCTION__);
-            goto error_list;
-        }
+    if (zlist_append (ctx->update_watchers, uc) < 0) {
+        flux_log_error (ctx->h, "%s: zlist_append", __FUNCTION__);
+        goto error;
     }
-    else {
-        if (zlist_append (ctx->update_lookups, uc) < 0) {
-            flux_log_error (ctx->h, "%s: zlist_append", __FUNCTION__);
-            goto error;
-        }
-        zlist_freefn (ctx->update_lookups, uc, update_ctx_destroy, true);
+    zlist_freefn (ctx->update_watchers, uc, update_ctx_destroy, true);
+
+    if (zhashx_insert (ctx->index_uw, uc->index_key, uc) < 0) {
+        flux_log_error (ctx->h, "%s: zhashx_insert", __FUNCTION__);
+        goto error_list;
     }
 
     return 0;
@@ -489,71 +443,6 @@ error_list:
 error:
     update_ctx_destroy (uc);
     return -1;
-}
-
-void update_lookup_cb (flux_t *h, flux_msg_handler_t *mh,
-                       const flux_msg_t *msg, void *arg)
-{
-    struct info_ctx *ctx = arg;
-    struct update_ctx *uc = NULL;
-    flux_jobid_t id;
-    const char *key = NULL;
-    int flags;
-    int valid_flags = 0;
-    const char *errmsg = NULL;
-    char *index_key = NULL;
-
-    if (flux_request_unpack (msg, NULL, "{s:I s:s s:i}",
-                             "id", &id,
-                             "key", &key,
-                             "flags", &flags) < 0) {
-        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
-        goto error;
-    }
-    if ((flags & ~valid_flags)) {
-        errno = EPROTO;
-        errmsg = "update-lookup request rejected with invalid flag";
-        goto error;
-    }
-    if (!streq (key, "R")) {
-        errno = EINVAL;
-        errmsg = "update-lookup unsupported key specified";
-        goto error;
-    }
-
-    if (!(index_key = get_index_key (id, key)))
-        goto error;
-
-    /* is somebody watching this jobid + key already, return the
-     * cached result */
-
-    if ((uc = zhashx_lookup (ctx->index_uw, index_key))
-        && uc->update_object) {
-        if (flux_msg_authorize (msg, uc->userid) < 0)
-            goto error;
-        if (flux_respond_pack (uc->ctx->h, msg, "{s:O}",
-                               uc->key, uc->update_object) < 0) {
-            flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
-            goto error;
-        }
-    }
-    else {
-        if (update_lookup (ctx,
-                           UPDATE_TYPE_LOOKUP,
-                           msg,
-                           id,
-                           key,
-                           flags) < 0)
-            goto error;
-    }
-
-    free (index_key);
-    return;
-
-error:
-    if (flux_respond_error (h, msg, errno, errmsg) < 0)
-        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-    free (index_key);
 }
 
 void update_watch_cb (flux_t *h, flux_msg_handler_t *mh,
@@ -597,7 +486,6 @@ void update_watch_cb (flux_t *h, flux_msg_handler_t *mh,
     /* if no watchers for this jobid yet, start it */
     if (!(uc = zhashx_lookup (ctx->index_uw, index_key))) {
         if (update_lookup (ctx,
-                           UPDATE_TYPE_WATCH,
                            msg,
                            id,
                            key,
@@ -628,6 +516,33 @@ error:
     if (flux_respond_error (h, msg, errno, errmsg) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     free (index_key);
+}
+
+int update_watch_get_cached (struct info_ctx *ctx,
+                             flux_jobid_t id,
+                             const char *key,
+                             json_t **current_object)
+{
+    struct update_ctx *uc;
+    char *index_key;
+    int rv = 0;
+
+    /* if somebody is already watching this jobid + key, we read the
+     * cached value */
+
+    if (!(index_key = get_index_key (id, key))) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    if ((uc = zhashx_lookup (ctx->index_uw, index_key))
+        && uc->update_object) {
+        (*current_object) = json_incref (uc->update_object);
+        rv = 1;
+    }
+
+    free (index_key);
+    return rv;
 }
 
 /* Cancel update_watch if it matches message.
@@ -678,23 +593,6 @@ void update_watch_cleanup (struct info_ctx *ctx)
     while ((uc = zlist_pop (ctx->update_watchers))) {
         const flux_msg_t *msg;
         eventlog_watch_cancel (uc);
-        msg = flux_msglist_first (uc->msglist);
-        while (msg) {
-            if (flux_respond_error (ctx->h, msg, ENOSYS, NULL) < 0)
-                flux_log_error (ctx->h, "%s: flux_respond_error",
-                                __FUNCTION__);
-            msg = flux_msglist_next (uc->msglist);
-        }
-        update_ctx_destroy (uc);
-    }
-}
-
-void update_lookup_cleanup (struct info_ctx *ctx)
-{
-    struct update_ctx *uc;
-
-    while ((uc = zlist_pop (ctx->update_lookups))) {
-        const flux_msg_t *msg;
         msg = flux_msglist_first (uc->msglist);
         while (msg) {
             if (flux_respond_error (ctx->h, msg, ENOSYS, NULL) < 0)

--- a/src/modules/job-info/update.h
+++ b/src/modules/job-info/update.h
@@ -12,15 +12,19 @@
 #define _FLUX_JOB_INFO_UPDATE_H
 
 #include <flux/core.h>
-
-void update_lookup_cb (flux_t *h, flux_msg_handler_t *mh,
-                       const flux_msg_t *msg, void *arg);
+#include <jansson.h>
 
 void update_watch_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg);
 
 void update_watch_cancel_cb (flux_t *h, flux_msg_handler_t *mh,
                              const flux_msg_t *msg, void *arg);
+
+/* returns 1 on found, 0 if not, -1 on error */
+int update_watch_get_cached (struct info_ctx *ctx,
+                             flux_jobid_t id,
+                             const char *key,
+                             json_t **current_object);
 
 /* Cancel all update watches that match msg.
  * match credentials & matchtag if cancel true
@@ -31,8 +35,6 @@ void update_watchers_cancel (struct info_ctx *ctx,
                              bool cancel);
 
 void update_watch_cleanup (struct info_ctx *ctx);
-
-void update_lookup_cleanup (struct info_ctx *ctx);
 
 int update_watch_count (struct info_ctx *ctx);
 

--- a/src/modules/job-info/update.h
+++ b/src/modules/job-info/update.h
@@ -32,6 +32,8 @@ void update_watchers_cancel (struct info_ctx *ctx,
 
 void update_watch_cleanup (struct info_ctx *ctx);
 
+void update_lookup_cleanup (struct info_ctx *ctx);
+
 int update_watch_count (struct info_ctx *ctx);
 
 #endif /* ! _FLUX_JOB_INFO_UPDATE_H */

--- a/src/modules/job-info/util.h
+++ b/src/modules/job-info/util.h
@@ -35,6 +35,13 @@ int parse_eventlog_entry (flux_t *h,
                           const char **name,
                           json_t **context);
 
+/* apply context updates to the R object */
+void apply_updates_R (flux_t *h,
+                      flux_jobid_t id,
+                      const char *key,
+                      json_t *R,
+                      json_t *context);
+
 #endif /* ! _FLUX_JOB_INFO_UTIL_H */
 
 /*

--- a/t/job-info/info_lookup.c
+++ b/t/job-info/info_lookup.c
@@ -20,15 +20,17 @@
 #include "src/common/libutil/log.h"
 #include "ccan/str/str.h"
 
-#define OPTIONS "j"
+#define OPTIONS "jc"
 static const struct option longopts[] = {
     {"json-decode", no_argument, 0, 'j'},
+    {"current", no_argument, 0, 'c'},
     { 0, 0, 0, 0 },
 };
 
 static void usage (void)
 {
-    fprintf (stderr, "Usage: info_lookup [--json-decode] <jobid> <key> ...\n");
+    fprintf (stderr, "Usage: info_lookup [--json-decode] "
+                     "[--current] <jobid> <key> ...\n");
     exit (1);
 }
 
@@ -45,6 +47,9 @@ int main (int argc, char *argv[])
         switch (ch) {
         case 'j': /* --json-decode */
             flags |= FLUX_JOB_LOOKUP_JSON_DECODE;
+            break;
+        case 'c': /* --current */
+            flags |= FLUX_JOB_LOOKUP_CURRENT;
             break;
         default:
             usage ();
@@ -104,7 +109,7 @@ int main (int argc, char *argv[])
             free (s);
         }
         else {
-            char *s;
+            const char *s;
             if (flux_rpc_get_unpack (f, "{s:s}", argv[i], &s) < 0)
                 log_msg_exit ("job-info.lookup: %s",
                               future_strerror (f, errno));

--- a/t/job-info/info_lookup.c
+++ b/t/job-info/info_lookup.c
@@ -14,9 +14,23 @@
 #include <unistd.h>
 #include <jansson.h>
 #include <stdio.h>
+#include <getopt.h>
 #include <flux/core.h>
 
 #include "src/common/libutil/log.h"
+#include "ccan/str/str.h"
+
+#define OPTIONS "j"
+static const struct option longopts[] = {
+    {"json-decode", no_argument, 0, 'j'},
+    { 0, 0, 0, 0 },
+};
+
+static void usage (void)
+{
+    fprintf (stderr, "Usage: info_lookup [--json-decode] <jobid> <key> ...\n");
+    exit (1);
+}
 
 int main (int argc, char *argv[])
 {
@@ -24,23 +38,32 @@ int main (int argc, char *argv[])
     flux_future_t *f;
     flux_jobid_t id;
     json_t *keys;
-    int i;
+    int i, ch;
+    int flags = 0;
 
-    if (argc < 3) {
-        fprintf (stderr, "Usage: info_lookup <jobid> <key> ...\n");
-        exit (1);
+    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
+        switch (ch) {
+        case 'j': /* --json-decode */
+            flags |= FLUX_JOB_LOOKUP_JSON_DECODE;
+            break;
+        default:
+            usage ();
+            break;
+        }
     }
+    if ((argc - optind) < 2)
+        usage ();
 
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (flux_job_id_parse (argv[1], &id) < 0)
+    if (flux_job_id_parse (argv[optind++], &id) < 0)
         log_msg_exit ("error parsing jobid: %s", argv[1]);
 
     if (!(keys = json_array ()))
         log_msg_exit ("json_array");
 
-    for (i = 2; i < argc; i++) {
+    for (i = optind; i < argc; i++) {
         json_t *key = json_string (argv[i]);
         if (!key)
             log_msg_exit ("json_string_value");
@@ -55,20 +78,39 @@ int main (int argc, char *argv[])
                              "{s:I s:O s:i}",
                              "id", id,
                              "keys", keys,
-                             "flags", 0)))
+                             "flags", flags)))
         log_err_exit ("flux_rpc_pack");
 
-    for (i = 2; i < argc; i++) {
-        json_t *value;
-        char *s;
-        if (flux_rpc_get_unpack (f, "{s:o}", argv[i], &value) < 0)
-            log_msg_exit ("job-info.lookup: %s",
-                          future_strerror (f, errno));
-        if (!(s = json_dumps (value, JSON_ENCODE_ANY)))
-            log_msg_exit ("invalid json result");
-        printf ("%s\n", s);
+    for (i = optind; i < argc; i++) {
+        if (flags & FLUX_JOB_LOOKUP_JSON_DECODE) {
+            json_t *value;
+            char *s;
+            if (flux_rpc_get_unpack (f, "{s:o}", argv[i], &value) < 0)
+                log_msg_exit ("job-info.lookup: %s",
+                              future_strerror (f, errno));
+            if (streq (argv[i], "jobspec") || streq (argv[i], "R")) {
+                if (!json_is_object (value))
+                    log_msg_exit ("job-info.lookup: key %s not an object",
+                                  argv[i]);
+            }
+            else {
+                if (!json_is_string (value))
+                    log_msg_exit ("job-info.lookup: key %s not a string",
+                                  argv[i]);
+            }
+            if (!(s = json_dumps (value, JSON_ENCODE_ANY)))
+                log_msg_exit ("invalid json result");
+            printf ("%s\n", s);
+            free (s);
+        }
+        else {
+            char *s;
+            if (flux_rpc_get_unpack (f, "{s:s}", argv[i], &s) < 0)
+                log_msg_exit ("job-info.lookup: %s",
+                              future_strerror (f, errno));
+            printf ("%s\n", s);
+        }
         fflush (stdout);
-        free (s);
     }
 
     flux_future_destroy (f);

--- a/t/job-info/update_lookup.c
+++ b/t/job-info/update_lookup.c
@@ -8,6 +8,10 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+/* Note that the job-info.update-lookup RPC target is deprecated.
+ * This is to test legacy behavior.
+ */
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/t/kvs/lookup_invalid.c
+++ b/t/kvs/lookup_invalid.c
@@ -14,7 +14,6 @@
 #include <assert.h>
 #include <libgen.h>
 #include <pthread.h>
-#include <getopt.h>
 #include <inttypes.h>
 #include <jansson.h>
 #include <flux/core.h>

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -322,4 +322,19 @@ test_expect_success 'lookup request with empty payload fails with EPROTO(71)' '
 	${RPC} job-info.lookup 71 </dev/null
 '
 
+test_expect_success 'lookup request with keys not and array fails with EPROTO(71)' '
+	$jq -j -c -n  "{id:12345, keys:1, flags:0}" \
+	  | ${RPC} job-info.lookup 71
+'
+
+test_expect_success 'lookup request with invalid keys fails with EPROTO(71)' '
+	$jq -j -c -n  "{id:12345, keys:[1], flags:0}" \
+	  | ${RPC} job-info.lookup 71
+'
+
+test_expect_success 'lookup request with invalid flags fails with EPROTO(71)' '
+	$jq -j -c -n  "{id:12345, keys:[\"jobspec\"], flags:8191}" \
+	  | ${RPC} job-info.lookup 71
+'
+
 test_done

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -311,6 +311,22 @@ test_expect_success 'job-info.lookup multiple keys fails on 1 bad entry' '
 '
 
 #
+# job info json decode tests
+#
+
+test_expect_success 'job-info.lookup: decode non-json returns string' '
+	jobid=$(submit_job) &&
+	${INFOLOOKUP} --json-decode $jobid eventlog > info_decode_1.out &&
+	grep submit info_decode_1.out
+'
+
+test_expect_success 'job-info.lookup: decode json returns object' '
+	jobid=$(submit_job) &&
+	${INFOLOOKUP} --json-decode $jobid jobspec > info_decode_2.out &&
+	grep sleep info_decode_2.out
+'
+
+#
 # stats & corner cases
 #
 

--- a/t/t2233-job-info-update.t
+++ b/t/t2233-job-info-update.t
@@ -272,7 +272,7 @@ test_expect_success NO_CHAIN_LINT 'job-info: update lookup returns cached R from
 	wait_update_watchers $((watchers+1)) &&
 	update1=$(expiration_add $jobid 100) &&
 	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch9.out &&
-        ${UPDATE_LOOKUP} $jobid R > lookup9.out &&
+	${UPDATE_LOOKUP} $jobid R > lookup9.out &&
 	flux cancel $jobid &&
 	wait $watchpid &&
 	test $(cat watch9.out | wc -l) -eq 2 &&


### PR DESCRIPTION
This PR could be split up a bit more, but for now it's one PR.

This adds several new lookup flags, and with their addition, the `job-info.update-lookup` RPC target can be deprecated.

The one "tricky" part was how to grab cached data from current `update-watch`es being done.  Perhaps the lookup of that "cached" info could just be dropped as it probably has minimal use.

I decided to not support `job-info.update-watch` within the original `job-info.lookup` RPC for several reasons.  Most notably because `lookup` can take multiple keys as input and `job-info.update-watch` takes only one key.  I could make it so a WATCH flag only works with one key.  Or we could have a "re-direct to this RPC" like we do with KVS watch.  But I didn't delve too much into this design yet.

~~I then updated PR #5592 to be based on this PR.~~  PR #5635 then follows this one up

TODO RFC spec 41 which I was going to hold off on until this gets some minimal review.