### PR TITLE
job-exec: remove layer of stats indirection

### DIFF
--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1481,7 +1481,7 @@ static void stats_cb (flux_t *h,
         }
         i++;
     }
-    if (flux_respond_pack (h, msg, "{s:o}", "impl", o) < 0)
+    if (flux_respond_pack (h, msg, "o", o) < 0)
         flux_log_error (h, "error responding to stats-get request");
     return;
 error:

--- a/t/t2403-job-exec-conf.t
+++ b/t/t2403-job-exec-conf.t
@@ -40,7 +40,7 @@ test_expect_success 'job-exec: bad kill-timeout config causes module failure' '
 '
 test_expect_success 'job-exec: can specify default-shell on cmdline' '
 	flux module reload -f job-exec job-shell=/path/to/shell &&
-	flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > stats1.out &&
+	flux module stats -p bulk-exec.config.default_job_shell job-exec > stats1.out &&
 	grep "/path/to/shell" stats1.out
 '
 test_expect_success 'job-exec: job-shell can be set in exec conf' '
@@ -50,7 +50,7 @@ test_expect_success 'job-exec: job-shell can be set in exec conf' '
 	job-shell = "my-flux-shell"
 	EOF
 	flux start -o,--config-path=${name}.toml -s1 \
-		flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > ${name}.out 2>&1 &&
+		flux module stats -p bulk-exec.config.default_job_shell job-exec > ${name}.out 2>&1 &&
 	grep "my-flux-shell" ${name}.out
 '
 test_expect_success 'job-exec: bad job-shell config causes module failure' '
@@ -65,33 +65,33 @@ test_expect_success 'job-exec: bad job-shell config causes module failure' '
 '
 test_expect_success 'job-exec: update default shell via config reload' '
 	flux module reload -f job-exec &&
-	flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > reload1A.out 2>&1 &&
+	flux module stats -p bulk-exec.config.default_job_shell job-exec > reload1A.out 2>&1 &&
 	grep "flux-shell" reload1A.out &&
 	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
 	[exec]
 	job-shell = "/path/reload-shell"
 	EOF
 	flux config reload &&
-	flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > reload1B.out 2>&1 &&
+	flux module stats -p bulk-exec.config.default_job_shell job-exec > reload1B.out 2>&1 &&
 	grep "reload-shell" reload1B.out &&
 	rm -f ${FLUX_CONF_DIR}/exec.toml
 '
 test_expect_success 'job-exec: cmdline default shell takes priority' '
 	flux module reload -f job-exec job-shell=/path/cmdline-shell &&
-	flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > reload2A.out 2>&1 &&
+	flux module stats -p bulk-exec.config.default_job_shell job-exec > reload2A.out 2>&1 &&
 	grep "cmdline-shell" reload2A.out &&
 	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
 	[exec]
 	job-shell = "/path/reload-shell"
 	EOF
 	flux config reload &&
-	flux module stats -p impl.bulk-exec.config.default_job_shell job-exec > reload2B.out 2>&1 &&
+	flux module stats -p bulk-exec.config.default_job_shell job-exec > reload2B.out 2>&1 &&
 	grep "cmdline-shell" reload2B.out &&
 	rm -f ${FLUX_CONF_DIR}/exec.toml
 '
 test_expect_success 'job-exec: can specify imp path on cmdline' '
 	flux module reload -f job-exec imp=/path/to/imp &&
-	flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > stats2.out &&
+	flux module stats -p bulk-exec.config.flux_imp_path job-exec > stats2.out &&
 	grep "/path/to/imp" stats2.out
 '
 test_expect_success 'job-exec: imp path can be set in exec conf' '
@@ -101,7 +101,7 @@ test_expect_success 'job-exec: imp path can be set in exec conf' '
 	imp = "my-flux-imp"
 	EOF
 	flux start -o,--config-path=${name}.toml -s1 \
-		flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > ${name}.out 2>&1 &&
+		flux module stats -p bulk-exec.config.flux_imp_path job-exec > ${name}.out 2>&1 &&
 	grep "my-flux-imp" ${name}.out
 '
 test_expect_success 'job-exec: bad imp config causes module failure' '
@@ -117,19 +117,19 @@ test_expect_success 'job-exec: bad imp config causes module failure' '
 # N.B. imp not configured by default
 test_expect_success 'job-exec: update imp path via config reload' '
 	flux module reload -f job-exec &&
