### PR TITLE
broker: add tunable parameters for extreme fanout configurations

### DIFF
--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -58,6 +58,19 @@ zmqdebug
    should be enabled: 0=disabled, 1=enabled.  Default: ``0``.  This configured
    value may be overridden by setting the ``tbon.zmqdebug`` broker attribute.
 
+zmq_io_threads
+   (optional) Integer value to set the number of I/O threads libzmq will start
+   on the leader node.  The default is 1.  This configured value may be
+   overridden by setting the ``tbon.zmq_io_threads`` broker attribute.
+
+child_rcvhwm
+   (optional) Integer value that limits the number of messages stored locally
+   on behalf of each downstream TBON peer.  When the limit is reached, messages
+   are queued on the peer instead.  Setting this reduces memory usage for
+   nodes with a large number of downstream peers, at the expense of message
+   latency.  The value should be 0 (unlimited) or >= 2.  The default is 0.
+   This configured value may be overridden by setting the ``tbon.child_rcvhwm``
+   broker attribute.
 
 EXAMPLE
 =======

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -174,6 +174,15 @@ tbon.zmqdebug [Updates: C]
    if available.  This is potentially useful for debugging overlay
    connectivity problems.  Default: ``0``.
 
+tbon.zmq_io_threads [Updates: C]
+   Set the number of I/O threads libzmq will start on the leader node.
+   Default: ``1``.
+
+tbon.child_rcvhwm [Updates: C]
+   Limit the number of messages stored locally on behalf of each downstream
+   TBON peer.  When the limit is reached, messages are queued on the peer
+   instead.  Default: ``0`` (unlimited).
+
 tbon.prefertcp [Updates: C]
    If set to an integer value other than zero, and the broker is bootstrapping
    with PMI, tcp:// endpoints will be used instead of ipc://, even if all

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -912,3 +912,5 @@ keypair
 unterminated
 upmi
 testexec
+rcvhwm
+libzmq

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -539,6 +539,35 @@ test_expect_success 'tbon.zmq_io_threads broker attr overrides' '
 test_expect_success 'setting tbon.zmq_io_threads to -1 fails' '
 	test_expect_code 1 flux broker ${ARGS} -Stbon.zmq_io_threads=-1 true
 '
+test_expect_success 'tbon.child_rcvhwm is 0 by default' '
+	echo 0 >hwm0.exp &&
+	flux broker ${ARGS} \
+		flux getattr tbon.child_rcvhwm >hwm0.out &&
+	test_cmp hwm0.exp hwm0.out
+'
+test_expect_success 'tbon.child_rcvhwm can be configured' '
+	cat <<-EOT >hwm.toml &&
+	[tbon]
+	child_rcvhwm = 5
+	EOT
+	echo 5 >hwm5.exp &&
+	flux broker ${ARGS} --config-path=hwm.toml \
+		flux getattr tbon.child_rcvhwm >hwm5.out &&
+	test_cmp hwm5.exp hwm5.out
+'
+test_expect_success 'tbon.child_rcvhwm broker attr overrides' '
+	echo 2 >hwm2.exp &&
+	flux broker ${ARGS} --config-path=hwm.toml \
+		-Stbon.child_rcvhwm=2 \
+		flux getattr tbon.child_rcvhwm >hwm2.out &&
+	test_cmp hwm2.exp hwm2.out
+'
+test_expect_success 'tbon.child_rcvhwm=-1 fails' '
+	test_expect_code 1 flux broker ${args} -Stbon.child_rcvhwm=-1 true
+'
+test_expect_success 'tbon.child_rcvhwm=1 fails' '
+	test_expect_code 1 flux broker ${args} -Stbon.child_rcvhwm=1 true
+'
 test_expect_success 'tbon.torpid_max, tbon.torpid_min can be configured' '
 	mkdir conf21 &&
 	cat <<-EOT >conf21/tbon.toml &&


### PR DESCRIPTION
This adds two new TOML/broker attrs:

**tbon.child_rcvhwm**

Allows the child receive buffer to be capped at some number of messages per peer.  It is currently unlimited.  This might help keep RSS growth in check on the leader broker of a big system

**tbon.zmq_io_threads**

Lets the number of I/O threads spawned by zeromq be increased from the default of 1.  Only affects the leader node.

I have only tested this on my small cluster with
```toml
[tbon]
zmq_io_threads = 2
child_rcvhwm = 5
```

I confirmed that rank 0 has started two I/O threads while other ranks started one, and that a "flood ping" (+) from rank 1 to rank 0 causes the RSS of rank 1 to grow not 0.

_______
(+) `flux ping -p 8k -i 0 -c 100000 0`