### PR TITLE
flux-job: add `flux job taskmap --to=hosts`

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -347,13 +347,14 @@ support task mapping formats:
 
    Print the hostname of the node that rank task *TASKID*
 
-.. option:: --to=raw|pmi|multiline
+.. option:: --to=raw|pmi|multiline|hosts
 
-   Convert the taskmap to *raw* or *pmi* formats (described in RFC 34), or
-   *multiline* which prints the node ID of each task, one per line. The
-   default behavior is to print the RFC 34 taskmap. This option can be useful
-   to convert between mapping forms, since :program:`flux job taskmap` can
-   take a raw, pmi, or RFC 34 task map on the command line.
+   Convert the taskmap to *raw* or *pmi* formats (described in RFC 34),
+   *multiline* which prints the node ID of each task, one per line,
+   or *hosts* which prints a list of taskids for each host. The default
+   behavior is to print the RFC 34 taskmap. This option can be useful
+   to convert between mapping forms, since :program:`flux job taskmap`
+   can take a raw, pmi, or RFC 34 task map on the command line.
 
 Only one of the above options may be used per call.
 

--- a/src/cmd/job/taskmap.c
+++ b/src/cmd/job/taskmap.c
@@ -175,7 +175,7 @@ int cmd_taskmap (optparse_t *p, int argc, char **argv)
     int val;
     const char *to;
     char *s;
-    flux_jobid_t id;
+    flux_jobid_t id = FLUX_JOBID_ANY;
 
     if (optindex == argc) {
         optparse_print_usage (p);
@@ -212,6 +212,8 @@ int cmd_taskmap (optparse_t *p, int argc, char **argv)
         if (result < 0)
             log_err_exit ("failed to get nodeid for task %d", val);
         if (optparse_hasopt (p, "hostname")) {
+            if (id == FLUX_JOBID_ANY)
+                log_msg_exit ("taskmap: can't use --hostname without a jobid");
             char *host = job_nodeid_to_hostname (id, result);
             printf ("%s\n", host);
             free (host);
@@ -234,6 +236,8 @@ int cmd_taskmap (optparse_t *p, int argc, char **argv)
             return 0;
         }
         else if (streq (to, "hosts")) {
+            if (id == FLUX_JOBID_ANY)
+                log_msg_exit ("taskmap: can't use --to=hosts without a jobid");
             output_hosts_to_taskids (map, id);
             return 0;
         }

--- a/src/cmd/job/taskmap.c
+++ b/src/cmd/job/taskmap.c
@@ -46,7 +46,7 @@ struct optparse_option taskmap_opts[] = {
     OPTPARSE_TABLE_END
 };
 
-static struct taskmap *flux_job_taskmap (flux_jobid_t id)
+static struct taskmap *get_job_taskmap (flux_jobid_t id)
 {
     struct taskmap *map;
     flux_t *h;
@@ -92,7 +92,7 @@ static struct taskmap *flux_job_taskmap (flux_jobid_t id)
     return map;
 }
 
-static char *flux_job_nodeid_to_hostname (flux_jobid_t id, int nodeid)
+static char *job_nodeid_to_hostname (flux_jobid_t id, int nodeid)
 {
     flux_t *h;
     flux_future_t *f;
@@ -143,7 +143,7 @@ int cmd_taskmap (optparse_t *p, int argc, char **argv)
             log_msg_exit ("error decoding taskmap: %s", error.text);
     }
     else
-        map = flux_job_taskmap (id);
+        map = get_job_taskmap (id);
 
     if ((val = optparse_get_int (p, "taskids", -1)) != -1) {
         const struct idset *ids = taskmap_taskids (map, val);
@@ -168,7 +168,7 @@ int cmd_taskmap (optparse_t *p, int argc, char **argv)
         if (result < 0)
             log_err_exit ("failed to get nodeid for task %d", val);
         if (optparse_hasopt (p, "hostname")) {
-            char *host = flux_job_nodeid_to_hostname (id, result);
+            char *host = job_nodeid_to_hostname (id, result);
             printf ("%s\n", host);
             free (host);
         }


### PR DESCRIPTION
This PR adds a `--to=hosts` option to `flux job taskmap`, which prints the hostname: tasks mapping for a job when given a jobid. E.g. for a 4 node 16 task "cyclic" job:

```
$ src/cmd/flux job taskmap --to=hosts $(flux job last)
fluke87: 0,4,8,12
fluke88: 1,5,9,13
fluke89: 2,6,10,14
fluke90: 3,7,11,15
```