### PR TITLE
job-manager: improve handling of offline ranks in job prolog

### DIFF
--- a/src/cmd/flux-perilog-run.py
+++ b/src/cmd/flux-perilog-run.py
@@ -112,6 +112,12 @@ async def run_with_timeout(cmd, label, timeout=1800.0):
     return p
 
 
+def plural(sequence):
+    if len(sequence) > 1:
+        return "s"
+    return ""
+
+
 async def run_per_rank(name, jobid, args):
     """Run args.exec_per_rank on every rank of jobid
 
@@ -141,7 +147,13 @@ async def run_per_rank(name, jobid, args):
     offline = offline_ranks(handle) & ranks
     if offline:
         returncode = 1
-        LOGGER.info("%s: %s: ranks %s offline. Skipping.", jobid, name, offline)
+        LOGGER.warning(
+            "%s: %s: rank%s %s offline. Skipping.",
+            jobid,
+            name,
+            plural(offline),
+            offline,
+        )
         ranks.subtract(offline)
         if args.drain_offline:
             drain(handle, offline, f"offline for {jobid} {name}")

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -493,6 +493,7 @@ check_LTLIBRARIES = \
 	job-manager/plugins/resource-update-expiration.la \
 	job-manager/plugins/update-test.la \
 	job-manager/plugins/project-bank-validate.la \
+	job-manager/plugins/offline.la \
 	stats/stats-basic.la \
 	stats/stats-immediate.la
 
@@ -1053,6 +1054,16 @@ job_manager_plugins_project_bank_validate_la_LDFLAGS = \
 job_manager_plugins_project_bank_validate_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la
+
+job_manager_plugin_offline_la_SOURCES = \
+	job-manager/plugins/offline.a
+job_manager_plugin_offline_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_offline_la_LDFLAGS = \
+        $(fluxplugin_ldflags) -module -rpath /nowhere
+job_manager_plugins_offline_la_LIBADD = \
+        $(top_builddir)/src/common/libflux-internal.la \
+        $(top_builddir)/src/common/libflux-core.la
 
 hwloc_hwloc_convert_SOURCES = hwloc/hwloc-convert.c
 hwloc_hwloc_convert_CPPFLAGS = $(HWLOC_CFLAGS) $(test_cppflags)

--- a/t/job-manager/plugins/offline.c
+++ b/t/job-manager/plugins/offline.c
@@ -1,0 +1,51 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* cleanup-event.c - emit a test event in CLEANUP state
+ */
+
+#include <flux/jobtap.h>
+
+/* Disconnect rank 3 by default */
+static int rank = 3;
+
+static int run_cb (flux_plugin_t *p,
+                   const char *topic,
+                   flux_plugin_arg_t *args,
+                   void *arg)
+{
+    /*  Immediately on state RUN, disconnect the configured rank
+     */
+    flux_t *h = flux_jobtap_get_flux (p);
+    flux_future_t *f;
+
+    /*  Assumes parent of rank is rank 0 */
+    if (!(f = flux_rpc_pack (h,
+                             "overlay.disconnect-subtree",
+                             0,
+                             0,
+                             "{s:i}",
+                             "rank", rank))
+        || flux_rpc_get (f, NULL) < 0) {
+        flux_log_error (h, "failed to disconnect rank %d", rank);
+    }
+    flux_future_destroy (f);
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_add_handler (p,
+                                    "job.state.run",
+                                     run_cb,
+                                     NULL);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -16,7 +16,9 @@ command = [
 ]
 EOF
 
-test_under_flux 4 full -o,--config-path=$(pwd)/config --test-exit-mode=leader
+test_under_flux 4 full \
+    -o,--config-path=$(pwd)/config,-Stbon.topo=kary:4 \
+    --test-exit-mode=leader
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 


### PR DESCRIPTION
Recently, jobs were consistently failing with an exception `job prolog failed with exit code=1` without any other details in the logs or job eventlog. It turned out that the scheduler was handing out offline nodes, and the prolog fails in this case, but due to the use of an incorrect log level, the log message for this condition was suppressed. Also, users were confused by the lack of detail in the job exception.

This PR improves prolog handling of offline ranks by

 - using the correct log level for the warning "prolog: rank[s] XX offline. Skipping."
 - raising a non-fatal job exception with this same detail (that some broker ranks were offline) so that a user is notified in the job eventlog of the reason the prolog will fail.

`flux perilog-run` can't raise the fatal exception itself, since would then cancel the prolog, which may be running on other ranks. The nonzero exit status from the prolog will raise the fatal exception, so a job eventlog failing in this manner might look like this:

```
[Apr22 22:39] submit userid=6885 urgency=16 flags=0 version=1
[  +0.011808] validate
[  +0.022818] depend
[  +0.022857] priority priority=16
[  +0.023847] alloc annotations={"sched":{"resource_summary":"rank[0-3]/core0"}}
[  +0.024318] prolog-start description="job-manager.prolog"
[  +0.253649] exception type="prolog" severity=1 note="rank 3 offline" userid=6885
[  +0.384952] exception type="prolog" severity=0 note="prolog exited with exit code=1" userid=6885
[  +0.385053] prolog-finish description="job-manager.prolog" status=256
[  +0.385087] free
[  +0.385109] clean
```

which is a bit better than completely silent failure.