### PR TITLE
job-exec: do not streq() an unbuffered string

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -139,7 +139,8 @@ static void output_cb (struct bulk_exec *exec,
     const char *cmd = flux_cmd_arg (flux_subprocess_get_cmd (p), 0);
 
     if (streq (stream, "stdout")) {
-        if (streq (data, "enter\n")
+        if (len == 6
+            && strncmp (data, "enter\n", 6) == 0
             && exec_barrier_enter (exec) < 0) {
             jobinfo_fatal_error (job,
                                  errno,

--- a/t/valgrind/workload.d/job-multinode
+++ b/t/valgrind/workload.d/job-multinode
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+NJOBS=${NJOBS:-2}
+
+flux submit --cc="1-$NJOBS" -N2 --wait hostname
+


### PR DESCRIPTION
Problem: The job-exec barrier protocol does a streq() string comparison on the data returned from a subprocess's stdout.  When subprocesses began to use the new UNBUF flag, this data became non-NUL terminated.  The streq() therefore became unsafe to use.

Update code to check data length and use strncmp() instead of streq().

Fixes #6057