### PR TITLE
flux-bulksubmit: support `{}`  in more options like `--cwd=`, `--signal=`, `--taskmap=`, etc.

### DIFF
--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -517,6 +517,7 @@ class Xcmd:
         "time_limit": "-t",
         "env": "--env=",
         "env_file": "--env-file=",
+        "env_remove": "--env-remove=",
         "urgency": "--urgency=",
         "setopt": "-o ",
         "setattr": "--setattr=",
@@ -532,6 +533,11 @@ class Xcmd:
         "taskmap": "--taskmap=",
         "requires": "--requires=",
         "wait": "--wait-event=",
+        "cwd": "--cwd=",
+        "flags": "--flags=",
+        "begin_time": "--begin-time=",
+        "signal": "--signal=",
+        "taskmap": "--taskmap=",
     }
 
     class Xinput:


### PR DESCRIPTION
Problem: The Xcmd class that implements option argument mutability in flux-bulksubmit(1) has a manual list of mutable options that is missing some useful options.

Update the list to include some missing options, like --cwd=, --signal=, --taskmap=, and --begin-time=.

Fixes #6295