### PR TITLE
validator: allow configurable minimum job size in the require-instance validator plugin

### DIFF
--- a/src/bindings/python/flux/job/validator/plugins/require-instance.py
+++ b/src/bindings/python/flux/job/validator/plugins/require-instance.py
@@ -22,19 +22,94 @@ not directly via `flux broker` or `flux start`.
 import errno
 from os.path import basename
 
+from flux.job import JobspecV1
 from flux.job.validator import ValidatorPlugin
 
 
+class JobSize:
+
+    def __init__(self, nnodes=0, ncores=0):
+        self.nnodes = nnodes
+        self.ncores = ncores
+
+    @classmethod
+    def from_jobspec(cls, jobspec):
+        counts = JobspecV1(**jobspec).resource_counts()
+        return JobSize(counts.get("node", None), counts.get("core", None))
+
+    def ignore_by_size(self, jobspec):
+        """
+        Return True if jobspec size is less than the currently configured
+        minimum job size required for a require-instance check
+        """
+        size = JobSize.from_jobspec(jobspec)
+        if size.nnodes is not None and size.nnodes >= self.nnodes:
+            return False
+        if size.ncores is not None and size.ncores >= self.ncores:
+            return False
+        return True
+
+    def configured(self):
+        return self.nnodes > 0 or self.ncores > 0
+
+    @property
+    def errstr(self):
+        result = "Direct job submission disabled"
+        if self.nnodes == 0 and self.ncores == 0:
+            result += " for all jobs in this instance"
+        else:
+            result += " for jobs >="
+            if self.nnodes > 0:
+                result += f" {self.nnodes} nodes"
+            if self.ncores > 0:
+                if self.nnodes > 0:
+                    result += " or"
+                result += f" {self.ncores} cores"
+        result += ". Please use flux-batch(1) or flux-alloc(1)"
+        return result
+
+
 class Validator(ValidatorPlugin):
+    def __init__(self, parser):
+        parser.add_argument(
+            "--require-instance-minnodes",
+            help="minimum node count that requires flux-batch/alloc be used."
+            + "default: 0",
+            metavar="N",
+            type=int,
+            default=0,
+        )
+        parser.add_argument(
+            "--require-instance-mincores",
+            metavar="N",
+            help="minimum core count that requires flux-batch/alloc be used."
+            + "default: 0",
+            type=int,
+            default=0,
+        )
+
+    def configure(self, args):
+        nnodes = args.require_instance_minnodes
+        ncores = args.require_instance_mincores
+        if nnodes > 0 and ncores == 0:
+            # Default ncores to a multiple of nnodes to avoid leaving an
+            # accidental hole that allows a cores-only job to be admitted
+            # by this plugin:
+            ncores = 16 * nnodes
+
+        self.minsize = JobSize(nnodes, ncores)
+
     def validate(self, args):
+
+        #  Ignore this job if it falls below a configured minsize:
+        if self.minsize.ignore_by_size(args.jobspec):
+            return
+
+        #  Otherwise, ensure this job is a new instance of Flux:
         if "batch" in args.jobspec["attributes"]["system"]:
             return
         command = args.jobspec["tasks"][0]["command"]
         arg0 = basename(command[0])
         if arg0 == "flux" and command[1] in ["broker", "start"]:
             return
-        return (
-            errno.EINVAL,
-            "Direct job submission is disabled for this instance."
-            + " Please use flux-batch(1) or flux-alloc(1)",
-        )
+        return (errno.EINVAL, self.minsize.errstr)

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -167,4 +167,22 @@ test_expect_success 'job-ingest: require-instance validator plugin works' '
 	test_must_fail flux submit hostname &&
 	test_must_fail flux submit flux getattr rank
 '
+test_expect_success 'job-ingest: require-instance min size can be configured' '
+	ARGS="--require-instance-minnodes=2,--require-instance-mincores=4" &&
+	ingest_module reload validator-plugins=require-instance \
+		validator-args="$ARGS" &&
+	flux submit -N1 hostname &&
+	flux submit -n2 hostname &&
+	test_must_fail flux submit -N4 hostname &&
+	test_must_fail flux submit -n4 hostname
+'
+test_expect_success 'job-ingest: require-instance min size can be for nodes only' '
+	ARGS="--require-instance-minnodes=2" &&
+	ingest_module reload validator-plugins=require-instance \
+		validator-args="$ARGS" &&
+	flux submit -N1 hostname &&
+	flux submit -n2 hostname &&
+	test_must_fail flux submit -N4 hostname &&
+	test_must_fail flux submit -n32 hostname
+'
 test_done


### PR DESCRIPTION
@trws had suggested in a meeting that the `require-instance` validator might be more useful if it had a configurable minimum job size to which the validator would apply. For example, a cluster might be configured to allow any jobs up to 16 nodes, but above that, `flux alloc` or `flux batch` should be used.

This PR adds new options to the `require-instance` validator `--require-instance-minnodes=N` and `require-instance-mincores=N` which, if used, allow jobs smaller than these numbers to be ignored by the plugin. To avoid a case where only `--require-instance-minnodes` is used, and all jobs that only specify cores are allowed to run, a very conservative default of 16 cores per node is assumed if `--require-instance-mincores` is not set.

It would be nice if this configuration could be set in the config file, but deciding where that goes (the job-ingest module "owns" everything under `[ingest]` and throws an error if extra keys are used), so that can be saved for later. (as could other improvements, like making the plugin per-queue, etc.)

Just throwing this up now to see what people think.