### PR TITLE
libflux: add `flux_watcher_is_active(3)`

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -205,6 +205,7 @@ MAN3_FILES_SECONDARY = \
 	man3/flux_reactor_active_decref.3 \
 	man3/flux_fd_watcher_get_fd.3 \
 	man3/flux_watcher_stop.3 \
+	man3/flux_watcher_is_active.3 \
 	man3/flux_watcher_destroy.3 \
 	man3/flux_watcher_next_wakeup.3 \
 	man3/flux_handle_watcher_get_flux.3 \

--- a/doc/man3/flux_watcher_start.rst
+++ b/doc/man3/flux_watcher_start.rst
@@ -13,6 +13,8 @@ SYNOPSIS
 
   void flux_watcher_stop (flux_watcher_t *w);
 
+  bool flux_watcher_is_active (flux_watcher_t *w);
+
   void flux_watcher_destroy (flux_watcher_t *w);
 
   double flux_watcher_next_wakeup (flux_watcher_t *w);
@@ -30,6 +32,9 @@ effect.  This may be called from within a :type:`flux_watcher_f` callback.
 so that it stops receiving events. If :var:`w` is already inactive, the call
 has no effect.  This may be called from within a :type:`flux_watcher_f`
 callback.
+
+:func:`flux_watcher_is_active` returns a true value if the watcher is active
+(i.e. it has been started and not yet stopped) and false otherwise.
 
 :func:`flux_watcher_destroy` destroys a :type:`flux_watcher_t` object :var:`w`,
 after stopping it. It is not safe to destroy a watcher object within a

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -281,6 +281,7 @@ man_pages = [
     ('man3/flux_timer_watcher_create', 'flux_timer_watcher_reset', 'set/reset a timer', [author], 3),
     ('man3/flux_timer_watcher_create', 'flux_timer_watcher_create', 'set/reset a timer', [author], 3),
     ('man3/flux_watcher_start', 'flux_watcher_stop', 'start/stop/destroy/query reactor watcher', [author], 3),
+    ('man3/flux_watcher_start', 'flux_watcher_is_active', 'start/stop/destroy/query reactor watcher', [author], 3),
     ('man3/flux_watcher_start', 'flux_watcher_destroy', 'start/stop/destroy/query reactor watcher', [author], 3),
     ('man3/flux_watcher_start', 'flux_watcher_next_wakeup', 'start/stop/destroy/query reactor watcher', [author], 3),
     ('man3/flux_watcher_start', 'flux_watcher_start', 'start/stop/destroy/query reactor watcher', [author], 3),

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -808,6 +808,19 @@ void flux_stat_watcher_get_rstat (flux_watcher_t *w,
         *prev = sw->prev;
 }
 
+bool flux_watcher_is_active (flux_watcher_t *w)
+{
+    if (w) {
+        /*  Handle periodic watcher as a special case:
+         */
+        if (flux_watcher_get_ops (w) == &periodic_watcher) {
+            struct f_periodic *fp = w->data;
+            return ev_is_active (&fp->evp);
+        }
+        return ev_is_active (w->data);
+    }
+    return false;
+}
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -76,6 +76,7 @@ void flux_watcher_start (flux_watcher_t *w);
 void flux_watcher_stop (flux_watcher_t *w);
 void flux_watcher_destroy (flux_watcher_t *w);
 double flux_watcher_next_wakeup (flux_watcher_t *w);
+bool flux_watcher_is_active (flux_watcher_t *w);
 
 /* flux_t handle
  */

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -104,7 +104,11 @@ static void test_fd (flux_reactor_t *reactor)
     w = flux_fd_watcher_create (reactor, fd[1], FLUX_POLLOUT, fdwriter, NULL);
     ok (r != NULL && w != NULL,
         "fd: reader and writer created");
+    ok (!flux_watcher_is_active (r),
+        "flux_watcher_is_active() returns false");
     flux_watcher_start (r);
+    ok (flux_watcher_is_active (r),
+        "flux_watcher_is_active() returns true after flux_watcher_start()");
     flux_watcher_start (w);
     ok (flux_reactor_run (reactor, 0) == 0,
         "fd: reactor ran to completion after %lu bytes", fdwriter_bufsize);
@@ -156,7 +160,11 @@ static void test_timer (flux_reactor_t *reactor)
         "timer: creating negative repeat fails with EINVAL");
     ok ((w = flux_timer_watcher_create (reactor, 0, 0, oneshot, NULL)) != NULL,
         "timer: creating zero timeout oneshot works");
