### PR TITLE
job-manager: canceled job need not wait for sched

### DIFF
--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -77,6 +77,11 @@ int module_start (module_t *p);
  */
 int module_stop (module_t *p, flux_t *h);
 
+/* Defer all messages that would be sent to module if flag=true.
+ * Stop deferring them and send backlog if flag=false.
+ */
+int module_set_defer (module_t *p, bool flag);
+
 /*  Mute module. Do not send any more messages.
  */
 void module_mute (module_t *p);

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -31,8 +31,13 @@ void alloc_dequeue_alloc_request (struct alloc *alloc, struct job *job);
 
 /* Send a request to cancel pending alloc request.
  * This function is a no-op if job->alloc_pending is not set.
+ * If finalize is true, update the job as though the cancelation
+ * request has already been handled, so the job can progress through
+ * CLEANUP without waiting for the scheduler response.
  */
-int alloc_cancel_alloc_request (struct alloc *alloc, struct job *job);
+int alloc_cancel_alloc_request (struct alloc *alloc,
+                                struct job *job,
+                                bool finalize);
 
 /* Accessor for the count of queued alloc requests.
  */

--- a/src/modules/job-manager/annotate.h
+++ b/src/modules/job-manager/annotate.h
@@ -16,8 +16,6 @@
 #include "job.h"
 #include "job-manager.h"
 
-void annotations_clear (struct job *job, bool *cleared);
-void annotations_sched_clear (struct job *job, bool *cleared);
 int annotations_update (struct job *job, const char *path, json_t *annotations);
 
 struct annotate *annotate_ctx_create (struct job_manager *ctx);
@@ -29,6 +27,14 @@ int update_annotation_recursive (json_t *orig, const char *path, json_t *new);
 int annotations_update_and_publish (struct job_manager *ctx,
                                     struct job *job,
                                     json_t *annotations);
+
+/* clear key from annotations, or clear all annotations if key == NULL.
+ * If that transitioned the annotations object from non-empty to empty,
+ * post an annotations event with the context of {"annotations":null}.
+ */
+void annotations_clear_and_publish (struct job_manager *ctx,
+                                    struct job *job,
+                                    const char *key);
 
 #endif /* ! _FLUX_JOB_MANAGER_ANNOTATE_H */
 /*

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -293,7 +293,7 @@ int event_job_action (struct event *event, struct job *job)
              * SCHED state, dequeue the job first.
              */
             if (job->alloc_pending)
-                alloc_cancel_alloc_request (ctx->alloc, job);
+                alloc_cancel_alloc_request (ctx->alloc, job, false);
             if (job->alloc_queued)
                 alloc_dequeue_alloc_request (ctx->alloc, job);
             break;
@@ -313,7 +313,7 @@ int event_job_action (struct event *event, struct job *job)
             break;
         case FLUX_JOB_STATE_CLEANUP:
             if (job->alloc_pending)
-                alloc_cancel_alloc_request (ctx->alloc, job);
+                alloc_cancel_alloc_request (ctx->alloc, job, true);
             if (job->alloc_queued)
                 alloc_dequeue_alloc_request (ctx->alloc, job);
 

--- a/src/modules/job-manager/prioritize.c
+++ b/src/modules/job-manager/prioritize.c
@@ -125,7 +125,7 @@ static int reprioritize_one (struct job_manager *ctx,
     }
     else if (job->alloc_pending) {
         if (job->priority == FLUX_JOB_PRIORITY_MIN) {
-            if (alloc_cancel_alloc_request (ctx->alloc, job) < 0)
+            if (alloc_cancel_alloc_request (ctx->alloc, job, false) < 0)
                 return -1;
         }
         else if (oneshot) {

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -665,7 +665,7 @@ static void queue_stop (struct queue *queue, const char *name)
                 if (job->alloc_queued)
                     alloc_dequeue_alloc_request (queue->ctx->alloc, job);
                 else if (job->alloc_pending)
-                    alloc_cancel_alloc_request (queue->ctx->alloc, job);
+                    alloc_cancel_alloc_request (queue->ctx->alloc, job, false);
             }
             job = zhashx_next (queue->ctx->active_jobs);
         }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -170,6 +170,7 @@ TESTSCRIPTS = \
 	t2302-sched-simple-up-down.t \
 	t2303-sched-hello.t \
 	t2304-sched-simple-alloc-check.t \
