### PR TITLE
make KVS garbage collection automatic

### DIFF
--- a/doc/man1/flux-shutdown.rst
+++ b/doc/man1/flux-shutdown.rst
@@ -82,6 +82,13 @@ OPTIONS
    the dump, and the link is removed.  :linux:man8:`systemd-tmpfiles`
    automatically cleans up dump files in ``/var/lib/flux/dump`` after 30 days.
 
+.. option:: --skip-gc
+
+   When garbage collection has been enabled automatically, as indicated
+   by the ``content.dump`` broker attribute, this option disables it
+   during shutdown.  Otherwise it is a preemptive "no" answer to the garbage
+   collection prompt.
+
 .. option:: -y, --yes
 
    Answer yes to any yes/no questions.

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -23,6 +23,7 @@ ExecStart=/bin/bash -c '\
   -Sbroker.quorum-timeout=none \
   -Sbroker.exit-norestart=42 \
   -Sbroker.sd-notify=1 \
+  -Scontent.dump=auto \
   -Scontent.restore=auto \
 '
 SyslogIdentifier=flux

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -4,7 +4,7 @@ Wants=munge.service
 
 [Service]
 Type=notify
-NotifyAccess=main
+NotifyAccess=all
 TimeoutStopSec=90
 KillMode=mixed
 ExecStart=/bin/bash -c '\

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -14,6 +14,7 @@ AM_CPPFLAGS = \
 	$(FLUX_SECURITY_CFLAGS) \
 	$(HWLOC_CFLAGS) \
 	$(JANSSON_CFLAGS) \
+	$(LIBSYSTEMD_CFLAGS) \
 	$(LIBARCHIVE_CFLAGS)
 
 
@@ -87,6 +88,7 @@ flux_LDADD = \
 	$(top_builddir)/src/common/libpmi/libpmi_common.la \
 	$(top_builddir)/src/common/libfilemap/libfilemap.la \
 	$(LIBARCHIVE_LIBS) \
+	$(LIBSYSTEMD_LIBS) \
 	$(fluxcmd_ldadd)
 
 #

--- a/src/cmd/builtin/shutdown.c
+++ b/src/cmd/builtin/shutdown.c
@@ -74,7 +74,9 @@ static bool gc_threshold_check (flux_t *h, optparse_t *p)
     get_gc_threshold (h, &gc_threshold);
 
     if (gc_threshold > 0 && version > gc_threshold) {
-        if (optparse_hasopt (p, "yes") || optparse_hasopt (p, "no")) {
+        if (optparse_hasopt (p, "yes")
+            || optparse_hasopt (p, "no")
+            || optparse_hasopt (p, "skip-gc")) {
             if (optparse_hasopt (p, "yes"))
                 rc = true;
             else
@@ -143,6 +145,11 @@ static int subcmd (optparse_t *p, int ac, char *av[])
     if (optparse_hasopt (p, "background"))
         flags &= ~FLUX_RPC_STREAMING;
 
+    if (optparse_hasopt (p, "skip-gc")) {
+        if (flux_attr_set (h, "content.dump", "") < 0)
+            log_err_exit ("error clearing content.dump attribute");
+    }
+
     if (optparse_hasopt (p, "gc")
         || optparse_hasopt (p, "dump")
         || gc_threshold_check (h, p)) {
@@ -176,6 +183,9 @@ static int subcmd (optparse_t *p, int ac, char *av[])
 }
 
 static struct optparse_option opts[] = {
+    { .name = "skip-gc", .has_arg = 0,
+      .usage = "Skip KVS garbage collection this time, if already enabled",
+    },
     { .name = "gc", .has_arg = 0,
       .usage = "Garbage collect KVS (short for --dump=auto)",
     },

--- a/t/system/0004-recovery.t
+++ b/t/system/0004-recovery.t
@@ -20,3 +20,12 @@ test_expect_success 'flux start --recover works from dump file' '
 test_expect_success 'restart flux' '
         sudo systemctl start flux
 '
+get_uptime_state () {
+	local state=$(flux uptime | cut -d' ' -f3) || state=unknown
+	echo $state
+}
+test_expect_success 'wait for flux to reach run state' '
+	while test $(get_uptime_state) != run; do \
+	    sleep 1; \
+	done
+'

--- a/t/t2808-shutdown-cmd.t
+++ b/t/t2808-shutdown-cmd.t
@@ -315,5 +315,20 @@ test_expect_success 'clean up dump files from previous tests' '
 	rm -f dump.tgz &&
 	rm -f dump/RESTORE
 '
+test_expect_success 'submit batch with dump=auto and wait for it to start (8)' '
+	cat >batch.sh <<-EOT &&
+	#!/bin/sh
+	touch job8-has-started
+	flux run sleep 300
+	EOT
+	chmod +x batch.sh &&
+	flux batch -t30m -n1 \
+	    --broker-opts=-Scontent.dump=auto batch.sh >jobid8 &&
+	$waitfile job8-has-started
+'
+test_expect_success 'shutdown --skip-gc does not produce dump' '
+	FLUX_URI=$(flux uri --local $(cat jobid8)) flux shutdown --skip-gc &&
+	test_must_fail tar tvf dump/RESTORE
+'
 
 test_done

--- a/t/t9000-system.t
+++ b/t/t9000-system.t
@@ -13,6 +13,8 @@ if test -n "$FLUX_ENABLE_SYSTEM_TESTS"; then
 		FLUX_TEST_INSTALLED_PATH=${FLUX_TEST_INSTALLED_PATH:-/usr/bin}
 	fi
 fi
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
 #  Do not run system tests by default unless FLUX_ENABLE_SYSTEM_TESTS


### PR DESCRIPTION
This enables KVS garbage collection when flux is started with systemd, and wires `flux-dump(1)` and `flux-restore(1)` into sd_notify(3) so that systemd won't kill the dump process if it takes too long, and `systemctl status flux` will show regular updates about how many keys have been dumped/restored.

I've tested this on my home system by beefing up the content store and reducing the TimeoutStopSec=90 in the unit file to just a few seconds.  Definitely kills flux-dump without this PR, and does not with it.

I probably need to add a little more testing but thought I'd post this as is since dinner just arrived!