### PR TITLE
format: fix clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,4 +23,3 @@ AlignAfterOpenBracket: true
 BinPackArguments : false
 AlignOperands : true
 BreakBeforeTernaryOperators : true
-AllowAllParametersOfDeclarationOnNextLine : false


### PR DESCRIPTION
Problem: the .clang-format file has a duplicated line that causes clang-format to break.

Remove the duplicated line.