### PR TITLE
flux-job: add shorthand paths for `flux job eventlog` and `wait-event`

### DIFF
--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -694,7 +694,7 @@ test_expect_success 'flux-job: load modules for live kill tests' '
 # N.B. SIGTERM == 15
 test_expect_success 'flux-job: kill basic works' '
 	id=$(flux submit --wait-event=start sleep 100) &&
-	flux job wait-event -vt 30 -p guest.exec.eventlog $id shell.start &&
+	flux job wait-event -vt 30 -p exec $id shell.start &&
 	flux job kill ${id} &&
 	flux job wait-event -t 30 ${id} finish > kill1.out &&
 	grep status=$((15+128<<8)) kill1.out
@@ -703,7 +703,7 @@ test_expect_success 'flux-job: kill basic works' '
 # N.B. SIGUSR1 == 10
 test_expect_success 'flux-job: kill --signal works' '
 	id=$(flux submit --wait-event=start sleep 100) &&
-	flux job wait-event -vt 30 -p guest.exec.eventlog $id shell.start &&
+	flux job wait-event -vt 30 -p exec $id shell.start &&
 	flux job kill --signal=SIGUSR1 ${id} &&
 	flux job wait-event -t 30 ${id} finish > kill2.out &&
 	grep status=$((10+128<<8)) kill2.out
@@ -711,7 +711,7 @@ test_expect_success 'flux-job: kill --signal works' '
 
 test_expect_success 'flux job: killall -f kills one job' '
 	id=$(flux submit sleep 600) &&
-	flux job wait-event -vt 30 -p guest.exec.eventlog $id shell.init &&
+	flux job wait-event -vt 30 -p exec $id shell.init &&
 	flux job killall -f &&
 	run_timeout 60 flux queue drain
 '
@@ -720,7 +720,7 @@ test_expect_success 'flux job: cancel can operate on multiple jobs' '
 	ids=$(flux submit --bcc=1-3 sleep 600) &&
 	for id in ${ids}; do
 		flux job wait-event \
-			-vt 30 -p guest.exec.eventlog $id shell.init
+			-vt 30 -p exec $id shell.init
 	done &&
 	flux job cancel ${ids} cancel multiple jobs &&
 	for id in ${ids}; do
@@ -742,8 +742,7 @@ test_expect_success 'flux job: raise can operate on multiple jobs' '
 test_expect_success 'flux job: kill can operate on multiple jobs' '
 	ids=$(flux submit --wait-event=start --bcc=1-3 sleep 600) &&
 	for id in ${ids}; do
-		flux job wait-event \
-			-t 30 -p guest.exec.eventlog ${id} shell.init
+		flux job wait-event -t 30 -p exec ${id} shell.init
 	done &&
 	flux job kill ${ids} &&
 	for id in ${ids}; do

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -199,7 +199,21 @@ test_expect_success 'flux job eventlog -p works (guest.exec.eventlog)' '
 	flux job eventlog -p "guest.exec.eventlog" $jobid > eventlog_path2.out &&
 	grep done eventlog_path2.out
 '
-
+test_expect_success 'flux job eventlog -p works (exec)' '
+	jobid=$(submit_job) &&
+	flux job eventlog -p exec $jobid > eventlog_path3.out &&
+	grep done eventlog_path3.out
+'
+test_expect_success 'flux job eventlog -p works (output)' '
+	jobid=$(submit_job) &&
+	flux job eventlog -p output $jobid > eventlog_path4.out &&
+	grep encoding eventlog_path4.out
+'
+test_expect_success 'flux job eventlog -p works (output)' '
+	jobid=$(submit_job) &&
+	flux job eventlog -p input $jobid > eventlog_path5.out &&
+	grep encoding eventlog_path5.out
+'
 test_expect_success 'flux job eventlog -p fails on invalid path' '
 	jobid=$(submit_job) &&
 	test_must_fail flux job eventlog -p "foobar" $jobid

--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -212,7 +212,10 @@ test_expect_success 'flux job wait-event -p works (guest.exec.eventlog)' '
 	fj_wait_event -p "guest.exec.eventlog" $jobid done > wait_event_path2.out &&
 	grep done wait_event_path2.out
 '
