### PR TITLE
fix `flux submit` and `bulksubmit` handling of mustache templates in command and args

### DIFF
--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -629,12 +629,14 @@ class Xcmd:
         self.command = []
         for arg in args.command:
             try:
-                result = arg.format(*inputs, **kwargs).split("::list::")
+                val = self.preserve_mustache(arg)
+                result = val.format(*inputs, **kwargs).split("::list::")
+                newval = self.restore_mustache(result)
             except (IndexError, KeyError):
                 LOGGER.error("Invalid replacement string in command: '%s'", arg)
                 sys.exit(1)
-            if result:
-                self.command.extend(result)
+            if newval:
+                self.command.extend(newval)
 
         #  Format all supported mutable options defined in `mutable_args`
         #  Note: only list and string options are supported.

--- a/t/t2713-python-cli-bulksubmit.t
+++ b/t/t2713-python-cli-bulksubmit.t
@@ -280,6 +280,15 @@ test_expect_success 'flux bulksubmit: preserves mustache templates' '
 	EOF
 	test_cmp mustache.expected mustache.out
 '
+test_expect_success 'flux bulksubmit: preserves mustache templates in command' '
+	flux bulksubmit --dry-run echo {{tmpdir}} ::: 0 1 >mustache-cmd.out &&
+	test_debug "cat mustache-cmd.out" &&
+	cat <<-EOF > mustache-cmd.expected  &&
+	bulksubmit: submit echo {{tmpdir}}
+	bulksubmit: submit echo {{tmpdir}}
+	EOF
+	test_cmp mustache-cmd.expected mustache-cmd.out
+'
 test_expect_success 'flux submit --log works and can substitute {cc}' '
 	flux submit --log=job{cc}.id --cc=1-5 hostname &&
 	for id in $(seq 1 5); do


### PR DESCRIPTION
The `flux submit` and `flux bulksubmit` commands fail to preserve mustache templates in the job command.

This PR fixes that.