### PR TITLE
job-manager: fix infinite loop when loading builtin jobtap plugin

### DIFF
--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1431,6 +1431,13 @@ int jobtap_plugin_load_first (struct jobtap *jobtap,
     return 0;
 }
 
+static bool is_builtin (const char *path)
+{
+    /*  A builtin plugin starts with '.' and does not contain a slash
+     */
+    return (path[0] == '.' && !strchr (path, '/'));
+}
+
 flux_plugin_t * jobtap_load (struct jobtap *jobtap,
                              const char *path,
                              json_t *conf,
@@ -1465,7 +1472,7 @@ flux_plugin_t * jobtap_load (struct jobtap *jobtap,
         if (rc < 0)
             goto error;
     }
-    if (path[0] == '.') {
+    if (is_builtin (path)) {
         if (jobtap_load_builtin (p, path) < 0
             && jobtap_load_builtin_ex (jobtap, p, path) < 0)
             goto error;

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1269,6 +1269,7 @@ static int jobtap_load_builtin_ex (struct jobtap *jobtap,
                 return -1;
             return (*ex->init_cb) (p, ex->arg);
         }
+        ex = zlistx_next (jobtap->builtins_ex);
     }
     errno = ENOENT;
     return -1;

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -25,6 +25,15 @@ test_expect_success 'job-manager: attempt to load invalid plugin fails' '
 	test_debug "cat list2.out" &&
 	test_cmp list1.out list2.out
 '
+test_expect_success 'job-manager: loading invalid builtin plugin fails' '
+	test_must_fail flux jobtap load .foo
+'
+test_expect_success 'job-manager: builtin plugin can be removed' '
+	flux jobtap remove .history &&
+	flux jobtap list >list-nohist.out &&
+	test_must_fail grep ^\.history list-nohist.out &&
+	flux jobtap load .history
+'
 test_expect_success 'job-manager: load with invalid conf fails' '
 	cat <<-EOF >badconf.py &&
 	import flux


### PR DESCRIPTION
A missing `zlistx_next()` in the jobtap code that searches for a matching builtin plugin name causes an infinite loop if a builtin plugin is loaded that doesn't match the first plugin name in the list.

Also, though it isn't advisable to specify a relative plugin path to `flux jobtap load`, if this is done and the path starts with `.`, the current code assumes a builtin plugin is specified.

This PR fixes both these issues.