-
+test_expect_success 'flux job wait-event -p works (exec)' '
+	fj_wait_event -p exec $jobid done > wait_event_path2.1.out &&
+	grep done wait_event_path2.1.out
+'
 test_expect_success 'flux job wait-event -p works (non-guest eventlog)' '
 	jobid=$(submit_job) &&
 	kvsdir=$(flux job id --to=kvs $jobid) &&
@@ -236,9 +239,9 @@ test_expect_success 'flux job wait-event -p fails on path "guest."' '
 	test_must_fail fj_wait_event -p "guest." $jobid submit
 '
 
-test_expect_success 'flux job wait-event -p and --waitcreate works (guest.exec.eventlog)' '
+test_expect_success 'flux job wait-event -p and --waitcreate works (exec)' '
 	jobid=$(submit_job) &&
-	fj_wait_event --waitcreate -p "guest.exec.eventlog" $jobid done > wait_event_path4.out &&
+	fj_wait_event --waitcreate -p exec $jobid done > wait_event_path4.out &&
 	grep done wait_event_path4.out
 '
 
@@ -298,7 +301,8 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p invalid and --waitcrea
 
 test_expect_success 'flux job wait-event -p times out on no event (live job)' '
 	jobid=$(submit_job_live sleeplong.json) &&
-	test_expect_code 142 run_timeout -s ALRM 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&
+	test_expect_code 142 run_timeout -s ALRM 0.2 \
+	    flux job wait-event -p exec $jobid foobar &&
 	flux cancel $jobid
 '
 
@@ -351,10 +355,10 @@ test_expect_success 'job-info: generate jobspec to consume all resources' '
 	flux run --dry-run -n4 -c2 sleep 300 > sleeplong-all-rsrc.json
 '
 
-test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog works (wait job)' '
+test_expect_success NO_CHAIN_LINT 'flux job wait-event -p exec works (wait job)' '
 	jobidall=$(submit_job_live sleeplong-all-rsrc.json)
 	jobid=$(submit_job_wait)
-	fj_wait_event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path7.out &
+	fj_wait_event -v -p exec ${jobid} done > wait_event_path7.out &
 	waitpid=$! &&
 	wait_watchers_nonzero "watchers" &&
 	wait_watchers_nonzero "guest_watchers" &&
@@ -370,7 +374,8 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
 test_expect_success 'flux job wait-event -p times out on no event (wait job)' '
 	jobidall=$(submit_job_live sleeplong-all-rsrc.json) &&
 	jobid=$(submit_job_wait) &&
-	test_expect_code 142 run_timeout -s ALRM 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&
+	test_expect_code 142 run_timeout -s ALRM 0.2 \
+	    flux job wait-event -p exec $jobid foobar &&
 	flux cancel $jobidall &&
 	flux cancel $jobid
 '
@@ -383,7 +388,7 @@ test_expect_success 'flux job wait-event -p times out on no event (wait job)' '
 test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog works (never start job)' '
 	jobidall=$(submit_job_live sleeplong-all-rsrc.json)
 	jobid=$(submit_job_wait)
-	fj_wait_event -v -p "guest.exec.eventlog" ${jobid} done > wait_event_path8.out &
+	fj_wait_event -v -p exec ${jobid} done > wait_event_path8.out &
 	waitpid=$! &&
 	wait_watchers_nonzero "watchers" &&
 	wait_watchers_nonzero "guest_watchers" &&

--- a/t/t2232-job-info-security.t
+++ b/t/t2232-job-info-security.t
@@ -99,20 +99,20 @@ test_expect_success 'flux job eventlog fails on bad first event (user)' '
 
 test_expect_success 'flux job guest.exec.eventlog works via -p (owner)' '
 	jobid=$(submit_job) &&
-	flux job eventlog -p guest.exec.eventlog $jobid
+	flux job eventlog -p exec $jobid
 '
 
 test_expect_success 'flux job guest.exec.eventlog works via -p (user)' '
 	jobid=$(submit_job 9000) &&
 	set_userid 9000 &&
-	flux job eventlog -p guest.exec.eventlog $jobid &&
+	flux job eventlog -p exec $jobid &&
 	unset_userid
 '
 
 test_expect_success 'flux job guest.exec.eventlog fails via -p (wrong user)' '
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job eventlog -p guest.exec.eventlog $jobid &&
+	! flux job eventlog -p exec $jobid &&
 	unset_userid
 '
 
@@ -202,33 +202,33 @@ test_expect_success 'flux job wait-event fails (wrong user)' '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (owner)' '
 	jobid=$(submit_job) &&
