### PR TITLE
librlist: fix segfault when initializing topology from XML in later hwloc versions

### DIFF
--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -61,7 +61,7 @@ static int init_topo_from_xml (hwloc_topology_t *tp,
                                unsigned long flags)
 {
     if ((topo_init_common (tp, flags) < 0)
-        || (hwloc_topology_set_xmlbuffer (*tp, xml, strlen (xml) + 1) < 0)
+        || (hwloc_topology_set_xmlbuffer (*tp, xml, strlen (xml)) < 0)
         || (hwloc_topology_load (*tp) < 0)) {
         hwloc_topology_destroy (*tp);
         return (-1);

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -2380,7 +2380,8 @@ fail:
     rlist_destroy (rl);
     rnode_destroy (n);
     free (ids);
-    hwloc_topology_destroy (topo);
+    if (topo)
+        hwloc_topology_destroy (topo);
     return NULL;
 }
 


### PR DESCRIPTION
This PR fixes an issue reported in the conda-forge environment with hwloc-2.9.3 reported [here](https://github.com/conda-forge/flux-core-feedstock/pull/35). The newer hwloc in that environment doesn't like including the terminating `NUL` with `hwloc_topology_set_xmlbuffer()` (I was unable to reproduce just using that version of hwloc outside of conda-forge. Maybe the change is actually in an underlying xml library). It doesn't seem to be a problem to exclude the `NUL` on other hwloc versions, so this PR just adjusts the size to the result of `strlen()`.

This failure also uncovered an actual bug: Passing `NULL` to `hwloc_topology_destroy(3)` causes a segfault, so also protect against that to avoid segfaults in the future.