### PR TITLE
update feasibility RPCs to conform to RFC 27

### DIFF
--- a/doc/guide/admin.rst
+++ b/doc/guide/admin.rst
@@ -780,7 +780,7 @@ distributed with Flux is shown below:
 
   $ flux job-validator --list-plugins
   Available plugins:
-  feasibility           Use sched.feasibility RPC to validate job
+  feasibility           Use feasibility service to validate job
   jobspec               Python bindings based jobspec validator
   require-instance      Require that all jobs are new instances of Flux
   schema                Validate jobspec using jsonschema

--- a/etc/rc1
+++ b/etc/rc1
@@ -102,7 +102,7 @@ done
 
 # Print module that has registered 'sched' service, if any
 lookup_sched_module() {
-    flux module list | awk '$NF == "sched" { print $1 }'
+    flux module list | awk '$NF ~ /^\s*(\w+,)?sched(,\w+)?\s*$/ { print $1 }'
 }
 
 if test $RANK -eq 0 -a "${FLUX_SCHED_MODULE}" != "none" \

--- a/src/bindings/python/flux/job/validator/plugins/feasibility.py
+++ b/src/bindings/python/flux/job/validator/plugins/feasibility.py
@@ -16,9 +16,6 @@ This allows jobs which are making infeasible or otherwise invalid
 requests to be rejected by the scheduler before ingest, instead of
 when the scheduler attempts to allocate resources for them.
 
-The RPC endpoint for feasibility checks can be set with an optional
---feasibility-service=NAME option.
-
 ENOSYS errors from the RPC are ignored, in case there is no feasibility
 service currently loaded.
 """
@@ -31,16 +28,6 @@ from flux.job.validator import ValidatorPlugin
 class Validator(ValidatorPlugin):
     def __init__(self, parser):
         self.service_name = "feasibility.check"
-        parser.add_argument(
-            "--feasibility-service",
-            metavar="NAME",
-            help="Set feasibility RPC service endpoint "
-            f"(default={self.service_name})",
-        )
-
-    def configure(self, args):
-        if args.feasibility_service:
-            self.service_name = args.feasibility_service
 
     def validate(self, args):
         try:

--- a/src/bindings/python/flux/job/validator/plugins/feasibility.py
+++ b/src/bindings/python/flux/job/validator/plugins/feasibility.py
@@ -8,9 +8,9 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-"""Use sched.feasibility RPC to validate job
+"""Use feasibility service to validate job
 
-This plugin validates jobs via a sched.feasibility RPC.
+This plugin validates jobs via a feasibility.check RPC.
 
 This allows jobs which are making infeasible or otherwise invalid
 requests to be rejected by the scheduler before ingest, instead of
@@ -19,8 +19,8 @@ when the scheduler attempts to allocate resources for them.
 The RPC endpoint for feasibility checks can be set with an optional
 --feasibility-service=NAME option.
 
-ENOSYS errors from the RPC are ignored, in case the loaded scheduler
-does not support the sched.feasibility RPC
+ENOSYS errors from the RPC are ignored, in case there is no feasibility
+service currently loaded.
 """
 
 import errno
@@ -30,7 +30,7 @@ from flux.job.validator import ValidatorPlugin
 
 class Validator(ValidatorPlugin):
     def __init__(self, parser):
-        self.service_name = "sched.feasibility"
+        self.service_name = "feasibility.check"
         parser.add_argument(
             "--feasibility-service",
             metavar="NAME",

--- a/src/modules/job-manager/update.c
+++ b/src/modules/job-manager/update.c
@@ -40,10 +40,10 @@
  * `job.update.*` callback. The `job.validate` step will only be skipped
  * all keys in an update have the validated flag set.
  *
- * Plugins may also request a job feasibility check (sched.feasibility RPC)
- * by setting a 'feasibility' flag to 1 in the FLUX_PLUGIN_OUT_ARGS. If any
- * plugin requests a feasibility check, then feasibility is run for the
- * proposed jobspec as a whole.
+ * Plugins may also request a job feasibility check by setting a
+ * 'feasibility' flag to 1 in the FLUX_PLUGIN_OUT_ARGS. If any plugin
+ * requests a feasibility check, then feasibility is run for the proposed
+ * jobspec as a whole.
  *
  * A plugin may request additional updates by setting an 'updates' key in
  * in the plugin out arguments. The updates key follows the same format as
@@ -362,7 +362,7 @@ static int update_feasibility_check (struct update *update,
                                            updates,
                                            validate))
         || !(f = flux_rpc_pack (update->ctx->h,
-                                "sched.feasibility",
+                                "feasibility.check",
                                 0,
                                 0,
                                 "{s:O}",

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -700,7 +700,7 @@ static void feasibility_cb (flux_t *h,
         goto err;
     }
     rlist_destroy (alloc);
-    if (flux_respond_pack (h, msg, "{s:i}", "errnum", 0) < 0)
+    if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "feasibility_cb: flux_respond_pack");
     return;
 err:

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -971,7 +971,6 @@ static int process_args (flux_t *h, struct simple_sched *ss,
 
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "*.resource-status", status_cb, FLUX_ROLE_USER },
-    { FLUX_MSGTYPE_REQUEST, "*.feasibility", feasibility_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST, "*.expiration", expiration_cb, FLUX_ROLE_OWNER },
     { FLUX_MSGTYPE_REQUEST,
       "feasibility.check",

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -78,9 +78,7 @@ test_expect_success 'validator plugin importer reports errors on import' '
 '
 test_expect_success 'flux job-validator --help shows help for selected plugins' '
 	flux job-validator --plugins=jobspec --help >help.jobspec.out 2>&1 &&
-	flux job-validator --plugins=feasibility --help >help.feas.out 2>&1 &&
-	grep require-version help.jobspec.out &&
-	grep feasibility-service=NAME help.feas.out
+	grep require-version help.jobspec.out
 '
 test_expect_success 'flux job-validator errors on invalid plugin' '
 	test_expect_code 1 flux job-validator --plugin=foo </dev/null &&
@@ -98,16 +96,6 @@ test_expect_success 'flux job-validator rejects non-V1 jobspec' '
 	flux run --dry-run hostname | jq -c ".version = 2" | \
 		test_expect_code 1 \
 		flux job-validator --jobspec-only --require-version=1
-'
-test_expect_success 'flux job-validator --feasibility-service works ' '
-	flux run -n 4888 --dry-run hostname | \
-		flux job-validator --jobspec-only --plugins=feasibility \
-		| jq -e ".errnum != 0" &&
-	flux run -n 4888 --dry-run hostname | \
-		flux job-validator --jobspec-only \
-			--plugins=feasibility \
-			--feasibility-service=kvs.ping \
-		| jq -e ".errnum == 0"
 '
 test_expect_success 'job-ingest: v1 jobspecs accepted by default' '
 	test_valid ${JOBSPEC}/valid_v1/*


### PR DESCRIPTION
This PR updates sched-simple, the feasibility validator plugin, and docs to conform with the RFC 27 specification of a `feasibility` service and `feasibility.check` RPC instead of `sched.feasibility`. This disentangles the feasibility checks from the scheduler service, and therefore allows more flexibility in how and where the feasibility service is implemented.

Before this PR passes CI, a small PR may be necessary in flux-sched to have qmanager register the `feasibility` service and add a handler for `feasibility.check` requests. (Later, a feasibility specific module in Fluxion may be supported)