### PR TITLE
python: fix `flux-watch: TypeError: Object of type 'bytes' is not JSON serializable`

### DIFF
--- a/src/bindings/python/flux/job/output.py
+++ b/src/bindings/python/flux/job/output.py
@@ -113,7 +113,9 @@ class OutputEvent(EventLogEvent):
             data = self.context["data"]
             if "encoding" in self.context:
                 if self.context["encoding"] == "base64":
-                    data = base64.b64decode(data)
+                    data = base64.b64decode(data).decode(
+                        "utf-8", errors="surrogateescape"
+                    )
             if "repeat" in self.context:
                 data *= self.context["repeat"]
             if labelio:

--- a/t/t2813-flux-watch.t
+++ b/t/t2813-flux-watch.t
@@ -130,4 +130,11 @@ test_expect_success 'flux-watch: --filter works' '
 	test_debug "cat failed.out" &&
 	grep "Watching ${nfailed} job" failed.out
 '
+test_expect_success 'flux-watch: handles binary data' '
+	id=$(flux submit dd if=/dev/urandom count=1) &&
+	test_debug "flux job eventlog -p guest.output -HL $id" &&
+	flux job attach $id >binary.expected &&
+	flux watch $id >binary.output &&
+	test_cmp binary.expected binary.output
+'
 test_done


### PR DESCRIPTION
This PR fixes binary output with `flux-watch(1)` as discussed in #5702. A test is also added.