### PR TITLE
fix potential segfault in test_terminus.t

### DIFF
--- a/src/common/libterminus/test/terminus.c
+++ b/src/common/libterminus/test/terminus.c
@@ -68,9 +68,6 @@ static int terminus_server (flux_t *h, void *arg)
     int rc = -1;
     struct flux_terminus_server *t;
 
-    /*  set rank == -1 for testing. Avoid flux_get_rank(3) */
-    setenv ("FLUX_TERMINUS_TEST_SERVER", "t", 1);
-
     /*  N.B.: test_server handle `h` already has reactor with SIGCHLD
      *   flag set.
      */
@@ -475,6 +472,9 @@ int main (int argc, char *argv[])
      */
     if (getenv ("SHELL") == NULL)
         setenv ("SHELL", "/bin/sh", 1);
+
+    /*  set rank == -1 for testing. Avoid flux_get_rank(3) */
+    setenv ("FLUX_TERMINUS_TEST_SERVER", "t", 1);
 
     test_invalid_args ();
     test_kill_server_empty ();


### PR DESCRIPTION
Problem: The terminus server function in the terminus unit tests calls `setenv(3)`, but this function is run in a thread and `setenv(3)` is not thread safe. This could result in rare segfaults if reading the environment races with setting it during the test.

Move the `setenv` to main(), there's no reason to be setting the environment variable specifically in terminus_server() anyway, since this is a unit test, all invocations of the server should have `FLUX_TERMINUS_TEST_SERVER` set.

Fixes #3120