### PR TITLE
flux-job: fix prolog refcount in attach status message

### DIFF
--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -1003,9 +1003,14 @@ static void attach_notify (struct attach_ctx *ctx,
 
     if (!event_name)
         return;
-    if (ctx->statusline
-        && !ctx->fatal_exception
-        && (msg = job_event_notify_string (event_name))) {
+
+    /* job_event_notify_string must be called for all events even if
+     * the statusline is not active for prolog-start/finish refcounting.
+     */
+    msg = job_event_notify_string (event_name);
+    if (msg
+        && ctx->statusline
+        && !ctx->fatal_exception) {
         int dt = ts - ctx->timestamp_zero;
         int width = 80;
         struct winsize w;


### PR DESCRIPTION
Problem: The `flux job attach` status line reference counting for prolog-start events doesn't work because job_event_notify_string(), which is where the refcount is done, is only called when the status line is active -- that is after 2s by default. The first prolog-start events could have been posted during this time, and the increment of the prolog-finish refcount is missed.

Always call job_event_notify_string() in attach_notify() to ensure the refcounting is correct.