### PR TITLE
cmd: support multiple queues in `flux jobs`, `pgrep`, and `pkill` `-q, --queue` option

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -46,9 +46,10 @@ OPTIONS
 
    List jobs with a specific job name.
 
-.. option:: -q, --queue=[QUEUE]
+.. option:: -q, --queue=QUEUE[,...]
 
-   List jobs in a specific queue.
+   List jobs in a specific queue or queues. Multiple queues may be separated
+   by a comma or by using the :option:`-q, --queue` option multiple times.
 
 .. option:: -c, --count=N
 

--- a/doc/man1/flux-pgrep.rst
+++ b/doc/man1/flux-pgrep.rst
@@ -56,9 +56,11 @@ OPTIONS
    results can be listed separated by comma. See the JOB STATUS section
    of the :man1:`flux-jobs` manual for more detail.
 
-.. option:: -q, --queue=QUEUE
+.. option:: -q, --queue=QUEUE[,...]
 
-   Only include jobs in the named queue *QUEUE*.
+   Only include jobs in the named queue *QUEUE*. Multiple queues may be
+   specified as a comma-separated list, or by using the :option:`--queue`
+   option multiple times.
 
 .. option:: -c, --count=N
 

--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -10,6 +10,7 @@
 import errno
 import os
 import pwd
+from collections.abc import Iterable
 
 import flux.constants
 from flux.future import WaitAllFuture
@@ -58,7 +59,11 @@ def job_list(
     if name:
         constraint["and"].append({"name": [name]})
     if queue:
-        constraint["and"].append({"queue": [queue]})
+        if isinstance(queue, str):
+            queue = [queue]
+        if not isinstance(queue, Iterable):
+            raise ValueError("queue parameter must be a string or iterable")
+        constraint["and"].append({"queue": list(queue)})
     if states and results:
         tmp = {"or": []}
         tmp["or"].append({"states": [states]})
@@ -201,7 +206,7 @@ class JobList:
     :max_entries: Maximum number of jobs to return
     :since: Limit jobs to those that have been active since a given timestamp.
     :name: Limit jobs to those with a specific name.
-    :queue: Limit jobs to those submitted to a specific queue.
+    :queue: Limit jobs to those submitted to a specific queue or queues
     """
 
     # pylint: disable=too-many-instance-attributes

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -265,10 +265,10 @@ def parse_args():
     parser.add_argument(
         "-q",
         "--queue",
-        action=FilterAction,
-        type=str,
-        metavar="QUEUE",
-        help="Limit output to specific queue",
+        action=FilterActionSetUpdate,
+        default=set(),
+        metavar="QUEUE,...",
+        help="Limit output to specific queue or queues",
     )
     parser.add_argument(
         "-o",

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -170,9 +170,9 @@ def parse_args():
     parser.add_argument(
         "-q",
         "--queue",
-        type=str,
-        metavar="QUEUE",
-        help="Limit output to specific queue",
+        type=FilterActionSetUpdate,
+        metavar="QUEUE,...",
+        help="Limit output to specific queue or queues",
     )
     parser.add_argument(
         "-c",

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -274,6 +274,10 @@ test_expect_success 'flux-jobs --queue works' '
 	test_debug "flux jobs -an --queue=foobar" &&
 	test $(flux jobs -an --queue=foobar | wc -l) -eq 0
 '
+test_expect_success 'flux-jobs --queue accepts multiple queues' '
+	test $(flux jobs -anq queue1,queue2 | wc -l) \
+		-eq $(job_list_state_count completed sched run)
+'
 
 # Recall pending = depend | priority | sched, running = run | cleanup,
 #  active = pending | running


### PR DESCRIPTION
This PR adds support for multiple queues in the `-q, --queue=` options of `flux jobs`, `flux pgrep`, and `flux pkill`. As a prereq, the `JobList` and `JobStats` classes are also extended to take multiple queues.

Fixes #6141