### PR TITLE
support display of `allocated` nodes in `flux resource status`

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -174,7 +174,8 @@ status
 Show system view of resources.  Valid states in the system view are:
 
 avail
-  available for scheduling when up
+  available for scheduling when up. This includes all nodes that are
+  not excluded, drained, or torpid.
 
 exclude
   excluded by configuration
@@ -187,6 +188,9 @@ drained
 
 drain
   shorthand for :option:`drained,draining`
+
+allocated
+  node is currently allocated to a job or housekeeping
 
 torpid
   node has been unresponsive for a period of time and is temporarily
@@ -363,8 +367,8 @@ subcommands:
 
 **state**
    State of node(s): "avail", "exclude", "drain", "draining", "drained",
-   "torpid". If the set of resources is offline, an asterisk suffix is
-   appended to the state, e.g. "avail*".
+   "torpid", "allocated". If the set of resources is offline, an asterisk
+   suffix is appended to the state, e.g. "avail*".
 
 **statex**
    Like **state**, but exclude the asterisk for offline resources.

--- a/src/bindings/python/flux/resource/status.py
+++ b/src/bindings/python/flux/resource/status.py
@@ -37,7 +37,7 @@ class ResourceStatus:
     Attributes:
         nodelist (Hostlist): rank ordered set of hostnames
         all (IDset): idset of all known ranks
-        avail (IDset): idset of ranks not excluded or drained
+        avail (IDset): idset of ranks not excluded, drained, or torpid
         offline (IDset): idset of ranks currently offline
         online (IDset): idset of ranks currently online
         exclude (IDset): idset of ranks excluded by configuration

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -286,7 +286,7 @@ def statuslines(rstatus, states, formatter, include_online=True, include_offline
         combine=lambda line, arg: line.update(arg.ranks, arg.hostlist),
     )
     states = set(states)
-    for state in ["avail", "exclude", "torpid"]:
+    for state in ["avail", "exclude", "allocated", "torpid"]:
         if not states & {state, "all"}:
             continue
         for online in (True, False):
@@ -368,6 +368,7 @@ def status(args):
         "draining",
         "drained",
         "torpid",
+        "allocated",
     ]
     default_states = "avail,exclude,draining,drained,torpid"
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -184,6 +184,7 @@ TESTSCRIPTS = \
 	t2351-resource-status-input.t \
 	t2352-resource-cmd-config.t \
 	t2353-resource-eventlog.t \
+	t2354-resource-status.t \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
 	t2402-job-exec-dummy.t \

--- a/t/t2354-resource-status.t
+++ b/t/t2354-resource-status.t
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+test_description='flux-resource status general tests'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4
+
+export FLUX_PYCLI_LOGLEVEL=10
+
+test_expect_success 'flux-resource status: works' '
+	flux resource status
+'
+test_expect_success 'flux-resource status: --states=help reports valid states' '
+	flux resource status --states=help >status-help.out 2>&1 &&
+	test_debug "cat status-help.out" &&
+	grep "valid states:" status-help.out
+'
+test_expect_success 'flux-resource status: bad --states reports valid states' '
+	test_expect_code 1 flux resource status --states=foo >status-bad.out 2>&1 &&
+	test_debug "cat status-bad.out" &&
+	grep "valid states:" status-bad.out
+'
+test_expect_success 'flux-resource status -s all shows all expected states' '
+	flux resource status -s all >status-all.out &&
+	test_debug "cat status-all.out" &&
+	grep avail status-all.out &&
+	grep exclude status-all.out &&
+	grep torpid status-all.out &&
+	grep allocated status-all.out &&
+	grep draining status-all.out &&
+	grep drained status-all.out
+'
+test_expect_success 'flux-resource status: allocated set is not displayed by default' '
+	flux submit -N1 --wait-event=alloc sleep inf &&
+	flux resource status >status-noalloc.out &&
+	test_must_fail grep allocated status-noalloc.out
+'
+test_expect_success 'flux-resource status: allocated nodes can be displayed' '
+	flux resource status -s allocated | grep allocated
+'
+test_done


### PR DESCRIPTION
Currently the `flux resource status` command doesn't support display of `allocated` resources, even though this information is available because it is necessary to split `draining` nodes from `drained`. The addition of this state is trivial, and could be useful in situations like #6248.

Note that this PR does not put `allocated` in the list of states to show by default, so the default output won't change. However, `flux resource status -s all` will now show the set of allocated nodes, which may be helpful when admins and users are trying to see the status of all nodes at a glance.