### PR TITLE
address RSS growth when there are excessive annotation events

### DIFF
--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -38,8 +38,9 @@ static int schedutil_alloc_respond_pack (flux_t *h,
     if (fmt) {
         json_t *o;
         va_start (ap, fmt);
-        if (!(o = json_vpack_ex (NULL, 0, fmt, ap))
-            || json_object_update (payload, o) < 0) {
+        o = json_vpack_ex (NULL, 0, fmt, ap);
+        va_end (ap);
+        if (!o || json_object_update (payload, o) < 0) {
             json_decref (o);
             goto nomem;
         }

--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -170,11 +170,11 @@ static void alloc_continuation (flux_future_t *f, void *arg)
     struct alloc *ctx = flux_future_aux_get (f, "flux::alloc_ctx");
     json_t *payload = NULL;
 
+    schedutil_remove_outstanding_future (util, f);
     if (flux_future_get (f, NULL) < 0) {
         flux_log_error (h, "commit R");
         goto error;
     }
-    schedutil_remove_outstanding_future (util, f);
     if (!(payload = json_object ())
         || (ctx->annotations && json_object_set (payload,
                                                  "annotations",
@@ -197,7 +197,6 @@ static void alloc_continuation (flux_future_t *f, void *arg)
     return;
 error:
     flux_reactor_stop_error (flux_get_reactor (h)); // XXX
-    alloc_destroy (ctx);
     ERRNO_SAFE_WRAP (json_decref, payload);
     flux_future_destroy (f);
 }

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -814,9 +814,11 @@ int event_job_process_entry (struct event *event,
         }
     }
 
-    if (json_array_append (job->eventlog, entry) < 0) {
-        errno = ENOMEM;
-        return -1;
+    if (!(flags & EVENT_NO_COMMIT)) {
+        if (json_array_append (job->eventlog, entry) < 0) {
+            errno = ENOMEM;
+            return -1;
+        }
     }
 
     if (journal_process_event (event->ctx->journal,

--- a/src/modules/job-manager/journal.h
+++ b/src/modules/job-manager/journal.h
@@ -34,7 +34,7 @@ void journal_listeners_disconnect_rpc (flux_t *h,
                                        const flux_msg_t *msg,
                                        void *arg);
 
-int journal_listeners_count (struct journal *journal);
+json_t *journal_get_stats (struct journal *journal);
 
 #endif /* _FLUX_JOB_MANAGER_JOURNAL_H */
 

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -894,16 +894,18 @@ wait_inactive() {
 	return 0
 }
 
-test_expect_success 'reload the job-list module' '
-	flux job list -a > before_reload.out &&
+# Note: annotations are not part of the following comparison
+# because they are omitted from the in-memory journal history
+test_expect_success 'reload the job-list module' "
+	flux job list -a | jq 'del(.annotations)' > before_reload.out &&
 	flux module reload job-list &&
 	wait_inactive
-'
+"
 
-test_expect_success 'job-list: list successfully reconstructed' '
-	flux job list -a > after_reload.out &&
+test_expect_success 'job-list: list successfully reconstructed' "
+	flux job list -a | jq 'del(.annotations)' > after_reload.out &&
 	test_cmp before_reload.out after_reload.out
-'
+"
 
 # the canceled checks may look confusing.  We canceled all active jobs
 # right above here, so all those active jobs became canceled as a result


### PR DESCRIPTION
Progress towards making flux core more robust in situations like #6114.  Marking WIP because there's still some unexplained RSS growth with "annotation spam" to run down.