### PR TITLE
drain nodes with unkillable tasks after configurable retries

### DIFF
--- a/src/common/libsubprocess/bulk-exec.h
+++ b/src/common/libsubprocess/bulk-exec.h
@@ -72,8 +72,8 @@ int bulk_exec_start (flux_t *h, struct bulk_exec *exec);
 /* Set ranks=NULL for all
  */
 flux_future_t * bulk_exec_kill (struct bulk_exec *exec,
-		                const struct idset *ranks,
-		                int signal);
+                                const struct idset *ranks,
+                                int signal);
 
 /*  Log per-rank kill errors for a failed bulk_exec_kill() RPC.
  */
@@ -81,7 +81,7 @@ void bulk_exec_kill_log_error (flux_future_t *f, flux_jobid_t id);
 
 flux_future_t *bulk_exec_imp_kill (struct bulk_exec *exec,
                                    const char *imp_path,
-				   const struct idset *ranks,
+                                   const struct idset *ranks,
                                    int signal);
 
 int bulk_exec_cancel (struct bulk_exec *exec);

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -669,6 +669,13 @@ static json_t *exec_stats (struct jobinfo *job)
         return exec_config_stats ();
 }
 
+static struct idset *active_ranks (struct jobinfo *job)
+{
+    if (job)
+        return bulk_exec_active_ranks ((struct bulk_exec *) job->data);
+    return NULL;
+}
+
 struct exec_implementation bulkexec = {
     .name =     "bulk-exec",
     .config =   exec_config,
@@ -678,6 +685,7 @@ struct exec_implementation bulkexec = {
     .kill =     exec_kill,
     .cancel =   exec_cancel,
     .stats =    exec_stats,
+    .active_ranks = active_ranks,
 };
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -47,6 +47,8 @@ struct jobinfo;
  *
  *   - stats:   (optional) get json object of exec implementation stats
  *
+ *   - active_ranks:
+ *              (optional) get the set of ranks with active job shells.
  */
 struct exec_implementation {
     const char *name;
@@ -62,6 +64,7 @@ struct exec_implementation {
     int  (*kill)    (struct jobinfo *job, int signum);
     int  (*cancel)  (struct jobinfo *job);
     json_t * (*stats) (struct jobinfo *job);
+    struct idset * (*active_ranks) (struct jobinfo *job);
 };
 
 /*  Exec job information */


### PR DESCRIPTION
This PR modifies the job-exec module to add a max number of retries when signaling the job shell. When this count is exceeded, the remaining active ranks are drained and the tasks are forced to complete so that the job can proceed to CLEANUP.

Fixes #6097

