### PR TITLE
add error text to down nodes in flux overlay status

### DIFF
--- a/doc/man1/flux-overlay.rst
+++ b/doc/man1/flux-overlay.rst
@@ -10,6 +10,7 @@ SYNOPSIS
 ========
 
 | **flux** **overlay** **status** [*-v*] [*--timeout=FSD*] [*--rank=N*]
+| **flux** **overlay** **errors** [*--timeout=FSD*]
 | **flux** **overlay** **lookup** *target*
 | **flux** **overlay** **parentof** *rank*
 | **flux** **overlay** **disconnect** [*--parent=RANK*] *target*
@@ -78,6 +79,18 @@ below.
 
    Wait until sub-tree enters *STATE* before reporting (full, partial, offline,
    degraded, lost).
+
+errors
+------
+
+.. program:: flux overlay errors
+
+:program:`flux overlay errors` summarizes any errors recorded for lost nodes.
+The output consists of one line per unique error with a hostlist prefix.
+
+.. option:: -t, --timeout=FSD
+
+   Set RPC timeout, 0=disable (default 0.5s)
 
 lookup
 ------
@@ -151,6 +164,18 @@ Round trip RPC times are shown with ``-vv``, e.g.
   ├─ 5 test5: offline for 12.754h
   ├─ 6 test6: full for 18.3052h (2.131 ms)
   └─ 7 test7: offline for 12.754h
+
+
+
+::
+
+At times an error summary for *lost* nodes may be useful, e.g.
+
+::
+
+  $ flux overlay errors
+  test[2,5]: lost connection
+  test[6-7]: lost parent
 
 A broker that is not responding but is not shown as *lost* or *offline* may
 be forcibly disconnected from the overlay network with

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1168,11 +1168,6 @@ static void hello_request_handler (struct overlay *ov, const flux_msg_t *msg)
 
     if (!version_check (version, ov->version, &error)) {
         child->error = error; // capture this error message for health report
-        flux_log (ov->h, LOG_ERR,
-                  "rejecting connection from %s (rank %lu): %s",
-                  flux_get_hostbyrank (ov->h, rank),
-                  (unsigned long)rank,
-                  error.text);
         errmsg = error.text;
         errno = EINVAL;
         goto error;

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -111,6 +111,7 @@ struct child {
     struct timespec status_timestamp;
     bool torpid;
     struct rpc_track *tracker;
+    flux_error_t error;
 };
 
 struct parent {
@@ -737,7 +738,8 @@ static void fail_child_rpcs (const flux_msg_t *msg, void *arg)
 
 static void overlay_child_status_update (struct overlay *ov,
                                          struct child *child,
-                                         int status)
+                                         int status,
+                                         const char *reason)
 {
     if (child->status != status) {
         if (subtree_is_online (child->status)
@@ -757,6 +759,7 @@ static void overlay_child_status_update (struct overlay *ov,
         overlay_monitor_notify (ov, child->rank);
         overlay_health_respond_all (ov);
     }
+    errprintf (&child->error, "%s", reason ? reason : "");
 }
 
 static void log_lost_connection (struct overlay *ov,
@@ -801,7 +804,10 @@ static int overlay_sendmsg_child (struct overlay *ov, const flux_msg_t *msg)
         if ((uuid = flux_msg_route_last (msg))
             && (child = child_lookup_online (ov, uuid))) {
             log_lost_connection (ov, child, "failed");
-            overlay_child_status_update (ov, child, SUBTREE_STATUS_LOST);
+            overlay_child_status_update (ov,
+                                         child,
+                                         SUBTREE_STATUS_LOST,
+                                         "lost connection");
         }
         errno = saved_errno;
     }
@@ -951,7 +957,7 @@ static void child_cb (flux_reactor_t *r,
             int type, status;
             if (flux_control_decode (msg, &type, &status) == 0
                 && type == CONTROL_STATUS)
-                overlay_child_status_update (ov, child, status);
+                overlay_child_status_update (ov, child, status, NULL);
             goto done;
         }
         case FLUX_MSGTYPE_REQUEST:
@@ -1156,11 +1162,12 @@ static void hello_request_handler (struct overlay *ov, const flux_msg_t *msg)
         "%s (rank %lu) reconnected after crash, dropping old connection state",
                   flux_get_hostbyrank (ov->h, child->rank),
                   (unsigned long)child->rank);
-        overlay_child_status_update (ov, child, SUBTREE_STATUS_LOST);
+        overlay_child_status_update (ov, child, SUBTREE_STATUS_LOST, NULL);
         hello_log_level = LOG_ERR; // want hello log to stand out in this case
     }
 
     if (!version_check (version, ov->version, &error)) {
+        child->error = error; // capture this error message for health report
         flux_log (ov->h, LOG_ERR,
                   "rejecting connection from %s (rank %lu): %s",
                   flux_get_hostbyrank (ov->h, rank),
@@ -1172,7 +1179,7 @@ static void hello_request_handler (struct overlay *ov, const flux_msg_t *msg)
     }
 
     snprintf (child->uuid, sizeof (child->uuid), "%s", uuid);
-    overlay_child_status_update (ov, child, status);
+    overlay_child_status_update (ov, child, status, NULL);
 
     flux_log (ov->h,
               hello_log_level,
@@ -1548,7 +1555,10 @@ static void overlay_goodbye_cb (flux_t *h,
         flux_msg_decref (response);
         goto error;
     }
-    overlay_child_status_update (ov, child, SUBTREE_STATUS_OFFLINE);
+    overlay_child_status_update (ov,
+                                 child,
+                                 SUBTREE_STATUS_OFFLINE,
+                                 "administrative shutdown");
     flux_msg_decref (response);
     return;
 error:
@@ -1649,6 +1659,14 @@ static int overlay_health_respond (struct overlay *ov, const flux_msg_t *msg)
                                  "status", subtree_status_str (child->status),
                                  "duration", duration)))
             goto nomem;
