### PR TITLE
testsuite: fix testsuite errors discovered in conda-forge build environment

### DIFF
--- a/src/common/librouter/test/sendfd.c
+++ b/src/common/librouter/test/sendfd.c
@@ -65,19 +65,25 @@ void test_large (void)
     const char *topic;
     const void *buf2;
     int buf2len;
+#if defined(F_GETPIPE_SZ)
     int min_size = 16384;
     int size;
+#endif
 
     memset (buf, 0x0f, sizeof (buf));
 
     if (pipe2 (pfd, O_CLOEXEC) < 0)
         BAIL_OUT ("pipe2 failed");
 
+#if defined(F_GETPIPE_SZ)
     size = fcntl (pfd[1], F_GETPIPE_SZ);
     if (size < min_size)
         (void)fcntl (pfd[1], F_SETPIPE_SZ, min_size);
     size = fcntl (pfd[1], F_GETPIPE_SZ);
     skip (size < min_size, 4, "%d byte pipe is too small", size);
+#else
+    skip (true, 4, "F_GETPIPE_SZ not defined");
+#endif
     if (!(msg = flux_request_encode_raw ("foo.bar", buf, sizeof (buf))))
         BAIL_OUT ("flux_request_encode failed");
     ok (sendfd (pfd[1], msg, NULL) == 0,

--- a/src/shell/rlimit.c
+++ b/src/shell/rlimit.c
@@ -58,8 +58,10 @@ static int rlimit_name_to_string (const char *name)
         return RLIMIT_NICE;
     if (streq (name, "rtprio"))
         return RLIMIT_RTPRIO;
+#ifdef RLIMIT_RTTIME
     if (streq (name, "rttime"))
         return RLIMIT_RTTIME;
+#endif
     if (streq (name, "sigpending"))
         return RLIMIT_SIGPENDING;
     return -1;

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -2213,21 +2213,14 @@ test_expect_success 'job-list returns expected jobspec changes after reload' '
 	flux job list -s inactive | grep $(cat update1.id) | jq -e ".duration == 1000.0"
 '
 
+#
+# After reload, job-list will not have ever seen any jobs submitted to
+# "defaultqueue" therefore the stats object is empty.
+#
 test_expect_success 'job stats in each queue correct after reload' '
 	defaultq=`flux job stats | jq ".queues[] | select( .name == \"defaultqueue\" )"` &&
 	updateq=`flux job stats | jq ".queues[] | select( .name == \"updatequeue\" )"` &&
-	echo $defaultq | jq -e ".job_states.depend == 0" &&
-	echo $defaultq | jq -e ".job_states.priority == 0" &&
-	echo $defaultq | jq -e ".job_states.sched == 0" &&
-	echo $defaultq | jq -e ".job_states.run == 0" &&
-	echo $defaultq | jq -e ".job_states.cleanup == 0" &&
-	echo $defaultq | jq -e ".job_states.inactive == 0" &&
-	echo $defaultq | jq -e ".job_states.total == 0" &&
-	echo $defaultq | jq -e ".successful == 0" &&
-	echo $defaultq | jq -e ".failed == 0" &&
-	echo $defaultq | jq -e ".canceled == 0" &&
-	echo $defaultq | jq -e ".timeout == 0" &&
-	echo $defaultq | jq -e ".inactive_purged == 0" &&
+	test -z "$defaultq" &&
 	echo $updateq | jq -e ".job_states.depend == 0" &&
 	echo $updateq | jq -e ".job_states.priority == 0" &&
 	echo $updateq | jq -e ".job_states.sched == 0" &&

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -183,8 +183,8 @@ test_expect_success 'flux submit --output id mustache passes through to shell' '
 	test $(jq ".attributes.system.shell.options.output.stdout.path" musid.out) = "\"foo.{{id}}\""
 '
 test_expect_success 'flux submit --cwd passes through to jobspec' '
-	flux submit --cwd=/foo/bar/baz hostname > cwd.out &&
-	jq -e ".attributes.system.cwd == \"/foo/bar/baz\""
+	flux submit --cwd=/foo/bar/baz --dry-run hostname > cwd.out &&
+	jq -e ".attributes.system.cwd == \"/foo/bar/baz\"" < cwd.out
 '
 test_expect_success 'flux submit command arguments work' '
 	flux submit --dry-run a b c >args.out &&
@@ -286,9 +286,11 @@ test_expect_success 'flux submit --tasks-per-node works' '
 		--tasks-per-node=2 \
 		--dry-run true > ntasks-per-node.json &&
 	jq -e \
-	 ".attributes.system.shell.options.\"per-resource\".type == \"node\"" &&
+	 ".attributes.system.shell.options.\"per-resource\".type == \"node\"" \
+		< ntasks-per-node.json &&
 	jq -e \
-	 ".attributes.system.shell.options.\"per-resource\".count == 2"
+	 ".attributes.system.shell.options.\"per-resource\".count == 2" \
+		< ntasks-per-node.json
 '
 test_expect_success 'flux submit --input=IDSET fails' '
 	test_must_fail flux submit --input=0 hostname &&

--- a/t/t2711-python-cli-run.t
+++ b/t/t2711-python-cli-run.t
@@ -231,14 +231,14 @@ while read line; do
 	per_resource=$(echo $line | awk -F== '{print $3}' | sed 's/  *$//')
 	test_expect_success "per-resource: $args" '
 	    echo $expected >expected.$test_count &&
-	    flux run $args --dry-run hostname > jobspec.$test_count &&
+	    flux run $args --dry-run --env=-* hostname > jobspec.$test_count &&
 	    $jj < jobspec.$test_count >output.$test_count &&
 	    test_debug "cat output.$test_count" &&
 	    test_cmp expected.$test_count output.$test_count &&
 	    if test -n "$per_resource"; then
 	        test_debug "echo expected $per_resource" &&
-	        jq -e ".attributes.system.shell.options.per_resource == \
-		   $per_resource"
+	        jq -e ".attributes.system.shell.options.\"per-resource\" == \
+		   $per_resource" < jobspec.$test_count
 	    fi
 	'
 done < per-resource-args.txt

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -240,7 +240,8 @@ test_expect_success 'flux batch: file can be added via directives' '
 	cat \$FLUX_JOB_TMPDIR/foo
 	EOF
 	flux batch --dry-run directives5.sh >d5.json &&
-	jq -e ".attributes.system.files.foo.data == \"This is a test file\n\""
+	jq -e ".attributes.system.files.foo.data == \"This is a test file\n\"" \
+		<d5.json
 '
 test_expect_success 'flux batch: multiline --add-file requires name=' '
 	cat <<-EOF >directives6.sh &&


### PR DESCRIPTION
This PR contains some fixes required for `make check` to pass in the conda-forge build environment.

This includes a workaround for missing `F_GETPIPE_SZ` as well as some real test bugs found because `jq` v1.7 uncovered some missing inputs to `jq` in the testsuite.

Fixes #5684