### PR TITLE
include all not drained hostnames in `flux resource undrain` error message

### DIFF
--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -262,6 +262,12 @@ test_expect_success 'undrain fails if any rank not drained' '
 	grep ".*rank 1.* not drained" undrain_0-1_not.err
 '
 
+test_expect_success 'undrain reports multiple ranks not drained' '
+	test_must_fail flux resource undrain 0-2 2>undrain_0-2_not.err &&
+	test_debug "cat undrain_0-2_not.err" &&
+	grep ".*ranks 1-2.* not drained" undrain_0-2_not.err
+'
+
 test_expect_success 'undrain --force works even if a target is not drained' '
 	flux resource undrain --force 0-1
 '

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -252,14 +252,14 @@ test_expect_success 'no nodes remain drained or excluded' '
 
 test_expect_success 'undrain fails if rank not drained' '
 	test_must_fail flux resource undrain 1 2>undrain_not.err &&
-	grep "rank 1 not drained" undrain_not.err
+	grep ".*rank 1.* not drained" undrain_not.err
 '
 
 test_expect_success 'undrain fails if any rank not drained' '
 	flux resource drain 0 &&
 	test_must_fail flux resource undrain 0-1 2>undrain_0-1_not.err &&
 	test_debug "cat undrain_0-1_not.err" &&
-	grep "rank 1 not drained" undrain_0-1_not.err
+	grep ".*rank 1.* not drained" undrain_0-1_not.err
 '
 
 test_expect_success 'undrain --force works even if a target is not drained' '


### PR DESCRIPTION
By default `flux resource undrain` aborts the entire operation if any target is not drained, but it only includes the first rank in the error message which has proved confusing.

This PR updates the error message to include all not drained hostnames (and their corresponding ranks). 