### PR TITLE
flux-batch: support `--quiet` option

### DIFF
--- a/doc/man1/common/job-other-batch.rst
+++ b/doc/man1/common/job-other-batch.rst
@@ -67,3 +67,7 @@
    examined within a test instance started with the
    :option:`flux-start --recovery` option.  If ``FILE`` is unspecified,
    ``flux-{{jobid}}-dump.tgz`` is used.
+
+.. option:: --quiet
+
+   Suppress logging of jobids to stdout

--- a/doc/man1/common/job-other-run.rst
+++ b/doc/man1/common/job-other-run.rst
@@ -39,7 +39,7 @@
 
 .. option:: --quiet
 
-   *(submit,bulksubmit)* Suppress logging of jobids to stdout.
+   Suppress logging of jobids to stdout
 
 .. option:: --log=FILE
 

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -926,6 +926,11 @@ class MiniCmd:
             help="Don't actually submit job, just emit jobspec",
         )
         parser.add_argument(
+            "--quiet",
+            action="store_true",
+            help="Do not print jobid to stdout on submission",
+        )
+        parser.add_argument(
             "--debug-emulate", action="store_true", help=argparse.SUPPRESS
         )
         return parser
@@ -1331,11 +1336,6 @@ class SubmitBulkCmd(SubmitBaseCmd):
         self.t0 = None
 
         super().__init__(prog, usage, description)
-        self.parser.add_argument(
-            "--quiet",
-            action="store_true",
-            help="Do not print jobid to stdout on submission",
-        )
         self.parser.add_argument(
             "--cc",
             metavar="IDSET",

--- a/src/bindings/python/flux/cli/batch.py
+++ b/src/bindings/python/flux/cli/batch.py
@@ -140,4 +140,5 @@ class BatchCmd(base.MiniCmd):
         self.script, args = self.process_script(args)
 
         jobid = self.submit(args)
-        print(jobid, file=sys.stdout)
+        if not args.quiet:
+            print(jobid, file=sys.stdout)

--- a/t/t2716-python-cli-batch-conf.t
+++ b/t/t2716-python-cli-batch-conf.t
@@ -14,6 +14,10 @@ flux setattr log-stderr-level 1
 NCORES=$(flux kvs get resource.R | flux R decode --count=core)
 test ${NCORES} -gt 4 && test_set_prereq MULTICORE
 
+test_expect_success 'flux-batch --quiet works' '
+	flux batch --quiet -n1 --wrap hostname >quiet.out &&
+	test_must_be_empty quiet.out
+'
 test_expect_success 'flux-batch: create test configs' '
 	cat <<-EOF >conf.json &&
 	{"resource": {"noverify": true}}


### PR DESCRIPTION
This PR enables the `--quiet` option on `flux-batch`.

Fixes #5644