### PR TITLE
libpmi: add `JANSSON_CFLAGS` to Makefile.am

### DIFF
--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libccan \
-	-I$(top_builddir)/src/common/libflux
+	-I$(top_builddir)/src/common/libflux \
+	$(JANSSON_CFLAGS)
 
 noinst_LTLIBRARIES = \
 	libpmi_client.la \


### PR DESCRIPTION
Problem: the libpmi Makefile.am does not check for JANSSON_CFLAGS, which is required to find the jansson header file.

Add the check. Closes #5670

This solution is [courtesy of](https://github.com/flux-framework/flux-core/issues/2892#issuecomment-1883973494) @garlick in #2892. :-)