### PR TITLE
support expandable width output formats and use them in `flux resource list` to avoid truncation of queue field

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -238,6 +238,19 @@ would eliminate the EXCEPTION-TYPE column if no jobs in the list received
 an exception. (Thus the job queue is only displayed if at least one job
 has a queue assigned in the default format shown above).
 
+If a format field is preceded by the special string ``+:`` this will
+cause the field width to be set to the maximum width such that no entry
+will be truncated. If the field already has a width, then this will be
+the minimum width of that field. For example::
+
+  {id.f58:>12} +:{queue:>5}
+
+would set the width of the ``QUEUE`` field to the maximum of 5 and the
+actual width of the largest presented queue.
+
+If a format field is preceded by the string ``?+:``, then the field is
+eliminated if empty, or set the maximum item width.
+
 As a reminder to the reader, some shells will interpret braces
 (``{`` and ``}``) in the format string.  They may need to be quoted.
 

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -799,7 +799,7 @@ class OutputFormat:
             raise KeyError(f"Invalid format field {exc} for {typestr}")
         return retval
 
-    def filter_empty(self, items):
+    def filter(self, items):
         """
         Check for format fields that are prefixed with `?:` (e.g. "?:{name}")
         and filter them out of the current format string if they result in an
@@ -935,8 +935,8 @@ class OutputFormat:
             pre (callable): Function to call before printing each item
             post (callable): Function to call after printing each item
         """
-        #  Preprocess original format by processing with filter_empty():
-        newfmt = self.filter_empty(items)
+        #  Preprocess original format by processing with filter():
+        newfmt = self.filter(items)
         #  Get the current class for creating a new formatter instance:
         cls = self.__class__
         #  Create new instance of the current class from filtered format:

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -521,7 +521,7 @@ def main():
             sys.exit(0 if stats.active else 1)
 
     jobs = fetch_jobs(args, formatter.fields)
-    sformatter = JobInfoFormat(formatter.filter_empty(jobs))
+    sformatter = JobInfoFormat(formatter.filter(jobs))
 
     if not args.no_header:
         print(sformatter.header())

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -274,7 +274,7 @@ def main():
     if PROGRAM == "flux-pkill":
         pkill(fh, args, jobs)
 
-    sformatter = JobInfoFormat(formatter.filter_empty(jobs))
+    sformatter = JobInfoFormat(formatter.filter(jobs))
 
     # "default" can be overridden by environment variable, so check if
     # it's different than the builtin default

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -66,15 +66,15 @@ class FluxResourceConfig(UtilConfig):
         "default": {
             "description": "Default flux-resource list format string",
             "format": (
-                "{state:>10} ?:{queue:<10.10} ?:{propertiesx:<10.10+} {nnodes:>6} "
-                "{ncores:>8} ?:{ngpus:>8} {nodelist}"
+                "{state:>10} ?+:{queue:<5} ?:{propertiesx:<10.10+} {nnodes:>6} "
+                "+:{ncores:>6} ?+:{ngpus:>5} {nodelist}"
             ),
         },
         "rlist": {
             "description": "Format including resource list details",
             "format": (
-                "{state:>10} ?:{queue:<8.8} ?:{propertiesx:<10.10+} {nnodes:>6} "
-                "{ncores:>8} {ngpus:>8} {rlist}"
+                "{state:>10} ?+:{queue:<5} ?:{propertiesx:<10.10+} {nnodes:>6} "
+                "+:{ncores:>6} ?:+{ngpus:>5} {rlist}"
             ),
         },
     }

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -196,7 +196,29 @@ test_expect_success 'flux-jobs: collapsible fields work' '
 	grep EXCEPTION-TYPE nocollapse.out &&
 	test_must_fail grep EXCEPTION-TYPE collapsed.out
 '
-
+# Note longest name from above should be 'nosuchcommand'
+# To ensure field was expanded to this width, ensure NAME header is right
+# justified:
+test_expect_success 'flux-jobs: expandable fields work' '
+	flux jobs -ao "+:{name:>1}" >expanded.out &&
+	grep "^ *NAME" expanded.out &&
+	grep "^ *sleep" expanded.out &&
+	grep "nosuchcommand" expanded.out
+'
+test_expect_success 'flux-jobs: specified width overrides expandable field' '
+	flux jobs -ao "+:{name:>16}" >expanded2.out &&
+	test_debug "cat expanded2.out" &&
+	grep "^   nosuchcommand" expanded2.out
+'
+test_expect_success 'flux-jobs: collapsible+expandable fields work' '
+	flux jobs -ao "{id.f58:<12} ?+:{exception.type:>1}" >both.out &&
+	flux jobs -f running,completed \
+		 -o "{id.f58:<12} ?+:{exception.type:>1}" >both-collapsed.out &&
+	test_debug "head -n1 both.out" &&
+	test_debug "head -n1 both-collapsed.out" &&
+	grep EXCEPTION-TYPE both.out &&
+	test_must_fail grep EXCEPTION-TYPE both-collapsed.out
+'
 test_expect_success 'flux-jobs: request indication of truncation works' '
 	flux jobs -n -c1 -ano "{id.f58:<5.5+}" | grep + &&
 	flux jobs -n -c1 -ano "{id.f58:<5.5h+}" | grep + &&


### PR DESCRIPTION
This PR adds two new output format "sentinels" `+:` and `?+:` to the `OutputFormat` class that allow automated adjustment of the field width to avoid truncation. `+:` only does the expansion, while `?+:` combines the functionality of `+:` and `?:` and expands the field to the maximum observed width and removes the field if all entries would result in an "empty" value.

Then `?+:` is applied to `flux resource list` default output for `queue` and `ngpus` fields. This avoids truncation of the QUEUE column, which may contain comma separated list of queues on system instances (and in the case of `ngpus` saves a couple characters of width in the common case)