### PR TITLE
suppress epilog on jobs canceled during shutdown (try no. 2)

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -113,7 +113,6 @@ fi
 if test $RANK -eq 0; then
     if test -z "${FLUX_DISABLE_JOB_CLEANUP}"; then
 	flux admin cleanup-push <<-EOT
-	flux jobtap remove perilog 2>/dev/null || true
 	flux queue stop --quiet --all --nocheckpoint
 	flux cancel --user=all --quiet --states RUN
 	flux queue idle --quiet

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -359,6 +359,7 @@ dist_check_SCRIPTS = \
 	issues/t5308-kvsdir-initial-path.py \
 	issues/t5368-kvs-commit-clear.py \
 	issues/t5657-kvs-getroot-namespace.sh \
+	issues/t5892-shutdown-no-epilog.sh \
 	issues/t2492-shell-lost.sh \
 	python/__init__.py \
 	python/subflux.py \

--- a/t/issues/t5892-shutdown-no-epilog.sh
+++ b/t/issues/t5892-shutdown-no-epilog.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# ensure epilog doesn't run on jobs canceled at shutdown
+
+cat <<-EOF >t5892.toml
+[job-manager]
+plugins = [
+  { load = "perilog.so" },
+]
+
+[job-manager.epilog]
+command = [ "touch", "t5892-epilog-flag" ]
+EOF
+
+flux start -o,--config-path=t5892.toml \
+	flux submit sleep inf
+
+rc=0
+if test -f t5892-epilog-flag; then
+	echo The epilog did run, contrary to expectations.>&2
+	rc=1
+else
+	echo The epilog did not run, as expected. >&2
+fi
+
+rm -f t5892-epilog-flag
+rm -f t5892.toml
+
+exit $rc


### PR DESCRIPTION
Problem: most unfortunately, a typo in rc1 rendered #5871 ineffectual.

Fix the typo and add a test this time.