-	flux job wait-event -p guest.exec.eventlog $jobid done
+	flux job wait-event -p exec $jobid done
 '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (user)' '
 	jobid=$(submit_job 9000) &&
 	set_userid 9000 &&
-	flux job wait-event -p guest.exec.eventlog $jobid done &&
+	flux job wait-event -p exec $jobid done &&
 	unset_userid
 '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog fails via -p (wrong user)' '
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job wait-event -p guest.exec.eventlog $jobid done &&
+	! flux job wait-event -p exec $jobid done &&
 	unset_userid
 '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (live job, owner)' '
 	jobid=$(submit_job_live) &&
-	flux job wait-event -p guest.exec.eventlog $jobid init &&
+	flux job wait-event -p exec $jobid init &&
 	flux cancel $jobid
 '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (live job, user)' '
 	jobid=$(submit_job_live 9000) &&
 	set_userid 9000 &&
-	flux job wait-event -p guest.exec.eventlog $jobid init &&
+	flux job wait-event -p exec $jobid init &&
 	unset_userid &&
 	flux cancel $jobid
 '
@@ -236,7 +236,7 @@ test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (live 
 test_expect_success 'flux job wait-event guest.exec.eventlog fails via -p (live job, wrong user)' '
 	jobid=$(submit_job_live 9000) &&
 	set_userid 9999 &&
-	! flux job wait-event -p guest.exec.eventlog $jobid init &&
+	! flux job wait-event -p exec $jobid init &&
 	unset_userid &&
 	flux cancel $jobid
 '

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -47,7 +47,7 @@ test_expect_success 'job-exec: status is maximum job shell exit codes' '
 test_expect_success 'job-exec: job exception kills job shells' '
 	id=$(flux submit -n4 -N4 sleep 300) &&
 	flux job wait-event -vt 5 $id start &&
-	flux job wait-event -vt 5 -p guest.exec.eventlog $id shell.start &&
+	flux job wait-event -vt 5 -p exec $id shell.start &&
 	flux cancel $id &&
 	flux job wait-event -vt 5 $id clean &&
 	flux job eventlog $id | grep -E "status=(15|36608)"

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -89,7 +89,7 @@ test_expect_success NO_ASAN 'job-exec: kill multiuser job uses the IMP' '
 		flux job submit --flags=signed sleep-job.signed) &&
 	flux job list-ids ${id} > ${id}.json &&
 	jq -e ".userid == 42" < ${id}.json &&
-	flux job wait-event -p guest.exec.eventlog -vt 30 ${id} shell.start &&
+	flux job wait-event -p exec -vt 30 ${id} shell.start &&
 	flux cancel ${id} &&
 	test_expect_code 143 run_timeout 30 flux job status -v ${id} &&
 	flux dmesg | grep "test-imp: Kill .*signal 15"

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -132,7 +132,7 @@ test_expect_success NO_CHAIN_LINT 'attach: output appears before cancel' '
 	jobid=$(flux submit ${script})
 	flux job attach -E ${jobid} 1>attach5.out 2>attach5.err &
 	waitpid=$! &&
-	flux job wait-event --timeout=10.0 -p guest.exec.eventlog ${jobid} test-output-ready &&
+	flux job wait-event --timeout=10.0 -p exec ${jobid} test-output-ready &&
 	flux cancel ${jobid} &&
 	! wait ${waitpid} &&
 	grep before attach5.out &&

--- a/t/t2501-job-status.t
+++ b/t/t2501-job-status.t
@@ -82,7 +82,7 @@ test_expect_success 'status: exit code ignores nonfatal exceptions' '
 	flux job status -vvv $jobid
 '
 test_expect_success 'status: returns 143 (SIGTERM) for canceled running job' '
-	flux job wait-event -p guest.exec.eventlog ${killed} shell.start &&
+	flux job wait-event -p exec ${killed} shell.start &&
 	flux cancel ${killed} &&
 	test_expect_code 143 flux job status -v ${killed}
 '

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -201,32 +201,32 @@ test_expect_success 'create helper job submission script' '
 '
 test_expect_success 'job-shell: test shell kill event handling' '
 	id=$(flux submit -n4 -N4 ./sleepinf.sh) &&
