### PR TITLE
librlist: sort rlist before generating R

### DIFF
--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -1709,6 +1709,10 @@ json_t *rlist_to_R (struct rlist *rl)
     if (!rl)
         return NULL;
 
+    /*  Reset default sort to order nodes by "rank" */
+    zlistx_set_comparator (rl->nodes, by_rank);
+    zlistx_sort (rl->nodes);
+
     if (!(R_lite = rlist_compressed (rl)))
         goto fail;
 


### PR DESCRIPTION
Problem: rlist_to_R() does not sort the internal list of nodes before generating R. This results in larger JSON output than necessary, especially for an rlist built from multiple rlist_append() operations.

Sort rnodes by rank in rlist_to_R() before generating the JSON result.

Fixes #5885