### PR TITLE
WIP: make all jobs "waitable"

### DIFF
--- a/src/modules/job-ingest/job.c
+++ b/src/modules/job-ingest/job.c
@@ -100,12 +100,6 @@ struct job *job_create_from_request (const flux_msg_t *msg,
                    FLUX_JOB_URGENCY_DEFAULT);
         goto inval;
     }
-    if (!(job->cred.rolemask & FLUX_ROLE_OWNER)
-        && (job->flags & FLUX_JOB_WAITABLE)) {
-        errprintf (error,
-                   "only the instance owner can submit with FLUX_JOB_WAITABLE");
-        goto inval;
-    }
     /* Validate jobspec signature, and unwrap(J) -> jobspec_str, _strsize.
      * Userid claimed by signature must match authenticated job->cred.userid.
      * If not the instance owner, a strong signature is required

--- a/src/modules/job-ingest/test/job.c
+++ b/src/modules/job-ingest/test/job.c
@@ -54,21 +54,6 @@ void test_job_flags_guest (void *sec, const char *J_signed)
     flux_msg_t *msg;
 
     skip (J_signed == NULL, 1,
-         "guest flags=WAITABLE (no guest support)");
-    msg = pack_request (false,
-                        "{s:s s:i s:i}",
-                        "J", J_signed,
-                        "urgency", FLUX_JOB_URGENCY_DEFAULT,
-                        "flags", FLUX_JOB_WAITABLE);
-    errno = 0;
-    if (!(job = job_create_from_request (msg, sec, &error)))
-        diag ("%s", error.text);
-    ok (job == NULL && errno == EINVAL,
-        "job_create_from_request flags=WAITABLE fails with EINVAL for guest");
-    flux_msg_decref (msg);
-    end_skip;
-
-    skip (J_signed == NULL, 1,
          "guest flags=NOVALIDATE (no guest support)");
     msg = pack_request (false,
                         "{s:s s:i s:i}",

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -348,8 +348,7 @@ int event_job_action (struct event *event, struct job *job)
             break;
         case FLUX_JOB_STATE_INACTIVE:
             job->eventlog_readonly = 1;
-            if ((job->flags & FLUX_JOB_WAITABLE))
-                wait_notify_inactive (ctx->wait, job);
+            wait_notify_inactive (ctx->wait, job);
             /* Reminder: event_job_action() may be called more than once
              * for a job + state, therefore zhashx_insert() may fail here and
              * not be indicative of a problem.

--- a/src/modules/job-manager/list.c
+++ b/src/modules/job-manager/list.c
@@ -118,16 +118,6 @@ void list_handle_request (flux_t *h,
         }
         job = zhashx_next (ctx->active_jobs);
     }
-    /* Finally list any zombies - INACTIVE (I)
-     * (random order)
-     */
-    job = wait_zombie_first (ctx->wait);
-    while (job) {
-        if (list_append_job (jobs, job) < 0)
-            goto error;
-        job = wait_zombie_next (ctx->wait);
-    }
-
     if (flux_respond_pack (h, msg, "{s:O}", "jobs", jobs) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     json_decref (jobs);

--- a/src/modules/job-manager/purge.c
+++ b/src/modules/job-manager/purge.c
@@ -28,6 +28,7 @@
 #include "conf.h"
 #include "jobtap-internal.h"
 #include "restart.h"
+#include "wait.h"
 
 #define INACTIVE_NUM_UNLIMITED  (-1)
 #define INACTIVE_AGE_UNLIMITED  (-1.)
@@ -148,6 +149,7 @@ static int process_job_purge (struct purge *purge,
                        job,
                        "job.inactive-remove",
                        NULL);
+    wait_notify_inactive_remove (purge->ctx->wait, job);
 
     (void)zlistx_delete (purge->queue, job->handle);
     job->handle = NULL;

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -268,8 +268,7 @@ static int restart_map_cb (struct job *job, void *arg, flux_error_t *error)
     }
     if (ctx->max_jobid < job->id)
         ctx->max_jobid = job->id;
