### PR TITLE
add environment variable to avoid `RTLD_DEEPBIND` when loading modules

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -351,6 +351,15 @@ components or writing tests.
    ``sched.resource-status`` RPC used in earlier releases still works for
    backwards compatibility.
 
+.. envvar:: FLUX_LOAD_WITH_DEEPBIND
+
+   By default flux loads all modules, plugins and dlopened libraries of any kind
+   with RTLD_DEEPBIND to avoid symbol conflicts.  If this environment variable
+   is set to 0 that flag will be cleared from the flags of all dlopen
+   invocations. This is mainly useful to override the allocator or otherwise
+   interpose a tool or library with LD_PRELOAD.  Be aware that this can cause
+   symbol conflicts with plugins, and is not recommended for production.
+
 MISCELLANEOUS
 =============
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -915,3 +915,7 @@ testexec
 rcvhwm
 libzmq
 userrc
+DEEPBIND
+PRELOAD
+RTLD
+dlopened

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -34,6 +34,7 @@
 #include <sys/syscall.h>
 #endif
 
+#include "src/common/libflux/plugin_private.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/errno_safe.h"
@@ -307,7 +308,7 @@ module_t *module_create (flux_t *h,
     mod_main_f *mod_main;
 
     dlerror ();
-    if (!(dso = dlopen (path, RTLD_NOW | RTLD_GLOBAL | FLUX_DEEPBIND))) {
+    if (!(dso = dlopen (path, RTLD_NOW | RTLD_GLOBAL | plugin_deepbind ()))) {
         errprintf (error, "%s", dlerror ());
         errno = ENOENT;
         return NULL;

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -87,6 +87,7 @@ libflux_la_SOURCES = \
 	service.c \
 	version.c \
 	plugin.c \
+	plugin_private.h \
 	sync.c \
 	disconnect.c \
 	stats.c \

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -25,6 +25,7 @@
 #include <sys/syscall.h>
 #endif
 
+#include "src/common/libflux/plugin_private.h"
 #include "src/common/librouter/rpc_track.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/log.h"
@@ -273,7 +274,7 @@ static connector_init_f *find_connector_dso (const char *scheme,
         errno = ENOENT;
         goto error;
     }
-    if (!(dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL | FLUX_DEEPBIND))) {
+    if (!(dso = dlopen (path, RTLD_LAZY | RTLD_LOCAL | plugin_deepbind ()))) {
         errprintf (errp, "dlopen: %s: %s", path, dlerror ());
         errno = EINVAL;
         goto error;

--- a/src/common/libflux/plugin_private.h
+++ b/src/common/libflux/plugin_private.h
@@ -1,0 +1,16 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef FLUX_CORE_PLUGIN_PRIVATE_H
+#define FLUX_CORE_PLUGIN_PRIVATE_H
+
+int plugin_deepbind (void);
+
+#endif /* FLUX_CORE_PLUGIN_PRIVATE_H */


### PR DESCRIPTION
Add an environment variable to control whether we actually apply the RTLD_DEEPBIND flag when calling dlopen.  More details in the commit message, but this makes it possible to run flux with an alternate allocator using LD_PRELOAD or certain other things that make heap tracing and certain other debugging and tracing tasks much easier.