### PR TITLE
include offline nodes in flux overlay errors output

### DIFF
--- a/doc/man1/flux-overlay.rst
+++ b/doc/man1/flux-overlay.rst
@@ -86,8 +86,9 @@ errors
 
 .. program:: flux overlay errors
 
-:program:`flux overlay errors` summarizes any errors recorded for lost nodes.
-The output consists of one line per unique error with a hostlist prefix.
+:program:`flux overlay errors` summarizes any errors recorded for lost or
+offline nodes.  The output consists of one line per unique error with a
+hostlist prefix.
 
 .. option:: -t, --timeout=FSD
 

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -913,8 +913,11 @@ void gather_errors (flux_t *h,
                 log_msg_exit ("error adding to error hash");
         }
         else if (streq (status, "offline")) {
-            /* Don't report offline nodes.
-             */
+            // report offline only if there is error text
+            if (error && strlen (error) > 0) {
+                if (errhash_add_one (errhash, child_rank, error) < 0)
+                    log_msg_exit ("error adding to error hash");
+            }
         }
         else { // recurse
             gather_errors (h, child_rank, errhash, timeout);

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -139,9 +139,9 @@ test_expect_success 'flux overlay status shows rank 3 offline' '
 	test_cmp health.exp health.out
 '
 
-test_expect_success 'flux overlay errors prints nothing' '
+test_expect_success 'flux overlay errors shows rank 3' '
 	flux overlay errors --timeout=0 >errors2.out &&
-	test $(wc -l <errors2.out) -eq 0
+	grep "fake3: administrative shutdown" errors2.out
 '
 
 test_expect_success 'flux overlay status --summary' '
@@ -202,9 +202,8 @@ test_expect_success 'ping to rank 14 fails with EHOSTUNREACH' '
 '
 
 test_expect_success 'flux overlay errors shows the lost connection' '
-	echo "fake14: lost connection" >errors3.exp &&
 	flux overlay errors --timeout=0 >errors3.out &&
-	test_cmp errors3.exp errors3.out
+	grep "fake14: lost connection" errors3.out
 '
 
 test_expect_success 'wait for rank 0 subtree to be degraded' '


### PR DESCRIPTION
Problem:  `flux overlay errors` does not show textual errors recorded for nodes in the "offline" state - only nodes that are "lost".  Among the errors not displayed are nodes that tried to connect with a mismatched flux version, which was the original motivator for the command!

Display any textual errors recorded for offline nodes.  This includes the version mismatch.  It also will show "administrative shutdown" as an error for nodes that are shutdown cleanly with `systemctl stop flux`.  I guess this is probably OK even though it's not an "error" per se, since it will only add one line to the compressed output and its meaning is probably obvious.

Example
```
$ flux overlay status
0 picl0: partial
├─ 1 picl1: partial
│  ├─ 3 picl3: full
│  ├─ 4 picl4: offline administrative shutdown
│  └─ 5 picl5: full
└─ 2 picl2: partial
   ├─ 6 picl6: offline administrative shutdown
   └─ 7 picl7: offline client (0.64.0) version mismatched with server (0.65.0)

$ flux overlay errors
picl7: client (0.64.0) version mismatched with server (0.65.0)
picl[4,6]: administrative shutdown
```