### PR TITLE
WIP: Experimental: Add JobList constraint parser and support constraint query strings in `flux jobs -f`

### DIFF
--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from itertools import chain
 
 import flux.constants
-from flux.core.inner import raw
+from flux.core.inner import ffi, raw
 from flux.job.JobID import JobID
 from flux.job.stats import JobStats
 from flux.memoized_property import memoized_property
@@ -40,6 +40,12 @@ except ImportError:
 
 def statetostr(stateid, fmt="L"):
     return raw.flux_job_statetostr(stateid, fmt).decode("utf-8")
+
+
+def strtostate(state):
+    result = ffi.new("flux_job_state_t [1]")
+    raw.flux_job_strtostate(state, result)
+    return int(result[0])
 
 
 def statetoemoji(stateid):
@@ -79,6 +85,12 @@ def resulttostr(resultid, fmt="L"):
     if resultid == "":
         return ""
     return raw.flux_job_resulttostr(resultid, fmt).decode("utf-8")
+
+
+def strtoresult(arg):
+    result = ffi.new("flux_job_result_t [1]")
+    raw.flux_job_strtoresult(arg, result)
+    return int(result[0])
 
 
 def resulttoemoji(resultid):

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -226,6 +226,17 @@ class FilterActionSetUpdate(argparse.Action):
         getattr(namespace, self.dest).update(values)
 
 
+class FilterActionConcatenate(argparse.Action):
+    """Concatenate filter arguments separated with space"""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, "filtered", True)
+        current = getattr(namespace, self.dest)
+        if current is not None:
+            values = current + " " + values
+        setattr(namespace, self.dest, values)
+
+
 # pylint: disable=redefined-builtin
 class FilterTrueAction(argparse.Action):
     def __init__(

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -331,7 +331,7 @@ def parse_fsd(fsd_string):
     return seconds
 
 
-def parse_datetime(string, now=None):
+def parse_datetime(string, now=None, assumeFuture=True):
     """Parse a possibly human readable datetime string or offset
 
     If string starts with `+` or `-`, then the remainder of the string
@@ -369,6 +369,9 @@ def parse_datetime(string, now=None):
 
     cal = Calendar()
     cal.ptc.StartHour = 0
+    if not assumeFuture:
+        cal.ptc.DOWParseStyle = 0
+        cal.ptc.YearParseStyle = 0
     time_struct, status = cal.parse(string, sourceTime=now.timetuple())
     if status == 0:
         raise ValueError(f'Invalid datetime: "{string}"')


### PR DESCRIPTION
This is an experimental PR that adds a special `JobListConstraintParser` class to support a specialized constraint parser syntax for `JobList` meant to be used with `flux jobs -f, --filter`. This is built on top of @chu11's PR #5656.

At this point, this is just a proof-of-concept of how this could work to extend the `-f, --filter` option of `flux jobs` to support generalized constraint queries while being backwards compatible.

The `JobListConstraintParser` class is a two pass parser.  The first pass converts tokens without an operator to states and/or results bitmasks, using `or` to join these together. The first pass can also be used to do other convenience conversions (like `host:` or `hosts:` to `hostlist:`, or as is done in this prototype `@dt` converted to `(not (t_cleanup:<dt or t_run:>dt))` to find jobs that were running at a given time). The second pass converts the now modified query string to a JSON constraint object suitable for the `job-list` service.

Finally, a `constraint` parameter is added to the Python job listing interfaces, and `flux job list -f, --filter` is converted to pass the option argument as a constraint.

e.g.:
```
ƒ(s=5,d=1,builddir) grondo@pi3:~/git/flux-core.git$ flux jobs -f host:pi0
       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
   ƒ4RtqYfo5 grondo   hostname   CD      1      1   0.259s pi0
   ƒ4Rtgek71 grondo   hostname   CD      1      1   0.274s pi0
ƒ(s=5,d=1,builddir) grondo@pi3:~/git/flux-core.git$ flux jobs -f host:pi[2-3]
       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
   ƒ4Rts2f5R grondo   hostname   CD      1      1   0.303s pi2
   ƒ4Rtm6hx3 grondo   hostname   CD      1      1   0.304s pi2
   ƒ4RtnahEQ grondo   hostname   CD      1      1   0.240s pi3
   ƒ4RtfAkpf grondo   hostname   CD      1      1   0.235s pi3
```
after running some sleep jobs:
```
ƒ(s=5,d=1,builddir) grondo@pi3:~/git/flux-core.git$ flux jobs -f 'host:pi0 running'
       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
   ƒ6gveP5Us grondo   sleep       R      1      1   3.658s pi0
   ƒ6gvYT8MV grondo   sleep       R      1      1   3.673s pi0
ƒ(s=5,d=1,builddir) grondo@pi3:~/git/flux-core.git$ flux jobs -f 'host:pi0 completed'
       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
   ƒ4RtqYfo5 grondo   hostname   CD      1      1   0.259s pi0
   ƒ4Rtgek71 grondo   hostname   CD      1      1   0.274s pi0

```

