### PR TITLE
perilog: support direct execution of prolog/epilog on job ranks for better performance

### DIFF
--- a/doc/man5/flux-config-job-manager.rst
+++ b/doc/man5/flux-config-job-manager.rst
@@ -9,6 +9,10 @@ DESCRIPTION
 The Flux **job-manager** service may be configured via the ``job-manager``
 table, which may contain the following keys:
 
+Note that this set of keys may be extended by loaded jobtap plugins.
+For details pertaining to some plugins distributed with flux see
+:ref:`plugin_specific_keys` below.
+
 
 KEYS
 ====
@@ -82,6 +86,86 @@ release-after
   first execution target for a given job completes, and all resources that
   have completed housekeeping when the timer fires are released. Following
   that, resources are released as each execution target completes.
+
+.. _plugin_specific_keys:
+
+PLUGIN SPECIFIC KEYS
+====================
+
+The following configuration keys are supported by included jobtap plugins.
+The documented config will have no effect if the associated plugin is not
+loaded into the job-manager.
+
+perilog.so
+----------
+
+The ``perilog.so`` plugin supports configuration and execution of job-manager
+prolog and/or epilog. The following keys are supported when the ``perilog.so``
+plugin is loaded:
+
+prolog
+   (optional) Table of configuration for a job-manager prolog. If enabled,
+   the prolog is initiated when the job enters the RUN state before any
+   job shells (i.e. user processes) are started. The following keys are
+   supported for the ``[job-manager.prolog]`` table:
+
+   command
+      (optional) An array of strings specifying the command to run. If
+      ``exec.imp`` is set, the the default command is ``["flux-imp",
+      "run", "prolog"]``, otherwise it is an error if command is not set.
+   per-rank
+      (optional) By default the job-manager prolog only runs ``command``
+      on rank 0. With ``per-rank=true``, the command will be run on each
+      rank assigned to the job.
+   timeout
+      (optional) A string value in Flux Standard Duration specifying a
+      timeout for the prolog, after which it is terminated (and a job
+      exception raised). The default prolog timeout is 30m. To disable
+      the timeout use ``0`` or ``infinity``.
+   kill-timeout
+      (optional) Floating-point number of seconds to wait after sending
+      SIGTERM to send SIGKILL to the prolog when the prolog has been
+      canceled due to timeout or exception. The default is 5.0. (This
+      key is mainly used for testing purposes).
+   cancel-on-exception
+      (optional) A boolean indicating whether a fatal job exception raised
+      while the prolog is active terminates the prolog. The default is true.
+
+epilog
+   (optional) Table of configuration for a job-manager epilog. If configured,
+   the epilog is started at the job ``finish`` event, i.e. after all user
+   processes and job shells have terminated. The ``[job-manager.epilog]``
+   table supports the following keys:
+
+   command
+      (optional) An array of strings specifying the command to run. If
+      ``exec.imp`` is set, the the default command is ``["flux-imp",
+      "run", "prolog"]``, otherwise it is an error if command is not set.
+   per-rank
+      (optional) By default the job-manager epilog only runs ``command``
+      on rank 0. With ``per-rank=true``, the command will be run on each
+      rank assigned to the job.
+   timeout
+      (optional) A string value in Flux Standard Duration specifying a
+      timeout for the epilog, after which it is terminated (and a job
+      exception raised). By default, the epilog timeout is disabled.
+   kill-timeout
+      (optional) Floating-point number of seconds to wait after sending
+      SIGTERM to send SIGKILL to the epilog when it has been canceled due
+      to timeout or exception. The default is 5.0. (This key is mainly
+      used for testing purposes)
+   cancel-on-exception
+      (optional) A boolean indicating whether a fatal job exception raised
+      while the epilog is active terminates the epilog. The default is true.
+      (cancel-on-exception is only used with the epilog for testing purposes)
+
+perilog
+  (optional) Common prolog/epilog configuration keys:
+
+   log-ignore
+      (optional) An array of regular expression strings to ignore in the
+      stdout and stderr of prolog and epilog processes.
+
 
 EXAMPLE
 =======

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -109,6 +109,7 @@ plugins_alloc_check_la_LDFLAGS = \
 plugins_perilog_la_SOURCES = \
 	plugins/perilog.c
 plugins_perilog_la_LIBADD = \