-    if ((job->flags & FLUX_JOB_WAITABLE))
-        wait_notify_active (ctx->wait, job);
+    wait_notify_active (ctx->wait, job);
     if (event_job_action (ctx->event, job) < 0) {
         flux_log_error (ctx->h,
                         "replay warning: %s action failed on job %s",

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -132,8 +132,7 @@ static int submit_job (struct job_manager *ctx,
         set_errorf (errors, job->id, "error posting validate event");
         goto error_post_invalid;
     }
-    if ((job->flags & FLUX_JOB_WAITABLE))
-        wait_notify_active (ctx->wait, job);
+    wait_notify_active (ctx->wait, job);
     if (ctx->max_jobid < job->id)
         ctx->max_jobid = job->id;
     return 0;

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -312,16 +312,6 @@ void wait_disconnect_rpc (flux_t *h,
     flux_msglist_disconnect (wait->requests, msg);
 }
 
-struct job *wait_zombie_first (struct waitjob *wait)
-{
-    return zhashx_first (wait->zombies);
-}
-
-struct job *wait_zombie_next (struct waitjob *wait)
-{
-    return zhashx_next (wait->zombies);
-}
-
 static void respond_unloading (flux_t *h, const flux_msg_t *msg)
 {
     if (flux_respond_error (h, msg, ENOSYS, "job-manager is unloading") < 0)

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -17,38 +17,37 @@
  * - a boolean success
  * - a textual error string
  *
- * The event that transitions a waitable job to the CLEANUP state is
- * captured in job->end_event.  RFC 21 dictates it must be a finish event
+ * The event that transitions a job to the CLEANUP state is captured in
+ * job->end_event.  RFC 21 dictates it must be a finish event
  * containing a wait(2) style status byte, or a fatal exception.
  * The event is converted to the summary above when the wait response
  * is constructed.
  *
  * If the target job is active when the wait request is received,
  * the request is tacked onto the 'struct job' and processed upon
- * transition to INACTIVE state.  If the target waitable job has already
- * transitioned to INACTIVE, it is found in the wait->zombies hash
- * and the request is processed immediately.
- *
- * Only jobs submitted with the FLUX_JOB_WAITABLE can be waited on.
+ * transition to INACTIVE state.  If the target job has already
+ * transitioned to INACTIVE, the request is processed immediately.
  *
  * Wait is destructive; that is, job completion info is consumed by
- * the first waiter.
+ * the first waiter.  Job completion is spoken for if job->waiter is
+ * non-NULL.  An inactive job has already been "reaped" if it is not
+ * in the zombie hash.
  *
- * Guests are not permitted to wait on jobs or set FLUX_JOB_WAITABLE,
- * to avoid possible unchecked zombie growth in a system instance.
+ * Guests are not permitted to wait on jobs.
  *
  * If the job id is FLUX_JOBID_ANY, then the response is:
- * (1) result of the first job found in the wait->zombies hash
- * (2) result of the next waitable job transitioning to INACTIVE,
- *     without a waiter on the specific ID
- * (3) ECHILD error if no waitable jobs are available, or there are
- *     more waiters than jobs
+ * (1) result of the first inactive zombie
+ * (2) result of the next job transitioning to INACTIVE without a waiter
+ * (3) ECHILD error if no un-waited-for jobs are available, or there are
+ *     no jobs extant that could fulfill the request in the future.
  */
 
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
 #include <stdbool.h>
+#include <unistd.h>
+#include <sys/types.h>
 #include <assert.h>
 #include <flux/core.h>
 
@@ -59,19 +58,115 @@
 #include "src/common/libjob/job_hash.h"
 #include "src/common/libjob/idf58.h"
 #include "ccan/str/str.h"
+#include "ccan/ptrint/ptrint.h"
 
 #include "drain.h"
 #include "submit.h"
 #include "job.h"
 
+struct wait_acct {
+    int unreaped_with_waiter;
+    int unreaped_no_waiter;
+};
+
+struct wait_user {
+    uint32_t userid;
+    zhashx_t *zombies;
+    struct wait_acct acct;
+    struct flux_msglist *wait_any_requests;
+};
+
 struct waitjob {
     struct job_manager *ctx;
     flux_msg_handler_t **handlers;
-    zhashx_t *zombies;
-    int waiters; // count of waiters blocked on specific active jobs
-    int waitables; // count of active waitable jobs
-    struct flux_msglist *requests; // requests to wait in FLUX_JOBID_ANY
+    zhashx_t *users;
 };
+
+static const void *userid2key (int userid)
+{
+    if (userid == 0)
+        return int2ptr ((uid_t)-1); // see uid_t note in plugins/history.c
+    return int2ptr (userid);
+}
+
+static int key2userid (const void *key)
+{
+    if (key == int2ptr ((uid_t)-1))
+        return 0;
+    return ptr2int (key);
+}
+
+void wait_user_destroy (struct wait_user *user)
+{
+    if (user) {
+        int saved_errno = errno;
+        flux_msglist_destroy (user->wait_any_requests);
+        zhashx_destroy (&user->zombies);
+        free (user);
+        errno = saved_errno;
+    }
+}
+
+static struct wait_user *wait_user_create (uint32_t userid)
+{
+    struct wait_user *user;
+
+    if (!(user = calloc (1, sizeof (*user))))
+        return NULL;
+    user->userid = userid;
+    if (!(user->wait_any_requests = flux_msglist_create ()))
+        goto error;
+    if (!(user->zombies = job_hash_create ()))
+        goto error;
+    zhashx_set_destructor (user->zombies, job_destructor);
+    zhashx_set_duplicator (user->zombies, job_duplicator);
+    return user;
+error:
+    wait_user_destroy (user);
+    return NULL;
+}
+
+static struct wait_user *wait_user_lookup (struct waitjob *wait,
+                                           uint32_t userid,
+                                           bool create)
+{
+    struct wait_user *user;
+
+    if (!(user = zhashx_lookup (wait->users, userid2key (userid)))) {
+        if (!(user = wait_user_create (userid))
+            || zhashx_insert (wait->users, userid2key (userid), user) < 0) {
+            wait_user_destroy (user);
+            return NULL;
+        }
+    }
+    return user;
+}
+
+// zhashx_destructor_fn footprint
+static void user_destructor (void **item)
+{
+    if (item) {
+        wait_user_destroy (*item);
+        *item = NULL;
+    }
+}
+
+// zhashx_hash_fn footprint
+static size_t userid_hasher (const void *key)
+{
+    return key2userid (key);
+}
+
+// zhashx_comparator_fn footprint
+static int userid_comparator (const void *item1, const void *item2)
+{
+    uint32_t a = key2userid (item1);
+    uint32_t b = key2userid (item2);
+
+    if (a == b)
+        return 0;
+    return (a < b) ? -1 : 1;
+}
 
 static int decode_job_result (struct job *job,
                               bool *success,
@@ -164,38 +259,168 @@ error:
         flux_log_error (h, "wait_respond id=%s", idf58 (job->id));
 }
 
+/* flux_job_wait (FLUX_JOB_ANY) must fail with ECHILD when there is
+ * nothing for it to wait on.  Therefore, if the number of available jobs
+ * (acct.unreaped_no_waiter) drops below the number of FLUX_JOB_ANY requests
+ * one FLUX_JOB_ANY waiter must die.  This may happen if a wait for a specific
+ * job is received after a FLUX_JOB_ANY wait.
+ */
+static void wait_any_fail_one_if_nochild (struct waitjob *wait,
+                                          struct wait_user *user)
+{
+    const flux_msg_t *msg;
+    int wait_any_count = flux_msglist_count (user->wait_any_requests);
+
+    if (user->acct.unreaped_no_waiter < wait_any_count
+        && !(msg = flux_msglist_last (user->wait_any_requests))) {
+        if (flux_respond_error (wait->ctx->h,
+                                msg,
+                                ECHILD,
+                                "there are no more un-waited-for jobs") < 0)
+            flux_log_error (wait->ctx->h,
+                            "error responding to job-manager.wait request");
+        flux_msglist_delete (user->wait_any_requests);
+    }
+}
+
+/* Callback from process_job_purge().
+ */
+void wait_notify_inactive_remove (struct waitjob *wait, struct job *job)
+{
+    struct wait_user *user;
+
+    if ((user = wait_user_lookup (wait, job->userid, false))) {
+        if (zhashx_lookup (user->zombies, &job->id)) {
+            zhashx_delete (user->zombies, &job->id);
+            user->acct.unreaped_no_waiter--;
+        }
+    }
+}
+
 /* Callback from event_job_action().  The 'job' has entered INACTIVE state.
- * Respond to a pending waiter, if any.  Otherwise insert into zombies
- * hash for a future wait request.
+ * If it has not already been reaped, respond to a pending waiter or
+ * add it to the user's zombie hash.
  */
 void wait_notify_inactive (struct waitjob *wait, struct job *job)
 {
-    flux_t *h = wait->ctx->h;
     const flux_msg_t *req;
+    struct wait_user *user;
+
+    if (!(user = wait_user_lookup (wait, job->userid, false)))
+        return;
 
     if (job->waiter) {
         wait_respond (wait, job->waiter, job);
         flux_msg_decref (job->waiter);
         job->waiter = NULL;
-        wait->waiters--;
+        user->acct.unreaped_with_waiter--;
     }
-    else if ((req = flux_msglist_first (wait->requests))) {
+    else if ((req = flux_msglist_first (user->wait_any_requests))) {
         wait_respond (wait, req, job);
-        flux_msglist_delete (wait->requests);
+        flux_msglist_delete (user->wait_any_requests);
+        user->acct.unreaped_no_waiter--;
     }
-    else {
-        if (zhashx_insert (wait->zombies, &job->id, job) < 0) // increfs job
-            flux_log (h, LOG_ERR, "zhashx_insert into zombies hash failed");
-    }
-    wait->waitables--;
+    else
+        zhashx_update (user->zombies, &job->id, job);
 }
 
 /* Callback from submit.c and restart.c where ctx->active_jobs is increased.
- * Maintain count of waitable jobs.
+ * Lookup/create a user context for this user update counts.
  */
 void wait_notify_active (struct waitjob *wait, struct job *job)
 {
-    wait->waitables++;
+    struct wait_user *user;
+
+    if ((user = wait_user_lookup (wait, job->userid, true)))
+        user->acct.unreaped_no_waiter++;
+}
+
+static int wait_rpc_any (struct waitjob *wait,
+                         struct wait_user *user,
+                         const flux_msg_t *msg,
+                         flux_error_t *error)
+{
+    struct job *job;
+    int wait_any_count = flux_msglist_count (user->wait_any_requests);
+
+    if (user->acct.unreaped_no_waiter == wait_any_count) {
+        errprintf (error, "there are no un-waited-for jobs");
+        errno = ECHILD;
+        return -1;
+    }
+    /* If there's a zombie, reap it.
+     */
+    if ((job = zhashx_first (user->zombies))) {
+        wait_respond (wait, msg, job);
+        user->acct.unreaped_no_waiter--;
+        zhashx_delete (user->zombies, &job->id);
+    }
+    /* Enqueue request until a job becomes a zombie.
+     */
+    else if (flux_msglist_append (user->wait_any_requests, msg) < 0) {
+        errprintf (error,
+                   "could not enqueue wait request: %s",
+                   strerror (errno));
+        return -1;
+    }
+    return 0;
+}
+
+static int wait_rpc_one (struct waitjob *wait,
+                         struct wait_user *user,
+                         const flux_msg_t *msg,
+                         flux_jobid_t id,
+                         flux_error_t *error)
+{
+    struct job *job;
+    struct job_manager *ctx = wait->ctx;
+
+    /* If job is already a zombie, reap it.
+    */
+    if ((job = zhashx_lookup (user->zombies, &id))) {
+        wait_respond (ctx->wait, msg, job);
+        user->acct.unreaped_no_waiter--;
+        zhashx_delete (user->zombies, &job->id);
+        wait_any_fail_one_if_nochild (wait, user);
+    }
+    /* If job is still active, enqueue the request.
+     */
+    else if ((job = zhashx_lookup (ctx->active_jobs, &id))) {
+        if (job->waiter) {
+            errprintf (error, "job id already has a waiter");
+            errno = ECHILD;
+            return -1;
+        }
+        if (user->userid != job->userid) {
+            errprintf (error, "job id does not belong to you");
+            errno = EPERM;
+            return -1;
+        }
+        job->waiter = flux_msg_incref (msg);
+        user->acct.unreaped_no_waiter--;
+        user->acct.unreaped_with_waiter++;
+        wait_any_fail_one_if_nochild (wait, user);
+    }
+    /* Try to give an informative error if neither of those things worked.
+     */
+    else if ((job = zhashx_lookup (ctx->inactive_jobs, &id))) {
+        if (user->userid != job->userid) {
+            errprintf (error, "job id does not belong to you");
+            errno = EPERM;
+            return -1;
+        }
+        else {
+            errprintf (error, "job id was already waited on");
+            errno = ECHILD;
+            return -1;
+        }
+    }
+    else {
+        errprintf (error, "invalid job id");
+        errno = ECHILD;
+        return -1;
+    }
+    return 0;
 }
 
 static void wait_rpc (flux_t *h,
@@ -204,82 +429,36 @@ static void wait_rpc (flux_t *h,
                       void *arg)
 {
     struct job_manager *ctx = arg;
-    struct waitjob *wait = ctx->wait;
+    struct flux_msg_cred cred;
     flux_jobid_t id;
-    struct job *job;
-    const char *errstr = NULL;
+    struct wait_user *user;
+    flux_error_t error;
 
-    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0) {
-        errstr = "malformed wait request";
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0
+        || flux_msg_get_cred (msg, &cred) < 0) {
+        errprintf (&error, "malformed wait request");
+        goto error;
+    }
+    if (!(user = wait_user_lookup (ctx->wait, cred.userid, false))) {
+        errno = EINVAL;
+        errprintf (&error, "unknown user");
         goto error;
     }
     if (id == FLUX_JOBID_ANY) {
-        /* If there's a zombie, respond and destroy it.
-         */
-        if ((job = zhashx_first (wait->zombies))) {
-            wait_respond (wait, msg, job);
-            zhashx_delete (wait->zombies, &job->id);
-        }
-        /* Enqueue request until a waitable job transitions to inactive.
-         */
-        else {
-            if (flux_msglist_append (wait->requests, msg) < 0)
-                goto error;
-        }
+        if (wait_rpc_any (ctx->wait, user, msg, &error) < 0)
+            goto error;
     }
     else {
-        /* If job is already a zombie, respond and destroy zombie. Done!
-         */
-        if ((job = zhashx_lookup (wait->zombies, &id))) {
-            wait_respond (wait, msg, job);
-            zhashx_delete (wait->zombies, &id); // decrefs job
-        }
-        /* If job is still active, enqueue the request.
-         */
-        else if ((job = zhashx_lookup (ctx->active_jobs, &id))) {
-            if (job->waiter) {
-                errstr = "job id already has a waiter";
-                goto error_nojob;
-            }
-            job->waiter = flux_msg_incref (msg);
-            wait->waiters++;
-            return;
-        }
-        /* Invalid jobid, not waitable, or already waited on.
-         */
-        else {
-            errstr = "invalid job id, or already waited on";
-            goto error_nojob;
-        }
-    }
-    /* Ensure that the action taken above does not result in more waiters than
-     * waitables.  Fail the most recently added FLUX_JOBID_ANY waiter if so.
-     * This could be due to
-     * (1) wait on specific ID increased wait->waiters, or
-     * (2) wait on FLUX_JOBID_ANY increased wait->requests.
-     */
-    if (flux_msglist_count (wait->requests) + wait->waiters > wait->waitables) {
-        const flux_msg_t *req = flux_msglist_last (wait->requests);
-
-        if (req) {
-            if (flux_respond_error (h,
-                                    req,
-                                    ECHILD,
-                                    "there are no more waitable jobs") < 0)
-                flux_log_error (h, "%s: flux_respond_error", __func__);
-            flux_msglist_delete (wait->requests);
-        }
+        if (wait_rpc_one (ctx->wait, user, msg, id, &error) < 0)
+            goto error;
     }
     return;
-
-error_nojob:
-    errno = ECHILD; // mimic wait(2)
 error:
-    if (flux_respond_error (h, msg, errno, errstr) < 0)
-        flux_log_error (h, "%s: flux_respond_error", __func__);
+    if (flux_respond_error (h, msg, errno, error.text) < 0)
+        flux_log_error (h, "error responding to wait request");
 }
 
-/* A client has disconnected.  Destroy any waiters registered by that client.
+/* A client has disconnected.  Destroy any acct.unreaped_with_waiter registered by that client.
  */
 void wait_disconnect_rpc (flux_t *h,
                           flux_msg_handler_t *mh,
@@ -289,20 +468,30 @@ void wait_disconnect_rpc (flux_t *h,
     struct job_manager *ctx = arg;
     struct waitjob *wait = ctx->wait;
     struct job *job;
+    struct flux_msg_cred cred;
+    struct wait_user *user;
 
-    job = zhashx_first (ctx->active_jobs);
-    while (job && wait->waiters > 0) {
-        if (job->waiter) {
-            if (flux_msg_route_match_first (job->waiter, msg)) {
-                flux_msg_decref (job->waiter);
-                job->waiter = NULL;
-                wait->waiters--;
+    if (flux_msg_get_cred (msg, &cred) < 0
+        || !(user = wait_user_lookup (wait, cred.userid, false)))
+        return;
+
+    if (user->acct.unreaped_with_waiter > 0) {
+        job = zhashx_first (ctx->active_jobs);
+        while (job) {
+            if (job->waiter && cred.userid == job->userid) {
+                if (flux_msg_route_match_first (job->waiter, msg)) {
+                    flux_msg_decref (job->waiter);
+                    job->waiter = NULL;
+                    user->acct.unreaped_no_waiter++;
+                    user->acct.unreaped_with_waiter--;
+                    if (user->acct.unreaped_with_waiter == 0)
+                        break;
+                }
             }
+            job = zhashx_next (ctx->active_jobs);
         }
-        job = zhashx_next (ctx->active_jobs);
     }
-
-    flux_msglist_disconnect (wait->requests, msg);
+    flux_msglist_disconnect (user->wait_any_requests, msg);
 }
 
 static void respond_unloading (flux_t *h, const flux_msg_t *msg)
@@ -322,34 +511,32 @@ void wait_ctx_destroy (struct waitjob *wait)
 
         /* Iterate through active jobs, sending ENOSYS response to
          * any pending wait requests, indicating that the module is unloading.
-         * Use wait->waiters count to avoid unnecessary scanning.
          */
         job = zhashx_first (wait->ctx->active_jobs);
-        while (job && wait->waiters > 0) {
+        while (job) {
             if (job->waiter) {
                 respond_unloading (h, job->waiter);
                 flux_msg_decref (job->waiter);
                 job->waiter = NULL;
-                wait->waiters--;
             }
             job = zhashx_next (wait->ctx->active_jobs);
         }
-
-        /* Send ENOSYS to any pending FLUX_JOBID_ANY wait requests,
-         * indicating that the module is unloading.
-         */
-        if (wait->requests) {
+        if (wait->users) {
+            struct wait_user *user;
             const flux_msg_t *msg;
 
-            while ((msg = flux_msglist_first (wait->requests))) {
-                respond_unloading (h, msg);
-                flux_msglist_delete (wait->requests);
-                msg = flux_msglist_next (wait->requests);
+            user = zhashx_first (wait->users);
+            while (user) {
+                while ((msg = flux_msglist_first (user->wait_any_requests))) {
+                    respond_unloading (h, msg);
+                    flux_msglist_delete (user->wait_any_requests);
+                    msg = flux_msglist_next (user->wait_any_requests);
+                }
+                user = zhashx_next (wait->users);
             }
-            flux_msglist_destroy (wait->requests);
+            zhashx_destroy (&wait->users);
         }
 
-        zhashx_destroy (&wait->zombies);
         free (wait);
         errno = saved_errno;
     }
@@ -360,7 +547,7 @@ static const struct flux_msg_handler_spec htab[] = {
         .typemask = FLUX_MSGTYPE_REQUEST,
         .topic_glob = "job-manager.wait",
         .cb = wait_rpc,
-        .rolemask = 0
+        .rolemask = FLUX_ROLE_USER
     },
     FLUX_MSGHANDLER_TABLE_END,
 };
@@ -372,18 +559,18 @@ struct waitjob *wait_ctx_create (struct job_manager *ctx)
     if (!(wait = calloc (1, sizeof (*wait))))
         return NULL;
     wait->ctx = ctx;
-
-    if (!(wait->zombies = job_hash_create ()))
-        goto error;
-    zhashx_set_destructor (wait->zombies, job_destructor);
-    zhashx_set_duplicator (wait->zombies, job_duplicator);
-
-    if (!(wait->requests = flux_msglist_create ()))
-        goto error;
-
+    if (!(wait->users = zhashx_new ()))
+        goto nomem;
+    zhashx_set_destructor (wait->users, user_destructor);
+    zhashx_set_key_hasher (wait->users, userid_hasher);
+    zhashx_set_key_comparator (wait->users, userid_comparator);
+    zhashx_set_key_destructor (wait->users, NULL);
+    zhashx_set_key_duplicator (wait->users, NULL);
     if (flux_msg_handler_addvec (ctx->h, htab, ctx, &wait->handlers) < 0)
         goto error;
     return wait;
+nomem:
+    errno = ENOMEM;
 error:
     wait_ctx_destroy (wait);
     return NULL;

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -173,8 +173,6 @@ void wait_notify_inactive (struct waitjob *wait, struct job *job)
     flux_t *h = wait->ctx->h;
     const flux_msg_t *req;
 
-    assert ((job->flags & FLUX_JOB_WAITABLE));
-
     if (job->waiter) {
         wait_respond (wait, job->waiter, job);
         flux_msg_decref (job->waiter);
@@ -197,7 +195,6 @@ void wait_notify_inactive (struct waitjob *wait, struct job *job)
  */
 void wait_notify_active (struct waitjob *wait, struct job *job)
 {
-    assert ((job->flags & FLUX_JOB_WAITABLE));
     wait->waitables++;
 }
 
@@ -244,10 +241,6 @@ static void wait_rpc (flux_t *h,
                 errstr = "job id already has a waiter";
                 goto error_nojob;
             }
-            if (!(job->flags & FLUX_JOB_WAITABLE)) {
-                errstr = "job was not submitted with FLUX_JOB_WAITABLE";
-                goto error_nojob;
-            }
             job->waiter = flux_msg_incref (msg);
             wait->waiters++;
             return;
@@ -255,7 +248,7 @@ static void wait_rpc (flux_t *h,
         /* Invalid jobid, not waitable, or already waited on.
          */
         else {
-            errstr = "invalid job id, or job may be inactive and not waitable";
+            errstr = "invalid job id, or already waited on";
             goto error_nojob;
         }
     }

--- a/src/modules/job-manager/wait.h
+++ b/src/modules/job-manager/wait.h
@@ -27,9 +27,6 @@ void wait_disconnect_rpc (flux_t *h,
                           const flux_msg_t *msg,
                           void *arg);
 
-struct job *wait_zombie_first (struct waitjob *wait);
-struct job *wait_zombie_next (struct waitjob *wait);
-
 #endif /* ! _FLUX_JOB_MANAGER_WAIT_H */
 
 /*

--- a/src/modules/job-manager/wait.h
+++ b/src/modules/job-manager/wait.h
@@ -17,6 +17,7 @@
 #include "job-manager.h"
 
 void wait_notify_inactive (struct waitjob *wait, struct job *job);
+void wait_notify_inactive_remove (struct waitjob *wait, struct job *job);
 void wait_notify_active (struct waitjob *wait, struct job *job);
 
 struct waitjob *wait_ctx_create (struct job_manager *ctx);

--- a/t/issues/t5308-kvsdir-initial-path.py
+++ b/t/issues/t5308-kvsdir-initial-path.py
@@ -10,7 +10,7 @@ from flux.job import JobspecV1
 
 handle = flux.Flux()
 jobspec = JobspecV1.from_command(command=["/bin/true"], num_tasks=1, num_nodes=1)
-jobid = flux.job.submit(handle, jobspec, waitable=True)
+jobid = flux.job.submit(handle, jobspec)
 flux.job.wait(handle, jobid=jobid)
 jobdir = flux.job.job_kvs(handle, jobid)
 jobdir["foo"] = "bar"

--- a/t/job-manager/submit-sliding-window.py
+++ b/t/job-manager/submit-sliding-window.py
@@ -35,7 +35,7 @@ running = 0
 
 while done < njobs:
     if running < fanout and done + running < njobs:
-        jobid = job.submit(h, jobspec, waitable=True)
+        jobid = job.submit(h, jobspec)
         print("submit: {}".format(jobid))
         running += 1
 

--- a/t/job-manager/submit-wait.py
+++ b/t/job-manager/submit-wait.py
@@ -32,10 +32,10 @@ jobspec_fail = JobspecV1.from_command(["/bin/false"])
 jobs = []
 for i in range(njobs):
     if i < njobs / 2:
-        jobid = job.submit(h, jobspec, waitable=True)
+        jobid = job.submit(h, jobspec)
         print("submit: {} /bin/true".format(jobid))
     else:
-        jobid = job.submit(h, jobspec_fail, waitable=True)
+        jobid = job.submit(h, jobspec_fail)
         print("submit: {} /bin/false".format(jobid))
     jobs.append(jobid)
 

--- a/t/job-manager/submit-waitany.py
+++ b/t/job-manager/submit-waitany.py
@@ -31,10 +31,10 @@ jobspec = JobspecV1.from_command(["/bin/true"])
 jobspec_fail = JobspecV1.from_command(["/bin/false"])
 for i in range(njobs):
     if i < njobs / 2:
-        jobid = job.submit(h, jobspec, waitable=True)
+        jobid = job.submit(h, jobspec)
         print("submit: {} /bin/true".format(jobid))
     else:
-        jobid = job.submit(h, jobspec_fail, waitable=True)
+        jobid = job.submit(h, jobspec_fail)
         print("submit: {} /bin/false".format(jobid))
 
 

--- a/t/job-manager/wait-interrupted.py
+++ b/t/job-manager/wait-interrupted.py
@@ -31,7 +31,7 @@ h = flux.Flux()
 jobspec = JobspecV1.from_command(["/bin/true"])
 jobs = []
 for i in range(njobs):
-    jobid = job.submit(h, jobspec, waitable=True)
+    jobid = job.submit(h, jobspec)
     print("submit: {} /bin/true".format(jobid))
     jobs.append(jobid)
 

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -165,7 +165,7 @@ class TestJob(unittest.TestCase):
             jobspec.queue = 12
 
     def test_13_job_kvs(self):
-        jobid = job.submit(self.fh, self.basic_jobspec, waitable=True)
+        jobid = job.submit(self.fh, self.basic_jobspec)
         job.wait(self.fh, jobid=jobid)
         for job_kvs_dir in [
             job.job_kvs(self.fh, jobid),
@@ -187,7 +187,7 @@ class TestJob(unittest.TestCase):
 
     def test_15_job_cancel(self):
         self.sleep_jobspec = JobspecV1.from_command(["sleep", "1000"])
-        jobid = job.submit(self.fh, self.sleep_jobspec, waitable=True)
+        jobid = job.submit(self.fh, self.sleep_jobspec)
         job.cancel(self.fh, jobid)
         fut = job.wait_async(self.fh, jobid=jobid).wait_for(5.0)
         return_id, success, errmsg = fut.get_status()
@@ -196,7 +196,7 @@ class TestJob(unittest.TestCase):
 
     def test_16_job_kill(self):
         self.sleep_jobspec = JobspecV1.from_command(["sleep", "1000"])
-        jobid = job.submit(self.fh, self.sleep_jobspec, waitable=True)
+        jobid = job.submit(self.fh, self.sleep_jobspec)
 
         #  Wait for shell to fully start to avoid delay in signal
         job.event_wait(self.fh, jobid, name="start")
@@ -297,7 +297,8 @@ class TestJob(unittest.TestCase):
 
     def test_20_005_job_event_watch_with_cancel(self):
         jobid = job.submit(
-            self.fh, JobspecV1.from_command(["sleep", "3"]), waitable=True
+            self.fh,
+            JobspecV1.from_command(["sleep", "3"]),
         )
         self.assertTrue(jobid > 0)
         events = []
@@ -317,7 +318,8 @@ class TestJob(unittest.TestCase):
 
     def test_20_005_1_job_event_watch_with_cancel_stop_true(self):
         jobid = job.submit(
-            self.fh, JobspecV1.from_command(["sleep", "3"]), waitable=True
+            self.fh,
+            JobspecV1.from_command(["sleep", "3"]),
         )
         self.assertTrue(jobid > 0)
         events = []
@@ -776,7 +778,7 @@ class TestJob(unittest.TestCase):
             ["python3", "-c", "import flux; print(flux.job.timeleft())"]
         )
         spec.duration = "1m"
-        jobid = job.submit(self.fh, spec, waitable=True)
+        jobid = job.submit(self.fh, spec)
         job.wait(self.fh, jobid=jobid)
         try:
             job.timeleft()

--- a/t/python/t0013-job-list.py
+++ b/t/python/t0013-job-list.py
@@ -38,7 +38,7 @@ class TestJob(unittest.TestCase):
         )
         compute_jobreq.cwd = os.getcwd()
         compute_jobreq.environment = dict(os.environ)
-        return flux.job.submit(self.fh, compute_jobreq, waitable=True)
+        return flux.job.submit(self.fh, compute_jobreq)
 
     @classmethod
     def getJobs(self, rpc_handle):

--- a/t/python/t0014-job-kvslookup.py
+++ b/t/python/t0014-job-kvslookup.py
@@ -31,7 +31,7 @@ class TestJob(unittest.TestCase):
         )
         testenv = {"FOO": "BAR"}
         compute_jobreq.environment = testenv
-        return flux.job.submit(self.fh, compute_jobreq, urgency=urgency, waitable=True)
+        return flux.job.submit(self.fh, compute_jobreq, urgency=urgency)
 
     @classmethod
     def setUpClass(self):

--- a/t/python/t0015-job-output.py
+++ b/t/python/t0015-job-output.py
@@ -68,7 +68,7 @@ class TestJobOutput(unittest.TestCase):
             jobspec.setattr_shell_option("verbose", 1)
         if redirect is not None:
             jobspec.stdout = redirect
-        return flux.job.submit(self.fh, jobspec, waitable=True, urgency=urgency)
+        return flux.job.submit(self.fh, jobspec, urgency=urgency)
 
     def release_job(self, jobid):
         # Release job by setting urgency to default:

--- a/t/t2208-job-manager-wait.t
+++ b/t/t2208-job-manager-wait.t
@@ -159,12 +159,15 @@ test_expect_success "a second wait fails on inactive job" '
 	flux job wait ${JOBID} &&
 	test_expect_code 2 flux job wait ${JOBID}
 '
-
 test_expect_success "guest cannot wait on a job" '
+	flux jobs -a
+'
+
+test_expect_success "a user cannot wait on another user's job" '
 	JOBID=$(flux submit /bin/true) &&
-	export FLUX_HANDLE_ROLEMASK=0x2 &&
+	export FLUX_HANDLE_USERID=$(($(id -u)+1)) &&
 	test_expect_code 1 flux job wait ${JOBID} &&
-	unset FLUX_HANDLE_ROLEMASK
+	unset FLUX_HANDLE_USERID
 '
 test_expect_success "wait works with deprecated waitable flag" '
 	JOBID=$(flux submit --flags waitable /bin/true) &&

--- a/t/t2304-sched-simple-alloc-check.t
+++ b/t/t2304-sched-simple-alloc-check.t
@@ -23,7 +23,7 @@ test_expect_success 'run an alloc-bypass sleep job' '
 '
 test_expect_success 'a regular job fails with an alloc-check exception' '
 	test_expect_code 1 \
-	    run_timeout 30 flux submit --flags=waitable -vvv \
+	    run_timeout 30 flux submit -vvv \
 	    --wait-event=exception \
 	    -N1 /bin/true >bypass.jobid
 '

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -35,7 +35,7 @@ terminus_jobid() {
 }
 
 test_expect_success 'pty: submit a job with an interactive pty' '
-	id=$(flux submit --flags waitable -o pty.interactive tty) &&
+	id=$(flux submit -o pty.interactive tty) &&
 	terminus_jobid $id list &&
 	$runpty flux job attach ${id} &&
 	flux job wait $id

--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -46,6 +46,9 @@ test_expect_success 'flux-shell: per-resource type=node works' '
 	EOF
 	test_cmp per-node.expected per-node.out
 '
+test_expect_success 'consume wait status all prior jobs' '
+	test_might_fail flux job wait --all
+'
 test_expect_success 'flux-shell: historical batch jobspec still work' '
 	for spec in $SHARNESS_TEST_SRCDIR/batch/jobspec/*.json; do
 		input=$(basename $spec) &&
@@ -55,7 +58,7 @@ test_expect_success 'flux-shell: historical batch jobspec still work' '
 		    jq -S ".attributes.system.environment.HOME=\"$HOME\"" |
 		    jq -S ".attributes.system.cwd=\"$(pwd)\"" \
 		    >$input &&
-		flux job submit --flags=waitable $input
+		flux job submit $input
 	done &&
 	flux job attach -vEX $(flux job last) &&
 	flux job wait --all --verbose

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -77,13 +77,13 @@ test_expect_success 'flux batch --exclusive works' '
 		jq -e ".type == \"node\" and .exclusive"
 '
 test_expect_success NO_ASAN 'flux batch: submit a series of jobs' '
-	id1=$(flux batch --flags=waitable -n1 batch-script.sh) &&
-	id2=$(flux batch --flags=waitable -n4 batch-script.sh) &&
-	id3=$(flux batch --flags=waitable -N2 -n4 batch-script.sh) &&
+	id1=$(flux batch -n1 batch-script.sh) &&
+	id2=$(flux batch -n4 batch-script.sh) &&
+	id3=$(flux batch -N2 -n4 batch-script.sh) &&
 	flux resource list &&
 	flux jobs &&
-	id4=$(flux batch --flags=waitable -N2 -n2 -x batch-script.sh) &&
-	id5=$(flux batch --flags=waitable -N2 batch-script.sh) &&
+	id4=$(flux batch -N2 -n2 -x batch-script.sh) &&
+	id5=$(flux batch -N2 batch-script.sh) &&
 	run_timeout 180 flux job wait --verbose --all
 '
 test_expect_success NO_ASAN 'flux batch: job results are expected' '
@@ -100,15 +100,15 @@ test_expect_success MULTICORE 'flux batch: exclusive flag worked' '
 '
 
 test_expect_success 'flux batch: --output=kvs directs output to kvs' '
-	id=$(flux batch -n1 --flags=waitable --output=kvs batch-script.sh) &&
+	id=$(flux batch -n1 --output=kvs batch-script.sh) &&
 	run_timeout 180 flux job attach $id > kvs-output.log 2>&1 &&
 	test_debug "cat kvs-output.log" &&
 	grep "size=1 nodes=1" kvs-output.log
 '
 test_expect_success 'flux batch: --broker-opts works' '
-	id=$(flux batch -n1 --flags=waitable \
+	id=$(flux batch -n1 \
 	     --broker-opts=-v batch-script.sh) &&
-	id2=$(flux batch -n1 --flags=waitable \
+	id2=$(flux batch -n1 \
 	     --broker-opts=-v,-v batch-script.sh) &&
 	run_timeout 180 flux job wait $id &&
 	test_debug "cat flux-${id}.out" &&
@@ -172,19 +172,19 @@ test_expect_success 'flux batch: MPI env vars are not set in batch script' '
 '
 test_expect_success 'flux batch: --dump works' '
 	id=$(flux batch -N1 --dump \
-		--flags=waitable --wrap true) &&
+		--wrap true) &&
 	run_timeout 180 flux job wait $id &&
 	tar tvf flux-${id}-dump.tgz
 '
 test_expect_success 'flux batch: --dump=FILE works' '
 	id=$(flux batch -N1 --dump=testdump.tgz \
-		--flags=waitable --wrap true) &&
+		--wrap true) &&
 	run_timeout 180 flux job wait $id &&
 	tar tvf testdump.tgz
 '
 test_expect_success 'flux batch: --dump=FILE works with mustache' '
 	id=$(flux batch -N1 --dump=testdump-{{id}}.tgz \
-		--flags=waitable --wrap true) &&
+		--wrap true) &&
 	run_timeout 180 flux job wait $id &&
 	tar tvf testdump-${id}.tgz
 '

--- a/t/t4000-issues-test-driver.t
+++ b/t/t4000-issues-test-driver.t
@@ -19,7 +19,6 @@ if test -z "$T4000_ISSUES_GLOB"; then
 fi
 
 flux bulksubmit -n1 -o pty --job-name={./%} -t 10m \
-	--flags=waitable \
 	--quiet --watch  \
 	flux start {} \
 	::: ${FLUX_SOURCE_DIR}/t/issues/${T4000_ISSUES_GLOB}


### PR DESCRIPTION
Problem: as described in #5738, requring jobs to be submitted with the `waitable` flag in order for them to work with `flux_job_wait(3)` is not really buying us much anymore, now that inactive jobs are kept in the job manager's memory by default.

This makes all jobs waitable by default.  Instance owner only, as before.

I marked this WIP for now pending
- documentation update
- need to make sure that unwaited-for jobs can be purged (and add a test)
- check performance/memory impact and mitigate if necessary
- consider whether wait should be made into a jobtap plugin instead of a builtin job manager service
- consider whether it is worth the effort to allow guests to wait on their own jobs