### PR TITLE
libsubprocess: do not spin on large lines

### DIFF
--- a/src/common/libsubprocess/ev_fbuf_read.c
+++ b/src/common/libsubprocess/ev_fbuf_read.c
@@ -23,10 +23,15 @@ static bool data_to_read (struct ev_fbuf_read *ebr, bool *is_eof)
     if (ebr->line) {
         if (fbuf_has_line (ebr->fb))
             return true;
-        /* if eof read, no lines, but left over data non-line data,
-         * this data should be flushed to the user */
-        else if (ebr->eof_read && fbuf_bytes (ebr->fb))
-            return true;
+        else {
+            /* if no line, but the buffer is full, we have to flush */
+            if (!fbuf_space (ebr->fb))
+                return true;
+            /* if eof read, no lines, but left over data non-line data,
+             * this data should be flushed to the user */
+            if (ebr->eof_read && fbuf_bytes (ebr->fb))
+                return true;
+        }
     }
     else {
         if (fbuf_bytes (ebr->fb) > 0)

--- a/src/common/libsubprocess/fbuf_watcher.c
+++ b/src/common/libsubprocess/fbuf_watcher.c
@@ -126,6 +126,9 @@ const char *fbuf_read_watcher_get_data (flux_watcher_t *w, int *lenp)
                 return NULL;
             if (*lenp > 0)
                 return data;
+            /* if no space, have to flush data out */
+            if (!(*lenp) && !fbuf_space (eb->fb))
+                return fbuf_read (eb->fb, -1, lenp);
         }
         /* Not line-buffered, or reading last bit of data which does
          * not contain a newline. Read any data:

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -157,8 +157,8 @@ static void process_new_state (flux_subprocess_t *p,
 
 static bool remote_out_data_available (struct subprocess_channel *c)
 {
-    /* no need to handle failure states, on fatal error, these
-     * reactors are closed */
+    /* no need to handle failure states, on fatal error, the
+     * io watchers are closed */
     if ((c->line_buffered && fbuf_has_line (c->read_buffer))
         || (!c->line_buffered && fbuf_bytes (c->read_buffer) > 0)
         || (c->read_eof_received && !c->eof_sent_to_caller))
@@ -202,8 +202,8 @@ static void remote_out_check_cb (flux_reactor_t *r,
         c->p->channels_eof_sent++;
     }
 
-    /* no need to handle failure states, on fatal error, these
-     * reactors are closed */
+    /* no need to handle failure states, on fatal error, the
+     * io watchers are closed */
     if (!remote_out_data_available (c) || c->eof_sent_to_caller) {
         /* if no data in buffer, shut down prep/check */
         flux_watcher_stop (c->out_prep_w);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -816,6 +816,13 @@ static int subprocess_read (flux_subprocess_t *p,
             if (!(ptr = fbuf_read_line (fb, &len)))
                 return -1;
         }
+        /* Special case if buffer full, we gotta flush it out even if
+         * there is no line
+         */
+        if (!len && !fbuf_space (fb)) {
+            if (!(ptr = fbuf_read (fb, -1, &len)))
+                return -1;
+        }
     }
     else {
         if (!(ptr = fbuf_read (fb, -1, &len)))

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -235,6 +235,9 @@ int flux_subprocess_read (flux_subprocess_t *p,
  *   the stream is line buffered and a line is not yet available. Use
  *   flux_subprocess_read_stream_closed() to distinguish between the
  *   two.
+ *
+ *   This function may return an incomplete line when the stream has
+ *   closed and the last output is not a line.
  */
 int flux_subprocess_read_line (flux_subprocess_t *p,
                                const char *stream,

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -236,8 +236,11 @@ int flux_subprocess_read (flux_subprocess_t *p,
  *   flux_subprocess_read_stream_closed() to distinguish between the
  *   two.
  *
- *   This function may return an incomplete line when the stream has
- *   closed and the last output is not a line.
+ *   This function may return an incomplete line when:
+ *
+ *   1) the stream has closed and the last output is not a line
+ *   2) a single line of output exceeds the size of an internal output
+ *      buffer (see BUFSIZE option).
  */
 int flux_subprocess_read_line (flux_subprocess_t *p,
                                const char *stream,

--- a/src/common/libsubprocess/test/iostress.c
+++ b/src/common/libsubprocess/test/iostress.c
@@ -292,12 +292,13 @@ int main (int argc, char *argv[])
     ok (iostress_run_check (h, "balanced", false, 0, 0, 8, 8, 80),
         "balanced worked");
 
-    // (remote?) stdout buffer is overrun
-    // Needs further investigation as no errors are thrown and completion is
-    // not called called after subprocess exit.  The doomsday timer stops
-    // the test.
-    ok (!iostress_run_check (h, "tinystdout", false, 0, 128, 1, 1, 256),
-        "tinystdout failed as expected");
+    // stdout buffer is overrun
+
+    // When the line size is greater than the buffer size, all the
+    // data is transferred. flux_subprocess_read_line() will receive a
+    // "line" that is not terminated with \n
+    ok (iostress_run_check (h, "tinystdout", false, 0, 128, 1, 1, 256),
+        "tinystdout works");
 
     // local stdin buffer is overrun (immediately)
     // remote stdin buffer is also overwritten

--- a/src/common/libsubprocess/test/iostress.c
+++ b/src/common/libsubprocess/test/iostress.c
@@ -38,6 +38,7 @@ struct iostress_ctx {
     int batchcount;
     int batchlines;
     int batchcursor;
+    int outputcount;
     bool direct;
     const char *name;
 };
@@ -68,9 +69,11 @@ static void iostress_output_cb (flux_subprocess_t *p, const char *stream)
     else if (len == 0)
         diag ("%s: EOF", stream);
     else {
-        //diag ("%s: %d bytes", stream, len);
-        ctx->linerecv++;
+        // diag ("%s: %d bytes", stream, len);
+        if (strstr (line, "\n"))
+            ctx->linerecv++;
     }
+    ctx->outputcount++;
 }
 
 static void iostress_completion_cb (flux_subprocess_t *p)
@@ -264,8 +267,8 @@ bool iostress_run_check (flux_t *h,
         ret = false;
     }
 
-    diag ("%s: processed %d of %d lines", name,
-          ctx.linerecv, ctx.batchcount * ctx.batchlines);
+    diag ("%s: processed %d of %d lines, %d calls to output cb", name,
+          ctx.linerecv, ctx.batchcount * ctx.batchlines, ctx.outputcount);
     if (ctx.linerecv < ctx.batchcount * ctx.batchlines)
         ret = false;
 


### PR DESCRIPTION
Problem: In several cases, libsubprocess hangs/spins can occur if the internal output buffer is full.  For example, if subprocess output is line buffered and a single line exceeds the buffer size, the buffer can never be emptied because output callbacks are never called (i.e. the buffer never contains a line).

Other situations can exist if the user simply does not read data when it becomes available.

Solution: Handle full output buffers with two special cases

- if output is line buffered and the buffer is full AND no line exists, call the output callback for the user to get the current data.
  flux_subprocess_read_line() and similar functions will return data that is not a full line.

- if the buffer is at capacity and the user elected to not read anything in the output callback, drop the data.  The internal assumption is that a user must read data that is given to them at that point in time.

Fixes #6262