### PR TITLE
add flux filemap get --overwrite and change the default overwrite behavior

### DIFF
--- a/doc/man1/flux-filemap.rst
+++ b/doc/man1/flux-filemap.rst
@@ -137,6 +137,11 @@ is not on a network file system without considering the ramifications.
    Specify a comma separated list of *tags*.  If no tags are specified,
    the *main* tag is assumed.
 
+.. option:: --overwrite
+
+   Overwrite existing files when extracting.  :program:`flux filemap get`
+   normally refuses to do this and treats it as a fatal error.
+
 unmap
 -----
 

--- a/src/cmd/builtin/filemap.c
+++ b/src/cmd/builtin/filemap.c
@@ -315,6 +315,10 @@ static void extract (flux_t *h,
     bool direct = optparse_hasopt (p, "direct");
     flux_future_t *f;
     flux_error_t error;
+    int opts = 0;
+
+    if (!optparse_hasopt (p, "overwrite"))
+        opts |= ARCHIVE_EXTRACT_NO_OVERWRITE;
 
     if (!(f = filemap_mmap_list (h, !direct, tags, pattern)))
         log_err_exit ("mmap-list");
@@ -326,7 +330,7 @@ static void extract (flux_t *h,
                 break; // end of stream
             log_msg_exit ("mmap-list: %s", future_strerror (f, errno));
         }
-        if (filemap_extract (h, files, direct, 0, &error, trace_fn, p) < 0)
+        if (filemap_extract (h, files, direct, opts, &error, trace_fn, p) < 0)
             log_msg_exit ("%s", error.text);
         flux_future_reset (f);
     }
@@ -415,6 +419,8 @@ static struct optparse_option get_opts[] = {
       .usage = "Specify comma-separated tags (default: main)", },
     { .name = "direct", .has_arg = 0,
       .usage = "Fetch filerefs directly (fastest for single client)", },
+    { .name = "overwrite", .has_arg = 0,
+      .usage = "Overwrite existing files when extracting", },
       OPTPARSE_TABLE_END
 };
 
@@ -441,7 +447,7 @@ static struct optparse_subcommand filemap_subcmds[] = {
       list_opts,
     },
     { "get",
-      "[--tags=LIST] [--directory=DIR] [PATTERN]",
+      "[--tags=LIST] [--directory=DIR] [--overwrite] [PATTERN]",
       "Extract files from content cache",
       subcmd_get,
       0,

--- a/src/cmd/builtin/filemap.c
+++ b/src/cmd/builtin/filemap.c
@@ -328,7 +328,7 @@ static void extract (flux_t *h,
                 break; // end of stream
             log_msg_exit ("mmap-list: %s", future_strerror (f, errno));
         }
-        if (filemap_extract (h, files, direct, &error, trace_fn, p) < 0)
+        if (filemap_extract (h, files, direct, 0, &error, trace_fn, p) < 0)
             log_msg_exit ("%s", error.text);
         flux_future_reset (f);
     }

--- a/src/cmd/builtin/filemap.c
+++ b/src/cmd/builtin/filemap.c
@@ -19,7 +19,6 @@
 #include <libgen.h>
 #include <jansson.h>
 #include <archive.h>
-#include <archive_entry.h>
 
 #include "ccan/base64/base64.h"
 #include "ccan/str/str.h"
@@ -310,7 +309,6 @@ static void trace_fn (void *arg,
 
 static void extract (flux_t *h,
                      optparse_t *p,
-                     struct archive *archive,
                      const char *pattern)
 {
     json_t *tags = get_list_option (p, "tags", "main");
@@ -341,7 +339,6 @@ static int subcmd_get (optparse_t *p, int ac, char *av[])
     const char *directory = optparse_get_str (p, "directory", NULL);
     const char *pattern = NULL;
     flux_t *h;
-    struct archive *archive;
 
     if (n < ac)
         pattern = av[n++];
@@ -355,10 +352,7 @@ static int subcmd_get (optparse_t *p, int ac, char *av[])
     }
     if (!(h = builtin_get_flux_handle (p)))
         log_err_exit ("flux_open");
-    if (!(archive = archive_write_disk_new ()))
-        log_msg_exit ("error creating libarchive context");
-    extract (h, p, archive, pattern);
-    archive_write_free (archive);
+    extract (h, p, pattern);
     flux_close (h);
     return 0;
 }

--- a/src/common/libfilemap/filemap.h
+++ b/src/common/libfilemap/filemap.h
@@ -51,6 +51,7 @@ flux_future_t *filemap_mmap_list (flux_t *h,
 int filemap_extract (flux_t *h,
                      json_t *files,
                      bool direct,
+		     int libarchive_flags,
                      flux_error_t *errp,
                      filemap_trace_f trace_cb,
                      void *arg);

--- a/src/shell/files.c
+++ b/src/shell/files.c
@@ -54,7 +54,7 @@ static int extract_job_files (flux_t *h,
         shell_log_errno ("chdir %s", dir);
         goto out;
     }
-    if (filemap_extract (h, files, true, &error, trace, NULL) < 0) {
+    if (filemap_extract (h, files, true, 0, &error, trace, NULL) < 0) {
         shell_log_error ("%s", error.text);
         goto out;
     }

--- a/src/shell/stage-in.c
+++ b/src/shell/stage-in.c
@@ -130,6 +130,7 @@ static int extract (struct stage_in *ctx)
         if (filemap_extract (ctx->h,
                              files,
                              ctx->direct,
+                             0,
                              &error,
                              trace_cb,
                              ctx) < 0) {

--- a/t/t0029-filemap-cmd.t
+++ b/t/t0029-filemap-cmd.t
@@ -304,6 +304,27 @@ test_expect_success 'size reduction should cause an error' '
 	test_must_fail flux filemap get -C copydir 2>reduced.err &&
 	grep changed reduced.err
 '
+test_expect_success 'unmap test file' '
+	flux filemap unmap
+'
+
+test_expect_success 're-create and map test file' '
+	${LPTEST} >testfile &&
+	flux filemap map ./testfile
+'
+test_expect_success 'get copydir/testfile' '
+	rm -f copydir/testfile &&
+	flux filemap get -C copydir
+'
+test_expect_success 'get --overwrite works' '
+	flux filemap get --overwrite -C copydir
+'
+test_expect_success 'get refuses to overwrite without explicit option' '
+	test_must_fail flux filemap get -C copydir
+'
+test_expect_success 'unmap test file' '
+	flux filemap unmap
+'
 
 test_expect_success 'remove content module' '
 	flux exec flux module remove content

--- a/t/t0029-filemap-cmd.t
+++ b/t/t0029-filemap-cmd.t
@@ -55,6 +55,12 @@ test_expect_success 'create test file' '
 test_expect_success 'map nonexistent file fails' '
 	test_must_fail flux filemap map notafile
 '
+test_expect_success 'map unreadable file fails with appropriate error' '
+	touch unreadable &&
+	chmod ugo-r unreadable &&
+	test_must_fail flux filemap map unreadable 2>unreadable.err &&
+	grep "Permission denied" unreadable.err
+'
 test_expect_success 'map test file' '
 	flux filemap map ./testfile
 '


### PR DESCRIPTION
Problem: as discussed in #5655, `flux filemap get` can too easily ovewrite the source file causing mahem in a file broadcast operation.

This changes the default behavior to fail the `get` operation if a destination file exists, and adds a `--overwrite` option that can be used to get the old behavior.

