### PR TITLE
add flux overlay trace

### DIFF
--- a/doc/man1/flux-overlay.rst
+++ b/doc/man1/flux-overlay.rst
@@ -14,6 +14,7 @@ SYNOPSIS
 | **flux** **overlay** **lookup** *target*
 | **flux** **overlay** **parentof** *rank*
 | **flux** **overlay** **disconnect** [*--parent=RANK*] *target*
+| **flux** **overlay** **trace** [*-r rank*] [*-t TYPE,...*] [*topic-glob*]
 
 
 DESCRIPTION
@@ -118,6 +119,41 @@ Disconnect a subtree rooted at *target* (hostname or rank).
 
   Set parent rank to *NODEID*.  By default, the parent is determined from
   the topology.
+
+trace
+-----
+
+.. program:: flux overlay trace
+
+Display message summaries for messages transmitted and received on the
+overlay network.  A topic string glob pattern may be supplied as a positional
+argument.
+
+.. option:: -r, --rank=NODEID
+
+   Filter output by overlay network peer rank.  Note that this rank is not
+   necessarily the same as the message source or destination.
+
+.. option:: -t, --type=TYPE,...
+
+   Filter output by message type, a comma-separated list.  Valid types are
+   ``request``, ``response``, ``event``, or ``control``.
+
+.. option:: -L, --color=WHEN
+
+   Colorize output when supported; WHEN can be ``always`` (default if omitted),
+   ``never``, or ``auto`` (default).
+
+.. option:: -H, --human
+
+   Display human-readable output. See also :option:`--color` and
+   :option:`--delta`.
+
+.. option:: -d, --delta
+
+   With :option:`--human`, display the time delta between messages instead
+   of a relative offset since the last absolute timestamp.
+
 
 
 EXAMPLES

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -17,22 +17,8 @@
 
 #include "src/common/libutil/stdlog.h"
 #include "src/common/libutil/timestamp.h"
+#include "src/common/libutil/ansi_color.h"
 #include "ccan/str/str.h"
