### PR TITLE
cmd: accept `-q` for `--queue` in `flux-jobs`, `pgrep`, and `pkill`

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -46,7 +46,7 @@ OPTIONS
 
    List jobs with a specific job name.
 
-.. option:: --queue=[QUEUE]
+.. option:: -q, --queue=[QUEUE]
 
    List jobs in a specific queue.
 

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -1377,7 +1377,7 @@ _flux_jobs()
         -n --no-header \
         -u --user= \
         --name= \
-        --queue= \
+        -q --queue= \
         -o --format= \
         --color= \
         -R --recursive \
@@ -1390,7 +1390,7 @@ _flux_jobs()
 
     _flux_split_longopt && split=true
     case $prev in
-        --queue)
+        --queue | -!(-*)q)
             _flux_complete_queue
             return
             ;;
@@ -1429,12 +1429,12 @@ _flux_pgrep()
         -f --filter= \
         -n --no-header \
         -u --user= \
-        --queue= \
+        -q --queue= \
         -o --format= \
     "
     _flux_split_longopt && split=true
     case $prev in
-        --queue)
+        --queue | -!(-*)q)
             _flux_complete_queue
             return
             ;;
@@ -1473,11 +1473,11 @@ _flux_pkill()
         --max-entries= \
         -f --filter= \
         -u --user= \
-        --queue= \
+        -q --queue= \
     "
     _flux_split_longopt && split=true
     case $prev in
-        --queue)
+        --queue | -!(-*)q)
             _flux_complete_queue
             return
             ;;

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -263,6 +263,7 @@ def parse_args():
         help="Limit output to specific job name",
     )
     parser.add_argument(
+        "-q",
         "--queue",
         action=FilterAction,
         type=str,

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -168,6 +168,7 @@ def parse_args():
         help="List jobs with specific job state or result",
     )
     parser.add_argument(
+        "-q",
         "--queue",
         type=str,
         metavar="QUEUE",


### PR DESCRIPTION
Problem: Use of `-q` as a shorthand for `--queue` is standard in most flux(1) subcommands, such as `flux resource list`, `flux submit`, etc. However, `-q` is not accepted in `flux jobs`, `flux pgrep` and `flux pkill`, which is awkward for users.

Accept `-q` in these commands. Update `flux-jobs(1)` (`flux-pgrep(1)` already claimed `-q` was supported).

Fixes #6130