### PR TITLE
actions: increase ci timeout from 90 to 120 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
       DOCKER_USERNAME: travisflux
       DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TRAVISFLUX_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 90
+    timeout-minutes: 120
     strategy:
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
       fail-fast: false


### PR DESCRIPTION
problem: some of the arm builders, especially the gcc-14 ones, run right up to the timeout of 90 minutes when succeeding, giving spurious failures to update all the container manifests

solution: increase the timeout to 120 minutes