### PR TITLE
improve broker messages when nodes die

### DIFF
--- a/src/broker/topology.h
+++ b/src/broker/topology.h
@@ -55,6 +55,7 @@ ssize_t topology_get_child_ranks (struct topology *topo,
 int topology_get_level (struct topology *topo);
 int topology_get_maxlevel (struct topology *topo);
 int topology_get_descendant_count (struct topology *topo);
+int topology_get_descendant_count_at (struct topology *topo, int rank);
 int topology_get_child_route (struct topology *topo, int rank);
 json_t *topology_get_json_subtree_at (struct topology *topo, int rank);
 

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -160,7 +160,7 @@ static void lost_shell_continuation (flux_future_t *f, void *arg)
     struct jobinfo *job = arg;
     if (flux_future_get (f, NULL) < 0)
         jobinfo_fatal_error (job, errno,
-                             "failed to notify job of lost shell");
+                             "failed to notify job of node failure");
     flux_future_destroy (f);
 }
 
@@ -244,8 +244,7 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
             lost_shell (job,
                         critical,
                         shell_rank,
-                        "%s on %s (shell rank %d)",
-                        "lost contact with job shell",
+                        "node failure on %s (shell rank %d)",
                         hostname,
                         shell_rank);
 
@@ -255,8 +254,7 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
             if (critical)
                 jobinfo_fatal_error (job,
                                      0,
-                                     "%s on broker %s (rank %d)",
-                                     "lost contact with job shell",
+                                     "node failure on %s (rank %d)",
                                      hostname,
                                      rank);
         }

--- a/t/issues/t3906-job-exec-exception.sh
+++ b/t/issues/t3906-job-exec-exception.sh
@@ -15,4 +15,4 @@ SHELL=/bin/sh flux start -s 4 -o,-Stbon.topo=kary:4 --test-exit-mode=leader '\
 
 cat t3906.output
 
-grep 'lost contact with job shell on broker.*rank 3' t3906.output
+grep 'node failure on .*rank 3' t3906.output


### PR DESCRIPTION
Problem: as noted in  #6021, the log messages like this one are confusing to users:
```
broker[0]: picl2 (rank 2) has disconnected unexpectedly. Marking it LOST.
```

Moreover, when the TBON is not flat, only the subtree root is called out.  The other nodes in the subtree are also lost but not called out.

For your consideration: this PR
- demotes the LOST messages to LOG_DEBUG
-  adds a new LOG_ERR message that tracks brokers leaving the `broker.online` group during broker RUN and CLEANUP states. 

Example, if I kill -9 rank 1 of a kary:2 8 node instance, I get the following on stderr:
```
 $ flux start -s8 -o,-Stbon.topo=kary:2
Jun 04 09:21:45.016921 PDT broker.err[0]: dead to Flux: system76-pc,system76-pc,system76-pc,system76-pc (rank 1,3-4,7)
```

In a system instance, if I power off rank 2 which leads the subtree consisting of 2,6-7 I get the following in the logs.
```
[ +21.998384] broker[0]: picl2 (rank 2) has disconnected unexpectedly. Marking it LOST.
[ +22.100710] broker[0]: dead to Flux: picl[2,6-7] (rank 2,6-7)
```

A downside of this approach for the system instance is it's a bit chatty if you shut down a non-leaf node that is not the root.  Here I stop flux on picl1 which causes its TBON children (3-5) to shut down nicely, triggering mutiple log entries:
```
[Jun04 09:36] broker[0]: dead to Flux: picl[3-4] (rank 3-4)
[  +0.127260] broker[0]: dead to Flux: picl5 (rank 5)
[  +0.285764] broker[0]: dead to Flux: picl1 (rank 1)
```
(That won't happen when rank 0 is shut down because that's shutting down the whole instance and we don't log these messages in SHUTDOWN state)

Anyway thought I'd try this and see what it looks like.  Thoughts?