-
-#define ANSI_COLOR_RED        "\x1b[31m"
-#define ANSI_COLOR_GREEN      "\x1b[32m"
-#define ANSI_COLOR_YELLOW     "\x1b[33m"
-#define ANSI_COLOR_BLUE       "\x1b[34m"
-#define ANSI_COLOR_MAGENTA    "\x1b[35m"
-#define ANSI_COLOR_CYAN       "\x1b[36m"
-#define ANSI_COLOR_GRAY       "\x1b[37m"
-
-#define ANSI_COLOR_RESET      "\x1b[0m"
-#define ANSI_COLOR_BOLD       "\x1b[1m"
-#define ANSI_COLOR_HALFBRIGHT "\x1b[2m"
-#define ANSI_COLOR_REVERSE    "\x1b[7m"
-
-#define ANSI_COLOR_RESET      "\x1b[0m"
 
 struct dmesg_ctx {
     optparse_t *p;

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -12,6 +12,8 @@
 # include <config.h>
 #endif
 #include <unistd.h>
+#include <time.h>
+#include <math.h>
 #include <jansson.h>
 #include <flux/core.h>
 
@@ -23,8 +25,10 @@
 #include "src/common/librlist/rlist.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/ansi_color.h"
+#include "src/common/libutil/parse_size.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "ccan/str/str.h"
+#include "ccan/array_size/array_size.h"
 
 #include "builtin.h"
 
@@ -85,6 +89,27 @@ static struct optparse_option disconnect_opts[] = {
     OPTPARSE_TABLE_END
 };
 
+static struct optparse_option trace_opts[] = {
+    { .name = "rank", .key = 'r', .has_arg = 1, .arginfo = "NODEID",
+      .usage = "Filter output by peer rank",
+    },
+    { .name = "type", .key = 't', .has_arg = 1,
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .arginfo = "TYPE,...",
+      .usage = "Filter output by message type "
+               "(request, response, event, control)",
+    },
+    { .name = "color", .key = 'L', .has_arg = 2, .arginfo = "WHEN",
+      .flags = OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG,
+      .usage = "Colorize output when supported; WHEN can be 'always' "
+               "(default if omitted), 'never', or 'auto' (default)." },
+    { .name = "human",  .key = 'H',  .has_arg = 0,
+      .usage = "Human readable output", },
+    { .name = "delta",  .key = 'd',  .has_arg = 0,
+      .usage = "With --human, show timestamp delta between messages", },
+    OPTPARSE_TABLE_END,
+};
+
 struct status {
     flux_t *h;
     int verbose;
@@ -113,6 +138,15 @@ struct status_node {
     bool ghost;
     enum connector connector;
     flux_error_t error;
+};
+
+struct trace_ctx {
+    int color;
+    int nodeid;
+    struct flux_match match;
+    int delta;
+    double last_sec;
+    double last_timestamp;
 };
 
 static json_t *overlay_topology;
@@ -669,6 +703,7 @@ static bool validate_wait (const char *wait)
     return true;
 }
 
+// N.B. used by both status and trace subcommands
 static int status_use_color (optparse_t *p)
 {
     const char *when;
@@ -1065,6 +1100,254 @@ static int subcmd_disconnect (optparse_t *p, int ac, char *av[])
 
     return 0;
 }
+
+struct typemap {
+    const char *s;
+    int type;
+};
+
+static struct typemap typemap[] = {
+    { ">", FLUX_MSGTYPE_REQUEST },
+    { "<", FLUX_MSGTYPE_RESPONSE},
+    { "e", FLUX_MSGTYPE_EVENT},
+    { "c", FLUX_MSGTYPE_CONTROL},
+};
+
+static const char *type2str (int type)
+{
+    int i;
+
+    for (i = 0; i < ARRAY_SIZE (typemap); i++)
+        if ((type & typemap[i].type))
+            return typemap[i].s;
+    return "?";
+}
+
+enum {
+    TRACE_COLOR_EVENT = FLUX_MSGTYPE_EVENT,
+    TRACE_COLOR_REQUEST = FLUX_MSGTYPE_REQUEST,
+    TRACE_COLOR_RESPONSE = FLUX_MSGTYPE_RESPONSE,
+    TRACE_COLOR_CONTROL = FLUX_MSGTYPE_CONTROL,
+    TRACE_COLOR_TIME = 0x10,
+    TRACE_COLOR_TIMEBREAK = 0x11,
+};
+
+static const char *trace_colors[] = {
+    [TRACE_COLOR_EVENT]         = ANSI_COLOR_YELLOW,
+    [TRACE_COLOR_REQUEST]       = ANSI_COLOR_BOLD_BLUE,
+    [TRACE_COLOR_RESPONSE]      = ANSI_COLOR_CYAN,
+    [TRACE_COLOR_CONTROL]       = ANSI_COLOR_BOLD,
+    [TRACE_COLOR_TIME]          = ANSI_COLOR_GREEN,
+    [TRACE_COLOR_TIMEBREAK]     = ANSI_COLOR_BOLD ANSI_COLOR_GREEN
+};
+
+static const char *months[] = {
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+    NULL
+};
+
+static const char *trace_color (struct trace_ctx *ctx, int type)
+{
+    if (ctx->color)
+        return trace_colors[type];
+    return "";
+}
+
+static const char *trace_color_reset (struct trace_ctx *ctx)
+{
+    if (ctx->color)
+        return ANSI_COLOR_RESET;
+    return "";
+}
+
+
+static void trace_print_human_timestamp (struct trace_ctx *ctx,
+                                         double timestamp)
+{
+
+    if ((time_t)(timestamp/60) == (time_t)(ctx->last_timestamp/60)) {
+        /* Within same minute, print offset in sec */
+        printf ("%s[%+11.6f]%s ",
+                trace_color (ctx, TRACE_COLOR_TIME),
+                timestamp - ctx->last_timestamp
+                    + fmod (ctx->last_timestamp, 60.),
+                trace_color_reset (ctx));
+    }
+    else {
+        struct tm tm;
+        time_t t = timestamp;
+
+        localtime_r (&t, &tm);
+
+        /* New minute, print datetime */
+        printf ("%s[%s%02d %02d:%02d]%s ",
+                trace_color (ctx, TRACE_COLOR_TIMEBREAK),
+                months [tm.tm_mon],
+                tm.tm_mday,
+                tm.tm_hour,
+                tm.tm_min,
+                trace_color_reset (ctx));
+        ctx->last_timestamp  = timestamp;
+    }
+}
+
+static void trace_print_human (struct trace_ctx *ctx,
+                               double timestamp,
+                               int message_type,
+                               const char *s)
+{
+    trace_print_human_timestamp (ctx, timestamp);
+    printf (" %s%s%s\n",
+            trace_color (ctx, message_type),
+            s,
+            trace_color_reset (ctx));
+}
+
+static void trace_print_timestamp (struct trace_ctx *ctx, double timestamp)
+{
+    time_t t = timestamp;
+    struct tm tm;
+    char buf[64] = "";
+
+    localtime_r (&t, &tm);
+
+    strftime (buf, sizeof (buf), "%Y-%m-%dT%T", &tm);
+    printf ("%s%s.%.3d%s",
+            trace_color (ctx, TRACE_COLOR_TIME),
+            buf,
+            (int)(1e3 * (timestamp - t)),
+            trace_color_reset (ctx));
+}
+
+static void trace_print (struct trace_ctx *ctx,
+                         double timestamp,
+                         int message_type,
+                         const char *s)
+{
+    trace_print_timestamp (ctx, timestamp);
+    printf (" %s%s%s\n",
+            trace_color (ctx, message_type),
+            s,
+            trace_color_reset (ctx));
+}
+
+static void trace_ctx_init (struct trace_ctx *ctx,
+                            optparse_t *p,
+                            int ac,
+                            char *av[])
+{
+    int n = optparse_option_index (p);
+
+    memset (ctx, 0, sizeof (*ctx));
+
+    if (n < ac - 1) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (optparse_hasopt (p, "delta")) {
+        if (!optparse_hasopt (p, "human"))
+            log_msg_exit ("--delta can only be used with --human");
+        ctx->delta = 1;
+    }
+    ctx->nodeid = optparse_get_int (p, "rank", FLUX_NODEID_ANY);
+    ctx->match = FLUX_MATCH_ANY;
+    if (n < ac)
+        ctx->match.topic_glob = av[n++];
+    else
+        ctx->match.topic_glob = "*";
+    ctx->color = status_use_color (p); // borrowed from status subcommand
+    if (optparse_hasopt (p, "type")) {
+        const char *arg;
+
+        optparse_getopt_iterator_reset (p, "type");
+        ctx->match.typemask = 0;
+        while ((arg = optparse_getopt_next (p, "type"))) {
+            if (streq (arg, "request"))
+                ctx->match.typemask |= FLUX_MSGTYPE_REQUEST;
+            else if (streq (arg, "response"))
+                ctx->match.typemask |= FLUX_MSGTYPE_RESPONSE;
+            else if (streq (arg, "event"))
+                ctx->match.typemask |= FLUX_MSGTYPE_EVENT;
+            else if (streq (arg, "control"))
+                ctx->match.typemask |= FLUX_MSGTYPE_CONTROL;
+            else
+                log_msg_exit ("valid types: request, response, event, control");
+        }
+    }
+}
+
+static int subcmd_trace (optparse_t *p, int ac, char *av[])
+{
+    flux_t *h = builtin_get_flux_handle (p);
+    flux_future_t *f;
+    struct trace_ctx ctx;
+
+    trace_ctx_init (&ctx, p, ac, av);
+
+    if (!(f = flux_rpc_pack (h,
+                             "overlay.trace",
+                             FLUX_NODEID_ANY,
+                             FLUX_RPC_STREAMING,
+                             "{s:i s:s s:i}",
+                             "typemask", ctx.match.typemask,
+                             "topic_glob", ctx.match.topic_glob,
+                             "nodeid", ctx.nodeid)))
+        log_err_exit ("error sending overlay.trace request");
+    do {
+        double timestamp;
+        const char *prefix;
+        int rank;
+        int type;
+        const char *topic;
+        int payload_size;
+        char buf[160];
+
+        if (flux_rpc_get_unpack (f,
+                                 "{s:F s:s s:i s:i s:s s:i}",
+                                 "timestamp", &timestamp,
+                                 "prefix", &prefix,
+                                 "rank", &rank,
+                                 "type", &type,
+                                 "topic", &topic,
+                                 "payload_size", &payload_size) < 0)
+            log_err_exit ("%s", future_strerror (f, errno));
+
+        char rankstr[16];
+        if (rank < 0)
+            snprintf (rankstr, sizeof (rankstr), "*");
+        else
+            snprintf (rankstr, sizeof (rankstr), "%d", rank);
+
+        snprintf (buf,
+                  sizeof (buf),
+                  "%s %s %s %s [%s]",
+                  prefix,
+                  rankstr,
+                  type2str (type),
+                  topic,
+                  encode_size (payload_size));
+
+        if (optparse_hasopt (p, "human"))
+            trace_print_human (&ctx, timestamp, type, buf);
+        else
+            trace_print (&ctx, timestamp, type, buf);
+        fflush (stdout);
+
+        flux_future_reset (f);
+    } while (1);
+}
+
 int cmd_overlay (optparse_t *p, int argc, char *argv[])
 {
     log_init ("flux-overlay");
@@ -1078,6 +1361,13 @@ int cmd_overlay (optparse_t *p, int argc, char *argv[])
 }
 
 static struct optparse_subcommand overlay_subcmds[] = {
+    { "trace",
+      "[OPTIONS] [topic-glob]",
+      "Trace messages received on overlay network",
+      subcmd_trace,
+      0,
+      trace_opts,
+    },
     { "errors",
       "[OPTIONS]",
       "Summarize overlay errors",

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -22,21 +22,13 @@
 #include "src/common/libhostlist/hostlist.h"
 #include "src/common/librlist/rlist.h"
 #include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/ansi_color.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "ccan/str/str.h"
 
 #include "builtin.h"
 
 static double default_timeout = 0.5;
-
-static const char *ansi_default = "\033[39m";
-static const char *ansi_red = "\033[31m";
-static const char *ansi_yellow = "\033[33m";
-static const char *ansi_blue = "\033[01;34m";
-static const char *ansi_reset = "\033[0m";
-
-//static const char *ansi_green = "\033[32m";
-static const char *ansi_dark_gray = "\033[90m";
 
 static struct optparse_option errors_opts[] = {
     { .name = "timeout", .key = 't', .has_arg = 1, .arginfo = "FSD",
@@ -199,17 +191,17 @@ static const char *status_colorize (struct status *ctx,
     if (ctx->color) {
         if (streq (status, "lost") && !ghost) {
             snprintf (buf, sizeof (buf), "%s%s%s",
-                      ansi_red, status, ansi_default);
+                      ANSI_COLOR_RED, status, ANSI_COLOR_DEFAULT);
             status = buf;
         }
         else if (streq (status, "offline") && !ghost) {
             snprintf (buf, sizeof (buf), "%s%s%s",
-                      ansi_yellow, status, ansi_default);
+                      ANSI_COLOR_YELLOW, status, ANSI_COLOR_DEFAULT);
             status = buf;
         }
         else if (ghost) {
             snprintf (buf, sizeof (buf), "%s%s%s",
-                      ansi_dark_gray, status, ansi_default);
+                      ANSI_COLOR_DARK_GRAY, status, ANSI_COLOR_DEFAULT);
             status = buf;
         }
     }
@@ -274,8 +266,8 @@ static const char *status_getname (struct status *ctx,
      */
     if (node->subtree_ranks
         && idset_has_intersection (ctx->highlight, node->subtree_ranks)) {
-        highlight_start = ctx->color ? ansi_blue : "<<";
-        highlight_end = ctx->color ? ansi_reset : ">>";
+        highlight_start = ctx->color ? ANSI_COLOR_BOLD_BLUE : "<<";
+        highlight_end = ctx->color ? ANSI_COLOR_RESET : ">>";
     }
 
     snprintf (buf,

--- a/src/common/libeventlog/formatter.c
+++ b/src/common/libeventlog/formatter.c
@@ -23,24 +23,10 @@
 #include "ccan/str/str.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/timestamp.h"
+#include "src/common/libutil/ansi_color.h"
 
 #include "eventlog.h"
 #include "formatter.h"
-
-#define ANSI_COLOR_RED        "\x1b[31m"
-#define ANSI_COLOR_GREEN      "\x1b[32m"
-#define ANSI_COLOR_YELLOW     "\x1b[33m"
-#define ANSI_COLOR_BLUE       "\x1b[34m"
-#define ANSI_COLOR_MAGENTA    "\x1b[35m"
-#define ANSI_COLOR_CYAN       "\x1b[36m"
-#define ANSI_COLOR_GRAY       "\x1b[37m"
-
-#define ANSI_COLOR_RESET      "\x1b[0m"
-#define ANSI_COLOR_BOLD       "\x1b[1m"
-#define ANSI_COLOR_HALFBRIGHT "\x1b[2m"
-#define ANSI_COLOR_REVERSE    "\x1b[7m"
-
-#define ANSI_COLOR_RESET      "\x1b[0m"
 
 enum {
     EVENTLOG_COLOR_NAME,

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -100,7 +100,8 @@ libutil_la_SOURCES = \
 	sigutil.h \
 	sigutil.c \
 	parse_size.h \
-	parse_size.c
+	parse_size.c \
+	ansi_color.h
 
 TESTS = test_sha1.t \
 	test_sha256.t \

--- a/src/common/libutil/ansi_color.h
+++ b/src/common/libutil/ansi_color.h
@@ -1,0 +1,35 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_ANSI_COLOR_H
+#define _UTIL_ANSI_COLOR_H
+
+#define ANSI_COLOR_RED        "\x1b[31m"
+#define ANSI_COLOR_GREEN      "\x1b[32m"
+#define ANSI_COLOR_YELLOW     "\x1b[33m"
+#define ANSI_COLOR_BLUE       "\x1b[34m"
+#define ANSI_COLOR_MAGENTA    "\x1b[35m"
+#define ANSI_COLOR_CYAN       "\x1b[36m"
+#define ANSI_COLOR_GRAY       "\x1b[37m"
+#define ANSI_COLOR_DEFAULT    "\x1b[39m"
+#define ANSI_COLOR_DARK_GRAY  "\x1b[90m"
+
+#define ANSI_COLOR_BOLD_BLUE  "\x1b[01;34m"
+
+#define ANSI_COLOR_RESET      "\x1b[0m"
+#define ANSI_COLOR_BOLD       "\x1b[1m"
+#define ANSI_COLOR_HALFBRIGHT "\x1b[2m"
+#define ANSI_COLOR_REVERSE    "\x1b[7m"
+
+#define ANSI_COLOR_RESET      "\x1b[0m"
+
+#endif /* !_UTIL_ANSI_COLOR_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -253,6 +253,7 @@ TESTSCRIPTS = \
 	t3307-system-leafcrash.t \
 	t3308-system-torpid.t \
 	t3309-system-reconnect.t \
+	t3400-overlay-trace.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \

--- a/t/t3400-overlay-trace.t
+++ b/t/t3400-overlay-trace.t
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+test_description='Test flux overlay trace'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4
+
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+test_expect_success 'flux overlay trace fails with extra positional argument' '
+	test_must_fail flux overlay trace x y
+'
+test_expect_success 'flux overlay trace fails with unknown argument' '
+	test_must_fail flux overlay trace --not-an-arg
+'
+test_expect_success 'flux overlay trace fails with wrong message type' '
+	test_must_fail flux overlay trace -t foo,bar
+'
+test_expect_success 'reload heartbeat with increased heart rate' '
+	flux module reload heartbeat period=0.2s
+'
+test_expect_success NO_CHAIN_LINT 'start background trace' '
+	flux overlay trace >trace.out &
+	echo $! >trace.pid
+'
+test_expect_success NO_CHAIN_LINT 'heartbeat.pulse event was captured' '
+	$waitfile -t 60 -p heartbeat.pulse trace.out
+'
+test_expect_success NO_CHAIN_LINT 'send one kvs.ping to rank 1' '
+	flux ping -r 1 -c 1 kvs
+'
+test_expect_success NO_CHAIN_LINT 'kvs.ping request/response was captured' '
+	$waitfile -t 60 -c 2 -p kvs.ping trace.out
+'
+test_expect_success NO_CHAIN_LINT 'stop background trace' '
+	kill -15 $(cat trace.pid); wait || true
+'
+test_done


### PR DESCRIPTION
Problem: there is no way to observe the message the broker is sending and receving on the overlay network.

Solution: the broker implements a streaming RPC that sends a one line summary of each message sent/received on the overlay network to a tool, `flux overlay trace`.

The format is:
```
[tx|rx] peer-rank message-type topic-string [size]
```
where e=event, >=request, <=response, c=control

I thought I'd post this and ask for feedback on the output format before proceeding (hence WIP).

Here's an example of an instance that running a couple of jobs then shutting down.
```
$ flux overlay trace
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e kvs.namespace-primary-setroot [209]
tx 1 e kvs.namespace-primary-setroot [177]
tx 1 e kvs.namespace-primary-setroot [170]
tx 1 e kvs.namespace-job-736687554560-created [116]
tx 1 e kvs.namespace-primary-setroot [174]
tx 1 e kvs.namespace-job-736687554560-setroot [167]
tx 1 e kvs.namespace-primary-setroot [177]
tx 1 e kvs.namespace-job-736687554560-setroot [167]
tx 1 e kvs.namespace-job-736687554560-setroot [160]
tx 1 e kvs.namespace-job-736687554560-setroot [161]
tx 1 e kvs.namespace-job-736687554560-setroot [168]
tx 1 e kvs.namespace-job-736687554560-setroot [168]
tx 1 e kvs.namespace-job-736687554560-setroot [161]
tx 1 e kvs.namespace-job-736687554560-setroot [168]
tx 1 e kvs.namespace-job-736687554560-setroot [168]
tx 1 e kvs.namespace-primary-setroot [175]
tx 1 e kvs.namespace-job-736687554560-removed [33]
tx 1 e kvs.namespace-primary-setroot [179]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e kvs.namespace-primary-setroot [211]
tx 1 e kvs.namespace-primary-setroot [179]
tx 1 e kvs.namespace-primary-setroot [172]
tx 1 e kvs.namespace-job-1056629063680-created [117]
tx 1 e kvs.namespace-primary-setroot [176]
tx 1 e kvs.namespace-job-1056629063680-setroot [169]
tx 1 > rexec.exec [4.2167969K]
rx 1 < rexec.exec [33]
tx 1 e kvs.namespace-primary-setroot [179]
tx 1 e kvs.namespace-job-1056629063680-setroot [169]
rx 1 > kvs.getroot [24]
tx 1 < kvs.getroot [118]
rx 1 > kvs.getroot [24]
rx 1 > kvs.getroot [24]
tx 1 < kvs.getroot [118]
tx 1 < kvs.getroot [118]
rx 1 > content.load [20]
tx 1 < content.load [305]
rx 1 > content.load [20]
tx 1 < content.load [121]
rx 1 > content.load [20]
tx 1 < content.load [211]
rx 1 > content.load [20]
tx 1 < content.load [121]
rx 1 > content.load [20]
tx 1 < content.load [121]
tx 1 e kvs.namespace-job-1056629063680-setroot [161]
rx 1 > content.load [20]
tx 1 < content.load [721]
tx 1 e kvs.namespace-job-1056629063680-setroot [162]
rx 1 > content.load [20]
rx 1 > content.load [20]
tx 1 < content.load [6.3105469K]
rx 1 > content.load [20]
tx 1 < content.load [176]
rx 1 > content.load [20]
tx 1 < content.load [109]
rx 1 > content.load [20]
tx 1 < content.load [51]
rx 1 > content.load [20]
tx 1 < content.load [49]
rx 1 > content.load [20]
tx 1 < content.load [77]
rx 1 > content.load [20]
tx 1 < content.load [132]
tx 1 < content.load [48]
rx 1 < rexec.exec [85]
tx 1 > rexec.write [68]
tx 1 e kvs.namespace-job-1056629063680-setroot [169]
rx 1 < rexec.exec [85]
tx 1 > rexec.write [68]
rx 1 > kvs.getroot [34]
tx 1 < kvs.getroot [127]
rx 1 > 5588-shell-fUkqh9EF.write [83]
tx 1 e kvs.namespace-job-1056629063680-setroot [169]
rx 1 > 5588-shell-fUkqh9EF.write [95]
rx 1 > 5588-shell-fUkqh9EF.write [83]
rx 1 > content.load [20]
rx 1 > 5588-shell-fUkqh9EF.doom [96]
tx 1 < content.load [304]
rx 1 > 5588-shell-fUkqh9EF.write [43]
rx 1 > content.load [20]
tx 1 < content.load [135]
tx 1 < 5588-shell-fUkqh9EF.write [0]
tx 1 < 5588-shell-fUkqh9EF.write [0]
tx 1 < 5588-shell-fUkqh9EF.write [0]
tx 1 e kvs.namespace-job-1056629063680-setroot [169]
tx 1 e kvs.namespace-job-1056629063680-setroot [162]
tx 1 < 5588-shell-fUkqh9EF.write [0]
rx 1 > 5588-shell-fUkqh9EF.disconnect [0]
rx 1 < rexec.exec [79]
rx 1 < rexec.exec [79]
rx 1 < rexec.exec [31]
rx 1 < rexec.exec [0]
tx 1 e kvs.namespace-job-1056629063680-setroot [169]
tx 1 e kvs.namespace-primary-setroot [176]
tx 1 e kvs.namespace-job-1056629063680-removed [34]
tx 1 e kvs.namespace-primary-setroot [179]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 e heartbeat.pulse [0]
tx 1 < state-machine.monitor [12]
tx 1 < state-machine.monitor [12]
tx 1 < state-machine.monitor [0]
rx 1 > log.append [86]
rx 1 > log.append [97]
rx 1 > log.append [99]
rx 1 > log.append [69]
rx 1 > resource.disconnect [0]
rx 1 > log.append [77]
rx 1 > log.append [69]
rx 1 > job-info.disconnect [0]
rx 1 > log.append [77]
rx 1 > log.append [71]
rx 1 > job-ingest.disconnect [0]
rx 1 > log.append [79]
rx 1 > log.append [68]
rx 1 > log.append [76]
rx 1 > log.append [70]
rx 1 > log.append [78]
rx 1 > log.append [64]
rx 1 > kvs.disconnect [0]
rx 1 > log.append [72]
rx 1 > log.append [68]
rx 1 > content.disconnect [0]
rx 1 > log.append [76]
rx 1 > overlay.goodbye [0]
tx 1 < overlay.goodbye [0]
```

Hmm, timestamps.