### PR TITLE
remove allocations in hostrange_find

### DIFF
--- a/src/common/libhostlist/hostlist.h
+++ b/src/common/libhostlist/hostlist.h
@@ -68,6 +68,35 @@ const char * hostlist_nth (struct hostlist * hl, int n);
 int hostlist_find (struct hostlist * hl, const char *hostname);
 
 /*
+ *  Create an opaque hostname object which can be used with the
+ *   more efficient hostlist_find_hostname() below. This interface
+ *   should be used when matching the same hostname to many hostlists
+ *   since it caches processing of the hostname instead of duplicating
+ *   the work on each call to hostlist_find().
+ *
+ *  Caller must call hostlist_hostname_destroy() to free memory associated
+ *   with the returns hostlist_hostname object.
+ *
+ *  Returns NULL on error.
+ */
+struct hostlist_hostname *hostlist_hostname_create (const char *hostname);
+
+/*
+ *  Free resources associated with hostname hn.
+ */
+void hostlist_hostname_destroy (struct hostlist_hostname *hn);
+
+/*
+ *  Search hostlist hl for the first host matching hostlist_hostname `hn`
+ *   and return position in list if found.
+ *
+ *  Leaves cursor pointing to the matching host.
+ *
+ *  Returns -1 if host is not found.
+ */
+int hostlist_find_hostname (struct hostlist *hl, struct hostlist_hostname *hn);
+
+/*
  *  Delete all hosts in the list represented by `hosts'
  *
  *  Returns the number of hosts successfully deleted, -1 on failure.

--- a/src/common/libhostlist/hostname.c
+++ b/src/common/libhostlist/hostname.c
@@ -16,7 +16,9 @@
 #include <string.h>
 #include <ctype.h>
 #include <errno.h>
+#include <math.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "hostname.h"
 
@@ -25,9 +27,10 @@
 /*
  * return the location of the last char in the hostname prefix
  */
