### PR TITLE
doc: fix typo in flux-jobs(1)

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -328,7 +328,7 @@ The field names that can be specified are:
 **status_abbrev**
    status but in a max 2 character abbreviation
 
-**status_abbrev**
+**status_emoji**
    status but an appropriate emoji instead of job state / result
 
 **name**


### PR DESCRIPTION
Problem: The field name for `status_emoji` is incorrect due to a cut and paste error.

Correct the field name for `status_emoji`.

Fixes #5997