### PR TITLE
shell: enhance exit-timeout and exit-on-error exceptions with hostname

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -79,6 +79,7 @@ MAN3_FILES_PRIMARY = \
 	man3/flux_shell_get_info.3 \
 	man3/flux_shell_get_jobspec_info.3 \
 	man3/flux_shell_get_taskmap.3 \
+	man3/flux_shell_get_hostlist.3 \
 	man3/flux_shell_getenv.3 \
 	man3/flux_shell_getopt.3 \
 	man3/flux_shell_killall.3 \

--- a/doc/man3/flux_shell_get_hostlist.rst
+++ b/doc/man3/flux_shell_get_hostlist.rst
@@ -1,0 +1,52 @@
+==========================
+flux_shell_get_hostname(3)
+==========================
+
+.. default-domain:: c
+
+SYNOPSIS
+========
+
+.. code-block:: c
+
+   #include <flux/shell.h>
+   #include <errno.h>
+
+   const struct hostlist * flux_shell_get_hostlist (flux_shell_t *shell);
+
+Link with :command:`-lflux-core -lflux-hostlist`.
+
+DESCRIPTION
+===========
+
+:func:`flux_shell_get_hostlist` returns the list of hosts assigned to the
+current job in ``struct hostlist`` form. This hostlist can be used to
+map job node IDs or job shell ranks to hostnames using the interfaces
+exported in ``libflux-hostlist.so``.
+
+
+RETURN VALUE
+============
+
+This function returns a pointer to the shell's internal :type:`struct hostlist`
+or ``NULL`` on failure with :var:`errno` set.
+
+
+ERRORS
+======
+
+EINVAL
+   if :var:`shell` is NULL or the function is called before the hostlist is
+   available to the job shell.
+
+
+RESOURCES
+=========
+
+.. include:: common/resources.rst
+
+
+FLUX RFC
+========
+
+:doc:`rfc:spec_34`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -252,6 +252,7 @@ man_pages = [
     ('man3/flux_shell_get_jobspec_info', 'flux_shell_jobspec_info_unpack', 'Manage shell jobspec summary information', [author], 3),
     ('man3/flux_shell_get_jobspec_info', 'flux_shell_get_jobspec_info', 'Manage shell jobspec summary information', [author], 3),
     ('man3/flux_shell_get_taskmap', 'flux_shell_get_taskmap', 'Get shell task mapping', [author], 3),
+    ('man3/flux_shell_get_hostlist', 'flux_shell_get_hostlist', 'Get the list of hosts in the current job', [author], 3),
     ('man3/flux_shell_getenv', 'flux_shell_get_environ', 'Get and set global environment variables', [author], 3),
     ('man3/flux_shell_getenv', 'flux_shell_setenvf', 'Get and set global environment variables', [author], 3),
     ('man3/flux_shell_getenv', 'flux_shell_unsetenv', 'Get and set global environment variables', [author], 3),

--- a/src/shell/info.h
+++ b/src/shell/info.h
@@ -14,6 +14,7 @@
 #include <flux/core.h>
 #include <flux/shell.h>
 #include <flux/taskmap.h>
+#include <flux/hostlist.h>
 
 #include <jansson.h>
 #include <stdbool.h>
@@ -33,6 +34,7 @@ struct shell_info {
     struct rcalc_rankinfo rankinfo;
     struct taskmap *taskmap;
     struct idset *taskids;
+    struct hostlist *hostlist;
     char *hwloc_xml;
     flux_future_t *R_watch_future;
 };

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -13,6 +13,7 @@
 
 #include <flux/core.h>
 #include <flux/taskmap.h>
+#include <flux/hostlist.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,6 +102,10 @@ int flux_shell_get_hwloc_xml (flux_shell_t *shell, const char **xmlp);
 /*  Return the current shell taskmap
  */
 const struct taskmap *flux_shell_get_taskmap (flux_shell_t *shell);
+
+/*  Return the list of hosts assigned to this job as a hostlist
+ */
+const struct hostlist *flux_shell_get_hostlist (flux_shell_t *shell);
 
 /*  Return shell info as a JSON string.
  *  {


### PR DESCRIPTION
This PR augments the error messages, and thus exception notes, from the shell `doom` plugin to include the affected hostname. This prevents users and admins from having to go through several steps to match a prematurely exiting task rank back to a hostname on which it ran.