### PR TITLE
resource: get local hwloc XML from parent when possible

### DIFF
--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -69,10 +69,10 @@ static int init_topo_from_xml (hwloc_topology_t *tp,
     return (0);
 }
 
-hwloc_topology_t rhwloc_xml_topology_load (const char *xml)
+hwloc_topology_t rhwloc_xml_topology_load (const char *xml, int flags)
 {
     hwloc_topology_t topo = NULL;
-    if (init_topo_from_xml (&topo, xml, 0) < 0)
+    if (init_topo_from_xml (&topo, xml, flags) < 0)
         return NULL;
     return topo;
 }
@@ -92,7 +92,7 @@ hwloc_topology_t rhwloc_xml_topology_load_file (const char *path)
     /*  Load hwloc from XML file, add current system information from uname(2)
      *  unless already set.
      */
-    if ((topo = rhwloc_xml_topology_load (buf))
+    if ((topo = rhwloc_xml_topology_load (buf, 0))
         && !rhwloc_hostname (topo)) {
         struct utsname utsname;
         int depth = hwloc_get_type_depth (topo, HWLOC_OBJ_MACHINE);

--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -123,6 +123,21 @@ out:
     return result;
 }
 
+/*  Restrict an XML topology by loading it with no flags (which automatically
+ *  restricts to current resource binding), then re-export to XML:
+ */
+char *rhwloc_topology_xml_restrict (const char *xml)
+{
+    char *result;
+    hwloc_topology_t topo;
+
+    if (!(topo = rhwloc_xml_topology_load (xml, 0)))
+        return NULL;
+    result = topo_xml_export (topo);
+    hwloc_topology_destroy (topo);
+    return result;
+}
+
 hwloc_topology_t rhwloc_xml_topology_load_file (const char *path,
                                                 rhwloc_flags_t flags)
 {

--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -77,7 +77,8 @@ hwloc_topology_t rhwloc_xml_topology_load (const char *xml, int flags)
     return topo;
 }
 
-hwloc_topology_t rhwloc_xml_topology_load_file (const char *path)
+hwloc_topology_t rhwloc_xml_topology_load_file (const char *path,
+                                                rhwloc_flags_t flags)
 {
     hwloc_topology_t topo;
     int fd;
@@ -92,7 +93,7 @@ hwloc_topology_t rhwloc_xml_topology_load_file (const char *path)
     /*  Load hwloc from XML file, add current system information from uname(2)
      *  unless already set.
      */
-    if ((topo = rhwloc_xml_topology_load (buf, 0))
+    if ((topo = rhwloc_xml_topology_load (buf, flags))
         && !rhwloc_hostname (topo)) {
         struct utsname utsname;
         int depth = hwloc_get_type_depth (topo, HWLOC_OBJ_MACHINE);
@@ -127,7 +128,7 @@ hwloc_topology_t rhwloc_local_topology_load (rhwloc_flags_t flags)
      *  to normal topology load.
      */
     if ((xml = getenv ("FLUX_HWLOC_XMLFILE"))
-        && (topo = rhwloc_xml_topology_load_file (xml)))
+        && (topo = rhwloc_xml_topology_load_file (xml, flags)))
         return topo;
 
     if (topo_init_common (&topo, 0) < 0)

--- a/src/common/librlist/rhwloc.h
+++ b/src/common/librlist/rhwloc.h
@@ -23,7 +23,7 @@ hwloc_topology_t rhwloc_local_topology_load (rhwloc_flags_t flags);
 
 /*  As above, but return hwloc_topoology_t from XML
  */
-hwloc_topology_t rhwloc_xml_topology_load (const char *xml);
+hwloc_topology_t rhwloc_xml_topology_load (const char *xml, int flags);
 
 /*  Load local topology and return XML as allocated string
  */

--- a/src/common/librlist/rhwloc.h
+++ b/src/common/librlist/rhwloc.h
@@ -22,8 +22,11 @@ typedef enum {
 hwloc_topology_t rhwloc_local_topology_load (rhwloc_flags_t flags);
 
 /*  As above, but return hwloc_topoology_t from XML
+ *  Topology is restricted to current CPU binding unless RHWLOC_NO_RESTRICT
+ *  flag is used.
  */
-hwloc_topology_t rhwloc_xml_topology_load (const char *xml, int flags);
+hwloc_topology_t rhwloc_xml_topology_load (const char *xml,
+                                           rhwloc_flags_t flags);
 
 /*  Load local topology and return XML as allocated string
  */

--- a/src/common/librlist/rhwloc.h
+++ b/src/common/librlist/rhwloc.h
@@ -32,6 +32,10 @@ hwloc_topology_t rhwloc_xml_topology_load (const char *xml,
  */
 char *rhwloc_local_topology_xml (rhwloc_flags_t flags);
 
+/*  Restrict an XML topology to current CPU binding and return result.
+ */
+char *rhwloc_topology_xml_restrict (const char *xml);
+
 /*  Return HostName from an hwloc topology object
  */
 const char *rhwloc_hostname (hwloc_topology_t topo);

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -2354,7 +2354,7 @@ struct rlist *rlist_from_hwloc (int rank, const char *xml)
         return NULL;
 
     if (xml)
-        topo = rhwloc_xml_topology_load (xml, 0);
+        topo = rhwloc_xml_topology_load (xml, RHWLOC_NO_RESTRICT);
     else
         topo = rhwloc_local_topology_load (0);
     if (!topo)

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -2354,7 +2354,7 @@ struct rlist *rlist_from_hwloc (int rank, const char *xml)
         return NULL;
 
     if (xml)
-        topo = rhwloc_xml_topology_load (xml);
+        topo = rhwloc_xml_topology_load (xml, 0);
     else
         topo = rhwloc_local_topology_load (0);
     if (!topo)

--- a/src/modules/resource/resource.h
+++ b/src/modules/resource/resource.h
@@ -22,9 +22,22 @@ struct resource_ctx {
     struct acquire *acquire;
     struct reslog *reslog;
 
+    flux_t *parent_h;
+    int parent_refcount;
+
     uint32_t rank;
     uint32_t size;
 };
+
+/*  Get a shared handle to he parent instance if the parent-uri attribute
+ *  is set. Adds a reference to the shared parent handle. Caller must call
+ *  resource_parent_handle_close().
+ *
+ *  Returns NULL on error with errno set to ENOENT if there is no parent-uri,
+ *  or error from flux_open(3).
+ */
+flux_t *resource_parent_handle_open (struct resource_ctx *ctx);
+void resource_parent_handle_close (struct resource_ctx *ctx);
 
 #endif /* !_FLUX_RESOURCE_H */
 

--- a/src/modules/resource/topo.c
+++ b/src/modules/resource/topo.c
@@ -304,7 +304,8 @@ static char *topo_get_local_xml (struct resource_ctx *ctx, bool no_restrict)
     }
     flux_log (ctx->h,
               LOG_INFO,
-              "retrieved local hwloc XML from parent");
+              "retrieved local hwloc XML from parent (norestrict=%s)",
+              no_restrict ? "true" : "false");
     if (no_restrict) {
         result = strdup (xml);
         goto out;

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -372,8 +372,13 @@ test_expect_success 'flux-start dies gracefully when run from removed dir' '
 command -v hwloc-ls >/dev/null && test_set_prereq HWLOC_LS
 test_expect_success HWLOC_LS 'FLUX_HWLOC_XMLFILE works' '
 	hwloc-ls --of xml -i "numa:2 core:3 pu:1" >test.xml &&
-	FLUX_HWLOC_XMLFILE=test.xml flux start -s 2 flux resource info \
-		>rinfo.out &&
+	cat <<-EOF >norestrict.conf &&
+	[resource]
+	norestrict = true
+	EOF
+	FLUX_HWLOC_XMLFILE=test.xml \
+		flux start -s2 -o,--conf=norestrict.conf \
+			flux resource info >rinfo.out &&
 	test_debug "cat rinfo.out" &&
 	grep "12 Cores" rinfo.out
 '

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -160,4 +160,15 @@ test_expect_success 'flux alloc: instance can bootstrap without update-watch RPC
 	test_debug "cat alloc.log" &&
 	grep "falling back to job-info.lookup" alloc.log
 '
+test_expect_success 'flux alloc: resource.norestrict works in subinstance' '
+	cat <<-EOF >topo-get.py &&
+	import flux
+	print(flux.Flux().rpc("resource.topo-get").get_str())
+	EOF
+	chmod +x topo-get.py &&
+	flux python ./topo-get.py >topo.expected &&
+	flux alloc -n1 --conf=resource.norestrict=true \
+		flux python ./topo-get.py >topo.out &&
+	test_cmp topo.expected topo.out
+'
 test_done


### PR DESCRIPTION
This PR adds the ability for the resource module to grab the local hwloc from its parent instance when possible, instead of always using `hwloc_topology_load(3)`. This should speed up this stage of the module's initialization greatly, as well as keeping a consistent topology available throughout a hierarchy as noted in #5611.

If there is no parent instance or the `resource.topo-get` RPC fails , then we fall back to `hwloc_topology_load(3)`.

This is a WIP for now to get feedback and until I figure out how to add some testing.