### PR TITLE
broker: avoid LOST due to EHOSTUNREACH messages during shutdown

### DIFF
--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -776,13 +776,10 @@ static int overlay_sendmsg_child (struct overlay *ov, const flux_msg_t *msg)
             && (child = child_lookup_online (ov, uuid))) {
             flux_log (ov->h,
                       LOG_ERR,
-                      "%s (rank %d) transitioning to %s->LOST"
-                      " after %ds due to %s",
+                      "%s (rank %d) has disconnected unexpectedly."
+                      " Marking it LOST.",
                       flux_get_hostbyrank (ov->h, child->rank),
-                      (int)child->rank,
-                      subtree_status_str (child->status),
-                      (int)(monotime_since (child->status_timestamp) / 1000.0),
-                      "EHOSTUNREACH error on send");
+                      (int)child->rank);
             overlay_child_status_update (ov, child, SUBTREE_STATUS_LOST);
         }
         errno = saved_errno;

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -156,6 +156,11 @@ int overlay_register_attrs (struct overlay *overlay);
  */
 void overlay_shutdown (struct overlay *overlay, bool unbind);
 
+/* Say goodbye to parent.
+ * After this, sends to parent are dropped.
+ */
+flux_future_t *overlay_goodbye_parent (struct overlay *overlay);
+
 #endif /* !_BROKER_OVERLAY_H */
 
 /*

--- a/src/broker/shutdown.c
+++ b/src/broker/shutdown.c
@@ -9,6 +9,10 @@
 \************************************************************/
 
 /* shutdown.c - manage instance shutdown on behalf of flux-shutdown(1)
+ *
+ * This is only active on rank 0.
+ * On rank 0, this posts the "goodbye" event to the broker state machine.
+ * On other ranks it is generated internally in state_machine.c.
  */
 
 #if HAVE_CONFIG_H
@@ -271,8 +275,10 @@ struct shutdown *shutdown_create (struct broker *ctx)
                                     shutdown,
                                     &shutdown->handlers) < 0)
         goto error;
-    if (!(shutdown->f_monitor = monitor_request (shutdown)))
-        return NULL;
+    if (ctx->rank == 0) {
+        if (!(shutdown->f_monitor = monitor_request (shutdown)))
+            return NULL;
+    }
     return shutdown;
 error:
     shutdown_destroy (shutdown);

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -98,6 +98,7 @@ static void action_run (struct state_machine *s);
 static void action_cleanup (struct state_machine *s);
 static void action_shutdown (struct state_machine *s);
 static void action_finalize (struct state_machine *s);
+static void action_goodbye (struct state_machine *s);
 static void action_exit (struct state_machine *s);
 
 static void runat_completion_cb (struct runat *r, const char *name, void *arg);
@@ -120,7 +121,7 @@ static struct state statetab[] = {
     { STATE_CLEANUP,    "cleanup",          action_cleanup },
     { STATE_SHUTDOWN,   "shutdown",         action_shutdown },
     { STATE_FINALIZE,   "finalize",         action_finalize },
-    { STATE_GOODBYE,    "goodbye",          NULL },
+    { STATE_GOODBYE,    "goodbye",          action_goodbye },
     { STATE_EXIT,       "exit",             action_exit },
 };
 
@@ -404,6 +405,14 @@ static void action_shutdown (struct state_machine *s)
                     overlay_get_child_peer_count (s->ctx->overlay));
     }
 #endif
+}
+
+static void action_goodbye (struct state_machine *s)
+{
+    /* On rank 0, "goodbye" is posted by shutdown.c.
+     */
+    if (s->ctx->rank > 0)
+        state_machine_post (s, "goodbye");
 }
 
 static void rmmod_continuation (flux_future_t *f, void *arg)

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -361,7 +361,7 @@ static void action_run (struct state_machine *s)
 static void action_cleanup (struct state_machine *s)
 {
     /* Prevent new downstream clients from saying hello, but
-     * let existing ones continue to communiate so they can
+     * let existing ones continue to communicate so they can
      * shut down and disconnect.
      */
     overlay_shutdown (s->ctx->overlay, false);

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -164,7 +164,8 @@ test_expect_success 'all expected events and state transitions occurred' '
 '
 
 test_expect_success 'capture state transitions from size=2 instance' '
-	flux start ${ARGS} --test-size=2 -o,-Slog-stderr-level=6 \
+	flux start ${ARGS} --test-size=2 \
+		-o,-Slog-stderr-level=6,-Slog-stderr-mode=local \
 		/bin/true 2>states2.log
 '
 
@@ -189,7 +190,7 @@ test_expect_success 'all expected events and state transitions occurred on rank 
 	grep "\[1\]: cleanup-none: cleanup->shutdown"		states2.log &&
 	grep "\[1\]: children-none: shutdown->finalize"	        states2.log &&
 	grep "\[1\]: rc3-none: finalize->goodbye"		states2.log &&
-	grep "\[1\]: goodbye: goodbye->exit"			states2.log
+	grep "\[1\]: goodbye: goodbye->exit"		        states2.log
 '
 
 test_expect_success 'capture state transitions from instance with rc1 failure' '


### PR DESCRIPTION
Problem: as noted in #5881, we observe many "transitioning to LOST due to EHOSTUNREACH" log messages during shutdown of a large system with a flat TBON.

This is due to a deficiency in the shutdown handshake.  Once a tbon child completes rc3, it sends an offline status control message to the parent and immediately disconnects.  The parent processes the status message asynchronously and may attempt to send messages to the child (for example routine broadcasts) after the child has closed the connection, which triggers this log message.

Improve the shutdown handshake by adding an RPC that the child must wait for before disconnecting.

In addition, make the message a little more user friendy so if it does appear it is more clear to users what is going on.