### PR TITLE
python: update required versions of black and mypy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,11 +25,9 @@ jobs:
 
   python-lint:
     name: python linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v5
-      with:
-        python-version: 3.6
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.black]
-profile = "black"
 target-version = ['py36']
-exclude = ["^env/", "^src/bindings/python/flux/utils/*/*.py", "^src/bindings/python/flux/utils/*/*/*.py"]
+force-exclude = "/^(env/|src/bindings/python/flux/utils)/"
 
 [tool.isort]
 profile = "black" # needed for black/isort compatibility

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -4,6 +4,6 @@ pyyaml>=3.10.0
 black==24.3.0
 flake8>=5.0.4
 isort>=5.9.3
-mypy==0.971
+mypy==1.9.0
 pre-commit>=2.9.2
 types-PyYAML

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -1,7 +1,7 @@
 cffi>=1.1
 ply>=3.9
 pyyaml>=3.10.0
-black==22.8.0
+black==24.3.0
 flake8>=5.0.4
 isort>=5.9.3
 mypy==0.971

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -869,25 +869,31 @@ class MiniCmd:
         parser.add_argument(
             "--input",
             type=str,
-            help="Redirect job stdin from FILENAME, bypassing KVS"
-            if not exclude_io
-            else argparse.SUPPRESS,
+            help=(
+                "Redirect job stdin from FILENAME, bypassing KVS"
+                if not exclude_io
+                else argparse.SUPPRESS
+            ),
             metavar="FILENAME",
         )
         parser.add_argument(
             "--output",
             type=str,
-            help="Redirect job stdout to FILENAME, bypassing KVS"
-            if not exclude_io
-            else argparse.SUPPRESS,
+            help=(
+                "Redirect job stdout to FILENAME, bypassing KVS"
+                if not exclude_io
+                else argparse.SUPPRESS
+            ),
             metavar="FILENAME",
         )
         parser.add_argument(
             "--error",
             type=str,
-            help="Redirect job stderr to FILENAME, bypassing KVS"
-            if not exclude_io
-            else argparse.SUPPRESS,
+            help=(
+                "Redirect job stderr to FILENAME, bypassing KVS"
+                if not exclude_io
+                else argparse.SUPPRESS
+            ),
             metavar="FILENAME",
         )
         parser.add_argument(
@@ -900,9 +906,11 @@ class MiniCmd:
             "-l",
             "--label-io",
             action="store_true",
-            help="Add rank labels to stdout, stderr lines"
-            if not exclude_io
-            else argparse.SUPPRESS,
+            help=(
+                "Add rank labels to stdout, stderr lines"
+                if not exclude_io
+                else argparse.SUPPRESS
+            ),
         )
         parser.add_argument(
             "--cwd", help="Set job working directory", metavar="DIRECTORY"

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -831,7 +831,7 @@ class JobInfoFormat(flux.util.OutputFormat):
         creations of scheduler or user.
         """
         format_list = string.Formatter().parse(fmt)
-        for (_, field, _, _) in format_list:
+        for _, field, _, _ in format_list:
             if field and not field in self.headings:
                 if field.startswith("annotations."):
                     field_heading = field[len("annotations.") :].upper()

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -615,7 +615,7 @@ class OutputFormat:
         which will be made "safe" for use with string headings.
         """
         format_list = []
-        for (text, field, spec, _) in self.format_list:
+        for text, field, spec, _ in self.format_list:
             #  Remove number formatting on any spec:
             spec = re.sub(r"(0?\.)?(\d+)?[bcdoxXeEfFgGn%]$", r"\2", spec)
 
@@ -644,7 +644,7 @@ class OutputFormat:
         if except_fields is None:
             except_fields = []
         lst = []
-        for (text, field, spec, conv) in self.format_list:
+        for text, field, spec, conv in self.format_list:
             # Skip this field if it is in except_fields
             if field in except_fields:
                 # Preserve any format "prefix" (i.e. the text):
@@ -704,7 +704,7 @@ class OutputFormat:
         #
         lst = []
         index = 0
-        for (text, field, _, conv) in self.format_list:
+        for text, field, _, conv in self.format_list:
             if text.endswith("?:"):
                 fmt = self._fmt_tuple("", "0." + field, None, conv)
                 lst.append(dict(fmt=fmt, index=index))

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -214,9 +214,11 @@ class FunctionWrapper(object):
                 raise EnvironmentError(
                     errnum,
                     "{}: {}".format(
-                        errno.errorcode[errnum]
-                        if errnum in errno.errorcode
-                        else "Errno" + str(errnum),
+                        (
+                            errno.errorcode[errnum]
+                            if errnum in errno.errorcode
+                            else "Errno" + str(errnum)
+                        ),
                         os.strerror(errnum),
                     ),
                 )

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -143,9 +143,11 @@ def parse_args():
     parser.add_argument(
         "-a",
         action="store_true",
-        help="Target jobs in all states"
-        if PROGRAM == "flux-pgrep"
-        else argparse.SUPPRESS,
+        help=(
+            "Target jobs in all states"
+            if PROGRAM == "flux-pgrep"
+            else argparse.SUPPRESS
+        ),
     )
     parser.add_argument("-A", action="store_true", help="Target all users")
     parser.add_argument(

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -150,7 +150,7 @@ matrix.add_build(
 )
 
 # Debian: arm64, expensive, only on master and tags, only install
-if matrix.branch == 'master' or matrix.tag:
+if matrix.branch == "master" or matrix.tag:
     matrix.add_build(
         name="bookworm - arm64",
         image="bookworm",
@@ -296,7 +296,7 @@ matrix.add_build(
         " --localstatedir=/var"
         " --with-flux-security"
     ),
-    docker_tag=True
+    docker_tag=True,
 )
 
 # inception

--- a/t/issues/t5308-kvsdir-initial-path.py
+++ b/t/issues/t5308-kvsdir-initial-path.py
@@ -19,4 +19,3 @@ jobdir.commit()
 jobdir2 = flux.job.job_kvs(handle, jobid)
 if jobdir2["foo"] != "bar":
     sys.exit(1)
-

--- a/t/job-manager/bulk-state.py
+++ b/t/job-manager/bulk-state.py
@@ -22,6 +22,7 @@ import sys
 
 expected_states = ["NEW", "DEPEND", "PRIORITY", "SCHED", "RUN", "CLEANUP", "INACTIVE"]
 
+
 # Return True if all jobs in the jobs dictionary have reached 'INACTIVE' state
 def all_inactive(jobs):
     for jobid in jobs:

--- a/t/jobspec/summarize-minimal-jobspec.py
+++ b/t/jobspec/summarize-minimal-jobspec.py
@@ -12,7 +12,7 @@ def load_jobspec(stream, prefix=""):
         data = stream.read().encode("utf-8")
         jobspec = yaml.safe_load(data)
         return jobspec
-    except (yaml.YAMLError) as e:
+    except yaml.YAMLError as e:
         print("{}{}".format(prefix, e.problem))
         sys.exit(1)
 

--- a/t/jobspec/y2j.py
+++ b/t/jobspec/y2j.py
@@ -6,7 +6,7 @@ try:
     obj = yaml.safe_load(sys.stdin)
 except (OSError, IOError) as e:
     sys.exit("y2j: " + e.strerror)
-except (yaml.YAMLError) as e:
+except yaml.YAMLError as e:
     sys.exit("y2j: " + e.problem)
 
 json.dump(obj, sys.stdout, separators=(",", ":"))

--- a/t/python/tap/pycotap/__init__.py
+++ b/t/python/tap/pycotap/__init__.py
@@ -15,6 +15,7 @@ if sys.hexversion >= 0x03000000:
 else:
     from StringIO import StringIO
 
+
 # Log modes
 class LogMode(object):
     LogToError, LogToDiagnostics, LogToYAML, LogToAttachment = range(4)

--- a/t/scripts/strerror_symbol
+++ b/t/scripts/strerror_symbol
@@ -21,7 +21,9 @@ import os
 import sys
 
 if len(sys.argv) != 2:
-    print("requires a single errno constant name or number and converts to strerror string")
+    print(
+        "requires a single errno constant name or number and converts to strerror string"
+    )
 
 try:
     print(os.strerror(getattr(errno, sys.argv[1])))


### PR DESCRIPTION
Dependabot noted a potential security issue in our currently required version of `black` in #5806, but a bit more than just bumping the version was required to get the suggested `black` version working, so I've done that here. This included apply the very minor formatting changes enacted by the new version.

The changes also required an update of `mypy`, so I've bumped that to the latest version as well. There did not seem to be any fallout.

Pending PRs _may_ have to reformatted if they include python code. However, I was surprised how little changed in the formatting when updating to the new black version.