### PR TITLE
make flux resource drain -o long reason expandable

### DIFF
--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -43,7 +43,7 @@ class FluxResourceConfig(UtilConfig):
             "description": "Long flux-resource status format string",
             "format": (
                 "{state:>12} {color_up}{up:>2}{color_off} "
-                "{nnodes:>6} {reason:<30.30+} {nodelist}"
+                "{nnodes:>6} +:{reason:<30.30+} {nodelist}"
             ),
         },
     }
@@ -51,8 +51,8 @@ class FluxResourceConfig(UtilConfig):
         "long": {
             "description": "Long flux-resource drain format string",
             "format": (
-                "{timestamp!d:%FT%T::<20} {state:<8.8} {ranks:<8.8+} "
-                "{reason:<30.30+} {nodelist}"
+                "{timestamp!d:%b%d %R::<12} {state:<8.8} {ranks:<8.8+} "
+                "+:{reason:<30.30+} {nodelist}"
             ),
         },
         "default": {


### PR DESCRIPTION
Problem: the "long" format of 'flux resource drain' doesn't show the un-truncated drain reason, but one might expect that to be the case.

Now that we have expandable field width support, use it for {reason} in the "long" format.  In addition, to conserve space, {timestamp} is changed to use same format as "default", since the longer representation wasn't particularly helpful.
```
$ flux resource drain
TIME         STATE    REASON                         NODELIST
Oct02 13:06  drained  This is a long drain message + pop-os
$ flux resource drain -o long
TIME         STATE    RANKS    REASON                                NODELIST
Oct02 13:06  drained  0        This is a long drain message isnt it? pop-os
```
Same for {reason} in the "long" format of 'flux resource status':
```
$ flux resource status -o long
       STATE UP NNODES REASON                                NODELIST
     drained  ✔      1 This is a long drain message isnt it? pop-os
```