### PR TITLE
configure: add check for valid version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,28 @@ AC_SUBST([AX_MAJOR_VERSION])
 AC_SUBST([AX_MINOR_VERSION])
 AC_SUBST([AX_POINT_VERSION])
 
+AC_MSG_CHECKING([whether version number is sane])
+AS_IF([printf "%d.%d.%d" ${AX_MAJOR_VERSION} ${AX_MINOR_VERSION} ${AX_POINT_VERSION} >/dev/null 2>&1], [
+    AC_MSG_RESULT([yes])
+],[
+    AC_MSG_RESULT([no])
+    version_err_msg="
+    VERSION ${VERSION} is invalid.
+    Try the following to remedy this:
+    
+      1. Run \`git fetch --tags\` before building. Versions in 
+         flux-core are derived from \`git describe\` which uses
+	 the most recent tag.
+      2. If you are running remote CI in a fork of the main repository, 
+         try pushing the upstream tags to your fork with
+	 \`git push --tags <your_remote>\` to make sure tags are 
+	 synchronized in your fork.
+      3. Set the variable manually, with FLUX_VERSION=<version>
+         in your environment.
+    "
+    AC_MSG_ERROR(["${version_err_msg}"])
+])
+
 ##
 # Initialize pkg-config for PKG_CHECK_MODULES to avoid conditional issues
 ##


### PR DESCRIPTION
Problem: autoconf will accept junk at configure time as a valid version, then go off and generate an invalid version.h file. This happens frequently with shallow clones, setups in CI, or other constrained user environments. It has caused new contributors a lot of confusion in the past.

Solution: Like [flux-framework/flux-sched#1291](https://github.com/flux-framework/flux-sched/issues/1291) suggested, reject invalid versions at configure time and provide appropriate suggestions to the user to remedy this.