### PR TITLE
content-sqlite: add sqlite config to module stats

### DIFF
--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -583,12 +583,15 @@ void stats_get_cb (flux_t *h,
         goto error;
     if (flux_respond_pack (h,
                            msg,
-                           "{s:i s:I s:I s:O s:O}",
+                           "{s:i s:I s:I s:O s:O s:{s:s s:s}}",
                            "object_count", count,
                            "dbfile_size", get_file_size (ctx->dbfile),
                            "dbfile_free", get_fs_free (ctx->dbfile),
                            "load_time", load_time,
-                           "store_time", store_time) < 0)
+                           "store_time", store_time,
+                           "config",
+                             "journal_mode", ctx->journal_mode,
+                             "synchronous", ctx->synchronous) < 0)
         flux_log_error (h, "error responding to stats-get request");
     json_decref (load_time);
     json_decref (store_time);

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -342,6 +342,18 @@ test_expect_success 'run flux with statedir and verify modes' '
 	    -o,-Sstatedir=$(pwd) flux dmesg >logs4  &&
 	grep "journal_mode=WAL synchronous=NORMAL" logs4
 '
+test_expect_success 'run flux without statedir and verify config' '
+	flux start -o,-Sbroker.rc1_path=$rc1_kvs,-Sbroker.rc3_path=$rc3_kvs \
+	    flux module stats content-sqlite >stats1 &&
+	$jq -e ".config.journal_mode == \"OFF\"" < stats1 &&
+	$jq -e ".config.synchronous == \"OFF\"" < stats1
+'
+test_expect_success 'run flux with statedir and verify config' '
+	flux start -o,-Sbroker.rc1_path=$rc1_kvs,-Sbroker.rc3_path=$rc3_kvs \
+	    -o,-Sstatedir=$(pwd) flux module stats content-sqlite >stats2  &&
+	$jq -e ".config.journal_mode == \"WAL\"" < stats2 &&
+	$jq -e ".config.synchronous == \"NORMAL\"" < stats2
+'
 
 # Will create in WAL mode since statedir is set
 recreate_database()


### PR DESCRIPTION
Problem: Some module configuration varies depending on flux configuration.  In addition, future sqlite configuration may change
during operations.  There is no way to know what the current configuration is.

Output the journal_mode and synchronous settings in the module stats.