### PR TITLE
job-exec: fix per-job `active_ranks` module stats

### DIFF
--- a/src/common/libsubprocess/bulk-exec.c
+++ b/src/common/libsubprocess/bulk-exec.c
@@ -96,9 +96,11 @@ struct idset *bulk_exec_active_ranks (struct bulk_exec *exec)
         return NULL;
     p = zlist_first (exec->processes);
     while (p) {
-        int rank = flux_subprocess_rank (p);
-        if (rank >= 0 && idset_set (ranks, rank) < 0) {
-            goto error;
+        if (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING) {
+            int rank = flux_subprocess_rank (p);
+            if (rank >= 0 && idset_set (ranks, rank) < 0) {
+                goto error;
+            }
         }
         p = zlist_next (exec->processes);
     }


### PR DESCRIPTION
`bulk_exec_active_ranks()` is supposed to report the ids of ranks on which bulk-exec subprocesses are still active, but it doesn't account for those that have exited. This causes the `active_ranks` key of `flux module stats job-exec` per-job stats to be incorrect (it always reports all ranks).

Fix `bulk_exec_active_ranks()` and add a test.