### PR TITLE
support fallback to the old `sched.resource-status` RPC for tools that use the new `resource.sched-status` RPC

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -344,7 +344,7 @@ components or writing tests.
    commands to resolve URIs to local form.  This is useful in test environments
    where the remote connector does not work.
 
-.. envvar:: FLUX_RESOURCE_STATUS_RPC
+.. envvar:: FLUX_RESOURCE_LIST_RPC
 
    If set, :man1:`flux-resource` uses the specified RPC topic string instead
    of ``resource.sched-status``.  This is used in test to verify that the

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -227,9 +227,9 @@ class InstanceInfo:
             if not uri or SchedResourceList is None:
                 raise ValueError
             handle = flux.Flux(str(uri))
-            future = handle.rpc("resource.sched-status", nodeid=0)
+            future = flux.resource.resource_list(handle)
             self.stats = StatsInfo(handle).update_sync()
-            self.resources = SchedResourceList(future.get())
+            self.resources = future.get()
             self.initialized = True
             return
         except (ValueError, OSError, FileNotFoundError):

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -25,6 +25,17 @@ test_expect_success 'FLUX_RESOURCE_LIST_RPC works' '
 test_expect_success 'results are the same as before' '
 	test_cmp default.out sched.out
 '
+test_expect_success 'make the same query with fallback to sched.resource-status' '
+	FLUX_RESOURCE_LIST_RPC=foo.status \
+	FLUX_HANDLE_TRACE=1 \
+	flux resource list >fallback.out 2>fallback.err
+'
+test_expect_success 'fallback works' '
+	grep sched.resource-status fallback.err
+'
+test_expect_success 'results are the same as before' '
+	test_cmp default.out fallback.out
+'
 test_expect_success 'flux resource list works on follower ranks' '
 	flux exec -r 1 flux resource list >follower.out
 '

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -61,6 +61,13 @@ test_expect_success 'flux-top summary shows no jobs initially' '
 	grep "0 running" nojobs.out &&
 	grep "0 failed" nojobs.out
 '
+test_expect_success 'flux-top falls back to sched.resource-status' '
+	FLUX_RESOURCE_LIST_RPC=foo.status \
+		$runpty \
+		flux top --test-exit --test-exit-dump=fallback.out >/dev/null &&
+	grep "nodes 0/${nnodes}" nojobs.out &&
+	grep "cores 0/${ncores}" nojobs.out
+'
 # Note: jpXCZedGfVQ is the base58 representation of FLUX_JOBID_ANY. We
 # grep for this value without f or ƒ in case build environment influences
 # presence of one of the other.


### PR DESCRIPTION
This PR implements the compatibility fallback for users of the new `resource.sched-status` RPC, so that these interfaces and utilities will still work when run against older versions of Flux.

Since `flux-top(1)` was the only C user of this RPC, a fallback was added in place for the summary pane.

For Python, the `ResourceListRPC` class is reworked to implement the fallback, so that all callers benefit.

The handy existing `FLUX_RESOURCE_LIST_RPC` environment variable is then used for testing purposes. By setting the rpc to an invalid value, the fallback is forced.

