### PR TITLE
add options for offline config file parsing

### DIFF
--- a/doc/man1/flux-config.rst
+++ b/doc/man1/flux-config.rst
@@ -54,6 +54,16 @@ scripts.
    *fsd* prints the value in its human-readable, string form. *fsd-integer*
    and *fsd-real* print the value in integer and real seconds, respectively.
 
+.. option:: -c, --config-path=PATH
+
+   Read configuration from PATH instead of fetching configuration from local
+   broker.  If PATH is a directory, then read all TOML files from that
+   directory. If PATH is a file, then load configuration as JSON if the file
+   extension is ``.json``, otherwise load the file as TOML.  As a special case,
+   ``system``, ``security``, and ``imp`` may be used as shorthand for the
+   compiled-in paths to system configuration objects.
+
+
 builtin
 -------
 

--- a/doc/man1/flux-config.rst
+++ b/doc/man1/flux-config.rst
@@ -76,6 +76,12 @@ configuration key names.  This command is available to all users.
    specific values if found to be in tree.  This enables Flux testing without
    requiring installation.
 
+.. option:: --intree
+   Force :program:`flux config builtin` to return in-tree paths.
+
+.. option:: --installed
+   Force :program:`flux config builtin` to return installed paths.
+
 load
 ----
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -860,3 +860,4 @@ validators
 hostpids
 Xauth
 dbus
+intree

--- a/src/cmd/builtin/config.c
+++ b/src/cmd/builtin/config.c
@@ -162,13 +162,21 @@ static int builtin_get (optparse_t *p, int ac, char *av[])
     int optindex = optparse_option_index (p);
     const char *name;
     const char *value;
+    int flags;
 
     if (optindex != ac - 1) {
         optparse_print_usage (p);
         exit (1);
     }
+    if (optparse_hasopt (p, "installed"))
+        flags = FLUX_CONF_INSTALLED;
+    else if (optparse_hasopt (p, "intree"))
+        flags = FLUX_CONF_INTREE;
+    else
+        flags = FLUX_CONF_AUTO;
+
     name = av[optindex];
-    value = flux_conf_builtin_get (name, FLUX_CONF_AUTO);
+    value = flux_conf_builtin_get (name, flags);
     if (!value)
         log_msg_exit ("%s is invalid", name);
     printf ("%s\n", value);
@@ -273,6 +281,15 @@ static struct optparse_option get_opts[] = {
     OPTPARSE_TABLE_END
 };
 
+static struct optparse_option builtin_opts[] = {
+    { .name = "intree", .has_arg = 0,
+      .usage = "Force in-tree paths to be used"
+    },
+    { .name = "installed", .has_arg = 0,
+      .usage = "Force installed paths to be used",
+    },
+    OPTPARSE_TABLE_END
+};
 
 static struct optparse_subcommand config_subcmds[] = {
     { "load",
@@ -301,7 +318,7 @@ static struct optparse_subcommand config_subcmds[] = {
       "Print compiled-in Flux configuration values",
       builtin_get,
       0,
-      NULL,
+      builtin_opts,
     },
     OPTPARSE_SUBCMD_END
 };

--- a/t/t0026-flux-R.t
+++ b/t/t0026-flux-R.t
@@ -367,4 +367,20 @@ test_expect_success 'flux R parse-config detects invalid property' '
 	test_must_fail flux R parse-config conf
 '
 
+test_expect_success 'flux R parse-config also works with resource.path' '
+	flux R encode -r 0-1 >R.path &&
+	cat <<-EOF >conf/resource.toml &&
+	resource.path = "R.path"
+	EOF
+	flux R parse-config conf
+'
+test_expect_success 'flux R parse-config fails when resource.path = bad R' '
+	echo "bad json" >R.path &&
+	test_must_fail flux R parse-config conf
+'
+test_expect_success 'flux R parse-config fails when resource.path = missing R' '
+	rm -f R.path &&
+	test_must_fail flux R parse-config conf
+'
+
 test_done

--- a/t/t2806-config-cmd.t
+++ b/t/t2806-config-cmd.t
@@ -4,6 +4,12 @@ test_description='Test flux config get'
 
 . $(dirname $0)/sharness.sh
 
+FLUXCONFDIR=$(dirname $(flux config builtin --installed rc1_path))
+test -d $FLUXCONFDIR/system/conf.d || test_set_prereq NO_SYSTEM_CONF
+test -d $FLUXCONFDIR/security/conf.d || test_set_prereq NO_SECURITY_CONF
+test -d $FLUXCONFDIR/imp/conf.d || test_set_prereq NO_IMP_CONF
+
+
 mkdir config
 cat <<EOF >config/config.toml
 [foo]
@@ -201,6 +207,30 @@ test_expect_success 'flux-config reload fails as guest' '
 '
 test_expect_success 'flux-config builtin works as guest' '
 	runas_guest flux config builtin rc1_path
+'
+test_expect_success 'flux-config get works when --config-path points to dir' '
+	mkdir -p altconfig &&
+	echo "flag = 99" >altconfig/foo.toml &&
+	flux config get --config-path=altconfig | jq -e .flag
+'
+test_expect_success 'flux-config get works when --config-path points to file' '
+	flux config get --config-path=altconfig/foo.toml | jq -e .flag
+'
+test_expect_success 'flux-config get fails when --config-path path is wrong' '
+	test_must_fail flux config get --config-path=/not/a/file
+'
+test_expect_success 'flux-config get fails when --config-path is invalid' '
+	echo "x x x" >badconf.toml &&
+	test_must_fail flux config get --config-path=badconf.toml
+'
+test_expect_success NO_SYSTEM_CONF 'flux-config get --config-path=system fails when missing' '
+	test_must_fail flux config get --config-path=system
+'
+test_expect_success NO_SECURITY_CONF 'flux-config get --config-path=security fails when missing' '
+	test_must_fail flux config get --config-path=security
+'
+test_expect_success NO_IMP_CONF 'flux-config get --config-path=imp fails when missing' '
+	test_must_fail flux config get --config-path=imp
 '
 
 test_done

--- a/t/t2806-config-cmd.t
+++ b/t/t2806-config-cmd.t
@@ -181,6 +181,15 @@ test_expect_success 'flux-config builtin fails on unknown key' '
 test_expect_success 'flux-config builtin works on known key' '
 	flux config builtin rc1_path
 '
+test_expect_success 'flux-config builtin --intree works' '
+	flux config builtin --intree rc1_path >rc1_path_intree
+'
+test_expect_success 'flux-config builtin --installed works' '
+	flux config builtin --installed rc1_path >rc1_path_installed
+'
+test_expect_success 'flux-config builtin intree and installed return different values' '
+	test_must_fail test_cmp rc1_path_intree rc1_path_installed
+'
 test_expect_success 'flux-config get works as guest' '
 	runas_guest flux config get >obj
 '


### PR DESCRIPTION
Problem: as noted in #5898, it may be useful for a sys admin to be able to probe the installed flux configuration before launching flux.

Add two new capabilities:
-  add  `flux config get --config-path=PATH` option (with special PATH names of `system`, `security`, and `imp`)
- enhance `flux R parse-config PATH` to follow `resource.path` if defined