+        if (!subtree_is_online (child->status) && child->error.text[0]) {
+            json_t *o;
+            if (!(o = json_string (child->error.text))
+                || json_object_set_new (entry, "error", o) < 0) {
+                json_decref (o);
+                // if this fails (unlikely), soldier on
+            }
+        }
         if (json_array_append_new (array, entry) < 0) {
             json_decref (entry);
             goto nomem;
@@ -1826,7 +1844,10 @@ static void overlay_disconnect_subtree_cb (flux_t *h,
         goto error;
     }
     log_lost_connection (ov, child, "disconnected by request");
-    overlay_child_status_update (ov, child, SUBTREE_STATUS_LOST);
+    overlay_child_status_update (ov,
+                                 child,
+                                 SUBTREE_STATUS_LOST,
+                                 "administrative disconnect");
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "error responding to overlay.disconnect-subtree");
     return;

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -22,6 +22,7 @@
 #include "src/common/libhostlist/hostlist.h"
 #include "src/common/librlist/rlist.h"
 #include "src/common/libutil/errprintf.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
 #include "ccan/str/str.h"
 
 #include "builtin.h"
@@ -36,6 +37,13 @@ static const char *ansi_reset = "\033[0m";
 
 //static const char *ansi_green = "\033[32m";
 static const char *ansi_dark_gray = "\033[90m";
