### PR TITLE
resource: round timestamp of drained ranks

### DIFF
--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -37,6 +37,7 @@
 #include "config.h"
 #endif
 #include <time.h>
+#include <math.h>
 #include <flux/core.h>
 #include <jansson.h>
 
@@ -281,7 +282,7 @@ json_t *drain_get_info (struct drain *drain)
         if (drain->info[rank].drained) {
             if (drainset_drain_rank (ds,
                                      rank,
-                                     drain->info[rank].timestamp,
+                                     round(drain->info[rank].timestamp),
                                      drain->info[rank].reason) < 0)
                 goto error;
         }


### PR DESCRIPTION
This PR rounds the drain timestamp in the resource module while building the drain object for a `resource.status` response. The idea here is that this will allow more compression in the `drain` object in the response and also result in less lines of output in `flux resource drain` (when sub-second precision in the output is used)

A kind of best case scenario is show by separately draining 16000 nodes, such that each rank has a different timestamp (but many are actually within the same second)

before
```
expecting success:
        flux dmesg -c >/dev/null &&
        time rpc "resource.status" >rstatus.json
        flux dmesg -HL


real    0m0.766s
user    0m0.193s
sys     0m0.040s
ok 7 - time resource.status rpc

expecting success:
        time flux python -m cProfile -o prof.out $flux_resource status

     STATE UP NNODES NODELIST
     avail  ✔      1 fake0
    avail*  ✗    383 fake[16001-16383]
  drained*  ✗  16000 fake[1-16000]

real    0m6.965s
user    0m5.753s
sys     0m0.092s
```

```
expecting success:
        flux dmesg -c >/dev/null &&
        time rpc "resource.status" >rstatus.json
        flux dmesg -HL


real    0m0.292s
user    0m0.205s
sys     0m0.031s
ok 7 - time resource.status rpc

expecting success:
        time flux python -m cProfile -o prof.out $flux_resource status

     STATE UP NNODES NODELIST
     avail  ✔      1 fake0
    avail*  ✗    383 fake[16001-16383]
  drained*  ✗  16000 fake[1-16000]

real    0m5.524s
user    0m4.784s
sys     0m0.065s
```

Note the RPC time was reduced from 0.766s to 0.292s -- probably from massively reducing the payload size.
There's only a slight difference in `flux resource status` because the command is now bound by performance of librlist operations (mostly `rlist_diff`).
