### PR TITLE
properly report signaled tasks in `flux job wait` and `flux job attach`

### DIFF
--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -1067,18 +1067,12 @@ void attach_event_continuation (flux_future_t *f, void *arg)
     }
     else {
         if (streq (name, "finish")) {
+            flux_error_t error;
             if (json_unpack (context, "{s:i}", "status", &status) < 0)
                 log_err_exit ("error decoding finish context");
-            if (WIFSIGNALED (status)) {
-                ctx->exit_code = WTERMSIG (status) + 128;
-                log_msg ("task(s) %s", strsignal (WTERMSIG (status)));
-            }
-            else if (WIFEXITED (status)) {
-                ctx->exit_code = WEXITSTATUS (status);
-                if (ctx->exit_code != 0)
-                    log_msg ("task(s) exited with exit code %d",
-                             ctx->exit_code);
-            }
+            ctx->exit_code = flux_job_waitstatus_to_exitcode (status, &error);
+            if (ctx->exit_code != 0)
+                log_msg ("%s", error.text);
         }
     }
 

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -282,6 +282,13 @@ char *flux_unwrap_string (const char *in,
                           uint32_t *userid,
                           flux_error_t *error);
 
+
+/* Convert the waitstatus from a job `finish` event to an exit code.
+ * If the job exited with nonzero status, then place an appropriate error
+ * message in errp->text.
+ */
+int flux_job_waitstatus_to_exitcode (int waitstatus, flux_error_t *errp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -107,27 +107,12 @@ static int decode_job_result (struct job *job,
      */
     else if (streq (name, "finish")) {
         int status;
-
         if (json_unpack (context, "{s:i}", "status", &status) < 0)
             return -1;
-        if (WIFSIGNALED (status)) {
-            errprintf (errp,
-                       "task(s) %s",
-                       strsignal (WTERMSIG (status)));
+        if (flux_job_waitstatus_to_exitcode (status, errp) != 0)
             *success = false;
-        }
-        else if (WIFEXITED (status)) {
-            errprintf (errp,
-                       "task(s) exited with exit code %d",
-                       WEXITSTATUS (status));
-            *success = WEXITSTATUS (status) == 0 ? true : false;
-        }
-        else {
-            errprintf (errp,
-                       "unexpected wait(2) status %d",
-                       status);
-            *success = false;
-        }
+        else
+            *success = true;
     }
     else
         return -1;


### PR DESCRIPTION
This PR adds a new `flux_job_waitstatus_to_exitcode(3)` function to libjob which replaces some custom code in `flux job attach` and the job-manager wait implementation.

In this implementation, the error message properly reports `job shell <sigstr>` when the _shell_ exited due to a signal (i.e. `WIFSIGNALED (waitstatus)` is nonzero), and `task(s) <sigstr>` if one or more _tasks_ exited due to a signal (exitcode > 128).

The job manager wait code and `flux job attach` are then updated to use this new function, and therefore `flux job wait` and `flux job attach` now consistently report the correct error output for these conditions.