### PR TITLE
broker: allow patch versions to interoperate

### DIFF
--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1041,22 +1041,27 @@ done:
     flux_msg_destroy (msg);
 }
 
+
+#define V_MAJOR(v)  (((v) >> 16) & 0xff)
+#define V_MINOR(v)  (((v) >> 8) & 0xff)
+#define V_PATCH(v)  ((v) & 0xff)
+
 /* Check child flux-core version 'v1' against this broker's version 'v2'.
- * For now we require an exact match of (major,minor,patch) and
+ * For now we require an exact match of MAJOR.MINOR, but not PATCH.
  * ignore any commit id appended to the version string.
  * Return 0 on error, or -1 on failure with message for child in 'error'.
  */
 static bool version_check (int v1, int v2, flux_error_t *error)
 {
-    if (v1 != v2) {
+    if (V_MAJOR (v1) != V_MAJOR (v2) || V_MINOR (v1) != V_MINOR (v2)) {
         errprintf (error,
                   "client (%u.%u.%u) version mismatched with server (%u.%u.%u)",
-                  (v1 >> 16) & 0xff,
-                  (v1 >> 8) & 0xff,
-                  v1 & 0xff,
-                  (v2 >> 16) & 0xff,
-                  (v2 >> 8) & 0xff,
-                  v2 & 0xff);
+                  V_MAJOR (v1),
+                  V_MINOR (v1),
+                  V_PATCH (v1),
+                  V_MAJOR (v2),
+                  V_MINOR (v2),
+                  V_PATCH (v2));
         return false;
     }
     return true;

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -265,7 +265,7 @@ error:
 }
 
 /* Compare proxy version with broker version.
- * Require major, minor, and patch numbers to match, ignoring patch suffix.
+ * Require major and minor to match.  Ignore patch and any git suffix.
  */
 static void version_check (flux_t *h, bool force)
 {
@@ -276,15 +276,16 @@ static void version_check (flux_t *h, bool force)
         log_err_exit ("flux_attr_get version");
     if (sscanf (version, "%u.%u.%u", &n[0], &n[1], &n[2]) != 3
         || n[0] != FLUX_CORE_VERSION_MAJOR
-        || n[1] != FLUX_CORE_VERSION_MINOR
-        || n[2] != FLUX_CORE_VERSION_PATCH) {
+        || n[1] != FLUX_CORE_VERSION_MINOR) {
         if (force) {
-            log_msg ("warning: proxy version %s != broker version %s",
+            log_msg ("warning: proxy version %s may not interoperate"
+                     " with broker version %s",
                       FLUX_CORE_VERSION_STRING,
                       version);
         }
         else {
-            log_msg_exit ("fatal: proxy version %s != broker version %s "
+            log_msg_exit ("fatal: proxy version %s may not interoperate"
+                          " with broker version %s "
                           "(--force to connect anyway)",
                           FLUX_CORE_VERSION_STRING,
                           version);


### PR DESCRIPTION
This just ignores the PATCH number in MAJOR.MINOR.PATCH version comparisions in the broker so we can install a patch version without restarting all of flux at once.

Also, if we're going to assume PATCH versions interoperate we may as well relax the check in flux-proxy, so do that too.