### PR TITLE
job-list: remove jobspec/R update dead code

### DIFF
--- a/src/modules/job-list/job_data.c
+++ b/src/modules/job-list/job_data.c
@@ -40,8 +40,6 @@ void job_destroy (void *data)
         json_decref (job->jobspec);
         json_decref (job->R);
         json_decref (job->exception_context);
-        json_decref (job->jobspec_updates);
-        json_decref (job->R_updates);
         free (job);
         errno = save_errno;
     }

--- a/src/modules/job-list/job_data.h
+++ b/src/modules/job-list/job_data.h
@@ -77,9 +77,6 @@ struct job {
     unsigned int states_mask;
     unsigned int states_events_mask;
     void *list_handle;
-    /* store updates that were received before jobspec/R objects */
-    json_t *jobspec_updates;
-    json_t *R_updates;
 
     int submit_version;         /* version number in submit context */
 };


### PR DESCRIPTION
Problem: Older code that handled jobspec/R updates when jobspec/R were not yet read in from the KVS.  This code is no longer necessary now that jobspec/R are sent via the event journal.

Remove all traces of cached "jobspec_updates" and "R_updates" code.