### PR TITLE
add a faster way to get resource allocation status than sched.resource-status RPC

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -32,8 +32,8 @@ acquires a subset of resources from the resource service to allocate to jobs,
 and relies on the resource service to inform it of status changes that affect
 the usability of resources by jobs as described in RFC 27.
 
-The :program:`flux resource list` subcommand queries the scheduler for its view
-of resources, including allocated/free status.
+The :program:`flux resource list` subcommand queries the resource module
+for the scheduler view of resources, including allocated/free status.
 
 The other :program:`flux resource` subcommands operate on the resource service
 and are primarily of interest to system administrators of a Flux system
@@ -182,9 +182,9 @@ online
 resources that share a state and online/offline state.
 
 .. note::
-  :program:`flux resource status` queries both the resource service and
-  the scheduler to identify resources that are available, excluded by
-  configuration, or administratively drained or draining.
+  :program:`flux resource status` queries both the administrative and
+  scheduler view of resources to identify resources that are available,
+  excluded by configuration, or administratively drained or draining.
 
 .. option:: -s, --states=STATE,...
 

--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -344,6 +344,12 @@ components or writing tests.
    commands to resolve URIs to local form.  This is useful in test environments
    where the remote connector does not work.
 
+.. envvar:: FLUX_RESOURCE_STATUS_RPC
+
+   If set, :man1:`flux-resource` uses the specified RPC topic string instead
+   of ``resource.sched-status``.  This is used in test to verify that the
+   ``sched.resource-status`` RPC used in earlier releases still works for
+   backwards compatibility.
 
 MISCELLANEOUS
 =============

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -227,7 +227,7 @@ class InstanceInfo:
             if not uri or SchedResourceList is None:
                 raise ValueError
             handle = flux.Flux(str(uri))
-            future = handle.rpc("sched.resource-status")
+            future = handle.rpc("resource.sched-status", nodeid=0)
             self.stats = StatsInfo(handle).update_sync()
             self.resources = SchedResourceList(future.get())
             self.initialized = True

--- a/src/bindings/python/flux/resource/list.py
+++ b/src/bindings/python/flux/resource/list.py
@@ -8,6 +8,8 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import os
+
 from flux.idset import IDset
 from flux.memoized_property import memoized_property
 from flux.resource import ResourceSet
@@ -98,4 +100,5 @@ def resource_list(flux_handle):
     Returns:
         ResourceListRPC: a future representing the request.
     """
-    return ResourceListRPC(flux_handle, "resource.sched-status", nodeid=0)
+    topic = os.getenv("FLUX_RESOURCE_LIST_RPC") or "resource.sched-status"
+    return ResourceListRPC(flux_handle, topic, nodeid=0)

--- a/src/bindings/python/flux/resource/list.py
+++ b/src/bindings/python/flux/resource/list.py
@@ -16,7 +16,7 @@ from flux.rpc import RPC
 
 class SchedResourceList:
     """
-    Encapsulate response from sched.resource-status query.
+    Encapsulate response from resource.sched-status query.
     The response will contain 3 Rv1 resource sets:
 
     :ivar all:         all resources known to scheduler
