### PR TITLE
doc: update flux admin guide URL

### DIFF
--- a/doc/guide/broker.rst
+++ b/doc/guide/broker.rst
@@ -383,7 +383,7 @@ The TBON has a fixed topology determined by configuration, and brokers do not
 adapt to route around down nodes.  In addition, Flux must be completely stopped
 to alter the topology configuration - it cannot be changed on the fly.
 
-See the `Flux Administrator's Guide <https://flux-framework.readthedocs.io/en/latest/guides/admin-guide.html>`_
+See the `Flux Administrator's Guide <https://flux-framework.readthedocs.io/projects/flux-core/en/latest/guide/admin.html>`_
 for a discussion on draining nodes and excluding nodes from scheduling via
 configuration.  Scheduling is somewhat orthogonal to this topic.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,7 +43,7 @@ context may benefit from the following material:
      - `Docs <https://flux-framework.readthedocs.io/en/latest/index.html>`_
 
    * - Flux as the primary resource manager on an HPC cluster
-     - `Flux Administrator's Guide <https://flux-framework.readthedocs.io/en/latest/guides/admin-guide.html>`_
+     - `Flux Administrator's Guide <https://flux-framework.readthedocs.io/projects/flux-core/en/latest/guide/admin.html>`_
 
    * - Flux Request for Comments Specifications
      - `RFC <https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/index.html>`_

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -74,7 +74,7 @@ RESOURCES
 
 .. include:: common/resources.rst
 
-Flux Administrator's Guide: https://flux-framework.readthedocs.io/en/latest/adminguide.html
+Flux Administrator's Guide: https://flux-framework.readthedocs.io/projects/flux-core/en/latest/guide/admin.html
 
 TOML: Tom's Obvious Minimal Language: https://toml.io/en/
 


### PR DESCRIPTION
Updates path to reflect current URL - https://flux-framework.readthedocs.io/projects/flux-core/en/latest/guide/admin.html