### PR TITLE
add configure time check for zeromq crypto and improve broker error handling at cert creation

### DIFF
--- a/config/x_ac_zeromq.m4
+++ b/config/x_ac_zeromq.m4
@@ -1,0 +1,8 @@
+# N.B oldest in CI are focal=libzmq-4.3.2-2, centos7=zeromq-4.1.4
+
+AC_DEFUN([X_AC_ZEROMQ], [
+
+    PKG_CHECK_MODULES([ZMQ], [libzmq >= 4.0.4])
+
+  ]
+)

--- a/config/x_ac_zeromq.m4
+++ b/config/x_ac_zeromq.m4
@@ -4,5 +4,32 @@ AC_DEFUN([X_AC_ZEROMQ], [
 
     PKG_CHECK_MODULES([ZMQ], [libzmq >= 4.0.4])
 
+    old_CFLAGS=$CFLAGS
+    CFLAGS="$CFLAGS $ZMQ_CFLAGS"
+
+    old_LIBS=$LIBS
+    LIBS="$LIBS $ZMQ_LIBS"
+
+    AC_MSG_CHECKING([whether zeromq has CURVE support])
+    AC_RUN_IFELSE([
+        AC_LANG_SOURCE([[
+            #include <zmq.h>
+	    int main () {
+	        char pub[41];
+	        char sec[41];
+	        if (zmq_curve_keypair (pub, sec) < 0) return 1;
+	        return 0;
+	    }
+	]])],
+	[have_zmq_curve_support=yes; AC_MSG_RESULT([yes])],
+	[AC_MSG_RESULT([no])]
+    )
+
+    CFLAGS=$old_CFLAGS
+    LIBS=$old_LIBS
+
+    AS_IF([test "x$have_zmq_curve_support" != "xyes"],
+        [AC_MSG_ERROR([zeromq CURVE/libsodium support is required])]
+    )
   ]
 )

--- a/configure.ac
+++ b/configure.ac
@@ -333,8 +333,7 @@ AM_CONDITIONAL([ENABLE_PYLINT], [test "x$PYLINT" = "xpylint"])
 AX_PROG_LUA([5.1],[5.5])
 AX_LUA_HEADERS
 AX_LUA_LIBS
-# N.B oldest in CI are focal=libzmq-4.3.2-2, centos7=zeromq-4.1.4
-PKG_CHECK_MODULES([ZMQ], [libzmq >= 4.0.4])
+X_AC_ZEROMQ
 X_AC_JANSSON
 PKG_CHECK_MODULES([LIBSYSTEMD], [libsystemd >= 0.23],
                                 [have_libsystemd=yes], [have_libsystemd=no])

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -2493,8 +2493,10 @@ struct overlay *overlay_create (flux_t *h,
         goto error;
     if (flux_msg_handler_addvec (h, htab, ov, &ov->handlers) < 0)
         goto error;
-    if (!(ov->cert = cert_create ()))
-        goto nomem;
+    if (!(ov->cert = cert_create ())) {
+        log_err ("could not create curve certificate");
+        goto error;
+    }
     if (!(ov->health_requests = flux_msglist_create ())
         || !(ov->trace_requests = flux_msglist_create ()))
         goto error;


### PR DESCRIPTION
Problem:  as noted in #6151, the error handling of `cert_create()` is wrong, and we lack a configure time test that zeromq was built with curve support.

This addresses both of those issues.

Leaving this a WIP for now since this purports to "fix" #6151 but we have not confirmed that this is the whole problem there.