+
+static struct optparse_option errors_opts[] = {
+    { .name = "timeout", .key = 't', .has_arg = 1, .arginfo = "FSD",
+      .usage = "Set RPC timeout, 0=disable (default 0.5s)",
+    },
+    OPTPARSE_TABLE_END
+};
 
 static struct optparse_option status_opts[] = {
     { .name = "rank", .key = 'r', .has_arg = 1, .arginfo = "NODEID",
@@ -460,25 +468,25 @@ static void status_ghostwalk (struct status *ctx,
     }
 }
 
-static double time_now (struct status *ctx)
+static double time_now (flux_t *h)
 {
-    return flux_reactor_now (flux_get_reactor (ctx->h));
+    return flux_reactor_now (flux_get_reactor (h));
 }
 
-static flux_future_t *health_rpc (struct status *ctx,
+static flux_future_t *health_rpc (flux_t *h,
                                   int rank,
                                   const char *wait,
                                   double timeout)
 {
     flux_future_t *f;
-    double start = time_now (ctx);
+    double start = time_now (h);
     const char *status;
     int rpc_flags = 0;
 
     if (wait)
         rpc_flags |= FLUX_RPC_STREAMING;
 
-    if (!(f = flux_rpc (ctx->h,
+    if (!(f = flux_rpc (h,
                         "overlay.health",
                         NULL,
                         rank,
@@ -486,7 +494,7 @@ static flux_future_t *health_rpc (struct status *ctx,
         return NULL;
 
     do {
-        if (flux_future_wait_for (f, timeout - (time_now (ctx) - start)) < 0
+        if (flux_future_wait_for (f, timeout - (time_now (h) - start)) < 0
             || flux_rpc_get_unpack (f, "{s:s}", "status", &status) < 0) {
             flux_future_destroy (f);
             return NULL;
@@ -522,7 +530,7 @@ static int status_healthwalk (struct status *ctx,
     monotime (&ctx->start);
     node.subtree_ranks = NULL;
 
-    if (!(f = health_rpc (ctx, rank, ctx->wait, ctx->timeout))
+    if (!(f = health_rpc (ctx->h, rank, ctx->wait, ctx->timeout))
         || flux_rpc_get_unpack (f,
                                 "{s:i s:s s:f s:o}",
                                 "rank", &node.rank,
@@ -778,6 +786,160 @@ static int subcmd_status (optparse_t *p, int ac, char *av[])
     return 0;
 }
 
+// zhashx_destructor_fn footprint
+static void idset_destructor (void **item)
+{
+    if (*item) {
+        idset_destroy (*item);
+        *item = NULL;
+    }
+}
+
+static struct idset *errhash_add_entry (zhashx_t *errhash,
+                                        const char *error)
+{
+    struct idset *entry;
+    if (!(entry = zhashx_lookup (errhash, error))) {
+        if (!(entry = idset_create (0, IDSET_FLAG_AUTOGROW)))
+            return NULL;
+        if (zhashx_insert (errhash, error, entry) < 0) {
+            idset_destroy (entry);
+            errno = ENOMEM;
+            return NULL;
+        }
+    }
+    return entry;
+}
+
+static int errhash_add_one (zhashx_t *errhash,
+                            int rank,
+                            const char *error)
+{
+    struct idset *entry;
+    if (!(entry = errhash_add_entry (errhash, error)))
+        return -1;
+    if (idset_set (entry, rank) < 0)
+        return -1;
+    return 0;
+}
+
+static int errhash_add_set (zhashx_t *errhash,
+                            const struct idset *ranks,
+                            const char *error)
+{
+    if (ranks && idset_count (ranks) > 0) {
+        struct idset *entry;
+        if (!(entry = errhash_add_entry (errhash, error))
+            || idset_add (entry, ranks) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+int errhash_add_children (zhashx_t *errhash, int rank, flux_t *h)
+{
+    struct idset *ranks = subtree_ranks (h, rank);
+    int rc;
+
+    idset_clear (ranks, rank);
+    rc = errhash_add_set (errhash, ranks, "lost parent");
+    idset_destroy (ranks);
+    return rc;
+}
+
+void gather_errors (flux_t *h,
+                    int rank,
+                    zhashx_t *errhash,
+                    double timeout)
+{
+    flux_future_t *f;
+    json_t *children;
+    size_t index;
+    json_t *value;
+
+    if (!(f = health_rpc (h, rank, NULL, timeout))
+        || flux_rpc_get_unpack (f,
+                                "{s:o}",
+                                "children", &children) < 0) {
+        const char *error = future_strerror (f, errno);
+        if (errhash_add_one (errhash, rank, error) < 0
+            || errhash_add_children (errhash, rank, h) < 0)
+            log_msg_exit ("error adding to error hash");
+        goto done;
+    }
+    json_array_foreach (children, index, value) {
+        int child_rank;
+        const char *status;
+        const char *error = NULL;
+        if (json_unpack (value,
+                         "{s:i s:s s?s}",
+                         "rank", &child_rank,
+                         "status", &status,
+                         "error", &error) < 0)
+            log_msg_exit ("error parsing topology");
+        if (streq (status, "lost")) {
+            if (!error)
+                error = "unknown error";
+            // record error for child_rank and its children
+            if (errhash_add_one (errhash, child_rank, error) < 0
+                || errhash_add_children (errhash, child_rank, h) < 0)
+                log_msg_exit ("error adding to error hash");
+        }
+        else if (streq (status, "offline")) {
+            /* Don't report offline nodes.
+             */
+        }
+        else { // recurse
+            gather_errors (h, child_rank, errhash, timeout);
+        }
+    }
+done:
+    flux_future_destroy (f);
+}
+
+void print_errors (flux_t *h, zhashx_t *errhash)
+{
+    struct idset *r;
+
+    r = zhashx_first (errhash);
+    while (r) {
+        char *ranks;
+        char *hostlist;
+
+        if (!(ranks = idset_encode (r, IDSET_FLAG_RANGE))
+            || !(hostlist = flux_hostmap_lookup (h, ranks, NULL)))
+            log_err_exit ("converting ranks to hostnames");
+        printf ("%s: %s\n",
+                hostlist,
+                (const char *)zhashx_cursor (errhash));
+        free (hostlist);
+        free (ranks);
+
+        r = zhashx_next (errhash);
+    }
+}
+
+static int subcmd_errors (optparse_t *p, int ac, char *av[])
+{
+    flux_t *h = builtin_get_flux_handle (p);
+    zhashx_t *errhash; // error string => ranks idset
+    double timeout;
+
+    timeout = optparse_get_duration (p, "timeout", default_timeout);
+    if (timeout == 0)
+        timeout = -1.0; // disabled
+
+    if (!(errhash = zhashx_new ()))
+        log_msg_exit ("could not create error hash");
+    zhashx_set_destructor (errhash, idset_destructor);
+
+    gather_errors (h, 0, errhash, timeout);
+    print_errors (h, errhash);
+
+    zhashx_destroy (&errhash);
+    return 0;
+}
+
 static int subcmd_lookup (optparse_t *p, int ac, char *av[])
 {
     int optindex = optparse_option_index (p);
@@ -924,6 +1086,13 @@ int cmd_overlay (optparse_t *p, int argc, char *argv[])
 }
 
 static struct optparse_subcommand overlay_subcmds[] = {
+    { "errors",
+      "[OPTIONS]",
+      "Summarize overlay errors",
+      subcmd_errors,
+      0,
+      errors_opts,
+    },
     { "status",
       "[OPTIONS]",
       "Display overlay subtree health status",

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -128,7 +128,7 @@ test_expect_success 'flux overlay status -vv works' '
 '
 
 test_expect_success 'flux overlay status shows rank 3 offline' '
-	echo "3 fake3: offline" >health.exp &&
+	echo "3 fake3: offline administrative shutdown" >health.exp &&
 	flux overlay status --timeout=0 --no-pretty \
 		| grep fake3 >health.out &&
 	test_cmp health.exp health.out

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -65,6 +65,11 @@ test_expect_success 'overlay status is full' '
 	test "$(flux overlay status --timeout=0 --summary)" = "full"
 '
 
+test_expect_success 'flux overlay errors prints nothing' '
+	flux overlay errors --timeout=0 >errors.out &&
+	test $(wc -l <errors.out) -eq 0
+'
+
 test_expect_success 'wait timeout of zero is not an immediate timeout' '
 	flux overlay status --wait=full --summary --timeout=0
 '
@@ -134,6 +139,11 @@ test_expect_success 'flux overlay status shows rank 3 offline' '
 	test_cmp health.exp health.out
 '
 
+test_expect_success 'flux overlay errors prints nothing' '
+	flux overlay errors --timeout=0 >errors2.out &&
+	test $(wc -l <errors2.out) -eq 0
+'
+
 test_expect_success 'flux overlay status --summary' '
 	flux overlay status --timeout=0 --summary
 '
@@ -189,6 +199,12 @@ test_expect_success 'ping to rank 14 fails with EHOSTUNREACH' '
 	echo "flux-ping: 14!broker.ping: $(strerror_symbol EHOSTUNREACH)" >ping.exp &&
 	test_must_fail flux ping 14 2>ping.err &&
 	test_cmp ping.exp ping.err
+'
+
+test_expect_success 'flux overlay errors shows the lost connection' '
+	echo "fake14: lost connection" >errors3.exp &&
+	flux overlay errors --timeout=0 >errors3.out &&
+	test_cmp errors3.exp errors3.out
 '
 
 test_expect_success 'wait for rank 0 subtree to be degraded' '
@@ -274,6 +290,10 @@ test_expect_success 'stop broker 12' '
 test_expect_success 'flux overlay status prints connection timed out on 12' '
 	flux overlay status -vv --no-pretty >status.out &&
 	grep "fake12: $(strerror_symbol ETIMEDOUT)" status.out
+'
+test_expect_success 'flux overlay errors prints connection timed out on 12' '
+	flux overlay errors >errors4.out &&
+	grep "fake12: $(strerror_symbol ETIMEDOUT)" errors4.out
 '
 
 test_expect_success 'continue broker 12' '

--- a/t/t3305-system-rpctrack-up.t
+++ b/t/t3305-system-rpctrack-up.t
@@ -96,7 +96,7 @@ test_expect_success 'report health status' '
 	flux overlay status --timeout=0
 '
 test_expect_success 'health status for rank 6 is lost' '
-	echo "6 fake6: lost" >status.exp &&
+	echo "6 fake6: lost administrative disconnect" >status.exp &&
 	flux overlay status --timeout=0 --down --no-pretty \
 		| grep fake6 >status.out &&
 	test_cmp status.exp status.out


### PR DESCRIPTION
Problem: as discussed in #6109, spelunking logs to find out why a node is offline is tedious, and repeated messages about mismatched versions decrease the log signal to noise ratio.

This adds an error message to `flux overlay status` for each offline node, if available, and eliminates the mismatched version log message.

Example:
```
$ flux overlay disconnect 39
flux-overlay: asking system76-pc (rank 1) to disconnect child system76-pc (rank 39)

$ flux overlay status --down -vvv
0 system76-pc: degraded for 8.38533s (0.377 ms)
├─ 1 system76-pc: degraded for 8.386s (0.328 ms)
│  └─ 39 system76-pc: lost for 8.386s administrative disconnect
```
Marking WIP to get feedback on this approach before proceeding to address test issues.