+	t2305-sched-slow.t \
 	t2310-resource-module.t \
 	t2311-resource-drain.t \
 	t2312-resource-exclude.t \

--- a/t/t2305-sched-slow.t
+++ b/t/t2305-sched-slow.t
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+test_description='test a scheduler that is slow to respond
+'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1
+
+# Usage: module_debug_defer modname True|False
+module_debug_defer () {
+	flux python -c "import flux; flux.Flux().rpc(\"broker.module-debug\",{\"name\":\"$1\",\"defer\":$2}).get()"
+}
+
+test_expect_success 'pause sched message handling' '
+	module_debug_defer sched-simple True
+'
+test_expect_success 'a job can be submitted when the scheduler is unresponsive' '
+	flux submit -N1 \
+	    --flags=debug --wait-event=debug.alloc-request \
+	    true >job1.id
+'
+test_expect_success 'the job is blocked on the alloc request' '
+	test_expect_code 137 run_timeout 2 \
+	    flux job wait-event $(cat job1.id) alloc
+'
+test_expect_success 'unpause sched message handling' '
+	module_debug_defer sched-simple False
+'
+test_expect_success 'the job gets its allocation and completes' '
+	run_timeout 30 flux job wait-event $(cat job1.id) clean
+'
+test_expect_success 'submit a job and wait for it to get an alloc response' '
+	flux submit -N1 --wait-event=alloc sleep 3600 >job2.id
+'
+test_expect_success 'pause sched message handling' '
+	module_debug_defer sched-simple True
+'
+test_expect_success 'cancel the job' '
+	flux cancel $(cat job2.id)
+'
+test_expect_success 'the job is able to get through CLEANUP state' '
+	run_timeout 30 flux job wait-event $(cat job2.id) clean
+'
+test_expect_success 'unpause sched message handling' '
+	module_debug_defer sched-simple False
+'
+test_expect_success 'another -N1 job can run so resources are free' '
+	run_timeout 30 flux run -N1 true
+'
+test_expect_success 'drain the only node in the instance' '
+	flux resource drain 0
+'
+test_expect_success 'submit a job' '
+	flux submit -N1 \
+	    --flags=debug --wait-event=debug.alloc-request \
+	    true >job3.id
+'
+test_expect_success 'the job is blocked on the alloc request' '
+	test_expect_code 137 run_timeout 2 \
+	    flux job wait-event $(cat job3.id) alloc
+'
+test_expect_success 'pause sched message handling' '
+	module_debug_defer sched-simple True
+'
+test_expect_success 'cancel the job' '
+	flux cancel $(cat job3.id)
+'
+test_expect_success 'the job is able to get through CLEANUP state' '
+	run_timeout 30 flux job wait-event $(cat job3.id) clean
+'
+test_expect_success 'unpause sched message handling' '
+	module_debug_defer sched-simple False
+'
+test_expect_success 'undrain the node' '
+	flux resource undrain 0
+'
+test_expect_success 'another -N1 job can run so everything still works!' '
+	run_timeout 30 flux run -N1 true
+'
+
+test_done


### PR DESCRIPTION
Problem: when a job is canceled with an outstanding sched.alloc request, the job is stuck in CLEANUP until the scheduler responds.

When the scheduler is slow, this needlessly prevents the job from terminating.

When the job enters CLEANUP state with a pending sched.alloc, send the cancel request as before but immediately remove the job from the pending_jobs list and clear job->alloc_pending.  The job can then transition to INACTIVE after the other cleanup activities are completed.  Meanwhile, when a response is received to sched.alloc, handle it internally.  If the alloc was successful, immediately free the resources.  If the alloc was canceled or unsuccessful, simply ignore the response.

Fixes #5876

~Marking WIP pending figuring out how to add a test.~