### PR TITLE
support short option `-S` for `--setattr=` in job submission commands

### DIFF
--- a/doc/man1/common/job-other-options.rst
+++ b/doc/man1/common/job-other-options.rst
@@ -48,7 +48,7 @@
    otherwise VAL is interpreted as a string. If VAL is not set, then the
    default value is 1. See `SHELL OPTIONS`_ below.
 
-.. option:: --setattr=KEY[=VAL]
+.. option:: -S, --setattr=KEY[=VAL]
 
    Set jobspec attribute. Keys may include periods to denote hierarchy.
    If KEY does not begin with ``system.``, ``user.``, or ``.``, then

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -378,7 +378,7 @@ _flux_submit_commands()
         -B --bank= \
         -t --time-limit= \
         -o --setopt= \
-        --setattr= \
+        -S --setattr= \
         --urgency= \
         --job-name= \
         --dependency= \

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -801,6 +801,7 @@ class MiniCmd:
             metavar="OPT",
         )
         parser.add_argument(
+            "-S",
             "--setattr",
             action="append",
             help="Set job attribute ATTR. An optional value is supported "

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -109,7 +109,7 @@ test_expect_success 'flux submit -B works' '
 	flux submit --env=-* --dry-run -B mybank2 hostname >bank2.out &&
 	grep -i "mybank2" bank2.out
 '
-test_expect_success 'flux submit --setattr works' '
+test_expect_success 'flux submit -S, --setattr works' '
 	flux submit --env=-* --dry-run \
 		--setattr user.meep=false \
 		--setattr user.foo=\"xxx\" \
@@ -117,14 +117,19 @@ test_expect_success 'flux submit --setattr works' '
 		--setattr foo \
 		--setattr .test=a \
 		--setattr test2=b \
-		--setattr system.bar=42 hostname >attr.out &&
+		--setattr system.bar=42 \
+		-S baz \
+		-Sbiz=4 hostname >attr.out &&
+	test_debug "jq .attributes attr.out" &&
 	jq -e ".attributes.user.meep == false" attr.out &&
 	jq -e ".attributes.user.foo == \"xxx\"" attr.out &&
 	jq -e ".attributes.user.foo2 == \"yyy\"" attr.out &&
 	jq -e ".attributes.system.foo == 1" attr.out &&
 	jq -e ".attributes.test == \"a\"" attr.out &&
 	jq -e ".attributes.system.test2 == \"b\"" attr.out &&
-	jq -e ".attributes.system.bar == 42" attr.out
+	jq -e ".attributes.system.bar == 42" attr.out &&
+	jq -e ".attributes.system.baz == 1" attr.out &&
+	jq -e ".attributes.system.biz == 4" attr.out
 '
 
 test_expect_success 'flux submit --setattr=^ATTR=VAL works' '


### PR DESCRIPTION
As suggested by @garlick and @jameshcorbett, this PR adds support for `-S` as shorthand for `--setattr` in all job submission commands.