### PR TITLE
broker: work around problem with launch by some versions of mpiexec.hydra

### DIFF
--- a/src/common/libpmi/test/keyval.c
+++ b/src/common/libpmi/test/keyval.c
@@ -58,6 +58,7 @@ static char *pmi[] = {
     "cmd=lookup_result rc=0 info=ok port=merp42\n",
     "cmd=unpublish_name service=zz\n",
     "cmd=unpublish_result rc=0 info=ok\n",
+    "cmd=get_result rc=0 msg=success value=a = b found=TRUE\n",
     NULL,
 };
 
@@ -274,6 +275,14 @@ int main(int argc, char** argv)
         && keyval_parse_word (pmi[23], "info", val, sizeof (val)) == EKV_SUCCESS
         && streq (val, "ok"),
         "parsed pmi-1 unpublish response");
+    ok (keyval_parse_word (pmi[24], "cmd", val, sizeof (val)) == EKV_SUCCESS
+        && streq (val, "get_result")
+        && keyval_parse_int (pmi[24], "rc", &i) == EKV_SUCCESS && i == 0
+        && keyval_parse_word (pmi[24], "msg", val, sizeof (val)) == EKV_SUCCESS
+        && streq (val, "success")
+        && keyval_parse_string (pmi[24], "value", val, sizeof (val)) == EKV_SUCCESS
+        && streq (val, "a = b"),
+        "parsed pmi-1 lookup response with mpich v4.2.0 quirk");
 
     ok (keyval_parse_word (spawn[0], "mcmd", val, sizeof (val)) == EKV_SUCCESS
         && streq (val, "spawn"),


### PR DESCRIPTION
Problem: mpiexec.hydra from mpich v4.2.0 and reportedly v4.1.1 can no longer launch Flux.
    
The mpich PMI-1 wire protocol used by hydra started appending `found=TRUE` to values returned by kvs get around v4.1.1. With tentative confirmation from mpich developers that this is likely a bug introduced during pmi refactoring, add a workaround to ignore that protocol element if present.
    
Fixes #6072

I manually confirmed this fixes the problem with mpich 4.2.0 and included a unit test.
