### PR TITLE
systemd: add prolog/epilog service units

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -601,6 +601,10 @@ AC_CONFIG_FILES( \
   etc/flux.service \
   etc/flux-housekeeping@.service \
   src/cmd/flux-run-housekeeping \
+  etc/flux-prolog@.service \
+  etc/flux-epilog@.service \
+  src/cmd/flux-run-prolog \
+  src/cmd/flux-run-epilog \
   doc/Makefile \
   doc/test/Makefile \
   t/Makefile \

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,7 +1,9 @@
 #if HAVE_SYSTEMD
 systemdsystemunit_DATA = \
 	flux.service \
-	flux-housekeeping@.service
+	flux-housekeeping@.service \
+	flux-prolog@.service \
+	flux-epilog@.service
 #endif
 
 tmpfilesdir = $(prefix)/lib/tmpfiles.d

--- a/etc/flux-epilog@.service.in
+++ b/etc/flux-epilog@.service.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Epilog for Flux job %I
+CollectMode=inactive-or-failed
+
+[Service]
+Type=oneshot
+EnvironmentFile=-@X_RUNSTATEDIR@/flux-epilog@%I.env
+ExecStart=@X_SYSCONFDIR@/flux/system/epilog
+ExecStopPost=-rm -f @X_RUNSTATEDIR@/flux-epilog@%I.env

--- a/etc/flux-prolog@.service.in
+++ b/etc/flux-prolog@.service.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Prolog for Flux job %I
+CollectMode=inactive-or-failed
+
+[Service]
+Type=oneshot
+EnvironmentFile=-@X_RUNSTATEDIR@/flux-prolog@%I.env
+ExecStart=@X_SYSCONFDIR@/flux/system/prolog
+ExecStopPost=-rm -f @X_RUNSTATEDIR@/flux-prolog@%I.env

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -124,7 +124,9 @@ dist_fluxcmd_SCRIPTS = \
 	flux-hostlist.py \
 	flux-post-job-event.py \
 	flux-run-housekeeping \
-	flux-housekeeping.py
+	flux-housekeeping.py \
+	flux-run-prolog \
+	flux-run-epilog
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux-run-epilog.in
+++ b/src/cmd/flux-run-epilog.in
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+if test $FLUX_JOB_ID; then
+    FLUX_JOB_ID=$(flux job id --to=f58plain $FLUX_JOB_ID)
+fi
+unitname=flux-epilog@${FLUX_JOB_ID:-unknown}
+
+terminate() {
+    systemctl stop $unitname
+    exit 1
+}
+
+trap terminate INT TERM
+
+umask 022
+printenv >@X_RUNSTATEDIR@/${unitname}.env
+
+# Run systemctl start in background and `wait` for it so that the trap
+# will run immediately when signal is received:
+systemctl start $unitname --quiet &
+wait

--- a/src/cmd/flux-run-prolog.in
+++ b/src/cmd/flux-run-prolog.in
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+if test $FLUX_JOB_ID; then
+    FLUX_JOB_ID=$(flux job id --to=f58plain $FLUX_JOB_ID)
+fi
+unitname=flux-prolog@${FLUX_JOB_ID:-unknown}
+
+terminate() {
+    systemctl stop $unitname
+    exit 1
+}
+
+trap terminate INT TERM
+
+umask 022
+printenv >@X_RUNSTATEDIR@/${unitname}.env
+
+# Run systemctl start in background and `wait` for it so that the trap
+# will run immediately when signal is received:
+systemctl start $unitname --quiet &
+wait


### PR DESCRIPTION
Problem: future housekeeping scripts should be run in a systemd cgroup for reliable termination, logging to the local systemd journal, and debugging using well known systemd tools.

Add a systemd "oneshot" service unit for housekeeping.  The service unit runs a user-provided `housekeeping` script. It is configured so that `systemctl start housekeeping` blocks until the the run is complete and its exit code reflects the exit code of the housekeeping script.

Add a helper script that can be configured as an IMP run command. It runs `systemctl start housekeeping` and traps SIGTERM, which can be sent to enforce a timeout.  Upon receipt of SIGTERM, it stops the unit and exits with a nonzero code.

To enable environment variables such as the FLUX_JOB_ID to be passed into the user-provided housekeeping script via the systemd unit, the helper script dumps its environment into `/run/housekeeping.env`, which is read in by the unit.

Also of note: the user-provided scripts are automatically idempotent when run this way.  systemd never starts multiple instances of the unit.  If one is running when a start request is received, the second start blocks until the existing run finishes and reports its status.

I split this out to a separate PR because I think it can be used to improve the existing epilog even before housekeeping as proposed in #5818 is available.  For example, on my test system, I renamed `/etc/flux/system/epilog` to `housekeeping` and configured the IMP with
```toml
[run.housekeeping]
allowed-users = [ "flux" ]
allowed-environment = [ "FLUX_*" ]
path = "/usr/lib/aarch64-linux-gnu/flux/cmd/flux-run-housekeeping"
```
and the job manager with
```toml
[job-manager.epilog]
command = [
   "flux", "perilog-run", "epilog",
   "--timeout=15s",
   "--with-imp",
   "-e", "housekeeping"
]
```
And now my epilog runs in the housekeeping unit.  After a job runs, `journalctl -u housekeeping` says
```
Jun 13 11:33:49 picl7 systemd[1]: Starting Node Maintenance for Flux...
Jun 13 11:33:49 picl7 housekeeping[55656]: running stress.sh
Jun 13 11:33:49 picl7 housekeeping[55663]: stress: info: [55663] dispatching hogs: 4 cpu, 0 io, 0 vm, 0 hdd
Jun 13 11:33:59 picl7 housekeeping[55663]: stress: info: [55663] successful run completed in 10s
Jun 13 11:33:59 picl7 systemd[1]: housekeeping.service: Succeeded.
Jun 13 11:33:59 picl7 systemd[1]: Finished Node Maintenance for Flux.
Jun 13 11:33:59 picl7 systemd[1]: housekeeping.service: Consumed 39.989s CPU time.
```
(my epilog just burns cpu for 10s)

`systemctl status housekeeping` provides the usual informative output:
```
● housekeeping.service - Node Maintenance for Flux
     Loaded: loaded (/lib/systemd/system/housekeeping.service; static)
     Active: activating (start) since Thu 2024-06-13 11:51:21 PDT; 3s ago
   Main PID: 55746 (housekeeping)
      Tasks: 7 (limit: 1599)
     Memory: 856.0K
        CPU: 15.185s
     CGroup: /system.slice/housekeeping.service
             ├─55746 /bin/sh /etc/flux/system/housekeeping
             ├─55749 /bin/sh /etc/flux/system/housekeeping.d/stress.sh
             ├─55750 stress -c 4 -t 10
             ├─55751 stress -c 4 -t 10
             ├─55752 stress -c 4 -t 10
             ├─55753 stress -c 4 -t 10
             └─55754 stress -c 4 -t 10

Jun 13 11:51:21 picl7 systemd[1]: Starting Node Maintenance for Flux...
Jun 13 11:51:21 picl7 housekeeping[55746]: running stress.sh
Jun 13 11:51:21 picl7 housekeeping[55750]: stress: info: [55750] dispatching hogs: 4 cpu, 0 io, 0 vm, 0 hdd
```