### PR TITLE
resource: fix initialization of multiple brokers per node when fallback to job-info.lookup is used

### DIFF
--- a/src/modules/resource/inventory.c
+++ b/src/modules/resource/inventory.c
@@ -498,7 +498,13 @@ static int lookup_R_fallback (struct inventory *inv, flux_jobid_t id)
         errno = EINVAL;
         goto done;
     }
-    rc = inventory_put (inv, R, "job-info");
+    /*  Only call inventory_put() if conversion of R was successful,
+     *  i.e. R != NULL. (if conversion failed, fall-through to dynamic
+     *  discovery will call inventory_put() later).
+     */
+    if (R && inventory_put (inv, R, "job-info") < 0)
+        goto done;
+    rc = 0;
 done:
     /*  Parent handle is not used again in fallback case:
      */

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -84,5 +84,13 @@ test_expect_success "flux sets jobid attribute" '
 	flux job attach $id >jobid.out &&
 	test_cmp jobid.exp jobid.out
 '
-
+test_expect_success 'flux can launch multiple brokers per node' '
+	flux alloc --exclusive -N2 -o per-resource.count=2 \
+		flux resource info
+'
+test_expect_success 'flux can launch multiple brokers per node (R lookup fallback)' '
+	flux alloc -N2 --exclusive -o per-resource.count=2 \
+		--conf=resource.no-update-watch=true \
+		flux resource info
+'
 test_done


### PR DESCRIPTION
I noticed while running some tests on corona that launching multiple brokers per node wasn't working.

The issue was introduced by 093509813cfe7fbafc4c84614069be82b17ea703. In the fallback code, `inventory_put()` is always attempted, even if the conversion of R failed and thus `R == NULL`. This causes `inventory_put()` to fail and in turn the load of the `resource` module.

The call to `inventory_put()` should only be made if `R != NULL` (as it is in the non-fallback case).

Also, add some tests that were clearly missing here (though this one's a bit of a corner case)