### PR TITLE
testsuite: fix lingering processes after `make check`

### DIFF
--- a/t/t2800-jobs-recursive.t
+++ b/t/t2800-jobs-recursive.t
@@ -104,4 +104,8 @@ test_expect_success 'flux jobs --json works with recursive jobs' '
 test_expect_success FLUX_SECURITY 'cancel alternate user job' '
 	flux cancel $(cat altid)
 '
+test_expect_success 'cancel recursive job safely' '
+	flux proxy $rid flux cancel --all &&
+	flux job wait-event -vt 30 $rid clean
+'
 test_done

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -108,6 +108,10 @@ test_expect_success 'flux uri resolves hierarchical jobids with ?local' '
 	test_debug "echo ${jobid}/${jobid2}?local is ${uri}"
 
 '
+test_expect_success 'terminate batch job cleanly' '
+	flux proxy $(flux uri --local ${jobid}) flux cancel --all &&
+	flux job wait-event -vt 30 ${jobid} clean
+'
 test_expect_success 'flux uri jobid returns error for non-instance job' '
 	id=$(flux submit sleep 600) &&
 	test_expect_code 1 flux uri $id


### PR DESCRIPTION
This PR attempts to fix or workaround an issue that I keep seeing: A couple orphaned instances that stick around after `make -j N check`. A quick investigation showed that the instances all had a sleep job stuck in CLEANUP, with the scheduler unloaded, and had at least instance-level 1 (so they were batch jobs run within the test instance).

I wasn't really able to make a reproducer for this issue, but terminating the affected instances more cleanly seems to resolve the problem (at least in my testing), so it seems like a good idea to do that.