### PR TITLE
job-manager: support suppression of prolog/epilog output with `perilog.log-ignore` pattern list

### DIFF
--- a/doc/guide/admin.rst
+++ b/doc/guide/admin.rst
@@ -666,6 +666,16 @@ components need to be configured, which is explained in the steps below.
           "-e", "/usr/libexec/flux/flux-imp,run,epilog"
        ]
 
+  4. (optional) If log messages from the prolog or epilog are filling
+     up the broker logs, a list of ignore patterns may be added via
+     the ``[job-manager.perilog]`` ``log-ignore`` array. Each entry
+     in the array should be a :linux:man7:`regex`. POSIX extended
+     regular expression syntax is supported, e.g.:
+
+     .. code-block:: toml
+     [job-manager]
+     perilog.log-ignore = [ ".*Xauth.*", "^foo:.*debug" ]
+
 Note that the ``flux perilog-run`` command will additionally execute any
 scripts in ``/etc/flux/system/{prolog,epilog}.d`` on rank 0 by default as
 part of the job-manager prolog/epilog. Only place scripts here if there is

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -858,3 +858,4 @@ uncomment
 unsatisfiable
 validators
 hostpids
+Xauth


### PR DESCRIPTION
On large systems, the `flux-perilog-run` script is generating hundreds of lines of useless output from an asyncio issue (see #5752). Additionally, there could be lots of other output or errors from the prolog/epilog that should be suppressed.

This PR introduces a new configuration list `job-manager.perilog.log-ignore` that contains a list of regexes to suppress from the logs for the prolog and epilog.

