### PR TITLE
WIP: job-exec: do not allow guest access to the testexec implementation by default

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -38,6 +38,10 @@ sdexec-properties
    (optional) A table of systemd properties to set for all jobs.  All values
    must be strings.  See SDEXEC PROPERTIES below.
 
+testexec
+   (options) A table of keys (see :ref:`testexec`) for configuring the
+   **job-exec** test execution implementation (used in mainly for testing).
+
 
 SDEXEC PROPERTIES
 =================
@@ -61,6 +65,15 @@ MemoryMin, MemoryLow
    described above.
 
 
+.. _testexec:
+
+TESTEXEC
+========
+
+allow-guests
+  Boolean value enables access to the testexec implementation from guest
+  users. By default, guests cannot use this implementation.
+
 EXAMPLES
 ========
 
@@ -76,6 +89,11 @@ EXAMPLES
    service = "sdexec"
    [exec.sdexec-properties]
    MemoryMax = "90%"
+
+::
+
+   [exec.testexec]
+   allow-guests = true
 
 
 RESOURCES

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -911,3 +911,4 @@ transactional
 keypair
 unterminated
 upmi
+testexec

--- a/t/t2292-job-update-running.t
+++ b/t/t2292-job-update-running.t
@@ -54,6 +54,12 @@ job_manager_get_starttime() {
 	job_manager_get_R $1 | jq .R.execution.starttime
 }
 
+test_expect_success 'configure testexec to allow guest access' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
 test_expect_success 'instance owner can adjust expiration of their own job' '
 	jobid=$(flux submit --wait-event=start -t5m sleep 300) &&
 	expiration=$(job_manager_get_expiration $jobid) &&

--- a/t/t2800-jobs-recursive.t
+++ b/t/t2800-jobs-recursive.t
@@ -45,6 +45,12 @@ test_expect_success 'start a recursive job' '
 			 flux queue idle") &&
 	flux job wait-event $id clean
 '
+test_expect_success 'allow guest user access to testexec' '
+	flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
 test_expect_success FLUX_SECURITY 'submit fake instance job as another user' '
 	submit_fake_user_instance
 '


### PR DESCRIPTION
This PR disables guest user access to the job-exec `testexec` implementation by default.

Since multiuser testexec jobs are used in the flux-core and flux-accounting testsuites, a new configuration option is added to optionally allow it: `exec.testexec.allow-guests`, which must be set to `true`.

flux-accounting tests will fail until `allow-guests` is set there. However, I was going to wait in case someone had a better idea of how to optionally allow this feature for testing.