### PR TITLE
job-manager: journal jobspec with submit event

### DIFF
--- a/src/modules/job-manager/journal.c
+++ b/src/modules/job-manager/journal.c
@@ -36,7 +36,7 @@
  * responses will be for events that are are posted in real time.
  *
  * Additional responses contain at most one event.  The redacted jobspec is
- * included with the "validate" event.  The redacted R object is included
+ * included with the "submit" event.  The redacted R object is included
  * with the "alloc" event.
  */
 
@@ -109,7 +109,7 @@ int journal_process_event (struct journal *journal,
                          "id", id,
                          "events", entry)))
         goto error;
-    if (streq (name, "validate")) {
+    if (streq (name, "submit")) {
         struct job *job;
         if (!(job = zhashx_lookup (ctx->active_jobs, &id))
             || !job->jobspec_redacted


### PR DESCRIPTION
Problem: job-list logs "update_jobspec: job xxx received jobspec update before jobspec" when flux-accounting sets a default bank.

The job manager journal attached the jobspec to the validate event, so it is not available when jobspec-update events are sent before validate.

Send it with submit instead of validate.  Adjust job-list to handle it with the submit event.

Fixes #5951