### PR TITLE
shell: make kvs output limit configurable and default single-user jobs to unlimited

### DIFF
--- a/doc/man1/common/job-shell-options.rst
+++ b/doc/man1/common/job-shell-options.rst
@@ -39,3 +39,8 @@
 
    * - :option:`hwloc.xmlfile`
      - Write hwloc XML gathered by job to a file and set ``HWLOC_XMLFILE``
+
+   * - :option:`output.limit`
+     - Set KVS output limit to SIZE bytes, where SIZE may be a floating point
+       value including optional SI units: k, K, M, G. This value is ignored
+       if output is directed to a file with :option:`--output`.

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -318,6 +318,14 @@ plugins include:
   this option directly, as it will be set automatically by options
   of higher level commands such as :man1:`flux-submit`.
 
+.. option:: output.limit=SIZE
+
+   Truncate KVS output after SIZE bytes have been written. SIZE may
+   be a floating point value with optional SI units k, K, M, G. A value of
+   0 is considered unlimited. The default KVS output limit is 10M for jobs
+   in a multi-user instance or unlimited for single-user instance jobs.
+   This value is ignored if output is directed to a file.
+
 .. option:: output.{stdout,stderr}.path=PATH
 
   Set job stderr/out file output to PATH.

--- a/doc/man3/flux_shell_get_info.rst
+++ b/doc/man3/flux_shell_get_info.rst
@@ -39,6 +39,7 @@ with the following layout:
 ::
 
    "jobid":I,
+   "instance_owner":i,
    "rank":i,
    "size":i,
    "ntasks";i,

--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -26,6 +26,7 @@
 struct flux_shell {
     flux_jobid_t jobid;
     int broker_rank;
+    uid_t broker_owner;
     char hostname [MAXHOSTNAMELEN + 1];
     int protocol_fd[2];
 

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -448,9 +448,10 @@ static json_t *flux_shell_get_info_object (flux_shell_t *shell)
         return o;
 
     if (!(o = json_pack_ex (&err, 0,
-                            "{ s:I s:i s:i s:i s:s s:O s:O s:{ s:i }}",
+                            "{ s:I s:i s:i s:i s:i s:s s:O s:O s:{ s:i }}",
                             "jobid", shell->info->jobid,
                             "rank",  shell->info->shell_rank,
+                            "instance_owner", (int) shell->broker_owner,
                             "size",  shell->info->shell_size,
                             "ntasks", shell->info->total_ntasks,
                             "service", shell_svc_name (shell->svc),

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -105,6 +105,7 @@ const struct taskmap *flux_shell_get_taskmap (flux_shell_t *shell);
 /*  Return shell info as a JSON string.
  *  {
  *   "jobid":I,
+ *   "instance_owner":i,
  *   "rank":i,
  *   "size":i,
  *   "ntasks";i,

--- a/t/system/0001-basic.t
+++ b/t/system/0001-basic.t
@@ -15,3 +15,10 @@ test_expect_success 'flux jobs lists job with correct userid' '
 test_expect_success 'flux proxy can submit jobs to system instance' '
 	flux proxy $(flux getattr local-uri) flux submit true
 '
+test_expect_success 'flux-shell limits kvs output to 10M for guest jobs' '
+	dd if=/dev/urandom bs=10240 count=800 | base64 --wrap 79 >large.in &&
+	flux run -vvv cat large.in >large.out 2>trunc.err &&
+	ls -lh large* &&
+	test_debug "cat trunc.err" &&
+	grep "stdout.*truncated" trunc.err
+'

--- a/t/t9000-system.t
+++ b/t/t9000-system.t
@@ -65,7 +65,7 @@ alias test_expect_success='expect_success_wrap'
 #
 for testscript in ${FLUX_SOURCE_DIR}/t/system/${T9000_SYSTEM_GLOB}; do
 	TEST_LABEL="$(basename $testscript)"
-	source $testscript
+	. $testscript
 done
 
 test_done


### PR DESCRIPTION
This PR adds support for a new `output.limit` job shell option which overrides the default KVS output limit.

The limit remains `10M` for multiuser instance jobs (when broker userid != job shell userid), but the limit is removed for single-user jobs (broker userid == shell userid).

This should resolve some of the issues users have hit with the KVS output limit inside batch jobs, where it is most convenient to have jobs output folded in with that of the batch output file.