### PR TITLE
job-exec: improve cleanup after lost shell events

### DIFF
--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -117,8 +117,10 @@ static int exec_exit_notify (struct bulk_exec *exec)
     return 0;
 }
 
-static void exit_batch_cb (flux_reactor_t *r, flux_watcher_t *w,
-                          int revents, void *arg)
+static void exit_batch_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
 {
     struct bulk_exec *exec = arg;
     exec_exit_notify (exec);
@@ -274,7 +276,8 @@ static void subprocess_destroy_finish (flux_future_t *f, void *arg)
     flux_subprocess_t *p = arg;
     if (flux_future_get (f, NULL) < 0) {
         flux_t *h = flux_subprocess_aux_get (p, "flux_t");
-        flux_log_error (h, "subprocess_kill: %ju: %s",
+        flux_log_error (h,
+                        "subprocess_kill: %ju: %s",
                         (uintmax_t) flux_subprocess_pid (p),
                         future_strerror (f, errno));
     }

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -127,7 +127,8 @@ static int exec_barrier_enter (struct bulk_exec *exec)
     return 0;
 }
 
-static void output_cb (struct bulk_exec *exec, flux_subprocess_t *p,
+static void output_cb (struct bulk_exec *exec,
+                       flux_subprocess_t *p,
                        const char *stream,
                        const char *data,
                        int len,
@@ -310,7 +311,8 @@ static void exit_cb (struct bulk_exec *exec,
     if (ctx->barrier_completion_count == 0
         || ctx->barrier_enter_count > 0) {
         if (bulk_exec_write (exec, "stdin", "exit=1\n", 7) < 0)
-            jobinfo_fatal_error (job, 0,
+            jobinfo_fatal_error (job,
+                                 0,
                                  "failed to terminate barrier: %s",
                                  strerror (errno));
     }
@@ -487,8 +489,10 @@ err:
     return -1;
 }
 
-static void exec_check_cb (flux_reactor_t *r, flux_watcher_t *w,
-                           int revents, void *arg)
+static void exec_check_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
 {
     struct jobinfo *job = arg;
     struct bulk_exec *exec = job->data;

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -35,9 +35,12 @@ static const char *jobspec_get_job_shell (json_t *jobspec)
 {
     const char *path = NULL;
     if (jobspec)
-        (void) json_unpack (jobspec, "{s:{s:{s:{s:s}}}}",
-                                     "attributes", "system", "exec",
-                                     "job_shell", &path);
+        (void) json_unpack (jobspec,
+                            "{s:{s:{s:{s:s}}}}",
+                            "attributes",
+                             "system",
+                              "exec",
+                               "job_shell", &path);
     return path;
 }
 
@@ -53,9 +56,11 @@ static const char *jobspec_get_cwd (json_t *jobspec)
 {
     const char *cwd = NULL;
     if (jobspec)
-        (void) json_unpack (jobspec, "{s:{s:{s:s}}}",
-                                     "attributes", "system",
-                                     "cwd", &cwd);
+        (void) json_unpack (jobspec,
+                            "{s:{s:{s:s}}}",
+                             "attributes",
+                              "system",
+                               "cwd", &cwd);
     return cwd;
 }
 

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -301,7 +301,8 @@ static int jobid_exception (flux_t *h, flux_jobid_t id,
                                       "note", note);
 }
 
-static int jobinfo_respond_error (struct jobinfo *job, int errnum,
+static int jobinfo_respond_error (struct jobinfo *job,
+                                  int errnum,
                                   const char *msg)
 {
     return jobid_exception (job->ctx->h,
@@ -319,21 +320,27 @@ static int jobinfo_send_release (struct jobinfo *job,
     int rc;
     flux_t *h = job->ctx->h;
     // XXX: idset ignored for now. Always release all resources
-    rc = flux_respond_pack (h, job->req, "{s:I s:s s{s:s s:b}}",
-                                         "id", job->id,
-                                         "type", "release",
-                                         "data", "ranks", "all",
-                                                 "final", true);
+    rc = flux_respond_pack (h,
+                            job->req,
+                            "{s:I s:s s{s:s s:b}}",
+                            "id", job->id,
+                            "type", "release",
+                            "data",
+                              "ranks", "all",
+                              "final", true);
     return rc;
 }
 
-static int jobinfo_respond (flux_t *h, struct jobinfo *job,
+static int jobinfo_respond (flux_t *h,
+                            struct jobinfo *job,
                             const char *event)
 {
-    return flux_respond_pack (h, job->req, "{s:I s:s s:{}}",
-                                           "id", job->id,
-                                           "type", event,
-                                           "data");
+    return flux_respond_pack (h,
+                              job->req,
+                              "{s:I s:s s:{}}",
+                              "id", job->id,
+                              "type", event,
+                              "data");
 }
 
 static void jobinfo_complete (struct jobinfo *job, const struct idset *ranks)
@@ -348,11 +355,13 @@ static void jobinfo_complete (struct jobinfo *job, const struct idset *ranks)
         jobinfo_emit_event_pack_nowait (job, "complete",
                                         "{ s:i }",
                                         "status", job->wait_status);
-        if (flux_respond_pack (h, job->req, "{s:I s:s s:{s:i}}",
-                                            "id", job->id,
-                                            "type", "finish",
-                                            "data",
-                                            "status", job->wait_status) < 0)
+        if (flux_respond_pack (h,
+                               job->req,
+                               "{s:I s:s s:{s:i}}",
+                               "id", job->id,
+                               "type", "finish",
+                               "data",
+                                 "status", job->wait_status) < 0)
             flux_log_error (h, "jobinfo_complete: flux_respond");
     }
 }
@@ -370,8 +379,10 @@ static void kill_shell_timer_cb (flux_reactor_t  *r,
     (*job->impl->kill) (job, SIGKILL);
 }
 
-static void kill_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
-                           int revents, void *arg)
+static void kill_timer_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
 {
     struct jobinfo *job = arg;
     flux_future_t *f;
@@ -424,7 +435,12 @@ static void timelimit_cb (flux_reactor_t *r,
     /*  Timelimit reached. Generate "timeout" exception and send SIGALRM.
      *  Wait for a gracetime then forcibly terminate job.
      */
-    if (jobid_exception (job->h, job->id, job->req, "timeout", 0, 0,
+    if (jobid_exception (job->h,
+                         job->id,
+                         job->req,
+                         "timeout",
+                         0,
+                         0,
                          "resource allocation expired") < 0)
         flux_log_error (job->h,
                         "failed to generate timeout exception for %s",
@@ -540,8 +556,10 @@ static void jobinfo_cancel (struct jobinfo *job)
 
 static int jobinfo_finalize (struct jobinfo *job);
 
-static void jobinfo_fatal_verror (struct jobinfo *job, int errnum,
-                                  const char *fmt, va_list ap)
+static void jobinfo_fatal_verror (struct jobinfo *job,
+                                  int errnum,
+                                  const char *fmt,
+                                  va_list ap)
 {
     int n;
     char msg [256];
@@ -575,7 +593,8 @@ static void jobinfo_fatal_verror (struct jobinfo *job, int errnum,
     }
 }
 
-void jobinfo_fatal_error (struct jobinfo *job, int errnum,
+void jobinfo_fatal_error (struct jobinfo *job,
+                          int errnum,
                           const char *fmt, ...)
 {
     flux_t *h = job->ctx->h;
@@ -1077,12 +1096,14 @@ static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
 
     job->ctx = ctx;
 
-    if (flux_request_unpack (job->req, NULL, "{s:I s:i s:O s:b s:o}",
-                                             "id", &job->id,
-                                             "userid", &job->userid,
-                                             "jobspec", &job->jobspec,
-                                             "reattach", &job->reattach,
-                                             "R", &R) < 0) {
+    if (flux_request_unpack (job->req,
+                             NULL,
+                             "{s:I s:i s:O s:b s:o}",
+                             "id", &job->id,
+                             "userid", &job->userid,
+                             "jobspec", &job->jobspec,
+                             "reattach", &job->reattach,
+                             "R", &R) < 0) {
         flux_log_error (ctx->h, "start: flux_request_unpack");
         jobinfo_decref (job);
         return -1;
@@ -1143,8 +1164,10 @@ error:
     return -1;
 }
 
-static void start_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+static void start_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     struct job_exec_ctx *ctx = arg;
 
@@ -1158,8 +1181,10 @@ static void start_cb (flux_t *h, flux_msg_handler_t *mh,
     }
 }
 
-static void exception_cb (flux_t *h, flux_msg_handler_t *mh,
-                          const flux_msg_t *msg, void *arg)
+static void exception_cb (flux_t *h,
+                          flux_msg_handler_t *mh,
+                          const flux_msg_t *msg,
+                          void *arg)
 {
     struct job_exec_ctx *ctx = arg;
     flux_jobid_t id;
@@ -1167,10 +1192,12 @@ static void exception_cb (flux_t *h, flux_msg_handler_t *mh,
     const char *type = NULL;
     struct jobinfo *job = NULL;
 
-    if (flux_event_unpack (msg, NULL, "{s:I s:s s:i}",
-                                      "id", &id,
-                                      "type", &type,
-                                      "severity", &severity) < 0) {
+    if (flux_event_unpack (msg,
+                           NULL,
+                           "{s:I s:s s:i}",
+                           "id", &id,
+                           "type", &type,
+                           "severity", &severity) < 0) {
         flux_log_error (h, "job-exception event");
         return;
     }
@@ -1204,7 +1231,8 @@ static void critical_ranks_cb (flux_t *h,
     struct idset *idset;
     struct jobinfo *job;
 
-    if (flux_request_unpack (msg, NULL,
+    if (flux_request_unpack (msg,
+                             NULL,
                              "{s:I s:s}",
                              "id", &id,
                              "ranks", &ranks) < 0)

--- a/src/modules/job-exec/rset.c
+++ b/src/modules/job-exec/rset.c
@@ -90,11 +90,13 @@ static int rset_read_time_window (struct resource_set *r, json_error_t *errp)
      */
     r->expiration = 0.;
     r->starttime = 0.;
-    if (json_unpack_ex (r->R, errp, 0,
+    if (json_unpack_ex (r->R,
+                        errp,
+                        0,
                         "{s:{s?F s?F}}",
                         "execution",
-                        "starttime",  &r->starttime,
-                        "expiration", &r->expiration) < 0)
+                         "starttime",  &r->starttime,
+                         "expiration", &r->expiration) < 0)
         return -1;
     return 0;
 }

--- a/src/modules/job-exec/testexec.c
+++ b/src/modules/job-exec/testexec.c
@@ -123,13 +123,18 @@ static int init_testconf (flux_t *h, struct testconf *conf, json_t *jobspec)
     conf->mock_exception = NULL;
     conf->enabled = false;
 
-    if (json_unpack_ex (jobspec, &err, 0,
-                     "{s:{s:{s:{s:o}}}}",
-                     "attributes", "system", "exec",
-                     "test", &test) < 0)
+    if (json_unpack_ex (jobspec,
+                        &err,
+                        0,
+                        "{s:{s:{s:{s:o}}}}",
+                        "attributes",
+                         "system",
+                          "exec",
+                           "test", &test) < 0)
         return 0;
     conf->enabled = true;
-    if (json_unpack_ex (test, &err, 0,
+    if (json_unpack_ex (test,
+                        &err, 0,
                         "{s?s s?i s?i s?i s?s}",
                         "run_duration", &trun,
                         "override", &conf->override,
@@ -156,7 +161,8 @@ static bool testconf_mock_exception (struct testconf *conf, const char *where)
  */
 static void timer_cb (flux_reactor_t *r,
                       flux_watcher_t *w,
-                      int revents, void *arg)
+                      int revents,
+                      void *arg)
 {
     struct testexec *te = arg;
 
@@ -367,7 +373,8 @@ static void testexec_request_cb (flux_t *h,
     uint32_t owner;
     int code = 0;
 
-    if (flux_request_unpack (msg, NULL,
+    if (flux_request_unpack (msg,
+                             NULL,
                              "{s:s s:I s?i}",
                              "event", &event,
                              "jobid", &id,

--- a/src/shell/exception.c
+++ b/src/shell/exception.c
@@ -48,7 +48,7 @@ static void exception_handler (flux_t *h,
     if (strlen (message) > 0)
         shell_warn ("%s", message);
 
-    if (streq (type, "lost-shell") && severity > 0) {
+    if (streq (type, "lost-shell")) {
         flux_plugin_arg_t *args = flux_plugin_arg_create ();
         if (!args
             || flux_plugin_arg_pack (args,


### PR DESCRIPTION
This PR fixes #5811 by always notifying the leader job shell of lost shells, whether they are critical or not. This then allows the leader shell to exit quickly when all its tasks terminate, rather than waiting for EOF from a lost shell during abnormal termination.
