### PR TITLE
add `-B, --bank=` option to submission commands

### DIFF
--- a/doc/man1/common/job-param-additional.rst
+++ b/doc/man1/common/job-param-additional.rst
@@ -6,6 +6,15 @@
    option is ignored, though :man1:`flux-jobs` may display the queue
    name in its rendering of the ``{queue}`` attribute.
 
+.. option:: -B, --bank=NAME
+
+   Set the bank name for this job to ``NAME``. This option is equivalent
+   to `--setattr=bank=NAME`, and results in the ``bank`` attribute being
+   set to ``NAME`` in the submitted jobspec. However, besides the bank
+   name appearing in job listing output, this option may have no effect
+   if no plugin or package that supports it (such as flux-accounting)
+   is installed and configured.
+
 .. option:: -t, --time-limit=MINUTES|FSD
 
    Set a time limit for the job in either minutes or Flux standard duration

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -375,6 +375,7 @@ _flux_submit_commands()
 
     local COMMON_OPTIONS="\
         -q --queue= \
+        -B --bank= \
         -t --time-limit= \
         -o --setopt= \
         --setattr= \

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -505,6 +505,7 @@ class Xcmd:
     #  the string representation of an Xcmd object.
     mutable_args = {
         "queue": "-q",
+        "bank": "-B",
         "ntasks": "-n",
         "nodes": "-N",
         "cores_per_task": "-c",

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -758,6 +758,13 @@ class MiniCmd:
             formatter_class=flux.util.help_formatter(),
         )
         parser.add_argument(
+            "-B",
+            "--bank",
+            type=str,
+            metavar="BANK",
+            help="Submit a job to a specific named bank",
+        )
+        parser.add_argument(
             "-q",
             "--queue",
             type=str,
@@ -1041,6 +1048,9 @@ class MiniCmd:
 
         if args.queue is not None:
             jobspec.setattr("system.queue", args.queue)
+
+        if args.bank is not None:
+            jobspec.setattr("system.bank", args.bank)
 
         if args.setattr is not None:
             for keyval in args.setattr:
@@ -1425,7 +1435,6 @@ class SubmitBulkCmd(SubmitBaseCmd):
             args.progress = None
 
     def watcher_start(self, args):
-
         if not self.watcher:
             #  Need to open self.flux_handle if it isn't already in order
             #  to start the watcher

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -94,7 +94,14 @@ test_expect_success 'flux submit --queue works' '
 test_expect_success 'flux submit --queue works' '
 	flux submit --env=-* --dry-run -q debug hostname >queue2.out && grep -i "debug" queue2.out
 '
-
+test_expect_success 'flux submit --bank works' '
+	flux submit --env=-* --dry-run --bank=mybank hostname >bank.out &&
+	grep -i "mybank" bank.out
+'
+test_expect_success 'flux submit -B works' '
+	flux submit --env=-* --dry-run -B mybank2 hostname >bank2.out &&
+	grep -i "mybank2" bank2.out
+'
 test_expect_success 'flux submit --setattr works' '
 	flux submit --env=-* --dry-run \
 		--setattr user.meep=false \


### PR DESCRIPTION
Now that `bank` and `project` have been [proposed](https://github.com/flux-framework/rfc/pull/420) as official members of canonical jobspec, and since they are supported by job-list, it seems like there are excellent arguments to at least support `-B, --bank=` options in our cli as suggested most recently by @ilumsden.

This PR starts with @ilumsden's draft PR #6157 (thanks Ian!), reworks the commit message to project standards, then adds the docs, testing, and new option to tab completions.

I didn't add `--project` here, even though it is also proposed as canonical in the rfc PR above. I like the idea of `-Sproject=NAME` for rarer cases such as this, though I'm not opposed to `--project` if people think that's a good idea.

For now, this seems like a good and simple ui improvement.