### PR TITLE
job-exec: retry kill of job tasks and job shell during job termination

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -618,7 +618,7 @@ static int exec_config (flux_t *h,
     return config_setup (h, conf, argc, argv, errp);
 }
 
-static json_t * exec_stats (void)
+static json_t *exec_config_stats (void)
 {
     json_t *o = NULL;
     json_t *conf = NULL;
@@ -639,6 +639,22 @@ error:
     ERRNO_SAFE_WRAP (json_decref, o);
     ERRNO_SAFE_WRAP (json_decref, conf);
     return NULL;
+}
+
+static json_t *exec_job_stats (struct jobinfo *job)
+{
+    struct bulk_exec *exec = job->data;
+    return json_pack ("{s:i s:i}",
+                      "total_shells", bulk_exec_total (exec),
+                      "active_shells", bulk_exec_current (exec));
+}
+
+static json_t *exec_stats (struct jobinfo *job)
+{
+    if (job)
+        return exec_job_stats (job);
+    else
+        return exec_config_stats ();
 }
 
 struct exec_implementation bulkexec = {

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -618,7 +618,7 @@ static int exec_config (flux_t *h,
     return config_setup (h, conf, argc, argv, errp);
 }
 
-static int exec_stats (json_t **stats)
+static json_t * exec_stats (void)
 {
     json_t *o = NULL;
     json_t *conf = NULL;
@@ -634,13 +634,11 @@ static int exec_stats (json_t **stats)
     if (json_object_set_new (o, "config", conf) < 0)
         goto error;
 
-    (*stats) = o;
-    return 0;
-
+    return o;
 error:
     ERRNO_SAFE_WRAP (json_decref, o);
     ERRNO_SAFE_WRAP (json_decref, conf);
-    return -1;
+    return NULL;
 }
 
 struct exec_implementation bulkexec = {

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -385,6 +385,11 @@ static void kill_shell_timer_cb (flux_reactor_t  *r,
               sigutil_signame (kill_signal),
               idf58 (job->id));
     (*job->impl->kill) (job, kill_signal);
+
+    /* Since we've transitioned to killing the shell directly, stop the
+     * flux_job_kill(3) timer:
+     */
+    flux_watcher_stop (job->kill_timer);
 }
 
 static void kill_timer_cb (flux_reactor_t *r,
@@ -419,7 +424,7 @@ static void jobinfo_killtimer_start (struct jobinfo *job, double after)
     if (job->kill_timer == NULL) {
         job->kill_timer = flux_timer_watcher_create (r,
                                                      after,
-                                                     0.,
+                                                     after,
                                                      kill_timer_cb,
                                                      job);
         flux_watcher_start (job->kill_timer);

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1528,7 +1528,7 @@ static void stats_cb (flux_t *h,
     }
     while ((impl = implementations[i]) && impl->name) {
         json_t *stats = NULL;
-        if (impl->stats && (stats = (*impl->stats) ())) {
+        if (impl->stats && (stats = (*impl->stats) (NULL))) {
             if (json_object_set_new (o, impl->name, stats) < 0) {
                 json_decref (stats);
                 errno = ENOMEM;

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1528,12 +1528,11 @@ static void stats_cb (flux_t *h,
     }
     while ((impl = implementations[i]) && impl->name) {
         json_t *stats = NULL;
-        if (impl->stats) {
-            if ((*impl->stats) (&stats) == 0 && stats) {
-                if (json_object_set_new (o, impl->name, stats) < 0) {
-                    errno = ENOMEM;
-                    goto error;
-                }
+        if (impl->stats && (stats = (*impl->stats) ())) {
+            if (json_object_set_new (o, impl->name, stats) < 0) {
+                json_decref (stats);
+                errno = ENOMEM;
+                goto error;
             }
         }
         i++;

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -386,6 +386,7 @@ static void kill_shell_timer_cb (flux_reactor_t  *r,
               sigutil_signame (kill_signal),
               idf58 (job->id));
     (*job->impl->kill) (job, kill_signal);
+    job->kill_shell_count++;
 
     /* Since we've transitioned to killing the shell directly, stop the
      * flux_job_kill(3) timer:
@@ -419,6 +420,7 @@ static void kill_timer_cb (flux_reactor_t *r,
                         sigutil_signame (kill_signal));
         return;
     }
+    job->kill_count++;
     /* Open loop */
     flux_future_destroy (f);
 }

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -61,7 +61,7 @@ struct exec_implementation {
     int  (*start)   (struct jobinfo *job);
     int  (*kill)    (struct jobinfo *job, int signum);
     int  (*cancel)  (struct jobinfo *job);
-    int  (*stats)   (json_t **stats);
+    json_t * (*stats) (void);
 };
 
 /*  Exec job information */

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -94,7 +94,9 @@ struct jobinfo {
 
     double                kill_timeout; /* grace time between sigterm,kill */
     flux_watcher_t       *kill_timer;
+    int                   kill_count;
     flux_watcher_t       *kill_shell_timer;
+    int                   kill_shell_count;
     flux_watcher_t       *expiration_timer;
 
     double                t0;        /* timestamp we initially saw this job */

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -61,7 +61,7 @@ struct exec_implementation {
     int  (*start)   (struct jobinfo *job);
     int  (*kill)    (struct jobinfo *job, int signum);
     int  (*cancel)  (struct jobinfo *job);
-    json_t * (*stats) (void);
+    json_t * (*stats) (struct jobinfo *job);
 };
 
 /*  Exec job information */

--- a/t/t2406-job-exec-cleanup.t
+++ b/t/t2406-job-exec-cleanup.t
@@ -25,4 +25,48 @@ test_expect_success 'job-exec: ensure cancellation kills job' '
 	test_expect_code 137 flux job status $id &&
 	test_must_fail ps -q $pid
 '
+test_expect_success 'job-exec: reload module with kill/term-signal=SIGURG' '
+	flux module reload job-exec \
+		kill-timeout=0.1s kill-signal=SIGURG term-signal=SIGURG
+'
+test_expect_success 'job-exec: submit a job' '
+	jobid=$(flux submit --wait-event=start -n1 sleep inf)
+'
+test_expect_success 'job-exec: job is listed in flux-module stats' '
+	flux module stats job-exec | jq .jobs.$jobid
+'
+test_expect_success 'job-exec: cancel test job to start kill timer' '
+	flux cancel $jobid
+'
+check_kill_count() {
+	id=$1
+	stat=$2
+	value=$3
+	timeout=${4:-10}
+	count=0
+	while ! flux module stats job-exec \
+		| jq -e ".jobs.${id}.${stat} >= ${value}"; do
+		count=$((count+1))
+		if test $count -gt $((timeout*2)); then
+			echo "${stat} >= ${value} timed out after ${timeout}s"
+			return 1
+		fi
+		sleep 0.5
+		flux module stats job-exec | jq .jobs.${id}.${stat}
+	done
+}
+test_expect_success 'job-exec: ensure kill_count > 1' '
+	check_kill_count $jobid kill_count 1
+'
+test_expect_success 'job-exec: ensure kill_shell_count > 1' '
+	check_kill_count $jobid kill_shell_count 1
+'
+test_expect_success 'job-exec: kill-timeout > original value (0.1)' '
+	flux module stats job-exec | jq .jobs.${jobid}.kill_timeout &&
+	flux module stats job-exec | jq -e ".jobs.${jobid}.kill_timeout > 0.1"
+'
+test_expect_success 'job-exec: kill test job with SIGKILL' '
+	flux job kill -s 9 $jobid &&
+	flux job wait-event -vt 15 $jobid clean
+'
 test_done


### PR DESCRIPTION
Currently, the job-exec module only attempts to signal job tasks (via `flux_job_kill(3)`) once, waits for a timeout (default 25s), then attempts to signal the job shell itself once (via `flux_subprocess_kill(3)`). On a large system, we've seen jobs stuck permanently in CLEANUP after termination because one or more job shells are still running after the signal is sent to the job shell.

This PR adds retries of both `flux_job_kill(3)` (during the initial timeout) and `flux_subprocess_kill(3)` while any job shells are still running. This should cleanup those cases where the initial attempts may fail due to the possible raciness inherent in these interfaces.

The retry is added to the `flux_job_kill(3)` because we do want to avoid just killing the job shell if possible, since this could leave orphan user processes laying around, lose output, etc. However, the real cleanup here will probably be a solution to #6011 in the system instance case. Once an attempt is made to kill the job shell directly, then the timer to send `flux_job_kill(3)` is stopped. Since the job shell kill timer may go on indefinitely, a backoff is used up to a maximum of 5 minutes.

Unsurprisingly, this doesn't yet have any tests since the situation is difficult to recreate. It would perhaps be possible to add some code to the job shell to simulate unkillable processes or a missed job kill event, or a flag for job-exec to not actually send a signal in some cases, etc. If that is desirable I can work on that next.