### PR TITLE
libsubprocess: use matchtag instead of pid for flux_subprocess_write()

### DIFF
--- a/src/common/libsubprocess/client.h
+++ b/src/common/libsubprocess/client.h
@@ -40,10 +40,7 @@ bool subprocess_rexec_is_output (flux_future_t *f,
                                  int *len,
                                  bool *eof);
 
-int subprocess_write (flux_t *h,
-                      const char *service_name,
-                      uint32_t rank,
-                      pid_t pid,
+int subprocess_write (flux_future_t *f,
                       const char *stream,
                       const char *data,
                       int len,

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -468,41 +468,6 @@ static int remote_output_buffered (flux_subprocess_t *p,
     return 0;
 }
 
-/* In the event channel had data / closed before process running */
-static int send_channel_data (flux_subprocess_t *p)
-{
-    struct subprocess_channel *c;
-    c = zhash_first (p->channels);
-    while (c) {
-        int bytes = fbuf_bytes (c->write_buffer);
-        if (c->closed || bytes > 0) {
-            const char *ptr = NULL;
-            int len = 0;
-            if (bytes > 0) {
-                if (!(ptr = fbuf_read (c->write_buffer, -1, &len))) {
-                    llog_debug (p,
-                                "error reading buffered data: %s",
-                                strerror (errno));
-                    set_failed (p, "internal fbuf_read error");
-                    return -1;
-                }
-            }
-            if (subprocess_write (p->f, c->name, ptr, len, c->closed) < 0) {
-                llog_debug (p,
-                            "error sending rexec.write request: %s",
-                            strerror (errno));
-                set_failed (p, "internal close error");
-                return -1;
-            }
-            /* Don't need this buffer anymore, reclaim the space */
-            fbuf_destroy (c->write_buffer);
-            c->write_buffer = NULL;
-        }
-        c = zhash_next (p->channels);
-    }
-    return 0;
-}
-
 static void rexec_continuation (flux_future_t *f, void *arg)
 {
     flux_subprocess_t *p = arg;
@@ -536,8 +501,6 @@ static void rexec_continuation (flux_future_t *f, void *arg)
     if (subprocess_rexec_is_started (f, &p->pid)) {
         p->pid_set = true;
         process_new_state (p, FLUX_SUBPROCESS_RUNNING);
-        if (send_channel_data (p) < 0)
-            goto error;
     }
     else if (subprocess_rexec_is_stopped (f)) {
         process_new_state (p, FLUX_SUBPROCESS_STOPPED);

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -487,14 +487,7 @@ static int send_channel_data (flux_subprocess_t *p)
                     return -1;
                 }
             }
-            if (subprocess_write (p->h,
-                                  p->service_name,
-                                  p->rank,
-                                  p->pid,
-                                  c->name,
-                                  ptr,
-                                  len,
-                                  c->closed) < 0) {
+            if (subprocess_write (p->f, c->name, ptr, len, c->closed) < 0) {
                 llog_debug (p,
                             "error sending rexec.write request: %s",
                             strerror (errno));

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -440,7 +440,8 @@ static void server_write_cb (flux_t *h,
      * that the log messages end up being a nuisance.
      */
     if (!(p = proc_find_byclient (s, msg))
-        || p->state != FLUX_SUBPROCESS_RUNNING)
+        || p->state == FLUX_SUBPROCESS_FAILED
+        || p->state == FLUX_SUBPROCESS_EXITED)
         goto out;
 
     if (data && len) {

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -729,14 +729,7 @@ int flux_subprocess_write (flux_subprocess_t *p,
             }
         }
         else { /* p->state == FLUX_SUBPROCESS_RUNNING */
-            if (subprocess_write (p->h,
-                                  p->service_name,
-                                  p->rank,
-                                  p->pid,
-                                  c->name,
-                                  buf,
-                                  len,
-                                  false) < 0) {
+            if (subprocess_write (p->f, c->name, buf, len, false) < 0) {
                 log_err ("error sending rexec.write request: %s",
                          strerror (errno));
                 return -1;
@@ -787,14 +780,7 @@ int flux_subprocess_close (flux_subprocess_t *p, const char *stream)
          */
         c->closed = true;
         if (p->state == FLUX_SUBPROCESS_RUNNING) {
-            if (subprocess_write (p->h,
-                                  p->service_name,
-                                  p->rank,
-                                  p->pid,
-                                  c->name,
-                                  NULL,
-                                  0,
-                                  true) < 0) {
+            if (subprocess_write (p->f, c->name, NULL, 0, true) < 0) {
                 log_err ("error sending rexec.write request: %s",
                          strerror (errno));
                 return -1;

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -54,7 +54,6 @@ void channel_destroy (void *arg)
         flux_watcher_destroy (c->buffer_read_stopped_w);
         c->buffer_read_w_started = false;
 
-        fbuf_destroy (c->write_buffer);
         fbuf_destroy (c->read_buffer);
         flux_watcher_destroy (c->out_prep_w);
         flux_watcher_destroy (c->out_idle_w);
@@ -707,35 +706,12 @@ int flux_subprocess_write (flux_subprocess_t *p,
             errno = EPIPE;
             return -1;
         }
-        if (p->state == FLUX_SUBPROCESS_INIT) {
-            if (!c->write_buffer) {
-                int buffer_size;
-                if ((buffer_size = cmd_option_bufsize (p, stream)) < 0) {
-                    log_err ("cmd_option_bufsize: %s", strerror (errno));
-                    return -1;
-                }
-                if (!(c->write_buffer = fbuf_create (buffer_size))) {
-                    log_err ("fbuf_create");
-                    return -1;
-                }
-            }
-            if (fbuf_space (c->write_buffer) < len) {
-                errno = ENOSPC;
-                return -1;
-            }
-            if ((ret = fbuf_write (c->write_buffer, buf, len)) < 0) {
-                log_err ("fbuf_write");
-                return -1;
-            }
+        if (subprocess_write (p->f, c->name, buf, len, false) < 0) {
+            log_err ("error sending rexec.write request: %s",
+                     strerror (errno));
+            return -1;
         }
-        else { /* p->state == FLUX_SUBPROCESS_RUNNING */
-            if (subprocess_write (p->f, c->name, buf, len, false) < 0) {
-                log_err ("error sending rexec.write request: %s",
-                         strerror (errno));
-                return -1;
-            }
-            ret = len;
-        }
+        ret = len;
     }
 
     return ret;
@@ -773,19 +749,12 @@ int flux_subprocess_close (flux_subprocess_t *p, const char *stream)
         c->closed = true;
     }
     else {
-        /* if process isn't running, eof plus any previously written
-         * data will be sent after process converts to running.  See
-         * send_channel_data() in remote.c.  If subprocess has already
-         * exited, this does nothing.
-         */
-        c->closed = true;
-        if (p->state == FLUX_SUBPROCESS_RUNNING) {
-            if (subprocess_write (p->f, c->name, NULL, 0, true) < 0) {
-                log_err ("error sending rexec.write request: %s",
-                         strerror (errno));
-                return -1;
-            }
+        if (subprocess_write (p->f, c->name, NULL, 0, true) < 0) {
+            log_err ("error sending rexec.write request: %s",
+                     strerror (errno));
+            return -1;
         }
+        c->closed = true;
     }
 
     return 0;

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -45,7 +45,6 @@ struct subprocess_channel {
     bool buffer_read_w_started;
 
     /* remote */
-    struct fbuf *write_buffer;  /* buffer pre-running data */
     struct fbuf *read_buffer;
     bool read_eof_received;
     flux_watcher_t *out_prep_w;

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -65,6 +65,7 @@ struct sdproc {
     flux_future_t *f_start;
     flux_future_t *f_stop;
     struct unit *unit;
+    struct flux_msglist *write_requests;
     struct channel *in;
     struct channel *out;
     struct channel *err;
@@ -365,6 +366,21 @@ static void start_continuation (flux_future_t *f, void *arg)
     sdexec_channel_close_fd (proc->in);
     sdexec_channel_close_fd (proc->out);
     sdexec_channel_close_fd (proc->err);
+    /* Now that stdin is ready, re-queue any messages write_cb() left in
+     * proc->write_requests.  Push these messages to the front of the flux_t
+     * queue so that they come before unprocessed writes, if any.
+     */
+    if (proc->write_requests) {
+        const flux_msg_t *request;
+        while ((request = flux_msglist_pop (proc->write_requests))) {
+            int rc = flux_requeue (ctx->h, request, FLUX_RQ_HEAD);
+            flux_msg_decref (request);
+            if (rc < 0) {
+                flux_log_error (ctx->h, "error requeuing early sdexec.write");
+                break;
+            }
+        }
+    }
     return;
 error:
     if (flux_respond_error (ctx->h, msg, errno, future_strerror (f, errno)))
@@ -445,6 +461,7 @@ static void sdproc_destroy (struct sdproc *proc)
         flux_future_destroy (proc->f_stop);
         sdexec_unit_destroy (proc->unit);
         json_decref (proc->cmd);
+        flux_msglist_destroy (proc->write_requests);
         free (proc);
         errno = saved_errno;
     }
@@ -758,6 +775,22 @@ static void write_cb (flux_t *h,
     if (!(exec_request = lookup_message_byclient (ctx->requests, msg))
         || !(proc = flux_msg_aux_get (exec_request, "sdproc"))) {
         flux_log (h, LOG_ERR, "sdexec.write: subprocess no longer exists");
+        return;
+    }
+    /* If the systemd unit has not started yet, enqueue the write request for
+     * later processing in start_continuation().  We can tell that it hasn't
+     * started if start_continuation() has not yet handed the stdin channel
+     * file descriptor over to systemd by calling the close function.
+     */
+    if (sdexec_channel_get_fd (proc->in) != -1) { // not yet claimed by systemd
+        if (!proc->write_requests) {
+            if (!(proc->write_requests = flux_msglist_create ())) {
+                flux_log_error (h, "sdexec.write: error creating write queue");
+                return;
+            }
+        }
+        if (flux_msglist_push (proc->write_requests, msg) < 0)
+            flux_log_error (h, "sdexec.write: error enqueueing write request");
         return;
     }
     if (iodecode (io, &stream, NULL, NULL, NULL, NULL) == 0


### PR DESCRIPTION
This is an attempt to implement the subprocess protocol change proposed in flux-framework/rfc#416, which allows a write request to be sent to a remote subprocess before the pid is received.

Unfortunately what seemed like a straightforward change broke a bunch of tests and I've yet to figure out why!

Wanted to post what I had so far and continue discussing this with @chu11