### PR TITLE
doc: add warning about stdio file paths in submission cli man pages

### DIFF
--- a/doc/man1/common/job-standard-io.rst
+++ b/doc/man1/common/job-standard-io.rst
@@ -1,3 +1,9 @@
+.. note::
+   Paths specified in the options :option:`--output`, :option:`--error`,
+   and :option:`--input` will be opened relative to the working directory
+   on the first node of the job allocation, not on the node from which
+   the job is submitted.
+
 .. option:: --input=FILENAME|RANKS
 
    Redirect stdin to the specified filename, bypassing the KVS.


### PR DESCRIPTION
Problem: It may surprise users that --output, --error, and --input files are opened on the first node of the allocation and relative to the working directory of the job, not on the submission node.

Add a note to the common job-standard-io.rst document warning users of this potential pitfall.

Fixes #6329