### PR TITLE
python: add rolemask parameter to msg_handler_create()

### DIFF
--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -247,8 +247,11 @@ class Flux(Wrapper):
         topic_glob="*",
         args=None,
         match_tag=raw.FLUX_MATCHTAG_NONE,
+        rolemask=None,
     ):
-        return MessageWatcher(self, type_mask, callback, topic_glob, match_tag, args)
+        return MessageWatcher(
+            self, type_mask, callback, topic_glob, match_tag, rolemask, args
+        )
 
     def timer_watcher_create(self, after, callback, repeat=0.0, args=None):
         return TimerWatcher(self, after, callback, repeat=repeat, args=args)

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -169,6 +169,7 @@ class MessageWatcher(Watcher):
         callback,
         topic_glob="*",
         match_tag=flux.constants.FLUX_MATCHTAG_NONE,
+        rolemask=None,
         args=None,
     ):
         self.callback = callback
@@ -197,6 +198,8 @@ class MessageWatcher(Watcher):
                 self.wargs,
             ),
         )
+        if rolemask:
+            flux_handle.msg_handler_allow_rolemask(self.handle, rolemask)
 
     def start(self):
         raw.flux_msg_handler_start(self.handle)

--- a/t/python/t0007-watchers.py
+++ b/t/python/t0007-watchers.py
@@ -86,6 +86,14 @@ class TestTimer(unittest.TestCase):
         ) as mw:
             self.assertIsNotNone(mw)
 
+    def test_msg_watcher_rolemask(self):
+        with self.f.msg_watcher_create(
+            lambda handle, x, y, z: handle.fatal_error("cb should not run"),
+            topic_glob="foo.*",
+            rolemask=flux.constants.FLUX_ROLE_ALL,
+        ) as mw:
+            self.assertIsNotNone(mw)
+
 
 class TestSignal(unittest.TestCase):
     @classmethod

--- a/t/python/t1000-service-add-remove.py
+++ b/t/python/t1000-service-add-remove.py
@@ -11,6 +11,7 @@
 ###############################################################
 
 import errno
+import os
 import sys
 import unittest
 
@@ -33,6 +34,10 @@ class TestServiceAddRemove(unittest.TestCase):
         rc = self.f.service_register("foo").get()
         self.assertEqual(rc, None)
 
+    def test_001_register_owner_service(self):
+        rc = self.f.service_register("owner").get()
+        self.assertEqual(rc, None)
+
     def test_002_service_add_eexist(self):
         with self.assertRaises(EnvironmentError) as e:
             self.f.service_register("foo").get()
@@ -44,10 +49,28 @@ class TestServiceAddRemove(unittest.TestCase):
             self.assertEqual(rc, 0)
 
         self.f.watcher = self.f.msg_watcher_create(
-            service_cb, FLUX_MSGTYPE_REQUEST, "foo.echo"
+            service_cb,
+            FLUX_MSGTYPE_REQUEST,
+            "foo.echo",
+            rolemask=flux.constants.FLUX_ROLE_ALL,
         )
         self.assertIsNotNone(self.f.watcher)
         self.f.watcher.start()
+
+    def test_003_add_owner_message_watcher(self):
+        def service_cb(f, t, msg, arg):
+            rc = f.respond(msg, msg.payload_str)
+            self.assertEqual(rc, 0)
+
+        # Note: default rolemask for handle.msg_watcher_create()
+        # should allow instance-owner only:
+        self.f.watcher2 = self.f.msg_watcher_create(
+            service_cb,
+            FLUX_MSGTYPE_REQUEST,
+            "owner.echo",
+        )
+        self.assertIsNotNone(self.f.watcher2)
+        self.f.watcher2.start()
 
     def test_004_service_rpc(self):
         cb_called = [False]  # So that cb_called[0] is mutable in inner function
@@ -68,6 +91,60 @@ class TestServiceAddRemove(unittest.TestCase):
         self.assertTrue(m is not None)
         ret = self.f.send(m)
         self.assertEqual(ret, 0)
+
+        ret = self.f.reactor_run()
+        self.assertTrue(ret >= 0)
+        self.assertTrue(cb_called[0])
+        w2.stop()
+        w2.destroy()
+
+    def send_user_request(self, topic, payload):
+        m = Message()
+        m.topic = topic
+        m.payload = payload
+        m.pimpl.set_rolemask(flux.constants.FLUX_ROLE_USER)
+        m.pimpl.set_userid(os.getuid() + 1)
+        self.assertTrue(m is not None)
+        ret = self.f.send(m)
+        self.assertEqual(ret, 0)
+
+    def test_004_service_rpc_user(self):
+        cb_called = [False]  # So that cb_called[0] is mutable in inner function
+        p = {"test": "bar"}
+
+        def cb(f, t, msg, arg):
+            cb_called[0] = True
+            self.assertEqual(msg.payload, p)
+            f.reactor_stop()
+
+        w2 = self.f.msg_watcher_create(cb, FLUX_MSGTYPE_RESPONSE, "foo.echo")
+        w2.start()
+        self.assertIsNotNone(w2, msg="msg_watcher_create response handler")
+
+        self.send_user_request("foo.echo", p)
+
+        ret = self.f.reactor_run()
+        self.assertTrue(ret >= 0)
+        self.assertTrue(cb_called[0])
+        w2.stop()
+        w2.destroy()
+
+    def test_004_service_rpc_user_eperm(self):
+        cb_called = [False]  # So that cb_called[0] is mutable in inner function
+        p = {"test": "baz"}
+
+        def cb(f, t, msg, arg):
+            cb_called[0] = True
+            with self.assertRaises(OSError) as exc:
+                msgtype, topic, data = msg.decode()
+            self.assertEqual(exc.exception.errno, errno.EPERM)
+            f.reactor_stop()
+
+        w2 = self.f.msg_watcher_create(cb, FLUX_MSGTYPE_RESPONSE, "owner.echo")
+        w2.start()
+        self.assertIsNotNone(w2, msg="msg_watcher_create response handler")
+
+        self.send_user_request("owner.echo", p)
 
         ret = self.f.reactor_run()
         self.assertTrue(ret >= 0)
@@ -105,8 +182,12 @@ class TestServiceAddRemove(unittest.TestCase):
         rc = self.f.service_unregister("foo").get()
         self.assertEqual(rc, None)
 
+        rc = self.f.service_unregister("owner").get()
+        self.assertEqual(rc, None)
+
         # done with message handler
         self.f.watcher.destroy()
+        self.f.watcher2.destroy()
         self.f.error_watcher.destroy()
 
     def test_006_unregister_service_enoent(self):


### PR DESCRIPTION
This PR fixes #5013 by adding an optional `rolemask` parameter to the `MessageWatcher` class initializer as well as `msg_handler_create()` which calls it.