### PR TITLE
doc: add dash to flux-job(1) manpage

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -16,7 +16,7 @@ SYNOPSIS
 | **flux** **job** **wait** [*-v*] [*--all*] [*id*]
 | **flux** **job** **kill** [*--signal=SIG*] *ids...*
 | **flux** **job** **killall** [*-f*] [*--user=USER*] [*--signal=SIG*]
-| **flux** **job** **raise** [*-severity=N*] [*--type=TYPE*] *ids...* [*--*] [*message...*]
+| **flux** **job** **raise** [*--severity=N*] [*--type=TYPE*] *ids...* [*--*] [*message...*]
 | **flux** **job** **raiseall** [*--severity=N*] [*--user=USER*] [*--states=STATES*] *type* [ [*--*] [*message...*]
 | **flux** **job** **taskmap** [*OPTIONS*] *id* | *taskmap*
 | **flux** **job** **timeleft** [*-H*] [*id*]


### PR DESCRIPTION
Sometimes I say "minus" and sometimes I say "dash," what's the right answer? 🤔 

Problem: the --severity option for flux job raise is missing a dash.

Add the dash.