-	flux job wait-event -p guest.exec.eventlog $id shell.init &&
-	flux job wait-event -p guest.output $id data &&
+	flux job wait-event -p exec $id shell.init &&
+	flux job wait-event -p output $id data &&
 	flux job kill $id &&
 	flux job wait-event $id finish >kill1.finish.out &&
 	grep status=$((15+128<<8)) kill1.finish.out
 '
 test_expect_success 'job-shell: test shell kill event handling: SIGKILL' '
 	id=$(flux submit -n4 -N4 ./sleepinf.sh) &&
-	flux job wait-event -p guest.exec.eventlog $id shell.init &&
-	flux job wait-event -p guest.output $id data &&
+	flux job wait-event -p exec $id shell.init &&
+	flux job wait-event -p output $id data &&
 	flux job kill -s SIGKILL $id &&
 	flux job wait-event $id finish >kill2.finish.out &&
 	grep status=$((9+128<<8)) kill2.finish.out
 '
 test_expect_success 'job-shell: test shell kill event handling: numeric signal' '
 	id=$(flux submit -n4 -N4 ./sleepinf.sh) &&
-	flux job wait-event -p guest.exec.eventlog $id shell.init &&
-	flux job wait-event -p guest.output $id data &&
+	flux job wait-event -p exec $id shell.init &&
+	flux job wait-event -p output $id data &&
 	flux job kill -s 2 $id &&
 	flux job wait-event $id finish >kill3.finish.out &&
 	grep status=$((2+128<<8)) kill3.finish.out
 '
 test_expect_success 'job-shell: mangled shell kill event logged' '
 	id=$(flux submit -n4 -N4 ./sleepinf.sh | flux job id) &&
-	flux job wait-event -p guest.exec.eventlog $id shell.init &&
-	flux job wait-event -p guest.output $id data &&
+	flux job wait-event -p exec $id shell.init &&
+	flux job wait-event -p output $id data &&
 	flux event pub shell-${id}.kill "{}" &&
 	flux job kill ${id} &&
 	flux job wait-event -vt 1 $id finish >kill4.finish.out &&
@@ -236,8 +236,8 @@ test_expect_success 'job-shell: mangled shell kill event logged' '
 '
 test_expect_success 'job-shell: shell kill event: kill(2) failure logged' '
 	id=$(flux submit -n4 -N4 ./sleepinf.sh | flux job id) &&
-	flux job wait-event -p guest.exec.eventlog $id shell.init &&
-	flux job wait-event -p guest.output $id data &&
+	flux job wait-event -p exec $id shell.init &&
+	flux job wait-event -p output $id data &&
 	flux event pub shell-${id}.kill "{\"signum\":199}" &&
 	flux job kill ${id} &&
 	flux job wait-event $id finish >kill5.finish.out &&

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -216,7 +216,7 @@ test_expect_success 'flux-shell: no fatal exception after stdin sent to exited t
 	EOF
 	chmod +x ${name}.sh &&
 	id=$(flux submit -n2 -o verbose ./${name}.sh) &&
-	flux job wait-event -v -p guest.exec.eventlog ${id} shell.start &&
+	flux job wait-event -v -p exec ${id} shell.start &&
 	flux kvs get --watch --waitcreate --count=1 ${name}.0.started &&
 	flux kvs get --watch --waitcreate --count=1 ${name}.1.started &&
 	echo | flux job attach -XE ${id} &&

--- a/t/t2609-job-shell-events.t
+++ b/t/t2609-job-shell-events.t
@@ -13,20 +13,20 @@ INITRC_PLUGINPATH="${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs"
 
 test_expect_success 'flux-shell: 1N: init and start shell events are emitted' '
 	id=$(flux submit -n1 -N1 /bin/true)  &&
-	flux job wait-event -vt 5 -p guest.exec.eventlog \
+	flux job wait-event -vt 5 -p exec \
 		-m leader-rank=0 ${id} shell.init &&
-	flux job wait-event -vt 5 -p guest.exec.eventlog \
+	flux job wait-event -vt 5 -p exec \
 		${id} shell.init  &&
-	flux job wait-event -vt 5 -p guest.exec.eventlog \
+	flux job wait-event -vt 5 -p exec \
 		${id} shell.start
 '
 test_expect_success 'flux-shell: 2N: init and start shell events are emitted' '
 	id=$(flux submit -n4 -N2 /bin/true)  &&
