### PR TITLE
job-exec: fix rare segfault at scale due to libsubprocess use-after-free

### DIFF
--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -898,6 +898,11 @@ static flux_future_t *add_pending_signal (flux_subprocess_t *p, int signum)
     if ((f = flux_future_create (NULL, NULL))) {
         flux_subprocess_aux_set (p, "sp::signal_future", f, NULL);
         p->signal_pending = signum;
+        /*  Take a reference on the returned future in case the caller
+         *  destroys it between now and when the signal is actually sent.
+         *  This reference will be dropped in fwd_pending_signal()
+         */
+        flux_future_incref (f);
     }
     return f;
 }


### PR DESCRIPTION
This PR fixes the crash in the job-exec module described in #5782.

As described there, the issue was a use-after-free in libsubprocess when a signal is sent to a remote subprocess before the subprocess is running.

I ran the reproducer below for 4 hours with no crashes on this branch. On master the issue reproduces within 30m reliably.

reproducer:
```
$ flux run -o cpu-affinity=off -o mpibind=off \
    --env=MALLOC_CONF=junk:true,tcache:false \
    --env=LD_PRELOAD=/g/g0/grondo/git/jemalloc/lib/libjemalloc.so \
    -o pty.interactive -o pty.capture -n 768 -N32  \
    src/cmd/flux start -o,-Stbon.topo=kary:800
$ while true; flux submit --cc=1-2048 true \
    && sleep 60 \
    && flux cancel --all \
    && sleep 30 \
    && flux cancel --all \
    && sleep 5 \
    && flux cancel --all \
    && flux queue idle; \
    done
```