### PR TITLE
testsuite: fix test that kills the wrong processes

### DIFF
--- a/t/issues/t2492-shell-lost.sh
+++ b/t/issues/t2492-shell-lost.sh
@@ -47,7 +47,7 @@ except KeyboardInterrupt:
     sys.exit(0)
 EOF
 )
-id=$(flux submit -N4 --tasks-per-node=2 \
+id=$(flux submit -N4 --tasks-per-node=1 \
 	--input=/dev/null \
 	-o exit-timeout=none \
 	--add-file=critical.py="${CRITICAL_RANKS}" \


### PR DESCRIPTION
Problem: the t2492-shell-lost.sh sends a SIGKILL to the wrong process.

This test runs a job whose two tasks on shell rank 3 try to send a SIGKILL to their parent, the shell.  One succeeds and the other, slower, task may be reparented before calling os.getppid and thus sends the signal to the wrong task.

Running two tasks per shell seems like it doesn't further the purpose of the test so just run one task per shell.

Fixes #5791