### PR TITLE
flux-python: add posix-compatible shebang wrapper

### DIFF
--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -81,6 +81,7 @@ flux_SOURCES = \
 	builtin/shutdown.c
 nodist_flux_SOURCES = \
 	builtin-cmds.c
+dist_bin_SCRIPTS = flux-python
 
 flux_LDADD = \
 	$(top_builddir)/src/common/libpmi/libupmi.la \

--- a/src/cmd/flux-python
+++ b/src/cmd/flux-python
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# This minimal wrapper exists to help handle systems where env -S is
+# unavailable and scripts wish to use `flux python`. Using a shebang like this
+# for flux python scripts allows them to rely only on posix to start:
+# #!/usr/bin/env flux-python
+
+exec flux python "$@"


### PR DESCRIPTION
problem: using `flux python` on minimal systems, say alpine or other minimal systems that do not provide an `env -S`, is currently non-trivial. Since the shebang only supports a single argument after the command, there's no way to search the path for flux to run flux python

solution: add a `flux-python` script, which is installed to the same bin path as `flux` itself, so that `#!/usr/bin/env flux-python` can be used as a shebang

ping @tgamblin