### PR TITLE
job-list: misc cleanup

### DIFF
--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -199,6 +199,9 @@ class JobList:
           not empty.
     :user: Username or userid for which to fetch jobs. Default is all users.
     :max_entries: Maximum number of jobs to return
+    :since: Limit jobs to those that have been active since a given timestamp.
+    :name: Limit jobs to those with a specific name.
+    :queue: Limit jobs to those submitted to a specific queue.
     """
 
     # pylint: disable=too-many-instance-attributes

--- a/src/modules/job-list/idsync.c
+++ b/src/modules/job-list/idsync.c
@@ -248,7 +248,7 @@ static void idsync_data_respond (struct idsync_ctx *isctx,
                                  struct idsync_data *isd,
                                  struct job *job)
 {
-    job_list_error_t err;
+    flux_error_t err;
     json_t *o;
 
     if (!(o = job_to_json (job, isd->attrs, &err)))

--- a/src/modules/job-list/job_util.h
+++ b/src/modules/job-list/job_util.h
@@ -15,14 +15,7 @@
 
 #include "job_data.h"
 
-typedef struct {
-    char text[160];
-} job_list_error_t;
-
-void __attribute__((format (printf, 2, 3)))
-seterror (job_list_error_t *errp, const char *fmt, ...);
-
-json_t *job_to_json (struct job *job, json_t *attrs, job_list_error_t *errp);
+json_t *job_to_json (struct job *job, json_t *attrs, flux_error_t *errp);
 
 #endif /* ! _FLUX_JOB_LIST_JOB_UTIL_H */
 

--- a/src/modules/job-list/test/match.c
+++ b/src/modules/job-list/test/match.c
@@ -231,7 +231,16 @@ static void test_basic_userid (void)
         while (tests->userid) {
             struct job *job;
             bool rv;
-            job = setup_job (tests->userid, NULL, NULL, 0, 0, 0.0, 0.0, 0.0, 0.0, 0.0);
+            job = setup_job (tests->userid,
+                             NULL,
+                             NULL,
+                             0,
+                             0,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0);
             rv = job_match (job, c);
             ok (rv == tests->expected,
                 "basic userid job match test #%d/#%d",
@@ -308,7 +317,16 @@ static void test_basic_name (void)
         while (!tests->end) {
             struct job *job;
             bool rv;
-            job = setup_job (0, tests->name, NULL, 0, 0, 0.0, 0.0, 0.0, 0.0, 0.0);
+            job = setup_job (0,
+                             tests->name,
+                             NULL,
+                             0,
+                             0,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0);
             rv = job_match (job, c);
             ok (rv == tests->expected,
                 "basic name job match test #%d/#%d",
@@ -385,7 +403,16 @@ static void test_basic_queue (void)
         while (!tests->end) {
             struct job *job;
             bool rv;
-            job = setup_job (0, NULL, tests->queue, 0, 0, 0.0, 0.0, 0.0, 0.0, 0.0);
+            job = setup_job (0,
+                             NULL,
+                             tests->queue,
+                             0,
+                             0,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0);
             rv = job_match (job, c);
             ok (rv == tests->expected,
                 "basic queue job match test #%d/#%d",
@@ -466,7 +493,16 @@ static void test_basic_states (void)
         while (tests->state) {
             struct job *job;
             bool rv;
-            job = setup_job (0, NULL, NULL, tests->state, 0, 0.0, 0.0, 0.0, 0.0, 0.0);
+            job = setup_job (0,
+                             NULL,
+                             NULL,
+                             tests->state,
+                             0,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0);
             rv = job_match (job, c);
             ok (rv == tests->expected,
                 "basic states job match test #%d/#%d",
@@ -550,7 +586,16 @@ static void test_basic_results (void)
         while (tests->state) {  /* result can be 0, iterate on state > 0 */
             struct job *job;
             bool rv;
-            job = setup_job (0, NULL, NULL, tests->state, tests->result, 0.0, 0.0, 0.0, 0.0, 0.0);
+            job = setup_job (0,
+                             NULL,
+                             NULL,
+                             tests->state,
+                             tests->result,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0);
             rv = job_match (job, c);
             ok (rv == tests->expected,
                 "basic results job match test #%d/#%d",
@@ -1046,7 +1091,16 @@ static void test_basic_conditionals (void)
         while (tests->userid) {
             struct job *job;
             bool rv;
-            job = setup_job (tests->userid, tests->name, NULL, 0, 0, 0.0, 0.0, 0.0, 0.0, 0.0);
+            job = setup_job (tests->userid,
+                             tests->name,
+                             NULL,
+                             0,
+                             0,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0,
+                             0.0);
             rv = job_match (job, c);
             ok (rv == tests->expected,
                 "basic conditionals job match test #%d/#%d",

--- a/src/modules/job-list/test/match.c
+++ b/src/modules/job-list/test/match.c
@@ -1427,7 +1427,7 @@ struct realworld_constraint_test {
                 "batch",
                 FLUX_JOB_STATE_SCHED,
                 0,
-                0,
+                0.0,
                 false,
             },
             {
@@ -1436,7 +1436,7 @@ struct realworld_constraint_test {
                 "batch",
                 FLUX_JOB_STATE_RUN,
                 0,
-                0,
+                0.0,
                 false,
             },
             {

--- a/src/modules/job-list/test/state_match.c
+++ b/src/modules/job-list/test/state_match.c
@@ -1099,6 +1099,36 @@ struct state_match_constraint_test {
             true,
         },
     },
+    /* cover every constraint operator
+     * - every test here should fail as we AND several impossible things
+     */
+    {
+        "{ \"and\": \
+           [ \
+             { \"userid\": [ 42 ] }, \
+             { \"name\": [ \"foo\" ] }, \
+             { \"queue\": [ \"foo\" ] }, \
+             { \"states\": [ \"running\" ] }, \
+             { \"results\": [ \"completed\" ] }, \
+             { \"t_submit\": [ \">=500.0\" ] }, \
+             { \"t_depend\": [ \">=100.0\" ] }, \
+             { \"t_run\": [ \"<=100.0\" ] }, \
+             { \"t_cleanup\": [ \">=100.0\" ] }, \
+             { \"t_inactive\": [ \"<=100.0\" ] } \
+           ] \
+        }",
+        {
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+        },
+    },
     {
         NULL,
         {


### PR DESCRIPTION
Peeled off some cleanups from other PR work.  The removal of `job_list_error_t` is the big cleanup here, as it'll end up conflicting with several of the PRs in progress.

