### PR TITLE
broker: use enclosing instance tbon.interface-hint unless overridden

### DIFF
--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -89,6 +89,11 @@ interface-hint
      network address in CIDR form, e.g. ``10.0.2.0/24``.  NOTE: IPv6
      network addresses are not supported at this time.
 
+   This configured value may be overridden by setting the
+   ``tbon.interface-hint`` broker attribute on the command line.
+   It is inherited by sub-instances spawned for batch jobs and allocations.
+   Refer to :man7:`flux-broker-attributes` for more information.
+
 
 EXAMPLE
 =======

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -188,12 +188,12 @@ tbon.prefertcp [Updates: C]
    with PMI, tcp:// endpoints will be used instead of ipc://, even if all
    brokers are on a single node.  Default: ``0``.
 
-tbon.interface-hint
-   When bootstrapping with PMI, tcp:// endpoints are chosen heuristically
+tbon.interface-hint [Updates: C, R]
+   When bootstrapping with PMI, tcp endpoints are chosen heuristically
    using one of the following methods:
 
    default-route
-      The address associated with the default route (the default hint).
+      The address associated with the default route (default, but see below).
    hostname
       The address associated with the system hostname.
    *interface*
@@ -202,6 +202,15 @@ tbon.interface-hint
      The address associated with the first interface that matches the
      network address in CIDR form, e.g. ``10.0.2.0/24``.  NOTE: IPv6
      network addresses are not supported at this time.
+
+   If the attribute is not explicitly set, its value is assigned from
+   (in descending precedence):
+
+   1. the TOML configuration key of the same name
+   2. the :envvar:`FLUX_IPADDR_INTERFACE` or :envvar:`FLUX_IPADDR_HOSTNAME`
+      environment variables (these should be considered deprecated)
+   3. the enclosing Flux instance's value (via the PMI KVS)
+   4. the compiled-in default of default-route
 
 tbon.torpid_min [Updates: C, R]
    The amount of time (in RFC 23 Flux Standard Duration format) that a broker

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -599,6 +599,13 @@ int boot_config (flux_t *h, struct overlay *overlay, attr_t *attrs)
      */
     overlay_set_ipv6 (overlay, conf.enable_ipv6);
 
+    /* Ensure that tbon.interface-hint is set.
+     */
+    if (overlay_set_tbon_interface_hint (overlay, NULL) < 0) {
+        log_err ("error setting tbon.interface-hint attribute");
+        goto error;
+    }
+
     /* If broker has "downstream" peers, determine the URI to bind to
      * from the config and tell overlay.  Also, set the tbon.endpoint
      * attribute to the URI peers will connect to.  If broker has no

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -95,6 +95,7 @@ const char *overlay_get_uuid (struct overlay *ov);
 bool overlay_uuid_is_parent (struct overlay *ov, const char *uuid);
 bool overlay_uuid_is_child (struct overlay *ov, const char *uuid);
 void overlay_set_ipv6 (struct overlay *ov, int enable);
+int overlay_set_tbon_interface_hint (struct overlay *ov, const char *val);
 
 /* Return an idset of critical ranks, i.e. non-leaf brokers
  */

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -423,6 +423,16 @@ out:
     return 0;
 }
 
