### PR TITLE
docker: add script help message for macOS

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -27,7 +27,7 @@ die() { echo -e "$prog: $@"; exit 1; }
 #
 declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,unit-test-only,quick-check,inception,platform:,workdir:,system"
 declare -r short_opts="hqIdi:S:j:t:D:Prup:"
-declare -r usage="
+declare usage="
 Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
 Build docker image for CI builds, then run tests inside the new\n\
 container as the current user and group.\n\
@@ -59,9 +59,13 @@ Options:\n\
 "
 
 # check if running in OSX
-if [[ "$(uname)" == "Darwin" ]]; then
+if [[ "$(uname)" == "Darwin" ]] && [[ $FORCE_GNU_GETOPT != 1 ]]; then
     # BSD getopt
     GETOPTS=`getopt $short_opts -- $*`
+    usage=${usage}"\n\
+    You are using BSD getopt on macOS. BSD getopt does not recognize '='\n\
+    between options. Use a space instead. If gnu-getopt is first in your\n\
+    PATH, force the script to use that by setting FORCE_GNU_GETOPT=1.\n"
 else
     # GNU getopt
     GETOPTS=`getopt -u -o $short_opts -l $long_opts -n $prog -- $@`


### PR DESCRIPTION
Recently, several core developers have noted that the docker-run-checks.sh script borks when command-line options that specify values do so with an equals sign rather than a space. Since this is not super intuitive, update the usage/help message for that script accordingly.

I pulled out all the = signs from the usage message and added a note, but maybe one or the other is more desirable.