### PR TITLE
libsubprocess: remove unused len parameter from flux_subprocess_read()

### DIFF
--- a/src/cmd/job/mpir.c
+++ b/src/cmd/job/mpir.c
@@ -188,7 +188,7 @@ static void output_cb (flux_subprocess_t *p, const char *stream)
 
     line = flux_subprocess_read_trimmed_line (p, stream, &len);
     if (line && len == 0)
-        line = flux_subprocess_read (p, stream, -1, &len);
+        line = flux_subprocess_read (p, stream, &len);
     if (len)
         log_msg ("MPIR: rank %d: %s: %s: %s", rank, prog, stream, line);
 }

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -246,7 +246,7 @@ static void proc_output_cb (flux_subprocess_t *p, const char *stream)
     const char *ptr;
     int lenp;
 
-    if (!(ptr = flux_subprocess_read (p, stream, -1, &lenp))) {
+    if (!(ptr = flux_subprocess_read (p, stream, &lenp))) {
         llog_error (s,
                     "error reading from subprocess stream %s: %s",
                     stream,

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -190,8 +190,7 @@ int flux_subprocess_write (flux_subprocess_t *p,
 int flux_subprocess_close (flux_subprocess_t *p, const char *stream);
 
 /*
- *  Read up to `len` bytes of unread data from stream `stream`.  To
- *   read all data, specify 'len' of -1.  'stream' can be "stdout",
+ *  Read unread data from stream `stream`.  'stream' can be "stdout",
  *   "stderr", or the name of a stream specified with flux_cmd_add_channel().
  *
  *   Returns pointer to buffer on success and NULL on error with errno
@@ -208,7 +207,6 @@ int flux_subprocess_close (flux_subprocess_t *p, const char *stream);
  */
 const char *flux_subprocess_read (flux_subprocess_t *p,
                                   const char *stream,
-                                  int len,
                                   int *lenp);
 
 /*

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -206,7 +206,7 @@ const char *flux_subprocess_read (flux_subprocess_t *p,
                                   int *lenp);
 
 /*
- *  Read line unread data from stream `stream`.  'stream' can be
+ *  Read line of unread data from stream `stream`.  'stream' can be
  *   "stdout", "stderr", or the name of a stream specified with
  *   flux_cmd_add_channel().
  *

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -197,8 +197,14 @@ int flux_subprocess_close (flux_subprocess_t *p, const char *stream);
  *   Returns pointer to buffer on success and NULL on error with errno
  *   set.  Buffer is guaranteed to be NUL terminated.  User shall not
  *   free returned pointer.  Length of buffer returned can optionally
- *   returned in 'lenp'.  A length of 0 indicates that the subprocess
- *   has closed this stream.
+ *   returned in 'lenp'.
+ *
+ *   In most cases, a length of 0 indicates that the subprocess has
+ *   closed this stream.  A length of 0 could be returned if read
+ *   functions are called multiple times within a single output
+ *   callback, so it is generally recommended to call this function
+ *   once per output callback.  flux_subprocess_read_stream_closed()
+ *   can always be used to verify if the stream is in fact closed.
  */
 const char *flux_subprocess_read (flux_subprocess_t *p,
                                   const char *stream,

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -215,6 +215,11 @@ const char *flux_subprocess_read (flux_subprocess_t *p,
  *   be NUL terminated.  If no line is available, returns pointer and
  *   length of zero.  User shall not free returned pointer.  Length of
  *   buffer returned can optionally returned in 'lenp'.
+ *
+ *   A length of zero may be returned if the stream is closed OR if
+ *   the stream is line buffered and a line is not yet available. Use
+ *   flux_subprocess_read_stream_closed() to distinguish between the
+ *   two.
  */
 const char *flux_subprocess_read_line (flux_subprocess_t *p,
                                        const char *stream,

--- a/src/common/libsubprocess/test/channel.c
+++ b/src/common/libsubprocess/test/channel.c
@@ -78,7 +78,7 @@ void channel_fd_env_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
@@ -142,7 +142,7 @@ void channel_in_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
@@ -213,7 +213,7 @@ void channel_in_and_out_cb (flux_subprocess_t *p, const char *stream)
         /* no check of flux_subprocess_read_stream_closed(), we aren't
          * closing channel in test below */
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
@@ -303,7 +303,7 @@ void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
         /* no check of flux_subprocess_read_stream_closed(), we aren't
          * closing channel in test below */
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
@@ -378,7 +378,7 @@ void channel_nul_terminate_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);

--- a/src/common/libsubprocess/test/stdio.c
+++ b/src/common/libsubprocess/test/stdio.c
@@ -96,7 +96,7 @@ void output_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
@@ -249,7 +249,7 @@ void output_default_stream_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", "stdout");
 
-        ptr = flux_subprocess_read (p, "stdout", -1, &lenp);
+        ptr = flux_subprocess_read (p, "stdout", &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", "stdout");
@@ -314,7 +314,7 @@ void output_no_newline_cb (flux_subprocess_t *p, const char *stream)
             && lenp == 0,
             "flux_subprocess_read_line on %s read 0 lines", stream);
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp > 0,
             "flux_subprocess_read on %s read success", stream);
@@ -331,7 +331,7 @@ void output_no_newline_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
@@ -402,7 +402,7 @@ void output_trimmed_line_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
@@ -494,7 +494,7 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
@@ -564,7 +564,7 @@ void stdin_closed_cb (flux_subprocess_t *p, const char *stream)
     ok (flux_subprocess_read_stream_closed (p, stream),
         "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-    ptr = flux_subprocess_read (p, stream, -1, &lenp);
+    ptr = flux_subprocess_read (p, stream, &lenp);
     ok (ptr != NULL
         && lenp == 0,
         "flux_subprocess_read on %s read EOF", stream);
@@ -709,12 +709,12 @@ void output_read_line_until_eof_error_cb (flux_subprocess_t *p, const char *stre
 
         /* drain whatever is in the buffer, we don't care about
          * contents for this test */
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL && lenp > 0,
             "flux_subprocess_read on %s success", stream);
     }
     else {
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
@@ -889,7 +889,7 @@ void line_output_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
@@ -1089,7 +1089,7 @@ void start_stdout_after_stderr_cb (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    ptr = flux_subprocess_read (p, stream, -1, &lenp);
+    ptr = flux_subprocess_read (p, stream, &lenp);
     (*counter)++;
     (*len_counter)+= lenp;
 
@@ -1190,7 +1190,7 @@ void mid_stop_cb (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    ptr = flux_subprocess_read (p, stream, -1, &lenp);
+    ptr = flux_subprocess_read (p, stream, &lenp);
     if (stdout_output_cb_count == 0) {
         flux_watcher_t *tw = NULL;
         ok (ptr && lenp > 0,

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -122,7 +122,7 @@ void test_corner_cases (flux_reactor_t *r)
     ok (flux_subprocess_close (NULL, "stdin") < 0
         && errno == EINVAL,
         "flux_subprocess_close fails with NULL pointer input");
-    ok (flux_subprocess_read (NULL, "stdout", -1, NULL) == NULL
+    ok (flux_subprocess_read (NULL, "stdout", NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_read fails with NULL pointer inputs");
     ok (flux_subprocess_read_line (NULL, "stdout", NULL) == NULL
@@ -201,10 +201,10 @@ void test_post_exec_errors (flux_reactor_t *r)
     ok (flux_subprocess_close (p, "foo") < 0
         && errno == EINVAL,
         "flux_subprocess_close returns EINVAL on bad stream");
-    ok (flux_subprocess_read (p, NULL, 0, NULL) == NULL
+    ok (flux_subprocess_read (p, NULL, NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_read returns EINVAL on bad input");
-    ok (flux_subprocess_read (p, "foo", -1, NULL) == NULL
+    ok (flux_subprocess_read (p, "foo", NULL) == NULL
         && errno == EINVAL,
         "flux_subprocess_read returns EINVAL on bad stream");
     ok (flux_subprocess_read_line (p, "foo", NULL) == NULL
@@ -383,7 +383,7 @@ void env_passed_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line returned correct data len");
     }
     else {
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
@@ -497,7 +497,7 @@ void output_processes_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);
@@ -579,7 +579,7 @@ void eof_cb (flux_subprocess_t *p, const char *stream)
     ok (flux_subprocess_read_stream_closed (p, stream),
         "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-    ptr = flux_subprocess_read (p, stream, -1, &lenp);
+    ptr = flux_subprocess_read (p, stream, &lenp);
     ok (ptr != NULL
         && lenp == 0,
         "flux_subprocess_read on %s read EOF", stream);
@@ -987,7 +987,7 @@ void fail_output_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, -1, &lenp);
+        ptr = flux_subprocess_read (p, stream, &lenp);
         ok (ptr != NULL
             && lenp == 0,
             "flux_subprocess_read on %s read EOF", stream);

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -233,7 +233,7 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
     }
 
     if (!lenp) {
-        if (!(ptr = flux_subprocess_read (p, stream, -1, &lenp))) {
+        if (!(ptr = flux_subprocess_read (p, stream, &lenp))) {
             flux_log_error (t->h, "%s: flux_subprocess_read",
                             __FUNCTION__);
             return;

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -1358,7 +1358,7 @@ static void task_none_output_cb (struct shell_task *task,
     }
     else if (!len) {
         /* stderr is unbuffered */
-        if (!(data = flux_subprocess_read (task->proc, stream, -1, &len))) {
+        if (!(data = flux_subprocess_read (task->proc, stream, &len))) {
             shell_log_errno ("read %s task %d", stream, task->rank);
             return;
         }

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -367,7 +367,7 @@ static void pmi_fd_cb (flux_shell_task_t *task,
     int rc;
 
     line = flux_subprocess_read_line (task->proc, "PMI_FD", &len);
-    if (len < 0) {
+    if (!line) {
         shell_trace ("%d: C: pmi read error: %s",
                      task->rank, flux_strerror (errno));
         return;

--- a/t/rexec/rexec_count_stdout.c
+++ b/t/rexec/rexec_count_stdout.c
@@ -64,7 +64,7 @@ void output_cb (flux_subprocess_t *p, const char *stream)
 
     /* we're at the end of the stream, read any lingering data */
     if (!lenp && flux_subprocess_read_stream_closed (p, stream)) {
-        if (!(ptr = flux_subprocess_read (p, stream, -1, &lenp))) {
+        if (!(ptr = flux_subprocess_read (p, stream, &lenp))) {
             log_err ("flux_subprocess_read");
             return;
         }


### PR DESCRIPTION
and some comment additions and an extra test.