### PR TITLE
job-exec: fix potential use-after-free in bulk-exec implementation

### DIFF
--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -419,6 +419,7 @@ void bulk_exec_destroy (struct bulk_exec *exec)
         flux_watcher_destroy (exec->prep);
         flux_watcher_destroy (exec->check);
         flux_watcher_destroy (exec->idle);
+        flux_watcher_destroy (exec->exit_batch_timer);
         aux_destroy (&exec->aux);
         free (exec->name);
         free (exec->service);


### PR DESCRIPTION
Problem: The exit_batch_timer is not destroyed in bulk_exec_destroy(), which could result in the timer firing on a bulk_exec structure which has already been destroyed. Testing shows that this is a rare, but reproducible condition when bulk_exec_imp_kill() is used. This is possibly because destruction of the bulk_exec structure is tied to that of the future returned from this function. This allows the caller to destroy the future and the bulk_exec object before the timer watcher is cleared, resulting in use-after-free and memory corruption.

Destroy the exit_batch_timer watcher in bulk_exec_destroy().