### PR TITLE
python: add `decode` method to Flux `Message` class

### DIFF
--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -22,7 +22,7 @@ __all__ = ["Message", "MessageWatcher", "msg_typestr"]
 
 def msg_typestr(msg_type):
     # the returned string is guaranteed to be ascii
-    return ffi.string(raw.flux_msg_typestr(msg_type)).decode("ascii")
+    return raw.flux_msg_typestr(msg_type).decode("ascii")
 
 
 class Message(WrapperPimpl):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -263,6 +263,7 @@ TESTSCRIPTS = \
 	python/t0005-kvs.py \
 	python/t0006-request.py \
 	python/t0007-watchers.py \
+	python/t0008-message.py \
 	python/t0010-job.py \
 	python/t0012-futures.py \
 	python/t0013-job-list.py \

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -74,4 +74,8 @@ def rerun_under_flux(size=1, personality="full"):
         command, env=child_env, bufsize=-1, stdout=sys.stdout, stderr=sys.stderr
     )
     p.wait()
+    if p.returncode > 0:
+        sys.exit(p.returncode)
+    elif p.returncode < 0:
+        sys.exit(128 + -p.returncode)
     return False

--- a/t/python/t0008-message.py
+++ b/t/python/t0008-message.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2024 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import json
+import unittest
+
+import flux
+from flux.message import Message
+from subflux import rerun_under_flux
+
+
+def __flux_size():
+    return 2
+
+
+class TestMessage(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.f = flux.Flux()
+        self.f.service_register("test").get()
+
+        self.msg_handler = self.f.msg_watcher_create(
+            lambda f, t, msg, arg: f.respond(msg),
+            flux.constants.FLUX_MSGTYPE_REQUEST,
+            "test.*",
+        )
+        self.msg_handler.start()
+
+    @classmethod
+    def tearDownClass(self):
+        self.f.service_unregister("test").get()
+        self.msg_handler.destroy()
+
+    def test_basic_request(self):
+        payload = {"test": "foo"}
+        m = Message()
+        self.assertIsNotNone(m)
+
+        # default type is request
+        self.assertEqual(m.type, flux.constants.FLUX_MSGTYPE_REQUEST)
+        self.assertEqual(m.type_str, "request")
+
+        m.topic = "test"
+        self.assertEqual(m.topic, "test")
+
+        m.payload_str = "blah"
+        self.assertEqual(m.payload_str, "blah")
+
+        m.payload = payload
+        self.assertEqual(m.payload, payload)
+        self.assertEqual(m.payload_str, json.dumps(payload))
+
+        msgtype, topic, payload_str = m.decode()
+        self.assertEqual(msgtype, flux.constants.FLUX_MSGTYPE_REQUEST)
+        self.assertEqual(topic, "test")
+        self.assertEqual(payload_str, json.dumps(payload))
+
+        # self.type setter works
+        m.type = flux.constants.FLUX_MSGTYPE_RESPONSE
+        self.assertEqual(m.type, flux.constants.FLUX_MSGTYPE_RESPONSE)
+
+    def test_basic_response(self):
+        m = Message(flux.constants.FLUX_MSGTYPE_RESPONSE)
+        self.assertIsNotNone(m)
+        self.assertEqual(m.type, flux.constants.FLUX_MSGTYPE_RESPONSE)
+        self.assertEqual(m.type_str, "response")
+
+        m.topic = "test"
+        self.assertEqual(m.topic, "test")
+
+        msgtype, topic, payload_str = m.decode()
+        self.assertEqual(msgtype, flux.constants.FLUX_MSGTYPE_RESPONSE)
+        self.assertEqual(topic, "test")
+        self.assertIsNone(payload_str)
+
+    def test_baseic_event(self):
+        m = Message(flux.constants.FLUX_MSGTYPE_EVENT)
+        self.assertIsNotNone(m)
+        self.assertEqual(m.type, flux.constants.FLUX_MSGTYPE_EVENT)
+        self.assertEqual(m.type_str, "event")
+
+        m.topic = "event.test"
+        self.assertEqual(m.topic, "event.test")
+
+        msgtype, topic, payload_str = m.decode()
+        self.assertEqual(msgtype, flux.constants.FLUX_MSGTYPE_EVENT)
+        self.assertEqual(topic, "event.test")
+        self.assertIsNone(payload_str)
+
+    def test_send(self):
+        payload = {"test": "foo"}
+        cb_called = [False]
+
+        def cb(handle, watcher, msg, called):
+            cb_called[0] = True
+            msgtype, topic, payload = msg.decode()
+            self.assertEqual(msgtype, flux.constants.FLUX_MSGTYPE_RESPONSE)
+            self.assertEqual(topic, "test.foo")
+            self.assertIsNone(payload)
+            handle.reactor_stop()
+
+        watcher = self.f.msg_watcher_create(
+            cb,
+            flux.constants.FLUX_MSGTYPE_RESPONSE,
+            "test.*",
+        )
+        self.assertIsNotNone(watcher)
+        watcher.start()
+
+        m = Message()
+        self.assertIsNotNone(m)
+
+        # default type is request
+        self.assertEqual(m.type, flux.constants.FLUX_MSGTYPE_REQUEST)
+        self.assertEqual(m.type_str, "request")
+
+        m.topic = "test.foo"
+        self.assertEqual(m.topic, "test.foo")
+        self.payload = payload
+        self.f.send(m)
+
+        rc = self.f.reactor_run()
+        self.assertTrue(rc > 0)
+        self.assertTrue(cb_called[0])
+
+        watcher.destroy()
+
+
+if __name__ == "__main__":
+    if rerun_under_flux(__flux_size()):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
Python `Message` objects currently offer some basic property getter and setters, but there is no convenient way to call the underlying `decode` API function for these messages. Notably, this makes it impossible to tell if a response contains an error.

This PR adds a `decode` method to the `Message` class which calls the underlying decode C API, raising an `OSError` exception if the decode fails, since this is an idiomatic way to detect an error in the case of requests.

Additionally, there were no unit tests of the `Message` class, so a set of tests is added.