### PR TITLE
resource: error message cleanup, add test for invalid exclude

### DIFF
--- a/src/modules/resource/exclude.c
+++ b/src/modules/resource/exclude.c
@@ -64,10 +64,11 @@ struct exclude *exclude_create (struct resource_ctx *ctx,
         if (!(exclude->idset = inventory_targets_to_ranks (ctx->inventory,
                                                            exclude_idset,
                                                            &error))) {
-            flux_log_error (ctx->h,
-                            "error decoding exclude set %s: %s",
-                            exclude_idset,
-                            error.text);
+            flux_log (ctx->h,
+                      LOG_ERR,
+                      "error decoding exclude set %s: %s",
+                      exclude_idset,
+                      error.text);
             goto error;
         }
         if (idset_count (exclude->idset) > 0

--- a/t/t2312-resource-exclude.t
+++ b/t/t2312-resource-exclude.t
@@ -97,5 +97,19 @@ test_expect_success 'instance with configured R can exclude hostnames' '
 	test $(flux start -s1 -o,--config-path=exclude3.toml \
 	    flux resource status -s exclude -no {nnodes}) -eq 1
 '
+test_expect_success 'incorrect excluded hostnames raises correct error' '
+	cat >exclude4.toml <<-EOT &&
+	[resource]
+	exclude = "badhost"
+	noverify = true
+	[[resource.config]]
+	hosts = "$(hostname -s)"
+	cores = "0"
+	EOT
+	test_must_fail flux start -o,--config-path=exclude4.toml true \
+		2>exclude4.err &&
+	test_debug "cat exclude4.err" &&
+	grep "invalid hosts: badhost" exclude4.err
+'
 
 test_done

--- a/t/t2315-resource-system.t
+++ b/t/t2315-resource-system.t
@@ -107,7 +107,7 @@ test_expect_success 'invalid exclude hosts cause instance failure' '
 	test_must_fail flux start -s 2 \
 		-o,--config-path=$(pwd)/${name},-Slog-filename=${name}/logfile \
 		flux resource list -s up -no {nnodes} > ${name}/nnodes &&
-    grep "nosuchhost: Invalid argument" ${name}/logfile
+    grep "invalid hosts: nosuchhost" ${name}/logfile
 '
 
 test_expect_success 'gpu resources in configured R are not verified' '


### PR DESCRIPTION
While looking at #6136 I noticed that `flux_log_error()` was used unnecessarily for the exclude idset error message.
This PR fixes that.

Also, thought I'd add a test for the specific issue of excluding a hostname that isn't in configuration.