+	$(top_builddir)/src/common/libsubprocess/libsubprocess.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libjob/libjob.la

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -174,7 +174,7 @@ static void emit_finish_event (struct perilog_proc *proc,
          *   event is emitted to ensure job isn't halfway started before
          *   the exception is raised:
          */
-        if (status != 0) {
+        if (status != 0 && !proc->canceled) {
             int code = WIFEXITED (status) ? WEXITSTATUS (status) : -1;
             int sig;
             char *errmsg;

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -116,6 +116,11 @@ static void perilog_proc_destroy (struct perilog_proc *proc)
     }
 }
 
+static const char *perilog_proc_name (struct perilog_proc *proc)
+{
+    return proc->prolog ? "prolog" : "epilog";
+}
+
 /*  zhashx_destructor_fn prototype
  */
 static void perilog_proc_destructor (void **item)
@@ -248,7 +253,7 @@ static void state_cb (flux_subprocess_t *sp, flux_subprocess_state_t state)
         flux_log (flux_jobtap_get_flux (proc->p),
                   LOG_ERR,
                   "%s %s: code=%d",
-                  proc->prolog ? "prolog": "epilog",
+                  perilog_proc_name (proc),
                   flux_subprocess_state_string (flux_subprocess_state (sp)),
                   code);
 
@@ -280,7 +285,7 @@ static void io_cb (flux_subprocess_t *sp, const char *stream)
     if ((len = flux_subprocess_getline (sp, stream, &s)) < 0) {
         flux_log_error (h, "%s: %s: %s: flux_subprocess_getline",
                         idf58 (proc->id),
-                        proc->prolog ? "prolog": "epilog",
+                        perilog_proc_name (proc),
                         stream);
         return;
     }
@@ -292,7 +297,7 @@ static void io_cb (flux_subprocess_t *sp, const char *stream)
                   level,
                   "%s: %s: %s: %s",
                   idf58 (proc->id),
-                  proc->prolog ? "prolog" : "epilog",
+                  perilog_proc_name (proc),
                   stream,
                   s);
     }

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -47,6 +47,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <regex.h>
+#include <math.h>
 #include "src/common/libmissing/macros.h"
 #define EXIT_CODE(x) __W_EXITCODE(x,0)
 
@@ -219,6 +220,10 @@ static struct perilog_procdesc *perilog_procdesc_create (json_t *o,
         errprintf (errp, "invalid %s timeout", prolog ? "prolog" : "epilog");
         goto error;
     }
