### PR TITLE
libsubprocess: fix bulk-exec reporting of active ranks

### DIFF
--- a/src/common/libsubprocess/bulk-exec.c
+++ b/src/common/libsubprocess/bulk-exec.c
@@ -121,7 +121,7 @@ struct idset *bulk_exec_active_ranks (struct bulk_exec *exec)
 
     p = zlist_first (exec->processes);
     while (p) {
-        if (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING) {
+        if (flux_subprocess_active (p)) {
             int rank = flux_subprocess_rank (p);
             if (rank >= 0 && idset_set (ranks, rank) < 0) {
                 goto error;

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -1011,6 +1011,13 @@ flux_subprocess_state_t flux_subprocess_state (flux_subprocess_t *p)
     return p->state;
 }
 
+bool flux_subprocess_active (flux_subprocess_t *p)
+{
+    /*  A subprocess is still active if it has not failed or completed.
+     */
+    return (p && p->state != FLUX_SUBPROCESS_FAILED && !p->completed);
+}
+
 const char *flux_subprocess_state_string (flux_subprocess_state_t state)
 {
     switch (state)

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -315,6 +315,11 @@ flux_subprocess_state_t flux_subprocess_state (flux_subprocess_t *p);
  */
 const char *flux_subprocess_state_string (flux_subprocess_state_t state);
 
+/*  Return true if subprocess p is still active, i.e. it is waiting to
+ *  start, still running, or waiting for eof on all streams.
+ */
+bool flux_subprocess_active (flux_subprocess_t *p);
+
 int flux_subprocess_rank (flux_subprocess_t *p);
 
 /* Returns the errno causing the FLUX_SUBPROCESS_FAILED state to be reached.


### PR DESCRIPTION
When a bulk-exec launched subprocess is terminated but still has children with open stdio fds, `bulk_exec_active_ranks()` reports an empty idset, even though the subprocess should still be considered active.

Add a libsubprocess accessor to determine if a subprocess is still active, i.e. is not failed or completed, and use this in bulk-exec to properly report all "active" subprocesses.

Fixes #6321