### PR TITLE
matrix: avoid overwriting env elements

### DIFF
--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -96,7 +96,9 @@ class BuildMatrix:
         """Add a build to the matrix.include array"""
 
         # Extra environment to add to this command:
-        env = env or {}
+        # NOTE: ensure we copy the dict rather than modify, re-used dicts can cause
+        #       overwriting
+        env = dict(env) if env is not None else {}
 
         # hwloc tries to look for opengl devices  by connecting to a port that might
         # sometimes be an x11 port, but more often for us is munge, turn it off


### PR DESCRIPTION
The good news: Everything we request be built now builds.
The bad news: Nothing gets tagged because I accidentally triggered a re-use bug in generate-matrix.


problem: re-using the env argument revealed we were not copying the dict but modifying the argument in place, causing multiarch builds to only tag amd64, and matrix generation to fail

solution: copy the env dict in add_build