### PR TITLE
CI: ignore merge errors and increase parallelism

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,6 +36,10 @@ CODE_COVERAGE_IGNORE_PATTERN = \
 	"*/common/libccan/*" \
 	"*/common/libmissing/*"
 
+# ignore lcov errors to avoid merge mismatch issue since lcov < 2 doesn't offer
+# an option to just ignore this error, we use this env var to ignore all, see:
+# https://github.com/flux-framework/flux-core/issues/6078
+export GCOV_ERROR_FILE=/dev/null
 CODE_COVERAGE_LCOV_OPTIONS =
 @CODE_COVERAGE_RULES@
 

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -241,12 +241,10 @@ if test "$RECHECK" = "t" -a $RC -ne 0; then
   #   under ./t were run (and presumably failed)
   #
   if test -s t/t0000-sharness.trs; then
-    cd t
     printf "::warning::make check failed, trying recheck in ./t\n"
-    checks_group "make recheck" ${MAKE} -j ${JOBS} recheck && \
+		(cd t ; checks_group "make recheck" ${MAKE} -j ${JOBS} recheck) && \
 			checks_group "${POSTCHECKCMDS}" "${POSTCHECKCMDS}"
     RC=$?
-    cd
    else
       printf "::warning::recheck requested but no tests in ./t were run\n"
    fi

--- a/src/test/docker/alpine/Dockerfile
+++ b/src/test/docker/alpine/Dockerfile
@@ -60,3 +60,7 @@ ENV LANG=C.UTF-8
 COPY scripts/fetch-and-build-catch.sh /fetch-and-build-catch.sh
 RUN /fetch-and-build-catch.sh
 
+# Install caliper by hand for now:
+COPY scripts/fetch-and-build-caliper.sh /fetch-and-build-caliper.sh
+RUN /fetch-and-build-caliper.sh
+

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -83,7 +83,7 @@ class BuildMatrix:
         name=None,
         image="fedora40",
         args=default_args,
-        jobs=4,
+        jobs=6,
         env=None,
         docker_tag=False,
         test_s3=False,
@@ -293,7 +293,6 @@ matrix.add_build(
     image="bookworm",
     coverage_flags="ci-basic",
     coverage=True,
-    jobs=4,
     args="--with-flux-security --enable-caliper",
 )
 
@@ -311,7 +310,6 @@ matrix.add_build(
     coverage_flags="ci-system",
     image="el8",
     coverage=True,
-    jobs=4,
     command_args="--system",
     args="--with-flux-security --enable-caliper",
 )


### PR DESCRIPTION
problem: we seem to get spurious branch merge mismatch errors in CI, and
ensuring atomicity has not helped

solution: ignore that specific class of errors with `--ignore-errors
mismatch`