### PR TITLE
add flux-hostlist(1)

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -54,7 +54,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-pgrep.1 \
 	man1/flux-cancel.1 \
 	man1/flux-watch.1 \
-	man1/flux-update.1
+	man1/flux-update.1 \
+	man1/flux-hostlist.1
 
 # These files are generated as clones of a primary page.
 # Sphinx handles this automatically if declared in the conf.py

--- a/doc/man1/flux-hostlist.rst
+++ b/doc/man1/flux-hostlist.rst
@@ -1,0 +1,219 @@
+.. flux-help-section: other
+
+================
+flux-hostlist(1)
+================
+
+SYNOPSIS
+========
+
+**flux** **hostlist** [*OPTIONS*] [*SOURCES*]
+
+DESCRIPTION
+===========
+
+.. program:: flux hostlist
+
+:program:`flux hostlist` takes zero or more *SOURCES* of host lists on the
+command line and concatenates them by default into a single RFC 29 Hostlist.
+
+*SOURCES* can optionally be combined by various set operations, for example
+to find the intersection, difference, or to subtract hostlists.
+
+SOURCES
+=======
+
+Valid *SOURCES* of hostlist information include:
+
+instance
+  hosts from the broker ``hostlist`` attribute
+
+jobid
+  hosts assigned to a job.
+
+local
+  *jobid* from ``FLUX_JOB_ID`` environment variable if set, otherwise
+  *instance*
+
+avail[able]
+  *instance* hostlist minus those nodes down or drained
+
+stdin or ``-``
+  read a list of hosts on stdin
+
+hosts
+  a literal RFC 29 Hostlist
+
+The default source is *local*.
+
+OPTIONS
+=======
+
+.. option:: -e, --expand
+
+  Expand hostlist result using the defined output delimiter. Default is
+  space-delimited.
+
+.. option:: -d, --delimiter=S
+
+  Set the delimiter for :option:`--expand` to string *S*.
+
+.. option:: -c, --count
+
+  Emit the number of hosts in the result hostlist instead of the hostlist
+  itself.
+
+.. option:: -n, --nth=N
+
+  Output only the host at index *N* (*-N* to index from the end). The command
+  will fail if *N* is not a valid index.
+
+.. option:: -L, --limit=N
+
+  Output at most *N* hosts (*-N* to output the last *N* hosts).
+
+.. option:: -S, --sort
+
+  Display sorted result.
+
+.. option:: -u, --union, --unique
+
+  Return only unique hosts. This implies :option:`--sort`. Without any
+  other manipulation options, this is equivalent to returning the set
+  union of all provided hosts. (By default, all inputs are concatenated).
+
+.. option:: -x, --exclude=HOSTS
+
+  Exclude all occurrences of *HOSTS* form the result.
+
+.. option:: -i, --intersect
+
+  Return the set intersection of all hostlists.
+
+.. option:: -m, --minus
+
+  Subtract all hostlists from the first.
+
+.. option:: -X, --xor
+
+  Return the symmetric difference of all hostlists.
+
+.. option:: -f, --fallback
+
+  If an argument to :command:`flux-hostlist` is a single hostname, and the
+  hostname can be interpreted as a valid Flux jobid (e.g. starts with ``f``
+  and otherwise contains valid base58 characters like ``fuzzy`` or ``foo1``),
+  then the command may fail with::
+
+    flux-hostlist: ERROR: job foo1 not found
+
+  With the :option:`--fallback` option arguments that appear to be jobids that
+  are not found are treated as hostnames, e.g.::
+ 
+    $ flux hostlist --fallback foo1 foo2
+    foo[1-2]
+  
+.. option:: -q, --quiet
+
+  Suppress output and exit with a nonzero exit code if the hostlist is empty.
+
+EXAMPLES
+========
+
+Create host file for the current job or instance if running in an initial
+program:
+
+::
+
+  $ flux hostlist -ed'\n' >hostfile
+
+Launch an MPI program using :program:`mpiexec.hydra` from within a batch
+script:
+
+::
+
+  #!/bin/sh
+  mpiexec.hydra -launcher ssh -hosts "$(flux hostlist -e)" mpi_hello
+
+List the hosts for one job: (Note: this is the same as
+:command:`flux jobs -no {nodelist} JOBID`)
+
+::
+
+  $ flux hostlist JOBID
+  host[1-2]
+
+List the unordered, unique hosts for multiple jobs:
+
+::
+
+  $ flux hostlist -u JOBID1 JOBID2 JOBID3
+  host[1-2,4]
+
+Determine if any failed jobs shared common nodes:
+
+::
+
+  $ flux hostlist --intersect $(flux jobs -f failed -no {id})
+  host4
+
+Determine if a given host appeared the last submitted job:
+
+::
+
+  if flux hostlist -q -i $(flux job last) host1; then
+      echo host1 was part of your last job
+  fi
+
+
+Count the number of currently available hosts:
+
+::
+
+  $ flux hostlist --count avail
+  4
+
+List all the hosts on which a job named 'myapp' ran:
+
+::
+
+  $ flux hostlist --union $(flux pgrep myapp)
+  host[2,4-5]
+
+List all hosts in the current instance which haven't had a job assigned
+in the last 100 jobs:
+
+::
+
+  $ flux hostlist --minus instance $(flux jobs -c 100 -ano {id})
+  host0
+
+EXIT STATUS
+===========
+
+0
+  Successful operation
+
+1
+  One or more *SOURCES* were invalid, an invalid index was specified to
+  :option:`--nth`, or :option:`--quiet` was used and the result hostlist
+  was empty.
+
+2
+  Invalid option specified or other command line error
+
+RESOURCES
+=========
+
+.. include:: common/resources.rst
+  
+FLUX RFC
+========
+
+:doc:`rfc:spec_29`
+
+
+SEE ALSO
+========
+
+:man1:`flux-getattr`, :man1:`flux-jobs`, :man7:`flux-broker-attributes`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -69,6 +69,7 @@ man_pages = [
     ('man1/flux-shell', 'flux-shell', 'the Flux job shell', [author], 1),
     ('man1/flux-watch', 'flux-watch', 'monitor one or more Flux jobs', [author], 1),
     ('man1/flux-update', 'flux-update', 'update active Flux jobs', [author], 1),
+    ('man1/flux-hostlist', 'flux-hostlist', 'fetch, combine, and manipulate Flux hostlists', [author], 1),
     ('man3/flux_attr_get', 'flux_attr_set', 'get/set Flux broker attributes', [author], 3),
     ('man3/flux_attr_get', 'flux_attr_get', 'get/set Flux broker attributes', [author], 3),
     ('man3/flux_aux_set', 'flux_aux_get', 'get/set auxiliary handle data', [author], 3),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -824,3 +824,6 @@ infeasible
 login
 workflow
 xmlfile
+hostfile
+ano
+myapp

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -123,7 +123,7 @@ def encode_topic(topic):
     return topic
 
 
-def help_formatter(argwidth=40):
+def help_formatter(argwidth=40, raw_description=False):
     """
     Return our 'clean' HelpFormatter, if possible, with a wider default
      for the max width allowed for options.
@@ -161,6 +161,16 @@ def help_formatter(argwidth=40):
             default = action.dest.upper()
             args_string = self._format_args(action, default)
             return optstring + "=" + args_string
+
+    class FluxRawDescriptionHelpFormatter(
+        FluxHelpFormatter, argparse.RawDescriptionHelpFormatter
+    ):
+        pass
+
+    if raw_description:
+        return lambda prog: FluxRawDescriptionHelpFormatter(
+            prog, max_help_position=argwidth
+        )
 
     return lambda prog: FluxHelpFormatter(prog, max_help_position=argwidth)
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -117,7 +117,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-watch.py \
 	flux-update.py \
 	flux-imp-exec-helper \
-	py-runner.py
+	py-runner.py \
+	flux-hostlist.py
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux-hostlist.py
+++ b/src/cmd/flux-hostlist.py
@@ -1,0 +1,378 @@
+#############################################################
+# Copyright 2024 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import argparse
+import logging
+import os
+import sys
+
+import flux
+import flux.util
+from flux.hostlist import Hostlist
+from flux.job import JobID, job_list_id
+from flux.resource import resource_status
+
+LOGGER = logging.getLogger("flux-hostlist")
+
+sources_description = """
+SOURCES may include:
+instance     hosts from the broker 'hostlist' attribute.
+jobid        hosts assigned to a job
+local        hosts assigned to current job if FLUX_JOB_ID is set, otherwise
+             returns the 'instance' hostlist
+avail[able]  instance hostlist minus those nodes down or drained
+stdin, '-'   read a list of hosts on stdin
+hosts        literal list of hosts
+
+The default when no SOURCES are supplied is 'local'.
+"""
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="flux-hostlist",
+        epilog=sources_description,
+        formatter_class=flux.util.help_formatter(raw_description=True),
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "-e",
+        "--expand",
+        action="store_true",
+        help="Expand hostlist using defined output delimiter",
+    )
+    parser.add_argument(
+        "-d",
+        "--delimiter",
+        type=str,
+        metavar="S",
+        default=" ",
+        help="Set output delimiter for expanded hostlist (default=' ')",
+    )
+    group.add_argument(
+        "-c",
+        "--count",
+        action="store_true",
+        help="Print the total number of hosts",
+    )
+    group.add_argument(
+        "-n",
+        "--nth",
+        type=int,
+        metavar="N",
+        help="Output host at index N (-N to index from end)",
+    )
+    parser.add_argument(
+        "-L",
+        "--limit",
+        metavar="N",
+        type=int,
+        help="Output at most N hosts (-N for the last N hosts)",
+    )
+    parser.add_argument(
+        "-S",
+        "--sort",
+        action="store_true",
+        help="Return sorted result",
+    )
+    parser.add_argument(
+        "-x",
+        "--exclude",
+        metavar="HOSTS",
+        type=Hostlist,
+        help="Exclude all occurrences of HOSTS from final result",
+    )
+    parser.add_argument(
+        "-u",
+        "--union",
+        "--unique",
+        action="store_true",
+        help="Return only unique hosts in the final hostlist. "
+        + "Without other options, this is the same as the union of all "
+        + "hostlist args (default mode is append).",
+    )
+    group2 = parser.add_mutually_exclusive_group()
+    group2.add_argument(
+        "-i",
+        "--intersect",
+        action="store_true",
+        help="Return the intersection of all hostlists",
+    )
+    group2.add_argument(
+        "-m",
+        "--minus",
+        action="store_true",
+        help="Subtract all hostlist args from first argument",
+    )
+    group2.add_argument(
+        "-X",
+        "--xor",
+        action="store_true",
+        help="Return the symmetric difference of all hostlists",
+    )
+    parser.add_argument(
+        "-f",
+        "--fallback",
+        action="store_true",
+        help="Fallback to treating jobids that are not found as hostnames"
+        + " (for hostnames that are also valid jobids e.g. f1, fuzz100, etc)",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="No output. Exit with nonzero exit status if hostlist is empty",
+    )
+    parser.add_argument(
+        "sources",
+        metavar="SOURCES",
+        nargs="*",
+        help="(optional) One or more hostlist sources",
+    )
+    return parser.parse_args()
+
+
+class FluxHandle:
+    """Singleton Flux handle"""
+
+    def __new__(cls):
+        if not hasattr(cls, "handle"):
+            cls.handle = flux.Flux()
+        return cls.handle
+
+
+class HostlistResult:
+    """class representing a simple hostlist result"""
+
+    def __init__(self, hosts, **kwargs):
+        self.result = Hostlist(hosts)
+
+
+class InstanceHostlistResult:
+    """class representing a hostlist from the instance hostlist attribute"""
+
+    def __init__(self, *args, **kwargs):
+        self.result = Hostlist(FluxHandle().attr_get("hostlist"))
+
+
+class JobHostlistResult:
+    """class representing a job hostlist obtained from job-list"""
+
+    def __init__(self, jobid, **kwargs):
+        self.arg = jobid
+        self.jobid = JobID(jobid)
+        self.fallback = kwargs.get("fallback", False)
+        self.future = job_list_id(FluxHandle(), self.jobid, attrs=["nodelist"])
+
+    @property
+    def result(self):
+        try:
+            job = self.future.get_jobinfo()
+        except OSError as exc:
+            if isinstance(exc, FileNotFoundError):
+                if self.fallback:
+                    # Fall back to treating potential jobid as hostname
+                    return Hostlist(self.arg)
+                else:
+                    raise ValueError(f"job {self.arg} not found") from None
+            else:
+                raise ValueError(f"job {self.arg}: {exc}") from None
+        return Hostlist(job.nodelist)
+
+
+class AvailableHostlistResult:
+    """class representing available hosts in enclosing instance"""
+
+    def __init__(self, *args, **kwargs):
+        """Get local hostlist and return only available hosts"""
+        # Store local hostlist in self.hl:
+        self.hl = LocalHostlistResult().result
+        # Send resource status RPCs to get available idset
+        self.rstatus = resource_status(FluxHandle())
+
+    @property
+    def result(self):
+        # Restrict returned hostlist to only those available:
+        avail = self.rstatus.get().avail
+        return self.hl[avail]
+
+
+class LocalHostlistResult:
+    """class representing 'local' hostlist from enclosing instance or job"""
+
+    def __init__(self, *args, **kwargs):
+        self.jobid_result = None
+        if "FLUX_JOB_ID" in os.environ:
+            # This process is running in the context of a job (not initial
+            # program) if "FLUX_JOB_ID" is found in current environment.
+            # Fetch hostlist via a query to job-list service:
+            self._base = JobHostlistResult(os.environ["FLUX_JOB_ID"])
+        else:
+            # O/w, this is either an initial program or the enclosing instance
+            # is the system instance. Fetch the hostlist attribuee either way
+            self._base = InstanceHostlistResult()
+
+    @property
+    def result(self):
+        return self._base.result
+
+
+class StdinHostlistResult:
+    """class representing a hostlist read on stdin"""
+
+    def __init__(self, *args, **kwargs):
+        hl = Hostlist()
+        for line in sys.stdin.readlines():
+            hl.append(line.rstrip())
+        self.result = hl
+
+
+class HostlistResolver:
+    """
+    Resolve a set of hostlist references in 'sources' into a list of hostlists.
+    """
+
+    result_types = {
+        "instance": InstanceHostlistResult,
+        "local": LocalHostlistResult,
+        "stdin": StdinHostlistResult,
+        "-": StdinHostlistResult,
+        "avail": AvailableHostlistResult,
+        "available": AvailableHostlistResult,
+    }
+
+    def __init__(self, sources, fallback=False):
+        self._results = []
+        self.fallback = fallback
+        for arg in sources:
+            self.append(arg)
+
+    def append(self, arg):
+        if arg in self.result_types:
+            lookup = self.result_types[arg](arg, fallback=self.fallback)
+            self._results.append(lookup)
+        else:
+            try:
+                #  Try argument as a jobid:
+                result = JobHostlistResult(arg, fallback=self.fallback)
+                self._results.append(result)
+            except ValueError:
+                try:
+                    #  Try argument as a literal Hostlist
+                    self._results.append(HostlistResult(arg))
+                except (TypeError, OSError, ValueError):
+                    raise ValueError(f"Invalid jobid or hostlist {arg}")
+
+    def results(self):
+        return [entry.result for entry in self._results]
+
+
+def intersect(hl1, hl2):
+    """Set intersection of Hostlists hl1 and hl2"""
+    result = Hostlist()
+    for host in hl1:
+        if host in hl2:
+            result.append(host)
+    result.uniq()
+    return result
+
+
+def difference(hl1, hl2):
+    """Return hosts in hl1 not in hl2"""
+    result = Hostlist()
+    for host in hl1:
+        if host not in hl2:
+            result.append(host)
+    return result
+
+
+def xor(hl1, hl2):
+    """Return hosts in hl1 or hl2 but not both"""
+    result = difference(hl1, hl2)
+    result.append(difference(hl2, hl1))
+    result.uniq()
+    return result
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+    sys.stdout = open(
+        sys.stdout.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+    sys.stderr = open(
+        sys.stderr.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+    args = parse_args()
+
+    if not args.sources:
+        args.sources = ["local"]
+
+    hostlists = HostlistResolver(args.sources, fallback=args.fallback).results()
+
+    hl = Hostlist()
+
+    if args.intersect:
+        hl = hostlists.pop(0)
+        for x in hostlists:
+            hl = intersect(hl, x)
+    elif args.xor:
+        hl = hostlists.pop(0)
+        for x in hostlists:
+            hl = xor(hl, x)
+    elif args.minus:
+        hl = hostlists.pop(0)
+        for x in hostlists:
+            hl.delete(x)
+    else:
+        for x in hostlists:
+            hl.append(x)
+
+    if args.exclude:
+        # Delete all occurrences of args.exclude
+        while hl.delete(args.exclude) > 0:
+            pass
+
+    if args.sort:
+        hl.sort()
+
+    if args.union:
+        hl.uniq()
+
+    if args.limit:
+        if args.limit > 0:
+            hl = hl[: args.limit]
+        else:
+            hl = hl[args.limit :]
+
+    if args.quiet:
+        sys.stdout = open(os.devnull, "w")
+
+    if args.nth is not None:
+        host = hl[args.nth]
+        if host:
+            print(host)
+    elif args.count:
+        print(f"{hl.count()}")
+    elif args.expand:
+        # Convert '\n' specified on command line to actual newline char
+        if hl:
+            print(args.delimiter.replace("\\n", "\n").join(hl))
+    else:
+        if hl:
+            print(hl.encode())
+
+    if args.quiet and not hl:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+
+# vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -228,6 +228,7 @@ TESTSCRIPTS = \
 	t2811-flux-pgrep.t \
 	t2812-flux-job-last.t \
 	t2813-flux-watch.t \
+	t2814-hostlist-cmd.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2814-hostlist-cmd.t
+++ b/t/t2814-hostlist-cmd.t
@@ -1,0 +1,149 @@
+#!/bin/sh
+
+test_description='Test flux hostlist command'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 2
+
+test_expect_success 'flux-hostlist --help works' '
+	flux hostlist --help >help.out &&
+	test_debug "cat help.out" &&
+	grep "SOURCES may include" help.out
+'
+test_expect_success 'flux-hostlist returns hostlist attr in initial program' '
+	flux hostlist >hl-instance.out &&
+	flux getattr hostlist >hl-instance.expected &&
+	test_cmp hl-instance.expected hl-instance.out
+'
+test_expect_success 'flux-hostlist returns job hostlist in job' '
+	flux run flux hostlist >hl-job.out &&
+	flux jobs -no {nodelist} $(flux job last) > hl-job.expected &&
+	test_cmp hl-job.expected hl-job.out
+'
+test_expect_success 'flux-hostlist works with a jobid' '
+	flux hostlist $(flux job last) >hl-jobid.out &&
+	test_cmp hl-job.expected hl-jobid.out
+'
+test_expect_success 'flux-hostlist fails with invalid jobid' '
+	test_must_fail flux hostlist foo1
+'
+test_expect_success 'flux-hostlist --fallback treats invalid jobid as host' '
+	flux hostlist --fallback foo1 >fallback.out &&
+	test "$(cat fallback.out)" = "foo1"
+'
+test_expect_success 'flux-hostlist -c works' '
+	flux hostlist --count  &&
+	test $(flux hostlist --count) -eq 2 &&
+	test $(flux hostlist -c "foo[1-10]") -eq 10
+'
+test_expect_success 'flux-hostlist works with "avail"' '
+	flux resource drain 0 &&
+	test $(flux hostlist --count avail) -eq 1 &&
+	flux resource undrain 0
+'
+test_expect_success 'flux-hostlist works with stdin' '
+	printf "foo1 foo2 foo3"   | flux hostlist - >hl-stdin1.out &&
+	printf "foo1\nfoo2\nfoo3" | flux hostlist - >hl-stdin2.out &&
+	test_debug "grep . hl-stdin*.out" &&
+	printf "foo[1-3]\n" >hl-stdin.expected &&
+	test_cmp hl-stdin.expected hl-stdin1.out &&
+	test_cmp hl-stdin.expected hl-stdin2.out
+'
+test_expect_success 'flux-hostlist works with hostlist args' '
+	flux hostlist "foo[1-3]" > hl-args1.out &&
+	flux hostlist --fallback foo1 foo2 foo3 > hl-args2.out &&
+	printf "foo[1-3]\n" >hl-args.expected &&
+	test_cmp hl-args.expected hl-args1.out &&
+	test_cmp hl-args.expected hl-args2.out
+'
+test_expect_success 'flux-hostlist rejects invalid hostlist' '
+	test_must_fail flux hostlist "foo[1-"
+'
+test_expect_success 'flux-hostlist returns empty hostlist for pending job' '
+	id=$(flux submit --urgency=hold hostname) &&
+	flux hostlist $id >hl-pending.out &&
+	test_must_be_empty hl-pending.out
+'
+# Note job "$id" should still be held when this next test is run:
+test_expect_success 'flux-hostlist --quiet works' '
+	flux hostlist --quiet foo[1-10] > quiet.out &&
+	test_must_be_empty quiet.out &&
+	test_must_fail flux hostlist -q $id
+'
+test_expect_success 'flux-hostlist -e, --expand works' '
+	test_debug "flux hostlist -e foo[1-3]" &&
+	test "$(flux hostlist -e foo[1-3])" = "foo1 foo2 foo3" &&
+	flux hostlist --expand --delimiter="\n" "foo[1-3]" >expand.out &&
+	cat <<-EOF >expand.expected &&
+	foo1
+	foo2
+	foo3
+	EOF
+	test_cmp expand.expected expand.out
+'
+test_expect_success 'flux-hostlist -n, --nth works' '
+	test "$(flux hostlist --nth=1 foo[1-10])" = foo2 &&
+	test "$(flux hostlist --nth=-1 foo[1-10])" = foo10
+'
+test_expect_success 'flux-hostlist -n errors with invalid index' '
+	test_must_fail flux hostlist -n 10 foo[1-10]
+'
+test_expect_success 'flux-hostlist -L, --limit works' '
+	test "$(flux hostlist -L 2 foo[1-10])" = "foo[1-2]" &&
+	test "$(flux hostlist -L -2 foo[1-10])" = "foo[9-10]"
+'
+test_expect_success 'flux-hostlist preserves hostlist order by default' '
+	test "$(flux hostlist host1 host0 host5 host4)" = "host[1,0,5,4]"
+'
+test_expect_success 'flux-hostlist preserves repeated hosts by default' '
+	test "$(flux hostlist host1 host1 host1)" = "host[1,1,1]"
+'
+test_expect_success 'flux-hostlist -S, --sort works' '
+	test "$(flux hostlist -S host3 host2 host1 host0)" = "host[0-3]"
+'
+test_expect_success 'flux-hostlist -S preserves duplicate hosts' '
+	test "$(flux hostlist -S host2 host1 host3 host1)" = "host[1,1-3]"
+'
+test_expect_success 'flux-hostlist -u  returns union of all hosts' '
+	test "$(flux hostlist -u host2 host1 host3 host1)" = "host[1-3]" &&
+	test "$(flux hostlist -u host[1-3] host2)" = "host[1-3]" &&
+	test "$(flux hostlist -u host[1-3] bar baz)" = "bar,baz,host[1-3]"
+'
+test_expect_success 'flux-hostlist -i, --intersect works' '
+	test "$(flux hostlist -i host[1-3] host[2-5])" = "host[2-3]" &&
+	test "$(flux hostlist -i host[1-3] host[2-5] host[3-10])" = "host3"
+'
+# Note symmetric difference of 3 sets is all elements that are in just one
+# set or all 3 sets due to associative property.
+test_expect_success 'flux-hostlist -X, --xor works' '
+	flux hostlist -X host[1-3] host[2-5] &&
+	test "$(flux hostlist -X host[1-3] host[2-5])" = "host[1,4-5]" &&
+	flux hostlist -X host[1-3] host[2-5] host[3-10] &&
+	test "$(flux hostlist -X host[1-3] host[2-5] host[3-10])" = "host[1,3,6-10]" &&
+	flux hostlist -X host[3-10] host[1-3] host[2-5] &&
+	test "$(flux hostlist -X host[3-10] host[1-3] host[2-5])" = "host[1,3,6-10]"
+'
+test_expect_success 'flux-hostlist -m, --minus works' '
+	flux hostlist -m host[1-10] host[2-3] &&
+	test "$(flux hostlist -m host[1-10] host[2-3])" = "host[1,4-10]" &&
+	flux hostlist -m host[1-10] host[2-3] host[5-10] &&
+	test "$(flux hostlist -m host[1-10] host[2-3] host[5-10])" = \
+             "host[1,4]" &&
+	test "$(flux hostlist -m host[1-10] host[1-20])" = "" &&
+	test_expect_code 1 flux hostlist -qm host[1-10] host[1-20]
+'
+test_expect_success 'flux-hostlist -m, --minus removes only first occurrence' '
+	flux hostlist -m host[1,1,1] host1 &&
+	test "$(flux hostlist -m host[1,1,1] host1)" = "host[1,1]"
+'
+test_expect_success 'flux-hostlist: -u can be used with -m' '
+	flux hostlist -m host[1,1,1] host1 &&
+	test "$(flux hostlist -um host[1,1,1] host1)" = "host1"
+'
+test_expect_success 'flux-hostlist -q, --quiet works' '
+	flux hostlist --quiet host[1-10] >quiet.out &&
+	test_must_be_empty quiet.out &&
+	test_must_fail flux hostlist --quiet --intersect host1 host2
+'
+test_done


### PR DESCRIPTION
As described in #3344, this PR adds an implementation of a `flux hostlist` command.

This implementation takes a set of hostlist "sources" on the command line, appending multiple sources by default, and returns the result on stdout. Several options are provided to manipulate, modify, or query the result before it is emitted:

```
usage: flux-hostlist [-h] [-e] [-d S] [-c] [-n N] [-L N] [-S] [-x HOSTS]
                     [-u | -i | -m | -X] [-f] [-q]
                     [SOURCES ...]

positional arguments:
  SOURCES              (optional) One or more hostlist sources

options:
  -h, --help           show this help message and exit
  -e, --expand         Expand hostlist using defined output delimiter
  -d, --delimiter=S    Set output delimiter for expanded hostlist
                       (default=',')
  -c, --count          Print the total number of hosts
  -n, --nth=N          Output host at index N (-N to index from end)
  -L, --limit=N        Output at most N hosts (-N for the last N hosts)
  -S, --sort           Return sorted result
  -x, --exclude=HOSTS  Exclude HOSTS from final result
  -u, --union          Return the union of all hostlists. Default is to append
  -i, --intersect      Return the intersection of all hostlists
  -m, --minus          Subtract all hostlist args from first argument
  -X, --xor            Return the symmetric difference of all hostlists
  -f, --fallback       Fallback to treating jobids that are not found as
                       hostnames (for hostnames that are also valid jobids
                       e.g. f1, fuzz100, etc)
  -q, --quiet          No output. Exit with nonzero exit status if hostlist is
                       empty

SOURCES may include:
instance     hosts from the broker 'hostlist' attribute.
jobid        hosts assigned to a job
local        hosts assigned to current job if FLUX_JOB_ID is set, otherwise
             returns the 'instance' hostlist
avail[able]  instance hostlist minus those nodes down or drained
stdin, '-'   read a list of hosts on stdin
hosts        literal list of hosts

The default when no SOURCES are supplied is 'local'.
```

One basic use case is creating a hostfile for a job or batch job. Since `flux-hostlist(1)` returns a job nodelist or the hostlist of the enclosing instance if the process is not in a job by default, this is simply done with `flux hostlist -ed '\n'`:

```console
$ flux hostlist -ed '\n'
pi1
pi2
pi3
pi4
```

Since `flux-hostlist(1)` can take sets of hosts on the command line as well as other sources, it can also be used as a generic `hostlist` utility, e.g.:

```console
$ flux hostlist -e host[1-10]
host1,host2,host3,host4,host5,host6,host7,host8,host9,host10
$ flux hostlist --intersect host[1-10] host[8-20]
host[8-10]
```

Since a hostlist source can be a jobid, `flux-hostlist(1)` can also be used to easily query information about job hostlists, e.g. did all failed jobs have one node in common?

```console
$ flux hostlist --intersect $(flux jobs -f failed -no {id})
pi4
```

and so on.

One drawback to supporting a generic sources list on the command line, is that some single hostnames can look like jobids. There is a `-f, --fallback` option provided to fall back to treating unknown jobids as individual hosts to handle this case, but this could be surprising:

```console
$ flux hostlist foo1 foo2 foo3
flux-hostlist: ERROR: job foo1 not found
$ flux hostlist -f foo1 foo2 foo3
foo[1-3]
```

This PR is a WIP because documentation still needs to be added. I figured I'd wait to get agreement about the interface here before doing that.