### PR TITLE
broker: only set parent-uri when instance is a job

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -61,8 +61,7 @@ local-uri [Updates: C]
    existing directory.
 
 parent-uri
-   The value of the broker's :envvar:`FLUX_URI` environment variable.  This is
-   the URI that should be passed to :man3:`flux_open` to establish a connection
+   The URI that should be passed to :man3:`flux_open` to establish a connection
    to the enclosing instance.
 
 instance-level

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -629,7 +629,14 @@ static void init_attrs (attr_t *attrs, pid_t pid, struct flux_msg_cred *cred)
 {
     const char *val;
 
-    val = getenv ("FLUX_URI");
+    /* Set the parent-uri attribute IFF this instance was run as a job
+     * in the enclosing instance.  "parent" in this context reflects
+     * a hierarchy of resource allocation.
+     */
+    if (getenv ("FLUX_JOB_ID"))
+        val = getenv ("FLUX_URI");
+    else
+        val = NULL;
     if (attr_add (attrs, "parent-uri", val, ATTR_IMMUTABLE) < 0)
         log_err_exit ("setattr parent-uri");
     unsetenv ("FLUX_URI");

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -39,9 +39,9 @@ test_expect_success "flux --parent works in subinstance" '
 '
 
 test_expect_success "flux --parent --parent works in subinstance" '
-	id=$(flux submit \
-		flux start ${ARGS} \
-		flux start ${ARGS} flux --parent --parent kvs put test=ok) &&
+	id=$(flux batch -n1 --wrap \
+		flux run flux start ${ARGS} \
+		flux --parent --parent kvs put test=ok) &&
 	flux job attach $id &&
 	flux job info $id guest.test > guest2.test &&
 	cat <<-EOF >guest2.test.exp &&


### PR DESCRIPTION
This ensures that the `parent-uri` broker attribute is only set when Flux was lauched as a Flux job, as discussed in #5622.