### PR TITLE
flux-resource: improve performance of `flux resource list`

### DIFF
--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -418,11 +418,14 @@ class ResourceSetExtra(ResourceSet):
     def __init__(self, arg=None, version=1, flux_config=None):
         self.flux_config = flux_config
         if isinstance(arg, ResourceSet):
-            super().__init__(arg.encode(), version)
+            self._rset = arg
             if arg.state:
                 self.state = arg.state
         else:
-            super().__init__(arg, version)
+            self._rset = ResourceSet(arg, version)
+
+    def __getattr__(self, attr):
+        return getattr(self._rset, attr)
 
     @property
     def propertiesx(self):

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -572,6 +572,14 @@ def get_resource_list(args):
     return resources, config
 
 
+def sort_output(args, items):
+    """
+    Sort by args.states order, then first rank in resource set
+    """
+    statepos = {x[1]: x[0] for x in enumerate(args.states)}
+    return sorted(items, key=lambda x: (statepos[x.state], x.ranks.first()))
+
+
 def list_handler(args):
     headings = {
         "state": "STATE",
@@ -591,7 +599,8 @@ def list_handler(args):
     formatter = flux.util.OutputFormat(fmt, headings=headings)
 
     lines = resources_uniq_lines(resources, args.states, formatter, config)
-    formatter.print_items(lines.values(), no_header=args.no_header)
+    items = sort_output(args, lines.values())
+    formatter.print_items(items, no_header=args.no_header)
 
 
 def info(args):


### PR DESCRIPTION
This PR improves the performance of `flux resource list` by modifying some really inefficient code:

 - The `ResourceSetExtra` wrapper class unnecessarily reinitializes the `ResourceSet` argument. Just stash the `ResourceSet` instead and forward method calls to it to avoid this wasted work.
 - `resources_uniq_lines()` iterates over each individual rank in each resource set to collect common lines of output together. Instead, split a resource set into all combinations of properties and iterate each of these sets. This _should_ be the minimum number of sets required to create possibly unique lines (at least at this point). This reduces the iteration count significantly.

Timing before with a very large resource set (~10K ranks):
```
 time flux resource list --from-stdin < ../../large-list.json >/dev/null

real	0m6.878s
user	0m6.762s
sys	0m0.089s
```

Timing after these changes:
```
$ time src/cmd/flux resource list --from-stdin < ../../large-list.json >/dev/null

real	0m1.790s
user	0m1.662s
sys	0m0.102s
```

Further improvements will probably have to be made in librlist itself.