### PR TITLE
resource: improve `resource.status` response time with many drained ranks

### DIFF
--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -859,8 +859,10 @@ int rlist_append (struct rlist *rl, const struct rlist *rl2)
     struct rnode *n = zlistx_first (rl2->nodes);
     while (n) {
         struct rnode *copy = rnode_copy_avail (n);
-        if (!copy || rlist_add_rnode (rl, copy) < 0)
+        if (!copy || rlist_add_rnode (rl, copy) < 0) {
+            rnode_destroy (copy);
             return -1;
+        }
         n = zlistx_next (rl2->nodes);
     }
 

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -39,7 +39,9 @@ libresource_la_SOURCES = \
 	drainset.h \
 	drainset.c
 
-TESTS = test_rutil.t
+TESTS = \
+	test_rutil.t \
+	test_drainset.t
 
 test_ldadd = \
 	$(builddir)/libresource.la \
@@ -68,3 +70,8 @@ test_rutil_t_SOURCES = test/rutil.c
 test_rutil_t_CPPFLAGS = $(test_cppflags)
 test_rutil_t_LDADD = $(test_ldadd)
 test_rutil_t_LDFLAGS = $(test_ldflags)
+
+test_drainset_t_SOURCES = test/drainset.c
+test_drainset_t_CPPFLAGS = $(test_cppflags)
+test_drainset_t_LDADD = $(test_ldadd)
+test_drainset_t_LDFLAGS = $(test_ldflags)

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -35,7 +35,9 @@ libresource_la_SOURCES = \
 	rutil.c \
 	rutil.h \
 	status.c \
-	status.h
+	status.h \
+	drainset.h \
+	drainset.c
 
 TESTS = test_rutil.t
 

