### PR TITLE
github: update deprecated actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         queries: security-and-quality
         config-file: ./.github/codeql/codeql-config.yml
@@ -83,6 +83,6 @@ jobs:
         make -j 4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     name: python linting
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.6
     - uses: actions/checkout@v4
@@ -193,7 +193,7 @@ jobs:
         fi
 
     - name: docker buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       if: matrix.needs_buildx
 
     - name: setup qemu-user-static
@@ -213,8 +213,9 @@ jobs:
       if: success() && matrix.coverage
       env:
         DOCKER_REPO:
-      uses: codecov/codecov-action@858dd794fbb81941b6d60b0dca860878cba60fa9 # v3.1.1
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{matrix.coverage_flags}}
 
     - name: docker deploy

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -190,7 +190,7 @@ matrix.add_build(
     name="coverage",
     coverage_flags="ci-basic",
     coverage=True,
-    jobs=2,
+    jobs=4,
     args="--with-flux-security --enable-caliper",
 )
 
@@ -243,7 +243,7 @@ matrix.add_build(
     coverage_flags="ci-system",
     image="el8",
     coverage=True,
-    jobs=2,
+    jobs=4,
     command_args="--system",
     args="--with-flux-security --enable-caliper",
 )


### PR DESCRIPTION
This PR fixes warnings about `Node.js 16 actions are deprecated.` 
Also, now that 4 cores are available to Github actions builders increase coverage build parallelism to `-j4`.