### PR TITLE
flux-job: improve EPERM error message

### DIFF
--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -1099,6 +1099,9 @@ void attach_event_continuation (flux_future_t *f, void *arg)
             goto done;
         if (errno == ENOENT)
             log_msg_exit ("Failed to attach to %s: No such job", ctx->jobid);
+        if (errno == EPERM)
+            log_msg_exit ("Failed to attach to %s: that is not your job",
+                          ctx->jobid);
         log_msg_exit ("flux_job_event_watch_get: %s",
                       future_strerror (f, errno));
     }

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -255,4 +255,13 @@ test_expect_success 'attach: writing to stdin of closed tasks returns EPIPE' '
 	test_debug "cat pipe.out" &&
 	grep -i "Broken pipe" pipe.out
 '
+test_expect_success 'attach: EPERM generates sensible error' '
+	jobid=$(flux job last) &&
+	( export FLUX_HANDLE_USERID=42 &&
+	  export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  test_must_fail flux job attach -vEX $jobid 2>eperm.err
+	) &&
+	test_debug "cat eperm.err" &&
+	grep -i "not your job" eperm.err
+'
 test_done


### PR DESCRIPTION
This PR just closes an old issue since the fix was simple enough.