### PR TITLE
pmi: prepend Flux PMI directory to LD_LIBRARY_PATH

### DIFF
--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -16,10 +16,6 @@ run_program() {
 	run_timeout $timeout flux run $OPTS -n${ntasks} -N${nnodes} $*
 }
 
-test_expect_success 'LD_LIBRARY_PATH is not being set by MPI personalties' '
-	test_must_fail flux run --env-remove=* printenv LD_LIBRARY_PATH
-'
-
 test_expect_success NO_ASAN "spectrum mpi only enabled with option" '
 	LD_PRELOAD_saved=${LD_PRELOAD} &&
 	unset LD_PRELOAD &&

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -20,6 +20,24 @@ test_expect_success 'flux run sets PMI_FD' '
 test_expect_success 'flux run sets FLUX_PMI_LIBRARY_PATH' '
 	flux run printenv FLUX_PMI_LIBRARY_PATH
 '
+test_expect_success 'flux run sets LD_LIBRARY_PATH if unset' '
+	flux run --env=-LD_LIBRARY_PATH printenv LD_LIBRARY_PATH \
+	    >libpath.out &&
+	echo $(dirname $(flux config builtin pmi_library_path)) \
+	    >libpath.exp &&
+	test_cmp libpath.exp libpath.out
+'
+test_expect_success 'flux run prepends to LD_LIBRARY_PATH if set' '
+	flux run --env=LD_LIBRARY_PATH=/a printenv LD_LIBRARY_PATH \
+	    >libpath2.out &&
+	echo $(dirname $(flux config builtin pmi_library_path)):/a \
+	    >libpath2.exp &&
+	test_cmp libpath2.exp libpath2.out
+'
+test_expect_success 'flux run -o pmi=off does not set LD_LIBRARY_PATH' '
+	test_must_fail flux run -o pmi=off --env=-LD_LIBRARY_PATH \
+	    printenv LD_LIBRARY_PATH
+'
 test_expect_success 'flux run -o pmi=simple sets PMI_FD' '
 	flux run -o pmi=simple printenv PMI_FD
 '


### PR DESCRIPTION
Problem: Flux installs its `libpmi.so` and `libpmi2.so` in a directory that is not searched by `ld.so` by default, which creates problems such as #5714 

When simple PMI is active (a requirement for Flux pmi libs to be functional), prepend this directory to LD_LIBRARY_PATH.

This will break the coral2 `cray-pals` plugin.  Or rather, it will prevent Cray MPICH from finding cray `libpmi2.so`, which will render `cray-pals` ineffectual.  So flux-framework/flux-coral2#122 should go in first.

