### PR TITLE
libsubprocess: protect against double EOF

### DIFF
--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -574,7 +574,7 @@ static int remote_output_local_unbuf (flux_subprocess_t *p,
     }
     /* N.B. any data not consumed by the user is lost, so if eof is
      * seen, we send it immediately */
-    if (eof) {
+    if (eof && !c->eof_sent_to_caller) {
         c->read_eof_received = true;
         c->unbuf_data = NULL;
         c->unbuf_len = 0;


### PR DESCRIPTION
Problem: A recent fix in the sdexec module corrected a double EOF, which caused the client side to hang when the LOCAL_UNBUF flag was used. The client side hang was due to incorrect counting of closed channels.

Solution: Properly flag that an EOF has been sent to the caller when the LOCAL_UNBUF flag is used, so that multiple EOFs are not reported to users.