### PR TITLE
ci: convert `system` test container to run under `podman` for better `systemd` support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
 
   ci-checks:
     needs: [generate-matrix]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       TAP_DRIVER_QUIET: 1
       FLUX_TEST_TIMEOUT: 300

--- a/t/t2410-sdexec-memlimit.t
+++ b/t/t2410-sdexec-memlimit.t
@@ -64,6 +64,11 @@ flux setattr log-stderr-level 7
 sdexec="flux exec --service sdexec"
 getcg=$(pwd)/getcg.sh
 
+if ! $sdexec $getcg memory.high; then
+	skip_all="$sdexec getcg doesn't work"
+	test_done
+fi
+
 #
 # memory.high: the throttling limit on memory usage
 #


### PR DESCRIPTION
Running our `system` test container under `docker` is now failing in GitHub actions on the 20.04 actions runner. We already knew that `docker` could no longer run the `system` container (which has to have the ability to start `systemd` as PID 1) on ubuntu 22.04, so it was probably inevitable that at some point this was going to break.

As an experiment, I updated the `system` container to run via `podman` in the `docker-run-systest.sh` script, because `podman` officially supports systemd via a `--systemd` option, and it seems to work. Since ubuntu 22.04 has the correct version of `podman`, this PR adds those changes and updates the github runners for the main workflow to `ubuntu-latest`.

Some other fallout was fixed along the way (notes in specific commit messages and comments.)