### PR TITLE
kvs: call content.flush before checkpoint

### DIFF
--- a/t/t0090-content-enospc.t
+++ b/t/t0090-content-enospc.t
@@ -58,4 +58,16 @@ test_expect_success 'content flush returns error on ENOSPC' '
 	grep "content.flush: No space left on device" flush.err
 '
 
+# flux start will fail b/c rc3 will fail due to ENOSPC
+test_expect_success 'kvs sync fails due to ENOSPC' '
+	rm -rf /test/tmpfs-1m/* &&
+	mkdir /test/tmpfs-1m/statedir &&
+	test_must_fail flux start \
+	    -o,-Scontent.backing-module=content-sqlite \
+	    -o,-Sstatedir=/test/tmpfs-1m/statedir \
+	    "./fillstatedir.sh; flux dmesg; flux kvs put --sync foo=1" > sync.out 2> sync.err &&
+	grep -q "No space left on device" sync.out &&
+	grep "flux_kvs_commit: No space left on device" sync.err
+'
+
 test_done

--- a/t/t1010-kvs-commit-sync.t
+++ b/t/t1010-kvs-commit-sync.t
@@ -18,13 +18,17 @@ checkpoint_get() {
         jq -j -c -n  "{key:\"$1\"}" | $RPC content.checkpoint-get
 }
 
-test_expect_success 'load content module' '
-	flux module load content
+test_expect_success 'load content module and kvs' '
+        flux module load content &&
+        flux module load kvs
+'
+
+test_expect_success 'sync does not work without a backing store' '
+        test_must_fail flux kvs put --sync testsync=1
 '
 
 test_expect_success 'load content-sqlite and kvs and add some data' '
         flux module load content-sqlite &&
-        flux module load kvs &&
         flux kvs put a=1 &&
         flux kvs put b=2
 '


### PR DESCRIPTION
Problem: When the KVS module is unloaded, a checkpoint of the root
reference is attempted.  However, a content.flush is not done
beforehand.  This could result in an invalid checkpoint reference
as data is not guaranteed to be flushed to the backing store.

Solution: Call content.flush before checkpointing.

Fixes #6237
----

I threw in a few new tests for some extra coverage of FLUX_KVS_SYNC too.