### PR TITLE
testsuite: improve test_must_fail_or_be_killed function

### DIFF
--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -49,7 +49,7 @@ test_must_fail_or_be_terminated() {
     elif test $exit_code = 0; then
         echo >&2 "test_must_fail: command succeeded: $*"
         return 1
-    elif test $exit_code -gt 129 -a $exit_code -le 192; then
+    elif test $exit_code -ge 129 -a $exit_code -le 192; then
         echo >&2 "test_must_fail: died by signal $(($exit_code-128)): $*"
         return 1
     elif test $exit_code = 127; then

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -50,7 +50,7 @@ test_must_fail_or_be_terminated() {
         echo >&2 "test_must_fail: command succeeded: $*"
         return 1
     elif test $exit_code -gt 129 -a $exit_code -le 192; then
-        echo >&2 "test_must_fail: died by non-SIGTERM signal: $*"
+        echo >&2 "test_must_fail: died by signal $(($exit_code-128)): $*"
         return 1
     elif test $exit_code = 127; then
         echo >&2 "test_must_fail: command not found: $*"

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -47,13 +47,13 @@ test_must_fail_or_be_terminated() {
     if test $exit_code = 143 -o $exit_code = 137; then
         return 0
     elif test $exit_code = 0; then
-        echo >&2 "test_must_fail: command succeeded: $*"
+        echo >&2 "test_must_fail_or_be_terminated: command succeeded: $*"
         return 1
     elif test $exit_code -ge 129 -a $exit_code -le 192; then
-        echo >&2 "test_must_fail: died by signal $(($exit_code-128)): $*"
+        echo >&2 "test_must_fail_or_be_terminated: died by signal $(($exit_code-128)): $*"
         return 1
     elif test $exit_code = 127; then
-        echo >&2 "test_must_fail: command not found: $*"
+        echo >&2 "test_must_fail_or_be_terminated: command not found: $*"
         return 1
     fi
     return 0

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -45,6 +45,18 @@ test_expect_success 'test run_timeout with success' '
 test_expect_success 'run_timeout fails if exec fails' '
 	test_must_fail run_timeout 1 /nonexistent/executable
 '
+test_expect_success 'test_must_fail_or_be_terminated fails on success' '
+	test_must_fail test_must_fail_or_be_terminated true
+'
+test_expect_success 'test_must_fail_or_be_terminated succeeds on nonzero exit' '
+	test_must_fail_or_be_terminated false
+'
+test_expect_success 'test_must_fail_or_be_terminated succeeds on SIGTERM' '
+	test_must_fail_or_be_terminated sh -c "kill \$\$"
+'
+test_expect_success 'test_must_fail_or_be_terminated fails on SIGHUP' '
+	test_must_fail test_must_fail_or_be_terminated sh -c "kill -HUP \$\$"
+'
 test_expect_success 'we can find a flux binary' '
 	flux --help >/dev/null
 '


### PR DESCRIPTION
Problem: As noted in #6336, one of the tests is occasionally failing due to an unexpected signal caught by `test_must_fail_or_be_killed` but we don't know which one.

This changes that function to print the signal number so we can get a clue as to what is happening (did it segfault?)

And there is some adjacent cleanup and tests added for the function itself.