### PR TITLE
add tbon.interface-hint broker attribute / configuration key with CIDR network support

### DIFF
--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -73,6 +73,23 @@ child_rcvhwm
    This configured value may be overridden by setting the ``tbon.child_rcvhwm``
    broker attribute.
 
+interface-hint
+   When the broker's bind address is not explicitly configured via
+   :man5:`flux-config-bootstrap`, it is chosen dynamically, influenced by
+   one of the following hints:
+
+   default-route
+     The address associated with the default route (the default hint).
+   hostname
+     The address associated with the system hostname.
+   *interface*
+     The address associated with the named network interface, e.g. ``enp4s0``
+   *network*
+     The address associated with the first interface that matches the
+     network address in CIDR form, e.g. ``10.0.2.0/24``.  NOTE: IPv6
+     network addresses are not supported at this time.
+
+
 EXAMPLE
 =======
 

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -188,6 +188,21 @@ tbon.prefertcp [Updates: C]
    with PMI, tcp:// endpoints will be used instead of ipc://, even if all
    brokers are on a single node.  Default: ``0``.
 
+tbon.interface-hint
+   When bootstrapping with PMI, tcp:// endpoints are chosen heuristically
+   using one of the following methods:
+
+   default-route
+      The address associated with the default route (the default hint).
+   hostname
+      The address associated with the system hostname.
+   *interface*
+     The address associated with the named network interface, e.g. ``enp4s0``
+   *network*
+     The address associated with the first interface that matches the
+     network address in CIDR form, e.g. ``10.0.2.0/24``.  NOTE: IPv6
+     network addresses are not supported at this time.
+
 tbon.torpid_min [Updates: C, R]
    The amount of time (in RFC 23 Flux Standard Duration format) that a broker
    will allow the connection to its TBON parent to remain idle before sending a

--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -232,7 +232,9 @@ affect the broker's PMI client.
 .. envvar:: FLUX_IPADDR_INTERFACE
 
    Force PMI bootstrap to assign the broker an address associated with a
-   particular network interface, like ``eth0``.
+   particular network interface, like ``eth0``.  Alternatively, the interface
+   may be specified by its IPv4 network address in CIDR form, e.g.
+   "192.168.1.1/24".
 
 
 CUSTOM OUTPUT FORMATS

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -925,3 +925,4 @@ oneshot
 peridir
 periname
 templated
+CIDR

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -926,3 +926,4 @@ peridir
 periname
 templated
 CIDR
+enp

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -149,10 +149,19 @@ static int format_bind_uri (char *buf, int bufsz, attr_t *attrs, int rank)
         char ipaddr[HOST_NAME_MAX + 1];
         flux_error_t error;
         int flags = 0;
-        const char *interface = getenv ("FLUX_IPADDR_INTERFACE");
+        const char *interface = NULL;
+        const char *hint;
 
-        if (getenv ("FLUX_IPADDR_HOSTNAME"))
+        if (attr_get (attrs, "tbon.interface-hint", &hint, NULL) < 0) {
+            log_err ("tbon.interface-hint attribute is not set");
+            return -1;
+        }
+        if (streq (hint, "hostname"))
             flags |= IPADDR_HOSTNAME;