-	flux job wait-event -vt 5 -p guest.exec.eventlog \
+	flux job wait-event -vt 5 -p exec \
 		-m leader-rank=0  ${id} shell.init &&
-	flux job wait-event -vt 5 -p guest.exec.eventlog \
+	flux job wait-event -vt 5 -p exec \
 		-m size=2 ${id} shell.init  &&
-	flux job wait-event -vt 5 -p guest.exec.eventlog \
+	flux job wait-event -vt 5 -p exec \
 		${id} shell.start
 '
 test_expect_success 'flux-shell: plugin can add event context' '
@@ -35,7 +35,7 @@ test_expect_success 'flux-shell: plugin can add event context' '
 	plugin.load { file = "test-event.so" }
 	EOT
 	id=$(flux submit -o initrc=test-event.lua -n2 -N2 hostname) &&
-	flux job wait-event -vt 5 -p guest.exec.eventlog \
+	flux job wait-event -vt 5 -p exec \
 		-m event-test=foo ${id} shell.init
 
 '

--- a/t/t2610-job-shell-mpir.t
+++ b/t/t2610-job-shell-mpir.t
@@ -13,11 +13,11 @@ INITRC_PLUGINPATH="${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs"
 mpir="${SHARNESS_TEST_DIRECTORY}/shell/mpir"
 
 shell_leader_rank() {
-    flux job wait-event -f json -p guest.exec.eventlog $1 shell.init | \
+    flux job wait-event -f json -p exec $1 shell.init | \
         jq '.context["leader-rank"]'
 }
 shell_service() {
-    flux job wait-event -f json -p guest.exec.eventlog $1 shell.init | \
+    flux job wait-event -f json -p exec $1 shell.init | \
         jq -r '.context["service"]'
 }
 
@@ -27,8 +27,7 @@ for test in 1:1 2:2 2:4 4:4 4:8 4:7; do
     test_expect_success "flux-shell: ${NODES}N/${TASKS}P: trace+mpir works" '
 	id=$(flux submit -o stop-tasks-in-exec \
              -n${TASKS} -N${NODES} /bin/true)  &&
-        flux job wait-event -vt 5 -p guest.exec.eventlog \
-                -m sync=true ${id} shell.start &&
+        flux job wait-event -vt 5 -p exec -m sync=true ${id} shell.start &&
         ${mpir} $(shell_leader_rank $id) $(shell_service $id) &&
         flux job kill -s CONT ${id} &&
         flux job attach ${id}
@@ -38,8 +37,7 @@ done
 
 test_expect_success 'flux-shell: test security of proctable method' '
     id=$(flux submit -o stop-tasks-in-exec /bin/true) &&
