### PR TITLE
python: Update default Jobspec setattr() path

### DIFF
--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -1046,18 +1046,20 @@ class MiniCmd:
             for keyval in args.setattr:
                 key, val = parse_jobspec_keyval("--setattr", keyval)
 
-                #  If key does not explicitly start with ".", "system."
+                #  If key does not explicitly start with ".", "attributes.", "system."
                 #   or "user.", then "system." is implied. This is a
                 #   meant to be a usability enhancement since almost all
                 #   uses of --setattr will target attributes.system.
                 #
-                if not key.startswith((".", "user.", "system.")):
+                #  Allow users to set keys at the top level by
+                #   specifying "." before the key name, e.g. the key
+                #   ".foo" sets "attributes.foo".
+                if not key.startswith((".", "attributes.", "user.", "system.")):
                     key = "system." + key
+                elif key.startswith("."):
+                    key = "attributes" + key
 
-                #  Allow key to begin with "." which simply forces the key
-                #   to start at the top level (since .system is not applied
-                #   due to above conditional)
-                jobspec.setattr(key.lstrip("."), val)
+                jobspec.setattr(key, val)
 
         if args.add_file is not None:
             for arg in args.add_file:

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -554,6 +554,8 @@ class Jobspec(object):
         set job attribute
         """
         if not key.startswith("attributes."):
+            if not key.startswith(("user.", "system.")):
+                key = "system." + key
             key = "attributes." + key
         set_treedict(self.jobspec, key, val)
 

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -784,6 +784,29 @@ class TestJob(unittest.TestCase):
         except OSError:
             pass
 
+    def test_35_setattr_defaults(self):
+        """Test setattr setting defaults"""
+        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
+        jobspec.setattr("cow", 1)
+        jobspec.setattr("system.cat", 2)
+        jobspec.setattr("user.dog", 3)
+        jobspec.setattr("attributes.system.chicken", 4)
+        jobspec.setattr("attributes.user.duck", 5)
+        jobspec.setattr("attributes.goat", 6)
+        # N.B. setattr defaults "key" to "attributes.system.key"
+        # but getattr defaults "key" to "attributes.key"
+        self.assertEqual(jobspec.getattr("system.cow"), 1)
+        self.assertEqual(jobspec.getattr("attributes.system.cow"), 1)
+        self.assertEqual(jobspec.getattr("system.cat"), 2)
+        self.assertEqual(jobspec.getattr("attributes.system.cat"), 2)
+        self.assertEqual(jobspec.getattr("user.dog"), 3)
+        self.assertEqual(jobspec.getattr("attributes.user.dog"), 3)
+        self.assertEqual(jobspec.getattr("system.chicken"), 4)
+        self.assertEqual(jobspec.getattr("attributes.system.chicken"), 4)
+        self.assertEqual(jobspec.getattr("user.duck"), 5)
+        self.assertEqual(jobspec.getattr("attributes.user.duck"), 5)
+        self.assertEqual(jobspec.getattr("attributes.goat"), 6)
+
 
 if __name__ == "__main__":
     from subflux import rerun_under_flux


### PR DESCRIPTION
Problem: By default the Jobspec setattr() function sets keys to attributes.key.  The default --setattr option in command line options like flux-submit default to set keys to attributes.system.key.  This inconsistency can be confusing.

Default Jobspec setattr() to set keys to "attributes.system.key". Adjust command line --setattr option accordingly for tweak.

Fixes #6042

----

Just throwing up this WIP in case there are any initial objections

- TODO - unit tests
- TODO - update callers to specify "foo" instead of "system.foo"?  maybe unnecessary to do this, will think about it