### PR TITLE
add `flux job hostpids` command

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -22,6 +22,7 @@ SYNOPSIS
 | **flux** **job** **timeleft** [*-H*] [*id*]
 | **flux** **job** **purge** [*-f*] [*--age-limit=FSD*] [*--num-limit=N*] [*ids...*]
 | **flux** **job** **info** [*--original*] [*--base*] *id* *key*
+| **flux** **job** **hostpids** [*OPTIONS*] *id*
 
 
 DESCRIPTION
@@ -456,6 +457,33 @@ R
      expiration time was extended (default)
 
    - with :option:`--base`: the initial R allocated by the scheduler
+
+hostpids
+--------
+
+.. program:: flux job hostpids
+
+:program:`flux job hostpids` prints a comma-delimited list of
+``hostname:PID`` pairs for all tasks in a running job. If the job is
+pending, :program:`flux job hostpids` will block until all tasks in the
+job are running.
+
+Options:
+
+.. option:: -d, --delimiter=STRING
+
+  Set the output delimiter to STRING (default=``,``).
+
+.. option:: -r, --ranks=IDSET
+
+  Restrict output to the task ranks in IDSET. The default is to display
+  all ranks.
+
+.. option:: -t, --timeout=DURATION
+
+  Timeout the command after DURATION, which is specified in FSD.
+  (a floating point value with optional suffix ``s`` for seconds,
+   ``m`` for minutes, ``h`` for hours, or ``d`` for days).
 
 
 RESOURCES

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -857,3 +857,4 @@ ttl
 uncomment
 unsatisfiable
 validators
+hostpids

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -443,6 +443,7 @@ _flux_job()
         taskmap \
         timeleft \
         last \
+        hostpids \
     "
     local nojob_subcmds="\
         cancelall \
@@ -555,6 +556,11 @@ _flux_job()
     "
     local timeleft_OPTS="\
         -H --human
+    "
+    local hostpids_OPTS="\
+        -d --delimiter= \
+        -t --timeout= \
+        -r --ranks= \
     "
     local last_OPTS=""
     if [[ $cmd != "job" ]]; then

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -156,7 +156,8 @@ flux_job_SOURCES = \
 	job/purge.c \
 	job/taskmap.c \
 	job/timeleft.c \
-	job/last.c
+	job/last.c \
+	job/hostpids.c
 
 flux_start_LDADD = \
 	$(fluxcmd_ldadd) \

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -138,6 +138,8 @@ flux_job_SOURCES = \
 	job/main.c \
 	job/common.c \
 	job/common.h \
+	job/mpir.c \
+	job/mpir.h \
 	job/attach.c \
 	job/submit.c \
 	job/list.c \

