### PR TITLE
libflux: add include for ssize_t to message.h

### DIFF
--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -16,6 +16,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
 #include "types.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
While debugging an issue in DYAD, @hariharan-devarajan and I found something odd stemming from `message.h` in `libflux`. When we used `flux_log` or `flux_log_error` in DYAD, everything worked fine. However, when we commented out the code using those functions, DYAD failed to build because `ssize_t` wasn't defined when the compiler was handling code from `message.h`.

We can work around this in DYAD by making sure we include `sys/types.h` (i.e., the header where `ssize_t` is defined) before including `flux/core.h`, but it would be better long term if that include happened in `message.h`. This PR simply adds that include.