### PR TITLE
mergify: use updated keys before deprecation bites

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,13 +1,7 @@
 queue_rules:
   - name: default
-    conditions:
-      - base=master
-      - label="merge-when-passing"
-      - label!="work-in-progress"
-      - "approved-reviews-by=@flux-framework/core"
-      - "#approved-reviews-by>0"
-      - "#changes-requested-reviews-by=0"
-      - -title~=^\[*[Ww][Ii][Pp]
+    update_method: rebase
+    merge_method: merge
 
 pull_request_rules:
   - name: rebase and merge when passing all checks
@@ -22,8 +16,6 @@ pull_request_rules:
     actions:
       queue:
         name: default
-        method: merge
-        update_method: rebase
   - name: remove outdated approved reviews
     conditions:
       - author!=@core


### PR DESCRIPTION
problem: mergify is deprecating some of the options we use, and removing them in a few weeks

solution: use the new versions