### PR TITLE
fix possible use-after-free in chained future implementation

### DIFF
--- a/src/common/libflux/composite_future.c
+++ b/src/common/libflux/composite_future.c
@@ -165,8 +165,12 @@ static flux_future_t *future_create_composite (int wait_any)
 {
     struct composite_future *cf = composite_future_create ();
     flux_future_t *f = flux_future_create (composite_future_init, (void *) cf);
-    if (!f || !cf || flux_future_aux_set (f, "flux::composite", cf,
-                         (flux_free_f) composite_future_destroy) < 0) {
+    if (!f
+        || !cf
+        || flux_future_aux_set (f,
+                                "flux::composite",
+                                cf,
+                                (flux_free_f) composite_future_destroy) < 0) {
         composite_future_destroy (cf);
         flux_future_destroy (f);
         return (NULL);
@@ -265,11 +269,11 @@ const char *flux_future_next_child (flux_future_t *f)
  *   If the user calls both and_then() and or_then(), the same cf->next
  *   future is returned, since only one of these calls will be used.
  *
- *  The underlying then() callback for `f` is subsequently set to use 
+ *  The underlying then() callback for `f` is subsequently set to use
  *   chained_continuation() below, which will call `and_then()` on successful
  *   fulfillment of f (aka `prev`) or or_then() on failure. These continuations
  *   are passed `f, arg` as if a normal continuation was used with
- *   flux_future_then(3). These callbacks may use one of 
+ *   flux_future_then(3). These callbacks may use one of
  *   flux_future_continue(3) or flux_future_continue_error(3) to schedule
  *   fulfillment of the internal `cf->next` future based on a new
  *   intermediate future created during the continuation (e.g. when a
@@ -367,7 +371,8 @@ static void chained_continuation (flux_future_t *prev, void *arg)
      *   cf->next using prev directly.
      */
     if (!cf->continued && flux_future_fulfill_with (cf->next, prev) < 0) {
-        flux_future_fatal_error (cf->next, errno,
+        flux_future_fatal_error (cf->next,
+                                 errno,
                                  "chained_continuation: fulfill_with failed");
     }
 
@@ -393,7 +398,9 @@ static void chained_continuation (flux_future_t *prev, void *arg)
 static void chained_future_init (flux_future_t *f, void *arg)
 {
     struct chained_future *cf = arg;
-    if (cf == NULL || cf->prev == NULL || cf->next == NULL
+    if (cf == NULL
+        || cf->prev == NULL
+        || cf->next == NULL
         || !(flux_future_get_reactor (f))) {
         errno = EINVAL;
         goto error;
@@ -454,7 +461,8 @@ static void chained_future_destroy (struct chained_future *cf)
 static struct chained_future *chained_future_create (flux_future_t *f)
 {
     struct chained_future *cf = flux_future_aux_get (f, "flux::chained");
-    if (cf == NULL && (cf = chained_future_alloc ())) {
+    if (cf == NULL
+        && (cf = chained_future_alloc ())) {
         if (flux_future_aux_set (f, "flux::chained",
                                  (void *) cf,
                                  (flux_free_f) chained_future_destroy) < 0) {
@@ -521,7 +529,8 @@ int flux_future_continue (flux_future_t *prev, flux_future_t *f)
 
 /* "Continue" the chained "next" future embedded in `prev` with an error
  */
-void flux_future_continue_error (flux_future_t *prev, int errnum,
+void flux_future_continue_error (flux_future_t *prev,
+                                 int errnum,
                                  const char *errstr)
 {
     struct chained_future *cf = chained_future_get (prev);
@@ -546,7 +555,8 @@ int flux_future_fulfill_next (flux_future_t *f,
 }
 
 flux_future_t *flux_future_and_then (flux_future_t *prev,
-                                     flux_continuation_f next_cb, void *arg)
+                                     flux_continuation_f next_cb,
+                                     void *arg)
 {
     struct chained_future *cf = chained_future_create (prev);
     if (!cf)
@@ -557,7 +567,8 @@ flux_future_t *flux_future_and_then (flux_future_t *prev,
 }
 
 flux_future_t *flux_future_or_then (flux_future_t *prev,
-                                    flux_continuation_f or_cb, void *arg)
+                                    flux_continuation_f or_cb,
+                                    void *arg)
 {
     struct chained_future *cf = chained_future_create (prev);
     if (!cf)

--- a/src/common/libflux/test/composite_future.c
+++ b/src/common/libflux/test/composite_future.c
@@ -372,7 +372,7 @@ error:
     flux_future_fulfill_error (f, errno, NULL);
 }
 
-static void flux_future_timeout_clear (flux_future_t *f)
+static void future_timeout_clear (flux_future_t *f)
 {
     flux_watcher_t *w = flux_future_aux_get (f, "watcher");
     ok (w != NULL, "timeout stop: got timer watcher");
@@ -380,7 +380,7 @@ static void flux_future_timeout_clear (flux_future_t *f)
         flux_watcher_stop (w);
 }
 
-static flux_future_t *flux_future_timeout (double s)
+static flux_future_t *future_timeout (double s)
 {
     double *dptr = calloc (1, sizeof (*dptr));
     if (dptr == NULL)
@@ -429,8 +429,8 @@ void test_composite_all_async (bool with_error)
     ok (flux_future_push (fc, "f1", f) == 0,
         "flux_future_push success");
 
-    if (!(f = flux_future_timeout (0.1)))
-        BAIL_OUT ("flux_future_timeout failed");
+    if (!(f = future_timeout (0.1)))
+        BAIL_OUT ("future_timeout failed");
 
     ok (flux_future_push (fc, "timeout", f) == 0,
         "flux_future_push timeout success");
@@ -470,7 +470,7 @@ void async_any_check (flux_future_t *fc, void *arg)
         "async: retrieved handle to timeout future");
     ok (flux_future_is_ready (f) == false,
         "async: timeout future not yet fulfilled");
-    flux_future_timeout_clear (f);
+    future_timeout_clear (f);
     async_any_check_rc = 0;
     /* Required so we pop out of reactor since we will still have
      *  active watchers */
@@ -493,8 +493,8 @@ void test_composite_any_async (bool with_error)
     ok (flux_future_push (fc, "f1", f) == 0,
         "flux_future_push success");
 
-    if (!(f = flux_future_timeout (1.0)))
-        BAIL_OUT ("flux_future_timeout failed");
+    if (!(f = future_timeout (1.0)))
+        BAIL_OUT ("future_timeout failed");
 
     ok (flux_future_push (fc, "timeout", f) == 0,
         "flux_future_push timeout success");


### PR DESCRIPTION
This PR fixes the problem with chained futures described in #5923: if a `next` future in a chain is destroyed before the `prev` future, then a segfault due to use-after-free could occur later if `prev` is eventually fulfilled since this references next.
The case where this is likely to occur is when `flux_future_then(3)` is called with a timeout on a `next` future, since the timeout will fulfill `next` with an error without even touching the `prev` future.

The fix is not exactly elegant. A reference to the `chained_future` object is placed in  the `next` future's `aux` list, so that when it is destroyed it can (optionally) destroy `prev`. However, this needs to be avoided in the common case where `prev` is destroyed before `next`, so an aux_item destructor is _also_ placed in `prev` to nullify `cf->prev` so that future is not double freed. Finally, since the underlying `chained_future` object is now referenced in multiple places, and these are not called in any guaranteed order, that structure gets a reference counter and a reference count of 3:

 1. for the presence in `prev` aux_item list as `flux::chained`
 2. for the anonymous linkage in `next` aux_item list
 3. for the anonymous linkage in `prev` aux_item list to call `nullify_prev`

A test is added and was tested under valgrind etc.