### PR TITLE
doc: fix typo in `FLUX_IPADDR_INTERFACE` entry in `flux-environment(7)`

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -229,7 +229,7 @@ affect the broker's PMI client.
    version 4 addresses.  Setting this variable to any value in the broker's
    environment causes it to prefer version 6 addresses.
 
-.. envvar:: FLUX_IPADDR_HOSTNAME
+.. envvar:: FLUX_IPADDR_INTERFACE
 
    Force PMI bootstrap to assign the broker an address associated with a
    particular network interface, like ``eth0``.


### PR DESCRIPTION
Problem: There's a typo in the flux-environment(7) manual page. FLUX_IPADDR_HOSTNAME is specified where FLUX_IPADDR_INTERFACE should have been used.

Update the entry to specify the correct nvironment variable.