### PR TITLE
modules/content: drop incorrect assertion

### DIFF
--- a/src/modules/content/cache.c
+++ b/src/modules/content/cache.c
@@ -190,8 +190,8 @@ static void cache_entry_destroy (struct cache_entry *e)
 {
     if (e) {
         int saved_errno = errno;
-        assert (e->load_requests == NULL);
-        assert (e->store_requests == NULL);
+        msgstack_destroy (&e->load_requests);
+        msgstack_destroy (&e->store_requests);
         if (e->mmapped)
             content_mmap_region_decref (e->data_container);
         else


### PR DESCRIPTION
Problem: sometimes brokers hit an assertion when the content module is unloaded during shutdown.

The assertion is that there are no pending load/store operations waiting on a cache entry when it is destroyed.  This is certainly possible, depending on the behavior of users of the load/store RPCs.  In the case of unload in rc3, dependent modules would have already been unloaded, so it seems safe to simply destroy any pending RPCs without responding to them.

Destroy them, if present.

Fixes #5706