### PR TITLE
job-manager: drop sched.free response requirement

### DIFF
--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -92,7 +92,6 @@ def alloc_query(handle):
         sys.exit(1)
     print("{0} alloc requests queued".format(query["queue_length"]))
     print("{0} alloc requests pending to scheduler".format(query["alloc_pending"]))
-    print("{0} free requests pending to scheduler".format(query["free_pending"]))
     print("{0} running jobs".format(query["running"]))
 
 

--- a/src/common/libschedutil/free.c
+++ b/src/common/libschedutil/free.c
@@ -19,11 +19,7 @@
 
 int schedutil_free_respond (schedutil_t *util, const flux_msg_t *msg)
 {
-    flux_jobid_t id;
-
-    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
-        return -1;
-    return flux_respond_pack (util->h, msg, "{s:I}", "id", id);
+    return 0;
 }
 
 /*

--- a/src/common/libschedutil/free.h
+++ b/src/common/libschedutil/free.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-/* Respond to a free request.
+/* This is a no-op now that sched.free doesn't require a response.
  */
 int schedutil_free_respond (schedutil_t *util, const flux_msg_t *msg);
 

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -327,16 +327,18 @@ int event_job_action (struct event *event, struct job *job)
                 && !job->perilog_active
                 && !job->alloc_bypass
                 && !job->start_pending
