### PR TITLE
add `doc/requirements.txt` to dist

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -451,6 +451,7 @@ EXTRA_DIST = \
 	domainrefs.py \
 	index.rst \
 	index_man.rst \
+	requirements.txt \
 	guide/build.rst \
 	guide/support.rst \
 	guide/images/lgplv3-147x51.png \


### PR DESCRIPTION
This is minor, but it would be useful if `doc/requirements.txt` was in the distribution tarball and it currently is not.

This simple PR adds it.