### PR TITLE
fix handling of `Ctrl-SPACE` (`NUL`) over job ptys (e.g. under `flux job attach`)

### DIFF
--- a/src/common/libterminus/client.c
+++ b/src/common/libterminus/client.c
@@ -271,8 +271,8 @@ static void pty_client_data (struct flux_pty_client *c, flux_future_t *f)
         llog_error (c, "unpack: %s", error.text);
         return;
     }
-    if (write (STDIN_FILENO, data, len) < 0) {
-        llog_error (c, "data decode failed: %s", strerror (errno));
+    if (write (STDOUT_FILENO, data, len) < 0) {
+        llog_error (c, "write %zu bytes: %s", len, strerror (errno));
         return;
     }
 }


### PR DESCRIPTION
This PR fixes handling of `NUL`s in pty data handling. Jansson by default will not unpack `NUL` unless `JSON_ALLOW_NUL` is used, so the read side of the pty was just dropping them.

As part of developing a test, an issue with `echo something | flux run -o pty.interactive ...` was discovered, which is also fixed here.

Fixes #5832