### PR TITLE
matrix/actions: add per-target timeout-minutes 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,6 @@ jobs:
       DOCKER_USERNAME: travisflux
       DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TRAVISFLUX_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 120
     strategy:
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
       fail-fast: false
@@ -199,6 +198,7 @@ jobs:
         docker run --rm --privileged aptman/qus -s -- -p --credential aarch64
 
     - name: docker-run-checks
+      timeout-minutes: ${{matrix.timeout_minutes}}
       env: ${{matrix.env}}
       run: ${{matrix.command}}
 
@@ -254,7 +254,7 @@ jobs:
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker manifest create fluxrm/flux-core:bookworm fluxrm/flux-core:bookworm-amd64 fluxrm/flux-core:bookworm-386 fluxrm/flux-core:bookworm-arm64
         docker manifest push fluxrm/flux-core:bookworm
-        for d in el9 noble alpine ; do
+        for d in el9 noble alpine fedora40 ; do
           docker manifest create fluxrm/flux-core:$d fluxrm/flux-core:$d-amd64 fluxrm/flux-core:$d-arm64
           docker manifest push fluxrm/flux-core:$d
         done


### PR DESCRIPTION
problem: we have widely varying timouts based on the target and the
usage, and only one timeout value

solution: add timeout-minutes to the matrix and expand it on the
docker-run-checks step.  The downside is that this will not time out if
another step stalls, but which other step would stall?


For now I'm setting the default timeout_minutes to 60, arm64 to 90, and adding back fedora40 at four hours.