### PR TITLE
sdexec: add stats-get RPC handler

### DIFF
--- a/src/common/libsdexec/channel.c
+++ b/src/common/libsdexec/channel.c
@@ -349,4 +349,26 @@ int sdexec_channel_write (struct channel *ch, json_t *io)
     return 0;
 }
 
+json_t *sdexec_channel_get_stats (struct channel *ch)
+{
+    json_t *o = NULL;
+
+    if (ch) {
+        if (ch->writable) {
+            o = json_pack ("{s:i s:i}",
+                           "local_fd", ch->fd[0],
+                           "remote_fd", ch->fd[1]);
+        }
+        else {
+            o = json_pack ("{s:i s:i s:i s:i s:b}",
+                           "local_fd", ch->fd[0],
+                           "remote_fd", ch->fd[1],
+                           "buf_used", outbuf_used (ch->buf),
+                           "buf_free", outbuf_free (ch->buf),
+                           "eof", ch->eof_received);
+        }
+    }
+    return o;
+}
+
 // vi:ts=4 sw=4 expandtab

--- a/src/common/libsdexec/channel.h
+++ b/src/common/libsdexec/channel.h
@@ -76,6 +76,8 @@ void sdexec_channel_start_output (struct channel *ch);
 
 void sdexec_channel_destroy (struct channel *ch);
 
+json_t *sdexec_channel_get_stats (struct channel *ch);
+
 #endif /* !_LIBSDEXEC_CHANNEL_H */
 
 // vi:ts=4 sw=4 expandtab

--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -279,6 +279,16 @@ test_expect_success NO_CHAIN_LINT 'sdexec.list works' '
 	kill -15 $testpid &&
 	test_expect_code 143 wait $testpid
 '
+test_expect_success NO_CHAIN_LINT 'sdexec.stats-get works' '
+	$sdexec -r 0 --setopt=SDEXEC_NAME=statstest.service \
+	    $sh -c "echo hello >sleep3.out && sleep 60" &
+	testpid=$! &&
+	$waitfile -q -t 30 sleep3.out &&
+	flux module stats sdexec >stats.out &&
+	grep statstest.service stats.out &&
+	kill -15 $testpid &&
+	test_expect_code 143 wait $testpid
+'
 test_expect_success 'sdexec sets FLUX_URI to local broker' '
 	echo $FLUX_URI >uri.exp &&
 	$sdexec -r 1 $printenv FLUX_URI >uri.out &&


### PR DESCRIPTION
Problem: sdexec internal state is opaque
    
Add support for the `sdexec.stats-get` RPC so 'flux module stats sdexec' returns something useful when debugging stuck jobs.

Example output with one job running:
```json
{
 "procs": {
  "imp-shell-0-f5XkPPeaUuu.service": {
   "state": "active.running",
   "pid": 922759,
   "in": {
    "local_fd": 139,
    "remote_fd": -1
   },
   "out": {
    "local_fd": 141,
    "remote_fd": -1,
    "buf_used": 0,
    "buf_free": 4194304,
    "eof": false
   },
   "err": {
    "local_fd": 26,
    "remote_fd": -1,
    "buf_used": 0,
    "buf_free": 4194304,
    "eof": false
   }
  }
 }
}
```