### PR TITLE
shell: fix incorrect values returned from `flux_shell_get_rank_info(3)`

### DIFF
--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -530,6 +530,7 @@ static json_t *flux_shell_get_rank_info_object (flux_shell_t *shell, int rank)
     char key [128];
     char *taskids = NULL;
     struct taskmap *map;
+    struct rcalc_rankinfo rankinfo;
 
     if (!shell->info)
         return NULL;
@@ -551,13 +552,16 @@ static json_t *flux_shell_get_rank_info_object (flux_shell_t *shell, int rank)
     if (!(taskids = get_rank_task_idset (map, rank)))
         return NULL;
 
+    if (rcalc_get_nth (shell->info->rcalc, rank, &rankinfo) < 0)
+        return NULL;
+
     o = json_pack_ex (&error, 0, "{ s:i s:i s:s s:{s:s s:s?}}",
-                   "broker_rank", rank,
+                   "broker_rank", rankinfo.rank,
                    "ntasks", taskmap_ntasks (map, rank),
                    "taskids", taskids,
                    "resources",
-                     "cores", shell->info->rankinfo.cores,
-                     "gpus",  shell->info->rankinfo.gpus);
+                     "cores", rankinfo.cores,
+                     "gpus",  rankinfo.gpus);
     free (taskids);
 
     if (o == NULL)


### PR DESCRIPTION
Embarrassingly, the values returned for non-local shell ranks from `flux_shell_get_rank_info(3)` and associated calls has been wrong. The local values are always returned even if the "info" for a different shell rank is requested.

This PR fixes the object constructed for this and associated calls to return the correct information, and includes what was obviously a missing test.