### PR TITLE
libtaskmap: support decode of raw (semicolon-delimited) taskmaps

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -349,9 +349,12 @@ support task mapping formats:
 .. option:: --to=raw|pmi|multiline
 
    Convert the taskmap to *raw* or *pmi* formats (described in RFC 34), or
-   *multiline* which prints the node ID of each task, one per line.
+   *multiline* which prints the node ID of each task, one per line. The
+   default behavior is to print the RFC 34 taskmap. This option can be useful
+   to convert between mapping forms, since :program:`flux job taskmap` can
+   take a raw, pmi, or RFC 34 task map on the command line.
 
-One one of the above options may be used per call.
+Only one of the above options may be used per call.
 
 timeleft
 --------

--- a/src/common/libtaskmap/taskmap.h
+++ b/src/common/libtaskmap/taskmap.h
@@ -41,8 +41,9 @@ void taskmap_destroy (struct taskmap *map);
 int taskmap_append (struct taskmap *map, int nodeid, int nnodes, int ppn);
 
 /*  Decode string 'map' into taskmap object.
- *  The string may be a JSON array, RFC 34 wrapped object, or a mapping
- *   encoded in PMI-1 PMI_process_mapping form described in RFC 13.
+ *  The string may be a JSON array, RFC 34 wrapped object, a mapping
+ *   encoded in PMI-1 PMI_process_mapping form described in RFC 13, or
+ *   a raw, semicolon-delimited list of taskids.
  *  Returns taskmap on success, or NULL on error with error string in 'errp'.
  */
 struct taskmap *taskmap_decode (const char *map, flux_error_t *errp);


### PR DESCRIPTION
Specification of a manual host to task rank mapping requires the `--taskmap=manual:ARG` scheme, where `ARG` is processed by libtaskmap `taskmap_decode(3)`, and thus supports either PMI_process_mapping style vector, or an [RFC 34 Task Map](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_34.html). These mappings are somewhat compact, but they aren't exactly user-friendly.

The 'raw' taskmap used in RFC 34 is simple to understand, and in fact users are encouraged to use `flux job taskmap --to=raw TASKMAP` to aid in creation and understanding of the taskmap format. However, it would be even more convenient if `flux job taskmap` could take a raw taskmap as input and emit an RFC 34 compatible taskmap.

This PR enables this practice by supporting raw taskmaps in `taskmap_decode(3)`. This means raw taskmaps are also allowed on the `--taskmap=manual` command line, fwiw.

e.g. 
```console
$ src/cmd/flux job taskmap '0,1,4,5;2,3,6,7'
[[0,2,2,2]]
$ src/cmd/flux job taskmap '0;3;1;2'
[[0,1,1,1],[2,2,1,1],[1,1,1,1]]
```
