### PR TITLE
flux-hostlist: change default source from `local` to `stdin`

### DIFF
--- a/doc/man1/flux-hostlist.rst
+++ b/doc/man1/flux-hostlist.rst
@@ -44,7 +44,7 @@ stdin or ``-``
 hosts
   a literal RFC 29 Hostlist
 
-The default source is *local*.
+The default source is *stdin*.
 
 OPTIONS
 =======
@@ -112,6 +112,11 @@ OPTIONS
  
     $ flux hostlist --fallback foo1 foo2
     foo[1-2]
+
+.. option:: -l, --local
+
+  Change the default input source to "local". This is a shorter way to
+  specify ``flux hostlist local``.
   
 .. option:: -q, --quiet
 
@@ -125,7 +130,7 @@ program:
 
 ::
 
-  $ flux hostlist -ed'\n' >hostfile
+  $ flux hostlist -led'\n' >hostfile
 
 Launch an MPI program using :program:`mpiexec.hydra` from within a batch
 script:
@@ -133,7 +138,7 @@ script:
 ::
 
   #!/bin/sh
-  mpiexec.hydra -launcher ssh -hosts "$(flux hostlist -e)" mpi_hello
+  mpiexec.hydra -launcher ssh -hosts "$(flux hostlist -le)" mpi_hello
 
 List the hosts for one job: (Note: this is the same as
 :command:`flux jobs -no {nodelist} JOBID`)

--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -360,6 +360,13 @@ components or writing tests.
    interpose a tool or library with LD_PRELOAD.  Be aware that this can cause
    symbol conflicts with plugins, and is not recommended for production.
 
+.. envvar:: FLUX_HOSTLIST_STDIN_TIMEOUT
+
+   The :command:`flux-hostlist` command reads from stdin by default. If no
+   data is available within 15s, the command times out to prevent a permanent
+   hang. This environment variable can be used to modify or disable (set to 0)
+   the timeout.
+
 MISCELLANEOUS
 =============
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -876,6 +876,7 @@ drwxr
 ecb
 eea
 ef
+le
 ExecStartPre
 loginctl
 md

--- a/src/cmd/flux-hostlist.py
+++ b/src/cmd/flux-hostlist.py
@@ -31,7 +31,8 @@ avail[able]  instance hostlist minus those nodes down or drained
 stdin, '-'   read a list of hosts on stdin
 hosts        literal list of hosts
 
-The default when no SOURCES are supplied is 'local'.
+The default when no SOURCES are supplied is 'stdin', unless the -l, --local
+option is used, in which case the default is 'local'.
 """
 
 
@@ -123,6 +124,12 @@ def parse_args():
         action="store_true",
         help="Fallback to treating jobids that are not found as hostnames"
         + " (for hostnames that are also valid jobids e.g. f1, fuzz100, etc)",
+    )
+    parser.add_argument(
+        "-l",
+        "--local",
+        action="store_true",
+        help="Set the default source to 'local' instead of 'stdin'",
     )
     parser.add_argument(
         "-q",
@@ -312,7 +319,10 @@ def main():
     args = parse_args()
 
     if not args.sources:
-        args.sources = ["local"]
+        if args.local:
+            args.sources = ["local"]
+        else:
+            args.sources = ["stdin"]
 
     hostlists = HostlistResolver(args.sources, fallback=args.fallback).results()
 

--- a/t/t2814-hostlist-cmd.t
+++ b/t/t2814-hostlist-cmd.t
@@ -12,12 +12,12 @@ test_expect_success 'flux-hostlist --help works' '
 	grep "SOURCES may include" help.out
 '
 test_expect_success 'flux-hostlist returns hostlist attr in initial program' '
-	flux hostlist >hl-instance.out &&
+	flux hostlist -l >hl-instance.out &&
 	flux getattr hostlist >hl-instance.expected &&
 	test_cmp hl-instance.expected hl-instance.out
 '
 test_expect_success 'flux-hostlist returns job hostlist in job' '
-	flux run flux hostlist >hl-job.out &&
+	flux run flux hostlist -l >hl-job.out &&
 	flux jobs -no {nodelist} $(flux job last) > hl-job.expected &&
 	test_cmp hl-job.expected hl-job.out
 '
@@ -33,8 +33,8 @@ test_expect_success 'flux-hostlist --fallback treats invalid jobid as host' '
 	test "$(cat fallback.out)" = "foo1"
 '
 test_expect_success 'flux-hostlist -c works' '
-	flux hostlist --count  &&
-	test $(flux hostlist --count) -eq 2 &&
+	flux hostlist --count local  &&
+	test $(flux hostlist --count local) -eq 2 &&
 	test $(flux hostlist -c "foo[1-10]") -eq 10
 '
 test_expect_success 'flux-hostlist works with "avail"' '
@@ -43,8 +43,8 @@ test_expect_success 'flux-hostlist works with "avail"' '
 	flux resource undrain 0
 '
 test_expect_success 'flux-hostlist works with stdin' '
-	printf "foo1 foo2 foo3"   | flux hostlist - >hl-stdin1.out &&
-	printf "foo1\nfoo2\nfoo3" | flux hostlist - >hl-stdin2.out &&
+	printf "foo1 foo2 foo3"   | flux hostlist >hl-stdin1.out &&
+	printf "foo1\nfoo2\nfoo3" | flux hostlist >hl-stdin2.out &&
 	test_debug "grep . hl-stdin*.out" &&
 	printf "foo[1-3]\n" >hl-stdin.expected &&
 	test_cmp hl-stdin.expected hl-stdin1.out &&


### PR DESCRIPTION
This PR addresse #6244 by changing `flux hostlist` with no args to read from `stdin` instead of `local` (which uses the enclosing instance or job if `FLUX_JOB_ID` is set).

This will break existing usage of `flux hostlist` where it is used, because the command will now hang instead of returning the enclosing hostlist. However, the current design choice was pretty bad and it is unlikely that this command has that much use so far, so it is probably better to just fix it now.

In order to mitigate the possibility of hangs with this change, a timeout was added to the read of `stdin` of 15s. After the timeout the command exits with a warning. Hopefully this workaround can be removed in the next release.

The existing behavior can be replicated with `flux hostlist local` or a new `flux hostlist -l, --local` option.

Fixes #6244