### PR TITLE
perilog: never send SIGKILL to prolog/epilog, drain active nodes after kill-timeout instead

### DIFF
--- a/doc/man5/flux-config-job-manager.rst
+++ b/doc/man5/flux-config-job-manager.rst
@@ -123,10 +123,12 @@ prolog
       exception raised). The default prolog timeout is 30m. To disable
       the timeout use ``0`` or ``infinity``.
    kill-timeout
-      (optional) Floating-point number of seconds to wait after sending
-      SIGTERM to send SIGKILL to the prolog when the prolog has been
-      canceled due to timeout or exception. The default is 5.0. (This
-      key is mainly used for testing purposes).
+      (optional) If a job exception is raised during the job prolog and
+      ``cancel-on-exception`` is true,  the prolog will be canceled by
+      sending it a SIGTERM signal. ``kill-timeout`` is the number of
+      seconds to wait until any nodes with prolog tasks that are still
+      active will be drained. The drain reason will include the string
+      "canceled then timed out". The default is 10.
    cancel-on-exception
       (optional) A boolean indicating whether a fatal job exception raised
       while the prolog is active terminates the prolog. The default is true.
@@ -151,10 +153,13 @@ epilog
       timeout for the epilog, after which it is terminated (and a job
       exception raised). By default, the epilog timeout is disabled.
    kill-timeout
-      (optional) Floating-point number of seconds to wait after sending
-      SIGTERM to send SIGKILL to the epilog when it has been canceled due
-      to timeout or exception. The default is 5.0. (This key is mainly
-      used for testing purposes)
+      (optional) If a job exception is raised during the job epilog and
+      ``cancel-on-exception`` is ``true``, then the epilog will be canceled
+      by sending it a SIGTERM signal. ``kill-timeout`` is the number of
+      seconds to wait until any nodes with prolog tasks that are still
+      active will be drained. The drain reason will include the string
+      "canceled then timed out". The default is 10. (``kill-timeout`` with
+      the job epilog should only be used for testing purposes)
    cancel-on-exception
       (optional) A boolean indicating whether a fatal job exception raised
       while the epilog is active terminates the epilog. The default is true.

--- a/src/cmd/flux-perilog-run.py
+++ b/src/cmd/flux-perilog-run.py
@@ -84,7 +84,11 @@ async def kill_process_tree(parent_pid, sig):
     # Iterate the list in reverse so that parent_pid comes last and
     # (for the most part) children are signaled before their parent:
     for pid in reversed(await get_children(parent_pid)):
-        os.kill(pid, sig)
+        try:
+            os.kill(pid, sig)
+        except ProcessLookupError:
+            # No error if process no longer exists
+            pass
 
 
 async def run_with_timeout(cmd, label, timeout=1800.0):

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -452,6 +452,7 @@ static flux_future_t *proc_drain_ranks (struct perilog_proc *proc,
     struct idset *failed = NULL;
     flux_future_t *f = NULL;
     unsigned long rank;
+    const char *msg;
     char reason[256];
     flux_t *h = flux_jobtap_get_flux (proc->p);
 
@@ -482,11 +483,19 @@ static flux_future_t *proc_drain_ranks (struct perilog_proc *proc,
                         perilog_proc_name (proc));
         goto out;
     }
