### PR TITLE
python: fix handle barrier method to return a Future

### DIFF
--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -267,7 +267,7 @@ class Flux(Wrapper):
         return FDWatcher(self, fd_int, events, callback, args=args)
 
     def barrier(self, name, nprocs):
-        self.flux_barrier(name, nprocs)
+        return Future(self.flux_barrier(name, nprocs))
 
     def get_rank(self):
         rank = ffi.new("uint32_t [1]")

--- a/t/issues/t2492-shell-lost.sh
+++ b/t/issues/t2492-shell-lost.sh
@@ -30,7 +30,7 @@ try:
     taskid = int(os.environ["FLUX_TASK_RANK"])
     if taskid == 0:
         print(f"waiting on barrier for {size} tasks", flush=True)
-    h.barrier("test", size)
+    h.barrier("test", size).get()
     if taskid == 0:
         print(f"exited barrier", flush=True)
 

--- a/t/python/t0003-barrier.py
+++ b/t/python/t0003-barrier.py
@@ -20,7 +20,7 @@ from subflux import rerun_under_flux
 def barr_count(x, name, count):
     print(x, name, count)
     f = flux.Flux()
-    f.barrier(name, count)
+    f.barrier(name, count).get()
 
 
 def __flux_size():
@@ -33,8 +33,8 @@ class TestBarrier(unittest.TestCase):
         self.f = flux.Flux()
 
     def test_single(self):
-        self.f.barrier("testbarrier1", 1)
-        self.f.barrier("testbarrier1", 1)
+        self.f.barrier("testbarrier1", 1).get()
+        self.f.barrier("testbarrier1", 1).get()
 
     def test_eight(self):
         p = mp.Pool(8)


### PR DESCRIPTION
`flux_barrier(3)` returns a `flux_future_t`, but the Python handle barrier method returns nothing.

This PR returns a Future from `handle.barrier()` as is necessary for proper functionality and updates callers.

Note: Clearly the barrier unit tests were not working, but I didn't have any good ideas how to properly test the barrier functionality, so left it alone for now besides addition of the missing `get()` calls.