### PR TITLE
job-ingest: fix handling of size > 16K and reserve some FLUID generator IDs for future use

### DIFF
--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -852,18 +852,8 @@ int mod_main (flux_t *h, int argc, char **argv)
         }
         flux_future_destroy (f);
         if (fluid_init (&ctx.gen, 0, fluid_get_timestamp (max_jobid) + 1) < 0) {
-            // See flux-framework/flux-core#5708
-            if (rank > 16383) {
-                flux_log (h,
-                          LOG_DEBUG,
-                          "job-ingest cannot allocate job IDs on ranks > 16383."
-                          " Exiting - upstream will handle ingest requests.");
-                rc = 0;
-            }
-            else {
-                flux_log (h, LOG_ERR, "fluid_init failed");
-                errno = EINVAL;
-            }
+            flux_log (h, LOG_ERR, "fluid_init failed");
+            errno = EINVAL;
             goto done;
         }
     }
@@ -885,8 +875,18 @@ int mod_main (flux_t *h, int argc, char **argv)
         }
         flux_future_destroy (f);
         if (fluid_init (&ctx.gen, rank, timestamp) < 0) {
-            flux_log (h, LOG_ERR, "fluid_init failed");
-            errno = EINVAL;
+            // See flux-framework/flux-core#5708
+            if (rank > 16383) {
+                flux_log (h,
+                          LOG_DEBUG,
+                          "job-ingest cannot allocate job IDs on ranks > 16383."
+                          " Exiting - upstream will handle ingest requests.");
+                rc = 0;
+            }
+            else {
+                flux_log (h, LOG_ERR, "fluid_init failed");
+                errno = EINVAL;
+            }
             goto done;
         }
     }


### PR DESCRIPTION
Problem: the fix for #5708 (gracefully handling FLUID ID range errors on nodes >= 16K) is incorrect. 

Fix it and add tests.

Also: reserve the top 16 generator IDs for future use as this may be hard to do later when Flux has actually been run on large systems.