### PR TITLE
systemd: improve housekeeping drain message

### DIFF
--- a/etc/flux-housekeeping@.service.in
+++ b/etc/flux-housekeeping@.service.in
@@ -9,13 +9,10 @@ ExecStart=@X_SYSCONFDIR@/flux/system/housekeeping
 ExecStopPost=-rm -f @X_RUNSTATEDIR@/flux-housekeeping@%I.env
 ExecStopPost=-sh -c '\
     if test "$SERVICE_RESULT" != "success"; then \
-        if test "$EXIT_CODE" = "killed" -o "$EXIT_CODE" = "dumped"; then \
-            message="killed by SIG${EXIT_STATUS}"; \
-        elif test "$EXIT_CODE" = "exited"; then \
-            message="exited with exit code $EXIT_CODE"; \
-        else \
-            message="code=$EXIT_CODE status=$EXIT_STATUS"; \
+        message="housekeeping@%I ${SERVICE_RESULT:-failure}"; \
+        if test "${EXIT_CODE}${EXIT_STATUS}"; then \
+            message="$message: $EXIT_CODE $EXIT_STATUS"; \
         fi; \
-        flux resource drain $(flux getattr rank) "housekeeping $message"; \
+        flux resource drain $(flux getattr rank) $message; \
     fi \
 '


### PR DESCRIPTION
Problem: sometimes systemd doesn't set $EXIT_CODE or $EXIT_STATUS and nodes that fail housekeeping are drained with the message "housekeeping code= status=".

Modify the unit file to generate a message that
- includes the jobid
- drops the code/status labels and just print the values, if set
- include the $SERVICE_RESULT or "failure" if unset

Examples:

When housekeeping script exits with nonzero code: `housekeeping@f2PsCLp3gf9 exit-code: exited 1`

When flux housekeeping kill is used: `housekeeping@f2PxL1tmvUX signal: killed TERM`

If no env vars available (theoretical): `housekeeping@fuzzybunny failure`

Fixes #6176

Edit: tested the first two on debian bookworm (systemd 252).  The env vars were added in 231.  El cap runs 239.