### PR TITLE
Update containers: el9, fedora40, noble, add arm64 for fedora40, el9, noble

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -254,4 +254,8 @@ jobs:
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker manifest create fluxrm/flux-core:bookworm fluxrm/flux-core:bookworm-amd64 fluxrm/flux-core:bookworm-386 fluxrm/flux-core:bookworm-arm64
         docker manifest push fluxrm/flux-core:bookworm
+        for d in el9 noble fedora40 ; do
+          docker manifest create fluxrm/flux-core:$d fluxrm/flux-core:$d-amd64 fluxrm/flux-core:$d-arm64
+          docker manifest push fluxrm/flux-core:$d
+        done
 

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ compile_flags.txt
 # local editor config dirs
 .idea
 .clangd
+.cache
 
 # Rules to ignore auto-generated test harness scripts
 test_*.t

--- a/config/ax_code_coverage.m4
+++ b/config/ax_code_coverage.m4
@@ -125,10 +125,10 @@ AC_DEFUN([AX_CODE_COVERAGE],[
 		dnl Build the code coverage flags
 		dnl Define CODE_COVERAGE_LDFLAGS for backwards compatibility
 		CODE_COVERAGE_CPPFLAGS="-DNDEBUG"
-		CODE_COVERAGE_CFLAGS="-O0 -g -fprofile-arcs -ftest-coverage"
-		CODE_COVERAGE_CXXFLAGS="-O0 -g -fprofile-arcs -ftest-coverage"
+		CODE_COVERAGE_CFLAGS="-O0 -g -fprofile-arcs -ftest-coverage -fprofile-update=atomic"
+		CODE_COVERAGE_CXXFLAGS="-O0 -g -fprofile-arcs -ftest-coverage -fprofile-update=atomic"
 		CODE_COVERAGE_LIBS="-lgcov"
-		CODE_COVERAGE_LDFLAGS="$CODE_COVERAGE_LIBS"
+		CODE_COVERAGE_LDFLAGS="$CODE_COVERAGE_LIBS -fprofile-update=atomic"
 
 		AC_SUBST([CODE_COVERAGE_CPPFLAGS])
 		AC_SUBST([CODE_COVERAGE_CFLAGS])

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,1 @@
-sphinx<6.0.0
-sphinx-rtd-theme>=0.5.2
-docutils>=0.14,<0.18
-urllib3<2
-jinja2<3.1.0
+../scripts/requirements-doc.txt

--- a/scripts/fetch-and-build-caliper.sh
+++ b/scripts/fetch-and-build-caliper.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir caliper
+pushd caliper
+wget -O - https://github.com/LLNL/Caliper/archive/v1.7.0.tar.gz | tar xvz --strip-components 1
+# patch for uint32_t error
+sed -i '39i#include <stdint.h>' include/caliper/common/Record.h
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr -DWITH_GOTCHA=Off
+cmake --build build -j 4 -t install
+popd
+rm -rf caliper

--- a/scripts/fetch-and-build-catch.sh
+++ b/scripts/fetch-and-build-catch.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir catch2
+pushd catch2
+wget -O - https://github.com/catchorg/Catch2/archive/refs/tags/v3.6.0.tar.gz | tar xvz --strip-components 1
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
+cmake --build build -j 4 -t install
+popd
+rm -rf catch2

--- a/scripts/fetch-and-build-mpich.sh
+++ b/scripts/fetch-and-build-mpich.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir catch2
+pushd catch2
+wget -O - https://www.mpich.org/static/downloads/4.2.2/mpich-4.2.2.tar.gz | tar xvz --strip-components 1
+mkdir -p build
+pushd build
+../configure --prefix=/usr --without-pmix
+make -j 4 install
+popd
+popd
+rm -rf catch2
+

--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -1,0 +1,9 @@
+markupsafe==2.0.0
+coverage
+cffi
+ply
+six
+pyyaml
+jsonschema>=2.6,<4.0
+sphinxcontrib-spelling
+-r requirements-doc.txt

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,0 +1,5 @@
+sphinx<6.0.0
+sphinx-rtd-theme>=0.5.2
+docutils>=0.14,<0.18
+urllib3<2
+jinja2<3.1.0

--- a/src/test/docker/alpine/Dockerfile
+++ b/src/test/docker/alpine/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add \
     bash \
     sudo \
     gcc \
+    g++ \
     autoconf \
     automake \
     libtool \
@@ -54,3 +55,8 @@ RUN groupadd -r munge \
  && useradd -d /etc/munge -g munge -s /sbin/nologin -r munge
 
 ENV LANG=C.UTF-8
+
+# Install catch by hand for now:
+COPY scripts/fetch-and-build-catch.sh /fetch-and-build-catch.sh
+RUN /fetch-and-build-catch.sh
+

--- a/src/test/docker/bookworm/Dockerfile
+++ b/src/test/docker/bookworm/Dockerfile
@@ -7,10 +7,7 @@ RUN apt-get update \
  && apt-get -qq install -y --no-install-recommends \
         apt-utils \
         wget \
- && rm -rf /var/lib/apt/lists/*
-
 # Utilities
-RUN apt-get update \
  && apt-get -qq install -y --no-install-recommends \
         locales \
         ca-certificates \
@@ -29,11 +26,7 @@ RUN apt-get update \
         mpich \
         valgrind \
         jq \
- && rm -rf /var/lib/apt/lists/*
-
 # Compilers, autotools
-RUN apt-get update \
- && apt-get -qq install -y --no-install-recommends \
         build-essential \
         pkg-config \
         autotools-dev \
@@ -46,38 +39,13 @@ RUN apt-get update \
         clang-tools-15 \
         gcc-12 \
         g++-12 \
- && rm -rf /var/lib/apt/lists/*
-
 # Python
-# NOTE: sudo pip install is necessary to get differentiated installations of
-# python binary components for multiple python3 variants, --ignore-installed
-# makes it ignore local versions of the packages if your home directory is
-# mapped into the container and contains the same libraries
-RUN apt-get update \
- && apt-get -qq install -y --no-install-recommends \
-	libffi-dev \
+        libffi-dev \
         python3.11-dev \
         python3-pip \
         python3-setuptools \
         python3-wheel \
- && rm -rf /var/lib/apt/lists/*
-
-RUN for PY in python3.11 ; do \
-        sudo $PY -m pip install --upgrade --ignore-installed \
-        --break-system-packages \
-	    "markupsafe==2.0.0" \
-            coverage cffi ply six pyyaml "jsonschema>=2.6,<4.0" \
-            sphinx sphinx-rtd-theme sphinxcontrib-spelling; \
-	sudo mkdir -p /usr/lib/${PY}/dist-packages; \
-	echo ../site-packages >/tmp/site-packages.pth; \
-	sudo mv /tmp/site-packages.pth /usr/lib/${PY}/dist-packages; \
-    done ; \
-    apt-get -qq purge -y python3-pip \
- && apt-get -qq autoremove -y
-
 # Other deps
-RUN apt-get update \
- && apt-get -qq install -y --no-install-recommends \
         libsodium-dev \
         libzmq3-dev \
         libjansson-dev \
@@ -93,11 +61,7 @@ RUN apt-get update \
         libevent-dev \
         libarchive-dev \
         libpam-dev \
- && rm -rf /var/lib/apt/lists/*
-
 # Testing utils and libs
-RUN apt-get update \
- && apt-get -qq install -y --no-install-recommends \
         faketime \
         libfaketime \
         pylint \
@@ -106,7 +70,23 @@ RUN apt-get update \
         aspell \
         aspell-en \
         time \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+# NOTE: sudo pip install is necessary to get differentiated installations of
+# python binary components for multiple python3 variants, --ignore-installed
+# makes it ignore local versions of the packages if your home directory is
+# mapped into the container and contains the same libraries
+ ;  for PY in python3.11 ; do \
+        sudo $PY -m pip install --upgrade --ignore-installed \
+        --break-system-packages \
+	    "markupsafe==2.0.0" \
+            coverage cffi ply six pyyaml "jsonschema>=2.6,<4.0" \
+            sphinx sphinx-rtd-theme sphinxcontrib-spelling; \
+	sudo mkdir -p /usr/lib/${PY}/dist-packages; \
+	echo ../site-packages >/tmp/site-packages.pth; \
+	sudo mv /tmp/site-packages.pth /usr/lib/${PY}/dist-packages; \
+    done ; \
+    apt-get -qq purge -y python3-pip \
+ && apt-get -qq autoremove -y
 
 RUN locale-gen en_US.UTF-8
 
@@ -114,16 +94,12 @@ RUN locale-gen en_US.UTF-8
 RUN luarocks install luaposix
 
 # Install caliper by hand for now:
-RUN mkdir caliper \
- && cd caliper \
- && wget -O - https://github.com/LLNL/Caliper/archive/v1.7.0.tar.gz | tar xvz --strip-components 1 \
- && mkdir build \
- && cd build \
- && CC=gcc CXX=g++ cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DWITH_GOTCHA=Off \
- && make -j 4 \
- && make install \
- && cd ../.. \
- && rm -rf caliper
+COPY scripts/fetch-and-build-caliper.sh /fetch-and-build-caliper.sh
+RUN /fetch-and-build-caliper.sh
+
+# Install catch by hand for now:
+COPY scripts/fetch-and-build-catch.sh /fetch-and-build-catch.sh
+RUN /fetch-and-build-catch.sh
 
 # Install openpmix, prrte
 RUN mkdir prrte \

--- a/src/test/docker/el9/Dockerfile
+++ b/src/test/docker/el9/Dockerfile
@@ -1,16 +1,14 @@
-FROM rockylinux:8
+FROM rockylinux:9
 
 LABEL maintainer="Mark Grondona <mgrondona@llnl.gov>"
 
 #  Enable PowerTools for development packages
-RUN yum -y update \
- && dnf -y install 'dnf-command(config-manager)' \
- && yum config-manager --set-enabled powertools \
- && yum -y update \
+RUN dnf -y install 'dnf-command(config-manager)' \
+ && dnf config-manager --enable crb \
 #  Enable EPEL
- && yum -y install epel-release \
+ && dnf -y install epel-release \
 #  Utilities
- && yum -y install \
+ && dnf -y install \
 	wget \
 	man-db \
 	less \
@@ -41,13 +39,13 @@ RUN yum -y update \
 	bison \
 	flex \
 #  Python
-	python36 \
 	python3-devel \
 	python3-cffi \
 	python3-six \
 	python3-yaml \
 	python3-jsonschema \
 	python3-sphinx \
+	python3-coverage \
 #  Development dependencies
 	libsodium-devel \
 	zeromq-devel \
@@ -64,6 +62,7 @@ RUN yum -y update \
 	systemd-devel \
 	libarchive-devel \
 	pam-devel \
+	mpich-devel \
 #  Other deps
 	perl-Time-HiRes \
 	lua-posix \
@@ -74,10 +73,11 @@ RUN yum -y update \
 	aspell-en \
 	glibc-langpack-en \
 	hwloc \
- && yum clean all
+	lcov \
+ && dnf clean all
 
 #  Set default /usr/bin/python to python3
-RUN alternatives --set python /usr/bin/python3
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Install caliper by hand for now:
 COPY scripts/fetch-and-build-caliper.sh /fetch-and-build-caliper.sh
@@ -87,23 +87,16 @@ RUN /fetch-and-build-caliper.sh
 COPY scripts/fetch-and-build-catch.sh /fetch-and-build-catch.sh
 RUN /fetch-and-build-catch.sh
 
-# Install mvapich2
-RUN mkdir mvapich2 \
- && cd mvapich2 \
- && wget -O - http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.6.tar.gz | tar xvz --strip-components 1 \
- && ./configure --with-device=ch3:sock --disable-fortran --prefix=/usr \
- && make -j4 \
- && make install \
- && cd .. \
- && rm -rf mvapich2
-
-# Install lcov
-RUN rpm --nodeps -i http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm
-
-# Install Python 3 coverage
-RUN pip3 install coverage
 
 ENV LANG=C.UTF-8
 RUN printf "LANG=C.UTF-8" > /etc/locale.conf
 
 COPY src/test/docker/el9/config.site /usr/share/config.site
+
+# the psm3 connector added to libfabrics in ~1.12 causes errors when allowed to
+# use non-local connectors on a system with virtual NICs, since we're in a
+# docker container, prevent this
+ENV PSM3_HAL=loopback
+# hwloc tries to look for opengl devices  by connecting to a port that might
+# sometimes be an x11 port, but more often for us is munge, turn it off
+ENV HWLOC_COMPONENTS=-gl

--- a/src/test/docker/el9/config.site
+++ b/src/test/docker/el9/config.site
@@ -1,0 +1,6 @@
+# Force libdir to /usr/lib64 if prefix=/usr on this platform
+if test "$prefix" = "/usr" ; then
+    test $sysconfdir = "${prefix}/etc" && sysconfdir=/etc
+    libdir=/usr/lib64
+fi
+:

--- a/src/test/docker/fedora40/Dockerfile
+++ b/src/test/docker/fedora40/Dockerfile
@@ -71,6 +71,7 @@ RUN dnf -y install \
 	aspell-en \
 	time \
 	glibc-langpack-en \
+	lcov \
  && dnf clean all
 
 #  Add /usr/bin/mpicc link so MPI tests are built

--- a/src/test/docker/fedora40/Dockerfile
+++ b/src/test/docker/fedora40/Dockerfile
@@ -1,0 +1,94 @@
+FROM fedora:40
+
+LABEL maintainer="Mark Grondona <mgrondona@llnl.gov>"
+
+#  Enable PowerTools for development packages
+#  Utilities
+RUN dnf -y install \
+	wget \
+	man-db \
+	less \
+	git \
+	sudo \
+	munge \
+	ccache \
+	lua \
+	mpich \
+	valgrind \
+	jq \
+	which \
+	file \
+	vim \
+	patch \
+	diffutils \
+	hostname \
+#  Compilers, autotools
+	pkgconfig \
+	libtool \
+	autoconf \
+	automake \
+	gcc \
+	gcc-c++ \
+	clang \
+	clang-tools-extra \
+	libasan \
+	make \
+	ninja-build \
+	cmake \
+#  Python
+	python3-devel \
+	python3-cffi \
+	python3-six \
+	python3-yaml \
+	python3-jsonschema \
+	python3-sphinx \
+	python3-setuptools \
+#  Development dependencies
+	libsodium-devel \
+	zeromq-devel \
+	jansson-devel \
+	munge-devel \
+	ncurses-devel \
+	lz4-devel \
+	sqlite-devel \
+	libuuid-devel \
+	hwloc-devel \
+	mpich-devel \
+	lua-devel \
+	valgrind-devel \
+	libs3-devel \
+	libarchive-devel \
+	pam-devel \
+	pmix-devel \
+	catch-devel \
+#  Other deps
+	perl-Time-HiRes \
+	lua-posix \
+	libfaketime \
+	cppcheck \
+	enchant \
+	aspell \
+	aspell-en \
+	time \
+	glibc-langpack-en \
+ && dnf clean all
+
+#  Add /usr/bin/mpicc link so MPI tests are built
+RUN alternatives --install /usr/bin/mpicc mpicc /usr/lib64/mpich/bin/mpicc 100
+
+ENV LANG=C.UTF-8
+RUN printf "LANG=C.UTF-8" > /etc/locale.conf
+
+COPY src/test/docker/fedora40/config.site /usr/share/config.site
+
+# Install caliper by hand for now:
+COPY scripts/fetch-and-build-caliper.sh /fetch-and-build-caliper.sh
+RUN /fetch-and-build-caliper.sh
+
+# the psm3 connector added to libfabrics in ~1.12 causes errors when allowed to
+# use non-local connectors on a system with virtual NICs, since we're in a
+# docker container, prevent this
+ENV PSM3_HAL=loopback
+# hwloc tries to look for opengl devices  by connecting to a port that might
+# sometimes be an x11 port, but more often for us is munge, turn it off
+ENV HWLOC_COMPONENTS=-gl

--- a/src/test/docker/fedora40/config.site
+++ b/src/test/docker/fedora40/config.site
@@ -1,0 +1,6 @@
+# Force libdir to /usr/lib64 if prefix=/usr on this platform
+if test "$prefix" = "/usr" ; then
+    test $sysconfdir = "${prefix}/etc" && sysconfdir=/etc
+    libdir=/usr/lib64
+fi
+:

--- a/src/test/docker/jammy/Dockerfile
+++ b/src/test/docker/jammy/Dockerfile
@@ -119,16 +119,13 @@ RUN locale-gen en_US.UTF-8
 RUN luarocks install luaposix
 
 # Install caliper by hand for now:
-RUN mkdir caliper \
- && cd caliper \
- && wget -O - https://github.com/LLNL/Caliper/archive/v1.7.0.tar.gz | tar xvz --strip-components 1 \
- && mkdir build \
- && cd build \
- && CC=gcc CXX=g++ cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DWITH_GOTCHA=Off \
- && make -j 4 \
- && make install \
- && cd ../.. \
- && rm -rf caliper
+COPY scripts/fetch-and-build-caliper.sh /fetch-and-build-caliper.sh
+RUN /fetch-and-build-caliper.sh
+
+# Install catch by hand for now:
+COPY scripts/fetch-and-build-catch.sh /fetch-and-build-catch.sh
+RUN /fetch-and-build-catch.sh
+
 
 # Install openpmix, prrte
 RUN mkdir prrte \

--- a/src/test/docker/noble/Dockerfile
+++ b/src/test/docker/noble/Dockerfile
@@ -1,0 +1,125 @@
+FROM ubuntu:noble
+
+LABEL maintainer="Tom Scogland <scogland1@llnl.gov>"
+
+# copy in requirements files
+COPY scripts/requirements-ci.txt /requirements-ci.txt
+COPY scripts/requirements-doc.txt /requirements-doc.txt
+
+# Utilities
+RUN apt-get update \
+# install latest pkg utils:
+ && apt-get -qq install -y --no-install-recommends \
+        apt-utils \
+ && apt-get -qq install -y --no-install-recommends \
+        locales \
+        ca-certificates \
+        wget \
+        man \
+        git \
+        flex \
+        ssh \
+        sudo \
+        vim \
+        luarocks \
+        munge \
+        lcov \
+        ccache \
+        lua5.2 \
+        lua5.2-posix-dev \
+        valgrind \
+        jq \
+# Compilers, autotools
+        build-essential \
+        pkg-config \
+        autotools-dev \
+        libtool \
+        autoconf \
+        automake \
+        make \
+        cmake \
+        ninja-build \
+        clang-18 \
+        clang-tools-18 \
+# default version
+        gcc-13 \
+        g++-13 \
+# newest
+        gcc-14 \
+        g++-14 \
+# Python
+        libffi-dev \
+## python 3.12
+        python3-dev \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+# Other deps
+        libsodium-dev \
+        libzmq3-dev \
+        libjansson-dev \
+        libmunge-dev \
+        libncursesw5-dev \
+        liblua5.2-dev \
+        liblz4-dev \
+        libsqlite3-dev \
+        uuid-dev \
+        libhwloc-dev \
+        libmpich-dev \
+        libs3-dev \
+        libevent-dev \
+        libarchive-dev \
+        libpam-dev \
+        libpmix-dev \
+# testing utils and libs
+        faketime \
+        libfaketime \
+        pylint \
+        cppcheck \
+        enchant-2 \
+        catch2 \
+        aspell \
+        aspell-en \
+        time \
+# Testing utils and libs
+# NOTE: sudo pip install is necessary to get differentiated installations of
+# python binary components for multiple python3 variants, --ignore-installed
+# makes it ignore local versions of the packages if your home directory is
+# mapped into the container and contains the same libraries
+ && (for PY in python3.12 ; do \
+        sudo $PY -m pip install --upgrade --ignore-installed --break-system-packages -r /requirements-ci.txt ; \
+        sudo mkdir -p /usr/lib/${PY}/dist-packages; \
+        echo ../site-packages >/tmp/site-packages.pth; \
+        sudo mv /tmp/site-packages.pth /usr/lib/${PY}/dist-packages; \
+    done) \
+ && apt-get -qq purge -y python3-pip \
+ && apt-get -qq autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# Ubuntu containers now "minimize" themselves, so manpages aren't installed.
+# To warn people about this, /usr/bin/man is a shell script that doesn't bother
+# to look for the man page, but just prints a warning.  Link /usr/bin/man.REAL
+# to /usr/bin/man to make this behave
+RUN ln -sf /usr/bin/man.REAL /usr/bin/man
+
+# Install caliper by hand for now:
+COPY scripts/fetch-and-build-caliper.sh /fetch-and-build-caliper.sh
+RUN /fetch-and-build-caliper.sh
+
+ENV LANG=C.UTF-8
+
+# the image has a UID 1000 named ubuntu now for some reason, fix it
+RUN userdel ubuntu
+# noble defaults to an invalid TZ /UTC
+ENV TZ="America/Los_Angeles"
+
+# noble currently packages an MPICH linked with PMIX, so we can't bootstrap it
+# natively, nor can its own mpiexec, see here:
+# https://bugs.launchpad.net/ubuntu/+source/mpich/+bug/2072338
+# so we build our own copy of current stable
+COPY scripts/fetch-and-build-mpich.sh /fetch-and-build-mpich.sh
+RUN /fetch-and-build-mpich.sh
+
+# hwloc tries to look for opengl devices  by connecting to a port that might
+# sometimes be an x11 port, but more often for us is munge, turn it off
+ENV HWLOC_COMPONENTS=-gl

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -67,7 +67,7 @@ class BuildMatrix:
     def add_build(
         self,
         name=None,
-        image="bookworm",
+        image="fedora40",
         args=default_args,
         jobs=4,
         env=None,
@@ -83,6 +83,14 @@ class BuildMatrix:
 
         # Extra environment to add to this command:
         env = env or {}
+
+        # hwloc tries to look for opengl devices  by connecting to a port that might
+        # sometimes be an x11 port, but more often for us is munge, turn it off
+        env["HWLOC_COMPONENTS"] = "-gl"
+        # the psm3 connector added to libfabrics in ~1.12 causes errors when allowed to
+        # use non-local connectors on a system with virtual NICs, since we're in a
+        # docker container, prevent this
+        env["PSM3_HAL"] = "loopback"
 
         needs_buildx = False
         if platform:
@@ -138,8 +146,8 @@ class BuildMatrix:
 
 matrix = BuildMatrix()
 
-# Debian: no args
-matrix.add_build(name="bookworm")
+# Fedora40: no args
+matrix.add_build(name="fedora40")
 
 # Debian: 32b
 matrix.add_build(
@@ -149,19 +157,21 @@ matrix.add_build(
     docker_tag=True,
 )
 
-# Debian: arm64, expensive, only on master and tags, only install
+# debian/Fedora40: arm64, expensive, only on master and tags, only install
 if matrix.branch == "master" or matrix.tag:
-    matrix.add_build(
-        name="bookworm - arm64",
-        image="bookworm",
-        platform="linux/arm64",
-        docker_tag=True,
-        command_args="--install-only ",
-    )
+    for d in ("bookworm", "noble", "fedora40", "el9"):
+        matrix.add_build(
+            name=f"{d} - arm64",
+            image="{d}",
+            platform="linux/arm64",
+            docker_tag=True,
+            command_args="--install-only ",
+        )
 
 # Debian: gcc-12, content-s3, distcheck
 matrix.add_build(
     name="bookworm - gcc-12,content-s3,distcheck",
+    image="bookworm",
     env=dict(
         CC="gcc-12",
         CXX="g++12",
@@ -171,14 +181,13 @@ matrix.add_build(
     test_s3=True,
 )
 
-# Ubuntu: py3.11,clang-15
+# fedora40: clang-18
 matrix.add_build(
-    name="bookworm - py3.11,clang-15",
+    name="fedora40 - clang-18",
     env=dict(
-        CC="clang-15",
-        CXX="clang++-15",
+        CC="clang-18",
+        CXX="clang++-18",
         CFLAGS="-O2 -gdwarf-4",
-        PYTHON_VERSION="3.11",
         chain_lint="t",
     ),
     args="--with-flux-security",
@@ -188,6 +197,7 @@ matrix.add_build(
 # coverage
 matrix.add_build(
     name="coverage",
+    image="bookworm",
     coverage_flags="ci-basic",
     coverage=True,
     jobs=4,
@@ -196,21 +206,30 @@ matrix.add_build(
 
 # Ubuntu: TEST_INSTALL
 matrix.add_build(
-    name="jammy - test-install",
-    image="jammy",
+    name="noble - test-install",
+    image="noble",
     env=dict(
         TEST_INSTALL="t",
     ),
     docker_tag=True,
 )
 
-# Debian: TEST_INSTALL
+# el9: TEST_INSTALL
 matrix.add_build(
-    name="bookworm - test-install",
+    name="el9 - test-install",
+    image="el9",
     env=dict(
         TEST_INSTALL="t",
     ),
     platform="linux/amd64",
+    docker_tag=True,
+)
+
+# Ubuntu 20.04: py3.8
+matrix.add_build(
+    name="focal - py3.8",
+    image="focal",
+    env=dict(PYTHON_VERSION="3.8"),
     docker_tag=True,
 )
 
@@ -240,41 +259,18 @@ matrix.add_build(
     args="--with-flux-security --enable-caliper",
 )
 
-# Fedora 34
+# Fedora 40
 matrix.add_build(
-    name="fedora34 - gcc-11.2,py3.9",
-    image="fedora34",
-    docker_tag=True,
-)
-
-# Fedora 38
-# Note: caliper does not compile on Fedora 38
-matrix.add_build(
-    name="fedora38 - gcc-13.1,py3.11",
-    image="fedora38",
+    name="fedora40 - gcc-14.1,py3.12",
+    image="fedora40",
     args=(
         "--prefix=/usr"
         " --sysconfdir=/etc"
         " --with-systemdsystemunitdir=/etc/systemd/system"
         " --localstatedir=/var"
         " --with-flux-security"
+        " --enable-caliper"
     ),
-    docker_tag=True,
-)
-
-# Fedora 39
-# Note: caliper does not compile on Fedora 38
-matrix.add_build(
-    name="fedora39 - gcc-13.2,py3.12",
-    image="fedora39",
-    args=(
-        "--prefix=/usr"
-        " --sysconfdir=/etc"
-        " --with-systemdsystemunitdir=/etc/systemd/system"
-        " --localstatedir=/var"
-        " --with-flux-security"
-    ),
-    env=dict(PSM3_HAL="loopback"),
     docker_tag=True,
 )
 
@@ -294,7 +290,6 @@ matrix.add_build(
 # inception
 matrix.add_build(
     name="inception",
-    image="bookworm",
     command_args="--inception",
 )
 

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -214,14 +214,6 @@ matrix.add_build(
     docker_tag=True,
 )
 
-# Ubuntu 20.04: py3.8
-matrix.add_build(
-    name="focal - py3.8",
-    image="focal",
-    env=dict(PYTHON_VERSION="3.8"),
-    docker_tag=True,
-)
-
 # RHEL8 clone
 matrix.add_build(
     name="el8",

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -16,6 +16,8 @@ if ! test -x ${HELLO}; then
     test_done
 fi
 
+# work around https://github.com/open-mpi/ompi/issues/7701 and similar in mpich
+export HWLOC_COMPONENTS=-gl
 export TEST_UNDER_FLUX_CORES_PER_RANK=4
 SIZE=2
 MAX_MPI_SIZE=$(($SIZE*$TEST_UNDER_FLUX_CORES_PER_RANK))

--- a/t/t3003-mpi-abort.t
+++ b/t/t3003-mpi-abort.t
@@ -33,6 +33,8 @@ if ! test -x ${FLUX_BUILD_DIR}/t/mpi/abort; then
     test_done
 fi
 
+# work around https://github.com/open-mpi/ompi/issues/7701 and similar in mpich
+export HWLOC_COMPONENTS=-gl
 export TEST_UNDER_FLUX_CORES_PER_RANK=4
 SIZE=2
 MAX_MPI_SIZE=$(($SIZE*$TEST_UNDER_FLUX_CORES_PER_RANK))


### PR DESCRIPTION
This ended up being more churn than I intended, but once I got into it here's where I ended up.

Effects:
* add containers for: ubuntu/noble, fedora/40, el9
* add 
* factor out caliper build into a script, fix build on fedora and noble with 1-line patch
* factor python deps into a requirements file so we don't have to keep copy/pasting it
* change ubuntu and debian dockerfiles to use a single apt update rather than many
* add catch2 all the way at the bottom, this is mainly for sched, but if we can count on it could also be used for core testing since it helps so much with things like actually printing values of unit tests that failed, and making fixtures a whole lot easier to manage, it's also not large
* add env var to fix stupid HWLOC problem where it tries to look for opengl devices by blindly talking to a port that sometimes is an x11 server

All of these are built and pushed for all appropriate architectures.  The bookworm, jammy and alpine tweaks shouldn't have any impact on existing tests, since they're additions or moving things, the rest are new containers at new names.

TODO:
* [x] update github actions to create manifests for the new arm64 containers
* [x] update check requirements