### PR TITLE
enable encode of pty data as base64 and make `flux alloc vi` test more reliable

### DIFF
--- a/src/common/libterminus/pty.h
+++ b/src/common/libterminus/pty.h
@@ -13,6 +13,7 @@
 #ifndef FLUX_PTY_H
 #define FLUX_PTY_H
 
+#include <jansson.h>
 #include <flux/core.h>
 
 typedef void (*pty_log_f) (void *arg,
@@ -201,9 +202,22 @@ int flux_pty_aux_set (struct flux_pty *pty,
 
 void * flux_pty_aux_get (struct flux_pty *pty, const char *name);
 
+
 /*  Function exported for testing only
  */
 void pty_client_send_data (struct flux_pty *pty, void *data, int len);
+
+
+/*  Common function for unpacking pty data msg.
+ */
+int pty_data_unpack (const flux_msg_t *msg,
+                     flux_error_t *errp,
+                     char **datap,
+                     size_t *lenp);
+
+/*  Common function for encoding pty data msg.
+ */
+json_t *pty_data_encode (const void *data, int len);
 
 #endif /* !FLUX_PTY_H */
 

--- a/src/common/libterminus/test/pty.c
+++ b/src/common/libterminus/test/pty.c
@@ -433,6 +433,14 @@ static void test_client (void)
         rc == 0 ? "Success" : strerror (errno));
     flux_future_destroy (f);
 
+    f = flux_pty_client_write (c, "bar\0\r\n", 6);
+    ok (f != NULL,
+        "flux_pty_client_write with U+0000");
+    ok (rc == 0,
+        "flux_pty_client_write: %s",
+        rc == 0 ? "Success" : strerror (errno));
+    flux_future_destroy (f);
+
     ok (flux_pty_client_detach (c) == 0,
         "flux_pty_client_detach");
 

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -173,13 +173,12 @@ test_expect_success 'flux alloc: resource.norestrict works in subinstance' '
 '
 test_expect_success 'flux alloc: flux alloc vi works' '
 	cat <<-'EOF' >input.json &&
-	[{"expect":"test\\\.txt", "send":":q!\n", "timeout":30}]
+	[{"expect":"test text file", "send":":q!\n", "timeout":30}]
 	EOF
 	cat <<-EOF >test.txt &&
 	test text file
 	EOF
-	$runpty -o vi.out --expect=input.json flux alloc -n1 vi test.txt &&
-	grep "test text file" vi.out
+	$runpty -o vi.out --expect=input.json flux alloc -n1 vi test.txt
 '
 test_expect_success 'flux alloc: flux alloc flux alloc works' '
 	cat <<-'EOF' >input2.json &&


### PR DESCRIPTION
This PR addresses a couple issues reported in #5696.

First, evidently some pty data fails to encode using the jansson API. This PR adds support for falling back to base64 when that (very rare) event occurs. 

Second, the `flux alloc vi` test is currently dependent on the filename showing in the vi statusline, which doesn't always seem to be the case. Make the test more reliable by just looking for the file data before quitting `vi`.

Fixes #5696