### PR TITLE
job-list: support "hostlist" constraint to allow jobs to be filtered by nodes

### DIFF
--- a/src/modules/job-list/job_data.c
+++ b/src/modules/job-list/job_data.c
@@ -35,6 +35,7 @@ void job_destroy (void *data)
         int save_errno = errno;
         free (job->ranks);
         free (job->nodelist);
+        hostlist_destroy (job->nodelist_hl);
         json_decref (job->annotations);
         grudgeset_destroy (job->dependencies);
         json_decref (job->jobspec);

--- a/src/modules/job-list/job_data.h
+++ b/src/modules/job-list/job_data.h
@@ -14,6 +14,7 @@
 #include <flux/core.h>
 #include <jansson.h>
 
+#include "src/common/libhostlist/hostlist.h"
 #include "src/common/libutil/grudgeset.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 
@@ -54,6 +55,7 @@ struct job {
     int nnodes;
     char *ranks;
     char *nodelist;
+    struct hostlist *nodelist_hl; /* cache of nodelist in hl form */
     double expiration;
     int wait_status;
     bool success;

--- a/src/modules/job-list/match.h
+++ b/src/modules/job-list/match.h
@@ -23,6 +23,7 @@
 struct match_ctx {
     flux_t *h;
     uint64_t max_comparisons;
+    uint32_t max_hostlist;
 };
 
 struct match_ctx *match_ctx_create (flux_t *h);

--- a/src/modules/job-list/state_match.c
+++ b/src/modules/job-list/state_match.c
@@ -366,7 +366,8 @@ struct state_constraint *state_constraint_create (json_t *constraint, flux_error
             }
             if (streq (op, "userid")
                 || streq (op, "name")
-                || streq (op, "queue"))
+                || streq (op, "queue")
+                || streq (op, "hostlist"))
                 return state_constraint_new (match_maybe, NULL, errp);
             else if (streq (op, "results"))
                 return state_constraint_new (match_result, NULL, errp);

--- a/src/modules/job-list/test/state_match.c
+++ b/src/modules/job-list/test/state_match.c
@@ -1108,6 +1108,7 @@ struct state_match_constraint_test {
              { \"userid\": [ 42 ] }, \
              { \"name\": [ \"foo\" ] }, \
              { \"queue\": [ \"foo\" ] }, \
+             { \"hostlist\": [ \"bar\" ] }, \
              { \"states\": [ \"running\" ] }, \
              { \"results\": [ \"completed\" ] }, \
              { \"t_submit\": [ \">=500.0\" ] }, \


### PR DESCRIPTION
TSIA.

Maybe the only interesting side note is that until we solve #5367 (which should probably follow this one up) we don't yet have a friendly user interface for this.  The tests send constraints objects straight to the `job-list` module.