### PR TITLE
shell: add `hwloc.restrict` option to restrict `HWLOC_XMLFILE` to assigned resources

### DIFF
--- a/doc/man1/common/job-shell-options.rst
+++ b/doc/man1/common/job-shell-options.rst
@@ -43,6 +43,11 @@
        presence of this environment variable may cause hwloc to ignore
        ``HWLOC_XMLFILE``.
 
+   * - :option:`hwloc.restrict`
+     - With :option:`hwloc.xmlfile`, restrict the exported topology XML to only
+       those resources assigned to the current job. By default, the XML is
+       not restricted.
+
    * - :option:`output.limit`
      - Set KVS output limit to SIZE bytes, where SIZE may be a floating point
        value including optional SI units: k, K, M, G. This value is ignored

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -457,6 +457,12 @@ plugins include:
   Note that this option will also unset ``HWLOC_COMPONENTS`` since presence
   of this environment variable may cause hwloc to ignore ``HWLOC_XMLFILE``.
 
+.. option:: hwloc.restrict
+
+  With :option:`hwloc.xmlfile`, restrict the exported topology XML to only
+  the resources assigned to the current job. By default the XML is not
+  restricted.
+
 .. warning::
   The directory referenced by :envvar:`FLUX_JOB_TMPDIR` is cleaned up when the
   job ends, is guaranteed to be unique, and is generally on fast local storage

--- a/src/shell/hwloc.c
+++ b/src/shell/hwloc.c
@@ -25,14 +25,16 @@
 #include <flux/shell.h>
 
 #include "src/common/libutil/read_all.h"
+#include "src/common/librlist/rhwloc.h"
 #include "ccan/str/str.h"
 
 #include "builtins.h"
 
-static int create_xmlfile (flux_shell_t *shell)
+static int create_xmlfile (flux_shell_t *shell, int do_restrict)
 {
     int fd = -1;
     char *xmlfile = NULL;
+    char *restricted_xml = NULL;
     const char *hwloc_xml;
     const char *tmpdir;
 
@@ -42,6 +44,13 @@ static int create_xmlfile (flux_shell_t *shell)
     if (flux_shell_get_hwloc_xml (shell, &hwloc_xml) < 0) {
         shell_log_error ("failed to get shell hwloc xml");
         goto error;
+    }
+    if (do_restrict) {
+        if (!(restricted_xml = rhwloc_topology_xml_restrict (hwloc_xml))) {
+            shell_log_errno ("failed to restrict topology xml");
+            goto error;
+        }
+        hwloc_xml = restricted_xml;
     }
     if (asprintf (&xmlfile, "%s/hwloc.xml", tmpdir) < 0) {
         shell_log_error ("asprintf HWLOC_XMLFILE failed");
@@ -75,6 +84,7 @@ error:
     if (fd >= 0)
         close (fd);
     free (xmlfile);
+    free (restricted_xml);
     return -1;
 }
 
@@ -85,14 +95,16 @@ static int hwloc_post_init (flux_plugin_t *p,
 {
     flux_shell_t *shell = flux_plugin_get_shell (p);
     int xmlfile = 0;
+    int do_restrict = 0;
 
     if (flux_shell_getopt_unpack (shell,
                                   "hwloc",
-                                  "{s?i}",
-                                    "xmlfile", &xmlfile) < 0)
+                                  "{s?i s?i}",
+                                    "xmlfile", &xmlfile,
+                                    "restrict", &do_restrict) < 0)
         return shell_log_errno ("failed to unpack hwloc options");
 
-    if (xmlfile && create_xmlfile (shell) < 0)
+    if (xmlfile && create_xmlfile (shell, do_restrict) < 0)
         return shell_log_errno ("failed to write HWLOC_XMLFILE");
     return 0;
 }

--- a/t/t2619-job-shell-hwloc.t
+++ b/t/t2619-job-shell-hwloc.t
@@ -33,4 +33,14 @@ test_expect_success 'shell: -o hwloc.xmlfile sets HWLOC_XMLFILE per node' '
 test_expect_success 'shell: bad hwloc.xmlfile value is an error' '
 	test_must_fail flux run -o hwloc.xmlfile=foo printenv HWLOC_XMLFILE
 '
+if which hwloc-bind > /dev/null; then
+        NCORES=$(hwloc-bind --get | hwloc-calc --number-of core | tail -n 1)
+        test $NCORES = 1 || test_set_prereq MULTICORE
+fi
+test_expect_success MULTICORE 'shell: -o hwloc.restrict restricts hwloc XML' '
+	flux run -n1 -o hwloc.xmlfile -o hwloc.restrict \
+		hwloc-calc --number-of core all &&
+	test $(flux run -n1 -o hwloc.xmlfile -o hwloc.restrict \
+		hwloc-calc --number-of core all) -eq 1
+'
 test_done


### PR DESCRIPTION
This PR adds the `hwloc.restrict` job shell option as described in #5934, along with a trivial test and docs.