### PR TITLE
plugin: frob for system attribute dependency name

### DIFF
--- a/broker.toml
+++ b/broker.toml
@@ -1,0 +1,30 @@
+[access]
+allow-guest-user = true
+allow-root-owner = true
+
+# Point to resource definition generated with flux-R(1).
+[resource]
+path = "/tmp/R"
+
+[bootstrap]
+curve_cert = "/tmp/curve.cert"
+default_port = 8050
+default_bind = "tcp://eth0:%p"
+default_connect = "tcp://%h.flux-service.default.svc.cluster.local:%p"
+
+# CHANGE THIS TO YOUR HOSTNAME (or container hostname)
+hosts = [
+{ host="3013fe118c9d"},
+]		
+
+
+[archive]
+dbpath = "/tmp/job-archive.sqlite"
+period = "1m"
+busytimeout = "50s"
+
+[ingest.frobnicator]
+plugins = [ "defaults", "constraints", "dependency" ]
+
+[sched-fluxion-qmanager]
+queue-policy = "fcfs"

--- a/dependency-name.md
+++ b/dependency-name.md
@@ -1,0 +1,118 @@
+# Dependency Name
+
+This is a branch of flux-core that provides an ability to specify a dependency name (the actual name, not the job id) to be given
+to a second job, with the goal of the second job waiting for the first to finish (afterok, meaning only on success) before starting.
+Here are some brief instructions for how to get this working locally in a development environment.
+
+## Usage
+
+We are going to make a frobnicator plugin. I'm still not sure what "frobnicator" means, so let's reference some of our previous wisdom:
+
+> Frobnicator "frobs jobspec at job submission time"
+
+And
+
+> frob jobspec knobs to swab JSON blobs stopping user sobs at job submission time. 
+
+But we cannot be certain if the frobnicator is truly enough to stop the sobs! I digress. We are going to write a plugin of this type because it will mutate the jobspec before letting it pass through. 
+
+### 1. Update broker.toml
+
+This means that the first thing we need to do is register the plugin in our [broker.toml](broker.toml). That means a section (in toml) that looks like this:
+
+```toml
+[ingest.frobnicator]
+plugins = [ "defaults", "constraints", "dependency" ]
+```
+
+The first two are done by default, and our custom plugin is called "dependency," which means the file "dependency.py" is added to `src/bindings/python/flux/job/frobnicator/plugins`.
+
+Note that the broker.toml also assumes having:
+
+- resource `R`
+- a Curve Certificate
+- the hostname of your host or development container (change this manually)
+
+To generate the first two:
+
+```bash
+flux R encode --local > /tmp/R
+flux keygen /tmp/curve.cert
+```
+
+### 2. Start the broker
+
+We can run `flux start` and provide our custom broker config to start the flux broker.
+
+```bash
+flux start -o --config=./broker.toml 
+```
+That should run without an error. Then try listing plugins.
+
+```bash
+flux job-frobnicator --list-plugins
+```
+```console
+Available plugins:
+constraints           Apply constraints to incoming jobspec based on broker config.
+defaults              Apply defaults to incoming jobspec based on broker config.
+dependency            Translate dependency.name into a job id for dependency.afterok
+```
+
+### 3. Submit Jobs
+
+We next are going to submit jobs, with one that depends on the first. Here is our first job:
+
+```bash
+flux submit --job-name sleepy sleep 10
+```
+
+And immediately after, run:
+
+```bash
+flux run --setattr=dependency.name=sleepy hostname
+```
+```console
+epy hostname
+flux-job: ƒ8CAShwy9 resolving dependencies                              00:00:08
+```
+
+Another way to see this is the same, but with submit, and then `flux jobs -a`
+
+```bash
+flux submit --job-name sleepy sleep 10
+flux submit --setattr=dependency.name=sleepy hostname
+flux jobs -a
+```
+```console
+$ flux jobs -a
+       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
+   ƒ8cveUCsy vscode   hostname    D      1      -        - depends:after-success=16821021310976
+   ƒ8crs43Aw vscode   sleepy      R      1      1   0.237s 3013fe118c9d
+```
+
+You'll see that it is waiting, above.
+Note that for this plugin design:
+
+1. The first matching name is chosen.
+2. If the dependency name isn't defined, no change in behavior
+3. If a name is defined and not found, you get an error (see below)
+
+```bash
+$ flux submit --setattr=dependency.name=doesnotexist hostname
+[Errno 1] Job with name doesnotexist is not known
+```
+
+And that's it! This was pretty easy / fun to write. Thanks to Tom for the hackathon today and everyone that attended and dealt with my dumb questions and having to look at my face. 🤪️
+
+### x. Development
+
+To work on this, I figured out how the dependency (as it actually works) would be added to a jobspec with a dry run:
+
+```bash
+flux submit --dry-run --dependency=after:"$(flux job id $(flux job last))" hostname | jq
+```
+
+That showed me it was under `jobspec.attributes['system']` and an attribute like `dependency.name=value` would get transformed into `{"dependency": {"name": "value"}}`
+
+Likely for experiments I'll do a custom view build with flux that has this module.

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -51,6 +51,7 @@ nobase_fluxpy_PYTHON = \
 	job/frobnicator/frobnicator.py \
 	job/frobnicator/plugins/defaults.py \
 	job/frobnicator/plugins/constraints.py \
