### PR TITLE
doc: update admin guide for systemd perilog

### DIFF
--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -920,3 +920,8 @@ DEEPBIND
 PRELOAD
 RTLD
 dlopened
+ne
+oneshot
+peridir
+periname
+templated


### PR DESCRIPTION
Problem: the admin guide does not describe how to configure the flux system instance to run the prolog and epilog scripts in systemd, but this probably should be recommended.

Add an example prolog/epilog script.

Change the IMP config instructions to point to systemd rather than the user-provided scripts.

Drop the paragraph about suppressing output in the flux log since it does not apply when set up this way.