### PR TITLE
ci: add fedora39 build

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -237,6 +237,8 @@ else
         -e S3_SECRET_ACCESS_KEY \
         -e S3_HOSTNAME \
         -e S3_BUCKET \
+	-e PSM3_HAL \
+	-e PSM3_DEVICES \
         --cap-add SYS_PTRACE \
         --tty \
         ${INTERACTIVE:+--interactive} \

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -270,6 +270,22 @@ matrix.add_build(
     docker_tag=True,
 )
 
+# Fedora 39
+# Note: caliper does not compile on Fedora 38
+matrix.add_build(
+    name="fedora39 - gcc-13.2,py3.12",
+    image="fedora39",
+    args=(
+        "--prefix=/usr"
+        " --sysconfdir=/etc"
+        " --with-systemdsystemunitdir=/etc/systemd/system"
+        " --localstatedir=/var"
+        " --with-flux-security"
+    ),
+    env=dict(PSM3_HAL="loopback"),
+    docker_tag=True,
+)
+
 matrix.add_build(
     name="alpine",
     image="alpine",


### PR DESCRIPTION
This PR simply adds a fedora 39 builder with Python 3.12 to CI.