+	job/frobnicator/plugins/dependency.py \
 	resource/Rlist.py \
 	resource/__init__.py \
 	resource/ResourceSetImplementation.py \

--- a/src/bindings/python/flux/job/frobnicator/plugins/dependency.py
+++ b/src/bindings/python/flux/job/frobnicator/plugins/dependency.py
@@ -1,0 +1,65 @@
+##############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+"""Translate dependency.name into a job id for dependency.afterok
+
+"""
+
+from flux.job.frobnicator import FrobnicatorPlugin
+
+
+class DependencyAdder:
+    """Get the system attribute for dependency.name and add a
+    task dependency. Raise an error if we can't find it.
+    """
+
+    def __init__(self, config={}):
+        # We don't need this for anything, just saving
+        # for the heck
+        self.config = config
+
+    def add_dependency(self, jobspec):
+        """We need to translate a dependency name into a job id. We will:
+        1. Get the desired name from system attribute dependency.name
+        2. list all flux jobs (I know, I know) and get the job id
+        3. Update the jobspec to have it.
+        4. Raise error if the name does not exist.
+
+        Bullet 2 is a bad design and thus this is only for experimentation.
+        """
+        dependency_name = jobspec.attributes["system"].get("dependency", {}).get("name")
+        if not dependency_name:
+            return
+
+        # We are going to add the first matched job as a dependency
+        import flux
+        import flux.job
+
+        handle = flux.Flux()
+        for job in flux.job.list.job_list(handle).get()["jobs"]:
+            if job["name"] == dependency_name:
+                jobspec.attributes["system"]["dependencies"] = [
+                    {"scheme": "afterok", "value": str(job["id"])}
+                ]
+                return
+
+        raise ValueError(f"Job with name {dependency_name} is not known")
+
+
+class Frobnicator(FrobnicatorPlugin):
+    def __init__(self, parser):
+        super().__init__(parser)
+
+    def configure(self, args, config):
+        self.config = DependencyAdder(config)
+
+    def frob(self, jobspec, user, urgency, flags):
+        """This frobber is looking for an attribute "dependency.name"""
+        self.config.add_dependency(jobspec)


### PR DESCRIPTION
:construction:  NOT FOR REVIEW! :construction: 

This PR is only opened to share the diff (and discuss possible design for an actual solution). We need this functionality for experiments, and this was the shortest path to get there!

Problem: we need a quick solution for assigning a jobid dependnecy to run after success (afterok) given a given name.
Solution: write a frobnicator plugin that handles this transformation to the jobspec.