### PR TITLE
t: add job environment to tests

### DIFF
--- a/t/python/t0015-job-output.py
+++ b/t/python/t0015-job-output.py
@@ -62,6 +62,7 @@ class TestJobOutput(unittest.TestCase):
         )
         urgency = FLUX_JOB_URGENCY_DEFAULT
         jobspec.setattr_shell_option("cpu-affinity", "off")
+        jobspec.environment = dict(os.environ)
         if hold:
             urgency = FLUX_JOB_URGENCY_HOLD
         if verbose:


### PR DESCRIPTION
Problem: The python/t0015-job-output.py test has an empty environment by default.  This can lead to problems on some distributions.

Set an environment equivalent to the current one to avoid this problem.

Fixes #6088