### PR TITLE
job-manager: don't log expiration update when unnecessary

### DIFF
--- a/src/modules/job-manager/plugins/validate-duration.c
+++ b/src/modules/job-manager/plugins/validate-duration.c
@@ -14,7 +14,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-
+#include <math.h>
 #include <flux/core.h>
 #include <flux/jobtap.h>
 
@@ -78,13 +78,17 @@ static int validate_duration (flux_plugin_t *p,
 static void kvs_lookup_cb (flux_future_t *f, void *arg)
 {
     flux_t *h = flux_future_get_flux (f);
+    double val;
     if (flux_kvs_lookup_get_unpack (f,
                                     "{s:{s:F}}",
                                     "execution",
-                                      "expiration", &expiration) < 0) {
+                                      "expiration", &val) < 0) {
         flux_log_error (h, "flux_kvs_lookup_unpack");
     }
     flux_future_reset (f);
+    if (fabs (val - expiration) < 1.e-5)
+        return;
+    expiration = val;
     flux_log (h,
               LOG_DEBUG,
               "duration-validator: updated expiration to %.2f",

--- a/src/modules/job-manager/update.c
+++ b/src/modules/job-manager/update.c
@@ -652,9 +652,12 @@ static void resource_update_cb (flux_future_t *f, void *arg)
     flux_future_reset (f);
 
     /*  If this is the first successful update, or there are no
-     *  running jobs, then there is nothing left to do.
+     *  running jobs, or the expiration was not updated, then there is
+     *  nothing left to do.
      */
-    if (old_expiration == -1. || update->ctx->running_jobs == 0)
+    if (old_expiration == -1.
+        || fabs (update->instance_expiration - old_expiration) < 1.e-5
+        || update->ctx->running_jobs == 0)
         return;
 
     flux_log (h,


### PR DESCRIPTION
This PR fixes a couple places in the job manager where an expiration update is logged even though the expiration didn't change.

Fixes #5973