### PR TITLE
speed up flux overlay status on a big system

### DIFF
--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -278,7 +278,7 @@ static const char *status_getname (struct status *ctx,
     return buf;
 }
 
-/* If --times, return string containing parenthesised elapsed
+/* If verbose >= 2, return string containing parenthesised elapsed
  * time since last RPC was started, with leading space.
  * Otherwise, return the empty string
  */

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -617,13 +617,18 @@ static bool show_badtrees (struct status *ctx,
                            bool parent,
                            int level)
 {
+    int have_children = false;
+
     if (streq (node->status, "full"))
         return false;
+    if (idset_count (node->subtree_ranks) > 1)
+        have_children = true;
     if (parent
         || streq (node->status, "lost")
-        || streq (node->status, "offline"))
+        || streq (node->status, "offline")
+        || (!have_children && ctx->verbose < 2))
         status_print (ctx, node, parent, level);
-    return true;
+    return have_children || ctx->verbose >= 2;
 }
 
 /* map fun - follow all live brokers and print everything
@@ -633,11 +638,16 @@ static bool show_all (struct status *ctx,
                       bool parent,
                       int level)
 {
+    int have_children = false;
+
+    if (idset_count (node->subtree_ranks) > 1)
+        have_children = true;
     if (parent
         || streq (node->status, "lost")
-        || streq (node->status, "offline"))
+        || streq (node->status, "offline")
+        || (!have_children && ctx->verbose < 2))
         status_print (ctx, node, parent, level);
-    return true;
+    return have_children || ctx->verbose >= 2;
 }
 
 static bool validate_wait (const char *wait)

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -272,7 +272,7 @@ test_expect_success 'stop broker 12' '
 '
 
 test_expect_success 'flux overlay status prints connection timed out on 12' '
-	flux overlay status --no-pretty >status.out &&
+	flux overlay status -vv --no-pretty >status.out &&
 	grep "fake12: $(strerror_symbol ETIMEDOUT)" status.out
 '
 


### PR DESCRIPTION
Problem: `flux overlay status` makes some unnecessary RPCs that slow things way down on el cap.  Specifically, the `overlay.health` RPC is made to leaf nodes despite the fact that the parent already knows the status of its children.

Eliminating that gets us about a 4x speedup on el cap.

before
```
[garlick@elcap1:cmd]$ time /usr/bin/flux overlay status >/dev/null

real	1m28.377s
user	0m56.726s
sys	0m0.905s
```
After
```
[garlick@elcap1:cmd]$ time ./flux overlay status >/dev/null

real	0m19.892s
user	0m18.275s
sys	0m0.209s
```