### PR TITLE
job-exec: raise fatal job exception if rank 0 job shell is lost due to signal

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -352,6 +352,17 @@ static void exit_cb (struct bulk_exec *exec,
                             shell_rank,
                             flux_get_hostbyrank (job->h, rank),
                             strsignal (signo));
+            else {
+                /*  Job can't continue without the leader shell, which has
+                 *  terminated unexpectedly. Cancel the job now to avoid
+                 *  a potential hang.
+                 */
+                jobinfo_fatal_error (job,
+                                     0,
+                                     "shell rank 0 (on %s): %s",
+                                     flux_get_hostbyrank (job->h, rank),
+                                     strsignal (signo));
+            }
         }
         rank = idset_next (ranks, rank);
     }


### PR DESCRIPTION
While working on #5813 I noticed the job execution system doesn't raise a fatal job exception and initiate cleanup when the rank 0 job shell is lost due to a signal. This could lead to a hang because the other job shells may continue running even though the job really can't continue without the leader shell.

The leader shell is currently notified if any non-rank-0 shell exits due to a signal. Expand this to raise a fatal error if the rank 0 shell exits due to a signal.

Expand the lost shell testing to test loss of rank 0 as well as rank 3 job shells.

This is based on top of #5813 to avoid conflicts.