### PR TITLE
minor cleanup in job-manager journal and job-list (mostly inline docs)

### DIFF
--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -982,11 +982,9 @@ static int journal_process_event (struct job_state_ctx *jsctx,
             return -1;
     }
     else if (streq (name, "flux-restart")) {
-        /* Presently, job-list depends on job-manager.events-journal
-         * service.  So if job-manager reloads, job-list must be
-         * reloaded, making the probability of reaching this
-         * `flux-restart` path very low.  Code added for completeness
-         * and in case dependency removed in the future.
+        /* This can only be seen while processing the journal backlog
+         * as it is posted by the job manager during its KVS restart,
+         * which happens synchronously before the journal RPC is processed.
          */
         if (journal_revert_job (jsctx,
                                 job,

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -22,9 +22,6 @@ enum job_manager_event_flags {
 
     /*  EVENT_NO_COMMIT events are the same as any other event, except
      *   that the event is not posted to the job eventlog in the KVS.
-     *   The event is not given a global sequence number, since this would
-     *   cause the events to be numbered incorrectly when replayed from
-     *   the eventlog in the KVS.
      */
     EVENT_NO_COMMIT = 1,
 };

--- a/src/modules/job-manager/journal.c
+++ b/src/modules/job-manager/journal.c
@@ -29,8 +29,6 @@
 #include "job.h"
 #include "journal.h"
 
-#define DEFAULT_JOURNAL_SIZE_LIMIT 1000
-
 struct journal {
     struct job_manager *ctx;
     flux_msg_handler_t **handlers;

--- a/src/modules/job-manager/prioritize.c
+++ b/src/modules/job-manager/prioritize.c
@@ -98,7 +98,7 @@ static int reprioritize_one (struct job_manager *ctx,
         && job->state != FLUX_JOB_STATE_PRIORITY
         && job->priority != FLUX_JOB_PRIORITY_MIN
         && job->priority != FLUX_JOB_PRIORITY_MAX)
-        flags = EVENT_JOURNAL_ONLY;
+        flags = EVENT_NO_COMMIT;
      */
 
     /*  Post 'priority' event.


### PR DESCRIPTION
@chu11 and I were both looking through the job-list source to be sure all is OK before we tag, and we both spotted some incorrect source comments.  Al, feel free to add to this PR.