### PR TITLE
improve handling of lost job shells

### DIFF
--- a/src/bindings/python/flux/job/watcher.py
+++ b/src/bindings/python/flux/job/watcher.py
@@ -401,7 +401,7 @@ class JobWatcher:
         if os.WIFEXITED(status):
             status = os.WEXITSTATUS(status)
         elif os.WIFSIGNALED(status):
-            status = 127 + os.WTERMSIG(status)
+            status = 128 + os.WTERMSIG(status)
         return status
 
     def start(self):

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -752,5 +752,17 @@ const char *bulk_exec_service_name (struct bulk_exec *exec)
     return exec->service;
 }
 
+flux_subprocess_t *bulk_exec_get_subprocess (struct bulk_exec *exec, int rank)
+{
+    flux_subprocess_t *p = zlist_first (exec->processes);
+    while (p) {
+        if (flux_subprocess_rank (p) == rank)
+            return p;
+        p = zlist_next (exec->processes);
+    }
+    errno = ENOENT;
+    return NULL;
+}
+
 /* vi: ts=4 sw=4 expandtab
  */

--- a/src/modules/job-exec/bulk-exec.h
+++ b/src/modules/job-exec/bulk-exec.h
@@ -97,4 +97,9 @@ int bulk_exec_total (struct bulk_exec *exec);
 /* Get subprocess remote exec service name (never returns NULL) */
 const char *bulk_exec_service_name (struct bulk_exec *exec);
 
+/*  Get the subprocess handle for a rank
+ */
+flux_subprocess_t *bulk_exec_get_subprocess (struct bulk_exec *exec,
+                                             int rank);
+
 #endif /* !HAVE_JOB_EXEC_BULK_EXEC_H */