--- a/src/cmd/job/hostpids.c
+++ b/src/cmd/job/hostpids.c
@@ -1,0 +1,219 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* flux-job hostpids */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <stdio.h>
+
+#include <flux/core.h>
+#include <flux/optparse.h>
+#include <flux/idset.h>
+
+#ifndef HAVE_STRLCPY
+#include "src/common/libmissing/strlcpy.h"
+#endif
+
+#include "src/common/libutil/log.h"
+#include "src/common/libjob/idf58.h"
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libdebugged/debugged.h"
+#include "ccan/str/str.h"
+
+#include "common.h"
+#include "mpir.h"
+
+typedef struct {
+    char *host_name;
+    char *executable_name;
+    int pid;
+} MPIR_PROCDESC;
+
+extern int MPIR_proctable_size;
+extern MPIR_PROCDESC *MPIR_proctable;
+
+struct optparse_option hostpids_opts[] =  {
+    { .name = "delimiter",
+      .key = 'd',
+      .has_arg = 1,
+      .arginfo = "STRING",
+      .usage = "Set output delimiter (default=\",\")",
+    },
+    { .name = "ranks",
+      .key = 'r',
+      .has_arg = 1,
+      .arginfo = "IDSET",
+      .usage = "Include only task ranks in IDSET",
+    },
+    { .name = "timeout",
+      .key = 't',
+      .has_arg = 1,
+      .arginfo = "DURATION",
+      .usage = "timeout after DURATION",
+    },
+    OPTPARSE_TABLE_END
+};
+
+struct hostpids_ctx {
+    flux_t *h;
+    flux_jobid_t id;
+    optparse_t *opts;
+    int leader_rank;
+    char shell_service[128];
+};
+
+static void print_hostpids (const char *delim, struct idset *ranks)
+{
+    const char *delimiter = "";
+    for (int i = 0; i < MPIR_proctable_size; i++) {
+        if (ranks && !idset_test (ranks, i))
+            continue;
+        printf ("%s%s:%d",
+                delimiter,
+                MPIR_proctable[i].host_name,
+                MPIR_proctable[i].pid);
+        delimiter = delim;
+    }
+    printf ("\n");
+}
+
+static void mpir_setup (struct hostpids_ctx *ctx)
+{
+    mpir_setup_interface (ctx->h,
+                          ctx->id,
+                          false,
+                          false,
+                          ctx->leader_rank,
+                          ctx->shell_service);
+}
+
+static void event_watch_cb (flux_future_t *f, void *arg)
+{
+    struct hostpids_ctx *ctx = arg;
+    const char *entry;
+    json_t *o = NULL;
+    double timestamp;
+    const char *name;
+    json_t *context;
+
+    if (flux_job_event_watch_get (f, &entry) < 0) {
+        if (errno == ENODATA)
+            goto done;
+        if (errno == ETIMEDOUT)
+            log_msg_exit ("hostpids: timeout waiting for shell.start event");
+        if (errno == EPERM)
+            log_msg_exit ("hostpids: Permission denied");
+        log_msg_exit ("flux_job_event_watch_get: %s",
+                      future_strerror (f, errno));
+    }
+    if (!(o = eventlog_entry_decode (entry)))
+        log_err_exit ("eventlog_entry_decode");
+    if (eventlog_entry_parse (o, &timestamp, &name, &context) < 0)
+        log_err_exit ("eventlog_entry_parse");
+    if (streq (name, "shell.init")) {
+        const char *service;
+        int len = sizeof (ctx->shell_service);
+        if (json_unpack (context,
+                         "{s:i s:s}",
+                         "leader-rank", &ctx->leader_rank,
+                         "service", &service) < 0)
+            log_err_exit ("error decoding shell.init event");
+        if (strlcpy (ctx->shell_service, service, len) >= len)
+            log_msg_exit ("error caching shell service name");
+    }
+    else if (streq (name, "shell.start")) {
+        /* Setup MPIR_procdesc and pop out of reactor to print result */
+        mpir_setup (ctx);
+        goto done;
+    }
+    json_decref (o);
+    flux_future_reset (f);
+    return;
+done:
+    json_decref (o);
+    flux_future_destroy (f);
+}
+
+static void check_valid_jobid (struct hostpids_ctx *ctx, const char *jobid)
+{
+    flux_future_t *f;
+    flux_job_state_t state;
+
+    /*  Arrange for early exit if job is in INACTIVE or CLEANUP
+     */
+    if (!(f = flux_job_list_id (ctx->h, ctx->id, "[\"state\"]")))
+        log_err_exit ("failed to issue job-list.list-id RPC");
+    if (flux_rpc_get_unpack (f, "{s:{s:i}}", "job", "state", &state) < 0) {
+        if (errno == ENOENT)
+            log_msg_exit ("%s: No such job", jobid);
+        log_err_exit ("job list failed for %s", jobid);
+    }
+    flux_future_destroy (f);
+    if (!(state & FLUX_JOB_STATE_ACTIVE))
+        log_msg_exit ("hostpids: job %s is inactive", jobid);
+}
+
+int cmd_hostpids (optparse_t *p, int argc, char **argv)
+{
+    int optindex = optparse_option_index (p);
+    flux_future_t *f;
+    struct hostpids_ctx ctx = { 0 };
+    struct idset *task_ranks = NULL;
+    idset_error_t error;
+    const char *jobid;
+    const char *delim = optparse_get_str (p, "delimiter", ",");
+    const char *ranks = optparse_get_str (p, "ranks", "all");
+    double timeout = optparse_get_duration (p, "timeout", -1.);
+
+    if (streq (delim, "\\n"))
+        delim = "\n";
+
+    if (argc - optindex != 1) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+
+    if (!streq (ranks, "all")
+        && !(task_ranks = idset_decode_ex (ranks, -1, -1, 0, &error)))
+        log_err_exit ("--ranks=%s: %s", ranks, error.text);
+
+    jobid = argv[optindex];
+    ctx.opts = p;
+    ctx.id = parse_jobid (jobid);
+    if (!(ctx.h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    check_valid_jobid (&ctx, jobid);
+
+    if (!(f = flux_job_event_watch (ctx.h,
+                                    ctx.id,
+                                    "guest.exec.eventlog",
+                                    FLUX_JOB_EVENT_WATCH_WAITCREATE)))
+        log_err_exit ("flux_job_event_watch");
+    if (flux_future_then (f, timeout, event_watch_cb, &ctx) < 0)
+        log_err_exit ("flux_future_then");
+
+    if (flux_reactor_run (flux_get_reactor (ctx.h), 0) < 0)
+        log_err_exit ("flux_reactor_run");
+
+    if (MPIR_proctable_size <= 0)
+        log_msg_exit ("failed to get MPIR_proctable from job shell");
+
+    print_hostpids (delim, task_ranks);
+    idset_destroy (task_ranks);
+    flux_close (ctx.h);
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/cmd/job/main.c
+++ b/src/cmd/job/main.c
@@ -91,6 +91,10 @@ extern struct optparse_option timeleft_opts[];
 
 extern int cmd_last (optparse_t *p, int argc, char **argv);
 
+extern int cmd_hostpids (optparse_t *p, int argc, char **argv);
+extern struct optparse_option hostpids_opts[];
+
+
 static struct optparse_option global_opts[] =  {
     OPTPARSE_TABLE_END
 };
@@ -256,6 +260,13 @@ static struct optparse_subcommand subcommands[] = {
       cmd_timeleft,
       0,
       timeleft_opts,
+    },
+    { "hostpids",
+      "[OPTIONS] JOBID",
+      "Print host:pid pairs for tasks in JOBID",
+      cmd_hostpids,
+      0,
+      hostpids_opts,
     },
     { "last",
       "SLICE",

--- a/src/cmd/job/mpir.c
+++ b/src/cmd/job/mpir.c
@@ -1,0 +1,119 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* flux-job MPIR support */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include <flux/core.h>
+#include <flux/optparse.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libjob/idf58.h"
+#include "src/common/libdebugged/debugged.h"
+#include "src/shell/mpir/proctable.h"
+#include "ccan/str/str.h"
+
+#ifndef VOLATILE
+# if defined(__STDC__) || defined(__cplusplus)
+# define VOLATILE volatile
+# else
+# define VOLATILE
+# endif
+#endif
+
+#define MPIR_NULL                  0
+#define MPIR_DEBUG_SPAWNED         1
+#define MPIR_DEBUG_ABORTING        2
+
+VOLATILE int MPIR_debug_state    = MPIR_NULL;
+struct proctable *proctable      = NULL;
+MPIR_PROCDESC *MPIR_proctable    = NULL;
+int MPIR_proctable_size          = 0;
+char *MPIR_debug_abort_string    = NULL;
+int MPIR_i_am_starter            = 1;
+int MPIR_acquired_pre_main       = 1;
+int MPIR_force_to_main           = 1;
+int MPIR_partial_attach_ok       = 1;
+
+static void setup_mpir_proctable (const char *s)
+{
+    if (!(proctable = proctable_from_json_string (s))) {
+        errno = EINVAL;
+        log_err_exit ("proctable_from_json_string");
+    }
+    MPIR_proctable = proctable_get_mpir_proctable (proctable,
+                                                   &MPIR_proctable_size);
+    if (!MPIR_proctable) {
+        errno = EINVAL;
+        log_err_exit ("proctable_get_mpir_proctable");
+    }
+}
+
+static void gen_attach_signal (flux_t *h, flux_jobid_t id)
+{
+    flux_future_t *f = NULL;
+    if (!(f = flux_job_kill (h, id, SIGCONT)))
+        log_err_exit ("flux_job_kill");
+    if (flux_rpc_get (f, NULL) < 0)
+        log_msg_exit ("kill %s: %s",
+                      idf58 (id),
+                      future_strerror (f, errno));
+    flux_future_destroy (f);
+}
+
+void mpir_setup_interface (flux_t *h,
+                           flux_jobid_t id,
+                           bool debug_emulate,
+                           bool stop_tasks_in_exec,
+                           int leader_rank,
+                           const char *shell_service)
+{
+    char topic [1024];
+    const char *s = NULL;
+    flux_future_t *f = NULL;
+
+    snprintf (topic, sizeof (topic), "%s.proctable", shell_service);
+
+    if (!(f = flux_rpc_pack (h, topic, leader_rank, 0, "{}")))
+        log_err_exit ("flux_rpc_pack");
+    if (flux_rpc_get (f, &s) < 0)
+        log_err_exit ("%s", topic);
+
+    setup_mpir_proctable (s);
+    flux_future_destroy (f);
+
+    MPIR_debug_state = MPIR_DEBUG_SPAWNED;
+
+    /* Signal the parallel debugger */
+    MPIR_Breakpoint ();
+
+    if (stop_tasks_in_exec || debug_emulate) {
+        /* To support MPIR_partial_attach_ok, we need to send SIGCONT to
+         * those MPI processes to which the debugger didn't attach.
+         * However, all of the debuggers that I know of do ignore
+         * additional SIGCONT being sent to the processes they attached to.
+         * Therefore, we send SIGCONT to *every* MPI process.
+         *
+         * We also send SIGCONT under the debug-emulate flag. This allows us
+         * to write a test for attach mode. The running job will exit
+         * on SIGCONT.
+         */
+        gen_attach_signal (h, id);
+    }
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/cmd/job/mpir.h
+++ b/src/cmd/job/mpir.h
@@ -1,0 +1,21 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef FLUX_JOB_MPIR_H
+#define FLUX_JOB_MPIR_H 1
+
+void mpir_setup_interface (flux_t *h,
+                           flux_jobid_t id,
+                           bool debug_emulate,
+                           bool stop_tasks_in_exec,
+                           int leader_rank,
+                           const char *shell_service);
+
+#endif /* !FLUX_JOB_MPIR_H */

--- a/src/shell/mpir/test/rangelist.c
+++ b/src/shell/mpir/test/rangelist.c
@@ -71,6 +71,47 @@ void test_rangelist_append_dups (void)
     rangelist_destroy (rl2);
 }
 
+void test_rangelist_append_range_dups (void)
+{
+    struct rangelist *rl = rangelist_create ();
+    ok (rangelist_append (rl, 1) == 0
+        && rangelist_append (rl, 1) == 0
+        && rangelist_append (rl, 1) == 0
+        && rangelist_append (rl, 1) == 0,
+        "rangelist_append 4 1s");
+    ok (rangelist_append (rl, 2) == 0
+        && rangelist_append (rl, 2) == 0
+        && rangelist_append (rl, 2) == 0
+        && rangelist_append (rl, 2) == 0,
+        "rangelist_append 4 2s");
+    ok (rangelist_append (rl, 3) == 0
+        && rangelist_append (rl, 3) == 0
+        && rangelist_append (rl, 3) == 0
+        && rangelist_append (rl, 3) == 0,
+        "rangelist_append 4 3s");
+    ok (rangelist_append (rl, 4) == 0
+        && rangelist_append (rl, 4) == 0
+        && rangelist_append (rl, 4) == 0
+        && rangelist_append (rl, 4) == 0,
+        "rangelist_append 4 4s");
+    rangelist_diag (rl);
+
+    json_t *o;
+    ok ((o = rangelist_to_json (rl)) != NULL,
+        "rangelist_to_json");
+
+    struct rangelist *rl2 = rangelist_from_json (o);
+    ok (rl2 != NULL,
+        "rangelist_from_json works size=%d",
+        rangelist_size (rl2));
+    ok (rangelist_size (rl2) == rangelist_size (rl),
+        "rangelist_size matches");
+
+    json_decref (o);
+    rangelist_destroy (rl);
+    rangelist_destroy (rl2);
+}
+
 void test_rangelist_basic (void)
 {
     struct rangelist *rl2;
@@ -158,6 +199,7 @@ int main (int argc, char **argv)
     test_rangelist_basic ();
     test_rangelist_append ();
     test_rangelist_append_dups ();
+    test_rangelist_append_range_dups ();
     done_testing ();
     return 0;
 }


### PR DESCRIPTION
This PR adds a `flux job hostpids` command which uses the job shell's `proctable` RPC to emit the `host:PID` pairs for all tasks in a job.

This is useful for tools that take this information on the command line and do not support Flux natively.