### PR TITLE
enhance `flux queue list` with `-q, --queue=` option and abillity to report queue enabled/started status

### DIFF
--- a/doc/man1/flux-queue.rst
+++ b/doc/man1/flux-queue.rst
@@ -42,7 +42,11 @@ list
 
 .. program:: flux queue list
 
-List queue defaults and limits.
+List queue status, defaults, and limits.
+
+.. option:: -q, --queue=QUEUE,...
+
+   Limit output to specified queues
 
 .. option:: -n, --no-header
 
@@ -218,6 +222,24 @@ The following field names can be specified:
 
 **queuem**
    queue name, but default queue is marked up with an asterisk
+
+**submission**
+   Description of queue submission status: ``enabled`` or ``disabled``
+
+**scheduling**
+   Description of queue scheduling status: ``started`` or ``stopped``
+
+**enabled**
+   Single character submission status: ``✔`` if enabled, ``✗`` if disabled.
+
+**started**
+   Single character scheduling status: ``✔`` if started, ``✗`` if stopped.
+
+**enabled.ascii**
+   Single character submission status: ``y`` if enabled, ``n`` if disabled.
+
+**started.ascii**
+   Single character scheduling status: ``y`` if started, ``n`` if stopped.
 
 **defaults.timelimit**
    default timelimit for jobs submitted to the queue

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -880,6 +880,7 @@ _flux_queue()
         -t --timeout= \
     "
     local list_OPTS="\
+        -q --queue= \
         -o --format= \
         -n --no-header \
     "

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -535,6 +535,24 @@ class UtilFormatter(Formatter):
         return retval
 
 
