### PR TITLE
content-sqlite: set sqlite pragmas with flux-config

### DIFF
--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -354,6 +354,20 @@ test_expect_success 'run flux with statedir and verify config' '
 	$jq -e ".config.journal_mode == \"WAL\"" < stats2 &&
 	$jq -e ".config.synchronous == \"NORMAL\"" < stats2
 '
+test_expect_success 'flux fails with invalid journal_mode config' '
+	flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+	    "flux module load content; \
+	    flux module load content-sqlite journal_mode=FOO; \
+	    flux module remove content" > invalid1.out 2> invalid1.err &&
+	grep "content-sqlite: Invalid argument" invalid1.err
+'
+test_expect_success 'flux fails with invalid synchronous config' '
+	flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+	    "flux module load content; \
+	    flux module load content-sqlite synchronous=BAR; \
+	    flux module remove content" > invalid2.out 2> invalid2.err &&
+	grep "content-sqlite: Invalid argument" invalid2.err
+'
 
 # Will create in WAL mode since statedir is set
 recreate_database()


### PR DESCRIPTION
Problem: In content-sqlite, the journal_mode and synchronous configs for sqlite can only be configured via the module command line.  This can be inconvenient, especially for testing.

Support their configuration via the flux config as well.