### PR TITLE
doc: update flux-shell(1) manpage

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -497,7 +497,7 @@ supported. Job shell specific functions and tables are described below:
 **plugin.searchpath**
   The current plugin searchpath. This value can be queried, set,
   or appended. E.g. to add a new path to the plugin search path:
-  ``plugin.searchpath = plugin.searchpath + ':' + path``
+  ``plugin.searchpath = plugin.searchpath .. ':' .. path``
 
 **plugin.load({file=glob, [conf=table]})**
   Explicitly load one more shell plugins. This function takes a table


### PR DESCRIPTION
Problem: there's inconsistency in the flux-shell(1) page, where some lua syntax is used and other places use pseudo- code.

Make it consistent by updating "+" to ".." (Lua).