### PR TITLE
python: update Flux handle location in validator plugin API

### DIFF
--- a/src/bindings/python/flux/job/validator/plugins/feasibility.py
+++ b/src/bindings/python/flux/job/validator/plugins/feasibility.py
@@ -31,7 +31,7 @@ class Validator(ValidatorPlugin):
 
     def validate(self, args):
         try:
-            args.flux.rpc(self.service_name, args.jobinfo).get()
+            self.flux.rpc(self.service_name, args.jobinfo).get()
         except OSError as err:
             if err.errno == errno.ENOSYS:
                 #  Treat ENOSYS as success

--- a/src/bindings/python/flux/job/validator/validator.py
+++ b/src/bindings/python/flux/job/validator/validator.py
@@ -11,7 +11,6 @@
 import argparse
 import concurrent.futures
 import json
-import threading
 from abc import ABC, abstractmethod
 
 import flux
@@ -63,28 +62,14 @@ class ValidatorJobInfo:
         userid (int): Submitting user id
         flags (int): Job flags supplied during submission
         urgency (int): Job urgency
-        flux (:obj:`Flux`): On-demand, per-thread Flux handle
-
     """
-
-    #  Thread-local storage, used to provide an on-demand, per-thread
-    #    Flux handle for validators that require one.
-    tls = threading.local()
 
     def __init__(self, jobinfo):
         self.jobinfo = jobinfo
 
     def __getattr__(self, attr):
-        if attr == "flux":
-            #  Allow one flux handle per thread, created on demand:
-            try:
-                return self.tls.flux
-            except AttributeError:
-                self.tls.flux = flux.Flux()
-                return self.tls.flux
-        else:
-            #  Return components of the validate request as attrs
-            return self.jobinfo[attr]
+        #  Return components of the validate request as attrs
+        return self.jobinfo[attr]
 
 
 class ValidatorPlugin(ABC):  # pragma: no cover

--- a/src/bindings/python/flux/job/validator/validator.py
+++ b/src/bindings/python/flux/job/validator/validator.py
@@ -88,10 +88,21 @@ class ValidatorJobInfo:
 
 
 class ValidatorPlugin(ABC):  # pragma: no cover
-    """Base class for Validator Plugins"""
+    """Base class for Validator Plugins
+
+    Attributes:
+        flux (:obj:`flux.Flux`): on-demand per-plugin (per-thread) Flux
+            handle.
+    """
 
     def __init__(self, parser):
         """Initialize a ValidatorPlugin"""
+
+    @property
+    def flux(self):
+        if not hasattr(self, "_flux"):
+            self._flux = flux.Flux()
+        return self._flux
 
     def configure(self, args):
         """Configure a ValidatorPlugin. Run after argparse.parse_args()


### PR DESCRIPTION
Currently, the Python validator plugin interface provides an on-demand Flux handle via the `ValidatorJobInfo` class. However, in retrospect, this was a big mistake. Since the `ValidatorJobInfo` object is created once per job, the handle is closed and must be reopened for each job passed to a validator plugin. Also, since the job info object is passed to multiple validators running in different threads, thread-local storage needs to be used, which complicates the implementation. Finally, the `ValidatorJobInfo` object is obviously not available when the plugin is configuring itself, which makes it impossible for plugins to contact Flux to configure themselves (or they have to open a handle themselves)

This PR instead provides a new `flux` attribute in the `ValidatorPlugin` class which opens and returns a Flux handle on first access. Because each plugin is run in its own thread, there is no longer a need to deal with TLS, simplifying the approach greatly. Finally, the handle is conveniently available any time the plugin is active, so the `configure` callback can now use it.

The handle provided by `ValidatorJobInfo` is then removed once the one internal user is updated. This could be a problem if there are out-of-tree validators out there (but I don't think that is likely at this point).