-    flux job wait-event -vt 5 -p guest.exec.eventlog \
-        -m sync=true ${id} shell.start &&
+    flux job wait-event -vt 5 -p exec -m sync=true ${id} shell.start &&
     shell_rank=$(shell_leader_rank $id) &&
     shell_service=$(shell_service $id) &&
     ( export FLUX_HANDLE_USERID=9999 &&

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -17,11 +17,11 @@ runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast"
 waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
 
 shell_leader_rank() {
-    flux job wait-event -f json -p guest.exec.eventlog $1 shell.init | \
+    flux job wait-event -f json -p exec $1 shell.init | 
         jq '.context["leader-rank"]'
 }
 shell_service() {
-    flux job wait-event -f json -p guest.exec.eventlog $1 shell.init | \
+    flux job wait-event -f json -p exec $1 shell.init | \
         jq -r '.context["service"]'
 }
 terminus_jobid() {
@@ -105,14 +105,14 @@ test_expect_success 'pty: pty.interactive forces a pty on rank 0' '
 		tty) &&
 	terminus_jobid $id list &&
 	$runpty flux job attach ${id} &&
-	flux job eventlog -p guest.output ${id} | grep "adding pty to rank 0"
+	flux job eventlog -p output ${id} | grep "adding pty to rank 0"
 '
 test_expect_success 'pty: -o pty.interactive and -o pty.capture can be used together' '
 	for i in $(seq 1 3); do
 		id=$(flux submit -o pty.interactive -o pty.capture tty) &&
 		$runpty flux job attach $id >ptyim.out 2>&1 &&
 		$runpty flux job attach $id &&
-		flux job eventlog -f json -p guest.output $id \
+		flux job eventlog -f json -p output $id \
 			| tail -n1 >last-event.$i
 	done &&
 	# Check that eof:true is the last event for all runs

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -8,7 +8,7 @@ test_under_flux 2 job
 
 test_expect_success 'flux-shell: first task exit posts shell.task-exit event' '
 	jobid=$(flux submit /bin/true) &&
-	run_timeout 10 flux job wait-event -p guest.exec.eventlog \
+	run_timeout 10 flux job wait-event -p exec \
 		$jobid shell.task-exit
 '
 

--- a/t/t2616-job-shell-taskmap.t
+++ b/t/t2616-job-shell-taskmap.t
@@ -67,20 +67,20 @@ test_expect_success 'flux job taskmap fails with invalid arguments' '
 '
 test_expect_success 'taskmap is posted in shell.start event' '
 	id=$(flux submit ./map.sh) &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+	flux job wait-event -p exec -f json $id shell.start \
 		| jq -e ".context.taskmap.map == [[0,1,1,1]]" &&
 	test_check_taskmap $id
 '
 test_expect_success 'taskmap is correct for --tasks-per-node=4' '
 	id=$(flux submit -N4 --tasks-per-node=4 ./map.sh) &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+	flux job wait-event -p exec -f json $id shell.start \
 		| jq -e ".context.taskmap.map == [[0,4,4,1]]" &&
 	test_check_taskmap $id
 '
 test_expect_success 'taskmap is unchanged with --taskmap=block' '
 	id=$(flux submit -N4 --tasks-per-node=4 \
 		--taskmap=block ./map.sh) &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+	flux job wait-event -p exec -f json $id shell.start \
 		| jq -e ".context.taskmap.map == [[0,4,4,1]]" &&
 	test_check_taskmap $id
 '
@@ -90,29 +90,29 @@ test_expect_success 'shell dies with --taskmap=block:oops' '
 '
 test_expect_success 'taskmap is correct for --tasks-per-node=2' '
 	id=$(flux submit -N4 --tasks-per-node=2 ./map.sh) &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+	flux job wait-event -p exec -f json $id shell.start &&
+	flux job wait-event -p exec -f json $id shell.start \
 		| jq -e ".context.taskmap.map == [[0,4,2,1]]" &&
 	test_check_taskmap $id
 '
 test_expect_success 'taskmap=cyclic works with valid args' '
 	id=$(flux submit --taskmap=cyclic -N4 --tasks-per-node=4 ./map.sh) &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+	flux job wait-event -p exec -f json $id shell.start &&
+	flux job wait-event -p exec -f json $id shell.start \
 		| jq -e ".context.taskmap.map == [[0,4,1,4]]" &&
 	test_check_taskmap $id
 '
 test_expect_success 'taskmap=cyclic:2 works' '
 	id=$(flux submit --taskmap=cyclic:2 -N4 --tasks-per-node=4 ./map.sh) &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+	flux job wait-event -p exec -f json $id shell.start &&
+	flux job wait-event -p exec -f json $id shell.start \
 		| jq -e ".context.taskmap.map == [[0,4,2,2]]" &&
 	test_check_taskmap $id
 '
 test_expect_success 'taskmap=cyclic:3 works' '
 	id=$(flux submit --taskmap=cyclic:3 -N4 --tasks-per-node=4 ./map.sh) &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+	flux job wait-event -p exec -f json $id shell.start &&
+	flux job wait-event -p exec -f json $id shell.start \
 		| jq -e ".context.taskmap.map == [[0,4,3,1],[0,4,1,1]]" &&
 	test_check_taskmap $id
 '
@@ -120,7 +120,7 @@ test_expect_success 'taskmap=manual works' '
 	id=$(flux submit \
 	     --taskmap=manual:"[[1,3,4,1],[0,1,4,1]]" \
 	     -N4 --tasks-per-node=4 ./map.sh) &&
-	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+	flux job wait-event -p exec -f json $id shell.start \
 		| jq -e ".context.taskmap.map == [[1,3,4,1],[0,1,4,1]]" &&
 	test_check_taskmap $id
 '


### PR DESCRIPTION
This PR is a simple update to add some shorthand names for well-known eventlogs wih `flux job wait-event` and `flux job eventlog`. It is a bit cumbersome to always be typing `flux job eventlog -p guest.exec.eventlog`, and after this PR you can just do `flux job eventlog -p exec ...`.