### PR TITLE
fix broker crash in `resource.status` RPC handling when exlcuded ranks are also down

### DIFF
--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -2164,6 +2164,7 @@ struct rlist *rlist_alloc (struct rlist *rl,
 
     if (!rl || !ai) {
         errno = EINVAL;
+        errprintf (errp, "Invalid argument");
         return NULL;
     }
 
@@ -2174,6 +2175,8 @@ struct rlist *rlist_alloc (struct rlist *rl,
         result = rlist_alloc_constrained (rl, ai, errp);
     else {
         result = rlist_try_alloc (rl, ai);
+        if (!result)
+            errprintf (errp, "%s", strerror (errno));
 
         if (!result && (errno == ENOSPC)) {
             if (!rlist_alloc_feasible (rl,

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -398,6 +398,7 @@ static int rlist_remove_rank (struct rlist *rl, int rank)
         errno = ENOENT;
         return -1;
     }
+    rank_hash_delete (rl, rank);
     zlistx_delete (rl->nodes, handle);
     return 0;
 }

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -2313,9 +2313,11 @@ static int rlist_mark_state (struct rlist *rl, bool up, const char *ids)
     i = idset_first (idset);
     while (i != IDSET_INVALID_ID) {
         struct rnode *n = rlist_find_rank (rl, i);
-        if (n->up != up)
-            count += idset_count (n->cores->avail);
-        n->up = up;
+        if (n) {
+            if (n->up != up)
+                count += idset_count (n->cores->avail);
+            n->up = up;
+        }
         i = idset_next (idset, i);
     }
     idset_destroy (idset);

--- a/src/common/librlist/test/rlist.c
+++ b/src/common/librlist/test/rlist.c
@@ -2112,6 +2112,43 @@ static void test_rlist_config_inval (void)
     json_decref (o);
 }
 
+static void test_issue_5868 (void)
+{
+    char *R;
+    char *s;
+    struct rlist *rl;
+    struct idset *ranks;
+
+    if (!(R = R_create ("0-3",
+                        "0-3",
+                        NULL,
+                        "foo[0-3]",
+                        NULL)))
+        BAIL_OUT ("issue5868: R_create");
+
+    if (!(rl = rlist_from_R (R)))
+        BAIL_OUT ("issue5868: rlist_from_R() failed");
+    /*  Remove ranks 0-1
+     */
+    if (!(ranks = idset_decode ("0-1")))
+        BAIL_OUT ("issue5868: idset_create failed");
+    if (rlist_remove_ranks (rl, ranks) < 0)
+        BAIL_OUT ("issue5868: rlist_remove_ranks failed");
+    idset_destroy (ranks);
+
+    ok (rlist_mark_down (rl, "0-2") == 0,
+        "issue5868: rlist_mark_down (0-2) ignores missing ranks");
+
+    s = rlist_dumps (rl);
+    diag ("%s", s);
+    is (s, "rank3/core[0-3]",
+        "issue5868: expected resources remain up");
+
+    free (s);
+    rlist_destroy (rl);
+    free (R);
+}
+
 int main (int ac, char *av[])
 {
     plan (NO_PLAN);
@@ -2142,7 +2179,7 @@ int main (int ac, char *av[])
     test_properties ();
     test_issue4290 ();
     test_rlist_config_inval ();
-
+    test_issue_5868 ();
     done_testing ();
 }
 


### PR DESCRIPTION
This PR fixes issue #5856.

When ranks are excluded, the resource module removes them from the constructed rlist with `rlist_remove_ranks()`. However, there is a bug in `rlist_remove_ranks()` that leaves pointers to the destroyed `rnode` objects in the rnode lookup hash. This causes a subsequent `rlist_mark_down()` to crash if an excluded rank is also down.

This PR fixes that main issue and also ignores missing ranks in `rlist_mark_down()` and `rlist_mark_up()` to avoid a subsequent NULL deref.

