### PR TITLE
shell: add `shell.post-init` plugin calllback topic between `shell.init` and first `task.init`

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -71,6 +71,7 @@ execution of the job:
  * change working directory to the cwd of the job
  * enter a barrier to ensure shell initialization is complete on all shells
  * emit ``shell.init`` event to exec.eventlog
+ * call ``shell.post-init`` plugin callbacks
  * create all local tasks. For each task, the following procedure is used
 
    - call ``task.init`` plugin callback
@@ -141,6 +142,10 @@ topics:
   Called after the shell has finished fetching and parsing the
   **jobspec** and **R** from the KVS, but before any tasks
   are started.
+
+**shell.post-init**
+  Called after the shell initialization barrier has completed, but
+  before starting any tasks.
 
 **task.init**
   Called for each task after the task info has been constructed

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1387,6 +1387,11 @@ static int shell_init (flux_shell_t *shell)
     return plugstack_call (shell->plugstack, "shell.init", NULL);
 }
 
+static int shell_post_init (flux_shell_t *shell)
+{
+    return plugstack_call (shell->plugstack, "shell.post-init", NULL);
+}
+
 static int shell_task_init (flux_shell_t *shell)
 {
     return plugstack_call (shell->plugstack, "task.init", NULL);
@@ -1617,6 +1622,11 @@ int main (int argc, char *argv[])
     if (shell.info->shell_rank == 0
         && shell_eventlogger_emit_event (shell.ev, "shell.init") < 0)
             shell_die_errno (1, "failed to emit event shell.init");
+
+    /* Call shell.post-init plugins.
+     */
+    if (shell_post_init (&shell) < 0)
+        shell_die_errno (1, "shell_post_init");
 
     /* Create tasks
      */


### PR DESCRIPTION
This simple PR just adds a new shell plugin callback topic: `shell.post-init`. This will be convenient for plugins that want to run after all other plugin `shell.init` callbacks have run, but before the first `task.init` callback (which is supposed to be task-specific).

It will be used in the solution for #5718.