### PR TITLE
broker/module.c: name threads

### DIFF
--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -91,6 +91,18 @@ static int setup_module_profiling (module_t *p)
     cali_begin_int_byname ("flux.rank", p->rank);
     cali_begin_string_byname ("flux.name", p->name);
 #endif
+    size_t len = strlen (p->name);
+    // one character longer than target to pass -Wstringop-truncation
+    char local_name[17] = {0};
+    const char *name_ptr = p->name;
+    // pthread name is limited to 16 bytes including \0 on linux
+    if (len > 15) {
+        strncpy (local_name, p->name, 16);
+        local_name[15] = 0;
+        name_ptr = local_name;
+    }
+    // Set the name of each thread to its module name
+    (void) pthread_setname_np (pthread_self (), name_ptr);
     return (0);
 }
 


### PR DESCRIPTION
Tiny change, but handy.

problem: As it is, all threads are named `flux-broker-<num>` when identified with `info threads` in gdb, or in perf, or wherever.

solution: Since almost all threads are actually actors executing a specific module, name the thread using the module name during module setup.

Here's an example "after":
![image](https://github.com/flux-framework/flux-core/assets/660149/de3301f6-9dcb-4afa-ae21-01ab825bf002)
