### PR TITLE
flux-dump: add --ignore-failed-read option

### DIFF
--- a/doc/man1/flux-dump.rst
+++ b/doc/man1/flux-dump.rst
@@ -76,6 +76,13 @@ OPTIONS
    store.  This may be slightly faster, depending on how frequently the same
    content blobs are referenced by multiple keys.
 
+.. option:: --ignore-failed-read
+
+   If KVS metadata is encountered that references nonexistent blobrefs
+   (for example after a disk full event), print an error but skip over the
+   KVS key and treat it as a warning.  Without this option, content load
+   failures are treated as immediate fatal errors.
+
 
 OTHER NOTES
 ===========

--- a/etc/rc3
+++ b/etc/rc3
@@ -66,7 +66,7 @@ if test $RANK -eq 0; then
             dumplink="${statedir:-.}/dump/RESTORE"
         fi
         echo "dumping content to ${dumpfile}"
-        if flux dump --quiet --checkpoint ${dumpfile}; then
+        if flux dump --quiet --ignore-failed-read --checkpoint ${dumpfile}; then
             test -n "$dumplink" && ln -s $(basename ${dumpfile}) ${dumplink}
         else
             exit_rc=1


### PR DESCRIPTION
This adds an option to allow a KVS dump to continue even when there are keys referencing nonexistent blobrefs.   This would have been handy last night when el cap ran out of disk space and we had to kill the rank 0 broker.  This left some dangling keys which prevented flux from starting.  Then after we got rid of those, we found some more in less critical places that we had to run down by iteratively running `flux dump`  and removing one key until it ran clean.

This option allows all the bad keys to be found in one go.

This PR also adds the option to the dump called from rc3 so that any bad keys that find their way into the KVS are simply not included on the next restart.