### PR TITLE
broker: don't post quorum-full in non-QUORUM state

### DIFF
--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -896,7 +896,7 @@ static void broker_online_cb (flux_future_t *f, void *arg)
     }
 
     if (quorum_reached) {
-        if (s->state != STATE_RUN) {
+        if (s->state == STATE_QUORUM) {
             state_machine_post (s, "quorum-full");
             if (s->quorum.warned) {
                 flux_log (s->ctx->h, LOG_ERR, "quorum reached");


### PR DESCRIPTION
Problem: many "quorum-full: ignored in shutdown" messages were observed during shutdown of Flux on a large system with a flat TBON.

The quorum-full broker event could be posted in any state but RUN. Restrict quorum-full posting to the QUORUM state.

Fixes #5983