### PR TITLE
matrix: remove fedora40 arm again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -254,7 +254,7 @@ jobs:
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker manifest create fluxrm/flux-core:bookworm fluxrm/flux-core:bookworm-amd64 fluxrm/flux-core:bookworm-386 fluxrm/flux-core:bookworm-arm64
         docker manifest push fluxrm/flux-core:bookworm
-        for d in el9 noble alpine fedora40 ; do
+        for d in el9 noble alpine ; do
           docker manifest create fluxrm/flux-core:$d fluxrm/flux-core:$d-amd64 fluxrm/flux-core:$d-arm64
           docker manifest push fluxrm/flux-core:$d
         done

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -83,7 +83,7 @@ class BuildMatrix:
     def add_build(
         self,
         name=None,
-        image="fedora40",
+        image=None,
         args=default_args,
         jobs=6,
         env=None,
@@ -208,18 +208,6 @@ matrix.add_multiarch_build(
         TEST_INSTALL="t",
     ),
 )
-fedora40_platforms = deepcopy(DEFAULT_MULTIARCH_PLATFORMS)
-fedora40_platforms["linux/arm64"]["timeout_minutes"] = 240
-matrix.add_multiarch_build(
-    name="fedora40",
-    default_suffix=" - test-install",
-    args=common_args,
-    platforms=fedora40_platforms,
-    env=dict(
-        TEST_INSTALL="t",
-    ),
-    docker_tag=True,
-)
 
 matrix.add_multiarch_build(
     name="noble",
@@ -246,6 +234,16 @@ matrix.add_multiarch_build(
     ),
 )
 # single arch builds that still produce a container
+matrix.add_build(
+    name="fedora40 - test-install",
+    image="fedora40",
+    args=common_args,
+    env=dict(
+        TEST_INSTALL="t",
+    ),
+    docker_tag=True,
+)
+
 # Ubuntu: TEST_INSTALL
 matrix.add_build(
     name="jammy - test-install",
@@ -282,6 +280,7 @@ matrix.add_build(
 # fedora40: clang-18
 matrix.add_build(
     name="fedora40 - clang-18",
+    image="fedora40",
     env=dict(
         CC="clang-18",
         CXX="clang++-18",
@@ -322,6 +321,7 @@ matrix.add_build(
 # inception
 matrix.add_build(
     name="inception",
+    image="fedora40",
     command_args="--inception",
 )
 


### PR DESCRIPTION
problem: everything now builds, the timeouts now work as expected, but the fedora40 builder takes so long that it often gets cancelled by another PR getting merged within that four hour window, as a result no manifest gets generated for that merge

solution: remove fedora40 for arm64 again


This should be the last one for a while.  The only other thing in here is I made it so that every single add_build has to specify an image.  It's too easy to lose track of which is which in some cases (I did a couple of times working on all of this) so better to be explicit.