### PR TITLE
job-manager: fix duplicate posting of jobspec-update event from plugins

### DIFF
--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -747,7 +747,7 @@ static int event_jobtap_call (struct event *event,
         if (json_unpack (entry, "{s:o}", "context", &updates) < 0) {
             flux_log (event->ctx->h,
                       LOG_ERR,
-                      "unable to unpack jobspec-update contexto for %s",
+                      "unable to unpack jobspec-update context for %s",
                       idf58 (job->id));
             return -1;
         }

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -508,17 +508,18 @@ test_expect_success 'job-manager: job.create can reject a job' '
 	test_must_fail flux submit hostname 2>submit.err &&
 	grep nope submit.err
 '
-
 test_expect_success 'job-manager: plugins can update jobspec' '
 	flux jobtap load --remove=all ${PLUGINPATH}/jobspec-update.so &&
 	jobid=$(flux submit --job-name=test hostname) &&
-	flux job attach $jobid &&
+	flux job eventlog -H $jobid &&
 	flux job eventlog $jobid | grep jobspec-update &&
 	flux job eventlog $jobid | grep attributes.system.update-test &&
 	flux job eventlog $jobid | \
-		test_must_fail grep attributes.system.run-update
+		test_must_fail grep attributes.system.run-update &&
+	test_must_fail flux job wait-event --count=2 -Hv \
+		--match-context=attributes.system.job.name=new \
+		$jobid jobspec-update
 '
-
 test_expect_success 'job-manager: plugin fails to load on config.update error' '
 	flux jobtap remove all &&
 	test_must_fail flux jobtap load ${PLUGINPATH}/config.so 2>config.err


### PR DESCRIPTION
As described in #5671, plugins that modify jobspec may end up having duplicate `jobspec-update` events posted. This is wasteful.

The problem occurs because `jobtap_post_jobspec_updates()`, which is called _after_ all plugin callbacks and posts any pending jobspec updates to avoid modifying jobspec while the plugin is still active,  may be called reentrantly as a result of the jobspec updates. The function does not clear `jobtap->jobspec_update` before posting the event, so the 2nd (or more?) calls will post the duplicate.

This PR fixes that issue by ensureing `jobtap_post_jobspec_updates()` is reentrant, and adds a reproducer for this issue to the testsuite.