### PR TITLE
support `resource.scheduling` in config TOML to amend configured R with a scheduling key

### DIFF
--- a/doc/man5/flux-config-resource.rst
+++ b/doc/man5/flux-config-resource.rst
@@ -54,6 +54,10 @@ config
      hosts = "test[90-100]"
      properties = ["debug"]
 
+scheduling
+   (optional) Set the path to a file stored as JSON which will be used
+   to amend the configured R with a RFC 20 ``scheduling`` key.
+
 exclude
    (optional) A string value that defines one or more nodes to withhold
    from scheduling, either in RFC 22 idset form, or in RFC 29 hostlist form.

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -104,19 +104,8 @@ static int parse_config (struct resource_ctx *ctx,
         rlist_destroy (rl);
     }
     else if (path) {
-        FILE *f;
         json_error_t e;
-
-        if (!(f = fopen (path, "r"))) {
-            errprintf (errp,
-                       "%s: %s",
-                       path,
-                       strerror (errno));
-            return -1;
-        }
-        o = json_loadf (f, 0, &e);
-        fclose (f);
-        if (!o) {
+        if (!(o = json_load_file (path, 0, &e))) {
             errprintf (errp,
                        "%s: %s on line %d",
                        e.source,

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -70,6 +70,7 @@ static int parse_config (struct resource_ctx *ctx,
     flux_error_t error;
     const char *exclude  = NULL;
     const char *path = NULL;
+    const char *scheduling_path = NULL;
     int noverify = 0;
     int norestrict = 0;
     int no_update_watch = 0;
@@ -78,9 +79,10 @@ static int parse_config (struct resource_ctx *ctx,
 
     if (flux_conf_unpack (conf,
                           &error,
-                          "{s?{s?s s?o s?s s?b s?b s?b !}}",
+                          "{s?{s?s s?s s?o s?s s?b s?b s?b !}}",
                           "resource",
                             "path", &path,
+                            "scheduling", &scheduling_path,
                             "config", &config,
                             "exclude", &exclude,
                             "norestrict", &norestrict,
@@ -111,6 +113,30 @@ static int parse_config (struct resource_ctx *ctx,
                        e.source,
                        e.text,
                        e.line);
+            return -1;
+        }
+    }
+    if (scheduling_path) {
+        json_t *scheduling;
+        json_error_t e;
+        if (!o) {
+            errprintf (errp,
+                       "resource.scheduling requires "
+                       "resource.path or [resource.config]");
+            return -1;
+        }
+        if (!(scheduling = json_load_file (scheduling_path, 0, &e))) {
+            errprintf (errp,
+                       "error loading resource.scheduling: %s on line %d",
+                       e.text,
+                       e.line);
+            json_decref (o);
+            return -1;
+        }
+        if (json_object_set_new (o, "scheduling", scheduling) < 0) {
+            errprintf (errp, "failed to set scheduling key in R");
+            json_decref (o);
+            json_decref (scheduling);
             return -1;
         }
     }


### PR DESCRIPTION
This PR adds a new `resource.scheduling` key in the Flux config TOML that, when set,  amends the configured _R_ with an externally defined `scheduling` key. Notably, this allows use of JGF with the `resource.config` array, which currently is not possible. It also would allow storing _R_ and JGF in separate files if this is desired.

It is an error if `resource.scheduling` is set but neither `resource.path` or `resource.config` are.

Fixes #6245

