### PR TITLE
broker: avoid 60s delay on follower shutdown

### DIFF
--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1581,6 +1581,13 @@ flux_future_t *overlay_goodbye_parent (struct overlay *ov)
 {
     flux_msg_t *msg;
 
+    /* Avoid 60s delay on shutdown of followers when upstream is down.
+     * flux-framework/flux-core#5991
+     */
+    if (!(ov->parent.hello_responded)) {
+        errno = EHOSTUNREACH;
+        return NULL;
+    }
     if (!(msg = flux_request_encode ("overlay.goodbye", NULL))
         || flux_msg_set_rolemask (msg, FLUX_ROLE_OWNER) < 0
         || overlay_sendmsg_parent (ov, msg) < 0) {


### PR DESCRIPTION
Problem: when the upstream broker is offline, it takes 60s for systemctl stop flux to complete.

The `overlay.goodbye` RPC has a 60s timeout.  Just skip it if the broker never made contact with its parent.

Fixes #5991

This seems to resolve the issue on my test system.