### PR TITLE
sdexec: avoid double EOF notification

### DIFF
--- a/src/common/libsdexec/channel.c
+++ b/src/common/libsdexec/channel.c
@@ -32,6 +32,7 @@ struct channel {
     char rankstr[16];
     int fd[2];
     flux_watcher_t *w;
+    bool eof_delivered;
     char *name;
     bool writable;
     channel_output_f output_cb;
@@ -70,6 +71,7 @@ static void channel_output_cb (flux_reactor_t *r,
     if (n <= 0) {
         io = ioencode (ch->name, ch->rankstr, NULL, 0, true);
         flux_watcher_stop (w);
+        ch->eof_delivered = true;
     }
     else
         io = ioencode (ch->name, ch->rankstr, buf, n, false);
@@ -109,7 +111,7 @@ void sdexec_channel_close_fd (struct channel *ch)
 
 void sdexec_channel_start_output (struct channel *ch)
 {
-    if (ch)
+    if (ch && !ch->eof_delivered)
         flux_watcher_start (ch->w);
 }
 

--- a/t/t2410-sdexec-memlimit.t
+++ b/t/t2410-sdexec-memlimit.t
@@ -37,7 +37,6 @@ mkdir -p config
 cat >config/config.toml <<EOT
 [systemd]
 enable = true
-sdbus-debug = true
 sdexec-debug = true
 [exec]
 service = "sdexec"
@@ -60,7 +59,7 @@ fi
 
 test_under_flux 1 full -o,--config-path=$(pwd)/config
 
-flux setattr log-stderr-level 1
+flux setattr log-stderr-level 7
 
 sdexec="flux exec --service sdexec"
 getcg=$(pwd)/getcg.sh
@@ -162,7 +161,6 @@ test_expect_success 'change values of memory containment' '
 	cat >config/config.toml <<-EOT &&
 	[systemd]
 	enable = true
-	sdbus-debug = true
 	sdexec-debug = true
 	[exec]
 	service = "sdexec"
@@ -180,5 +178,7 @@ test_expect_success 'memory.max configuration changed' '
 	flux run $getcg memory.max >maxupdate.out &&
 	test_cmp inf.exp maxupdate.out
 '
+
+flux setattr log-stderr-level 3
 
 test_done


### PR DESCRIPTION
Problem: sdexec sends two EOF notifications for each channel, which causes libsubprocess to get confused and not signal subprocess completion in UNBUF mode.

The sdexec channel class stops its own watcher after sending EOF, but the sdexec module restarts the watcher during completion to ensure it can send EOF in an error case where it was not started.  This results in two EOF notifications.
    
Add an `eof_delivered` flag to the channel and use it to ensure that only one eof is sent.
    
Also, adjust the output of `t2410-sdexec-memlimit.t` (which was hanging) to give more of an indication of what is going on, since it is pretty terse otherwise.