### PR TITLE
add `--force` option to `flux resource undrain`

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -17,7 +17,7 @@ SYNOPSIS
 
 | **flux** **resource** **drain** [*-n*] [*-o* *FORMAT*] [*-i* *TARGETS*]
 | **flux** **resource** **drain** [*-f*] [*-u*] [*targets*] [*reason*]
-| **flux** **resource** **undrain** *targets*
+| **flux** **resource** **undrain** [*-f*] *targets*
 
 | **flux** **resource** **reload** [-f] [--xml] *path*
 
@@ -312,6 +312,10 @@ undrain
 Undrain the nodes specified by the *targets* argument (IDSET or HOSTLIST).
 
 This command is restricted to the Flux instance owner.
+
+.. option:: -f, --force
+
+  Do not fail if any of the *targets* are not drained.
 
 reload
 ------

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -161,7 +161,10 @@ def undrain(args):
     """
     Send an "undrain" request to resource module for args.targets
     """
-    RPC(flux.Flux(), "resource.undrain", {"targets": args.targets}, nodeid=0).get()
+    payload = {"targets": args.targets}
+    if args.force:
+        payload["mode"] = "force"
+    RPC(flux.Flux(), "resource.undrain", payload, nodeid=0).get()
 
 
 class QueueResources:
@@ -798,6 +801,12 @@ def main():
 
     undrain_parser = subparsers.add_parser(
         "undrain", formatter_class=flux.util.help_formatter()
+    )
+    undrain_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Do not fail if any targets are not drained",
     )
     undrain_parser.add_argument(
         "targets", help="List of targets to resume (IDSET or HOSTLIST)"

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -255,6 +255,32 @@ test_expect_success 'undrain fails if rank not drained' '
 	grep "rank 1 not drained" undrain_not.err
 '
 
+test_expect_success 'undrain fails if any rank not drained' '
+	flux resource drain 0 &&
+	test_must_fail flux resource undrain 0-1 2>undrain_0-1_not.err &&
+	test_debug "cat undrain_0-1_not.err" &&
+	grep "rank 1 not drained" undrain_0-1_not.err
+'
+
+test_expect_success 'undrain --force works even if a target is not drained' '
+	flux resource undrain --force 0-1
+'
+
+test_expect_success 'undrain --force returns success when no targets drained' '
+	flux resource undrain --force 0-1
+'
+
+undrain_bad_mode() {
+	flux python -c 'import flux; \
+	  flux.Flux().rpc("resource.undrain", \
+			  {"targets": "0", "mode": "foo"}).get()'
+}
+
+test_expect_success 'undrain RPC rejects invalid mode' '
+	test_must_fail undrain_bad_mode 2>undrain_bad_mode.err &&
+	grep "invalid undrain mode" undrain_bad_mode.err
+'
+
 test_expect_success 'drain fails if idset is empty' '
 	test_must_fail flux resource drain "" 2>drain_empty.err &&
 	grep "idset is empty" drain_empty.err


### PR DESCRIPTION
`flux resource undrain` currently aborts the entire operation if one or more targets is not currently drained. This makes it difficult to simply ensure a set of ranks/hosts are undrained.

Add a `mode=force` option to the `resource.undrain` RPC and a corresponding `--force` option to `flux resource undrain`.

Fixes #6306 
