### PR TITLE
add message queue counts to flux module list

### DIFF
--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -108,12 +108,14 @@ static json_t *modhash_entry_tojson (module_t *p,
 
     if (!(svcs  = service_list_byuuid (sw, module_get_uuid (p))))
         return NULL;
-    entry = json_pack ("{s:s s:s s:i s:i s:O}",
+    entry = json_pack ("{s:s s:s s:i s:i s:O s:i s:i}",
                        "name", module_get_name (p),
                        "path", module_get_path (p),
                        "idle", (int)(now - module_get_lastseen (p)),
                        "status", module_get_status (p),
-                       "services", svcs);
+                       "services", svcs,
+                       "sendqueue", module_get_send_queue_count (p),
+                       "recvqueue", module_get_recv_queue_count (p));
     json_decref (svcs);
     return entry;
 }

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -685,6 +685,28 @@ int module_event_cast (module_t *p, const flux_msg_t *msg)
     return 0;
 }
 
+ssize_t module_get_send_queue_count (module_t *p)
+{
+    size_t count;
+    if (flux_opt_get (p->h_broker,
+                      FLUX_OPT_SEND_QUEUE_COUNT,
+                      &count,
+                      sizeof (count)) < 0)
+        return -1;
+    return count;
+}
+
+ssize_t module_get_recv_queue_count (module_t *p)
+{
+    size_t count;
+    if (flux_opt_get (p->h_broker,
+                      FLUX_OPT_RECV_QUEUE_COUNT,
+                      &count,
+                      sizeof (count)) < 0)
+        return -1;
+    return count;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -96,6 +96,9 @@ int module_subscribe (module_t *p, const char *topic);
 int module_unsubscribe (module_t *p, const char *topic);
 int module_event_cast (module_t *p, const flux_msg_t *msg);
 
+ssize_t module_get_send_queue_count (module_t *p);
+ssize_t module_get_recv_queue_count (module_t *p);
+
 #endif /* !_BROKER_MODULE_H */
 
 /*

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -70,6 +70,8 @@ enum {
 #define FLUX_OPT_TESTING_USERID     "flux::testing_userid"
 #define FLUX_OPT_TESTING_ROLEMASK   "flux::testing_rolemask"
 #define FLUX_OPT_ROUTER_NAME        "flux::router_name"
+#define FLUX_OPT_SEND_QUEUE_COUNT   "flux::send_queue_count"
+#define FLUX_OPT_RECV_QUEUE_COUNT   "flux::recv_queue_count"
 
 /* Create/destroy a broker handle.
  * The 'uri' scheme name selects a connector to dynamically load.

--- a/src/common/libflux/msg_deque.c
+++ b/src/common/libflux/msg_deque.c
@@ -218,6 +218,19 @@ bool msg_deque_empty (struct msg_deque *q)
     return res;
 }
 
+size_t msg_deque_count (struct msg_deque *q)
+{
+    if (!q)
+        return 0;
+    msg_deque_lock (q);
+    size_t count = 0;
+    flux_msg_t *msg = NULL;
+    list_for_each (&q->messages, msg, list)
+        count++;
+    msg_deque_unlock (q);
+    return count;
+}
+
 int msg_deque_pollfd (struct msg_deque *q)
 {
     if (!q) {

--- a/src/common/libflux/msg_deque.h
+++ b/src/common/libflux/msg_deque.h
@@ -11,6 +11,8 @@
 #ifndef _FLUX_CORE_MSG_DEQUE_H
 #define _FLUX_CORE_MSG_DEQUE_H
 
+#include <sys/types.h>
+
 /* If flags contains MSG_DEQUE_SINGLE_THREAD, pthread locking is eliminated
  * and messages are permitted to be pushed with a reference count > 1.
  */
@@ -34,6 +36,7 @@ int msg_deque_pollfd (struct msg_deque *q);
 int msg_deque_pollevents (struct msg_deque *q);
 
 bool msg_deque_empty (struct msg_deque *q);
+size_t msg_deque_count (struct msg_deque *q);
 
 #endif // !_FLUX_CORE_MSG_DEQUE_H
 

--- a/src/common/libflux/test/msg_deque.c
+++ b/src/common/libflux/test/msg_deque.c
@@ -37,17 +37,25 @@ void check_queue (void)
         "msg_deque_create works");
     ok (msg_deque_empty (q) == true,
         "msg_deque_empty is true");
+    ok (msg_deque_count (q) == 0,
+        "msg_deque_count = 0");
     ok (msg_deque_push_back (q, msg1) == 0,
         "msg_deque_push_back msg1 works");
     ok (msg_deque_empty (q) == false,
         "msg_deque_empty is false");
+    ok (msg_deque_count (q) == 1,
+        "msg_deque_count = 1");
     ok (msg_deque_push_back (q, msg2) == 0,
         "msg_deque_push_back msg2 works");
     ok (msg_deque_empty (q) == false,
         "msg_deque_empty is false");
+    ok (msg_deque_count (q) == 2,
+        "msg_deque_count = 2");
     ok ((msg = msg_deque_pop_front (q)) == msg1,
         "msg_deque_pop_front popped msg1");
     flux_msg_destroy (msg);
+    ok (msg_deque_count (q) == 1,
+        "msg_deque_count = 1");
     ok (msg_deque_empty (q) == false,
         "msg_deque_empty is false");
     ok ((msg = msg_deque_pop_front (q)) == msg2,
@@ -55,6 +63,8 @@ void check_queue (void)
     flux_msg_destroy (msg);
     ok (msg_deque_empty (q) == true,
         "msg_deque_empty is true");
+    ok (msg_deque_count (q) == 0,
+        "msg_deque_count = 0");
     ok (msg_deque_pop_front (q) == NULL,
         "msg_deque_pop_front returned NULL");
 
@@ -203,6 +213,9 @@ void check_inval (void)
         "msg_deque_destroy q=NULL doesn't crash");
     ok (errno == 42,
         "msg_deque_destroy doesn't clobber errno");
+
+    ok (msg_deque_count (NULL) == 0,
+        "msg_deque_count q=NULL is 0");
 
     // msg_deque_push_back
     errno = 0;


### PR DESCRIPTION
This just adds a count of the number of messages queued for each module to `flux module list` output.  `Send` is the number of messages sent by the broker but not yet read by the module.  `Recv` is the number of messages sent by the module and not yet read by the broker.  So this is from the broker's point of view.

Here I added a check watcher to `barrier.so` to have it continually send KVS lookups to `kvs.so` and immediately discard the future:
```
$ flux module list
Module                   Idle  S Send Recv Service
cron                       15  R    0    0 
resource                    8  R    0    0 
job-exec                    8  R    0    0 
job-list                   12  R    0    0 
sched-simple                8  R    0    0 sched
heartbeat                   0  R    0    0 
kvs-watch                  12  R    0    0 
connector-local             0  R    0    0 
kvs                         0  R 1160859    7 
barrier                     0  R    0 221241 
job-info                   12  R    0    0 
job-manager                 8  R    0    0 
content                     2  R    0    0 
job-ingest                  8  R    0    0 
content-sqlite              2  R    0    0 content-backing
```
The problem we recently faced with the escalating RSS that was due to scheduler spamming the job manager would have been immediately evident in this output.