### PR TITLE
matrix: fix matrix generation for arm64 and remove redundant fedora

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -254,7 +254,7 @@ jobs:
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker manifest create fluxrm/flux-core:bookworm fluxrm/flux-core:bookworm-amd64 fluxrm/flux-core:bookworm-386 fluxrm/flux-core:bookworm-arm64
         docker manifest push fluxrm/flux-core:bookworm
-        for d in el9 noble fedora40 ; do
+        for d in el9 noble fedora40 alpine ; do
           docker manifest create fluxrm/flux-core:$d fluxrm/flux-core:$d-amd64 fluxrm/flux-core:$d-arm64
           docker manifest push fluxrm/flux-core:$d
         done

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -146,9 +146,6 @@ class BuildMatrix:
 
 matrix = BuildMatrix()
 
-# Fedora40: no args
-matrix.add_build(name="fedora40")
-
 # Debian: 32b
 matrix.add_build(
     name="bookworm - 32 bit",
@@ -211,6 +208,31 @@ matrix.add_build(
     env=dict(
         TEST_INSTALL="t",
     ),
+    platform="linux/amd64",
+    args="--with-flux-security --enable-caliper",
+    docker_tag=True,
+)
+
+# Ubuntu: TEST_INSTALL
+matrix.add_build(
+    name="jammy - test-install",
+    image="jammy",
+    env=dict(
+        TEST_INSTALL="t",
+    ),
+    args="--with-flux-security --enable-caliper",
+    docker_tag=True,
+)
+
+# Debian: TEST_INSTALL
+matrix.add_build(
+    name="bookworm - test-install",
+    image="bookworm",
+    env=dict(
+        TEST_INSTALL="t",
+    ),
+    platform="linux/amd64",
+    args="--with-flux-security --enable-caliper",
     docker_tag=True,
 )
 
@@ -261,7 +283,7 @@ matrix.add_build(
 
 # Fedora 40
 matrix.add_build(
-    name="fedora40 - gcc-14.1,py3.12",
+    name="fedora40 - gcc-14",
     image="fedora40",
     args=(
         "--prefix=/usr"

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -163,7 +163,16 @@ if matrix.branch == "master" or matrix.tag:
             platform="linux/arm64",
             docker_tag=True,
             command_args="--install-only ",
+            args=(
+                "--prefix=/usr"
+                " --sysconfdir=/etc"
+                " --with-systemdsystemunitdir=/etc/systemd/system"
+                " --localstatedir=/var"
+                " --with-flux-security"
+            ),
         )
+
+# builds to match arm64 images must have linux/amd64 platform explicitly
 
 # Debian: gcc-12, content-s3, distcheck
 matrix.add_build(
@@ -200,6 +209,7 @@ matrix.add_build(
     jobs=4,
     args="--with-flux-security --enable-caliper",
 )
+
 
 # Ubuntu: TEST_INSTALL
 matrix.add_build(
@@ -244,6 +254,7 @@ matrix.add_build(
         TEST_INSTALL="t",
     ),
     platform="linux/amd64",
+    args="--with-flux-security --enable-caliper",
     docker_tag=True,
 )
 
@@ -257,16 +268,9 @@ matrix.add_build(
 
 # RHEL8 clone
 matrix.add_build(
-    name="el8",
-    image="el8",
-    env=dict(PYTHON_VERSION="3.6", LDFLAGS="-Wl,-z,relro  -Wl,-z,now"),
-    docker_tag=True,
-)
-
-# RHEL8 clone
-matrix.add_build(
     name="el8 - ascii",
     image="el8",
+    env=dict(PYTHON_VERSION="3.6", LDFLAGS="-Wl,-z,relro  -Wl,-z,now"),
     args="--enable-broken-locale-mode",
 )
 
@@ -293,6 +297,7 @@ matrix.add_build(
         " --with-flux-security"
         " --enable-caliper"
     ),
+    platform="linux/amd64",
     docker_tag=True,
 )
 

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -159,7 +159,7 @@ if matrix.branch == "master" or matrix.tag:
     for d in ("bookworm", "noble", "fedora40", "el9"):
         matrix.add_build(
             name=f"{d} - arm64",
-            image="{d}",
+            image=f"{d}",
             platform="linux/arm64",
             docker_tag=True,
             command_args="--install-only ",


### PR DESCRIPTION
problem: the no-args fedora40 and version with just prefix arguments are identical for all intents and purposes

solution: remove the no-args version in favor of the one that generates a docker tag

@grondo, sorry for the churn here, but I only realized this was essentially a duplicate when I went to port the changes to sched.  Should be a quick cleanup if you agree.  Sadly will require updating the branch protections again.

Also found that the explicit platform we had on bookworm needs to be on all the multi-arch images, so that's in here now.  Finally dropped the non-ascii el8 builder in favor of bringing the base bookworm/jammy builders back since they were not intentionally dropped.