### PR TITLE
kvs: correct code logic about what is an append

### DIFF
--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -495,6 +495,10 @@ static int kvstxn_append (kvstxn_t *kt, json_t *dirent,
         /* entry not found, treat like normal insertion */
         if (treeobj_insert_entry (dir, final_name, dirent) < 0)
             return -1;
+        /* N.B. although this is an "insert", we still treat this as
+         * an "append".  If we don't, the "append" could be issued
+         * twice, leading to duplicated data.  See issue #6207. */
+        (*append) = true;
     }
     else if (treeobj_is_valref (entry)) {
         char ref[BLOBREF_MAX_STRING_SIZE];


### PR DESCRIPTION
Problem: In PR #2547, a fix was added into the KVS to deal with duplicate appends to a KVS entry.  However, a corner case was left in the code. When an append is done to a KVS entry that does not exist, the append is treated like a normal insertion.  This corner case should also be counted as an "append".  Otherwise, duplicate appends could happen at the beginning of a KVS entry when it is created.

Solution: Set the append flag to true when a KVS entry does not exist and the append is treated like an insert.

Fixes #6207

----

Side note, now that all "good paths" are counted as appends, I could moved  `(*append) = true` into the end of the function before `return 0`.  But given how the error handling is done in the function, I felt leaving each of the `(*append) = true` near their "we did an append" I thought was better.  But that's just me.  Could be overridden by review votes :-)