@@ -98,4 +98,4 @@ def resource_list(flux_handle):
     Returns:
         ResourceListRPC: a future representing the request.
     """
-    return ResourceListRPC(flux_handle, "sched.resource-status")
+    return ResourceListRPC(flux_handle, "resource.sched-status", nodeid=0)

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -408,7 +408,7 @@ static void resource_continuation (flux_future_t *f, void *arg)
 
     if (flux_rpc_get_unpack (f, "o", &o) < 0) {
         if (errno != ENOSYS) /* Instance may not be up yet */
-            fatal (errno, "sched.resource-status RPC failed");
+            fatal (errno, "resource.sched-status RPC failed");
     }
     else {
         json_t *queue_constraint;
@@ -432,7 +432,7 @@ static void resource_continuation (flux_future_t *f, void *arg)
                                &sum->core.down,
                                &sum->gpu.down,
                                queue_constraint) < 0)
-            fatal (0, "error decoding sched.resource-status RPC response");
+            fatal (0, "error decoding resource.sched-status RPC response");
     }
     flux_future_destroy (f);
     sum->f_resource = NULL;
@@ -539,7 +539,7 @@ void summary_pane_query (struct summary_pane *sum)
 {
     if (!sum->f_resource) {
         if (!(sum->f_resource = flux_rpc (sum->top->h,
-                                          "sched.resource-status",
+                                          "resource.sched-status",
                                           NULL,
                                           0,
                                           0))

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -223,7 +223,9 @@ job_manager_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
-	$(JANSSON_LIBS)
+	$(top_builddir)/src/common/librlist/librlist.la \
+	$(JANSSON_LIBS) \
+	$(HWLOC_LIBS)
 job_manager_la_LDFLAGS = \
 	$(fluxlib_ldflags) \
 	-avoid-version \

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -125,10 +125,13 @@ TESTS = \
 test_ldadd = \
 	libjob-manager.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(LIBPTHREAD) $(JANSSON_LIBS)
+	$(LIBPTHREAD) \
+	$(JANSSON_LIBS) \
+	$(HWLOC_LIBS)
 
 test_cppflags = \
 	$(AM_CPPFLAGS)

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -161,8 +161,10 @@ int cancel_request (struct alloc *alloc, struct job *job)
 /* Handle a sched.alloc response.
  * Update flags.
  */
-static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
-                               const flux_msg_t *msg, void *arg)
+static void alloc_response_cb (flux_t *h,
+                               flux_msg_handler_t *mh,
+                               const flux_msg_t *msg,
+                               void *arg)
 {
     struct job_manager *ctx = arg;
     struct alloc *alloc = ctx->alloc;
@@ -349,8 +351,10 @@ error:
 /* sched-hello:
  * Scheduler obtains jobs that have resources allocated.
  */
-static void hello_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+static void hello_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     struct job_manager *ctx = arg;
     struct job *job;
@@ -392,8 +396,10 @@ error:
  * and tells job-manager to start allocations.  job-manager tells
  * scheduler how many jobs are in the queue.
  */
-static void ready_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+static void ready_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     struct job_manager *ctx = arg;
     const char *mode;
@@ -480,8 +486,10 @@ static bool alloc_work_available (struct job_manager *ctx)
  * Runs right before reactor calls poll(2).
  * If a job can be scheduled, start idle watcher.
  */
-static void prep_cb (flux_reactor_t *r, flux_watcher_t *w,
-                     int revents, void *arg)
+static void prep_cb (flux_reactor_t *r,
+                     flux_watcher_t *w,
+                     int revents,
+                     void *arg)
 {
     struct job_manager *ctx = arg;
 
@@ -493,8 +501,10 @@ static void prep_cb (flux_reactor_t *r, flux_watcher_t *w,
  * Runs right after reactor calls poll(2).
  * Stop idle watcher, and send next alloc request, if available.
  */
-static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
-                      int revents, void *arg)
+static void check_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
 {
     struct job_manager *ctx = arg;
     struct alloc *alloc = ctx->alloc;
@@ -662,7 +672,8 @@ int alloc_queue_recalc_pending (struct alloc *alloc)
            && tail) {
         if (job_priority_comparator (head, tail) < 0) {
             if (alloc_cancel_alloc_request (alloc, tail) < 0) {
-                flux_log_error (alloc->ctx->h, "%s: alloc_cancel_alloc_request",
+                flux_log_error (alloc->ctx->h,
+                                "%s: alloc_cancel_alloc_request",
                                 __FUNCTION__);
                 return -1;
             }

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -33,7 +33,9 @@ libresource_la_SOURCES = \
 	inventory.c \
 	inventory.h \
 	rutil.c \
-	rutil.h
+	rutil.h \
+	status.c \
+	status.h
 
 TESTS = test_rutil.t
 

--- a/src/modules/resource/acquire.c
+++ b/src/modules/resource/acquire.c
@@ -301,13 +301,15 @@ static void cancel_cb (flux_t *h,
  */
 void acquire_disconnect (struct acquire *acquire, const flux_msg_t *msg)
 {
-    flux_t *h = acquire->ctx->h;
-    int count;
+    if (acquire) { // acquire is NULL on rank > 0
+        flux_t *h = acquire->ctx->h;
+        int count;
 
-    if ((count = flux_msglist_disconnect (acquire->requests, msg)) < 0)
-        flux_log_error (h, "error handling discnonect request");
-    if (count > 0)
-        flux_log (h, LOG_DEBUG, "aborted %d resource.acquire(s)", count);
+        if ((count = flux_msglist_disconnect (acquire->requests, msg)) < 0)
+            flux_log_error (h, "error handling discnonect request");
+        if (count > 0)
+            flux_log (h, LOG_DEBUG, "aborted %d resource.acquire(s)", count);
+    }
 }
 
 /* An event was committed to resource.eventlog.

--- a/src/modules/resource/monitor.c
+++ b/src/modules/resource/monitor.c
@@ -30,9 +30,7 @@
  *   ranks in the initial program for the same reason as above.
  * - the 'resource.monitor-waitup' RPC allows a test to wait for some number
  *   of ranks to be up, where "up" is defined as having had an online event
- *   posted.  Thus, after waiting, resource.status (flux resource status)
- *   should show those ranks up, while sched.resource-status
- *   (flux resource list command) may still show them down.
+ *   posted.
  */
 
 #if HAVE_CONFIG_H

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -172,7 +172,6 @@ error:
 }
 
 /* Handle client disconnect.
- * Abort a streaming resource.acquire RPC, if it matches.
  */
 static void disconnect_cb (flux_t *h,
                            flux_msg_handler_t *mh,
@@ -183,6 +182,8 @@ static void disconnect_cb (flux_t *h,
 
     if (ctx->acquire)
         acquire_disconnect (ctx->acquire, msg);
+    if (ctx->status)
+        status_disconnect (ctx->status, msg);
 }
 
 flux_t *resource_parent_handle_open (struct resource_ctx *ctx)
@@ -247,7 +248,7 @@ static const struct flux_msg_handler_spec htab[] = {
         .typemask = FLUX_MSGTYPE_REQUEST,
         .topic_glob = "resource.disconnect",
         .cb = disconnect_cb,
-        .rolemask = 0
+        .rolemask = FLUX_ROLE_USER
     },
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -34,6 +34,7 @@
 #include "exclude.h"
 #include "acquire.h"
 #include "rutil.h"
+#include "status.h"
 
 /* Parse [resource] table.
  *
@@ -184,56 +185,6 @@ static void disconnect_cb (flux_t *h,
         acquire_disconnect (ctx->acquire, msg);
 }
 
-static void status_cb (flux_t *h,
-                       flux_msg_handler_t *mh,
-                       const flux_msg_t *msg,
-                       void *arg)
-{
-    struct resource_ctx *ctx = arg;
-    json_t *drain;
-    const json_t *R;
-    json_t *o = NULL;
-    const char *errstr = NULL;
-
-    if (flux_request_decode (msg, NULL, NULL) < 0)
-        goto error;
-    if (ctx->rank != 0) {
-        errno = EPROTO;
-        errstr = "this RPC only works on rank 0";
-        goto error;
-    }
-    if (!(R = inventory_get (ctx->inventory)))
-        goto error;
-    if (!(drain = drain_get_info (ctx->drain)))
-        goto error;
-    if (!(o = json_pack ("{s:O s:o}", "R", R, "drain", drain))) {
-        json_decref (drain);
-        errno = ENOMEM;
-        goto error;
-    }
-    if (rutil_set_json_idset (o,
-                              "online",
-                              monitor_get_up (ctx->monitor)) < 0)
-        goto error;
-    if (rutil_set_json_idset (o,
-                              "offline",
-                              monitor_get_down (ctx->monitor)) < 0)
-        goto error;
-    if (rutil_set_json_idset (o,
-                              "exclude",
-                              exclude_get (ctx->exclude)) < 0)
-        goto error;
-    if (flux_respond_pack (h, msg, "o", o) < 0) {
-        flux_log_error (h, "error responding to resource.status request");
-        json_decref (o);
-    }
-    return;
-error:
-    if (flux_respond_error (h, msg, errno, errstr) < 0)
-        flux_log_error (h, "error responding to resource.status request");
-    json_decref (o);
-}
-
 flux_t *resource_parent_handle_open (struct resource_ctx *ctx)
 {
     if (!ctx->parent_h) {
@@ -261,6 +212,7 @@ static void resource_ctx_destroy (struct resource_ctx *ctx)
 {
     if (ctx) {
         int saved_errno = errno;
+        status_destroy (ctx->status);
         acquire_destroy (ctx->acquire);
         drain_destroy (ctx->drain);
         topo_destroy (ctx->topology);
@@ -290,12 +242,6 @@ static const struct flux_msg_handler_spec htab[] = {
         .topic_glob = "resource.config-reload",
         .cb = config_reload_cb,
         .rolemask = 0
-    },
-    {
-        .typemask = FLUX_MSGTYPE_REQUEST,
-        .topic_glob = "resource.status",
-        .cb = status_cb,
-        .rolemask = FLUX_ROLE_USER,
     },
     {
         .typemask = FLUX_MSGTYPE_REQUEST,
@@ -500,7 +446,6 @@ int mod_main (flux_t *h, int argc, char **argv)
         if (!(ctx->drain = drain_create (ctx, eventlog)))
             goto error;
     }
-
     /*  topology is initialized after exclude/drain etc since this
      *  rank may attempt to drain itself due to a topology mismatch.
      */
@@ -509,6 +454,8 @@ int mod_main (flux_t *h, int argc, char **argv)
     if (!(ctx->monitor = monitor_create (ctx,
                                          inventory_get_size (ctx->inventory),
                                          monitor_force_up)))
+        goto error;
+    if (!(ctx->status = status_create (ctx)))
         goto error;
     if (ctx->rank == 0) {
         if (post_restart_event (ctx, eventlog ? 1 : 0) < 0)

--- a/src/modules/resource/resource.h
+++ b/src/modules/resource/resource.h
@@ -21,6 +21,7 @@ struct resource_ctx {
     struct exclude *exclude;
     struct acquire *acquire;
     struct reslog *reslog;
+    struct status *status;
 
     flux_t *parent_h;
     int parent_refcount;

--- a/src/modules/resource/status.c
+++ b/src/modules/resource/status.c
@@ -13,6 +13,7 @@
 #endif
 #include <jansson.h>
 #include <flux/core.h>
+#include <flux/idset.h>
 
 #include "resource.h"
 #include "inventory.h"
@@ -24,13 +25,15 @@
 
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/errno_safe.h"
+#include "src/common/librlist/rlist.h"
 
 struct status {
     struct resource_ctx *ctx;
     flux_msg_handler_t **handlers;
+    struct flux_msglist *requests;
 };
 
-static json_t *prepare_response (struct status *status)
+static json_t *prepare_status_payload (struct status *status)
 {
     struct resource_ctx *ctx = status->ctx;
     const struct idset *down = monitor_get_down (ctx->monitor);
@@ -76,7 +79,7 @@ static void status_cb (flux_t *h,
         errno = EPROTO;
         goto error;
     }
-    if (!(o = prepare_response (status))) {
+    if (!(o = prepare_status_payload (status))) {
         errprintf (&error, "error preparing response: %s", strerror (errno));
         goto error;
     }
@@ -90,11 +93,373 @@ error:
     json_decref (o);
 }
 
+/* Mark the ranks in 'ids' DOWN in the resource set 'rl'.
+ */
+static int mark_down (struct rlist *rl, const struct idset *ids)
+{
+    if (ids) {
+        char *s;
+
+        if (!(s = idset_encode (ids, IDSET_FLAG_RANGE)))
+            return -1;
+        if (rlist_mark_down (rl, s) < 0) {
+            free (s);
+            errno = EINVAL;
+            return -1;
+        }
+        free (s);
+    }
+    return 0;
+}
+
+/* Get an Rv1 resource object that includes all resources.
+ */
+static json_t *get_all (struct rlist *rl)
+{
+    json_t *o;
+    struct rlist *r;
+
+    if (!(r = rlist_copy_empty (rl))
+        || rlist_mark_up (r, "all") < 0
+        || !(o = rlist_to_R (r)))
+        goto error;
+    rlist_destroy (r);
+    return o;
+error:
+    rlist_destroy (r);
+    return NULL;
+}
+
+/* Get an Rv1 resource object that includes only DOWN resources.
+ */
+static json_t *get_down (struct rlist *rl)
+{
+    json_t *o;
+    struct rlist *r;
+
+    if (!(r = rlist_copy_down (rl))
+        || !(o = rlist_to_R (r)))
+        goto error;
+    rlist_destroy (r);
+    return o;
+error:
+    rlist_destroy (r);
+    return NULL;
+}
+
+/* Create an empty but valid Rv1 object.
+ */
+static json_t *get_empty_set (void)
+{
+    struct rlist *rl;
+    json_t *o;
+
+    if (!(rl = rlist_create ()))
+        return NULL;
+    o = rlist_to_R (rl);
+    rlist_destroy (rl);
+    return o;
+}
+
+/* Update property 'name' in 'alloc' resource set.
+ * Take the intersection of the alloc ranks vs the property ranks,
+ * and if non-empty, add properties to 'alloc' for those ranks.
+ */
+static int update_one_property (struct rlist *alloc,
+                                struct idset *alloc_ranks,
+                                struct idset *prop_ranks,
+                                const char *name)
+{
+    struct idset *ids;
+    char *targets = NULL;
+    int rc = -1;
+
+    if (!(ids = idset_intersect (alloc_ranks, prop_ranks))
+        || idset_count (ids) == 0) {
+        rc = 0;
+        goto done;
+    }
+    if (!(targets = idset_encode (ids, IDSET_FLAG_RANGE)))
+        goto done;
+    if (rlist_add_property (alloc, NULL, name, targets) < 0)
+        goto done;
+    rc = 0;
+done:
+    free (targets);
+    idset_destroy (ids);
+    return rc;
+}
+
+/* Fetch properties from a resource set in JSON form.
+ */
+static json_t *get_properties (struct rlist *rl)
+{
+    char *s;
+    json_t *o = NULL;
+
+    if ((s = rlist_properties_encode (rl)))
+        o = json_loads (s, 0, NULL);
+    free (s);
+    return o;
+}
+
+/* Given a resource set 'all' with properties, assign any to 'alloc'
+ * that have matching ranks.
+ */
+static int update_properties (struct rlist *alloc, struct rlist *all)
+{
+    struct idset *alloc_ranks;
+    json_t *props;
+    const char *name;
+    json_t *val;
+
+    if (!(alloc_ranks = rlist_ranks (alloc)))
+        return -1;
+    if (!(props = get_properties (all))
+        || json_object_size (props) == 0) {
+        json_decref (props);
+        return 0;
+    }
+    json_object_foreach (props, name, val) {
+        struct idset *prop_ranks;
+
+        if (!(prop_ranks = idset_decode (json_string_value (val))))
+            continue;
+        if (update_one_property (alloc, alloc_ranks, prop_ranks, name) < 0) {
+            idset_destroy (prop_ranks);
+            goto error;
+        }
+        idset_destroy (prop_ranks);
+    }
+    idset_destroy (alloc_ranks);
+    json_decref (props);
+    return 0;
+error:
+    idset_destroy (alloc_ranks);
+    json_decref (props);
+    return -1;
+}
+
+static json_t *update_properties_json (json_t *R, struct rlist *all)
+{
+    struct rlist *alloc;
+    json_t *R2 = NULL;
+
+    if (!(alloc = rlist_from_json (R, NULL)))
+        return NULL;
+    if (update_properties (alloc, all) < 0)
+        goto done;
+    R2 = rlist_to_R (alloc);
+done:
+    rlist_destroy (alloc);
+    return R2;
+}
+
+/* Create an rlist object from R.  Omit the scheduling key.  Then:
+ * - exclude the ranks in 'exclude' (if non-NULL)
+ * - mark down the ranks in 'down' and/or 'drain' (if non-NULL)
+ */
+static struct rlist *create_rlist (const json_t *R,
+                                   const struct idset *exclude,
+                                   const struct idset *down,
+                                   struct idset *drain)
+{
+    json_t *cpy;
+    struct rlist *rl;
+
+    if (!(cpy = json_copy ((json_t *)R))) { // thin copy - to del top level key
+        errno = ENOMEM;
+        return NULL;
+    }
+    (void)json_object_del (cpy, "scheduling");
+
+    if (!(rl = rlist_from_json (cpy, NULL)))
+        goto error;
+
+    if (exclude) {
+        if (rlist_remove_ranks (rl, (struct idset *)exclude) < 0)
+            goto error;
+    }
+    if (mark_down (rl, down) < 0 || mark_down (rl, drain) < 0)
+        goto error;
+    json_decref (cpy);
+    return rl;
+error:
+    json_decref (cpy);
+    rlist_destroy (rl);
+    errno = EINVAL;
+    return NULL;
+}
+
+/* See issue #5776 for an example of what the sched.resource-status
+ * RPC returns.  This payload intended to be identical, except 'allocated'
+ * is the calculated set provided by the job manager rather than the actual
+ * one from the scheduler itself (for performance reasons).
+ */
+static json_t *prepare_sched_status_payload (struct status *status,
+                                             json_t *allocated)
+{
+    struct resource_ctx *ctx = status->ctx;
+    const struct idset *exclude = exclude_get (ctx->exclude);
+    const struct idset *down = monitor_get_down (ctx->monitor);
+    struct idset *drain = drain_get (ctx->drain);
+    const json_t *R;
+    json_t *o;
+    struct rlist *rl = NULL;
+    json_t *result = NULL;
+
+    if (!(R = inventory_get (ctx->inventory))
+        || !(rl = create_rlist (R, exclude, down, drain))
+        || !(result = json_object ()))
+        goto error;
+
+    if (!(o = get_all (rl))
+        || json_object_set_new (result, "all", o) < 0) {
+        json_decref (o);
+        goto error;
+    }
+    if (!(o = get_down (rl))
+        || json_object_set_new (result, "down", o) < 0) {
+        json_decref (o);
+        goto error;
+    }
+    if (allocated)
+        o = update_properties_json (allocated, rl);
+    else
+        o = get_empty_set ();
+    if (!o || json_object_set_new (result, "allocated", o) < 0) {
+        json_decref (o);
+        goto error;
+    }
+
+    idset_destroy (drain);
+    rlist_destroy (rl);
+    return result;
+error:
+    ERRNO_SAFE_WRAP (json_decref, result);
+    idset_destroy (drain);
+    rlist_destroy (rl);
+    return NULL;
+}
+
+static void remove_request (struct flux_msglist *ml, const flux_msg_t *msg)
+{
+    const flux_msg_t *m;
+
+    m = flux_msglist_first (ml);
+    while (m) {
+        if (m == msg) {
+            flux_msglist_delete (ml); // delete @cursor
+            break;
+        }
+        m = flux_msglist_next (ml);
+    }
+}
+
+/* The job-manager.resource-status RPC has completed.
+ * Finish handling resource.sched-status.  Notes:
+ * - Treat ENOSYS from job-manager.resource-status as the empty set.  This
+ *   could happen IRL because the resource module loads before job-manager.
+ * - Both the future and the message are unreferenced/destroyed
+ *   when msg is removed from the status->requests list.
+ */
+static void sched_status_continuation (flux_future_t *f, void *arg)
+{
+    const flux_msg_t *msg = flux_future_aux_get (f, "flux::request");
+    struct status *status = arg;
+    flux_t *h = status->ctx->h;
+    flux_error_t error;
+    json_t *allocated = NULL;
+    json_t *o = NULL;
+
+    if (flux_rpc_get_unpack (f, "{s:o}", "allocated", &allocated) < 0
+        && errno != ENOSYS) {
+        errprintf (&error,
+                   "job-manager.resource-status request failed: %s",
+                   future_strerror (f, errno));
+        goto error;
+    }
+    if (!(o = prepare_sched_status_payload (status, allocated))) {
+        errprintf (&error, "error preparing response: %s", strerror (errno));
+        goto error;
+    }
+    if (flux_respond_pack (h, msg, "O", o) < 0)
+        flux_log_error (h, "error responding to resource.sched-status");
+    json_decref (o);
+    remove_request (status->requests, msg);
+    return;
+error:
+    if (flux_respond_error (h, msg, EINVAL, error.text) < 0)
+        flux_log_error (h, "error responding to resource.sched-status");
+    json_decref (o);
+    remove_request (status->requests, msg);
+}
+
+/* To answer this query, an RPC must be sent to the job manager to get
+ * the set of allocated resources.  Get that started, then place the request
+ * on status->requests and continue answering in the RPC continuation.
+ * The rest of the information required is local.
+ */
+static void sched_status_cb (flux_t *h,
+                             flux_msg_handler_t *mh,
+                             const flux_msg_t *msg,
+                             void *arg)
+{
+    struct status *status = arg;
+    flux_future_t *f;
+    flux_error_t error;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0) {
+        errprintf (&error, "error decoding request: %s", strerror (errno));
+        goto error;
+    }
+    if (status->ctx->rank != 0) {
+        errprintf (&error, "this RPC only works on rank 0");
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(f = flux_rpc (h, "job-manager.resource-status", NULL, 0, 0))
+        || flux_future_then (f, -1, sched_status_continuation, status) < 0
+        || flux_future_aux_set (f, "flux::request", (void *)msg, NULL) < 0
+        || flux_msg_aux_set (msg,
+                             NULL,
+                             f,
+                             (flux_free_f)flux_future_destroy) < 0) {
+        errprintf (&error,
+                   "error sending job-manager.resource-status request: %s",
+                   strerror (errno));
+        flux_future_destroy (f);
+        goto error;
+    }
+    if (flux_msglist_append (status->requests, msg) < 0) {
+        errprintf (&error, "error saving request mesg: %s", strerror (errno));
+        goto error;
+    }
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, error.text) < 0)
+        flux_log_error (h, "error responding to resource.sched-status");
+}
+
+/* Disconnect hook called from resource module's main disconnect
+ * message handler.
+ */
+void status_disconnect (struct status *status, const flux_msg_t *msg)
+{
+    (void)flux_msglist_disconnect (status->requests, msg);
+}
+
 static const struct flux_msg_handler_spec htab[] = {
     {
         .typemask = FLUX_MSGTYPE_REQUEST,
         .topic_glob = "resource.status",
         .cb = status_cb,
+        .rolemask = FLUX_ROLE_USER,
+    },
+    {
+        .typemask = FLUX_MSGTYPE_REQUEST,
+        .topic_glob = "resource.sched-status",
+        .cb = sched_status_cb,
         .rolemask = FLUX_ROLE_USER,
     },
     FLUX_MSGHANDLER_TABLE_END,
@@ -105,6 +470,7 @@ void status_destroy (struct status *status)
     if (status) {
         int saved_errno = errno;
         flux_msg_handler_delvec (status->handlers);
+        flux_msglist_destroy (status->requests);
         free (status);
         errno = saved_errno;
     }
@@ -117,6 +483,8 @@ struct status *status_create (struct resource_ctx *ctx)
     if (!(status = calloc (1, sizeof (*status))))
         return NULL;
     status->ctx = ctx;
+    if (!(status->requests = flux_msglist_create ()))
+        goto error;
     if (flux_msg_handler_addvec (ctx->h, htab, status, &status->handlers) < 0)
         goto error;
     return status;

--- a/src/modules/resource/status.c
+++ b/src/modules/resource/status.c
@@ -1,0 +1,120 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ \************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "resource.h"
+#include "inventory.h"
+#include "drain.h"
+#include "rutil.h"
+#include "monitor.h"
+#include "exclude.h"
+#include "status.h"
+
+struct status {
+    struct resource_ctx *ctx;
+    flux_msg_handler_t **handlers;
+};
+
+
+static void status_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    struct status *status = arg;
+    struct resource_ctx *ctx = status->ctx;
+    json_t *drain;
+    const json_t *R;
+    json_t *o = NULL;
+    const char *errstr = NULL;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0)
+        goto error;
+    if (ctx->rank != 0) {
+        errno = EPROTO;
+        errstr = "this RPC only works on rank 0";
+        goto error;
+    }
+    if (!(R = inventory_get (ctx->inventory)))
+        goto error;
+    if (!(drain = drain_get_info (ctx->drain)))
+        goto error;
+    if (!(o = json_pack ("{s:O s:o}",
+                         "R", R,
+                         "drain", drain))) {
+        json_decref (drain);
+        errno = ENOMEM;
+        goto error;
+    }
+    if (rutil_set_json_idset (o,
+                              "online",
+                              monitor_get_up (ctx->monitor)) < 0)
+        goto error;
+    if (rutil_set_json_idset (o,
+                              "offline",
+                              monitor_get_down (ctx->monitor)) < 0)
+        goto error;
+    if (rutil_set_json_idset (o,
+                              "exclude",
+                              exclude_get (ctx->exclude)) < 0)
+        goto error;
+    if (flux_respond_pack (h, msg, "o", o) < 0) {
+        flux_log_error (h, "error responding to resource.status request");
+        json_decref (o);
+    }
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to resource.status request");
+    json_decref (o);
+}
+
+
+static const struct flux_msg_handler_spec htab[] = {
+    {
+        .typemask = FLUX_MSGTYPE_REQUEST,
+        .topic_glob = "resource.status",
+        .cb = status_cb,
+        .rolemask = FLUX_ROLE_USER,
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+void status_destroy (struct status *status)
+{
+    if (status) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (status->handlers);
+        free (status);
+        errno = saved_errno;
+    }
+}
+
+struct status *status_create (struct resource_ctx *ctx)
+{
+    struct status *status;
+
+    if (!(status = calloc (1, sizeof (*status))))
+        return NULL;
+    status->ctx = ctx;
+    if (flux_msg_handler_addvec (ctx->h, htab, status, &status->handlers) < 0)
+        goto error;
+    return status;
+error:
+    status_destroy (status);
+    return NULL;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/resource/status.h
+++ b/src/modules/resource/status.h
@@ -13,6 +13,7 @@
 
 struct status *status_create (struct resource_ctx *ctx);
 void status_destroy (struct status *status);
+void status_disconnect (struct status *status, const flux_msg_t *msg);
 
 #endif /* ! _RESOURCE_STATUS_H */
 

--- a/src/modules/resource/status.h
+++ b/src/modules/resource/status.h
@@ -1,0 +1,19 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ \************************************************************/
+
+#ifndef _RESOURCE_STATUS_H
+#define _RESOURCE_STATUS_H
+
+struct status *status_create (struct resource_ctx *ctx);
+void status_destroy (struct status *status);
+
+#endif /* ! _RESOURCE_STATUS_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -14,6 +14,17 @@ test_expect_success 'flux resource list: default lists some expected fields' '
 	grep NNODES default.out &&
 	grep NCORES default.out
 '
+test_expect_success 'make the same query using sched.resource-status' '
+	FLUX_RESOURCE_LIST_RPC=sched.resource-status \
+	FLUX_HANDLE_TRACE=1 \
+	flux resource list >sched.out 2>sched.err
+'
+test_expect_success 'FLUX_RESOURCE_LIST_RPC works' '
+	grep sched.resource-status sched.err
+'
+test_expect_success 'results are the same as before' '
+	test_cmp default.out sched.out
+'
 
 test_expect_success 'flux resource list: FLUX_RESOURCE_LIST_FORMAT_DEFAULT works' '
 	FLUX_RESOURCE_LIST_FORMAT_DEFAULT="{nodelist} {nodelist}" \
@@ -331,6 +342,11 @@ test_expect_success 'flux resource lists expected queues in states (single)' '
 	test $(grep -c "free 1 debug" list2.out) -eq 1 &&
 	test $(grep -c "allocated 1 batch" list2.out) -eq 1 &&
 	test $(grep -c "allocated 1 debug" list2.out) -eq 1
+'
+test_expect_success 'sched.resource-status produces the same results' '
+	FLUX_RESOURCE_LIST_RPC=sched.resource-status \
+	flux resource list -o "{state} {nnodes} {queue}" > list2_sched.out &&
+	test_cmp list2.out list2_sched.out
 '
 test_expect_success 'cleanup jobs' '
 	flux cancel $(cat job1A.id) $(cat job1B.id)

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -25,6 +25,12 @@ test_expect_success 'FLUX_RESOURCE_LIST_RPC works' '
 test_expect_success 'results are the same as before' '
 	test_cmp default.out sched.out
 '
+test_expect_success 'flux resource list works on follower ranks' '
+	flux exec -r 1 flux resource list >follower.out
+'
+test_expect_success 'results are the same as before' '
+	test_cmp default.out follower.out
+'
 
 test_expect_success 'flux resource list: FLUX_RESOURCE_LIST_FORMAT_DEFAULT works' '
 	FLUX_RESOURCE_LIST_FORMAT_DEFAULT="{nodelist} {nodelist}" \


### PR DESCRIPTION
As discussed in #5776, this adds
- resource tracking in the job manager and a new RPC to request the current set of allocated resources
- expansion of the payload of `resource.status` to include the keys found in `sched.resource-status`
- update users (top, python) to call `resource.status` instead of `sched.resource-status`

Marking as a WIP pending

- [x] see what the throughput impact is.  Edit: none at this point
- [x] ~decide what to do with the `alloc-check` plugin since this effectively does the same thing~ Edit: second iteration of the design no longer does this
- [x] ~decide if it was a good idea to combine the two RPCs or whether we should provide two, or perhaps take a step back and design a new one.~  Edit Let's have two RPCs, just like before.
- [x] ~should we leave the scheduler RPC handlers in place and provide some way to use them in test?~  Edit: keep for back compat, but add tests so the code is not left uncovered
- [x] ~update flux-resource(1) which mentions "scheduler view of resources" a lot~ Edit: view is ok - just get fix language about explicitly contacting the schedule
- [x] ~`flux resource status` currently calls the `resource.status` RPCs twice~ Now that there are two RPCs again, this is perfectly fine.