### PR TITLE
broker: add timezone abbrev to log message timestamps

### DIFF
--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -380,13 +380,15 @@ static void log_timestamp (FILE *fp,
     struct tm tm;
     struct timeval tv;
     char datetime[16]; /* 'MMM DD HH:MM:SS' */
+    char timezone[16]; /* TZ abbrev should be short, give 15 chars max */
 
     if (flags & LOG_NO_TIMESTAMP)
         return;
     if (timestamp_parse (hdr->timestamp, &tm, &tv) < 0
-        || strftime (datetime, sizeof (datetime), "%b %d %T", &tm) == 0)
+        || strftime (datetime, sizeof (datetime), "%b %d %T", &tm) == 0
+        || strftime (timezone, sizeof (timezone), "%Z", &tm) == 0)
         fprintf (fp, "%s ", hdr->timestamp);
-    fprintf (fp, "%s.%06ld ", datetime, tv.tv_usec);
+    fprintf (fp, "%s.%06ld %s ", datetime, tv.tv_usec, timezone);
 }
 
 /* Log a message to 'fp', if non-NULL.


### PR DESCRIPTION
Problem: The timezone designation is not included with broker log messages, making determination of when an error message in a logfile occurred slightly ambiguous.

Add the timezone abbreviation to the timestamp.

Fixes #6015