### PR TITLE
Fix handling of `--` used to separate options from command in `flux submit`, `run`, and `batch`

### DIFF
--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -1232,6 +1232,11 @@ class SubmitBaseCmd(MiniCmd):
         if not args.command:
             raise ValueError("job command and arguments are missing")
 
+        #  Remove first -- from command in case user used it to separate
+        #  Flux cli options from command and options
+        if args.command[0] == "--":
+            args.command.pop(0)
+
         #  Ensure integer args are converted to int() here.
         #  This is done because we do not use type=int in argparse in order
         #   to allow these options to be mutable for bulksubmit:

--- a/src/bindings/python/flux/cli/batch.py
+++ b/src/bindings/python/flux/cli/batch.py
@@ -60,6 +60,11 @@ class BatchCmd(base.MiniCmd):
         Returns the ingested script and new argparse args Namespace.
         """
         if args.SCRIPT:
+            # Remove leading "--" in case it was used to separate flux-batch(1)
+            # options from user script and options:
+            if args.SCRIPT[0] == "--":
+                args.SCRIPT.pop(0)
+
             if args.wrap:
                 #  Return script which will be wrapped by caller
                 return " ".join(args.SCRIPT) + "\n", args

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -6,6 +6,9 @@ test_description='Test flux submit command'
 
 test_under_flux 4
 
+NCORES=$(flux resource list -no {ncores})
+test ${NCORES} -gt 4 && test_set_prereq MULTICORE
+
 # Set CLIMain log level to logging.DEBUG (10), to enable stack traces
 export FLUX_PYCLI_LOGLEVEL=10
 
@@ -23,7 +26,7 @@ test_expect_success 'flux submit + flux job attach works' '
 	jobid=$(flux submit hostname) &&
 	flux job attach $jobid
 '
-test_expect_success HAVE_MULTICORE 'flux submit --ntasks=2 --cores-per-task=2 works' '
+test_expect_success MULTICORE 'flux submit --ntasks=2 --cores-per-task=2 works' '
 	jobid=$(flux submit --ntasks=2 --cores-per-task=2 hostname) &&
 	flux job attach $jobid
 '

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -22,6 +22,10 @@ test_expect_success 'flux submit fails with error message' '
 	test_must_fail flux submit 2>usage.err &&
 	grep "job command and arguments are missing" usage.err
 '
+test_expect_success 'flux submit ignores ambiguous args after --' '
+	flux submit -n2 --dry-run -- hostname --n=2 \
+		| jq -e ".tasks[0].command[0] == \"hostname\""
+'
 test_expect_success 'flux submit + flux job attach works' '
 	jobid=$(flux submit hostname) &&
 	flux job attach $jobid

--- a/t/t2711-python-cli-run.t
+++ b/t/t2711-python-cli-run.t
@@ -17,6 +17,10 @@ test_expect_success 'flux run fails with error message' '
 	test_must_fail flux run 2>usage.err &&
 	grep "job command and arguments are missing" usage.err
 '
+test_expect_success 'flux run ignores ambiguous args after --' '
+	flux run -n2 --dry-run -- hostname --n=2 \
+		| jq -e ".tasks[0].command[0] == \"hostname\""
+'
 test_expect_success 'flux run works' '
 	flux run hostname >run.out &&
 	hostname >run.exp &&

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -29,6 +29,10 @@ test_expect_success 'flux alloc can set initial-program' '
 	flux alloc -n1 --dry-run myapp --foo | \
 	    jq -e ".tasks[0].command == [ \"flux\", \"broker\", \"myapp\", \"--foo\" ]"
 '
+test_expect_success 'flux alloc ignores ambiguous option after --' '
+	flux alloc -n1 --dry-run -- myapp --n=2 | \
+	    jq -e ".tasks[0].command == [ \"flux\", \"broker\", \"--\", \"myapp\", \"--n=2\" ]"
+'
 test_expect_success 'flux alloc -N2 requests 2 nodes exclusively' '
 	flux alloc -N2 --dry-run hostname | jq -S ".resources[0]" | jq -e ".type == \"node\" and .exclusive"
 '

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -42,6 +42,15 @@ test_expect_success 'flux batch --wrap option works' '
 	EOF
 	test_cmp script-wrap.expected script-wrap.out
 '
+test_expect_success 'flux batch --wrap option works with --' '
+	flux batch -n1 --dry-run --wrap -- foo --n=2 | \
+		jq -j .attributes.system.files.script.data >script-wrap.out &&
+	cat <<-EOF >script-wrap.expected &&
+	#!/bin/sh
+	foo --n=2
+	EOF
+	test_cmp script-wrap.expected script-wrap.out
+'
 test_expect_success 'flux batch --wrap option works on stdin' '
 	printf "foo\nbar\nbaz\n" | \
 	    flux batch -n1 --dry-run --wrap | \


### PR DESCRIPTION
Since Python `argparse` throws an error if an ambiguous `argparse` option is used after the last non-option argument (e.g. `flux run -n2 foo --n=2` throws an error, even though `argparse` should just ignore everything from `foo` onwards), there should be some way for users to work around this problem. However, the standard use of `--` doesn't work here, because Python then includes the `--` as part of `args.command` (in the case of `flux run` and `flux submit`) or `args.SCRIPT` in the case of `flux batch`.

This PR simply ignores `--` when it is the first entry of `args.command` or `args.SCRIPT` and adds some tests that verify the solution works. (i.e. `flux run -n2 -- foo --n=2` can be used to workaround the error noted above).

There may be some better way to support this with `argparse` (perhaps the bug is fixed in recent versions), but I couldn't find it.