### PR TITLE
doc: add missing standard-io options to flux-batch(1)

### DIFF
--- a/doc/man1/common/job-standard-io.rst
+++ b/doc/man1/common/job-standard-io.rst
@@ -20,10 +20,6 @@
      Expands to the current job name. If a name is not set for the job,
      then the basename of the command will be used.
 
-   For :man1:`flux-batch` the default *TEMPLATE* is *flux-{{id}}.out*.
-   To force output to KVS so it is available with ``flux job attach``,
-   set *TEMPLATE* to *none* or *kvs*.
-
 .. option:: --error=TEMPLATE
 
    Redirect stderr to the specified filename *TEMPLATE*, bypassing the KVS.

--- a/doc/man1/flux-batch.rst
+++ b/doc/man1/flux-batch.rst
@@ -87,6 +87,16 @@ resources required for a virtual task. The default slot size is 1 core.
 
 .. include:: common/job-param-additional.rst
 
+STANDARD I/O
+============
+
+For :man1:`flux-batch` the default :option:`--output` *TEMPLATE*
+is *flux-{{id}}.out*.  To force output to KVS so it is available with
+``flux job attach`` or :man1:`flux-watch` , set the :option:`--output`
+*TEMPLATE* to *none* or *kvs*.
+
+.. include:: common/job-standard-io.rst
+
 CONSTRAINTS
 ===========
 


### PR DESCRIPTION
Problem: Documentation of standard io options is not included in flux-batch(1).

Add a STANDARD I/O section to flux-batch(1) and include the missing common/job-standard-io.rst text. Since flux-batch(1) now has its own manual, remove the generic statement about flux-batch(1) from the common file and put a similar statement directly in flux-batch(1).