### PR TITLE
add flux module trace

### DIFF
--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -12,6 +12,7 @@ SYNOPSIS
 | **flux** **module** **list** [*-l*]
 | **flux** **module** **stats** [*-R*] [*--clear*] *name*
 | **flux** **module** **debug** [*--setbit=VAL*] [*--clearbit=VAL*] [*--set=MASK*] [*--clear=MASK*] *name*
+| **flux** **module** **trace** [*-t TYPE,...*] [-T *topic-glob*] *name...*
 
 
 
@@ -141,6 +142,39 @@ flag bits is private to the module and its test drivers.
 .. option:: -c, --clearbit=VAL
 
   Set one debug flag *VAL* to 0.
+
+trace
+-----
+
+.. program:: flux module trace
+
+Display message summaries for messages transmitted and received by the
+named modules.
+
+.. option:: -T, --topic=GLOB
+
+   Filter output by topic string.
+
+.. option:: -t, --type=TYPE,...
+
+   Filter output by message type, a comma-separated list.  Valid types are
+   ``request``, ``response``, ``event``, or ``control``.
+
+.. option:: -L, --color=WHEN
+
+   Colorize output when supported; WHEN can be ``always`` (default if omitted),
+   ``never``, or ``auto`` (default).
+
+.. option:: -H, --human
+
+   Display human-readable output. See also :option:`--color` and
+   :option:`--delta`.
+
+.. option:: -d, --delta
+
+   With :option:`--human`, display the time delta between messages instead
+   of a relative offset since the last absolute timestamp.
+
 
 DEBUG OPTIONS
 =============

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -61,6 +61,10 @@ struct broker {
 
 typedef struct broker broker_ctx_t;
 
+int broker_event_sendmsg_new (broker_ctx_t *ctx, flux_msg_t **msg);
+int broker_response_sendmsg_new (broker_ctx_t *ctx, flux_msg_t **msg);
+void broker_request_sendmsg_new (broker_ctx_t *ctx, flux_msg_t **msg);
+
 #endif /* !_BROKER_H */
 
 /*

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -57,7 +57,7 @@ int modhash_response_sendmsg_new (modhash_t *mh, flux_msg_t **msg)
     return module_sendmsg_new (p, msg);
 }
 
-void modhash_add (modhash_t *mh, module_t *p)
+static void modhash_add (modhash_t *mh, module_t *p)
 {
     int rc;
 
@@ -68,7 +68,7 @@ void modhash_add (modhash_t *mh, module_t *p)
                   (zhash_free_fn *)module_destroy);
 }
 
-void modhash_remove (modhash_t *mh, module_t *p)
+static void modhash_remove (modhash_t *mh, module_t *p)
 {
     zhash_delete (mh->zh_byuuid, module_get_uuid (p));
 }

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -17,15 +17,27 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/log.h"
+#include "src/common/libutil/dirwalk.h"
 #include "src/common/libutil/iterators.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/errno_safe.h"
 #include "ccan/str/str.h"
+#include "ccan/array_size/array_size.h"
 
 #include "module.h"
+#include "broker.h"
 #include "modhash.h"
+#include "overlay.h"
 
 struct modhash {
     zhash_t *zh_byuuid;
+    flux_msg_handler_t **handlers;
+    struct broker *ctx;
 };
+
+static json_t *modhash_get_modlist (modhash_t *mh,
+                                    double now,
+                                    struct service_switch *sw);
 
 int modhash_response_sendmsg_new (modhash_t *mh, flux_msg_t **msg)
 {
@@ -61,17 +73,500 @@ void modhash_remove (modhash_t *mh, module_t *p)
     zhash_delete (mh->zh_byuuid, module_get_uuid (p));
 }
 
-modhash_t *modhash_create (void)
+static int module_insmod_respond (flux_t *h, module_t *p)
+{
+    int rc;
+    int errnum = 0;
+    int status = module_get_status (p);
+    const flux_msg_t *msg = module_pop_insmod (p);
+
+    if (msg == NULL)
+        return 0;
+
+    /* If the module is EXITED, return error to insmod if mod_main() < 0
+     */
+    if (status == FLUX_MODSTATE_EXITED)
+        errnum = module_get_errnum (p);
+    if (errnum == 0)
+        rc = flux_respond (h, msg, NULL);
+    else
+        rc = flux_respond_error (h, msg, errnum, NULL);
+
+    flux_msg_decref (msg);
+    return rc;
+}
+
+static int module_rmmod_respond (flux_t *h, module_t *p)
+{
+    const flux_msg_t *msg;
+    int rc = 0;
+    while ((msg = module_pop_rmmod (p))) {
+        if (flux_respond (h, msg, NULL) < 0)
+            rc = -1;
+        flux_msg_decref (msg);
+    }
+    return rc;
+}
+
+/* If a message from a connector-routed client is not matched by this function,
+ * then it will fail with EAGAIN if the broker is in a pre-INIT state.
+ */
+static bool allow_early_request (const flux_msg_t *msg)
+{
+    const struct flux_match match[] = {
+        // state-machine.wait may be needed early by flux_reconnect(3) users
+        { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "state-machine.wait" },
+        // let state-machine.get and attr.get work for flux-uptime(1)
+        { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "state-machine.get" },
+        { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "attr.get" },
+        { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "log.dmesg" },
+    };
+    for (int i = 0; i < ARRAY_SIZE (match); i++)
+        if (flux_msg_cmp (msg, match[i]))
+            return true;
+    return false;
+}
+
+/* Callback to send disconnect messages on behalf of unloading module.
+ */
+static void disconnect_send_cb (const flux_msg_t *msg, void *arg)
+{
+    broker_ctx_t *ctx = arg;
+    flux_msg_t *cpy;
+    if (!(cpy = flux_msg_copy (msg, false)))
+        return;
+    broker_request_sendmsg_new (ctx, &cpy);
+}
+
+/* Handle messages on the service socket of a module.
+ */
+static void module_cb (module_t *p, void *arg)
+{
+    broker_ctx_t *ctx = arg;
+    flux_msg_t *msg = module_recvmsg (p);
+    int type;
+    int count;
+
+    if (!msg)
+        goto done;
+    if (flux_msg_get_type (msg, &type) < 0)
+        goto done;
+    switch (type) {
+        case FLUX_MSGTYPE_RESPONSE:
+            (void)broker_response_sendmsg_new (ctx, &msg);
+            break;
+        case FLUX_MSGTYPE_REQUEST:
+            count = flux_msg_route_count (msg);
+            /* Requests originated by the broker module will have a route
+             * count of 1.  Ensure that, when the module is unloaded, a
+             * disconnect message is sent to all services used by broker module.
+             */
+            if (count == 1) {
+                if (module_disconnect_arm (p, msg, disconnect_send_cb, ctx) < 0)
+                    flux_log_error (ctx->h, "error arming module disconnect");
+            }
+            /* Requests sent by the module on behalf of _its_ peers, e.g.
+             * connector-local module with connected clients, will have a
+             * route count greater than one here.  If this broker is not
+             * "online" (entered INIT state), politely rebuff these requests.
+             * Possible scenario for this message: user submitting a job on
+             * a login node before cluster reboot is complete.
+             */
+            else if (count > 1 && !ctx->online && !allow_early_request (msg)) {
+                const char *errmsg = "Upstream Flux broker is offline."
+                                     " Try again later.";
+
+                if (flux_respond_error (ctx->h, msg, EAGAIN, errmsg) < 0)
+                    flux_log_error (ctx->h, "send offline response message");
+                break;
+            }
+            broker_request_sendmsg_new (ctx, &msg);
+            break;
+        case FLUX_MSGTYPE_EVENT:
+            if (broker_event_sendmsg_new (ctx, &msg) < 0) {
+                flux_log_error (ctx->h,
+                                "%s(%s): broker_event_sendmsg_new %s",
+                                __FUNCTION__,
+                                module_get_name (p),
+                                flux_msg_typestr (type));
+            }
+            break;
+        default:
+            flux_log (ctx->h,
+                      LOG_ERR,
+                      "%s(%s): unexpected %s",
+                      __FUNCTION__,
+                      module_get_name (p),
+                      flux_msg_typestr (type));
+            break;
+    }
+done:
+    flux_msg_destroy (msg);
+}
+
+static void module_status_cb (module_t *p, int prev_status, void *arg)
+{
+    broker_ctx_t *ctx = arg;
+    int status = module_get_status (p);
+    const char *name = module_get_name (p);
+
+    /* Transition from INIT
+     * If module started normally, i.e. INIT->RUNNING, then
+     * respond to insmod requests now. O/w, delay responses until
+     * EXITED, when any errnum is available.
+     */
+    if (prev_status == FLUX_MODSTATE_INIT
+        && status == FLUX_MODSTATE_RUNNING) {
+        if (module_insmod_respond (ctx->h, p) < 0)
+            flux_log_error (ctx->h, "flux_respond to insmod %s", name);
+    }
+
+    /* Transition to EXITED
+     * Remove service routes, respond to insmod & rmmod request(s), if any,
+     * and remove the module (which calls pthread_join).
+     */
+    if (status == FLUX_MODSTATE_EXITED) {
+        flux_log (ctx->h, LOG_DEBUG, "module %s exited", name);
+        service_remove_byuuid (ctx->services, module_get_uuid (p));
+
+        if (module_insmod_respond (ctx->h, p) < 0)
+            flux_log_error (ctx->h, "flux_respond to insmod %s", name);
+
+        if (module_rmmod_respond (ctx->h, p) < 0)
+            flux_log_error (ctx->h, "flux_respond to rmmod %s", name);
+
+        modhash_remove (ctx->modhash, p);
+    }
+}
+
+static int mod_svc_cb (flux_msg_t **msg, void *arg)
+{
+    module_t *p = arg;
+    return module_sendmsg_new (p, msg);
+}
+
+/* Load broker module.
+ * 'name' is the name to use for the module (NULL = use dso basename minus ext)
+ * 'path' is either a dso path or a dso basename (e.g. "kvs" or "/a/b/kvs.so".
+ */
+int modhash_load (modhash_t *mh,
+                  const char *name,
+                  const char *path,
+                  json_t *args,
+                  const flux_msg_t *request,
+                  flux_error_t *error)
+{
+    const char *searchpath;
+    char *pattern = NULL;
+    zlist_t *files = NULL;
+    module_t *p;
+
+    if (!strchr (path, '/')) {
+        if (!(searchpath = getenv ("FLUX_MODULE_PATH"))) {
+            errprintf (error, "FLUX_MODULE_PATH is not set in the environment");
+            errno = EINVAL;
+            return -1;
+        }
+        if (asprintf (&pattern, "%s.so*", path) < 0) {
+            errprintf (error, "out of memory");
+            return -1;
+        }
+        if (!(files = dirwalk_find (searchpath,
+                                    DIRWALK_REALPATH | DIRWALK_NORECURSE,
+                                    pattern,
+                                    1,
+                                    NULL,
+                                    NULL))
+            || zlist_size (files) == 0) {
+            errprintf (error, "module not found in search path");
+            errno = ENOENT;
+            goto error;
+        }
+        path = zlist_first (files);
+    }
+    if (!(p = module_create (mh->ctx->h,
+                             overlay_get_uuid (mh->ctx->overlay),
+                             name,
+                             path,
+                             mh->ctx->rank,
+                             args,
+                             error)))
+        goto error;
+    modhash_add (mh, p);
+    if (service_add (mh->ctx->services,
+                     module_get_name (p),
+                     module_get_uuid (p),
+                     mod_svc_cb,
+                     p) < 0) {
+        errprintf (error, "error registering %s service", module_get_name (p));
+        goto module_remove;
+    }
+    module_set_poller_cb (p, module_cb, mh->ctx);
+    module_set_status_cb (p, module_status_cb, mh->ctx);
+    if (request && module_push_insmod (p, request) < 0) { // response deferred
+        errprintf (error, "error saving %s request", module_get_name (p));
+        goto service_remove;
+    }
+    if (module_start (p) < 0) {
+        errprintf (error, "error starting %s module", module_get_name (p));
+        goto service_remove;
+    }
+    flux_log (mh->ctx->h, LOG_DEBUG, "insmod %s", module_get_name (p));
+    zlist_destroy (&files);
+    free (pattern);
+    return 0;
+service_remove:
+    service_remove_byuuid (mh->ctx->services, module_get_uuid (p));
+module_remove:
+    modhash_remove (mh, p);
+error:
+    ERRNO_SAFE_WRAP (zlist_destroy, &files);
+    ERRNO_SAFE_WRAP (free, pattern);
+    return -1;
+}
+
+/* Load a module, asynchronously.
+ * N.B. modhash_load () handles response, unless it returns -1.
+ */
+static void load_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    broker_ctx_t *ctx = arg;
+    const char *name = NULL;
+    const char *path;
+    json_t *args;
+    flux_error_t error;
+    const char *errmsg = NULL;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s?s s:s s:o}",
+                             "name", &name,
+                             "path", &path,
+                             "args", &args) < 0)
+        goto error;
+    if (modhash_load (ctx->modhash, name, path, args, msg, &error) < 0) {
+        errmsg = error.text;
+        goto error;
+    }
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+
+static int unload_module (broker_ctx_t *ctx,
+                          const char *name,
+                          const flux_msg_t *request)
+{
+    module_t *p;
+
+    if (!(p = modhash_lookup_byname (ctx->modhash, name))) {
+        errno = ENOENT;
+        return -1;
+    }
+    if (module_stop (p, ctx->h) < 0)
+        return -1;
+    if (module_push_rmmod (p, request) < 0)
+        return -1;
+    flux_log (ctx->h, LOG_DEBUG, "rmmod %s", name);
+    return 0;
+}
+
+/* Unload a module, asynchronously.
+ * N.B. unload_module() handles response, unless it fails early
+ * and returns -1.
+ */
+static void remove_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    broker_ctx_t *ctx = arg;
+    const char *name;
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "name", &name) < 0)
+        goto error;
+    if (unload_module (ctx, name, msg) < 0)
+        goto error;
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+/* List loaded modules
+ */
+static void list_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    broker_ctx_t *ctx = arg;
+    json_t *mods = NULL;
+    double now = flux_reactor_now (flux_get_reactor (h));
+
+    if (flux_request_decode (msg, NULL, NULL) < 0)
+        goto error;
+    if (!(mods = modhash_get_modlist (ctx->modhash, now, ctx->services)))
+        goto error;
+    if (flux_respond_pack (h, msg, "{s:O}", "mods", mods) < 0)
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+    json_decref (mods);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+static void debug_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
+{
+    broker_ctx_t *ctx = arg;
+    const char *name;
+    int defer = -1;
+    module_t *p;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s?b}",
+                             "name", &name,
+                             "defer", &defer) < 0)
+        goto error;
+    if (!(p = modhash_lookup_byname (ctx->modhash, name))) {
+        errno = ENOENT;
+        goto error;
+    }
+    if (defer != -1) {
+        if (module_set_defer (p, defer) < 0)
+            goto error;
+    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to module.debug request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "error responding to module.debug request");
+}
+
+static void status_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    broker_ctx_t *ctx = arg;
+    int status;
+    int errnum = 0;
+    const char *sender;
+    module_t *p;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:i s?i}",
+                             "status", &status,
+                             "errnum", &errnum) < 0
+        || !(sender = flux_msg_route_first (msg))
+        || !(p = modhash_lookup (ctx->modhash, sender))) {
+        const char *errmsg = "error decoding/finding module.status";
+        if (flux_msg_is_noresponse (msg))
+            flux_log_error (h, "%s", errmsg);
+        else if (flux_respond_error (h, msg, errno, errmsg) < 0)
+            flux_log_error (h, "error responding to module.status");
+        return;
+    }
+    switch (status) {
+        case FLUX_MODSTATE_FINALIZING:
+            module_mute (p);
+            break;
+        case FLUX_MODSTATE_EXITED:
+            module_set_errnum (p, errnum);
+            break;
+        default:
+            break;
+    }
+    /* Send a response if required.
+     * Hint: module waits for response in FINALIZING state.
+     */
+    if (!flux_msg_is_noresponse (msg)) {
+        if (flux_respond (h, msg, NULL) < 0) {
+            flux_log_error (h,
+                            "%s: error responding to module.status",
+                            module_get_name (p));
+        }
+    }
+    /* N.B. this will cause module_status_cb() to be called.
+     */
+    module_set_status (p, status);
+}
+
+static void disconnect_cb (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "module.load",
+        load_cb,
+        0,
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "module.remove",
+        remove_cb,
+        0,
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "module.list",
+        list_cb,
+        FLUX_ROLE_USER,
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "module.status",
+        status_cb,
+        0,
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "module.debug",
+        debug_cb,
+        0,
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "module.disconnect",
+        disconnect_cb,
+        0,
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+modhash_t *modhash_create (struct broker *ctx)
 {
     modhash_t *mh = calloc (1, sizeof (*mh));
     if (!mh)
         return NULL;
+    mh->ctx = ctx;
+    if (flux_msg_handler_addvec (ctx->h, htab, ctx, &mh->handlers) < 0)
+        goto error;
     if (!(mh->zh_byuuid = zhash_new ())) {
         errno = ENOMEM;
-        modhash_destroy (mh);
-        return NULL;
+        goto error;
     }
     return mh;
+error:
+    modhash_destroy (mh);
+    return NULL;
 }
 
 int modhash_destroy (modhash_t *mh)
@@ -93,6 +588,7 @@ int modhash_destroy (modhash_t *mh)
             }
             zhash_destroy (&mh->zh_byuuid);
         }
