### PR TITLE
resource: upgrade KVS resource.eventlog if needed

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -17,6 +17,7 @@ extend-exclude = [
   "src/common/libmissing/*.[ch]",
   "t/hwloc-data/*",
   "doc/test/spell.en.pws",
+  "t/resource/resource.eventlog.*",
 ]
 
 [default.extend-words]

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -37,7 +37,9 @@ libresource_la_SOURCES = \
 	status.c \
 	status.h \
 	drainset.h \
-	drainset.c
+	drainset.c \
+	upgrade.h \
+	upgrade.c
 
 TESTS = \
 	test_rutil.t \

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -605,14 +605,14 @@ static struct idset *decode_targets (struct drain *drain,
     int index;
 
     if (!(ids = idset_decode (ranks))
-        || (nodelist && !(nl = hostlist_decode (nodelist)))
+        || !(nl = hostlist_decode (nodelist))
         || !(newids = idset_create (drain->ctx->size, 0)))
         goto done;
 
     index = 0;
     rank = idset_first (ids);
     while (rank != IDSET_INVALID_ID) {
-        const char *host = nl ?  hostlist_nth (nl, index++) : NULL;
+        const char *host = hostlist_nth (nl, index++);
 
         add_target (newids, rank, host, drain->ctx->h);
         rank = idset_next (ids, rank);
@@ -647,9 +647,9 @@ static int replay_eventlog (struct drain *drain,
             }
             if (streq (name, "drain")) {
                 int overwrite = 1;
-                const char *nodelist = NULL;
+                const char *nodelist;
                 if (json_unpack (context,
-                                 "{s:s s?s s?s s?i}",
+                                 "{s:s s:s s?s s?i}",
                                  "idset", &s,
                                  "nodelist", &nodelist,
                                  "reason", &reason,
@@ -681,7 +681,7 @@ static int replay_eventlog (struct drain *drain,
             else if (streq (name, "undrain")) {
                 const char *nodelist = NULL;
                 if (json_unpack (context,
-                                 "{s:s s?s}",
+                                 "{s:s s:s}",
                                  "idset", &s,
                                  "nodelist", &nodelist) < 0) {
                     errprintf (error,

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -35,6 +35,7 @@
 #include "acquire.h"
 #include "rutil.h"
 #include "status.h"
+#include "upgrade.h"
 
 /* Parse [resource] table.
  *
@@ -370,6 +371,12 @@ int mod_main (flux_t *h, int argc, char **argv)
         if (!(ctx->reslog = reslog_create (h)))
             goto error;
         if (reload_eventlog (h, &eventlog) < 0)
+            goto error;
+        /* One time only: purge the eventlog (including KVS) of
+         * pre-0.62.0 events, upgrading drain events with hostnames.
+         * See flux-framework/flux-core#5931.
+         */
+        if (upgrade_eventlog (h, &eventlog) < 0)
             goto error;
         if (!(ctx->acquire = acquire_create (ctx)))
             goto error;

--- a/src/modules/resource/upgrade.c
+++ b/src/modules/resource/upgrade.c
@@ -1,0 +1,294 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* upgrade.c - update resource.eventlog with new format
+ *
+ * The resource.eventlog format changed in 0.62.0.  If a 'resource-init'
+ * event is found, it is the older format and can be upgraded:
+ * - drop all events prior to the last resource-init
+ * - convert drain summary of the last resource-init into discrete drain events
+ * - remove all remaining events that are no longer valid
+ * - add a nodelist to drain/undrain events, if missing
+ *
+ * If an upgrade occurred, rewrite the kvs resource.eventlog.  This eliminates
+ * the risk of drain events referring to the wrong hosts if the rank:host
+ * mapping changes in the future.  This rewrite will only occur once as the
+ * upgrade code does nothing if a resource-init event is not found and they
+ * are no longer produced as of 0.62.0.
+ *
+ * N.B. the new format consisting only of drain/undrain/resource-define
+ * events can be parsed by old flux-core releases so a flux-core downgrade
+ * is possible.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/timestamp.h"
+#include "src/common/libidset/idset.h"
+#include "src/common/libeventlog/eventlog.h"
+#include "ccan/str/str.h"
+
+#include "reslog.h"
+#include "upgrade.h"
+
+static int rewrite_eventlog (flux_t *h, json_t *newlog)
+{
+    char *s;
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    int rc = -1;
+
+    if (!(s = eventlog_encode (newlog))
+        || !(txn = flux_kvs_txn_create ())
+        || flux_kvs_txn_put (txn, 0, RESLOG_KEY, s) < 0
+        || !(f = flux_kvs_commit (h, NULL, 0, txn))
+        || flux_rpc_get (f, NULL) < 0)
+        goto done;
+    rc = 0;
+done:
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+    ERRNO_SAFE_WRAP (free, s);
+    return rc;
+}
+
+/* Add nodelist to (un)drain context.
+ * If any ranks are invalid, the entire event is thrown out (and logged).
+ * See also flux-framework/flux-core#4791.
+ */
+static int upgrade_drain_context (const char *name,
+                                  double ts,
+                                  json_t *context,
+                                  flux_t *h)
+{
+    const char *idset;
+    const char *nodelist = NULL;
+    const char *reason = NULL;
+
+    if (json_unpack (context,
+                     "{s:s s?s s?s}",
+                     "idset", &idset,
+                     "nodelist", &nodelist,
+                     "reason", &reason) < 0) {
+        flux_log (h,
+                  LOG_WARNING,
+                  "dropping old %s event with invalid context",
+                  name);
+        return -1;
+    }
+    if (!nodelist) {
+        char *nl;
+        json_t *o = NULL;
+
+        if (!(nl = flux_hostmap_lookup (h, idset, NULL))
+            || !(o = json_string (nl))
+            || json_object_set_new (context, "nodelist", o) < 0) {
+            char timebuf[64] = { 0 };
+            timestamp_tostr ((time_t)ts, timebuf, sizeof (timebuf));
+            flux_log (h,
+                      LOG_WARNING,
+                      "dropping old %s event with invalid ranks"
+                      " (ranks=%s timestamp=%s UTC reason=%s)",
+                      name,
+                      idset,
+                      timebuf,
+                      reason ? reason : "");
+            json_decref (o);
+            free (nl);
+            return -1;
+        }
+        free (nl);
+    }
+    return 0;
+}
+
+static ssize_t upgrade_insert_index (json_t *eventlog, double timestamp)
+{
+    size_t index;
+    json_t *entry;
+    json_array_foreach (eventlog, index, entry) {
+        double ts;
+        if (eventlog_entry_parse (entry, &ts, NULL, NULL) < 0)
+            return -1;
+        if (ts >= timestamp)
+            return index;
+    }
+    return 0;
+}
+
+static int upgrade_insert_drain_event (json_t *eventlog,
+                                       double timestamp,
+                                       const char *idset,
+                                       const char *nodelist,
+                                       const char *reason)
+{
+    ssize_t index;
+    json_t *entry;
+
+    if ((index = upgrade_insert_index (eventlog, timestamp)) < 0)
+        return -1;
+    if (reason) {
+        entry = eventlog_entry_pack (timestamp,
+                                     "drain",
+                                     "{s:s s:s s:s}",
+                                     "idset", idset,
+                                     "nodelist", nodelist,
+                                     "reason", reason);
+        }
+    else {
+        entry = eventlog_entry_pack (timestamp,
+                                     "drain",
+                                     "{s:s s:s}",
+                                     "idset", idset,
+                                     "nodelist", nodelist);
+    }
+    if (!entry)
+        return -1;
+    if (json_array_insert_new (eventlog, index, entry) < 0) {
+        json_decref (entry);
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+/* Add drain events to the eventlog that are reconstructed from the drain
+ * summary object of a legacy 'resource-init' event.
+ */
+static int upgrade_resource_init (json_t *context, json_t *eventlog, flux_t *h)
+{
+    const char *idset;
+    json_t *drain;
+    json_t *o;
+
+    if (json_unpack (context, "{s:o}", "drain", &drain) < 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    json_object_foreach (drain, idset, o) {
+        double ts;
+        char *reason = NULL;
+        char *nl;
+
+        if (json_unpack (o,
+                         "{s:f s?s}",
+                         "timestamp", &ts,
+                         "reason", &reason) < 0) {
+            errno = EPROTO;
+            return -1;
+        }
+        if (!(nl = flux_hostmap_lookup (h, idset, NULL))) {
+            char timebuf[64] = { 0 };
+            timestamp_tostr ((time_t)ts, timebuf, sizeof (timebuf));
+            flux_log (h,
+                      LOG_WARNING,
+                      "dropping old drain data with invalid ranks"
+                      " (ranks=%s timestamp=%s UTC reason=%s)",
+                      idset,
+                      timebuf,
+                      reason ? reason : NULL);
+            continue;
+        }
+        if (upgrade_insert_drain_event (eventlog, ts, idset, nl, reason) < 0) {
+            ERRNO_SAFE_WRAP (free, nl);
+            return -1;
+        }
+        free (nl);
+    }
+    return 0;
+}
+
+int upgrade_eventlog (flux_t *h, json_t **eventlog)
+{
+    json_t *newlog = NULL;
+    ssize_t index;
+    json_t *entry;
+    double ts;
+    const char *name;
+    json_t *context;
+
+    if (!*eventlog)
+        return 0;
+    /* Scan backwards for resource-init.  If not found, nothing to do.
+     */
+    for (index = json_array_size (*eventlog) - 1; index >= 0; index--) {
+        if (!(entry = json_array_get (*eventlog, index))
+            || eventlog_entry_parse (entry, NULL, &name, &context) < 0)
+            goto parse_error;
+        if (streq (name, "resource-init"))
+            break;
+    }
+    if (index < 0)
+        return 0;
+
+    /* Create new eventlog containing only expanded drain summary from last
+     * resource-init.  Ignore events prior to that one.
+     */
+    if (!(newlog = json_array ()))
+        goto nomem;
+    if (upgrade_resource_init (context, newlog, h) < 0) {
+        flux_log (h,
+                  LOG_ERR,
+                  "%s: fatal error processing resource-init on line %zu",
+                  RESLOG_KEY,
+                  index + 1);
+        goto error;
+    }
+
+    /* Append more valid events, augmenting drain/undrain with nodelist
+     * as needed.
+     */
+    for (index = index + 1; index < json_array_size (*eventlog); index++) {
+        if (!(entry = json_array_get (*eventlog, index))
+            || eventlog_entry_parse (entry, &ts, &name, &context) < 0)
+            goto parse_error;
+        if (streq (name, "drain") || streq (name, "undrain")) {
+            // logs any drain/undrain events that could not be upgraded
+            if (upgrade_drain_context (name, ts, context, h) < 0)
+                continue;
+        }
+        else if (!streq (name, "resource-define"))
+            continue;
+        if (json_array_append (newlog, entry) < 0)
+            goto nomem;
+    }
+    if (rewrite_eventlog (h, newlog) < 0)
+        goto error;
+    size_t oldsize = json_array_size (*eventlog);
+    size_t newsize = json_array_size (newlog);
+    flux_log (h,
+              LOG_INFO,
+              "%s: reduced from %zu to %zu entries",
+              RESLOG_KEY,
+              oldsize,
+              newsize);
+    json_decref (*eventlog);
+    *eventlog = newlog;
+    return 0;
+nomem:
+    errno = ENOMEM;
+error:
+    ERRNO_SAFE_WRAP (json_decref, newlog);
+    return -1;
+parse_error:
+    flux_log (h, LOG_ERR, "%s: parse error on line %zu", RESLOG_KEY, index + 1);
+    json_decref (newlog);
+    errno = EINVAL;
+    return -1;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/resource/upgrade.h
+++ b/src/modules/resource/upgrade.h
@@ -1,0 +1,21 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_UPGRADE_H
+#define _FLUX_RESOURCE_UPGRADE_H
+
+#include <jansson.h>
+#include <flux/core.h>
+
+int upgrade_eventlog (flux_t *h, json_t **eventlog);
+
+#endif /* !_FLUX_RESOURCE_UPGRADE_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -180,6 +180,7 @@ TESTSCRIPTS = \
 	t2350-resource-list.t \
 	t2351-resource-status-input.t \
 	t2352-resource-cmd-config.t \
+	t2353-resource-eventlog.t \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
 	t2402-job-exec-dummy.t \
@@ -313,6 +314,7 @@ EXTRA_DIST= \
 	scripts/groups.py \
 	scripts/rexec.py \
 	jobspec \
+	resource \
 	marshall \
 	batch \
 	job-manager/dumps \

--- a/t/resource/resource.eventlog.thing2
+++ b/t/resource/resource.eventlog.thing2
@@ -1,0 +1,4611 @@
+{"timestamp":1683047871.7659676,"name":"resource-init","context":{"restart":false,"drain":{},"online":"","exclude":"0-2"}}
+{"timestamp":1683047871.7666073,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683047873.7181838,"name":"online","context":{"idset":"0"}}
+{"timestamp":1683047902.596009,"name":"online","context":{"idset":"2"}}
+{"timestamp":1683047903.0977581,"name":"online","context":{"idset":"5"}}
+{"timestamp":1683047903.1142714,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1683047903.9205258,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1683047904.2724149,"name":"online","context":{"idset":"9"}}
+{"timestamp":1683047904.3048165,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1683047904.4366722,"name":"online","context":{"idset":"1,6,18"}}
+{"timestamp":1683047904.489671,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1683047904.5168133,"name":"online","context":{"idset":"10,20"}}
+{"timestamp":1683047904.5168378,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1683047904.5602491,"name":"online","context":{"idset":"30"}}
+{"timestamp":1683047904.5602727,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1683047904.600184,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1683047904.6232867,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1683047904.6344221,"name":"online","context":{"idset":"14"}}
+{"timestamp":1683047904.7251253,"name":"online","context":{"idset":"7,19,25-26,28"}}
+{"timestamp":1683047904.7251632,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1683047904.7483013,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1683047904.7484841,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1683047904.763068,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1683047904.7697272,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1683047904.8203282,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1683047904.8510849,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1683047904.9891832,"name":"online","context":{"idset":"3,16"}}
+{"timestamp":1683047905.0296061,"name":"online","context":{"idset":"12"}}
+{"timestamp":1683047905.0463812,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1683047905.094475,"name":"online","context":{"idset":"8"}}
+{"timestamp":1683047905.0945046,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1683047905.1459196,"name":"online","context":{"idset":"24"}}
+{"timestamp":1683047905.1459477,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1683047905.2036214,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1683047905.3042328,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1683047907.3272793,"name":"resource-init","context":{"restart":true,"drain":{},"online":"","exclude":"0-2"}}
+{"timestamp":1683047907.3279848,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683047909.2514827,"name":"online","context":{"idset":"0"}}
+{"timestamp":1683047909.8647997,"name":"online","context":{"idset":"2,5"}}
+{"timestamp":1683047910.2986803,"name":"online","context":{"idset":"9,33,35"}}
+{"timestamp":1683047910.38449,"name":"online","context":{"idset":"6"}}
+{"timestamp":1683047910.4932876,"name":"online","context":{"idset":"18,34"}}
+{"timestamp":1683047910.5096874,"name":"online","context":{"idset":"1"}}
+{"timestamp":1683047910.673635,"name":"online","context":{"idset":"10,14,19-20,26,28-30"}}
+{"timestamp":1683047910.8216505,"name":"online","context":{"idset":"4,7,13,25"}}
+{"timestamp":1683047910.9668987,"name":"online","context":{"idset":"3,16-17"}}
+{"timestamp":1683047911.0953674,"name":"online","context":{"idset":"8,32"}}
+{"timestamp":1683047911.1962578,"name":"online","context":{"idset":"12"}}
+{"timestamp":1683047911.3117402,"name":"online","context":{"idset":"11,24,31"}}
+{"timestamp":1683047911.5406401,"name":"online","context":{"idset":"15,23"}}
+{"timestamp":1683047912.0250113,"name":"online","context":{"idset":"27"}}
+{"timestamp":1683048405.4099133,"name":"drain","context":{"idset":"21-22","reason":"flux issues","overwrite":0}}
+{"timestamp":1683049263.283375,"name":"online","context":{"idset":"21"}}
+{"timestamp":1683049271.6013002,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1683049272.4109766,"name":"online","context":{"idset":"21"}}
+{"timestamp":1683049286.1057158,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1683049286.9015405,"name":"online","context":{"idset":"21"}}
+{"timestamp":1683049348.3732798,"name":"online","context":{"idset":"22"}}
+{"timestamp":1683049380.3666673,"name":"undrain","context":{"idset":"21-22"}}
+{"timestamp":1683115661.9314654,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1683115661.9337087,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1683115661.936327,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1683115661.9368961,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1683115661.9399431,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1683115661.9418101,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1683115661.9421139,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1683115661.9445498,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1683115661.9446898,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1683115661.9458606,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1683115661.9460535,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1683115661.9464996,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1683115661.9479113,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1683115661.9503944,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1683115661.9509339,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1683115661.9513922,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1683115661.9520171,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1683115661.9534485,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1683115661.9559844,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1683115661.9579349,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1683115661.9581363,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1683115661.9586751,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1683115661.9603388,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1683115661.961334,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1683115661.9633029,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1683115661.9673383,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1683115662.0135608,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1683115662.1136427,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1683115662.1499932,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1683115662.1543112,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1683115662.1878328,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1683115662.1894391,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1683115662.22647,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1683115662.3265238,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1683115662.4758015,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1683115854.553304,"name":"resource-init","context":{"restart":true,"drain":{},"online":"","exclude":"0-2"}}
+{"timestamp":1683115854.5546751,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683115856.9609318,"name":"online","context":{"idset":"0"}}
+{"timestamp":1683115857.6518917,"name":"online","context":{"idset":"2,23-35"}}
+{"timestamp":1683115857.9520576,"name":"online","context":{"idset":"17-20"}}
+{"timestamp":1683115858.0855093,"name":"online","context":{"idset":"1"}}
+{"timestamp":1683115858.233273,"name":"online","context":{"idset":"9,13-14"}}
+{"timestamp":1683115858.3422999,"name":"online","context":{"idset":"3,8,16"}}
+{"timestamp":1683115858.4449484,"name":"online","context":{"idset":"5-6,10-12,15"}}
+{"timestamp":1683115858.6592736,"name":"online","context":{"idset":"4,7"}}
+{"timestamp":1683116422.665045,"name":"online","context":{"idset":"36"}}
+{"timestamp":1683156347.6795416,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1683156348.7177422,"name":"online","context":{"idset":"1"}}
+{"timestamp":1683160404.1286287,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1287606,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1288059,"name":"drain","context":{"idset":"3","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.128864,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.128907,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1289487,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1289907,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.129029,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1290691,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.129112,"name":"drain","context":{"idset":"10","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1291697,"name":"drain","context":{"idset":"11","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1292145,"name":"drain","context":{"idset":"12","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1292553,"name":"drain","context":{"idset":"13","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1292968,"name":"drain","context":{"idset":"14","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1293421,"name":"drain","context":{"idset":"15","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.129384,"name":"drain","context":{"idset":"16","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1294291,"name":"drain","context":{"idset":"17","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1294715,"name":"drain","context":{"idset":"18","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1295171,"name":"drain","context":{"idset":"19","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1295598,"name":"drain","context":{"idset":"20","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1296029,"name":"drain","context":{"idset":"23","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1296492,"name":"drain","context":{"idset":"24","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1296921,"name":"drain","context":{"idset":"25","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1297357,"name":"drain","context":{"idset":"26","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1297786,"name":"drain","context":{"idset":"27","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1298234,"name":"drain","context":{"idset":"28","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1298707,"name":"drain","context":{"idset":"29","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1299155,"name":"drain","context":{"idset":"30","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1299617,"name":"drain","context":{"idset":"31","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1300075,"name":"drain","context":{"idset":"32","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1300535,"name":"drain","context":{"idset":"33","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1301022,"name":"drain","context":{"idset":"34","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1301482,"name":"drain","context":{"idset":"35","reason":"broker was unresponsive"}}
+{"timestamp":1683160404.1302085,"name":"drain","context":{"idset":"36","reason":"broker was unresponsive"}}
+{"timestamp":1683162792.0288348,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1683162792.0291719,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1683162792.0299144,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1683162792.0302522,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1683162792.0307651,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1683162792.0321119,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1683162792.0322206,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1683162792.0322802,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1683162792.032337,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1683162792.0323975,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1683162792.0324569,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1683162792.03441,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1683162792.0344741,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1683162792.0345421,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1683162792.0345948,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1683162792.0346484,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1683162792.0347013,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1683162792.0347521,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1683162792.0348027,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1683162792.0390036,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1683162792.0425341,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1683162792.0461166,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1683162792.0474489,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1683162792.066206,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1683162792.0683291,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1683162792.0706203,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1683162792.0737317,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1683162792.0764561,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1683162792.0932703,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1683162792.0934169,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1683162792.099987,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1683162792.1145844,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1683162792.2152812,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1683162792.3455136,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1683162799.9691737,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683162799.9709246,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683163237.2204976,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683163237.2218342,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683164784.3887296,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683164784.3904054,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683165084.0717537,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683165084.0730741,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683165568.0012693,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683165568.0029511,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683165853.3905201,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683165853.391911,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683165891.8675637,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683165891.86902,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683165965.4596598,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683165965.4610212,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683165996.5902231,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683165996.5916562,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683166103.1004114,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683166103.1017964,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683166144.7767034,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683166144.7781787,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683166170.6458168,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683166170.6472063,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683166191.6923981,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683166191.6938186,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683166216.7372274,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683166216.7386281,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683166239.5474751,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683166239.5488527,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683166269.2655847,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683166269.2670062,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683166345.6680517,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1683160404.1288059,"reason":"broker was unresponsive"},"4":{"timestamp":1683160404.128864,"reason":"broker was unresponsive"},"5":{"timestamp":1683160404.128907,"reason":"broker was unresponsive"},"6":{"timestamp":1683160404.1289487,"reason":"broker was unresponsive"},"7":{"timestamp":1683160404.1289907,"reason":"broker was unresponsive"},"8":{"timestamp":1683160404.129029,"reason":"broker was unresponsive"},"9":{"timestamp":1683160404.1290691,"reason":"broker was unresponsive"},"10":{"timestamp":1683160404.129112,"reason":"broker was unresponsive"},"11":{"timestamp":1683160404.1291697,"reason":"broker was unresponsive"},"12":{"timestamp":1683160404.1292145,"reason":"broker was unresponsive"},"13":{"timestamp":1683160404.1292553,"reason":"broker was unresponsive"},"14":{"timestamp":1683160404.1292968,"reason":"broker was unresponsive"},"15":{"timestamp":1683160404.1293421,"reason":"broker was unresponsive"},"16":{"timestamp":1683160404.129384,"reason":"broker was unresponsive"},"17":{"timestamp":1683160404.1294291,"reason":"broker was unresponsive"},"18":{"timestamp":1683160404.1294715,"reason":"broker was unresponsive"},"19":{"timestamp":1683160404.1295171,"reason":"broker was unresponsive"},"20":{"timestamp":1683160404.1295598,"reason":"broker was unresponsive"},"23":{"timestamp":1683160404.1296029,"reason":"broker was unresponsive"},"24":{"timestamp":1683160404.1296492,"reason":"broker was unresponsive"},"25":{"timestamp":1683160404.1296921,"reason":"broker was unresponsive"},"26":{"timestamp":1683160404.1297357,"reason":"broker was unresponsive"},"27":{"timestamp":1683160404.1297786,"reason":"broker was unresponsive"},"28":{"timestamp":1683160404.1298234,"reason":"broker was unresponsive"},"29":{"timestamp":1683160404.1298707,"reason":"broker was unresponsive"},"30":{"timestamp":1683160404.1299155,"reason":"broker was unresponsive"},"31":{"timestamp":1683160404.1299617,"reason":"broker was unresponsive"},"32":{"timestamp":1683160404.1300075,"reason":"broker was unresponsive"},"33":{"timestamp":1683160404.1300535,"reason":"broker was unresponsive"},"34":{"timestamp":1683160404.1301022,"reason":"broker was unresponsive"},"35":{"timestamp":1683160404.1301482,"reason":"broker was unresponsive"},"36":{"timestamp":1683160404.1302085,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683166345.6698284,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683166350.0508087,"name":"online","context":{"idset":"0"}}
+{"timestamp":1683166350.7550082,"name":"online","context":{"idset":"2,7,11,18"}}
+{"timestamp":1683166350.8653672,"name":"online","context":{"idset":"1"}}
+{"timestamp":1683166351.0565979,"name":"online","context":{"idset":"33-36"}}
+{"timestamp":1683166351.2053781,"name":"online","context":{"idset":"8,25-26"}}
+{"timestamp":1683166351.3159494,"name":"online","context":{"idset":"6,16,23"}}
+{"timestamp":1683166351.4343805,"name":"online","context":{"idset":"3-4,15,17,19,29-30,32"}}
+{"timestamp":1683166351.5475409,"name":"online","context":{"idset":"5,14,20,27-28,31"}}
+{"timestamp":1683166351.6889558,"name":"online","context":{"idset":"10,13,24"}}
+{"timestamp":1683166351.7959569,"name":"online","context":{"idset":"9"}}
+{"timestamp":1683166351.9071267,"name":"online","context":{"idset":"12"}}
+{"timestamp":1683166533.6951408,"name":"undrain","context":{"idset":"3-20,23-36"}}
+{"timestamp":1683732056.9009645,"name":"drain","context":{"idset":"3-36","reason":"toss_update","overwrite":0}}
+{"timestamp":1683748321.620621,"name":"resource-init","context":{"restart":true,"drain":{"3-36":{"timestamp":1683732056.9009645,"reason":"toss_update"}},"online":"","exclude":"0-2"}}
+{"timestamp":1683748321.6220922,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1683748337.1150377,"name":"online","context":{"idset":"0"}}
+{"timestamp":1683748337.8054342,"name":"online","context":{"idset":"1-2"}}
+{"timestamp":1683748338.1250315,"name":"online","context":{"idset":"33-36"}}
+{"timestamp":1683748338.3085253,"name":"online","context":{"idset":"5-6,16,18,26,29"}}
+{"timestamp":1683748338.4158349,"name":"online","context":{"idset":"9-10,13,30"}}
+{"timestamp":1683748338.5213413,"name":"online","context":{"idset":"4,12,14-15,17,23-24,31"}}
+{"timestamp":1683748338.6356888,"name":"online","context":{"idset":"3,7-8,19-20,25,27-28,32"}}
+{"timestamp":1683748338.7448418,"name":"online","context":{"idset":"11"}}
+{"timestamp":1683748501.7866225,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1683748505.8864768,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1683748595.7863703,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1683748595.7865174,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1683748595.8868542,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1683748597.7858415,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1683748597.785953,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1683748597.7860334,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1683748597.7861118,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1683748597.7862685,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1683748597.7863908,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1683748597.7864666,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1683748597.7865393,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1683748597.7866199,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1683748597.786694,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1683748597.7867956,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1683748597.7868979,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1683748597.7869904,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1683748597.7870839,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1683748597.7871747,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1683748597.7872636,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1683748597.7873456,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1683748597.7874224,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1683748597.7874992,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1683748597.7875776,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1683748597.787653,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1683748597.787724,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1683748597.7878053,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1683748597.7878752,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1683748597.7879422,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1683748597.7880123,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1683748597.7880771,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1683748597.7881405,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1683748597.7882028,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1683748597.8860688,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1683748599.8867273,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1683750917.7638783,"name":"online","context":{"idset":"17"}}
+{"timestamp":1683750918.0665629,"name":"online","context":{"idset":"34,36"}}
+{"timestamp":1683750918.1825147,"name":"online","context":{"idset":"33,35"}}
+{"timestamp":1683750918.3327434,"name":"online","context":{"idset":"4"}}
+{"timestamp":1683750918.8656781,"name":"online","context":{"idset":"11"}}
+{"timestamp":1683750919.2380023,"name":"online","context":{"idset":"10"}}
+{"timestamp":1683750919.3473537,"name":"online","context":{"idset":"3,6-7,9,31"}}
+{"timestamp":1683750919.4803805,"name":"online","context":{"idset":"5,14,22-23,32"}}
+{"timestamp":1683750919.60566,"name":"online","context":{"idset":"16,20,24,28"}}
+{"timestamp":1683750919.7868838,"name":"online","context":{"idset":"15"}}
+{"timestamp":1683750920.2277422,"name":"online","context":{"idset":"18,29"}}
+{"timestamp":1683750920.4562454,"name":"online","context":{"idset":"21,25"}}
+{"timestamp":1683750920.6095209,"name":"online","context":{"idset":"30"}}
+{"timestamp":1683750923.3069961,"name":"online","context":{"idset":"12,19"}}
+{"timestamp":1683751117.47542,"name":"drain","context":{"idset":"13","reason":"kernel panic","overwrite":1}}
+{"timestamp":1683751377.4147542,"name":"online","context":{"idset":"1"}}
+{"timestamp":1683751576.992115,"name":"online","context":{"idset":"2"}}
+{"timestamp":1683751620.01055,"name":"drain","context":{"idset":"8,13,26-27","reason":"kernel panic","overwrite":1}}
+{"timestamp":1683751635.792393,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1683751635.8673952,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1683751636.6359398,"name":"online","context":{"idset":"1-2"}}
+{"timestamp":1683751648.5732882,"name":"undrain","context":{"idset":"1-2"}}
+{"timestamp":1683751664.1794326,"name":"undrain","context":{"idset":"3-7,9-12,14-25,28-36"}}
+{"timestamp":1683819539.2826321,"name":"drain","context":{"idset":"7,14","reason":"JRG: drain partner for ts","overwrite":0}}
+{"timestamp":1683819703.886971,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1683819705.8869145,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1683819837.6678538,"name":"drain","context":{"idset":"25,28","reason":"JRG: drain partner for ts","overwrite":0}}
+{"timestamp":1683819987.5234661,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1683819987.624042,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1683822684.1630032,"name":"online","context":{"idset":"26"}}
+{"timestamp":1683822689.6634328,"name":"online","context":{"idset":"27"}}
+{"timestamp":1683823582.3581014,"name":"online","context":{"idset":"13"}}
+{"timestamp":1683824478.2114956,"name":"online","context":{"idset":"8"}}
+{"timestamp":1683825207.3232718,"name":"online","context":{"idset":"7"}}
+{"timestamp":1683825285.9102516,"name":"undrain","context":{"idset":"7-8,13-14,25-28"}}
+{"timestamp":1683825654.1066372,"name":"online","context":{"idset":"14,25,28"}}
+{"timestamp":1683826214.8493531,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1683827333.6086311,"name":"drain","context":{"idset":"6","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1683834228.9709909,"name":"drain","context":{"idset":"14,25,28","reason":"needs nodeup","overwrite":0}}
+{"timestamp":1683924227.8873079,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1683924317.7245147,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1684169752.0742114,"name":"online","context":{"idset":"1"}}
+{"timestamp":1684169855.2418246,"name":"undrain","context":{"idset":"6-7"}}
+{"timestamp":1684169874.5458691,"name":"undrain","context":{"idset":"1"}}
+{"timestamp":1684169890.8460426,"name":"undrain","context":{"idset":"14,25,28"}}
+{"timestamp":1684170384.2680445,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684191914.9674315,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1684192627.3388937,"name":"online","context":{"idset":"7"}}
+{"timestamp":1684192657.4986045,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1684373149.0404875,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684385808.0802972,"name":"drain","context":{"idset":"4","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684427407.8861322,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1684427409.8872719,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1684428234.0527787,"name":"online","context":{"idset":"7"}}
+{"timestamp":1684428234.2411191,"name":"online","context":{"idset":"4"}}
+{"timestamp":1684428317.6829014,"name":"undrain","context":{"idset":"4,7"}}
+{"timestamp":1684529922.0356793,"name":"drain","context":{"idset":"5","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684788881.8864245,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1684789666.8649645,"name":"online","context":{"idset":"5"}}
+{"timestamp":1684875277.3919578,"name":"undrain","context":{"idset":"5"}}
+{"timestamp":1684876575.1180613,"name":"drain","context":{"idset":"6","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684879563.0264273,"name":"drain","context":{"idset":"5","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684947045.7866769,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1684947045.8872795,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1684947816.0801024,"name":"online","context":{"idset":"5"}}
+{"timestamp":1684947816.2800372,"name":"online","context":{"idset":"6"}}
+{"timestamp":1684947841.7853084,"name":"undrain","context":{"idset":"5-6"}}
+{"timestamp":1684962858.6031675,"name":"drain","context":{"idset":"4","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684963193.6090403,"name":"drain","context":{"idset":"11","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684963194.0522773,"name":"drain","context":{"idset":"9","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684963195.1113918,"name":"drain","context":{"idset":"17","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684963195.3092155,"name":"drain","context":{"idset":"14","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684963195.5571187,"name":"drain","context":{"idset":"16","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684964849.8869543,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1684964851.786428,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1684964851.786556,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1684964851.7866561,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1684964851.7867382,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1684964851.8866146,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1684966219.7870421,"name":"online","context":{"idset":"17"}}
+{"timestamp":1684966220.1725612,"name":"online","context":{"idset":"4"}}
+{"timestamp":1684966220.4602518,"name":"online","context":{"idset":"16"}}
+{"timestamp":1684966220.5746324,"name":"online","context":{"idset":"9,11,14"}}
+{"timestamp":1684966236.8948069,"name":"drain","context":{"idset":"25","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684966236.9342258,"name":"drain","context":{"idset":"19","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684966236.9849858,"name":"drain","context":{"idset":"26","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684966238.7645166,"name":"drain","context":{"idset":"29","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1684966376.7974205,"name":"undrain","context":{"idset":"4,9,11,14,16-17"}}
+{"timestamp":1685038875.7861464,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1685038875.7863345,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1685038875.8865273,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1685038877.8871939,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1685039799.1612513,"name":"online","context":{"idset":"19"}}
+{"timestamp":1685039799.760076,"name":"online","context":{"idset":"25-26,29"}}
+{"timestamp":1685039822.1983812,"name":"undrain","context":{"idset":"19,25-26,29"}}
+{"timestamp":1685116354.1591506,"name":"drain","context":{"idset":"4","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1685122455.886898,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1685123615.4631956,"name":"online","context":{"idset":"4"}}
+{"timestamp":1685123660.0416374,"name":"undrain","context":{"idset":"4"}}
+{"timestamp":1685477306.8740525,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1685636807.8869379,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1685637658.6232207,"name":"online","context":{"idset":"7"}}
+{"timestamp":1685637680.696929,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1685662530.4070165,"name":"drain","context":{"idset":"13","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1685724447.8871636,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1685725782.5904732,"name":"online","context":{"idset":"13"}}
+{"timestamp":1685725804.3359475,"name":"undrain","context":{"idset":"13"}}
+{"timestamp":1685783215.8770959,"name":"drain","context":{"idset":"4","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1685982853.8874407,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1685985089.760874,"name":"online","context":{"idset":"4"}}
+{"timestamp":1685992650.7199693,"name":"undrain","context":{"idset":"4"}}
+{"timestamp":1686081678.624018,"name":"drain","context":{"idset":"5","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1686087358.259593,"name":"drain","context":{"idset":"8","overwrite":0}}
+{"timestamp":1686087378.6208158,"name":"drain","context":{"idset":"8","reason":"update ansible","overwrite":0}}
+{"timestamp":1686155275.7866137,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1686155275.8867335,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1686156961.3388293,"name":"online","context":{"idset":"5,8"}}
+{"timestamp":1686156987.2019901,"name":"undrain","context":{"idset":"5,8"}}
+{"timestamp":1686163657.8210664,"name":"drain","context":{"idset":"16","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1686199056.2598407,"name":"drain","context":{"idset":"10","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1686241510.0051856,"name":"drain","context":{"idset":"4","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1686244713.8866267,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1686244715.7862122,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1686244715.8870401,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1686245753.0504334,"name":"online","context":{"idset":"10"}}
+{"timestamp":1686245753.4295375,"name":"online","context":{"idset":"4"}}
+{"timestamp":1686245753.7659333,"name":"online","context":{"idset":"16"}}
+{"timestamp":1686247133.0394862,"name":"undrain","context":{"idset":"4,10,16"}}
+{"timestamp":1686255123.8593733,"name":"drain","context":{"idset":"6","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1686284476.9858832,"name":"drain","context":{"idset":"10","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1686321815.584425,"name":"drain","context":{"idset":"5","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1686322466.3920152,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1686322466.3951468,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1686322466.4364505,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1686322466.4379063,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1686322466.4444304,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1686322466.4477501,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1686322466.4530685,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1686322466.4654698,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1686322466.466115,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1686322466.4735317,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1686322466.4799979,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1686322466.4824643,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1686322466.4837935,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1686322466.4849913,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1686322466.4860542,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1686322466.4869874,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1686322466.489466,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1686322466.4953475,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1686322466.4959507,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1686322466.4974937,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1686322466.5088444,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1686322466.5099525,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1686322466.5146184,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1686322466.5286646,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1686322466.5323284,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1686322466.5357804,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1686322466.5637023,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1686322466.6063449,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1686322466.6248019,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1686322466.6379604,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1686322466.645273,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1686322466.6569867,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1686322466.6611462,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1686322466.6932139,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1686322466.6998024,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1686322466.8006725,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1686341189.0594072,"name":"resource-init","context":{"restart":true,"drain":{"5":{"timestamp":1686321815.584425,"reason":"nodediag failed amdgpu"},"6":{"timestamp":1686255123.8593733,"reason":"nodediag failed amdgpu"},"10":{"timestamp":1686284476.9858832,"reason":"nodediag failed amdgpu"}},"online":"","exclude":"0-2"}}
+{"timestamp":1686341189.0605321,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1686341270.6031895,"name":"online","context":{"idset":"0"}}
+{"timestamp":1686341271.4912853,"name":"online","context":{"idset":"2,4,6,8,10,12,14-15,17-21,25,27-31"}}
+{"timestamp":1686341271.5993192,"name":"online","context":{"idset":"3,5,22-24,32"}}
+{"timestamp":1686341271.707767,"name":"online","context":{"idset":"9,13,16"}}
+{"timestamp":1686341271.8114624,"name":"online","context":{"idset":"11"}}
+{"timestamp":1686341271.9252803,"name":"online","context":{"idset":"7"}}
+{"timestamp":1686343739.8611534,"name":"undrain","context":{"idset":"5-6,10"}}
+{"timestamp":1686583886.191025,"name":"drain","context":{"idset":"25","reason":"broken partner node","overwrite":0}}
+{"timestamp":1686583930.416127,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1686600272.1024852,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1686601277.5063143,"name":"drain","context":{"idset":"27","reason":"broker was unresponsive"}}
+{"timestamp":1686601277.6069403,"name":"drain","context":{"idset":"28","reason":"broker was unresponsive"}}
+{"timestamp":1686601373.5063775,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1686601373.60671,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1686603329.5065322,"name":"drain","context":{"idset":"31","reason":"broker was unresponsive"}}
+{"timestamp":1686603329.606683,"name":"drain","context":{"idset":"32","reason":"broker was unresponsive"}}
+{"timestamp":1686603421.5067344,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1686603421.6070187,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1686605170.4152982,"name":"online","context":{"idset":"1"}}
+{"timestamp":1686605221.9310002,"name":"online","context":{"idset":"2"}}
+{"timestamp":1686640758.723974,"name":"drain","context":{"idset":"19","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1686714184.3147929,"name":"drain","context":{"idset":"4","reason":"prolog failed for jobid f9BEzgpsKaX","overwrite":0}}
+{"timestamp":1686898410.7932065,"name":"drain","context":{"idset":"13","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1687321671.2697661,"name":"drain","context":{"idset":"12","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1687376313.3019717,"name":"drain","context":{"idset":"5","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1687545496.1398079,"name":"drain","context":{"idset":"3","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1687602315.0311725,"name":"drain","context":{"idset":"20","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1687611462.1927361,"name":"drain","context":{"idset":"15","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1687810982.8620956,"name":"drain","context":{"idset":"24","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1687812810.336946,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1687812811.5060968,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1687812811.5062549,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1687812811.6064847,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1687813437.5062656,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1687813437.5064354,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1687813437.5065238,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1687813437.5066056,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1687813437.6068332,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1687814273.1174664,"name":"online","context":{"idset":"12"}}
+{"timestamp":1687814273.3896263,"name":"online","context":{"idset":"28"}}
+{"timestamp":1687814273.5063608,"name":"online","context":{"idset":"24"}}
+{"timestamp":1687814273.6072438,"name":"online","context":{"idset":"4"}}
+{"timestamp":1687814273.7244589,"name":"online","context":{"idset":"20,31-32"}}
+{"timestamp":1687814274.1748614,"name":"online","context":{"idset":"25"}}
+{"timestamp":1687814274.8954172,"name":"online","context":{"idset":"15,27"}}
+{"timestamp":1687814276.2386823,"name":"online","context":{"idset":"19"}}
+{"timestamp":1687814276.6125693,"name":"online","context":{"idset":"13"}}
+{"timestamp":1687814277.3528614,"name":"online","context":{"idset":"3"}}
+{"timestamp":1687814281.3044066,"name":"online","context":{"idset":"5"}}
+{"timestamp":1687814423.7734134,"name":"undrain","context":{"idset":"3-5,12-13,15,19-20,24-25,27-28,31-32"}}
+{"timestamp":1687814477.9647334,"name":"online","context":{"idset":"26"}}
+{"timestamp":1687814538.5924499,"name":"online","context":{"idset":"35-36"}}
+{"timestamp":1687814538.7238629,"name":"online","context":{"idset":"34"}}
+{"timestamp":1687814541.1967599,"name":"online","context":{"idset":"33"}}
+{"timestamp":1687840245.3926859,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1687877401.032244,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1687877401.1322174,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1687877401.1350052,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1687877401.1374559,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1687877401.1383166,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1687877401.1801558,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1687877401.1865575,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1687877401.2065289,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1687877401.2066252,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1687877401.2160223,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1687877401.2203431,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1687877401.2221334,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1687877401.2257354,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1687877401.2259455,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1687877401.232667,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1687877401.2535379,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1687877401.2653077,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1687877401.2695031,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1687877401.2817261,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1687877401.3349619,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1687877401.3411489,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1687877401.3416047,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1687877401.3604689,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1687877401.3948221,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1687877401.4154084,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1687877401.4188719,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1687877401.419081,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1687877401.4363878,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1687877401.4367635,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1687877401.4737442,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1687877401.5021513,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1687877401.6027293,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1687877401.8565438,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1687877401.9398537,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1687877401.9445074,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1687877402.0454702,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1687904320.5474653,"name":"resource-init","context":{"restart":true,"drain":{"7":{"timestamp":1687840245.3926859,"reason":"nodediag failed amdgpu"}},"online":"","exclude":"0-2"}}
+{"timestamp":1687904320.5484357,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1687904433.3020122,"name":"online","context":{"idset":"0"}}
+{"timestamp":1687908205.6857595,"name":"online","context":{"idset":"2"}}
+{"timestamp":1687908205.8818951,"name":"online","context":{"idset":"1"}}
+{"timestamp":1687908257.2212946,"name":"online","context":{"idset":"36"}}
+{"timestamp":1687908257.349519,"name":"online","context":{"idset":"35"}}
+{"timestamp":1687908257.4529624,"name":"online","context":{"idset":"33"}}
+{"timestamp":1687908257.6890216,"name":"online","context":{"idset":"11,22,31"}}
+{"timestamp":1687908257.7632115,"name":"online","context":{"idset":"17,34"}}
+{"timestamp":1687908257.8818374,"name":"online","context":{"idset":"14"}}
+{"timestamp":1687908258.1154268,"name":"online","context":{"idset":"9,15,25,30"}}
+{"timestamp":1687908258.2620282,"name":"online","context":{"idset":"7,10,13,21,28"}}
+{"timestamp":1687908258.4321821,"name":"online","context":{"idset":"5,12,32"}}
+{"timestamp":1687908258.5474312,"name":"online","context":{"idset":"6,8,16,19-20,26,29"}}
+{"timestamp":1687908258.7407665,"name":"online","context":{"idset":"4,24"}}
+{"timestamp":1687908258.8792,"name":"online","context":{"idset":"23"}}
+{"timestamp":1687908259.1107841,"name":"online","context":{"idset":"27"}}
+{"timestamp":1687910197.7839174,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1688078114.7269762,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1688106590.6283898,"name":"drain","context":{"idset":"4","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1688171254.8969445,"name":"drain","context":{"idset":"10","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1688175536.9519937,"name":"drain","context":{"idset":"5","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1688180189.8124971,"name":"drain","context":{"idset":"6","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1688399436.2427216,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1688399436.2792625,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1688399436.3036582,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1688399436.342623,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1688399436.4429579,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1688400379.405575,"name":"online","context":{"idset":"6,10"}}
+{"timestamp":1688400379.6050229,"name":"online","context":{"idset":"4"}}
+{"timestamp":1688400379.7331963,"name":"online","context":{"idset":"5,7"}}
+{"timestamp":1688400402.4930494,"name":"undrain","context":{"idset":"4-7,10"}}
+{"timestamp":1688582005.6532092,"name":"drain","context":{"idset":"8","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1688593034.9604552,"name":"drain","context":{"idset":"10","reason":"prolog failed for jobid fDMXsKKtAuV","overwrite":0}}
+{"timestamp":1688657096.1994245,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1688657096.2996619,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1688657918.6158512,"name":"online","context":{"idset":"8"}}
+{"timestamp":1688657918.7541385,"name":"online","context":{"idset":"10"}}
+{"timestamp":1688657938.6868944,"name":"undrain","context":{"idset":"8,10"}}
+{"timestamp":1688658590.118628,"name":"online","context":{"idset":"3"}}
+{"timestamp":1688659286.2997916,"name":"drain","context":{"idset":"15","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1988866,"name":"drain","context":{"idset":"3","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1989958,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1990526,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1991146,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1991673,"name":"drain","context":{"idset":"10","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1992216,"name":"drain","context":{"idset":"13","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1992729,"name":"drain","context":{"idset":"14","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1993372,"name":"drain","context":{"idset":"21","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1993895,"name":"drain","context":{"idset":"22","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1994412,"name":"drain","context":{"idset":"23","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1994936,"name":"drain","context":{"idset":"26","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1995478,"name":"drain","context":{"idset":"27","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1996002,"name":"drain","context":{"idset":"28","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1996512,"name":"drain","context":{"idset":"29","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1997035,"name":"drain","context":{"idset":"30","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1997607,"name":"drain","context":{"idset":"31","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1998119,"name":"drain","context":{"idset":"32","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.199868,"name":"drain","context":{"idset":"33","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1999199,"name":"drain","context":{"idset":"34","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.1999757,"name":"drain","context":{"idset":"35","reason":"broker was unresponsive"}}
+{"timestamp":1688659288.2998974,"name":"drain","context":{"idset":"36","reason":"broker was unresponsive"}}
+{"timestamp":1688659290.1991863,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1688659290.1992748,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1688659290.1993392,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1688659290.1993949,"name":"drain","context":{"idset":"11","reason":"broker was unresponsive"}}
+{"timestamp":1688659290.1994505,"name":"drain","context":{"idset":"12","reason":"broker was unresponsive"}}
+{"timestamp":1688659290.1995049,"name":"drain","context":{"idset":"16","reason":"broker was unresponsive"}}
+{"timestamp":1688659290.1995595,"name":"drain","context":{"idset":"17","reason":"broker was unresponsive"}}
+{"timestamp":1688659290.1996155,"name":"drain","context":{"idset":"19","reason":"broker was unresponsive"}}
+{"timestamp":1688659290.1996703,"name":"drain","context":{"idset":"20","reason":"broker was unresponsive"}}
+{"timestamp":1688659290.1997263,"name":"drain","context":{"idset":"24","reason":"broker was unresponsive"}}
+{"timestamp":1688659290.2997088,"name":"drain","context":{"idset":"25","reason":"broker was unresponsive"}}
+{"timestamp":1688659352.1988606,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1688659352.1990268,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1688659352.1991479,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1688659352.1992471,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1688659352.199347,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1688659352.1994436,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1688659352.199538,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1688659352.1996324,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1688659352.1997294,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1688659352.1998203,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1688659352.1999235,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1688659352.2000113,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1688659352.2001076,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1688659352.2001967,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1688659352.2002838,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1688659352.2003691,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1688659352.2004533,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1688659352.200537,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1688659352.2006211,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1688659352.2007172,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1688659352.2008095,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1688659352.2994893,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1688659354.1992891,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1688659354.1993945,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1688659354.1994736,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1688659354.1995513,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1688659354.199625,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1688659354.1996973,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1688659354.1997666,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1688659354.1998348,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1688659354.1998999,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1688659354.1999621,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1688659354.2994742,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1688659454.299504,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1688659456.2998719,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1688659520.2993138,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1688659524.2996466,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1688664406.7924533,"name":"online","context":{"idset":"34"}}
+{"timestamp":1688664407.2633905,"name":"online","context":{"idset":"33"}}
+{"timestamp":1688664407.3953438,"name":"online","context":{"idset":"35-36"}}
+{"timestamp":1688664817.5081546,"name":"online","context":{"idset":"25"}}
+{"timestamp":1688664817.6003385,"name":"online","context":{"idset":"12,14"}}
+{"timestamp":1688664817.774579,"name":"online","context":{"idset":"4,16"}}
+{"timestamp":1688664817.8522401,"name":"online","context":{"idset":"6,10"}}
+{"timestamp":1688664817.8663456,"name":"online","context":{"idset":"8"}}
+{"timestamp":1688664818.0299041,"name":"online","context":{"idset":"24,26"}}
+{"timestamp":1688664818.1399195,"name":"online","context":{"idset":"20,23"}}
+{"timestamp":1688664818.2645066,"name":"online","context":{"idset":"21,27"}}
+{"timestamp":1688664818.4887064,"name":"online","context":{"idset":"29,31-32"}}
+{"timestamp":1688664818.6602981,"name":"online","context":{"idset":"22,28"}}
+{"timestamp":1688664818.7976594,"name":"online","context":{"idset":"18-19"}}
+{"timestamp":1688664818.9596338,"name":"online","context":{"idset":"17"}}
+{"timestamp":1688664819.232636,"name":"online","context":{"idset":"30"}}
+{"timestamp":1688665846.1987448,"name":"drain","context":{"idset":"18","reason":"broker was unresponsive"}}
+{"timestamp":1688665910.1993361,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1688665910.1994951,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1688665910.1995933,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1688665910.29967,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1688665912.1988769,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1688665912.1989894,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1688665912.1990802,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1688665912.1991749,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1688665912.1992574,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1688665912.1993387,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1688665912.1994197,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1688665912.1994998,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1688665912.1995788,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1688665912.1996551,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1688665912.1997297,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1688665912.1998043,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1688665912.1998761,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1688665912.1999466,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1688665912.2000172,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1688665912.2000988,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1688665912.2001696,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1688665912.2002385,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1688665912.2003069,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1688665912.2003722,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1688665912.2004399,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1688665912.2005024,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1688665912.2997966,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1688670141.0095379,"name":"online","context":{"idset":"34"}}
+{"timestamp":1688670141.0667126,"name":"online","context":{"idset":"35"}}
+{"timestamp":1688670141.1802998,"name":"online","context":{"idset":"30,36"}}
+{"timestamp":1688670141.2821019,"name":"online","context":{"idset":"14,33"}}
+{"timestamp":1688670141.4063599,"name":"online","context":{"idset":"12"}}
+{"timestamp":1688670141.5081363,"name":"online","context":{"idset":"4,16,18"}}
+{"timestamp":1688670141.6180561,"name":"online","context":{"idset":"8,10,17,19,21,23,29"}}
+{"timestamp":1688670141.8388829,"name":"online","context":{"idset":"6,22,24,28"}}
+{"timestamp":1688670142.1664474,"name":"online","context":{"idset":"26-27,31"}}
+{"timestamp":1688670142.2991445,"name":"online","context":{"idset":"20"}}
+{"timestamp":1688670146.0061364,"name":"online","context":{"idset":"25"}}
+{"timestamp":1688670147.0567355,"name":"online","context":{"idset":"32"}}
+{"timestamp":1688670808.6534574,"name":"online","context":{"idset":"2"}}
+{"timestamp":1688679194.2991319,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1688684441.6714115,"name":"online","context":{"idset":"5"}}
+{"timestamp":1688684641.5234241,"name":"online","context":{"idset":"7"}}
+{"timestamp":1688684764.7449234,"name":"online","context":{"idset":"23"}}
+{"timestamp":1688685147.0165372,"name":"online","context":{"idset":"9,11,13,15"}}
+{"timestamp":1688685309.7357225,"name":"online","context":{"idset":"3"}}
+{"timestamp":1688685371.1002295,"name":"undrain","context":{"idset":"2-36"}}
+{"timestamp":1688685702.1457357,"name":"online","context":{"idset":"1"}}
+{"timestamp":1688685801.2628367,"name":"undrain","context":{"idset":"1"}}
+{"timestamp":1689032110.3276999,"name":"drain","context":{"idset":"4","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1689039484.0110605,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1689096034.9438431,"name":"drain","context":{"idset":"11","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1689102581.2256565,"name":"drain","context":{"idset":"12","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1689196105.8417664,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1689196112.2339582,"name":"online","context":{"idset":"7"}}
+{"timestamp":1689196124.29951,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1689196130.2843678,"name":"online","context":{"idset":"4"}}
+{"timestamp":1689196201.914103,"name":"drain","context":{"idset":"14","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1689197276.1991103,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1689197276.298995,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1689198395.2306502,"name":"drain","context":{"idset":"8","reason":"Bad Partner Node -JRG","overwrite":0}}
+{"timestamp":1689199022.4479749,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1689199937.3286381,"name":"online","context":{"idset":"14"}}
+{"timestamp":1689199938.045433,"name":"online","context":{"idset":"4"}}
+{"timestamp":1689199975.8796816,"name":"undrain","context":{"idset":"4,11-12,14"}}
+{"timestamp":1689367957.115541,"name":"drain","context":{"idset":"10","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1689613038.6692147,"name":"drain","context":{"idset":"16","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1689613442.8834677,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1689613513.5442095,"name":"undrain","context":{"idset":"16"}}
+{"timestamp":1689613722.300096,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1689614194.0921583,"name":"online","context":{"idset":"10"}}
+{"timestamp":1689614214.5322115,"name":"undrain","context":{"idset":"10"}}
+{"timestamp":1689617139.2870436,"name":"online","context":{"idset":"7-8"}}
+{"timestamp":1689617188.9689901,"name":"undrain","context":{"idset":"7-8"}}
+{"timestamp":1689635623.1902571,"name":"drain","context":{"idset":"3","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1689703778.8647578,"name":"undrain","context":{"idset":"3"}}
+{"timestamp":1690022582.6543586,"name":"drain","context":{"idset":"14","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1690211526.6994858,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1690212463.4472229,"name":"online","context":{"idset":"14"}}
+{"timestamp":1690212474.6213264,"name":"undrain","context":{"idset":"14"}}
+{"timestamp":1690490826.1335647,"name":"drain","context":{"idset":"11","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1690495750.3843153,"name":"undrain","context":{"idset":"11"}}
+{"timestamp":1690496505.8267486,"name":"drain","context":{"idset":"11","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1690506341.1792128,"name":"drain","context":{"idset":"3","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1690566152.3814771,"name":"undrain","context":{"idset":"3,11"}}
+{"timestamp":1690566398.0980511,"name":"drain","context":{"idset":"11","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1690568286.9487793,"name":"drain","context":{"idset":"17","overwrite":0}}
+{"timestamp":1690568428.1994469,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1690568428.2994387,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1690569436.607836,"name":"drain","context":{"idset":"11,17","reason":"problems","overwrite":1}}
+{"timestamp":1690570623.6640644,"name":"online","context":{"idset":"11"}}
+{"timestamp":1690570624.0570786,"name":"online","context":{"idset":"17"}}
+{"timestamp":1690570828.777142,"name":"drain","context":{"idset":"11-12,16-17","reason":"problems","overwrite":1}}
+{"timestamp":1690571136.199415,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1690571136.3001318,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1690573325.5275173,"name":"drain","context":{"idset":"10","reason":"nodediag failed network","overwrite":0}}
+{"timestamp":1690576260.2995269,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1690576342.2997634,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1690576348.2996907,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1690576350.3001435,"name":"drain","context":{"idset":"28","reason":"broker was unresponsive"}}
+{"timestamp":1690576464.2274606,"name":"drain","context":{"idset":"9","reason":"epilog failed for jobid fHow2NCBFiX","overwrite":0}}
+{"timestamp":1690576826.3002801,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1690576934.2997983,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1690577850.1987164,"name":"online","context":{"idset":"1"}}
+{"timestamp":1690578212.2993898,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1690579069.0934014,"name":"drain","context":{"idset":"24","reason":"problems","overwrite":0}}
+{"timestamp":1690579192.8717432,"name":"online","context":{"idset":"2"}}
+{"timestamp":1690579249.722357,"name":"undrain","context":{"idset":"1-2,9,28"}}
+{"timestamp":1690579532.3830347,"name":"undrain","context":{"idset":"16-17"}}
+{"timestamp":1690579872.9060335,"name":"online","context":{"idset":"12"}}
+{"timestamp":1690579874.0192597,"name":"online","context":{"idset":"11"}}
+{"timestamp":1690579906.2709489,"name":"undrain","context":{"idset":"11-12"}}
+{"timestamp":1690580224.6935222,"name":"drain","context":{"idset":"10,24","reason":"network","overwrite":1}}
+{"timestamp":1690580243.0597839,"name":"drain","context":{"idset":"11","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1690580378.8876145,"name":"drain","context":{"idset":"9,13,15,23","reason":"mounts","overwrite":0}}
+{"timestamp":1690580384.2991683,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1690580542.2990541,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1690580544.1995158,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1690580544.2997844,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1690580932.5026376,"name":"drain","context":{"idset":"12","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1690581221.9751191,"name":"online","context":{"idset":"10"}}
+{"timestamp":1690581237.8314309,"name":"undrain","context":{"idset":"10"}}
+{"timestamp":1690581332.6279323,"name":"online","context":{"idset":"24"}}
+{"timestamp":1690581353.4348707,"name":"undrain","context":{"idset":"24"}}
+{"timestamp":1690581486.464009,"name":"online","context":{"idset":"23"}}
+{"timestamp":1690581486.9054739,"name":"online","context":{"idset":"9"}}
+{"timestamp":1690581575.166748,"name":"undrain","context":{"idset":"9,23"}}
+{"timestamp":1690581811.5191987,"name":"drain","context":{"idset":"17","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1690581946.8825738,"name":"drain","context":{"idset":"9","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1690581948.0500565,"name":"undrain","context":{"idset":"13"}}
+{"timestamp":1690582033.6935301,"name":"drain","context":{"idset":"24","reason":"nodediag failed network pci","overwrite":0}}
+{"timestamp":1690582100.1153636,"name":"drain","context":{"idset":"10","reason":"nodediag failed network pci","overwrite":0}}
+{"timestamp":1690582161.8840003,"name":"drain","context":{"idset":"15","reason":"kernel panic","overwrite":1}}
+{"timestamp":1690582484.1384256,"name":"drain","context":{"idset":"23","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1690849054.3003924,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1690903832.300009,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1690960686.3002448,"name":"drain","context":{"idset":"29","reason":"broker was unresponsive"}}
+{"timestamp":1690992317.0297036,"name":"drain","context":{"idset":"3-36","reason":"reboot","overwrite":1}}
+{"timestamp":1690992504.1993451,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1690992504.1995513,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1690992504.199666,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1690992504.1997762,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1690992504.1998782,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1690992504.1999753,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1690992504.2000692,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1690992504.2001839,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1690992504.2002792,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1690992504.2003684,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1690992504.2004647,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1690992504.2005601,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1690992504.2006497,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1690992504.2007368,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1690992504.2008221,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1690992504.200906,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1690992504.200999,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1690992504.2011001,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1690992504.2012293,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1690992504.2013133,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1690992504.2014012,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1690992504.2014921,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1690992504.2015834,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1690992504.2016742,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1690992504.2017589,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1690992504.2018399,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1690992504.2019172,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1690992504.2019858,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1690992504.202065,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1690992504.2021472,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1690992504.2022169,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1690992504.2022865,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1690992504.4741726,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1690992504.5989015,"name":"drain","context":{"idset":"3","reason":"epilog failed for jobid fJmp3rSQgHV","overwrite":0}}
+{"timestamp":1690992504.703413,"name":"drain","context":{"idset":"5","reason":"epilog failed for jobid fJmTLjscSNb","overwrite":0}}
+{"timestamp":1690992504.782114,"name":"drain","context":{"idset":"6","reason":"epilog failed for jobid fJmToWCaSXy","overwrite":0}}
+{"timestamp":1690992672.1996136,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1690992672.3004735,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1690992736.1986208,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1690992736.2990053,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1690996345.984442,"name":"drain","context":{"idset":"13,15","reason":"kernel panic","overwrite":1}}
+{"timestamp":1690997042.1635592,"name":"drain","context":{"idset":"12,28","reason":"problems","overwrite":1}}
+{"timestamp":1690997120.1992862,"name":"online","context":{"idset":"34"}}
+{"timestamp":1690997120.6286302,"name":"online","context":{"idset":"33,35"}}
+{"timestamp":1690997121.2039685,"name":"online","context":{"idset":"20,32,36"}}
+{"timestamp":1690997121.6595905,"name":"online","context":{"idset":"9"}}
+{"timestamp":1690997121.8084345,"name":"online","context":{"idset":"7"}}
+{"timestamp":1690997122.4174283,"name":"online","context":{"idset":"14"}}
+{"timestamp":1690997122.5426803,"name":"online","context":{"idset":"10-11"}}
+{"timestamp":1690997122.7820618,"name":"online","context":{"idset":"19"}}
+{"timestamp":1690997122.9053044,"name":"online","context":{"idset":"3-4,27"}}
+{"timestamp":1690997122.9862652,"name":"online","context":{"idset":"8,18"}}
+{"timestamp":1690997123.2814095,"name":"online","context":{"idset":"29"}}
+{"timestamp":1690997124.0982022,"name":"online","context":{"idset":"17,25"}}
+{"timestamp":1690997124.54755,"name":"online","context":{"idset":"31"}}
+{"timestamp":1690997124.6578283,"name":"online","context":{"idset":"21"}}
+{"timestamp":1690997125.1125975,"name":"online","context":{"idset":"24"}}
+{"timestamp":1690997125.3401279,"name":"online","context":{"idset":"5"}}
+{"timestamp":1690997125.8039761,"name":"online","context":{"idset":"6"}}
+{"timestamp":1690997126.6471901,"name":"online","context":{"idset":"16"}}
+{"timestamp":1690997127.8135917,"name":"online","context":{"idset":"23,30"}}
+{"timestamp":1690997128.1114681,"name":"online","context":{"idset":"22"}}
+{"timestamp":1690997129.7832563,"name":"online","context":{"idset":"26"}}
+{"timestamp":1690997214.0611939,"name":"undrain","context":{"idset":"3-11,14,16-27,29-36"}}
+{"timestamp":1690997227.6415937,"name":"drain","context":{"idset":"3","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1690997227.7701278,"name":"drain","context":{"idset":"4","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1690997296.6268826,"name":"online","context":{"idset":"2"}}
+{"timestamp":1690997296.7732763,"name":"online","context":{"idset":"1"}}
+{"timestamp":1690997458.092768,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1690997458.1528273,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1690997458.8855021,"name":"online","context":{"idset":"1-2"}}
+{"timestamp":1690997468.9780183,"name":"undrain","context":{"idset":"1-2"}}
+{"timestamp":1690997547.6303101,"name":"online","context":{"idset":"12,28"}}
+{"timestamp":1690997578.0582342,"name":"undrain","context":{"idset":"12,28"}}
+{"timestamp":1691000897.9105389,"name":"undrain","context":{"idset":"3-4"}}
+{"timestamp":1691004422.7056198,"name":"drain","context":{"idset":"12,28","reason":"slingshot issues","overwrite":0}}
+{"timestamp":1691442630.0027142,"name":"drain","context":{"idset":"22-24","reason":"prolog failed for jobid fKnrKWWhhAf","overwrite":0}}
+{"timestamp":1691448647.3717091,"name":"drain","context":{"idset":"8","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1691612538.2998984,"name":"drain","context":{"idset":"31","reason":"broker was unresponsive"}}
+{"timestamp":1691614913.0310326,"name":"drain","context":{"idset":"32","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1691614921.4570794,"name":"drain","context":{"idset":"29","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1691615275.3902726,"name":"drain","context":{"idset":"27","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1691624238.9873762,"name":"undrain","context":{"idset":"8,27,29,31-32"}}
+{"timestamp":1691764622.1993239,"name":"drain","context":{"idset":"17","reason":"broker was unresponsive"}}
+{"timestamp":1691764622.1995289,"name":"drain","context":{"idset":"18","reason":"broker was unresponsive"}}
+{"timestamp":1691764622.2995217,"name":"drain","context":{"idset":"20","reason":"broker was unresponsive"}}
+{"timestamp":1691764640.2992983,"name":"drain","context":{"idset":"19","reason":"broker was unresponsive"}}
+{"timestamp":1691768050.1996939,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1691768050.1998925,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1691768050.1999657,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1691768050.300416,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1691768930.1993332,"name":"drain","context":{"idset":"10","reason":"broker was unresponsive"}}
+{"timestamp":1691768930.199543,"name":"drain","context":{"idset":"16","reason":"broker was unresponsive"}}
+{"timestamp":1691768930.1996176,"name":"drain","context":{"idset":"21","reason":"broker was unresponsive"}}
+{"timestamp":1691768930.2992833,"name":"drain","context":{"idset":"25","reason":"broker was unresponsive"}}
+{"timestamp":1691788933.6739111,"name":"drain","context":{"idset":"33","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1692122326.299922,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1692122757.0054886,"name":"drain","context":{"idset":"14","reason":"bad partner node--JRG","overwrite":0}}
+{"timestamp":1692123016.2987294,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1692123078.1629097,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1692124727.9253373,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1692124728.025419,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1692124728.1764028,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1692124728.2768204,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1692124728.3880005,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1692124728.6233335,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1692124728.7769127,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1692124728.8796751,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1692124728.9803061,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1692124729.3554881,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1692124729.4556353,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1692126037.8088713,"name":"online","context":{"idset":"8-9,25"}}
+{"timestamp":1692126037.9934978,"name":"online","context":{"idset":"4-5,17,19"}}
+{"timestamp":1692126038.1051362,"name":"online","context":{"idset":"18"}}
+{"timestamp":1692126038.2778707,"name":"online","context":{"idset":"21"}}
+{"timestamp":1692126039.0095937,"name":"online","context":{"idset":"20"}}
+{"timestamp":1692126039.6706393,"name":"online","context":{"idset":"10"}}
+{"timestamp":1692126083.3534234,"name":"undrain","context":{"idset":"4-5,8-10,17-21,25"}}
+{"timestamp":1692126674.7791092,"name":"online","context":{"idset":"15"}}
+{"timestamp":1692126674.9873233,"name":"online","context":{"idset":"13"}}
+{"timestamp":1692126958.8009717,"name":"online","context":{"idset":"16"}}
+{"timestamp":1692126963.5234253,"name":"online","context":{"idset":"14"}}
+{"timestamp":1692126975.5350831,"name":"undrain","context":{"idset":"13-16"}}
+{"timestamp":1692127306.7844043,"name":"online","context":{"idset":"33"}}
+{"timestamp":1692127318.6979246,"name":"undrain","context":{"idset":"33"}}
+{"timestamp":1692127660.7011418,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1692127660.8594623,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1692199531.4708548,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1692199531.5716386,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1692206742.4304099,"name":"online","context":{"idset":"23"}}
+{"timestamp":1692206742.6160614,"name":"online","context":{"idset":"24"}}
+{"timestamp":1692206772.8497257,"name":"undrain","context":{"idset":"23-24"}}
+{"timestamp":1692207208.9126787,"name":"undrain","context":{"idset":"22"}}
+{"timestamp":1692226126.2994025,"name":"drain","context":{"idset":"19","reason":"broker was unresponsive"}}
+{"timestamp":1692304039.7136846,"name":"undrain","context":{"idset":"19"}}
+{"timestamp":1692313146.9445035,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1692313147.2367971,"name":"drain","context":{"idset":"6","reason":"epilog failed for jobid fMjUAMbbngf","overwrite":0}}
+{"timestamp":1692382720.2868474,"name":"drain","context":{"idset":"17","reason":"epilog failed for jobid fMt4CjcDCNb","overwrite":0}}
+{"timestamp":1692396716.9669497,"name":"online","context":{"idset":"6"}}
+{"timestamp":1692396738.6329165,"name":"undrain","context":{"idset":"6,17"}}
+{"timestamp":1692398144.4991741,"name":"drain","context":{"idset":"13","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1692482422.5127513,"name":"drain","context":{"idset":"3","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1692490653.2078135,"name":"drain","context":{"idset":"30","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1692560929.7375612,"name":"undrain","context":{"idset":"3,13,30"}}
+{"timestamp":1692561123.4332354,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1692561123.5736334,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1692561123.6739783,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1692561142.0953584,"name":"drain","context":{"idset":"3,13,30","reason":"reboot","overwrite":2}}
+{"timestamp":1692578303.7812779,"name":"online","context":{"idset":"3,13"}}
+{"timestamp":1692578304.0520732,"name":"online","context":{"idset":"30"}}
+{"timestamp":1692578320.7994485,"name":"undrain","context":{"idset":"3,13,30"}}
+{"timestamp":1692731196.3000994,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1692731393.1728163,"name":"drain","context":{"idset":"15","reason":"epilog failed for jobid fNhQKdVuXiX","overwrite":0}}
+{"timestamp":1692779548.2996812,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1692779575.4191892,"name":"drain","context":{"idset":"31","reason":"epilog failed for jobid fNoq5483591","overwrite":0}}
+{"timestamp":1692786104.2991579,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1692786112.2993193,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1692786126.5591235,"name":"drain","context":{"idset":"4","reason":"epilog failed for jobid fNpiaHq2VEw","overwrite":0}}
+{"timestamp":1692786132.5700204,"name":"drain","context":{"idset":"22","reason":"epilog failed for jobid fNpVJC9Hz4o","overwrite":0}}
+{"timestamp":1692786548.2992902,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1692786579.7509997,"name":"drain","context":{"idset":"18","reason":"epilog failed for jobid fNpZhLxexhV","overwrite":0}}
+{"timestamp":1692802818.0876265,"name":"drain","context":{"idset":"8","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1692806199.7085576,"name":"drain","context":{"idset":"19","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692806200.7858949,"name":"drain","context":{"idset":"20","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692807122.8234079,"name":"drain","context":{"idset":"33","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692807258.9694161,"name":"drain","context":{"idset":"9","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692807259.1322889,"name":"drain","context":{"idset":"11","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692807259.1423004,"name":"drain","context":{"idset":"13","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692807260.5390677,"name":"drain","context":{"idset":"14","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692807405.4076908,"name":"drain","context":{"idset":"21","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692807405.707001,"name":"drain","context":{"idset":"16","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692807405.904201,"name":"drain","context":{"idset":"23","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692807406.347533,"name":"drain","context":{"idset":"24","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692807514.2667327,"name":"drain","context":{"idset":"26","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1692810253.0905623,"name":"resource-init","context":{"restart":true,"drain":{"4":{"timestamp":1692786126.5591235,"reason":"epilog failed for jobid fNpiaHq2VEw"},"8":{"timestamp":1692802818.0876265,"reason":"nodediag failed amdgpu"},"9":{"timestamp":1692807258.9694161,"reason":"nodediag failed pci"},"11":{"timestamp":1692807259.1322889,"reason":"nodediag failed pci"},"13":{"timestamp":1692807259.1423004,"reason":"nodediag failed pci"},"14":{"timestamp":1692807260.5390677,"reason":"nodediag failed pci"},"15":{"timestamp":1692731393.1728163,"reason":"epilog failed for jobid fNhQKdVuXiX"},"16":{"timestamp":1692807405.707001,"reason":"nodediag failed pci"},"18":{"timestamp":1692786579.7509997,"reason":"epilog failed for jobid fNpZhLxexhV"},"19":{"timestamp":1692806199.7085576,"reason":"nodediag failed pci"},"20":{"timestamp":1692806200.7858949,"reason":"nodediag failed pci"},"21":{"timestamp":1692807405.4076908,"reason":"nodediag failed pci"},"22":{"timestamp":1692786132.5700204,"reason":"epilog failed for jobid fNpVJC9Hz4o"},"23":{"timestamp":1692807405.904201,"reason":"nodediag failed pci"},"24":{"timestamp":1692807406.347533,"reason":"nodediag failed pci"},"26":{"timestamp":1692807514.2667327,"reason":"nodediag failed pci"},"12,28":{"timestamp":1691004422.7056198,"reason":"slingshot issues"},"31":{"timestamp":1692779575.4191892,"reason":"epilog failed for jobid fNoq5483591"},"33":{"timestamp":1692807122.8234079,"reason":"nodediag failed pci"}},"online":"","exclude":"0-2"}}
+{"timestamp":1692810253.0927088,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1692810726.6551633,"name":"online","context":{"idset":"0"}}
+{"timestamp":1692818620.4226494,"name":"online","context":{"idset":"35"}}
+{"timestamp":1692818621.1485355,"name":"online","context":{"idset":"36"}}
+{"timestamp":1692818621.4851315,"name":"online","context":{"idset":"33-34"}}
+{"timestamp":1692818621.7543807,"name":"online","context":{"idset":"3,10,16,23"}}
+{"timestamp":1692818621.9002204,"name":"online","context":{"idset":"4-5,15,27"}}
+{"timestamp":1692818622.0238256,"name":"online","context":{"idset":"9,13,32"}}
+{"timestamp":1692818622.1857233,"name":"online","context":{"idset":"8,18,20"}}
+{"timestamp":1692818622.3141024,"name":"online","context":{"idset":"19,26"}}
+{"timestamp":1692818622.4271135,"name":"online","context":{"idset":"7,11,14,24-25"}}
+{"timestamp":1692818622.5699735,"name":"online","context":{"idset":"17,21-22"}}
+{"timestamp":1692818622.7709751,"name":"online","context":{"idset":"29-31"}}
+{"timestamp":1692818623.0506318,"name":"online","context":{"idset":"6"}}
+{"timestamp":1692818731.4312236,"name":"undrain","context":{"idset":"8"}}
+{"timestamp":1692818755.4927576,"name":"undrain","context":{"idset":"4"}}
+{"timestamp":1692818765.7528849,"name":"undrain","context":{"idset":"9,11"}}
+{"timestamp":1692818784.1905811,"name":"undrain","context":{"idset":"13-14"}}
+{"timestamp":1692818793.4161901,"name":"undrain","context":{"idset":"15"}}
+{"timestamp":1692818807.8567481,"name":"undrain","context":{"idset":"16,21,23-24"}}
+{"timestamp":1692818835.5674458,"name":"undrain","context":{"idset":"18"}}
+{"timestamp":1692818842.9867311,"name":"undrain","context":{"idset":"19-20"}}
+{"timestamp":1692818847.184705,"name":"undrain","context":{"idset":"22"}}
+{"timestamp":1692818852.7119665,"name":"undrain","context":{"idset":"26"}}
+{"timestamp":1692818858.4308116,"name":"undrain","context":{"idset":"31"}}
+{"timestamp":1692818862.0798388,"name":"undrain","context":{"idset":"33"}}
+{"timestamp":1692819097.2627742,"name":"online","context":{"idset":"2"}}
+{"timestamp":1692819100.0029969,"name":"online","context":{"idset":"1"}}
+{"timestamp":1692839662.078393,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1692839662.0804343,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1692839662.0821981,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1692839662.0830526,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1692839662.0831323,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1692839662.0832038,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1692839662.0832705,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1692839662.0833356,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1692839662.0833981,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1692839662.0834618,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1692839662.0835207,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1692839662.08358,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1692839662.0836363,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1692839662.0836906,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1692839662.083756,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1692839662.0838127,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1692839662.0838647,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1692839662.0839164,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1692839662.0839696,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1692839662.084022,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1692839662.0840764,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1692839662.0841267,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1692839662.0841763,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1692839662.0842271,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1692839662.0842719,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1692839662.0843182,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1692839662.0843611,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1692839662.0844007,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1692839662.084439,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1692839662.0844786,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1692839662.0845215,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1692839662.0845597,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1692839662.0845954,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1692839662.1837966,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1692839672.7889924,"name":"resource-init","context":{"restart":true,"drain":{"12,28":{"timestamp":1691004422.7056198,"reason":"slingshot issues"}},"online":"","exclude":"0-2"}}
+{"timestamp":1692839672.7910104,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1692839773.6606281,"name":"online","context":{"idset":"0"}}
+{"timestamp":1692839774.2982254,"name":"online","context":{"idset":"1"}}
+{"timestamp":1692839774.5696738,"name":"online","context":{"idset":"33-36"}}
+{"timestamp":1692839774.7861044,"name":"online","context":{"idset":"2-11,13-16,25-27,29-32"}}
+{"timestamp":1692839774.9076021,"name":"online","context":{"idset":"17-24"}}
+{"timestamp":1692840488.7268288,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1692840488.7270803,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1692840488.7286444,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1692840488.7287424,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1692840488.7300775,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1692840488.7301459,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1692840488.7302103,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1692840488.7302716,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1692840488.7303338,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1692840488.7303958,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1692840488.7304547,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1692840488.7305162,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1692840488.7305748,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1692840488.7306318,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1692840488.730689,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1692840488.7307563,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1692840488.7308125,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1692840488.7308667,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1692840488.7309198,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1692840488.7309768,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1692840488.7310297,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1692840488.7310805,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1692840488.7311316,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1692840488.7311802,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1692840488.7312312,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1692840488.7312748,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1692840488.7313178,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1692840488.7313595,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1692840488.7313998,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1692840488.7314396,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1692840488.7314785,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1692840488.7315185,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1692840488.7315571,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1692840488.8301249,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1692840604.9479165,"name":"resource-init","context":{"restart":true,"drain":{"12,28":{"timestamp":1691004422.7056198,"reason":"slingshot issues"}},"online":"","exclude":"0-2"}}
+{"timestamp":1692840604.9502103,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1692840706.9745557,"name":"online","context":{"idset":"0"}}
+{"timestamp":1692840707.6075892,"name":"online","context":{"idset":"1"}}
+{"timestamp":1692840707.8797638,"name":"online","context":{"idset":"33-36"}}
+{"timestamp":1692840708.1067026,"name":"online","context":{"idset":"2-11,13-16,25-27,29-32"}}
+{"timestamp":1692840708.2231889,"name":"online","context":{"idset":"17-24"}}
+{"timestamp":1692888332.4160767,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1692888332.4714563,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1692888332.4738617,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1692888332.4811044,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1692888332.4819741,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1692888332.4958029,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1692888332.4972484,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1692888332.4982464,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1692888332.5012705,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1692888332.5019438,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1692888332.5127399,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1692888332.5136507,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1692888332.5140741,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1692888332.5165415,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1692888332.5208981,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1692888332.5316179,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1692888332.5330238,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1692888332.533669,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1692888332.5341415,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1692888332.5342319,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1692888332.5401263,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1692888332.5404348,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1692888332.5406432,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1692888332.5464191,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1692888332.5471454,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1692888332.5475042,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1692888332.5648067,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1692888332.6206682,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1692888332.6771173,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1692888332.68908,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1692888332.6954186,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1692888332.7086511,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1692888332.7097418,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1692888332.8105443,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1692888354.0190606,"name":"resource-init","context":{"restart":true,"drain":{"12,28":{"timestamp":1691004422.7056198,"reason":"slingshot issues"}},"online":"","exclude":"0-2"}}
+{"timestamp":1692888354.0216832,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1692888408.6009319,"name":"resource-init","context":{"restart":true,"drain":{"12,28":{"timestamp":1691004422.7056198,"reason":"slingshot issues"}},"online":"","exclude":"0-2"}}
+{"timestamp":1692888408.6032491,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1692888507.7297277,"name":"online","context":{"idset":"0"}}
+{"timestamp":1692888508.3635125,"name":"online","context":{"idset":"1"}}
+{"timestamp":1692888508.5616102,"name":"online","context":{"idset":"2"}}
+{"timestamp":1692888509.0067315,"name":"online","context":{"idset":"33,35-36"}}
+{"timestamp":1692888509.1411369,"name":"online","context":{"idset":"6,34"}}
+{"timestamp":1692888509.2970431,"name":"online","context":{"idset":"9,12,14"}}
+{"timestamp":1692888509.4015825,"name":"online","context":{"idset":"4-5,7,18,24"}}
+{"timestamp":1692888509.5268667,"name":"online","context":{"idset":"16-17,32"}}
+{"timestamp":1692888509.6310351,"name":"online","context":{"idset":"3,8,10,13,15,19,21-22,26,29"}}
+{"timestamp":1692888509.7378364,"name":"online","context":{"idset":"11,25,28,30"}}
+{"timestamp":1692888509.9337234,"name":"online","context":{"idset":"20,27,31"}}
+{"timestamp":1692888510.141408,"name":"online","context":{"idset":"23"}}
+{"timestamp":1692928872.6934316,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1692928902.9457812,"name":"drain","context":{"idset":"14","reason":"epilog failed for jobid fP6EugNSjTV","overwrite":0}}
+{"timestamp":1692942089.6350839,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1692942108.3691027,"name":"drain","context":{"idset":"21","reason":"epilog failed for jobid fP7wiriRRLb","overwrite":0}}
+{"timestamp":1692949182.6933129,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1692949210.9409411,"name":"drain","context":{"idset":"8","reason":"epilog failed for jobid fP9fFuKDnMd","overwrite":0}}
+{"timestamp":1692965158.6932912,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1692965185.0472045,"name":"drain","context":{"idset":"15","reason":"epilog failed for jobid fPBPoHVV2nB","overwrite":0}}
+{"timestamp":1692965640.0887954,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1692965672.9308987,"name":"drain","context":{"idset":"31","reason":"epilog failed for jobid fPBPtWsp4Yw","overwrite":0}}
+{"timestamp":1692970496.6928623,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1692970532.4701481,"name":"drain","context":{"idset":"5","reason":"epilog failed for jobid fPBusRAn2N3","overwrite":0}}
+{"timestamp":1692973814.6940987,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1692973974.6932034,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1692974101.5216386,"name":"drain","context":{"idset":"25","reason":"epilog failed for jobid fPCDVJTg51R","overwrite":0}}
+{"timestamp":1692974258.478868,"name":"drain","context":{"idset":"30","reason":"epilog failed for jobid fPCJtSH3uC3","overwrite":0}}
+{"timestamp":1692978974.356133,"name":"online","context":{"idset":"14,31"}}
+{"timestamp":1692978974.4817019,"name":"online","context":{"idset":"8,15,21"}}
+{"timestamp":1692978974.587189,"name":"online","context":{"idset":"5,30"}}
+{"timestamp":1692978974.7004957,"name":"online","context":{"idset":"25"}}
+{"timestamp":1692979025.3250048,"name":"undrain","context":{"idset":"5,8,14-15,21,25,30-31"}}
+{"timestamp":1692981308.692697,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1692981344.4308941,"name":"drain","context":{"idset":"29","reason":"epilog failed for jobid fPDQGhUFiTy","overwrite":0}}
+{"timestamp":1692981462.6925905,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1692981737.3271539,"name":"drain","context":{"idset":"3","reason":"epilog failed for jobid fPCyEvWGLyV","overwrite":0}}
+{"timestamp":1692981958.6921132,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1692981991.0464966,"name":"drain","context":{"idset":"13","reason":"epilog failed for jobid fPDQBKHvwkb","overwrite":0}}
+{"timestamp":1692983594.6940067,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1692983631.5715263,"name":"drain","context":{"idset":"8","reason":"epilog failed for jobid fPEMH7DJZiF","overwrite":0}}
+{"timestamp":1692985834.6936679,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1692985870.5246086,"name":"drain","context":{"idset":"16","reason":"epilog failed for jobid fPEeMswUoKV","overwrite":0}}
+{"timestamp":1692987090.7268119,"name":"undrain","context":{"idset":"12"}}
+{"timestamp":1692987654.6772084,"name":"undrain","context":{"idset":"28"}}
+{"timestamp":1692988898.6930771,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1692988931.6343505,"name":"drain","context":{"idset":"12","reason":"epilog failed for jobid fPF6H7w68Gw","overwrite":0}}
+{"timestamp":1692989299.2486513,"name":"online","context":{"idset":"29"}}
+{"timestamp":1692989299.4475136,"name":"online","context":{"idset":"16"}}
+{"timestamp":1692989299.6108832,"name":"online","context":{"idset":"3,8"}}
+{"timestamp":1692989299.8308446,"name":"online","context":{"idset":"13"}}
+{"timestamp":1692989329.9504247,"name":"undrain","context":{"idset":"3,8,13,16,29"}}
+{"timestamp":1692990419.3606191,"name":"online","context":{"idset":"12"}}
+{"timestamp":1692990448.1998105,"name":"undrain","context":{"idset":"12"}}
+{"timestamp":1692990852.6927257,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1692990885.0082393,"name":"drain","context":{"idset":"8","reason":"epilog failed for jobid fPFMhTCN1pb","overwrite":0}}
+{"timestamp":1692991200.1587262,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1692991232.0767906,"name":"drain","context":{"idset":"25","reason":"epilog failed for jobid fPFMc4tdJhV","overwrite":0}}
+{"timestamp":1692992050.6934326,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1692992085.6083233,"name":"drain","context":{"idset":"21","reason":"epilog failed for jobid fPFSaPsY9wm","overwrite":0}}
+{"timestamp":1692993492.6942213,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1692993524.3757982,"name":"drain","context":{"idset":"4","reason":"epilog failed for jobid fPFf3syxMdq","overwrite":0}}
+{"timestamp":1692993979.3875608,"name":"online","context":{"idset":"21,25"}}
+{"timestamp":1692993979.7023747,"name":"online","context":{"idset":"8"}}
+{"timestamp":1692993991.5430374,"name":"undrain","context":{"idset":"8,21,25"}}
+{"timestamp":1692994196.6930029,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1692994227.504024,"name":"drain","context":{"idset":"13","reason":"epilog failed for jobid fPFii52NRqh","overwrite":0}}
+{"timestamp":1692994421.8648996,"name":"online","context":{"idset":"4"}}
+{"timestamp":1692994436.1136961,"name":"undrain","context":{"idset":"4"}}
+{"timestamp":1692995057.1525946,"name":"online","context":{"idset":"13"}}
+{"timestamp":1692995072.4509242,"name":"undrain","context":{"idset":"13"}}
+{"timestamp":1692995346.6930807,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1692995380.8087437,"name":"drain","context":{"idset":"14","reason":"epilog failed for jobid fPG2vrdRqDh","overwrite":0}}
+{"timestamp":1692996210.3570321,"name":"online","context":{"idset":"14"}}
+{"timestamp":1692996217.7698519,"name":"undrain","context":{"idset":"14"}}
+{"timestamp":1692996480.3820291,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1692996517.5173485,"name":"drain","context":{"idset":"4","reason":"epilog failed for jobid fPGBZj8GqQ3","overwrite":0}}
+{"timestamp":1692997094.1965477,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1692997095.48786,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1692997131.3929069,"name":"drain","context":{"idset":"28,30","reason":"epilog failed for jobid fPG1J8YfLpo","overwrite":0}}
+{"timestamp":1692997913.4696326,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1692997946.7347782,"name":"drain","context":{"idset":"27","reason":"epilog failed for jobid fPDKKZ7ycsZ","overwrite":0}}
+{"timestamp":1692997994.126179,"name":"online","context":{"idset":"30"}}
+{"timestamp":1692997994.2624452,"name":"online","context":{"idset":"28"}}
+{"timestamp":1692998011.1306953,"name":"undrain","context":{"idset":"28,30"}}
+{"timestamp":1692998092.6264634,"name":"online","context":{"idset":"4"}}
+{"timestamp":1692998118.7271602,"name":"undrain","context":{"idset":"4"}}
+{"timestamp":1692998564.6937833,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1692998598.5913801,"name":"drain","context":{"idset":"19","reason":"epilog failed for jobid fPGTScDYnJT","overwrite":0}}
+{"timestamp":1692999668.6931415,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1692999703.5506082,"name":"drain","context":{"idset":"11","reason":"epilog failed for jobid fPDLuP63YpX","overwrite":0}}
+{"timestamp":1692999836.6939063,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1692999870.6680562,"name":"drain","context":{"idset":"5","reason":"epilog failed for jobid fPGbLcpS2sH","overwrite":0}}
+{"timestamp":1693000882.0961971,"name":"online","context":{"idset":"27"}}
+{"timestamp":1693000913.5161023,"name":"undrain","context":{"idset":"27"}}
+{"timestamp":1693001001.437541,"name":"online","context":{"idset":"19"}}
+{"timestamp":1693001001.6205437,"name":"online","context":{"idset":"5"}}
+{"timestamp":1693001002.4923496,"name":"online","context":{"idset":"11"}}
+{"timestamp":1693001004.6923308,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1693001011.63676,"name":"undrain","context":{"idset":"5,11,19"}}
+{"timestamp":1693001040.1972437,"name":"drain","context":{"idset":"16","reason":"epilog failed for jobid fPGmxsbq5Sf","overwrite":0}}
+{"timestamp":1693001885.2384911,"name":"online","context":{"idset":"16"}}
+{"timestamp":1693001898.3726585,"name":"undrain","context":{"idset":"16"}}
+{"timestamp":1693011082.6934776,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1693011203.227948,"name":"drain","context":{"idset":"19","reason":"epilog failed for jobid fPJ6YZ84qvP","overwrite":0}}
+{"timestamp":1693012146.5565341,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1693012180.82723,"name":"drain","context":{"idset":"5","reason":"epilog failed for jobid fPJEcxJUBpB","overwrite":0}}
+{"timestamp":1693012372.6932833,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1693012405.8921275,"name":"drain","context":{"idset":"21","reason":"epilog failed for jobid fPJ6duznFGB","overwrite":0}}
+{"timestamp":1693013664.6931405,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1693013699.2285278,"name":"drain","context":{"idset":"26","reason":"epilog failed for jobid fPJQMRYtEtw","overwrite":0}}
+{"timestamp":1693014798.6929038,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1693014830.4584987,"name":"drain","context":{"idset":"28","reason":"epilog failed for jobid fPJQVfbSfFu","overwrite":0}}
+{"timestamp":1693014938.6934071,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1693014972.7858858,"name":"drain","context":{"idset":"24","reason":"epilog failed for jobid fPJa6hJ3maw","overwrite":0}}
+{"timestamp":1693015956.6934924,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1693015995.3466806,"name":"drain","context":{"idset":"23","reason":"epilog failed for jobid fPJjZ7Npuhy","overwrite":0}}
+{"timestamp":1693017008.693646,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1693017042.5336194,"name":"drain","context":{"idset":"11","reason":"epilog failed for jobid fPJsXFLGD7m","overwrite":0}}
+{"timestamp":1693018172.6930799,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1693018210.0101104,"name":"drain","context":{"idset":"27","reason":"epilog failed for jobid fPK2FQ12tnT","overwrite":0}}
+{"timestamp":1693019222.6939104,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1693019257.9437957,"name":"drain","context":{"idset":"6","reason":"epilog failed for jobid fPKALxnmV4K","overwrite":0}}
+{"timestamp":1693069117.4770873,"name":"online","context":{"idset":"19"}}
+{"timestamp":1693069117.6357889,"name":"online","context":{"idset":"6,27"}}
+{"timestamp":1693069117.911077,"name":"online","context":{"idset":"5,23-24"}}
+{"timestamp":1693069118.0529895,"name":"online","context":{"idset":"11"}}
+{"timestamp":1693069118.2053845,"name":"online","context":{"idset":"26"}}
+{"timestamp":1693069118.3075943,"name":"online","context":{"idset":"21,28"}}
+{"timestamp":1693069850.6702559,"name":"undrain","context":{"idset":"5-6,11,19,21,23-24,26-28"}}
+{"timestamp":1693073246.6926479,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1693073295.4430041,"name":"drain","context":{"idset":"28","reason":"epilog failed for jobid fPRvfvvBbFD","overwrite":0}}
+{"timestamp":1693075352.7019544,"name":"online","context":{"idset":"28"}}
+{"timestamp":1693075394.425863,"name":"undrain","context":{"idset":"28"}}
+{"timestamp":1693077146.6937301,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1693077184.1476595,"name":"drain","context":{"idset":"29","reason":"epilog failed for jobid fPSe8sWFo19","overwrite":0}}
+{"timestamp":1693082133.8461447,"name":"online","context":{"idset":"29"}}
+{"timestamp":1693082150.7168832,"name":"undrain","context":{"idset":"29"}}
+{"timestamp":1693083420.6940818,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1693083457.7626688,"name":"drain","context":{"idset":"29","reason":"epilog failed for jobid fPTWyvHkBw5","overwrite":0}}
+{"timestamp":1693084351.6119845,"name":"online","context":{"idset":"29"}}
+{"timestamp":1693084353.4917769,"name":"undrain","context":{"idset":"29"}}
+{"timestamp":1693087378.6933606,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1693087415.4070444,"name":"drain","context":{"idset":"29","reason":"epilog failed for jobid fPTzE3yy6PH","overwrite":0}}
+{"timestamp":1693088231.0766566,"name":"online","context":{"idset":"29"}}
+{"timestamp":1693088242.2064247,"name":"undrain","context":{"idset":"29"}}
+{"timestamp":1693089546.6931736,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1693089582.2626336,"name":"drain","context":{"idset":"29","reason":"epilog failed for jobid fPUKksg27Gj","overwrite":0}}
+{"timestamp":1693090767.4459538,"name":"online","context":{"idset":"29"}}
+{"timestamp":1693090777.2486236,"name":"undrain","context":{"idset":"29"}}
+{"timestamp":1693091994.6924961,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1693092027.8113558,"name":"drain","context":{"idset":"29","reason":"epilog failed for jobid fPUeZu3ZYRM","overwrite":0}}
+{"timestamp":1693107038.6936531,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1693107072.423353,"name":"drain","context":{"idset":"30","reason":"epilog failed for jobid fPWceGTrxbh","overwrite":0}}
+{"timestamp":1693109110.6942401,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1693109147.1780446,"name":"drain","context":{"idset":"8","reason":"epilog failed for jobid fPWtJL2s6Hm","overwrite":0}}
+{"timestamp":1693110946.6943264,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1693110984.2162261,"name":"drain","context":{"idset":"25","reason":"epilog failed for jobid fPX8ChM6XeX","overwrite":0}}
+{"timestamp":1693115544.8214228,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1693115575.996702,"name":"drain","context":{"idset":"24","reason":"epilog failed for jobid fPXjBmADjH9","overwrite":0}}
+{"timestamp":1693119346.5935655,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1693119346.6940176,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1693119397.1507294,"name":"drain","context":{"idset":"19,21","reason":"epilog failed for jobid fPXvuPZABuh","overwrite":0}}
+{"timestamp":1693140302.6939485,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1693140340.5296221,"name":"drain","context":{"idset":"23","reason":"epilog failed for jobid fPaYLtC5m75","overwrite":0}}
+{"timestamp":1693145386.6932325,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1693145429.3317924,"name":"drain","context":{"idset":"14","reason":"epilog failed for jobid fPbMj2tQoaf","overwrite":0}}
+{"timestamp":1693152247.1315928,"name":"online","context":{"idset":"14"}}
+{"timestamp":1693152247.3962998,"name":"online","context":{"idset":"8,19,23-25"}}
+{"timestamp":1693152247.6464467,"name":"online","context":{"idset":"30"}}
+{"timestamp":1693152247.7710569,"name":"online","context":{"idset":"21,29"}}
+{"timestamp":1693152956.7186906,"name":"undrain","context":{"idset":"8,14,19,21,23-25,29-30"}}
+{"timestamp":1693155834.6931961,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1693155870.9070299,"name":"drain","context":{"idset":"25","reason":"epilog failed for jobid fPcoT5SGCj9","overwrite":0}}
+{"timestamp":1693158884.8680108,"name":"online","context":{"idset":"25"}}
+{"timestamp":1693159279.9315217,"name":"undrain","context":{"idset":"25"}}
+{"timestamp":1693168522.6928248,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1693168562.3432541,"name":"drain","context":{"idset":"32","reason":"epilog failed for jobid fPeKsiY6Tiw","overwrite":0}}
+{"timestamp":1693170617.2663209,"name":"online","context":{"idset":"32"}}
+{"timestamp":1693170702.0847383,"name":"undrain","context":{"idset":"32"}}
+{"timestamp":1693173820.6928408,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1693173857.950772,"name":"drain","context":{"idset":"32","reason":"epilog failed for jobid fPf7q8YJ9Nf","overwrite":0}}
+{"timestamp":1693175879.1142633,"name":"online","context":{"idset":"32"}}
+{"timestamp":1693176892.9215524,"name":"undrain","context":{"idset":"32"}}
+{"timestamp":1693182952.6938405,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1693182990.0572627,"name":"drain","context":{"idset":"32","reason":"epilog failed for jobid fPgA6EjPtbq","overwrite":0}}
+{"timestamp":1693204968.6938605,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1693205011.3026438,"name":"drain","context":{"idset":"7","reason":"epilog failed for jobid fPiiAxgTwbM","overwrite":0}}
+{"timestamp":1693214222.6935496,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1693214263.0673358,"name":"drain","context":{"idset":"16","reason":"epilog failed for jobid fPk1HHVszeB","overwrite":0}}
+{"timestamp":1693224570.6936901,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1693224615.163466,"name":"drain","context":{"idset":"5","reason":"epilog failed for jobid fPmsskgZVAw","overwrite":0}}
+{"timestamp":1693225714.6927469,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1693225753.1680527,"name":"drain","context":{"idset":"4","reason":"epilog failed for jobid fPnFgTWm1dh","overwrite":0}}
+{"timestamp":1693226492.6940167,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1693226532.3100181,"name":"drain","context":{"idset":"6","reason":"epilog failed for jobid fPnMcVVpfBD","overwrite":0}}
+{"timestamp":1693235276.3274584,"name":"online","context":{"idset":"6"}}
+{"timestamp":1693235276.4584951,"name":"online","context":{"idset":"4,7,32"}}
+{"timestamp":1693235276.5595891,"name":"online","context":{"idset":"5,16"}}
+{"timestamp":1693235464.0781851,"name":"undrain","context":{"idset":"4-7,16,32"}}
+{"timestamp":1693236784.6937306,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1693236824.494689,"name":"drain","context":{"idset":"4","reason":"epilog failed for jobid fPohqooqPSX","overwrite":0}}
+{"timestamp":1693237662.3132401,"name":"online","context":{"idset":"4"}}
+{"timestamp":1693237683.4895632,"name":"undrain","context":{"idset":"4"}}
+{"timestamp":1693237910.6939559,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1693237950.0238178,"name":"drain","context":{"idset":"7","reason":"epilog failed for jobid fPorSnKHg15","overwrite":0}}
+{"timestamp":1693239120.7819343,"name":"online","context":{"idset":"7"}}
+{"timestamp":1693239477.6610184,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1693336466.8601806,"name":"resource-init","context":{"restart":true,"drain":{},"online":"","exclude":"0-2"}}
+{"timestamp":1693336466.8630674,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1693336554.1257296,"name":"drain","context":{"idset":"29","reason":"gpu problem","overwrite":1}}
+{"timestamp":1693336614.5787406,"name":"online","context":{"idset":"0"}}
+{"timestamp":1693336615.7312009,"name":"online","context":{"idset":"33-36"}}
+{"timestamp":1693336615.9318366,"name":"online","context":{"idset":"3-4,6-7,28,32"}}
+{"timestamp":1693336616.0435956,"name":"online","context":{"idset":"5,10,14,18,25,30-31"}}
+{"timestamp":1693336616.1483233,"name":"online","context":{"idset":"8,11-13,15-17,21-24,26-27"}}
+{"timestamp":1693336616.2690451,"name":"online","context":{"idset":"9,19-20"}}
+{"timestamp":1693336736.8194189,"name":"online","context":{"idset":"1"}}
+{"timestamp":1693336864.1696694,"name":"online","context":{"idset":"2"}}
+{"timestamp":1693344476.2600584,"name":"drain","context":{"idset":"35-36","reason":"test","overwrite":2}}
+{"timestamp":1693344500.4448104,"name":"drain","context":{"idset":"35-36","reason":"testing","overwrite":2}}
+{"timestamp":1693344508.8272488,"name":"undrain","context":{"idset":"35-36"}}
+{"timestamp":1693347384.1156151,"name":"drain","context":{"idset":"35-36","reason":"testing","overwrite":2}}
+{"timestamp":1693347398.5303981,"name":"undrain","context":{"idset":"35-36"}}
+{"timestamp":1693442649.4925799,"name":"drain","context":{"idset":"20","reason":"broker was unresponsive"}}
+{"timestamp":1693473379.4922233,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1693473414.3371141,"name":"drain","context":{"idset":"10","reason":"epilog failed for jobid fQJuk2QLfuR","overwrite":0}}
+{"timestamp":1693474669.4933288,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1693474704.2976325,"name":"drain","context":{"idset":"15","reason":"epilog failed for jobid fQJunbkrKWF","overwrite":0}}
+{"timestamp":1693474901.4930291,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1693474945.992835,"name":"drain","context":{"idset":"28","reason":"epilog failed for jobid fQK4C69BJAb","overwrite":0}}
+{"timestamp":1693475665.4928,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1693475725.4134254,"name":"drain","context":{"idset":"31","reason":"epilog failed for jobid fQK4DDumSFq","overwrite":0}}
+{"timestamp":1693476587.4923387,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1693476618.3815503,"name":"drain","context":{"idset":"14","reason":"epilog failed for jobid fQJumK1tXVy","overwrite":0}}
+{"timestamp":1693480531.4921169,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1693480560.8330817,"name":"drain","context":{"idset":"9","reason":"epilog failed for jobid fQKnyWf6bLb","overwrite":0}}
+{"timestamp":1693481057.4929502,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1693481104.2750595,"name":"drain","context":{"idset":"30","reason":"epilog failed for jobid fQL4jdEQgoq","overwrite":0}}
+{"timestamp":1693487477.4925506,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1693487513.1185639,"name":"drain","context":{"idset":"11","reason":"epilog failed for jobid fQKxq3XJDPD","overwrite":0}}
+{"timestamp":1693488269.4931738,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1693488309.3189213,"name":"drain","context":{"idset":"19","reason":"epilog failed for jobid fQKyWYPSSoh","overwrite":0}}
+{"timestamp":1693489709.4928045,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1693489742.4288378,"name":"drain","context":{"idset":"21","reason":"epilog failed for jobid fQLjBTG546b","overwrite":0}}
+{"timestamp":1693490575.4925683,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1693490610.927757,"name":"drain","context":{"idset":"22","reason":"epilog failed for jobid fQMKybEXJkX","overwrite":0}}
+{"timestamp":1693494013.4925382,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1693494306.5553958,"name":"drain","context":{"idset":"12","reason":"epilog failed for jobid fQMEm4KFbj5","overwrite":0}}
+{"timestamp":1693497137.1210482,"name":"online","context":{"idset":"30-31"}}
+{"timestamp":1693497137.2961125,"name":"online","context":{"idset":"10,15"}}
+{"timestamp":1693497137.4275651,"name":"online","context":{"idset":"9,14,19,22,28"}}
+{"timestamp":1693497137.5747464,"name":"online","context":{"idset":"11-12,21"}}
+{"timestamp":1693497214.3862979,"name":"undrain","context":{"idset":"9-12,14-15,19,21-22,28,30-31"}}
+{"timestamp":1693499594.0660608,"name":"undrain","context":{"idset":"20"}}
+{"timestamp":1693500019.4932446,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1693500041.3811715,"name":"drain","context":{"idset":"3","reason":"epilog failed for jobid fQNY3k5JY4o","overwrite":0}}
+{"timestamp":1693500853.492872,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1693500886.3848197,"name":"drain","context":{"idset":"9","reason":"epilog failed for jobid fQNSpiCJrkf","overwrite":0}}
+{"timestamp":1693503129.4933991,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1693503425.1009226,"name":"drain","context":{"idset":"32","reason":"epilog failed for jobid fQMg5hUm6hm","overwrite":0}}
+{"timestamp":1693526239.4931784,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1693526284.5399024,"name":"drain","context":{"idset":"25","reason":"epilog failed for jobid fQRsqefC79Z","overwrite":0}}
+{"timestamp":1693532195.492908,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1693532231.5887942,"name":"drain","context":{"idset":"21","reason":"epilog failed for jobid fQRsD9B9tE3","overwrite":0}}
+{"timestamp":1693537015.4933822,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1693537060.625174,"name":"drain","context":{"idset":"14","reason":"epilog failed for jobid fQTF2giMGt7","overwrite":0}}
+{"timestamp":1693542567.4929557,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1693542600.6197138,"name":"drain","context":{"idset":"24","reason":"epilog failed for jobid fQSyLseAK8j","overwrite":0}}
+{"timestamp":1693543801.0668077,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1693543837.3347449,"name":"drain","context":{"idset":"15","reason":"epilog failed for jobid fQTzwHTsJYf","overwrite":0}}
+{"timestamp":1693545441.4931166,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1693545478.529911,"name":"drain","context":{"idset":"23","reason":"epilog failed for jobid fQTVdiZ2Ac7","overwrite":0}}
+{"timestamp":1693555567.4938772,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1693555612.3994486,"name":"drain","context":{"idset":"18","reason":"epilog failed for jobid fQVeWzA7Y8o","overwrite":0}}
+{"timestamp":1693557577.4927566,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1693557611.183881,"name":"drain","context":{"idset":"6","reason":"epilog failed for jobid fQVZJFH1dDy","overwrite":0}}
+{"timestamp":1693567129.4931338,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1693567177.8554506,"name":"drain","context":{"idset":"20","reason":"epilog failed for jobid fQWY1TeJNiB","overwrite":0}}
+{"timestamp":1693567435.4920487,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1693567474.1776569,"name":"drain","context":{"idset":"22","reason":"epilog failed for jobid fQVkRjowCBZ","overwrite":0}}
+{"timestamp":1693574501.4921758,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1693574621.8089411,"name":"drain","context":{"idset":"17","reason":"epilog failed for jobid fQXosqDz5Uj","overwrite":0}}
+{"timestamp":1693577165.4934106,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1693577208.2196689,"name":"drain","context":{"idset":"28","reason":"epilog failed for jobid fQY4y6TXmDh","overwrite":0}}
+{"timestamp":1693581814.387049,"name":"drain","context":{"idset":"4-5,7-8,10-13,16,19,26-27,30-31,33-36","reason":"new amdgpu driver","overwrite":0}}
+{"timestamp":1693582408.7510896,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1693582408.8518887,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1693582409.1621885,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1693582409.3978972,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1693582409.6699097,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1693582409.7709568,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1693582410.2017663,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1693582410.466002,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1693582410.5432501,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1693582410.6434178,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1693582411.095886,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1693582411.1849205,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1693582411.2851183,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1693582411.5521903,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1693582411.6644709,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1693583590.9687114,"name":"online","context":{"idset":"34"}}
+{"timestamp":1693583591.2487428,"name":"online","context":{"idset":"14,35"}}
+{"timestamp":1693583591.4040947,"name":"online","context":{"idset":"7,21,36"}}
+{"timestamp":1693583591.6972558,"name":"online","context":{"idset":"6,22,26"}}
+{"timestamp":1693583591.8047123,"name":"online","context":{"idset":"13,16,27"}}
+{"timestamp":1693583591.9467471,"name":"online","context":{"idset":"31"}}
+{"timestamp":1693583592.0625422,"name":"online","context":{"idset":"4,9,11,23"}}
+{"timestamp":1693583592.1891153,"name":"online","context":{"idset":"8,17,19,24-25,30"}}
+{"timestamp":1693583592.3058054,"name":"online","context":{"idset":"15,28"}}
+{"timestamp":1693583592.5419185,"name":"online","context":{"idset":"3"}}
+{"timestamp":1693583596.0248094,"name":"online","context":{"idset":"10"}}
+{"timestamp":1693583596.1524935,"name":"online","context":{"idset":"18,20,32"}}
+{"timestamp":1693583666.072778,"name":"undrain","context":{"idset":"3-4,6-11,13-28,30-32,34-36"}}
+{"timestamp":1693587771.5588708,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1693587771.6589165,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1693588903.9847393,"name":"online","context":{"idset":"12"}}
+{"timestamp":1693588904.505547,"name":"online","context":{"idset":"5"}}
+{"timestamp":1693589159.7618353,"name":"undrain","context":{"idset":"5,12"}}
+{"timestamp":1693602934.3333118,"name":"drain","context":{"idset":"3-28,30-36","reason":"new cxi driver","overwrite":2}}
+{"timestamp":1693603264.7497387,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1693603264.7516146,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1693603264.8017521,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1693603264.841748,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1693603264.9205859,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1693603264.9341574,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1693603264.9578574,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1693603265.0272853,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1693603265.0330496,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1693603265.1340661,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1693603265.1982298,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1693603265.2988882,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1693603265.3786747,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1693603265.4793363,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1693603265.735456,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1693604517.2994635,"name":"online","context":{"idset":"33"}}
+{"timestamp":1693604517.4844265,"name":"online","context":{"idset":"7"}}
+{"timestamp":1693604517.5873699,"name":"online","context":{"idset":"25"}}
+{"timestamp":1693604517.7054024,"name":"online","context":{"idset":"34,36"}}
+{"timestamp":1693604517.8594475,"name":"online","context":{"idset":"23,30,35"}}
+{"timestamp":1693604518.0348506,"name":"online","context":{"idset":"18,28,32"}}
+{"timestamp":1693604518.1766758,"name":"online","context":{"idset":"26-27"}}
+{"timestamp":1693604518.3579655,"name":"online","context":{"idset":"24"}}
+{"timestamp":1693604522.935909,"name":"online","context":{"idset":"31"}}
+{"timestamp":1693604558.0336232,"name":"undrain","context":{"idset":"7,18,23-28,30-36"}}
+{"timestamp":1693607159.4930558,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1693607520.4945188,"name":"drain","context":{"idset":"22","reason":"epilog failed for jobid fQburJV78R5","overwrite":0}}
+{"timestamp":1693790868.7590442,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1693790868.7899907,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1693790868.850961,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1693790868.8904476,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1693790868.9909716,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1693790869.029995,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1693790869.0335042,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1693790869.0354211,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1693790869.0698073,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1693790869.075845,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1693790869.1177683,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1693790869.2185192,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1693790869.5328162,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1693790869.7237177,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1693790870.4344425,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1693790870.5209782,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1693790870.6213653,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1693791940.7364676,"name":"online","context":{"idset":"17,21"}}
+{"timestamp":1693791941.1338775,"name":"online","context":{"idset":"5,8"}}
+{"timestamp":1693791941.4626355,"name":"online","context":{"idset":"22"}}
+{"timestamp":1693791941.6012306,"name":"online","context":{"idset":"16,19-20"}}
+{"timestamp":1693791941.7321491,"name":"online","context":{"idset":"3,6,14"}}
+{"timestamp":1693791941.9272761,"name":"online","context":{"idset":"4,9,12-13"}}
+{"timestamp":1693791942.0531232,"name":"online","context":{"idset":"11"}}
+{"timestamp":1693791942.1950555,"name":"online","context":{"idset":"10"}}
+{"timestamp":1693791942.364476,"name":"online","context":{"idset":"15"}}
+{"timestamp":1693792030.7497768,"name":"undrain","context":{"idset":"3-6,8-17,19-22"}}
+{"timestamp":1694127765.3925214,"name":"drain","context":{"idset":"20","reason":"broker was unresponsive"}}
+{"timestamp":1694127765.3926573,"name":"drain","context":{"idset":"22","reason":"broker was unresponsive"}}
+{"timestamp":1694127765.3927159,"name":"drain","context":{"idset":"24","reason":"broker was unresponsive"}}
+{"timestamp":1694127765.3927748,"name":"drain","context":{"idset":"26","reason":"broker was unresponsive"}}
+{"timestamp":1694127765.3928375,"name":"drain","context":{"idset":"27","reason":"broker was unresponsive"}}
+{"timestamp":1694127765.3928926,"name":"drain","context":{"idset":"28","reason":"broker was unresponsive"}}
+{"timestamp":1694127765.4929497,"name":"drain","context":{"idset":"32","reason":"broker was unresponsive"}}
+{"timestamp":1694127767.4929996,"name":"drain","context":{"idset":"30","reason":"broker was unresponsive"}}
+{"timestamp":1694127769.393142,"name":"drain","context":{"idset":"17","reason":"broker was unresponsive"}}
+{"timestamp":1694127769.3932486,"name":"drain","context":{"idset":"18","reason":"broker was unresponsive"}}
+{"timestamp":1694127769.3933229,"name":"drain","context":{"idset":"19","reason":"broker was unresponsive"}}
+{"timestamp":1694127769.3933783,"name":"drain","context":{"idset":"21","reason":"broker was unresponsive"}}
+{"timestamp":1694127769.3934302,"name":"drain","context":{"idset":"23","reason":"broker was unresponsive"}}
+{"timestamp":1694127769.3934836,"name":"drain","context":{"idset":"25","reason":"broker was unresponsive"}}
+{"timestamp":1694127769.4935405,"name":"drain","context":{"idset":"31","reason":"broker was unresponsive"}}
+{"timestamp":1694127830.919374,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1694127830.9196122,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1694127830.9197199,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1694127830.9198136,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1694127830.9199073,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1694127830.9199991,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1694127830.9200897,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1694127830.920176,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1694127830.92026,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1694127830.9203501,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1694127830.920435,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1694127830.9205184,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1694127830.9205983,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1694127830.9206793,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1694127831.0262504,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1694127831.234967,"name":"drain","context":{"idset":"21","reason":"epilog failed for jobid fRnY4JbkYqD","overwrite":0}}
+{"timestamp":1694127831.2598069,"name":"drain","context":{"idset":"22","reason":"epilog failed for jobid fRn9zGVopHu","overwrite":0}}
+{"timestamp":1694127831.2860894,"name":"drain","context":{"idset":"23","reason":"epilog failed for jobid fRnFJZGbo19","overwrite":0}}
+{"timestamp":1694127831.314266,"name":"drain","context":{"idset":"25","reason":"epilog failed for jobid fRmkfnUidHR","overwrite":0}}
+{"timestamp":1694127831.3411562,"name":"drain","context":{"idset":"24,26","reason":"epilog failed for jobid fRnFxoBZN9V","overwrite":0}}
+{"timestamp":1694127863.9925857,"name":"drain","context":{"idset":"17-19","reason":"epilog failed for jobid fRmuU6GLWEs","overwrite":0}}
+{"timestamp":1694136279.1119742,"name":"online","context":{"idset":"17"}}
+{"timestamp":1694136279.8665237,"name":"online","context":{"idset":"22-23"}}
+{"timestamp":1694136280.2967498,"name":"online","context":{"idset":"18,21"}}
+{"timestamp":1694136280.5123765,"name":"online","context":{"idset":"19-20,24"}}
+{"timestamp":1694136281.1614838,"name":"online","context":{"idset":"25,31"}}
+{"timestamp":1694136281.5977638,"name":"online","context":{"idset":"26,28,30,32"}}
+{"timestamp":1694136545.1400652,"name":"undrain","context":{"idset":"17-26,28,30-32"}}
+{"timestamp":1694139410.2371705,"name":"online","context":{"idset":"27"}}
+{"timestamp":1694139433.0136747,"name":"undrain","context":{"idset":"27"}}
+{"timestamp":1694364920.6817245,"name":"drain","context":{"idset":"11","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1694364921.2717447,"name":"drain","context":{"idset":"9","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1694364924.2942569,"name":"drain","context":{"idset":"8","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1694365043.3932631,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1694365043.3961675,"name":"drain","context":{"idset":"11","reason":"epilog failed for jobid fS6ruRWwPmq","overwrite":0}}
+{"timestamp":1694365043.3964453,"name":"drain","context":{"idset":"9","reason":"epilog failed for jobid fS6qejBdvNB","overwrite":0}}
+{"timestamp":1694365043.4926968,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1694365047.3962376,"name":"drain","context":{"idset":"8","reason":"epilog failed for jobid fS6rGwG4aNs","overwrite":0}}
+{"timestamp":1694365047.4933856,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1694373844.3244154,"name":"online","context":{"idset":"9"}}
+{"timestamp":1694373845.4932554,"name":"online","context":{"idset":"8"}}
+{"timestamp":1694373845.6917944,"name":"online","context":{"idset":"11"}}
+{"timestamp":1694373869.5854402,"name":"undrain","context":{"idset":"8-9,11"}}
+{"timestamp":1694385033.4926529,"name":"drain","context":{"idset":"3","reason":"broker was unresponsive"}}
+{"timestamp":1694385035.392266,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1694385035.4931104,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1694385037.3926828,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1694385037.3927979,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1694385037.3928633,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1694385037.4933655,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1694385099.3919275,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1694385099.3921208,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1694385099.3922215,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1694385099.3923328,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1694385099.3924248,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1694385099.3925312,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1694385099.5095546,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1694385099.7267785,"name":"drain","context":{"idset":"3","reason":"epilog failed for jobid fSMfSnEspBZ","overwrite":0}}
+{"timestamp":1694385099.7459412,"name":"drain","context":{"idset":"4","reason":"epilog failed for jobid fSNY488BHU3","overwrite":0}}
+{"timestamp":1694385099.7718592,"name":"drain","context":{"idset":"5","reason":"epilog failed for jobid fSNYgknp2aT","overwrite":0}}
+{"timestamp":1694385099.7993665,"name":"drain","context":{"idset":"6-7","reason":"epilog failed for jobid fSNZK3ScU2s","overwrite":0}}
+{"timestamp":1694385099.8190832,"name":"drain","context":{"idset":"8","reason":"epilog failed for jobid fSNfakhqEzb","overwrite":0}}
+{"timestamp":1694452217.3010468,"name":"online","context":{"idset":"2"}}
+{"timestamp":1694452257.4710085,"name":"undrain","context":{"idset":"2"}}
+{"timestamp":1694452319.2943318,"name":"online","context":{"idset":"6"}}
+{"timestamp":1694452319.8180544,"name":"online","context":{"idset":"5,7-8"}}
+{"timestamp":1694452319.9793844,"name":"online","context":{"idset":"4"}}
+{"timestamp":1694452320.0997944,"name":"online","context":{"idset":"3"}}
+{"timestamp":1694452334.4502833,"name":"undrain","context":{"idset":"3-8"}}
+{"timestamp":1694471805.4940894,"name":"drain","context":{"idset":"21","reason":"broker was unresponsive"}}
+{"timestamp":1694471807.4934354,"name":"drain","context":{"idset":"24","reason":"broker was unresponsive"}}
+{"timestamp":1694471809.4936566,"name":"drain","context":{"idset":"19","reason":"broker was unresponsive"}}
+{"timestamp":1694471869.4929519,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1694471869.7307694,"name":"drain","context":{"idset":"24","reason":"epilog failed for jobid fSZrDiXYULF","overwrite":0}}
+{"timestamp":1694471871.3924346,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1694471871.4930208,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1694473143.3715377,"name":"drain","context":{"idset":"21","reason":"epilog failed for jobid fSa1tAxwJiK","overwrite":0}}
+{"timestamp":1694538460.6354742,"name":"online","context":{"idset":"19,24"}}
+{"timestamp":1694538479.3726845,"name":"undrain","context":{"idset":"19,24"}}
+{"timestamp":1694543241.9688122,"name":"online","context":{"idset":"21"}}
+{"timestamp":1694543255.9704905,"name":"undrain","context":{"idset":"21"}}
+{"timestamp":1694546517.3925986,"name":"drain","context":{"idset":"11","reason":"broker was unresponsive"}}
+{"timestamp":1694546517.4926074,"name":"drain","context":{"idset":"13","reason":"broker was unresponsive"}}
+{"timestamp":1694546519.4934289,"name":"drain","context":{"idset":"16","reason":"broker was unresponsive"}}
+{"timestamp":1694546521.3932989,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1694546521.3934104,"name":"drain","context":{"idset":"10","reason":"broker was unresponsive"}}
+{"timestamp":1694546521.3934922,"name":"drain","context":{"idset":"12","reason":"broker was unresponsive"}}
+{"timestamp":1694546521.3935566,"name":"drain","context":{"idset":"14","reason":"broker was unresponsive"}}
+{"timestamp":1694546521.4941707,"name":"drain","context":{"idset":"15","reason":"broker was unresponsive"}}
+{"timestamp":1694546581.7713592,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1694546582.0040925,"name":"drain","context":{"idset":"14","reason":"epilog failed for jobid fSiPXZHJMTd","overwrite":0}}
+{"timestamp":1694546583.3919053,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1694546583.392041,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1694546583.3921421,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1694546583.3922403,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1694546583.3923645,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1694546583.3924901,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1694546583.3956997,"name":"drain","context":{"idset":"13","reason":"prolog failed for jobid fSjrs7eQHK5","overwrite":0}}
+{"timestamp":1694546583.3958344,"name":"drain","context":{"idset":"12","reason":"epilog failed for jobid fSZK1oEotEb","overwrite":0}}
+{"timestamp":1694546583.4198148,"name":"drain","context":{"idset":"16,19","reason":"epilog failed for jobid fSZLvPNJg1D","overwrite":0}}
+{"timestamp":1694546583.4978905,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1694546583.7259452,"name":"drain","context":{"idset":"10","reason":"epilog failed for jobid fSjmDDFTQnb","overwrite":0}}
+{"timestamp":1694546583.7264616,"name":"drain","context":{"idset":"9","reason":"epilog failed for jobid fSjm8P9j6jy","overwrite":0}}
+{"timestamp":1694546583.7863164,"name":"drain","context":{"idset":"11","reason":"epilog failed for jobid fSjofVjbe9D","overwrite":0}}
+{"timestamp":1694546583.802917,"name":"drain","context":{"idset":"15","reason":"epilog failed for jobid fSiR6CcjY4P","overwrite":0}}
+{"timestamp":1694547235.3932333,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1694547235.4933429,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1694547239.3928602,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1694547239.3930256,"name":"drain","context":{"idset":"3","reason":"broker was unresponsive"}}
+{"timestamp":1694547239.3930922,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1694547239.3931534,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1694547239.49296,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1694547299.4933469,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1694547300.5466597,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1694547300.5707254,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1694547300.5709035,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1694547300.5710094,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1694547300.6706436,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1694547300.8837578,"name":"drain","context":{"idset":"5-6","reason":"epilog failed for jobid fSjV2ThwYrT","overwrite":0}}
+{"timestamp":1694547300.9073741,"name":"drain","context":{"idset":"4","reason":"epilog failed for jobid fSjWE1wbEfZ","overwrite":0}}
+{"timestamp":1694547300.9406824,"name":"drain","context":{"idset":"3,8","reason":"epilog failed for jobid fSjbqGPAhAo","overwrite":0}}
+{"timestamp":1694547302.1490448,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1694547302.3275039,"name":"drain","context":{"idset":"7","reason":"epilog failed for jobid fSjWE2c8uzX","overwrite":0}}
+{"timestamp":1694548245.6069736,"name":"drain","context":{"idset":"17","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694548263.4930742,"name":"drain","context":{"idset":"26","reason":"broker was unresponsive"}}
+{"timestamp":1694548306.7050459,"name":"drain","context":{"idset":"33","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694548315.5017011,"name":"drain","context":{"idset":"27","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694548329.4926527,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1694548512.3219762,"name":"drain","context":{"idset":"36","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694548986.2525644,"name":"drain","context":{"idset":"18","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694549022.9844933,"name":"drain","context":{"idset":"30","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694549652.3126264,"name":"drain","context":{"idset":"20","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694549652.912406,"name":"drain","context":{"idset":"22","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694550057.7064192,"name":"drain","context":{"idset":"34","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694550057.8867466,"name":"drain","context":{"idset":"35","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694550099.5576289,"name":"drain","context":{"idset":"21","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694550099.7630906,"name":"drain","context":{"idset":"25","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694551321.3928807,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1694551321.3930371,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1694551321.3931231,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1694551321.3932054,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1694551321.393297,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1694551321.3933742,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1694551321.3934536,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1694551321.493623,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1694551323.392761,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1694551323.3929193,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1694551323.3929992,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1694551323.3930793,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1694551323.4932587,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1694552755.1612029,"name":"online","context":{"idset":"2"}}
+{"timestamp":1694552755.7371101,"name":"drain","context":{"idset":"31","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694552818.1389978,"name":"drain","context":{"idset":"28","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694552845.4848061,"name":"online","context":{"idset":"4"}}
+{"timestamp":1694552845.5561788,"name":"online","context":{"idset":"20"}}
+{"timestamp":1694552846.4003496,"name":"online","context":{"idset":"35"}}
+{"timestamp":1694552846.5685811,"name":"online","context":{"idset":"13,33,36"}}
+{"timestamp":1694552846.7161493,"name":"online","context":{"idset":"7,10"}}
+{"timestamp":1694552846.8710604,"name":"online","context":{"idset":"5,16,19,34"}}
+{"timestamp":1694552846.999337,"name":"online","context":{"idset":"6,8"}}
+{"timestamp":1694552847.1211102,"name":"online","context":{"idset":"12"}}
+{"timestamp":1694552847.2916598,"name":"online","context":{"idset":"3,25,27"}}
+{"timestamp":1694552847.3922844,"name":"online","context":{"idset":"18,26"}}
+{"timestamp":1694552847.4928238,"name":"online","context":{"idset":"22"}}
+{"timestamp":1694552847.6528332,"name":"online","context":{"idset":"15,21"}}
+{"timestamp":1694552848.2039104,"name":"online","context":{"idset":"14,17"}}
+{"timestamp":1694552848.7633526,"name":"online","context":{"idset":"30"}}
+{"timestamp":1694552849.9407275,"name":"online","context":{"idset":"9"}}
+{"timestamp":1694554222.1397951,"name":"drain","context":{"idset":"23","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694555052.7110417,"name":"undrain","context":{"idset":"3-10,12-22,25-27,30,33-36"}}
+{"timestamp":1694555088.7858651,"name":"undrain","context":{"idset":"2"}}
+{"timestamp":1694555408.2738843,"name":"online","context":{"idset":"11"}}
+{"timestamp":1694555446.653342,"name":"undrain","context":{"idset":"11"}}
+{"timestamp":1694555663.3924425,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1694555663.3925972,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1694555663.492775,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1694556028.3223269,"name":"drain","context":{"idset":"15","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694556119.3933318,"name":"drain","context":{"idset":"11","reason":"broker was unresponsive"}}
+{"timestamp":1694556119.4942381,"name":"drain","context":{"idset":"16","reason":"broker was unresponsive"}}
+{"timestamp":1694556123.3930633,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1694556123.3931987,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1694556123.3932619,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1694556123.3933337,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1694556123.3933887,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1694556123.393451,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1694556123.3935103,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1694556123.3935695,"name":"drain","context":{"idset":"10","reason":"broker was unresponsive"}}
+{"timestamp":1694556123.3936262,"name":"drain","context":{"idset":"12","reason":"broker was unresponsive"}}
+{"timestamp":1694556123.3936827,"name":"drain","context":{"idset":"13","reason":"broker was unresponsive"}}
+{"timestamp":1694556123.4937646,"name":"drain","context":{"idset":"14","reason":"broker was unresponsive"}}
+{"timestamp":1694556127.4938982,"name":"drain","context":{"idset":"3","reason":"broker was unresponsive"}}
+{"timestamp":1694556184.0845962,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1694556184.2777247,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1694556184.2779658,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1694556184.2781126,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1694556184.2782629,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1694556184.2784247,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1694556184.2785504,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1694556184.2818074,"name":"drain","context":{"idset":"16","reason":"prolog failed for jobid fSm86Yo5r7Z","overwrite":0}}
+{"timestamp":1694556184.3496494,"name":"drain","context":{"idset":"14","reason":"epilog failed for jobid fSkMPznaxPq","overwrite":0}}
+{"timestamp":1694556184.3774798,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1694556184.5804021,"name":"drain","context":{"idset":"13","reason":"epilog failed for jobid fSm2m9Xq7QK","overwrite":0}}
+{"timestamp":1694556188.3482277,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1694556188.3484235,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1694556188.3485184,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1694556188.3486435,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1694556188.3487625,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1694556188.348881,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1694556188.4485335,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1694556188.6504016,"name":"drain","context":{"idset":"3,11","reason":"epilog failed for jobid fSm5V38tsZH","overwrite":0}}
+{"timestamp":1694556188.7160029,"name":"drain","context":{"idset":"4-10,12","reason":"epilog failed for jobid fSkDNj9Dfu1","overwrite":0}}
+{"timestamp":1694556208.7923725,"name":"drain","context":{"idset":"32","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694556607.4932303,"name":"online","context":{"idset":"23"}}
+{"timestamp":1694556607.8635976,"name":"online","context":{"idset":"31"}}
+{"timestamp":1694556607.9706838,"name":"online","context":{"idset":"28"}}
+{"timestamp":1694556626.2337809,"name":"undrain","context":{"idset":"23,28,31"}}
+{"timestamp":1694557687.1784673,"name":"drain","context":{"idset":"36","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694558685.4934235,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1694558687.4926767,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1694559165.2057498,"name":"drain","context":{"idset":"33","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694559167.7050798,"name":"drain","context":{"idset":"34","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694559543.8702047,"name":"online","context":{"idset":"2"}}
+{"timestamp":1694559558.2941148,"name":"undrain","context":{"idset":"2"}}
+{"timestamp":1694559627.3927946,"name":"online","context":{"idset":"36"}}
+{"timestamp":1694559631.6405895,"name":"online","context":{"idset":"32"}}
+{"timestamp":1694559673.5842316,"name":"undrain","context":{"idset":"32,36"}}
+{"timestamp":1694559795.2715712,"name":"online","context":{"idset":"4,13"}}
+{"timestamp":1694559795.4581873,"name":"online","context":{"idset":"12,15"}}
+{"timestamp":1694559795.7025201,"name":"online","context":{"idset":"10-11"}}
+{"timestamp":1694559795.8776264,"name":"online","context":{"idset":"3,5,8"}}
+{"timestamp":1694559796.1151538,"name":"online","context":{"idset":"6"}}
+{"timestamp":1694559796.442688,"name":"online","context":{"idset":"9"}}
+{"timestamp":1694559796.6418886,"name":"online","context":{"idset":"7,14"}}
+{"timestamp":1694559796.7443104,"name":"online","context":{"idset":"16"}}
+{"timestamp":1694559892.6119835,"name":"undrain","context":{"idset":"3-16"}}
+{"timestamp":1694560020.8998604,"name":"undrain","context":{"idset":"33-34"}}
+{"timestamp":1694560051.2570765,"name":"drain","context":{"idset":"3","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694560051.4419634,"name":"drain","context":{"idset":"4","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694560208.9581587,"name":"drain","context":{"idset":"6","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694560221.192837,"name":"drain","context":{"idset":"5","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694560240.4115741,"name":"drain","context":{"idset":"7","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694560249.7555604,"name":"drain","context":{"idset":"8","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694560413.4660096,"name":"drain","context":{"idset":"24","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1694560646.4120975,"name":"undrain","context":{"idset":"3-8,24"}}
+{"timestamp":1694570762.4267509,"name":"drain","context":{"idset":"13","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1694806707.492825,"name":"drain","context":{"idset":"24","reason":"broker was unresponsive"}}
+{"timestamp":1694806771.4938312,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1694808843.3430884,"name":"resource-init","context":{"restart":true,"drain":{"13":{"timestamp":1694570762.4267509,"reason":"nodediag failed amdgpu"},"24":{"timestamp":1694806707.492825,"reason":"broker was unresponsive"},"29":{"timestamp":1693336554.1257296,"reason":"gpu problem"}},"online":"","exclude":"0-2"}}
+{"timestamp":1694808843.3474295,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1694808977.6337438,"name":"online","context":{"idset":"0"}}
+{"timestamp":1694808978.2850685,"name":"online","context":{"idset":"1-2"}}
+{"timestamp":1694808978.7424824,"name":"online","context":{"idset":"24,33-36"}}
+{"timestamp":1694808978.9883254,"name":"online","context":{"idset":"9-10,13,16,21,28"}}
+{"timestamp":1694808979.100316,"name":"online","context":{"idset":"4,14"}}
+{"timestamp":1694808979.2069995,"name":"online","context":{"idset":"5-6,8,31-32"}}
+{"timestamp":1694808979.3099139,"name":"online","context":{"idset":"3,17-18,23,25,27,30"}}
+{"timestamp":1694808979.4181035,"name":"online","context":{"idset":"11,19-20"}}
+{"timestamp":1694808979.5568295,"name":"online","context":{"idset":"7,12,22"}}
+{"timestamp":1694808979.7230718,"name":"online","context":{"idset":"15,26"}}
+{"timestamp":1694809261.8481922,"name":"undrain","context":{"idset":"13"}}
+{"timestamp":1694809355.1442113,"name":"undrain","context":{"idset":"24"}}
+{"timestamp":1694809856.9357831,"name":"drain","context":{"idset":"13","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1695208553.9116523,"name":"drain","context":{"idset":"11","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1695230615.9773138,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1695230896.188288,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1695234328.7933946,"name":"online","context":{"idset":"11"}}
+{"timestamp":1695234355.2638817,"name":"undrain","context":{"idset":"11"}}
+{"timestamp":1695236829.1097085,"name":"drain","context":{"idset":"14","reason":"Bad partner Node --JRG","overwrite":0}}
+{"timestamp":1695239529.1416612,"name":"drain","context":{"idset":"30","reason":"Broken partner Node --JRG","overwrite":0}}
+{"timestamp":1695239550.4974294,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1695239663.1198502,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1695242352.9642303,"name":"drain","context":{"idset":"23,26-28,31-36","reason":"reboot","overwrite":0}}
+{"timestamp":1695242710.6683557,"name":"online","context":{"idset":"29"}}
+{"timestamp":1695242904.4688151,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1695242904.4689343,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1695242904.4689982,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1695242904.4690573,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1695242904.4691193,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1695242904.469187,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1695242904.4692962,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1695242904.4693856,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1695242904.4694784,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1695242904.5689483,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1695243728.1752021,"name":"online","context":{"idset":"13"}}
+{"timestamp":1695243841.1206043,"name":"online","context":{"idset":"36"}}
+{"timestamp":1695243841.3439813,"name":"online","context":{"idset":"33-34"}}
+{"timestamp":1695243841.5057547,"name":"online","context":{"idset":"35"}}
+{"timestamp":1695243842.166719,"name":"online","context":{"idset":"26"}}
+{"timestamp":1695243843.5583124,"name":"online","context":{"idset":"23"}}
+{"timestamp":1695243844.0716164,"name":"online","context":{"idset":"27-28,31-32"}}
+{"timestamp":1695243873.0925901,"name":"undrain","context":{"idset":"23,26-28,31-36"}}
+{"timestamp":1695244727.0948634,"name":"online","context":{"idset":"14"}}
+{"timestamp":1695244759.8195512,"name":"undrain","context":{"idset":"13-14,29-30"}}
+{"timestamp":1695245833.0632102,"name":"drain","context":{"idset":"17-22,24-25","reason":"reboot","overwrite":0}}
+{"timestamp":1695246342.5705495,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1695246910.4693441,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1695246910.4695542,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1695246910.5697722,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1695247332.2481599,"name":"drain","context":{"idset":"17,21,24-25","reason":"reboot rabbit202","overwrite":1}}
+{"timestamp":1695247858.1964905,"name":"online","context":{"idset":"18,20"}}
+{"timestamp":1695247858.3633893,"name":"online","context":{"idset":"19"}}
+{"timestamp":1695247859.083652,"name":"online","context":{"idset":"22"}}
+{"timestamp":1695247871.8212187,"name":"undrain","context":{"idset":"18-20,22"}}
+{"timestamp":1695247918.9038091,"name":"drain","context":{"idset":"3-12,15-16","reason":"reboot rabbit201","overwrite":0}}
+{"timestamp":1695248071.8803959,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1695248071.880595,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1695248071.8806896,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1695248071.8807871,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1695248071.8808832,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1695248071.9809854,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1695248244.5702522,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1695248644.5693998,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1695248646.247659,"name":"drain","context":{"idset":"4-5,7-9,16,21,25","reason":"rebooting","overwrite":1}}
+{"timestamp":1695248950.7797859,"name":"online","context":{"idset":"4,7"}}
+{"timestamp":1695248951.0067792,"name":"online","context":{"idset":"16,21"}}
+{"timestamp":1695248951.186501,"name":"online","context":{"idset":"8"}}
+{"timestamp":1695248951.3317935,"name":"online","context":{"idset":"25"}}
+{"timestamp":1695248960.2487793,"name":"undrain","context":{"idset":"4,7-8,16,21,25"}}
+{"timestamp":1695250726.8325274,"name":"online","context":{"idset":"9"}}
+{"timestamp":1695250726.9582059,"name":"online","context":{"idset":"5"}}
+{"timestamp":1695250767.7852254,"name":"undrain","context":{"idset":"5,9"}}
+{"timestamp":1695250812.8066359,"name":"drain","context":{"idset":"10,12","reason":"rebooting","overwrite":1}}
+{"timestamp":1695250918.469943,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1695250918.5698633,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1695251258.4694579,"name":"drain","context":{"idset":"33","reason":"broker was unresponsive"}}
+{"timestamp":1695251258.4696302,"name":"drain","context":{"idset":"34","reason":"broker was unresponsive"}}
+{"timestamp":1695251258.4696972,"name":"drain","context":{"idset":"35","reason":"broker was unresponsive"}}
+{"timestamp":1695251258.5694363,"name":"drain","context":{"idset":"36","reason":"broker was unresponsive"}}
+{"timestamp":1695251319.4540858,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1695251319.4543397,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1695251319.4544823,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1695251319.5543692,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1695251725.3434494,"name":"online","context":{"idset":"12"}}
+{"timestamp":1695251725.5701909,"name":"online","context":{"idset":"10"}}
+{"timestamp":1695251733.3659105,"name":"undrain","context":{"idset":"10,12"}}
+{"timestamp":1695253119.1275048,"name":"drain","context":{"idset":"15,24,33-36","reason":"rebooting","overwrite":1}}
+{"timestamp":1695253163.8887029,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1695253163.9884446,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1695254051.2585862,"name":"online","context":{"idset":"15"}}
+{"timestamp":1695254051.5039124,"name":"online","context":{"idset":"35"}}
+{"timestamp":1695254051.8219604,"name":"online","context":{"idset":"33,36"}}
+{"timestamp":1695254052.5705345,"name":"online","context":{"idset":"24"}}
+{"timestamp":1695254076.6296866,"name":"undrain","context":{"idset":"15,24,33,35-36"}}
+{"timestamp":1695315586.4690893,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1695315586.4692485,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1695315586.4693487,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1695315586.5693605,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1695316528.3236618,"name":"online","context":{"idset":"11"}}
+{"timestamp":1695316528.4689631,"name":"online","context":{"idset":"34"}}
+{"timestamp":1695316528.7876818,"name":"online","context":{"idset":"3"}}
+{"timestamp":1695316529.5244102,"name":"online","context":{"idset":"17"}}
+{"timestamp":1695316532.4574356,"name":"online","context":{"idset":"6"}}
+{"timestamp":1695316584.8852313,"name":"undrain","context":{"idset":"3,6,11,17,34"}}
+{"timestamp":1695318781.9085276,"name":"drain","context":{"idset":"8,11,17","reason":"reboot","overwrite":0}}
+{"timestamp":1695318816.004847,"name":"undrain","context":{"idset":"8,11,17"}}
+{"timestamp":1695319063.6897438,"name":"drain","context":{"idset":"5,12,17","reason":"reboot","overwrite":0}}
+{"timestamp":1695319113.7370782,"name":"undrain","context":{"idset":"5,12,17"}}
+{"timestamp":1695335912.3149285,"name":"drain","context":{"idset":"4,6,9,13,15-17","reason":"reboot","overwrite":0}}
+{"timestamp":1695336011.2302337,"name":"undrain","context":{"idset":"4,6,9,13,15-17"}}
+{"timestamp":1695336764.6342952,"name":"online","context":{"idset":"30"}}
+{"timestamp":1695406383.9461868,"name":"drain","context":{"idset":"9","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1695406387.1402626,"name":"drain","context":{"idset":"4","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1695409704.5695939,"name":"drain","context":{"idset":"18","reason":"broker was unresponsive"}}
+{"timestamp":1695411134.570504,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1695415266.5705278,"name":"drain","context":{"idset":"11","reason":"broker was unresponsive"}}
+{"timestamp":1695467754.4617822,"name":"drain","context":{"idset":"3","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1695494449.7392883,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1695494449.8320849,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1695494449.9323273,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1695494450.7577915,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1695494451.063839,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1695494451.6891913,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1695496227.3982773,"name":"online","context":{"idset":"9"}}
+{"timestamp":1695496228.7241158,"name":"online","context":{"idset":"11"}}
+{"timestamp":1695496229.0595677,"name":"online","context":{"idset":"6"}}
+{"timestamp":1695496229.1790628,"name":"online","context":{"idset":"3,18"}}
+{"timestamp":1695496229.337409,"name":"online","context":{"idset":"4"}}
+{"timestamp":1695497074.9545805,"name":"undrain","context":{"idset":"3-4,6,9,11,18"}}
+{"timestamp":1695666433.3264205,"name":"drain","context":{"idset":"33","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1695667860.9667566,"name":"drain","context":{"idset":"35","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1695749129.920666,"name":"drain","context":{"idset":"3-16","reason":"reboot rzvenral201","overwrite":0}}
+{"timestamp":1695749199.2882497,"name":"drain","context":{"idset":"33-36","reason":"reboot rzvenral203","overwrite":1}}
+{"timestamp":1695749396.4693985,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1695749396.4695807,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1695749396.4696805,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1695749396.5698104,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1695750361.1937747,"name":"online","context":{"idset":"33,36"}}
+{"timestamp":1695750361.4054453,"name":"online","context":{"idset":"35"}}
+{"timestamp":1695750361.7065837,"name":"online","context":{"idset":"34"}}
+{"timestamp":1695750433.3597615,"name":"undrain","context":{"idset":"33-36"}}
+{"timestamp":1695750577.5004592,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1695750577.5006459,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1695750577.5007296,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1695750577.5008087,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1695750577.6011407,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1695752887.2220776,"name":"online","context":{"idset":"7,12"}}
+{"timestamp":1695752887.634948,"name":"online","context":{"idset":"11"}}
+{"timestamp":1695752888.3641381,"name":"online","context":{"idset":"8"}}
+{"timestamp":1695752942.7414231,"name":"undrain","context":{"idset":"7-8,11-12"}}
+{"timestamp":1695753128.4698985,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1695753128.470063,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1695753128.4701478,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1695753128.4702311,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1695753128.5703528,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1695754399.3707793,"name":"online","context":{"idset":"3"}}
+{"timestamp":1695754399.5838237,"name":"online","context":{"idset":"13"}}
+{"timestamp":1695754399.7624662,"name":"online","context":{"idset":"4,14,16"}}
+{"timestamp":1695754400.1109872,"name":"online","context":{"idset":"15"}}
+{"timestamp":1695754422.0923116,"name":"undrain","context":{"idset":"3-4,13-16"}}
+{"timestamp":1695754574.4693918,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1695754574.5692599,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1695755534.0806277,"name":"online","context":{"idset":"9"}}
+{"timestamp":1695755534.9843693,"name":"online","context":{"idset":"10"}}
+{"timestamp":1695755545.3749273,"name":"undrain","context":{"idset":"9-10"}}
+{"timestamp":1695764371.4299631,"name":"drain","context":{"idset":"5-6","reason":"reboot fake201","overwrite":1}}
+{"timestamp":1695766538.4528015,"name":"drain","context":{"idset":"26","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1695769332.5701342,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1695769746.5696454,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1695770394.4689617,"name":"online","context":{"idset":"26"}}
+{"timestamp":1695770416.1032333,"name":"undrain","context":{"idset":"26"}}
+{"timestamp":1695770523.9955704,"name":"online","context":{"idset":"6"}}
+{"timestamp":1695770548.218996,"name":"undrain","context":{"idset":"6"}}
+{"timestamp":1695833270.569526,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1695834056.4698198,"name":"online","context":{"idset":"5"}}
+{"timestamp":1695914354.9481988,"name":"drain","context":{"idset":"3-36","reason":"cooling work","overwrite":1}}
+{"timestamp":1695914498.4694517,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1695914498.4695992,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1695914498.4696898,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1695914498.4697738,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1695914498.4698589,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1695914498.4699452,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1695914498.4700329,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1695914498.4701238,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1695914498.4702365,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1695914498.4724231,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1695914498.5724671,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1695914498.7973464,"name":"drain","context":{"idset":"6","reason":"epilog failed for jobid fVp7nj4f9Ub","overwrite":0}}
+{"timestamp":1695914500.469897,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1695914500.4700277,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1695914500.4701126,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1695914500.470196,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1695914500.4702868,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1695914500.4703655,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1695914500.470443,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1695914500.4705298,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1695914500.4706147,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1695914500.4707041,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1695914500.4707859,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1695914500.4708679,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1695914500.4709671,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1695914500.4710457,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1695914500.4711311,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1695914500.4712055,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1695914500.4713051,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1695914500.4713705,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1695914500.4714532,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1695914500.4715152,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1695914500.4715898,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1695914500.4716539,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1695914500.4717159,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1695914500.5700793,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1695914500.8095329,"name":"drain","context":{"idset":"3-4","reason":"epilog failed for jobid fVoQPr6goRH","overwrite":0}}
+{"timestamp":1695914504.5696707,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1695914566.4697719,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1695914566.5702643,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1695922748.2531843,"name":"online","context":{"idset":"22"}}
+{"timestamp":1695922749.3104026,"name":"online","context":{"idset":"19,21"}}
+{"timestamp":1695922749.454987,"name":"online","context":{"idset":"23-24"}}
+{"timestamp":1695922749.6207023,"name":"online","context":{"idset":"18,20"}}
+{"timestamp":1695922749.7251558,"name":"online","context":{"idset":"27-28"}}
+{"timestamp":1695922749.8518152,"name":"online","context":{"idset":"17,30"}}
+{"timestamp":1695922749.9958036,"name":"online","context":{"idset":"25-26,29,31"}}
+{"timestamp":1695922750.167105,"name":"online","context":{"idset":"32"}}
+{"timestamp":1695922924.6296678,"name":"online","context":{"idset":"35-36"}}
+{"timestamp":1695922924.7699745,"name":"online","context":{"idset":"33-34"}}
+{"timestamp":1695923168.4695063,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1695923168.4696996,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1695923168.5694275,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1695923170.5695405,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1695924487.481142,"name":"online","context":{"idset":"35"}}
+{"timestamp":1695924596.8184311,"name":"online","context":{"idset":"34"}}
+{"timestamp":1695924597.1681366,"name":"online","context":{"idset":"33"}}
+{"timestamp":1695924597.2947226,"name":"online","context":{"idset":"36"}}
+{"timestamp":1695925320.4320128,"name":"online","context":{"idset":"15"}}
+{"timestamp":1695925322.3619802,"name":"online","context":{"idset":"11-12"}}
+{"timestamp":1695925322.5443008,"name":"online","context":{"idset":"14,16"}}
+{"timestamp":1695925322.8427496,"name":"online","context":{"idset":"13"}}
+{"timestamp":1695925885.1539776,"name":"undrain","context":{"idset":"11-36"}}
+{"timestamp":1695925979.2590265,"name":"online","context":{"idset":"3,5"}}
+{"timestamp":1695925979.3715463,"name":"online","context":{"idset":"9"}}
+{"timestamp":1695925979.85725,"name":"online","context":{"idset":"8,10"}}
+{"timestamp":1695925980.0025549,"name":"online","context":{"idset":"4"}}
+{"timestamp":1695925980.1239684,"name":"online","context":{"idset":"7"}}
+{"timestamp":1695926000.417845,"name":"undrain","context":{"idset":"3-5,7-10"}}
+{"timestamp":1695926074.2143967,"name":"online","context":{"idset":"1"}}
+{"timestamp":1695926172.2053049,"name":"online","context":{"idset":"2"}}
+{"timestamp":1695927147.7243402,"name":"online","context":{"idset":"6"}}
+{"timestamp":1695927168.4761686,"name":"undrain","context":{"idset":"6"}}
+{"timestamp":1695927172.764044,"name":"undrain","context":{"idset":"1-2"}}
+{"timestamp":1696049214.2751634,"name":"drain","context":{"idset":"36","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1696049336.4733171,"name":"drain","context":{"idset":"36","reason":"epilog failed for jobid fVw1PkTxj3D","overwrite":0}}
+{"timestamp":1696049336.5707746,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1696049436.3897679,"name":"drain","context":{"idset":"33","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1696049558.4730098,"name":"drain","context":{"idset":"33","reason":"epilog failed for jobid fVw1PjLjGe3","overwrite":0}}
+{"timestamp":1696049558.5698428,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1696051724.3890257,"name":"drain","context":{"idset":"34","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1696051724.3930049,"name":"drain","context":{"idset":"35","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1696051845.0969639,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1696051845.9287763,"name":"drain","context":{"idset":"34-35","reason":"epilog failed for jobid fVw1PjuLzqd","overwrite":0}}
+{"timestamp":1696051846.0263746,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1696260317.9004247,"name":"online","context":{"idset":"34"}}
+{"timestamp":1696260318.2212117,"name":"online","context":{"idset":"35"}}
+{"timestamp":1696260318.427664,"name":"online","context":{"idset":"33,36"}}
+{"timestamp":1696260343.2356935,"name":"undrain","context":{"idset":"33-36"}}
+{"timestamp":1696361739.484163,"name":"resource-init","context":{"restart":true,"drain":{},"online":"","exclude":"0-2"}}
+{"timestamp":1696361739.488512,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1696361848.3139358,"name":"online","context":{"idset":"0"}}
+{"timestamp":1696367375.989265,"name":"online","context":{"idset":"1"}}
+{"timestamp":1696367456.9520044,"name":"online","context":{"idset":"2"}}
+{"timestamp":1696367540.8946981,"name":"online","context":{"idset":"19"}}
+{"timestamp":1696367541.7176154,"name":"online","context":{"idset":"21,24,31"}}
+{"timestamp":1696367541.82342,"name":"online","context":{"idset":"17,22"}}
+{"timestamp":1696367541.8389444,"name":"online","context":{"idset":"23"}}
+{"timestamp":1696367541.9670861,"name":"online","context":{"idset":"26"}}
+{"timestamp":1696367542.0977304,"name":"online","context":{"idset":"29"}}
+{"timestamp":1696367542.2126846,"name":"online","context":{"idset":"18"}}
+{"timestamp":1696367542.6921132,"name":"online","context":{"idset":"30,32,34"}}
+{"timestamp":1696367542.8247058,"name":"online","context":{"idset":"28"}}
+{"timestamp":1696367543.1525059,"name":"online","context":{"idset":"3,33"}}
+{"timestamp":1696367543.2563179,"name":"online","context":{"idset":"6,35-36"}}
+{"timestamp":1696367543.6327751,"name":"online","context":{"idset":"7"}}
+{"timestamp":1696367543.9991419,"name":"online","context":{"idset":"8"}}
+{"timestamp":1696367544.1515977,"name":"online","context":{"idset":"4-5"}}
+{"timestamp":1696367544.9943063,"name":"online","context":{"idset":"13"}}
+{"timestamp":1696367545.3554242,"name":"online","context":{"idset":"10,12,16"}}
+{"timestamp":1696367545.6052694,"name":"online","context":{"idset":"9,14"}}
+{"timestamp":1696367545.7209013,"name":"online","context":{"idset":"11"}}
+{"timestamp":1696367546.263943,"name":"online","context":{"idset":"20"}}
+{"timestamp":1696368789.7928324,"name":"online","context":{"idset":"25"}}
+{"timestamp":1696369429.8857908,"name":"online","context":{"idset":"27"}}
+{"timestamp":1696369432.7091043,"name":"online","context":{"idset":"15"}}
+{"timestamp":1696371783.904444,"name":"drain","context":{"idset":"3-36","overwrite":0}}
+{"timestamp":1696374013.0991428,"name":"undrain","context":{"idset":"33-36"}}
+{"timestamp":1696374231.2920842,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1696374231.2922313,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1696374231.2923207,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1696374231.2924063,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1696374231.2924888,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1696374231.2925711,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1696374231.2926514,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1696374231.2927308,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1696374231.2928216,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1696374231.2929015,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1696374231.2929788,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1696374231.2930639,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1696374231.2931576,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1696374231.2932549,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1696374231.2933438,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1696374231.2934384,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1696374231.2935176,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1696374231.2936106,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1696374231.2936943,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1696374231.2937882,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1696374231.2938678,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1696374231.2939594,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1696374231.2940342,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1696374231.3926938,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1696374233.2916529,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1696374233.2917626,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1696374233.2918413,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1696374233.2919044,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1696374233.291966,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1696374233.3923733,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1696375378.7849121,"name":"online","context":{"idset":"5"}}
+{"timestamp":1696375380.5587616,"name":"online","context":{"idset":"7-8"}}
+{"timestamp":1696375380.6781337,"name":"online","context":{"idset":"3-4,6"}}
+{"timestamp":1696375380.9142597,"name":"online","context":{"idset":"9"}}
+{"timestamp":1696375381.4437442,"name":"online","context":{"idset":"14-15"}}
+{"timestamp":1696375381.7829304,"name":"online","context":{"idset":"10-11"}}
+{"timestamp":1696375381.9498675,"name":"online","context":{"idset":"12-13,16"}}
+{"timestamp":1696375413.1883564,"name":"undrain","context":{"idset":"3-16"}}
+{"timestamp":1696375497.0232635,"name":"online","context":{"idset":"22"}}
+{"timestamp":1696375497.820205,"name":"online","context":{"idset":"23"}}
+{"timestamp":1696375498.3633559,"name":"online","context":{"idset":"18"}}
+{"timestamp":1696375498.5012205,"name":"online","context":{"idset":"17,20,32"}}
+{"timestamp":1696375498.7925093,"name":"online","context":{"idset":"19,21,24"}}
+{"timestamp":1696375499.2008862,"name":"online","context":{"idset":"25,29"}}
+{"timestamp":1696375499.391989,"name":"online","context":{"idset":"26-28,30-31"}}
+{"timestamp":1696375516.5483057,"name":"undrain","context":{"idset":"17-32"}}
+{"timestamp":1696545408.6339865,"name":"drain","context":{"idset":"20","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1696551358.4757018,"name":"drain","context":{"idset":"10","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1696551361.5697751,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1696590945.296252,"name":"drain","context":{"idset":"5","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1696870243.3924413,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1696870307.391957,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1696870419.3920469,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1696870421.291321,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1696870421.2914369,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1696870421.3913386,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1696871316.748493,"name":"online","context":{"idset":"1"}}
+{"timestamp":1696871451.8389604,"name":"undrain","context":{"idset":"1"}}
+{"timestamp":1696871509.903842,"name":"online","context":{"idset":"10"}}
+{"timestamp":1696871510.2226219,"name":"online","context":{"idset":"20"}}
+{"timestamp":1696871510.4789412,"name":"online","context":{"idset":"7"}}
+{"timestamp":1696871510.7859912,"name":"online","context":{"idset":"5"}}
+{"timestamp":1696871555.2600594,"name":"undrain","context":{"idset":"5,7,10,20"}}
+{"timestamp":1696967347.3243403,"name":"drain","context":{"idset":"10","reason":"prolog failed for jobid fYBFh8aFQKH","overwrite":0}}
+{"timestamp":1696970075.9116812,"name":"drain","context":{"idset":"6","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1696970080.169271,"name":"drain","context":{"idset":"3","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1696975179.2917118,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1696975179.2918873,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1696975179.3920841,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1696976455.7352934,"name":"online","context":{"idset":"3,6"}}
+{"timestamp":1696976455.8650832,"name":"online","context":{"idset":"10"}}
+{"timestamp":1696977036.84763,"name":"undrain","context":{"idset":"3,6,10"}}
+{"timestamp":1697199087.3926661,"name":"drain","context":{"idset":"3","reason":"broker was unresponsive"}}
+{"timestamp":1697204835.3934171,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1697233921.3931305,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1697233923.3921604,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1697234939.0788538,"name":"online","context":{"idset":"5"}}
+{"timestamp":1697234939.3919539,"name":"online","context":{"idset":"3"}}
+{"timestamp":1697235045.3879631,"name":"undrain","context":{"idset":"3,5"}}
+{"timestamp":1697282155.7388096,"name":"drain","context":{"idset":"6","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1697315773.7159965,"name":"drain","context":{"idset":"10","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1697315897.2949798,"name":"drain","context":{"idset":"10","reason":"epilog failed for jobid fYjhDpzWuAo","overwrite":0}}
+{"timestamp":1697315897.3920014,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1697317292.8000019,"name":"drain","context":{"idset":"4","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1697317415.2947545,"name":"drain","context":{"idset":"4","reason":"epilog failed for jobid fYkmU3hSKvF","overwrite":0}}
+{"timestamp":1697317415.3923233,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1697320673.3915865,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1697322081.7616789,"name":"online","context":{"idset":"6"}}
+{"timestamp":1697322081.954576,"name":"online","context":{"idset":"4,10"}}
+{"timestamp":1697322101.3007145,"name":"undrain","context":{"idset":"4,6,10"}}
+{"timestamp":1697397096.7157972,"name":"drain","context":{"idset":"8","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1697397219.2952788,"name":"drain","context":{"idset":"8","reason":"epilog failed for jobid fYjJjXYbvsy","overwrite":0}}
+{"timestamp":1697397219.3926458,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1697476525.1993411,"name":"online","context":{"idset":"8"}}
+{"timestamp":1697497458.4749491,"name":"drain","context":{"idset":"9","reason":"prolog failed for jobid fZNhhyBzFxB","overwrite":0}}
+{"timestamp":1697502264.7814496,"name":"undrain","context":{"idset":"8"}}
+{"timestamp":1697627738.1683393,"name":"drain","context":{"idset":"3","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1697652109.3920152,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1697652111.3923502,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1697653238.9130418,"name":"online","context":{"idset":"3"}}
+{"timestamp":1697653239.0210137,"name":"online","context":{"idset":"9"}}
+{"timestamp":1697653256.2960627,"name":"undrain","context":{"idset":"3,9"}}
+{"timestamp":1697973387.1837721,"name":"drain","context":{"idset":"4","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1698233438.4140465,"name":"drain","context":{"idset":"8","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1698252247.2912412,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1698252247.3915036,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1698259000.5326769,"name":"online","context":{"idset":"4"}}
+{"timestamp":1698259001.1321256,"name":"online","context":{"idset":"8"}}
+{"timestamp":1698263018.9727104,"name":"drain","context":{"idset":"24,27-28,31","reason":"prolog failed for jobid fb6zmBg6Gby","overwrite":0}}
+{"timestamp":1698267577.2945733,"name":"drain","context":{"idset":"9","reason":"epilog failed for jobid fb4sAVw1K2X","overwrite":0}}
+{"timestamp":1698267577.391259,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1698267584.1027615,"name":"online","context":{"idset":"9"}}
+{"timestamp":1698267686.6756842,"name":"drain","context":{"idset":"10","reason":"epilog failed for jobid fb4sAXmkRKM","overwrite":0}}
+{"timestamp":1698267730.8553238,"name":"drain","context":{"idset":"13","reason":"epilog failed for jobid fb4sAc6JKwd","overwrite":0}}
+{"timestamp":1698267730.8574178,"name":"drain","context":{"idset":"15","reason":"epilog failed for jobid fb4sAh6suBD","overwrite":0}}
+{"timestamp":1698267730.8578885,"name":"drain","context":{"idset":"14","reason":"epilog failed for jobid fb4sAeAPKmZ","overwrite":0}}
+{"timestamp":1698267730.8593297,"name":"drain","context":{"idset":"16","reason":"epilog failed for jobid fb4sAkCGQGw","overwrite":0}}
+{"timestamp":1698267730.8606985,"name":"drain","context":{"idset":"11","reason":"epilog failed for jobid fb4sAYbC2LP","overwrite":0}}
+{"timestamp":1698267730.8631144,"name":"drain","context":{"idset":"12","reason":"epilog failed for jobid fb4sAaB7Fom","overwrite":0}}
+{"timestamp":1698270654.8468909,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1698270654.8470414,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1698270654.8471239,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1698270654.8472025,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1698270654.8472764,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1698270654.9469812,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1698270656.1940918,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1698270656.2946701,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1698270756.7174747,"name":"undrain","context":{"idset":"4,8"}}
+{"timestamp":1698270897.2919047,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1698270897.2920525,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1698270897.2921364,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1698270897.392051,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1698271606.6720197,"name":"online","context":{"idset":"9"}}
+{"timestamp":1698271607.0914681,"name":"online","context":{"idset":"10,12"}}
+{"timestamp":1698271607.5585918,"name":"online","context":{"idset":"11,13-16"}}
+{"timestamp":1698271628.9827583,"name":"undrain","context":{"idset":"9-16"}}
+{"timestamp":1698271870.1094556,"name":"online","context":{"idset":"31"}}
+{"timestamp":1698271870.4247196,"name":"online","context":{"idset":"24,27"}}
+{"timestamp":1698271870.635812,"name":"online","context":{"idset":"28"}}
+{"timestamp":1698271893.0165224,"name":"undrain","context":{"idset":"24,27-28,31"}}
+{"timestamp":1698333678.5632927,"name":"drain","context":{"idset":"7","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1698333801.2948267,"name":"drain","context":{"idset":"7","reason":"epilog failed for jobid fb4hSKQB9wd","overwrite":0}}
+{"timestamp":1698333801.3920548,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1698345157.770261,"name":"drain","context":{"idset":"6","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1698345281.2950342,"name":"drain","context":{"idset":"6","reason":"epilog failed for jobid fb4ZQBwL1Cj","overwrite":0}}
+{"timestamp":1698345281.392262,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1698345697.703357,"name":"drain","context":{"idset":"3","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1698345821.2949822,"name":"drain","context":{"idset":"3","reason":"epilog failed for jobid faticeKSnQF","overwrite":0}}
+{"timestamp":1698345821.3917544,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1698347925.8042543,"name":"drain","context":{"idset":"11","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1698350173.3921878,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1698350823.8025548,"name":"drain","context":{"idset":"5","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1698350947.29479,"name":"drain","context":{"idset":"5","reason":"epilog failed for jobid fb4MHi23ftT","overwrite":0}}
+{"timestamp":1698350947.3921909,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1698351375.690933,"name":"drain","context":{"idset":"9","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1698353076.4954288,"name":"online","context":{"idset":"11"}}
+{"timestamp":1698353076.6207273,"name":"online","context":{"idset":"6"}}
+{"timestamp":1698353076.7670624,"name":"online","context":{"idset":"3"}}
+{"timestamp":1698353076.9272208,"name":"online","context":{"idset":"7"}}
+{"timestamp":1698353095.9239471,"name":"undrain","context":{"idset":"3,6-7,11"}}
+{"timestamp":1698353247.3931322,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1698353950.2829504,"name":"drain","context":{"idset":"12","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1698363089.3925822,"name":"online","context":{"idset":"5"}}
+{"timestamp":1698363089.6374276,"name":"online","context":{"idset":"9"}}
+{"timestamp":1698363107.0968122,"name":"undrain","context":{"idset":"5,9"}}
+{"timestamp":1698363255.3918436,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1698364826.3114753,"name":"online","context":{"idset":"12"}}
+{"timestamp":1698365071.1923492,"name":"undrain","context":{"idset":"12"}}
+{"timestamp":1698405337.8258264,"name":"drain","context":{"idset":"4","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1698424731.3931534,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1698428817.2914388,"name":"online","context":{"idset":"4"}}
+{"timestamp":1698428838.6191571,"name":"undrain","context":{"idset":"4"}}
+{"timestamp":1698578138.9341917,"name":"drain","context":{"idset":"4","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1698685077.3925338,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1698686158.8228524,"name":"online","context":{"idset":"4"}}
+{"timestamp":1698686195.740227,"name":"undrain","context":{"idset":"4"}}
+{"timestamp":1698700585.291842,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1698700585.291985,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1698700585.292047,"name":"drain","context":{"idset":"11","reason":"broker was unresponsive"}}
+{"timestamp":1698700585.3920979,"name":"drain","context":{"idset":"12","reason":"broker was unresponsive"}}
+{"timestamp":1698700587.292206,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1698700587.2922881,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1698700587.2923448,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1698700587.2923892,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1698700587.2924407,"name":"drain","context":{"idset":"10","reason":"broker was unresponsive"}}
+{"timestamp":1698700587.3931458,"name":"drain","context":{"idset":"13","reason":"broker was unresponsive"}}
+{"timestamp":1698700589.2915025,"name":"drain","context":{"idset":"14","reason":"broker was unresponsive"}}
+{"timestamp":1698700589.2915699,"name":"drain","context":{"idset":"15","reason":"broker was unresponsive"}}
+{"timestamp":1698700589.39223,"name":"drain","context":{"idset":"16","reason":"broker was unresponsive"}}
+{"timestamp":1698700651.2920702,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1698700651.2922037,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1698700651.292285,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1698700651.2923675,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1698700651.2924426,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1698700651.2925155,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1698700651.2925889,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1698700651.2926621,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1698700651.2927458,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1698700651.2928348,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1698700651.2929311,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1698700651.2930212,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1698700651.4059091,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1698704298.5438437,"name":"drain","context":{"idset":"3","overwrite":0}}
+{"timestamp":1698706962.42255,"name":"online","context":{"idset":"13"}}
+{"timestamp":1698706962.5882916,"name":"online","context":{"idset":"16"}}
+{"timestamp":1698706964.9933019,"name":"online","context":{"idset":"11"}}
+{"timestamp":1698706965.5792594,"name":"online","context":{"idset":"4,6"}}
+{"timestamp":1698706965.7902374,"name":"online","context":{"idset":"12"}}
+{"timestamp":1698706965.987498,"name":"online","context":{"idset":"5"}}
+{"timestamp":1698706966.4626861,"name":"online","context":{"idset":"9-10"}}
+{"timestamp":1698706967.2082438,"name":"online","context":{"idset":"14"}}
+{"timestamp":1698706967.4468448,"name":"online","context":{"idset":"15"}}
+{"timestamp":1698706987.7337122,"name":"undrain","context":{"idset":"4-6,9-16"}}
+{"timestamp":1698707008.5378728,"name":"drain","context":{"idset":"3","reason":"reboot","overwrite":1}}
+{"timestamp":1698707734.8893569,"name":"online","context":{"idset":"7"}}
+{"timestamp":1698707735.390667,"name":"online","context":{"idset":"8"}}
+{"timestamp":1698707764.3252654,"name":"undrain","context":{"idset":"7-8"}}
+{"timestamp":1698708211.6830432,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1698709006.4060557,"name":"online","context":{"idset":"1"}}
+{"timestamp":1698709217.3928361,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1698709989.7559566,"name":"online","context":{"idset":"3"}}
+{"timestamp":1698710013.2454998,"name":"undrain","context":{"idset":"3"}}
+{"timestamp":1698782609.2916038,"name":"drain","context":{"idset":"3","reason":"broker was unresponsive"}}
+{"timestamp":1698782609.3916175,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1698782611.3904872,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1698782613.2914286,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1698782613.2915061,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1698782613.3923416,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1698782672.867095,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1698782673.203989,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1698782673.9481406,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1698782674.1745343,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1698782674.1746461,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1698782674.2749512,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1698798539.3923759,"name":"online","context":{"idset":"6"}}
+{"timestamp":1698798539.7028329,"name":"online","context":{"idset":"5"}}
+{"timestamp":1698798539.8589263,"name":"online","context":{"idset":"8"}}
+{"timestamp":1698798540.1221759,"name":"online","context":{"idset":"3"}}
+{"timestamp":1698798540.3043318,"name":"online","context":{"idset":"4"}}
+{"timestamp":1698798543.2804992,"name":"online","context":{"idset":"7"}}
+{"timestamp":1698798567.457871,"name":"undrain","context":{"idset":"3-8"}}
+{"timestamp":1698898119.2212982,"name":"drain","context":{"idset":"35","reason":"prolog failed for jobid fcYCXjbBs5Z","overwrite":0}}
+{"timestamp":1698983885.7954438,"name":"drain","context":{"idset":"23","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1698984009.2946894,"name":"drain","context":{"idset":"23","reason":"epilog failed for jobid fcY66BLsgoR","overwrite":0}}
+{"timestamp":1698984009.3922031,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1699028178.7412593,"name":"drain","context":{"idset":"16","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1699028287.7114272,"name":"drain","context":{"idset":"24,28","reason":"prolog failed for jobid fcqFc6ub4KH","overwrite":0}}
+{"timestamp":1699028299.9856875,"name":"drain","context":{"idset":"16","reason":"epilog failed for jobid fcdvE8oVBKd","overwrite":0}}
+{"timestamp":1699028300.0829937,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1699041783.4963048,"name":"drain","context":{"idset":"9","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1699041907.2950048,"name":"drain","context":{"idset":"9","reason":"epilog failed for jobid fcbvJx7ExD5","overwrite":0}}
+{"timestamp":1699041907.3918917,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1699047955.533289,"name":"drain","context":{"idset":"13","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1699048079.2952232,"name":"drain","context":{"idset":"13","reason":"epilog failed for jobid fced5wutVPV","overwrite":0}}
+{"timestamp":1699048079.3924296,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1699057837.3206918,"name":"undrain","context":{"idset":"23"}}
+{"timestamp":1699057847.8625484,"name":"undrain","context":{"idset":"16"}}
+{"timestamp":1699057852.7588508,"name":"undrain","context":{"idset":"13"}}
+{"timestamp":1699057855.8148282,"name":"undrain","context":{"idset":"9"}}
+{"timestamp":1699058447.0979354,"name":"online","context":{"idset":"9"}}
+{"timestamp":1699058519.6965454,"name":"online","context":{"idset":"13"}}
+{"timestamp":1699058581.3929327,"name":"online","context":{"idset":"16"}}
+{"timestamp":1699058677.6374595,"name":"online","context":{"idset":"23"}}
+{"timestamp":1699059829.2918489,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1699059829.2920172,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1699059829.3917878,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1699064612.878504,"name":"online","context":{"idset":"24"}}
+{"timestamp":1699064771.0378337,"name":"online","context":{"idset":"28"}}
+{"timestamp":1699064891.9431348,"name":"online","context":{"idset":"35"}}
+{"timestamp":1699064935.7478447,"name":"undrain","context":{"idset":"24"}}
+{"timestamp":1699064938.7538722,"name":"undrain","context":{"idset":"28"}}
+{"timestamp":1699064942.4479222,"name":"undrain","context":{"idset":"35"}}
+{"timestamp":1699108294.5256507,"name":"drain","context":{"idset":"6","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1699108417.2946174,"name":"drain","context":{"idset":"6","reason":"epilog failed for jobid fcoENDFQ44o","overwrite":0}}
+{"timestamp":1699108417.3921847,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1699110183.8238149,"name":"drain","context":{"idset":"7","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1699110215.1377816,"name":"drain","context":{"idset":"10","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1699110215.1401656,"name":"drain","context":{"idset":"3","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1699110293.8338606,"name":"drain","context":{"idset":"15","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1699110307.2946231,"name":"drain","context":{"idset":"7","reason":"epilog failed for jobid fcpVC2nM7NP","overwrite":0}}
+{"timestamp":1699110307.3919404,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1699110337.2923136,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1699110337.2956264,"name":"drain","context":{"idset":"3,10","reason":"epilog failed for jobid fckt3jJF271","overwrite":0}}
+{"timestamp":1699110337.3926568,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1699110417.2943027,"name":"drain","context":{"idset":"15","reason":"epilog failed for jobid fcpf6JEFuSf","overwrite":0}}
+{"timestamp":1699110417.3919351,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1699111462.6613293,"name":"drain","context":{"idset":"8","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1699111585.2952204,"name":"drain","context":{"idset":"8","reason":"epilog failed for jobid fcohinGC7KD","overwrite":0}}
+{"timestamp":1699111585.3919103,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1699121757.3931863,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1699121759.3925927,"name":"drain","context":{"idset":"12","reason":"broker was unresponsive"}}
+{"timestamp":1699121761.2923708,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1699121761.2924676,"name":"drain","context":{"idset":"11","reason":"broker was unresponsive"}}
+{"timestamp":1699121761.392585,"name":"drain","context":{"idset":"14","reason":"broker was unresponsive"}}
+{"timestamp":1699121825.2919405,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1699121825.2920818,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1699121825.29217,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1699121825.2922897,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1699121825.2950382,"name":"drain","context":{"idset":"5","reason":"epilog failed for jobid fcs6mwTWFou","overwrite":0}}
+{"timestamp":1699121825.2952077,"name":"drain","context":{"idset":"4","reason":"epilog failed for jobid fcgs1wLsAcF","overwrite":0}}
+{"timestamp":1699121825.2956748,"name":"drain","context":{"idset":"11","reason":"epilog failed for jobid fcmR9Yzvtxf","overwrite":0}}
+{"timestamp":1699121825.2957509,"name":"drain","context":{"idset":"12","reason":"epilog failed for jobid fcmR9ZY4dsu","overwrite":0}}
+{"timestamp":1699121825.2965109,"name":"drain","context":{"idset":"14","reason":"epilog failed for jobid fcsrmGJMWbh","overwrite":0}}
+{"timestamp":1699121825.3921025,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1699122870.7949834,"name":"online","context":{"idset":"8"}}
+{"timestamp":1699122871.0461578,"name":"online","context":{"idset":"10"}}
+{"timestamp":1699122871.1708541,"name":"online","context":{"idset":"6,15"}}
+{"timestamp":1699122871.2769408,"name":"online","context":{"idset":"7"}}
+{"timestamp":1699123010.2086968,"name":"undrain","context":{"idset":"3,6-8,10,15"}}
+{"timestamp":1699123038.2324941,"name":"undrain","context":{"idset":"4-5,11-12,14"}}
+{"timestamp":1699134773.7312596,"name":"online","context":{"idset":"14"}}
+{"timestamp":1699134828.0693393,"name":"online","context":{"idset":"5"}}
+{"timestamp":1699134828.2369177,"name":"online","context":{"idset":"11"}}
+{"timestamp":1699134828.4359407,"name":"online","context":{"idset":"12"}}
+{"timestamp":1699134828.6169968,"name":"online","context":{"idset":"3-4"}}
+{"timestamp":1699294593.3923998,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1699294654.6535254,"name":"drain","context":{"idset":"7","reason":"epilog failed for jobid fdHY5ToUDBu","overwrite":0}}
+{"timestamp":1699294654.750855,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1699294660.3354294,"name":"drain","context":{"idset":"7","reason":"PY: SS not passing traffic","overwrite":1}}
+{"timestamp":1699295541.0629618,"name":"online","context":{"idset":"7"}}
+{"timestamp":1699295785.0277631,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1699317389.3926749,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1699317450.2493403,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1699317933.3927598,"name":"drain","context":{"idset":"11","reason":"broker was unresponsive"}}
+{"timestamp":1699317993.8062329,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1699346875.3029735,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1699369347.2923512,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2924886,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2925568,"name":"drain","context":{"idset":"10","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2926049,"name":"drain","context":{"idset":"13","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2926564,"name":"drain","context":{"idset":"14","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2927122,"name":"drain","context":{"idset":"15","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2927637,"name":"drain","context":{"idset":"17","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2928226,"name":"drain","context":{"idset":"18","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.292865,"name":"drain","context":{"idset":"19","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2929163,"name":"drain","context":{"idset":"20","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2929604,"name":"drain","context":{"idset":"21","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.293009,"name":"drain","context":{"idset":"30","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2930548,"name":"drain","context":{"idset":"31","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2930977,"name":"drain","context":{"idset":"32","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.293143,"name":"drain","context":{"idset":"34","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.2931898,"name":"drain","context":{"idset":"35","reason":"broker was unresponsive"}}
+{"timestamp":1699369347.3927314,"name":"drain","context":{"idset":"36","reason":"broker was unresponsive"}}
+{"timestamp":1699369349.2917762,"name":"drain","context":{"idset":"3","reason":"broker was unresponsive"}}
+{"timestamp":1699369349.2918913,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1699369349.2919486,"name":"drain","context":{"idset":"12","reason":"broker was unresponsive"}}
+{"timestamp":1699369349.2920022,"name":"drain","context":{"idset":"16","reason":"broker was unresponsive"}}
+{"timestamp":1699369349.2920561,"name":"drain","context":{"idset":"22","reason":"broker was unresponsive"}}
+{"timestamp":1699369349.2921069,"name":"drain","context":{"idset":"23","reason":"broker was unresponsive"}}
+{"timestamp":1699369349.2921586,"name":"drain","context":{"idset":"27","reason":"broker was unresponsive"}}
+{"timestamp":1699369349.2922087,"name":"drain","context":{"idset":"28","reason":"broker was unresponsive"}}
+{"timestamp":1699369349.2922649,"name":"drain","context":{"idset":"29","reason":"broker was unresponsive"}}
+{"timestamp":1699369349.3917236,"name":"drain","context":{"idset":"33","reason":"broker was unresponsive"}}
+{"timestamp":1699369351.292166,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1699369351.2922516,"name":"drain","context":{"idset":"24","reason":"broker was unresponsive"}}
+{"timestamp":1699369351.2923048,"name":"drain","context":{"idset":"25","reason":"broker was unresponsive"}}
+{"timestamp":1699369351.392276,"name":"drain","context":{"idset":"26","reason":"broker was unresponsive"}}
+{"timestamp":1699369413.2922878,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1699369413.2924371,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1699369413.2925241,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1699369413.2926304,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1699369413.2927108,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1699369413.2927995,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1699369413.2928779,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1699369413.2929537,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1699369413.2930269,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1699369413.2931013,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1699369413.2931817,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1699369413.2932818,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1699369413.2933567,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1699369413.2934515,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1699369413.2935398,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1699369413.2936442,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1699369413.2937167,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1699369413.2937953,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1699369413.2938795,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1699369413.2939658,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1699369413.294055,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1699369413.2941287,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1699369413.2942057,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1699369413.2942903,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1699369413.2943516,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1699369413.2944188,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1699369413.2944992,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1699369413.2945759,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1699369413.2946355,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1699369413.2946968,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1699369413.2947514,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1699369413.3923542,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1699369425.3920414,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1699369429.3926032,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1699369493.2919865,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1699369493.3918357,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1699370892.7646363,"name":"drain","context":{"idset":"1-36","reason":"power","overwrite":1}}
+{"timestamp":1699488151.3346119,"name":"undrain","context":{"idset":"1-29,31-36"}}
+{"timestamp":1699489005.8119237,"name":"resource-init","context":{"restart":true,"drain":{"30":{"timestamp":1699369347.293009,"reason":"power"}},"online":"","exclude":"0-2"}}
+{"timestamp":1699489005.8190696,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1699489113.8772976,"name":"online","context":{"idset":"0"}}
+{"timestamp":1699489114.7384281,"name":"online","context":{"idset":"1,25,34-36"}}
+{"timestamp":1699489114.8581324,"name":"online","context":{"idset":"2-4,6-8,10-11,16-19,21,26,29,32-33"}}
+{"timestamp":1699489115.0029328,"name":"online","context":{"idset":"5,9,12-13,15,20,24,27,30-31"}}
+{"timestamp":1699489115.1116974,"name":"online","context":{"idset":"23"}}
+{"timestamp":1699489115.2776752,"name":"online","context":{"idset":"22"}}
+{"timestamp":1699489115.5477419,"name":"online","context":{"idset":"14,28"}}
+{"timestamp":1699489148.3917992,"name":"undrain","context":{"idset":"30"}}
+{"timestamp":1699489159.5188849,"name":"drain","context":{"idset":"30","reason":"slingshot","overwrite":0}}
+{"timestamp":1699575108.637388,"name":"drain","context":{"idset":"20","reason":"prolog failed for jobid fdniybWyUyu","overwrite":0}}
+{"timestamp":1699575109.6672521,"name":"drain","context":{"idset":"21","reason":"prolog failed for jobid fdniz3e8pzK","overwrite":0}}
+{"timestamp":1699895806.9774122,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1699895808.9767456,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1699896574.3995235,"name":"online","context":{"idset":"21"}}
+{"timestamp":1699896574.7458112,"name":"online","context":{"idset":"20"}}
+{"timestamp":1699896591.9724834,"name":"undrain","context":{"idset":"20-21"}}
+{"timestamp":1700035884.1490028,"name":"drain","context":{"idset":"5","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1700064964.198509,"name":"drain","context":{"idset":"15","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1700064964.3989232,"name":"drain","context":{"idset":"12","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1700064964.7390661,"name":"drain","context":{"idset":"16","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1700065086.8772142,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1700065086.8773477,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1700065086.880022,"name":"drain","context":{"idset":"12","reason":"epilog failed for jobid fehab5PQi4P","overwrite":0}}
+{"timestamp":1700065086.8803043,"name":"drain","context":{"idset":"15","reason":"epilog failed for jobid fehabAM2JjH","overwrite":0}}
+{"timestamp":1700065086.8805048,"name":"drain","context":{"idset":"16","reason":"epilog failed for jobid fehabB7VwBd","overwrite":0}}
+{"timestamp":1700065086.9771562,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1700070405.6457081,"name":"drain","context":{"idset":"8","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1700070528.8796451,"name":"drain","context":{"idset":"8","reason":"epilog failed for jobid feh7YDLq7Ys","overwrite":0}}
+{"timestamp":1700070528.9768076,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1700071532.9770131,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1700076369.9128747,"name":"drain","context":{"idset":"7","reason":"prolog failed for jobid fevPmv1M4nb","overwrite":0}}
+{"timestamp":1700078303.4495046,"name":"online","context":{"idset":"16"}}
+{"timestamp":1700078303.8907287,"name":"online","context":{"idset":"8"}}
+{"timestamp":1700078304.2167811,"name":"online","context":{"idset":"5,12"}}
+{"timestamp":1700078304.384872,"name":"online","context":{"idset":"15"}}
+{"timestamp":1700089031.8503606,"name":"undrain","context":{"idset":"5,8,12,15-16"}}
+{"timestamp":1700159042.9772828,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1700159736.7272673,"name":"drain","context":{"idset":"6-7","reason":"power","overwrite":1}}
+{"timestamp":1700172915.8992052,"name":"online","context":{"idset":"7"}}
+{"timestamp":1700172934.300209,"name":"undrain","context":{"idset":"6-7"}}
+{"timestamp":1700208688.4000249,"name":"drain","context":{"idset":"18","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1700243939.8287182,"name":"drain","context":{"idset":"16","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1700258828.4672754,"name":"drain","context":{"idset":"3-4,6-7,10,13,26-29,31-36","reason":"prolog failed for jobid ffLD89qKQUP","overwrite":0}}
+{"timestamp":1700266384.8764987,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1700266384.8766551,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1700266384.8767509,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1700266384.876847,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1700266384.8769641,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1700266384.8771141,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1700266384.8772485,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1700266384.8774004,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1700266384.8774958,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1700266384.8776093,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1700266384.8777108,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1700266384.8777995,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1700266384.8779044,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1700266384.8779888,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1700266384.8780749,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1700266384.9767907,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1700267472.818424,"name":"online","context":{"idset":"35"}}
+{"timestamp":1700267472.8771179,"name":"online","context":{"idset":"34"}}
+{"timestamp":1700267473.0915711,"name":"online","context":{"idset":"36"}}
+{"timestamp":1700267473.2974079,"name":"online","context":{"idset":"10,32"}}
+{"timestamp":1700267473.6894,"name":"online","context":{"idset":"29"}}
+{"timestamp":1700267473.8003049,"name":"online","context":{"idset":"3,7,31"}}
+{"timestamp":1700267474.1726189,"name":"online","context":{"idset":"26,28"}}
+{"timestamp":1700267474.3206975,"name":"online","context":{"idset":"4,6,13"}}
+{"timestamp":1700267474.8321686,"name":"online","context":{"idset":"33"}}
+{"timestamp":1700267483.6822319,"name":"online","context":{"idset":"27"}}
+{"timestamp":1700267590.1225169,"name":"undrain","context":{"idset":"3-4,6-7,10,13,26-29,31-36"}}
+{"timestamp":1700349290.2823999,"name":"drain","context":{"idset":"3","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1700396138.7971628,"name":"drain","context":{"idset":"5","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1700397056.8089654,"name":"drain","context":{"idset":"7","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1700506100.9769244,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1700506102.8764036,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1700506102.8765171,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1700506102.8766017,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1700506102.9765563,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1700507850.0688097,"name":"online","context":{"idset":"5"}}
+{"timestamp":1700507850.3549366,"name":"online","context":{"idset":"3,18"}}
+{"timestamp":1700507850.727433,"name":"online","context":{"idset":"7,16"}}
+{"timestamp":1700507973.7227995,"name":"undrain","context":{"idset":"3,5,7,16,18"}}
+{"timestamp":1700528095.3053153,"name":"resource-init","context":{"restart":true,"drain":{"30":{"timestamp":1699489159.5188849,"reason":"slingshot"}},"online":"","exclude":"0-2"}}
+{"timestamp":1700528095.3161066,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1700528195.8459127,"name":"online","context":{"idset":"0"}}
+{"timestamp":1700528196.5190885,"name":"online","context":{"idset":"1,9,11,24,30"}}
+{"timestamp":1700528196.9206679,"name":"online","context":{"idset":"14,22"}}
+{"timestamp":1700528197.351217,"name":"online","context":{"idset":"10,19,21,25"}}
+{"timestamp":1700528197.4799309,"name":"online","context":{"idset":"12,20,33,35"}}
+{"timestamp":1700528197.5915165,"name":"online","context":{"idset":"26,29,34,36"}}
+{"timestamp":1700528197.721211,"name":"online","context":{"idset":"17,23"}}
+{"timestamp":1700528197.8893113,"name":"online","context":{"idset":"3-8,13,15-16,18,28,32"}}
+{"timestamp":1700528198.0259795,"name":"online","context":{"idset":"31"}}
+{"timestamp":1700528198.155797,"name":"online","context":{"idset":"27"}}
+{"timestamp":1700528254.0412312,"name":"drain","context":{"idset":"37-38","reason":"bringup","overwrite":0}}
+{"timestamp":1700528575.4661686,"name":"online","context":{"idset":"37"}}
+{"timestamp":1700528577.0804734,"name":"online","context":{"idset":"38"}}
+{"timestamp":1700529152.3117254,"name":"undrain","context":{"idset":"37-38"}}
+{"timestamp":1700529171.5986621,"name":"drain","context":{"idset":"37-38","reason":"bringup","overwrite":0}}
+{"timestamp":1700536160.8567002,"name":"online","context":{"idset":"2"}}
+{"timestamp":1700541684.5625112,"name":"drain","context":{"idset":"5","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1700587860.9530828,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1700588006.9533737,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1700588645.7332644,"name":"online","context":{"idset":"5"}}
+{"timestamp":1700588664.8276482,"name":"undrain","context":{"idset":"5"}}
+{"timestamp":1700588768.5785282,"name":"online","context":{"idset":"37"}}
+{"timestamp":1700588952.9534194,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1700591890.9532151,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1700593384.6241543,"name":"online","context":{"idset":"38"}}
+{"timestamp":1700594421.3975861,"name":"online","context":{"idset":"37"}}
+{"timestamp":1700594460.6090927,"name":"undrain","context":{"idset":"37-38"}}
+{"timestamp":1700598087.4373732,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1700598242.2822433,"name":"drain","context":{"idset":"19","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1700598243.248647,"name":"drain","context":{"idset":"20","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1700598248.2793508,"name":"drain","context":{"idset":"23","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1700598993.0988183,"name":"online","context":{"idset":"1"}}
+{"timestamp":1700601420.8410716,"name":"drain","context":{"idset":"16","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1700601548.8526855,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1700601548.8528366,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1700601548.952945,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1700602474.8535249,"name":"online","context":{"idset":"20"}}
+{"timestamp":1700602475.0568032,"name":"online","context":{"idset":"19"}}
+{"timestamp":1700602478.2918952,"name":"online","context":{"idset":"23"}}
+{"timestamp":1700602503.5103755,"name":"undrain","context":{"idset":"19-20,23"}}
+{"timestamp":1700606476.9530838,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1700607587.0649736,"name":"online","context":{"idset":"16"}}
+{"timestamp":1700607610.5347455,"name":"undrain","context":{"idset":"16"}}
+{"timestamp":1700607850.80937,"name":"drain","context":{"idset":"30","reason":"INC0387666 slingshot","overwrite":1}}
+{"timestamp":1700640683.2579532,"name":"drain","context":{"idset":"6","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1700674784.9530308,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1700675551.2108107,"name":"online","context":{"idset":"6"}}
+{"timestamp":1700675565.4636285,"name":"undrain","context":{"idset":"6"}}
+{"timestamp":1700677464.9535511,"name":"drain","context":{"idset":"22","reason":"broker was unresponsive"}}
+{"timestamp":1700677478.9534569,"name":"drain","context":{"idset":"26","reason":"broker was unresponsive"}}
+{"timestamp":1700683112.8529162,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1700683112.953594,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1700683864.490814,"name":"online","context":{"idset":"26"}}
+{"timestamp":1700683864.6018417,"name":"online","context":{"idset":"22"}}
+{"timestamp":1700683878.6395471,"name":"undrain","context":{"idset":"22,26"}}
+{"timestamp":1700695360.9541607,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1700697112.9542968,"name":"drain","context":{"idset":"13","reason":"broker was unresponsive"}}
+{"timestamp":1700697362.9534664,"name":"drain","context":{"idset":"12","reason":"broker was unresponsive"}}
+{"timestamp":1700709360.953629,"name":"drain","context":{"idset":"20","reason":"broker was unresponsive"}}
+{"timestamp":1700709442.9539337,"name":"drain","context":{"idset":"33","reason":"broker was unresponsive"}}
+{"timestamp":1700709534.9525211,"name":"drain","context":{"idset":"35","reason":"broker was unresponsive"}}
+{"timestamp":1700727541.2388046,"name":"drain","context":{"idset":"16","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1700765251.6028256,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1700765251.6220119,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1700765251.656575,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1700765251.7570655,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1700765252.1407251,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1700765252.2413249,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1700766830.7990587,"name":"online","context":{"idset":"12"}}
+{"timestamp":1700766834.232316,"name":"online","context":{"idset":"33"}}
+{"timestamp":1700766837.192215,"name":"online","context":{"idset":"13"}}
+{"timestamp":1700766837.7811439,"name":"online","context":{"idset":"20"}}
+{"timestamp":1700767085.9624467,"name":"online","context":{"idset":"35"}}
+{"timestamp":1700767135.4771924,"name":"undrain","context":{"idset":"12-13,20,33,35"}}
+{"timestamp":1700813475.2471993,"name":"drain","context":{"idset":"12","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1700852049.1028593,"name":"drain","context":{"idset":"34","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1700852172.8564291,"name":"drain","context":{"idset":"34","reason":"epilog failed for jobid fgUaagfW7hH","overwrite":0}}
+{"timestamp":1700852172.9532881,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1700860036.4205709,"name":"drain","context":{"idset":"11","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1700860036.4478204,"name":"drain","context":{"idset":"15","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1700860036.458883,"name":"drain","context":{"idset":"7","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1700860158.8532872,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1700860158.8534117,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1700860158.8569019,"name":"drain","context":{"idset":"7,11,15","reason":"epilog failed for jobid fgTkwYZNFQj","overwrite":0}}
+{"timestamp":1700860158.9536226,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1701000963.4046471,"name":"drain","context":{"idset":"4","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1701052437.3778055,"name":"drain","context":{"idset":"27","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701052512.6240931,"name":"drain","context":{"idset":"36","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701052890.3582969,"name":"drain","context":{"idset":"35","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701063980.9528418,"name":"drain","context":{"idset":"18","reason":"broker was unresponsive"}}
+{"timestamp":1701064186.953969,"name":"drain","context":{"idset":"24","reason":"broker was unresponsive"}}
+{"timestamp":1701064976.9536586,"name":"drain","context":{"idset":"28","reason":"broker was unresponsive"}}
+{"timestamp":1701065368.9544134,"name":"drain","context":{"idset":"26","reason":"broker was unresponsive"}}
+{"timestamp":1701065718.953711,"name":"drain","context":{"idset":"29","reason":"broker was unresponsive"}}
+{"timestamp":1701065826.9545522,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1701065874.954386,"name":"drain","context":{"idset":"10","reason":"broker was unresponsive"}}
+{"timestamp":1701105958.9526954,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1701105960.8530724,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1701105960.8532269,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1701105960.8533654,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1701105960.8535094,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1701105960.8536546,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1701105960.8538096,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1701105960.8539543,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1701105960.8540728,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1701105960.8541956,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1701105960.854322,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1701105960.854434,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1701105960.9534769,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1701106914.7540598,"name":"online","context":{"idset":"34"}}
+{"timestamp":1701106915.2636046,"name":"online","context":{"idset":"36"}}
+{"timestamp":1701106915.4484129,"name":"online","context":{"idset":"35"}}
+{"timestamp":1701106917.1517596,"name":"online","context":{"idset":"29"}}
+{"timestamp":1701106917.4132476,"name":"online","context":{"idset":"18"}}
+{"timestamp":1701106917.5180743,"name":"online","context":{"idset":"5"}}
+{"timestamp":1701106917.7051921,"name":"online","context":{"idset":"28"}}
+{"timestamp":1701106917.8164611,"name":"online","context":{"idset":"10"}}
+{"timestamp":1701106917.9704268,"name":"online","context":{"idset":"4,24"}}
+{"timestamp":1701106918.1437535,"name":"online","context":{"idset":"15"}}
+{"timestamp":1701106918.3250985,"name":"online","context":{"idset":"11-12,16"}}
+{"timestamp":1701106918.579062,"name":"online","context":{"idset":"27"}}
+{"timestamp":1701106919.5485005,"name":"online","context":{"idset":"7"}}
+{"timestamp":1701106920.8930874,"name":"online","context":{"idset":"9"}}
+{"timestamp":1701106923.1337166,"name":"online","context":{"idset":"26"}}
+{"timestamp":1701106950.991709,"name":"undrain","context":{"idset":"4-5,7,9-12,15-16,18,24,26-29,34-36"}}
+{"timestamp":1701126562.9535944,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1701126564.9539931,"name":"drain","context":{"idset":"38","reason":"broker was unresponsive"}}
+{"timestamp":1701126626.8526976,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1701126626.952862,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1701127447.9797184,"name":"online","context":{"idset":"37"}}
+{"timestamp":1701127449.6792653,"name":"online","context":{"idset":"38"}}
+{"timestamp":1701127472.5349426,"name":"undrain","context":{"idset":"37-38"}}
+{"timestamp":1701129232.7590051,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1701130471.0113797,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1701130644.1098347,"name":"online","context":{"idset":"38"}}
+{"timestamp":1701159081.3354793,"name":"drain","context":{"idset":"6","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701192684.952827,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1701193590.9541714,"name":"online","context":{"idset":"6"}}
+{"timestamp":1701193616.0303135,"name":"undrain","context":{"idset":"6"}}
+{"timestamp":1701194679.1422541,"name":"online","context":{"idset":"37"}}
+{"timestamp":1701215866.8780124,"name":"drain","context":{"idset":"33","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1701215989.9989283,"name":"drain","context":{"idset":"33","reason":"epilog failed for jobid fhJG9B7kMQb","overwrite":0}}
+{"timestamp":1701215990.1645505,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1701221094.8531473,"name":"online","context":{"idset":"33"}}
+{"timestamp":1701221110.2168121,"name":"undrain","context":{"idset":"33"}}
+{"timestamp":1701221890.2115817,"name":"drain","context":{"idset":"5","reason":"prolog failed for jobid fhWNRgYYF75","overwrite":0}}
+{"timestamp":1701260201.7623339,"name":"drain","context":{"idset":"4","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1701281064.8525774,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1701281064.9530203,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1701282351.7328186,"name":"online","context":{"idset":"5"}}
+{"timestamp":1701282352.0775335,"name":"online","context":{"idset":"4"}}
+{"timestamp":1701282385.9530389,"name":"undrain","context":{"idset":"4-5"}}
+{"timestamp":1701297107.1814916,"name":"drain","context":{"idset":"34","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1701297107.7543116,"name":"drain","context":{"idset":"36","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1701297228.8559952,"name":"drain","context":{"idset":"34","reason":"epilog failed for jobid fhUuSHVww5H","overwrite":0}}
+{"timestamp":1701297228.9535019,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1701297230.8563724,"name":"drain","context":{"idset":"36","reason":"epilog failed for jobid fhUuSWTbex7","overwrite":0}}
+{"timestamp":1701297230.9537764,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1701302862.9531925,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1701303128.6111143,"name":"drain","context":{"idset":"37","reason":"epilog failed for jobid fhgfgzikswM","overwrite":0}}
+{"timestamp":1701304202.9529107,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1701305288.477783,"name":"online","context":{"idset":"37"}}
+{"timestamp":1701305289.7210245,"name":"online","context":{"idset":"36"}}
+{"timestamp":1701305289.9497516,"name":"online","context":{"idset":"34"}}
+{"timestamp":1701305315.9905713,"name":"undrain","context":{"idset":"34,36-37"}}
+{"timestamp":1701319936.082268,"name":"drain","context":{"idset":"26","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701358972.047065,"name":"drain","context":{"idset":"15","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1701358972.066498,"name":"drain","context":{"idset":"12","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1701359094.853497,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1701359094.8568695,"name":"drain","context":{"idset":"12,15","reason":"epilog failed for jobid fhcrckaxLoZ","overwrite":0}}
+{"timestamp":1701359094.9535708,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1701365952.9527454,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1701366925.2531323,"name":"online","context":{"idset":"12"}}
+{"timestamp":1701366925.4867017,"name":"online","context":{"idset":"26"}}
+{"timestamp":1701366925.7637291,"name":"online","context":{"idset":"15"}}
+{"timestamp":1701366961.4027386,"name":"undrain","context":{"idset":"12,15,26"}}
+{"timestamp":1701373221.5968745,"name":"drain","context":{"idset":"14","reason":"prolog failed for jobid fhrCJsjV29D","overwrite":0}}
+{"timestamp":1701392691.8721631,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1701392695.8550963,"name":"drain","context":{"idset":"38","reason":"epilog failed for jobid fhh2SZJaKa7","overwrite":0}}
+{"timestamp":1701392695.9527285,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1701393930.0869064,"name":"online","context":{"idset":"38"}}
+{"timestamp":1701393994.6838474,"name":"undrain","context":{"idset":"38"}}
+{"timestamp":1701394951.7747519,"name":"online","context":{"idset":"37"}}
+{"timestamp":1701418290.3531911,"name":"drain","context":{"idset":"12","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701449289.6232569,"name":"drain","context":{"idset":"33","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1701449412.8565145,"name":"drain","context":{"idset":"33","reason":"epilog failed for jobid fhpqiPR3BHh","overwrite":0}}
+{"timestamp":1701449412.953402,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1701475408.9530563,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1701478980.3553545,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1701478980.3554902,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1701478980.4553776,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1701479979.6894453,"name":"online","context":{"idset":"33"}}
+{"timestamp":1701479981.4392173,"name":"online","context":{"idset":"14"}}
+{"timestamp":1701479981.5758379,"name":"online","context":{"idset":"8"}}
+{"timestamp":1701479981.7810931,"name":"online","context":{"idset":"12"}}
+{"timestamp":1701479996.6731365,"name":"undrain","context":{"idset":"8,12,14,33"}}
+{"timestamp":1701677487.7598543,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701716423.6854734,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1701716479.3822803,"name":"drain","context":{"idset":"37","reason":"rank 37 got hostname 'fake49', expected 'fake48'","overwrite":0}}
+{"timestamp":1701716479.7590168,"name":"online","context":{"idset":"37"}}
+{"timestamp":1701716517.2845697,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1701716533.4856949,"name":"online","context":{"idset":"38"}}
+{"timestamp":1701716776.9533837,"name":"drain","context":{"idset":"26","reason":"broker was unresponsive"}}
+{"timestamp":1701716840.9528441,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1701716849.9518716,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1701716853.9477618,"name":"online","context":{"idset":"37"}}
+{"timestamp":1701716918.9912782,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1701716980.3091452,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1701716989.9850876,"name":"online","context":{"idset":"37"}}
+{"timestamp":1701717430.9535971,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1701721997.7595863,"name":"online","context":{"idset":"26"}}
+{"timestamp":1701721997.879786,"name":"online","context":{"idset":"7"}}
+{"timestamp":1701722128.8029187,"name":"undrain","context":{"idset":"7,26"}}
+{"timestamp":1701766276.7053413,"name":"drain","context":{"idset":"29","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701778667.1842024,"name":"drain","context":{"idset":"4","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1701795901.8405099,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1701795901.9413099,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1701796767.7301815,"name":"online","context":{"idset":"29"}}
+{"timestamp":1701796768.1676579,"name":"online","context":{"idset":"4"}}
+{"timestamp":1701796794.877584,"name":"undrain","context":{"idset":"4,29"}}
+{"timestamp":1701812895.4540799,"name":"drain","context":{"idset":"29","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701812896.2534604,"name":"drain","context":{"idset":"33","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701812896.5196271,"name":"drain","context":{"idset":"31","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701812896.7873545,"name":"drain","context":{"idset":"24","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701812897.5567648,"name":"drain","context":{"idset":"28","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701812898.799644,"name":"drain","context":{"idset":"27","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701812901.2077107,"name":"drain","context":{"idset":"32","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701818792.2969351,"name":"drain","context":{"idset":"37","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1701818914.8560069,"name":"drain","context":{"idset":"37","reason":"epilog failed for jobid fif1kg1Ckr3","overwrite":0}}
+{"timestamp":1701818914.9531524,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1701823138.853173,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1701823138.9532938,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1701823140.8525681,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1701823140.85267,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1701823140.8527598,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1701823140.8528514,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1701823140.9533591,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1701824096.4172492,"name":"online","context":{"idset":"37"}}
+{"timestamp":1701824097.7542925,"name":"online","context":{"idset":"24,29,31"}}
+{"timestamp":1701824098.0622606,"name":"online","context":{"idset":"27"}}
+{"timestamp":1701824098.2181828,"name":"online","context":{"idset":"32"}}
+{"timestamp":1701824098.4493425,"name":"online","context":{"idset":"28"}}
+{"timestamp":1701824269.3116562,"name":"undrain","context":{"idset":"24,27-29,31-32,37"}}
+{"timestamp":1701824371.3500421,"name":"online","context":{"idset":"33"}}
+{"timestamp":1701824419.8681149,"name":"undrain","context":{"idset":"33"}}
+{"timestamp":1701851036.3875821,"name":"drain","context":{"idset":"13","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701878758.9535968,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1701878820.2483778,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1701882800.1549294,"name":"drain","context":{"idset":"37","reason":"PY: fixing ansible","overwrite":1}}
+{"timestamp":1701883306.8476236,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1701884948.8141625,"name":"online","context":{"idset":"13"}}
+{"timestamp":1701885095.779413,"name":"undrain","context":{"idset":"13"}}
+{"timestamp":1701910907.5715537,"name":"drain","context":{"idset":"19","reason":"prolog failed for jobid fj4dt1qoP5H","overwrite":0}}
+{"timestamp":1701910998.4841919,"name":"drain","context":{"idset":"20","reason":"prolog failed for jobid fj4ea2PBEg7","overwrite":0}}
+{"timestamp":1701910999.6706903,"name":"drain","context":{"idset":"24","reason":"prolog failed for jobid fj4eaZrBzab","overwrite":0}}
+{"timestamp":1701911000.6049147,"name":"drain","context":{"idset":"25","reason":"prolog failed for jobid fj4eb1BPirK","overwrite":0}}
+{"timestamp":1701911001.2846067,"name":"drain","context":{"idset":"26","reason":"prolog failed for jobid fj4ebR18BVh","overwrite":0}}
+{"timestamp":1701911002.1896272,"name":"drain","context":{"idset":"27","reason":"prolog failed for jobid fj4ebiHKozo","overwrite":0}}
+{"timestamp":1701911002.9842908,"name":"drain","context":{"idset":"29,31","reason":"prolog failed for jobid fj4ecBTGeZM","overwrite":0}}
+{"timestamp":1701911003.9599996,"name":"drain","context":{"idset":"13-14","reason":"prolog failed for jobid fj4ecTncjdh","overwrite":0}}
+{"timestamp":1701911004.9687643,"name":"drain","context":{"idset":"18,32","reason":"prolog failed for jobid fj4ecw1XYkw","overwrite":0}}
+{"timestamp":1701911504.7977931,"name":"undrain","context":{"idset":"13-14,18-20,24-27,29,31-32"}}
+{"timestamp":1701963445.8773975,"name":"online","context":{"idset":"37"}}
+{"timestamp":1701963480.7096951,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1701968351.5623353,"name":"drain","context":{"idset":"34,36","reason":"PY: reboot to clear stuck vgs command","overwrite":0}}
+{"timestamp":1701968543.515173,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1701968543.6161551,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1701969432.0619378,"name":"online","context":{"idset":"36"}}
+{"timestamp":1701969433.5945344,"name":"online","context":{"idset":"34"}}
+{"timestamp":1701969527.6011508,"name":"undrain","context":{"idset":"34,36"}}
+{"timestamp":1701978395.1557112,"name":"drain","context":{"idset":"15","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701978396.3450153,"name":"drain","context":{"idset":"19","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1701978401.2024601,"name":"drain","context":{"idset":"18","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1702023464.0420282,"name":"drain","context":{"idset":"21","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1702037737.4594746,"name":"drain","context":{"idset":"5","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1702059012.852978,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1702059012.8531165,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1702059012.8532057,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1702059012.8533256,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1702059012.9534004,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1702067451.4339504,"name":"online","context":{"idset":"15"}}
+{"timestamp":1702067451.5392158,"name":"online","context":{"idset":"5,18"}}
+{"timestamp":1702067451.6909463,"name":"online","context":{"idset":"21"}}
+{"timestamp":1702067452.2679474,"name":"online","context":{"idset":"19"}}
+{"timestamp":1702067476.0392332,"name":"undrain","context":{"idset":"5,15,18-19,21"}}
+{"timestamp":1702068010.6769617,"name":"drain","context":{"idset":"29","reason":"HPE broken partner","overwrite":0}}
+{"timestamp":1702068155.2566652,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1702068194.7452779,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1702074503.368654,"name":"online","context":{"idset":"30"}}
+{"timestamp":1702074536.8337717,"name":"undrain","context":{"idset":"30"}}
+{"timestamp":1702075658.4518621,"name":"online","context":{"idset":"29"}}
+{"timestamp":1702075680.1610546,"name":"undrain","context":{"idset":"29"}}
+{"timestamp":1702124234.7505603,"name":"drain","context":{"idset":"4","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1702210587.2471874,"name":"drain","context":{"idset":"5","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1702245018.9540093,"name":"drain","context":{"idset":"38","reason":"broker was unresponsive"}}
+{"timestamp":1702245080.8915226,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1702274170.9542608,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1702274232.9537771,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702274393.2229354,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1702274393.3234415,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1702274451.3240116,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1702274451.3420672,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1702274451.3435495,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1702274451.3528678,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1702274451.3617544,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1702274451.3647869,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1702274451.3651228,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1702274451.3689363,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1702274451.371609,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1702274451.3717117,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1702274451.3741186,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1702274451.375289,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1702274451.3785677,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1702274451.3821907,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1702274451.3832026,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1702274451.3834455,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1702274451.3899031,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1702274451.3915849,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1702274451.3974776,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1702274451.4005067,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1702274451.40362,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1702274451.4213212,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1702274451.4247935,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1702274451.4255688,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1702274451.4386511,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1702274451.4390132,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1702274451.4580169,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1702274451.4805262,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1702274451.5584519,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1702274451.5711403,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1702274451.5757923,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1702274451.6080027,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1702274451.7088685,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1702274451.9065208,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1702276207.7201791,"name":"resource-init","context":{"restart":true,"drain":{"4":{"timestamp":1702124234.7505603,"reason":"nodediag failed clocksource"},"5":{"timestamp":1702210587.2471874,"reason":"nodediag failed clocksource"},"37":{"timestamp":1702274170.9542608,"reason":"broker was unresponsive"},"38":{"timestamp":1702245018.9540093,"reason":"broker was unresponsive"}},"online":"","exclude":"0-2"}}
+{"timestamp":1702276207.7318258,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1702276349.1935189,"name":"online","context":{"idset":"0"}}
+{"timestamp":1702277097.2154074,"name":"online","context":{"idset":"2"}}
+{"timestamp":1702277097.8842518,"name":"online","context":{"idset":"17,25"}}
+{"timestamp":1702277098.2104175,"name":"online","context":{"idset":"1,33"}}
+{"timestamp":1702277098.3544037,"name":"online","context":{"idset":"3,6,34-36"}}
+{"timestamp":1702277098.5333254,"name":"online","context":{"idset":"8"}}
+{"timestamp":1702277098.7339046,"name":"online","context":{"idset":"10,18"}}
+{"timestamp":1702277098.8607471,"name":"online","context":{"idset":"9,14,22"}}
+{"timestamp":1702277098.9648981,"name":"online","context":{"idset":"7,13,15-16,29"}}
+{"timestamp":1702277099.1237836,"name":"online","context":{"idset":"11-12,26,28,30-32"}}
+{"timestamp":1702277099.281203,"name":"online","context":{"idset":"19,23"}}
+{"timestamp":1702277099.4191446,"name":"online","context":{"idset":"20-21,24,27"}}
+{"timestamp":1702277492.9462025,"name":"online","context":{"idset":"4-5"}}
+{"timestamp":1702277523.3593323,"name":"undrain","context":{"idset":"4-5"}}
+{"timestamp":1702277983.7360792,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1702278830.7754617,"name":"online","context":{"idset":"33"}}
+{"timestamp":1702280100.875088,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702280102.0336528,"name":"online","context":{"idset":"38"}}
+{"timestamp":1702280592.8421693,"name":"undrain","context":{"idset":"37-38"}}
+{"timestamp":1702282440.4214761,"name":"online","context":{"idset":"40"}}
+{"timestamp":1702282440.587117,"name":"online","context":{"idset":"39"}}
+{"timestamp":1702283414.2176678,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1702283668.7954352,"name":"drain","context":{"idset":"40","reason":"nodediag failed dmi","overwrite":0}}
+{"timestamp":1702284385.7253036,"name":"undrain","context":{"idset":"40"}}
+{"timestamp":1702286618.7669322,"name":"online","context":{"idset":"39"}}
+{"timestamp":1702298778.195142,"name":"drain","context":{"idset":"5","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1702308812.1210415,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1702308812.1219859,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1702308812.1270146,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1702308812.1961768,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1702308812.1988029,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1702308812.2002356,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1702308812.2037203,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1702308812.2044513,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1702308812.2087283,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1702308812.2216442,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1702308812.223887,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1702308812.2281246,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1702308812.2290885,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1702308812.2352684,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1702308812.2385743,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1702308812.239598,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1702308812.2434587,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1702308812.2435801,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1702308812.2479947,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1702308812.2504306,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1702308812.2543991,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1702308812.2569563,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1702308812.266587,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1702308812.2690885,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1702308812.2697146,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702308812.2706609,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1702308812.2719796,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1702308812.2949955,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1702308812.2960951,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1702308812.3019445,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1702308812.3108439,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1702308812.3192089,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1702308812.3245025,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1702308812.3342228,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1702308812.382365,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1702308812.3988628,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1702308812.4292569,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1702308812.4577823,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1702308812.493525,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1702308812.5944772,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1702309131.6121182,"name":"resource-init","context":{"restart":true,"drain":{"5":{"timestamp":1702298778.195142,"reason":"nodediag failed clocksource"}},"online":"","exclude":"0-2"}}
+{"timestamp":1702309131.6208649,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1702309272.1151943,"name":"online","context":{"idset":"0"}}
+{"timestamp":1702309272.7324517,"name":"online","context":{"idset":"1-2,37-38,40"}}
+{"timestamp":1702309272.9053628,"name":"online","context":{"idset":"39"}}
+{"timestamp":1702309273.3336928,"name":"online","context":{"idset":"17,25,33"}}
+{"timestamp":1702309273.7654843,"name":"online","context":{"idset":"34"}}
+{"timestamp":1702309273.8711681,"name":"online","context":{"idset":"35-36"}}
+{"timestamp":1702309274.1371846,"name":"online","context":{"idset":"5,19"}}
+{"timestamp":1702309274.3497546,"name":"online","context":{"idset":"21,31-32"}}
+{"timestamp":1702309274.4709182,"name":"online","context":{"idset":"9"}}
+{"timestamp":1702309274.577786,"name":"online","context":{"idset":"26"}}
+{"timestamp":1702309274.6836348,"name":"online","context":{"idset":"3,10,13,24,30"}}
+{"timestamp":1702309274.7857888,"name":"online","context":{"idset":"7,11,14,27-29"}}
+{"timestamp":1702309274.8959508,"name":"online","context":{"idset":"4,6,8,12,15-16,18,20,22-23"}}
+{"timestamp":1702310232.5106225,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1702310232.5130959,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702310232.513654,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1702310232.5207326,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1702310232.5208516,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1702310232.5210075,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1702310232.5211031,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1702310232.5211833,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1702310232.521265,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1702310232.5213451,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1702310232.5214245,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1702310232.5214963,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1702310232.5215714,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1702310232.5216427,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1702310232.5217147,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1702310232.5217888,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1702310232.5218551,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1702310232.5219283,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1702310232.5219948,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1702310232.522063,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1702310232.5221269,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1702310232.5221896,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1702310232.5222497,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1702310232.5223093,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1702310232.5223691,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1702310232.5224376,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1702310232.5225344,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1702310232.5226185,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1702310232.5226903,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1702310232.5227616,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1702310232.5228486,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1702310232.5229206,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1702310232.5229819,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1702310232.5230262,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1702310232.5230718,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1702310232.5231109,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1702310232.5231521,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1702310232.5231912,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1702310232.6214869,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1702310232.7294195,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1702310280.6637087,"name":"resource-init","context":{"restart":true,"drain":{"5":{"timestamp":1702298778.195142,"reason":"nodediag failed clocksource"}},"online":"","exclude":"0-2"}}
+{"timestamp":1702310280.6763558,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1702310422.1774747,"name":"online","context":{"idset":"0"}}
+{"timestamp":1702310422.5893102,"name":"online","context":{"idset":"37-40"}}
+{"timestamp":1702310422.8579738,"name":"online","context":{"idset":"1-2,17,25"}}
+{"timestamp":1702310423.5986114,"name":"online","context":{"idset":"33-36"}}
+{"timestamp":1702310424.2028623,"name":"online","context":{"idset":"6,26-32"}}
+{"timestamp":1702310424.303607,"name":"online","context":{"idset":"4-5,7-16"}}
+{"timestamp":1702310424.5019128,"name":"online","context":{"idset":"3"}}
+{"timestamp":1702310424.6107025,"name":"online","context":{"idset":"18-24"}}
+{"timestamp":1702337161.0397501,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1702337223.0765028,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702341025.0403366,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1702342008.4741027,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702342009.6231403,"name":"online","context":{"idset":"5"}}
+{"timestamp":1702342051.7974765,"name":"undrain","context":{"idset":"5"}}
+{"timestamp":1702342054.2306139,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1702349179.0398324,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1702349239.6942458,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702349401.0386865,"name":"drain","context":{"idset":"39","reason":"broker was unresponsive"}}
+{"timestamp":1702349463.1146221,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1702350507.0402167,"name":"drain","context":{"idset":"40","reason":"broker was unresponsive"}}
+{"timestamp":1702350571.0397055,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1702354121.4120078,"name":"drain","context":{"idset":"3","reason":"prolog failed for jobid fk39HALdZEX","overwrite":0}}
+{"timestamp":1702399094.8263469,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702399095.5832965,"name":"online","context":{"idset":"40"}}
+{"timestamp":1702400806.6579204,"name":"undrain","context":{"idset":"37,40"}}
+{"timestamp":1702401575.4470444,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1702401933.0393498,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1702402702.8123894,"name":"online","context":{"idset":"1"}}
+{"timestamp":1702403106.0567842,"name":"online","context":{"idset":"3"}}
+{"timestamp":1702403177.0554161,"name":"undrain","context":{"idset":"3"}}
+{"timestamp":1702410074.5838664,"name":"drain","context":{"idset":"28","reason":"prolog failed for jobid fkAUSFEwZHZ","overwrite":0}}
+{"timestamp":1702410526.8299801,"name":"online","context":{"idset":"39"}}
+{"timestamp":1702411473.9227118,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1702411558.7064481,"name":"undrain","context":{"idset":"39"}}
+{"timestamp":1702411616.4302118,"name":"online","context":{"idset":"39"}}
+{"timestamp":1702411631.3031528,"name":"drain","context":{"idset":"39","reason":"PY: testing","overwrite":0}}
+{"timestamp":1702412527.0392172,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1702413294.9220665,"name":"online","context":{"idset":"28"}}
+{"timestamp":1702413314.4278688,"name":"undrain","context":{"idset":"28"}}
+{"timestamp":1702424187.0402038,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1702424247.6741664,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702424519.4449563,"name":"undrain","context":{"idset":"39"}}
+{"timestamp":1702427554.2943933,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702427891.2274237,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1702455087.0223324,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1702488683.039556,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1702489455.0401332,"name":"online","context":{"idset":"7"}}
+{"timestamp":1702495684.8998308,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1702495808.5808952,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1702496854.3403103,"name":"online","context":{"idset":"1"}}
+{"timestamp":1702506522.8454924,"name":"drain","context":{"idset":"8","reason":"prolog failed for jobid fkP7Hri4UM5","overwrite":0}}
+{"timestamp":1702511237.0398281,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1702512096.1238697,"name":"online","context":{"idset":"8"}}
+{"timestamp":1702512117.7957139,"name":"undrain","context":{"idset":"8"}}
+{"timestamp":1702520399.0400796,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1702520461.0391576,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702529532.5290723,"name":"drain","context":{"idset":"16","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1702530149.239682,"name":"drain","context":{"idset":"22","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1702556884.1671352,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702560019.74124,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1702563257.0400224,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1702563321.0400693,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702572051.0398183,"name":"drain","context":{"idset":"39","reason":"broker was unresponsive"}}
+{"timestamp":1702572112.3739946,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1702573305.469384,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702573413.8514426,"name":"online","context":{"idset":"39"}}
+{"timestamp":1702573769.4145412,"name":"undrain","context":{"idset":"37,39"}}
+{"timestamp":1702575760.524508,"name":"drain","context":{"idset":"6","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1702575882.4307845,"name":"drain","context":{"idset":"6","reason":"epilog failed for jobid fkKkZMFj32F","overwrite":0}}
+{"timestamp":1702575882.5283887,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1702579723.0405271,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1702579789.0389578,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702581658.7020204,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702581741.6182137,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1702582941.0403638,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1702583002.2153196,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702587094.1938002,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702587132.3235631,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1702587694.9424226,"name":"drain","context":{"idset":"37","reason":"epilog failed for jobid fkZjRrSRkJj","overwrite":0}}
+{"timestamp":1702587695.0398016,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702588206.5553834,"name":"drain","context":{"idset":"9","reason":"prolog failed for jobid fkZoxd8YfYT","overwrite":0}}
+{"timestamp":1702588539.4200974,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702590323.0398645,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702591288.9391472,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702591328.8237958,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1702592892.4924378,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1702592892.4925838,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1702592892.5932083,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1702594719.3096571,"name":"online","context":{"idset":"16"}}
+{"timestamp":1702594719.4391856,"name":"online","context":{"idset":"22"}}
+{"timestamp":1702594719.7527783,"name":"online","context":{"idset":"9"}}
+{"timestamp":1702594721.0406103,"name":"online","context":{"idset":"6"}}
+{"timestamp":1702594808.3496635,"name":"undrain","context":{"idset":"6,9,16,22"}}
+{"timestamp":1702642538.4557698,"name":"drain","context":{"idset":"4","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1702654607.8243327,"name":"drain","context":{"idset":"10","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1702654730.9424093,"name":"drain","context":{"idset":"10","reason":"epilog failed for jobid fkXBiGf3hcb","overwrite":0}}
+{"timestamp":1702654731.0401156,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1702656379.1050396,"name":"drain","context":{"idset":"15","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1702656502.9424868,"name":"drain","context":{"idset":"15","reason":"epilog failed for jobid fkXNqLaHCC7","overwrite":0}}
+{"timestamp":1702656503.039345,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1702666443.0407522,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1702666504.5086689,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702667465.1501162,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702667487.8057892,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1702667665.0402017,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1702667725.2592912,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702668835.6585331,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702668864.001379,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1702685491.0398669,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1702685552.2358146,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1702687309.5363533,"name":"drain","context":{"idset":"3","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1702688171.4812565,"name":"online","context":{"idset":"37"}}
+{"timestamp":1702688941.8244691,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1702749759.040215,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1702868152.1978023,"name":"drain","context":{"idset":"6","reason":"prolog failed for jobid fmCV7Dye2Rd","overwrite":0}}
+{"timestamp":1702920376.9387784,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1702920376.9389367,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1702920377.0386806,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1702921280.5596735,"name":"online","context":{"idset":"6"}}
+{"timestamp":1702921281.0392511,"name":"online","context":{"idset":"10"}}
+{"timestamp":1702921281.2256243,"name":"online","context":{"idset":"3,15"}}
+{"timestamp":1702921281.5373106,"name":"online","context":{"idset":"4"}}
+{"timestamp":1702921416.4519536,"name":"undrain","context":{"idset":"3-4,6,10,15"}}
+{"timestamp":1702923782.5089264,"name":"online","context":{"idset":"14"}}
+{"timestamp":1702973787.6204503,"name":"drain","context":{"idset":"11","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1702990012.9007058,"name":"drain","context":{"idset":"5","reason":"nodediag failed clocksource","overwrite":0}}
+{"timestamp":1703005287.0094831,"name":"resource-init","context":{"restart":true,"drain":{"5":{"timestamp":1702990012.9007058,"reason":"nodediag failed clocksource"},"11":{"timestamp":1702973787.6204503,"reason":"nodediag failed amdgpu"}},"online":"","exclude":"0-2"}}
+{"timestamp":1703005287.0209093,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1703005380.8044343,"name":"online","context":{"idset":"0"}}
+{"timestamp":1703007506.748992,"name":"drain","context":{"idset":"41-42","reason":"PY: A0 blade not installed yet","overwrite":0}}
+{"timestamp":1703017567.9816012,"name":"resource-init","context":{"restart":true,"drain":{"5":{"timestamp":1702990012.9007058,"reason":"nodediag failed clocksource"},"11":{"timestamp":1702973787.6204503,"reason":"nodediag failed amdgpu"},"41-42":{"timestamp":1703007506.748992,"reason":"PY: A0 blade not installed yet"}},"online":"","exclude":"0-2"}}
+{"timestamp":1703017567.9884784,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1703017658.2612751,"name":"online","context":{"idset":"0"}}
+{"timestamp":1703022624.5109766,"name":"online","context":{"idset":"35-36"}}
+{"timestamp":1703022625.70275,"name":"online","context":{"idset":"34"}}
+{"timestamp":1703022627.2973711,"name":"online","context":{"idset":"1"}}
+{"timestamp":1703022627.6679659,"name":"online","context":{"idset":"25,27,30"}}
+{"timestamp":1703022627.8004818,"name":"online","context":{"idset":"9,11,17"}}
+{"timestamp":1703022627.9512756,"name":"online","context":{"idset":"10,21,31"}}
+{"timestamp":1703022628.1422527,"name":"online","context":{"idset":"4,14,18-19,22,24,32"}}
+{"timestamp":1703022628.2432194,"name":"online","context":{"idset":"26,28-29"}}
+{"timestamp":1703022628.5521581,"name":"online","context":{"idset":"3,8,15-16"}}
+{"timestamp":1703022628.6627808,"name":"online","context":{"idset":"5-7,12,20"}}
+{"timestamp":1703023335.8967862,"name":"online","context":{"idset":"33"}}
+{"timestamp":1703023337.052326,"name":"online","context":{"idset":"23"}}
+{"timestamp":1703023337.2780862,"name":"online","context":{"idset":"13"}}
+{"timestamp":1703024553.8917868,"name":"online","context":{"idset":"2"}}
+{"timestamp":1703024606.5306613,"name":"undrain","context":{"idset":"5,11"}}
+{"timestamp":1703027224.0858884,"name":"online","context":{"idset":"37"}}
+{"timestamp":1703027226.2197955,"name":"online","context":{"idset":"38"}}
+{"timestamp":1703027241.508929,"name":"online","context":{"idset":"40"}}
+{"timestamp":1703027298.2163057,"name":"online","context":{"idset":"39"}}
+{"timestamp":1703086629.0763271,"name":"drain","context":{"idset":"21","reason":"broker was unresponsive"}}
+{"timestamp":1703086629.0764401,"name":"drain","context":{"idset":"22","reason":"broker was unresponsive"}}
+{"timestamp":1703086629.0764842,"name":"drain","context":{"idset":"23","reason":"broker was unresponsive"}}
+{"timestamp":1703086629.0765295,"name":"drain","context":{"idset":"27","reason":"broker was unresponsive"}}
+{"timestamp":1703086629.0765724,"name":"drain","context":{"idset":"30","reason":"broker was unresponsive"}}
+{"timestamp":1703086629.0766141,"name":"drain","context":{"idset":"31","reason":"broker was unresponsive"}}
+{"timestamp":1703086629.1771214,"name":"drain","context":{"idset":"32","reason":"broker was unresponsive"}}
+{"timestamp":1703086633.076751,"name":"drain","context":{"idset":"24","reason":"broker was unresponsive"}}
+{"timestamp":1703086633.0768337,"name":"drain","context":{"idset":"25","reason":"broker was unresponsive"}}
+{"timestamp":1703086633.0768745,"name":"drain","context":{"idset":"26","reason":"broker was unresponsive"}}
+{"timestamp":1703086633.0769155,"name":"drain","context":{"idset":"28","reason":"broker was unresponsive"}}
+{"timestamp":1703086633.1771865,"name":"drain","context":{"idset":"29","reason":"broker was unresponsive"}}
+{"timestamp":1703086669.177108,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1703086671.0762548,"name":"drain","context":{"idset":"3","reason":"broker was unresponsive"}}
+{"timestamp":1703086671.0763476,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1703086671.0763965,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1703086671.1764746,"name":"drain","context":{"idset":"10","reason":"broker was unresponsive"}}
+{"timestamp":1703086673.0765722,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1703086673.176594,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1703086675.0760224,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1703086675.1768608,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1703086695.0770924,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1703086695.0776894,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1703086695.078099,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1703086695.0784938,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1703086695.0789032,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1703086695.0792909,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1703086695.0796716,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1703086695.08004,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1703086695.080395,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1703086695.0807636,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1703086695.0811071,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1703086695.1764846,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1703086737.0771942,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1703086737.0776532,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1703086737.0780587,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1703086737.0785234,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1703086737.0788922,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1703086737.1039343,"name":"drain","context":{"idset":"3","reason":"epilog failed for jobid fme4Jz6kJYo","overwrite":0}}
+{"timestamp":1703086737.1042635,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1703086737.1368959,"name":"drain","context":{"idset":"5","reason":"epilog failed for jobid fme4KP2bCL7","overwrite":0}}
+{"timestamp":1703086737.1377397,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1703086737.1641114,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1703086737.191705,"name":"drain","context":{"idset":"10","reason":"prolog failed for jobid fme53QtrDRh","overwrite":0}}
+{"timestamp":1703086737.2234833,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1703095639.074228,"name":"online","context":{"idset":"2"}}
+{"timestamp":1703098931.1762896,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1703098991.1764648,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1703100433.508466,"name":"online","context":{"idset":"37"}}
+{"timestamp":1703100530.5117028,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1703100665.1762986,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1703100725.7727311,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1703103915.177366,"name":"drain","context":{"idset":"39","reason":"broker was unresponsive"}}
+{"timestamp":1703103975.6191986,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1703105606.417419,"name":"drain","context":{"idset":"12","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1703105606.9069738,"name":"drain","context":{"idset":"33","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1703111965.1768701,"name":"drain","context":{"idset":"40","reason":"broker was unresponsive"}}
+{"timestamp":1703112025.7398331,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1703112701.4838443,"name":"online","context":{"idset":"39"}}
+{"timestamp":1703112761.9953258,"name":"undrain","context":{"idset":"39"}}
+{"timestamp":1703112767.9237671,"name":"undrain","context":{"idset":"2"}}
+{"timestamp":1703112919.076087,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1703112919.1764116,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1703113713.8616202,"name":"online","context":{"idset":"37"}}
+{"timestamp":1703113777.6444333,"name":"online","context":{"idset":"40"}}
+{"timestamp":1703113793.5585494,"name":"undrain","context":{"idset":"40"}}
+{"timestamp":1703113834.0246243,"name":"online","context":{"idset":"33"}}
+{"timestamp":1703113834.1924689,"name":"online","context":{"idset":"29"}}
+{"timestamp":1703113835.6727128,"name":"online","context":{"idset":"22"}}
+{"timestamp":1703113835.8911901,"name":"online","context":{"idset":"3,26,28"}}
+{"timestamp":1703113835.9619699,"name":"online","context":{"idset":"9,30"}}
+{"timestamp":1703113836.0874784,"name":"online","context":{"idset":"5,7,12,23,25"}}
+{"timestamp":1703113836.2199962,"name":"online","context":{"idset":"8,10"}}
+{"timestamp":1703113836.4400773,"name":"online","context":{"idset":"6,27,32"}}
+{"timestamp":1703113836.8093512,"name":"online","context":{"idset":"21"}}
+{"timestamp":1703113836.9443181,"name":"online","context":{"idset":"31"}}
+{"timestamp":1703113837.076762,"name":"online","context":{"idset":"24"}}
+{"timestamp":1703113848.7682681,"name":"undrain","context":{"idset":"3,5-10,12,21-33"}}
+{"timestamp":1703113929.8703461,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1703114077.176579,"name":"drain","context":{"idset":"39","reason":"broker was unresponsive"}}
+{"timestamp":1703114143.176676,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1703119224.6683815,"name":"drain","context":{"idset":"4","reason":"PY: stuck at dracut prompt during boot","overwrite":1}}
+{"timestamp":1703133829.0768898,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1703180213.1758702,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1703181414.0066707,"name":"online","context":{"idset":"39"}}
+{"timestamp":1703181484.2031064,"name":"online","context":{"idset":"7"}}
+{"timestamp":1703181493.7081728,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1703181565.7944391,"name":"undrain","context":{"idset":"39"}}
+{"timestamp":1703181643.67327,"name":"drain","context":{"idset":"7","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1703183701.7814758,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1703184318.0241668,"name":"online","context":{"idset":"4"}}
+{"timestamp":1703184371.913034,"name":"undrain","context":{"idset":"4"}}
+{"timestamp":1703184548.309891,"name":"drain","context":{"idset":"7","reason":"nodediag failed pci","overwrite":0}}
+{"timestamp":1703185422.9947088,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1703232674.0035756,"name":"drain","context":{"idset":"11","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1703283363.1774337,"name":"drain","context":{"idset":"38","reason":"broker was unresponsive"}}
+{"timestamp":1703283424.4064424,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1703310063.2960367,"name":"drain","context":{"idset":"36","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1703310185.0779183,"name":"drain","context":{"idset":"36","reason":"epilog failed for jobid fmwzzg2A1sM","overwrite":0}}
+{"timestamp":1703310185.1756499,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1703578271.5332837,"name":"drain","context":{"idset":"8","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1703664679.3936038,"name":"drain","context":{"idset":"4","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1703785589.1773751,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1703785650.6433456,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1703795099.1763301,"name":"drain","context":{"idset":"39","reason":"broker was unresponsive"}}
+{"timestamp":1703795160.274107,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1703796544.1518242,"name":"drain","context":{"idset":"9","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1704084619.847229,"name":"drain","context":{"idset":"10","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1704218341.7785819,"name":"online","context":{"idset":"38"}}
+{"timestamp":1704218498.8216968,"name":"undrain","context":{"idset":"38"}}
+{"timestamp":1704220219.0766718,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1704220219.0771384,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1704220219.0775056,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1704220219.0778596,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1704220219.1766179,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1704221027.7788346,"name":"online","context":{"idset":"37"}}
+{"timestamp":1704221153.0278296,"name":"online","context":{"idset":"36"}}
+{"timestamp":1704221155.6162174,"name":"online","context":{"idset":"8"}}
+{"timestamp":1704221155.8061788,"name":"online","context":{"idset":"11"}}
+{"timestamp":1704221156.0115113,"name":"online","context":{"idset":"4"}}
+{"timestamp":1704221156.4679382,"name":"online","context":{"idset":"9-10"}}
+{"timestamp":1704221194.2381713,"name":"undrain","context":{"idset":"4,8-11,36-37"}}
+{"timestamp":1704221257.1774049,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1704221321.176841,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1704222277.714283,"name":"online","context":{"idset":"37"}}
+{"timestamp":1704222344.9355865,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1704230727.4579914,"name":"drain","context":{"idset":"5","reason":"prolog failed for jobid fpDxPnLxPTV","overwrite":0}}
+{"timestamp":1704304109.175693,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1704304921.6074066,"name":"online","context":{"idset":"5"}}
+{"timestamp":1704304985.1896803,"name":"undrain","context":{"idset":"5"}}
+{"timestamp":1704312765.7163844,"name":"drain","context":{"idset":"39","reason":"JRG: RAS fatal errors in NC /var/log/messages","overwrite":1}}
+{"timestamp":1704315192.4061677,"name":"drain","context":{"idset":"8-9","reason":"prolog failed for jobid fpR2CEDEZwV","overwrite":0}}
+{"timestamp":1704329477.0763071,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1704329477.1766841,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1704330281.0766232,"name":"online","context":{"idset":"9"}}
+{"timestamp":1704330281.785533,"name":"online","context":{"idset":"8"}}
+{"timestamp":1704330300.4311273,"name":"undrain","context":{"idset":"8-9"}}
+{"timestamp":1704346103.3437648,"name":"drain","context":{"idset":"9","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1704393717.1765666,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1704393894.1579807,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1704395021.0693572,"name":"online","context":{"idset":"1"}}
+{"timestamp":1704395084.5798326,"name":"online","context":{"idset":"9"}}
+{"timestamp":1704402321.3310444,"name":"drain","context":{"idset":"29","reason":"prolog failed for jobid fpcSE5u1MCs","overwrite":0}}
+{"timestamp":1704404169.784796,"name":"drain","context":{"idset":"39-40","reason":"PY: updating to latest nC and BIOS firmware","overwrite":1}}
+{"timestamp":1704404317.2961793,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1704405155.0651531,"name":"online","context":{"idset":"40"}}
+{"timestamp":1704416839.0757353,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1704416839.1758513,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1704417227.0403957,"name":"drain","context":{"idset":"4","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704417349.0780368,"name":"drain","context":{"idset":"4","reason":"epilog failed for jobid fpFkz2WCi6s","overwrite":0}}
+{"timestamp":1704417349.1960282,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1704418063.8032138,"name":"online","context":{"idset":"9"}}
+{"timestamp":1704418071.4334302,"name":"online","context":{"idset":"29"}}
+{"timestamp":1704418162.6154728,"name":"undrain","context":{"idset":"9,29"}}
+{"timestamp":1704423012.176228,"name":"online","context":{"idset":"39"}}
+{"timestamp":1704425017.4079537,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1704425440.9206297,"name":"undrain","context":{"idset":"39"}}
+{"timestamp":1704426533.0761485,"name":"online","context":{"idset":"4"}}
+{"timestamp":1704426713.1523278,"name":"undrain","context":{"idset":"4"}}
+{"timestamp":1704427045.1984978,"name":"online","context":{"idset":"40"}}
+{"timestamp":1704427084.2816494,"name":"undrain","context":{"idset":"40"}}
+{"timestamp":1704427122.3931665,"name":"drain","context":{"idset":"37-38","reason":"PY: updating to latest nC and BIOS firmware","overwrite":0}}
+{"timestamp":1704427145.905529,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1704427146.0056887,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1704429477.4677393,"name":"online","context":{"idset":"37"}}
+{"timestamp":1704429513.9227068,"name":"online","context":{"idset":"38"}}
+{"timestamp":1704429549.5674293,"name":"undrain","context":{"idset":"37-38"}}
+{"timestamp":1704430836.5624995,"name":"drain","context":{"idset":"22","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1704468422.2665482,"name":"drain","context":{"idset":"5","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704468545.0782218,"name":"drain","context":{"idset":"5","reason":"epilog failed for jobid fpZgT6iSV35","overwrite":0}}
+{"timestamp":1704468545.1764069,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1704469025.4350758,"name":"drain","context":{"idset":"6","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704469147.0788727,"name":"drain","context":{"idset":"6","reason":"epilog failed for jobid fpZoH2g6167","overwrite":0}}
+{"timestamp":1704469147.1767488,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1704469500.1771808,"name":"drain","context":{"idset":"11","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704469513.5916858,"name":"drain","context":{"idset":"13","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704469623.078299,"name":"drain","context":{"idset":"11","reason":"epilog failed for jobid fpZv45r8KM9","overwrite":0}}
+{"timestamp":1704469623.1757755,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1704469633.6408656,"name":"drain","context":{"idset":"7","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704469637.0790184,"name":"drain","context":{"idset":"13","reason":"epilog failed for jobid fpZv4Ug3G15","overwrite":0}}
+{"timestamp":1704469637.1766734,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1704469757.0789235,"name":"drain","context":{"idset":"7","reason":"epilog failed for jobid fpZuUkWLtZm","overwrite":0}}
+{"timestamp":1704469757.1773319,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1704470027.4122105,"name":"drain","context":{"idset":"14","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704470150.0259581,"name":"drain","context":{"idset":"14","reason":"epilog failed for jobid fpZxPo39Fyy","overwrite":0}}
+{"timestamp":1704470150.1224692,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1704471051.0191936,"name":"drain","context":{"idset":"16","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704471173.0787227,"name":"drain","context":{"idset":"16","reason":"epilog failed for jobid fpa6mEyMckP","overwrite":0}}
+{"timestamp":1704471173.1764519,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1704471286.2472734,"name":"drain","context":{"idset":"12","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704471388.6405947,"name":"drain","context":{"idset":"15","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704471409.0788207,"name":"drain","context":{"idset":"12","reason":"epilog failed for jobid fpZv4DmiUi3","overwrite":0}}
+{"timestamp":1704471409.1761262,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1704471511.0782049,"name":"drain","context":{"idset":"15","reason":"epilog failed for jobid fpa24fbaBrw","overwrite":0}}
+{"timestamp":1704471511.1758633,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1704473853.7885721,"name":"drain","context":{"idset":"3","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704473977.0787308,"name":"drain","context":{"idset":"3","reason":"epilog failed for jobid fpZDfjGjdCs","overwrite":0}}
+{"timestamp":1704473977.1762962,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1704474347.2599247,"name":"drain","context":{"idset":"10","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1704474471.0783703,"name":"drain","context":{"idset":"10","reason":"epilog failed for jobid fpZv3646KBV","overwrite":0}}
+{"timestamp":1704474471.1761105,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1704485385.7332985,"name":"drain","context":{"idset":"24","reason":"prolog failed for jobid fpoKQ1csvkF","overwrite":0}}
+{"timestamp":1704501657.1763797,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1704502656.8815482,"name":"online","context":{"idset":"24"}}
+{"timestamp":1704502658.2845204,"name":"online","context":{"idset":"5,13"}}
+{"timestamp":1704502658.4946239,"name":"online","context":{"idset":"3,6,10,12,14"}}
+{"timestamp":1704502658.6800616,"name":"online","context":{"idset":"7,16"}}
+{"timestamp":1704502658.8290875,"name":"online","context":{"idset":"15"}}
+{"timestamp":1704502658.9953873,"name":"online","context":{"idset":"11"}}
+{"timestamp":1704502713.4039626,"name":"undrain","context":{"idset":"3,5-7,10-16,24"}}
+{"timestamp":1704502901.1761694,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1704503702.0201564,"name":"online","context":{"idset":"22"}}
+{"timestamp":1704503721.3588314,"name":"undrain","context":{"idset":"22"}}
+{"timestamp":1704504193.9167588,"name":"drain","context":{"idset":"40","reason":"PY: testing newer kernel","overwrite":0}}
+{"timestamp":1704504271.4356518,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1704505251.1893077,"name":"drain","context":{"idset":"37-39","reason":"PY: reboot to newer amdgpu driver to support newer firmware","overwrite":0}}
+{"timestamp":1704505276.6790709,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1704506121.7133114,"name":"online","context":{"idset":"37"}}
+{"timestamp":1704737561.9239538,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1704737562.0239801,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1704737562.1353397,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1704738454.1005588,"name":"online","context":{"idset":"38"}}
+{"timestamp":1704738454.5790424,"name":"online","context":{"idset":"37"}}
+{"timestamp":1704738455.1761711,"name":"online","context":{"idset":"40"}}
+{"timestamp":1704738481.5520215,"name":"undrain","context":{"idset":"37-38,40"}}
+{"timestamp":1704739435.0763011,"name":"online","context":{"idset":"39"}}
+{"timestamp":1704739607.1499445,"name":"undrain","context":{"idset":"39"}}
+{"timestamp":1704832067.0774658,"name":"drain","context":{"idset":"15","reason":"prolog failed for jobid fqajdhPuzsh","overwrite":0}}
+{"timestamp":1704841351.3610871,"name":"drain","context":{"idset":"16","reason":"prolog failed for jobid fqbxBDtY7ou","overwrite":0}}
+{"timestamp":1704848753.1757495,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1704848755.1758671,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1704852175.7796268,"name":"undrain","context":{"idset":"15-16"}}
+{"timestamp":1704861939.8878314,"name":"drain","context":{"idset":"8","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1704921560.0937643,"name":"online","context":{"idset":"15"}}
+{"timestamp":1704921563.3839161,"name":"online","context":{"idset":"16"}}
+{"timestamp":1704923789.8260546,"name":"drain","context":{"idset":"15-16","reason":"reboot","overwrite":0}}
+{"timestamp":1704923947.0763023,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1704923947.1765828,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1704926813.0760851,"name":"online","context":{"idset":"16"}}
+{"timestamp":1704926813.1762075,"name":"online","context":{"idset":"15"}}
+{"timestamp":1704926832.9978969,"name":"undrain","context":{"idset":"15-16"}}
+{"timestamp":1704927013.1756945,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1704927791.0760164,"name":"online","context":{"idset":"8"}}
+{"timestamp":1704927799.7545106,"name":"undrain","context":{"idset":"8"}}
+{"timestamp":1705077719.1773093,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1705099364.3870585,"name":"drain","context":{"idset":"15","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1705099364.4231994,"name":"drain","context":{"idset":"18","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1705100168.2664351,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1705100169.2358968,"name":"online","context":{"idset":"2"}}
+{"timestamp":1705100282.3923693,"name":"drain","context":{"idset":"38","overwrite":0}}
+{"timestamp":1705100431.0763104,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1705100431.0768092,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1705100431.1764483,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1705100870.3264933,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1705101281.30984,"name":"online","context":{"idset":"15,18"}}
+{"timestamp":1705101750.0339606,"name":"undrain","context":{"idset":"15,18"}}
+{"timestamp":1705102791.5190539,"name":"online","context":{"idset":"2"}}
+{"timestamp":1705102893.3078043,"name":"online","context":{"idset":"38"}}
+{"timestamp":1705102918.7926245,"name":"undrain","context":{"idset":"2"}}
+{"timestamp":1705102922.4910748,"name":"undrain","context":{"idset":"38"}}
+{"timestamp":1705131853.7059011,"name":"drain","context":{"idset":"33-40","reason":"reboot","overwrite":0}}
+{"timestamp":1705132099.0769536,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1705132099.0773089,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1705132099.0776746,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1705132099.0780151,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1705132099.0783367,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1705132099.0786636,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1705132099.0789673,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1705132099.1764219,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1705133395.9693029,"name":"online","context":{"idset":"35"}}
+{"timestamp":1705133396.3905811,"name":"online","context":{"idset":"33,36"}}
+{"timestamp":1705133396.7917016,"name":"online","context":{"idset":"34"}}
+{"timestamp":1705133437.5936582,"name":"undrain","context":{"idset":"33-36"}}
+{"timestamp":1705133528.6349225,"name":"online","context":{"idset":"37"}}
+{"timestamp":1705133529.3426721,"name":"online","context":{"idset":"39"}}
+{"timestamp":1705133529.7742326,"name":"online","context":{"idset":"38"}}
+{"timestamp":1705133565.0310783,"name":"undrain","context":{"idset":"37-39"}}
+{"timestamp":1705134797.1761992,"name":"online","context":{"idset":"40"}}
+{"timestamp":1705134811.707335,"name":"undrain","context":{"idset":"40"}}
+{"timestamp":1705417902.2889421,"name":"drain","context":{"idset":"3-40","reason":"power work","overwrite":0}}
+{"timestamp":1705418061.0787849,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1705418061.0793388,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1705418061.0796938,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1705418061.0800562,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1705418061.0803843,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1705418061.0807362,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1705418061.0810475,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1705418061.0813479,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1705418061.0816615,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1705418061.0819526,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1705418061.0822358,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1705418061.0825224,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1705418061.0827954,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1705418061.083056,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1705418061.0833127,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1705418061.0835712,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1705418061.083822,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1705418061.0840566,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1705418061.0842865,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1705418061.0845075,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1705418061.0847449,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1705418061.0849557,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1705418061.0851636,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1705418061.0853581,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1705418061.085562,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1705418061.085746,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1705418061.1766455,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1705418063.0768652,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1705418063.0770783,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1705418063.07725,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1705418063.0774062,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1705418063.0775721,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1705418063.0777025,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1705418063.0778315,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1705418063.077975,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1705418063.0780902,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1705418063.0781946,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1705418063.1767712,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1705418533.0762556,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1705418533.1766021,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1705418595.076611,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1705418595.1772313,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1705454585.9442623,"name":"online","context":{"idset":"33"}}
+{"timestamp":1705454586.0932512,"name":"online","context":{"idset":"35"}}
+{"timestamp":1705454587.1512265,"name":"online","context":{"idset":"18"}}
+{"timestamp":1705454587.3003485,"name":"online","context":{"idset":"20"}}
+{"timestamp":1705454587.6638947,"name":"online","context":{"idset":"19"}}
+{"timestamp":1705454587.8148596,"name":"online","context":{"idset":"23,31,39"}}
+{"timestamp":1705454587.9441233,"name":"online","context":{"idset":"26"}}
+{"timestamp":1705454588.0514374,"name":"online","context":{"idset":"17,25,28,32"}}
+{"timestamp":1705454588.2118852,"name":"online","context":{"idset":"27,29-30,37"}}
+{"timestamp":1705454588.4454341,"name":"online","context":{"idset":"24"}}
+{"timestamp":1705454588.5579503,"name":"online","context":{"idset":"22"}}
+{"timestamp":1705454627.7267556,"name":"undrain","context":{"idset":"17-20,22-33,35,37,39"}}
+{"timestamp":1705456370.3285453,"name":"online","context":{"idset":"21"}}
+{"timestamp":1705456520.1144907,"name":"drain","context":{"idset":"33-40","reason":"reboot","overwrite":1}}
+{"timestamp":1705457105.0766304,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1705457105.0770462,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1705457105.0772684,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1705457105.1770749,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1705458561.5621066,"name":"drain","context":{"idset":"17-32","reason":"reboot","overwrite":1}}
+{"timestamp":1705458711.0777566,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1705458711.078239,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1705458711.0785036,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1705458711.078764,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1705458711.0790155,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1705458711.0792651,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1705458711.0794911,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1705458711.0797012,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1705458711.0799112,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1705458711.0801051,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1705458711.0802944,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1705458711.080457,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1705458711.0806341,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1705458711.0807846,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1705458711.0809221,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1705458711.1761711,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1705459605.3949301,"name":"online","context":{"idset":"2"}}
+{"timestamp":1705459606.1314061,"name":"online","context":{"idset":"1"}}
+{"timestamp":1705459974.4402516,"name":"online","context":{"idset":"24"}}
+{"timestamp":1705459975.88131,"name":"online","context":{"idset":"4"}}
+{"timestamp":1705459975.9931026,"name":"online","context":{"idset":"10"}}
+{"timestamp":1705459976.0196617,"name":"online","context":{"idset":"9"}}
+{"timestamp":1705459976.3268795,"name":"online","context":{"idset":"7"}}
+{"timestamp":1705459976.4507449,"name":"online","context":{"idset":"20"}}
+{"timestamp":1705459976.5556335,"name":"online","context":{"idset":"3"}}
+{"timestamp":1705459976.6223674,"name":"online","context":{"idset":"31"}}
+{"timestamp":1705459976.7330828,"name":"online","context":{"idset":"8,13,35"}}
+{"timestamp":1705459976.9030261,"name":"online","context":{"idset":"29,36"}}
+{"timestamp":1705459977.0292499,"name":"online","context":{"idset":"6,25"}}
+{"timestamp":1705459977.0770373,"name":"online","context":{"idset":"12,34"}}
+{"timestamp":1705459977.1764545,"name":"online","context":{"idset":"15-16,19,26,33"}}
+{"timestamp":1705459977.3156424,"name":"online","context":{"idset":"11,22-23,32"}}
+{"timestamp":1705459977.4602265,"name":"online","context":{"idset":"28,39"}}
+{"timestamp":1705459977.5880234,"name":"online","context":{"idset":"17-18,21,30"}}
+{"timestamp":1705459977.718024,"name":"online","context":{"idset":"27"}}
+{"timestamp":1705460084.7650936,"name":"undrain","context":{"idset":"3-4,6-13,15-36,39"}}
+{"timestamp":1705460116.4266584,"name":"undrain","context":{"idset":"1-2"}}
+{"timestamp":1705460275.2885256,"name":"online","context":{"idset":"40"}}
+{"timestamp":1705460275.8773069,"name":"online","context":{"idset":"38"}}
+{"timestamp":1705460293.4556468,"name":"undrain","context":{"idset":"38,40"}}
+{"timestamp":1705460586.9204471,"name":"online","context":{"idset":"5"}}
+{"timestamp":1705460587.5093296,"name":"online","context":{"idset":"14"}}
+{"timestamp":1705460617.3798587,"name":"undrain","context":{"idset":"5,14"}}
+{"timestamp":1705461107.071501,"name":"online","context":{"idset":"37"}}
+{"timestamp":1705461125.0405931,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1705461630.4973726,"name":"drain","context":{"idset":"37-38","overwrite":0}}
+{"timestamp":1705461783.1763082,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1705461785.1771924,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1705462594.094785,"name":"online","context":{"idset":"37"}}
+{"timestamp":1705462594.7651672,"name":"online","context":{"idset":"38"}}
+{"timestamp":1705462749.0762894,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1705462749.1764178,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1705462856.9122601,"name":"drain","context":{"idset":"37-38","reason":"issues","overwrite":1}}
+{"timestamp":1705463771.4986887,"name":"online","context":{"idset":"37"}}
+{"timestamp":1705463772.1375372,"name":"online","context":{"idset":"38"}}
+{"timestamp":1705505789.1767933,"name":"drain","context":{"idset":"34","reason":"broker was unresponsive"}}
+{"timestamp":1705505791.1769941,"name":"drain","context":{"idset":"24","reason":"broker was unresponsive"}}
+{"timestamp":1705505793.0751381,"name":"drain","context":{"idset":"29","reason":"broker was unresponsive"}}
+{"timestamp":1705505793.0752432,"name":"drain","context":{"idset":"31","reason":"broker was unresponsive"}}
+{"timestamp":1705505793.1758785,"name":"drain","context":{"idset":"36","reason":"broker was unresponsive"}}
+{"timestamp":1705505795.0767117,"name":"drain","context":{"idset":"17","reason":"broker was unresponsive"}}
+{"timestamp":1705505795.0768142,"name":"drain","context":{"idset":"18","reason":"broker was unresponsive"}}
+{"timestamp":1705505795.0768709,"name":"drain","context":{"idset":"21","reason":"broker was unresponsive"}}
+{"timestamp":1705505795.0769191,"name":"drain","context":{"idset":"23","reason":"broker was unresponsive"}}
+{"timestamp":1705505795.0769596,"name":"drain","context":{"idset":"27","reason":"broker was unresponsive"}}
+{"timestamp":1705505795.077004,"name":"drain","context":{"idset":"30","reason":"broker was unresponsive"}}
+{"timestamp":1705505795.1767178,"name":"drain","context":{"idset":"32","reason":"broker was unresponsive"}}
+{"timestamp":1705505855.076185,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1705505855.175977,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1705505857.0768919,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1705505857.0772853,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1705505857.0777867,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1705505857.0782986,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1705505857.0788043,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1705505857.0792863,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1705505857.0797651,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1705505857.0802295,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1705505857.0806859,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1705505857.1764579,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1705505873.1771455,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1705505875.0768461,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1705505875.0769351,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1705505875.0769789,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1705505875.0770183,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1705505875.0770574,"name":"drain","context":{"idset":"10","reason":"broker was unresponsive"}}
+{"timestamp":1705505875.0771003,"name":"drain","context":{"idset":"13","reason":"broker was unresponsive"}}
+{"timestamp":1705505875.1773081,"name":"drain","context":{"idset":"14","reason":"broker was unresponsive"}}
+{"timestamp":1705505879.0764294,"name":"drain","context":{"idset":"11","reason":"broker was unresponsive"}}
+{"timestamp":1705505879.0765405,"name":"drain","context":{"idset":"12","reason":"broker was unresponsive"}}
+{"timestamp":1705505879.0765891,"name":"drain","context":{"idset":"15","reason":"broker was unresponsive"}}
+{"timestamp":1705505879.177242,"name":"drain","context":{"idset":"16","reason":"broker was unresponsive"}}
+{"timestamp":1705505941.0766764,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1705505941.077009,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1705505941.077394,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1705505941.0777779,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1705505941.0781138,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1705505941.0784523,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1705505941.0788333,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1705505941.0791879,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1705505941.0795398,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1705505941.0798664,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1705505941.080184,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1705505941.1763687,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1705508165.0749257,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1705508165.1749942,"name":"drain","context":{"idset":"3","reason":"broker was unresponsive"}}
+{"timestamp":1705508167.1767666,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1705508227.0791981,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1705508227.1763835,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1705508229.1766996,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1705509072.7750583,"name":"online","context":{"idset":"36"}}
+{"timestamp":1705509072.9799345,"name":"online","context":{"idset":"34"}}
+{"timestamp":1705509074.3846283,"name":"online","context":{"idset":"10"}}
+{"timestamp":1705509074.7569745,"name":"online","context":{"idset":"8,15"}}
+{"timestamp":1705509074.8913467,"name":"online","context":{"idset":"5,12,14"}}
+{"timestamp":1705509074.9961476,"name":"online","context":{"idset":"6-7,9,16"}}
+{"timestamp":1705509075.0765879,"name":"online","context":{"idset":"13"}}
+{"timestamp":1705509075.2873397,"name":"online","context":{"idset":"11"}}
+{"timestamp":1705509075.7214129,"name":"online","context":{"idset":"32"}}
+{"timestamp":1705509076.6215942,"name":"online","context":{"idset":"18"}}
+{"timestamp":1705509077.0103676,"name":"online","context":{"idset":"23"}}
+{"timestamp":1705509077.4727845,"name":"online","context":{"idset":"27"}}
+{"timestamp":1705509077.5832779,"name":"online","context":{"idset":"21,24,29-31"}}
+{"timestamp":1705509077.8083739,"name":"online","context":{"idset":"17"}}
+{"timestamp":1705509194.4199202,"name":"undrain","context":{"idset":"5-18,21,23-24,27,29-32,34,36"}}
+{"timestamp":1705515448.4612179,"name":"online","context":{"idset":"3"}}
+{"timestamp":1705515448.7505858,"name":"online","context":{"idset":"4"}}
+{"timestamp":1705515486.1279497,"name":"undrain","context":{"idset":"3-4"}}
+{"timestamp":1705515741.0764961,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1705515741.1762512,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1705516042.4868581,"name":"online","context":{"idset":"2"}}
+{"timestamp":1705516089.4515889,"name":"undrain","context":{"idset":"2"}}
+{"timestamp":1705517353.1759307,"name":"drain","context":{"idset":"21","reason":"broker was unresponsive"}}
+{"timestamp":1705517415.1767612,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1705519332.3071222,"name":"online","context":{"idset":"37"}}
+{"timestamp":1705520131.6543047,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1705527069.4102743,"name":"drain","context":{"idset":"8","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1705527982.8316302,"name":"online","context":{"idset":"21"}}
+{"timestamp":1705528521.1774228,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1705533037.3725274,"name":"online","context":{"idset":"8"}}
+{"timestamp":1705533097.2585104,"name":"drain","context":{"idset":"8,21","reason":"lustre","overwrite":1}}
+{"timestamp":1705533101.0842159,"name":"drain","context":{"idset":"8,21","reason":"rzlustre1","overwrite":1}}
+{"timestamp":1705533235.2193933,"name":"drain","context":{"idset":"33-38","reason":"reboot","overwrite":1}}
+{"timestamp":1705533395.0768631,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1705533395.0772877,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1705533395.0776651,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1705533395.0780051,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1705533395.1763148,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1705535672.0477474,"name":"online","context":{"idset":"33-35"}}
+{"timestamp":1705535672.3032405,"name":"online","context":{"idset":"36"}}
+{"timestamp":1705535689.3250225,"name":"drain","context":{"idset":"33-36","reason":"rzlustre1","overwrite":1}}
+{"timestamp":1705536036.030407,"name":"drain","context":{"idset":"37-38","reason":"rzlustre1","overwrite":1}}
+{"timestamp":1705536366.7492385,"name":"online","context":{"idset":"37"}}
+{"timestamp":1705536367.6604602,"name":"online","context":{"idset":"38"}}
+{"timestamp":1705541994.7175405,"name":"undrain","context":{"idset":"8,21,33-38"}}
+{"timestamp":1705690655.1770999,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1705690716.176085,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1705696817.321147,"name":"drain","context":{"idset":"7","reason":"prolog failed for jobid fsY2NqJQxpw","overwrite":0}}
+{"timestamp":1705702495.1467571,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1705702568.9118104,"name":"drain","context":{"idset":"3-6,8-16","reason":"reboot","overwrite":0}}
+{"timestamp":1705703096.5585637,"name":"undrain","context":{"idset":"3-6,8-16"}}
+{"timestamp":1705703198.9350264,"name":"online","context":{"idset":"7"}}
+{"timestamp":1705703210.0724232,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1705703218.6942365,"name":"drain","context":{"idset":"18","reason":"reboot","overwrite":0}}
+{"timestamp":1705703293.5811298,"name":"online","context":{"idset":"37"}}
+{"timestamp":1705703379.1771948,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1705703419.0854983,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1705704070.1505249,"name":"online","context":{"idset":"18"}}
+{"timestamp":1705704094.202615,"name":"undrain","context":{"idset":"18"}}
+{"timestamp":1705945397.2033477,"name":"drain","context":{"idset":"10-16","reason":"reboot","overwrite":0}}
+{"timestamp":1705945547.076607,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1705945547.0786419,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1705945547.0790009,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1705945547.0793445,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1705945547.0797,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1705945547.0800416,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1705945547.1760995,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1705945671.6312306,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1705945671.733875,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1705946404.1911609,"name":"online","context":{"idset":"10"}}
+{"timestamp":1705946404.3999074,"name":"online","context":{"idset":"16"}}
+{"timestamp":1705946404.5257316,"name":"online","context":{"idset":"14"}}
+{"timestamp":1705946404.8332956,"name":"online","context":{"idset":"12,15"}}
+{"timestamp":1705946551.207793,"name":"undrain","context":{"idset":"10,12,14-16"}}
+{"timestamp":1705946625.7682307,"name":"online","context":{"idset":"1-2"}}
+{"timestamp":1705946864.4133422,"name":"drain","context":{"idset":"33-36","overwrite":0}}
+{"timestamp":1705946873.99635,"name":"drain","context":{"idset":"33-36","reason":"reboot","overwrite":1}}
+{"timestamp":1705947042.8566463,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1705947043.9258516,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1705947043.9263005,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1705947044.0255835,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1705947145.1763422,"name":"online","context":{"idset":"11"}}
+{"timestamp":1705947145.5614455,"name":"online","context":{"idset":"13"}}
+{"timestamp":1705947194.3063715,"name":"undrain","context":{"idset":"11,13"}}
+{"timestamp":1705947218.559588,"name":"drain","context":{"idset":"3-6,8-9","reason":"reboot","overwrite":0}}
+{"timestamp":1705947383.1758711,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1705947774.4943244,"name":"online","context":{"idset":"33"}}
+{"timestamp":1705947774.8092341,"name":"online","context":{"idset":"36"}}
+{"timestamp":1705947774.9654417,"name":"online","context":{"idset":"34-35"}}
+{"timestamp":1705947798.7687445,"name":"undrain","context":{"idset":"33-36"}}
+{"timestamp":1705948441.176707,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1705948951.061954,"name":"online","context":{"idset":"5"}}
+{"timestamp":1705948968.7197225,"name":"undrain","context":{"idset":"5"}}
+{"timestamp":1705949116.2231996,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1705949141.0521028,"name":"online","context":{"idset":"9"}}
+{"timestamp":1705949164.5613205,"name":"undrain","context":{"idset":"9"}}
+{"timestamp":1705949765.4823706,"name":"online","context":{"idset":"6"}}
+{"timestamp":1705949785.5363228,"name":"undrain","context":{"idset":"6"}}
+{"timestamp":1705963345.0764065,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1705963345.0768015,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1705963345.176568,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1705964656.5190966,"name":"online","context":{"idset":"3"}}
+{"timestamp":1705964657.1766195,"name":"online","context":{"idset":"4"}}
+{"timestamp":1705964657.4742959,"name":"online","context":{"idset":"8"}}
+{"timestamp":1705964791.8943598,"name":"undrain","context":{"idset":"3-4,8"}}
+{"timestamp":1706112906.7013509,"name":"drain","context":{"idset":"39","reason":"PY: rebooting for rabbit disk hang","overwrite":0}}
+{"timestamp":1706112981.176795,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1706113047.0764794,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1706113047.1769791,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1706114053.8999605,"name":"online","context":{"idset":"39"}}
+{"timestamp":1706128850.0062456,"name":"online","context":{"idset":"6"}}
+{"timestamp":1706128884.2961507,"name":"undrain","context":{"idset":"6,39"}}
+{"timestamp":1706206451.6634552,"name":"drain","context":{"idset":"11","reason":"prolog failed for jobid ftgnoLS7CvK","overwrite":0}}
+{"timestamp":1706209481.1769612,"name":"drain","context":{"idset":"40","reason":"broker was unresponsive"}}
+{"timestamp":1706209543.176717,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1706210266.9565492,"name":"online","context":{"idset":"40"}}
+{"timestamp":1706212141.3145847,"name":"undrain","context":{"idset":"40"}}
+{"timestamp":1706231588.639426,"name":"drain","context":{"idset":"16","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1706280579.1767466,"name":"drain","context":{"idset":"40","reason":"broker was unresponsive"}}
+{"timestamp":1706280645.1761458,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1706281376.2264013,"name":"online","context":{"idset":"40"}}
+{"timestamp":1706282321.6449487,"name":"undrain","context":{"idset":"40"}}
+{"timestamp":1706282397.1771758,"name":"drain","context":{"idset":"39","reason":"broker was unresponsive"}}
+{"timestamp":1706282409.1769855,"name":"drain","context":{"idset":"40","reason":"broker was unresponsive"}}
+{"timestamp":1706282459.176713,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1706282471.1763806,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1706283383.9041438,"name":"online","context":{"idset":"40"}}
+{"timestamp":1706286632.0476611,"name":"undrain","context":{"idset":"40"}}
+{"timestamp":1706287593.5105553,"name":"online","context":{"idset":"39"}}
+{"timestamp":1706289115.0758376,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1706289115.0761757,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1706289115.1763816,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1706289853.9267108,"name":"online","context":{"idset":"11"}}
+{"timestamp":1706289854.1598382,"name":"online","context":{"idset":"16"}}
+{"timestamp":1706289871.7308803,"name":"undrain","context":{"idset":"11,16"}}
+{"timestamp":1706290600.4223185,"name":"online","context":{"idset":"39"}}
+{"timestamp":1706290653.1102376,"name":"undrain","context":{"idset":"39"}}
+{"timestamp":1706580010.3903203,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1706581206.3307719,"name":"online","context":{"idset":"38"}}
+{"timestamp":1706641589.1762068,"name":"drain","context":{"idset":"38","reason":"broker was unresponsive"}}
+{"timestamp":1706641650.4750149,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1706642387.1767986,"name":"online","context":{"idset":"38"}}
+{"timestamp":1706643749.7222111,"name":"undrain","context":{"idset":"38"}}
+{"timestamp":1706720842.1346092,"name":"drain","context":{"idset":"3","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1706720843.0839674,"name":"drain","context":{"idset":"4","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1706721075.9347234,"name":"drain","context":{"idset":"5-40","reason":"toss_update","overwrite":0}}
+{"timestamp":1706721529.0761945,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1706721529.076376,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1706721589.0783482,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1706721589.0788786,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1706721589.0792286,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1706721589.0795765,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1706721589.0799077,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1706721589.0802236,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1706721589.0805423,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1706721589.0808475,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1706721589.0811434,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1706721589.0814302,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1706721589.0817316,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1706721589.0820143,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1706721589.0822821,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1706721589.0825558,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1706721589.0828197,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1706721589.0830755,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1706721589.0833256,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1706721589.1766827,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1706721591.0776072,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1706721591.077862,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1706721591.0780888,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1706721591.0783007,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1706721591.0785105,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1706721591.0787234,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1706721591.0789313,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1706721591.0791116,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1706721591.0792894,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1706721591.0794642,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1706721591.0796378,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1706721591.0797884,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1706721591.0799332,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1706721591.0800743,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1706721591.0802205,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1706721591.0803452,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1706721591.0804725,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1706721591.0805891,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1706721591.0807006,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1706721591.0808012,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1706721591.0808949,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1706721591.1763742,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1706728720.5130961,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1706720842.1346092,"reason":"nodediag failed cxi"},"4":{"timestamp":1706720843.0839674,"reason":"nodediag failed cxi"},"5-40":{"timestamp":1706721075.9347234,"reason":"toss_update"},"41-42":{"timestamp":1703007506.748992,"reason":"PY: A0 blade not installed yet"}},"online":"","exclude":"0-2"}}
+{"timestamp":1706728720.5247622,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1706728847.3685839,"name":"online","context":{"idset":"0"}}
+{"timestamp":1706745364.2693398,"name":"online","context":{"idset":"36"}}
+{"timestamp":1706745364.7345064,"name":"online","context":{"idset":"35"}}
+{"timestamp":1706745366.4553585,"name":"online","context":{"idset":"10"}}
+{"timestamp":1706745366.73332,"name":"online","context":{"idset":"4"}}
+{"timestamp":1706745367.1881649,"name":"online","context":{"idset":"16"}}
+{"timestamp":1706745367.4764736,"name":"online","context":{"idset":"15"}}
+{"timestamp":1706745367.5967507,"name":"online","context":{"idset":"5,8"}}
+{"timestamp":1706745367.7194331,"name":"online","context":{"idset":"7"}}
+{"timestamp":1706745367.8382893,"name":"online","context":{"idset":"6"}}
+{"timestamp":1706745370.5187676,"name":"online","context":{"idset":"9"}}
+{"timestamp":1706745385.0182507,"name":"online","context":{"idset":"33"}}
+{"timestamp":1706745795.8052304,"name":"drain","context":{"idset":"4-10,15-16,33,35-36","reason":"good","overwrite":1}}
+{"timestamp":1706747333.1057575,"name":"online","context":{"idset":"17,24"}}
+{"timestamp":1706747333.4820509,"name":"online","context":{"idset":"29"}}
+{"timestamp":1706747333.6125054,"name":"online","context":{"idset":"22,32"}}
+{"timestamp":1706747334.2185085,"name":"online","context":{"idset":"11"}}
+{"timestamp":1706747334.7962711,"name":"online","context":{"idset":"3,12"}}
+{"timestamp":1706747785.9179277,"name":"online","context":{"idset":"23"}}
+{"timestamp":1706747827.5908408,"name":"drain","context":{"idset":"3,11-12,17,22-24,27-29,32","reason":"good","overwrite":1}}
+{"timestamp":1706747964.351794,"name":"online","context":{"idset":"27"}}
+{"timestamp":1706748287.4043443,"name":"online","context":{"idset":"28"}}
+{"timestamp":1706748536.9759698,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1706748536.9769161,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1706748536.9779179,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1706748536.9790306,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1706748536.9793239,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1706748536.9800203,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1706748536.980602,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1706748536.9809282,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1706748536.9812248,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1706748536.9815211,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1706748536.9817886,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1706748536.9820507,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1706748536.9822276,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1706748536.9824383,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1706748536.9826577,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1706748536.9828157,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1706748536.9830136,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1706748536.9831991,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1706748536.9833782,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1706748536.983783,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1706748536.9839201,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1706748536.9849381,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1706748537.084136,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1706748593.5542626,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1706720842.1346092,"reason":"good"},"4":{"timestamp":1706720843.0839674,"reason":"good"},"5-12,15-17,22-24,27-29,32-33,35-36":{"timestamp":1706721075.9347234,"reason":"good"},"13-14,18-21,25-26,30-31,34,37-40":{"timestamp":1706721075.9347234,"reason":"toss_update"},"41-42":{"timestamp":1703007506.748992,"reason":"PY: A0 blade not installed yet"}},"online":"","exclude":"0-2"}}
+{"timestamp":1706748593.5650852,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1706748719.048049,"name":"online","context":{"idset":"0"}}
+{"timestamp":1706748721.3197691,"name":"online","context":{"idset":"33,35-36"}}
+{"timestamp":1706748722.302475,"name":"online","context":{"idset":"17,22-24,27-29,32"}}
+{"timestamp":1706748723.5637898,"name":"online","context":{"idset":"9-12,15-16"}}
+{"timestamp":1706748723.7059767,"name":"online","context":{"idset":"3-8"}}
+{"timestamp":1706748774.3453927,"name":"online","context":{"idset":"1"}}
+{"timestamp":1706748775.2264295,"name":"online","context":{"idset":"2"}}
+{"timestamp":1706748775.2815068,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1706748775.3821931,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1706748776.1876004,"name":"online","context":{"idset":"1"}}
+{"timestamp":1706748777.024087,"name":"online","context":{"idset":"2"}}
+{"timestamp":1706749084.7990324,"name":"drain","context":{"idset":"37-40","reason":"missing","overwrite":1}}
+{"timestamp":1706749637.6373034,"name":"online","context":{"idset":"26"}}
+{"timestamp":1706749648.7229364,"name":"drain","context":{"idset":"26","reason":"good","overwrite":1}}
+{"timestamp":1706749672.0298612,"name":"drain","context":{"idset":"25","reason":"booting issue","overwrite":1}}
+{"timestamp":1706749677.7778151,"name":"drain","context":{"idset":"25","reason":"power issue","overwrite":1}}
+{"timestamp":1706749767.6410849,"name":"undrain","context":{"idset":"3-12,15-17,22-24,26-29,32-33,35-36"}}
+{"timestamp":1706750344.3442359,"name":"online","context":{"idset":"18"}}
+{"timestamp":1706750344.9971077,"name":"online","context":{"idset":"20,31"}}
+{"timestamp":1706750345.3029773,"name":"online","context":{"idset":"30"}}
+{"timestamp":1706750346.7780282,"name":"online","context":{"idset":"13"}}
+{"timestamp":1706750514.8563862,"name":"undrain","context":{"idset":"13,18,20,30-31"}}
+{"timestamp":1706750666.9721839,"name":"drain","context":{"idset":"14,21,34","reason":"amdgpu","overwrite":1}}
+{"timestamp":1706750729.8045704,"name":"drain","context":{"idset":"19","reason":"slingshot","overwrite":1}}
+{"timestamp":1706750774.8932064,"name":"drain","context":{"idset":"25","reason":"power","overwrite":1}}
+{"timestamp":1706769164.2996287,"name":"drain","context":{"idset":"26","reason":"power","overwrite":0}}
+{"timestamp":1706769393.3319452,"name":"drain","context":{"idset":"13,22,33","reason":"amdgpu","overwrite":0}}
+{"timestamp":1706769425.8386352,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1706769681.7382486,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1706769681.7386494,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1706769681.8380325,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1706770995.3408291,"name":"online","context":{"idset":"19"}}
+{"timestamp":1706771093.6684139,"name":"undrain","context":{"idset":"19"}}
+{"timestamp":1706772029.0987186,"name":"online","context":{"idset":"33"}}
+{"timestamp":1706772029.4746823,"name":"online","context":{"idset":"34"}}
+{"timestamp":1706772029.6453948,"name":"online","context":{"idset":"26"}}
+{"timestamp":1706772030.2231698,"name":"online","context":{"idset":"21"}}
+{"timestamp":1706772030.4770749,"name":"online","context":{"idset":"22"}}
+{"timestamp":1706772030.6101782,"name":"online","context":{"idset":"25"}}
+{"timestamp":1706772031.9725184,"name":"online","context":{"idset":"13"}}
+{"timestamp":1706772032.3089271,"name":"online","context":{"idset":"14"}}
+{"timestamp":1706772050.5552862,"name":"undrain","context":{"idset":"13-14,21-22,25-26,33-34"}}
+{"timestamp":1706776123.3806469,"name":"online","context":{"idset":"42"}}
+{"timestamp":1706776801.838424,"name":"offline","context":{"idset":"42"}}
+{"timestamp":1706776908.258662,"name":"drain","context":{"idset":"37-38","reason":"power","overwrite":1}}
+{"timestamp":1706777647.09671,"name":"online","context":{"idset":"42"}}
+{"timestamp":1706777649.0804358,"name":"online","context":{"idset":"41"}}
+{"timestamp":1706777650.6052032,"name":"online","context":{"idset":"39"}}
+{"timestamp":1706777670.2255673,"name":"online","context":{"idset":"40"}}
+{"timestamp":1706777757.3656499,"name":"undrain","context":{"idset":"39-42"}}
+{"timestamp":1706811878.4463639,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1706814751.1820986,"name":"online","context":{"idset":"1"}}
+{"timestamp":1706815529.7124064,"name":"undrain","context":{"idset":"37-38"}}
+{"timestamp":1706815597.7502842,"name":"drain","context":{"idset":"37-38","reason":"Cassini issue --JRG","overwrite":0}}
+{"timestamp":1706815699.8314655,"name":"online","context":{"idset":"38"}}
+{"timestamp":1706815700.6026566,"name":"online","context":{"idset":"37"}}
+{"timestamp":1706815717.8863459,"name":"undrain","context":{"idset":"37-38"}}
+{"timestamp":1706819865.5647526,"name":"drain","context":{"idset":"38","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1706820552.918191,"name":"drain","context":{"idset":"37","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1706835991.8379133,"name":"drain","context":{"idset":"39","reason":"broker was unresponsive"}}
+{"timestamp":1706836053.8388202,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1706836863.1143255,"name":"online","context":{"idset":"39"}}
+{"timestamp":1706837425.0361998,"name":"undrain","context":{"idset":"39"}}
+{"timestamp":1706845727.7374389,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1706845727.8374994,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1706847508.1874907,"name":"online","context":{"idset":"37"}}
+{"timestamp":1706847541.7185102,"name":"online","context":{"idset":"38"}}
+{"timestamp":1706847692.2123916,"name":"undrain","context":{"idset":"37-38"}}
+{"timestamp":1707108746.0045073,"name":"drain","context":{"idset":"7","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1707153041.8383341,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1707162881.4573922,"name":"online","context":{"idset":"7"}}
+{"timestamp":1707164377.96945,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1707181063.4005086,"name":"offline","context":{"idset":"41"}}
+{"timestamp":1707182419.0137868,"name":"online","context":{"idset":"41"}}
+{"timestamp":1707233575.8383245,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1707233637.7587218,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1707234478.4798162,"name":"online","context":{"idset":"37"}}
+{"timestamp":1707235135.8375456,"name":"drain","context":{"idset":"38","reason":"broker was unresponsive"}}
+{"timestamp":1707235197.1114519,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1707236019.1379948,"name":"online","context":{"idset":"38"}}
+{"timestamp":1707239279.7997193,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1707242450.5040295,"name":"online","context":{"idset":"1"}}
+{"timestamp":1707242881.8376813,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1707243712.6798022,"name":"online","context":{"idset":"37"}}
+{"timestamp":1707243865.837508,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1707244693.2677257,"name":"online","context":{"idset":"38"}}
+{"timestamp":1707246835.8380017,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1707247712.0254409,"name":"online","context":{"idset":"37"}}
+{"timestamp":1707251877.8387382,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1707251943.8383164,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1707252739.5220263,"name":"online","context":{"idset":"1"}}
+{"timestamp":1707281571.2528114,"name":"drain","context":{"idset":"6","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1707291535.9030697,"name":"undrain","context":{"idset":"1"}}
+{"timestamp":1707291829.405098,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1707292331.3300004,"name":"drain","context":{"idset":"37","reason":"PY: BIOS updated to 0.2.2","overwrite":1}}
+{"timestamp":1707321045.0225461,"name":"online","context":{"idset":"37"}}
+{"timestamp":1707321118.1157029,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1707326499.3476722,"name":"drain","context":{"idset":"37","reason":"nodediag failed dmi","overwrite":0}}
+{"timestamp":1707337626.9213357,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1707344731.8382325,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1707344792.9465225,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1707352482.5177982,"name":"online","context":{"idset":"37"}}
+{"timestamp":1707352524.419502,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1707371679.5023351,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1707371679.6025698,"name":"offline","context":{"idset":"42"}}
+{"timestamp":1707371679.9682324,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1707371680.0894804,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1707371680.2077699,"name":"offline","context":{"idset":"41"}}
+{"timestamp":1707373046.9836395,"name":"online","context":{"idset":"42"}}
+{"timestamp":1707373065.2995386,"name":"online","context":{"idset":"38"}}
+{"timestamp":1707373068.8663907,"name":"online","context":{"idset":"40"}}
+{"timestamp":1707373080.0197823,"name":"online","context":{"idset":"39"}}
+{"timestamp":1707373235.2243419,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1707373323.8380773,"name":"drain","context":{"idset":"42","reason":"broker was unresponsive"}}
+{"timestamp":1707373389.8384104,"name":"offline","context":{"idset":"42"}}
+{"timestamp":1707374418.8318408,"name":"online","context":{"idset":"41"}}
+{"timestamp":1707374554.2347,"name":"online","context":{"idset":"6"}}
+{"timestamp":1707374642.895611,"name":"undrain","context":{"idset":"6,38"}}
+{"timestamp":1707374890.1903248,"name":"drain","context":{"idset":"42","reason":"HPE: clocksource is wrong","overwrite":1}}
+{"timestamp":1707403283.3868968,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1707423359.4330695,"name":"online","context":{"idset":"3"}}
+{"timestamp":1707423395.7569091,"name":"drain","context":{"idset":"28","reason":"reboot","overwrite":0}}
+{"timestamp":1707423603.7411213,"name":"drain","context":{"idset":"28","reason":"prolog failed for jobid fw9uVXa94oR","overwrite":0}}
+{"timestamp":1707423603.8385482,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1707424044.1677125,"name":"drain","context":{"idset":"23","reason":"reboot","overwrite":0}}
+{"timestamp":1707424189.741046,"name":"drain","context":{"idset":"23","reason":"prolog failed for jobid fw4gQZNLXUb","overwrite":0}}
+{"timestamp":1707424189.8380446,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1707424337.837878,"name":"online","context":{"idset":"28"}}
+{"timestamp":1707424352.8584485,"name":"undrain","context":{"idset":"23"}}
+{"timestamp":1707424491.0924864,"name":"online","context":{"idset":"42"}}
+{"timestamp":1707424568.3163893,"name":"undrain","context":{"idset":"42"}}
+{"timestamp":1707424679.9889822,"name":"drain","context":{"idset":"14","reason":"reboot","overwrite":0}}
+{"timestamp":1707424698.0068271,"name":"undrain","context":{"idset":"28"}}
+{"timestamp":1707424809.838382,"name":"drain","context":{"idset":"23","reason":"reboot","overwrite":0}}
+{"timestamp":1707424872.6790259,"name":"online","context":{"idset":"23"}}
+{"timestamp":1707424884.4999027,"name":"undrain","context":{"idset":"23"}}
+{"timestamp":1707424921.5031865,"name":"undrain","context":{"idset":"14"}}
+{"timestamp":1707437851.3219905,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1707438674.136807,"name":"online","context":{"idset":"1"}}
+{"timestamp":1707454355.6548223,"name":"drain","context":{"idset":"13","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1707496524.0364501,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1707497971.2689891,"name":"online","context":{"idset":"1"}}
+{"timestamp":1707518163.8375447,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1707518224.4281309,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1707527387.8385627,"name":"drain","context":{"idset":"39","reason":"broker was unresponsive"}}
+{"timestamp":1707527449.3115797,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1707713664.2276361,"name":"drain","context":{"idset":"6","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1707768453.8382242,"name":"drain","context":{"idset":"40","reason":"broker was unresponsive"}}
+{"timestamp":1707768515.4643099,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1707769288.1925364,"name":"online","context":{"idset":"40"}}
+{"timestamp":1707769763.5749722,"name":"undrain","context":{"idset":"40"}}
+{"timestamp":1707776304.3889184,"name":"online","context":{"idset":"37"}}
+{"timestamp":1707776828.1324644,"name":"online","context":{"idset":"39"}}
+{"timestamp":1707777151.9349496,"name":"undrain","context":{"idset":"37,39"}}
+{"timestamp":1707792783.2998366,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1707792783.4003525,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1707795595.239007,"name":"online","context":{"idset":"6"}}
+{"timestamp":1707795595.4831834,"name":"online","context":{"idset":"13"}}
+{"timestamp":1707799880.0881984,"name":"drain","context":{"idset":"16","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1707818410.8097675,"name":"undrain","context":{"idset":"6,13"}}
+{"timestamp":1707850381.8391364,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1707850445.8383119,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1707851273.8377619,"name":"online","context":{"idset":"37"}}
+{"timestamp":1707851630.2794707,"name":"undrain","context":{"idset":"37"}}
+{"timestamp":1707860787.8375132,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1707861914.3243656,"name":"online","context":{"idset":"16"}}
+{"timestamp":1707862299.8390322,"name":"drain","context":{"idset":"42","reason":"broker was unresponsive"}}
+{"timestamp":1707862365.8380234,"name":"offline","context":{"idset":"42"}}
+{"timestamp":1707862432.2866926,"name":"undrain","context":{"idset":"16"}}
+{"timestamp":1707862485.838378,"name":"drain","context":{"idset":"41","reason":"broker was unresponsive"}}
+{"timestamp":1707862550.7934186,"name":"offline","context":{"idset":"41"}}
+{"timestamp":1707862797.8382277,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1707863200.8929882,"name":"online","context":{"idset":"42"}}
+{"timestamp":1707863321.3038337,"name":"online","context":{"idset":"41"}}
+{"timestamp":1707863575.9863987,"name":"undrain","context":{"idset":"41"}}
+{"timestamp":1707863591.0056872,"name":"undrain","context":{"idset":"42"}}
+{"timestamp":1707863690.6313021,"name":"online","context":{"idset":"37"}}
+{"timestamp":1707864194.4303365,"name":"drain","context":{"idset":"17","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1707925467.8379104,"name":"drain","context":{"idset":"38","reason":"broker was unresponsive"}}
+{"timestamp":1707925531.7405128,"name":"drain","context":{"idset":"38","reason":"epilog failed for jobid fwPkxhixb4b","overwrite":0}}
+{"timestamp":1707925531.8382971,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1707926335.7360427,"name":"online","context":{"idset":"38"}}
+{"timestamp":1707927796.7848685,"name":"undrain","context":{"idset":"38"}}
+{"timestamp":1707957384.5151241,"name":"drain","context":{"idset":"4","reason":"prolog failed for jobid fxaUHGm9LGF","overwrite":0}}
+{"timestamp":1708018317.2358747,"name":"drain","context":{"idset":"27","reason":"reboot","overwrite":0}}
+{"timestamp":1708018493.8377426,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1708018495.8382566,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1708022983.2222366,"name":"online","context":{"idset":"4"}}
+{"timestamp":1708023019.3887846,"name":"undrain","context":{"idset":"4"}}
+{"timestamp":1708023091.0536761,"name":"drain","context":{"idset":"17","reason":"nodediag gpu","overwrite":1}}
+{"timestamp":1708059599.2390714,"name":"drain","context":{"idset":"5","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1708060733.3597038,"name":"drain","context":{"idset":"27","reason":"prolog failed for jobid fxchr7WnLRD","overwrite":0}}
+{"timestamp":1708120227.8380058,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1708120291.7382793,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1708120291.8384812,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1708130676.3031666,"name":"online","context":{"idset":"7"}}
+{"timestamp":1708130677.1603243,"name":"online","context":{"idset":"5"}}
+{"timestamp":1708130701.28105,"name":"undrain","context":{"idset":"5,7"}}
+{"timestamp":1708130871.8384726,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1708131640.5834272,"name":"online","context":{"idset":"27"}}
+{"timestamp":1708131663.7243624,"name":"undrain","context":{"idset":"27"}}
+{"timestamp":1708184693.4654632,"name":"drain","context":{"idset":"37-38","reason":"prolog failed for jobid fy6FUPcDxSB","overwrite":0}}
+{"timestamp":1708318642.0552068,"name":"drain","context":{"idset":"6","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1708318643.7309797,"name":"drain","context":{"idset":"5","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1708444977.9638999,"name":"drain","context":{"idset":"8","reason":"prolog failed for jobid fygME8fgRoV","overwrite":0}}
+{"timestamp":1708449591.7375274,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1708449591.8376031,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1708449591.851578,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1708449591.8521047,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1708449591.9517674,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1708450464.5751729,"name":"online","context":{"idset":"37"}}
+{"timestamp":1708450473.1423843,"name":"online","context":{"idset":"38"}}
+{"timestamp":1708451811.1425228,"name":"undrain","context":{"idset":"5,37-38"}}
+{"timestamp":1708453109.7380123,"name":"online","context":{"idset":"6"}}
+{"timestamp":1708453188.7591531,"name":"undrain","context":{"idset":"6"}}
+{"timestamp":1708453305.3757787,"name":"online","context":{"idset":"8"}}
+{"timestamp":1708453448.2236412,"name":"undrain","context":{"idset":"8"}}
+{"timestamp":1708455499.5559287,"name":"online","context":{"idset":"5"}}
+{"timestamp":1708492751.9970648,"name":"drain","context":{"idset":"5","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1708545245.1021707,"name":"drain","context":{"idset":"18","reason":"bad partner node-JRG","overwrite":0}}
+{"timestamp":1708557653.8370645,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1708562587.2785451,"name":"online","context":{"idset":"17"}}
+{"timestamp":1708562587.8421595,"name":"online","context":{"idset":"18"}}
+{"timestamp":1708563437.7380364,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1708563547.8739662,"name":"drain","context":{"idset":"17-18","reason":"rzlustre1","overwrite":1}}
+{"timestamp":1708564536.7295566,"name":"online","context":{"idset":"5"}}
+{"timestamp":1708564572.8504648,"name":"drain","context":{"idset":"5","reason":"rzlustre1","overwrite":1}}
+{"timestamp":1708630723.3196564,"name":"drain","context":{"idset":"8","reason":"prolog failed for jobid fz6gbidG4BR","overwrite":0}}
+{"timestamp":1708644045.3878703,"name":"undrain","context":{"idset":"5,17-18"}}
+{"timestamp":1708644341.8381383,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1708645956.1694183,"name":"online","context":{"idset":"8"}}
+{"timestamp":1708646380.946867,"name":"undrain","context":{"idset":"8"}}
+{"timestamp":1708904368.7411003,"name":"drain","context":{"idset":"3-4,7,9-10,19-26,28-32","reason":"upset with ansible","overwrite":0}}
+{"timestamp":1709057827.7397962,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1709057827.7404201,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1709057827.7408397,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1709057827.7412193,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1709057827.741601,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1709057827.7419708,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1709057827.7423189,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1709057827.7426829,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1709057827.7430236,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1709057827.7433569,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1709057827.74369,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1709057827.7440076,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1709057827.7443242,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1709057827.744637,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1709057827.7449427,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1709057827.7452464,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1709057827.838057,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1709057829.8380287,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1709059282.4735003,"name":"online","context":{"idset":"25"}}
+{"timestamp":1709059295.3923523,"name":"online","context":{"idset":"10"}}
+{"timestamp":1709059296.3855255,"name":"online","context":{"idset":"9"}}
+{"timestamp":1709059305.3444204,"name":"online","context":{"idset":"3"}}
+{"timestamp":1709059307.7188857,"name":"online","context":{"idset":"4"}}
+{"timestamp":1709059308.7391601,"name":"online","context":{"idset":"7"}}
+{"timestamp":1709059313.2648256,"name":"online","context":{"idset":"20"}}
+{"timestamp":1709059317.2187514,"name":"online","context":{"idset":"24"}}
+{"timestamp":1709059320.4163654,"name":"online","context":{"idset":"22"}}
+{"timestamp":1709059320.6105793,"name":"online","context":{"idset":"19"}}
+{"timestamp":1709059324.661155,"name":"online","context":{"idset":"28"}}
+{"timestamp":1709059325.2961633,"name":"online","context":{"idset":"23,32"}}
+{"timestamp":1709059325.4128139,"name":"online","context":{"idset":"21"}}
+{"timestamp":1709059326.0691898,"name":"online","context":{"idset":"26,30"}}
+{"timestamp":1709059505.9985266,"name":"undrain","context":{"idset":"3-4,7,9-10,19-26,28,32"}}
+{"timestamp":1709059683.8389406,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1709061018.7839279,"name":"online","context":{"idset":"31"}}
+{"timestamp":1709061025.4733136,"name":"online","context":{"idset":"30"}}
+{"timestamp":1709061122.3658459,"name":"undrain","context":{"idset":"30-31"}}
+{"timestamp":1709061365.9024534,"name":"drain","context":{"idset":"29","reason":"slingshot","overwrite":1}}
+{"timestamp":1709063423.5311122,"name":"online","context":{"idset":"29"}}
+{"timestamp":1709063443.3044019,"name":"undrain","context":{"idset":"29"}}
+{"timestamp":1709161676.2219987,"name":"drain","context":{"idset":"37-40","reason":"prolog failed for jobid f21JF1TqjUiT","overwrite":0}}
+{"timestamp":1709164881.736146,"name":"drain","context":{"idset":"23","reason":"broker was unresponsive"}}
+{"timestamp":1709164881.8361363,"name":"drain","context":{"idset":"24","reason":"broker was unresponsive"}}
+{"timestamp":1709164945.7385306,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1709164945.7417045,"name":"drain","context":{"idset":"23-24","reason":"epilog failed for jobid f21JcpsrK4Aj","overwrite":0}}
+{"timestamp":1709164945.8380418,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1709179855.5453553,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1709179855.545892,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1709179855.5463035,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1709179855.6452386,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1709180633.2748382,"name":"online","context":{"idset":"24"}}
+{"timestamp":1709180633.631073,"name":"online","context":{"idset":"23"}}
+{"timestamp":1709180665.4889343,"name":"undrain","context":{"idset":"23-24"}}
+{"timestamp":1709180756.8987303,"name":"online","context":{"idset":"38"}}
+{"timestamp":1709180758.1303515,"name":"online","context":{"idset":"39"}}
+{"timestamp":1709181329.0336177,"name":"undrain","context":{"idset":"38-39"}}
+{"timestamp":1709182330.5757935,"name":"online","context":{"idset":"37"}}
+{"timestamp":1709182334.7743187,"name":"online","context":{"idset":"40"}}
+{"timestamp":1709182473.5151224,"name":"undrain","context":{"idset":"37,40"}}
+{"timestamp":1709234309.8842003,"name":"drain","context":{"idset":"7","reason":"Epilog failed to complete","overwrite":0}}
+{"timestamp":1709234433.7404156,"name":"drain","context":{"idset":"7","reason":"epilog failed for jobid f21GSNfTD1uy","overwrite":0}}
+{"timestamp":1709234433.8382061,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1709243313.3831859,"name":"drain","context":{"idset":"17-32","reason":"reconfigure for gfs2","overwrite":0}}
+{"timestamp":1709244375.7721577,"name":"undrain","context":{"idset":"17-32"}}
+{"timestamp":1709265844.0127952,"name":"online","context":{"idset":"7"}}
+{"timestamp":1709265879.8928845,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1709597344.9819255,"name":"drain","context":{"idset":"41-42","reason":"Moving to another system","overwrite":0}}
+{"timestamp":1709597377.888833,"name":"offline","context":{"idset":"42"}}
+{"timestamp":1709597377.9894373,"name":"offline","context":{"idset":"41"}}
+{"timestamp":1709597575.8377159,"name":"drain","context":{"idset":"38","reason":"broker was unresponsive"}}
+{"timestamp":1709597579.8376544,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1709597641.7380157,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1709597641.8376784,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1709677515.8374412,"name":"drain","context":{"idset":"20","reason":"broker was unresponsive"}}
+{"timestamp":1709677578.462805,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1709677671.8378823,"name":"drain","context":{"idset":"17","reason":"broker was unresponsive"}}
+{"timestamp":1709677732.4794781,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1709678452.5885799,"name":"online","context":{"idset":"20"}}
+{"timestamp":1709678453.1054296,"name":"online","context":{"idset":"17"}}
+{"timestamp":1709682455.7374618,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1709682455.8375278,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1709683709.0123544,"name":"online","context":{"idset":"17"}}
+{"timestamp":1709683709.1793685,"name":"online","context":{"idset":"20"}}
+{"timestamp":1709683726.4352436,"name":"undrain","context":{"idset":"17,20"}}
+{"timestamp":1709757811.8391249,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1709757813.8378968,"name":"drain","context":{"idset":"36","reason":"broker was unresponsive"}}
+{"timestamp":1709757815.7377646,"name":"drain","context":{"idset":"11","reason":"broker was unresponsive"}}
+{"timestamp":1709757815.7378817,"name":"drain","context":{"idset":"12","reason":"broker was unresponsive"}}
+{"timestamp":1709757815.7379401,"name":"drain","context":{"idset":"13","reason":"broker was unresponsive"}}
+{"timestamp":1709757815.8385437,"name":"drain","context":{"idset":"34","reason":"broker was unresponsive"}}
+{"timestamp":1709757877.7387321,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1709757877.7393889,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1709757877.7398379,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1709757877.7401838,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1709757877.7405124,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1709757877.9124072,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1709760682.498179,"name":"online","context":{"idset":"36"}}
+{"timestamp":1709760682.8654833,"name":"online","context":{"idset":"34"}}
+{"timestamp":1709760684.03791,"name":"online","context":{"idset":"13"}}
+{"timestamp":1709760684.3850274,"name":"online","context":{"idset":"12"}}
+{"timestamp":1709760684.4930096,"name":"online","context":{"idset":"11"}}
+{"timestamp":1709760698.4456573,"name":"undrain","context":{"idset":"11-13,34,36"}}
+{"timestamp":1709761654.2443032,"name":"drain","context":{"idset":"6-7","reason":"nodediag amdgpu","overwrite":1}}
+{"timestamp":1709761738.9148006,"name":"online","context":{"idset":"6"}}
+{"timestamp":1709762029.8381662,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1709762041.1106775,"name":"drain","context":{"idset":"5","reason":"nodediag amdgpu","overwrite":1}}
+{"timestamp":1709762048.5661969,"name":"undrain","context":{"idset":"7"}}
+{"timestamp":1709762091.2446463,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1709762091.3586822,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1709764852.2865758,"name":"online","context":{"idset":"5"}}
+{"timestamp":1709764852.4182868,"name":"online","context":{"idset":"6"}}
+{"timestamp":1709764869.762249,"name":"undrain","context":{"idset":"5-6"}}
+{"timestamp":1710351361.4649928,"name":"online","context":{"idset":"38"}}
+{"timestamp":1710351469.6394072,"name":"online","context":{"idset":"37"}}
+{"timestamp":1710351917.6409914,"name":"undrain","context":{"idset":"37-38"}}
+{"timestamp":1710453685.8383853,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1710456027.8384783,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1710463182.9698641,"name":"online","context":{"idset":"2"}}
+{"timestamp":1710463475.6963859,"name":"undrain","context":{"idset":"2"}}
+{"timestamp":1710529055.8373916,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1710547575.8380218,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1710548508.9344761,"name":"online","context":{"idset":"2"}}
+{"timestamp":1710548578.8410048,"name":"undrain","context":{"idset":"2"}}
+{"timestamp":1710803147.8377545,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1710804529.8390036,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1710805366.4394033,"name":"online","context":{"idset":"2"}}
+{"timestamp":1710805394.5424531,"name":"undrain","context":{"idset":"2"}}
+{"timestamp":1710886419.8374178,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1710886507.8374052,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1710896965.7381608,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1710896965.8387263,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1710898099.1616108,"name":"online","context":{"idset":"1"}}
+{"timestamp":1710898100.151648,"name":"online","context":{"idset":"2"}}
+{"timestamp":1710898231.1469281,"name":"undrain","context":{"idset":"1-2"}}
+{"timestamp":1711021713.8387303,"name":"drain","context":{"idset":"26","reason":"broker was unresponsive"}}
+{"timestamp":1711021779.8388457,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1711040131.5446091,"name":"online","context":{"idset":"26"}}
+{"timestamp":1711040144.4600034,"name":"undrain","context":{"idset":"26"}}
+{"timestamp":1711153568.6771774,"name":"drain","context":{"idset":"10","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1711383329.4488847,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1711384583.5716627,"name":"online","context":{"idset":"10"}}
+{"timestamp":1711384610.2533531,"name":"undrain","context":{"idset":"10"}}
+{"timestamp":1711393749.1217792,"name":"drain","context":{"idset":"8","reason":"prolog failed for jobid f26LfFy2dMcK","overwrite":0}}
+{"timestamp":1711396867.7688053,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1711399450.7398818,"name":"online","context":{"idset":"8"}}
+{"timestamp":1711402842.4289572,"name":"undrain","context":{"idset":"8"}}
+{"timestamp":1711562071.5155444,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1711562071.5476818,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1711562071.5529733,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1711562071.5535269,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1711562071.5606616,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1711562071.5619266,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1711562071.5698957,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1711562071.5733974,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1711562071.5740981,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1711562071.5750401,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1711562071.5751336,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1711562071.5768588,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1711562071.5773368,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1711562071.5808523,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1711562071.5816214,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1711562071.5820677,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1711562071.5849607,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1711562071.5860474,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1711562071.5866809,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1711562071.5896459,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1711562071.5908241,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1711562071.5915174,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1711562071.5927622,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1711562071.5946543,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1711562071.5951457,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1711562071.5954111,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1711562071.5960329,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1711562071.5962002,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1711562071.5964334,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1711562071.5989981,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1711562071.6009147,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1711562071.6111562,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1711562071.6114984,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1711562071.6116772,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1711562071.6147885,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1711562071.715518,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1711562071.7776322,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1711562071.8012199,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1711562071.8033273,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1711562071.902746,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1711562657.7498362,"name":"resource-init","context":{"restart":true,"drain":{"41-42":{"timestamp":1709597344.9819255,"reason":"Moving to another system"}},"online":"","exclude":"0-2"}}
+{"timestamp":1711562657.7543545,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1711562719.6342204,"name":"online","context":{"idset":"0"}}
+{"timestamp":1711562720.3250408,"name":"online","context":{"idset":"1,37-40"}}
+{"timestamp":1711562720.8339283,"name":"online","context":{"idset":"33,35"}}
+{"timestamp":1711562720.963738,"name":"online","context":{"idset":"14"}}
+{"timestamp":1711562721.1101327,"name":"online","context":{"idset":"7,9,15-16"}}
+{"timestamp":1711562721.2148492,"name":"online","context":{"idset":"3-4,23,25,29"}}
+{"timestamp":1711562721.3656094,"name":"online","context":{"idset":"20-22,24,28,30"}}
+{"timestamp":1711562721.5184519,"name":"online","context":{"idset":"17-18"}}
+{"timestamp":1711562721.6294758,"name":"online","context":{"idset":"19,27,31-32"}}
+{"timestamp":1711562721.9826868,"name":"online","context":{"idset":"34,36"}}
+{"timestamp":1711562722.1093643,"name":"online","context":{"idset":"2,26"}}
+{"timestamp":1711562723.063693,"name":"online","context":{"idset":"6"}}
+{"timestamp":1711562723.1796999,"name":"online","context":{"idset":"5,8,12"}}
+{"timestamp":1711562723.3877113,"name":"online","context":{"idset":"11,13"}}
+{"timestamp":1711562723.4933889,"name":"online","context":{"idset":"10"}}
+{"timestamp":1711562798.5095389,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1711562798.5153723,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1711562798.518075,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1711562798.5220656,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1711562798.5228508,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1711562798.5232172,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1711562798.5273449,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1711562798.5292459,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1711562798.5296848,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1711562798.5300696,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1711562798.5327139,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1711562798.5361392,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1711562798.5371253,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1711562798.5379517,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1711562798.5395818,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1711562798.5424609,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1711562798.544009,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1711562798.5447056,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1711562798.5471637,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1711562798.5475664,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1711562798.5479436,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1711562798.5496936,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1711562798.5522764,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1711562798.5542397,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1711562798.5545228,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1711562798.5622208,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1711562798.5646443,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1711562798.5664985,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1711562798.5687649,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1711562798.5754938,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1711562798.578809,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1711562798.5821683,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1711562798.582479,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1711562798.6288555,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1711562798.6554906,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1711562798.7030022,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1711562798.7058046,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1711562798.7169104,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1711562798.7620802,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1711562798.8625369,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1711564987.0683236,"name":"online","context":{"idset":"40"}}
+{"timestamp":1711564997.0785792,"name":"online","context":{"idset":"37"}}
+{"timestamp":1711565003.3187122,"name":"online","context":{"idset":"38"}}
+{"timestamp":1711565020.3591337,"name":"online","context":{"idset":"39"}}
+{"timestamp":1711568271.2818451,"name":"online","context":{"idset":"2"}}
+{"timestamp":1711568271.818464,"name":"online","context":{"idset":"1"}}
+{"timestamp":1711568272.5509593,"name":"online","context":{"idset":"7,33"}}
+{"timestamp":1711568272.7834377,"name":"online","context":{"idset":"4"}}
+{"timestamp":1711568272.8876348,"name":"online","context":{"idset":"15"}}
+{"timestamp":1711568272.9492731,"name":"online","context":{"idset":"6"}}
+{"timestamp":1711568273.2199152,"name":"online","context":{"idset":"11"}}
+{"timestamp":1711568273.441834,"name":"online","context":{"idset":"5"}}
+{"timestamp":1711568273.9095511,"name":"online","context":{"idset":"16,34,36"}}
+{"timestamp":1711568274.1564608,"name":"online","context":{"idset":"10,35"}}
+{"timestamp":1711568274.2421155,"name":"online","context":{"idset":"14"}}
+{"timestamp":1711568275.6102519,"name":"online","context":{"idset":"23"}}
+{"timestamp":1711568276.2137187,"name":"online","context":{"idset":"21"}}
+{"timestamp":1711568277.2376351,"name":"online","context":{"idset":"17"}}
+{"timestamp":1711568277.4104073,"name":"online","context":{"idset":"22,32"}}
+{"timestamp":1711568277.5535326,"name":"online","context":{"idset":"31"}}
+{"timestamp":1711568277.7249949,"name":"online","context":{"idset":"8,18"}}
+{"timestamp":1711568277.8286169,"name":"online","context":{"idset":"20"}}
+{"timestamp":1711568278.1102707,"name":"online","context":{"idset":"12,19,25"}}
+{"timestamp":1711568278.2225249,"name":"online","context":{"idset":"3,13,26,29-30"}}
+{"timestamp":1711568278.3303578,"name":"online","context":{"idset":"27"}}
+{"timestamp":1711568278.5839033,"name":"online","context":{"idset":"9"}}
+{"timestamp":1711568288.8238063,"name":"online","context":{"idset":"28"}}
+{"timestamp":1711568325.3388956,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1711575841.9812288,"name":"online","context":{"idset":"24"}}
+{"timestamp":1711575842.4057868,"name":"online","context":{"idset":"23"}}
+{"timestamp":1712228549.7403214,"name":"drain","context":{"idset":"6","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1712571153.6118443,"name":"drain","context":{"idset":"3","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712571190.9812348,"name":"drain","context":{"idset":"9","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712571686.9373195,"name":"drain","context":{"idset":"7","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712571713.349153,"name":"drain","context":{"idset":"4","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712571723.3367388,"name":"drain","context":{"idset":"10","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712571745.2987714,"name":"drain","context":{"idset":"11","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712571784.7699995,"name":"drain","context":{"idset":"5","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712575118.5378792,"name":"drain","context":{"idset":"12","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712575340.6836975,"name":"drain","context":{"idset":"14","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712576782.937218,"name":"drain","context":{"idset":"8","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712576871.8109212,"name":"drain","context":{"idset":"13","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712577040.1794808,"name":"drain","context":{"idset":"15","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712583966.6428049,"name":"drain","context":{"idset":"16","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712583998.4048991,"name":"drain","context":{"idset":"20","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712584588.0363107,"name":"drain","context":{"idset":"18","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712584890.672461,"name":"drain","context":{"idset":"17","reason":"nodediag failed cxi","overwrite":0}}
+{"timestamp":1712587838.6220341,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1712587838.6247785,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1712587838.6253071,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1712587838.6254673,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1712587838.6260877,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1712587838.626611,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1712587838.628412,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1712587838.6288271,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1712587838.6289394,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1712587838.6294975,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1712587838.6308565,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1712587838.6313334,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1712587838.6323359,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1712587838.6334319,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1712587838.6548884,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1712587838.6808522,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1712587838.7061007,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1712587838.711508,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1712587838.7213881,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1712587838.7261713,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1712587838.7282426,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1712587838.7287235,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1712587838.7376254,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1712587838.746058,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1712587838.7483242,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1712587838.7505665,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1712587838.7540851,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1712587838.773119,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1712587838.7741294,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1712587838.7765293,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1712587838.7780209,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1712587838.7789896,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1712587838.7929807,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1712587838.7932806,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1712587838.8016355,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1712587838.8389187,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1712587838.9048545,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1712587838.9207585,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1712587838.9490297,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1712587839.0483029,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1712590818.3365602,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1712571153.6118443,"reason":"nodediag failed cxi"},"4":{"timestamp":1712571713.349153,"reason":"nodediag failed cxi"},"5":{"timestamp":1712571784.7699995,"reason":"nodediag failed cxi"},"6":{"timestamp":1712228549.7403214,"reason":"nodediag failed amdgpu"},"7":{"timestamp":1712571686.9373195,"reason":"nodediag failed cxi"},"8":{"timestamp":1712576782.937218,"reason":"nodediag failed cxi"},"9":{"timestamp":1712571190.9812348,"reason":"nodediag failed cxi"},"10":{"timestamp":1712571723.3367388,"reason":"nodediag failed cxi"},"11":{"timestamp":1712571745.2987714,"reason":"nodediag failed cxi"},"12":{"timestamp":1712575118.5378792,"reason":"nodediag failed cxi"},"13":{"timestamp":1712576871.8109212,"reason":"nodediag failed cxi"},"14":{"timestamp":1712575340.6836975,"reason":"nodediag failed cxi"},"15":{"timestamp":1712577040.1794808,"reason":"nodediag failed cxi"},"16":{"timestamp":1712583966.6428049,"reason":"nodediag failed cxi"},"17":{"timestamp":1712584890.672461,"reason":"nodediag failed cxi"},"18":{"timestamp":1712584588.0363107,"reason":"nodediag failed cxi"},"20":{"timestamp":1712583998.4048991,"reason":"nodediag failed cxi"},"41-42":{"timestamp":1709597344.9819255,"reason":"Moving to another system"}},"online":"","exclude":"0-2"}}
+{"timestamp":1712590818.3373437,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1712590855.650671,"name":"online","context":{"idset":"0"}}
+{"timestamp":1712598618.1848156,"name":"resource-init","context":{"restart":true,"drain":{"3":{"timestamp":1712571153.6118443,"reason":"nodediag failed cxi"},"4":{"timestamp":1712571713.349153,"reason":"nodediag failed cxi"},"5":{"timestamp":1712571784.7699995,"reason":"nodediag failed cxi"},"6":{"timestamp":1712228549.7403214,"reason":"nodediag failed amdgpu"},"7":{"timestamp":1712571686.9373195,"reason":"nodediag failed cxi"},"8":{"timestamp":1712576782.937218,"reason":"nodediag failed cxi"},"9":{"timestamp":1712571190.9812348,"reason":"nodediag failed cxi"},"10":{"timestamp":1712571723.3367388,"reason":"nodediag failed cxi"},"11":{"timestamp":1712571745.2987714,"reason":"nodediag failed cxi"},"12":{"timestamp":1712575118.5378792,"reason":"nodediag failed cxi"},"13":{"timestamp":1712576871.8109212,"reason":"nodediag failed cxi"},"14":{"timestamp":1712575340.6836975,"reason":"nodediag failed cxi"},"15":{"timestamp":1712577040.1794808,"reason":"nodediag failed cxi"},"16":{"timestamp":1712583966.6428049,"reason":"nodediag failed cxi"},"17":{"timestamp":1712584890.672461,"reason":"nodediag failed cxi"},"18":{"timestamp":1712584588.0363107,"reason":"nodediag failed cxi"},"20":{"timestamp":1712583998.4048991,"reason":"nodediag failed cxi"},"41-42":{"timestamp":1709597344.9819255,"reason":"Moving to another system"}},"online":"","exclude":"0-2"}}
+{"timestamp":1712598618.1856339,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1712598654.729003,"name":"online","context":{"idset":"0"}}
+{"timestamp":1712598821.7026219,"name":"online","context":{"idset":"1"}}
+{"timestamp":1712598823.1951349,"name":"online","context":{"idset":"2"}}
+{"timestamp":1712598824.9349616,"name":"online","context":{"idset":"40"}}
+{"timestamp":1712598827.9501436,"name":"online","context":{"idset":"39"}}
+{"timestamp":1712598880.8823647,"name":"online","context":{"idset":"37"}}
+{"timestamp":1712598882.2186096,"name":"online","context":{"idset":"38"}}
+{"timestamp":1712598951.9832847,"name":"online","context":{"idset":"36"}}
+{"timestamp":1712598952.0610816,"name":"online","context":{"idset":"35"}}
+{"timestamp":1712598952.1085169,"name":"online","context":{"idset":"33"}}
+{"timestamp":1712598953.3848193,"name":"online","context":{"idset":"14,22"}}
+{"timestamp":1712598953.9689507,"name":"online","context":{"idset":"8"}}
+{"timestamp":1712598954.1856146,"name":"online","context":{"idset":"4,6,10,21"}}
+{"timestamp":1712598954.3061726,"name":"online","context":{"idset":"13,18,25"}}
+{"timestamp":1712598954.448626,"name":"online","context":{"idset":"3"}}
+{"timestamp":1712598954.5744207,"name":"online","context":{"idset":"5,29"}}
+{"timestamp":1712598954.8848865,"name":"online","context":{"idset":"7,23"}}
+{"timestamp":1712598954.9875467,"name":"online","context":{"idset":"9,15-16,28"}}
+{"timestamp":1712598955.2929707,"name":"online","context":{"idset":"11-12,17,19-20,24,26-27,30-32"}}
+{"timestamp":1712598981.4848742,"name":"undrain","context":{"idset":"3-18,20"}}
+{"timestamp":1712676551.6560497,"name":"drain","context":{"idset":"33-34","reason":"PY: rebooting to clear stuck GPU on fake43","overwrite":0}}
+{"timestamp":1712676619.458843,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1712770780.37569,"name":"online","context":{"idset":"33"}}
+{"timestamp":1712770780.5136557,"name":"online","context":{"idset":"34"}}
+{"timestamp":1712775868.9787755,"name":"undrain","context":{"idset":"33-34"}}
+{"timestamp":1713219996.2825902,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1713221278.8298764,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1713221808.6494505,"name":"online","context":{"idset":"40"}}
+{"timestamp":1713221966.8193207,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1713222297.9752064,"name":"online","context":{"idset":"37"}}
+{"timestamp":1713223013.1917467,"name":"online","context":{"idset":"40"}}
+{"timestamp":1713463334.8191154,"name":"drain","context":{"idset":"38","reason":"broker was unresponsive"}}
+{"timestamp":1713463394.8459895,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1713464267.1192989,"name":"online","context":{"idset":"38"}}
+{"timestamp":1713464390.9905565,"name":"undrain","context":{"idset":"38"}}
+{"timestamp":1713982737.5843689,"name":"resource-init","context":{"restart":true,"drain":{},"online":"","exclude":"0-2"}}
+{"timestamp":1713982737.585748,"name":"resource-define","context":{"method":"configuration"}}
+{"timestamp":1713982782.8416674,"name":"online","context":{"idset":"0"}}
+{"timestamp":1713982783.7456343,"name":"online","context":{"idset":"37-39"}}
+{"timestamp":1713982783.8473592,"name":"online","context":{"idset":"40"}}
+{"timestamp":1713982785.0302947,"name":"online","context":{"idset":"35"}}
+{"timestamp":1713982785.2778559,"name":"online","context":{"idset":"33-34,36"}}
+{"timestamp":1713982785.6222816,"name":"online","context":{"idset":"21"}}
+{"timestamp":1713982785.7510157,"name":"online","context":{"idset":"23-24,28"}}
+{"timestamp":1713982785.8817627,"name":"online","context":{"idset":"22"}}
+{"timestamp":1713982786.4081388,"name":"online","context":{"idset":"25,27,31"}}
+{"timestamp":1713982786.5279021,"name":"online","context":{"idset":"26,29-30,32"}}
+{"timestamp":1713982864.3269086,"name":"online","context":{"idset":"3,17"}}
+{"timestamp":1713982864.7409158,"name":"online","context":{"idset":"19"}}
+{"timestamp":1713982865.3713729,"name":"online","context":{"idset":"13"}}
+{"timestamp":1713982866.455795,"name":"online","context":{"idset":"7,14"}}
+{"timestamp":1713982866.4785533,"name":"online","context":{"idset":"10"}}
+{"timestamp":1713982866.6512744,"name":"online","context":{"idset":"4"}}
+{"timestamp":1713982867.3172619,"name":"online","context":{"idset":"1"}}
+{"timestamp":1713982867.5152628,"name":"online","context":{"idset":"15"}}
+{"timestamp":1713982867.6863558,"name":"online","context":{"idset":"2"}}
+{"timestamp":1713982867.8120506,"name":"online","context":{"idset":"16"}}
+{"timestamp":1713982867.9819324,"name":"online","context":{"idset":"20"}}
+{"timestamp":1713982868.5041931,"name":"online","context":{"idset":"12,18"}}
+{"timestamp":1713982868.7936485,"name":"online","context":{"idset":"5,11"}}
+{"timestamp":1713982868.9076262,"name":"online","context":{"idset":"9"}}
+{"timestamp":1713982870.2439618,"name":"online","context":{"idset":"8"}}
+{"timestamp":1713982870.8293262,"name":"online","context":{"idset":"6"}}
+{"timestamp":1713984872.8405976,"name":"drain","context":{"idset":"7","reason":"broker was unresponsive"}}
+{"timestamp":1713984872.8406949,"name":"drain","context":{"idset":"10","reason":"broker was unresponsive"}}
+{"timestamp":1713984872.8407395,"name":"drain","context":{"idset":"14","reason":"broker was unresponsive"}}
+{"timestamp":1713984872.8407865,"name":"drain","context":{"idset":"15","reason":"broker was unresponsive"}}
+{"timestamp":1713984872.8408284,"name":"drain","context":{"idset":"16","reason":"broker was unresponsive"}}
+{"timestamp":1713984872.8408709,"name":"drain","context":{"idset":"20","reason":"broker was unresponsive"}}
+{"timestamp":1713984872.8409133,"name":"drain","context":{"idset":"37","reason":"broker was unresponsive"}}
+{"timestamp":1713984872.8409557,"name":"drain","context":{"idset":"38","reason":"broker was unresponsive"}}
+{"timestamp":1713984872.8410015,"name":"drain","context":{"idset":"39","reason":"broker was unresponsive"}}
+{"timestamp":1713984872.940526,"name":"drain","context":{"idset":"40","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.8410339,"name":"drain","context":{"idset":"1","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.8411019,"name":"drain","context":{"idset":"5","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.841146,"name":"drain","context":{"idset":"9","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.8411889,"name":"drain","context":{"idset":"11","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.8412344,"name":"drain","context":{"idset":"12","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.8412771,"name":"drain","context":{"idset":"18","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.841321,"name":"drain","context":{"idset":"21","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.8413656,"name":"drain","context":{"idset":"22","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.841409,"name":"drain","context":{"idset":"23","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.8414536,"name":"drain","context":{"idset":"24","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.8415015,"name":"drain","context":{"idset":"28","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.8415487,"name":"drain","context":{"idset":"33","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.8416054,"name":"drain","context":{"idset":"34","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.8416548,"name":"drain","context":{"idset":"35","reason":"broker was unresponsive"}}
+{"timestamp":1713984874.9416409,"name":"drain","context":{"idset":"36","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8412435,"name":"drain","context":{"idset":"2","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8413322,"name":"drain","context":{"idset":"3","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8413849,"name":"drain","context":{"idset":"4","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8414385,"name":"drain","context":{"idset":"6","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8414896,"name":"drain","context":{"idset":"8","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8415391,"name":"drain","context":{"idset":"13","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8415997,"name":"drain","context":{"idset":"17","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8416491,"name":"drain","context":{"idset":"19","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8416982,"name":"drain","context":{"idset":"25","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8417473,"name":"drain","context":{"idset":"26","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8417974,"name":"drain","context":{"idset":"27","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.841846,"name":"drain","context":{"idset":"29","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8418953,"name":"drain","context":{"idset":"30","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.8419483,"name":"drain","context":{"idset":"31","reason":"broker was unresponsive"}}
+{"timestamp":1713984876.9409621,"name":"drain","context":{"idset":"32","reason":"broker was unresponsive"}}
+{"timestamp":1713984938.8429897,"name":"offline","context":{"idset":"1"}}
+{"timestamp":1713984938.8431396,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1713984938.8432672,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1713984938.8433542,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1713984938.8434412,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1713984938.8435524,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1713984938.8436768,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1713984938.8437963,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1713984938.8439171,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1713984938.9546599,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1713984938.9548442,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1713984939.0674968,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1713984939.0676787,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1713984939.0677655,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1713984939.067858,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1713984939.0679886,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1713984939.0681605,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1713984939.0682442,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1713984939.0683408,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1713984939.0684171,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1713984939.0684907,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1713984939.0685947,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1713984939.0686648,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1713984939.068747,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1713984939.0688295,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1713984939.0689001,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1713984939.0689836,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1713984939.0690727,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1713984939.069139,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1713984939.0692298,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1713984939.069309,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1713984939.0693872,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1713984939.0694754,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1713984939.0695643,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1713984939.0696478,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1713984939.0697224,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1713984939.0697982,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1713984939.0699034,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1713984939.069973,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1713984939.0702,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1713991933.4650676,"name":"online","context":{"idset":"40"}}
+{"timestamp":1713991939.3504162,"name":"online","context":{"idset":"37"}}
+{"timestamp":1713991949.2638226,"name":"online","context":{"idset":"39"}}
+{"timestamp":1713991961.650804,"name":"online","context":{"idset":"38"}}
+{"timestamp":1713992115.2157364,"name":"online","context":{"idset":"2"}}
+{"timestamp":1713992115.3365548,"name":"online","context":{"idset":"1"}}
+{"timestamp":1713992115.5741246,"name":"online","context":{"idset":"34-35"}}
+{"timestamp":1713992115.8788595,"name":"online","context":{"idset":"36"}}
+{"timestamp":1713992116.1903315,"name":"online","context":{"idset":"25"}}
+{"timestamp":1713992116.9413693,"name":"online","context":{"idset":"27"}}
+{"timestamp":1713992117.1335239,"name":"online","context":{"idset":"18"}}
+{"timestamp":1713992117.2841096,"name":"online","context":{"idset":"28,32"}}
+{"timestamp":1713992117.3792427,"name":"online","context":{"idset":"29,31"}}
+{"timestamp":1713992117.5268309,"name":"online","context":{"idset":"24"}}
+{"timestamp":1713992117.5507739,"name":"online","context":{"idset":"19"}}
+{"timestamp":1713992117.7393384,"name":"online","context":{"idset":"21,30"}}
+{"timestamp":1713992117.8687425,"name":"online","context":{"idset":"26"}}
+{"timestamp":1713992117.9964063,"name":"online","context":{"idset":"17,22-23,33"}}
+{"timestamp":1713992118.155268,"name":"online","context":{"idset":"20"}}
+{"timestamp":1713992118.8408706,"name":"online","context":{"idset":"13"}}
+{"timestamp":1713992119.0468056,"name":"online","context":{"idset":"10,12"}}
+{"timestamp":1713992119.1555443,"name":"online","context":{"idset":"15"}}
+{"timestamp":1713992119.4292426,"name":"online","context":{"idset":"3,5,7,9,14"}}
+{"timestamp":1713992119.5524788,"name":"online","context":{"idset":"8"}}
+{"timestamp":1713992119.8194516,"name":"online","context":{"idset":"4,16"}}
+{"timestamp":1713992119.9976468,"name":"online","context":{"idset":"11"}}
+{"timestamp":1713992124.5133836,"name":"online","context":{"idset":"6"}}
+{"timestamp":1713992229.4854674,"name":"undrain","context":{"idset":"1-40"}}
+{"timestamp":1714425971.7527313,"name":"drain","context":{"idset":"35","reason":"nodediag failed amdgpu","overwrite":0}}
+{"timestamp":1714500646.9410026,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1714502158.667922,"name":"online","context":{"idset":"35"}}
+{"timestamp":1714502177.7259822,"name":"undrain","context":{"idset":"35"}}
+{"timestamp":1714660938.0305953,"name":"offline","context":{"idset":"38"}}
+{"timestamp":1714660938.0343237,"name":"offline","context":{"idset":"39"}}
+{"timestamp":1714660938.0614443,"name":"offline","context":{"idset":"40"}}
+{"timestamp":1714660938.1122987,"name":"offline","context":{"idset":"37"}}
+{"timestamp":1714660938.1363149,"name":"offline","context":{"idset":"13"}}
+{"timestamp":1714660938.1387,"name":"offline","context":{"idset":"33"}}
+{"timestamp":1714660938.1524351,"name":"offline","context":{"idset":"34"}}
+{"timestamp":1714660938.1669891,"name":"offline","context":{"idset":"9"}}
+{"timestamp":1714660938.1757388,"name":"offline","context":{"idset":"25"}}
+{"timestamp":1714660938.1778321,"name":"offline","context":{"idset":"6"}}
+{"timestamp":1714660938.1792617,"name":"offline","context":{"idset":"3"}}
+{"timestamp":1714660938.1812356,"name":"offline","context":{"idset":"22"}}
+{"timestamp":1714660938.1842203,"name":"offline","context":{"idset":"14"}}
+{"timestamp":1714660938.1869106,"name":"offline","context":{"idset":"18"}}
+{"timestamp":1714660938.187104,"name":"offline","context":{"idset":"10"}}
+{"timestamp":1714660938.20121,"name":"offline","context":{"idset":"4"}}
+{"timestamp":1714660938.201539,"name":"offline","context":{"idset":"11"}}
+{"timestamp":1714660938.2091799,"name":"offline","context":{"idset":"15"}}
+{"timestamp":1714660938.2097588,"name":"offline","context":{"idset":"24"}}
+{"timestamp":1714660938.2232111,"name":"offline","context":{"idset":"31"}}
+{"timestamp":1714660938.2355559,"name":"offline","context":{"idset":"7"}}
+{"timestamp":1714660938.2444515,"name":"offline","context":{"idset":"32"}}
+{"timestamp":1714660938.2542441,"name":"offline","context":{"idset":"17"}}
+{"timestamp":1714660938.2931008,"name":"offline","context":{"idset":"36"}}
+{"timestamp":1714660938.3234859,"name":"offline","context":{"idset":"12"}}
+{"timestamp":1714660938.3264921,"name":"offline","context":{"idset":"26"}}
+{"timestamp":1714660938.3791785,"name":"offline","context":{"idset":"35"}}
+{"timestamp":1714660938.4207473,"name":"offline","context":{"idset":"16"}}
+{"timestamp":1714660938.4209492,"name":"offline","context":{"idset":"8"}}
+{"timestamp":1714660938.4210281,"name":"offline","context":{"idset":"29"}}
+{"timestamp":1714660938.4395285,"name":"offline","context":{"idset":"21"}}
+{"timestamp":1714660938.4401307,"name":"offline","context":{"idset":"27"}}
+{"timestamp":1714660938.4465513,"name":"offline","context":{"idset":"19"}}
+{"timestamp":1714660938.4614763,"name":"offline","context":{"idset":"30"}}
+{"timestamp":1714660938.4616222,"name":"offline","context":{"idset":"28"}}
+{"timestamp":1714660938.4826641,"name":"offline","context":{"idset":"23"}}
+{"timestamp":1714660938.5833383,"name":"offline","context":{"idset":"20"}}
+{"timestamp":1714660938.6960547,"name":"offline","context":{"idset":"5"}}
+{"timestamp":1714660942.9150043,"name":"offline","context":{"idset":"2"}}
+{"timestamp":1714660943.0154507,"name":"offline","context":{"idset":"1"}}

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -376,7 +376,7 @@ test_expect_success 'nodes drained in old eventlog are drained after replay' '
 
 test_expect_success 'resource can replay eventlog with bad ranks' '
 	flux kvs put --raw resource.eventlog=- <<-EOT &&
-	{"timestamp":1713906351.000000,"name":"drain","context":{"idset":"42","reason":"","overwrite":0}}
+	{"timestamp":1713906351.000000,"name":"drain","context":{"idset":"42","nodelist":"fake42","reason":"","overwrite":0}}
 	EOT
 	flux module reload resource noverify
 '
@@ -385,7 +385,7 @@ test_expect_success 'no nodes are drained after replay' '
 	test -z "$(flux resource drain -n -o {nnodes})"
 '
 
-test_expect_success 'reload resource with two nodes drained and nodelist' '
+test_expect_success 'reload resource with two nodes drained' '
 	flux kvs put --raw resource.eventlog=- <<-EOT &&
 	{"timestamp":1713906350.984611,"name":"drain","context":{"idset":"1-2","nodelist":"fake[1-2]","reason":"uvula","overwrite":0}}
 	EOT

--- a/t/t2353-resource-eventlog.t
+++ b/t/t2353-resource-eventlog.t
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+test_description='Test resource eventlog upgrade
+
+Use the actual eventlog from test systems to see how the
+upgrade to v0.62.0 is going to go.
+'
+
+. `dirname $0`/sharness.sh
+
+export TEST_UNDER_FLUX_QUORUM=1
+export TEST_UNDER_FLUX_START_MODE=leader # only start rank 0
+
+SIZE=16384  # large instance to accommodate all test input
+test_under_flux $SIZE system
+
+test_expect_success 'test size is correct' '
+	test $(flux getattr size) -eq $SIZE
+'
+test_expect_success 'everything is down but rank 0' '
+	flux uptime | grep "$(($SIZE-1)) offline"
+'
+test_expect_success 'unload scheduler' '
+	flux module remove sched-simple
+'
+
+for eventlog in ${SHARNESS_TEST_SRCDIR}/resource/resource.eventlog.*; do
+	filename=$(basename $eventlog)
+	test_expect_success "load test resources $filename" '
+		flux dmesg -C &&
+		flux kvs put --raw resource.eventlog=- <$eventlog &&
+		flux module reload resource noverify
+	'
+	test_expect_success 'eventlog upgrade reduced entry count' '
+		flux dmesg | grep "resource.eventlog: reduced"
+	'
+	test_expect_success 'reloading resource module does not rewrite log' '
+		flux dmesg -C &&
+		flux module reload resource noverify &&
+		flux dmesg >dmesg.out &&
+		test_must_fail grep "resource.eventlog: reduced" dmesg.out
+	'
+	test_expect_success 'parse eventlog entry names' '
+		flux kvs get --raw resource.eventlog >$filename &&
+		jq -r -e ".name" <$filename >$filename.names
+	'
+	test_expect_success 'eventlog now contains no legacy events' '
+		test_must_fail grep -E "offline|online|resource-init" \
+		    $filename.names
+	'
+	# one orig resource-define plus two resource loads in the test
+	test_expect_success 'eventlog contains 3 resource-define events' '
+		count=$(grep "resource-define" $filename.names | wc -l) &&
+		test $count -eq 3
+	'
+done
+test_expect_success 'load scheduler' '
+	flux module load sched-simple
+'
+
+test_done


### PR DESCRIPTION
   Problem: under-specified resource.eventlog drain/undrain events, copious online/offline events, and bloated resource-init events are allowed to remain in resource.eventlog after recent updates that address these issues for new events.
    
If the resource.eventlog contains a resource-init event, rewrite the eventlog in the KVS with an upgraded version:
- remove resource-init, online, offline events
- add nodelist to under-specified drain/undrain events
    
Fixes #5931