-	test_must_fail flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > reload3A.out 2>&1 &&
+	test_must_fail flux module stats -p bulk-exec.config.flux_imp_path job-exec > reload3A.out 2>&1 &&
 	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
 	[exec]
 	imp = "/path/reload-imp"
 	EOF
 	flux config reload &&
-	flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > reload3B.out 2>&1 &&
+	flux module stats -p bulk-exec.config.flux_imp_path job-exec > reload3B.out 2>&1 &&
 	grep "reload-imp" reload3B.out &&
 	rm -f ${FLUX_CONF_DIR}/exec.toml
 '
 test_expect_success 'job-exec: cmdline imp path takes priority' '
 	flux module reload -f job-exec imp=/path/cmdline-imp &&
-	flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > reload4A.out 2>&1 &&
+	flux module stats -p bulk-exec.config.flux_imp_path job-exec > reload4A.out 2>&1 &&
 	grep "cmdline-imp" reload4A.out &&
 	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
 	[exec]
@@ -137,13 +137,13 @@ test_expect_success 'job-exec: cmdline imp path takes priority' '
 	EOF
 	flux dmesg -C &&
 	flux config reload &&
-	flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec > reload4B.out 2>&1 &&
+	flux module stats -p bulk-exec.config.flux_imp_path job-exec > reload4B.out 2>&1 &&
 	grep "cmdline-imp" reload4B.out &&
 	rm -f ${FLUX_CONF_DIR}/exec.toml
 '
 test_expect_success 'job-exec: can specify exec service on cmdline' '
 	flux module reload -f job-exec service=foo &&
-	flux module stats -p impl.bulk-exec.config.exec_service job-exec > stats3.out &&
+	flux module stats -p bulk-exec.config.exec_service job-exec > stats3.out &&
 	grep "foo" stats3.out
 '
 test_expect_success 'job-exec: exec service can be set in exec conf' '
@@ -153,33 +153,33 @@ test_expect_success 'job-exec: exec service can be set in exec conf' '
 	service = "bar"
 	EOF
 	flux start -o,--config-path=${name}.toml -s1 \
-		flux module stats -p impl.bulk-exec.config.exec_service job-exec > ${name}.out 2>&1 &&
+		flux module stats -p bulk-exec.config.exec_service job-exec > ${name}.out 2>&1 &&
 	grep "bar" ${name}.out
 '
 # N.B. exec service defaults to rexec
 test_expect_success 'job-exec: update exec service via config reload' '
 	flux module reload -f job-exec &&
-	flux module stats -p impl.bulk-exec.config.exec_service job-exec > reload5A.out 2>&1 &&
+	flux module stats -p bulk-exec.config.exec_service job-exec > reload5A.out 2>&1 &&
 	grep "rexec" reload5A.out &&
 	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
 	[exec]
 	service = "reload-exec-service"
 	EOF
 	flux config reload &&
-	flux module stats -p impl.bulk-exec.config.exec_service job-exec > reload5B.out 2>&1 &&
+	flux module stats -p bulk-exec.config.exec_service job-exec > reload5B.out 2>&1 &&
 	grep "reload-exec-service" reload5B.out &&
 	rm -f ${FLUX_CONF_DIR}/exec.toml
 '
 test_expect_success 'job-exec: cmdline exec service takes priority' '
 	flux module reload -f job-exec service=cmdline-exec-service &&
-	flux module stats -p impl.bulk-exec.config.exec_service job-exec > reload6A.out 2>&1 &&
+	flux module stats -p bulk-exec.config.exec_service job-exec > reload6A.out 2>&1 &&
 	grep "cmdline-exec-service" reload6A.out &&
 	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
 	[exec]
 	service = "reload-exec-service"
 	EOF
 	flux config reload &&
-	flux module stats -p impl.bulk-exec.config.exec_service job-exec > reload6B.out 2>&1 &&
+	flux module stats -p bulk-exec.config.exec_service job-exec > reload6B.out 2>&1 &&
 	grep "cmdline-exec-service" reload6B.out &&
 	rm -f ${FLUX_CONF_DIR}/exec.toml
 '
@@ -191,14 +191,14 @@ test_expect_success 'job-exec: exec service override can be set in exec conf' '
 	service-override = true
 	EOF
 	flux start -o,--config-path=${name}.toml -s1 \
