### PR TITLE
doc: add path to 'manpages' to conf.py

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -427,7 +427,6 @@ stderr_devnull_0 = >/dev/null 2>&1
 
 $(MAN_FILES): manpages.py conf.py $(RST_FILES)
 	$(sphinx_man) \
-	PYTHONPATH=$(PYTHONPATH):$(abs_srcdir) \
 	SPHINX_BUILDDIR=$(abs_builddir) $(PYTHON) \
 		-m sphinx $(sphinx_verbose_flags) -b man $(srcdir) ./man \
 		$(STDERR_DEVNULL)
@@ -440,7 +439,6 @@ $(MAN_FILES): manpages.py conf.py $(RST_FILES)
 .PHONY: html
 html: conf.py $(RST_FILES)
 	$(sphinx_html) \
-	PYTHONPATH=$(PYTHONPATH):$(abs_srcdir) \
 	SPHINX_BUILDDIR=$(abs_builddir) $(PYTHON) \
 		-m sphinx $(sphinx_verbose_flags) -b html $(srcdir) ./html \
 		$(STDERR_DEVNULL)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,6 +22,11 @@
 #
 import os
 import sys
+
+# add `manpages` directory to sys.path
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).absolute().parent))
+
 from manpages import man_pages
 import docutils.nodes
 


### PR DESCRIPTION
I ran into an issue building the documentation while following the README, `sphinx-build` couldn't find the `manpages` module. Adding the path to `sys.path` manually or on a one-off basis is easy enough but I think adding this will be a bit more foolproof?