### PR TITLE
actions: only run CI for push on master

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 name: asan
 jobs:
   check-asan:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,9 @@
-on: [pull_request, push, merge_group]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  merge_group:
 name: ci
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Actions are being slow today, and I think this is part of why.

problem: we currently run CI in full on both push and PR for all branches, and it mostly just fails on push because it doesn't receive label context. What we really need is for push triggered builds to run on master and only PR-triggered otherwise.

solution: limit push event triggers to the master branch.