-static int host_prefix_end (const char *hostname)
+static int host_prefix_end (const char *hostname, int len)
 {
-    int len = strlen (hostname);
+    if (len < 0)
+        return -1;
     int idx = len - 1;
 
     /* Rewind to the last non-digit in hostname
@@ -44,16 +47,101 @@ static int host_prefix_end (const char *hostname)
 static int hostname_len (const char *hostname)
 {
     int len = strlen (hostname);
-    for (int i = 0; i < len; i++)
-        if (strchr (INVALID_CHARS, hostname[i]))
-            return -1;
+    if (len != strcspn (hostname, INVALID_CHARS))
+        return -1;
     return len;
 }
 
-struct hostname * hostname_create_with_suffix (const char *hostname,
-                                               int idx)
+struct stack_hostname *hostname_stack_create_from_hostname (
+    struct stack_hostname *hn,
+    struct hostlist_hostname *src)
 {
-    struct hostname * hn = NULL;
+    if (!hn || !src) {
+        errno = EINVAL;
+        return NULL;
+    }
+    hn->hostname = src->hostname;
+    hn->suffix = src->suffix;
+    hn->len = src->len;
+    hn->len_prefix = src->len_prefix;
+    hn->width = src->width;
+    hn->num = src->num;
+    return hn;
+}
+
+struct stack_hostname *hostname_stack_create_with_suffix (
+    struct stack_hostname *hn,
+    const char *hostname,
+    int len,
+    int idx)
+{
+    if (!hostname || !hn || len < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    hn->hostname = hostname;
+    hn->len = len;
+    hn->len_prefix = idx + 1;
+    hn->num = 0;
+    hn->suffix = NULL;
+    if (idx == hn->len - 1) {
+        return hn;
+    }
+    hn->suffix = hn->hostname + hn->len_prefix;
+
+    char *p = NULL;
+    hn->num = strtoul (hn->suffix, &p, 10);
+    if (p == hn->suffix && hn->num == 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    hn->width = hn->len - hn->len_prefix;
+    return hn;
+}
+
+struct stack_hostname *hostname_stack_copy_one_less_digit (
+    struct stack_hostname *dst,
+    struct stack_hostname *src)
+{
+
+    if (!dst || !src) {
+        errno = EINVAL;
+        return NULL;
+    }
+    *dst = *src;
+    dst->len_prefix = src->len_prefix + 1;
+    if (src->len_prefix == dst->len - 1) {
+        return dst;
+    }
+    dst->suffix = dst->hostname + dst->len_prefix;
+
+    dst->width = dst->len - dst->len_prefix;
+    if (dst->width < 0 || dst->width > 10) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    // remove the most significant decimal digit without reparsing
+    // lookup table because pow is slow
+    static const int pow10[10] = {
+        1,
+        10,
+        100,
+        1000,
+        10000,
+        100000,
+        1000000,
+        10000000,
+        100000000,
+        1000000000};
+    dst->num = src->num % pow10[dst->width];
+    return dst;
+}
+
+struct hostlist_hostname *hostname_create_with_suffix (const char *hostname,
+                                                       int idx)
+{
+    struct hostlist_hostname *hn = NULL;
     int len;
     char *p = NULL;
 
@@ -71,10 +159,13 @@ struct hostname * hostname_create_with_suffix (const char *hostname,
     }
 
     hn->num = 0;
+    hn->len = len;
+    hn->len_prefix = idx + 1;
+    hn->width = hn->len - hn->len_prefix;
     hn->prefix = NULL;
     hn->suffix = NULL;
 
-    if (idx == strlen (hostname) - 1) {
+    if (idx == len - 1) {
         if ((hn->prefix = strdup (hostname)) == NULL) {
             hostname_destroy (hn);
             return NULL;
@@ -101,23 +192,37 @@ struct hostname * hostname_create_with_suffix (const char *hostname,
     return hn;
 }
 
+struct stack_hostname *hostname_stack_create (struct stack_hostname *hn,
+                                              const char *hostname)
+{
+    int len = 0;
+    if (!hostname || (len = hostname_len (hostname)) < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return hostname_stack_create_with_suffix (hn,
+                                              hostname,
+                                              len,
+                                              host_prefix_end (hostname, len));
+}
 
 /*
- * create a struct hostname * object from a string hostname
+ * create a struct hostlist_hostname * object from a string hostname
  */
-struct hostname * hostname_create (const char *hostname)
+struct hostlist_hostname *hostname_create (const char *hostname)
 {
+    int end;
     if (!hostname) {
         errno = EINVAL;
         return NULL;
     }
-    return hostname_create_with_suffix (hostname,
-                                        host_prefix_end (hostname));
+    end = host_prefix_end (hostname, hostname_len (hostname));
+    return hostname_create_with_suffix (hostname, end);
 }
 
 /* free a hostname object
  */
-void hostname_destroy (struct hostname * hn)
+void hostname_destroy (struct hostlist_hostname * hn)
 {
     int saved_errno = errno;
     if (hn) {
@@ -131,14 +236,14 @@ void hostname_destroy (struct hostname * hn)
 
 /* return true if the hostname has a valid numeric suffix
  */
-int hostname_suffix_is_valid (struct hostname * hn)
+int hostname_suffix_is_valid (struct hostlist_hostname * hn)
 {
     return (hn && hn->suffix != NULL);
 }
 
 /* return the width (in characters) of the numeric part of the hostname
  */
-int hostname_suffix_width (struct hostname * hn)
+int hostname_suffix_width (struct hostlist_hostname * hn)
 {
     if (!hn) {
         errno = EINVAL;

--- a/src/common/libhostlist/hostname.h
+++ b/src/common/libhostlist/hostname.h
@@ -15,9 +15,12 @@
  * Convenience structure representing a hostname as a prefix,
  *  optional numeric part, and suffix.
  */
-struct hostname {
+struct hostlist_hostname {
     char *hostname;         /* cache of initialized hostname        */
     char *prefix;           /* hostname prefix                      */
+    int len; /* length minus invalid characters */
+    int len_prefix; /* length of the prefix */
+    int width;   /* length of the suffix */
     unsigned long num;      /* numeric suffix                       */
 
     /* string representation of numeric suffix
@@ -25,11 +28,36 @@ struct hostname {
     char *suffix;
 };
 
-struct hostname * hostname_create (const char *s);
-struct hostname * hostname_create_with_suffix (const char *s, int i);
-void hostname_destroy (struct hostname *hn);
+struct stack_hostname {
+    const char *hostname;         /* cache of initialized hostname        */
+    int len; /* length minus invalid characters */
+    int len_prefix; /* length of the prefix */
+    int width;   /* length of the suffix */
+    unsigned long num;      /* numeric suffix                       */
 
-int hostname_suffix_is_valid (struct hostname *hn);
-int hostname_suffix_width (struct hostname *hn);
+    /* string representation of numeric suffix
+     * points into `hostname'                                       */
+    const char *suffix;
+};
+
+struct hostlist_hostname * hostname_create (const char *s);
+struct hostlist_hostname * hostname_create_with_suffix (const char *s, int i);
+struct stack_hostname *hostname_stack_create (struct stack_hostname *hn,
+                                              const char *hostname);
+struct stack_hostname *hostname_stack_create_from_hostname (
+    struct stack_hostname *hn,
+    struct hostlist_hostname *hn_src);
+struct stack_hostname *hostname_stack_create_with_suffix (
+    struct stack_hostname *hn,
+    const char *hostname,
+    int len,
+    int idx);
+struct stack_hostname *hostname_stack_copy_one_less_digit (
+    struct stack_hostname *dst,
+    struct stack_hostname *src);
+void hostname_destroy (struct hostlist_hostname *hn);
+
+int hostname_suffix_is_valid (struct hostlist_hostname *hn);
+int hostname_suffix_width (struct hostlist_hostname *hn);
 
 #endif /* !HAVE_FLUX_HOSTLIST_HOSTNAME_H */

--- a/src/common/libhostlist/hostrange.h
+++ b/src/common/libhostlist/hostrange.h
@@ -17,6 +17,7 @@
  */
 struct hostrange {
     char *prefix;        /* alphanumeric prefix: */
+    unsigned long len_prefix; /* length of the prefix */
 
     /* beginning (lo) and end (hi) of suffix range */
     unsigned long lo, hi;
@@ -31,7 +32,7 @@ struct hostrange {
 
 struct hostrange * hostrange_create_single (const char *);
 
-struct hostrange * hostrange_create (char *s,
+struct hostrange * hostrange_create (const char *s,
                                      unsigned long lo,
                                      unsigned long hi,
                                      int width);
@@ -56,7 +57,7 @@ int hostrange_join (struct hostrange *, struct hostrange *);
 struct hostrange * hostrange_intersect (struct hostrange *,
                                         struct hostrange *);
 
-int hostrange_hn_within (struct hostrange *, struct hostname *);
+int hostrange_hn_within (struct hostrange *, struct stack_hostname *);
 
 size_t hostrange_numstr(struct hostrange *, size_t, char *);
 

--- a/src/common/libhostlist/test/hostlist.c
+++ b/src/common/libhostlist/test/hostlist.c
@@ -343,6 +343,35 @@ void test_find ()
     }
 }
 
+void test_find_hostname ()
+{
+    struct find_test *t = find_tests;
+
+    ok (hostlist_find_hostname (NULL, NULL) == -1 && errno == EINVAL,
+        "hostlist_find_hostname (NULL, NULL) returns EINVAL");
+
+    while (t && t->input) {
+        int rc;
+        struct hostlist_hostname *hn;
+        struct hostlist *hl = hostlist_decode (t->input);
+        if (!hl)
+            BAIL_OUT ("hostlist_decode (%s) failed!", t->input);
+        if (!(hn = hostlist_hostname_create (t->arg)))
+            BAIL_OUT ("hostlist_hostname_create (%s) failed!", t->arg);
+        rc = hostlist_find_hostname (hl, hn);
+        ok (rc == t->rc,
+            "hostlist_find_hostname ('%s', '%s') returned %d",
+            t->input, t->arg, rc);
+        if (t->rc >= 0)
+            is (hostlist_current (hl), t->arg,
+                "hostlist_find leaves cursor pointing to found host");
+        hostlist_hostname_destroy (hn);
+        hostlist_destroy (hl);
+        t++;
+    }
+}
+
+
 struct delete_test {
     char *input;
     char *delete;
@@ -616,6 +645,7 @@ int main (int argc, char *argv[])
     test_append ();
     test_nth ();
     test_find ();
+    test_find_hostname ();
     test_delete ();
     test_sortuniq ();
     test_iteration ();

--- a/src/common/libhostlist/test/hostname.c
+++ b/src/common/libhostlist/test/hostname.c
@@ -48,7 +48,7 @@ int main (int argc, char *argv[])
 
     t = hostname_tests;
     while (t && t->input != NULL) {
-        struct hostname *hn = hostname_create (t->input);
+        struct hostlist_hostname *hn = hostname_create (t->input);
         if (t->prefix == NULL) {
             /* Check expected failure */
             ok (hn == NULL && errno == EINVAL,

--- a/src/common/libhostlist/test/hostrange.c
+++ b/src/common/libhostlist/test/hostrange.c
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#include "src/common/libhostlist/hostname.h"
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -160,32 +161,32 @@ struct cmp_test {
 };
 
 struct cmp_test cmp_tests[] = {
-    { { "foo", 0, 15, 0, 0 },
-      { "foo", 1, 15, 0, 0 },
+    { { "foo", 3, 0, 15, 0, 0 },
+      { "foo", 3, 1, 15, 0, 0 },
       -1, },
-    { { "foo", 0, 15, 0, 0 },
-      { "foo", 0, 15, 0, 0 },
+    { { "foo", 3, 0, 15, 0, 0 },
+      { "foo", 3, 0, 15, 0, 0 },
       0, },
-    { { "foo", 0, 15, 0, 0 },
-      { "foo", 0,  0, 0, 1 },
+    { { "foo", 3, 0, 15, 0, 0 },
+      { "foo", 3, 0,  0, 0, 1 },
       1, },
-    { { "bar", 0,  0, 0, 1 },
-      { "foo", 0,  0, 0, 1 },
+    { { "bar", 3, 0,  0, 0, 1 },
+      { "foo", 3, 0,  0, 0, 1 },
       -1, },
-    { { "",    0,  5, 0, 0 },
-      { "",    5,  5, 0, 0 },
+    { { "", 0,   0,  5, 0, 0 },
+      { "",  0,  5,  5, 0, 0 },
       -1,
     },
-    { { "",    0,  5, 0, 0 },
-      { "",    0,  5, 2, 0 },
+    { { "", 0,   0,  5, 0, 0 },
+      { "", 0,   0,  5, 2, 0 },
       -1,
     },
-    { { "",    12,  12, 0, 0 },
-      { "",    15,  15, 0, 0 },
+    { { "", 0,   12,  12, 0, 0 },
+      { "", 0,   15,  15, 0, 0 },
       -1,
     },
-    { { "",    15,  15, 0, 0 },
-      { "",    12,  12, 0, 0 },
+    { { "", 0,   15,  15, 0, 0 },
+      { "", 0,   12,  12, 0, 0 },
       1,
     },
     { { 0 }, { 0 }, 0 },
@@ -405,7 +406,8 @@ void test_within ()
     while (t && t->hostname) {
         int result;
         struct hostrange *hr;
-        struct hostname *hn = hostname_create (t->hostname);
+        struct stack_hostname hn_storage = {};
+        struct stack_hostname *hn = hostname_stack_create (&hn_storage, t->hostname);
 
         if (hn == NULL)
             BAIL_OUT ("hostname_create failed!");
@@ -420,7 +422,6 @@ void test_within ()
             "hostrange_hn_within (%s[%lu-%lu], %s) returned %d",
             t->prefix, t->lo, t->hi, t->hostname, result);
 
-        hostname_destroy (hn);
         hostrange_destroy (hr);
         t++;
     }


### PR DESCRIPTION
This is an in-progress PR looking at making hostrange_find allocation-free.  It actually does that, and also keeps track of the length of all string components such that it can use comparison functions that don't have to check for a null terminator, but when I was doing tests with this a few weeks ago, it was no faster for the flux-sched case.  Maybe worth poking at to see if I did something screwy but something strange is going on.