### PR TITLE
job-info: support lookup of updated jobspec, remove manual construction of updated R / jobspec

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -3308,42 +3308,6 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
     return (0);
 }
 
-char *reconstruct_current_jobspec (const char *jobspec_str,
-                                   const char *eventlog_str)
-{
-    json_t *jobspec;
-    json_t *eventlog;
-    size_t index;
-    json_t *entry;
-    char *result;
-
-    if (!(jobspec = json_loads (jobspec_str, 0, NULL)))
-        log_msg_exit ("error decoding jobspec");
-    if (!(eventlog = eventlog_decode (eventlog_str)))
-        log_msg_exit ("error decoding eventlog");
-    json_array_foreach (eventlog, index, entry) {
-        const char *name;
-        json_t *context;
-
-        if (eventlog_entry_parse (entry, NULL, &name, &context) < 0)
-            log_msg_exit ("error decoding eventlog entry");
-        if (streq (name, "jobspec-update")) {
-            const char *path;
-            json_t *value;
-
-            json_object_foreach (context, path, value) {
-                if (jpath_set (jobspec, path, value) < 0)
-                    log_err_exit ("failed to update jobspec");
-            }
-        }
-    }
-    if (!(result = json_dumps (jobspec, JSON_COMPACT)))
-        log_msg_exit ("failed to encode jobspec object");
-    json_decref (jobspec);
-    json_decref (eventlog);
-    return result;
-}
-
 void info_usage (void)
 {
     fprintf (stderr,
@@ -3403,33 +3367,11 @@ int cmd_info (optparse_t *p, int argc, char **argv)
             log_msg_exit ("Failed to unwrap J to get jobspec: %s", error.text);
         val = new_val;
     }
-    /* The current (non --base) jobspec has to be reconstructed by fetching
-     * the jobspec and the eventlog and updating the former with the latter.
-     */
-    else if (!optparse_hasopt (p, "base") && streq (key, "jobspec")) {
-        const char *jobspec;
-        const char *eventlog;
-
-        // fetch the two keys in parallel
-        if (!(f = flux_rpc_pack (h,
-                                 "job-info.lookup",
-                                 FLUX_NODEID_ANY,
-                                 0,
-                                 "{s:I s:[ss] s:i}",
-                                 "id", id,
-                                 "keys", "jobspec", "eventlog",
-                                 "flags", 0))
-            || flux_rpc_get_unpack (f,
-                                    "{s:s s:s}",
-                                    "jobspec", &jobspec,
-                                    "eventlog", &eventlog) < 0)
-            log_msg_exit ("%s", future_strerror (f, errno));
-        val = new_val = reconstruct_current_jobspec (jobspec, eventlog);
-    }
-    /* The current (non --base) R is obtained through the
+    /* The current (non --base) R and jobspec are obtained through the
      * job-info.lookup RPC w/ the CURRENT flag.
      */
-    else if (!optparse_hasopt (p, "base") && streq (key, "R")) {
+    else if (!optparse_hasopt (p, "base")
+             && (streq (key, "R") || streq (key, "jobspec"))) {
         if (!(f = flux_rpc_pack (h,
                                  "job-info.lookup",
                                  FLUX_NODEID_ANY,

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -37,7 +37,7 @@ enum job_lookup_flags {
     FLUX_JOB_LOOKUP_JSON_DECODE = 1,
     /* get current value of special fields by applying eventlog
      * updates for those fields
-     * - currently works for R
+     * - currently works for jobspec and R
      */
     FLUX_JOB_LOOKUP_CURRENT = 2,
 };

--- a/src/modules/job-info/update.c
+++ b/src/modules/job-info/update.c
@@ -83,6 +83,8 @@ static struct update_ctx *update_ctx_create (struct info_ctx *ctx,
         goto error;
     if (streq (key, "R"))
         uc->update_name = "resource-update";
+    else if (streq (key, "jobspec"))
+        uc->update_name = "jobspec-update";
     else {
         errno = EINVAL;
         goto error;
@@ -180,6 +182,12 @@ static void eventlog_continuation (flux_future_t *f, void *arg)
                                  uc->key,
                                  uc->update_object,
                                  context);
+            else if (streq (uc->key, "jobspec"))
+                apply_updates_jobspec (uc->ctx->h,
+                                       uc->id,
+                                       uc->key,
+                                       uc->update_object,
+                                       context);
 
             msg = flux_msglist_first (uc->msglist);
             while (msg) {
@@ -315,6 +323,12 @@ static void lookup_continuation (flux_future_t *f, void *arg)
                                  uc->key,
                                  uc->update_object,
                                  context);
+            else if (streq (uc->key, "jobspec"))
+                apply_updates_jobspec (uc->ctx->h,
+                                       uc->id,
+                                       uc->key,
+                                       uc->update_object,
+                                       context);
             uc->initial_update_count++;
         }
         else if (streq (name, "clean"))
@@ -474,7 +488,7 @@ void update_watch_cb (flux_t *h, flux_msg_handler_t *mh,
         errmsg = "update-watch request rejected without streaming RPC flag";
         goto error;
     }
-    if (!streq (key, "R")) {
+    if (!streq (key, "R") && !streq (key, "jobspec")) {
         errno = EINVAL;
         errmsg = "update-watch unsupported key specified";
         goto error;

--- a/src/modules/job-info/util.c
+++ b/src/modules/job-info/util.c
@@ -125,6 +125,25 @@ void apply_updates_R (flux_t *h,
     }
 }
 
+void apply_updates_jobspec (flux_t *h,
+                            flux_jobid_t id,
+                            const char *key,
+                            json_t *jobspec,
+                            json_t *context)
+{
+    const char *ckey;
+    json_t *value;
+
+    json_object_foreach (context, ckey, value) {
+        if (jpath_set (jobspec,
+                       ckey,
+                       value) < 0)
+            flux_log (h, LOG_INFO,
+                      "%s: failed to update job %s %s",
+                      __FUNCTION__, idf58 (id), key);
+    }
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-info/util.h
+++ b/src/modules/job-info/util.h
@@ -42,6 +42,13 @@ void apply_updates_R (flux_t *h,
                       json_t *R,
                       json_t *context);
 
+/* apply context updates to the jobspec object */
+void apply_updates_jobspec (flux_t *h,
+                            flux_jobid_t id,
+                            const char *key,
+                            json_t *jobspec,
+                            json_t *context);
+
 #endif /* ! _FLUX_JOB_INFO_UTIL_H */
 
 /*

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -159,6 +159,7 @@ class TestJob(unittest.TestCase):
         data = rpc.get()
         self.check_jobspec_str(data, self.jobid1, 0)
         data = rpc.get_decode()
+        self.check_jobspec_decoded(data, self.jobid1, 0)
         self.assertEqual(data["id"], self.jobid1, 0)
 
     def test_info_01_job_info_lookup_keys(self):

--- a/t/t2233-job-info-update.t
+++ b/t/t2233-job-info-update.t
@@ -310,6 +310,57 @@ test_expect_success NO_CHAIN_LINT 'job-info: lookup current returns cached R fro
 '
 
 #
+# lookup w/ current and update-watch works with jobspec
+#
+
+# Usage: check_duration jobid VALUE
+# Check and wait for duration to reach VALUE.
+#
+check_duration() {
+       local jobid=$1
+       local value=$2
+       local i=0
+       while (! ${INFO_LOOKUP} -c ${jobid} jobspec | jq -e ".attributes.system.duration == ${value}" \
+	       && [ $i -lt 200 ] )
+       do
+	       sleep 0.1
+	       i=$((i + 1))
+       done
+       if [ "$i" -eq "200" ]
+       then
+	       return 1
+       fi
+       return 0
+}
+
+test_expect_success 'job-info: lookup current works with jobspec' '
+	jobid=$(flux submit --urgency=hold true) &&
+	check_duration $jobid 0 &&
+	flux update $jobid duration=100s &&
+	check_duration $jobid 100.0 &&
+	flux update $jobid duration=200s &&
+	check_duration $jobid 200.0 &&
+	flux cancel $jobid
+'
+
+test_expect_success NO_CHAIN_LINT 'job-info: update watch works with jobspec' '
+	jobid=$(flux submit --urgency=hold true) &&
+	flux update $jobid duration=100s &&
+	watchers=$(get_update_watchers)
+	${UPDATE_WATCH} $jobid jobspec > watchjobspec.out &
+	watchpid=$! &&
+	wait_update_watchers $((watchers+1)) &&
+	${WAITFILE} --count=1 --timeout=30 --pattern="duration" watchjobspec.out &&
+	flux update $jobid duration=200s &&
+	${WAITFILE} --count=2 --timeout=30 --pattern="duration" watchjobspec.out &&
+	flux cancel $jobid &&
+	wait $watchpid &&
+	test $(cat watchjobspec.out | wc -l) -eq 2 &&
+	head -n1 watchjobspec.out | jq -e ".attributes.system.duration == 100.0" &&
+	tail -n1 watchjobspec.out | jq -e ".attributes.system.duration == 200.0"
+'
+
+#
 # security tests
 #
 
@@ -327,6 +378,7 @@ test_expect_success 'job-info: non job owner cannot lookup key' '
 	jobid=`flux submit --wait-event=start sleep inf` &&
 	set_userid 9999 &&
 	test_must_fail ${UPDATE_LOOKUP} $jobid R &&
+	test_must_fail ${INFO_LOOKUP} -u $jobid jobspec &&
 	unset_userid &&
 	flux cancel $jobid
 '
@@ -335,6 +387,7 @@ test_expect_success 'job-info: non job owner cannot watch key' '
 	jobid=`flux submit --wait-event=start sleep inf` &&
 	set_userid 9999 &&
 	test_must_fail ${UPDATE_WATCH} $jobid R &&
+	test_must_fail ${UPDATE_WATCH} $jobid jobspec &&
 	unset_userid &&
 	flux cancel $jobid
 '


### PR DESCRIPTION
Problem: It is inconvenient that lookup w/ updates and update-watch support reading/watching an updated R but not an updated jobspec.

Support returning an updated jobspec.

Then remove the manually updated jobspec/R code in `flux-job` and the Python `kvslookup` library.  

Built on top of #5633.

Could potentially be split into two PRs .... 