### PR TITLE
flux-resource: fix missing queue in `flux resource list` output for states with no nodes

### DIFF
--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -492,8 +492,9 @@ def drain_list(args):
 
 
 class ResourceSetExtra(ResourceSet):
-    def __init__(self, arg=None, version=1, flux_config=None):
+    def __init__(self, arg=None, version=1, flux_config=None, queue=None):
         self.flux_config = flux_config
+        self._queue = queue
         if isinstance(arg, ResourceSet):
             self._rset = arg
             if arg.state:
@@ -517,6 +518,13 @@ class ResourceSetExtra(ResourceSet):
 
     @property
     def queue(self):
+        #  Note: queue may be set manually in self._queue for an empty
+        #  ResourceSet, which cannot otherwise have an associated queue.
+        if self._queue is not None:
+            return self._queue
+
+        #  If self._queue is not set, then build list of queues from
+        #  set properties and queue configuration:
         queues = ""
         if self.flux_config and "queues" in self.flux_config:
             if not self.ranks:

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -27,7 +27,7 @@ from flux.resource import (
     resource_status,
 )
 from flux.rpc import RPC
-from flux.util import Deduplicator, UtilConfig
+from flux.util import Deduplicator, FilterActionSetUpdate, UtilConfig
 
 
 class FluxResourceConfig(UtilConfig):
@@ -198,7 +198,7 @@ def ranks_by_queue(resource_set, config, queues):
     """
     queue_resources = QueueResources(resource_set, config)
     ranks = IDset()
-    for queue in queues.split(","):
+    for queue in queues:
         ranks.add(queue_resources.queue(queue).ranks)
     return ranks
 
@@ -759,6 +759,8 @@ def main():
     drain_parser.add_argument(
         "-q",
         "--queue",
+        action=FilterActionSetUpdate,
+        default=set(),
         metavar="QUEUE,...",
         help="Include only specified queues in output",
     )
@@ -824,6 +826,8 @@ def main():
     status_parser.add_argument(
         "-q",
         "--queue",
+        action=FilterActionSetUpdate,
+        default=set(),
         metavar="QUEUE,...",
         help="Include only specified queues in output",
     )
@@ -879,6 +883,8 @@ def main():
     list_parser.add_argument(
         "-q",
         "--queue",
+        action=FilterActionSetUpdate,
+        default=set(),
         metavar="QUEUE,...",
         help="Include only specified queues in output",
     )
@@ -911,6 +917,8 @@ def main():
     info_parser.add_argument(
         "-q",
         "--queue",
+        action=FilterActionSetUpdate,
+        default=set(),
         metavar="QUEUE,...",
         help="Include only specified queues in output",
     )
@@ -959,6 +967,8 @@ def main():
     R_parser.add_argument(
         "-q",
         "--queue",
+        action=FilterActionSetUpdate,
+        default=set(),
         metavar="QUEUE,...",
         help="Include only specified queues in output",
     )

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -541,6 +541,32 @@ test_expect_success 'flux resource list --queue works for a queue with no constr
 	test $(grep "allocated 1" queue-every.out | grep -c debug) -eq 1 &&
 	test $(grep "allocated 1" queue-every.out | grep -c every) -eq 2
 '
+test_expect_success 'flux resource list includes queue names for empty sets' '
+	# There are no nodes in 'down' state in this test, so use that:
+	flux resource list -s down -no "{queue} {state} {nnodes}" \
+		>queue-empty1.out &&
+	cat <<-EOF >queue-empty1.expected &&
+	every down 0
+	batch down 0
+	debug down 0
+	EOF
+	test_cmp queue-empty1.expected queue-empty1.out
+'
+test_expect_success 'flux resource list includes queue names for empty sets (single)' '
+	flux resource list -q batch -s down -no "{queue} {state} {nnodes}" \
+		>queue-batch-down.out &&
+	cat <<-EOF >queue-batch-down.expected &&
+	batch down 0
+	EOF
+	test_cmp queue-batch-down.expected queue-batch-down.out
+'
+test_expect_success 'flux resource list includes queue names for empty sets (multiple)' '
+	flux resource list -q batch,debug \
+		-s down -no "{queue} {state} {nnodes}" \
+		>queue-batch,debug-down.out &&
+	grep "debug down 0" queue-batch,debug-down.out &&
+	grep "batch down 0" queue-batch,debug-down.out
+'
 test_expect_success 'cleanup jobs' '
 	flux cancel $(cat job2A.id) $(cat job2B.id)
 '

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -517,9 +517,7 @@ test_expect_success 'flux resource lists expected queues (every)' '
 	flux resource list -o "{state} {nnodes} {queue}" > listqueue_every.out &&
 	test $(grep "free 2" listqueue_every.out | grep -c batch) -eq 1 &&
 	test $(grep "free 2" listqueue_every.out | grep -c debug) -eq 1 &&
-	test $(grep "free 2" listqueue_every.out | grep -c every) -eq 2 &&
-	test $(grep "allocated 0" listqueue_every.out | grep -c every) -eq 0 &&
-	test $(grep "down 0" listqueue_every.out | grep -c every) -eq 0
+	test $(grep "free 2" listqueue_every.out | grep -c every) -eq 2
 '
 test_expect_success 'run a few jobs (every)' '
 	flux submit -q batch sleep 30 > job2A.id &&
@@ -532,8 +530,7 @@ test_expect_success 'flux resource lists expected queues in states (every)' '
 	test $(grep "free 1" listqueue_every2.out | grep -c every) -eq 2 &&
 	test $(grep "allocated 1" listqueue_every2.out | grep -c batch) -eq 1 &&
 	test $(grep "allocated 1" listqueue_every2.out | grep -c debug) -eq 1 &&
-	test $(grep "allocated 1" listqueue_every2.out | grep -c every) -eq 2 &&
-	test $(grep "down 0" listqueue_every2.out | grep -c every) -eq 0
+	test $(grep "allocated 1" listqueue_every2.out | grep -c every) -eq 2
 '
 test_expect_success 'flux resource list --queue works for a queue with no constraints' '
 	flux resource list --queue=every -o "{state} {nnodes} {queue}" >queue-every.out &&
@@ -542,8 +539,7 @@ test_expect_success 'flux resource list --queue works for a queue with no constr
 	test $(grep "free 1" queue-every.out | grep -c every) -eq 2 &&
 	test $(grep "allocated 1" queue-every.out | grep -c batch) -eq 1 &&
 	test $(grep "allocated 1" queue-every.out | grep -c debug) -eq 1 &&
-	test $(grep "allocated 1" queue-every.out | grep -c every) -eq 2 &&
-	test $(grep "down 0" queue-every.out | grep -c every) -eq 0
+	test $(grep "allocated 1" queue-every.out | grep -c every) -eq 2
 '
 test_expect_success 'cleanup jobs' '
 	flux cancel $(cat job2A.id) $(cat job2B.id)


### PR DESCRIPTION
This PR fixes #6166 by appending an empty resource set for each configured or requested queue, instead of a pure empty resource set, which can have no queue. Thus, when node nodes are in a given state, `{queue}` will not be blank, instead there will be a line in output for each queue.