### PR TITLE
libsubprocess: reduce remote output prep/check

### DIFF
--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -143,16 +143,17 @@ static void subprocess_free (flux_subprocess_t *p)
     }
 }
 
-static flux_subprocess_t *subprocess_create (flux_t *h,
-                                         flux_reactor_t *r,
-                                         int flags,
-                                         const flux_cmd_t *cmd,
-                                         const flux_subprocess_ops_t *ops,
-                                         const flux_subprocess_hooks_t *hooks,
-                                         int rank,
-                                         bool local,
-                                         subprocess_log_f log_fn,
-                                         void *log_data)
+static flux_subprocess_t *subprocess_create (
+    flux_t *h,
+    flux_reactor_t *r,
+    int flags,
+    const flux_cmd_t *cmd,
+    const flux_subprocess_ops_t *ops,
+    const flux_subprocess_hooks_t *hooks,
+    int rank,
+    bool local,
+    subprocess_log_f log_fn,
+    void *log_data)
 {
     flux_subprocess_t *p = calloc (1, sizeof (*p));
 
@@ -374,9 +375,9 @@ static int subprocess_setup_state_change (flux_subprocess_t *p)
 }
 
 static void completed_prep_cb (flux_reactor_t *r,
-                                  flux_watcher_t *w,
-                                  int revents,
-                                  void *arg)
+                               flux_watcher_t *w,
+                               int revents,
+                               void *arg)
 {
     flux_subprocess_t *p = arg;
 

--- a/src/common/libsubprocess/test/fbuf_watcher.c
+++ b/src/common/libsubprocess/test/fbuf_watcher.c
@@ -272,11 +272,11 @@ static void test_buffer (flux_reactor_t *reactor)
 
     count = 0;
     w = fbuf_read_watcher_create (reactor,
-                                         fd[0],
-                                         1024,
-                                         buffer_read,
-                                         0,
-                                         &count);
+                                  fd[0],
+                                  1024,
+                                  buffer_read,
+                                  0,
+                                  &count);
     ok (w != NULL,
         "buffer: read created");
 
@@ -303,11 +303,11 @@ static void test_buffer (flux_reactor_t *reactor)
 
     count = 0;
     w = fbuf_read_watcher_create (reactor,
-                                         fd[0],
-                                         1024,
-                                         buffer_read_data_unbuffered,
-                                         0,
-                                         &count);
+                                  fd[0],
+                                  1024,
+                                  buffer_read_data_unbuffered,
+                                  0,
+                                  &count);
     ok (w != NULL,
         "buffer: read created");
 
@@ -335,11 +335,11 @@ static void test_buffer (flux_reactor_t *reactor)
 
     count = 0;
     w = fbuf_read_watcher_create (reactor,
-                                         fd[0],
-                                         1024,
-                                         buffer_read_line,
-                                         FBUF_WATCHER_LINE_BUFFER,
-                                         &count);
+                                  fd[0],
+                                  1024,
+                                  buffer_read_line,
+                                  FBUF_WATCHER_LINE_BUFFER,
+                                  &count);
     ok (w != NULL,
         "buffer: read line created");
 
@@ -365,11 +365,11 @@ static void test_buffer (flux_reactor_t *reactor)
     /* read line with fbuf_read_watcher_get_data() */
     count = 0;
     w = fbuf_read_watcher_create (reactor,
-                                         fd[0],
-                                         1024,
-                                         buffer_read_data,
-                                         FBUF_WATCHER_LINE_BUFFER,
-                                         &count);
+                                  fd[0],
+                                  1024,
+                                  buffer_read_data,
+                                  FBUF_WATCHER_LINE_BUFFER,
+                                  &count);
     ok (w != NULL,
         "buffer: read line created");
 
@@ -397,11 +397,11 @@ static void test_buffer (flux_reactor_t *reactor)
 
     count = 0;
     w = fbuf_write_watcher_create (reactor,
-                                          fd[0],
-                                          1024,
-                                          buffer_write,
-                                          0,
-                                          &count);
+                                   fd[0],
+                                   1024,
+                                   buffer_write,
+                                   0,
+                                   &count);
     ok (w != NULL,
         "buffer: write created");
 
@@ -435,11 +435,11 @@ static void test_buffer (flux_reactor_t *reactor)
 
     count = 0;
     w = fbuf_write_watcher_create (reactor,
-                                          fd[0],
-                                          1024,
-                                          buffer_write,
-                                          0,
-                                          &count);
+                                   fd[0],
+                                   1024,
+                                   buffer_write,
+                                   0,
+                                   &count);
     ok (w != NULL,
         "buffer: write created");
 
