### PR TITLE
do not filter caches when loading hwloc topology

### DIFF
--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -40,10 +40,6 @@ static int topo_init_common (hwloc_topology_t *tp, unsigned long flags)
                                            HWLOC_TYPE_FILTER_KEEP_IMPORTANT)
         < 0)
         return -1;
-    if (hwloc_topology_set_cache_types_filter(*tp,
-                                              HWLOC_TYPE_FILTER_KEEP_STRUCTURE)
-        < 0)
-        return -1;
     if (hwloc_topology_set_icache_types_filter(*tp,
                                                HWLOC_TYPE_FILTER_KEEP_STRUCTURE)
         < 0)


### PR DESCRIPTION
As discussed in #5934, this PR removes the lines from librlist that are currently filtering out L2/L3/etc caches in the hwloc topology loaded by flux, thus making this information unavailable to components and processes that use this topology, since it is shared from parent to child instance and shell to shell plugin.