### PR TITLE
job-manager: improve sched.alloc request tracking

### DIFF
--- a/t/t2204-job-manager-limited.t
+++ b/t/t2204-job-manager-limited.t
@@ -148,4 +148,78 @@ test_expect_success 'job-manager: no annotations in canceled jobs in flux jobs (
         fjobs_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success 'job-manager: all jobs are inactive' '
+        flux queue idle --timeout 30s
+'
+test_expect_success 'job-manager: submit 5 jobs using one node each' '
+        flux submit --log=job{cc}.id --cc="1-5" -N1 true
+'
+test_expect_success 'job-manager: job state RSSSS' '
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+test_expect_success 'job-manager: queue status shows 2 alloc pending, 2 queued' '
+        flux queue status -v |grep "2 alloc requests queued" &&
+        flux queue status -v |grep "2 alloc requests pending"
+'
+test_expect_success 'job-manager: cancel one pending job' '
+        flux cancel $(cat job2.id)
+'
+test_expect_success 'job-manager: job state RISSS' '
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+test_expect_success 'job-manager: 2 alloc req pending, 1 queued' '
+        flux queue status -v |grep "1 alloc requests queued" &&
+        flux queue status -v |grep "2 alloc requests pending"
+'
+test_expect_success 'job-manager: reload the scheduler' '
+	flux module reload sched-simple mode=limited=2
+'
+test_expect_success 'job-manager: job state RISSS' '
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+test_expect_success 'job-manager: 2 alloc req pending, 1 queued' '
+        flux queue status -v |grep "1 alloc requests queued" &&
+        flux queue status -v |grep "2 alloc requests pending"
+'
+test_expect_success 'job-manager: cancel one running job' '
+        flux cancel $(cat job1.id)
+'
+test_expect_success 'job-manager: job state IIRSS' '
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+test_expect_success 'job-manager: 2 alloc req pending, 0 queued' '
+        flux queue status -v |grep "0 alloc requests queued" &&
+        flux queue status -v |grep "2 alloc requests pending"
+'
+test_expect_success 'job-manager: cancel all jobs' '
+        flux cancel --all
+'
+test_expect_success 'job-manager: job state IIIII' '
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) I &&
+        jmgr_check_state $(cat job4.id) I &&
+        jmgr_check_state $(cat job5.id) I
+'
+test_expect_success 'job-manager: 0 alloc req pending, 0 queued' '
+        flux queue status -v |grep "0 alloc requests queued" &&
+        flux queue status -v |grep "0 alloc requests pending"
+'
+
 test_done


### PR DESCRIPTION
Problem: we observed underflow in the `flux queue status -v` pending alloc count in #6059 with fluxion.

I was unable to reproduce the underflow.  This PR adds tests since there were none for the alloc/pending counts, and simplifies the code.

TL;DR In limited mode, the job manager places pending alloc requests in a priority queue so that it can reorder them and cancel/resubmit if priorities change.  In unlimited mode, the list was eschewed for a counter.  It's the counter that went wrong here (somehow).   The cleanup is to always use the priority queue so that we only have one code path to worry about and since list removal is idempotent, the underflow case should be gone.

I can't imagine the priority queue presents a performance issue.  I did run a quick check, running `flux module reload sched-simple mode=unlimited` and running the throughput test with 1000 jobs 3x each on master and this PR and didn't see much of a difference, if any.