### PR TITLE
progress: ensure we don't access outside style

### DIFF
--- a/src/bindings/python/flux/progress.py
+++ b/src/bindings/python/flux/progress.py
@@ -303,6 +303,8 @@ class ProgressBar(Bottombar):
         part = int(length * len(style) * fraction) - fill * len(style)
         if part:
             fill += 1
+            if part >= len(style):
+                part = -1
             filled += style[part]
 
         #  Build the bar string as 'filled':


### PR DESCRIPTION
problem: in some corner case the equation produces an offset of exactly len(style) rather than a valid offset

solution: when that happens, set it to -1 to access the last element