### PR TITLE
job-list: initialize queue stats

### DIFF
--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -795,6 +795,7 @@ class WatchImplementation(Future, ABC):
         try:
             super().__del__()
         except AttributeError:
+            # not an error if super did not implement
             pass
 
     def __init__(self, future_handle):

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -1798,6 +1798,13 @@ void job_state_destroy (void *data)
     }
 }
 
+int job_state_config_reload (struct job_state_ctx *jsctx,
+                             const flux_conf_t *conf,
+                             flux_error_t *errp)
+{
+    return job_stats_config_reload (jsctx->statsctx, conf, errp);
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -72,6 +72,10 @@ void job_state_unpause_cb (flux_t *h, flux_msg_handler_t *mh,
 
 int job_state_init_from_kvs (struct job_state_ctx *jsctx);
 
+int job_state_config_reload (struct job_state_ctx *jsctx,
+                             const flux_conf_t *conf,
+                             flux_error_t *errp);
+
 #endif /* ! _FLUX_JOB_LIST_JOB_STATE_H */
 
 /*

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -51,6 +51,10 @@ void job_stats_disconnect (struct job_stats_ctx *statsctx,
  */
 int job_stats_watchers (struct job_stats_ctx *statsctx);
 
+int job_stats_config_reload (struct job_stats_ctx *statsctx,
+                             const flux_conf_t *conf,
+                             flux_error_t *errp);
+
 #endif /* ! _FLUX_JOB_LIST_JOB_STATS_H */
 
 // vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
Problem: Job queue stats are generated in job-list when a job is submitted into it.  If a job queue never has a job submitted to it, no job stats exist for the queue.  This isn't what users would expect, they should expect queue stats to be 0 for the queue.

Solution: Read the flux config and initialize queue stats to 0 for any queues that have been configured.

Fixes #5688

----

Uhhh I clearly messed up my branch with rebasing somehow ... will fix

I'm not sure why a CodeQL warning showed up in this PR.  I figured the "not a warning" in original PR was enough, but I guess not??  Or maybe b/c it was due to my messed up rebasing earlier.  Anyways, I just added a tiny fix to fix it.

Oh yeah, side note.  Implementation may look a little weird.  Why have config_reload() call down into stats.[ch], why not put everything in stats.c?  I needed config reload setup for another PR, so decided to just solve this issue first along the way.