### PR TITLE
content: allow content.flush to return errors

### DIFF
--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -17,6 +17,12 @@ MAXBLOB=1048576
 test_expect_success 'load content module' '
 	flux exec flux module load content blob-size-limit=$MAXBLOB
 '
+
+test_expect_success 'content flush fails with ENOSYS with no backing store' '
+	test_must_fail flux content flush 2> flush.err &&
+	grep "Function not implemented" flush.err
+'
+
 HASHFUN=`flux getattr content.hash`
 
 register_backing() {

--- a/t/t0090-content-enospc.t
+++ b/t/t0090-content-enospc.t
@@ -27,12 +27,11 @@ test_expect_success 'clear & setup test statedir' '
 	mkdir /test/tmpfs-1m/statedir
 '
 
-# rc3 currently hangs under ENOSPC, so disable it. flux start will fail for time being
+# flux start will fail b/c rc3 will fail due to ENOSPC
 test_expect_success 'flux still operates with content-sqlite running out of space' '
 	test_must_fail flux start \
 	    -o,-Scontent.backing-module=content-sqlite \
 	    -o,-Sstatedir=/test/tmpfs-1m/statedir \
-	    -o,-Sbroker.rc3_path= \
 	    "./fillstatedir.sh; flux dmesg; flux run echo helloworld" > sql.out 2> sql.err &&
         grep -q "No space left on device" sql.out &&
         grep "helloworld" sql.out
@@ -43,12 +42,11 @@ test_expect_success 'clear & setup test statedir' '
 	mkdir /test/tmpfs-1m/statedir
 '
 
-# rc3 currently hangs under ENOSPC, so disable it. flux start will fail for time being
+# flux start will fail b/c rc3 will fail due to ENOSPC
 test_expect_success 'flux still operates with content-files running out of space' '
 	test_must_fail flux start \
 	    -o,-Scontent.backing-module=content-files \
 	    -o,-Sstatedir=/test/tmpfs-1m/statedir \
-	    -o,-Sbroker.rc3_path= \
 	    "./fillstatedir.sh; flux dmesg; flux run echo helloworld" > files.out 2> files.err &&
         grep -q "No space left on device" files.out &&
         grep "helloworld" files.out

--- a/t/t0090-content-enospc.t
+++ b/t/t0090-content-enospc.t
@@ -54,4 +54,19 @@ test_expect_success 'flux still operates with content-files running out of space
         grep "helloworld" files.out
 '
 
+test_expect_success 'clear & setup test statedir' '
+	rm -rf /test/tmpfs-1m/* &&
+	mkdir /test/tmpfs-1m/statedir
+'
+
+# flux start will fail b/c rc3 will fail due to ENOSPC
+test_expect_success 'content flush returns error on ENOSPC' '
+	test_must_fail flux start \
+	    -o,-Scontent.backing-module=content-sqlite \
+	    -o,-Sstatedir=/test/tmpfs-1m/statedir \
+	    "./fillstatedir.sh; flux dmesg; flux content flush" > flush.out 2> flush.err &&
+        grep -q "No space left on device" flush.out &&
+        grep "content.flush: No space left on device" flush.err
+'
+
 test_done


### PR DESCRIPTION
This is an experimental PR, mostly to solve #6155 and #6100 (maybe I should split this PR into two later on), but also to experiment/brainstorm in general for future ENOSPC stuffs.

When ENOSPC is hit, rc3 hangs.  After #6170 was merged, the culprit is `flux content flush` which will never return.

I added a flag to the `content.flush` target that allows it to return ENOSPC if ENOSPC is hit when trying to write to the backing store.  I then support a `--nowait` option to `flux content flush` and use that option in rc3 to eliminate the hang.

A few thoughts on this approach:

A) There may be some initial belief that we should just always return ENOSPC, but per #6010 we may not want to do that.  The option gives us flexibility for the future, perhaps a "give up after X seconds" approach may be more reasonable down the road.  

B) Internally `FLUX_KVS_SYNC` calls `content.flush`, so that can also hang.  So I initially began to support a FLUX_KVS_SYNC_NOWAIT.  That support isn't listed pushed here b/c I happened to fix #6168, so it was no longer needed for this specific case.  But it is probably still needed in general.  Anything that can FLUX_KVS_SYNC can lead to all future KVS writes hanging (#5978) (flux kvs checkpointing for example).  This can also be a consideration to make returning ENOSPC errors the default for `content.flush`, although I'm still leaning towards having a flag.

C) The `content` module actually stops tracking dirty cache entries if any content store request fails.  That is an issue in and of itself.  Without such tracking, I did not know if ENOSPC had been hit earlier and couldn't return an appropriate error if cache stores were in flight.  So I store those ENOSPC failures on a separate list.  That list could be used later on, perhaps re-trying them after some time period or in future calls to `content.flush`.  But for now, I do nothing after putting those items on the list.

I should have written down my thoughts as I was doing this.  Will comment if I remember anything else.

Oh yeah, this is built on top of #6127