### PR TITLE
github: run asan build on fedora36

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -14,13 +14,12 @@ jobs:
     - name: docker-run-checks with ASan
       timeout-minutes: 40
       env:
-        PRELOAD: /usr/lib64/libasan.so.6
-        ASAN_OPTIONS: detect_leaks=0,start_deactivated=true,replace_str=true
+        ASAN_OPTIONS: detect_leaks=0,start_deactivated=true,replace_str=true,verify_asan_link_order=false
         FLUX_TEST_TIMEOUT: 300
         TAP_DRIVER_QUIET: t
       run: >
         src/test/docker/docker-run-checks.sh \
-          --image=fedora34 --unit-test-only -j2 \
+          --image=fedora36 --unit-test-only -j4 \
           -- --with-flux-security --enable-sanitizer=address
 
     - name: after failure


### PR DESCRIPTION
Problem: The address sanitizer CI build started failing for unknown reason. The failure is occurring in the make program before even running any tests in 'make check.'

Take the following steps to attempt to address the issue:

 - The asan build currently runs on Fedora 34, which is getting old at this point. Update the sanitizer run to use Fedora 36.

 - Drop the LD_PRELOAD of the libasan library, which seems to be causing the failure in some unrelated programs not compiled with -fsanitize=address (a guess).

 - Add 'verify_asan_link_order=false' to ASAN_OPTIONS to avoid libasan complaints about link order. This is only important if malloc, free, etc., are replaced by libs. In that case libasan _must_ be first in the link order. See https://github.com/google/sanitizers/wiki/AddressSanitizerFlags

 - Update -j2 to -j4 (github runners now have 4 vcpus)