### PR TITLE
python: add `conf_get()` convenience method to `flux.Flux` handle

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -175,6 +175,23 @@ def help_formatter(argwidth=40, raw_description=False):
     return lambda prog: FluxHelpFormatter(prog, max_help_position=argwidth)
 
 
+def get_treedict(in_dict, key, default=None):
+    """
+    get_treedict(d, "a.b.c" [,default=None]) is like:
+    >>> try:
+    >>>     return d[a][b][c]
+    >>> except KeyError:
+    >>>     return default
+    """
+    if "." in key:
+        next_key, rest = key.split(".", 1)
+        try:
+            return get_treedict(in_dict[next_key], rest, default)
+        except KeyError:
+            return default
+    return in_dict.get(key, default)
+
+
 def set_treedict(in_dict, key, val):
     """
     set_treedict(d, "a.b.c", 42) is like d[a][b][c] = 42

--- a/t/python/t0001-handle.py
+++ b/t/python/t0001-handle.py
@@ -88,6 +88,30 @@ class TestHandle(unittest.TestCase):
         rank = self.f.get_rank()
         self.assertEqual(attr_rank, rank)
 
+    def test_conf_get(self):
+        # Works with empty config
+        self.assertEqual(self.f.conf_get(), {})
+
+        # load test config
+        testconf = {"a": {"b": {"c": 42}, "foo": "bar"}}
+        self.f.rpc("config.load", testconf).get()
+
+        # conf_get() still returns old config
+        self.assertEqual(self.f.conf_get(), {})
+
+        # conf_get() with update=True returns new config
+        self.assertEqual(self.f.conf_get(update=True), testconf)
+
+        # conf_get() with key works
+        self.assertEqual(self.f.conf_get("a"), testconf["a"])
+        self.assertEqual(self.f.conf_get("a.b"), testconf["a"]["b"])
+        self.assertEqual(self.f.conf_get("a.b.c"), testconf["a"]["b"]["c"])
+        self.assertEqual(self.f.conf_get("a.foo"), testconf["a"]["foo"])
+
+        # conf_get() works with default
+        self.assertIsNone(self.f.conf_get("a.baz"))
+        self.assertEqual(self.f.conf_get("a.baz", default=42), 42)
+
 
 if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):


### PR DESCRIPTION
As part of some other work, it seemed like it would be nice to have a convenient method to get values from current Flux configuration. This is one possible simple approach.

This PR adds a `flux.Flux.conf_get()` method:

```python
    def conf_get(self, key=None, default=None, update=False):
````

On first access or if `update=True`, the current config is synchronously fetched from the broker and cached. If `key` is `None`, then the entire object is returned, otherwise `key` is a dotted string representation of a key from the config to return. If `key` does not exist, then `default` is returned.

This should make it easy for Python components to use the Flux configuration.

As I said, this is just one approach, but thought I'd throw it up as a PR for comments.