### PR TITLE
testsuite: fix random-generation of kvs archive files in t0021

### DIFF
--- a/t/t0021-archive-cmd.t
+++ b/t/t0021-archive-cmd.t
@@ -2,8 +2,6 @@
 
 test_description='Test flux-archive'
 
-. `dirname $0`/content/content-helper.sh
-
 . `dirname $0`/sharness.sh
 
 test_under_flux 2
@@ -15,7 +13,7 @@ umask 022
 
 # Usage: randbytes bytes
 randbytes() {
-	dd if=/dev/random bs=$1 count=1
+	dd if=/dev/urandom bs=$1 count=1
 }
 
 test_expect_success 'flux archive create --badopt prints unrecognized option' '
@@ -86,7 +84,7 @@ test_expect_success 'flux archive list works' '
 	test_cmp list.exp list.out
 '
 test_expect_success 'flux archive list -l works' '
-	flux archive list --l >list_l.out &&
+	flux archive list -l >list_l.out &&
 	cat >list_l.exp <<-EOT &&
 	f 0644     2048 testfile2
 	d 0755        0 testdir


### PR DESCRIPTION
Problem: the randbytes() function in t0021-archive-cmd.t uses /dev/random to create files of size 128 and 2048 bytes, respectively. However, /dev/random can be truncated at <128 bytes and, when it is, the file created by dd will be as well. This causes a size mismatch in the kvs, which causes tests 13, 14, and 18 to fail. This first showed up in GitLab CI on TOSS 4.

We can instead utilize the /dev/urandom file, which is not truncated, and thus guaranteed to create files of the proper sizes. Also, some cleanup of t0021-archive-cmd.t is baked into this PR.

When merged, closes issue #5750.