### PR TITLE
shell: support opening output files with `-o output.mode=append`

### DIFF
--- a/doc/man1/common/job-shell-options.rst
+++ b/doc/man1/common/job-shell-options.rst
@@ -47,3 +47,7 @@
      - Set KVS output limit to SIZE bytes, where SIZE may be a floating point
        value including optional SI units: k, K, M, G. This value is ignored
        if output is directed to a file with :option:`--output`.
+
+   * - :option:`output.mode`
+     - Set the open mode for output files to either "truncate" or "append".
+       The default is "truncate".

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -330,6 +330,11 @@ plugins include:
 
   Set job stderr/out file output to PATH.
 
+.. option:: output.mode=truncate|append
+
+  Set the mode in which output files are opened to either truncate or
+  append. The default is to truncate.
+
 .. option:: input.stdin.type=TYPE
 
   Set job input for **stdin** to *TYPE*. *TYPE* may be either ``service``

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -366,4 +366,27 @@ test_expect_success LONGTEST 'job-shell: no truncation at 10MB for single-user j
 test_expect_success 'job-shell: invalid output.limit string is rejected' '
 	test_must_fail flux run -o output.limit=foo hostname
 '
+test_expect_success 'job-shell: output.mode=append works' '
+	flux bulksubmit --watch --output=append.out \
+		-o output.mode=append echo {} \
+		::: one two three &&
+	test_debug "cat append.out" &&
+	test $(wc -l < append.out) -eq 3 &&
+	grep one append.out &&
+	grep two append.out &&
+	grep three append.out
+'
+test_expect_success 'job-shell: output.mode=truncate works' '
+	cat <<-EOF >trunc.out &&
+	test text
+	EOF
+	flux run --output=trunc.out hostname &&
+	test $(wc -l <trunc.out) -eq 1 &&
+	test_must_fail grep "test text" trunc.out
+'
+test_expect_success 'job-shell: invalid output.mode emits warning' '
+	flux run --output=inval.out -o output.mode=foo hostname 2>inval.err &&
+	test_debug "cat inval.out" &&
+	grep "ignoring invalid output.mode=foo" inval.err
+'
 test_done


### PR DESCRIPTION
This PR adds a new job shell output option `output.mode`. The valid values are "truncate" (the default) and "append", which opens any output files with `O_APPEND` instead of `O_TRUNC`.
