### PR TITLE
libsubprocess: improve read API

### DIFF
--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -244,7 +244,7 @@ static void stdio_cb (flux_subprocess_t *p, const char *stream)
     const char *line;
     int len;
 
-    if ((line = flux_subprocess_getline (p, stream, &len)) && len > 0) {
+    if ((len = flux_subprocess_getline (p, stream, &line)) > 0) {
         if (streq (stream, "stderr"))
             flux_log (r->h, LOG_ERR, "%s.%d: %s", entry->name, index, line);
         else

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -208,7 +208,7 @@ void output_cb (flux_subprocess_t *p, const char *stream)
     const char *buf;
     int len;
 
-    if (!(buf = flux_subprocess_getline (p, stream, &len)))
+    if ((len = flux_subprocess_getline (p, stream, &buf)) < 0)
         log_err_exit ("flux_subprocess_getline");
 
     if (len) {

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -205,16 +205,16 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 void output_cb (flux_subprocess_t *p, const char *stream)
 {
     FILE *fstream = streq (stream, "stderr") ? stderr : stdout;
-    const char *ptr;
-    int lenp;
+    const char *buf;
+    int len;
 
-    if (!(ptr = flux_subprocess_getline (p, stream, &lenp)))
+    if (!(buf = flux_subprocess_getline (p, stream, &len)))
         log_err_exit ("flux_subprocess_getline");
 
-    if (lenp) {
+    if (len) {
         if (optparse_getopt (opts, "label-io", NULL) > 0)
             fprintf (fstream, "%d: ", flux_subprocess_rank (p));
-        fwrite (ptr, lenp, 1, fstream);
+        fwrite (buf, len, 1, fstream);
     }
 }
 

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -424,7 +424,7 @@ void channel_cb (flux_subprocess_t *p, const char *stream)
     assert (cli);
     assert (streq (stream, "PMI_FD"));
 
-    if (!(buf = flux_subprocess_read_line (p, stream, &len)))
+    if ((len = flux_subprocess_read_line (p, stream, &buf)) < 0)
         log_err_exit ("%s: flux_subprocess_read_line", __FUNCTION__);
 
     if (len) {

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -418,17 +418,17 @@ static void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 void channel_cb (flux_subprocess_t *p, const char *stream)
 {
     struct client *cli = flux_subprocess_aux_get (p, "cli");
-    const char *ptr;
-    int rc, lenp;
+    const char *buf;
+    int rc, len;
 
     assert (cli);
     assert (streq (stream, "PMI_FD"));
 
-    if (!(ptr = flux_subprocess_read_line (p, stream, &lenp)))
+    if (!(buf = flux_subprocess_read_line (p, stream, &len)))
         log_err_exit ("%s: flux_subprocess_read_line", __FUNCTION__);
 
-    if (lenp) {
-        rc = pmi_simple_server_request (ctx.pmi.srv, ptr, cli, cli->rank);
+    if (len) {
+        rc = pmi_simple_server_request (ctx.pmi.srv, buf, cli, cli->rank);
         if (rc < 0)
             log_err_exit ("%s: pmi_simple_server_request", __FUNCTION__);
         if (rc == 1)

--- a/src/cmd/job/mpir.c
+++ b/src/cmd/job/mpir.c
@@ -186,10 +186,10 @@ static void output_cb (flux_subprocess_t *p, const char *stream)
     const char *prog = basename (MPIR_executable_path);
     int rank = flux_subprocess_rank (p);
 
-    line = flux_subprocess_read_trimmed_line (p, stream, &len);
-    if (line && len == 0)
-        line = flux_subprocess_read (p, stream, &len);
-    if (len)
+    len = flux_subprocess_read_trimmed_line (p, stream, &line);
+    if (len == 0)
+        len = flux_subprocess_read (p, stream, &line);
+    if (len > 0)
         log_msg ("MPIR: rank %d: %s: %s: %s", rank, prog, stream, line);
 }
 

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -243,10 +243,10 @@ static void proc_output_cb (flux_subprocess_t *p, const char *stream)
 {
     subprocess_server_t *s = flux_subprocess_aux_get (p, srvkey);
     const flux_msg_t *request = flux_subprocess_aux_get (p, msgkey);
-    const char *ptr;
-    int lenp;
+    const char *buf;
+    int len;
 
-    if (!(ptr = flux_subprocess_read (p, stream, &lenp))) {
+    if (!(buf = flux_subprocess_read (p, stream, &len))) {
         llog_error (s,
                     "error reading from subprocess stream %s: %s",
                     stream,
@@ -254,8 +254,8 @@ static void proc_output_cb (flux_subprocess_t *p, const char *stream)
         goto error;
     }
 
-    if (lenp) {
-        if (proc_output (p, stream, s, request, ptr, lenp, false) < 0)
+    if (len) {
+        if (proc_output (p, stream, s, request, buf, len, false) < 0)
             goto error;
     }
     else {

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -246,7 +246,7 @@ static void proc_output_cb (flux_subprocess_t *p, const char *stream)
     const char *buf;
     int len;
 
-    if (!(buf = flux_subprocess_read (p, stream, &len))) {
+    if ((len = flux_subprocess_read (p, stream, &buf)) < 0) {
         llog_error (s,
                     "error reading from subprocess stream %s: %s",
                     stream,

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -217,27 +217,27 @@ void subprocess_standard_output (flux_subprocess_t *p, const char *stream)
 {
     /* everything except stderr goes to stdout */
     FILE *fstream = !strcasecmp (stream, "stderr") ? stderr : stdout;
-    const char *ptr;
-    int lenp;
+    const char *buf;
+    int len;
 
     /* Do not use flux_subprocess_getline(), this should work
      * regardless if stream is line buffered or not */
 
-    if (!(ptr = flux_subprocess_read_line (p, stream, &lenp))) {
+    if (!(buf = flux_subprocess_read_line (p, stream, &len))) {
         log_err ("subprocess_standard_output: read_line");
         return;
     }
 
     /* we're at the end of the stream, read any lingering data */
-    if (!lenp && flux_subprocess_read_stream_closed (p, stream)) {
-        if (!(ptr = flux_subprocess_read (p, stream, &lenp))) {
+    if (!len && flux_subprocess_read_stream_closed (p, stream)) {
+        if (!(buf = flux_subprocess_read (p, stream, &len))) {
             log_err ("subprocess_standard_output: read");
             return;
         }
     }
 
-    if (lenp)
-        fwrite (ptr, lenp, 1, fstream);
+    if (len)
+        fwrite (buf, len, 1, fstream);
 }
 
 /*

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -231,7 +231,7 @@ void subprocess_standard_output (flux_subprocess_t *p, const char *stream)
     /* we're at the end of the stream, read any lingering data */
     if (!lenp && flux_subprocess_read_stream_closed (p, stream)) {
         if (!(ptr = flux_subprocess_read (p, stream, &lenp))) {
-            log_err ("subprocess_standard_output: read_line");
+            log_err ("subprocess_standard_output: read");
             return;
         }
     }

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -223,14 +223,14 @@ void subprocess_standard_output (flux_subprocess_t *p, const char *stream)
     /* Do not use flux_subprocess_getline(), this should work
      * regardless if stream is line buffered or not */
 
-    if (!(buf = flux_subprocess_read_line (p, stream, &len))) {
+    if ((len = flux_subprocess_read_line (p, stream, &buf)) < 0) {
         log_err ("subprocess_standard_output: read_line");
         return;
     }
 
     /* we're at the end of the stream, read any lingering data */
-    if (!len && flux_subprocess_read_stream_closed (p, stream)) {
-        if (!(buf = flux_subprocess_read (p, stream, &len))) {
+    if (len == 0 && flux_subprocess_read_stream_closed (p, stream)) {
+        if ((len = flux_subprocess_read (p, stream, &buf)) < 0) {
             log_err ("subprocess_standard_output: read");
             return;
         }
@@ -764,38 +764,39 @@ int flux_subprocess_close (flux_subprocess_t *p, const char *stream)
     return 0;
 }
 
-static const char *subprocess_read (flux_subprocess_t *p,
-                                    const char *stream,
-                                    int *lenp,
-                                    bool read_line,
-                                    bool trimmed,
-                                    bool line_buffered_required,
-                                    bool *readonly)
+static int subprocess_read (flux_subprocess_t *p,
+                            const char *stream,
+                            const char **bufp,
+                            bool read_line,
+                            bool trimmed,
+                            bool line_buffered_required,
+                            bool *readonly)
 {
     struct subprocess_channel *c;
     struct fbuf *fb;
     const char *ptr;
+    int len;
 
     if (!p || !stream
            || (p->local && p->in_hook)) {
         errno = EINVAL;
-        return NULL;
+        return -1;
     }
 
     c = zhash_lookup (p->channels, stream);
     if (!c || !(c->flags & CHANNEL_READ)) {
         errno = EINVAL;
-        return NULL;
+        return -1;
     }
 
     if (line_buffered_required && !c->line_buffered) {
         errno = EPERM;
-        return NULL;
+        return -1;
     }
 
     if (p->local) {
         if (!(fb = fbuf_read_watcher_get_buffer (c->buffer_read_w)))
-            return NULL;
+            return -1;
     }
     else
         fb = c->read_buffer;
@@ -806,41 +807,44 @@ static const char *subprocess_read (flux_subprocess_t *p,
 
     if (read_line) {
         if (trimmed) {
-            if (!(ptr = fbuf_read_trimmed_line (fb, lenp)))
-                return NULL;
+            if (!(ptr = fbuf_read_trimmed_line (fb, &len)))
+                return -1;
         }
         else {
-            if (!(ptr = fbuf_read_line (fb, lenp)))
-                return NULL;
+            if (!(ptr = fbuf_read_line (fb, &len)))
+                return -1;
         }
     }
     else {
-        if (!(ptr = fbuf_read (fb, -1, lenp)))
-            return NULL;
+        if (!(ptr = fbuf_read (fb, -1, &len)))
+            return -1;
     }
 
-    return ptr;
+    if (bufp && len > 0)
+        (*bufp) = ptr;
+    return len;
 }
 
-const char *flux_subprocess_read (flux_subprocess_t *p,
-                                  const char *stream,
-                                  int *lenp)
+int flux_subprocess_read (flux_subprocess_t *p,
+                          const char *stream,
+                          const char **bufp)
 {
-    return subprocess_read (p, stream, lenp, false, false, false, NULL);
+    return subprocess_read (p, stream, bufp, false, false, false, NULL);
 }
 
-const char *flux_subprocess_read_line (flux_subprocess_t *p,
+
+int flux_subprocess_read_line (flux_subprocess_t *p,
+                               const char *stream,
+                               const char **bufp)
+{
+    return subprocess_read (p, stream, bufp, true, false, false, NULL);
+}
+
+int flux_subprocess_read_trimmed_line (flux_subprocess_t *p,
                                        const char *stream,
-                                       int *lenp)
+                                       const char **bufp)
 {
-    return subprocess_read (p, stream, lenp, true, false, false, NULL);
-}
-
-const char *flux_subprocess_read_trimmed_line (flux_subprocess_t *p,
-                                               const char *stream,
-                                               int *lenp)
-{
-    return subprocess_read (p, stream, lenp, true, true, false, NULL);
+    return subprocess_read (p, stream, bufp, true, true, false, NULL);
 }
 
 bool flux_subprocess_read_stream_closed (flux_subprocess_t *p,
@@ -864,25 +868,21 @@ bool flux_subprocess_read_stream_closed (flux_subprocess_t *p,
     return fb ? fbuf_is_readonly (fb) : false;
 }
 
-const char *flux_subprocess_getline (flux_subprocess_t *p,
-                                     const char *stream,
-                                     int *lenp)
+int flux_subprocess_getline (flux_subprocess_t *p,
+                             const char *stream,
+                             const char **bufp)
 {
-    const char *ptr;
     int len;
     bool readonly;
 
-    ptr = subprocess_read (p, stream, &len, true, false, true, &readonly);
+    len = subprocess_read (p, stream, bufp, true, false, true, &readonly);
 
     /* if no lines available and EOF received, read whatever is
      * lingering in the buffer */
-    if (ptr && len == 0 && readonly)
-        ptr = flux_subprocess_read (p, stream, &len);
+    if (len == 0 && readonly)
+        len = flux_subprocess_read (p, stream, bufp);
 
-    if (lenp)
-        (*lenp) = len;
-
-    return ptr;
+    return len;
 }
 
 static flux_future_t *add_pending_signal (flux_subprocess_t *p, int signum)

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -193,10 +193,9 @@ int flux_subprocess_close (flux_subprocess_t *p, const char *stream);
  *  Read unread data from stream `stream`.  'stream' can be "stdout",
  *   "stderr", or the name of a stream specified with flux_cmd_add_channel().
  *
- *   Returns pointer to buffer on success and NULL on error with errno
- *   set.  Buffer is guaranteed to be NUL terminated.  User shall not
- *   free returned pointer.  Length of buffer returned can optionally
- *   returned in 'lenp'.
+ *   Returns length of data on success and -1 on error with errno set.
+ *   Buffer of data is returned in bufp.  Buffer is guaranteed to be
+ *   NUL terminated.  User shall not free returned pointer.
  *
  *   In most cases, a length of 0 indicates that the subprocess has
  *   closed this stream.  A length of 0 could be returned if read
@@ -205,36 +204,36 @@ int flux_subprocess_close (flux_subprocess_t *p, const char *stream);
  *   once per output callback.  flux_subprocess_read_stream_closed()
  *   can always be used to verify if the stream is in fact closed.
  */
-const char *flux_subprocess_read (flux_subprocess_t *p,
-                                  const char *stream,
-                                  int *lenp);
+int flux_subprocess_read (flux_subprocess_t *p,
+                          const char *stream,
+                          const char **bufp);
 
 /*
  *  Read line of unread data from stream `stream`.  'stream' can be
  *   "stdout", "stderr", or the name of a stream specified with
  *   flux_cmd_add_channel().
  *
- *   Returns pointer to buffer on success and NULL on error with errno
- *   set.  Buffer will include newline character and is guaranteed to
- *   be NUL terminated.  If no line is available, returns pointer and
- *   length of zero.  User shall not free returned pointer.  Length of
- *   buffer returned can optionally returned in 'lenp'.
+ *   Returns length of data on success and -1 on error with errno set.
+ *   Buffer with line is returned in bufp.  Buffer will include
+ *   newline character and is guaranteed to be NUL terminated.  If no
+ *   line is available, returns length of zero.  User shall not free
+ *   returned pointer.
  *
  *   A length of zero may be returned if the stream is closed OR if
  *   the stream is line buffered and a line is not yet available. Use
  *   flux_subprocess_read_stream_closed() to distinguish between the
  *   two.
  */
-const char *flux_subprocess_read_line (flux_subprocess_t *p,
-                                       const char *stream,
-                                       int *lenp);
+int flux_subprocess_read_line (flux_subprocess_t *p,
+                               const char *stream,
+                               const char **bufp);
 
 /* Identical to flux_subprocess_read_line(), but does not return
  * trailing newline.
  */
-const char *flux_subprocess_read_trimmed_line (flux_subprocess_t *p,
-                                               const char *stream,
-                                               int *lenp);
+int flux_subprocess_read_trimmed_line (flux_subprocess_t *p,
+                                       const char *stream,
+                                       const char **bufp);
 
 /* Determine if the read stream has is closed / received an EOF.  This
  * function can be useful if you are reading lines via
@@ -258,14 +257,13 @@ bool flux_subprocess_read_stream_closed (flux_subprocess_t *p,
  *   last data on the stream does not terminate in a newline
  *   character, this function will return that last data without the
  *   trailing newline.
- * - if the stream has been closed / reached EOF, lenp will be set to
- *   0.
+ * - if the stream has been closed / reached EOF, 0 will be returned.
  * - if the stream is not line buffered, NULL and errno = EPERM will
  *   be returned.
  */
-const char *flux_subprocess_getline (flux_subprocess_t *p,
-                                     const char *stream,
-                                     int *lenp);
+int flux_subprocess_getline (flux_subprocess_t *p,
+                             const char *stream,
+                             const char **bufp);
 
 /*
  *  Create RPC to send signal `signo` to subprocess `p`.

--- a/src/common/libsubprocess/test/channel.c
+++ b/src/common/libsubprocess/test/channel.c
@@ -58,16 +58,16 @@ void completion_cb (flux_subprocess_t *p)
 
 void channel_fd_env_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
 
     ok (!strcasecmp (stream, "stdout"),
         "channel_fd_env_cb called with correct stream");
 
     if (!channel_fd_env_cb_count) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf
-            && len > 0,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", stream);
 
         ok (strstarts (buf, "FOO="),
@@ -78,9 +78,8 @@ void channel_fd_env_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -120,16 +119,16 @@ void test_channel_fd_env (flux_reactor_t *r)
 
 void channel_in_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
 
     ok (!strcasecmp (stream, "stdout"),
         "channel_in_cb called with correct stream");
 
     if (!channel_in_cb_count) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL
-            && len == 7,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len == 7
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", stream);
 
         ok (!memcmp (buf, "foobar\n", 7),
@@ -142,9 +141,8 @@ void channel_in_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -191,16 +189,16 @@ void test_channel_fd_in (flux_reactor_t *r)
 
 void channel_in_and_out_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
 
     ok (!strcasecmp (stream, "TEST_CHANNEL"),
         "channel_in_and_out_cb called with correct stream");
 
     if (!channel_in_and_out_cb_count) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL
-            && len == 7,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len == 7
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", stream);
 
         ok (!memcmp (buf, "foobaz\n", 7),
@@ -213,9 +211,8 @@ void channel_in_and_out_cb (flux_subprocess_t *p, const char *stream)
         /* no check of flux_subprocess_read_stream_closed(), we aren't
          * closing channel in test below */
 
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -263,34 +260,34 @@ void test_channel_fd_in_and_out (flux_reactor_t *r)
 
 void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
 
     ok (!strcasecmp (stream, "TEST_CHANNEL"),
         "channel_multiple_lines_cb called with correct stream");
 
     if (multiple_lines_channel_cb_count == 0) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL
-            && len > 0,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", stream);
 
         ok (streq (buf, "bob\n"),
             "flux_subprocess_read_line returned correct data");
     }
     else if (multiple_lines_channel_cb_count == 1) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL
-            && len > 0,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", stream);
 
         ok (streq (buf, "dan\n"),
             "flux_subprocess_read_line returned correct data");
     }
     else if (multiple_lines_channel_cb_count == 2) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL
-            && len > 0,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", stream);
 
         ok (streq (buf, "jo\n"),
@@ -303,9 +300,8 @@ void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
         /* no check of flux_subprocess_read_stream_closed(), we aren't
          * closing channel in test below */
 
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -359,13 +355,13 @@ void test_channel_multiple_lines (flux_reactor_t *r)
 
 void channel_nul_terminate_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
 
     if (!channel_nul_terminate_cb_count) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL
-            && len == 7,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len == 7
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", stream);
 
         ok (!memcmp (buf, "foobaz\n\0", 8),
@@ -378,9 +374,8 @@ void channel_nul_terminate_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 

--- a/src/common/libsubprocess/test/channel.c
+++ b/src/common/libsubprocess/test/channel.c
@@ -58,19 +58,19 @@ void completion_cb (flux_subprocess_t *p)
 
 void channel_fd_env_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
 
     ok (!strcasecmp (stream, "stdout"),
         "channel_fd_env_cb called with correct stream");
 
     if (!channel_fd_env_cb_count) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr
-            && lenp > 0,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf
+            && len > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (strstarts (ptr, "FOO="),
+        ok (strstarts (buf, "FOO="),
             "environment variable FOO created in subprocess");
         /* no length check, can't predict channel FD value */
     }
@@ -78,9 +78,9 @@ void channel_fd_env_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -120,19 +120,19 @@ void test_channel_fd_env (flux_reactor_t *r)
 
 void channel_in_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
 
     ok (!strcasecmp (stream, "stdout"),
         "channel_in_cb called with correct stream");
 
     if (!channel_in_cb_count) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 7,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL
+            && len == 7,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!memcmp (ptr, "foobar\n", 7),
+        ok (!memcmp (buf, "foobar\n", 7),
             "read on channel returned correct data");
 
         ok (flux_subprocess_close (p, "TEST_CHANNEL") == 0,
@@ -142,9 +142,9 @@ void channel_in_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -191,19 +191,19 @@ void test_channel_fd_in (flux_reactor_t *r)
 
 void channel_in_and_out_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
 
     ok (!strcasecmp (stream, "TEST_CHANNEL"),
         "channel_in_and_out_cb called with correct stream");
 
     if (!channel_in_and_out_cb_count) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 7,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL
+            && len == 7,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!memcmp (ptr, "foobaz\n", 7),
+        ok (!memcmp (buf, "foobaz\n", 7),
             "read on channel returned correct data");
 
         ok (flux_subprocess_close (p, "TEST_CHANNEL") == 0,
@@ -213,9 +213,9 @@ void channel_in_and_out_cb (flux_subprocess_t *p, const char *stream)
         /* no check of flux_subprocess_read_stream_closed(), we aren't
          * closing channel in test below */
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -263,37 +263,37 @@ void test_channel_fd_in_and_out (flux_reactor_t *r)
 
 void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
 
     ok (!strcasecmp (stream, "TEST_CHANNEL"),
         "channel_multiple_lines_cb called with correct stream");
 
     if (multiple_lines_channel_cb_count == 0) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp > 0,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL
+            && len > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (streq (ptr, "bob\n"),
+        ok (streq (buf, "bob\n"),
             "flux_subprocess_read_line returned correct data");
     }
     else if (multiple_lines_channel_cb_count == 1) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp > 0,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL
+            && len > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (streq (ptr, "dan\n"),
+        ok (streq (buf, "dan\n"),
             "flux_subprocess_read_line returned correct data");
     }
     else if (multiple_lines_channel_cb_count == 2) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp > 0,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL
+            && len > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (streq (ptr, "jo\n"),
+        ok (streq (buf, "jo\n"),
             "flux_subprocess_read_line returned correct data");
 
         ok (flux_subprocess_close (p, "TEST_CHANNEL") == 0,
@@ -303,9 +303,9 @@ void channel_multiple_lines_cb (flux_subprocess_t *p, const char *stream)
         /* no check of flux_subprocess_read_stream_closed(), we aren't
          * closing channel in test below */
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -359,16 +359,16 @@ void test_channel_multiple_lines (flux_reactor_t *r)
 
 void channel_nul_terminate_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
 
     if (!channel_nul_terminate_cb_count) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 7,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL
+            && len == 7,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (!memcmp (ptr, "foobaz\n\0", 8),
+        ok (!memcmp (buf, "foobaz\n\0", 8),
             "read on channel returned correct data");
 
         ok (flux_subprocess_close (p, "TEST_CHANNEL") == 0,
@@ -378,9 +378,9 @@ void channel_nul_terminate_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 

--- a/src/common/libsubprocess/test/iochan.c
+++ b/src/common/libsubprocess/test/iochan.c
@@ -64,7 +64,7 @@ static void iochan_output_cb (flux_subprocess_t *p, const char *stream)
     const char *line;
     int len;
 
-    if (!(line = flux_subprocess_read_line (p, stream, &len)))
+    if ((len = flux_subprocess_read_line (p, stream, &line)) < 0)
         diag ("%s: %s", stream, strerror (errno));
     else if (len == 0)
         diag ("%s: EOF", stream);

--- a/src/common/libsubprocess/test/iostress.c
+++ b/src/common/libsubprocess/test/iostress.c
@@ -63,7 +63,7 @@ static void iostress_output_cb (flux_subprocess_t *p, const char *stream)
     const char *line;
     int len;
 
-    if (!(line = flux_subprocess_read_line (p, stream, &len)))
+    if ((len = flux_subprocess_read_line (p, stream, &line)) < 0)
         diag ("%s: %s", stream, strerror (errno));
     else if (len == 0)
         diag ("%s: EOF", stream);

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -59,7 +59,7 @@ static void simple_output_cb (flux_subprocess_t *p, const char *stream)
     const char *line;
     int len;
 
-    if (!(line = flux_subprocess_read_line (p, stream, &len)))
+    if ((len = flux_subprocess_read_line (p, stream, &line)) < 0)
         diag ("%s: %s", stream, strerror (errno));
     else if (len == 0)
         diag ("%s: EOF", stream);
@@ -67,7 +67,7 @@ static void simple_output_cb (flux_subprocess_t *p, const char *stream)
         diag ("%s: %d bytes", stream, len);
 
     if (streq (stream, "stdout")) {
-        if (line == NULL)
+        if (len < 0)
             ctx->scorecard.stdout_error = 1;
         else if (len == 0)
             ctx->scorecard.stdout_eof = 1;
@@ -75,7 +75,7 @@ static void simple_output_cb (flux_subprocess_t *p, const char *stream)
             ctx->scorecard.stdout_lines++;
     }
     else if (streq (stream, "stderr")) {
-        if (line == NULL)
+        if (len < 0)
             ctx->scorecard.stderr_error = 1;
         else if (len == 0)
             ctx->scorecard.stderr_eof = 1;
@@ -293,7 +293,7 @@ static void stop_output_cb (flux_subprocess_t *p, const char *stream)
     const char *line;
     int len;
 
-    if (!(line = flux_subprocess_read_line (p, stream, &len)))
+    if ((len = flux_subprocess_read_line (p, stream, &line)) < 0)
         diag ("%s: %s", stream, strerror (errno));
     else if (len == 0)
         diag ("%s: EOF", stream);

--- a/src/common/libsubprocess/test/stdio.c
+++ b/src/common/libsubprocess/test/stdio.c
@@ -66,9 +66,9 @@ void completion_cb (flux_subprocess_t *p)
 
 void output_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
+    const char *buf;
     char cmpbuf[1024];
-    int lenp = 0;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -81,26 +81,26 @@ void output_cb (flux_subprocess_t *p, const char *stream)
     }
 
     if ((*counter) == 0) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp > 0,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL
+            && len > 0,
             "flux_subprocess_read_line on %s success", stream);
 
         sprintf (cmpbuf, "%s:hi\n", stream);
 
-        ok (streq (ptr, cmpbuf),
+        ok (streq (buf, cmpbuf),
             "flux_subprocess_read_line returned correct data");
         /* 1 + 2 + 1 for ':', "hi", '\n' */
-        ok (lenp == (strlen (stream) + 1 + 2 + 1),
+        ok (len == (strlen (stream) + 1 + 2 + 1),
             "flux_subprocess_read_line returned correct data len");
     }
     else {
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -139,9 +139,9 @@ void test_basic_stdout (flux_reactor_t *r)
 
 void output_no_readline_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
+    const char *buf;
     char cmpbuf[1024];
-    int lenp = 0;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -153,13 +153,13 @@ void output_no_readline_cb (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    ptr = flux_subprocess_read (p, stream, &lenp);
-    ok (ptr != NULL,
+    buf = flux_subprocess_read (p, stream, &len);
+    ok (buf != NULL,
         "flux_subprocess_read on %s success", stream);
 
-    if (lenp > 0) {
-        memcpy (outputbuf + outputbuf_len, ptr, lenp);
-        outputbuf_len += lenp;
+    if (len > 0) {
+        memcpy (outputbuf + outputbuf_len, buf, len);
+        outputbuf_len += len;
     }
     else {
         ok (flux_subprocess_read_stream_closed (p, stream),
@@ -301,31 +301,31 @@ void test_basic_default_output (flux_reactor_t *r)
 
 void output_default_stream_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
+    const char *buf;
     char cmpbuf[1024];
-    int lenp = 0;
+    int len = 0;
 
     if (output_default_stream_cb_count == 0) {
-        ptr = flux_subprocess_read_line (p, "stdout", &lenp);
-        ok (ptr != NULL
-            && lenp > 0,
+        buf = flux_subprocess_read_line (p, "stdout", &len);
+        ok (buf != NULL
+            && len > 0,
             "flux_subprocess_read_line on %s success", "stdout");
 
         sprintf (cmpbuf, "%s:hi\n", stream);
 
-        ok (streq (ptr, cmpbuf),
+        ok (streq (buf, cmpbuf),
             "flux_subprocess_read_line returned correct data");
         /* 1 + 2 + 1 for ':', "hi", '\n' */
-        ok (lenp == (strlen (stream) + 1 + 2 + 1),
+        ok (len == (strlen (stream) + 1 + 2 + 1),
             "flux_subprocess_read_line returned correct data len");
     }
     else {
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", "stdout");
 
-        ptr = flux_subprocess_read (p, "stdout", &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, "stdout", &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", "stdout");
     }
 
@@ -368,9 +368,9 @@ void test_basic_stdin (flux_reactor_t *r)
 
 void output_no_newline_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
+    const char *buf;
     char cmpbuf[1024];
-    int lenp = 0;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -383,31 +383,31 @@ void output_no_newline_cb (flux_subprocess_t *p, const char *stream)
     }
 
     if ((*counter) == 0) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read_line on %s read 0 lines", stream);
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp > 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len > 0,
             "flux_subprocess_read on %s read success", stream);
 
         sprintf (cmpbuf, "%s:hi", stream);
 
-        ok (streq (ptr, cmpbuf),
+        ok (streq (buf, cmpbuf),
             "flux_subprocess_read returned correct data");
         /* 1 + 2 + 1 for ':', "hi" */
-        ok (lenp == (strlen (stream) + 1 + 2),
+        ok (len == (strlen (stream) + 1 + 2),
             "flux_subprocess_read_line returned correct data len");
     }
     else {
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -447,9 +447,9 @@ void test_basic_no_newline (flux_reactor_t *r)
 
 void output_trimmed_line_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
+    const char *buf;
     char cmpbuf[1024];
-    int lenp = 0;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -462,23 +462,23 @@ void output_trimmed_line_cb (flux_subprocess_t *p, const char *stream)
     }
 
     if ((*counter) == 0) {
-        ptr = flux_subprocess_read_trimmed_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp > 0,
+        buf = flux_subprocess_read_trimmed_line (p, stream, &len);
+        ok (buf != NULL
+            && len > 0,
             "flux_subprocess_read_trimmed_line on %s success", stream);
 
         sprintf (cmpbuf, "%s:hi", stream);
 
-        ok (streq (ptr, cmpbuf),
+        ok (streq (buf, cmpbuf),
             "flux_subprocess_read_trimmed_line returned correct data");
     }
     else {
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -518,8 +518,8 @@ void test_basic_trimmed_line (flux_reactor_t *r)
 
 void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -532,45 +532,45 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
     }
 
     if ((*counter) == 0) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp > 0,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL
+            && len > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (streq (ptr, "foo\n"),
+        ok (streq (buf, "foo\n"),
             "flux_subprocess_read_line returned correct data");
-        ok (lenp == 4,
+        ok (len == 4,
             "flux_subprocess_read_line returned correct data len");
     }
     else if ((*counter) == 1) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp > 0,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL
+            && len > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (streq (ptr, "bar\n"),
+        ok (streq (buf, "bar\n"),
             "flux_subprocess_read_line returned correct data");
-        ok (lenp == 4,
+        ok (len == 4,
             "flux_subprocess_read_line returned correct data len");
     }
     else if ((*counter) == 2) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp > 0,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL
+            && len > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (streq (ptr, "bo\n"),
+        ok (streq (buf, "bo\n"),
             "flux_subprocess_read_line returned correct data");
-        ok (lenp == 3,
+        ok (len == 3,
             "flux_subprocess_read_line returned correct data len");
     }
     else {
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -622,8 +622,8 @@ void test_basic_multiple_lines (flux_reactor_t *r)
 
 void stdin_closed_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -638,9 +638,9 @@ void stdin_closed_cb (flux_subprocess_t *p, const char *stream)
     ok (flux_subprocess_read_stream_closed (p, stream),
         "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-    ptr = flux_subprocess_read (p, stream, &lenp);
-    ok (ptr != NULL
-        && lenp == 0,
+    buf = flux_subprocess_read (p, stream, &len);
+    ok (buf != NULL
+        && len == 0,
         "flux_subprocess_read on %s read EOF", stream);
 
     (*counter)++;
@@ -682,8 +682,8 @@ void test_basic_stdin_closed (flux_reactor_t *r)
 
 void output_read_line_until_eof_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -695,27 +695,27 @@ void output_read_line_until_eof_cb (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    ptr = flux_subprocess_getline (p, stream, &lenp);
+    buf = flux_subprocess_getline (p, stream, &len);
     if ((*counter) == 0) {
-        ok (ptr != NULL,
+        ok (buf != NULL,
             "flux_subprocess_getline on %s success", stream);
-        ok (streq (ptr, "foo\n"),
+        ok (streq (buf, "foo\n"),
             "flux_subprocess_getline returned correct data");
-        ok (lenp == 4,
+        ok (len == 4,
             "flux_subprocess_getline returned correct data len");
     }
     else if ((*counter) == 1) {
-        ok (ptr != NULL,
+        ok (buf != NULL,
             "flux_subprocess_getline on %s success", stream);
-        ok (streq (ptr, "bar"),
+        ok (streq (buf, "bar"),
             "flux_subprocess_getline returned correct data");
-        ok (lenp == 3,
+        ok (len == 3,
             "flux_subprocess_getline returned correct data len");
     }
     else {
-        ok (ptr != NULL,
+        ok (buf != NULL,
             "flux_subprocess_getline on %s success", stream);
-        ok (lenp == 0,
+        ok (len == 0,
             "flux_subprocess_getline returned EOF");
     }
 
@@ -764,8 +764,8 @@ void test_basic_read_line_until_eof (flux_reactor_t *r)
 
 void output_read_line_until_eof_error_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -776,21 +776,21 @@ void output_read_line_until_eof_error_cb (flux_subprocess_t *p, const char *stre
     }
 
     if ((*counter) == 0) {
-        ptr = flux_subprocess_getline (p, stream, &lenp);
-        ok (!ptr && errno == EPERM,
+        buf = flux_subprocess_getline (p, stream, &len);
+        ok (!buf && errno == EPERM,
             "flux_subprocess_getline returns EPERM "
             "on non line-buffered stream");
 
         /* drain whatever is in the buffer, we don't care about
          * contents for this test */
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL && lenp > 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL && len > 0,
             "flux_subprocess_read on %s success", stream);
     }
     else {
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
     (*counter)++;
@@ -943,8 +943,8 @@ void test_flag_stdio_fallthrough (flux_reactor_t *r)
 
 void line_output_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -955,16 +955,16 @@ void line_output_cb (flux_subprocess_t *p, const char *stream)
     }
 
     if ((*counter) == 0) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr != NULL && lenp == 4401,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf != NULL && len == 4401,
             "flux_subprocess_read_line read line correctly");
     }
     else {
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -1145,8 +1145,8 @@ void test_stream_start_stop_basic (flux_reactor_t *r)
 
 void start_stdout_after_stderr_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
     int *counter;
     int *len_counter;
 
@@ -1163,11 +1163,11 @@ void start_stdout_after_stderr_cb (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    ptr = flux_subprocess_read (p, stream, &lenp);
+    buf = flux_subprocess_read (p, stream, &len);
     (*counter)++;
-    (*len_counter)+= lenp;
+    (*len_counter)+= len;
 
-    if (ptr && lenp && (*len_counter) == 10001) {
+    if (buf && len && (*len_counter) == 10001) {
         if (streq (stream, "stderr")) {
             ok (stdout_output_cb_count == 0
                 && stdout_output_cb_len_count == 0,
@@ -1253,8 +1253,8 @@ void mid_stop_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
 
 void mid_stop_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -1264,11 +1264,11 @@ void mid_stop_cb (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    ptr = flux_subprocess_read (p, stream, &lenp);
+    buf = flux_subprocess_read (p, stream, &len);
     if (stdout_output_cb_count == 0) {
         flux_watcher_t *tw = NULL;
-        ok (ptr && lenp > 0,
-            "flux_subprocess_read read data on stdout: %d", lenp);
+        ok (buf && len > 0,
+            "flux_subprocess_read read data on stdout: %d", len);
         flux_subprocess_stream_stop (p, "stdout");
         diag ("flux_subprocess_stream_stop on stdout");
         ok ((tw = flux_subprocess_aux_get (p, "tw")) != NULL,
@@ -1276,8 +1276,8 @@ void mid_stop_cb (flux_subprocess_t *p, const char *stream)
         flux_watcher_start (tw);
     }
     else if (stdout_output_cb_count == 1) {
-        ok (ptr && lenp > 0,
-            "flux_subprocess_read read data on stdout: %d", lenp);
+        ok (buf && len > 0,
+            "flux_subprocess_read read data on stdout: %d", len);
         ok (timer_cb_count == 1,
             "next stdout callback called after time callback called");
     }

--- a/src/common/libsubprocess/test/stdio.c
+++ b/src/common/libsubprocess/test/stdio.c
@@ -66,9 +66,9 @@ void completion_cb (flux_subprocess_t *p)
 
 void output_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
+    const char *buf = NULL;
     char cmpbuf[1024];
-    int len = 0;
+    int len;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -81,9 +81,9 @@ void output_cb (flux_subprocess_t *p, const char *stream)
     }
 
     if ((*counter) == 0) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL
-            && len > 0,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", stream);
 
         sprintf (cmpbuf, "%s:hi\n", stream);
@@ -98,9 +98,8 @@ void output_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -139,9 +138,9 @@ void test_basic_stdout (flux_reactor_t *r)
 
 void output_no_readline_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
+    const char *buf = NULL;
     char cmpbuf[1024];
-    int len = 0;
+    int len;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -153,8 +152,8 @@ void output_no_readline_cb (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    buf = flux_subprocess_read (p, stream, &len);
-    ok (buf != NULL,
+    len = flux_subprocess_read (p, stream, &buf);
+    ok (len >= 0,
         "flux_subprocess_read on %s success", stream);
 
     if (len > 0) {
@@ -301,14 +300,14 @@ void test_basic_default_output (flux_reactor_t *r)
 
 void output_default_stream_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
+    const char *buf = NULL;
     char cmpbuf[1024];
-    int len = 0;
+    int len;
 
     if (output_default_stream_cb_count == 0) {
-        buf = flux_subprocess_read_line (p, "stdout", &len);
-        ok (buf != NULL
-            && len > 0,
+        len = flux_subprocess_read_line (p, "stdout", &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", "stdout");
 
         sprintf (cmpbuf, "%s:hi\n", stream);
@@ -323,9 +322,8 @@ void output_default_stream_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", "stdout");
 
-        buf = flux_subprocess_read (p, "stdout", &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read (p, "stdout", &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", "stdout");
     }
 
@@ -368,9 +366,9 @@ void test_basic_stdin (flux_reactor_t *r)
 
 void output_no_newline_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
+    const char *buf = NULL;
     char cmpbuf[1024];
-    int len = 0;
+    int len;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -383,14 +381,13 @@ void output_no_newline_cb (flux_subprocess_t *p, const char *stream)
     }
 
     if ((*counter) == 0) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read_line on %s read 0 lines", stream);
 
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL
-            && len > 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read on %s read success", stream);
 
         sprintf (cmpbuf, "%s:hi", stream);
@@ -405,9 +402,8 @@ void output_no_newline_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -447,9 +443,9 @@ void test_basic_no_newline (flux_reactor_t *r)
 
 void output_trimmed_line_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
+    const char *buf = NULL;
     char cmpbuf[1024];
-    int len = 0;
+    int len;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -462,9 +458,9 @@ void output_trimmed_line_cb (flux_subprocess_t *p, const char *stream)
     }
 
     if ((*counter) == 0) {
-        buf = flux_subprocess_read_trimmed_line (p, stream, &len);
-        ok (buf != NULL
-            && len > 0,
+        len = flux_subprocess_read_trimmed_line (p, stream, &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read_trimmed_line on %s success", stream);
 
         sprintf (cmpbuf, "%s:hi", stream);
@@ -476,9 +472,8 @@ void output_trimmed_line_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -518,8 +513,8 @@ void test_basic_trimmed_line (flux_reactor_t *r)
 
 void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -532,9 +527,9 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
     }
 
     if ((*counter) == 0) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL
-            && len > 0,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", stream);
 
         ok (streq (buf, "foo\n"),
@@ -543,9 +538,9 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line returned correct data len");
     }
     else if ((*counter) == 1) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL
-            && len > 0,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", stream);
 
         ok (streq (buf, "bar\n"),
@@ -554,9 +549,9 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_read_line returned correct data len");
     }
     else if ((*counter) == 2) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL
-            && len > 0,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read_line on %s success", stream);
 
         ok (streq (buf, "bo\n"),
@@ -568,9 +563,8 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -622,8 +616,8 @@ void test_basic_multiple_lines (flux_reactor_t *r)
 
 void stdin_closed_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -638,9 +632,8 @@ void stdin_closed_cb (flux_subprocess_t *p, const char *stream)
     ok (flux_subprocess_read_stream_closed (p, stream),
         "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-    buf = flux_subprocess_read (p, stream, &len);
-    ok (buf != NULL
-        && len == 0,
+    len = flux_subprocess_read (p, stream, &buf);
+    ok (len == 0,
         "flux_subprocess_read on %s read EOF", stream);
 
     (*counter)++;
@@ -682,8 +675,8 @@ void test_basic_stdin_closed (flux_reactor_t *r)
 
 void output_read_line_until_eof_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -695,9 +688,9 @@ void output_read_line_until_eof_cb (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    buf = flux_subprocess_getline (p, stream, &len);
+    len = flux_subprocess_getline (p, stream, &buf);
     if ((*counter) == 0) {
-        ok (buf != NULL,
+        ok (len > 0,
             "flux_subprocess_getline on %s success", stream);
         ok (streq (buf, "foo\n"),
             "flux_subprocess_getline returned correct data");
@@ -705,7 +698,7 @@ void output_read_line_until_eof_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_getline returned correct data len");
     }
     else if ((*counter) == 1) {
-        ok (buf != NULL,
+        ok (len > 0,
             "flux_subprocess_getline on %s success", stream);
         ok (streq (buf, "bar"),
             "flux_subprocess_getline returned correct data");
@@ -713,8 +706,6 @@ void output_read_line_until_eof_cb (flux_subprocess_t *p, const char *stream)
             "flux_subprocess_getline returned correct data len");
     }
     else {
-        ok (buf != NULL,
-            "flux_subprocess_getline on %s success", stream);
         ok (len == 0,
             "flux_subprocess_getline returned EOF");
     }
@@ -764,8 +755,8 @@ void test_basic_read_line_until_eof (flux_reactor_t *r)
 
 void output_read_line_until_eof_error_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -776,21 +767,21 @@ void output_read_line_until_eof_error_cb (flux_subprocess_t *p, const char *stre
     }
 
     if ((*counter) == 0) {
-        buf = flux_subprocess_getline (p, stream, &len);
-        ok (!buf && errno == EPERM,
+        len = flux_subprocess_getline (p, stream, &buf);
+        ok (len < 0 && errno == EPERM,
             "flux_subprocess_getline returns EPERM "
             "on non line-buffered stream");
 
         /* drain whatever is in the buffer, we don't care about
          * contents for this test */
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL && len > 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read on %s success", stream);
     }
     else {
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL
-            && len == 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
     (*counter)++;
@@ -943,8 +934,8 @@ void test_flag_stdio_fallthrough (flux_reactor_t *r)
 
 void line_output_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -955,16 +946,17 @@ void line_output_cb (flux_subprocess_t *p, const char *stream)
     }
 
     if ((*counter) == 0) {
-        buf = flux_subprocess_read_line (p, stream, &len);
-        ok (buf != NULL && len == 4401,
+        len = flux_subprocess_read_line (p, stream, &buf);
+        ok (len == 4401
+            && buf != NULL,
             "flux_subprocess_read_line read line correctly");
     }
     else {
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        buf = flux_subprocess_read (p, stream, &len);
-        ok (buf != NULL && len == 0,
+        len = flux_subprocess_read (p, stream, &buf);
+        ok (len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -1145,8 +1137,8 @@ void test_stream_start_stop_basic (flux_reactor_t *r)
 
 void start_stdout_after_stderr_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
     int *counter;
     int *len_counter;
 
@@ -1163,11 +1155,11 @@ void start_stdout_after_stderr_cb (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    buf = flux_subprocess_read (p, stream, &len);
+    len = flux_subprocess_read (p, stream, &buf);
     (*counter)++;
     (*len_counter)+= len;
 
-    if (buf && len && (*len_counter) == 10001) {
+    if (len > 0 && buf != NULL && (*len_counter) == 10001) {
         if (streq (stream, "stderr")) {
             ok (stdout_output_cb_count == 0
                 && stdout_output_cb_len_count == 0,
@@ -1253,8 +1245,8 @@ void mid_stop_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
 
 void mid_stop_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *buf;
-    int len = 0;
+    const char *buf = NULL;
+    int len;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -1264,10 +1256,11 @@ void mid_stop_cb (flux_subprocess_t *p, const char *stream)
         return;
     }
 
-    buf = flux_subprocess_read (p, stream, &len);
+    len = flux_subprocess_read (p, stream, &buf);
     if (stdout_output_cb_count == 0) {
         flux_watcher_t *tw = NULL;
-        ok (buf && len > 0,
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read read data on stdout: %d", len);
         flux_subprocess_stream_stop (p, "stdout");
         diag ("flux_subprocess_stream_stop on stdout");
@@ -1276,7 +1269,8 @@ void mid_stop_cb (flux_subprocess_t *p, const char *stream)
         flux_watcher_start (tw);
     }
     else if (stdout_output_cb_count == 1) {
-        ok (buf && len > 0,
+        ok (len > 0
+            && buf != NULL,
             "flux_subprocess_read read data on stdout: %d", len);
         ok (timer_cb_count == 1,
             "next stdout callback called after time callback called");

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -365,27 +365,27 @@ void test_flag_fork_exec (flux_reactor_t *r)
 
 void env_passed_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
 
     ok (!strcasecmp (stream, "stdout"),
         "env_passed_cb called with correct stream");
 
     if (!env_passed_cb_count) {
-        ptr = flux_subprocess_read_line (p, stream, &lenp);
-        ok (ptr
-            && lenp > 0,
+        buf = flux_subprocess_read_line (p, stream, &len);
+        ok (buf
+            && len > 0,
             "flux_subprocess_read_line on %s success", stream);
 
-        ok (strstarts (ptr, "FOOBAR=foobaz"),
+        ok (strstarts (buf, "FOOBAR=foobaz"),
             "environment variable FOOBAR in subprocess");
-        ok (lenp == 14,
+        ok (len == 14,
             "flux_subprocess_read_line returned correct data len");
     }
     else {
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -468,21 +468,21 @@ void test_kill (flux_reactor_t *r)
 
 void output_processes_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp;
+    const char *buf;
+    int len;
 
     if (output_processes_cb_count == 0
         || output_processes_cb_count == 1) {
-        ptr = flux_subprocess_read_trimmed_line (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp > 0,
+        buf = flux_subprocess_read_trimmed_line (p, stream, &len);
+        ok (buf != NULL
+            && len > 0,
             "flux_subprocess_read_trimmed_line read valid data");
 
-        if (ptr && lenp) {
+        if (buf && len) {
             if (output_processes_cb_count == 0)
-                parent_pid = atoi (ptr);
+                parent_pid = atoi (buf);
             else
-                child_pid = atoi (ptr);
+                child_pid = atoi (buf);
         }
 
         if (output_processes_cb_count == 1) {
@@ -497,9 +497,9 @@ void output_processes_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
 
@@ -563,8 +563,8 @@ void test_kill_setpgrp (flux_reactor_t *r)
 
 void eof_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -579,9 +579,9 @@ void eof_cb (flux_subprocess_t *p, const char *stream)
     ok (flux_subprocess_read_stream_closed (p, stream),
         "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-    ptr = flux_subprocess_read (p, stream, &lenp);
-    ok (ptr != NULL
-        && lenp == 0,
+    buf = flux_subprocess_read (p, stream, &len);
+    ok (buf != NULL
+        && len == 0,
         "flux_subprocess_read on %s read EOF", stream);
 
     (*counter)++;
@@ -970,8 +970,8 @@ void fail_completion_cb (flux_subprocess_t *p)
 
 void fail_output_cb (flux_subprocess_t *p, const char *stream)
 {
-    const char *ptr;
-    int lenp = 0;
+    const char *buf;
+    int len = 0;
     int *counter;
 
     if (!strcasecmp (stream, "stdout"))
@@ -987,9 +987,9 @@ void fail_output_cb (flux_subprocess_t *p, const char *stream)
         ok (flux_subprocess_read_stream_closed (p, stream),
             "flux_subprocess_read_stream_closed saw EOF on %s", stream);
 
-        ptr = flux_subprocess_read (p, stream, &lenp);
-        ok (ptr != NULL
-            && lenp == 0,
+        buf = flux_subprocess_read (p, stream, &len);
+        ok (buf != NULL
+            && len == 0,
             "flux_subprocess_read on %s read EOF", stream);
     }
     else

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -217,7 +217,7 @@ static void state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state
 static void io_cb (flux_subprocess_t *p, const char *stream)
 {
     cron_task_t *t = flux_subprocess_aux_get (p, "task");
-    const char *buf = NULL;
+    const char *buf;
     int len;
     bool is_stderr = false;
 
@@ -226,14 +226,14 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
     if (streq (stream, "stderr"))
         is_stderr = true;
 
-    if (!(buf = flux_subprocess_read_trimmed_line (p, stream, &len))) {
+    if ((len = flux_subprocess_read_trimmed_line (p, stream, &buf)) < 0) {
         flux_log_error (t->h, "%s: flux_subprocess_read_trimmed_line",
                         __FUNCTION__);
         return;
     }
 
     if (!len) {
-        if (!(buf = flux_subprocess_read (p, stream, &len))) {
+        if ((len = flux_subprocess_read (p, stream, &buf)) < 0) {
             flux_log_error (t->h, "%s: flux_subprocess_read",
                             __FUNCTION__);
             return;

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -217,8 +217,8 @@ static void state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state
 static void io_cb (flux_subprocess_t *p, const char *stream)
 {
     cron_task_t *t = flux_subprocess_aux_get (p, "task");
-    const char *ptr = NULL;
-    int lenp;
+    const char *buf = NULL;
+    int len;
     bool is_stderr = false;
 
     assert (t);
@@ -226,22 +226,22 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
     if (streq (stream, "stderr"))
         is_stderr = true;
 
-    if (!(ptr = flux_subprocess_read_trimmed_line (p, stream, &lenp))) {
+    if (!(buf = flux_subprocess_read_trimmed_line (p, stream, &len))) {
         flux_log_error (t->h, "%s: flux_subprocess_read_trimmed_line",
                         __FUNCTION__);
         return;
     }
 
-    if (!lenp) {
-        if (!(ptr = flux_subprocess_read (p, stream, &lenp))) {
+    if (!len) {
+        if (!(buf = flux_subprocess_read (p, stream, &len))) {
             flux_log_error (t->h, "%s: flux_subprocess_read",
                             __FUNCTION__);
             return;
         }
     }
 
-    if (t->io_cb && lenp)
-        (*t->io_cb) (t->h, t, t->arg, is_stderr, ptr, lenp);
+    if (t->io_cb && len)
+        (*t->io_cb) (t->h, t, t->arg, is_stderr, buf, len);
 }
 
 int cron_task_kill (cron_task_t *t, int sig)

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -224,7 +224,7 @@ static void exec_output_cb (flux_subprocess_t *p, const char *stream)
     const char *s;
     int len;
 
-    if (!(s = flux_subprocess_getline (p, stream, &len))) {
+    if ((len = flux_subprocess_getline (p, stream, &s)) < 0) {
         flux_log_error (exec->h, "flux_subprocess_getline");
         return;
     }

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -229,7 +229,7 @@ static void worker_output_cb (flux_subprocess_t *p, const char *stream)
     const char *s;
     int len;
 
-    if (!(s = flux_subprocess_read_trimmed_line (p, stream, &len))) {
+    if ((len = flux_subprocess_read_trimmed_line (p, stream, &s)) < 0) {
         flux_log_error (w->h, "%s: subprocess_read_trimmed_line", w->name);
         return;
     }

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -277,7 +277,7 @@ static void io_cb (flux_subprocess_t *sp, const char *stream)
     const char *s;
     int len;
 
-    if (!(s = flux_subprocess_getline (sp, stream, &len))) {
+    if ((len = flux_subprocess_getline (sp, stream, &s)) < 0) {
         flux_log_error (h, "%s: %s: %s: flux_subprocess_getline",
                         idf58 (proc->id),
                         proc->prolog ? "prolog": "epilog",

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -1320,8 +1320,8 @@ static void task_line_output_cb (struct shell_task *task,
     const char *data;
     int len;
 
-    data = flux_subprocess_getline (task->proc, stream, &len);
-    if (!data) {
+    len = flux_subprocess_getline (task->proc, stream, &data);
+    if (len < 0) {
         shell_log_errno ("read %s task %d", stream, task->rank);
     }
     else if (len > 0) {
@@ -1352,13 +1352,13 @@ static void task_none_output_cb (struct shell_task *task,
     const char *data;
     int len;
 
-    data = flux_subprocess_read_line (task->proc, stream, &len);
-    if (!data) {
+    len = flux_subprocess_read_line (task->proc, stream, &data);
+    if (len < 0) {
         shell_log_errno ("read line %s task %d", stream, task->rank);
     }
     else if (!len) {
         /* stderr is unbuffered */
-        if (!(data = flux_subprocess_read (task->proc, stream, &len))) {
+        if ((len = flux_subprocess_read (task->proc, stream, &data)) < 0) {
             shell_log_errno ("read %s task %d", stream, task->rank);
             return;
         }

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -366,8 +366,8 @@ static void pmi_fd_cb (flux_shell_task_t *task,
     const char *line;
     int rc;
 
-    line = flux_subprocess_read_line (task->proc, "PMI_FD", &len);
-    if (!line) {
+    len = flux_subprocess_read_line (task->proc, "PMI_FD", &line);
+    if (len < 0) {
         shell_trace ("%d: C: pmi read error: %s",
                      task->rank, flux_strerror (errno));
         return;

--- a/t/rexec/rexec_count_stdout.c
+++ b/t/rexec/rexec_count_stdout.c
@@ -57,14 +57,14 @@ void output_cb (flux_subprocess_t *p, const char *stream)
     /* Do not use flux_subprocess_getline(), testing is against
      * streams that are line buffered and not line buffered */
 
-    if (!(buf = flux_subprocess_read_line (p, stream, &len))) {
+    if ((len = flux_subprocess_read_line (p, stream, &buf)) < 0) {
         log_err ("flux_subprocess_read_line");
         return;
     }
 
     /* we're at the end of the stream, read any lingering data */
     if (!len && flux_subprocess_read_stream_closed (p, stream)) {
-        if (!(buf = flux_subprocess_read (p, stream, &len))) {
+        if ((len = flux_subprocess_read (p, stream, &buf)) < 0) {
             log_err ("flux_subprocess_read");
             return;
         }

--- a/t/rexec/rexec_count_stdout.c
+++ b/t/rexec/rexec_count_stdout.c
@@ -51,27 +51,27 @@ void completion_cb (flux_subprocess_t *p)
 void output_cb (flux_subprocess_t *p, const char *stream)
 {
     FILE *fstream = streq (stream, "stderr") ? stderr : stdout;
-    const char *ptr;
-    int lenp;
+    const char *buf;
+    int len;
 
     /* Do not use flux_subprocess_getline(), testing is against
      * streams that are line buffered and not line buffered */
 
-    if (!(ptr = flux_subprocess_read_line (p, stream, &lenp))) {
+    if (!(buf = flux_subprocess_read_line (p, stream, &len))) {
         log_err ("flux_subprocess_read_line");
         return;
     }
 
     /* we're at the end of the stream, read any lingering data */
-    if (!lenp && flux_subprocess_read_stream_closed (p, stream)) {
-        if (!(ptr = flux_subprocess_read (p, stream, &lenp))) {
+    if (!len && flux_subprocess_read_stream_closed (p, stream)) {
+        if (!(buf = flux_subprocess_read (p, stream, &len))) {
             log_err ("flux_subprocess_read");
             return;
         }
     }
 
-    if (lenp)
-        fwrite (ptr, lenp, 1, fstream);
+    if (len)
+        fwrite (buf, len, 1, fstream);
 
     if (!strcasecmp (stream, "stdout"))
         stdout_count++;

--- a/t/rexec/rexec_getline.c
+++ b/t/rexec/rexec_getline.c
@@ -73,7 +73,7 @@ void output_cb (flux_subprocess_t *p, const char *stream)
     const char *buf;
     int len;
 
-    if (!(buf = flux_subprocess_getline (p, stream, &len)))
+    if ((len = flux_subprocess_getline (p, stream, &buf)) < 0)
         log_err_exit ("flux_subprocess_getline");
     if (len)
         fwrite (buf, len, 1, fstream);

--- a/t/rexec/rexec_getline.c
+++ b/t/rexec/rexec_getline.c
@@ -70,13 +70,13 @@ void stdin2stream (flux_subprocess_t *p, const char *stream)
 void output_cb (flux_subprocess_t *p, const char *stream)
 {
     FILE *fstream = streq (stream, "stderr") ? stderr : stdout;
-    const char *ptr;
-    int lenp;
+    const char *buf;
+    int len;
 
-    if (!(ptr = flux_subprocess_getline (p, stream, &lenp)))
+    if (!(buf = flux_subprocess_getline (p, stream, &len)))
         log_err_exit ("flux_subprocess_getline");
-    if (lenp)
-        fwrite (ptr, lenp, 1, fstream);
+    if (len)
+        fwrite (buf, len, 1, fstream);
     else
         fprintf (fstream, "EOF\n");
 }


### PR DESCRIPTION
Problem: The flux_subprocess_read() family of functions return a pointer to a buffer on success and length of buffer in an
optional parameter.

This API style isn't the most intuitive as it is quite different than the read(2) system call.  Most notably when EOF
is reached on a read stream you have to check if the buffer pointer is non-NULL and the length returned from an optional parameter is 0.

Solution:  Update the read family of functions to return the length from the function and the buffer pointer in an optional parameter.

Update all callers accordingly.

---

side notes

notes, b/c so much code already used `int`s and `char *`s for these functions, I elected to keep `int` vs `ssize_t` and `char *` vs `void *`.

Relatively simple refactoring ... sorry but the review will be a little tedious, lots of adjustments everywhere  :-)