### PR TITLE
broker: call PMI_Abort() if something goes wrong during PMI bootstrap

### DIFF
--- a/doc/man1/flux-pmi.rst
+++ b/doc/man1/flux-pmi.rst
@@ -88,6 +88,11 @@ barrier
 
   Execute N barrier (step 2) operations (default 1).
 
+.. option:: --abort=RANK
+
+  Instead of entering the barrier, arrange for RANK to call the PMI
+  abort function.
+
 exchange
 --------
 

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -493,15 +493,19 @@ static void pmi_debug_trace (void *client, const char *buf)
     fprintf (stderr, "%d: %s", cli->rank, buf);
 }
 
-int pmi_kvs_put (void *arg, const char *kvsname,
-                 const char *key, const char *val)
+int pmi_kvs_put (void *arg,
+                 const char *kvsname,
+                 const char *key,
+                 const char *val)
 {
     zhash_update (ctx.pmi.kvs, key, xstrdup (val));
     zhash_freefn (ctx.pmi.kvs, key, (zhash_free_fn *)free);
     return 0;
 }
 
-int pmi_kvs_get (void *arg, void *client, const char *kvsname,
+int pmi_kvs_get (void *arg,
+                 void *client,
+                 const char *kvsname,
                  const char *key)
 {
     char *v = zhash_lookup (ctx.pmi.kvs, key);

--- a/src/common/libpmi/upmi.c
+++ b/src/common/libpmi/upmi.c
@@ -470,6 +470,28 @@ int upmi_finalize (struct upmi *upmi, flux_error_t *errp)
     return 0;
 }
 
+int upmi_abort (struct upmi *upmi, const char *msg, flux_error_t *errp)
+{
+    flux_error_t error;
+
+    if (!upmi || !msg) {
+        errprintf (errp, "invalid argument\n");
+        return -1;
+    }
+    if (upmi_call (upmi,
+                   "upmi.abort",
+                   &error,
+                   "{s:s}",
+                   "msg", msg) < 0) {
+        errprintf (errp, "%s", error.text);
+        upmi_trace (upmi, "abort: %s", error.text);
+        return -1;
+    }
+    // possibly not reached
+    upmi_trace (upmi, "abort: success");
+    return 0;
+}
+
 int upmi_put (struct upmi *upmi,
               const char *key,
               const char *value,

--- a/src/common/libpmi/upmi.h
+++ b/src/common/libpmi/upmi.h
@@ -55,6 +55,7 @@ int upmi_get (struct upmi *upmi,
               flux_error_t *error);
 int upmi_barrier (struct upmi *upmi,
                   flux_error_t *error);
+int upmi_abort (struct upmi *upmi, const char *msg, flux_error_t *error);
 
 #endif /* !_LIBPMI_UPMI_H */
 

--- a/src/common/libpmi/upmi_simple.c
+++ b/src/common/libpmi/upmi_simple.c
@@ -126,6 +126,26 @@ static int op_barrier (flux_plugin_t *p,
     return 0;
 }
 
+static int op_abort (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *data)
+{
+    struct plugin_ctx *ctx = flux_plugin_aux_get (p, plugin_name);
+    const char *msg;
+    int result;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:s}",
+                                "msg", &msg) < 0)
+        return upmi_seterror (p, args, "error unpacking abort arguments");
+    result = pmi_simple_client_abort (ctx->client, 1, msg);
+    if (result != PMI_SUCCESS)
+        return upmi_seterror (p, args, "%s", pmi_strerror (result));
+    return 0;
+}
+
 static int op_initialize (flux_plugin_t *p,
                           const char *topic,
                           flux_plugin_arg_t *args,
@@ -195,6 +215,7 @@ static const struct flux_plugin_handler optab[] = {
     { "upmi.put",           op_put,         NULL },
     { "upmi.get",           op_get,         NULL },
     { "upmi.barrier",       op_barrier,     NULL },
+    { "upmi.abort",         op_abort,       NULL },
     { "upmi.initialize",    op_initialize,  NULL },
     { "upmi.finalize",      op_finalize,    NULL },
     { "upmi.preinit",       op_preinit,     NULL },

--- a/src/common/libpmi/upmi_single.c
+++ b/src/common/libpmi/upmi_single.c
@@ -103,6 +103,24 @@ static int op_barrier (flux_plugin_t *p,
     return 0;
 }
 
+static int op_abort (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *data)
+{
+    const char *msg;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:s}",
+                                "msg", &msg) < 0)
+        return upmi_seterror (p, args, "error unpacking abort arguments");
+    fprintf (stderr, "%s\n", msg);
+    exit (1);
+    //NOTREACHED
+    return 0;
+}
+
 static int op_initialize (flux_plugin_t *p,
                           const char *topic,
                           flux_plugin_arg_t *args,
@@ -148,6 +166,7 @@ static const struct flux_plugin_handler optab[] = {
     { "upmi.put",           op_put,         NULL },
     { "upmi.get",           op_get,         NULL },
     { "upmi.barrier",       op_barrier,     NULL },
+    { "upmi.abort",         op_abort,       NULL },
     { "upmi.initialize",    op_initialize,  NULL },
     { "upmi.finalize",      op_finalize,    NULL },
     { "upmi.preinit",       op_preinit,     NULL },

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -102,7 +102,8 @@ static void shell_pmi_abort (void *arg,
      *   This allows the shell to continue to process events and stdio
      *   until the exec system terminates the job due to the exception.
      */
-    flux_shell_raise ("exec", 0,
+    flux_shell_raise ("exec",
+                      0,
                       "MPI_Abort%s%s",
                       msg ? ": " : "",
                       msg ? msg : "");
@@ -285,17 +286,17 @@ done:
 
 /* pmi_simple_ops->kvs_get() signature */
 static int exchange_kvs_get (void *arg,
-                              void *cli,
-                              const char *kvsname,
-                              const char *key)
+                             void *cli,
+                             const char *kvsname,
+                             const char *key)
 {
     struct shell_pmi *pmi = arg;
     json_t *o;
     const char *val = NULL;
 
     if ((o = json_object_get (pmi->locals, key))
-            || (o = json_object_get (pmi->pending, key))
-            || (o = json_object_get (pmi->global, key))) {
+        || (o = json_object_get (pmi->pending, key))
+        || (o = json_object_get (pmi->global, key))) {
         val = json_string_value (o);
         pmi_simple_server_kvs_get_complete (pmi->server, cli, val);
         return 0;
@@ -324,9 +325,9 @@ static int exchange_barrier_enter (void *arg)
 
 /* pmi_simple_ops->kvs_put() signature */
 static int exchange_kvs_put (void *arg,
-                              const char *kvsname,
-                              const char *key,
-                              const char *val)
+                             const char *kvsname,
+                             const char *key,
+                             const char *val)
 {
     struct shell_pmi *pmi = arg;
 
@@ -369,7 +370,8 @@ static void pmi_fd_cb (flux_shell_task_t *task,
     len = flux_subprocess_read_line (task->proc, "PMI_FD", &line);
     if (len < 0) {
         shell_trace ("%d: C: pmi read error: %s",
-                     task->rank, flux_strerror (errno));
+                     task->rank,
+                     flux_strerror (errno));
         return;
     }
     if (len == 0) {

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -104,7 +104,7 @@ static void shell_pmi_abort (void *arg,
      */
     flux_shell_raise ("exec",
                       0,
-                      "MPI_Abort%s%s",
+                      "PMI_Abort%s%s",
                       msg ? ": " : "",
                       msg ? msg : "");
 }

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -476,7 +476,7 @@ test_expect_success 'TOML tcp.interface-hint=wrong type fails' '
 '
 test_expect_success 'tcp.interface-hint=badiface fails' '
 	test_expect_code 137 flux start -o,-Stbon.interface-hint=badiface \
-		${ARGS} --test-exit-timeout=1s -s2 -o,-Stbon.prefertcp=1 true
+		${ARGS} -s2 -o,-Stbon.prefertcp=1 true
 '
 test_expect_success 'tcp.interface-hint=default-route works' '
 	flux start -o,-Stbon.interface-hint=default-route,-Stbon.prefertcp=1 \
@@ -487,7 +487,7 @@ test_expect_success 'tcp.interface-hint=hostname works' '
 		${ARGS} -s2 true
 '
 test_expect_success 'tbon.endpoint cannot be set' '
-	test_must_fail flux start ${ARGS} -s2 \
+	test_expect_code 137 flux start ${ARGS} -s2 \
 		-o,--setattr=tbon.endpoint=ipc:///tmp/customflux /bin/true
 '
 test_expect_success 'tbon.parent-endpoint cannot be read on rank 0' '

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -137,7 +137,7 @@ test_expect_success 'job-exec: decrease kill timeout for tests' '
 test_expect_success 'job-shell: PMI_Abort works' '
 	! flux run -N4 -n4 ${PMI_INFO} --abort=1 >abort.log 2>&1 &&
 	test_debug "cat abort.log" &&
-	grep "job.exception.*MPI_Abort: Test abort error." abort.log
+	grep "job.exception.*PMI_Abort: Test abort error." abort.log
 '
 test_expect_success 'job-shell: create expected I/O output' '
 	${LPTEST} | sed -e "s/^/0: /" >lptest.exp &&

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -175,6 +175,11 @@ test_expect_success 'flux-pmi barrier --count works' '
 	flux run --label-io -n2 \
 	    flux pmi barrier --count=2
 '
+test_expect_success 'flux-pmi barrier --abort works' '
+	test_expect_code 143 flux run --label-io -n2 \
+	    flux pmi barrier --abort=1 2>barrier_abort.err &&
+	grep -i abort barrier_abort.err
+'
 test_expect_success 'flux-pmi exchange works' '
 	flux run --label-io -n2 \
 	    flux pmi exchange
@@ -238,6 +243,10 @@ test_expect_success 'flux-pmi --method=libpmi barrier works w/ flux libpmi.so' '
 	flux run -n2 bash -c "\
 	    flux pmi -v --method=libpmi:$(cat libpmi) barrier"
 '
+test_expect_success 'flux-pmi --method=libpmi barrier abort works w/ flux libpmi.so' '
+	test_expect_code 143 flux run -n2 bash -c "\
+	    flux pmi -v --method=libpmi:$(cat libpmi) barrier --abort 1"
+'
 test_expect_success 'flux-pmi --method=libpmi exchange works w/ flux libpmi.so' '
 	flux run -n2 bash -c "\
 	    flux pmi -v --method=libpmi:$(cat libpmi) exchange"
@@ -267,6 +276,10 @@ test_expect_success 'flux-pmi --method=libpmi2:/bad/path fails' '
 test_expect_success 'flux-pmi --method=libpmi2 barrier works w/ flux pmi lib' '
 	flux run -n2 bash -c "\
 	    flux pmi -v --method=libpmi2:$(cat libpmi2) barrier"
+'
+test_expect_success 'flux-pmi --method=libpmi2 barrier works w/ flux pmi lib' '
+	test_expect_code 143 flux run -n2 bash -c "\
+	    flux pmi -v --method=libpmi2:$(cat libpmi2) barrier --abort 1"
 '
 test_expect_success 'flux-pmi --method=libpmi2 exchange works w/ flux pmi lib' '
 	flux run -n2 bash -c "\


### PR DESCRIPTION
Problem: brokers can hang if some of them enter the PMI barrier and others encounter a fatal error.

For example, #6278 demonstrates such a hang when `tbon.interface-hint` suggests an interface that doesn't exist.

With this PR, that example fails immediately like this:
```
$ flux start -s2 -o,-Stbon.prefertcp=1,-Stbon.interface-hint=192.16.1.1/24
flux-broker: could not find address associated with 192.16.1.1/24
flux-start: 0: PMI_Abort(): fatal bootstrap error
flux-start: 0 (pid 1227875) exited with rc=1
flux-start: 1 (pid 1227876) Killed
```
or
```
$ flux start -s2
ƒ(s=2,d=0,builddir) $ flux batch -N2 --broker-opts=-Stbon.interface-hint=192.16.1.1/24 --wrap true
ƒH51ZWG7

ƒ(s=2,d=0,builddir) $ flux job attach ƒH51ZWG7
0.075s: job.exception type=exec severity=0 PMI_Abort: fatal bootstrap error
flux-job: task(s) Killed
0: stdout redirected to flux-ƒH51ZWG7.out
0: stderr redirected to flux-ƒH51ZWG7.out

ƒ(s=2,d=0,builddir) $ cat flux-ƒH51ZWG7.out
flux-broker: could not find address associated with 192.16.1.1/24
```