### PR TITLE
housekeeping: deprecate use-systemd-config option

### DIFF
--- a/doc/man5/flux-config-job-manager.rst
+++ b/doc/man5/flux-config-job-manager.rst
@@ -70,13 +70,9 @@ HOUSEKEEPING
 ============
 
 command
-  (optional) An array of strings specifying the housekeeping command. Either
-  ``command`` or ``use-systemd-unit`` must be specified.
-
-use-systemd-unit
-  (optional) A boolean value indicating whether to run the flux-housekeeping
-  systemd unit to handle housekeeping, rather than a specific command.
-  Either ``use-systemd-unit`` or ``command`` must be specified.
+  (optional) An array of strings specifying the housekeeping command.
+  If unspecified but the housekeeping table exists, then assume the command is
+  ``imp run housekeeping``.
 
 release-after
   (optional) A string specified in Flux Standard Duration (FSD). If unset,
@@ -110,7 +106,6 @@ EXAMPLE
    ]
 
    [job-manager.housekeeping]
-   use-systemd-unit = true
    release-after = "1m"
 
 

--- a/t/t2226-housekeeping.t
+++ b/t/t2226-housekeeping.t
@@ -157,6 +157,29 @@ test_expect_success 'configuring housekeeping with bad key fails' '
 	EOT
 	grep "left unpacked" load.err
 '
+test_expect_success 'configuring housekeeping with no cmd or exec.imp fails' '
+	test_must_fail flux config load 2>load_noimp.err <<-EOT &&
+	[job-manager.housekeeping]
+	EOT
+	grep "exec.imp is undefined" load_noimp.err
+'
+test_expect_success 'but is accepted if exec.imp is defined' '
+	flux config load <<-EOT
+	[exec]
+	imp = "/bin/true"
+	[job-manager.housekeeping]
+	EOT
+'
+test_expect_success 'deprecated use-systemd-unit is ignored with log warning' '
+	flux dmesg -C &&
+	flux config load <<-EOT &&
+	[exec]
+	imp = "/bin/true"
+	[job-manager.housekeeping]
+	use-systemd-unit = true
+	EOT
+	flux dmesg | grep "use-systemd-unit is deprecated"
+'
 test_expect_success 'configuring housekeeping with bad fsd fails' '
 	test_must_fail flux config load 2>load2.err <<-EOT &&
 	[job-manager.housekeeping]


### PR DESCRIPTION
In an offline discussion with @grondo about his pr #6235, we noted that housekeeping's `use-systemd-unit` key is misleading.  It's the IMP config that decides whether or not systemd is used to run the housekeeping script.  Really this is just selecting a comand of `imp run housekeeping`.

This changes the logic to use the above command if the housekeeping `command` key is undefined.
Note this means the housekeeping config table could be empty and still valid (housekeeping enabled).

If `use-systemd-unit` is present, it is a config error.   I could make it accept it and issue a deprecation warning if we think that's better.