### PR TITLE
job-list: limit constraint comparisons to avoid DoS

### DIFF
--- a/src/cmd/job/list.c
+++ b/src/cmd/job/list.c
@@ -119,7 +119,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
                              "constraint", c)))
         log_err_exit ("flux_rpc_pack");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
-        log_err_exit ("flux job-list.list");
+        log_msg_exit ("flux job-list.list: %s", future_strerror (f, errno));
     json_array_foreach (jobs, index, value) {
         char *str;
         str = json_dumps (value, 0);
@@ -173,7 +173,7 @@ int cmd_list_inactive (optparse_t *p, int argc, char **argv)
                              "constraint", c)))
         log_err_exit ("flux_rpc_pack");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
-        log_err_exit ("flux job-list.list");
+        log_msg_exit ("flux job-list.list: %s", future_strerror (f, errno));
     json_array_foreach (jobs, index, value) {
         char *str;
         str = json_dumps (value, 0);
@@ -193,7 +193,7 @@ void list_id_continuation (flux_future_t *f, void *arg)
     json_t *job;
     char *str;
     if (flux_rpc_get_unpack (f, "{s:o}", "job", &job) < 0)
-        log_err_exit ("flux_job_list_id");
+        log_msg_exit ("flux job-list.list-d: %s", future_strerror (f, errno));
     str = json_dumps (job, 0);
     if (!str)
         log_msg_exit ("error parsing list-id response");

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -206,6 +206,8 @@ static void list_ctx_destroy (struct list_ctx *ctx)
             job_state_destroy (ctx->jsctx);
         if (ctx->isctx)
             idsync_ctx_destroy (ctx->isctx);
+        if (ctx->mctx)
+            match_ctx_destroy (ctx->mctx);
         free (ctx);
         errno = saved_errno;
     }
@@ -226,6 +228,8 @@ static struct list_ctx *list_ctx_create (flux_t *h)
     if (!(ctx->jsctx = job_state_create (ctx)))
         goto error;
     if (!(ctx->deferred_requests = flux_msglist_create ()))
+        goto error;
+    if (!(ctx->mctx = match_ctx_create (ctx->h)))
         goto error;
     return ctx;
 error:

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -138,6 +138,10 @@ static void config_reload_cb (flux_t *h,
         errstr = error.text;
         goto error;
     }
+    if (job_match_config_reload (ctx->mctx, conf, &error) < 0) {
+        errstr = error.text;
+        goto error;
+    }
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "error responding to config-reload request");
     return;

--- a/src/modules/job-list/job-list.h
+++ b/src/modules/job-list/job-list.h
@@ -17,6 +17,7 @@
 
 #include "job_state.h"
 #include "idsync.h"
+#include "match.h"
 
 struct list_ctx {
     flux_t *h;
@@ -24,6 +25,7 @@ struct list_ctx {
     struct job_state_ctx *jsctx;
     struct idsync_ctx *isctx;
     struct flux_msglist *deferred_requests;
+    struct match_ctx *mctx;
 };
 
 const char **job_attrs (void);

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -314,7 +314,7 @@ void list_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = EPROTO;
         goto error;
     }
