### PR TITLE
librlist: ensure `properties` is an array when parsing `resource.config` entries

### DIFF
--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -2583,6 +2583,13 @@ struct rlist *rlist_from_config (json_t *conf, flux_error_t *errp)
             errprintf (errp, "config[%zu]: %s", index, error.text);
             goto error;
         }
+        if (properties != NULL && !json_is_array (properties)) {
+            errprintf (errp,
+                       "config[%zu]: %s",
+                       index,
+                       "properties must be an array");
+            goto error;
+        }
         if (rlist_config_add_entry (rl,
                                     hl,
                                     errp,

--- a/t/t0026-flux-R.t
+++ b/t/t0026-flux-R.t
@@ -355,7 +355,19 @@ test_expect_success 'flux R parse-config detects invalid property' '
 	EOF
 	test_must_fail flux R parse-config conf
 '
-
+test_expect_success 'flux R parse-config detects when properties not an array' '
+	mkdir -p conf &&
+	cat <<-EOF >conf/resource.toml &&
+	[[resource.config]]
+	hosts = "foo[0-10]"
+	cores = "0-1"
+	[[resource.config]]
+	hosts = "foo11"
+	cores = "0-3"
+	properties = "foo"
+	EOF
+	test_must_fail flux R parse-config conf
+'
 test_expect_success 'flux R parse-config also works with resource.path' '
 	flux R encode -r 0-1 >R.path &&
 	cat <<-EOF >conf/resource.toml &&

--- a/t/t0026-flux-R.t
+++ b/t/t0026-flux-R.t
@@ -310,17 +310,6 @@ test_expect_success 'flux R parse-config detects host with no resources' '
 	EOF
 	test_must_fail flux R parse-config conf
 '
-test_expect_success 'flux R parse-config detects host with no resources' '
-	mkdir -p conf &&
-	cat <<-EOF >conf/resource.toml &&
-	[[resource.config]]
-	hosts = "foo[0-10]"
-	cores = "0-1"
-	[[resource.config]]
-	hosts = "foo11"
-	EOF
-	test_must_fail flux R parse-config conf
-'
 test_expect_success 'flux R parse-config detects missing hosts entry' '
 	mkdir -p conf &&
 	cat <<-EOF >conf/resource.toml &&


### PR DESCRIPTION
There's an oversight in librlist parsing of `resource.config` entries, and a non-array `properties` value is silently ignored.

Validate that any `properties` entry is a JSON array and generate an error if not.