### PR TITLE
don't free alloc-bypass resources when scheduler reloads

### DIFF
--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -331,7 +331,7 @@ static void hello_cb (flux_t *h,
     flux_log (h, LOG_DEBUG, "scheduler: hello");
     job = zhashx_first (ctx->active_jobs);
     while (job) {
-        if (job->has_resources) {
+        if (job->has_resources && !job->alloc_bypass) {
             if (flux_respond_pack (h,
                                    msg,
                                    "{s:I s:I s:I s:f}",

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -325,11 +325,12 @@ int event_job_action (struct event *event, struct job *job)
             if (job->has_resources
                 && !job_event_is_queued (job, "epilog-start")
                 && !job->perilog_active
-                && !job->alloc_bypass
                 && !job->start_pending
                 && !job->free_posted) {
-                if (alloc_send_free_request (ctx->alloc, job) < 0)
-                    return -1;
+                if (!job->alloc_bypass) {
+                    if (alloc_send_free_request (ctx->alloc, job) < 0)
+                        return -1;
+                }
                 if (event_job_post_pack (ctx->event, job, "free", 0, NULL) < 0)
                     return -1;
                 job->free_posted = 1;

--- a/t/t2273-job-alloc-bypass.t
+++ b/t/t2273-job-alloc-bypass.t
@@ -104,5 +104,54 @@ test_expect_success 'alloc-bypass: reload scheduler' '
 test_expect_success 'alloc-bypass: scheduler still has no nodes allocated' '
 	test $(FLUX_RESOURCE_LIST_RPC=sched.resource-status flux resource list -s allocated -no {nnodes}) -eq 0
 '
+#
+# now try a bypass job that persists across a flux restart
+#
+test_expect_success 'generate a config that loads alloc-bypass' '
+	cat <<-EOT >config.toml
+	[[job-manager.plugins]]
+	load = "alloc-bypass.so"
+	EOT
+'
+test_expect_success 'generate a script to submit a testexec+alloc-bypass job' '
+	cat >prog.sh <<-EOT &&
+	#!/bin/sh
+	flux submit -vvv -N 1 \
+            --flags=debug \
+            --setattr=system.exec.test.run_duration=100s \
+            --setattr=system.alloc-bypass.R="\$(flux resource R)" \
+            --wait-event=start \
+	    sleep 300
+	EOT
+	chmod +x prog.sh
+'
+test_expect_success 'run test job in a persistent instance' '
+	FLUX_DISABLE_JOB_CLEANUP=t flux start -s1 \
+	    -o,--config-path=config.toml \
+	    -o,-Sstatedir=$(pwd) \
+	    ./prog.sh
+'
+test_expect_success 'restart that instance and get the resource alloc count' '
+	FLUX_DISABLE_JOB_CLEANUP=t flux start -s1 \
+	    -o,--config-path=config.toml \
+	    -o,-Sstatedir=$(pwd) \
+	    sh -c "flux jobs -no {state} \$(flux job last); \
+	        FLUX_RESOURCE_LIST_RPC=sched.resource-status \
+		flux resource list -s allocated -no {nnodes}" >restart.out
+'
+test_expect_success 'the job was running and resources were not allocated' '
+	cat >restart.exp <<-EOT &&
+	RUN
+	0
+	EOT
+	test_cmp restart.exp restart.out
+'
+test_expect_success 'restart that instance and cancel the job' '
+	flux start -s1 \
+	    -o,--config-path=config.toml \
+	    -o,-Sstatedir=$(pwd) \
+	    sh -c "flux cancel \$(flux job last); \
+	    flux job wait-event -vvv \$(flux job last) clean"
+'
 
 test_done


### PR DESCRIPTION
This fixes #5797 by omitting alloc-bypass jobs from the "hello" phase of the scheduler handshake.

It looks like `set-flags` is already used to ensure `job->alloc_bypass` survives a flux restsart.

I did notice that my flux restart test hangs without FLUX_DISABLE_JOB_CLEANUP set, as the alloc-bypass job gets stuck in CLEANUP, so that needs following up.   Will open a separate issue.