-    if (!(c = list_constraint_create (constraint, &error))) {
+    if (!(c = list_constraint_create (ctx->mctx, constraint, &error))) {
         errprintf (&err,
                    "invalid payload: constraint object invalid: %s",
                    error.text);

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -56,6 +56,7 @@ int get_jobs_from_list (json_t *jobs,
 
     job = zlistx_first (list);
     while (job) {
+        int ret;
 
         /*  If job->t_inactive > 0. we're on the inactive jobs list and jobs are
          *  sorted on the inactive list, larger t_inactive first.
@@ -68,7 +69,9 @@ int get_jobs_from_list (json_t *jobs,
         if (job->t_inactive > 0. && job->t_inactive <= since)
             break;
 
-        if (job_match (job, c)) {
+        if ((ret = job_match (job, c, errp)) < 0)
+            return -1;
+        if (ret) {
             json_t *o;
             if (!(o = job_to_json (job, attrs, errp)))
                 return -1;

--- a/src/modules/job-list/match.h
+++ b/src/modules/job-list/match.h
@@ -31,9 +31,12 @@ struct list_constraint *list_constraint_create (json_t *constraint,
 
 void list_constraint_destroy (struct list_constraint *constraint);
 
-/*  Return true if job matches constraints in RFC 31 constraint
- *   specification 'constraint'.
+/*  Return 1 if job matches constraints in RFC 31 constraint
+ *   specification 'constraint'.  Return 0 if not.  Return -1
+ *   on error.
  */
-bool job_match (const struct job *job, struct list_constraint *constraint);
+int job_match (const struct job *job,
+               struct list_constraint *constraint,
+               flux_error_t *errp);
 
 #endif /* !HAVE_JOB_LIST_MATCH_H */

--- a/src/modules/job-list/match.h
+++ b/src/modules/job-list/match.h
@@ -20,13 +20,22 @@
 
 #include "job_data.h"
 
+struct match_ctx {
+    flux_t *h;
+};
+
+struct match_ctx *match_ctx_create (flux_t *h);
+
+void match_ctx_destroy (struct match_ctx *mctx);
+
 /*  Load and validate RFC 31 constraint spec 'constraint'.  'constraint'
  *  can be NULL to indicate a constraint that matches everything.
  *
  *  Returns a list constraint object if constraint is valid spec,
  *  Returns NULL with error in errp if errp != NULL.
  */
-struct list_constraint *list_constraint_create (json_t *constraint,
+struct list_constraint *list_constraint_create (struct match_ctx *mctx,
+                                                json_t *constraint,
                                                 flux_error_t *errp);
 
 void list_constraint_destroy (struct list_constraint *constraint);

--- a/src/modules/job-list/match.h
+++ b/src/modules/job-list/match.h
@@ -22,6 +22,7 @@
 
 struct match_ctx {
     flux_t *h;
+    uint64_t max_comparisons;
 };
 
 struct match_ctx *match_ctx_create (flux_t *h);
@@ -47,5 +48,9 @@ void list_constraint_destroy (struct list_constraint *constraint);
 int job_match (const struct job *job,
                struct list_constraint *constraint,
                flux_error_t *errp);
+
+int job_match_config_reload (struct match_ctx *mctx,
+                             const flux_conf_t *conf,
+                             flux_error_t *errp);;
 
 #endif /* !HAVE_JOB_LIST_MATCH_H */

--- a/src/modules/job-list/test/match.c
+++ b/src/modules/job-list/test/match.c
@@ -24,6 +24,7 @@ static void list_constraint_create_corner_case (const char *str,
                                                 ...)
 {
     struct list_constraint *c;
+    struct match_ctx mctx = { .h = NULL };
     char buf[1024];
     flux_error_t error;
     json_error_t jerror;
@@ -37,7 +38,7 @@ static void list_constraint_create_corner_case (const char *str,
     vsnprintf(buf, sizeof (buf), fmt, ap);
     va_end (ap);
 
-    c = list_constraint_create (jc, &error);
+    c = list_constraint_create (&mctx, jc, &error);
 
     ok (c == NULL, "list_constraint_create fails on %s", buf);
     diag ("error: %s", error.text);
@@ -49,6 +50,10 @@ static void test_corner_case (void)
     ok (job_match (NULL, NULL, NULL) < 0
         && errno == EINVAL,
         "job_match returns EINVAL on NULL inputs");
+
+    ok (list_constraint_create (NULL, NULL, NULL) == NULL
+        && errno == EINVAL,
+        "list_constraint_create fails on all NULL inputs");
 
     list_constraint_create_corner_case ("{\"userid\":[1], \"name\":[\"foo\"] }",
                                         "object with too many keys");
@@ -133,6 +138,7 @@ static struct job *setup_job (uint32_t userid,
 static struct list_constraint *create_list_constraint (const char *constraint)
 {
     struct list_constraint *c;
+    struct match_ctx mctx = { .h = NULL };
     flux_error_t error;
     json_error_t jerror;
     json_t *jc = NULL;
@@ -142,7 +148,7 @@ static struct list_constraint *create_list_constraint (const char *constraint)
             BAIL_OUT ("json constraint invalid: %s", jerror.text);
     }
 
-    if (!(c = list_constraint_create (jc, &error)))
+    if (!(c = list_constraint_create (&mctx, jc, &error)))
         BAIL_OUT ("list constraint create fail: %s", error.text);
 
     json_decref (jc);

--- a/src/modules/job-list/test/match.c
+++ b/src/modules/job-list/test/match.c
@@ -19,12 +19,16 @@
 #include "src/modules/job-list/match.h"
 #include "ccan/str/str.h"
 
+/* normally created by job-list "main code" and passed to job_match().
+ * we create a global one here and initialize it manually.
+ */
+struct match_ctx mctx = { .h = NULL, .max_comparisons = 0 };
+
 static void list_constraint_create_corner_case (const char *str,
                                                 const char *fmt,
                                                 ...)
 {
     struct list_constraint *c;
-    struct match_ctx mctx = { .h = NULL };
     char buf[1024];
     flux_error_t error;
     json_error_t jerror;
@@ -138,7 +142,6 @@ static struct job *setup_job (uint32_t userid,
 static struct list_constraint *create_list_constraint (const char *constraint)
 {
     struct list_constraint *c;
-    struct match_ctx mctx = { .h = NULL };
     flux_error_t error;
     json_error_t jerror;
     json_t *jc = NULL;

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -802,12 +802,12 @@ test_expect_success 'flux job list-inactive w/ count limits output of inactive j
 
 test_expect_success 'flux job list-inactive w/ since -1 leads to error' '
 	test_must_fail flux job list-inactive --since=-1 > list_inactive_error1.out 2>&1 &&
-	grep "Protocol error" list_inactive_error1.out
+	grep "invalid payload: since" list_inactive_error1.out
 '
 
 test_expect_success 'flux job list-inactive w/ count -1 leads to error' '
 	test_must_fail flux job list-inactive --count=-1 > list_inactive_error2.out 2>&1 &&
-	grep "Protocol error" list_inactive_error2.out
+	grep "invalid payload: max_entries" list_inactive_error2.out
 '
 
 test_expect_success 'flux job list-inactive w/ since (most recent timestamp)' '


### PR DESCRIPTION
Problem: Job-list constraints are not limited in their size.  A nefarious user could cause a DoS of the job-list service by sending an extremely large constraint request.

Solution: Set a reasonable max on constraint sizes.  The maximum length a constraint array can be is 256 elements and the maximum recursive depth (via and/or/not operators) is set to 16.

Add unit tests.

Fixes #5669

----

This was something I came up with ... good idea?  bad idea?  the limit sizes ok?