### PR TITLE
deps/docker: add 'time' as a dependency for tests

### DIFF
--- a/scripts/install-deps-deb.sh
+++ b/scripts/install-deps-deb.sh
@@ -24,6 +24,7 @@ apt install \
   python3-sphinx \
   aspell \
   aspell-en \
+  time \
   valgrind \
   libmpich-dev \
   jq

--- a/scripts/install-deps-rpm.sh
+++ b/scripts/install-deps-rpm.sh
@@ -24,6 +24,7 @@ yum install \
   python3-sphinx \
   aspell \
   aspell-en \
+  time \
   valgrind-devel \
   mpich-devel \
   jq

--- a/src/test/docker/bookworm/Dockerfile
+++ b/src/test/docker/bookworm/Dockerfile
@@ -105,6 +105,7 @@ RUN apt-get update \
         enchant-2 \
         aspell \
         aspell-en \
+        time \
  && rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8

--- a/src/test/docker/fedora39/Dockerfile
+++ b/src/test/docker/fedora39/Dockerfile
@@ -65,6 +65,7 @@ RUN yum -y update \
 	enchant \
 	aspell \
 	aspell-en \
+	time \
 	glibc-langpack-en \
  && yum clean all
 

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -104,6 +104,7 @@ RUN apt-get update \
         enchant \
         aspell \
         aspell-en \
+        time \
  && rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8

--- a/src/test/docker/jammy/Dockerfile
+++ b/src/test/docker/jammy/Dockerfile
@@ -110,6 +110,7 @@ RUN apt-get update \
         enchant-2 \
         aspell \
         aspell-en \
+        time \
  && rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
problem: Apparently bookworm, jammy, focal, and new fedoras don't install /usr/bin/time by default.  I ran into this trying to include time output in a test.

Evidently the "time" builtin in bash is suppressed inside the scope of an eval like we use in sharness, either way this seems less annoying than having to avoid it.

solution: install it, added to each of the docker files as well as the install-deps-*.sh files.