+    /* Special case: INFINITY disables timeout so set timeout = 0.0:
+     */
+    if (pd->timeout == INFINITY)
+        pd->timeout = 0.;
     if (!cmd) {
         errprintf (errp, "no command specified and exec.imp not defined");
         goto error;

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -576,13 +576,18 @@ static void io_cb (struct bulk_exec *bulk_exec,
 
     if (!perilog_log_ignore (&perilog_config, buf)) {
         int level = LOG_INFO;
+        int rank = flux_subprocess_rank (sp);
+        const char *hostname = flux_get_hostbyrank (h, rank);
+
         if (streq (stream, "stderr"))
             level = LOG_ERR;
         flux_log (h,
                   level,
-                  "%s: %s: %s: %s",
+                  "%s: %s: %s (rank %d): %s: %s",
                   idf58 (proc->id),
                   perilog_proc_name (proc),
+                  hostname,
+                  rank,
                   stream,
                   buf);
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -162,6 +162,7 @@ TESTSCRIPTS = \
 	t2272-job-begin-time.t \
 	t2273-job-alloc-bypass.t \
 	t2274-manager-perilog.t \
+	t2274-manager-perilog-per-rank.t \
 	t2275-job-duration-validator.t \
 	t2276-job-requires.t \
 	t2280-job-memo.t \

--- a/t/t2274-manager-perilog-per-rank.t
+++ b/t/t2274-manager-perilog-per-rank.t
@@ -1,0 +1,302 @@
+#!/bin/sh
+
+test_description='Test perilog jobtap plugin with per-rank=true'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 full \
+	--test-exit-mode=leader
+
+OFFLINE_PLUGIN=${FLUX_BUILD_DIR}/t/job-manager/plugins/.libs/offline.so
+startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+
+flux setattr log-stderr-level 1
+
+# In case the testsuite is running as a Flux job
+unset FLUX_JOB_ID
+
+drained_ranks() { flux resource status -no {ranks} -s drain; }
+
+no_drained_ranks() { test "$(drained_ranks)" = ""; }
+
+undrain_all() {
+	ranks="$(drained_ranks)"
+	if test -n "$ranks"; then
+	    flux resource undrain $ranks
+	fi
+}
+
+test_expect_success 'perilog: load plugin with no config' '
+	flux jobtap load perilog.so
+'
+test_expect_success 'perilog: query shows no prolog/epilog config' '
+	test_debug "flux jobtap query perilog.so | jq .conf" &&
+	flux jobtap query perilog.so \
+		| jq -e ".conf.prolog == {} and .conf.epilog == {}"
+'
+test_expect_success 'perilog: timeout can be set to 0' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	per-rank = true
+	timeout = "0"
+	command = [ "test" ]
+	EOF
+	flux jobtap query perilog.so | jq .conf &&
+	flux jobtap query perilog.so \
+		| jq -e ".conf.prolog.timeout == 0.0"
+'
+test_expect_success 'perilog: timeout can be set to infinity (equiv to 0)' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	per-rank = true
+	timeout = "infinity"
+	command = [ "test" ]
+	EOF
+	flux jobtap query perilog.so | jq .conf &&
+	flux jobtap query perilog.so \
+		| jq -e ".conf.prolog.timeout == 0"
+'
+test_expect_success 'perilog: invalid config is rejected' '
+	test_must_fail flux config load <<-EOF 2>config.err.$((i+=1)) &&
+	[job-manager.prolog]
+	command = "foo"
+	EOF
+	test_debug "cat config.err.$i" &&
+	grep "command must be an array" config.err.$i &&
+	test_must_fail flux config load <<-EOF 2>config.err.$((i+=1)) &&
+	[job-manager.prolog]
+	command = [ "foo" ]
+	timeout = "5x"
+	EOF
+	test_debug "cat config.err.$i" &&
+	grep "invalid prolog timeout" config.err.$i &&
+	test_must_fail flux config load <<-EOF 2>config.err.$((i+=1)) &&
+	[job-manager.epilog]
+	command = [ "foo" ]
+	timeout = "5p"
+	EOF
+	test_debug "cat config.err.$i" &&
+	grep "invalid epilog timeout" config.err.$i &&
+	test_must_fail flux config load <<-EOF 2>config.err.$((i+=1)) &&
+	[job-manager.prolog]
+	EOF
+	test_debug "cat config.err.$i" &&
+	grep "no command specified" config.err.$i &&
+	test_must_fail flux config load <<-EOF 2>config.err.$((i+=1)) &&
+	[job-manager.prolog]
+	command = [ 1, 2, 3 ]
+	EOF
+	test_debug "cat config.err.$i" &&
+	grep "malformed prolog command" config.err.$i &&
+	test_must_fail flux config load <<-EOF 2>config.err.$((i+=1)) &&
+	[job-manager.prolog]
+	command = [ "foo" ]
+	per-rank = true
+	foo = 1
+	EOF
+	test_debug "cat config.err.$i" &&
+	grep "1 object.*left unpacked: foo" config.err.$i &&
+	test_must_fail flux config load <<-EOF 2>config.err.$((i+=1)) &&
+	[job-manager.epilog]
+	command = [ "foo" ]
+	kill-timeout = 5.5
+	EOF
+	test_debug "cat config.err.$i" &&
+	grep "kill-timeout not allowed for epilog" config.err.$i
+'
+test_expect_success 'perilog: config uses IMP with exec.imp and no command' '
+	flux config load <<-EOF &&
+	exec.imp = "imp"
+	[job-manager.prolog]
+	per-rank = true
+	[job-manager.epilog]
+	per-rank = true
+	EOF
+	flux jobtap query perilog.so \
+		| jq ".conf.prolog.command == [\"imp\", \"run\", \"prolog\"]" &&
+	flux jobtap query perilog.so \
+		| jq ".conf.epilog.command == [\"imp\", \"run\", \"prolog\"]"
+'
+test_expect_success 'perilog: prolog default cancel-on-exception is true' '
+	flux jobtap query perilog.so \
+		| jq ".conf.prolog.cancel_on_exception == true"
+'
+test_expect_success 'perilog: epilog default cancel-on-exception is false' '
+	flux jobtap query perilog.so \
+		| jq ".conf.epilog.cancel_on_exception == false"
+'
+test_expect_success 'perilog: load a basic per-rank prolog config' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	per-rank = true
+	command = [ "flux", "getattr", "rank" ]
+	EOF
+	flux jobtap query perilog.so | jq .conf.prolog
+'
+test_expect_success 'perilog: 4 node job works with per-rank prolog' '
+	jobid=$(flux submit -vvv -N4 hostname) &&
+	flux job wait-event -vt 30 $jobid prolog-start &&
+	flux job wait-event -t 30 $jobid prolog-finish &&
+	flux job wait-event -vt 30 $jobid clean &&
+	no_drained_ranks
+'
+test_expect_success 'perilog: stdout was copied to dmesg log' '
+	flux dmesg -H &&
+	flux dmesg -H | grep "$jobid: prolog:.*rank 0.*stdout: 0" &&
+	flux dmesg -H | grep "$jobid: prolog:.*rank 1.*stdout: 1" &&
+	flux dmesg -H | grep "$jobid: prolog:.*rank 2.*stdout: 2" &&
+	flux dmesg -H | grep "$jobid: prolog:.*rank 3.*stdout: 3" 
+'
+test_expect_success 'perilog: load a basic per-rank prolog config' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	per-rank = true
+	command = [ "sleep", "5" ]
+	EOF
+	flux jobtap query perilog.so | jq .conf.prolog
+'
+test_expect_success 'perilog: prolog runs on all 4 ranks of a 4 node job' '
+	jobid=$(flux submit -N4 hostname) &&
+	flux job wait-event -vt 30 $jobid prolog-start &&
+	flux jobtap query perilog.so | jq .procs &&
+	flux jobtap query perilog.so \
+		| jq -e ".procs.$jobid.active_ranks == \"0-3\"" &&
+	flux jobtap query perilog.so \
+		| jq -e ".procs.$jobid.total == 4" &&
+	flux jobtap query perilog.so \
+		| jq -e ".procs.$jobid.active == 4" &&
+	flux cancel $jobid &&
+	flux jobtap query perilog.so &&
+	flux job wait-event $jobid clean
+'
+test_expect_success 'perilog: canceled prolog does not drain ranks' '
+	no_drained_ranks
+'
+test_expect_success 'perilog: signaled prolog is reported' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	per-rank = true
+	command = [ "sh", "-c", "kill \$\$" ]
+	EOF
+	jobid=$(flux submit hostname) &&
+	flux job wait-event -vHt 30 $jobid exception &&
+	flux job wait-event -t 30 $jobid exception >exception.out &&
+	grep "prolog killed by signal 15" exception.out
+'
+test_expect_success 'perilog: prolog failure drains affected ranks' '
+	undrain_all &&
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	per-rank = true
+	command = [ "sh",
+	            "-c",
+	            "if test \$(flux getattr rank) -eq 3; then exit 1; fi" ]
+	EOF
+	flux dmesg -C &&
+	jobid=$(flux submit -N4 hostname) &&
+	flux job wait-event -vHt 30 $jobid prolog-start &&
+	flux jobtap query perilog.so | jq .procs.$jobid &&
+	test_must_fail flux job attach $jobid &&
+	flux dmesg -H &&
+	flux resource drain -no "{ranks} {reason}" &&
+	test "$(drained_ranks)" = "3" &&
+	test "$(flux resource drain -no {reason})" = "prolog failed for job $jobid" &&
+	flux resource drain
+'
+test_expect_success 'perilog: prolog timeout works and drains ranks' '
+	undrain_all &&
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	timeout = "1s"
+	per-rank = true
+	command = [ "sh",
+	            "-c",
+	            "if test \$(flux getattr rank) -eq 3; then sleep 30; fi" ]
+	EOF
+	jobid=$(flux submit -N4 hostname) &&
+	flux job wait-event -Hvt 30 $jobid prolog-start &&
+	flux jobtap query perilog.so | jq .procs.$jobid &&
+	test_must_fail flux job attach $jobid &&
+	test "$(drained_ranks)" = "3" &&
+	test "$(flux resource drain -no {reason})" = "prolog timed out for job $jobid" &&
+	undrain_all
+'
+test_expect_success 'perilog: prolog can drain multiple ranks' '
+	undrain_all &&
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	per-rank = true
+	command = [ "false" ]
+	EOF
+	test_must_fail flux run -N4 hostname &&
+	flux resource drain -o long &&
+	test "$(drained_ranks)" = "0-3" &&
+	undrain_all
+'
+test_expect_success 'perilog: epilog runs on all ranks with per-rank' '
+	undrain_all &&
+	flux config load <<-EOF &&
+	[job-manager.epilog]
+	per-rank = true
+	cancel-on-exception = true
+	command = [ "sleep", "15" ]
+	EOF
+	jobid=$(flux submit -N4 hostname) &&
+	flux job wait-event -vHt 30 $jobid epilog-start &&
+	flux jobtap query perilog.so | jq .procs.$jobid &&
+	flux jobtap query perilog.so \
+		| jq -e ".procs.$jobid.active_ranks == \"0-3\"" &&
+	flux jobtap query perilog.so \
+		| jq -e ".procs.$jobid.total == 4" &&
+	flux jobtap query perilog.so \
+		| jq -e ".procs.$jobid.active == 4" &&
+	flux jobtap query perilog.so \
+		| jq -e ".conf.epilog.cancel_on_exception == true" &&
+	flux cancel $jobid &&
+	flux jobtap query perilog.so | jq &&
+	flux job wait-event -vHt 20 $jobid clean
+'
+test_expect_success 'perilog: canceled epilog does not drain ranks' '
+	no_drained_ranks
+'
+test_expect_success 'perilog: epilog failure drains ranks' '
+	undrain_all &&
+	flux config load <<-EOF &&
+	[job-manager.epilog]
+	per-rank = true
+	command = [ "sh",
+	            "-c",
+                    "if test \$(flux getattr rank) -eq 1; then exit 1; fi" ]
+	EOF
+	flux jobtap query perilog.so | jq &&
+	jobid=$(flux submit -N4 hostname) &&
+	flux job wait-event -vHt 30 $jobid epilog-finish &&
+	flux resource drain -o long &&
+	test "$(drained_ranks)" = "1" &&
+	test "$(flux resource drain -no {reason})" = "epilog failed for job $jobid" &&
+	undrain_all
+'
+test_expect_success 'perilog: load offline plugin before perilog.so' '
+	flux jobtap remove perilog.so &&
+	flux jobtap load $OFFLINE_PLUGIN &&
+	flux jobtap load perilog.so
+'
+test_expect_success 'perilog: load simple prolog for offline rank testing' '
+	flux config load <<-EOF
+	[job-manager.prolog]
+	per-rank = true
+	command = [ "flux", "getattr", "rank" ]
+	EOF
+'
+# Note: bulk-exec does not return an error code on EHOSTUNREACH since
+# it is assumed a job exception will be raised by the instance.
+# Here we are just checking that the prolog finishes without blocking the
+# job from moving to CLEANUP/INACTIVE.
+test_expect_success 'perilog: prolog is successful with offline rank' '
+	undrain_all &&
+	jobid=$(flux submit -N4 -n4 true) &&
+	flux job wait-event -t 30 $jobid prolog-start &&
+	flux job wait-event -vHt 30 $jobid prolog-finish &&
+	flux jobtap remove offline.so
+'
+test_done

--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -213,7 +213,7 @@ test_expect_success 'perilog: prolog/epilog output is logged' '
 	test_when_finished "rm -f prolog.d/log.sh" &&
 	jobid=$(flux submit --job-name=output-test hostname) &&
 	flux job wait-event -t 15 $jobid prolog-finish &&
-	flux dmesg | grep "prolog: stdout: this is the prolog" &&
+	flux dmesg -H | grep "prolog:.*this is the prolog" &&
 	flux job wait-event -vt 15 $jobid clean
 '
 test_expect_success 'perilog: fails if configuration is not valid' '

--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -321,18 +321,18 @@ test_expect_success 'perilog: bad log-ignore entry is caught' '
 	[job-manager.perilog]
 	log-ignore = "foo"
 	EOF
-	flux config reload &&
-	test_must_fail flux jobtap load --remove=*.so perilog.so &&
-	flux dmesg -Hc | grep "not an array"
+	test_must_fail flux config reload 2>bad-log-ignore.err &&
+	test_debug "cat bad-log-ignore.err" &&
+	grep "not an array" bad-log-ignore.err
 '
 test_expect_success 'perilog: bad log-ignore regexp is caught' '
 	cat <<-EOF >config/perilog.toml &&
 	[job-manager.perilog]
 	log-ignore = [ "[" ]
 	EOF
-	flux config reload &&
-	test_must_fail flux jobtap load perilog.so &&
-	flux dmesg -Hc | grep "[fF]ailed to compile"
+	test_must_fail flux config reload 2>bad-log-ignore-regexp.err &&
+	test_debug "cat bad-log-ignore-regexp.err" &&
+	grep "[fF]ailed to compile" bad-log-ignore-regexp.err
 '
 
 #  Note: run this job before taking rank 3 offline below
@@ -356,7 +356,7 @@ test_expect_success 'perilog: create config to run flux-perilog-run' '
 '
 test_expect_success 'perilog: load offline.so before perilog.so' '
 	flux jobtap load $OFFLINE_PLUGIN &&
-	flux jobtap load perilog.so
+	flux jobtap load --remove=perilog.so perilog.so
 '
 test_expect_success 'perilog: prolog with offline ranks raises sev 1 exception' '
 	id=$(flux submit -N4 -n4 true) &&


### PR DESCRIPTION
Posting this PR as a WIP to get early feedback and to give reviewers a head start.

This PR reimplements the perilog jobtap plugin using bulk-exec in order to support direct execution of prolog/epilog on the ranks of a job instead of using `perilog-run`, which has been shown to take several minutes to start `flux exec` for a job comprising thousands of nodes.

The plugin should continue to work the same unless a new `per-rank = true` option is set, in which case the plugin uses bulk-exec to launch the defined `command` across all ranks that are part of the starting/ending job.

Support for other `flux perilog-run` features are also moved directly into the plugin, including draining failed ranks, a `timeout` parameter, and a `use-imp` boolean which replaces `command` with `["$imp", "run", "$name"]` if used.

The plugin also now supports a jobtap query callback which can be used to observe the current config, as well as active job prolog and epilogs, including which ranks are still actively running these proceses.

This will be a WIP because it still needs testing (results of which may change some of the code). 

Fixes #6216