### PR TITLE
job-manager: skip housekeeping for alloc-bypass jobs

### DIFF
--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -328,10 +328,15 @@ int event_job_action (struct event *event, struct job *job)
                 && !job->perilog_active
                 && !job->start_pending
                 && !job->free_posted) {
-                if (housekeeping_start (ctx->housekeeping,
-                                        job->R_redacted,
-                                        job->id,
-                                        job->userid) < 0)
+
+                /* Release resources to housekeeping, but only if they were
+                 * allocated by the scheduler.
+                 */
+                if (!job->alloc_bypass
+                    && housekeeping_start (ctx->housekeeping,
+                                           job->R_redacted,
+                                           job->id,
+                                           job->userid) < 0)
                     return -1;
                 if (event_job_post_pack (ctx->event, job, "free", 0, NULL) < 0)
                     return -1;

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -393,7 +393,10 @@ void free_cb (flux_t *h, const flux_msg_t *msg, const char *R_str, void *arg)
     }
 
     if (try_free (h, ss, id, R, final) < 0) {
-        flux_log_error (h, "free: could not free R");
+        flux_log_error (h, "free: could not free R. Stopping scheduler.");
+        /* Make this error fatal to the scheduler so that tests will fail.
+         */
+        flux_reactor_stop_error (flux_get_reactor (h));
         return;
     }
     /* This is a no-op now that sched.free requires no response

--- a/t/t2273-job-alloc-bypass.t
+++ b/t/t2273-job-alloc-bypass.t
@@ -36,6 +36,9 @@ test_expect_success 'alloc-bypass: works' '
 	        --setattr=system.alloc-bypass.R="$(flux kvs get resource.R)" \
 	        -o per-resource.type=node hostname
 '
+test_expect_success 'alloc-bypass: scheduler still running' '
+	flux ping -c 1 sched-simple
+'
 test_expect_success 'alloc-bypass: works with per-resource.type=core' '
 	flux run \
 	    --setattr=system.alloc-bypass.R="$(flux kvs get resource.R)" \


### PR DESCRIPTION
This is the most minimal fix for #6218 - it just completely skips housekeeping for alloc-bypass jobs.
This _seems_ like the right approach, i.e. it may be surprising to have housekeeping run, if configured, for jobs using alloc-bypass. However, prolog/epilog actions are not similarly skipped for alloc-bypass jobs (and this is probably necessary, because some of these actions may be required for job functionality), so an argument could be made to keep housekeeping support for alloc-bypass.

Anyway, this PR is WIP to ensure we have agreement first on no support for housekeeping on alloc-bypass jobs.

This PR also turns a failed free request in sched-simple from a log message into a hard error so that we can catch future failures in the testsuite and CI.