-		flux module stats -p impl.bulk-exec.config.exec_service_override job-exec > ${name}.out 2>&1 &&
+		flux module stats -p bulk-exec.config.exec_service_override job-exec > ${name}.out 2>&1 &&
 	val=$(cat ${name}.out) &&
 	test $val -eq 1
 '
 # N.B. exec service defaults to off/disabled
 test_expect_success 'job-exec: update exec service override via config reload' '
 	flux module reload -f job-exec &&
-	flux module stats -p impl.bulk-exec.config.exec_service_override job-exec > reload7A.out 2>&1 &&
+	flux module stats -p bulk-exec.config.exec_service_override job-exec > reload7A.out 2>&1 &&
 	val=$(cat reload7A.out) &&
 	test $val -eq 0 &&
 	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
@@ -206,7 +206,7 @@ test_expect_success 'job-exec: update exec service override via config reload' '
 	service-override = true
 	EOF
 	flux config reload &&
-	flux module stats -p impl.bulk-exec.config.exec_service_override job-exec > reload7B.out 2>&1 &&
+	flux module stats -p bulk-exec.config.exec_service_override job-exec > reload7B.out 2>&1 &&
 	val=$(cat reload7B.out) &&
 	test $val -eq 1 &&
 	rm -f ${FLUX_CONF_DIR}/exec.toml
@@ -221,7 +221,7 @@ test_expect_success 'job-exec: sdexex properties can be set in exec conf' '
 	MemoryMax = "100M"
 	EOF
 	flux start -o,--config-path=${name}.toml -s1 \
-		flux module stats -p impl.bulk-exec.config.sdexec_properties job-exec > ${name}.out 2>&1 &&
+		flux module stats -p bulk-exec.config.sdexec_properties job-exec > ${name}.out 2>&1 &&
 	jq -e ".MemoryHigh == \"200M\"" < ${name}.out &&
 	jq -e ".MemoryMax == \"100M\"" < ${name}.out
 '
@@ -251,7 +251,7 @@ test_expect_success 'job-exec: bad sdexec properties causes module failure (type
 # N.B. sdexec properties defaults to not set
 test_expect_success 'job-exec: update sdexec properties via config reload' '
 	flux module reload -f job-exec &&
-	test_must_fail flux module stats -p impl.bulk-exec.config.sdexec_properties job-exec > reload8A.out 2>&1 &&
+	test_must_fail flux module stats -p bulk-exec.config.sdexec_properties job-exec > reload8A.out 2>&1 &&
 	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
 	[exec]
 	service = "sdexec"
@@ -259,7 +259,7 @@ test_expect_success 'job-exec: update sdexec properties via config reload' '
 	MemoryHigh = "200M"
 	EOF
 	flux config reload &&
-	flux module stats -p impl.bulk-exec.config.sdexec_properties job-exec > reload8B.out 2>&1 &&
+	flux module stats -p bulk-exec.config.sdexec_properties job-exec > reload8B.out 2>&1 &&
 	jq -e ".MemoryHigh == \"200M\"" < reload8B.out &&
 	rm -f ${FLUX_CONF_DIR}/exec.toml
 '
@@ -268,7 +268,7 @@ test_expect_success 'job-exec: update sdexec properties via config reload' '
 test_expect_success 'job-exec: bad sdexec properties leads to error on via config reload' '
 	flux config reload &&
 	flux module reload -f job-exec &&
-	test_must_fail flux module stats -p impl.bulk-exec.config.sdexec_properties job-exec > reload9A.out 2>&1 &&
+	test_must_fail flux module stats -p bulk-exec.config.sdexec_properties job-exec > reload9A.out 2>&1 &&
 	cat <<-EOF > ${FLUX_CONF_DIR}/exec.toml &&
 	[exec]
 	service = "sdexec"

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -28,7 +28,7 @@ export FLUX_CONF_DIR=$(pwd)/conf.d
 test_under_flux 2 job
 
 test_expect_success 'job-exec: module configured to use IMP' '
-	flux module stats -p impl.bulk-exec.config.flux_imp_path job-exec | grep ${IMP}
+	flux module stats -p bulk-exec.config.flux_imp_path job-exec | grep ${IMP}
 '
 test_expect_success 'job-exec: job as instance owner works' '
 	test "$(id -u)" = "$(flux run id -u)"


### PR DESCRIPTION
Problem: All job-exec stats are listed under a key "impl", which is excessive.

Remove the top level key "impl".  Now the top level keys are simply the names of the exec implementations, i.e. "bulk-exec".

Update all tests accordingly.