### PR TITLE
testsuite: fix racy flux job attach test

### DIFF
--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -129,7 +129,7 @@ test_expect_success 'attach: reports Terminated when tasks are terminated' '
 	grep Terminated terminated.err
 '
 test_expect_success 'attach: reports job shell Killed if job shell is killed' '
-	id=$(flux submit --wait-event=exec.shell.start sh -c "kill -9 \$PPID") &&
+	id=$(flux submit sh -c "kill -9 \$PPID") &&
 	test_must_fail_or_be_terminated flux job attach $id 2>shell-killed.out &&
 	grep "job shell Killed" shell-killed.out
 '


### PR DESCRIPTION
Problem: when t2500-job-attach.t is run on a busy system, the "attach: reports job shell Killed if job shell is killed" test sometimes fails.

'flux submit --wait-event=exec.shell.start kill -9 $PPID' may fail if the shell is terminated before shell.start can be posted.

Moving the --wait-event to the 'flux job attach' command seems to address the problem.

Fixes #6211