### PR TITLE
add -x option to flux-alloc and flux-batch

### DIFF
--- a/doc/man1/common/job-param-batch.rst
+++ b/doc/man1/common/job-param-batch.rst
@@ -15,6 +15,6 @@
 
    Distribute allocated resource slots across *N* individual nodes.
 
-.. option:: --exclusive
+.. option:: -x, --exclusive
 
    With :option:`--nodes`, allocate nodes exclusively.

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -1647,7 +1647,8 @@ def add_batch_alloc_args(parser):
         help="Distribute allocated resource slots across N individual nodes",
     )
     parser.add_argument(
+        "-x",
         "--exclusive",
         action="store_true",
-        help="With --nodes, allocate nodes exclusively",
+        help="With -N, --nodes, allocate nodes exclusively",
     )

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -82,7 +82,7 @@ test_expect_success NO_ASAN 'flux batch: submit a series of jobs' '
 	id3=$(flux batch --flags=waitable -N2 -n4 batch-script.sh) &&
 	flux resource list &&
 	flux jobs &&
-	id4=$(flux batch --flags=waitable -N2 -n2 --exclusive batch-script.sh) &&
+	id4=$(flux batch --flags=waitable -N2 -n2 -x batch-script.sh) &&
 	id5=$(flux batch --flags=waitable -N2 batch-script.sh) &&
 	run_timeout 180 flux job wait --verbose --all
 '

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -85,7 +85,7 @@ test_expect_success "flux sets jobid attribute" '
 	test_cmp jobid.exp jobid.out
 '
 test_expect_success 'flux can launch multiple brokers per node' '
-	flux alloc --exclusive -N2 -o per-resource.count=2 \
+	flux alloc -x -N2 -o per-resource.count=2 \
 		flux resource info
 '
 test_expect_success 'flux can launch multiple brokers per node (R lookup fallback)' '


### PR DESCRIPTION
Problem: for some reason, the `--exclusive` option in `flux-alloc` and `flux-batch` is not paired with a short `-x` option like it is in the other submission commands.

Add the short option.