### PR TITLE
job-exec: add `kill-signal` and `term-signal` module parameters

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -38,6 +38,18 @@ sdexec-properties
    (optional) A table of systemd properties to set for all jobs.  All values
    must be strings.  See SDEXEC PROPERTIES below.
 
+kill-timeout
+   (optional) The amount of time to wait after ``SIGTERM`` is sent to a job
+   before sending ``SIGKILL``.
+
+term-signal
+   (optional) Specify an alternate signal to ``SIGTERM`` when terminating
+   job tasks. Mainly used for testing.
+
+kill-signal
+   (optional) Specify an alternate signal to ``SIGKILL`` when killing tasks
+   and the job shell. Mainly used for testing.
+
 testexec
    (options) A table of keys (see :ref:`testexec`) for configuring the
    **job-exec** test execution implementation (used in mainly for testing).

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1495,7 +1495,10 @@ static void stats_cb (flux_t *h,
     json_t *o = NULL;
     int i = 0;
 
-    if (!(o = json_object ())) {
+    if (!(o = json_pack ("{s:f s:s s:s}",
+                         "kill-timeout", kill_timeout,
+                         "term-signal", sigutil_signame (term_signal),
+                         "kill-signal", sigutil_signame (kill_signal)))) {
         errno = ENOMEM;
         goto error;
     }

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1577,6 +1577,7 @@ int mod_main (flux_t *h, int argc, char **argv)
 {
     int saved_errno = 0;
     int rc = -1;
+    bool subscribed = false;
     flux_error_t error;
     struct job_exec_ctx *ctx = job_exec_ctx_create (h, argc, argv);
 
@@ -1600,6 +1601,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "flux_event_subscribe");
         goto out;
     }
+    subscribed = true;
     if (exec_hello (h, "job-exec") < 0)
         goto out;
 
@@ -1608,7 +1610,7 @@ out:
     unload_implementations (ctx);
 
     saved_errno = errno;
-    if (flux_event_unsubscribe (h, "job-exception") < 0)
+    if (subscribed && flux_event_unsubscribe (h, "job-exception") < 0)
         flux_log_error (h, "flux_event_unsubscribe ('job-exception')");
     job_exec_ctx_destroy (ctx);
     errno = saved_errno;

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1536,6 +1536,9 @@ static void config_reload_cb (flux_t *h,
         goto error;
     }
 
+    if (job_exec_set_config_globals (h, conf, 0, NULL, &err) < 0)
+        goto error;
+
     while ((impl = implementations[i]) && impl->name) {
         if (impl->config) {
             if ((*impl->config) (h, conf, ctx->argc, ctx->argv, &err) < 0)

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1395,7 +1395,6 @@ static int job_exec_set_config_globals (flux_t *h,
             errno = EINVAL;
             return -1;
         }
-        flux_log (h, LOG_INFO, "using kill-timeout of %.4gs", kill_timeout);
     }
     if (ksignal) {
         if ((kill_signal = sigutil_signum (ksignal)) < 0) {

--- a/t/t2403-job-exec-conf.t
+++ b/t/t2403-job-exec-conf.t
@@ -11,7 +11,7 @@ test_under_flux 1 job
 test_expect_success 'job-exec: can specify kill-timeout on cmdline' '
 	flux dmesg -C &&
 	flux module reload job-exec kill-timeout=1m &&
-	flux dmesg | grep "using kill-timeout of 60s"
+	flux module stats job-exec | jq ".[\"kill-timeout\"] == 60"
 '
 test_expect_success 'job-exec: bad kill-timeout value causes module failure' '
 	flux dmesg -C &&
@@ -25,8 +25,8 @@ test_expect_success 'job-exec: kill-timeout can be set in exec conf' '
 	kill-timeout = ".5m"
 	EOF
 	flux start -o,--config-path=${name}.toml -s1 \
-		flux dmesg > ${name}.log 2>&1 &&
-	grep "using kill-timeout of 30s" ${name}.log
+		flux module stats job-exec > ${name}.json 2>&1 &&
+	cat ${name}.json | jq ".[\"kill-timeout\"] == 30"
 '
 test_expect_success 'job-exec: bad kill-timeout config causes module failure' '
 	name=bad-killconf &&

--- a/t/t2403-job-exec-conf.t
+++ b/t/t2403-job-exec-conf.t
@@ -26,7 +26,14 @@ test_expect_success 'job-exec: kill-timeout can be set in exec conf' '
 	EOF
 	flux start -o,--config-path=${name}.toml -s1 \
 		flux module stats job-exec > ${name}.json 2>&1 &&
+	test_debug "jq -S . < ${name}.json" &&
 	cat ${name}.json | jq ".[\"kill-timeout\"] == 30"
+'
+test_expect_success 'job-exec: kill-timeout can be set with a config reload' '
+	flux module load job-exec &&
+	flux dmesg -C &&
+	echo exec.kill-timeout=\".5m\" | flux config load &&
+	flux module stats job-exec | jq ".[\"kill-timeout\"] == 30"
 '
 test_expect_success 'job-exec: bad kill-timeout config causes module failure' '
 	name=bad-killconf &&
@@ -37,6 +44,52 @@ test_expect_success 'job-exec: bad kill-timeout config causes module failure' '
 	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
 		flux dmesg > ${name}.log 2>&1 &&
 	grep "invalid kill-timeout: foo" ${name}.log
+'
+test_expect_success 'job-exec: bad kill-timeout causes config reload failure' '
+	echo exec.kill-timeout=\"foo\" | test_must_fail flux config load
+'
+test_expect_success 'job-exec: reset config' '
+	echo | flux config load
+'
+test_expect_success 'job-exec: can specify term-signal on cmdline' '
+	flux dmesg -C &&
+	flux module reload job-exec term-signal=SIGUSR1 &&
+	flux module stats job-exec | jq ".[\"term-signal\"] == \"SIGUSR1\""
+'
+test_expect_success 'job-exec: can specify kill-signal on cmdline' '
+	flux dmesg -C &&
+	flux module reload job-exec kill-signal=SIGUSR2 &&
+	flux module stats job-exec | jq ".[\"kill-signal\"] == \"SIGUSR2\""
+'
+test_expect_success 'job-exec: bad term/kill-signal value causes failure' '
+	flux dmesg -C &&
+	test_expect_code 1 flux module reload job-exec kill-signal=SIGFOO &&
+	dmesg-grep.py -vt 10 "invalid kill-signal: SIGFOO" &&
+	flux dmesg -C &&
+	test_expect_code 1 flux module reload -f job-exec term-signal=-1 &&
+	dmesg-grep.py -vt 10 "invalid term-signal: -1"
+'
+test_expect_success 'job-exec: term/kill-signal can be set in exec conf' '
+	name=sigconf &&
+	cat <<-EOF > ${name}.toml &&
+	[exec]
+	kill-signal = "SIGINT"
+	term-signal = "SIGHUP"
+	EOF
+	flux start -o,--config-path=${name}.toml -s1 \
+		flux module stats job-exec > ${name}.json 2>&1 &&
+	cat ${name}.json | jq ".[\"kill-signal\"] == \"SIGINT\"" &&
+	cat ${name}.json | jq ".[\"term-signal\"] == \"SIGTERM\""
+'
+test_expect_success 'job-exec: bad term/kill-signal config causes module failure' '
+	name=bad-sigconf &&
+	cat <<-EOF > ${name}.toml &&
+	[exec]
+	kill-signal = "foo"
+	EOF
+	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
+		flux dmesg > ${name}.log 2>&1 &&
+	grep "invalid kill-signal: foo" ${name}.log
 '
 test_expect_success 'job-exec: can specify default-shell on cmdline' '
 	flux module reload -f job-exec job-shell=/path/to/shell &&


### PR DESCRIPTION
This PR was split off #6014 and mainly adds new `kill-signal` and `term-signal` module parameters as for testing as suggested by @garlick.

Since this was a good chunk of work with its own tests, documentation updates, etc, it seemed reasonable to propose as a separate PR.