### PR TITLE
run epilog even if job prolog fails or is canceled

### DIFF
--- a/doc/man5/flux-config-job-manager.rst
+++ b/doc/man5/flux-config-job-manager.rst
@@ -132,10 +132,11 @@ prolog
       while the prolog is active terminates the prolog. The default is true.
 
 epilog
-   (optional) Table of configuration for a job-manager epilog. If configured,
-   the epilog is started at the job ``finish`` event, i.e. after all user
-   processes and job shells have terminated. The ``[job-manager.epilog]``
-   table supports the following keys:
+   (optional) Table of configuration for a job-manager epilog. If
+   configured, the epilog is started at the job ``finish`` event,
+   i.e. after all user processes and job shells have terminated, or after
+   prolog failure (in which case there will not be a job ``finish`` event.)
+   The ``[job-manager.epilog]`` table supports the following keys:
 
    command
       (optional) An array of strings specifying the command to run. If

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -477,6 +477,11 @@ out:
     return f;
 }
 
+static void perilog_proc_finish (struct perilog_proc *proc)
+{
+    emit_finish_event (proc, proc->bulk_exec);
+    perilog_proc_delete (proc);
+}
 
 static void drain_failed_cb (flux_future_t *f, void *arg)
 {
@@ -493,8 +498,7 @@ static void drain_failed_cb (flux_future_t *f, void *arg)
     }
     /* future destroyed by perilog_proc_delete()
      */
-    emit_finish_event (proc, proc->bulk_exec);
-    perilog_proc_delete (proc);
+    perilog_proc_finish (proc);
 }
 
 static bool perilog_per_rank (struct perilog_proc *proc)
@@ -532,8 +536,7 @@ static void completion_cb (struct bulk_exec *bulk_exec, void *arg)
                             idf58 (proc->id),
                             perilog_proc_name (proc));
         }
-        emit_finish_event (proc, bulk_exec);
-        perilog_proc_delete (proc);
+        perilog_proc_finish (proc);
     }
 }
 


### PR DESCRIPTION
This PR addresses #6055 by triggering the job epilog when the prolog completes if it fails, e.g. due to timeout or if it is canceled due to a job exception.

Fixes #6055