### PR TITLE
broker: allow single-user rexec to rank 0

### DIFF
--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -8,6 +8,14 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+/* exec.c - broker subprocess server
+ *
+ * The service is restricted to the instance owner.
+ * In addition, remote access to rank 0 is prohibited on multi-user instances.
+ * This is a precaution for system instances where rank 0 is deployed on a
+ * management node with restricted user access.
+ */
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -20,11 +28,26 @@
 #include "exec.h"
 #include "overlay.h"
 
+/* The motivating use case for this was discussed in
+ * flux-framework/flux-core#5676
+ */
+static int is_multiuser_instance (flux_t *h)
+{
+    int allow_guest_user = 0;
+    (void)flux_conf_unpack (flux_get_conf (h),
+                            NULL,
+                            "{s:{s:b}}",
+                            "access",
+                              "allow-guest-user", &allow_guest_user);
+    return allow_guest_user;
+}
+
 static int reject_nonlocal (const flux_msg_t *msg,
                             void *arg,
                             flux_error_t *error)
 {
-    if (!flux_msg_is_local (msg)) {
+    flux_t *h = arg;
+    if (!flux_msg_is_local (msg) && is_multiuser_instance (h)) {
         errprintf (error,
                "Remote rexec requests are not allowed on rank 0");
         return -1;
@@ -42,7 +65,7 @@ int exec_initialize (flux_t *h, uint32_t rank, attr_t *attrs)
     if (!(s = subprocess_server_create (h, "rexec", local_uri, flux_llog, h)))
         goto cleanup;
     if (rank == 0)
-        subprocess_server_set_auth_cb (s, reject_nonlocal, NULL);
+        subprocess_server_set_auth_cb (s, reject_nonlocal, h);
     if (flux_aux_set (h,
                       "flux::exec",
                       s,

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -40,9 +40,21 @@ test_expect_success 'exec to all except a set of ranks' '
 	1
 	EOT
 '
-
+test_expect_success 'configure access.allow-guest-user = true' '
+	flux config load <<-EOT
+	access.allow-guest-user = true
+	EOT
+'
 test_expect_success 'exec to rank 0 from another rank is an error' '
 	test_must_fail flux exec -n -r 1 flux exec -n -r 0 /bin/true
+'
+test_expect_success 'configure access.allow-guest-user = false' '
+	flux config load <<-EOT
+	access.allow-guest-user = false
+	EOT
+'
+test_expect_success 'exec to rank 0 from another rank works' '
+	flux exec -n -r 1 flux exec -n -r 0 /bin/true
 '
 
 test_expect_success 'exec to non-existent rank is an error' '

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -243,7 +243,11 @@ test_expect_success 'rexec read_getline call works on remote streams' '
 	echo "barEOF" >> expected &&
 	test_cmp expected output
 '
-
+test_expect_success 'configure access.allow-guest-user = true' '
+	flux config load <<-EOT
+	access.allow-guest-user = true
+	EOT
+'
 test_expect_success 'get URI for rank 1 and check that it works' '
 	$rexec -r 1 flux getattr local-uri >uri1 &&
 	test $(FLUX_URI=$(cat uri1) flux getattr rank) -eq 1
@@ -276,6 +280,15 @@ test_expect_success NO_CHAIN_LINT 'ps, kill fail remotely on rank 0' '
 		$rexec_script kill --rank 0 15 $pid) &&
 	$rexec_script kill 15 $pid &&
 	wait_rexec_process_count 0 0
+'
+
+test_expect_success 'configure access.allow-guest-user = false' '
+	flux config load <<-EOT
+	access.allow-guest-user = false
+	EOT
+'
+test_expect_success 'rexec from rank 1 to rank 0 works' '
+	(FLUX_URI=$(cat uri1) $rexec -r 0 /bin/true)
 '
 
 test_expect_success NO_CHAIN_LINT 'kill fails with ESRCH when pid is unknown' '


### PR DESCRIPTION
Problem: remote rexec to rank 0 is not permitted, but it would be useful to allow shell plugins to run things on rank 0 in order to utilize leader-only services like 'flux filemap map'.

Remote rexec is restricted in order to prevent the flux user from remotely executing arbitrary programs on a restricted management node. This is not a concern for other Flux instances such as batch jobs.

Change the rexec authorization callback to allow remote access on rank 0 if the 'access.allow-guest-user' TOML key is unset or false.

Update tests.