-                && !job->free_pending) {
+                && !job->free_posted) {
                 if (alloc_send_free_request (ctx->alloc, job) < 0)
                     return -1;
+                if (event_job_post_pack (ctx->event, job, "free", 0, NULL) < 0)
+                    return -1;
+                job->free_posted = 1;
             }
 
             /* Post cleanup event when cleanup is complete.
              */
             if (!job->alloc_queued
                 && !job->alloc_pending
-                && !job->free_pending
                 && !job->start_pending
                 && !job->has_resources
                 && !job_event_is_queued (job, "epilog-start")

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -41,7 +41,7 @@ struct job {
     uint8_t alloc_queued:1; // queued for alloc, but alloc request not sent
     uint8_t alloc_pending:1;// alloc request sent to sched
     uint8_t alloc_bypass:1; // alloc bypass enabled
-    uint8_t free_pending:1; // free request sent to sched
+    uint8_t free_posted:1;  // free event already posted
     uint8_t has_resources:1;
     uint8_t start_pending:1;// start request sent to job-exec
     uint8_t reattach:1;

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -2356,8 +2356,7 @@ static int jobtap_emit_perilog_event (struct jobtap *jobtap,
      */
     if ((prolog && job->start_pending)
         || ((prolog && start) && job->state == FLUX_JOB_STATE_CLEANUP)
-        || (!prolog && job->state != FLUX_JOB_STATE_CLEANUP)
-        || (!prolog && job->free_pending)) {
+        || (!prolog && job->state != FLUX_JOB_STATE_CLEANUP)) {
         errno = EINVAL;
         return -1;
     }

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -36,7 +36,6 @@ void test_create (void)
         && job->flags == 0,
         "job_create set id, urgency, userid, and t_submit to expected values");
     ok (!job->alloc_pending
-        && !job->free_pending
         && !job->has_resources,
         "job_create set no internal flags");
     ok (job->handle == NULL,
@@ -190,7 +189,6 @@ void test_create_from_eventlog (void)
     ok (job->id == 2,
         "job_create_from_eventlog log=(submit) set id from param");
     ok (!job->alloc_pending
-        && !job->free_pending
         && !job->has_resources,
         "job_create_from_eventlog log=(submit)  set no internal flags");
     ok (job->userid == 66,
@@ -224,7 +222,6 @@ void test_create_from_eventlog (void)
     ok (job->t_submit == 42.2,
         "job_create_from_eventlog log=(submit+urgency) set t_submit from submit");
     ok (!job->alloc_pending
-        && !job->free_pending
         && !job->has_resources,
         "job_create_from_eventlog log=(submit+urgency) set no internal flags");
     ok (job->state == FLUX_JOB_STATE_DEPEND,
@@ -252,7 +249,6 @@ void test_create_from_eventlog (void)
     ok (job->t_submit == 42.2,
         "job_create_from_eventlog log=(submit+depend+priority) set t_submit from submit");
     ok (!job->alloc_pending
-        && !job->free_pending
         && !job->has_resources,
         "job_create_from_eventlog log=(submit+depend+priority) set no internal flags");
     ok (job->state == FLUX_JOB_STATE_SCHED,
@@ -276,7 +272,6 @@ void test_create_from_eventlog (void)
     ok (job->t_submit == 42.2,
         "job_create_from_eventlog log=(submit+ex0) set t_submit from submit");
     ok (!job->alloc_pending
-        && !job->free_pending
         && !job->has_resources,
         "job_create_from_eventlog log=(submit+ex0) set no internal flags");
     ok (job->state == FLUX_JOB_STATE_CLEANUP,
@@ -296,7 +291,6 @@ void test_create_from_eventlog (void)
     ok (job->state == FLUX_JOB_STATE_DEPEND,
         "job_create_from_eventlog log=(submit+ex1) set state=DEPEND");
     ok (!job->alloc_pending
-        && !job->free_pending
         && !job->has_resources,
         "job_create_from_eventlog log=(submit+ex1) set no internal flags");
     job_decref (job);
@@ -312,7 +306,6 @@ void test_create_from_eventlog (void)
                   error.text);
     }
     ok (!job->alloc_pending
-        && !job->free_pending
         && job->has_resources,
         "job_create_from_eventlog log=(submit+depend+priority+alloc) set has_resources flag");
     ok (job->R_redacted != NULL,
@@ -345,7 +338,6 @@ void test_create_from_eventlog (void)
                   error.text);
     }
     ok (!job->alloc_pending
-        && !job->free_pending
         && !job->has_resources,
         "job_create_from_eventlog log=(submit+depend+priority+alloc+ex0+free) set no internal flags");
     ok (job->state == FLUX_JOB_STATE_CLEANUP,

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -365,16 +365,16 @@ void free_cb (flux_t *h, const flux_msg_t *msg, const char *R_str, void *arg)
 
     if (flux_request_unpack (msg, NULL, "{s:o}", "R", &R) < 0) {
         flux_log (h, LOG_ERR, "free: error unpacking sched.free request");
-        if (flux_respond_error (h, msg, EINVAL, NULL) < 0)
-            flux_log_error (h, "free_cb: flux_respond_error");
         return;
     }
 
     if (try_free (h, ss, R) < 0) {
-        if (flux_respond_error (h, msg, errno, NULL) < 0)
-            flux_log_error (h, "free_cb: flux_respond_error");
+        flux_log_error (h, "free: could not free R");
         return;
     }
+    /* This is a no-op now that sched.free requires no response
+     * but we still call it to get test coverage.
+     */
     if (schedutil_free_respond (ss->util_ctx, msg) < 0)
         flux_log_error (h, "free_cb: schedutil_free_respond");
 

--- a/t/t2223-job-manager-queue-priority-order-limited.t
+++ b/t/t2223-job-manager-queue-priority-order-limited.t
@@ -37,7 +37,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	Scheduling is started
 	2 alloc requests queued
 	2 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_all1.exp counts_all1.out
@@ -58,7 +57,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	Scheduling is stopped
 	0 alloc requests queued
 	0 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_all2.exp counts_all2.out
@@ -89,7 +87,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	Scheduling is started
 	1 alloc requests queued
 	2 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_all3.exp counts_all3.out
@@ -173,7 +170,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	debug: Scheduling is started
 	6 alloc requests queued
 	2 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_named1.exp counts_named1.out
@@ -211,7 +207,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	debug: Scheduling is stopped
 	0 alloc requests queued
 	2 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_named2.exp counts_named2.out
@@ -253,7 +248,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	debug: Scheduling is started
 	2 alloc requests queued
 	2 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_named3.exp counts_named3.out

--- a/t/t2224-job-manager-queue-priority-order-unlimited.t
+++ b/t/t2224-job-manager-queue-priority-order-unlimited.t
@@ -36,7 +36,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	Scheduling is started
 	0 alloc requests queued
 	3 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_all1.exp counts_all1.out
@@ -57,7 +56,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	Scheduling is stopped
 	0 alloc requests queued
 	0 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_all2.exp counts_all2.out
@@ -87,7 +85,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	Scheduling is started
 	0 alloc requests queued
 	2 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_all3.exp counts_all3.out
@@ -144,7 +141,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	debug: Scheduling is started
 	0 alloc requests queued
 	8 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_named1.exp counts_named1.out
@@ -182,7 +178,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	debug: Scheduling is stopped
 	0 alloc requests queued
 	2 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_named2.exp counts_named2.out
@@ -224,7 +219,6 @@ test_expect_success 'job-manager: queue counts are as expected' '
 	debug: Scheduling is started
 	0 alloc requests queued
 	4 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	2 running jobs
 	EOT
 	test_cmp counts_named3.exp counts_named3.out

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -260,7 +260,6 @@ test_expect_success 'flux-queue: queue status -v shows expected counts' '
 	Scheduling is started
 	1 alloc requests queued
 	1 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	1 running jobs
 	EOT
 	test_cmp stat.exp stat.out
@@ -282,7 +281,6 @@ test_expect_success 'flux-queue: queue status -v shows expected counts' '
 	Scheduling is stopped
 	0 alloc requests queued
 	0 alloc requests pending to scheduler
-	0 free requests pending to scheduler
 	0 running jobs
 	EOT
 	test_cmp stat2.exp stat2.out

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -187,8 +187,7 @@ test_expect_success 'sched-simple: remove sched-simple and cancel jobs' '
 '
 test_expect_success 'sched-simple: there are no outstanding sched requests' '
 	flux queue status -v >queue_status.out &&
-	grep "0 alloc requests pending to scheduler" queue_status.out &&
-	grep "0 free requests pending to scheduler" queue_status.out
+	grep "0 alloc requests pending to scheduler" queue_status.out
 '
 test_expect_success 'sched-simple: reload in unlimited mode' '
 	flux module load sched-simple mode=unlimited &&
@@ -257,8 +256,7 @@ test_expect_success 'sched-simple: remove sched-simple and cancel jobs' '
 '
 test_expect_success 'sched-simple: there are no outstanding sched requests' '
 	flux queue status -v >queue_status.out &&
-	grep "0 alloc requests pending to scheduler" queue_status.out &&
-	grep "0 free requests pending to scheduler" queue_status.out
+	grep "0 alloc requests pending to scheduler" queue_status.out
 '
 
 test_expect_success 'sched-simple: load sched-simple and wait for queue drain' '


### PR DESCRIPTION
Problem: the `sched.free` RPC requires a response but the response is unnecessary for correct job management.
    
Moreover, the coupling between the RPC response and the job state machine makes some anticipated changes harder to design.
    
Make `sched.free` a "fire and forget" RPC.  Simply post the `free` event immediately instead of deferring it until the response is received..

Update `flux queue status -v` output to not show pending free rpcs, since they can no longer be pending.
    
This change should be accompanied by an update to RFC 27.
