### PR TITLE
flux-job: fix `wait-event -m, --match-context`

### DIFF
--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -182,6 +182,11 @@ test_expect_success 'flux job wait-event w/ bad match-context fails (invalid val
 	test_must_fail fj_wait_event --match-context=type=foo $JOBID exception
 '
 
+# Note: in test below, foo=0 would match severity=0 in buggy version
+test_expect_success 'flux job wait-event w/ bad match-context fails (issue #5845)' '
+	test_must_fail fj_wait_event --match-context=foo=0 $JOBID exception
+'
+
 test_expect_success 'flux job wait-event w/ bad match-context fails (invalid input)' '
 	test_must_fail fj_wait_event --match-context=foo $JOBID exception
 '


### PR DESCRIPTION
This PR fixes context matching in `flux job wait-event -m, --match-context`, which currently returns a match if the value matches but key does not.