+    ok (!flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns false");
     flux_watcher_start (w);
+    ok (flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns true after flux_watcher_start()");
     oneshot_runs = 0;
     t0 = flux_reactor_now (reactor);
     ok (flux_reactor_run (reactor, 0) == 0,
@@ -265,7 +273,11 @@ static void test_periodic (flux_reactor_t *reactor)
     ok ((w = flux_periodic_watcher_create (reactor, 0, 0, NULL, oneshot, NULL))
         != NULL,
         "periodic: creating zero offset/interval works");
+    ok (!flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns false");
     flux_watcher_start (w);
+    ok (flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns true after flux_watcher_start()");
     oneshot_runs = 0;
     ok (flux_reactor_run (reactor, 0) == 0,
         "periodic: reactor ran to completion");
@@ -335,7 +347,11 @@ static void test_idle (flux_reactor_t *reactor)
     w = flux_idle_watcher_create (reactor, idle_cb, NULL);
     ok (w != NULL,
         "created idle watcher");
+    ok (!flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns false");
     flux_watcher_start (w);
+    ok (flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns true after flux_watcher_start()");
 
     ok (flux_reactor_run (reactor, 0) == 0,
         "reactor ran successfully");
@@ -376,7 +392,11 @@ static void test_prepcheck (flux_reactor_t *reactor)
                                    prepchecktimer_cb, NULL);
     ok (w != NULL,
         "created timer watcher that fires every 0.01s");
+    ok (!flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns false");
     flux_watcher_start (w);
+    ok (flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns true after flux_watcher_start()");
 
     prep = flux_prepare_watcher_create (reactor, prepare_cb, NULL);
     ok (w != NULL,
@@ -427,7 +447,11 @@ static void test_signal (flux_reactor_t *reactor)
     w = flux_signal_watcher_create (reactor, SIGUSR1, sigusr1_cb, NULL);
     ok (w != NULL,
         "created signal watcher");
+    ok (!flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns false");
     flux_watcher_start (w);
+    ok (flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns true after flux_watcher_start()");
 
     idle = flux_idle_watcher_create (reactor, sigidle_cb, NULL);
     ok (idle != NULL,
@@ -478,7 +502,11 @@ static void test_child  (flux_reactor_t *reactor)
 
     ok (kill (child_pid, SIGHUP) == 0,
         "sent child SIGHUP");
+    ok (!flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns false");
     flux_watcher_start (w);
+    ok (flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns true after flux_watcher_start()");
 
     ok (flux_reactor_run (r, 0) == 0,
         "reactor ran successfully");
@@ -544,7 +572,11 @@ static void test_stat (flux_reactor_t *reactor)
     w = flux_stat_watcher_create (reactor, ctx.path, 0., stat_cb, &ctx);
     ok (w != NULL,
         "created stat watcher");
+    ok (!flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns false");
     flux_watcher_start (w);
+    ok (flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns true after flux_watcher_start()");
 
     tw = flux_timer_watcher_create (reactor, 0.01, 0.01,
                                     stattimer_cb, &ctx);
@@ -588,7 +620,12 @@ static void test_active_ref (flux_reactor_t *r)
 
     if (!(w = flux_idle_watcher_create (r, active_idle_cb, &count)))
         BAIL_OUT ("flux_idle_watcher_create failed");
+
+    ok (!flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns false");
     flux_watcher_start (w);
+    ok (flux_watcher_is_active (w),
+        "flux_watcher_is_active() returns true after flux_watcher_start()");
 
     count = 0;
     ok (flux_reactor_run (r, 0) < 0 && count == 16,
@@ -647,6 +684,9 @@ int main (int argc, char *argv[])
 
     ok (flux_reactor_run (reactor, 0) == 0,
         "reactor ran to completion (no watchers)");
+
+    ok (!flux_watcher_is_active (NULL),
+        "flux_watcher_is_active (NULL) returns false");
 
     test_timer (reactor);
     test_periodic (reactor);


### PR DESCRIPTION
While working on something I noticed that there was no libflux version of the `ev_is_active()` call, which could come in handy to check if a watcher has been started.

This simple PR just adds `flux_watcher_is_active(3)`, tests, and documentation.