### PR TITLE
sdexec: don't return ENODATA without start/finish

### DIFF
--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -170,6 +170,19 @@ static void finalize_exec_request_if_done (struct sdproc *proc)
                        sdexec_unit_systemd_error (proc->unit));
             exec_respond_error (proc, ENOENT, error.text);
         }
+        else if (!proc->started_response_sent) {
+            exec_respond_error (proc,
+                                EINVAL,
+                                "Internal error: unfailed inactive.dead unit"
+                                " never received ExecMainPID property");
+        }
+        else if (!proc->finished_response_sent) {
+            exec_respond_error (proc,
+                                EINVAL,
+                                "Internal error: unfailed inactive.dead unit"
+                                " never received ExecMainCode and"
+                                " ExecMainStatus properties.");
+        }
         else
             exec_respond_error (proc, ENODATA, NULL);
     }


### PR DESCRIPTION
Problem: in an OOM situation, sdexec was observed to return ENODATA to an exec request without having sent started or finished responses, which violates RFC 42.

Fail with EINVAL and a detailed error response message if this happens.

Fixes #6012.