### PR TITLE
job-exec: support config reload

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -609,9 +609,13 @@ static void exec_exit (struct jobinfo *job)
     job->data = NULL;
 }
 
-static int exec_config (flux_t *h, int argc, char **argv)
+static int exec_config (flux_t *h,
+                        const flux_conf_t *conf,
+                        int argc,
+                        char **argv,
+                        flux_error_t *errp)
 {
-    return config_init (h, argc, argv);
+    return config_setup (h, conf, argc, argv, errp);
 }
 
 static int exec_stats (json_t **stats)

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-/* Flux job-exec configuration common code */
+/* Flux bulk-exec configuration code */
 
 #if HAVE_CONFIG_H
 # include "config.h"
@@ -176,7 +176,8 @@ error:
     return -1;
 }
 
-/*  Initialize common configurations for use by job-exec exec modules.
+/*  Initialize configurations for use by job-exec bulk-exec
+ *  implementation
  */
 int config_init (flux_t *h, int argc, char **argv)
 {

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -17,6 +17,11 @@
 
 #include "job-exec.h"
 
+/* Configuration getters.  It is not safe to hold on to returned
+ * values.  Callers should strdup() / json_incref() / etc. values
+ * they wish to access for later use.
+ */
+
 const char *config_get_job_shell (struct jobinfo *job);
 
 const char *config_get_cwd (struct jobinfo *job);
@@ -31,7 +36,11 @@ bool config_get_exec_service_override (void);
 
 int config_get_stats (json_t **config_stats);
 
-int config_init (flux_t *h, int argc, char **argv);
+int config_setup (flux_t *h,
+                  const flux_conf_t *conf,
+                  int argc,
+                  char **argv,
+                  flux_error_t *errp);
 
 #endif /* !HAVE_JOB_EXEC_CONFIG_EXEC_H */
 

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -25,7 +25,8 @@ struct jobinfo;
  *
  *  An exec implementation must include the methods below (except where noted):
  *
- *   - config:  (optional) called once at module load for configuration
+ *   - config:  (optional) called at module load for configuration and config
+ *              reload.
  *
  *   - unload:  (optional) called once at module unload
  *
@@ -49,7 +50,11 @@ struct jobinfo;
  */
 struct exec_implementation {
     const char *name;
-    int  (*config)  (flux_t *h, int argc, char **argv);
+    int  (*config)  (flux_t *h,
+                     const flux_conf_t *conf,
+                     int argc,
+                     char **argv,
+                     flux_error_t *errp);
     void (*unload)  (void);
     int  (*init)    (struct jobinfo *job);
     void (*exit)    (struct jobinfo *job);

--- a/src/modules/job-exec/testexec.c
+++ b/src/modules/job-exec/testexec.c
@@ -478,10 +478,16 @@ error:
     return NULL;
 }
 
-static int testexec_config (flux_t *h, int argc, char **argv)
+static int testexec_config (flux_t *h,
+                            const flux_conf_t *conf,
+                            int argc,
+                            char **argv,
+                            flux_error_t *errp)
 {
-    if (!(testexec_ctx = testexec_ctx_create (h)))
-        return -1;
+    if (!testexec_ctx) {
+        if (!(testexec_ctx = testexec_ctx_create (h)))
+            return -1;
+    }
     return 0;
 }
 

--- a/t/t2403-job-exec-conf.t
+++ b/t/t2403-job-exec-conf.t
@@ -4,6 +4,8 @@ test_description='Test flux job exec configuration'
 
 . $(dirname $0)/sharness.sh
 
+export FLUX_CONF_DIR=$(pwd)/conf.d
+mkdir -p conf.d
 test_under_flux 1 job
 
 test_expect_success 'job-exec: can specify kill-timeout on cmdline' '
@@ -61,6 +63,32 @@ test_expect_success 'job-exec: bad job-shell config causes module failure' '
 		flux dmesg > ${name}.log 2>&1 &&
 	grep "error reading config value exec.job-shell" ${name}.log
 '
+test_expect_success 'job-exec: update default shell via config reload' '
+	flux module reload -f job-exec &&
+	flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > reload1A.out 2>&1 &&
+	grep "flux-shell" reload1A.out &&
+	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
+	[exec]
+	job-shell = "/path/reload-shell"
+	EOF
+	flux config reload &&
+	flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > reload1B.out 2>&1 &&
+	grep "reload-shell" reload1B.out &&
+	rm -f ${FLUX_CONF_DIR}/exec.toml
+'
+test_expect_success 'job-exec: cmdline default shell takes priority' '
+	flux module reload -f job-exec job-shell=/path/cmdline-shell &&
+	flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > reload2A.out 2>&1 &&
+	grep "cmdline-shell" reload2A.out &&
+	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
+	[exec]
+	job-shell = "/path/reload-shell"
+	EOF
+	flux config reload &&
+	flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > reload2B.out 2>&1 &&
+	grep "cmdline-shell" reload2B.out &&
+	rm -f ${FLUX_CONF_DIR}/exec.toml
+'
 test_expect_success 'job-exec: can specify imp path on cmdline' '
 	flux module reload -f job-exec imp=/path/to/imp &&
 	flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > stats2.out &&
@@ -86,6 +114,33 @@ test_expect_success 'job-exec: bad imp config causes module failure' '
 		flux dmesg > ${name}.log 2>&1 &&
 	grep "error reading config value exec.imp" ${name}.log
 '
+# N.B. imp not configured by default
+test_expect_success 'job-exec: update imp path via config reload' '
+	flux module reload -f job-exec &&
+	test_must_fail flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > reload3A.out 2>&1 &&
+	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
+	[exec]
+	imp = "/path/reload-imp"
+	EOF
+	flux config reload &&
+	flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > reload3B.out 2>&1 &&
+	grep "reload-imp" reload3B.out &&
+	rm -f ${FLUX_CONF_DIR}/exec.toml
+'
+test_expect_success 'job-exec: cmdline imp path takes priority' '
+	flux module reload -f job-exec imp=/path/cmdline-imp &&
+	flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > reload4A.out 2>&1 &&
+	grep "cmdline-imp" reload4A.out &&
+	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
+	[exec]
+	imp = "/path/reload-imp"
+	EOF
+	flux dmesg -C &&
+	flux config reload &&
+	flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > reload4B.out 2>&1 &&
+	grep "cmdline-imp" reload4B.out &&
+	rm -f ${FLUX_CONF_DIR}/exec.toml
+'
 test_expect_success 'job-exec: can specify exec service on cmdline' '
 	flux module reload -f job-exec service=foo &&
 	flux module stats -p impl.bulk-exec.config.exec_service job-exec > stats3.out &&
@@ -101,6 +156,33 @@ test_expect_success 'job-exec: exec service can be set in exec conf' '
 		flux module stats -p impl.bulk-exec.config.exec_service job-exec > ${name}.out 2>&1 &&
 	grep "bar" ${name}.out
 '
+# N.B. exec service defaults to rexec
+test_expect_success 'job-exec: update exec service via config reload' '
+	flux module reload -f job-exec &&
+	flux module stats -p impl.bulk-exec.config.exec_service job-exec > reload5A.out 2>&1 &&
+	grep "rexec" reload5A.out &&
+	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
+	[exec]
+	service = "reload-exec-service"
+	EOF
+	flux config reload &&
+	flux module stats -p impl.bulk-exec.config.exec_service job-exec > reload5B.out 2>&1 &&
+	grep "reload-exec-service" reload5B.out &&
+	rm -f ${FLUX_CONF_DIR}/exec.toml
+'
+test_expect_success 'job-exec: cmdline exec service takes priority' '
+	flux module reload -f job-exec service=cmdline-exec-service &&
+	flux module stats -p impl.bulk-exec.config.exec_service job-exec > reload6A.out 2>&1 &&
+	grep "cmdline-exec-service" reload6A.out &&
+	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
+	[exec]
+	service = "reload-exec-service"
+	EOF
+	flux config reload &&
+	flux module stats -p impl.bulk-exec.config.exec_service job-exec > reload6B.out 2>&1 &&
+	grep "cmdline-exec-service" reload6B.out &&
+	rm -f ${FLUX_CONF_DIR}/exec.toml
+'
 test_expect_success 'job-exec: exec service override can be set in exec conf' '
 	name=exec-service-override &&
 	cat <<-EOF > ${name}.toml &&
@@ -112,6 +194,22 @@ test_expect_success 'job-exec: exec service override can be set in exec conf' '
 		flux module stats -p impl.bulk-exec.config.exec_service_override job-exec > ${name}.out 2>&1 &&
 	val=$(cat ${name}.out) &&
 	test $val -eq 1
+'
+# N.B. exec service defaults to off/disabled
+test_expect_success 'job-exec: update exec service override via config reload' '
+	flux module reload -f job-exec &&
+	flux module stats -p impl.bulk-exec.config.exec_service_override job-exec > reload7A.out 2>&1 &&
+	val=$(cat reload7A.out) &&
+	test $val -eq 0 &&
+	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
+	[exec]
+	service-override = true
+	EOF
+	flux config reload &&
+	flux module stats -p impl.bulk-exec.config.exec_service_override job-exec > reload7B.out 2>&1 &&
+	val=$(cat reload7B.out) &&
+	test $val -eq 1 &&
+	rm -f ${FLUX_CONF_DIR}/exec.toml
 '
 test_expect_success 'job-exec: sdexex properties can be set in exec conf' '
 	name=sdexec-properties &&
@@ -149,5 +247,36 @@ test_expect_success 'job-exec: bad sdexec properties causes module failure (type
 	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
 		flux dmesg > ${name}.log 2>&1 &&
 	grep "exec.sdexec-properties.MemoryHigh is not a string" ${name}.log
+'
+# N.B. sdexec properties defaults to not set
+test_expect_success 'job-exec: update sdexec properties via config reload' '
+	flux module reload -f job-exec &&
+	test_must_fail flux module stats -p impl.bulk-exec.config.sdexec_properties job-exec > reload8A.out 2>&1 &&
+	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
+	[exec]
+	service = "sdexec"
+	[exec.sdexec-properties]
+	MemoryHigh = "200M"
+	EOF
+	flux config reload &&
+	flux module stats -p impl.bulk-exec.config.sdexec_properties job-exec > reload8B.out 2>&1 &&
+	jq -e ".MemoryHigh == \"200M\"" < reload8B.out &&
+	rm -f ${FLUX_CONF_DIR}/exec.toml
+'
+# N.B. do config reload call before flux module reload to clear
+# sdexec-properties from previous test
+test_expect_success 'job-exec: bad sdexec properties leads to error on via config reload' '
+	flux config reload &&
+	flux module reload -f job-exec &&
+	test_must_fail flux module stats -p impl.bulk-exec.config.sdexec_properties job-exec > reload9A.out 2>&1 &&
+	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
+	[exec]
+	service = "sdexec"
+	[exec.sdexec-properties]
+	MemoryHigh = 42
+	EOF
+	test_must_fail flux config reload 2> reload9B.err &&
+	grep "exec.sdexec-properties.MemoryHigh is not a string" reload9B.err &&
+	rm -f ${FLUX_CONF_DIR}/exec.toml
 '
 test_done


### PR DESCRIPTION
Problem: job-exec requires the job-exec module to be reloaded to read changes to configuration.  This is inconvenient and can affect running jobs.

Support reading/loading configuration changes via the config-reload message callback.  If anything is configured on the command line during module load time, that configuration still override's anything in broker configuration.

----

only minor thing is I called the exec_implementation function "reload" instead of "config_reload", just b/c I didn't want one function to be much longer than any other function and muck all the pretty alignment that already exists.  "reload" could be ambiguous, like this callback is for when the module is reloaded?? 

(edit: don't have docker on system I'm on today, so some tests are not tested ... we'll see if they pass in CI, there may be some iteration if not).

