### PR TITLE
change default tbon.topo to kary:32

### DIFF
--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -17,7 +17,7 @@ KEYS
 
 topo
    (optional) A URI that selects a specific tree topology.  The default value
-   is ``kary:2`` when bootstrapping from PMI, and ``custom`` when bootstrapping
+   is ``kary:32`` when bootstrapping from PMI, and ``custom`` when bootstrapping
    from configuration, as described in :man5:`flux-config-bootstrap`.
    The configured value may be overridden by setting the ``tbon.topo`` broker
    attribute.

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -151,7 +151,7 @@ tbon.topo [Updates: C]
    scheme selects a complete, k-ary tree with fanout *k*, with ``kary:0``
    meaning that rank 0 is the parent of all other ranks by convention.  The
    ``binomial`` scheme selects a binomial tree topology of the minimum order
-   that fits the instance size.  Default: ``kary:2``, unless bootstrapping by
+   that fits the instance size.  Default: ``kary:32``, unless bootstrapping by
    TOML configuration, then see :man5:`flux-config-bootstrap`.
 
 tbon.descendants

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -2021,7 +2021,7 @@ static int overlay_configure_zmqdebug (struct overlay *ov)
  */
 static int overlay_configure_topo (struct overlay *ov)
 {
-    const char *topo_uri = "kary:2";
+    const char *topo_uri = "kary:32";
     const flux_conf_t *cf;
 
     if ((cf = flux_get_conf (ov->h))) {

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -538,8 +538,8 @@ test_expect_success 'tbon.topo with unknown scheme fails' '
 		/bin/true 2>badscheme.err &&
 	grep "unknown topology scheme" badscheme.err
 '
-test_expect_success 'tbon.topo is kary:2 by default' '
-	echo "kary:2" >topo.exp &&
+test_expect_success 'tbon.topo is kary:32 by default' '
+	echo "kary:32" >topo.exp &&
 	flux broker ${ARGS} flux getattr tbon.topo >topo.out &&
 	test_cmp topo.exp topo.out
 '


### PR DESCRIPTION
Problem: The default tbon.topo is kary:2, which is almost certainly not optimal for any case.

Let's try kary:32.
