### PR TITLE
wait for job `clean` event by default in `flux run`  and `flux job attach`

### DIFF
--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -1274,13 +1274,13 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_get_reactor");
 
     /*  Check for the event name that attach should wait for in the
-     *   main job eventlog. The default is the "finish" event.
-     *   If the event never appears in the eventlog, flux-job attach
-     *   will still exit after the 'clean' event, since the job-info
-     *   module reponds with ENODATA after the final event, which by
-     *   definition is "clean".
+     *   main job eventlog. The default is the "clean" event.
+     *   If an event other than "clean" is specified, but never appears
+     *   in the eventlog, flux-job attach will still exit after the 'clean'
+     *   event, since the job-info module reponds with ENODATA after the
+     *   final event, which by definition is "clean".
      */
-    ctx.wait_event = optparse_get_str (p, "wait-event", "finish");
+    ctx.wait_event = optparse_get_str (p, "wait-event", "clean");
 
     if (optparse_hasopt (ctx.p, "debug")
         || optparse_hasopt (ctx.p, "debug-emulate")) {

--- a/t/t2711-python-cli-run.t
+++ b/t/t2711-python-cli-run.t
@@ -55,7 +55,9 @@ test_expect_success 'flux run -vvv produces exec events on stderr' '
 	flux run -vvv hostname 2>vvv.err &&
 	grep complete vvv.err
 '
-
+test_expect_success 'flux run waits for clean event by default' '
+	grep clean vvv.err
+'
 test_expect_success 'flux run --cwd works' '
 	mkdir cwd_test &&
 	flux run --cwd=$(realpath cwd_test) pwd > cwd.out &&


### PR DESCRIPTION
This PR is meant to be merged after #5818. It updates the default wait-event for `flux job attach` to `clean` from `finish`. This means that `flux run`  and `flux alloc` will now wait until a job is fully inactive before exiting. This handles cases where epilog actions perform some work that is expected to be complete before a synchronous job run completes (by exiting).