### PR TITLE
job-manager: misc cleanup in scheduler interface

### DIFF
--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -42,16 +42,14 @@ struct alloc {
     struct job_manager *ctx;
     flux_msg_handler_t **handlers;
     zlistx_t *queue;
-    zlistx_t *sent;
+    zlistx_t *sent;             // track jobs w/ alloc reqs, mode=limited only
     bool scheduler_is_online;
     flux_watcher_t *prep;
     flux_watcher_t *check;
     flux_watcher_t *idle;
-    // e.g. for mode limited w/ limit=1, is 1, for mode unlimited set to 0
-    unsigned int alloc_limit;
-    // e.g. for mode limited w/ limit=1, max of 1
-    unsigned int sent_count;
-    char *sched_sender; // for disconnect
+    unsigned int alloc_limit;   // will have a value of 0 in mode=unlimited
+    unsigned int sent_count;    // track number of jobs w/ alloc reqs
+    char *sched_sender;         // scheduler uuid for disconnect processing
 };
 
 static void requeue_pending (struct alloc *alloc, struct job *job)

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -44,8 +44,6 @@ struct alloc {
     zlistx_t *queue;
     zlistx_t *pending_jobs;
     bool ready;
-    bool stopped;
-    char *stopped_reason;
     flux_watcher_t *prep;
     flux_watcher_t *check;
     flux_watcher_t *idle;
@@ -791,7 +789,6 @@ void alloc_ctx_destroy (struct alloc *alloc)
         flux_watcher_destroy (alloc->idle);
         zlistx_destroy (&alloc->queue);
         zlistx_destroy (&alloc->pending_jobs);
-        free (alloc->stopped_reason);
         free (alloc->sched_sender);
         free (alloc);
         errno = saved_errno;

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -146,6 +146,14 @@ json_t *job_jobspec_with_updates (struct job *job, json_t *updates);
  */
 int job_apply_resource_updates (struct job *job, json_t *updates);
 
+/* job->handle tracks list position.
+ */
+zlistx_t *job_priority_queue_create (void);
+int job_priority_queue_insert (zlistx_t *l, struct job *job);
+int job_priority_queue_delete (zlistx_t *l, struct job *job);
+void job_priority_queue_reorder (zlistx_t *l, struct job *job);
+void job_priority_queue_sort (zlistx_t *l);
+
 #endif /* _FLUX_JOB_MANAGER_JOB_H */
 
 /*


### PR DESCRIPTION
While trying to find the cause of issue #5964, I finally got fed up and did some cleanup in alloc.c.

Nothing too risky here.

I didn't get to the bottom of the actual issue but figured this cleanup could stand alone.