--- a/src/modules/job-exec/bulk-exec.h
+++ b/src/modules/job-exec/bulk-exec.h
@@ -25,8 +25,8 @@ typedef void (*exec_exit_f) (struct bulk_exec *, void *arg,
 typedef void (*exec_io_f)   (struct bulk_exec *,
                              flux_subprocess_t *,
                              const char *stream,
-			     const char *data,
-			     int data_len,
+                             const char *data,
+                             int data_len,
                              void *arg);
 
 typedef void (*exec_error_f) (struct bulk_exec *,
@@ -42,10 +42,10 @@ struct bulk_exec_ops {
 };
 
 struct bulk_exec * bulk_exec_create (struct bulk_exec_ops *ops,
-		                     const char *service,
-				     flux_jobid_t id,
-				     const char *name,
-				     void *arg);
+                                     const char *service,
+                                     flux_jobid_t id,
+                                     const char *name,
+                                     void *arg);
 
 void *bulk_exec_aux_get (struct bulk_exec *exec, const char *key);
 

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -188,6 +188,11 @@ static int lost_shell (struct jobinfo *job,
                        FLUX_JOB_EXCEPTION_CRIT,
                        "%s",
                        msg);
+        /* If an exception was raised, do not duplicate the message
+         * to the shell exception service since the message will already
+         * be displayed as part of the exception note:
+         */
+        msg = "";
     }
 
     /* Also notify job shell rank 0 of exception

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -164,19 +164,29 @@ static void lost_shell_continuation (flux_future_t *f, void *arg)
 static int lost_shell (struct jobinfo *job,
                        bool raise_exception,
                        int shell_rank,
-                       const char *hostname)
+                       const char *fmt,
+                       ...)
 {
     flux_future_t *f;
+    char msgbuf[160];
+    int msglen = sizeof (msgbuf);
+    char *msg = msgbuf;
+    va_list ap;
+
+    if (fmt) {
+        va_start (ap, fmt);
+        if (vsnprintf (msg, msglen, fmt, ap) >= msglen)
+            (void) snprintf (msg, msglen, "%s", "lost contact with job shell");
+        va_end (ap);
+    }
 
     if (raise_exception) {
         /* Raise a non-fatal job exception */
         jobinfo_raise (job,
                        "node-failure",
                        FLUX_JOB_EXCEPTION_CRIT,
-                       "%s on %s (shell rank %d)",
-                       "lost contact with job shell",
-                       hostname,
-                       shell_rank);
+                       "%s",
+                       msg);
     }
 
     /* Also notify job shell rank 0 of exception
@@ -210,7 +220,13 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
     if (cmd) {
         if (errnum == EHOSTUNREACH) {
             if (!idset_test (job->critical_ranks, shell_rank)
-                && lost_shell (job, true, shell_rank, hostname) == 0)
+                && lost_shell (job,
+                               true,
+                               shell_rank,
+                               "%s on %s (shell rank %d)",
+                               "lost contact with job shell",
+                               hostname,
+                               shell_rank) == 0)
                 return;
             jobinfo_fatal_error (job,
                                 0,

--- a/src/shell/exception.c
+++ b/src/shell/exception.c
@@ -48,7 +48,7 @@ static void exception_handler (flux_t *h,
 
     if (flux_respond (h, msg, NULL) < 0)
         shell_log_errno ("flux_respond");
-
+    return;
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         shell_log_errno ("flux_respond_error");

--- a/src/shell/exception.c
+++ b/src/shell/exception.c
@@ -34,14 +34,19 @@ static void exception_handler (flux_t *h,
     const char *type;
     int severity = -1;
     int shell_rank = -1;
+    const char *message = "";
 
     if (flux_request_unpack (msg,
                              NULL,
-                             "{s:s s:i s:i}",
+                             "{s:s s:i s:i s?s}",
                              "type", &type,
                              "severity", &severity,
-                             "shell_rank", &shell_rank) < 0)
+                             "shell_rank", &shell_rank,
+                             "message", &message) < 0)
         goto error;
+
+    if (strlen (message) > 0)
+        shell_warn ("%s", message);
 
     if (streq (type, "lost-shell") && severity > 0) {
         flux_plugin_arg_t *args = flux_plugin_arg_create ();

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -617,7 +617,7 @@ static void shell_output_write_completion (flux_future_t *f, void *arg)
 {
     struct shell_output *out = arg;
 
-    if (flux_future_get (f, NULL) < 0)
+    if (flux_future_get (f, NULL) < 0 && errno != ENOSYS)
         shell_log_errno ("shell_output_write");
     zlist_remove (out->pending_writes, f);
     flux_future_destroy (f);
@@ -738,7 +738,7 @@ void shell_output_destroy (struct shell_output *out)
             flux_future_t *f;
 
             while ((f = zlist_pop (out->pending_writes))) { // follower only
-                if (flux_future_get (f, NULL) < 0)
+                if (flux_future_get (f, NULL) < 0 && errno != ENOSYS)
                     shell_log_errno ("shell_output_write");
                 flux_future_destroy (f);
             }

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -88,6 +88,7 @@ struct shell_output {
     struct eventlogger *ev;
     double batch_timeout;
     int refcount;
+    struct idset *active_shells;
     zlist_t *pending_writes;
     json_t *output;
     bool stopped;
@@ -528,15 +529,25 @@ static void shell_output_decref (struct shell_output *out,
     }
 }
 
+static void shell_output_decref_shell_rank (struct shell_output *out,
+                                            int shell_rank,
+                                            flux_msg_handler_t *mh)
+{
+    if (idset_test (out->active_shells, shell_rank)
+        && idset_clear (out->active_shells, shell_rank) == 0)
+        shell_output_decref (out, mh);
+}
+
 static int shell_output_write_leader (struct shell_output *out,
                                       const char *type,
+                                      int shell_rank,
                                       json_t *o,
                                       flux_msg_handler_t *mh) // may be NULL
 {
     json_t *entry;
 
     if (streq (type, "eof")) {
-        shell_output_decref (out, mh);
+        shell_output_decref_shell_rank (out, shell_rank, mh);
         return 0;
     }
     if (!(entry = eventlog_entry_pack (0., type, "O", o))) // increfs 'o'
@@ -581,16 +592,18 @@ static void shell_output_write_cb (flux_t *h,
                                    void *arg)
 {
     struct shell_output *out = arg;
+    int shell_rank;
     json_t *o;
     const char *type;
 
     if (flux_request_unpack (msg,
                              NULL,
-                             "{s:s s:o}",
+                             "{s:s s:i s:o}",
                              "name", &type,
+                             "shell_rank", &shell_rank,
                              "context", &o) < 0)
         goto error;
-    if (shell_output_write_leader (out, type, o, mh) < 0)
+    if (shell_output_write_leader (out, type, shell_rank, o, mh) < 0)
         goto error;
     if (flux_respond (out->shell->h, msg, NULL) < 0)
         shell_log_errno ("flux_respond");
@@ -618,9 +631,10 @@ static int shell_output_write_type (struct shell_output *out,
                                     json_t *context)
 {
     flux_future_t *f = NULL;
+    int shell_rank = out->shell->info->shell_rank;
 
-    if (out->shell->info->shell_rank == 0) {
-        if (shell_output_write_leader (out, type, context, NULL) < 0)
+    if (shell_rank == 0) {
+        if (shell_output_write_leader (out, type, 0, context, NULL) < 0)
             shell_log_errno ("shell_output_write_leader");
     }
     else {
@@ -628,8 +642,9 @@ static int shell_output_write_type (struct shell_output *out,
                                        "write",
                                         0,
                                         0,
-                                        "{s:s s:O}",
+                                        "{s:s s:i s:O}",
                                         "name", type,
+                                        "shell_rank", shell_rank,
                                         "context", context)))
             goto error;
         if (flux_future_then (f, -1, shell_output_write_completion, out) < 0)
@@ -699,10 +714,11 @@ static void shell_output_type_file_cleanup (struct shell_output_type_file *ofp)
 void shell_output_destroy (struct shell_output *out)
 {
     if (out) {
+        int shell_rank = out->shell->info->shell_rank;
         int saved_errno = errno;
         flux_future_t *f = NULL;
 
-        if (out->shell->info->shell_rank != 0) {
+        if (shell_rank != 0) {
             /* Nonzero shell rank: send EOF to leader shell to notify
              *  that no more messages will be sent to shell.write
              */