+
+    if (proc->canceled)
+        msg = "canceled then timed out";
+    else if (proc->timedout)
+        msg = "timed out";
+    else
+        msg = "failed";
+
     (void) snprintf (reason,
                      sizeof (reason),
                      "%s %s for job %s",
                      perilog_proc_name (proc),
-                     proc->timedout ? "timed out" : "failed",
+                     msg,
                      idf58 (proc->id));
 
     if (!(f = flux_rpc_pack (h,

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -248,7 +248,7 @@ static struct perilog_procdesc *perilog_procdesc_create (json_t *o,
     }
 
     pd->cmd = cmd;
-    pd->kill_timeout = kill_timeout > 0. ? kill_timeout : 5.;
+    pd->kill_timeout = kill_timeout > 0. ? kill_timeout : 10.;
     pd->per_rank = per_rank;
     pd->prolog = prolog;
     pd->uses_imp = uses_imp;

--- a/t/t2274-manager-perilog-per-rank.t
+++ b/t/t2274-manager-perilog-per-rank.t
@@ -222,6 +222,24 @@ test_expect_success 'perilog: epilog triggered by prolog has correct userid' '
 	flux job wait-event -vHt 30 $jobid clean &&
 	flux dmesg -H  | grep FLUX_JOB_USERID=$(id -u)
 '
+test_expect_success 'perilog: canceled prolog drains active ranks after kill_timeout' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	per-rank = true
+	command = [ "sh", "-c", "trap \"\" 15; if test \$(flux getattr rank) -eq 3; then sleep 10; fi" ]
+	kill-timeout = 0.5
+	EOF
+	flux jobtap query perilog.so | jq .conf.prolog &&
+	jobid=$(flux submit -N4 hostname) &&
+	flux job wait-event $jobid prolog-start &&
+	flux cancel $jobid &&
+	flux job wait-event $jobid prolog-finish &&
+	test_debug "echo drained_ranks=$(drained_ranks)" &&
+	test "$(drained_ranks)" = "3" &&
+	flux resource drain -no {reason} | grep "canceled then timed out" &&
+	flux job wait-event -vt 15 $jobid clean &&
+	flux resource undrain 3
+'
 test_expect_success 'perilog: signaled prolog is reported' '
 	flux config load <<-EOF &&
 	[job-manager.prolog]

--- a/t/t2274-manager-perilog-per-rank.t
+++ b/t/t2274-manager-perilog-per-rank.t
@@ -166,7 +166,7 @@ test_expect_success 'perilog: load a basic per-rank prolog config' '
 	flux config load <<-EOF &&
 	[job-manager.prolog]
 	per-rank = true
-	command = [ "sleep", "5" ]
+	command = [ "sleep", "30" ]
 	[job-manager.epilog]
 	per-rank = true
 	command = [ "sleep", "30" ]
@@ -175,6 +175,7 @@ test_expect_success 'perilog: load a basic per-rank prolog config' '
 	flux jobtap query perilog.so | jq .conf.prolog
 '
 test_expect_success 'perilog: prolog runs on all 4 ranks of a 4 node job' '
+	flux dmesg -c &&
 	jobid=$(flux submit -N4 hostname) &&
 	flux job wait-event -vt 30 $jobid prolog-start &&
 	flux jobtap query perilog.so | jq .procs &&

--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -73,7 +73,7 @@ test_expect_success 'perilog: perilog-run timeout works with local scripts' '
 	printf "#!/bin/sh\nsleep 60" >prolog.d/timeout.sh &&
 	chmod +x prolog.d/timeout.sh &&
 	( export FLUX_JOB_ID=f1 &&
-	  test_expect_code 143 \
+	  test_must_fail_or_be_terminated \
 	    flux perilog-run prolog --timeout=0.5s -vv -d prolog.d
 	) &&
 	rm -f prolog.d/timeout.sh
@@ -128,12 +128,12 @@ test_expect_success 'perilog: can be run with timeout' '
 	EOF
 	chmod +x fail-timeout.sh &&
 	(export FLUX_JOB_ID=${jobid} &&
-	 test_expect_code 143 flux perilog-run prolog --timeout=1s \
+	 test_expect_code 143 flux perilog-run prolog --timeout=2s \
 		-ve./fail-timeout.sh,1 \
 		>fail-timeout.out 2>&1
 	) &&
 	test_debug "cat fail-timeout.out" &&
-	flux resource drain &&
+	flux resource drain -o "{ranks:>12} {reason}"&&
 	test "$(drained_ranks)" = "1" &&
 	grep "timeout" fail-timeout.out &&
 	undrain_all
@@ -260,20 +260,6 @@ test_expect_success 'perilog: epilog can be specified without a prolog' '
 	flux job wait-event -t 15 $jobid epilog-start &&
 	flux job wait-event -t 15 $jobid epilog-finish
 '
-test_expect_success 'perilog: canceled prolog does not drain ranks' '
-	cat <<-EOF >config/perilog.toml &&
-	[job-manager.prolog]
-	command = [ "flux", "perilog-run", "prolog", "-vesleep,30" ]
-	EOF
-	flux config reload &&
-	flux jobtap load --remove=*.so perilog.so &&
-	jobid=$(flux submit hostname) &&
-	flux job wait-event -t 15 $jobid prolog-start &&
-	flux cancel $jobid &&
-	flux job wait-event -vt 15 $jobid prolog-finish &&
-	flux resource drain &&
-	test "$(drained_ranks)" = ""
-'
 test_expect_success 'perilog: log-ignore works' '
 	cat <<-EOF >config/perilog.toml &&
 	[job-manager.prolog]
@@ -311,7 +297,10 @@ test_expect_success 'perilog: bad log-ignore regexp is caught' '
 '
 
 #  Note: run this job before taking rank 3 offline below
+#  Undrain all ranks since one or more could be left drained due to timeouts
+#  on slow systems from tests above.
 test_expect_success 'perilog: run job across all 4 ranks' '
+	undrain_all &&
 	jobid=$(flux submit --wait-event=clean -N4 -n4 true)
 '
 #  Note: rank 3 is taken offline after this point for testing handling


### PR DESCRIPTION
This PR modifies the perilog plugin to never send SIGKILL to the prolog/epilog. Instead, after kill-timeout has expired, nodes still actively running a perilog are drained and the finish event posted.

To avoid too eagerly draining nodes, the default kill-timeout is doubled from 5 to 10 seconds.
