### PR TITLE
flux job info: improve error messages

### DIFF
--- a/src/cmd/job/info.c
+++ b/src/cmd/job/info.c
@@ -55,6 +55,7 @@ static void info_usage (void)
 int cmd_info (optparse_t *p, int argc, char **argv)
 {
     flux_t *h;
+    flux_error_t error;
     int optindex = optparse_option_index (p);
     flux_jobid_t id;
     const char *id_str;
@@ -72,8 +73,8 @@ int cmd_info (optparse_t *p, int argc, char **argv)
     id = parse_jobid (id_str);
     key = argv[optindex++];
 
-    if (!(h = flux_open (NULL, 0)))
-        log_err_exit ("flux_open");
+    if (!(h = flux_open_ex (NULL, 0, &error)))
+        log_msg_exit ("flux_open: %s", error.text);
 
     /* The --original (pre-frobnication) jobspec is obtained by fetching J.
      * J is the original jobspec, signed, so we must unwrap it to get to the

--- a/src/modules/job-info/allow.c
+++ b/src/modules/job-info/allow.c
@@ -25,7 +25,8 @@
 /* Parse the submit userid from the event log.
  * Assume "submit" is the first event.
  */
-static int eventlog_get_userid (struct info_ctx *ctx, const char *s,
+static int eventlog_get_userid (struct info_ctx *ctx,
+                                const char *s,
                                 uint32_t *useridp)
 {
     json_t *a = NULL;
@@ -90,8 +91,10 @@ static void store_lru (struct info_ctx *ctx, flux_jobid_t id, uint32_t userid)
 /* Optimization:
  * Avoid calling eventlog_get_userid() if message cred has OWNER role.
  */
-int eventlog_allow (struct info_ctx *ctx, const flux_msg_t *msg,
-                    flux_jobid_t id, const char *s)
+int eventlog_allow (struct info_ctx *ctx,
+                    const flux_msg_t *msg,
+                    flux_jobid_t id,
+                    const char *s)
 {
     struct flux_msg_cred cred;
 

--- a/src/modules/job-info/allow.c
+++ b/src/modules/job-info/allow.c
@@ -37,7 +37,6 @@ static int eventlog_get_userid (struct info_ctx *ctx,
     int rv = -1;
 
     if (!(a = eventlog_decode (s))) {
-        flux_log_error (ctx->h, "%s: eventlog_decode", __FUNCTION__);
         /* if eventlog improperly formatted, we'll consider this a
          * protocol error */
         if (errno == EINVAL)
@@ -48,12 +47,9 @@ static int eventlog_get_userid (struct info_ctx *ctx,
         errno = EPROTO;
         goto error;
     }
-    if (eventlog_entry_parse (entry, NULL, &name, &context) < 0) {
-        flux_log_error (ctx->h, "%s: eventlog_decode", __FUNCTION__);
+    if (eventlog_entry_parse (entry, NULL, &name, &context) < 0)
         goto error;
-    }
     if (!streq (name, "submit") || !context) {
-        flux_log (ctx->h, LOG_ERR, "%s: invalid event: %s", __FUNCTION__, name);
         errno = EPROTO;
         goto error;
     }

--- a/src/modules/job-info/allow.c
+++ b/src/modules/job-info/allow.c
@@ -20,47 +20,37 @@
 #include "allow.h"
 
 #include "src/common/libeventlog/eventlog.h"
+#include "src/common/libutil/errno_safe.h"
 #include "ccan/str/str.h"
 
 /* Parse the submit userid from the event log.
- * Assume "submit" is the first event.
+ * RFC 18 defines the structure of eventlogs.
+ * RFC 21 requires that the first entry is "submit" and defines its context.
  */
 static int eventlog_get_userid (struct info_ctx *ctx,
                                 const char *s,
                                 uint32_t *useridp)
 {
-    json_t *a = NULL;
-    json_t *entry = NULL;
-    const char *name = NULL;
-    json_t *context = NULL;
+    json_t *o = NULL;
+    const char *name;
     int userid;
     int rv = -1;
 
-    if (!(a = eventlog_decode (s))) {
-        /* if eventlog improperly formatted, we'll consider this a
-         * protocol error */
-        if (errno == EINVAL)
-            errno = EPROTO;
-        goto error;
-    }
-    if (!(entry = json_array_get (a, 0))) {
-        errno = EPROTO;
-        goto error;
-    }
-    if (eventlog_entry_parse (entry, NULL, &name, &context) < 0)
-        goto error;
-    if (!streq (name, "submit") || !context) {
-        errno = EPROTO;
-        goto error;
-    }
-    if (json_unpack (context, "{ s:i }", "userid", &userid) < 0) {
+    if (!s
+        || !(o = json_loads (s, JSON_DISABLE_EOF_CHECK, NULL))
+        || json_unpack (o,
+                        "{s:s s:{s:i}}",
+                        "name", &name,
+                        "context",
+                          "userid", &userid) < 0
+        || !streq (name, "submit")) {
         errno = EPROTO;
         goto error;
     }
     (*useridp) = userid;
     rv = 0;
 error:
-    json_decref (a);
+    ERRNO_SAFE_WRAP (json_decref, o);
     return rv;
 }
 

--- a/src/modules/job-info/allow.h
+++ b/src/modules/job-info/allow.h
@@ -20,8 +20,10 @@
  * event which records the job owner.  Will cache recently looked
  * up job owners in an LRU cache.
  */
-int eventlog_allow (struct info_ctx *ctx, const flux_msg_t *msg,
-                    flux_jobid_t id, const char *s);
+int eventlog_allow (struct info_ctx *ctx,
+                    const flux_msg_t *msg,
+                    flux_jobid_t id,
+                    const char *s);
 
 /* Determine if user who sent request 'msg' is allowed to access job
  * eventlog via LRU cache.  Returns 1 if access allowed, 0 if

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -22,8 +22,10 @@
 #include "guest_watch.h"
 #include "update.h"
 
-static void disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
-                           const flux_msg_t *msg, void *arg)
+static void disconnect_cb (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
 {
     struct info_ctx *ctx = arg;
     watchers_cancel (ctx, msg, false);
@@ -31,8 +33,10 @@ static void disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
     update_watchers_cancel (ctx, msg, false);
 }
 
-static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+static void stats_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     struct info_ctx *ctx = arg;
     int lookups = zlist_size (ctx->lookups);
@@ -40,7 +44,9 @@ static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
     int guest_watchers = zlist_size (ctx->guest_watchers);
     int update_lookups = 0;     /* no longer supported */
     int update_watchers = update_watch_count (ctx);
-    if (flux_respond_pack (h, msg, "{s:i s:i s:i s:i s:i}",
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:i s:i s:i s:i s:i}",
                            "lookups", lookups,
                            "watchers", watchers,
                            "guest_watchers", guest_watchers,

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -20,6 +20,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libjob/idf58.h"
+#include "src/common/libutil/errprintf.h"
 #include "ccan/str/str.h"
 
 #include "job-info.h"
@@ -95,26 +96,13 @@ static int lookup_key (struct lookup_ctx *l,
     if (flux_future_get_child (fall, key) != NULL)
         return 0;
 
-    if (flux_job_kvs_key (path, sizeof (path), l->id, key) < 0) {
-        flux_log_error (l->ctx->h, "%s: flux_job_kvs_key", __FUNCTION__);
-        goto error;
+    if (flux_job_kvs_key (path, sizeof (path), l->id, key) < 0
+        || !(f = flux_kvs_lookup (l->ctx->h, NULL, 0, path))
+        || flux_future_push (fall, key, f) < 0) {
+        flux_future_destroy (f);
+        return -1;
     }
-
-    if (!(f = flux_kvs_lookup (l->ctx->h, NULL, 0, path))) {
-        flux_log_error (l->ctx->h, "%s: flux_kvs_lookup", __FUNCTION__);
-        goto error;
-    }
-
-    if (flux_future_push (fall, key, f) < 0) {
-        flux_log_error (l->ctx->h, "%s: flux_future_push", __FUNCTION__);
-        goto error;
-    }
-
     return 0;
-
-error:
-    flux_future_destroy (f);
-    return -1;
 }
 
 static int lookup_keys (struct lookup_ctx *l)
@@ -123,10 +111,8 @@ static int lookup_keys (struct lookup_ctx *l)
     size_t index;
     json_t *key;
 
-    if (!(fall = flux_future_wait_all_create ())) {
-        flux_log_error (l->ctx->h, "%s: flux_wait_all_create", __FUNCTION__);
-        goto error;
-    }
+    if (!(fall = flux_future_wait_all_create ()))
+        return -1;
     flux_future_set_flux (fall, l->ctx->h);
 
     if (l->lookup_eventlog) {
@@ -139,13 +125,8 @@ static int lookup_keys (struct lookup_ctx *l)
             goto error;
     }
 
-    if (flux_future_then (fall,
-                          -1,
-                          info_lookup_continuation,
-                          l) < 0) {
-        flux_log_error (l->ctx->h, "%s: flux_future_then", __FUNCTION__);
+    if (flux_future_then (fall, -1, info_lookup_continuation, l) < 0)
         goto error;
-    }
 
     l->f = fall;
     return 0;
@@ -247,31 +228,41 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
     json_t *o = NULL;
     json_t *tmp = NULL;
     char *data = NULL;
+    flux_error_t error;
 
     if (!l->allow) {
         flux_future_t *f;
 
         if (!(f = flux_future_get_child (fall, "eventlog"))) {
-            flux_log_error (ctx->h, "%s: flux_future_get_child", __FUNCTION__);
+            errprintf (&error,
+                       "internal error: flux_future_get_child eventlog: %s",
+                       strerror (errno));
             goto error;
         }
 
         if (flux_kvs_lookup_get (f, &s) < 0) {
-            if (errno != ENOENT)
-                flux_log_error (l->ctx->h, "%s: flux_kvs_lookup_get", __FUNCTION__);
+            errprintf (&error,
+                       "%s",
+                       errno == ENOENT ? "invalid job id" : strerror (errno));
             goto error;
         }
 
-        if (eventlog_allow (ctx, l->msg, l->id, s) < 0)
+        if (eventlog_allow (ctx, l->msg, l->id, s) < 0) {
+            char *errmsg;
+            if (errno == EPERM)
+                errmsg = "access is restricted to job/instance owner";
+            else
+                errmsg = "error parsing eventlog";
+            errprintf (&error, "%s", errmsg);
             goto error;
+        }
         l->allow = true;
     }
 
-    if (!(o = json_object ()))
-        goto enomem;
-
-    tmp = json_integer (l->id);
-    if (json_object_set_new (o, "id", tmp) < 0) {
+    if (!(o = json_object ())
+        || !(tmp = json_integer (l->id))
+        || json_object_set_new (o, "id", tmp) < 0) {
+        errprintf (&error, "error creating response object");
         json_decref (tmp);
         goto enomem;
     }
@@ -282,47 +273,53 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
         json_t *val = NULL;
 
         if (!(f = flux_future_get_child (fall, keystr))) {
-            flux_log_error (ctx->h, "%s: flux_future_get_child", __FUNCTION__);
+            errprintf (&error,
+                       "internal error: flux_future_get_child %s: %s",
+                       keystr,
+                       strerror (errno));
             goto error;
         }
 
         if (flux_kvs_lookup_get (f, &s) < 0) {
-            if (errno != ENOENT)
-                flux_log_error (l->ctx->h, "%s: flux_kvs_lookup_get", __FUNCTION__);
+            errprintf (&error,
+                       "%s: %s",
+                       keystr,
+                       errno == ENOENT ? "key not found" : strerror (errno));
             goto error;
         }
 
         /* treat empty value as invalid */
         if (!s) {
+            errprintf (&error, "%s: value is unexpectedly empty", keystr);
             errno = EPROTO;
             goto error;
         }
 
         if ((l->flags & FLUX_JOB_LOOKUP_CURRENT)
-            && (streq (keystr, "R")
-                || streq (keystr, "jobspec"))) {
-            if (lookup_current (l, fall, keystr, s, &current_value) < 0)
+            && (streq (keystr, "R") || streq (keystr, "jobspec"))) {
+            if (lookup_current (l, fall, keystr, s, &current_value) < 0) {
+                errprintf (&error,
+                           "%s: error applying eventlog to original value: %s",
+                           keystr,
+                           strerror (errno));
                 goto error;
+            }
             s = current_value;
         }
 
         /* check for JSON_DECODE flag last, as changes above could affect
          * desired value */
         if ((l->flags & FLUX_JOB_LOOKUP_JSON_DECODE)
-            && (streq (keystr, "jobspec")
-                || streq (keystr, "R"))) {
+            && (streq (keystr, "jobspec") || streq (keystr, "R"))) {
             /* We assume if it was stored in the KVS it's valid JSON,
              * so failure is ENOMEM */
-            if (!(val = json_loads (s, 0, NULL)))
-                goto enomem;
+            val = json_loads (s, 0, NULL);
         }
-        else {
-            if (!(val = json_string (s)))
-                goto enomem;
-        }
-
-        if (json_object_set_new (o, keystr, val) < 0) {
+        else
+            val = json_string (s);
+        if (!val || json_object_set_new (o, keystr, val) < 0) {
             json_decref (val);
+            errprintf (&error, "%s: error adding value to response", keystr);
             goto enomem;
         }
 
@@ -334,20 +331,19 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
      * taken error path */
     assert (l->allow);
 
-    if (!(data = json_dumps (o, JSON_COMPACT)))
+    if (!(data = json_dumps (o, JSON_COMPACT))) {
+        errprintf (&error, "error preparing response");
         goto enomem;
-
-    if (flux_respond (ctx->h, l->msg, data) < 0) {
-        flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
-        goto error;
     }
+    if (flux_respond (ctx->h, l->msg, data) < 0)
+        flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
 
     goto done;
 
 enomem:
     errno = ENOMEM;
 error:
-    if (flux_respond_error (ctx->h, l->msg, errno, NULL) < 0)
+    if (flux_respond_error (ctx->h, l->msg, errno, error.text) < 0)
         flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
 
 done:
@@ -388,19 +384,17 @@ static int check_allow (struct lookup_ctx *l)
 /* If we need the eventlog for an allow check or for update-lookup
  * we need to add it to the key lookup list.
  */
-static int check_to_lookup_eventlog (struct lookup_ctx *l)
+static void check_to_lookup_eventlog (struct lookup_ctx *l)
 {
     if (!l->allow || (l->flags & FLUX_JOB_LOOKUP_CURRENT)) {
         size_t index;
         json_t *key;
         json_array_foreach (l->keys, index, key) {
             if (streq (json_string_value (key), "eventlog"))
-                return 0;
+                return;
         }
         l->lookup_eventlog = true;
     }
-
-    return 0;
 }
 
 static json_t *get_json_string (json_t *o)
@@ -508,33 +502,49 @@ static int lookup (flux_t *h,
                    struct info_ctx *ctx,
                    flux_jobid_t id,
                    json_t *keys,
-                   int flags)
+                   int flags,
+                   flux_error_t *error)
 {
     struct lookup_ctx *l = NULL;
     int ret;
 
-    if (!(l = lookup_ctx_create (ctx, msg, id, keys, flags)))
+    if (!(l = lookup_ctx_create (ctx, msg, id, keys, flags))) {
+        errprintf (error,
+                   "could not create lookup context: %s",
+                   strerror (errno));
         goto error;
+    }
 
-    if (check_allow (l) < 0)
+    if (check_allow (l) < 0) {
+        errprintf (error, "access is restricted to job/instance owner");
         goto error;
+    }
 
-    if ((ret = lookup_cached (l)) < 0)
+    if ((ret = lookup_cached (l)) < 0) {
+        errprintf (error,
+                   "internal error attempting to use update-watch cache: %s",
+                   strerror (errno));
         goto error;
+    }
 
     if (ret) {
         lookup_ctx_destroy (l);
         return 0;
     }
 
-    if (check_to_lookup_eventlog (l) < 0)
-        goto error;
+    check_to_lookup_eventlog (l);
 
-    if (lookup_keys (l) < 0)
+    if (lookup_keys (l) < 0) {
+        errprintf (error,
+                   "error sending KVS lookup request(s): %s",
+                   strerror (errno));
         goto error;
+    }
 
     if (zlist_append (ctx->lookups, l) < 0) {
-        flux_log_error (h, "%s: zlist_append", __FUNCTION__);
+        errprintf (error,
+                   "internal error saving lookup context: out of memory");
+        errno = ENOMEM;
         goto error;
     }
     zlist_freefn (ctx->lookups, l, lookup_ctx_destroy, true);
@@ -557,6 +567,7 @@ void lookup_cb (flux_t *h,
     flux_jobid_t id;
     int flags;
     int valid_flags = FLUX_JOB_LOOKUP_JSON_DECODE | FLUX_JOB_LOOKUP_CURRENT;
+    flux_error_t error;
     const char *errmsg = NULL;
 
     if (flux_request_unpack (msg,
@@ -586,8 +597,10 @@ void lookup_cb (flux_t *h,
         }
     }
 
-    if (lookup (h, msg, ctx, id, keys, flags) < 0)
+    if (lookup (h, msg, ctx, id, keys, flags, &error) < 0) {
+        errmsg = error.text;
         goto error;
+    }
 
     return;
 
@@ -608,6 +621,7 @@ void update_lookup_cb (flux_t *h,
     json_t *keys = NULL;
     int flags;
     int valid_flags = 0;
+    flux_error_t error;
     const char *errmsg = NULL;
 
     if (flux_request_unpack (msg,
@@ -638,9 +652,11 @@ void update_lookup_cb (flux_t *h,
                 ctx,
                 id,
                 keys,
-                FLUX_JOB_LOOKUP_JSON_DECODE | FLUX_JOB_LOOKUP_CURRENT) < 0)
+                FLUX_JOB_LOOKUP_JSON_DECODE | FLUX_JOB_LOOKUP_CURRENT,
+                &error) < 0) {
+        errmsg = error.text;
         goto error;
-
+    }
     return;
 
 error:

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -43,12 +43,15 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg);
 
 static void lookup_ctx_destroy (void *data)
 {
-    if (data) {
-        struct lookup_ctx *ctx = data;
+    struct lookup_ctx *ctx = data;
+
+    if (ctx) {
+        int saved_errno = errno;
         flux_msg_decref (ctx->msg);
         json_decref (ctx->keys);
         flux_future_destroy (ctx->f);
         free (ctx);
+        errno = saved_errno;
     }
 }
 
@@ -59,7 +62,6 @@ static struct lookup_ctx *lookup_ctx_create (struct info_ctx *ctx,
                                              int flags)
 {
     struct lookup_ctx *l = calloc (1, sizeof (*l));
-    int saved_errno;
 
     if (!l)
         return NULL;
@@ -78,9 +80,7 @@ static struct lookup_ctx *lookup_ctx_create (struct info_ctx *ctx,
     return l;
 
 error:
-    saved_errno = errno;
     lookup_ctx_destroy (l);
-    errno = saved_errno;
     return NULL;
 }
 

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -564,10 +564,8 @@ void lookup_cb (flux_t *h,
                              "{s:I s:o s:i}",
                              "id", &id,
                              "keys", &keys,
-                             "flags", &flags) < 0) {
-        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+                             "flags", &flags) < 0)
         goto error;
-    }
 
     if (flags & ~valid_flags) {
         errno = EPROTO;
@@ -617,10 +615,8 @@ void update_lookup_cb (flux_t *h,
                              "{s:I s:s s:i}",
                              "id", &id,
                              "key", &key,
-                             "flags", &flags) < 0) {
-        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+                             "flags", &flags) < 0)
         goto error;
-    }
     if ((flags & ~valid_flags)) {
         errno = EPROTO;
         errmsg = "update-lookup request rejected with invalid flag";

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -227,7 +227,6 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
     json_t *key;
     json_t *o = NULL;
     json_t *tmp = NULL;
-    char *data = NULL;
     flux_error_t error;
 
     if (!l->allow) {
@@ -331,11 +330,7 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
      * taken error path */
     assert (l->allow);
 
-    if (!(data = json_dumps (o, JSON_COMPACT))) {
-        errprintf (&error, "error preparing response");
-        goto enomem;
-    }
-    if (flux_respond (ctx->h, l->msg, data) < 0)
+    if (flux_respond_pack (ctx->h, l->msg, "O", o) < 0)
         flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
 
     goto done;
@@ -350,7 +345,6 @@ done:
     /* flux future destroyed in lookup_ctx_destroy, which is called
      * via zlist_remove() */
     json_decref (o);
-    free (data);
     free (current_value);
     zlist_remove (ctx->lookups, l);
 }

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -182,15 +182,18 @@ static int lookup_current (struct lookup_ctx *l,
     }
 
     if (!(f_eventlog = flux_future_get_child (fall, "eventlog"))) {
-        flux_log_error (l->ctx->h, "%s: flux_future_get_child",
+        flux_log_error (l->ctx->h,
+                        "%s: flux_future_get_child",
                         __FUNCTION__);
         goto error;
     }
 
     if (flux_kvs_lookup_get (f_eventlog, &s_eventlog) < 0) {
-        if (errno != ENOENT)
-            flux_log_error (l->ctx->h, "%s: flux_kvs_lookup_get",
+        if (errno != ENOENT) {
+            flux_log_error (l->ctx->h,
+                            "%s: flux_kvs_lookup_get",
                             __FUNCTION__);
+        }
         goto error;
     }
 
@@ -462,7 +465,9 @@ static int lookup_cached (struct lookup_ctx *l)
 
     if (ret) {
         if (l->flags & FLUX_JOB_LOOKUP_JSON_DECODE) {
-            if (flux_respond_pack (l->ctx->h, l->msg, "{s:I s:O}",
+            if (flux_respond_pack (l->ctx->h,
+                                   l->msg,
+                                   "{s:I s:O}",
                                    "id", l->id,
                                    key_str, current_object) < 0) {
                 flux_log_error (l->ctx->h, "%s: flux_respond", __FUNCTION__);
@@ -477,7 +482,9 @@ static int lookup_cached (struct lookup_ctx *l)
                 errno = ENOMEM;
                 goto cleanup;
             }
-            if (flux_respond_pack (l->ctx->h, l->msg, "{s:I s:O}",
+            if (flux_respond_pack (l->ctx->h,
+                                   l->msg,
+                                   "{s:I s:O}",
                                    "id", l->id,
                                    key_str, o) < 0) {
                 json_decref (o);
@@ -538,8 +545,10 @@ error:
     return -1;
 }
 
-void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
-                const flux_msg_t *msg, void *arg)
+void lookup_cb (flux_t *h,
+                flux_msg_handler_t *mh,
+                const flux_msg_t *msg,
+                void *arg)
 {
     struct info_ctx *ctx = arg;
     size_t index;
@@ -550,7 +559,9 @@ void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
     int valid_flags = FLUX_JOB_LOOKUP_JSON_DECODE | FLUX_JOB_LOOKUP_CURRENT;
     const char *errmsg = NULL;
 
-    if (flux_request_unpack (msg, NULL, "{s:I s:o s:i}",
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:I s:o s:i}",
                              "id", &id,
                              "keys", &keys,
                              "flags", &flags) < 0) {
@@ -588,8 +599,10 @@ error:
 }
 
 /* legacy rpc target */
-void update_lookup_cb (flux_t *h, flux_msg_handler_t *mh,
-                       const flux_msg_t *msg, void *arg)
+void update_lookup_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
 {
     struct info_ctx *ctx = arg;
     flux_jobid_t id;
@@ -599,7 +612,9 @@ void update_lookup_cb (flux_t *h, flux_msg_handler_t *mh,
     int valid_flags = 0;
     const char *errmsg = NULL;
 
-    if (flux_request_unpack (msg, NULL, "{s:I s:s s:i}",
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:I s:s s:i}",
                              "id", &id,
                              "key", &key,
                              "flags", &flags) < 0) {

--- a/src/modules/job-info/lookup.h
+++ b/src/modules/job-info/lookup.h
@@ -13,12 +13,16 @@
 
 #include <flux/core.h>
 
-void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
-                const flux_msg_t *msg, void *arg);
+void lookup_cb (flux_t *h,
+                flux_msg_handler_t *mh,
+                const flux_msg_t *msg,
+                void *arg);
 
 /* legacy rpc target */
-void update_lookup_cb (flux_t *h, flux_msg_handler_t *mh,
-                       const flux_msg_t *msg, void *arg);
+void update_lookup_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg);
 
 #endif /* ! _FLUX_JOB_INFO_LOOKUP_H */
 

--- a/src/modules/job-info/update.c
+++ b/src/modules/job-info/update.c
@@ -481,10 +481,8 @@ void update_watch_cb (flux_t *h,
                              "{s:I s:s s:i}",
                              "id", &id,
                              "key", &key,
-                             "flags", &flags) < 0) {
-        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+                             "flags", &flags) < 0)
         goto error;
-    }
     if ((flags & ~valid_flags)) {
         errno = EPROTO;
         errmsg = "update-watch request rejected with invalid flag";

--- a/src/modules/job-info/update.c
+++ b/src/modules/job-info/update.c
@@ -191,7 +191,9 @@ static void eventlog_continuation (flux_future_t *f, void *arg)
 
             msg = flux_msglist_first (uc->msglist);
             while (msg) {
-                if (flux_respond_pack (uc->ctx->h, msg, "{s:O}",
+                if (flux_respond_pack (uc->ctx->h,
+                                       msg,
+                                       "{s:O}",
                                        uc->key, uc->update_object) < 0) {
                     flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
                     goto error_cancel;
@@ -275,7 +277,8 @@ static void lookup_continuation (flux_future_t *f, void *arg)
     bool submit_parsed = false;
     const flux_msg_t *msg;
 
-    if (flux_rpc_get_unpack (f, "{s:s s:s}",
+    if (flux_rpc_get_unpack (f,
+                             "{s:s s:s}",
                              uc->key, &key_str,
                              "eventlog", &eventlog_str) < 0) {
         if (errno != ENOENT && errno != EPERM)
@@ -459,8 +462,10 @@ error:
     return -1;
 }
 
-void update_watch_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+void update_watch_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     struct info_ctx *ctx = arg;
     struct update_ctx *uc = NULL;
@@ -471,7 +476,9 @@ void update_watch_cb (flux_t *h, flux_msg_handler_t *mh,
     const char *errmsg = NULL;
     char *index_key = NULL;
 
-    if (flux_request_unpack (msg, NULL, "{s:I s:s s:i}",
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:I s:s s:i}",
                              "id", &id,
                              "key", &key,
                              "flags", &flags) < 0) {
@@ -510,7 +517,9 @@ void update_watch_cb (flux_t *h, flux_msg_handler_t *mh,
         if (uc->update_object) {
             if (flux_msg_authorize (msg, uc->userid) < 0)
                 goto error;
-            if (flux_respond_pack (uc->ctx->h, msg, "{s:O}",
+            if (flux_respond_pack (uc->ctx->h,
+                                   msg,
+                                   "{s:O}",
                                    uc->key, uc->update_object) < 0) {
                 flux_log_error (ctx->h, "%s: flux_respond", __FUNCTION__);
                 goto error;
@@ -593,8 +602,10 @@ void update_watchers_cancel (struct info_ctx *ctx,
     }
 }
 
-void update_watch_cancel_cb (flux_t *h, flux_msg_handler_t *mh,
-                             const flux_msg_t *msg, void *arg)
+void update_watch_cancel_cb (flux_t *h,
+                             flux_msg_handler_t *mh,
+                             const flux_msg_t *msg,
+                             void *arg)
 {
     struct info_ctx *ctx = arg;
     update_watchers_cancel (ctx, msg, true);
@@ -609,9 +620,11 @@ void update_watch_cleanup (struct info_ctx *ctx)
         eventlog_watch_cancel (uc);
         msg = flux_msglist_first (uc->msglist);
         while (msg) {
-            if (flux_respond_error (ctx->h, msg, ENOSYS, NULL) < 0)
-                flux_log_error (ctx->h, "%s: flux_respond_error",
+            if (flux_respond_error (ctx->h, msg, ENOSYS, NULL) < 0) {
+                flux_log_error (ctx->h,
+                                "%s: flux_respond_error",
                                 __FUNCTION__);
+            }
             msg = flux_msglist_next (uc->msglist);
         }
         update_ctx_destroy (uc);

--- a/src/modules/job-info/update.h
+++ b/src/modules/job-info/update.h
@@ -14,11 +14,15 @@
 #include <flux/core.h>
 #include <jansson.h>
 
-void update_watch_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg);
+void update_watch_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg);
 
-void update_watch_cancel_cb (flux_t *h, flux_msg_handler_t *mh,
-                             const flux_msg_t *msg, void *arg);
+void update_watch_cancel_cb (flux_t *h,
+                             flux_msg_handler_t *mh,
+                             const flux_msg_t *msg,
+                             void *arg);
 
 /* returns 1 on found, 0 if not, -1 on error */
 int update_watch_get_cached (struct info_ctx *ctx,

--- a/src/modules/job-info/util.c
+++ b/src/modules/job-info/util.c
@@ -118,10 +118,14 @@ void apply_updates_R (flux_t *h,
         if (streq (ckey, "expiration"))
             if (jpath_set (R,
                            "execution.expiration",
-                           value) < 0)
-                flux_log (h, LOG_INFO,
+                           value) < 0) {
+                flux_log (h,
+                          LOG_INFO,
                           "%s: failed to update job %s %s",
-                          __FUNCTION__, idf58 (id), key);
+                          __FUNCTION__,
+                          idf58 (id),
+                          key);
+                }
     }
 }
 
@@ -137,10 +141,14 @@ void apply_updates_jobspec (flux_t *h,
     json_object_foreach (context, ckey, value) {
         if (jpath_set (jobspec,
                        ckey,
-                       value) < 0)
-            flux_log (h, LOG_INFO,
+                       value) < 0) {
+            flux_log (h,
+                      LOG_INFO,
                       "%s: failed to update job %s %s",
-                      __FUNCTION__, idf58 (id), key);
+                      __FUNCTION__,
+                      idf58 (id),
+                      key);
+        }
     }
 }
 

--- a/src/modules/job-info/util.h
+++ b/src/modules/job-info/util.h
@@ -23,7 +23,8 @@ flux_msg_t *cred_msg_pack (const char *topic,
                            ...);
 
 /* helper to parse next eventlog entry when whole eventlog is read */
-bool get_next_eventlog_entry (const char **pp, const char **tok,
+bool get_next_eventlog_entry (const char **pp,
+                              const char **tok,
                               size_t *toklen);
 
 /* parse chunk from eventlog_parse_next, 'entry' is required and

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -397,10 +397,8 @@ void watch_cb (flux_t *h,
                              "{s:I s:s s:i}",
                              "id", &id,
                              "path", &path,
-                             "flags", &flags) < 0) {
-        flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
+                             "flags", &flags) < 0)
         goto error;
-    }
     if ((flags & ~valid_flags)) {
         errno = EPROTO;
         errmsg = "eventlog-watch request rejected with invalid flag";

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -132,7 +132,10 @@ static int watch_key (struct watch_ctx *w)
         pathptr = w->path;
     }
     else {
-        if (flux_job_kvs_key (fullpath, sizeof (fullpath), w->id, w->path) < 0) {
+        if (flux_job_kvs_key (fullpath,
+                              sizeof (fullpath),
+                              w->id,
+                              w->path) < 0) {
             flux_log_error (w->ctx->h, "%s: flux_job_kvs_key", __FUNCTION__);
             return -1;
         }
@@ -256,10 +259,12 @@ static void watch_continuation (flux_future_t *f, void *arg)
 
     input = s;
     while (get_next_eventlog_entry (&input, &tok, &toklen)) {
-        if (flux_respond_pack (ctx->h, w->msg,
+        if (flux_respond_pack (ctx->h,
+                               w->msg,
                                "{s:s#}",
                                "event", tok, toklen) < 0) {
-            flux_log_error (ctx->h, "%s: flux_respond_pack",
+            flux_log_error (ctx->h,
+                            "%s: flux_respond_pack",
                             __FUNCTION__);
             goto error_cancel;
         }
@@ -273,7 +278,8 @@ static void watch_continuation (flux_future_t *f, void *arg)
         if (!w->guest && streq (w->path, "eventlog")) {
             if (check_eventlog_end (w, tok, toklen) > 0) {
                 if (flux_kvs_lookup_cancel (w->watch_f) < 0) {
-                    flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
+                    flux_log_error (ctx->h,
+                                    "%s: flux_kvs_lookup_cancel",
                                     __FUNCTION__);
                     goto error;
                 }
@@ -294,7 +300,8 @@ error_cancel:
     if (!w->kvs_watch_canceled) {
         int save_errno = errno;
         if (flux_kvs_lookup_cancel (w->watch_f) < 0)
-            flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
+            flux_log_error (ctx->h,
+                            "%s: flux_kvs_lookup_cancel",
                             __FUNCTION__);
         errno = save_errno;
     }
@@ -371,8 +378,10 @@ error:
     return -1;
 }
 
-void watch_cb (flux_t *h, flux_msg_handler_t *mh,
-               const flux_msg_t *msg, void *arg)
+void watch_cb (flux_t *h,
+               flux_msg_handler_t *mh,
+               const flux_msg_t *msg,
+               void *arg)
 {
     struct info_ctx *ctx = arg;
     struct watch_ctx *w = NULL;
@@ -383,7 +392,9 @@ void watch_cb (flux_t *h, flux_msg_handler_t *mh,
     int valid_flags = FLUX_JOB_EVENT_WATCH_WAITCREATE;
     const char *errmsg = NULL;
 
-    if (flux_request_unpack (msg, NULL, "{s:I s:s s:i}",
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:I s:s s:i}",
                              "id", &id,
                              "path", &path,
                              "flags", &flags) < 0) {
@@ -440,9 +451,11 @@ static void send_kvs_watch_cancel (struct info_ctx *ctx,
 
         /* if the watching hasn't started yet, no need to cancel */
         if (w->watch_f) {
-            if (flux_kvs_lookup_cancel (w->watch_f) < 0)
-                flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
+            if (flux_kvs_lookup_cancel (w->watch_f) < 0) {
+                flux_log_error (ctx->h,
+                                "%s: flux_kvs_lookup_cancel",
                                 __FUNCTION__);
+            }
         }
     }
 }
@@ -472,13 +485,14 @@ void watch_cleanup (struct info_ctx *ctx)
 
     while ((w = zlist_pop (ctx->watchers))) {
         if (w->watch_f) {
-            if (flux_kvs_lookup_cancel (w->watch_f) < 0)
-                flux_log_error (ctx->h, "%s: flux_kvs_lookup_cancel",
+            if (flux_kvs_lookup_cancel (w->watch_f) < 0) {
+                flux_log_error (ctx->h,
+                                "%s: flux_kvs_lookup_cancel",
                                 __FUNCTION__);
+            }
         }
         if (flux_respond_error (ctx->h, w->msg, ENOSYS, NULL) < 0)
-            flux_log_error (ctx->h, "%s: flux_respond_error",
-                            __FUNCTION__);
+            flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
         watch_ctx_destroy (w);
     }
 }

--- a/src/modules/job-info/watch.h
+++ b/src/modules/job-info/watch.h
@@ -13,11 +13,15 @@
 
 #include <flux/core.h>
 
-void watch_cb (flux_t *h, flux_msg_handler_t *mh,
-               const flux_msg_t *msg, void *arg);
+void watch_cb (flux_t *h,
+               flux_msg_handler_t *mh,
+               const flux_msg_t *msg,
+               void *arg);
 
-void watch_cancel_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg);
+void watch_cancel_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg);
 
 /* Cancel all lookups that match msg.
  * match credentials & matchtag if cancel true

--- a/t/issues/t4413-empty-eventlog.sh
+++ b/t/issues/t4413-empty-eventlog.sh
@@ -7,6 +7,6 @@ jobpath=`flux job id --to=kvs 123456789`
 flux kvs put "${jobpath}.eventlog"=""
 
 # Issue 4413, previously would return Cannot allocate memory
-flux job info 123456789 eventlog 2>&1 | grep "Protocol error"
+flux job info 123456789 eventlog 2>&1 | grep "unexpectedly empty"
 
 

--- a/t/issues/t4413-empty-eventlog.sh
+++ b/t/issues/t4413-empty-eventlog.sh
@@ -7,6 +7,6 @@ jobpath=`flux job id --to=kvs 123456789`
 flux kvs put "${jobpath}.eventlog"=""
 
 # Issue 4413, previously would return Cannot allocate memory
-flux job info 123456789 eventlog 2>&1 | grep "unexpectedly empty"
+flux job info 123456789 eventlog 2>&1 | grep "error parsing eventlog"
 
 

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -381,4 +381,16 @@ test_expect_success 'lookup request with invalid flags fails with EPROTO(71)' '
 	  | ${RPC} job-info.lookup 71
 '
 
+#
+# issue 6325
+#
+test_expect_success 'flux job info on bad job id gives good error message' '
+	test_must_fail flux job info fuzzybunny R 2>fuzzy.err &&
+	grep "invalid job id" fuzzy.err
+'
+test_expect_success 'flux job info on bad key gives good error message' '
+	test_must_fail flux job info $(flux job last) badkey 2>badkey.err &&
+	grep "key not found" badkey.err
+'
+
 test_done

--- a/t/t2232-job-info-security.t
+++ b/t/t2232-job-info-security.t
@@ -86,14 +86,14 @@ test_expect_success 'flux job eventlog fails (wrong user)' '
 	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job eventlog $jobid
+	test_must_fail flux job eventlog $jobid
 '
 
 test_expect_success 'flux job eventlog fails on bad first event (user)' '
 	unset_userid &&
 	jobid=$(bad_first_event 9000) &&
 	set_userid 9999 &&
-	! flux job eventlog $jobid
+	test_must_fail flux job eventlog $jobid
 '
 
 test_expect_success 'flux job guest.exec.eventlog works via -p (owner)' '
@@ -112,7 +112,7 @@ test_expect_success 'flux job guest.exec.eventlog fails via -p (wrong user)' '
 	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job eventlog -p exec $jobid
+	test_must_fail flux job eventlog -p exec $jobid
 '
 
 #
@@ -135,7 +135,7 @@ test_expect_success 'flux job info eventlog fails (wrong user)' '
 	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job info $jobid eventlog
+	test_must_fail flux job info $jobid eventlog
 '
 
 test_expect_success 'flux job info jobspec works (owner)' '
@@ -155,26 +155,26 @@ test_expect_success 'flux job info jobspec fails (wrong user)' '
 	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job info $jobid jobspec
+	test_must_fail flux job info $jobid jobspec
 '
 
 test_expect_success 'flux job info foobar fails (owner)' '
 	unset_userid &&
 	jobid=$(submit_job) &&
-	! flux job info $jobid foobar
+	test_must_fail flux job info $jobid foobar
 '
 
 test_expect_success 'flux job info foobar fails (user)' '
 	jobid=$(submit_job 9000) &&
 	set_userid 9000 &&
-	! flux job info $jobid foobar
+	test_must_fail flux job info $jobid foobar
 '
 
 test_expect_success 'flux job info foobar fails (wrong user)' '
 	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job info $jobid foobar
+	test_must_fail flux job info $jobid foobar
 '
 
 #
@@ -197,7 +197,7 @@ test_expect_success 'flux job wait-event fails (wrong user)' '
 	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job wait-event $jobid submit
+	test_must_fail flux job wait-event $jobid submit
 '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (owner)' '
@@ -216,7 +216,7 @@ test_expect_success 'flux job wait-event guest.exec.eventlog fails via -p (wrong
 	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job wait-event -p exec $jobid done
+	test_must_fail flux job wait-event -p exec $jobid done
 '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (live job, owner)' '
@@ -240,7 +240,7 @@ test_expect_success 'cancel job' '
 test_expect_success 'flux job wait-event guest.exec.eventlog fails via -p (live job, wrong user)' '
 	jobid=$(submit_job_live 9000) &&
 	set_userid 9999 &&
-	! flux job wait-event -p exec $jobid init
+	test_must_fail flux job wait-event -p exec $jobid init
 '
 
 test_expect_success 'cancel job' '

--- a/t/t2232-job-info-security.t
+++ b/t/t2232-job-info-security.t
@@ -261,7 +261,7 @@ test_expect_success 'flux job info dummy works (owner)' '
 
 test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 dummy 2>&1 | grep "Protocol error" &&
+        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog" &&
 	unset_userid
 '
 
@@ -272,7 +272,7 @@ test_expect_success 'create eventlog with invalid data / not JSON' '
 
 test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 dummy 2>&1 | grep "Protocol error" &&
+        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog" &&
 	unset_userid
 '
 
@@ -284,7 +284,7 @@ test_expect_success 'create eventlog without submit context' '
 
 test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 dummy 2>&1 | grep "Protocol error" &&
+        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog" &&
 	unset_userid
 '
 
@@ -296,7 +296,7 @@ test_expect_success 'create eventlog without submit userid' '
 
 test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 dummy 2>&1 | grep "Protocol error" &&
+        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog" &&
 	unset_userid
 '
 
@@ -308,7 +308,7 @@ test_expect_success 'create eventlog that is binary garbage' '
 
 test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 dummy 2>&1 | grep "Protocol error" &&
+        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog" &&
 	unset_userid
 '
 

--- a/t/t2232-job-info-security.t
+++ b/t/t2232-job-info-security.t
@@ -79,25 +79,25 @@ test_expect_success 'flux job eventlog works (owner)' '
 test_expect_success 'flux job eventlog works (user)' '
 	jobid=$(submit_job 9000) &&
 	set_userid 9000 &&
-	flux job eventlog $jobid &&
-	unset_userid
+	flux job eventlog $jobid
 '
 
 test_expect_success 'flux job eventlog fails (wrong user)' '
+	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job eventlog $jobid &&
-	unset_userid
+	! flux job eventlog $jobid
 '
 
 test_expect_success 'flux job eventlog fails on bad first event (user)' '
+	unset_userid &&
 	jobid=$(bad_first_event 9000) &&
 	set_userid 9999 &&
-	! flux job eventlog $jobid &&
-	unset_userid
+	! flux job eventlog $jobid
 '
 
 test_expect_success 'flux job guest.exec.eventlog works via -p (owner)' '
+	unset_userid &&
 	jobid=$(submit_job) &&
 	flux job eventlog -p exec $jobid
 '
@@ -105,15 +105,14 @@ test_expect_success 'flux job guest.exec.eventlog works via -p (owner)' '
 test_expect_success 'flux job guest.exec.eventlog works via -p (user)' '
 	jobid=$(submit_job 9000) &&
 	set_userid 9000 &&
-	flux job eventlog -p exec $jobid &&
-	unset_userid
+	flux job eventlog -p exec $jobid
 '
 
 test_expect_success 'flux job guest.exec.eventlog fails via -p (wrong user)' '
+	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job eventlog -p exec $jobid &&
-	unset_userid
+	! flux job eventlog -p exec $jobid
 '
 
 #
@@ -121,6 +120,7 @@ test_expect_success 'flux job guest.exec.eventlog fails via -p (wrong user)' '
 #
 
 test_expect_success 'flux job info eventlog works (owner)' '
+	unset_userid &&
 	jobid=$(submit_job) &&
 	flux job info $jobid eventlog
 '
@@ -128,37 +128,38 @@ test_expect_success 'flux job info eventlog works (owner)' '
 test_expect_success 'flux job info eventlog works (user)' '
 	jobid=$(submit_job 9000) &&
 	set_userid 9000 &&
-	flux job info $jobid eventlog &&
-	unset_userid
+	flux job info $jobid eventlog
 '
 
 test_expect_success 'flux job info eventlog fails (wrong user)' '
+	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job info $jobid eventlog &&
-	unset_userid
+	! flux job info $jobid eventlog
 '
 
 test_expect_success 'flux job info jobspec works (owner)' '
+	unset_userid &&
 	jobid=$(submit_job) &&
 	flux job info $jobid jobspec
 '
 
 test_expect_success 'flux job info jobspec works (user)' '
+	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9000 &&
-	flux job info $jobid jobspec &&
-	unset_userid
+	flux job info $jobid jobspec
 '
 
 test_expect_success 'flux job info jobspec fails (wrong user)' '
+	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job info $jobid jobspec &&
-	unset_userid
+	! flux job info $jobid jobspec
 '
 
 test_expect_success 'flux job info foobar fails (owner)' '
+	unset_userid &&
 	jobid=$(submit_job) &&
 	! flux job info $jobid foobar
 '
@@ -166,15 +167,14 @@ test_expect_success 'flux job info foobar fails (owner)' '
 test_expect_success 'flux job info foobar fails (user)' '
 	jobid=$(submit_job 9000) &&
 	set_userid 9000 &&
-	! flux job info $jobid foobar &&
-	unset_userid
+	! flux job info $jobid foobar
 '
 
 test_expect_success 'flux job info foobar fails (wrong user)' '
+	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job info $jobid foobar &&
-	unset_userid
+	! flux job info $jobid foobar
 '
 
 #
@@ -182,6 +182,7 @@ test_expect_success 'flux job info foobar fails (wrong user)' '
 #
 
 test_expect_success 'flux job wait-event works (owner)' '
+	unset_userid &&
 	jobid=$(submit_job) &&
 	flux job wait-event $jobid submit
 '
@@ -189,18 +190,18 @@ test_expect_success 'flux job wait-event works (owner)' '
 test_expect_success 'flux job wait-event works (user)' '
 	jobid=$(submit_job 9000) &&
 	set_userid 9000 &&
-	flux job wait-event $jobid submit &&
-	unset_userid
+	flux job wait-event $jobid submit
 '
 
 test_expect_success 'flux job wait-event fails (wrong user)' '
+	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job wait-event $jobid submit &&
-	unset_userid
+	! flux job wait-event $jobid submit
 '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (owner)' '
+	unset_userid &&
 	jobid=$(submit_job) &&
 	flux job wait-event -p exec $jobid done
 '
@@ -208,18 +209,18 @@ test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (owner
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (user)' '
 	jobid=$(submit_job 9000) &&
 	set_userid 9000 &&
-	flux job wait-event -p exec $jobid done &&
-	unset_userid
+	flux job wait-event -p exec $jobid done
 '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog fails via -p (wrong user)' '
+	unset_userid &&
 	jobid=$(submit_job 9000) &&
 	set_userid 9999 &&
-	! flux job wait-event -p exec $jobid done &&
-	unset_userid
+	! flux job wait-event -p exec $jobid done
 '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (live job, owner)' '
+	unset_userid &&
 	jobid=$(submit_job_live) &&
 	flux job wait-event -p exec $jobid init &&
 	flux cancel $jobid
@@ -228,7 +229,10 @@ test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (live 
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (live job, user)' '
 	jobid=$(submit_job_live 9000) &&
 	set_userid 9000 &&
-	flux job wait-event -p exec $jobid init &&
+	flux job wait-event -p exec $jobid init
+'
+
+test_expect_success 'cancel job' '
 	unset_userid &&
 	flux cancel $jobid
 '
@@ -236,7 +240,10 @@ test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (live 
 test_expect_success 'flux job wait-event guest.exec.eventlog fails via -p (live job, wrong user)' '
 	jobid=$(submit_job_live 9000) &&
 	set_userid 9999 &&
-	! flux job wait-event -p exec $jobid init &&
+	! flux job wait-event -p exec $jobid init
+'
+
+test_expect_success 'cancel job' '
 	unset_userid &&
 	flux cancel $jobid
 '
@@ -261,22 +268,22 @@ test_expect_success 'flux job info dummy works (owner)' '
 
 test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog" &&
-	unset_userid
+        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog"
 '
 
 test_expect_success 'create eventlog with invalid data / not JSON' '
+	unset_userid &&
 	jobpath=`flux job id --to=kvs 123456789`&&
 	flux kvs put "${jobpath}.eventlog"="foobar"
 '
 
 test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog" &&
-	unset_userid
+        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog"
 '
 
 test_expect_success 'create eventlog without submit context' '
+	unset_userid &&
         submitstr="{\"timestamp\":123.4,\"name\":\"submit\"}" &&
 	jobpath=`flux job id --to=kvs 123456789` &&
 	echo $submitstr | flux kvs put --raw "${jobpath}.eventlog"=-
@@ -284,11 +291,11 @@ test_expect_success 'create eventlog without submit context' '
 
 test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog" &&
-	unset_userid
+        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog"
 '
 
 test_expect_success 'create eventlog without submit userid' '
+	unset_userid
         submitstr="{\"timestamp\":123.4,\"name\":\"submit\",\"context\":{}}" &&
 	jobpath=`flux job id --to=kvs 123456789` &&
 	echo $submitstr | flux kvs put --raw "${jobpath}.eventlog"=-
@@ -296,11 +303,11 @@ test_expect_success 'create eventlog without submit userid' '
 
 test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog" &&
-	unset_userid
+        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog"
 '
 
 test_expect_success 'create eventlog that is binary garbage' '
+	unset_userid &&
 	jobpath=`flux job id --to=kvs 123456789` &&
         dd if=/dev/urandom bs=64 count=1 > binary.out &&
 	flux kvs put --raw "${jobpath}.eventlog"=- < binary.out
@@ -308,7 +315,10 @@ test_expect_success 'create eventlog that is binary garbage' '
 
 test_expect_success 'flux job info dummy fails (user)' '
 	set_userid 9000 &&
-        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog" &&
+        flux job info 123456789 dummy 2>&1 | grep "error parsing eventlog"
+'
+
+test_expect_success 'clean up' '
 	unset_userid
 '
 

--- a/t/t2232-job-info-security.t
+++ b/t/t2232-job-info-security.t
@@ -4,7 +4,7 @@ test_description='Test flux job info service security'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 4 job
+test_under_flux 1 job
 
 # We have to fake a job submission by a guest into the KVS.
 # This method of editing the eventlog preserves newline separators.


### PR DESCRIPTION
Problem: as noted in #6325, `flux job info` prints the same error message for a missing key as for an unknown job id.

Fixing this turned out to be tricky because the `job-info.lookup` service is just acting as a proxy for a KVS lookup and doesn't have a direct way to check for an invalid ID - it just knows that a KVS lookup for` job.<id>.R` (or whatever) got ENOENT.  However it does also lookup the job  eventlog for access control purposes for guests only.  The instance owner is immune from such checks.

The solution is to always look up the eventlog regardless of request credentials if _that_ fails with ENOENT then we know the job ID does not exist.

Because this code is pretty old, a fair bit of modernization was also required.   And there is more to do but I tried to keep this focused on the code involved in the reported problem.