@@ -710,8 +726,10 @@ void shell_output_destroy (struct shell_output *out)
                                            "write",
                                             0,
                                             0,
-                                            "{s:s s:{}}",
-                                            "name", "eof", "context")))
+                                            "{s:s s:i s:{}}",
+                                            "name", "eof",
+                                            "shell_rank", shell_rank,
+                                            "context")))
                 shell_log_errno ("shell.write: eof");
             flux_future_destroy (f);
         }
@@ -1127,11 +1145,19 @@ static int shell_lost (flux_plugin_t *p,
                        void *data)
 {
     struct shell_output *out = data;
+    int shell_rank;
+
     /*  A shell has been lost. We need to decref the output refcount by 1
      *  since we'll never hear from that shell to avoid rank 0 shell from
      *  hanging.
      */
-    shell_output_decref (out, NULL);
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:i}",
+                                "shell_rank", &shell_rank) < 0)
+        return shell_log_errno ("shell.lost: unpack of shell_rank failed");
+    shell_output_decref_shell_rank (out, shell_rank, NULL);
+    shell_debug ("lost shell rank %d", shell_rank);
     return 0;
 }
 
@@ -1223,6 +1249,15 @@ struct shell_output *shell_output_create (flux_shell_t *shell)
              *   to be decremented as they send EOF or exit.
              */
             out->refcount = (shell->info->shell_size - 1 + ntasks);
