### PR TITLE
libsubprocess: support FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF

### DIFF
--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -118,7 +118,9 @@ test_channel_t_LDADD = $(test_ldadd)
 test_channel_t_LDFLAGS = $(test_ldflags)
 
 test_remote_t_SOURCES = test/remote.c
-test_remote_t_CPPFLAGS = $(test_cppflags)
+test_remote_t_CPPFLAGS = \
+	-DTEST_SUBPROCESS_DIR=\"$(top_builddir)/src/common/libsubprocess/\" \
+	$(test_cppflags)
 test_remote_t_LDADD = $(test_ldadd)
 test_remote_t_LDFLAGS = $(test_ldflags)
 

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -246,7 +246,10 @@ static void proc_output_cb (flux_subprocess_t *p, const char *stream)
     const char *buf;
     int len;
 
-    if ((len = flux_subprocess_read (p, stream, &buf)) < 0) {
+    len = flux_subprocess_getline (p, stream, &buf);
+    if (len < 0 && errno == EPERM) // not line buffered
+        len = flux_subprocess_read (p, stream, &buf);
+    if (len < 0) {
         llog_error (s,
                     "error reading from subprocess stream %s: %s",
                     stream,

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -61,6 +61,17 @@ enum {
     FLUX_SUBPROCESS_FLAGS_SETPGRP = 2,
     /* use fork(2)/exec(2) even if posix_spawn(3) available */
     FLUX_SUBPROCESS_FLAGS_FORK_EXEC = 4,
+    /* flux_rexec(): In order to improve performance, do not locally
+     * copy and buffer output from the remote subprocess.  Immediately
+     * call output callbacks.  Users should call
+     * flux_subprocess_read() to retrieve the data.  If
+     * flux_subprocess_read() is not called, data will be lost.  Data
+     * will not be NUL terminated.  flux_subprocess_read() should be
+     * called only once.  If called more than once, the same data is
+     * returned.  Use of other read functions will result in a EPERM
+     * error.
+     */
+    FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF = 8,
 };
 
 /*
@@ -195,7 +206,8 @@ int flux_subprocess_close (flux_subprocess_t *p, const char *stream);
  *
  *   Returns length of data on success and -1 on error with errno set.
  *   Buffer of data is returned in bufp.  Buffer is guaranteed to be
- *   NUL terminated.  User shall not free returned pointer.
+ *   NUL terminated unless the FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF flag
+ *   has been specified.  User shall not free returned pointer.
  *
  *   In most cases, a length of 0 indicates that the subprocess has
  *   closed this stream.  A length of 0 could be returned if read

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -55,6 +55,9 @@ struct subprocess_channel {
     flux_watcher_t *out_prep_w;
     flux_watcher_t *out_idle_w;
     flux_watcher_t *out_check_w;
+    /* for FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF */
+    const char *unbuf_data;
+    int unbuf_len;
 
     /* misc */
     bool line_buffered;         /* for buffer_read_w / read_buffer */

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -172,6 +172,16 @@ void test_corner_cases (flux_reactor_t *r)
         && errno == EINVAL,
         "flux_subprocess_aux_get fails with NULL pointer input");
 
+    ok ((cmd = flux_cmd_create (1, avgood, NULL)) != NULL,
+        "flux_cmd_create with /bin/true works");
+    ok (flux_local_exec (r,
+                         FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF,
+                         cmd,
+                         NULL) == NULL
+        && errno == EINVAL,
+        "flux_local_exec fails with invalid flag");
+    flux_cmd_destroy (cmd);
+
     flux_close (h);
 }
 

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -224,8 +224,8 @@ static void exec_output_cb (flux_subprocess_t *p, const char *stream)
     const char *s;
     int len;
 
-    if ((len = flux_subprocess_getline (p, stream, &s)) < 0) {
-        flux_log_error (exec->h, "flux_subprocess_getline");
+    if ((len = flux_subprocess_read (p, stream, &s)) < 0) {
+        flux_log_error (exec->h, "flux_subprocess_read");
         return;
     }
     if (len) {
@@ -264,7 +264,8 @@ static struct exec_cmd *exec_cmd_create (const struct idset *ranks,
         fprintf (stderr, "exec_cmd_create: flux_cmd_copy failed");
         goto err;
     }
-    c->flags = flags;
+    /* bulk-exec always uses unbuffered reads for performance */
+    c->flags = flags | FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF;
     return (c);
 err:
     exec_cmd_destroy (c);

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -107,9 +107,9 @@
 #include "checkpoint.h"
 #include "exec_config.h"
 
-static double kill_timeout=5.0;
-static int term_signal = SIGTERM;
-static int kill_signal = SIGKILL;
+static double kill_timeout;
+static int term_signal;
+static int kill_signal;
 
 #define DEBUG_FAIL_EXPIRATION 1
 
@@ -1367,6 +1367,18 @@ static int job_exec_set_config_globals (flux_t *h,
     const char *tsignal = NULL;
     const char *ksignal = NULL;
     flux_error_t error;
+
+    /* Per trws comment in 97421e88987535260b10d6a19551cea625f26ce4
+     *
+     * The musl libc loader doesn't actually unload objects on
+     * dlclose, so a subsequent dlopen doesn't re-clear globals and
+     * similar.
+     *
+     * So we must re-initialize globals everytime we reload the module.
+     */
+    kill_timeout = 5.0;
+    term_signal = SIGTERM;
+    kill_signal = SIGKILL;
 
     if (flux_conf_unpack (conf,
                           &error,


### PR DESCRIPTION
Per discussion in #5919, some notes

- built on top of my cleanups in #5974
- should the use of this flag in  job-exec be a different PR?
- in job-exec subprocess flags are passed in via the API to bulk-exec, so it felt wrong to just assume that flag is always set.  So that led to adding a new `flux_subprocess_get_flags()` function and calling an appropriate "read" function depending on flags.  This could be done differently of course, perhaps the flags aren't passed in from the API and are internalized within `bulk-exec`?
- haven't tested to ensure that the performance profile changes as expected, dunno if we have a simple reproducer laying around? Edit: I did now, see notes in #5919 
