### PR TITLE
flux-job: attach: support MPIR tool launch extension

### DIFF
--- a/src/cmd/job/mpir.c
+++ b/src/cmd/job/mpir.c
@@ -13,8 +13,8 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <errno.h>
 #include <unistd.h>
+#include <errno.h>
 #include <signal.h>
 
 #include <flux/core.h>
@@ -25,6 +25,8 @@
 #include "src/common/libdebugged/debugged.h"
 #include "src/shell/mpir/proctable.h"
 #include "ccan/str/str.h"
+
+extern char **environ;
 
 #ifndef VOLATILE
 # if defined(__STDC__) || defined(__cplusplus)
@@ -47,6 +49,9 @@ int MPIR_i_am_starter            = 1;
 int MPIR_acquired_pre_main       = 1;
 int MPIR_force_to_main           = 1;
 int MPIR_partial_attach_ok       = 1;
+
+char MPIR_executable_path[256];
+char MPIR_server_arguments[1024];
 
 static void setup_mpir_proctable (const char *s)
 {
@@ -74,6 +79,169 @@ static void gen_attach_signal (flux_t *h, flux_jobid_t id)
     flux_future_destroy (f);
 }
 
+static int mpir_args_assign (const char *argv0,
+                             const char *args,
+                             int args_len,
+                             int *argc,
+                             const char ***argv)
+{
+    int i = 0;
+    int n = 0;
+
+    *argv = NULL;
+    *argc = 0;
+
+    /*  First get number of entries in args */
+    while (i < args_len) {
+        int len = strlen (args+i);
+        if (len == 0)
+            break;
+        n++;
+        i += len + 1;
+    }
+    n = n + 1;
+
+    if (!(*argv = calloc (n+1, sizeof (char *)))) {
+        log_err ("MPIR: failed to allocate argv for tool launch");
+        return -1;
+    }
+
+    (*argv)[0] = argv0;
+    *argc = n;
+
+    if (n == 1)
+        return 0;
+
+    /*  Now assign remainder of argv */
+    i = 0;
+    n = 1;
+    while (i < args_len) {
+        int len = strlen (args+i);
+        if (len == 0)
+            break;
+        (*argv)[n++] = args+i;
+        i += len + 1;
+    }
+    return 0;
+}
+
+static int mpir_create_argv (const char path[],
+                             const char args[],
+                             int args_len,
+                             int *argc,
+                             const char ***argv)
+{
+    return mpir_args_assign (path, args, args_len, argc, argv);
+}
+
+static void completion_cb (flux_subprocess_t *p)
+{
+    int rank = flux_subprocess_rank (p);
+    int exitcode = flux_subprocess_exit_code (p);
+    int signum = flux_subprocess_signaled (p);
+    const char *prog = basename (MPIR_executable_path);
+
+    if (signum > 0)
+        log_msg ("MPIR: rank %d: %s: %s", rank, prog, strsignal (signum));
+    else if (exitcode != 0)
+        log_msg ("MPIR: rank %d: %s: Exit %d", rank, prog, exitcode);
+    flux_subprocess_destroy (p);
+}
+
+static flux_cmd_t *mpir_make_tool_cmd (const char *path,
+                                       const char *server_args,
+                                       int server_args_len)
+{
+    flux_cmd_t *cmd = NULL;
+    char *dir = NULL;
+    char **argv;
+    int argc;
+
+    if (mpir_create_argv (path,
+                          server_args,
+                          server_args_len,
+                          &argc,
+                          (const char ***) &argv) < 0)
+        return NULL;
+
+    if (argc == 0
+        || !(cmd = flux_cmd_create (argc, argv, environ))) {
+        log_err ("failed to create command from MPIR_executable_path");
+        return NULL;
+    }
+
+    flux_cmd_unsetenv (cmd, "FLUX_PROXY_REMOTE");
+    if (!(dir = get_current_dir_name ())
+        || flux_cmd_setcwd (cmd, dir) < 0)
+        log_err_exit ("failed to get or set current directory");
+    free (argv);
+    free (dir);
+    return cmd;
+}
+
+static void output_cb (flux_subprocess_t *p, const char *stream)
+{
+    const char *line;
+    int len = 0;
+    const char *prog = basename (MPIR_executable_path);
+    int rank = flux_subprocess_rank (p);
+
+    line = flux_subprocess_read_trimmed_line (p, stream, &len);
+    if (line && len == 0)
+        line = flux_subprocess_read (p, stream, -1, &len);
+    if (len)
+        log_msg ("MPIR: rank %d: %s: %s: %s", rank, prog, stream, line);
+}
+
+static void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
+{
+    if (state == FLUX_SUBPROCESS_FAILED) {
+        const char *prog = basename (MPIR_executable_path);
+        int rank = flux_subprocess_rank (p);
+        const char *errmsg = flux_subprocess_fail_error (p);
+        log_msg ("MPIR: rank %d: %s: %s", rank, prog, errmsg);
+        flux_subprocess_destroy (p);
+    }
+}
+
+static void launch_tool_daemons (flux_t *h,
+                                 const char *exec_service,
+                                 const char *tool_path,
+                                 const char *tool_args,
+                                 int tool_args_len,
+                                 struct idset *ranks)
+{
+    unsigned int rank;
+    flux_cmd_t *cmd;
+
+    flux_subprocess_ops_t ops = {
+        .on_completion = completion_cb,
+        .on_stdout = output_cb,
+        .on_stderr = output_cb,
+        .on_state_change = state_cb,
+    };
+
+    if (!(cmd = mpir_make_tool_cmd (tool_path, tool_args, tool_args_len)))
+        return;
+
+    rank = idset_first (ranks);
+    while (rank != IDSET_INVALID_ID) {
+        flux_subprocess_t *p;
+        if (!(p = flux_rexec_ex (h,
+                                 exec_service,
+                                 rank,
+                                 0,
+                                 cmd,
+                                 &ops,
+                                 NULL,
+                                 NULL)))
+            log_err ("MPIR: failed to launch %s", tool_path);
+        rank = idset_next (ranks, rank);
+    }
+    flux_cmd_destroy (cmd);
+    return;
+}
+
 void mpir_setup_interface (flux_t *h,
                            flux_jobid_t id,
                            bool debug_emulate,
@@ -81,11 +249,14 @@ void mpir_setup_interface (flux_t *h,
                            int leader_rank,
                            const char *shell_service)
 {
+    int len;
     char topic [1024];
     const char *s = NULL;
     flux_future_t *f = NULL;
 
-    snprintf (topic, sizeof (topic), "%s.proctable", shell_service);
+    len = snprintf (topic, sizeof (topic), "%s.proctable", shell_service);
+    if (len >= sizeof (topic))
+        log_msg_exit ("mpir: failed to create shell proctable topic string");
 
     if (!(f = flux_rpc_pack (h, topic, leader_rank, 0, "{}")))
         log_err_exit ("flux_rpc_pack");
@@ -94,6 +265,20 @@ void mpir_setup_interface (flux_t *h,
 
     setup_mpir_proctable (s);
     flux_future_destroy (f);
+
+    if (strlen (MPIR_executable_path) > 0) {
+        struct idset *ranks = proctable_get_ranks (proctable, NULL);
+        len = snprintf (topic, sizeof (topic), "%s.rexec", shell_service);
+        if (len >= sizeof (topic))
+            log_msg_exit ("mpir: failed to create shell rexec topic string");
+        launch_tool_daemons (h,
+                             topic,
+                             MPIR_executable_path,
+                             MPIR_server_arguments,
+                             sizeof (MPIR_server_arguments),
+                             ranks);
+        idset_destroy (ranks);
+    }
 
     MPIR_debug_state = MPIR_DEBUG_SPAWNED;
 

--- a/src/shell/mpir/proctable.h
+++ b/src/shell/mpir/proctable.h
@@ -9,6 +9,7 @@
 \************************************************************/
 
 #include <jansson.h>
+#include <flux/idset.h>
 
 #ifndef HAVE_PROCTABLE_H
 #define HAVE_PROCTABLE_H
@@ -39,6 +40,7 @@ json_t * proctable_to_json (struct proctable *p);
 /*  Append information for one task to the proctable `p`.
  */
 int proctable_append_task (struct proctable *p,
+                           int broker_rank,
                            const char *hostname,
                            const char *executable,
                            int taskid,
@@ -63,6 +65,14 @@ int proctable_append_proctable_destroy (struct proctable *p1,
  */
 MPIR_PROCDESC *proctable_get_mpir_proctable (struct proctable *p,
                                              int *sizep);
+
+/*  Return the idset of broker ranks which hold the taskids in the
+ *   provided idset. If taskids == NULL, then return all broker ranks.
+ */
+struct idset *proctable_get_ranks (struct proctable *p,
+                                   const struct idset *taskids);
+
+int proctable_get_broker_rank (struct proctable *p, int taskid);
 
 #endif
 

--- a/src/shell/mpir/test/proctable.c
+++ b/src/shell/mpir/test/proctable.c
@@ -17,64 +17,65 @@
 
 struct entry {
     const char *host;
+    int broker_rank;
     const char *executable;
     int taskid;
     int pid;
 };
 
 struct entry basic [] = {
-    { "foo0", "myapp", 0, 1234 },
-    { "foo0", "myapp", 1, 1235 },
-    { "foo0", "myapp", 2, 1236 },
-    { "foo0", "myapp", 3, 1237 },
-    { "foo1", "myapp", 4, 4589 },
-    { "foo1", "myapp", 5, 4590 },
-    { "foo1", "myapp", 6, 4591 },
-    { "foo1", "myapp", 7, 4592 },
-    { NULL, NULL, 0, 0 }
+    { "foo0", 0, "myapp", 0, 1234 },
+    { "foo0", 0, "myapp", 1, 1235 },
+    { "foo0", 0, "myapp", 2, 1236 },
+    { "foo0", 0, "myapp", 3, 1237 },
+    { "foo1", 1, "myapp", 4, 4589 },
+    { "foo1", 1, "myapp", 5, 4590 },
+    { "foo1", 1, "myapp", 6, 4591 },
+    { "foo1", 1, "myapp", 7, 4592 },
+    { NULL, 0, NULL, 0, 0 }
 };
 
 struct entry leadingzeros [] = {
-    { "foo00", "myapp", 0, 1234 },
-    { "foo00", "myapp", 1, 1235 },
-    { "foo00", "myapp", 2, 1236 },
-    { "foo00", "myapp", 3, 1237 },
-    { "foo01", "myapp", 4, 4589 },
-    { "foo01", "myapp", 5, 4590 },
-    { "foo01", "myapp", 6, 4591 },
-    { "foo01", "myapp", 7, 4592 },
-    { NULL, NULL, 0, 0 }
+    { "foo00", 13, "myapp", 0, 1234 },
+    { "foo00", 13, "myapp", 1, 1235 },
+    { "foo00", 13, "myapp", 2, 1236 },
+    { "foo00", 13, "myapp", 3, 1237 },
+    { "foo01", 15, "myapp", 4, 4589 },
+    { "foo01", 15, "myapp", 5, 4590 },
+    { "foo01", 15, "myapp", 6, 4591 },
+    { "foo01", 15, "myapp", 7, 4592 },
+    { NULL, 0, NULL, 0, 0 }
 };
 
 struct entry moreleadingzeros [] = {
-    { "foo008", "myapp", 0, 1234 },
-    { "foo008", "myapp", 1, 1235 },
-    { "foo009", "myapp", 2, 2689 },
-    { "foo009", "myapp", 3, 2690 },
-    { "foo010", "myapp", 4, 1236 },
-    { "foo010", "myapp", 5, 1237 },
-    { "foo011", "myapp", 6, 4589 },
-    { "foo011", "myapp", 7, 4590 },
-    { "foo012", "myapp", 8, 8591 },
-    { "foo012", "myapp", 9, 8592 },
-    { NULL, NULL, 0, 0 }
+    { "foo008", 8, "myapp", 0, 1234 },
+    { "foo008", 8, "myapp", 1, 1235 },
+    { "foo009", 9, "myapp", 2, 2689 },
+    { "foo009", 9, "myapp", 3, 2690 },
+    { "foo010", 10, "myapp", 4, 1236 },
+    { "foo010", 10, "myapp", 5, 1237 },
+    { "foo011", 11, "myapp", 6, 4589 },
+    { "foo011", 11, "myapp", 7, 4590 },
+    { "foo012", 12, "myapp", 8, 8591 },
+    { "foo012", 12, "myapp", 9, 8592 },
+    { NULL, 0, NULL, 0, 0 }
 };
 
 
 struct entry append1 [] = {
-    { "foo0", "myapp", 0, 1234 },
-    { "foo0", "myapp", 1, 1235 },
-    { "foo0", "myapp", 2, 1236 },
-    { "foo0", "myapp", 3, 1237 },
-    { NULL, NULL, 0, 0 },
+    { "foo0", 0, "myapp", 0, 1234 },
+    { "foo0", 0, "myapp", 1, 1235 },
+    { "foo0", 0, "myapp", 2, 1236 },
+    { "foo0", 0, "myapp", 3, 1237 },
+    { NULL, 0, NULL, 0, 0 },
 };
 
 struct entry append2 [] = {
-    { "foo1", "myapp", 4, 4589 },
-    { "foo1", "myapp", 5, 4590 },
-    { "foo1", "myapp", 6, 4591 },
-    { "foo1", "myapp", 7, 4592 },
-    { NULL, NULL, 0, 0 },
+    { "foo1", 1, "myapp", 4, 4589 },
+    { "foo1", 1, "myapp", 5, 4590 },
+    { "foo1", 1, "myapp", 6, 4591 },
+    { "foo1", 1, "myapp", 7, 4592 },
+    { NULL, 0, NULL, 0, 0 },
 };
 
 static struct proctable * proctable_test_create (struct entry e[])
@@ -84,12 +85,14 @@ static struct proctable * proctable_test_create (struct entry e[])
         BAIL_OUT ("proctable_create failed");
     while (e->host) {
         ok (proctable_append_task (p,
+                                   e->broker_rank,
                                    e->host,
                                    e->executable,
                                    e->taskid,
                                    e->pid) == 0,
-            "proctable_append [%s,%s,%d,%d]",
+            "proctable_append [%s,%d,%s,%d,%d]",
                                    e->host,
+                                   e->broker_rank,
                                    e->executable,
                                    e->taskid,
                                    e->pid);
@@ -124,13 +127,18 @@ static void proctable_check (struct proctable *p, const struct entry e[])
         "proctable_first_task works");
 
     for (int i = 0; i < size; i++) {
+        int broker_rank;
         is (table[i].host_name, e[i].host,
             "task%d: host is %s", i, table[i].host_name);
         is (table[i].executable_name, e[i].executable,
             "task%d: executable is %s", i, table[i].executable_name);
         ok (table[i].pid == e[i].pid,
             "task%d: pid is %d", i, table[i].pid);
+        broker_rank = proctable_get_broker_rank (p, i);
+        ok (broker_rank == e[i].broker_rank,
+            "task%d: broker rank is %d", i, broker_rank);
     }
+
 }
 
 static void dump_json (json_t *o)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -722,6 +722,8 @@ shell_mpir_SOURCES = shell/mpir.c
 shell_mpir_CPPFLAGS = $(test_cppflags)
 shell_mpir_LDADD = \
 	$(top_builddir)/src/shell/libmpir.la \
+	$(top_builddir)/src/cmd/job/mpir.o \
+	$(top_builddir)/src/common/libdebugged/libdebugged.la \
 	$(test_ldadd)
 shell_mpir_LDFLAGS = $(test_ldflags)
 

--- a/t/t2610-job-shell-mpir.t
+++ b/t/t2610-job-shell-mpir.t
@@ -48,5 +48,50 @@ test_expect_success 'flux-shell: test security of proctable method' '
 	flux job kill -s CONT ${id} &&
 	flux job attach ${id}
 '
+test_expect_success 'mpir: tool launch is supported' '
+	id=$(flux submit -N4 -n8 -o stop-tasks-in-exec /bin/true) &&
+	flux job wait-event -vt 5 -p exec -m sync=true $id shell.start &&
+	shell_rank=$(shell_leader_rank $id) &&
+	shell_service=$(shell_service $id) &&
+	${mpir} -r ${shell_rank} -s ${shell_service} \
+	    --tool-launch /bin/echo this is a tool >tool.log 2>&1 &&
+	test_debug "cat tool.log" &&
+	grep "MPIR: rank 0: echo: stdout: this is a tool" tool.log &&
+	grep "MPIR: rank 1: echo: stdout: this is a tool" tool.log &&
+	grep "MPIR: rank 2: echo: stdout: this is a tool" tool.log &&
+	grep "MPIR: rank 3: echo: stdout: this is a tool" tool.log &&
+	test $(grep -c "MPIR:.*this is a tool" tool.log) -eq 4 &&
+	flux job kill -s CONT $id &&
+	flux job attach $id
+'
+# Empty args for MPIR_executable_path -- also run with shell leader not
+# on broker rank 0 to ensure this configuration works with tool launch
+test_expect_success 'mpir: tool launch works with empty MPIR_server_arguments' '
+	id=$(flux submit --requires=rank:1,3 \
+	     -N2 -n2 -o stop-tasks-in-exec /bin/true) &&
+	flux job wait-event -vt 5 -p exec -m sync=true $id shell.start &&
+	shell_rank=$(shell_leader_rank $id) &&
+	shell_service=$(shell_service $id) &&
+	${mpir} -r ${shell_rank} -s ${shell_service} \
+	    --tool-launch hostname >tool2.log 2>&1 &&
+	test_debug "cat tool2.log" &&
+	grep "MPIR: rank 1: hostname: stdout:" tool2.log &&
+	grep "MPIR: rank 3: hostname: stdout:" tool2.log &&
+	test $(grep -c "MPIR:.*hostname:" tool2.log) -eq 2 &&
+	flux job kill -s CONT $id &&
+	flux job attach $id
+'
+test_expect_success 'mpir: tool launch reports errors' '
+	id=$(flux submit -N2 -n2 -o stop-tasks-in-exec /bin/true) &&
+	flux job wait-event -vt 5 -p exec -m sync=true $id shell.start &&
+	shell_rank=$(shell_leader_rank $id) &&
+	shell_service=$(shell_service $id) &&
+	${mpir} -r ${shell_rank} -s ${shell_service} \
+	    --tool-launch nosuchcommand >tool3.log 2>&1 &&
+	test_debug "cat tool3.log" &&
+	grep "MPIR: rank 0: nosuchcommand: error launching process" tool3.log &&
+	flux job kill -s CONT $id &&
+	flux job attach $id
+'
 
 test_done

--- a/t/t2610-job-shell-mpir.t
+++ b/t/t2610-job-shell-mpir.t
@@ -28,7 +28,7 @@ for test in 1:1 2:2 2:4 4:4 4:8 4:7; do
 	id=$(flux submit -o stop-tasks-in-exec \
              -n${TASKS} -N${NODES} /bin/true)  &&
         flux job wait-event -vt 5 -p exec -m sync=true ${id} shell.start &&
-        ${mpir} $(shell_leader_rank $id) $(shell_service $id) &&
+        ${mpir} -r $(shell_leader_rank $id) -s $(shell_service $id) &&
         flux job kill -s CONT ${id} &&
         flux job attach ${id}
     '
@@ -42,9 +42,9 @@ test_expect_success 'flux-shell: test security of proctable method' '
     shell_service=$(shell_service $id) &&
     ( export FLUX_HANDLE_USERID=9999 &&
       export FLUX_HANDLE_ROLEMASK=0x2 &&
-      test_expect_code 1 ${mpir} $shell_rank $shell_service
+      test_expect_code 1 ${mpir} -r $shell_rank -s $shell_service
     ) &&
-    ${mpir} $(shell_leader_rank $id) $(shell_service $id) &&
+    ${mpir} -r $(shell_leader_rank $id) -s $(shell_service $id) &&
     flux job kill -s CONT ${id} &&
     flux job attach ${id}
 '

--- a/t/t2610-job-shell-mpir.t
+++ b/t/t2610-job-shell-mpir.t
@@ -13,12 +13,12 @@ INITRC_PLUGINPATH="${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs"
 mpir="${SHARNESS_TEST_DIRECTORY}/shell/mpir"
 
 shell_leader_rank() {
-    flux job wait-event -f json -p exec $1 shell.init | \
-        jq '.context["leader-rank"]'
+	flux job wait-event -f json -p exec $1 shell.init | \
+	    jq '.context["leader-rank"]'
 }
 shell_service() {
-    flux job wait-event -f json -p exec $1 shell.init | \
-        jq -r '.context["service"]'
+	flux job wait-event -f json -p exec $1 shell.init | \
+	    jq -r '.context["service"]'
 }
 
 for test in 1:1 2:2 2:4 4:4 4:8 4:7; do
@@ -26,27 +26,27 @@ for test in 1:1 2:2 2:4 4:4 4:8 4:7; do
     NODES=${test%:*}
     test_expect_success "flux-shell: ${NODES}N/${TASKS}P: trace+mpir works" '
 	id=$(flux submit -o stop-tasks-in-exec \
-             -n${TASKS} -N${NODES} /bin/true)  &&
-        flux job wait-event -vt 5 -p exec -m sync=true ${id} shell.start &&
-        ${mpir} -r $(shell_leader_rank $id) -s $(shell_service $id) &&
-        flux job kill -s CONT ${id} &&
-        flux job attach ${id}
+	    -n${TASKS} -N${NODES} /bin/true)  &&
+	flux job wait-event -vt 5 -p exec -m sync=true ${id} shell.start &&
+	${mpir} -r $(shell_leader_rank $id) -s $(shell_service $id) &&
+	flux job kill -s CONT ${id} &&
+	flux job attach ${id}
     '
 done
 
 
 test_expect_success 'flux-shell: test security of proctable method' '
-    id=$(flux submit -o stop-tasks-in-exec /bin/true) &&
-    flux job wait-event -vt 5 -p exec -m sync=true ${id} shell.start &&
-    shell_rank=$(shell_leader_rank $id) &&
-    shell_service=$(shell_service $id) &&
-    ( export FLUX_HANDLE_USERID=9999 &&
-      export FLUX_HANDLE_ROLEMASK=0x2 &&
-      test_expect_code 1 ${mpir} -r $shell_rank -s $shell_service
-    ) &&
-    ${mpir} -r $(shell_leader_rank $id) -s $(shell_service $id) &&
-    flux job kill -s CONT ${id} &&
-    flux job attach ${id}
+	id=$(flux submit -o stop-tasks-in-exec /bin/true) &&
+	flux job wait-event -vt 5 -p exec -m sync=true ${id} shell.start &&
+	shell_rank=$(shell_leader_rank $id) &&
+	shell_service=$(shell_service $id) &&
+	( export FLUX_HANDLE_USERID=9999 &&
+	  export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  test_expect_code 1 ${mpir} -r $shell_rank -s $shell_service
+	) &&
+	${mpir} -r $(shell_leader_rank $id) -s $(shell_service $id) &&
+	flux job kill -s CONT ${id} &&
+	flux job attach ${id}
 '
 
 test_done


### PR DESCRIPTION
This PR adds the minimum support for the MPIR tool daemon launch extensions documented in [The MPIR Process Acquisition Interface Version 1.1 ](https://www.mpi-forum.org/docs/mpir-specification-03-01-2018.pdf), Section 7.1. It also splits the MPIR code in `src/cmd/job/attach.c` into its own source file so that the implementation can be tested with the "shell" mpir test utility in `t/shell/mpir.c`.

Currently the tool specified in `MPIR_executable_path` and `MPIR_server_arguments` is launched with libsubprocess. We depend on the disconnect handler to clean up stray tool processes if `flux job attach` is terminated or otherwise exits early.

This is currently a WIP because it adds a list of task/broker rank pairs to the shell `proctable` response since this was the simplest approach for now, but there's probably a more efficient way.

This PR is based on top of #5756 

