### PR TITLE
fix more performance issues in `flux resource`

### DIFF
--- a/src/bindings/python/flux/resource/status.py
+++ b/src/bindings/python/flux/resource/status.py
@@ -112,10 +112,14 @@ class ResourceStatus:
             ranks = IDset(drain_ranks)
             if include_ranks is not None:
                 ranks = ranks.intersect(include_ranks)
-            self.drained += ranks - self.allocated
-            self.draining += ranks - self.drained
+            self.drained += ranks
             info = DrainInfo(ranks, entry["timestamp"], entry["reason"])
             self.drain_info.append(info)
+
+        # create the set of draining ranks as the intersection of
+        #  drained and allocated
+        self.draining = self.drained & self.allocated
+        self.drained -= self.draining
 
         # available: all ranks not excluded or drained/draining
         self.avail = self.all - self.get_idset("exclude", "drained", "draining")

--- a/src/bindings/python/flux/resource/status.py
+++ b/src/bindings/python/flux/resource/status.py
@@ -108,6 +108,7 @@ class ResourceStatus:
 
         # drain_info: ranks, timestamp, reason tuples for all drained resources
         self.drain_info = []
+        self._drain_lookup = {}
         for drain_ranks, entry in self.rstatus["drain"].items():
             ranks = IDset(drain_ranks)
             if include_ranks is not None:
@@ -115,6 +116,8 @@ class ResourceStatus:
             self.drained += ranks
             info = DrainInfo(ranks, entry["timestamp"], entry["reason"])
             self.drain_info.append(info)
+            for rank in ranks:
+                self._drain_lookup[rank] = info
 
         # create the set of draining ranks as the intersection of
         #  drained and allocated
@@ -146,7 +149,7 @@ class ResourceStatus:
         """
         if rank not in self.all:
             raise ValueError("invalid rank {rank}")
-        return next((i for i in self.drain_info if rank in i.ranks), None)
+        return self._drain_lookup.get(rank)
 
 
 class ResourceStatusRPC:

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -443,10 +443,10 @@ class ResourceSetExtra(ResourceSet):
     def queue(self):
         queues = ""
         if self.flux_config and "queues" in self.flux_config:
+            if not self.ranks:
+                return ""
             properties = json.loads(self.get_properties())
             for key, value in self.flux_config["queues"].items():
-                if not self.rlist:
-                    continue
                 if "requires" not in value or set(value["requires"]).issubset(
                     set(properties)
                 ):


### PR DESCRIPTION
This PR picks off some more performance issues in `flux resource list` and `status`.

It is built on top of #5863.

This reduces the time for `flux resource list` on a large system with queues from 5s to ~2s, and reduces the `flux resource status` time when there are 16K drained ranks from >40s to ~7s.