### PR TITLE
doc: add warning about Python argparse in flux-jobs(1)

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -75,6 +75,15 @@ OPTIONS
    "last Monday", etc. It is assumed to be an error if a timestamp in
    the future is supplied.
 
+   .. note::
+      Due to a quirk in the Python argument parsing implementation,
+      it is suggested to always use ``=`` between the :option:`--since`
+      option and its argument, e.g. ``--since=-1d`` rather than ``--since
+      -1d``. In the second case Python mistakenly considers the option
+      argument an unknown option and will raise an error about a missing
+      argument to :option:`--since`.
+
+
 .. option:: -f, --filter=STATE|RESULT
 
    List jobs with specific job state or result. Multiple states or


### PR DESCRIPTION
Problem: There's a quirk in the Python argparse implementation that causes a required option argument that has a leading dash to be ignored when a space between long option and its argument is used instead of an equals. This is common with the `flux jobs --since` option because relative FSD is allowed so `-1h`, `-30m`, etc are expected option arguments. This can be very confusing to users who may not have an inkling of what's going on.

Add a note in the flux-jobs(1) man page regarding this quirk in hopes users will see and become aware of it. Suggest that `=` always be used between `--since` and its argument to avoid the problem.