### PR TITLE
shutdown: unload perilog plugin during shutdown

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -113,6 +113,7 @@ fi
 if test $RANK -eq 0; then
     if test -z "${FLUX_DISABLE_JOB_CLEANUP}"; then
 	flux admin cleanup-push <<-EOT
+	flux jobtap remove perilog 2>/dev/null || true
 	flux queue stop --quiet --all --nocheckpoint
 	flux cancel --user=all --quiet --states RUN
 	flux queue idle --quiet


### PR DESCRIPTION
Problem: when flux is shutting down and canceling running jobs, the epilog can greatly extend the shutdown time.

Unload the perilog plugin as part  of the cleanup tasks so that canceled jobs can complete quickly in the shutdown case.


Note: @grondo's good IMHO idea!  This was peeled off of #5860 because it seems like it might be a good candidate for a point release, whereas #5860 is too big of a change for that.