### PR TITLE
Adds a new --bank/-B flag to Flux scheduling commands to simplify setting a bank

### DIFF
--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -758,6 +758,13 @@ class MiniCmd:
             formatter_class=flux.util.help_formatter(),
         )
         parser.add_argument(
+            "-B",
+            "--bank",
+            type=str,
+            metavar="BANK",
+            help="Submit a job to a specific named bank",
+        )
+        parser.add_argument(
             "-q",
             "--queue",
             type=str,
@@ -1041,6 +1048,9 @@ class MiniCmd:
 
         if args.queue is not None:
             jobspec.setattr("system.queue", args.queue)
+
+        if args.bank is not None:
+            jobspec.setattr("system.bank", args.bank)
 
         if args.setattr is not None:
             for keyval in args.setattr:
@@ -1425,7 +1435,6 @@ class SubmitBulkCmd(SubmitBaseCmd):
             args.progress = None
 
     def watcher_start(self, args):
-
         if not self.watcher:
             #  Need to open self.flux_handle if it isn't already in order
             #  to start the watcher


### PR DESCRIPTION
Currently, when Flux is running in system mode, users have to use `--setattr=system.bank=<BANK_NAME>` to select a bank. This PR adds a new `--bank`/`-B` flag to the following Flux commands to simplify this:
* `flux alloc`
* `flux batch`
* `flux run`
* `flux submit`
* `flux bulksubmit`

This new flag is essentially synonymous to Slurm's `--account`/`-A` flag.

There are still three outstanding things to do in this PR:
1. Test it
2. Decide what to do in situations where flux-accounting does not exist
3. Correct the commit message format since I wasn't really sure what the correct prefix is for the part of the code I'm editing 