### PR TITLE
job-exec: add timeout for job start barrier

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -50,6 +50,16 @@ kill-signal
    (optional) Specify an alternate signal to ``SIGKILL`` when killing tasks
    and the job shell. Mainly used for testing.
 
+barrier-timeout
+   (optional) Specify the default job shell start barrier timeout in FSD.
+   All multi-node jobs enter a barrier at startup once the Flux job shell
+   completes initialization tasks such as changing the working directory
+   and processing the initrc file. Once the first node enters this barrier,
+   the job execution system starts a timer, and if the timer expires
+   before the barrier is complete, raises a job exception and drains the
+   nodes on which the barrier is waiting.  To disable the barrier timeout,
+   set this value to ``"0"``. (Default: ``30m``).
+
 testexec
    (options) A table of keys (see :ref:`testexec`) for configuring the
    **job-exec** test execution implementation (used in mainly for testing).

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -118,7 +118,7 @@ static struct exec_ctx *exec_ctx_create (struct jobinfo *job,
 {
     struct exec_ctx *ctx = calloc (1, sizeof (*ctx));
     flux_reactor_t *r = flux_get_reactor (job->h);
-    double barrier_timeout = 1800.;
+    double barrier_timeout = config_get_default_barrier_timeout ();
 
     if (!r || !ctx || !(ctx->barrier_pending_ranks = idset_copy (ranks)))
         goto error;

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -53,6 +53,8 @@
 extern char **environ;
 
 struct exec_ctx {
+    struct jobinfo *job;
+
     const char * mock_exception;   /* fake exception */
     int barrier_enter_count;
     int barrier_completion_count;
@@ -68,12 +70,13 @@ static void exec_ctx_destroy (struct exec_ctx *tc)
     }
 }
 
-static struct exec_ctx *exec_ctx_create (json_t *jobspec)
+static struct exec_ctx *exec_ctx_create (struct jobinfo *job)
 {
     struct exec_ctx *ctx = calloc (1, sizeof (*ctx));
     if (ctx == NULL)
         return NULL;
-    (void) json_unpack (jobspec, "{s:{s:{s:{s:{s:s}}}}}",
+    ctx->job = job;
+    (void) json_unpack (job->jobspec, "{s:{s:{s:{s:{s:s}}}}}",
                                  "attributes", "system", "exec",
                                      "bulkexec",
                                          "mock_exception",
@@ -443,7 +446,7 @@ static int exec_init (struct jobinfo *job)
         flux_log_error (job->h, "exec_init: bulk_exec_create");
         goto err;
     }
-    if (!(ctx = exec_ctx_create (job->jobspec))) {
+    if (!(ctx = exec_ctx_create (job))) {
         flux_log_error (job->h, "exec_init: exec_ctx_create");
         goto err;
     }

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -76,11 +76,13 @@ static struct exec_ctx *exec_ctx_create (struct jobinfo *job)
     if (ctx == NULL)
         return NULL;
     ctx->job = job;
-    (void) json_unpack (job->jobspec, "{s:{s:{s:{s:{s:s}}}}}",
-                                 "attributes", "system", "exec",
-                                     "bulkexec",
-                                         "mock_exception",
-                                         &ctx->mock_exception);
+    (void) json_unpack (job->jobspec,
+                        "{s:{s:{s:{s:{s:s}}}}}",
+                        "attributes",
+                          "system",
+                            "exec",
+                              "bulkexec",
+                                "mock_exception", &ctx->mock_exception);
     return ctx;
 }
 

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -116,13 +116,15 @@ int config_get_stats (json_t **config_stats)
 {
     json_t *o = NULL;
 
-    if (!(o = json_pack ("{s:s? s:s? s:s? s:s? s:i}",
+    if (!(o = json_pack ("{s:s? s:s? s:s? s:s? s:i s:f}",
                          "default_cwd", default_cwd,
                          "default_job_shell", exec_conf.default_job_shell,
                          "flux_imp_path", exec_conf.flux_imp_path,
                          "exec_service", exec_conf.exec_service,
                          "exec_service_override",
-                         exec_conf.exec_service_override))) {
+                         exec_conf.exec_service_override,
+                         "default_barrier_timeout",
+                         exec_conf.default_barrier_timeout))) {
         errno = ENOMEM;
         return -1;
     }

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -34,6 +34,8 @@ json_t *config_get_sdexec_properties (void);
 
 bool config_get_exec_service_override (void);
 
+double config_get_default_barrier_timeout (void);
+
 int config_get_stats (json_t **config_stats);
 
 int config_setup (flux_t *h,

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -144,6 +144,11 @@ void jobinfo_raise (struct jobinfo *job,
                     int severity,
                     const char *fmt, ...);
 
+int jobinfo_drain_ranks (struct jobinfo *job,
+                         const char *ranks,
+                         const char *fmt,
+                         ...);
+
 /* Append a log output message to exec.eventlog for job
  */
 void jobinfo_log_output (struct jobinfo *job,

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -94,6 +94,11 @@ test_expect_success 'job-exec: invalid job shell generates exception' '
 		| flux job submit) &&
 	flux job wait-event -vt 5 $id clean
 '
+test_expect_success 'job-exec: invalid bulkexec key in jobspec raises error' '
+	flux dmesg -C &&
+	test_must_fail flux run --setattr=exec.bulkexec.foo=bar hostname &&
+	flux dmesg -H | grep "failed to unpack system.exec.bulkexec"
+'
 test_expect_success 'job-exec: exception during init terminates job' '
 	id=$(flux run --dry-run -n2 -N2 sleep 30 \
 		| $jq ".attributes.system.exec.bulkexec.mock_exception = \"init\"" \

--- a/t/t2713-python-cli-bulksubmit.t
+++ b/t/t2713-python-cli-bulksubmit.t
@@ -113,7 +113,7 @@ test_expect_success 'flux submit --wait/progress with job exceptions' '
         test_expect_code 1 $runpty flux bulksubmit \
 	    -n1 --progress --wait \
 	    --setattr=system.exec.bulkexec.mock_exception={} hostname \
-	    ::: 0 init init 0 0 \
+	    ::: none init init none none \
 	    >bs9.out &&
 	grep "PD:1 *R:0 *CD:0 *F:0" bs9.out &&
 	grep "PD:0 *R:0 *CD:3 *F:2" bs9.out &&


### PR DESCRIPTION
This PR adds a timeout for the execution system "start barrier". 

All job shells participate in a barrier after initialization, which includes change of working directory, processing the initrc, etc. After this PR, a timer (default 30m) will be started after the first job shell enters the barrier. If the timer expires before the barrier fully completes, a job exception of the form:
```
exception type="exec" severity=0 userid=1001 note="start barrier timeout waiting for 1/4 nodes (rank 3)
```
will be raised, and the affected rank or ranks drained with the message:
```
job f3oxE4XH start timeout: possible node hang
```
The default barrier timeout can be overridden in jobspec (mainly for testing) via `attributes.system.exec.bulkexec.barrier-timeout`, or via config `exec.barrier-timeout`.

Fixes #6103