### PR TITLE
avoid idset leak when nodes leave the broker.online group

### DIFF
--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -923,6 +923,7 @@ static void broker_online_cb (flux_future_t *f, void *arg)
             free (hosts);
             free (ranks);
         }
+        idset_destroy (loss);
     }
 
     idset_destroy (previous_online);


### PR DESCRIPTION
Valgrind caught this leak when running a test under `FLUX_TEST_VALGRIND=t`.