+static int set_flux_tbon_interface_hint (struct shell_pmi *pmi)
+{
+    const char *hint;
+
+    if (!(hint = flux_attr_get (pmi->shell->h, "tbon.interface-hint")))
+        return 0;
+    put_dict (pmi->locals, "flux.tbon-interface-hint", hint);
+    return 0;
+}
+
 static int set_flux_instance_level (struct shell_pmi *pmi)
 {
     char *p;
@@ -575,6 +585,7 @@ static struct shell_pmi *pmi_create (flux_shell_t *shell, json_t *config)
     if (!nomap && init_clique (pmi) < 0)
         goto error;
     if (set_flux_instance_level (pmi) < 0
+        || set_flux_tbon_interface_hint (pmi) < 0
         || (!nomap && set_flux_taskmap (pmi) < 0))
         goto error;
     return pmi;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -90,6 +90,7 @@ TESTSCRIPTS = \
 	t0016-cron-faketime.t \
 	t0017-security.t \
 	t0018-content-files.t \
+	t0019-tbon-config.t \
 	t0020-terminus.t \
 	t0021-archive-cmd.t \
 	t0022-jj-reader.t \

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -183,12 +183,6 @@ test_expect_success 'flux-start with size 2 has rank 1 peer' '
 		flux module stats --parse=child-count overlay >child2.out &&
 	test_cmp child2.exp child2.out
 '
-test_expect_success 'flux-start with size 2 works with tbon.zmqdebug' '
-	flux start ${ARGS} -o,-Stbon.zmqdebug=1 -s2 /bin/true
-'
-test_expect_success 'flux-start with non-integer tbon.zmqdebug fails' '
-	test_must_fail flux start ${ARGS} -o,-Stbon.zmqdebug=foo /bin/true
-'
 test_expect_success 'flux-start fails with unknown option' "
 	test_must_fail flux start ${ARGS} --unknown /bin/true
 "
@@ -422,82 +416,6 @@ test_expect_success 'flux-start -o,--setattr ATTR=VAL can set broker attributes'
 	ATTR_VAL=`flux start ${ARGS} -o,--setattr=foo-test=42 flux getattr foo-test` &&
 	test $ATTR_VAL -eq 42
 '
-test_expect_success 'tbon.endpoint can be read' '
-	ATTR_VAL=`flux start ${ARGS} -s2 flux getattr tbon.endpoint` &&
-	echo $ATTR_VAL | grep "://"
-'
-test_expect_success 'tbon.endpoint uses ipc:// in standalone instance' '
-	flux start ${ARGS} -s2 \
-		flux getattr tbon.endpoint >endpoint.out &&
-	grep "^ipc://" endpoint.out
-'
-test_expect_success 'tbon.endpoint uses tcp:// if process mapping unavailable' '
-	flux start ${ARGS} -s2 --test-pmi-clique=none \
-		flux getattr tbon.endpoint >endpoint2.out &&
-	grep "^tcp" endpoint2.out
-'
-test_expect_success 'tbon.endpoint uses tcp:// if tbon.prefertcp is set' '
-	flux start ${ARGS} -s2 -o,-Stbon.prefertcp=1 \
-		flux getattr tbon.endpoint >endpoint2.out &&
-	grep "^tcp" endpoint2.out
-'
-test_expect_success 'FLUX_IPADDR_INTERFACE=lo works' '
-	FLUX_IPADDR_INTERFACE=lo flux start \
-		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
-		flux getattr tbon.endpoint >endpoint3.out &&
-	grep "127.0.0.1" endpoint3.out
-'
-test_expect_success 'tbon.interface-hint=lo works' '
-	flux start -o,-Stbon.interface-hint=lo \
-		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
-		flux getattr tbon.endpoint >endpoint3a.out &&
-	grep "127.0.0.1" endpoint3a.out
-'
-test_expect_success 'tbon.interface-hint=127.0.0.0/8 works' '
-	flux start -o,-Stbon.interface-hint=127.0.0.0/8 \
-		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
-		flux getattr tbon.endpoint >endpoint3b.out &&
-	grep "127.0.0.1" endpoint3b.out
-'
-test_expect_success 'TOML tbon.interface-hint=127.0.0.0/8 works' '
-	cat >hint.toml <<-EOT &&
-	tbon.interface-hint = "127.0.0.0/8"
-	EOT
-	flux start -o,--config-path=hint.toml \
-		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
-		flux getattr tbon.endpoint >endpoint3c.out &&
-	grep "127.0.0.1" endpoint3c.out
-'
-test_expect_success 'TOML tbon.interface-hint=wrong type fails' '
-	cat >badhint.toml <<-EOT &&
-	tbon.interface-hint = 42
-	EOT
-	test_must_fail flux start -o,--config-path=badhint.toml ${ARGS} true
-'
-test_expect_success 'tbon.interface-hint=badiface fails' '
-	test_expect_code 137 flux start -o,-Stbon.interface-hint=badiface \
-		${ARGS} -s2 -o,-Stbon.prefertcp=1 true
-'
-test_expect_success 'tbon.interface-hint=default-route works' '
-	flux start -o,-Stbon.interface-hint=default-route,-Stbon.prefertcp=1 \
-		${ARGS} -s2 true
-'
-test_expect_success 'tbon.interface-hint=hostname works' '
-	flux start -o,-Stbon.interface-hint=hostname,-Stbon.prefertcp=1 \
-		${ARGS} -s2 true
-'
-test_expect_success 'tbon.endpoint cannot be set' '
-	test_expect_code 137 flux start ${ARGS} -s2 \
-		-o,--setattr=tbon.endpoint=ipc:///tmp/customflux /bin/true
-'
-test_expect_success 'tbon.parent-endpoint cannot be read on rank 0' '
-	test_must_fail flux start ${ARGS} -s2 flux getattr tbon.parent-endpoint
-'
-test_expect_success 'tbon.parent-endpoint can be read on not rank 0' '
-	NUM=`flux start ${ARGS} -s4 flux exec -n flux getattr tbon.parent-endpoint | grep ipc | wc -l` &&
-	test $NUM -eq 3
-'
-
 test_expect_success 'hostlist attr is set on size 1 instance' '
 	hn=$(hostname) &&
 	cat >hostlist1.exp <<-EOT &&
@@ -671,33 +589,6 @@ test_expect_success 'broker broker.pid attribute is immutable' '
 '
 test_expect_success 'broker --verbose option works' '
 	flux start ${ARGS} -o,-v /bin/true
-'
-test_expect_success 'broker -Stbon.fanout=4 is an alias for tbon.topo=kary:4' '
-	echo kary:4 >fanout.exp &&
-	flux start ${ARGS} -o,-Stbon.fanout=4 \
-		flux getattr tbon.topo >fanout.out &&
-	test_cmp fanout.exp fanout.out
-'
-test_expect_success 'broker -Stbon.topo=kary:8 option works' '
-	echo kary:8 >topo.exp &&
-	flux start ${ARGS} -o,-Stbon.topo=kary:8 \
-		flux getattr tbon.topo >topo.out &&
-	test_cmp topo.exp topo.out
-'
-test_expect_success 'broker -Stbon.topo=kary:0 works' '
-	flux start ${ARGS} -o,-Stbon.topo=kary:0 /bin/true
-'
-test_expect_success 'broker -Stbon.topo=custom option works' '
-	echo custom >topo2.exp &&
-	flux start ${ARGS} -o,-Stbon.topo=custom \
-		flux getattr tbon.topo >topo2.out &&
-	test_cmp topo2.exp topo2.out
-'
-test_expect_success 'broker -Stbon.topo=binomial option works' '
-	echo binomial >topo_binomial.exp &&
-	flux start ${ARGS} -o,-Stbon.topo=binomial \
-		flux getattr tbon.topo >topo_binomial.out &&
-	test_cmp topo_binomial.exp topo_binomial.out
 '
 test_expect_success 'broker fails on invalid broker.critical-ranks option' '
 	test_must_fail flux start ${ARGS} -o,-Sbroker.critical-ranks=0-1

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -447,19 +447,19 @@ test_expect_success 'FLUX_IPADDR_INTERFACE=lo works' '
 		flux getattr tbon.endpoint >endpoint3.out &&
 	grep "127.0.0.1" endpoint3.out
 '
-test_expect_success 'tcp.interface-hint=lo works' '
+test_expect_success 'tbon.interface-hint=lo works' '
 	flux start -o,-Stbon.interface-hint=lo \
 		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
 		flux getattr tbon.endpoint >endpoint3a.out &&
 	grep "127.0.0.1" endpoint3a.out
 '
-test_expect_success 'tcp.interface-hint=127.0.0.0/8 works' '
+test_expect_success 'tbon.interface-hint=127.0.0.0/8 works' '
 	flux start -o,-Stbon.interface-hint=127.0.0.0/8 \
 		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
 		flux getattr tbon.endpoint >endpoint3b.out &&
 	grep "127.0.0.1" endpoint3b.out
 '
-test_expect_success 'TOML tcp.interface-hint=127.0.0.0/8 works' '
+test_expect_success 'TOML tbon.interface-hint=127.0.0.0/8 works' '
 	cat >hint.toml <<-EOT &&
 	tbon.interface-hint = "127.0.0.0/8"
 	EOT
@@ -468,21 +468,21 @@ test_expect_success 'TOML tcp.interface-hint=127.0.0.0/8 works' '
 		flux getattr tbon.endpoint >endpoint3c.out &&
 	grep "127.0.0.1" endpoint3c.out
 '
-test_expect_success 'TOML tcp.interface-hint=wrong type fails' '
+test_expect_success 'TOML tbon.interface-hint=wrong type fails' '
 	cat >badhint.toml <<-EOT &&
 	tbon.interface-hint = 42
 	EOT
 	test_must_fail flux start -o,--config-path=badhint.toml ${ARGS} true
 '
-test_expect_success 'tcp.interface-hint=badiface fails' '
+test_expect_success 'tbon.interface-hint=badiface fails' '
 	test_expect_code 137 flux start -o,-Stbon.interface-hint=badiface \
 		${ARGS} -s2 -o,-Stbon.prefertcp=1 true
 '
-test_expect_success 'tcp.interface-hint=default-route works' '
+test_expect_success 'tbon.interface-hint=default-route works' '
 	flux start -o,-Stbon.interface-hint=default-route,-Stbon.prefertcp=1 \
 		${ARGS} -s2 true
 '
-test_expect_success 'tcp.interface-hint=hostname works' '
+test_expect_success 'tbon.interface-hint=hostname works' '
 	flux start -o,-Stbon.interface-hint=hostname,-Stbon.prefertcp=1 \
 		${ARGS} -s2 true
 '

--- a/t/t0019-tbon-config.t
+++ b/t/t0019-tbon-config.t
@@ -68,7 +68,8 @@ test_expect_success 'TOML tbon.interface-hint=wrong type fails' '
 	test_must_fail flux start -o,--config-path=badhint.toml ${ARGS} true
 '
 test_expect_success 'tbon.interface-hint=badiface fails' '
-	test_expect_code 137 flux start -o,-Stbon.interface-hint=badiface \
+	test_must_fail_or_be_terminated flux start \
+		-o,-Stbon.interface-hint=badiface \
 		${ARGS} -s2 -o,-Stbon.prefertcp=1 true
 '
 test_expect_success 'tbon.interface-hint=default-route works' '
@@ -95,7 +96,7 @@ test_expect_success 'tbon.interface-hint from parent can be overridden' '
 	grep default-router childhint2.out
 '
 test_expect_success 'tbon.endpoint cannot be set' '
-	test_expect_code 137 flux start ${ARGS} -s2 \
+	test_must_fail_or_be_terminated flux start ${ARGS} -s2 \
 		-o,--setattr=tbon.endpoint=ipc:///tmp/customflux /bin/true
 '
 test_expect_success 'tbon.parent-endpoint cannot be read on rank 0' '

--- a/t/t0019-tbon-config.t
+++ b/t/t0019-tbon-config.t
@@ -79,6 +79,21 @@ test_expect_success 'tbon.interface-hint=hostname works' '
 	flux start -o,-Stbon.interface-hint=hostname,-Stbon.prefertcp=1 \
 		${ARGS} -s2 true
 '
+test_expect_success 'tbon.interface-hint defaults to default-router' '
+	flux start ${ARGS} flux getattr tbon.interface-hint >defhint.out &&
+	grep default-route defhint.out
+'
+test_expect_success 'tbon.interface-hint default comes from parent' '
+	flux start -o,-Stbon.interface-hint=hostname \
+	    flux alloc -N1 flux getattr tbon.interface-hint >childhint.out &&
+	grep hostname childhint.out
+'
+test_expect_success 'tbon.interface-hint from parent can be overridden' '
+	flux start -o,-Stbon.interface-hint=hostname \
+	    flux alloc -N1 --broker-opts=-Stbon.interface-hint=default-router \
+	    flux getattr tbon.interface-hint >childhint2.out &&
+	grep default-router childhint2.out
+'
 test_expect_success 'tbon.endpoint cannot be set' '
 	test_expect_code 137 flux start ${ARGS} -s2 \
 		-o,--setattr=tbon.endpoint=ipc:///tmp/customflux /bin/true

--- a/t/t0019-tbon-config.t
+++ b/t/t0019-tbon-config.t
@@ -1,0 +1,120 @@
+#!/bin/sh
+#
+
+test_description='Test the brokers tbon.* configuration'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
+
+test_expect_success 'flux-start with size 2 works with tbon.zmqdebug' '
+	flux start ${ARGS} -o,-Stbon.zmqdebug=1 -s2 /bin/true
+'
+test_expect_success 'flux-start with non-integer tbon.zmqdebug fails' '
+	test_must_fail flux start ${ARGS} -o,-Stbon.zmqdebug=foo /bin/true
+'
+test_expect_success 'tbon.endpoint can be read' '
+	ATTR_VAL=`flux start ${ARGS} -s2 flux getattr tbon.endpoint` &&
+	echo $ATTR_VAL | grep "://"
+'
+test_expect_success 'tbon.endpoint uses ipc:// in standalone instance' '
+	flux start ${ARGS} -s2 \
+		flux getattr tbon.endpoint >endpoint.out &&
+	grep "^ipc://" endpoint.out
+'
+test_expect_success 'tbon.endpoint uses tcp:// if process mapping unavailable' '
+	flux start ${ARGS} -s2 --test-pmi-clique=none \
+		flux getattr tbon.endpoint >endpoint2.out &&
+	grep "^tcp" endpoint2.out
+'
+test_expect_success 'tbon.endpoint uses tcp:// if tbon.prefertcp is set' '
+	flux start ${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+		flux getattr tbon.endpoint >endpoint2.out &&
+	grep "^tcp" endpoint2.out
+'
+test_expect_success 'FLUX_IPADDR_INTERFACE=lo works' '
+	FLUX_IPADDR_INTERFACE=lo flux start \
+		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+		flux getattr tbon.endpoint >endpoint3.out &&
+	grep "127.0.0.1" endpoint3.out
+'
+test_expect_success 'tbon.interface-hint=lo works' '
+	flux start -o,-Stbon.interface-hint=lo \
+		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+		flux getattr tbon.endpoint >endpoint3a.out &&
+	grep "127.0.0.1" endpoint3a.out
+'
+test_expect_success 'tbon.interface-hint=127.0.0.0/8 works' '
+	flux start -o,-Stbon.interface-hint=127.0.0.0/8 \
+		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+		flux getattr tbon.endpoint >endpoint3b.out &&
+	grep "127.0.0.1" endpoint3b.out
+'
+test_expect_success 'TOML tbon.interface-hint=127.0.0.0/8 works' '
+	cat >hint.toml <<-EOT &&
+	tbon.interface-hint = "127.0.0.0/8"
+	EOT
+	flux start -o,--config-path=hint.toml \
+		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+		flux getattr tbon.endpoint >endpoint3c.out &&
+	grep "127.0.0.1" endpoint3c.out
+'
+test_expect_success 'TOML tbon.interface-hint=wrong type fails' '
+	cat >badhint.toml <<-EOT &&
+	tbon.interface-hint = 42
+	EOT
+	test_must_fail flux start -o,--config-path=badhint.toml ${ARGS} true
+'
+test_expect_success 'tbon.interface-hint=badiface fails' '
+	test_expect_code 137 flux start -o,-Stbon.interface-hint=badiface \
+		${ARGS} -s2 -o,-Stbon.prefertcp=1 true
+'
+test_expect_success 'tbon.interface-hint=default-route works' '
+	flux start -o,-Stbon.interface-hint=default-route,-Stbon.prefertcp=1 \
+		${ARGS} -s2 true
+'
+test_expect_success 'tbon.interface-hint=hostname works' '
+	flux start -o,-Stbon.interface-hint=hostname,-Stbon.prefertcp=1 \
+		${ARGS} -s2 true
+'
+test_expect_success 'tbon.endpoint cannot be set' '
+	test_expect_code 137 flux start ${ARGS} -s2 \
+		-o,--setattr=tbon.endpoint=ipc:///tmp/customflux /bin/true
+'
+test_expect_success 'tbon.parent-endpoint cannot be read on rank 0' '
+	test_must_fail flux start ${ARGS} -s2 flux getattr tbon.parent-endpoint
+'
+test_expect_success 'tbon.parent-endpoint can be read on not rank 0' '
+	NUM=`flux start ${ARGS} -s4 flux exec -n flux getattr tbon.parent-endpoint | grep ipc | wc -l` &&
+	test $NUM -eq 3
+'
+test_expect_success 'broker -Stbon.fanout=4 is an alias for tbon.topo=kary:4' '
+	echo kary:4 >fanout.exp &&
+	flux start ${ARGS} -o,-Stbon.fanout=4 \
+		flux getattr tbon.topo >fanout.out &&
+	test_cmp fanout.exp fanout.out
+'
+test_expect_success 'broker -Stbon.topo=kary:8 option works' '
+	echo kary:8 >topo.exp &&
+	flux start ${ARGS} -o,-Stbon.topo=kary:8 \
+		flux getattr tbon.topo >topo.out &&
+	test_cmp topo.exp topo.out
+'
+test_expect_success 'broker -Stbon.topo=kary:0 works' '
+	flux start ${ARGS} -o,-Stbon.topo=kary:0 /bin/true
+'
+test_expect_success 'broker -Stbon.topo=custom option works' '
+	echo custom >topo2.exp &&
+	flux start ${ARGS} -o,-Stbon.topo=custom \
+		flux getattr tbon.topo >topo2.out &&
+	test_cmp topo2.exp topo2.out
+'
+test_expect_success 'broker -Stbon.topo=binomial option works' '
+	echo binomial >topo_binomial.exp &&
+	flux start ${ARGS} -o,-Stbon.topo=binomial \
+		flux getattr tbon.topo >topo_binomial.out &&
+	test_cmp topo_binomial.exp topo_binomial.out
+'
+test_done


### PR DESCRIPTION
Problem: we don't have a way to configure subinstances to use a particular network, other than setting the global environment variable FLUX_IPADDR_INTERFACE.
    
Change the way the default `tbon.interface-hint` is set.  Instead of hard coding "default-route", use the value that is set in the enclosing instance, if any.
    
This would allow a system instance to configure `tbon.interface-hint` and batch/alloc jobs that it starts would use that value unless overridden.  If the value is not configured, then the attribute will have the default value which will be inherited by the child.
