### PR TITLE
etc: add some missing functionality to bash completions

### DIFF
--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -854,14 +854,19 @@ _flux_queue()
         -h --help \
         -q --queue= \
         -a --all \
+        --quiet \
+        -v --verbose \
+        --nocheckpoint \
     "
     local start_OPTS="\
         -h --help \
+        -q --queue= \
         -v --verbose \
         --quiet \
     "
     local stop_OPTS="\
         -h --help \
+        -q --queue= \
         -v --verbose \
         --quiet \
     "
@@ -2125,6 +2130,11 @@ _flux_core()
         ;;
     broker)
         _flux_broker $subcmd
+        ;;
+    python)
+        # reset to defaults and let readline take over
+        compopt -o default
+        COMPREPLY=()
         ;;
     -*)
         COMPREPLY=( $(compgen -W "${FLUX_OPTS}" -- "$cur") )


### PR DESCRIPTION
Problem: The bash tab completions are currently missing a couple things:

 - the flux-queue(1) completions are missing the --queue option for a couple subcommands
 - the flux-python(1) command doesn't have any completions, so you can't complete the path of a script to pass to `flux python` with tab.

Fix these issues.