### PR TITLE
libev: fix memory fence on i386 under valgrind

### DIFF
--- a/src/common/libev/ev.c
+++ b/src/common/libev/ev.c
@@ -791,7 +791,7 @@ struct signalfd_siginfo
   #if ECB_GCC_VERSION(2,5) || defined __INTEL_COMPILER || (__llvm__ && __GNUC__) || __SUNPRO_C >= 0x5110 || __SUNPRO_CC >= 0x5110
     #define ECB_MEMORY_FENCE_RELAXED __asm__ __volatile__ ("" : : : "memory")
     #if __i386 || __i386__
-      #define ECB_MEMORY_FENCE         __asm__ __volatile__ ("lock; orb $0, -1(%%esp)" : : : "memory")
+      #define ECB_MEMORY_FENCE         __asm__ __volatile__ ("lock; orb $0, 0(%%esp)"  : : : "memory")
       #define ECB_MEMORY_FENCE_ACQUIRE __asm__ __volatile__ (""                        : : : "memory")
       #define ECB_MEMORY_FENCE_RELEASE __asm__ __volatile__ (""                        : : : "memory")
     #elif ECB_GCC_AMD64

--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -61,14 +61,6 @@
    fun:_dl_lookup_symbol_x
 }
 {
-   <issue_1897>
-   Memcheck:Addr1
-   ...
-   fun:ev_run
-   fun:flux_reactor_run
-   ...
-}
-{
    <issue_2223>
    Memcheck:Leak
    match-leak-kinds: definite


### PR DESCRIPTION
problem: libev accesses one byte past the end of the stack in its custom assembly memory fence.  I have no idea why, it doesn't help, and causes valgrind to throw a warning every single time it gets invoked.

solution: Apply this patch identified for debian upstream in 2017 so it
will stop doing that: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850861