### PR TITLE
cmd/startlog: initialize enum to non zero

### DIFF
--- a/src/cmd/builtin/startlog.c
+++ b/src/cmd/builtin/startlog.c
@@ -31,7 +31,7 @@ static const char *startlog_key;
 static int startlog_version;
 
 enum post_flags {
-    POST_FLAG_FLUSH,
+    POST_FLAG_FLUSH = 1,
 };
 
 static void post_startlog_event (flux_t *h,


### PR DESCRIPTION
Problem: The enum POST_FLAG_FLUSH was not initialized, therefore it defaults to 0.  This means when a user passes a flag of "0", it ends up being equal to POST_FLAG_FLUSH, leading to undesired behavior.

Initialize POST_FLAG_FLUSH to 1.