### PR TITLE
job-exec: silence some nuisance logging

### DIFF
--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -407,18 +407,14 @@ static void server_write_cb (flux_t *h,
         goto out;
     }
 
+    /* If the subprocess can't be found or is no longer running, just silently
+     * drop the data. This is expected if tasks are killed or exit with data
+     * in flight, and is not necessarily an error, and can be common enough
+     * that the log messages end up being a nuisance.
+     */
     if (!(p = proc_find_bypid (s, pid))
-        || p->state != FLUX_SUBPROCESS_RUNNING) {
-        if (len > 0) { // skip logging if no data is being dropped (e.g. eof)
-            llog_error (s,
-                        "Error writing %d bytes to subprocess pid %d %s: %s",
-                        len,
-                        (int)pid,
-                        stream,
-                        p ? "not running" : "unknown pid");
-        }
+        || p->state != FLUX_SUBPROCESS_RUNNING)
         goto out;
-    }
 
     if (data && len) {
         int rc = flux_subprocess_write (p, stream, data, len);

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -549,7 +549,7 @@ void bulk_exec_kill_log_error (flux_future_t *f, flux_jobid_t id)
         uint32_t rank = flux_rpc_get_nodeid (cf);
         if (flux_future_is_ready (cf)
             && flux_future_get (cf, NULL) < 0
-            && errno != ENOENT
+            && errno != ESRCH
             && rank != FLUX_NODEID_ANY) {
             flux_log (h,
                       LOG_ERR,

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -585,11 +585,6 @@ static int exec_kill (struct jobinfo *job, int signum)
         return 0;
     }
 
-    flux_log (job->h, LOG_DEBUG,
-              "exec_kill: %s: signal %d",
-              idf58 (job->id),
-              signum);
-
     jobinfo_incref (job);
     if (flux_future_then (f, 3., exec_kill_cb, job) < 0) {
         flux_log_error (job->h,


### PR DESCRIPTION
While testing some other things it was apparent that job-exec is a contributor to nuisance logging. Especially bad was some libsubprocess server logging when data can't be written to processes that have since disappeared due to being killed.

This PR cleans up some of that useless logging. (and fixes one place where it was already meant to be cleaned up)