### PR TITLE
job-exec: cmdline options for signals should override config settings

### DIFF
--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1550,7 +1550,11 @@ static void config_reload_cb (flux_t *h,
         goto error;
     }
 
-    if (job_exec_set_config_globals (h, conf, 0, NULL, &err) < 0)
+    if (job_exec_set_config_globals (h,
+                                     conf,
+                                     ctx->argc,
+                                     ctx->argv,
+                                     &err) < 0)
         goto error;
 
     while ((impl = implementations[i]) && impl->name) {


### PR DESCRIPTION
Problem: cmdline options to the job-exec module should always override configuration settings, but this is not the case for kill-timeout, term-signal, and kill-signal when the configuration is reloaded.

Ensure that cmdline options for kill-timeout, term-signal, and kill-signal always override configuration settings.

----

This was an oversight from commit in #5975