### PR TITLE
kvs: remove excessive logging

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2066,8 +2066,12 @@ static void error_event_cb (flux_t *h, flux_msg_handler_t *mh,
     }
 
     /* if root not initialized, nothing to do
-     * - it is ok that the namespace be marked for removal, we may be
-     *   cleaning up lingering transactions.
+     * - note that it is possible the namespace has been marked for
+     *   removal, we may be cleaning up lingering transactions and
+     *   need to report to those callers that namespace not available
+     *   via finalize_transaction_bynames() below.
+     * - i.e. we're calling kvsroot_mgr_lookup_root() not
+     *   kvsroot_mgr_lookup_root_safe().
      */
     if (!(root = kvsroot_mgr_lookup_root (ctx->krm, ns))) {
         flux_log (ctx->h, LOG_ERR, "%s: received unknown namespace %s",

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -950,8 +950,6 @@ static void kvstxn_apply (kvstxn_t *kt)
     assert (root);
 
     if (root->remove) {
-        flux_log (ctx->h, LOG_DEBUG, "%s: namespace %s removed", __FUNCTION__,
-                  ns);
         errnum = ENOTSUP;
         goto done;
     }
@@ -2073,11 +2071,8 @@ static void error_event_cb (flux_t *h, flux_msg_handler_t *mh,
      * - i.e. we're calling kvsroot_mgr_lookup_root() not
      *   kvsroot_mgr_lookup_root_safe().
      */
-    if (!(root = kvsroot_mgr_lookup_root (ctx->krm, ns))) {
-        flux_log (ctx->h, LOG_ERR, "%s: received unknown namespace %s",
-                  __FUNCTION__, ns);
+    if (!(root = kvsroot_mgr_lookup_root (ctx->krm, ns)))
         return;
-    }
 
     finalize_transaction_bynames (ctx, root, names, errnum);
 }
@@ -2129,11 +2124,8 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *mh,
      *   order (commit/fence completes before namespace removed, but
      *   namespace remove event received before setroot).
      */
-    if (!(root = kvsroot_mgr_lookup_root (ctx->krm, ns))) {
-        flux_log (ctx->h, LOG_ERR, "%s: received unknown namespace %s",
-                  __FUNCTION__, ns);
+    if (!(root = kvsroot_mgr_lookup_root (ctx->krm, ns)))
         return;
-    }
 
     if (root->setroot_pause) {
         flux_msg_t *msgcpy;


### PR DESCRIPTION
Problem: When a namespace is marked for removal, it is normal to cleanup lingering/left over transactions that are not yet complete.  On some tests, this appears to lead to many unnecessary log messages.

Remove log messages related to cleanup of transactions on removed namespaces.  They are unnecessary and excessive.  Those transactions will receive a ENOTSUP error and can report that the namespace has been removed.

Fixes #5789