### PR TITLE
kvs: store correct namespace after getroot lookup

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -311,18 +311,13 @@ static void getroot_completion (flux_future_t *f, void *arg)
     msg = flux_future_aux_get (f, "msg");
     assert (msg);
 
-    if (flux_request_unpack (msg, NULL, "{ s:s }",
-                             "namespace", &ns) < 0) {
-        flux_log_error (ctx->h, "%s: flux_request_unpack", __FUNCTION__);
-        goto error;
-    }
-
     /* N.B. owner read into uint32_t */
-    if (flux_rpc_get_unpack (f, "{ s:i s:i s:s s:i }",
+    if (flux_rpc_get_unpack (f, "{ s:i s:i s:s s:i s:s }",
                              "owner", &owner,
                              "rootseq", &rootseq,
                              "rootref", &ref,
-                             "flags", &flags) < 0) {
+                             "flags", &flags,
+                             "namespace", &ns) < 0) {
         if (errno != ENOTSUP)
             flux_log_error (ctx->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
         goto error;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -377,8 +377,7 @@ static int getroot_request_send (struct kvs_ctx *ctx,
                                  const char *ns,
                                  flux_msg_handler_t *mh,
                                  const flux_msg_t *msg,
-                                 lookup_t *lh,
-                                 flux_msg_handler_f cb)
+                                 lookup_t *lh)
 {
     flux_future_t *f = NULL;
     flux_msg_t *msgcpy = NULL;
@@ -422,7 +421,6 @@ static struct kvsroot *getroot (struct kvs_ctx *ctx, const char *ns,
                                 flux_msg_handler_t *mh,
                                 const flux_msg_t *msg,
                                 lookup_t *lh,
-                                flux_msg_handler_f cb,
                                 bool *stall)
 {
     struct kvsroot *root;
@@ -435,7 +433,7 @@ static struct kvsroot *getroot (struct kvs_ctx *ctx, const char *ns,
             return NULL;
         }
         else {
-            if (getroot_request_send (ctx, ns, mh, msg, lh, cb) < 0) {
+            if (getroot_request_send (ctx, ns, mh, msg, lh) < 0) {
                 flux_log_error (ctx->h, "getroot_request_send");
                 return NULL;
             }
@@ -1386,7 +1384,7 @@ static lookup_t *lookup_common (flux_t *h, flux_msg_handler_t *mh,
         ns = lookup_missing_namespace (lh);
         assert (ns);
 
-        root = getroot (ctx, ns, mh, msg, lh, replay_cb, &stall);
+        root = getroot (ctx, ns, mh, msg, lh, &stall);
         assert (!root);
 
         if (stall)
@@ -1679,13 +1677,7 @@ static void commit_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(root = getroot (ctx,
-                          ns,
-                          mh,
-                          msg,
-                          NULL,
-                          commit_request_cb,
-                          &stall))) {
+    if (!(root = getroot (ctx, ns, mh, msg, NULL, &stall))) {
         if (stall)
             return;
         goto error;
@@ -1873,13 +1865,7 @@ static void fence_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(root = getroot (ctx,
-                          ns,
-                          mh,
-                          msg,
-                          NULL,
-                          fence_request_cb,
-                          &stall))) {
+    if (!(root = getroot (ctx, ns, mh, msg, NULL, &stall))) {
         if (stall)
             goto stall;
         goto error;
@@ -1986,8 +1972,7 @@ static void wait_version_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(root = getroot (ctx, ns, mh, msg, NULL, wait_version_request_cb,
-                          &stall))) {
+    if (!(root = getroot (ctx, ns, mh, msg, NULL, &stall))) {
         if (stall)
             return;
         goto error;
@@ -2047,8 +2032,7 @@ static void getroot_request_cb (flux_t *h, flux_msg_handler_t *mh,
          * first.
          */
         bool stall = false;
-        if (!(root = getroot (ctx, ns, mh, msg, NULL,
-                              getroot_request_cb, &stall))) {
+        if (!(root = getroot (ctx, ns, mh, msg, NULL, &stall))) {
             if (stall)
                 return;
             goto error;
@@ -2678,13 +2662,7 @@ static void setroot_pause_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(root = getroot (ctx,
-                          ns,
-                          mh,
-                          msg,
-                          NULL,
-                          setroot_pause_request_cb,
-                          &stall))) {
+    if (!(root = getroot (ctx, ns, mh, msg, NULL, &stall))) {
         if (stall)
             return;
         goto error;
@@ -2749,13 +2727,7 @@ static void setroot_unpause_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(root = getroot (ctx,
-                          ns,
-                          mh,
-                          msg,
-                          NULL,
-                          setroot_unpause_request_cb,
-                          &stall))) {
+    if (!(root = getroot (ctx, ns, mh, msg, NULL, &stall))) {
         if (stall)
             return;
         goto error;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2040,11 +2040,12 @@ static void getroot_request_cb (flux_t *h, flux_msg_handler_t *mh,
     }
 
     /* N.B. owner cast into int */
-    if (flux_respond_pack (h, msg, "{ s:i s:i s:s s:i }",
+    if (flux_respond_pack (h, msg, "{ s:i s:i s:s s:i s:s }",
                            "owner", root->owner,
                            "rootseq", root->seq,
                            "rootref", root->ref,
-                           "flags", root->flags) < 0)
+                           "flags", root->flags,
+                           "namespace", root->ns_name) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     return;
 error:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -355,6 +355,7 @@ dist_check_SCRIPTS = \
 	issues/t5105-signal-propagation.sh \
 	issues/t5308-kvsdir-initial-path.py \
 	issues/t5368-kvs-commit-clear.py \
+	issues/t5657-kvs-getroot-namespace.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t5657-kvs-getroot-namespace.sh
+++ b/t/issues/t5657-kvs-getroot-namespace.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -e
+
+# internal KVS getroot request does not cache namespace with correct name
+
+TEST=issue5657
+
+cat <<-EOF >t5657test.sh
+#!/bin/sh -e
+
+flux kvs namespace create issue5657ns
+
+flux kvs put --namespace=issue5657ns a=1
+flux kvs link -T issue5657ns a link2a
+
+# double check getting link2a treeobj on rank 1 works
+flux exec -r 1 flux kvs get --treeobj link2a
+
+# before fix, next line would hang because symlink would not cache correct
+# namespace name, leading to internal infinite loop
+
+flux exec -r 1 flux kvs get link2a
+
+EOF
+
+chmod +x t5657test.sh
+
+flux start -s 2 ./t5657test.sh


### PR DESCRIPTION
Per discussion in #5657

To solve, I added a "namespace" field in the getroot response.  Obviously could have done an "aux" thing instead.  But felt this was the most reasonable / potentially useful in other ways solution.

I did not add "get" functions for the namespace in `libkvs/kvs_getroot`.  Maybe should / could?  I initially did, but then it seemed silly to add it into `flux kvs getroot` (i.e `flux kvs getroot --namespace foo-namespace` would output `foo-namespace`).
