### PR TITLE
shell: generate fatal error if `block` taskmap scheme has an argument

### DIFF
--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1337,9 +1337,17 @@ static int shell_taskmap (flux_shell_t *shell)
         shell_log_error ("failed to parse taskmap shell option");
         return -1;
     }
-    if (rc == 0
-        || streq (scheme, "block"))
+    if (rc == 0)
         return 0;
+    if (streq (scheme, "block")) {
+        /*  A value is not allowed for the block taskmap scheme:
+         */
+        if (strlen (value) > 0)
+            shell_die (1,
+                       "block taskmap does not accept a value (got %s)",
+                       value);
+        return 0;
+    }
 
     shell_trace ("remapping tasks with scheme=%s value=%s",
                  scheme,

--- a/t/t2616-job-shell-taskmap.t
+++ b/t/t2616-job-shell-taskmap.t
@@ -84,6 +84,10 @@ test_expect_success 'taskmap is unchanged with --taskmap=block' '
 		| jq -e ".context.taskmap.map == [[0,4,4,1]]" &&
 	test_check_taskmap $id
 '
+test_expect_success 'shell dies with --taskmap=block:oops' '
+	test_must_fail_or_be_terminated flux run -N4 --tasks-per-node=4 \
+		--taskmap=block:oops ./map.sh
+'
 test_expect_success 'taskmap is correct for --tasks-per-node=2' '
 	id=$(flux submit -N4 --tasks-per-node=2 ./map.sh) &&
 	flux job wait-event -p guest.exec.eventlog -f json $id shell.start &&


### PR DESCRIPTION
This simple PR fixes #5723: If a user inadvertently specifies `--taskmap=block:arg` when they meant `--taskmap=other_scheme:arg`, the shell currently silently ignores `arg` and silently continues with the `block` scheme. Since an argument is not expected or allowed with the `block` taskmap scheme, the shell should generate an error in this case. 

Fixes #5723