### PR TITLE
job-exec: add `active_ranks` and fix `active_shells` count in per-job stats

### DIFF
--- a/src/common/libsubprocess/bulk-exec.h
+++ b/src/common/libsubprocess/bulk-exec.h
@@ -92,6 +92,12 @@ int bulk_exec_rc (struct bulk_exec *exec);
 /* Returns current number of processes starting/running */
 int bulk_exec_current (struct bulk_exec *exec);
 
+/* Return number of processes that are complete */
+int bulk_exec_complete (struct bulk_exec *exec);
+
+/* Return idset of ranks on which processes are still active */
+struct idset *bulk_exec_active_ranks (struct bulk_exec *exec);
+
 int bulk_exec_write (struct bulk_exec *exec, const char *stream,
                      const char *buf, size_t len);
 


### PR DESCRIPTION
This PR fixes the `active_shells` count in the job-exec per-job module stats and also adds an `active_ranks` member with an idset of ranks on which job shells are still active. This can aid in finding an unkillable shell in large jobs.