+        flux_msg_handler_delvec (mh->handlers);
         free (mh);
     }
     errno = saved_errno;
@@ -120,9 +616,11 @@ static json_t *modhash_entry_tojson (module_t *p,
     return entry;
 }
 
-json_t *modhash_get_modlist (modhash_t *mh,
-                             double now,
-                             struct service_switch *sw)
+/* Prepare RFC 5 'mods' array for lsmod response.
+ */
+static json_t *modhash_get_modlist (modhash_t *mh,
+                                    double now,
+                                    struct service_switch *sw)
 {
     json_t *mods = NULL;
     module_t *p;

--- a/src/broker/modhash.h
+++ b/src/broker/modhash.h
@@ -28,9 +28,6 @@ typedef struct modhash modhash_t;
 modhash_t *modhash_create (struct broker *ctx);
 int modhash_destroy (modhash_t *mh);
 
-void modhash_add (modhash_t *mh, module_t *p);
-void modhash_remove (modhash_t *mh, module_t *p);
-
 /* Send an event message to all modules that have matching subscription.
  */
 int modhash_event_mcast (modhash_t *mh, const flux_msg_t *msg);

--- a/src/broker/modhash.h
+++ b/src/broker/modhash.h
@@ -18,13 +18,14 @@
 #include "attr.h"
 #include "service.h"
 #include "module.h"
+#include "broker.h"
 
 typedef struct modhash modhash_t;
 
 /* Hash-o-modules, keyed by uuid
  * Destructor returns the number of modules that had to be canceled.
  */
-modhash_t *modhash_create (void);
+modhash_t *modhash_create (struct broker *ctx);
 int modhash_destroy (modhash_t *mh);
 
 void modhash_add (modhash_t *mh, module_t *p);
@@ -49,16 +50,17 @@ module_t *modhash_lookup (modhash_t *mh, const char *uuid);
  */
 module_t *modhash_lookup_byname (modhash_t *mh, const char *name);
 
-/* Prepare RFC 5 'mods' array for lsmod response.
- */
-json_t *modhash_get_modlist (modhash_t *mh,
-                             double now,
-                             struct service_switch *sw);
-
 /* Iterator
  */
 module_t *modhash_first (modhash_t *mh);
 module_t *modhash_next (modhash_t *mh);
+
+int modhash_load (modhash_t *mh,
+                  const char *name,
+                  const char *path,
+                  json_t *args,
+                  const flux_msg_t *request,
+                  flux_error_t *error);
 
 #endif /* !_BROKER_MODHASH_H */
 

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -49,7 +49,7 @@ struct broker_module {
 
     double lastseen;
 
-    flux_t *h_broker;       /* broker end of interthread channel */
+    flux_t *h_broker_end;   /* broker end of interthread channel */
     char uri[128];
 
     uuid_t uuid;            /* uuid for unique request sender identity */
@@ -80,7 +80,7 @@ struct broker_module {
     struct flux_msglist *insmod_requests;
     struct flux_msglist *deferred_messages;
 
-    flux_t *h;               /* module's handle */
+    flux_t *h_module_end;   /* module end of interthread_channel */
     struct subhash *sub;
 };
 
@@ -150,14 +150,15 @@ static int module_finalizing (module_t *p)
 {
     flux_future_t *f;
 
-    if (!(f = flux_rpc_pack (p->h,
+    if (!(f = flux_rpc_pack (p->h_module_end,
                              "broker.module-status",
                              FLUX_NODEID_ANY,
                              0,
                              "{s:i}",
                              "status", FLUX_MODSTATE_FINALIZING))
         || flux_rpc_get (f, NULL)) {
-        flux_log_error (p->h, "broker.module-status FINALIZING error");
+        flux_log_error (p->h_module_end,
+                        "broker.module-status FINALIZING error");
         flux_future_destroy (f);
         return -1;
     }
@@ -181,21 +182,21 @@ static void *module_thread (void *arg)
 
     /* Connect to broker socket, enable logging, register built-in services
      */
-    if (!(p->h = flux_open (p->uri, 0))) {
+    if (!(p->h_module_end = flux_open (p->uri, 0))) {
         log_err ("flux_open %s", uri);
         goto done;
     }
-    if (attr_cache_from_json (p->h, p->attr_cache) < 0) {
+    if (attr_cache_from_json (p->h_module_end, p->attr_cache) < 0) {
         log_err ("%s: error priming broker attribute cache", p->name);
         goto done;
     }
-    flux_log_set_appname (p->h, p->name);
-    if (flux_set_conf (p->h, p->conf) < 0) {
+    flux_log_set_appname (p->h_module_end, p->name);
+    if (flux_set_conf (p->h_module_end, p->conf) < 0) {
         log_err ("%s: error setting config object", p->name);
         goto done;
     }
-    p->conf = NULL; // flux_set_conf() transfers ownership to p->h
-    if (modservice_register (p->h, p) < 0) {
+    p->conf = NULL; // flux_set_conf() transfers ownership to p->h_module_end
+    if (modservice_register (p->h_module_end, p) < 0) {
         log_err ("%s: modservice_register", p->name);
         goto done;
     }
@@ -219,11 +220,11 @@ static void *module_thread (void *arg)
         goto done;
     }
     argz_extract (p->argz, p->argz_len, av);
-    if (p->main (p->h, ac, av) < 0) {
+    if (p->main (p->h_module_end, ac, av) < 0) {
         mod_main_errno = errno;
         if (mod_main_errno == 0)
             mod_main_errno = ECONNRESET;
-        flux_log (p->h, LOG_CRIT, "module exiting abnormally");
+        flux_log (p->h_module_end, LOG_CRIT, "module exiting abnormally");
     }
 
     /* Before processing unhandled requests, ensure that this module
@@ -232,34 +233,42 @@ static void *module_thread (void *arg)
      * which could cause the broker to block.
      */
     if (module_finalizing (p) < 0)
-        flux_log_error (p->h, "failed to set module state to finalizing");
+        flux_log_error (p->h_module_end,
+                        "failed to set module state to finalizing");
 
     /* If any unhandled requests were received during shutdown,
      * respond to them now with ENOSYS.
      */
-    while ((msg = flux_recv (p->h, FLUX_MATCH_REQUEST, FLUX_O_NONBLOCK))) {
+    while ((msg = flux_recv (p->h_module_end,
+                             FLUX_MATCH_REQUEST,
+                             FLUX_O_NONBLOCK))) {
         const char *topic = "unknown";
         (void)flux_msg_get_topic (msg, &topic);
-        flux_log (p->h, LOG_DEBUG, "responding to post-shutdown %s", topic);
-        if (flux_respond_error (p->h, msg, ENOSYS, NULL) < 0)
-            flux_log_error (p->h, "responding to post-shutdown %s", topic);
+        flux_log (p->h_module_end,
+                  LOG_DEBUG,
+                  "responding to post-shutdown %s",
+                  topic);
+        if (flux_respond_error (p->h_module_end, msg, ENOSYS, NULL) < 0)
+            flux_log_error (p->h_module_end,
+                            "responding to post-shutdown %s",
+                            topic);
         flux_msg_destroy (msg);
     }
-    if (!(f = flux_rpc_pack (p->h,
+    if (!(f = flux_rpc_pack (p->h_module_end,
                              "broker.module-status",
                              FLUX_NODEID_ANY,
                              FLUX_RPC_NORESPONSE,
                              "{s:i s:i}",
                              "status", FLUX_MODSTATE_EXITED,
                              "errnum", mod_main_errno))) {
-        flux_log_error (p->h, "broker.module-status EXITED error");
+        flux_log_error (p->h_module_end, "broker.module-status EXITED error");
         goto done;
     }
     flux_future_destroy (f);
 done:
     free (av);
-    flux_close (p->h);
-    p->h = NULL;
+    flux_close (p->h_module_end);
+    p->h_module_end = NULL;
     return NULL;
 }
 
@@ -372,17 +381,17 @@ module_t *module_create (flux_t *h,
      */
     // copying 13 + 37 + 1 = 51 bytes into 128 byte buffer cannot fail
     (void)snprintf (p->uri, sizeof (p->uri), "interthread://%s", p->uuid_str);
-    if (!(p->h_broker = flux_open (p->uri, FLUX_O_NOREQUEUE))
-        || flux_opt_set (p->h_broker,
+    if (!(p->h_broker_end = flux_open (p->uri, FLUX_O_NOREQUEUE))
+        || flux_opt_set (p->h_broker_end,
                          FLUX_OPT_ROUTER_NAME,
                          parent_uuid,
                          strlen (parent_uuid) + 1) < 0
-        || flux_set_reactor (p->h_broker, r) < 0) {
+        || flux_set_reactor (p->h_broker_end, r) < 0) {
         errprintf (error, "could not create %s interthread handle", p->name);
         goto cleanup;
     }
     if (!(p->broker_w = flux_handle_watcher_create (r,
-                                                    p->h_broker,
+                                                    p->h_broker_end,
                                                     FLUX_POLLIN,
                                                     module_cb,
                                                     p))) {
@@ -431,7 +440,7 @@ int module_get_status (module_t *p)
 
 flux_msg_t *module_recvmsg (module_t *p)
 {
-    return flux_recv (p->h_broker, FLUX_MATCH_ANY, FLUX_O_NONBLOCK);
+    return flux_recv (p->h_broker_end, FLUX_MATCH_ANY, FLUX_O_NONBLOCK);
 }
 
 int module_sendmsg_new (module_t *p, flux_msg_t **msg)
@@ -460,7 +469,7 @@ int module_sendmsg_new (module_t *p, flux_msg_t **msg)
         *msg = NULL;
         return 0;
     }
-    return flux_send_new (p->h_broker, msg, 0);
+    return flux_send_new (p->h_broker_end, msg, 0);
 }
 
 int module_disconnect_arm (module_t *p,
@@ -506,7 +515,7 @@ void module_destroy (module_t *p)
 
     flux_watcher_stop (p->broker_w);
     flux_watcher_destroy (p->broker_w);
-    flux_close (p->h_broker);
+    flux_close (p->h_broker_end);
 
 #ifndef __SANITIZE_ADDRESS__
     dlclose (p->dso);
@@ -562,7 +571,7 @@ int module_set_defer (module_t *p, bool flag)
     if (!flag && p->deferred_messages) {
         const flux_msg_t *msg;
         while ((msg = flux_msglist_pop (p->deferred_messages))) {
-            if (flux_send_new (p->h_broker, (flux_msg_t **)&msg, 0) < 0) {
+            if (flux_send_new (p->h_broker_end, (flux_msg_t **)&msg, 0) < 0) {
                 flux_msg_decref (msg);
                 return -1;
             }
@@ -688,7 +697,7 @@ int module_event_cast (module_t *p, const flux_msg_t *msg)
 ssize_t module_get_send_queue_count (module_t *p)
 {
     size_t count;
-    if (flux_opt_get (p->h_broker,
+    if (flux_opt_get (p->h_broker_end,
                       FLUX_OPT_SEND_QUEUE_COUNT,
                       &count,
                       sizeof (count)) < 0)
@@ -699,7 +708,7 @@ ssize_t module_get_send_queue_count (module_t *p)
 ssize_t module_get_recv_queue_count (module_t *p)
 {
     size_t count;
-    if (flux_opt_get (p->h_broker,
+    if (flux_opt_get (p->h_broker_end,
                       FLUX_OPT_RECV_QUEUE_COUNT,
                       &count,
                       sizeof (count)) < 0)

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -151,14 +151,13 @@ static int module_finalizing (module_t *p)
     flux_future_t *f;
 
     if (!(f = flux_rpc_pack (p->h_module_end,
-                             "broker.module-status",
+                             "module.status",
                              FLUX_NODEID_ANY,
                              0,
                              "{s:i}",
                              "status", FLUX_MODSTATE_FINALIZING))
         || flux_rpc_get (f, NULL)) {
-        flux_log_error (p->h_module_end,
-                        "broker.module-status FINALIZING error");
+        flux_log_error (p->h_module_end, "module.status FINALIZING error");
         flux_future_destroy (f);
         return -1;
     }
@@ -255,13 +254,13 @@ static void *module_thread (void *arg)
         flux_msg_destroy (msg);
     }
     if (!(f = flux_rpc_pack (p->h_module_end,
-                             "broker.module-status",
+                             "module.status",
                              FLUX_NODEID_ANY,
                              FLUX_RPC_NORESPONSE,
                              "{s:i s:i}",
                              "status", FLUX_MODSTATE_EXITED,
                              "errnum", mod_main_errno))) {
-        flux_log_error (p->h_module_end, "broker.module-status EXITED error");
+        flux_log_error (p->h_module_end, "module.status EXITED error");
         goto done;
     }
     flux_future_destroy (f);
@@ -453,11 +452,11 @@ int module_sendmsg_new (module_t *p, flux_msg_t **msg)
     if (flux_msg_get_type (*msg, &type) < 0
         || flux_msg_get_topic (*msg, &topic) < 0)
         return -1;
-    /* Muted modules only accept response to broker.module-status
+    /* Muted modules only accept response to module.status
      */
     if (p->muted) {
         if (type != FLUX_MSGTYPE_RESPONSE
-            || !streq (topic, "broker.module-status")) {
+            || !streq (topic, "module.status")) {
             errno = ENOSYS;
             return -1;
         }

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -99,6 +99,9 @@ int module_event_cast (module_t *p, const flux_msg_t *msg);
 ssize_t module_get_send_queue_count (module_t *p);
 ssize_t module_get_recv_queue_count (module_t *p);
 
+int module_trace (module_t *p, const flux_msg_t *msg);
+void module_trace_disconnect (module_t *p, const flux_msg_t *msg);
+
 #endif /* !_BROKER_MODULE_H */
 
 /*

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -446,7 +446,7 @@ static void rmmod_continuation (flux_future_t *f, void *arg)
     struct state_machine *s = arg;
 
     if (flux_rpc_get (f, NULL) < 0)
-        flux_log_error (s->ctx->h, "broker.rmmod connector-local");
+        flux_log_error (s->ctx->h, "module.remove connector-local");
     flux_reactor_stop (flux_get_reactor (s->ctx->h));
     flux_future_destroy (f);
 }
@@ -471,14 +471,14 @@ static void subproc_continuation (flux_future_t *f, void *arg)
     /* Next task is to remove the connector-local module.
      */
     if (!(f = flux_rpc_pack (h,
-                             "broker.rmmod",
+                             "module.remove",
                              FLUX_NODEID_ANY,
                              0,
                              "{s:s}",
                              "name",
                              "connector-local"))
         || flux_future_then (f, -1, rmmod_continuation, s) < 0) {
-        flux_log_error (h, "error sending broker.rmmod connector-local");
+        flux_log_error (h, "error sending module.remove connector-local");
         flux_reactor_stop (flux_get_reactor (h));
         flux_future_destroy (f);
     }

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -276,9 +276,9 @@ static void module_load (flux_t *h,
                                "path", fullpath ? fullpath : path,
                                "args", args))
         || (name && set_string (payload, "name", name) < 0))
-        log_msg_exit ("failed to create broker.insmod payload");
+        log_msg_exit ("failed to create module.load payload");
     if (!(f = flux_rpc_pack (h,
-                             "broker.insmod",
+                             "module.load",
                              FLUX_NODEID_ANY,
                              0,
                              "O",
@@ -321,7 +321,7 @@ static void module_remove (flux_t *h, optparse_t *p, const char *path)
         log_err_exit ("could not canonicalize module path '%s'", path);
 
     if (!(f = flux_rpc_pack (h,
-                             "broker.rmmod",
+                             "module.remove",
                              FLUX_NODEID_ANY,
                              0,
                              "{s:s}",
@@ -538,7 +538,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!(f = flux_rpc (h, "broker.lsmod", NULL, FLUX_NODEID_ANY, 0))
+    if (!(f = flux_rpc (h, "module.list", NULL, FLUX_NODEID_ANY, 0))
         || flux_rpc_get_unpack (f, "{s:o}", "mods", &o) < 0)
         log_err_exit ("list");
     lsmod_print_header (stdout, longopt);

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -39,7 +39,7 @@ int flux_module_set_running (flux_t *h)
     flux_future_t *f;
 
     if (!(f = flux_rpc_pack (h,
-                             "broker.module-status",
+                             "module.status",
                              FLUX_NODEID_ANY,
                              FLUX_RPC_NORESPONSE,
                              "{s:i}",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -255,6 +255,7 @@ TESTSCRIPTS = \
 	t3308-system-torpid.t \
 	t3309-system-reconnect.t \
 	t3400-overlay-trace.t \
+	t3401-module-trace.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -18,11 +18,11 @@ testmod=${FLUX_BUILD_DIR}/t/module/.libs/testmod.so
 legacy=${FLUX_BUILD_DIR}/t/module/.libs/legacy.so
 
 module_status_bad_proto() {
-	flux python -c "import flux; print(flux.Flux().rpc(\"broker.module-status\").get())"
+	flux python -c "import flux; print(flux.Flux().rpc(\"module.status\").get())"
 }
 
 module_status () {
-	flux python -c "import flux; print(flux.Flux().rpc(\"broker.module-status\",{\"status\":0}).get())"
+	flux python -c "import flux; print(flux.Flux().rpc(\"module.status\",{\"status\":0}).get())"
 }
 
 module_getinfo () {
@@ -31,7 +31,7 @@ module_getinfo () {
 
 # Usage: module_debug_defer modname True|False
 module_debug_defer () {
-        flux python -c "import flux; flux.Flux().rpc(\"broker.module-debug\",{\"name\":\"$1\",\"defer\":$2}).get()"
+        flux python -c "import flux; flux.Flux().rpc(\"module.debug\",{\"name\":\"$1\",\"defer\":$2}).get()"
 }
 
 
@@ -242,13 +242,13 @@ test_expect_success 'flux_module_set_running - signal module to enter reactor' '
 test_expect_success 'flux_module_set_running - remove test module' '
 	flux module remove running
 '
-test_expect_success 'broker.module-status rejects malformed request' '
+test_expect_success 'module.status rejects malformed request' '
 	test_must_fail module_status_bad_proto 2>proto.err &&
-	grep "error decoding/finding broker.module-status" proto.err
+	grep "error decoding/finding module.status" proto.err
 '
-test_expect_success 'broker.module-status rejects request from unknown sender' '
+test_expect_success 'module.status rejects request from unknown sender' '
 	test_must_fail module_status 2>sender.err &&
-	grep "error decoding/finding broker.module-status" sender.err
+	grep "error decoding/finding module.status" sender.err
 '
 # issue #5255
 test_expect_success 'module with version ext can be loaded by name' '

--- a/t/t2305-sched-slow.t
+++ b/t/t2305-sched-slow.t
@@ -11,7 +11,7 @@ test_under_flux 1
 
 # Usage: module_debug_defer modname True|False
 module_debug_defer () {
-	flux python -c "import flux; flux.Flux().rpc(\"broker.module-debug\",{\"name\":\"$1\",\"defer\":$2}).get()"
+	flux python -c "import flux; flux.Flux().rpc(\"module.debug\",{\"name\":\"$1\",\"defer\":$2}).get()"
 }
 
 test_expect_success 'pause sched message handling' '

--- a/t/t3401-module-trace.t
+++ b/t/t3401-module-trace.t
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+test_description='Test flux module trace'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1
+
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+test_expect_success 'flux module trace fails with missing module name' '
+	test_must_fail flux module trace
+'
+test_expect_success 'flux module trace fails with unknown argument' '
+	test_must_fail flux module trace --not-an-arg
+'
+test_expect_success 'flux module trace fails with wrong message type' '
+	test_must_fail flux module trace -t foo,bar
+'
+test_expect_success 'reload heartbeat with increased heart rate' '
+	flux module reload heartbeat period=0.2s
+'
+test_expect_success NO_CHAIN_LINT 'start background trace' '
+	flux module trace kvs >trace.out &
+	echo $! >trace.pid
+'
+test_expect_success NO_CHAIN_LINT 'heartbeat.pulse event was captured' '
+	$waitfile -t 60 -p heartbeat.pulse trace.out
+'
+test_expect_success NO_CHAIN_LINT 'send one kvs.ping' '
+	flux ping -c 1 kvs
+'
+test_expect_success NO_CHAIN_LINT 'kvs.ping request/response was captured' '
+	$waitfile -t 60 -c 2 -p kvs.ping trace.out
+'
+test_expect_success NO_CHAIN_LINT 'stop background trace' '
+	kill -15 $(cat trace.pid); wait || true
+'
+
+test_expect_success NO_CHAIN_LINT 'start background trace on multiple modules' '
+	flux module trace kvs barrier >trace2.out &
+	echo $! >trace2.pid
+'
+test_expect_success NO_CHAIN_LINT 'heartbeat.pulse event was captured' '
+	$waitfile -t 60 -p heartbeat.pulse trace2.out
+'
+test_expect_success NO_CHAIN_LINT 'send one barrier.ping' '
+	flux ping -c 1 barrier
+'
+test_expect_success NO_CHAIN_LINT 'barrier.ping request/response was captured' '
+	$waitfile -t 60 -c 2 -p barrier.ping trace2.out
+'
+test_expect_success NO_CHAIN_LINT 'stop background trace' '
+	kill -15 $(cat trace2.pid); wait || true
+'
+test_done


### PR DESCRIPTION
After adding `flux overlay trace`, it seemed natural to add a tool for tracking messages sent/received by broker modules.

This also shovels some module related code in the main broker source file (broker.c) into modhash.c without modification.

Example: trace `resource` and `sched-simple` when a job is run:
```
$ flux module trace resource sched-simple
2024-08-08T09:57:10.250 sched-simple rx > sched.alloc [485]
2024-08-08T09:57:10.250 sched-simple tx > log.append [102]
2024-08-08T09:57:10.250 sched-simple tx > kvs.commit [330]
2024-08-08T09:57:10.250 sched-simple tx > log.append [90]
2024-08-08T09:57:10.251 sched-simple rx < kvs.commit [72]
2024-08-08T09:57:10.251 sched-simple tx < sched.alloc [283]
2024-08-08T09:57:10.267     resource rx > resource.topo-get [0]
2024-08-08T09:57:10.267     resource tx < resource.topo-get [17.05957K]
2024-08-08T09:57:10.275     resource rx > resource.disconnect [0]
2024-08-08T09:57:10.277 sched-simple rx > sched.free [188]
2024-08-08T09:57:10.277 sched-simple tx > log.append [96]
```