### PR TITLE
perilog: ensure default prolog timeout matches documentation

### DIFF
--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -171,13 +171,17 @@ static struct perilog_procdesc *perilog_procdesc_create (json_t *o,
     struct perilog_procdesc *pd = NULL;
     int per_rank = 0;
     int cancel_on_exception = -1;
-    const char *timeout = NULL;
+    const char *timeout;
     double kill_timeout = -1.;
     flux_cmd_t *cmd = NULL;
     json_t *command = NULL;
     json_error_t error;
 
     const char *name = prolog ? "prolog" : "epilog";
+
+    /*  Set default timeout for prolog to 30m, unlimited for epilog
+     */
+    timeout = prolog ? "30m" : "0";
 
     if (json_unpack_ex (o,
                         &error,

--- a/t/t2274-manager-perilog-per-rank.t
+++ b/t/t2274-manager-perilog-per-rank.t
@@ -34,6 +34,21 @@ test_expect_success 'perilog: query shows no prolog/epilog config' '
 	flux jobtap query perilog.so \
 		| jq -e ".conf.prolog == {} and .conf.epilog == {}"
 '
+test_expect_success 'perilog: default timeouts are expected values' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	command = ["prolog"]
+	per-rank = true
+	[job-manager.epilog]
+	command = ["epilog"]
+	per-rank = true
+	EOF
+	flux jobtap query perilog.so | jq .conf &&
+	flux jobtap query perilog.so \
+		| jq -e ".conf.prolog.timeout == 1800.0" &&
+	flux jobtap query perilog.so \
+		| jq -e ".conf.epilog.timeout == 0.0"
+'
 test_expect_success 'perilog: timeout can be set to 0' '
 	flux config load <<-EOF &&
 	[job-manager.prolog]


### PR DESCRIPTION
The documentation states that the `perilog.so` plugin prolog, if configured, has a default timeout of "30m", but this wasn't actually the case.

Fix the code to add the 30m default for the prolog, and add the missing test.

If people feel it would be better to not have defaults for either prolog/epilog I can instead fix the documentation. I could go either way.