### PR TITLE
suppress confusing log messages when broker is signaled during shutdown

### DIFF
--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -228,8 +228,10 @@ static void state_change_cb (flux_subprocess_t *p,
             break;
         case FLUX_SUBPROCESS_RUNNING:
             if (entry->aborted) {
-                if (!(f = flux_subprocess_kill (p, abort_signal)))
-                    flux_log_error (r->h, "%s: error aborting", entry->name);
+                if (!(f = flux_subprocess_kill (p, abort_signal))) {
+                    if (errno != ESRCH)
+                        flux_log_error (r->h, "kill %s", entry->name);
+                }
                 flux_future_destroy (f);
             }
             break;
@@ -630,8 +632,10 @@ int runat_abort (struct runat *r, const char *name)
     }
     if ((cmd = zlist_head (entry->commands)) && cmd->p != NULL) {
         flux_future_t *f;
-        if (!(f = flux_subprocess_kill (cmd->p, abort_signal)))
-            flux_log_error (r->h, "%s: error aborting", entry->name);
+        if (!(f = flux_subprocess_kill (cmd->p, abort_signal))) {
+            if (errno != ESRCH)
+                flux_log_error (r->h, "kill %s", entry->name);
+        }
         flux_future_destroy (f);
     }
     entry->aborted = true;

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -570,6 +570,8 @@ void state_machine_kill (struct state_machine *s, int signum)
                 state_machine_post (s, "shutdown");
             break;
         case STATE_CLEANUP:
+            if (!runat_is_defined (s->ctx->runat, "cleanup"))
+                break;
             if (runat_abort (s->ctx->runat, "cleanup") < 0)
                 flux_log_error (h, "runat_abort cleanup (signal %d)", signum);
             break;

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -918,15 +918,14 @@ flux_future_t *flux_subprocess_kill (flux_subprocess_t *p, int signum)
 
     if (p->state != FLUX_SUBPROCESS_RUNNING
         && p->state != FLUX_SUBPROCESS_INIT) {
-        /* XXX right errno? */
-        errno = EINVAL;
+        errno = ESRCH;
         return NULL;
     }
 
     if (p->local) {
         int ret;
         if (p->pid <= (pid_t) 0) {
-            errno = EINVAL;
+            errno = ESRCH;
             return NULL;
         }
         if (p->flags & FLUX_SUBPROCESS_FLAGS_SETPGRP)

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -432,6 +432,11 @@ void completion_sigterm_cb (flux_subprocess_t *p)
         "subprocess terminated by SIGTERM");
     flux_reactor_stop (flux_subprocess_get_reactor (p));
     completion_sigterm_cb_count++;
+
+    errno = 0;
+    ok (flux_subprocess_kill (p, SIGTERM) == NULL && errno == ESRCH,
+        "flux_subprocess_kill fails with ESRCH");
+
 }
 
 void test_kill (flux_reactor_t *r)
@@ -460,6 +465,7 @@ void test_kill (flux_reactor_t *r)
     ok (flux_future_get (f, NULL) == 0, "flux_future_get (f) returns 0");
     ok (flux_reactor_run (r, 0) == 0, "reactor_run exits normally");
     ok (completion_sigterm_cb_count == 1, "completion sigterm callback called 1 time");
+
     flux_subprocess_destroy (p);
     flux_future_destroy (f);
     flux_cmd_destroy (cmd);


### PR DESCRIPTION
This addresses the log messages noted in #5995, which are more confusing than helpful.