### PR TITLE
job-manager/prioritize: update priority before sending

### DIFF
--- a/src/modules/job-manager/prioritize.c
+++ b/src/modules/job-manager/prioritize.c
@@ -114,6 +114,14 @@ static int reprioritize_one (struct job_manager *ctx,
                              "priority", priority) < 0)
         return -1;
 
+    /*  Posting the priority event used to immediately set job->priority,
+     *   but after flux-framework/flux-core#4351, the event may be deferred.
+     *   Since the code below for sched.prioritize and queue reordering needs
+     *   the new job->priority value, set it here *also*.
+     *   See also: flux-framework/flux-core#6062
+     */
+    job->priority = priority;
+
     /*  Update alloc queues, cancel outstanding alloc requests for
      *   newly "held" jobs, and if in "oneshot" mode, notify scheduler
      *   of priority change


### PR DESCRIPTION
I think this might take the cake for me for heisenbug of the week.  Somehow all of this worked correctly until after I fixed the ordering and async issues in qmanager.  My guess is there's a race condition, maybe it worked because in other cases job-manager received the update event and thus updated it sooner? Not sure, I have yet to find where it actually updates the job structure.  Either way, this is what caused the catastrophic CI failure after I fixed the reconsider spinning issue over in flux-framework/flux-sched#1227. Also no clue how this passed all the tests before, the `sched.prioritize` messages consistently carry the wrong value. 🤷‍♂️ 

problem: On receiving a message from `flux job urgency` the job-manager prioritize code updates the value of job->priority after sending the update to the scheduler, using the value of job->priority.  As a result, the scheduler receives an update RPC setting the priority to whatever it was last set to and only on the next such update does it receive the requested value.

solution: update job->priority before sending the RPC to the scheduler