### PR TITLE
broker: add FLUX_IPADDR_INTERFACE to select broker network interface

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -229,6 +229,11 @@ affect the broker's PMI client.
    version 4 addresses.  Setting this variable to any value in the broker's
    environment causes it to prefer version 6 addresses.
 
+.. envvar:: FLUX_IPADDR_HOSTNAME
+
+   Force PMI bootstrap to assign the broker an address associated with a
+   particular network interface, like ``eth0``.
+
 
 CUSTOM OUTPUT FORMATS
 =====================

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -151,7 +151,7 @@ static int format_bind_uri (char *buf, int bufsz, attr_t *attrs, int rank)
 
         if (ipaddr_getprimary (ipaddr, sizeof (ipaddr),
                                error, sizeof (error)) < 0) {
-            log_err ("%s", error);
+            log_msg ("%s", error);
             return -1;
         }
         if (snprintf (buf, bufsz, "tcp://%s:*", ipaddr) >= bufsz)

--- a/src/common/libutil/ipaddr.h
+++ b/src/common/libutil/ipaddr.h
@@ -18,6 +18,7 @@
  * 1. Find the interface associated with the default route, then
  *    look up address of that interface.
  * 2. Look up address associated with the hostname
+ * 3. Look up address associated with a specific interface.
  *
  * Main use case: determine bind address for a PMI-bootstrapped flux broker.
  *
@@ -29,6 +30,8 @@
  * FLUX_IPADDR_HOSTNAME
  *   if set, only method 2 is tried above
  *   if unset, first method 1 is tried, then if that fails, method 2 is tried
+ * FLUX_IPADDR_INTERFACE
+ *   if set, only method 3 is tried above
  *
  * Return address as a string in buf (up to len bytes, always null terminated)
  * Return 0 on success, -1 on error with error message written to errstr

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -429,6 +429,17 @@ test_expect_success 'tbon.endpoint uses tcp:// if tbon.prefertcp is set' '
 		flux getattr tbon.endpoint >endpoint2.out &&
 	grep "^tcp" endpoint2.out
 '
+test_expect_success 'FLUX_IPADDR_INTERFACE=lo works' '
+	FLUX_IPADDR_INTERFACE=lo flux start \
+		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+		flux getattr tbon.endpoint >endpoint3.out &&
+	grep "127.0.0.1" endpoint3.out
+'
+test_expect_success 'FLUX_IPADDR_INTERFACE=badiface fails' '
+	(export FLUX_IPADDR_INTERFACE=badiface; \
+		test_expect_code 137 flux start \
+		${ARGS} --test-exit-timeout=1s -s2 -o,-Stbon.prefertcp=1 true)
+'
 test_expect_success 'tbon.endpoint cannot be set' '
 	test_must_fail flux start ${ARGS} -s2 \
 		-o,--setattr=tbon.endpoint=ipc:///tmp/customflux /bin/true


### PR DESCRIPTION
Problem: during scale testing, it was observed that Flux was using an unstable network fabric, but there is no way to tell it to use another one.

Add the FLUX_IPADDR_INTERFACE environment variable.   It can be set to an interface name in the broker's environment, and then PMI bootstrap will select an address associated with that interface.