### PR TITLE
github: set kernel.randomize_va_space=0 for asan build

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -11,9 +11,13 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - run: git fetch --tags || true
+    - name: disable ASLR
+      run: |
+        sudo sysctl -w kernel.randomize_va_space=0
     - name: docker-run-checks with ASan
       timeout-minutes: 40
       env:
+        PRELOAD: /usr/lib64/libasan.so.8
         ASAN_OPTIONS: detect_leaks=0,start_deactivated=true,replace_str=true,verify_asan_link_order=false
         FLUX_TEST_TIMEOUT: 300
         TAP_DRIVER_QUIET: t


### PR DESCRIPTION
Problem: Recent kernel address space layout randomization (ASLR) appears to confuse some versions of address sanitizers, leading to random failures in github CI.

Disable kernel.randomize_va_space for the github asan build to avoid these failures. Thanks to @vchuravy for pointing out the issue.

Since LD_PRELOAD of libasan wasn't the root cause, reinstate preloading the libasan library to get as full coverage as possible.

Fixes #5801.