### PR TITLE
fix broker hang under `flux proxy`

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -641,6 +641,11 @@ static void init_attrs (attr_t *attrs, pid_t pid, struct flux_msg_cred *cred)
         log_err_exit ("setattr parent-uri");
     unsetenv ("FLUX_URI");
 
+    /* Unset FLUX_PROXY_REMOTE since once a new broker starts we're no
+     * longer technically running under the influence of flux-proxy(1).
+     */
+    unsetenv ("FLUX_PROXY_REMOTE");
+
     val = getenv ("FLUX_KVS_NAMESPACE");
     if (attr_add (attrs, "parent-kvs-namespace", val, ATTR_IMMUTABLE) < 0)
         log_err_exit ("setattr parent-kvs-namespace");

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -142,6 +142,10 @@ test_expect_success 'parent-uri under remote flux-proxy is rewritten' '
 	test_debug "cat proxy-parent-uri.out" &&
 	grep ssh://user@$(hostname) proxy-parent-uri.out
 '
+test_expect_success 'flux-start does not hang under flux-proxy' '
+	run_timeout --kill-after=10 --env=FLUX_SSH=${tssh} 60 \
+		flux proxy $uri flux start true
+'
 test_expect_success 'cancel test job' '
 	flux cancel $id &&
 	flux job wait-event -vt 10 $id clean


### PR DESCRIPTION
This applies the changes discussed in #5679 to fix `flux start` hangs under `flux proxy`.