### PR TITLE
cron: use posix_spawn() for cron tasks when possible

### DIFF
--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -444,10 +444,7 @@ static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const flux_msg_t *msg)
         goto out_err;
     }
 
-    if (!cwd)
-        cwd = ctx->cwd;
-
-    if ((e->cwd = strdup (cwd)) == NULL) {
+    if (cwd && (e->cwd = strdup (cwd)) == NULL) {
         flux_log_error (h, "cron.create: strdup (cwd)");
         errno = ENOMEM;
         goto out_err;

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -61,10 +61,14 @@ struct cron_ctx {
 static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const flux_msg_t *msg);
 static void cron_entry_destroy (cron_entry_t *e);
 static int cron_entry_stop (cron_entry_t *e);
-static void cron_entry_finished_handler (flux_t *h, cron_task_t *t,
-    void *arg);
-static void cron_entry_io_cb (flux_t *h, cron_task_t *t, void *arg,
-    bool is_stderr, const char *data, int datalen);
+static void cron_entry_finished_handler (flux_t *h,
+                                         cron_task_t *t,
+                                         void *arg);
+static void cron_entry_io_cb (flux_t *h,
+                              cron_task_t *t,
+                              void *arg,
+                              bool is_stderr,
+                              const char *data, int datalen);
 static int cron_entry_run_task (cron_entry_t *e);
 static int cron_entry_defer (cron_entry_t *e);
 
@@ -109,8 +113,11 @@ int cron_entry_schedule_task (cron_entry_t *e)
     /* Refuse to run more than one task at once
      */
     if (e->task) {
-        flux_log (h, LOG_INFO, "cron-%ju: %s: task still running or scheduled",
-                  e->id, e->name);
+        flux_log (h,
+                  LOG_INFO,
+                  "cron-%ju: %s: task still running or scheduled",
+                  e->id,
+                  e->name);
         return (0);
     }
     if (!(e->task = cron_task_new (h, cron_entry_finished_handler, e))) {
@@ -139,8 +146,14 @@ static void cron_entry_io_cb (flux_t *h, cron_task_t *t, void *arg,
 {
     cron_entry_t *e = arg;
     int level = is_stderr ? LOG_ERR : LOG_INFO;
-    flux_log (h, level, "cron-%ju[%s]: rank=%d: command=\"%s\": \"%s\"",
-              e->id, e->name, e->rank, e->command, data);
+    flux_log (h,
+              level,
+              "cron-%ju[%s]: rank=%d: command=\"%s\": \"%s\"",
+              e->id,
+              e->name,
+              e->rank,
+              e->command,
+              data);
 }
 
 /* Push task t onto the front of the completed tasks list for
@@ -166,9 +179,11 @@ static void cron_entry_failure (cron_entry_t *e)
     e->stats.failure++;
     e->stats.failcount++;
     if (e->stop_on_failure && e->stats.failcount >= e->stop_on_failure) {
-        flux_log (e->ctx->h, LOG_ERR,
-                "cron-%ju: exceeded failure limit of %d. stopping",
-                e->id, e->stop_on_failure);
+        flux_log (e->ctx->h,
+                  LOG_ERR,
+                  "cron-%ju: exceeded failure limit of %d. stopping",
+                  e->id,
+                  e->stop_on_failure);
         cron_entry_stop (e);
     }
 }
@@ -186,8 +201,11 @@ static void cron_entry_finished_handler (flux_t *h, cron_task_t *t, void *arg)
         cron_entry_failure (e);
     }
     else if (cron_task_status (t) != 0) {
-        flux_log (h, LOG_ERR, "cron-%ju: \"%s\": Failed: %s",
-                 e->id, e->command, cron_task_state (t));
+        flux_log (h,
+                  LOG_ERR, "cron-%ju: \"%s\": Failed: %s",
+                  e->id,
+                  e->command,
+                  cron_task_state (t));
         cron_entry_failure (e);
     }
     else
@@ -224,8 +242,10 @@ static int cron_entry_stop (cron_entry_t *e)
 /*
  * Callback used to stop a cron entry safely.
  */
-static void entry_stop_cb (flux_reactor_t *r, flux_watcher_t *w,
-                           int revents, void *arg)
+static void entry_stop_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
 {
     cron_entry_stop (arg);
     flux_watcher_stop (w);
@@ -240,7 +260,8 @@ int cron_entry_stop_safe (cron_entry_t *e)
 {
     flux_reactor_t *r = flux_get_reactor (e->ctx->h);
     flux_watcher_t *w = flux_prepare_watcher_create (r,
-                            entry_stop_cb, e);
+                                                     entry_stop_cb,
+                                                     e);
     if (!w)
         return (-1);
     flux_watcher_start (w);
@@ -312,8 +333,10 @@ static void cron_entry_destroy (cron_entry_t *e)
     free (e);
 }
 
-static void deferred_cb (flux_t *h, flux_msg_handler_t *mh,
-                         const flux_msg_t *msg, void *arg)
+static void deferred_cb (flux_t *h,
+                         flux_msg_handler_t *mh,
+                         const flux_msg_t *msg,
+                         void *arg)
 {
     cron_ctx_t *ctx = arg;
     cron_entry_t *e;
@@ -340,8 +363,11 @@ static int cron_entry_defer (cron_entry_t *e)
     if (zlist_push (ctx->deferred, e) < 0)
         return (-1);
     e->stats.deferred++;
-    flux_log (ctx->h, LOG_DEBUG, "deferring cron-%ju to next %s event",
-             e->id, ctx->sync_event);
+    flux_log (ctx->h,
+              LOG_DEBUG,
+              "deferring cron-%ju to next %s event",
+              e->id,
+              ctx->sync_event);
 
     if (zlist_size (ctx->deferred) == 1)
         flux_msg_handler_start (ctx->mh);
@@ -370,11 +396,12 @@ static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const flux_msg_t *msg)
     int saved_errno = EPROTO;
 
     /* Get required fields "type", "name" and "command" */
-    if (flux_msg_unpack (msg, "{ s:s, s:s, s:s, s:O }",
-            "type", &type,
-            "name", &name,
-            "command", &command,
-            "args", &args) < 0) {
+    if (flux_msg_unpack (msg,
+                         "{ s:s, s:s, s:s, s:O }",
+                         "type", &type,
+                         "name", &name,
+                         "command", &command,
+                         "args", &args) < 0) {
         flux_log_error (h, "cron.create: Failed to get name/command/args");
         goto done;
     }
@@ -403,14 +430,15 @@ static cron_entry_t *cron_entry_create (cron_ctx_t *ctx, const flux_msg_t *msg)
     e->stop_on_failure = 0;    /* Whether the cron job is stopped on failure */
     e->timeout = -1.0;         /* Task timeout (default -1, no timeout)      */
 
-    if (flux_msg_unpack (msg, "{ s?O, s?s, s?i, s?i, s?i, s?i, s?F }",
-            "environ",            &e->env,
-            "cwd",                &cwd,
-            "repeat",             &e->repeat,
-            "rank",               &e->rank,
-            "task-history-count", &e->task_history_count,
-            "stop-on-failure",    &e->stop_on_failure,
-            "timeout",            &e->timeout) < 0) {
+    if (flux_msg_unpack (msg,
+                         "{ s?O, s?s, s?i, s?i, s?i, s?i, s?F }",
+                         "environ", &e->env,
+                         "cwd", &cwd,
+                         "repeat", &e->repeat,
+                         "rank", &e->rank,
+                         "task-history-count", &e->task_history_count,
+                         "stop-on-failure", &e->stop_on_failure,
+                         "timeout", &e->timeout) < 0) {
         saved_errno = EPROTO;
         flux_log_error (h, "cron.create: flux_msg_unpack");
         goto out_err;
@@ -498,16 +526,20 @@ static int cron_ctx_sync_event_init (cron_ctx_t *ctx, const char *topic)
 {
     struct flux_match match = FLUX_MATCH_EVENT;
 
-    flux_log (ctx->h, LOG_INFO,
-        "synchronizing cron tasks to event %s", topic);
+    flux_log (ctx->h,
+              LOG_INFO,
+              "synchronizing cron tasks to event %s",
+              topic);
 
     if ((ctx->sync_event = strdup (topic)) == NULL) {
         flux_log_error (ctx->h, "sync_event_init: strdup");
         return (-1);
     }
     match.topic_glob = ctx->sync_event;
-    ctx->mh = flux_msg_handler_create (ctx->h, match,
-                                       deferred_cb, (void *) ctx);
+    ctx->mh = flux_msg_handler_create (ctx->h,
+                                       match,
+                                       deferred_cb,
+                                       (void *) ctx);
     if (!ctx->mh) {
         flux_log_error (ctx->h, "sync_event_init: msg_handler_create");
         return (-1);
@@ -580,13 +612,13 @@ static json_t *cron_entry_to_json (cron_entry_t *e)
      *  Common entry contents:
      */
     if (!(o = json_pack ("{ s:I, s:i, s:s, s:s, s:i, s:b, s:s }",
-                   "id", (json_int_t) e->id,
-                   "rank", e->rank,
-                   "name", e->name,
-                   "command", e->command,
-                   "repeat", e->repeat,
-                   "stopped", e->stopped,
-                   "type", e->typename)))
+                         "id", (json_int_t) e->id,
+                         "rank", e->rank,
+                         "name", e->name,
+                         "command", e->command,
+                         "repeat", e->repeat,
+                         "stopped", e->stopped,
+                         "type", e->typename)))
         return NULL;
 
     if (e->timeout >= 0.0)
@@ -630,8 +662,10 @@ fail:
 /*
  *  Handle cron.create: create a new cron entry
  */
-static void cron_create_handler (flux_t *h, flux_msg_handler_t *w,
-                                  const flux_msg_t *msg, void *arg)
+static void cron_create_handler (flux_t *h,
+                                 flux_msg_handler_t *w,
+                                 const flux_msg_t *msg,
+                                 void *arg)
 {
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
@@ -659,8 +693,10 @@ error:
         flux_log_error (h, "cron.request: flux_respond_error");
 }
 
-static void cron_sync_handler (flux_t *h, flux_msg_handler_t *w,
-                                const flux_msg_t *msg, void *arg)
+static void cron_sync_handler (flux_t *h,
+                               flux_msg_handler_t *w,
+                               const flux_msg_t *msg,
+                               void *arg)
 {
     cron_ctx_t *ctx = arg;
     const char *topic;
@@ -691,7 +727,9 @@ static void cron_sync_handler (flux_t *h, flux_msg_handler_t *w,
         ctx->sync_epsilon = epsilon;
 
     if (ctx->sync_event) {
-        if (flux_respond_pack (h, msg, "{ s:s s:f }",
+        if (flux_respond_pack (h,
+                               msg,
+                               "{ s:s s:f }",
                                "sync_event", ctx->sync_event,
                                "sync_epsilon", ctx->sync_epsilon) < 0)
             flux_log_error (h, "cron.request: flux_respond_pack");
@@ -729,8 +767,10 @@ static cron_entry_t *cron_ctx_find_entry (cron_ctx_t *ctx, int64_t id)
  *  Return a cron entry referenced by request in flux message msg.
  *  [service] is name of service for logging purposes.
  */
-static cron_entry_t *entry_from_request (flux_t *h, const flux_msg_t *msg,
-                                         cron_ctx_t *ctx, const char *service)
+static cron_entry_t *entry_from_request (flux_t *h,
+                                         const flux_msg_t *msg,
+                                         cron_ctx_t *ctx,
+                                         const char *service)
 {
     int64_t id;
 
@@ -746,8 +786,10 @@ static cron_entry_t *entry_from_request (flux_t *h, const flux_msg_t *msg,
 /*
  *  "cron.delete" handler
  */
-static void cron_delete_handler (flux_t *h, flux_msg_handler_t *w,
-                                 const flux_msg_t *msg, void *arg)
+static void cron_delete_handler (flux_t *h,
+                                 flux_msg_handler_t *w,
+                                 const flux_msg_t *msg,
+                                 void *arg)
 {
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
@@ -780,8 +822,10 @@ error:
 /*
  *  "cron.stop" handler: stop a cron entry until restarted
  */
-static void cron_stop_handler (flux_t *h, flux_msg_handler_t *w,
-                               const flux_msg_t *msg, void *arg)
+static void cron_stop_handler (flux_t *h,
+                               flux_msg_handler_t *w,
+                               const flux_msg_t *msg,
+                               void *arg)
 {
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
@@ -808,8 +852,10 @@ error:
 /*
  *  "cron.start" handler: start a stopped cron entry
  */
-static void cron_start_handler (flux_t *h, flux_msg_handler_t *w,
-                               const flux_msg_t *msg, void *arg)
+static void cron_start_handler (flux_t *h,
+                                flux_msg_handler_t *w,
+                                const flux_msg_t *msg,
+                                void *arg)
 {
     cron_entry_t *e;
     cron_ctx_t *ctx = arg;
@@ -837,8 +883,10 @@ error:
 /*
  *  Handle "cron.list" -- dump a list of current cron entries via JSON
  */
-static void cron_ls_handler (flux_t *h, flux_msg_handler_t *w,
-                             const flux_msg_t *msg, void *arg)
+static void cron_ls_handler (flux_t *h,
+                             flux_msg_handler_t *w,
+                             const flux_msg_t *msg,
+                             void *arg)
 {
     cron_ctx_t *ctx = arg;
     cron_entry_t *e = NULL;

--- a/src/modules/cron/datetime.c
+++ b/src/modules/cron/datetime.c
@@ -114,7 +114,8 @@ static double reschedule_cb (flux_watcher_t *w, double now, void *arg)
          */
         if (e->repeat == 0 || e->repeat < e->stats.count + 1) {
             flux_log_error (dt->h,
-                    "cron-%ju: Unable to get next wakeup. Stopping.", e->id);
+                            "cron-%ju: Unable to get next wakeup. Stopping.",
+                            e->id);
         }
         cron_entry_stop_safe (e);
         return now + 1.e19;
@@ -129,9 +130,10 @@ static void *cron_datetime_create (flux_t *h, cron_entry_t *e, json_t *arg)
         return (NULL);
     dt->h = h;
     dt->w = flux_periodic_watcher_create (flux_get_reactor (h),
-                                         0., 0.,
-                                         reschedule_cb,
-                                         datetime_cb, (void *) e);
+                                          0.,
+                                          0.,
+                                          reschedule_cb,
+                                          datetime_cb, (void *) e);
     if (dt->w == NULL) {
         flux_log_error (h, "periodic_watcher_create");
         datetime_entry_destroy (dt);

--- a/src/modules/cron/event.c
+++ b/src/modules/cron/event.c
@@ -26,8 +26,10 @@ struct cron_event {
     char *event;
 };
 
-static void ev_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
-                         int revents, void *arg)
+static void ev_timer_cb (flux_reactor_t *r,
+                         flux_watcher_t *w,
+                         int revents,
+                         void *arg)
 {
     cron_entry_t *e = arg;
     struct cron_event *ev = cron_entry_type_data (e);
@@ -37,8 +39,10 @@ static void ev_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
     ev->paused = 0;
 }
 
-static void event_handler (flux_t *h, flux_msg_handler_t *w,
-                           const flux_msg_t *msg, void *arg)
+static void event_handler (flux_t *h,
+                           flux_msg_handler_t *w,
+                           const flux_msg_t *msg,
+                           void *arg)
 {
     cron_entry_t *e = arg;
     struct cron_event *ev = cron_entry_type_data (e);
@@ -63,8 +67,11 @@ static void event_handler (flux_t *h, flux_msg_handler_t *w,
         if (remaining > 1e-5) {
             flux_reactor_t *r = flux_get_reactor (h);
             flux_watcher_t *w;
-            if (!(w = flux_timer_watcher_create (r, remaining, 0.,
-                                                 ev_timer_cb, (void *) e)))
+            if (!(w = flux_timer_watcher_create (r,
+                                                 remaining,
+                                                 0.,
+                                                 ev_timer_cb,
+                                                 (void *) e)))
                 flux_log_error (h, "timer_watcher_create");
             else {
                 /* Pause the event watcher. Continue to count events but
@@ -72,9 +79,11 @@ static void event_handler (flux_t *h, flux_msg_handler_t *w,
                  */
                 ev->paused = 1;
                 flux_watcher_start (w);
-                flux_log (h, LOG_DEBUG,
+                flux_log (h,
+                          LOG_DEBUG,
                           "cron-%ju: delaying %4.03fs due to min interval",
-                          e->id, remaining);
+                          e->id,
+                          remaining);
             }
             return;
         }
@@ -105,11 +114,12 @@ static void *cron_event_create (flux_t *h, cron_entry_t *e, json_t *arg)
     const char *event;
     struct flux_match match = FLUX_MATCH_EVENT;
 
-    if (json_unpack (arg, "{ s:s, s?i, s?i, s?F }",
-                          "topic", &event,
-                          "nth",   &nth,
-                          "after", &after,
-                          "min_interval", &min_interval) < 0) {
+    if (json_unpack (arg,
+                     "{s:s s?i s?i s?F}",
+                     "topic", &event,
+                     "nth",   &nth,
+                     "after", &after,
+                     "min_interval", &min_interval) < 0) {
         flux_log_error (h, "cron event: json_unpack");
         errno = EPROTO;
         return NULL;

--- a/src/modules/cron/interval.c
+++ b/src/modules/cron/interval.c
@@ -26,8 +26,10 @@ struct cron_interval {
 };
 
 
-static void interval_handler (flux_reactor_t *r, flux_watcher_t *w,
-                              int revents, void *arg)
+static void interval_handler (flux_reactor_t *r,
+                              flux_watcher_t *w,
+                              int revents,
+                              void *arg)
 {
     cron_entry_schedule_task ((cron_entry_t *)arg);
 }
@@ -40,9 +42,10 @@ static void *cron_interval_create (flux_t *h, cron_entry_t *e, json_t *arg)
     /*  Unpack 'interval' and 'after' arguments. If after was not specified,
      *   (and thus is still < 0.0), then it is set to interval by default.
      */
-    if (json_unpack (arg, "{ s:F, s?F }",
-                          "interval", &i,
-                          "after", &after) < 0) {
+    if (json_unpack (arg,
+                     "{s:F s?F}",
+                     "interval", &i,
+                     "after", &after) < 0) {
         return NULL;
     }
     if (after < 0.0)
@@ -55,7 +58,9 @@ static void *cron_interval_create (flux_t *h, cron_entry_t *e, json_t *arg)
     iv->seconds = i;
     iv->after = after;
     iv->w = flux_timer_watcher_create (flux_get_reactor (h),
-                                       after, i, interval_handler,
+                                       after,
+                                       i,
+                                       interval_handler,
                                        (void *) e);
     if (!iv->w) {
         flux_log_error (h, "cron_interval: flux_timer_watcher_create");
@@ -86,9 +91,9 @@ static void cron_interval_stop (void *arg)
 static json_t *cron_interval_to_json (void *arg)
 {
     struct cron_interval *iv = arg;
-    return json_pack ("{ s:f, s:f, s:f }",
-                      "interval",    iv->seconds,
-                      "after",       iv->after,
+    return json_pack ("{s:f s:f s:f}",
+                      "interval", iv->seconds,
+                      "after", iv->after,
                       "next_wakeup", flux_watcher_next_wakeup (iv->w));
 }
 

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -181,7 +181,8 @@ static void completion_cb (flux_subprocess_t *p)
     cron_task_handle_finished (p, t);
 }
 
-static void state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
+static void state_change_cb (flux_subprocess_t *p,
+                             flux_subprocess_state_t state)
 {
     cron_task_t *t = flux_subprocess_aux_get (p, "task");
 
@@ -227,14 +228,16 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
         is_stderr = true;
 
     if ((len = flux_subprocess_read_trimmed_line (p, stream, &buf)) < 0) {
-        flux_log_error (t->h, "%s: flux_subprocess_read_trimmed_line",
+        flux_log_error (t->h,
+                        "%s: flux_subprocess_read_trimmed_line",
                         __FUNCTION__);
         return;
     }
 
     if (!len) {
         if ((len = flux_subprocess_read (p, stream, &buf)) < 0) {
-            flux_log_error (t->h, "%s: flux_subprocess_read",
+            flux_log_error (t->h,
+                            "%s: flux_subprocess_read",
                             __FUNCTION__);
             return;
         }
@@ -265,9 +268,9 @@ int cron_task_kill (cron_task_t *t, int sig)
 
 
 static flux_cmd_t *exec_cmd_create (struct cron_task *t,
-    const char *command,
-    const char *cwd,
-    json_t *env)
+                                    const char *command,
+                                    const char *cwd,
+                                    json_t *env)
 {
     flux_cmd_t *cmd = NULL;
     char *tmp_cwd = NULL;
@@ -314,8 +317,10 @@ static flux_cmd_t *exec_cmd_create (struct cron_task *t,
 }
 
 int cron_task_run (cron_task_t *t,
-    int rank, const char *command, const char *cwd,
-    json_t *env)
+                   int rank,
+                   const char *command,
+                   const char *cwd,
+                   json_t *env)
 {
     flux_t *h = t->h;
     flux_subprocess_t *p = NULL;

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -273,7 +273,6 @@ static flux_cmd_t *exec_cmd_create (struct cron_task *t,
                                     json_t *env)
 {
     flux_cmd_t *cmd = NULL;
-    char *tmp_cwd = NULL;
 
     if (!(cmd = flux_cmd_create (0, NULL, NULL))) {
         flux_log_error (t->h, "exec_cmd_create: flux_cmd_create");
@@ -285,7 +284,7 @@ static flux_cmd_t *exec_cmd_create (struct cron_task *t,
         flux_log_error (t->h, "exec_cmd_create: flux_cmd_argv_append");
         goto error;
     }
-    if (flux_cmd_setcwd (cmd, cwd) < 0) {
+    if (cwd && flux_cmd_setcwd (cmd, cwd) < 0) {
         flux_log_error (t->h, "exec_cmd_create: flux_cmd_setcwd");
         goto error;
     }
@@ -308,10 +307,8 @@ static flux_cmd_t *exec_cmd_create (struct cron_task *t,
         }
     }
 
-    free (tmp_cwd);
     return (cmd);
  error:
-    free (tmp_cwd);
     flux_cmd_destroy (cmd);
     return (NULL);
 }

--- a/src/modules/cron/task.h
+++ b/src/modules/cron/task.h
@@ -20,8 +20,12 @@ typedef struct cron_task cron_task_t;
 
 /*  io callback fn for cron task
  */
-typedef void (*cron_task_io_f) (flux_t *h, cron_task_t *t, void *arg,
-                                bool is_stderr, const char *data, int datalen);
+typedef void (*cron_task_io_f) (flux_t *h,
+                                cron_task_t *t,
+                                void *arg,
+                                bool is_stderr,
+                                const char *data,
+                                int datalen);
 
 /*  task state change handler for cron task, check state with
  *   cron_task_state().

--- a/src/modules/cron/types.h
+++ b/src/modules/cron/types.h
@@ -16,6 +16,6 @@
  *  Lookup cron entry operations for cron entry type named "name"
  */
 int cron_type_operations_lookup (const char *name,
-    struct cron_entry_ops *ops);
+                                 struct cron_entry_ops *ops);
 
 #endif /* !HAVE_CRON_TYPES_H */


### PR DESCRIPTION
This PR fixes #6104 by allowing cron tasks to have a default, unset cwd if just using the broker cwd. This allows use of the posix_spawn() default subprocess mechanism in most cases, instead of always falling back to fork().