### PR TITLE
bypass KVS for job stdin with `--input=FILE`

### DIFF
--- a/src/shell/input/file.c
+++ b/src/shell/input/file.c
@@ -10,8 +10,7 @@
 
 /* file input handling
  *
- * For input type "file", read a single input file on shell rank 0
- * and place data in guest.input.
+ * Redirect stdin of tasks to a file.
  *
  */
 #define FLUX_SHELL_PLUGIN_NAME "input.file"
@@ -39,24 +38,12 @@
 struct file_input {
     flux_shell_t *shell;
     const char *path;
-    int fd;
-    flux_watcher_t *w;
-    char *ranks;
 };
-
-static void file_read_cb (flux_reactor_t *r,
-                          flux_watcher_t *w,
-                          int revents,
-                          void *arg);
 
 static void file_input_destroy (struct file_input *fp)
 {
     if (fp) {
         int saved_errno = errno;
-        if (fp->fd >= 0)
-            close (fp->fd);
-        flux_watcher_destroy (fp->w);
-        free (fp->ranks);
         free (fp);
         errno = saved_errno;
     }
@@ -73,29 +60,13 @@ static struct file_input *file_input_create (flux_shell_t *shell,
     fp->shell = shell;
     fp->path = path;
 
-    if ((fp->fd = open (fp->path, O_RDONLY)) < 0) {
+    /*  Path will be opened separately in each task.
+     *  Ensure access here though so users get a single error message
+     *  before launching tasks.
+     */
+    if (access (fp->path, R_OK) < 0) {
         shell_die_errno (1, "error opening input file '%s'", fp->path);
         goto error;
-    }
-    if (!(fp->w = flux_fd_watcher_create (shell->r,
-                                          fp->fd,
-                                          FLUX_POLLIN,
-                                          file_read_cb,
-                                          fp))) {
-        shell_log_errno ("flux_fd_watcher_create");
-        goto error;
-    }
-    if (shell->info->total_ntasks > 1) {
-        if (asprintf (&fp->ranks, "[0-%d]", shell->info->total_ntasks) < 0) {
-            shell_log_errno ("asprintf");
-            goto error;
-        }
-    }
-    else {
-        if (!(fp->ranks = strdup ("0"))) {
-            shell_log_errno ("asprintf");
-            goto error;
-        }
     }
     return fp;
 error:
@@ -103,50 +74,28 @@ error:
     return NULL;
 }
 
-static int file_input_to_kvs (struct file_input *fp,
-                              void *buf,
-                              int len,
-                              bool eof)
+static int file_input_task_exec (flux_plugin_t *p,
+                                 const char *topic,
+                                 flux_plugin_arg_t *args,
+                                 void *data)
 {
-    json_t *context = NULL;
-    int saved_errno;
-    int rc = -1;
+    struct file_input *fp = data;
+    int fd;
 
-    if (!(context = ioencode ("stdin", fp->ranks, buf, len, eof)))
-        goto error;
-    if (input_eventlog_put (fp->shell, context) < 0)
-        goto error;
-    rc = 0;
- error:
-    saved_errno = errno;
-    json_decref (context);
-    errno = saved_errno;
-    return rc;
-}
-
-static void file_read_cb (flux_reactor_t *r,
-                          flux_watcher_t *w,
-                          int revents,
-                          void *arg)
-{
-    struct file_input *fp = arg;
-    long ps = sysconf (_SC_PAGESIZE);
-    char buf[ps];
-    ssize_t n;
-
-    assert (ps > 0);
-
-    while ((n = read (fp->fd, buf, ps)) > 0) {
-        if (file_input_to_kvs (fp, buf, n, false) < 0)
-            shell_die_errno (1, "shell_input_put_kvs_raw");
+    if ((fd = open (fp->path, O_RDONLY)) < 0) {
+        fprintf (stderr,
+                 "error opening input file '%s': %s",
+                 fp->path,
+                 strerror (errno));
+        exit (1);
     }
-    if (n < 0)
-        shell_die_errno (1, "shell_input_put_kvs_raw");
-    if (file_input_to_kvs (fp, NULL, 0, true) < 0)
-        shell_die_errno (1, "shell_input_put_kvs_raw");
-
-    flux_watcher_stop (w);
+    if (dup2 (fd, STDIN_FILENO) < 0) {
+        fprintf (stderr, "dup2: %s", strerror (errno));
+        exit (1);
+    }
+    return 0;
 }
+
 
 static int file_input_init (flux_plugin_t *p,
                             const char *topic,
@@ -185,12 +134,11 @@ static int file_input_init (flux_plugin_t *p,
         return -1;
     }
 
-    /* Emit input eventlog header */
-    if (input_eventlog_init (shell) < 0)
+    if (flux_plugin_add_handler (p,
+                                 "task.exec",
+                                 file_input_task_exec,
+                                 fp) < 0)
         return -1;
-
-    /* Eventlog is ready, start fd watcher */
-    flux_watcher_start (fp->w);
 
     return 0;
 }

--- a/src/shell/input/kvs.c
+++ b/src/shell/input/kvs.c
@@ -169,6 +169,21 @@ static int input_kvs_start (flux_plugin_t *p,
 {
     flux_shell_t *shell = flux_plugin_get_shell (p);
     struct task_input_kvs *kp;
+    const char *type = "service";
+
+    /*  No need to watch kvs input eventlog if input mode is not "kvs"
+     *  or unset.
+     */
+    if (flux_shell_getopt_unpack (shell,
+                                  "input",
+                                  "{s?{s?s}}",
+                                  "stdin",
+                                   "type", &type) < 0)
+        return -1;
+
+    if (!streq (type, "service"))
+        return 0;
+
 
     if (!(kp = task_input_kvs_create (shell))
         || flux_plugin_aux_set (p,

--- a/src/shell/input/service.c
+++ b/src/shell/input/service.c
@@ -104,7 +104,7 @@ static void input_service_stdin_cb (flux_t *h,
             goto error;
         }
     }
-    if (input_eventlog_put (in->shell, o) < 0)
+    if (input_eventlog_put_event (in->shell, "data", o) < 0)
         goto error;
     if (eof && subtract_idset (in->open_tasks, ranks, ids) < 0)
         shell_log_errno ("failed to remove '%s' from open tasks", ranks);

--- a/src/shell/input/util.c
+++ b/src/shell/input/util.c
@@ -36,7 +36,9 @@ static void input_put_kvs_completion (flux_future_t *f, void *arg)
         shell_log_errno ("flux_shell_remove_completion_ref");
 }
 
-int input_eventlog_put (flux_shell_t *shell, json_t *context)
+int input_eventlog_put_event (flux_shell_t *shell,
+                              const char *name,
+                              json_t *context)
 {
     flux_t *h;
     flux_kvs_txn_t *txn = NULL;
@@ -48,7 +50,7 @@ int input_eventlog_put (flux_shell_t *shell, json_t *context)
 
     if (!(h = flux_shell_get_flux (shell)))
         goto error;
-    if (!(entry = eventlog_entry_pack (0.0, "data", "O", context)))
+    if (!(entry = eventlog_entry_pack (0.0, name, "O", context)))
         goto error;
     if (!(entrystr = eventlog_entry_encode (entry)))
         goto error;

--- a/src/shell/input/util.h
+++ b/src/shell/input/util.h
@@ -21,10 +21,12 @@
  */
 int input_eventlog_init (flux_shell_t *shell);
 
-/*  Put an input eventlog entry defined in `context` to the KVS input
+/*  Put an input eventlog entry `name` defined in `context` to the KVS input
  *  eventlog.
  */
-int input_eventlog_put (flux_shell_t *shell, json_t *context);
+int input_eventlog_put_event (flux_shell_t *shell,
+                              const char *name,
+                              json_t *context);
 
 #endif /* !SHELL_INPUT_INTERNAL_H */
 

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -139,6 +139,11 @@ test_expect_success 'flux-shell: run 1-task input file as stdin job' '
         test_cmp input_stdin_file file0.out
 '
 
+test_expect_success 'flux-shell: input from file results in redirect event' '
+	flux job wait-event -Hp input -t 5 -m stream=stdin \
+		$(flux job last) redirect
+'
+
 test_expect_success 'flux-shell: run 2-task input file as stdin job' '
         flux run -n2 --input=input_stdin_file --label-io \
              ${TEST_SUBPROCESS_DIR}/test_echo -O -n > file1.out &&


### PR DESCRIPTION
This PR modifies the shell `input.file` plugin to bypass the KVS when an input file is specified, rather than reading the file into the KVS input eventlog, i.e. this makes the behavior match documentation. If input is redirected from a file, an RFC 24 redirect event is posted in place of any data.

This also solves the problem of stdin flow control when file input is used since each task now has its input redirected from the file instead of shuttling through the KVS. (flow control is still an issue with interactive input though, so this doesn't fully solve issue #2459)

It would also be trivial now to support a mustache template for a stdin FILE, e.g. to support input per task or node, etc., however, that work is left for the future.