### PR TITLE
limit output to 1G in single user instances

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -326,9 +326,9 @@ plugins include:
 .. option:: output.limit=SIZE
 
    Truncate KVS output after SIZE bytes have been written. SIZE may
-   be a floating point value with optional SI units k, K, M, G. A value of
-   0 is considered unlimited. The default KVS output limit is 10M for jobs
-   in a multi-user instance or unlimited for single-user instance jobs.
+   be a floating point value with optional SI units k, K, M, G.  The maximum
+   value is 1G.  The default KVS output limit is 10M for jobs
+   in a multi-user instance or 1G for single-user instance jobs.
    This value is ignored if output is directed to a file.
 
 .. option:: output.{stdout,stderr}.path=PATH

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -1218,7 +1218,7 @@ static int get_output_limit (struct shell_output *out)
         }
     }
     if (parse_size (out->kvs_limit_string, &size) < 0) {
-        shell_log_errno ("Invalid KVS output.limit=%s", out->kvs_limit_string);
+        shell_log ("Invalid KVS output.limit=%s", out->kvs_limit_string);
         return -1;
     }
     out->kvs_limit_bytes = (size_t) size;

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -368,8 +368,17 @@ test_expect_success LONGTEST 'job-shell: no truncation at 10MB for single-user j
 	flux run cat 10M+ >10M+.output &&
 	test_cmp 10M+ 10M+.output
 '
-test_expect_success 'job-shell: invalid output.limit string is rejected' '
+test_expect_success 'job-shell: invalid output.limit string is rejected (text)' '
 	test_must_fail flux run -o output.limit=foo hostname
+'
+test_expect_success 'job-shell: invalid output.limit string is rejected (zero)' '
+	test_must_fail flux run -o output.limit=0 hostname
+'
+test_expect_success 'job-shell: invalid output.limit string is rejected (big num)' '
+	test_must_fail flux run -o output.limit=4000000000 hostname
+'
+test_expect_success 'job-shell: invalid output.limit string is rejected (big num suffix)' '
+	test_must_fail flux run -o output.limit=4G hostname
 '
 test_expect_success 'job-shell: output.mode=append works' '
 	flux bulksubmit --watch --output=append.out \


### PR DESCRIPTION
Problem: The KVS has a size limit of INT_MAX for when returning kvs values.  This limit can be exceeded by a job's standard output because it is continually appended and the total size is not yet tracked by the KVS.  When reading the output later, such as via `flux job attach`, this can lead to EOVERFLOW errors.

Solution: For a single user instance, default to a maximum standard output of 1G instead of "unlimited".  1G should provide a practical maximum for most users and encourage them to send standard output to a file if they want to save excess standard output.  If desired, the value can still be overwritten via the "output.limit" setting.

Fixes #6256

----

Any thoughts of if the limit should be higher? lower?   I picked 1G mostly b/c I disliked the limit of "2G - 1".  

I also timed things and on my single user instance reading the 1G stdout via `flux job attach` took about 140 seconds.  2 minutes seems to be just beyond that "annoyance limit".  I could also see making the max 500M so that the `flux job attach` is more around 1 minute.