+
+            /*  Account for active shells to avoid double-decrement of
+             *  refcount when a shell exits prematurely
+             */
+            if (!(out->active_shells = idset_create (0, IDSET_FLAG_AUTOGROW))
+                || idset_range_set (out->active_shells,
+                                    0,
+                                    shell->info->shell_size - 1) < 0)
+                goto error;
             if (flux_shell_add_completion_ref (shell, "output.write") < 0)
                 goto error;
             if (!(out->output = json_array ())) {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -357,6 +357,7 @@ dist_check_SCRIPTS = \
 	issues/t5308-kvsdir-initial-path.py \
 	issues/t5368-kvs-commit-clear.py \
 	issues/t5657-kvs-getroot-namespace.sh \
+	issues/t2492-shell-lost.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t2492-shell-lost.sh
+++ b/t/issues/t2492-shell-lost.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+log() { printf "t2492: $@\n" >&2; }
+die() { log "$@"; exit 1; }
+
+#  Check if we need to start parent job, if so, reexec under flux-start
+#  using the per-broker for test-pmi-clique so that the instance mapping
+#  simulates multiple nodes.
+#
+export FLUX_URI_RESOLVE_LOCAL=t
+if test "$T2492_ACTIVE" != "t"; then
+    export T2492_ACTIVE=t
+    log "Re-launching test script under flux-start using $(command -v flux)"
+    exec flux start -s 4 $0
+fi
+
+CRITICAL_RANKS=$(cat <<EOF
+import os
+import sys
+import time
+import flux
+
+try:
+    h = flux.Flux()
+    #
+    # Wait on barrier to ensure all tasks have started
+    # (prevents premature termintion by SIGINT while Python is initiating)
+    #
+    size = int(os.environ["FLUX_JOB_SIZE"])
+    taskid = int(os.environ["FLUX_TASK_RANK"])
+    if taskid == 0:
+        print(f"waiting on barrier for {size} tasks", flush=True)
+    h.barrier("test", size)
+    if taskid == 0:
+        print(f"exited barrier", flush=True)
+
+    # Kill job shell on broker rank 3
+    broker_rank = h.get_rank()
+    if broker_rank == 3:
+        #  kill job shell
+        os.kill(os.getppid(), 9)
+        sys.exit(0)
+
+    # Sleep in all other tasks
+    time.sleep(600)
+except KeyboardInterrupt:
+    sys.exit(0)
+EOF
+)
+id=$(flux submit -N4 --tasks-per-node=2 \
+	--input=/dev/null \
+	-o exit-timeout=none \
+	--add-file=critical.py="${CRITICAL_RANKS}" \
+	flux python {{tmpdir}}/critical.py)
+
+log "Sumbmitted job $id. Waiting for shell rank 3 to be lost"
+
+value="shell rank 3 (on $(hostname -s)): Killed"
+flux job wait-event -Wt 15 -Hvp output -m message="$value" $id log 
+
+log "Sending SIGINT to $id. Job should now exit"
+flux job kill --signal=2 $id
+flux job attach -vEX $id
+rc=$?
+log "Job exited with rc=$rc (expecting 137 (128+9))"
+test $rc -eq 137 || die "Unexpected job exit code $rc"

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -42,7 +42,23 @@ test_expect_success 'flux-shell: run script with 2 nodes and exit-on-error' '
 	test_must_fail run_timeout 30 flux run \
 		-n2 -N2 -o exit-on-error ./testscript.sh
 '
-
+test_expect_success 'flux-shell: exit-timeout catches lost shell' '
+	cat >test2.sh <<-"EOF" &&
+	#!/bin/bash
+	if test $FLUX_TASK_RANK -eq 1; then
+	    kill -9 $PPID
+	    exit
+	fi
+	sleep 30
+	EOF
+	chmod +x test2.sh &&
+	test_must_fail run_timeout 30 flux run \
+		-n2 -N2 -o exit-timeout=1s ./test2.sh
+'
+test_expect_success 'flux-shell: exit-on-error catches lost shell' '
+	test_must_fail run_timeout 30 flux run \
+		-n2 -N2 -o exit-on-error ./test2.sh
+'
 test_expect_success 'flux-shell: exit-timeout=aaa is rejected' '
 	test_must_fail flux run -o exit-timeout=aaa /bin/true
 '


### PR DESCRIPTION
Currently, job shells are detected as "lost" during a job only if a whole node or broker disappears. If a job shell abnormally terminates for some other reason, the rest of the job is not aware which can lead to hangs at exit as noted in #2492.
Also, tasks managed by lost shells are not considered exited, so the exit-timeout and exit-on-error parameters do not have an effect in this case, which could lead a broken job to run until its timeout.

This PR attempts to partially address this situation by having the job execution system report to the leader shell when any other job shell terminates due to a signal. Other abnormal exit conditions are not captured because this is expected behavior, and the hope is that the shell was able to complete its normal shutdown activities in this case, such as sending EOF to the output service of the leader shell and reporting task exit to the doom plugin.

The shell rank that terminated is also passed along to the shell exception handler and the `shell.lost` plugin callback. The output plugin then uses this to adjust its reference count so that it doesn't wait forever for an eof that will never arrive.

Finally, the doom plugin gets a `shell.lost` callback and treats this as a task exit so that the first-task exit timer begins, or a job exception is raised immediately if `exit-on-error` is set.
