### PR TITLE
docker: Demote fedora40 to x86_64 only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -254,7 +254,7 @@ jobs:
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker manifest create fluxrm/flux-core:bookworm fluxrm/flux-core:bookworm-amd64 fluxrm/flux-core:bookworm-386 fluxrm/flux-core:bookworm-arm64
         docker manifest push fluxrm/flux-core:bookworm
-        for d in el9 noble fedora40 alpine ; do
+        for d in el9 noble alpine ; do
           docker manifest create fluxrm/flux-core:$d fluxrm/flux-core:$d-amd64 fluxrm/flux-core:$d-arm64
           docker manifest push fluxrm/flux-core:$d
         done

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -218,14 +218,6 @@ matrix.add_multiarch_build(
     ),
 )
 matrix.add_multiarch_build(
-    name="fedora40",
-    default_suffix=" - test-install",
-    args=common_args,
-    env=dict(
-        TEST_INSTALL="t",
-    ),
-)
-matrix.add_multiarch_build(
     name="alpine",
     default_suffix=" - test-install",
     args=(
@@ -241,6 +233,14 @@ matrix.add_multiarch_build(
 )
 
 # single arch builds that still produce a container
+matrix.add_build(
+    name="fedora40 - test-install",
+    args=common_args,
+    env=dict(
+        TEST_INSTALL="t",
+    ),
+    docker_tag=True,
+)
 # Ubuntu: TEST_INSTALL
 matrix.add_build(
     name="jammy - test-install",


### PR DESCRIPTION
After all the reworks, I just flat can't get flux to build on fedora40 under arm64 emulation in a reasonable amount of time.  No clue why, noble should have the same issue (or worse) and it's done in only a bit over half the time.  So for now I'm throwing in the towel. Will revisit when GHA supports arm runners for OSS.