### PR TITLE
job-exec: support module stats to see current bulk-exec configuration

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -626,6 +626,7 @@ struct exec_implementation bulkexec = {
     .start =    exec_start,
     .kill =     exec_kill,
     .cancel =   exec_cancel,
+    .stats =    NULL,
 };
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -267,13 +267,6 @@ int config_init (flux_t *h, int argc, char **argv)
         }
     }
 
-    flux_log (h, LOG_DEBUG, "using default shell path %s", default_job_shell);
-    if (flux_imp_path) {
-        flux_log (h,
-                  LOG_DEBUG,
-                  "using imp path %s (with helper)",
-                  flux_imp_path);
-    }
     return 0;
 }
 

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -29,6 +29,8 @@ json_t *config_get_sdexec_properties (void);
 
 bool config_get_exec_service_override (void);
 
+int config_get_stats (json_t **config_stats);
+
 int config_init (flux_t *h, int argc, char **argv);
 
 #endif /* !HAVE_JOB_EXEC_CONFIG_EXEC_H */

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -271,7 +271,8 @@ int jobinfo_emit_event_pack_nowait (struct jobinfo *job,
     return rc;
 }
 
-static int jobid_exception (flux_t *h, flux_jobid_t id,
+static int jobid_exception (flux_t *h,
+                            flux_jobid_t id,
                             const flux_msg_t *msg,
                             const char *type,
                             int severity,

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -23,7 +23,7 @@ struct jobinfo;
 
 /*  Exec implementation interface:
  *
- *  An exec implementation must include the methods below:
+ *  An exec implementation must include the methods below (except where noted):
  *
  *   - config:  (optional) called once at module load for configuration
  *
@@ -44,6 +44,8 @@ struct jobinfo;
  *
  *   - cancel:  cancel any pending work (i.e. shells yet to be executed)
  *
+ *   - stats:   (optional) get json object of exec implementation stats
+ *
  */
 struct exec_implementation {
     const char *name;
@@ -54,6 +56,7 @@ struct exec_implementation {
     int  (*start)   (struct jobinfo *job);
     int  (*kill)    (struct jobinfo *job, int signum);
     int  (*cancel)  (struct jobinfo *job);
+    int  (*stats)   (json_t **stats);
 };
 
 /*  Exec job information */

--- a/src/modules/job-exec/testexec.c
+++ b/src/modules/job-exec/testexec.c
@@ -500,6 +500,7 @@ struct exec_implementation testexec = {
     .exit =     testexec_exit,
     .start =    testexec_start,
     .kill =     testexec_kill,
+    .stats =    NULL,
 };
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -39,8 +39,10 @@ const char **job_attrs (void)
     return attrs;
 }
 
-static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+static void stats_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     struct list_ctx *ctx = arg;
 

--- a/t/t2403-job-exec-conf.t
+++ b/t/t2403-job-exec-conf.t
@@ -18,26 +18,22 @@ test_expect_success 'job-exec: bad kill-timeout value causes module failure' '
 '
 test_expect_success 'job-exec: kill-timeout can be set in exec conf' '
 	name=killconf &&
-	mkdir ${name}.d &&
-	cat <<-EOF > ${name}.d/exec.toml &&
+	cat <<-EOF > ${name}.toml &&
 	[exec]
 	kill-timeout = ".5m"
 	EOF
-	( export FLUX_CONF_DIR=${name}.d &&
-	  flux start -s1 flux dmesg > ${name}.log 2>&1
-	) &&
+	flux start -o,--config-path=${name}.toml -s1 \
+		flux dmesg > ${name}.log 2>&1 &&
 	grep "using kill-timeout of 30s" ${name}.log
 '
 test_expect_success 'job-exec: bad kill-timeout config causes module failure' '
 	name=bad-killconf &&
-	mkdir ${name}.d &&
-	cat <<-EOF > ${name}.d/exec.toml &&
+	cat <<-EOF > ${name}.toml &&
 	[exec]
 	kill-timeout = "foo"
 	EOF
-	( export FLUX_CONF_DIR=${name}.d &&
-	  test_must_fail flux start -s1 flux dmesg > ${name}.log 2>&1
-	) &&
+	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
+		flux dmesg > ${name}.log 2>&1 &&
 	grep "invalid kill-timeout: foo" ${name}.log
 '
 test_expect_success 'job-exec: can specify default-shell on cmdline' '
@@ -48,26 +44,22 @@ test_expect_success 'job-exec: can specify default-shell on cmdline' '
 '
 test_expect_success 'job-exec: job-shell can be set in exec conf' '
 	name=shellconf &&
-	mkdir ${name}.d &&
-	cat <<-EOF > ${name}.d/exec.toml &&
+	cat <<-EOF > ${name}.toml &&
 	[exec]
 	job-shell = "my-flux-shell"
 	EOF
-	( export FLUX_CONF_DIR=${name}.d &&
-	  flux start -s1 flux dmesg > ${name}.log 2>&1
-	) &&
+	flux start -o,--config-path=${name}.toml -s1 \
+		flux dmesg > ${name}.log 2>&1 &&
 	grep "using default shell path my-flux-shell" ${name}.log
 '
 test_expect_success 'job-exec: bad job-shell config causes module failure' '
 	name=bad-shellconf &&
-	mkdir ${name}.d &&
-	cat <<-EOF > ${name}.d/exec.toml &&
+	cat <<-EOF > ${name}.toml &&
 	[exec]
 	job-shell = 42
 	EOF
-	( export FLUX_CONF_DIR=${name}.d &&
-	  test_must_fail flux start -s1 flux dmesg > ${name}.log 2>&1
-	) &&
+	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
+		flux dmesg > ${name}.log 2>&1 &&
 	grep "error reading config value exec.job-shell" ${name}.log
 '
 test_expect_success 'job-exec: can specify imp path on cmdline' '
@@ -78,26 +70,22 @@ test_expect_success 'job-exec: can specify imp path on cmdline' '
 '
 test_expect_success 'job-exec: imp path can be set in exec conf' '
 	name=impconf &&
-	mkdir ${name}.d &&
-	cat <<-EOF > ${name}.d/exec.toml &&
+	cat <<-EOF > ${name}.toml &&
 	[exec]
 	imp = "my-flux-imp"
 	EOF
-	( export FLUX_CONF_DIR=${name}.d &&
-	  flux start -s1 flux dmesg > ${name}.log 2>&1
-	) &&
+	flux start -o,--config-path=${name}.toml -s1 \
+		flux dmesg > ${name}.log 2>&1 &&
 	grep "using imp path my-flux-imp" ${name}.log
 '
 test_expect_success 'job-exec: bad imp config causes module failure' '
 	name=bad-impconf &&
-	mkdir ${name}.d &&
-	cat <<-EOF > ${name}.d/exec.toml &&
+	cat <<-EOF > ${name}.toml &&
 	[exec]
 	imp = 42
 	EOF
-	( export FLUX_CONF_DIR=${name}.d &&
-	  test_must_fail flux start -s1 flux dmesg > ${name}.log 2>&1
-	) &&
+	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
+		flux dmesg > ${name}.log 2>&1 &&
 	grep "error reading config value exec.imp" ${name}.log
 '
 

--- a/t/t2403-job-exec-conf.t
+++ b/t/t2403-job-exec-conf.t
@@ -37,10 +37,9 @@ test_expect_success 'job-exec: bad kill-timeout config causes module failure' '
 	grep "invalid kill-timeout: foo" ${name}.log
 '
 test_expect_success 'job-exec: can specify default-shell on cmdline' '
-	flux dmesg -C &&
 	flux module reload -f job-exec job-shell=/path/to/shell &&
-	flux dmesg &&
-	flux dmesg | grep "default shell path /path/to/shell"
+	flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > stats1.out &&
+	grep "/path/to/shell" stats1.out
 '
 test_expect_success 'job-exec: job-shell can be set in exec conf' '
 	name=shellconf &&
@@ -49,8 +48,8 @@ test_expect_success 'job-exec: job-shell can be set in exec conf' '
 	job-shell = "my-flux-shell"
 	EOF
 	flux start -o,--config-path=${name}.toml -s1 \
-		flux dmesg > ${name}.log 2>&1 &&
-	grep "using default shell path my-flux-shell" ${name}.log
+		flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > ${name}.out 2>&1 &&
+	grep "my-flux-shell" ${name}.out
 '
 test_expect_success 'job-exec: bad job-shell config causes module failure' '
 	name=bad-shellconf &&
@@ -63,10 +62,9 @@ test_expect_success 'job-exec: bad job-shell config causes module failure' '
 	grep "error reading config value exec.job-shell" ${name}.log
 '
 test_expect_success 'job-exec: can specify imp path on cmdline' '
-	flux dmesg -C &&
 	flux module reload -f job-exec imp=/path/to/imp &&
-	flux dmesg &&
-	flux dmesg | grep "using imp path /path/to/imp"
+	flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > stats2.out &&
+	grep "/path/to/imp" stats2.out
 '
 test_expect_success 'job-exec: imp path can be set in exec conf' '
 	name=impconf &&
@@ -75,8 +73,8 @@ test_expect_success 'job-exec: imp path can be set in exec conf' '
 	imp = "my-flux-imp"
 	EOF
 	flux start -o,--config-path=${name}.toml -s1 \
-		flux dmesg > ${name}.log 2>&1 &&
-	grep "using imp path my-flux-imp" ${name}.log
+		flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > ${name}.out 2>&1 &&
+	grep "my-flux-imp" ${name}.out
 '
 test_expect_success 'job-exec: bad imp config causes module failure' '
 	name=bad-impconf &&

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -28,7 +28,7 @@ export FLUX_CONF_DIR=$(pwd)/conf.d
 test_under_flux 2 job
 
 test_expect_success 'job-exec: module configured to use IMP' '
-	flux dmesg | grep "using imp path ${IMP}"
+	flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec | grep ${IMP}
 '
 test_expect_success 'job-exec: job as instance owner works' '
 	test "$(id -u)" = "$(flux run id -u)"


### PR DESCRIPTION
Per comments in #5913, did a bunch of cleanup/re-work in prep of job-exec config reload (#5900).  

- job-exec module stats that export current config values (did it in a "impl.bulk-exec.config." object).
- modernize tests in t2403-job-exec-conf.t
- update to use module stats to determine conf
- add missing coverage of other job-exec confs
