### PR TITLE
doc: correct typo in flux_requeue(3)

### DIFF
--- a/doc/man3/flux_requeue.rst
+++ b/doc/man3/flux_requeue.rst
@@ -26,7 +26,7 @@ can be received with :man3:`flux_recv` as though it arrived from the broker.
 FLUX_RQ_TAIL
    :var:`msg` is placed at the tail of the message queue.
 
-FLUX_RQ_TAIL
+FLUX_RQ_HEAD
    :var:`msg` is placed at the head of the message queue.
 
 


### PR DESCRIPTION
Problem: FLUX_RQ_TAIL is listed twice in flux_requeue(3).  One of them should be FLUX_RQ_HEAD.

Fix the typo.

Fixes #5659