### PR TITLE
autoconf: support python 3.12

### DIFF
--- a/config/ax_python_devel.m4
+++ b/config/ax_python_devel.m4
@@ -107,7 +107,7 @@ AC_DEFUN([AX_PYTHON_DEVEL],[
 	   # Check for a version of Python >= 2.1.0
 	   #
 	   AC_MSG_CHECKING([for a version of Python >= '2.1.0'])
-	   ac_supports_python_ver=`$PYTHON -c "import sys; \
+	   ac_supports_python_ver=`$PYTHON -c "import sys;import setuptools; \
 		ver = sys.version.split ()[[0]]; \
 		print (ver >= '2.1.0')"`
 	   if test "$ac_supports_python_ver" != "True"; then
@@ -150,6 +150,7 @@ class VPy:
         return tuple(map(int, s.strip().replace("rc", ".").split(".")))
     def __init__(self):
         import sys
+        import setuptools
         self.vpy = tuple(sys.version_info)[[:3]]
     def __eq__(self, s):
         return self.vpy == self.vtup(s)

--- a/scripts/install-deps-deb.sh
+++ b/scripts/install-deps-deb.sh
@@ -20,6 +20,7 @@ apt install \
   python3-dev \
   python3-cffi \
   python3-ply \
+  python3-setuptools \
   python3-yaml \
   python3-sphinx \
   aspell \

--- a/scripts/install-deps-rpm.sh
+++ b/scripts/install-deps-rpm.sh
@@ -22,6 +22,7 @@ yum install \
   python36-ply \
   python36-yaml \
   python3-sphinx \
+  python3-setuptools \
   aspell \
   aspell-en \
   time \

--- a/src/test/docker/alpine/Dockerfile
+++ b/src/test/docker/alpine/Dockerfile
@@ -24,6 +24,7 @@ RUN apk add \
     py3-yaml \
     py3-jsonschema \
     py3-ply \
+    py3-setuptools \
     py3-sphinx \
     lua5.1-dev \
     lua5.1-posix \


### PR DESCRIPTION
problem: flux-core currently can't configure with python3.12 due to setuptools no longer being part of the default distribution

solution: import setuptools where necessary to keep things working in the ax_python_devel file


This worked to build a copy of flux, but I didn't get the dep install scripts updated yet because I couldn't get an image downloaded on this wifi.  Now off to dinner and the airport.