@@ -472,11 +472,11 @@ static void test_buffer (flux_reactor_t *reactor)
 
     count = 0;
     w = fbuf_read_watcher_create (reactor,
-                                         fd[0],
-                                         12, /* 12 bytes = 2 "foobars"s */
-                                         buffer_read_fill,
-                                         0,
-                                         &count);
+                                  fd[0],
+                                  12, /* 12 bytes = 2 "foobars"s */
+                                  buffer_read_fill,
+                                  0,
+                                  &count);
     ok (w != NULL,
         "buffer: read created");
 
@@ -506,11 +506,11 @@ static void test_buffer (flux_reactor_t *reactor)
 
     count = 0;
     w = fbuf_read_watcher_create (reactor,
-                                         fd[0],
-                                         12, /* 12 bytes = 2 "foobar"s */
-                                         buffer_read_overflow,
-                                         0,
-                                         &count);
+                                  fd[0],
+                                  12, /* 12 bytes = 2 "foobar"s */
+                                  buffer_read_overflow,
+                                  0,
+                                  &count);
     ok (w != NULL,
         "buffer overflow test: read line created");
 
@@ -543,11 +543,11 @@ static void test_buffer (flux_reactor_t *reactor)
         "buffer: hey I can has a pipe!");
 
     w = fbuf_write_watcher_create (reactor,
-                                          pfds[1],
-                                          1024,
-                                          buffer_write,
-                                          0,
-                                          &count);
+                                   pfds[1],
+                                   1024,
+                                   buffer_write,
+                                   0,
+                                   &count);
     ok (w == NULL && errno == EINVAL,
         "buffer: write_watcher_create fails with EINVAL if fd !nonblocking");
 
@@ -555,11 +555,11 @@ static void test_buffer (flux_reactor_t *reactor)
         "buffer: fd_set_nonblocking");
 
     w = fbuf_write_watcher_create (reactor,
-                                          pfds[1],
-                                          1024,
-                                          buffer_write,
-                                          0,
-                                          &count);
+                                   pfds[1],
+                                   1024,
+                                   buffer_write,
+                                   0,
+                                   &count);
     ok (w != NULL,
         "buffer: write watcher close: watcher created");
     fb = fbuf_write_watcher_get_buffer (w);
@@ -845,11 +845,11 @@ static void test_buffer_refcnt (flux_reactor_t *reactor)
     bfc.count = 0;
     bfc.fd = fd[1];
     w = fbuf_read_watcher_create (reactor,
-                                         fd[0],
-                                         1024,
-                                         buffer_read_fd_decref,
-                                         0,
-                                         &bfc);
+                                  fd[0],
+                                  1024,
+                                  buffer_read_fd_decref,
+                                  0,
+                                  &bfc);
     ok (w != NULL,
         "buffer decref: read created");
     bfc.w = w;
@@ -889,11 +889,11 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
     bfc.count = 0;
     bfc.fd = fd[1];
     w = fbuf_read_watcher_create (reactor,
-                                         fd[0],
-                                         1024,
-                                         buffer_read_fd_close,
-                                         0,
-                                         &bfc);
+                                  fd[0],
+                                  1024,
+                                  buffer_read_fd_close,
+                                  0,
+                                  &bfc);
     ok (w != NULL,
         "buffer corner case: read created");
 
@@ -926,11 +926,11 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
     bfc.count = 0;
     bfc.fd = fd[1];
     w = fbuf_read_watcher_create (reactor,
-                                         fd[0],
-                                         1024,
-                                         buffer_read_line_fd_close,
-                                         FBUF_WATCHER_LINE_BUFFER,
-                                         &bfc);
+                                  fd[0],
+                                  1024,
+                                  buffer_read_line_fd_close,
+                                  FBUF_WATCHER_LINE_BUFFER,
+                                  &bfc);
     ok (w != NULL,
         "buffer corner case: read line created");
 
@@ -963,11 +963,11 @@ static void test_buffer_corner_case (flux_reactor_t *reactor)
     bfc.count = 0;
     bfc.fd = fd[1];
     w = fbuf_read_watcher_create (reactor,
-                                         fd[0],
-                                         1024,
-                                         buffer_read_line_fd_close_and_left_over_data,
-                                         FBUF_WATCHER_LINE_BUFFER,
-                                         &bfc);
+                                  fd[0],
+                                  1024,
+                                  buffer_read_line_fd_close_and_left_over_data,
+                                  FBUF_WATCHER_LINE_BUFFER,
+                                  &bfc);
     ok (w != NULL,
         "buffer corner case: read line created");
 


### PR DESCRIPTION
Problem: Profiling shows that a significant amount of time can be spent in the prep/check of remote subprocess output. This is even in the case when the output buffer is empty.

Enable the remote output prep/check only when the buffer is non-empty.

----

Side note, after trying and flailing on the "input" side of this, I realized that a bunch of code in `libsubprocess`'s remote code simply assumes the prep/check for input is always running.  So that work requires more thought.  Posting this so we can atleast get this in for the next release if I can't figure out the input side by then.