### PR TITLE
reject jobs submitted as user root in a multi-user instance

### DIFF
--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -82,6 +82,12 @@ static const double batch_timeout = 0.01;
  */
 static int max_fluid_generator_id = 16384 - 16 - 1;
 
+/* By default, root (userid=0) jobs are rejected at submission
+ * unless the instance owner is also root. However, for testing
+ * purposes it may be useful to allow root jobs:
+ */
+static bool allow_root_jobs = false;
+
 struct job_ingest_ctx {
     flux_t *h;
     struct pipeline *pipeline;
@@ -579,7 +585,7 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
     /* Do not allow root user to submit jobs in a multi-user instance.
      * The jobs will fail at runtime anyway.
      */
-    if (ctx->owner != 0 && job->cred.userid == 0) {
+    if (ctx->owner != 0 && !allow_root_jobs && job->cred.userid == 0) {
         errmsg = "submission of jobs as user root not supported";
         goto error;
     }
@@ -702,6 +708,9 @@ static int job_ingest_configure (struct job_ingest_ctx *ctx,
         }
         else if (strstarts (argv[i], "max-fluid-generator-id=")) {
             max_fluid_id = argv[i] + 23;
+        }
+        else if (streq (argv[i], "allow-root-jobs")) {
+            allow_root_jobs = true;
         }
         else {
             errprintf (error, "Invalid option: %s", argv[i]);

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -95,6 +95,17 @@ test_expect_success HAVE_FLUX_SECURITY 'flux-job: submit ignores security-config
 		signed.json >submit-signed.out 2>&1 &&
 	grep "Ignoring security config" submit-signed.out
 '
+test_expect_success HAVE_FLUX_SECURITY 'flux-job: submit as root fails' '
+	flux run --dry-run -n1 hostname | \
+	    flux python \
+	    ${SHARNESS_TEST_SRCDIR}/scripts/sign-as.py 0 >signed0.json &&
+	    ( export FLUX_HANDLE_USERID=0 &&
+	      test_must_fail \
+	          flux job submit --flags=signed signed0.json 2>signed0.err \
+	    ) &&
+	test_debug "cat signed0.err" &&
+        grep "submission of jobs as user root not supported" signed0.err
+'
 test_expect_success 'flux-job: can submit jobspec on stdin with -' '
 	flux job submit - <basic.json
 '

--- a/t/t2812-flux-job-last.t
+++ b/t/t2812-flux-job-last.t
@@ -66,6 +66,9 @@ submit_as_root()
 
 # issue #5475
 # Execution may fail but submission should work - enough for this test
+test_expect_success FLUX_SECURITY 'reload job-ingest with allow-root-jobs' '
+	flux module reload job-ingest allow-root-jobs
+'
 test_expect_success FLUX_SECURITY 'run a job as fake root' '
 	submit_as_root true &&
 	FLUX_HANDLE_USERID=0 flux job last


### PR DESCRIPTION
This PR addresses #6144 by rejecting jobs directly in job-ingest if they are submitted as userid 0 when the instance owner is not also 0.

The reasoning behind handling this directly in job-ingest is simplicity. Also, it does seem like this check should always be in place, since there is not currently a way a root job could execute successfully due to limits/guardrails in the flux-security behavior. Therefore, a validator plugin doesn't really make sense. (IMO)

