### PR TITLE
testsuite: fix sdexec-memlimit config update test

### DIFF
--- a/t/t2410-sdexec-memlimit.t
+++ b/t/t2410-sdexec-memlimit.t
@@ -159,7 +159,7 @@ test_expect_success STRESS 'exceeding memory.max causes job failure' '
 #
 
 test_expect_success 'change values of memory containment' '
-	cat >config/config.toml <<EOT
+	cat >config/config.toml <<-EOT &&
 	[systemd]
 	enable = true
 	sdbus-debug = true


### PR DESCRIPTION
Problem: tests that show sdexec memory limits can be updated on the fly always fail.

Add a missing "-" in the here-is token for tab-prefixed data. Also add a missing && between the hereis and config load. The missing && allowed the here-is problem to go unnoticed.

Fixes #5972