### PR TITLE
resource: cache resource status information to reduce broker load

### DIFF
--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -1580,7 +1580,7 @@ int rlist_json_nodelist (struct rlist *rl, json_t **result)
     return 0;
 }
 
-static zhashx_t *rlist_properties (struct rlist *rl)
+static zhashx_t *rlist_properties (const struct rlist *rl)
 {
     int saved_errno;
     struct rnode *n;
@@ -1631,7 +1631,7 @@ error:
     return NULL;
 }
 
-static int rlist_json_properties (struct rlist *rl, json_t **result)
+static int rlist_json_properties (const struct rlist *rl, json_t **result)
 {
     int saved_errno;
     int rc = -1;
@@ -1687,7 +1687,7 @@ out:
     return rc;
 }
 
-char *rlist_properties_encode (struct rlist *rl)
+char *rlist_properties_encode (const struct rlist *rl)
 {
     char *result = NULL;
     json_t *o = NULL;

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -1345,7 +1345,7 @@ fail:
     return NULL;
 }
 
-static json_t * rlist_compressed (struct rlist *rl)
+static json_t * rlist_compressed (const struct rlist *rl)
 {
     struct multi_rnode *mrn = NULL;
     json_t *o = json_array ();
@@ -1570,7 +1570,7 @@ fail:
     return NULL;
 }
 
-int rlist_json_nodelist (struct rlist *rl, json_t **result)
+int rlist_json_nodelist (const struct rlist *rl, json_t **result)
 {
     struct hostlist *hl = rlist_nodelist (rl);
     if (!hl)
@@ -1701,7 +1701,7 @@ char *rlist_properties_encode (const struct rlist *rl)
     return result;
 }
 
-json_t *rlist_to_R (struct rlist *rl)
+json_t *rlist_to_R (const struct rlist *rl)
 {
     json_t *R = NULL;
     json_t *R_lite = NULL;
@@ -1748,7 +1748,7 @@ fail:
     return NULL;
 }
 
-char *rlist_encode (struct rlist *rl)
+char *rlist_encode (const struct rlist *rl)
 {
     json_t *o;
     char *R;

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -285,7 +285,7 @@ int rlist_assign_properties (struct rlist *rl,
 /*  Encode properties to a JSON string which conforms to RFC 20 properties
  *   specification. Caller must free.
  */
-char *rlist_properties_encode (struct rlist *rl);
+char *rlist_properties_encode (const struct rlist *rl);
 
 struct rlist *rlist_from_config (json_t *conf, flux_error_t *errp);
 

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -200,14 +200,14 @@ struct idset * rlist_hosts_to_ranks (const struct rlist *rl,
  *  Serialize a resource list into v1 "R" format. This encodes only the
  *   "available" ids in each resource node into execution.R_lite
  */
-json_t * rlist_to_R (struct rlist *rl);
+json_t * rlist_to_R (const struct rlist *rl);
 
 
 /*
  *  Encode resource list into v1 "R" string format.
  *  Identical to `R = rlist_to_R (rl); return json_dumps (R, 0);`.
  */
-char *rlist_encode (struct rlist *rl);
+char *rlist_encode (const struct rlist *rl);
 
 /*
  *  Dump short form description of rlist `rl` as a single line string.

--- a/src/modules/resource/acquire.c
+++ b/src/modules/resource/acquire.c
@@ -454,7 +454,7 @@ void acquire_destroy (struct acquire *acquire)
         int saved_errno = errno;
 
         flux_msg_handler_delvec (acquire->handlers);
-        reslog_set_callback (acquire->ctx->reslog, NULL, NULL);
+        reslog_remove_callback (acquire->ctx->reslog, reslog_cb, acquire);
 
         if (acquire->requests) {
             const flux_msg_t *msg;
@@ -491,7 +491,8 @@ struct acquire *acquire_create (struct resource_ctx *ctx)
                                  acquire,
                                  &acquire->handlers) < 0)
         goto error;
-    reslog_set_callback (ctx->reslog, reslog_cb, acquire);
+    if (reslog_add_callback (ctx->reslog, reslog_cb, acquire) < 0)
+        goto error;
     return acquire;
 error:
     acquire_destroy (acquire);

--- a/src/modules/resource/reslog.h
+++ b/src/modules/resource/reslog.h
@@ -44,7 +44,8 @@ int reslog_sync (struct reslog *reslog);
 
 /* Get a callback for each event.
  */
-void reslog_set_callback (struct reslog *reslog, reslog_cb_f cb, void *arg);
+int reslog_add_callback (struct reslog *reslog, reslog_cb_f cb, void *arg);
+void reslog_remove_callback (struct reslog *reslog, reslog_cb_f cb, void *arg);
 
 #define RESLOG_KEY "resource.eventlog"
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -386,6 +386,7 @@ dist_check_SCRIPTS = \
 	valgrind/workload.d/job-cancel \
 	valgrind/workload.d/job-list \
 	valgrind/workload.d/job-sdexec \
+	valgrind/workload.d/resource \
 	content/content-helper.sh \
 	kvs/kvs-helper.sh \
 	kvs/change-checkpoint.py \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -380,6 +380,12 @@ dist_check_SCRIPTS = \
 	scripts/pipe.py \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
+	valgrind/workload.d/job-info \
+	valgrind/workload.d/job-multinode \
+	valgrind/workload.d/job-wait \
+	valgrind/workload.d/job-cancel \
+	valgrind/workload.d/job-list \
+	valgrind/workload.d/job-sdexec \
 	content/content-helper.sh \
 	kvs/kvs-helper.sh \
 	kvs/change-checkpoint.py \

--- a/t/valgrind/workload.d/resource
+++ b/t/valgrind/workload.d/resource
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+flux submit --wait-event=alloc sleep inf
+
+flux resource drain 0
+
+# calls both resource.status and resource.sched-status
+flux resource status
+
+# second call should use cached values
+flux resource status
+
+flux resource undrain 0
+
+# Cancel the sleep job and wait for it to complete
+flux cancel $(flux job last)
+flux queue drain


### PR DESCRIPTION
Problem: on a large system, frequent use of `flux resource list` or `flux resource status` triggers significant broker CPU consumption.  Commands like `flux top` or `watch flux resource list` are not unreasonable things to do, yet they are costly.

As noted in #6009, we repeatedly calculate the same resource sets, even when they don't change.

Add a simple cache.