### PR TITLE
flux-resource: suppress empty lines in output

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -776,7 +776,7 @@ class OutputFormat:
             print(formatter.header())
         for item in items:
             line = formatter.format(item)
-            if not line:
+            if not line or line.isspace():
                 continue
             if callable(pre):
                 pre(item)

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -134,6 +134,13 @@ test_expect_success 'flux-resource list supports -q, --queue' '
 	grep debug fluke-both.output &&
 	grep batch fluke-both.output
 '
+test_expect_success 'flux-resource list skips empty lines (issue#6093)' '
+	flux resource list -i fluke[3,103] -no "{queue} {nodelist}" \
+		--from-stdin --config-file=$FLUKE_CONFIG \
+                < $FLUKE_INPUT >fluke-empty-lines-test.out &&
+	test_debug "cat fluke-empty-lines-test.out" &&
+	test $(wc -l < fluke-empty-lines-test.out) -eq 2
+'
 test_expect_success 'flux-resource R supports -q, --queue' '
 	flux resource R --queue=debug \
 		--from-stdin --config-file=$FLUKE_CONFIG \


### PR DESCRIPTION
This fixes an issue in `flux resource` and other utilities where a line consisting of only whitespace is not skipped, only completely empty lines. 