+        else if (streq (hint, "default-route"))
+            ; // default behavior
+        else
+            interface = hint;
         if (getenv ("FLUX_IPADDR_V6"))
             flags |= IPADDR_V6;
         if (ipaddr_getprimary (ipaddr,

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -148,8 +148,18 @@ static int format_bind_uri (char *buf, int bufsz, attr_t *attrs, int rank)
     else {
         char ipaddr[HOST_NAME_MAX + 1];
         flux_error_t error;
+        int flags = 0;
+        const char *interface = getenv ("FLUX_IPADDR_INTERFACE");
 
-        if (ipaddr_getprimary (ipaddr, sizeof (ipaddr), &error) < 0) {
+        if (getenv ("FLUX_IPADDR_HOSTNAME"))
+            flags |= IPADDR_HOSTNAME;
+        if (getenv ("FLUX_IPADDR_V6"))
+            flags |= IPADDR_V6;
+        if (ipaddr_getprimary (ipaddr,
+                               sizeof (ipaddr),
+                               flags,
+                               interface,
+                               &error) < 0) {
             log_msg ("%s", error.text);
             return -1;
         }

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -147,11 +147,10 @@ static int format_bind_uri (char *buf, int bufsz, attr_t *attrs, int rank)
     }
     else {
         char ipaddr[HOST_NAME_MAX + 1];
-        char error[200];
+        flux_error_t error;
 
-        if (ipaddr_getprimary (ipaddr, sizeof (ipaddr),
-                               error, sizeof (error)) < 0) {
-            log_msg ("%s", error);
+        if (ipaddr_getprimary (ipaddr, sizeof (ipaddr), &error) < 0) {
+            log_msg ("%s", error.text);
             return -1;
         }
         if (snprintf (buf, bufsz, "tcp://%s:*", ipaddr) >= bufsz)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -19,6 +19,8 @@ noinst_LTLIBRARIES = libutil.la
 libutil_la_SOURCES = \
 	ipaddr.c \
 	ipaddr.h \
+	cidr.c \
+	cidr.h \
 	log.c \
 	log.h \
 	xzmalloc.c \

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -120,6 +120,7 @@ TESTS = test_sha1.t \
 	test_read_all.t \
 	test_tomltk.t \
 	test_ipaddr.t \
+	test_cidr.t \
 	test_fluid.t \
 	test_aux.t \
 	test_fdutils.t \
@@ -228,6 +229,10 @@ test_ipaddr_t_LDADD = $(test_ldadd)
 test_getaddr_SOURCES = test/getaddr.c
 test_getaddr_CPPFLAGS = $(test_cppflags)
 test_getaddr_LDADD = $(test_ldadd)
+
+test_cidr_t_SOURCES = test/cidr.c
+test_cidr_t_CPPFLAGS = $(test_cppflags)
+test_cidr_t_LDADD = $(test_ldadd)
 
 test_fluid_t_SOURCES = test/fluid.c
 test_fluid_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -152,7 +152,9 @@ test_cppflags = \
 	-I$(top_srcdir)/src/common/libtap \
 	$(AM_CPPFLAGS) $(JANSSON_CFLAGS)
 
-check_PROGRAMS = $(TESTS)
+check_PROGRAMS = \
+	$(TESTS) \
+	test_getaddr
 
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
@@ -220,6 +222,10 @@ test_tomltk_t_LDADD = $(test_ldadd)
 test_ipaddr_t_SOURCES = test/ipaddr.c
 test_ipaddr_t_CPPFLAGS = $(test_cppflags)
 test_ipaddr_t_LDADD = $(test_ldadd)
+
+test_getaddr_SOURCES = test/getaddr.c
+test_getaddr_CPPFLAGS = $(test_cppflags)
+test_getaddr_LDADD = $(test_ldadd)
 
 test_fluid_t_SOURCES = test/fluid.c
 test_fluid_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libutil/cidr.c
+++ b/src/common/libutil/cidr.c
@@ -1,0 +1,95 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* cidr.c - parse RFC 4632 CIDR notation */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <errno.h>
+
+#include "errno_safe.h"
+#include "cidr.h"
+
+/* Destructively parse /N from the end of 's'.
+ * Leaves 's' containing only the string before the / character.
+ * If /N is missing, return max_value.
+ */
+static int parse_netprefix (char *s, int max_value)
+{
+    char *cp;
+    char *endptr;
+    int n = max_value;
+
+    if ((cp = strrchr (s, '/'))) {
+        *cp++ = '\0';
+        errno = 0;
+        n = strtoul (cp, &endptr, 10);
+        if (errno != 0 || *endptr != '\0' || n > max_value) {
+            errno = EINVAL;
+            return -1;
+        }
+    }
+    return n;
+}
+
+static uint32_t netprefix_to_netmask4 (int prefix)
+{
+    if (prefix > 0)
+        return htonl (~((1 << (32 - prefix)) - 1));
+    return 0;
+}
+
+int cidr_parse4 (struct cidr4 *cidrp, const char *s)
+{
+    char *cpy;
+    struct cidr4 cidr;
+    int prefix;
+    int n;
+
+    if (!cidrp || !s) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(cpy = strdup (s)))
+        return -1;
+    if ((prefix = parse_netprefix (cpy, 32)) < 0)
+        goto error;
+    cidr.mask.s_addr = netprefix_to_netmask4 (prefix);
+    if ((n = inet_pton (AF_INET, cpy, &cidr.addr)) < 0)
+        goto error;
+    if (n == 0) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    free (cpy);
+    *cidrp = cidr;
+    return 0;
+error:
+    ERRNO_SAFE_WRAP (free, cpy);
+    return -1;
+}
+
+bool cidr_match4 (struct cidr4 *cidr, struct in_addr *addr)
+{
+    if (!cidr || !addr)
+        return false;
+    uint32_t mask = cidr->mask.s_addr;
+    if ((addr->s_addr & mask) == (cidr->addr.s_addr & mask))
+        return true;
+    return false;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/cidr.h
+++ b/src/common/libutil/cidr.h
@@ -1,0 +1,27 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_CIDR_H
+#define _UTIL_CIDR_H
+
+#include <arpa/inet.h>
+#include <stdbool.h>
+
+struct cidr4 {
+    struct in_addr addr;
+    struct in_addr mask;
+};
+
+int cidr_parse4 (struct cidr4 *cidr, const char *s);
+bool cidr_match4 (struct cidr4 *cidr, struct in_addr *addr);
+
+#endif /* !_UTIL_CIDR_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/ipaddr.c
+++ b/src/common/libutil/ipaddr.c
@@ -199,17 +199,20 @@ static int getprimary_hostaddr (char *buf, int len, int prefer_family,
     return 0;
 }
 
-int ipaddr_getprimary (char *buf, int len, flux_error_t *error)
+int ipaddr_getprimary (char *buf,
+                       int len,
+                       int flags,
+                       const char *interface,
+                       flux_error_t *error)
 {
-    int prefer_family = getenv ("FLUX_IPADDR_V6") ? AF_INET6 : AF_INET;
-    const char *iface_name;
+    int prefer_family = (flags & IPADDR_V6) ? AF_INET6 : AF_INET;
     int rc = -1;
 
-    if ((iface_name = getenv ("FLUX_IPADDR_INTERFACE"))) {
-        rc = getnamed_ifaddr (buf, len, iface_name, prefer_family, error);
+    if (interface) {
+        rc = getnamed_ifaddr (buf, len, interface, prefer_family, error);
     }
     else {
-        if (getenv ("FLUX_IPADDR_HOSTNAME") == NULL)
+        if (!(flags & IPADDR_HOSTNAME))
             rc = getprimary_ifaddr (buf, len, prefer_family, error);
         if (rc < 0) {
             rc = getprimary_hostaddr (buf, len, prefer_family, error);

--- a/src/common/libutil/ipaddr.c
+++ b/src/common/libutil/ipaddr.c
@@ -79,10 +79,10 @@ static struct ifaddrs *find_ifaddr (struct ifaddrs *ifaddr,
 
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
         if (streq (ifa->ifa_name, name)
-                && ifa->ifa_addr != NULL
-                && ifa->ifa_addr->sa_family == family
-                && (ifa->ifa_addr->sa_family != AF_INET6
-                    || !is_linklocal6 ((struct sockaddr_in6 *)ifa->ifa_addr)))
+            && ifa->ifa_addr != NULL
+            && ifa->ifa_addr->sa_family == family
+            && (ifa->ifa_addr->sa_family != AF_INET6
+                || !is_linklocal6 ((struct sockaddr_in6 *)ifa->ifa_addr)))
             break;
     }
     return ifa;
@@ -153,7 +153,9 @@ static struct addrinfo *find_addrinfo (struct addrinfo *addrinfo, int family)
     return ai;
 }
 
-static int getprimary_hostaddr (char *buf, int len, int prefer_family,
+static int getprimary_hostaddr (char *buf,
+                                int len,
+                                int prefer_family,
                                 flux_error_t *error)
 {
     char hostname[HOST_NAME_MAX + 1];

--- a/src/common/libutil/ipaddr.c
+++ b/src/common/libutil/ipaddr.c
@@ -127,7 +127,7 @@ static int getnamed_ifaddr (char *buf,
         ifa = find_ifaddr (ifaddr, name, prefer_family);
     }
     if (!ifa) {
-        errprintf (error, "could not find address of %s", name);
+        errprintf (error, "could not find address associated with %s", name);
         freeifaddrs (ifaddr);
         return -1;
     }

--- a/src/common/libutil/ipaddr.c
+++ b/src/common/libutil/ipaddr.c
@@ -24,21 +24,10 @@
 #include <stdio.h>
 
 #include "ccan/str/str.h"
+#include "errprintf.h"
 
 #include "log.h"
 #include "ipaddr.h"
-
-static __attribute__ ((format (printf, 3, 4)))
-void esprintf (char *buf, int len, const char *fmt, ...)
-{
-    if (buf) {
-        va_list ap;
-
-        va_start (ap, fmt);
-        vsnprintf (buf, len, fmt, ap);
-        va_end (ap);
-    }
-}
 
 /* Identify an IPv6 link-local address so it can be skipped.
  * The leftmost 10 bits of the 128 bit address will be 0xfe80.
@@ -54,8 +43,7 @@ static bool is_linklocal6 (struct sockaddr_in6 *sin)
     return false;
 }
 
-static int getprimary_iface4 (char *buf, size_t size,
-                              char *errstr, int errstrsz)
+static int getprimary_iface4 (char *buf, size_t size, flux_error_t *error)
 {
     const char *path = "/proc/net/route";
     FILE *f;
@@ -63,7 +51,7 @@ static int getprimary_iface4 (char *buf, size_t size,
     char line[256];
 
     if (!(f = fopen (path, "r"))) {
-        esprintf (errstr, errstrsz, "%s: %s", path, strerror (errno));
+        errprintf (error, "%s: %s", path, strerror (errno));
         return -1;
     }
     while (fgets (line, sizeof (line), f)) {
@@ -79,7 +67,7 @@ static int getprimary_iface4 (char *buf, size_t size,
         }
     }
     fclose (f);
-    esprintf (errstr, errstrsz, "%s: no default route", path);
+    errprintf (error, "%s: no default route", path);
     return -1;
 }
 
@@ -104,15 +92,14 @@ static int getnamed_ifaddr (char *buf,
                             int len,
                             const char *name,
                             int prefer_family,
-                            char *errstr,
-                            int errstrsz)
+                            flux_error_t *error)
 {
     struct ifaddrs *ifaddr;
     struct ifaddrs *ifa;
-    int error;
+    int e;
 
     if (getifaddrs (&ifaddr) < 0) {
-        esprintf (errstr, errstrsz, "getifaddrs: %s", strerror (errno));
+        errprintf (error, "getifaddrs: %s", strerror (errno));
         return -1;
     }
     if (!(ifa = find_ifaddr (ifaddr, name, prefer_family))) {
@@ -120,21 +107,21 @@ static int getnamed_ifaddr (char *buf,
         ifa = find_ifaddr (ifaddr, name, prefer_family);
     }
     if (!ifa) {
-        esprintf (errstr, errstrsz, "could not find address of %s", name);
+        errprintf (error, "could not find address of %s", name);
         freeifaddrs (ifaddr);
         return -1;
     }
-    error = getnameinfo (ifa->ifa_addr,
-                         ifa->ifa_addr->sa_family == AF_INET
-                             ? sizeof (struct sockaddr_in)
-                             : sizeof (struct sockaddr_in6),
-                         buf, // <== result copied here
-                         len,
-                         NULL,
-                         0,
-                         NI_NUMERICHOST);
-    if (error) {
-        esprintf (errstr, errstrsz, "getnameinfo: %s", gai_strerror (error));
+    e = getnameinfo (ifa->ifa_addr,
+                     ifa->ifa_addr->sa_family == AF_INET
+                         ? sizeof (struct sockaddr_in)
+                         : sizeof (struct sockaddr_in6),
+                     buf, // <== result copied here
+                     len,
+                     NULL,
+                     0,
+                     NI_NUMERICHOST);
+    if (e) {
+        errprintf (error, "getnameinfo: %s", gai_strerror (e));
         freeifaddrs (ifaddr);
         return -1;
     }
@@ -145,13 +132,12 @@ static int getnamed_ifaddr (char *buf,
 static int getprimary_ifaddr (char *buf,
                               int len,
                               int prefer_family,
-                              char *errstr,
-                              int errstrsz)
+                              flux_error_t *error)
 {
     char name[64];
-    if (getprimary_iface4 (name, sizeof (name), errstr, errstrsz) < 0)
+    if (getprimary_iface4 (name, sizeof (name), error) < 0)
         return -1;
-    return getnamed_ifaddr (buf, len, name, prefer_family, errstr, errstrsz);
+    return getnamed_ifaddr (buf, len, name, prefer_family, error);
 }
 
 static struct addrinfo *find_addrinfo (struct addrinfo *addrinfo, int family)
@@ -168,25 +154,24 @@ static struct addrinfo *find_addrinfo (struct addrinfo *addrinfo, int family)
 }
 
 static int getprimary_hostaddr (char *buf, int len, int prefer_family,
-                                char *errstr, int errstrsz)
+                                flux_error_t *error)
 {
     char hostname[HOST_NAME_MAX + 1];
     struct addrinfo hints, *res = NULL;
     struct addrinfo *rp;
-    int error;
+    int e;
 
     if (gethostname (hostname, sizeof (hostname)) < 0) {
-        esprintf (errstr, errstrsz, "gethostname: %s", strerror (errno));
+        errprintf (error, "gethostname: %s", strerror (errno));
         return -1;
     }
     memset (&hints, 0, sizeof (hints));
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
 
-    error = getaddrinfo (hostname, NULL, &hints, &res);
-    if (error) {
-        esprintf (errstr, errstrsz, "getaddrinfo %s: %s",
-                  hostname, gai_strerror (error));
+    e = getaddrinfo (hostname, NULL, &hints, &res);
+    if (e) {
+        errprintf (error, "getaddrinfo %s: %s", hostname, gai_strerror (e));
         return -1;
     }
     if (!(rp = find_addrinfo (res, prefer_family))) {
@@ -194,19 +179,19 @@ static int getprimary_hostaddr (char *buf, int len, int prefer_family,
         rp = find_addrinfo (res, prefer_family);
     }
     if (!rp) {
-        esprintf (errstr, errstrsz, "could not find address of %s", hostname);
+        errprintf (error, "could not find address of %s", hostname);
         freeaddrinfo (res);
         return -1;
     }
-    error = getnameinfo (rp->ai_addr,
-                         rp->ai_addrlen,
-                         buf, // <== result copied here
-                         len,
-                         NULL,
-                         0,
-                         NI_NUMERICHOST);
-    if (error) {
-        esprintf (errstr, errstrsz, "getnameinfo: %s", gai_strerror (error));
+    e = getnameinfo (rp->ai_addr,
+                     rp->ai_addrlen,
+                     buf, // <== result copied here
+                     len,
+                     NULL,
+                     0,
+                     NI_NUMERICHOST);
+    if (e) {
+        errprintf (error, "getnameinfo: %s", gai_strerror (e));
         freeaddrinfo (res);
         return -1;
     }
@@ -214,30 +199,20 @@ static int getprimary_hostaddr (char *buf, int len, int prefer_family,
     return 0;
 }
 
-int ipaddr_getprimary (char *buf, int len,
-                       char *errstr, int errstrsz)
+int ipaddr_getprimary (char *buf, int len, flux_error_t *error)
 {
     int prefer_family = getenv ("FLUX_IPADDR_V6") ? AF_INET6 : AF_INET;
     const char *iface_name;
     int rc = -1;
 
     if ((iface_name = getenv ("FLUX_IPADDR_INTERFACE"))) {
-        rc = getnamed_ifaddr (buf,
-                              len,
-                              iface_name,
-                              prefer_family,
-                              errstr,
-                              errstrsz);
+        rc = getnamed_ifaddr (buf, len, iface_name, prefer_family, error);
     }
     else {
         if (getenv ("FLUX_IPADDR_HOSTNAME") == NULL)
-            rc = getprimary_ifaddr (buf, len, prefer_family, errstr, errstrsz);
+            rc = getprimary_ifaddr (buf, len, prefer_family, error);
         if (rc < 0) {
-            rc = getprimary_hostaddr (buf,
-                                      len,
-                                      prefer_family,
-                                      errstr,
-                                      errstrsz);
+            rc = getprimary_hostaddr (buf, len, prefer_family, error);
         }
     }
     return rc;

--- a/src/common/libutil/ipaddr.h
+++ b/src/common/libutil/ipaddr.h
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef _UTIL_GETIP_H
-#define _UTIL_GETIP_H
+#ifndef _UTIL_IPADDR_H
+#define _UTIL_IPADDR_H
 
 #include <sys/socket.h> // for AF_INET, AF_INET6
 #include "src/common/libflux/types.h" // for flux_error_t
@@ -49,7 +49,7 @@ int ipaddr_getprimary (char *buf,
                        const char *interface,
                        flux_error_t *error);
 
-#endif /* !_UTIL_GETIP_H */
+#endif /* !_UTIL_IPADDR_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libutil/ipaddr.h
+++ b/src/common/libutil/ipaddr.h
@@ -12,6 +12,7 @@
 #define _UTIL_GETIP_H
 
 #include <sys/socket.h> // for AF_INET, AF_INET6
+#include "src/common/libflux/types.h" // for flux_error_t
 
 /* Guess at a usable network address for the local node using one
  * of these methods:
@@ -34,10 +35,10 @@
  *   if set, only method 3 is tried above
  *
  * Return address as a string in buf (up to len bytes, always null terminated)
- * Return 0 on success, -1 on error with error message written to errstr
+ * Return 0 on success, -1 on error with error message written to 'error'
  * if non-NULL.
  */
-int ipaddr_getprimary (char *buf, int len, char *errstr, int errstrsz);
+int ipaddr_getprimary (char *buf, int len, flux_error_t *error);
 
 #endif /* !_UTIL_GETIP_H */
 

--- a/src/common/libutil/ipaddr.h
+++ b/src/common/libutil/ipaddr.h
@@ -14,6 +14,11 @@
 #include <sys/socket.h> // for AF_INET, AF_INET6
 #include "src/common/libflux/types.h" // for flux_error_t
 
+enum {
+    IPADDR_V6 = 1,
+    IPADDR_HOSTNAME = 2,
+};
+
 /* Guess at a usable network address for the local node using one
  * of these methods:
  * 1. Find the interface associated with the default route, then
@@ -23,22 +28,26 @@
  *
  * Main use case: determine bind address for a PMI-bootstrapped flux broker.
  *
- * Some environment variables alter the default behavior:
+ * Flags and the optional 'interface' param alter the default behavior:
  *
- * FLUX_IPADDR_IPV6
+ * IPADDR_IPV6
  *   if set, IPv6 addresses are preferred, with fallback to IPv4
  *   if unset, IPv4 addresses are preferred, with fallback to IPv6
- * FLUX_IPADDR_HOSTNAME
+ * IPADDR_HOSTNAME
  *   if set, only method 2 is tried above
  *   if unset, first method 1 is tried, then if that fails, method 2 is tried
- * FLUX_IPADDR_INTERFACE
+ * 'interface'
  *   if set, only method 3 is tried above
  *
  * Return address as a string in buf (up to len bytes, always null terminated)
  * Return 0 on success, -1 on error with error message written to 'error'
  * if non-NULL.
  */
-int ipaddr_getprimary (char *buf, int len, flux_error_t *error);
+int ipaddr_getprimary (char *buf,
+                       int len,
+                       int flags,
+                       const char *interface,
+                       flux_error_t *error);
 
 #endif /* !_UTIL_GETIP_H */
 

--- a/src/common/libutil/test/cidr.c
+++ b/src/common/libutil/test/cidr.c
@@ -1,0 +1,127 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/param.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/cidr.h"
+#include "ccan/array_size/array_size.h"
+
+struct cidr_test {
+    const char *input;
+    const char *addr;
+    const char *mask;
+    const char *match;
+    const char *nomatch;
+};
+
+struct cidr_test testvec[] = {
+    {   .input = "0.0.0.0/16",
+        .addr = "0.0.0.0",
+        .mask = "255.255.0.0",
+        .match = "0.0.255.255",
+        .nomatch = "1.1.1.1"
+    },
+    {   .input = "255.255.255.255/8",
+        .addr = "255.255.255.255",
+        .mask = "255.0.0.0",
+        .match = "255.1.1.1",
+        .nomatch = "254.1.1.1"
+    },
+    {   .input = "192.168.0.0/24",
+        .addr = "192.168.0.0",
+        .mask = "255.255.255.0",
+        .match = "192.168.0.1",
+        .nomatch = "192.168.1.1"
+    },
+    {   .input = "192.168.0.1/32", // "host route" in RFC 4632
+        .addr = "192.168.0.1",
+        .mask = "255.255.255.255",
+        .match = "192.168.0.1",
+        .nomatch = "192.168.0.2"
+    },
+    {   .input = "192.168.0.0",
+        .addr = "192.168.0.0",
+        .mask = "255.255.255.255",
+        .match = "192.168.0.0",
+        .nomatch = "192.168.0.1"
+    },
+    {   .input = "0.0.0.0/0",   // "default route" in RFC 4632
+        .addr = "0.0.0.0",
+        .mask = "0.0.0.0",
+        .match = "255.255.255.255",
+        NULL    // skip
+    },
+};
+
+bool addr_is (struct in_addr *addr, const char *s)
+{
+    struct in_addr a;
+    if (inet_pton (AF_INET, s, &a) < 0 || a.s_addr != addr->s_addr)
+        return false;
+    return true;
+}
+
+bool match_addr (struct cidr4 *cidr, const char *s)
+{
+    struct in_addr a;
+    if (inet_pton (AF_INET, s, &a) < 0 || !cidr_match4 (cidr, &a))
+        return false;
+    return true;
+}
+
+int main (int argc, char** argv)
+{
+    int n;
+    struct cidr4 cidr;
+    struct in_addr addr;
+
+    plan (NO_PLAN);
+
+    for (int i = 0; i < ARRAY_SIZE (testvec); i++) {
+        n = cidr_parse4 (&cidr, testvec[i].input);
+        ok (n == 0
+            && addr_is (&cidr.addr, testvec[i].addr)
+            && addr_is (&cidr.mask, testvec[i].mask),
+            "%s => %s/%s",
+            testvec[i].input,
+            testvec[i].addr,
+            testvec[i].mask);
+
+        if (testvec[i].match) {
+            ok (match_addr (&cidr, testvec[i].match) == true,
+                "%s matches", testvec[i].match);
+        }
+        if (testvec[i].nomatch) {
+            ok (match_addr (&cidr, testvec[i].nomatch) == false,
+                "%.8x does not match", testvec[i].nomatch);
+        }
+    }
+
+    errno = 0;
+    ok (cidr_parse4 (NULL, "0.0.0.0") < 0 && errno == EINVAL,
+        "cidr_parse4 cidr=NULL fails with EINVAL");
+    errno = 0;
+    ok (cidr_parse4 (&cidr, NULL) < 0 && errno == EINVAL,
+        "cidr_parse4 s=NULL fails with EINVAL");
+
+    ok (cidr_match4 (NULL, &addr) == false,
+        "cidr_match4 cidr=NULL returns false");
+    ok (cidr_match4 (&cidr, NULL) == false,
+        "cidr_match4 addr=NULL returns false");
+
+    done_testing ();
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/test/getaddr.c
+++ b/src/common/libutil/test/getaddr.c
@@ -1,0 +1,45 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/param.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/ipaddr.h"
+#include "src/common/libutil/log.h"
+
+
+int main(int argc, char** argv)
+{
+    char buf[MAXHOSTNAMELEN + 1];
+    flux_error_t error;
+    char *name = getenv ("FLUX_IPADDR_INTERFACE");
+    int flags = 0;
+
+    log_init ("getaddr");
+
+    if (argc > 2)
+        log_msg_exit ("too many arguments");
+    if (argc == 2)
+        name = argv[1];
+    if (getenv ("FLUX_IPADDR_HOSTNAME"))
+        flags |= IPADDR_HOSTNAME;
+    if (getenv ("FLUX_IPADDR_V6"))
+        flags |= IPADDR_V6;
+
+    if (ipaddr_getprimary (buf, sizeof (buf), flags, name, &error) < 0)
+        log_msg_exit ("%s", error.text);
+
+    printf ("%s\n", buf);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/test/ipaddr.c
+++ b/src/common/libutil/test/ipaddr.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #endif
 #include <sys/param.h>
+#include <flux/core.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/ipaddr.h"
@@ -32,38 +33,38 @@ static void setopt (const char *name, int val)
 int main(int argc, char** argv)
 {
     char host[MAXHOSTNAMELEN + 1];
-    char err[200];
+    flux_error_t error;
     int n;
 
     plan (NO_PLAN);
 
     setopt ("FLUX_IPADDR_HOSTNAME", 0);
     setopt ("FLUX_IPADDR_V6", 0);
-    n = ipaddr_getprimary (host, sizeof (host), err, sizeof (err));
+    n = ipaddr_getprimary (host, sizeof (host), &error);
     ok (n == 0,
         "ipaddr_getprimary (hostname=0 v6=0) works");
-    diag ("%s", n == 0 ? host : err);
+    diag ("%s", n == 0 ? host : error.text);
 
     setopt ("FLUX_IPADDR_HOSTNAME", 0);
     setopt ("FLUX_IPADDR_V6", 1);
-    n = ipaddr_getprimary (host, sizeof (host), err, sizeof (err));
+    n = ipaddr_getprimary (host, sizeof (host), &error);
     ok (n == 0,
         "ipaddr_getprimary (hostname=0 v6=1) works");
-    diag ("%s", n == 0 ? host : err);
+    diag ("%s", n == 0 ? host : error.text);
 
     setopt ("FLUX_IPADDR_HOSTNAME", 1);
     setopt ("FLUX_IPADDR_V6", 0);
-    n = ipaddr_getprimary (host, sizeof (host), err, sizeof (err));
+    n = ipaddr_getprimary (host, sizeof (host), &error);
     ok (n == 0,
         "ipaddr_getprimary (hostname=1 v6=0) works");
-    diag ("%s", n == 0 ? host : err);
+    diag ("%s", n == 0 ? host : error.text);
 
     setopt ("FLUX_IPADDR_HOSTNAME", 1);
     setopt ("FLUX_IPADDR_V6", 1);
-    n = ipaddr_getprimary (host, sizeof (host), err, sizeof (err));
+    n = ipaddr_getprimary (host, sizeof (host), &error);
     ok (n == 0,
         "ipaddr_getprimary (hostname=1 v6=1)");
-    diag ("%s", n == 0 ? host : err);
+    diag ("%s", n == 0 ? host : error.text);
 
     done_testing();
 }

--- a/src/common/libutil/test/ipaddr.c
+++ b/src/common/libutil/test/ipaddr.c
@@ -18,18 +18,6 @@
 #include "src/common/libutil/ipaddr.h"
 
 
-static void setopt (const char *name, int val)
-{
-    if (val) {
-        if (setenv (name, "1", 1) < 0)
-            BAIL_OUT ("setenv %s", name);
-    }
-    else {
-        if (unsetenv (name) < 0)
-            BAIL_OUT ("unsetenv %s", name);
-    }
-}
-
 int main(int argc, char** argv)
 {
     char host[MAXHOSTNAMELEN + 1];
@@ -38,30 +26,26 @@ int main(int argc, char** argv)
 
     plan (NO_PLAN);
 
-    setopt ("FLUX_IPADDR_HOSTNAME", 0);
-    setopt ("FLUX_IPADDR_V6", 0);
-    n = ipaddr_getprimary (host, sizeof (host), &error);
+    n = ipaddr_getprimary (host, sizeof (host), 0, NULL, &error);
     ok (n == 0,
         "ipaddr_getprimary (hostname=0 v6=0) works");
     diag ("%s", n == 0 ? host : error.text);
 
-    setopt ("FLUX_IPADDR_HOSTNAME", 0);
-    setopt ("FLUX_IPADDR_V6", 1);
-    n = ipaddr_getprimary (host, sizeof (host), &error);
+    n = ipaddr_getprimary (host, sizeof (host), IPADDR_V6, NULL, &error);
     ok (n == 0,
         "ipaddr_getprimary (hostname=0 v6=1) works");
     diag ("%s", n == 0 ? host : error.text);
 
-    setopt ("FLUX_IPADDR_HOSTNAME", 1);
-    setopt ("FLUX_IPADDR_V6", 0);
-    n = ipaddr_getprimary (host, sizeof (host), &error);
+    n = ipaddr_getprimary (host, sizeof (host), IPADDR_HOSTNAME, NULL, &error);
     ok (n == 0,
         "ipaddr_getprimary (hostname=1 v6=0) works");
     diag ("%s", n == 0 ? host : error.text);
 
-    setopt ("FLUX_IPADDR_HOSTNAME", 1);
-    setopt ("FLUX_IPADDR_V6", 1);
-    n = ipaddr_getprimary (host, sizeof (host), &error);
+    n = ipaddr_getprimary (host,
+                           sizeof (host),
+                           IPADDR_HOSTNAME | IPADDR_V6,
+                           NULL,
+                           &error);
     ok (n == 0,
         "ipaddr_getprimary (hostname=1 v6=1)");
     diag ("%s", n == 0 ? host : error.text);

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -447,10 +447,44 @@ test_expect_success 'FLUX_IPADDR_INTERFACE=lo works' '
 		flux getattr tbon.endpoint >endpoint3.out &&
 	grep "127.0.0.1" endpoint3.out
 '
-test_expect_success 'FLUX_IPADDR_INTERFACE=badiface fails' '
-	(export FLUX_IPADDR_INTERFACE=badiface; \
-		test_expect_code 137 flux start \
-		${ARGS} --test-exit-timeout=1s -s2 -o,-Stbon.prefertcp=1 true)
+test_expect_success 'tcp.interface-hint=lo works' '
+	flux start -o,-Stbon.interface-hint=lo \
+		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+		flux getattr tbon.endpoint >endpoint3a.out &&
+	grep "127.0.0.1" endpoint3a.out
+'
+test_expect_success 'tcp.interface-hint=127.0.0.0/8 works' '
+	flux start -o,-Stbon.interface-hint=127.0.0.0/8 \
+		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+		flux getattr tbon.endpoint >endpoint3b.out &&
+	grep "127.0.0.1" endpoint3b.out
+'
+test_expect_success 'TOML tcp.interface-hint=127.0.0.0/8 works' '
+	cat >hint.toml <<-EOT &&
+	tbon.interface-hint = "127.0.0.0/8"
+	EOT
+	flux start -o,--config-path=hint.toml \
+		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+		flux getattr tbon.endpoint >endpoint3c.out &&
+	grep "127.0.0.1" endpoint3c.out
+'
+test_expect_success 'TOML tcp.interface-hint=wrong type fails' '
+	cat >badhint.toml <<-EOT &&
+	tbon.interface-hint = 42
+	EOT
+	test_must_fail flux start -o,--config-path=badhint.toml ${ARGS} true
+'
+test_expect_success 'tcp.interface-hint=badiface fails' '
+	test_expect_code 137 flux start -o,-Stbon.interface-hint=badiface \
+		${ARGS} --test-exit-timeout=1s -s2 -o,-Stbon.prefertcp=1 true
+'
+test_expect_success 'tcp.interface-hint=default-route works' '
+	flux start -o,-Stbon.interface-hint=default-route,-Stbon.prefertcp=1 \
+		${ARGS} -s2 true
+'
+test_expect_success 'tcp.interface-hint=hostname works' '
+	flux start -o,-Stbon.interface-hint=hostname,-Stbon.prefertcp=1 \
+		${ARGS} -s2 true
 '
 test_expect_success 'tbon.endpoint cannot be set' '
 	test_must_fail flux start ${ARGS} -s2 \


### PR DESCRIPTION
Problem:  starting an instance with its overlay assigned to a particular network is tricky if you network interface names are unpredictable.  And environment variables are a hacky way to influence the broker's choice.

The broker chooses a network address to bind to (and to exchange with PMI peers) using a heuristic usually based on the default route.  You can set environment variables to choose the address associated with the hostname instead, or a specific interface by name.

This adds
- the option of specifying the interface by network address (ipv4  CIDR, e.g. 10.0.2.0/24)
- a new broker attribute `tbon.interface-hint` which can have the values of `default-route` (the default), `hostname` (as described above), or name that can be either an interface name or a network address
- a TOML config key of the same name

Fixes #5754