### PR TITLE
Support optional arg in -L (--color) short option

### DIFF
--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -81,6 +81,7 @@ static struct optparse_option dmesg_opts[] = {
     { .name = "delta",  .key = 'd',  .has_arg = 0,
       .usage = "With --human, show timestamp delta between messages", },
     { .name = "color", .key = 'L', .has_arg = 2, .arginfo = "WHEN",
+      .flags = OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG,
       .usage = "Colorize output when supported; WHEN can be 'always' "
                "(default if omitted), 'never', or 'auto' (default)." },
     OPTPARSE_TABLE_END,

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -63,6 +63,7 @@ static struct optparse_option status_opts[] = {
                " inaccessible behind offline/lost overlay parents",
     },
     { .name = "color", .key = 'L', .has_arg = 2, .arginfo = "WHEN",
+      .flags = OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG,
       .usage = "Colorize output when supported; WHEN can be 'always' "
                "(default if omitted), 'never', or 'auto' (default)."
     },

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -2221,6 +2221,7 @@ static struct optparse_option eventlog_get_opts[] =  {
       .usage = "Display human-readable output",
     },
     { .name = "color", .key = 'L', .has_arg = 2, .arginfo = "WHEN",
+      .flags = OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG,
       .usage = "Colorize output when supported; WHEN can be 'always' "
                "(default if omitted), 'never', or 'auto' (default)."
     },
@@ -2250,6 +2251,7 @@ static struct optparse_option eventlog_wait_event_opts[] =  {
       .usage = "Display human-readable output",
     },
     { .name = "color", .key = 'L', .has_arg = 2, .arginfo = "WHEN",
+      .flags = OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG,
       .usage = "Colorize output when supported; WHEN can be 'always' "
                "(default if omitted), 'never', or 'auto' (default)."
     },

--- a/src/cmd/job/eventlog.c
+++ b/src/cmd/job/eventlog.c
@@ -37,6 +37,7 @@ struct optparse_option eventlog_opts[] =  {
                "and --time-format.",
     },
     { .name = "color", .key = 'L', .has_arg = 2, .arginfo = "WHEN",
+      .flags = OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG,
       .usage = "Colorize output when supported; WHEN can be 'always' "
                "(default if omitted), 'never', or 'auto' (default)."
     },
@@ -74,6 +75,7 @@ struct optparse_option wait_event_opts[] =  {
       .usage = "Output all events before matched event",
     },
     { .name = "color", .key = 'L', .has_arg = 2, .arginfo = "WHEN",
+      .flags = OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG,
       .usage = "Colorize output when supported; WHEN can be 'always' "
                "(default if omitted), 'never', or 'auto' (default)."
     },

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -138,16 +138,20 @@ test_expect_success 'dmesg -H, --human --delta works' '
 test_expect_success 'dmesg --delta without --human fails' '
 	test_must_fail flux dmesg --delta
 '
-test_expect_success 'dmesg -H, --human --color works' '
-	flux dmesg --human --color | sed -n 1p | grep "^" &&
-	flux dmesg --human --color | sed -n 2p | grep "^"
-'
-test_expect_success 'dmesg colorizes lines by severity' '
-	for s in emerg alert crit err warning notice debug; do
-	    flux logger --severity=$s severity=$s &&
-	    flux dmesg --human --color | grep "[^ ]*severity=$s"
-	done
-'
+
+for opt in "-L" "-Lalways" "--color" "--color=always"; do
+	test_expect_success "dmesg -H, --human $opt works" '
+		flux dmesg --human $opt | sed -n 1p | grep "^" &&
+		flux dmesg --human $opt | sed -n 2p | grep "^"
+	'
+	test_expect_success "dmesg colorizes lines by severity" '
+		for s in emerg alert crit err warning notice debug; do
+		    flux logger --severity=$s severity=$s &&
+		    flux dmesg --human $opt | grep "[^ ]*severity=$s"
+		done
+	'
+done
+
 test_expect_success 'dmesg with invalid --color option fails' '
 	test_must_fail flux dmesg --color=foo
 '

--- a/t/t1008-kvs-eventlog.t
+++ b/t/t1008-kvs-eventlog.t
@@ -69,7 +69,7 @@ test_expect_success 'flux kvs eventlog get/wait-event reject invalid --color' '
 	test_must_fail flux kvs eventlog get --color=foo test.human &&
 	test_must_fail flux kvs eventlog wait-event --color=foo test.human primus
 '
-for opt in "-L" "--color" "--color=always"; do
+for opt in "-L" "-Lalways" "--color" "--color=always"; do
 	test_expect_success "flux kvs eventlog get $opt forces color on" '
 		name=notty${opt##--color=} &&
 		outfile=color-${name:-default}.out &&

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -255,7 +255,7 @@ test_expect_success 'flux job eventlog/wait-event reject invalid --color' '
         test_must_fail flux job eventlog --color=foo $jobid &&
         test_must_fail flux job wait-event --color=foo $jobid
 '
-for opt in "-L" "--color" "--color=always"; do
+for opt in "-L" "-Lalways" "--color" "--color=always"; do
         test_expect_success "flux job eventlog $opt forces color on" '
                 name=notty${opt##--color=} &&
                 outfile=color-${name:-default}.out &&

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -136,7 +136,7 @@ nul_ctrl_d() {
 }
 test_expect_success 'pty: NUL (Ctrl-SPACE) character not dropped' '
 	nul_ctrl_d | flux run -vvv -o pty.interactive -o pty.capture cat -v &&
-	flux job eventlog -HLp output $(flux job last) &&
-	flux job eventlog -HLp output $(flux job last) | grep \\^@
+	flux job eventlog -HL -p output $(flux job last) &&
+	flux job eventlog -HL -p output $(flux job last) | grep \\^@
 '
 test_done

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -97,9 +97,13 @@ test_expect_success 'flux overlay status --highlight expected failures' '
 '
 
 test_expect_success 'flux overlay status --color option works' '
+	test_must_fail flux overlay status -Lfoo &&
 	test_must_fail flux overlay status --color=foo &&
+	flux overlay status -Lnever --highlight=0 | grep "<<0" &&
 	flux overlay status --color=never --highlight=0 | grep "<<0" &&
+	flux overlay status -Lauto --highlight=0 | grep "<<0" &&
 	flux overlay status --color=auto --highlight=0 | grep "<<0" &&
+	flux overlay status -L --highlight=0 | grep "\[" &&
 	flux overlay status --color --highlight=0 | grep "\["
 '
 


### PR DESCRIPTION
Problem: Several flux commands support a --color option.  However, a short option (-L) is inconsistently supported.  In addition to this inconsistency, the options to --color are optional and may not always work with the short option.

For consistency across flux tools, only support the long --color option.

Update tests that tested the -L short option.

Update manpages and remove refernce to -L short option.

Fixes #5828