### PR TITLE
flux-exec: set up systemd environment to support sdexec debugging

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -426,6 +426,16 @@ MISCELLANEOUS
    command front end executable used by the ssh connector to start
    :program:`flux relay` on the remote system.
 
+.. envvar:: DBUS_SESSION_BUS_ADDRESS
+
+   :man1:`flux-exec` sets this to point to the Flux instance owner's
+   D-Bus instance, to ensure that a remote invocation of
+   :option:`systemctl --user` accesses the service manager for the Flux
+   instance owner.  This is helpful when debugging a system instance
+   configured to launch jobs with systemd, as described in
+   :man5:`flux-config-exec`.
+
+
 .. _sub_command_environment:
 
 SUB-COMMAND ENVIRONMENT

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -859,3 +859,4 @@ unsatisfiable
 validators
 hostpids
 Xauth
+dbus

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -646,6 +646,19 @@ int main (int argc, char *argv[])
                                      &imp_path);
     }
 
+    /* Allow systemd commands to work on flux systemd instance by
+     * setting DBUS_SESSION_BUS_ADDRESS if not already set.
+     * See flux-framework/flux-core#5901
+     */
+    const char *security_owner;
+    if (!(security_owner = flux_attr_get (h, "security.owner")))
+        log_err_exit ("failed to fetch security.owner attribute");
+    (void)flux_cmd_setenvf (cmd,
+                            0,
+                            "DBUS_SESSION_BUS_ADDRESS",
+                            "unix:path=/run/user/%s/bus",
+                            security_owner);
+
     /* Get input ranks from --jobid if given:
      */
     if (optparse_getopt (opts, "jobid", &optargp) > 0) {

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -269,4 +269,17 @@ test_expect_success 'stdin broadcast -- long lines' '
 	done
 '
 
+test_expect_success 'dbus environment variable is set' '
+	DBUS_SESSION_BUS_ADDRESS= \
+	    flux exec -r 0 printenv DBUS_SESSION_BUS_ADDRESS
+'
+test_expect_success 'dbus environment variable is not overwritten if set' '
+	DBUS_SESSION_BUS_ADDRESS=xyz \
+	    flux exec -r 0 printenv DBUS_SESSION_BUS_ADDRESS >dbus.out &&
+	cat >dbus.exp <<-EOT &&
+	xyz
+	EOT
+	test_cmp dbus.exp dbus.out
+'
+
 test_done


### PR DESCRIPTION
Problem: it is tricky to run systemd commands using flux-exec(1) on a system instance configured with exec.service=sdexec because the user systemd environment is not set up.
    
If not already set, set DBUS_SESSION_BUS_ADDRESS so that systemd --user commands access the dbus instance running as the flux user.

Thus commands like this can work (after sudo to root or flux):
```
flux exec -r 3 systemctl --user list-units --type=service
flux exec -r 3 systemctl --user status imp-shell-3-ftSp9MrEVNw.service
```

Fixes #5901.