--- a/src/modules/resource/drainset.c
+++ b/src/modules/resource/drainset.c
@@ -1,0 +1,212 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/*  drainset.c - a set of drained ranks with timestamp and reason
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <time.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/errprintf.h"
+#include "ccan/str/str.h"
+
+#include "drainset.h"
+
+struct draininfo {
+    struct idset *ranks;
+    double timestamp;
+    char *reason;
+};
+
+struct drainset {
+    zhashx_t *map;
+};
+
+static void draininfo_destroy (struct draininfo *d)
+{
+    if (d) {
+        int saved_errno = errno;
+        idset_destroy (d->ranks);
+        free (d->reason);
+        free (d);
+        errno = saved_errno;
+    }
+}
+
+static void draininfo_free (void **item)
+{
+    if (item) {
+        draininfo_destroy (*item);
+        *item = NULL;
+    }
+}
+
+static struct draininfo *draininfo_create_rank (unsigned int rank,
+                                                const char *reason,
+                                                double timestamp)
+{
+    struct draininfo *d;
+    if (!(d = calloc (1, sizeof (*d)))
+        || !(d->ranks = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || idset_set (d->ranks, rank) < 0
+        || (reason && !(d->reason = strdup (reason))))
+        goto error;
+    d->timestamp = timestamp;
+    return d;
+error:
+    draininfo_destroy (d);
+    return NULL;
+}
+
+/* Use "modified Bernstein hash" as employed by zhashx internally, but input
+ * is draininfo reason+timestamp instead of a simple NULL-terminated string.
+ * Copied from: msg_hash_uuid_matchtag_hasher()
+ */
+static size_t draininfo_hasher (const void *key)
+{
+    const struct draininfo *d = key;
+    size_t key_hash = 0;
+    const char *cp;
+
+    cp = d->reason ? d->reason : "";
+    while (*cp)
+        key_hash = 33 * key_hash ^ *cp++;
+    cp = (const char *) &d->timestamp;
+    for (int i = 0; i < sizeof (d->timestamp); i++)
+        key_hash = 33 * key_hash ^ *cp++;
+    return key_hash;
+}
+
+static int drainmap_key_cmp (const void *key1, const void *key2)
+{
+    const struct draininfo *d1 = key1;
+    const struct draininfo *d2 = key2;
+    if (d1->timestamp == d2->timestamp) {
+        const char *s1 = d1->reason;
+        const char *s2 = d2->reason;
+        return strcmp (s1 ? s1 : "", s2 ? s2 : "");
+    }
+    return d1->timestamp < d2->timestamp ? -1 : 1;
+}
+
+static zhashx_t *drainmap_create ()
+{
+    zhashx_t *map;
+
+    if (!(map = zhashx_new ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    zhashx_set_key_hasher (map, draininfo_hasher);
+    zhashx_set_key_comparator (map, drainmap_key_cmp);
+    zhashx_set_key_destructor (map, draininfo_free);
+    zhashx_set_key_duplicator (map, NULL);
+    return map;
+}
+
+void drainset_destroy (struct drainset *ds)
+{
+    if (ds) {
+        int saved_errno = errno;
+        zhashx_destroy (&ds->map);
+        free (ds);
+        errno = saved_errno;
+    }
+}
+
+struct drainset *drainset_create (void)
+{
+    struct drainset *ds;
+
+    if (!(ds = malloc (sizeof (*ds)))
+        || !(ds->map = drainmap_create ()))
+        goto error;
+    return ds;
+error:
+    drainset_destroy (ds);
+    return NULL;
+}
+
+static struct draininfo *drainset_find (struct drainset *ds,
+                                        double timestamp,
+                                        const char *reason)
+{
+    struct draininfo tmp = {.timestamp = timestamp, .reason = (char *)reason};
+    return zhashx_lookup (ds->map, &tmp);
+}
+
+int drainset_drain_rank (struct drainset *ds,
+                         unsigned int rank,
+                         double timestamp,
+                         const char *reason)
+{
+    int rc = -1;
+    struct draininfo *match;
+    struct draininfo *new = NULL;
+    if (!ds) {
+        errno = EINVAL;
+        return -1;
+    }
+    if ((match = drainset_find (ds, timestamp, reason))) {
+        if (idset_set (match->ranks, rank) < 0)
+            return -1;
+        return 0;
+    }
+    if (!(new = draininfo_create_rank (rank, reason, timestamp))
+        || zhashx_insert (ds->map, new, new) < 0) {
+        draininfo_destroy (new);
+        goto out;
+    }
+    rc = 0;
+out:
+    return rc;
+}
+
+json_t *drainset_to_json (struct drainset *ds)
+{
+    json_t *o;
+    struct draininfo *d;
+
+    if (!(o = json_object ()))
+        goto nomem;
+    d = zhashx_first (ds->map);
+    while (d) {
+        json_t *val;
+        char *s;
+        if (!(val = json_pack ("{s:f s:s}",
+                               "timestamp", d->timestamp,
+                               "reason", d->reason ? d->reason : ""))
+            || !(s = idset_encode (d->ranks, IDSET_FLAG_RANGE))) {
+            json_decref (val);
+            goto nomem;
+        }
+        if (json_object_set_new (o, s, val) < 0) {
+            ERRNO_SAFE_WRAP (json_decref, val);
+            ERRNO_SAFE_WRAP (free, s);
+            goto error;
+        }
+        free (s);
+        d = zhashx_next (ds->map);
+    }
+    return o;
+nomem:
+    errno = EPROTO;
+error:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/drainset.h
+++ b/src/modules/resource/drainset.h
@@ -1,0 +1,34 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_DRAINSET_H
+#define _FLUX_RESOURCE_DRAINSET_H
+
+#include <stdbool.h>
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/idset.h>
+
+struct drainset * drainset_create (void);
+void drainset_destroy (struct drainset *dset);
+
+int drainset_drain_rank (struct drainset *dset,
+                         unsigned int rank,
+                         double timestamp,
+                         const char *reason);
+
+json_t *drainset_to_json (struct drainset *dset);
+
+#endif /* ! _FLUX_RESOURCE_DRAINSET_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/rutil.h
+++ b/src/modules/resource/rutil.h
@@ -20,10 +20,6 @@ int rutil_idset_diff (const struct idset *old_set,
                       struct idset **add,
                       struct idset **sub);
 
-/* Check whether id is a member of encoded idset
- */
-bool rutil_idset_decode_test (const char *idset, unsigned long id);
-
 /* Set key=val in a json object, where val is the string
  * representation of 'ids', or the empty string if 'ids' is NULL.
  */
@@ -42,27 +38,15 @@ char *rutil_read_file (const char *path, flux_error_t *errp);
 json_t *rutil_load_file (const char *path, flux_error_t *errp);
 json_t *rutil_load_xml_dir (const char *path, flux_error_t *errp);
 
-/* Build object with idset keys.
- * Start with empty json_t object, then insert objects by id.
- * If json_equal() returns true on values, they are combined.
- */
-int rutil_idkey_insert_id (json_t *obj, unsigned int id, json_t *val);
-int rutil_idkey_insert_idset (json_t *obj, struct idset *ids, json_t *val);
-
 /* Map over object with idset keys, calling 'map' for each id.
  * map function returns 0 on success, -1 with errno set to abort.
  */
 typedef int (*rutil_idkey_map_f)(unsigned int id, json_t *val, void *arg);
 int rutil_idkey_map (json_t *obj, rutil_idkey_map_f map, void *arg);
 
-/* Merge obj2 into obj1, where both are objects with idset keys.
- */
-int rutil_idkey_merge (json_t *obj1, json_t *obj2);
-
 /* Count ranks represented in idkey object.
  */
 int rutil_idkey_count (json_t *obj);
-
 
 #endif /* !_FLUX_RESOURCE_RUTIL_H */
 

--- a/src/modules/resource/status.c
+++ b/src/modules/resource/status.c
@@ -218,6 +218,7 @@ static int update_properties (struct rlist *alloc, struct rlist *all)
     if (!(props = get_properties (all))
         || json_object_size (props) == 0) {
         json_decref (props);
+        idset_destroy (alloc_ranks);
         return 0;
     }
     json_object_foreach (props, name, val) {

--- a/src/modules/resource/test/drainset.c
+++ b/src/modules/resource/test/drainset.c
@@ -1,0 +1,111 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <errno.h>
+#include <string.h>
+
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
+
+#include "src/modules/resource/drainset.h"
+
+static void check_drainset (struct drainset *ds,
+                           const char *json_str)
+{
+    char *s;
+    json_t *o = drainset_to_json (ds);
+    json_t *expected = json_loads (json_str, 0, NULL);
+    if (!o || !expected)
+        BAIL_OUT ("drainset_to_json failed");
+    if (!(s = json_dumps (o, JSON_COMPACT)))
+        BAIL_OUT ("json_dumps failed");
+    diag ("drainset_to_json = %s", s);
+    diag ("expected =         %s", json_str);
+    ok (json_equal (expected, o),
+        "drainset_to_json got expected result");
+    json_decref (expected);
+    json_decref (o);
+    free (s);
+}
+
+static void test_empty ()
+{
+    struct drainset *ds = drainset_create ();
+    if (!ds)
+        BAIL_OUT ("drainset_create failed");
+    diag ("empty drainset should return empty JSON object");
+    check_drainset (ds, "{}");
+    drainset_destroy (ds);
+}
+
+static void test_basic ()
+{
+    struct drainset *ds = drainset_create ();
+    if (!ds)
+        BAIL_OUT ("drainset_create failed");
+
+    ok (drainset_drain_rank (NULL, 0, 1234.0, NULL) < 0 && errno == EINVAL,
+        "drainset_drain_rank (NULL, ...) returns EINVAL");
+
+    for (unsigned int i = 0; i < 8; i++) {
+        ok (drainset_drain_rank (ds, i, 1234.0, "test") == 0,
+            "drainset_drain_rank: rank=%u", i);
+    }
+    check_drainset (ds,
+                    "{\"0-7\":{\"timestamp\":1234.0,\"reason\":\"test\"}}");
+    drainset_destroy (ds);
+}
+
+static void test_multiple ()
+{
+    struct drainset *ds = drainset_create ();
+
+    if (!ds)
+        BAIL_OUT ("drainset_create failed");
+
+    ok (drainset_drain_rank (ds, 0, 1234.0, "test") == 0,
+        "drainset_drain_rank: rank=0");
+    ok (drainset_drain_rank (ds, 1, 2345.0, "test") == 0,
+        "drainset_drain_rank: rank=1");
+    ok (drainset_drain_rank (ds, 2, 1234.0, "test1") == 0,
+        "drainset_drain_rank: rank=1");
+    ok (drainset_drain_rank (ds, 3, 1234.0, "test") == 0,
+        "drainset_drain_rank: rank=0");
+    ok (drainset_drain_rank (ds, 4, 1234.0, NULL) == 0,
+        "drainset_drain_rank: rank=1");
+
+    check_drainset (ds,
+                    "{\"0,3\":{\"timestamp\":1234.0,\"reason\":\"test\"},"
+                    "\"1\":{\"timestamp\":2345.0,\"reason\":\"test\"},"
+                    "\"2\":{\"timestamp\":1234.0,\"reason\":\"test1\"},"
+                    "\"4\":{\"timestamp\":1234.0,\"reason\":\"\"}}");
+    drainset_destroy (ds);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+    test_empty ();
+    test_basic ();
+    test_multiple ();
+    done_testing ();
+    return (0);
+}
+
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/t/t2312-resource-exclude.t
+++ b/t/t2312-resource-exclude.t
@@ -56,7 +56,7 @@ test_expect_success 'config with bad exclude idset fails' '
 	[resource]
 	exclude = "xxzz"
 	EOT
-	test_must_fail flux start -o,--config-path=resource.toml
+	test_must_fail flux start -o,--config-path=resource.toml true
 '
 
 test_expect_success 'config with out of range exclude idset fails' '
@@ -64,7 +64,7 @@ test_expect_success 'config with out of range exclude idset fails' '
 	[resource]
 	exclude = "1"
 	EOT
-	test_must_fail flux start -o,--config-path=resource.toml
+	test_must_fail flux start -o,--config-path=resource.toml true
 '
 
 # See flux-framework/flux-core#5337


### PR DESCRIPTION
This PR improves the time it takes the `resource` module to assemble the `drain` key in the `resource.status` response when there are many drained targets.

The previous method of building the response piecemeal in a `json_t` object is dropped in favor of a custom class that more efficiently represents a set of drained ranks.

A sharness test that simulates a 2^14 size instance was used to simulate some worst-case performance scenarios at scale. The `resource.status` RPC was timed in the following scenarios:

 - no drained ranks
 - 16,000 drained ranks, but matching timestamps and reason fields
 - 16,000 drained ranks, each with differing timestamp or reason fields

The timing is for just the RPC (i.e. `future.wait_for(-1)` was used instead of `future.get()` to avoid the penalty of `json.loads()` in Python)

The `drainit.py` script is a custom script that sends a separate RPC per target to give all drained ranks a different timestamp.

On current master:
```
expecting success: 
	time rpc "resource.status"


real	0m0.252s
user	0m0.191s
sys	0m0.038s
ok 1 - time resource.status rpc, no drained ranks

expecting success: 
	flux resource drain 1-16000 this is a drain reason

ok 2 - drain all ranks with same timestamp

expecting success: 
	time rpc "resource.status"


real	0m52.827s
user	0m0.207s
sys	0m0.031s
ok 3 - time resource.status rpc all drained ranks

expecting success: 
	flux resource undrain 1-16000

ok 4 - undrain all ranks

expecting success: 
	time flux python drainit.py 1-16000


real	4m26.065s
user	0m0.989s
sys	0m0.390s
ok 5 - drain 16000 ranks with differing timestamps

expecting success: 
	time rpc "resource.status" >/dev/null

  
real	40m46.993s
user	0m0.193s
sys	0m0.043s
ok 6 - time resource.status rpc

# passed all 6 test(s)
1..6
```

and on this PR branch:
```
expecting success: 
	time rpc "resource.status"


real	0m0.233s
user	0m0.175s
sys	0m0.033s
ok 1 - time resource.status rpc, no drained ranks

expecting success: 
	flux resource drain 1-16000 this is a drain reason

ok 2 - drain all ranks with same timestamp

expecting success: 
	time rpc "resource.status"


real	0m0.254s
user	0m0.189s
sys	0m0.033s
ok 3 - time resource.status rpc all drained ranks

expecting success: 
	flux resource undrain 1-16000

ok 4 - undrain all ranks

expecting success: 
	time flux python drainit.py 1-16000


real	4m24.734s
user	0m0.916s
sys	0m0.412s
ok 5 - drain 16000 ranks with differing timestamps

expecting success: 
	time rpc "resource.status" >/dev/null


real	0m0.765s
user	0m0.191s
sys	0m0.047s
ok 6 - time resource.status rpc

# passed all 6 test(s)
1..6
```

Further improvements could be made by storing drained ranks directly in a `drainset` instead of an array, so that the object doesn't have to be built and thrown away on each request. However, there's really diminishing returns here (and I measured and the actual time to assemble the entire response is <200ms in the worst case, the rest of the time must be message handling), and the implementation would be slightly tricky because of the `overwrite` behavior, so I've left that for later.
