### PR TITLE
broker: catch an improper use of groups and handle it gracefully

### DIFF
--- a/src/broker/groups.c
+++ b/src/broker/groups.c
@@ -441,6 +441,11 @@ static void join_request_cb (flux_t *h,
 
     if (flux_request_unpack (msg, NULL, "{s:s}", "name", &name) < 0)
         goto error;
+    if (!flux_msg_is_local (msg)) {
+        errno = EPROTO;
+        errmsg = "groups.join is restricted to the local broker";
+        goto error;
+    }
     if (!(group = group_lookup (g, name, true)))
         goto error;
     if (group->join_request) {
@@ -485,6 +490,11 @@ static void leave_request_cb (flux_t *h,
 
     if (flux_request_unpack (msg, NULL, "{s:s}", "name", &name) < 0)
         goto error;
+    if (!flux_msg_is_local (msg)) {
+        errno = EPROTO;
+        errmsg = "groups.leave is restricted to the local broker";
+        goto error;
+    }
     if (!(group = group_lookup (g, name, false))
         || !group->join_request) {
         snprintf (errbuf,

--- a/t/scripts/groups.py
+++ b/t/scripts/groups.py
@@ -120,14 +120,23 @@ def join(args):
     """
     h = flux.Flux()
 
-    h.rpc("groups.join", {"name": args.name}).get()
+    h.rpc("groups.join", {"name": args.name}, nodeid=args.rank).get()
     if args.dubjoin:
-        h.rpc("groups.join", {"name": args.name}).get()
+        h.rpc("groups.join", {"name": args.name}, nodeid=args.rank).get()
 
     if args.leave:
-        h.rpc("groups.leave", {"name": args.name}).get()
+        h.rpc("groups.leave", {"name": args.name}, nodeid=args.rank).get()
         if args.dubleave:
             h.rpc("groups.leave", {"name": args.name}).get()
+
+
+def leave(args):
+    """
+    Leave group.
+    """
+    h = flux.Flux()
+
+    h.rpc("groups.leave", {"name": args.name}, nodeid=args.rank).get()
 
 
 LOGGER = logging.getLogger("groups")
@@ -183,14 +192,27 @@ def main():
     # join
     join_parser = subparsers.add_parser(
         "join",
-        usage="groups join [--dubjoin] [--leave] [--dubleave] name",
+        usage="groups join [--rank N] [--dubjoin] [--leave] [--dubleave] name",
         formatter_class=flux.util.help_formatter(),
     )
     join_parser.add_argument("--dubjoin", action="store_true")
     join_parser.add_argument("--leave", action="store_true")
     join_parser.add_argument("--dubleave", action="store_true")
+    join_parser.add_argument("--rank", type=int, default=flux.constants.FLUX_NODEID_ANY)
     join_parser.add_argument("name")
     join_parser.set_defaults(func=join)
+
+    # leave
+    leave_parser = subparsers.add_parser(
+        "leave",
+        usage="groups leave [--rank N] name",
+        formatter_class=flux.util.help_formatter(),
+    )
+    leave_parser.add_argument(
+        "--rank", type=int, default=flux.constants.FLUX_NODEID_ANY
+    )
+    leave_parser.add_argument("name")
+    leave_parser.set_defaults(func=leave)
 
     args = parser.parse_args()
     args.func(args)

--- a/t/t0027-broker-groups.t
+++ b/t/t0027-broker-groups.t
@@ -30,6 +30,15 @@ test_expect_success 'groups.get on rank > 0 fails with reasonable error' '
 	grep "only available on rank 0" test0.err
 '
 
+test_expect_success 'nonlocal groups.join fails with appropriate error' '
+	test_must_fail ${GROUPSCMD} join --rank 1 foo 2>rmtjoin.err &&
+	grep "restricted to the local broker" rmtjoin.err
+'
+test_expect_success 'nonlocal groups.leave fails with appropriate error' '
+	test_must_fail ${GROUPSCMD} leave --rank 1 foo 2>rmtleave.err &&
+	grep "restricted to the local broker" rmtleave.err
+'
+
 badjoin() {
 	flux python -c "import flux; print(flux.Flux().rpc(\"groups.join\").get())"
 }


### PR DESCRIPTION
Problem: `groups.join` and `groups.leave` RPCs do not behave as designed when used remotely, but this is allowed by the RPC handlers.
    
Respond with an error if the join/leave request is not of local origin.
