### PR TITLE
testsuite: fix potential hang in t2812-flux-job-last.t

### DIFF
--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -259,6 +259,7 @@ done:
 static int restart_map_cb (struct job *job, void *arg, flux_error_t *error)
 {
     struct job_manager *ctx = arg;
+    flux_job_state_t state = job->state;
 
     if (zhashx_insert (ctx->active_jobs, &job->id, job) < 0) {
         errprintf (error,
@@ -272,7 +273,8 @@ static int restart_map_cb (struct job *job, void *arg, flux_error_t *error)
         wait_notify_active (ctx->wait, job);
     if (event_job_action (ctx->event, job) < 0) {
         flux_log_error (ctx->h,
-                        "replay warning: %s action failed on job %s",
+                        "replay warning: %s->%s action failed on job %s",
+                        flux_job_statetostr (state, "L"),
                         flux_job_statetostr (job->state, "L"),
                         idf58 (job->id));
     }

--- a/t/t2812-flux-job-last.t
+++ b/t/t2812-flux-job-last.t
@@ -40,6 +40,7 @@ test_expect_success 'flux job last N lists the last N jobs' '
 # issue #4930
 test_expect_success 'flux-job last lists inactive jobs after instance restart' '
 	flux job last "[:]" >lastdump.exp &&
+	flux queue idle &&
 	flux dump dump.tgz &&
 	flux start -o,-Scontent.restore=dump.tgz \
 		flux job last "[:]" >lastdump.out &&


### PR DESCRIPTION
This PR most likely fixes #5815. The issue seems to be that a job is still in CLEANUP when `flux dump` is called, and restarting from the dump with an active job causes the error message, then hang.

I've run this branch a couple times in CI without any reproducers of the original issue.