+class AltField:
+    """
+    Convenient wrapper for fields that have an ascii and non-ascii
+    representation. Allows the ascii representation to be selected with
+    {field.ascii}.
+    """
+
+    def __init__(self, default, ascii):
+        self.default = default
+        self.ascii = ascii
+
+    def __str__(self):
+        return self.default
+
+    def __format__(self, fmt):
+        return str(self).__format__(fmt)
+
+
 class OutputFormat:
     """
     Store a parsed version of the program's output format,

--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -110,8 +110,12 @@ class FluxQueueConfig(UtilConfig):
         "default": {
             "description": "Default flux-queue list format string",
             "format": (
-                "?:{queuem:<8.8} {defaults.timelimit!F:>11} {limits.timelimit!F:>10} {limits.range.nnodes:>10} "
-                "{limits.range.ncores:>10} {limits.range.ngpus:>10}"
+                "?:{queuem:<8.8} "
+                "{defaults.timelimit!F:>8} "
+                "{limits.timelimit!F:>8} "
+                "{limits.range.nnodes:>10} "
+                "{limits.range.ncores:>10} "
+                "{limits.range.ngpus:>10}"
             ),
         },
     }
@@ -264,8 +268,8 @@ def list(args):
     headings = {
         "queue": "QUEUE",
         "queuem": "QUEUE",
-        "defaults.timelimit": "DEFAULTTIME",
-        "limits.timelimit": "TIMELIMIT",
+        "defaults.timelimit": "TDEFAULT",
+        "limits.timelimit": "TLIMIT",
         "limits.range.nnodes": "NNODES",
         "limits.range.ncores": "NCORES",
         "limits.range.ngpus": "NGPUS",

--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -429,6 +429,10 @@ LOGGER = logging.getLogger("flux-queue")
 
 @flux.util.CLIMain(LOGGER)
 def main():
+    sys.stdout = open(
+        sys.stdout.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+
     parser = argparse.ArgumentParser(prog="flux-queue")
     subparsers = parser.add_subparsers(
         title="subcommands", description="", dest="subcommand"

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -27,7 +27,7 @@ from flux.resource import (
     resource_status,
 )
 from flux.rpc import RPC
-from flux.util import Deduplicator, FilterActionSetUpdate, UtilConfig
+from flux.util import AltField, Deduplicator, FilterActionSetUpdate, UtilConfig
 
 
 class FluxResourceConfig(UtilConfig):
@@ -201,24 +201,6 @@ def ranks_by_queue(resource_set, config, queues):
     for queue in queues:
         ranks.add(queue_resources.queue(queue).ranks)
     return ranks
-
-
-class AltField:
-    """
-    Convenient wrapper for fields that have an ascii and non-ascii
-    representation. Allows the ascii representation to be selected with
-    {field.ascii}.
-    """
-
-    def __init__(self, default, ascii):
-        self.default = default
-        self.ascii = ascii
-
-    def __str__(self):
-        return self.default
-
-    def __format__(self, fmt):
-        return str(self).__format__(fmt)
 
 
 class ResourceStatusLine:

--- a/t/t2241-queue-cmd-list.t
+++ b/t/t2241-queue-cmd-list.t
@@ -9,8 +9,8 @@ test_under_flux 1 full
 
 test_expect_success 'flux-queue: default lists expected fields' '
 	flux queue list > default.out &&
-	grep DEFAULTTIME default.out &&
-	grep TIMELIMIT default.out &&
+	grep TDEFAULT default.out &&
+	grep TLIMIT default.out &&
 	grep NNODES default.out &&
 	grep NCORES default.out &&
 	grep NGPUS default.out
@@ -25,8 +25,8 @@ test_expect_success 'flux-queue: FLUX_QUEUE_LIST_FORMAT_DEFAULT works' '
 
 test_expect_success 'flux-queue: --no-header works' '
 	flux queue list --no-header > default_no_header.out &&
-	test_must_fail grep DEFAULTTIME default_no_header.out &&
-	test_must_fail grep TIMELIMIT default_no_header.out &&
+	test_must_fail grep TDEFAULT default_no_header.out &&
+	test_must_fail grep TLIMIT default_no_header.out &&
 	test_must_fail grep NNODES default_no_header.out &&
 	test_must_fail grep NCORES default_no_header.out &&
 	test_must_fail grep NGPUS default_no_header.out
@@ -41,8 +41,8 @@ ALL_LIMITS_FMT="\
 
 test_expect_success 'flux-queue: expected headers with non-default fields output' '
 	flux queue list -o "${ALL_LIMITS_FMT}" > non_default.out &&
-	grep DEFAULTTIME non_default.out &&
-	grep TIMELIMIT non_default.out &&
+	grep TDEFAULT non_default.out &&
+	grep TLIMIT non_default.out &&
 	grep NNODES non_default.out &&
 	grep NCORES non_default.out &&
 	grep NGPUS non_default.out &&


### PR DESCRIPTION
As noted in #6145, it is confusing to users why there are separate `flux-queue(1)` `status` and `list` subcommands.

This PR enhances `flux queue list` to fetch queue status in addition to configuration, and uses this data to support the following new output fields:

 * `{submission}` - text representation of submission status: `enabled` or `disabled`
 * `{scheduling}` - text representation of scheduling status: `started` or `stopped`
 * `{enabled}` - single character boolean for enabled/disabled status (`✔/y` or `✗/n`)
 * `{started}` - single character boolean for started/stopped status  (`✔/y` or `✗/n`)
 
 The default output format is now:
```
                "?:{queuem:<8.8} "
                "{color_enabled}{enabled:>2}{color_off} "
                "{color_started}{started:>2}{color_off} "
                "{defaults.timelimit!F:>8} "
                "{limits.timelimit!F:>8} "
                "{limits.range.nnodes:>10} "
                "{limits.range.ncores:>10} "
                "{limits.range.ngpus:>10}"
```

So that the enabled/started status is easily visible by default with `flux queue list`, e.g.:

```
QUEUE    EN ST TDEFAULT   TLIMIT     NNODES     NCORES      NGPUS
pbatch*   ✔  ✔      30m       1d      0-inf      0-inf      0-inf
pdebug    ✔  ✔      30m       1h      0-inf      0-inf      0-inf
pnvmeof   ✔  ✔      30m       1d      0-inf      0-inf      0-inf
```

Additionally, a `-q, --queue=` option is added to `flux queue list`. Now the submission status (for example) of a queue can be obtained via something like:

```console
$ flux queue list --queue=pbatch -no {submission}
enabled
```
field names were chosen somewhat arbitrarily, so up for discussion.