### PR TITLE
systemd: make scripts fail if systemctl start does

### DIFF
--- a/doc/guide/admin.rst
+++ b/doc/guide/admin.rst
@@ -691,7 +691,7 @@ following steps:
 
        exit_rc=0
        periname=prolog
-       peridir=/usr/flux/system/${periname}.d
+       peridir=/etc/flux/system/${periname}.d
 
        # This script may be run in test with 'sudo flux run-prolog'
        test $FLUX_JOB_USERID && userid=$(id -n -u $FLUX_JOB_USERID 2>/dev/null)

--- a/src/cmd/flux-run-epilog.in
+++ b/src/cmd/flux-run-epilog.in
@@ -18,4 +18,4 @@ printenv >@X_RUNSTATEDIR@/${unitname}.env
 # Run systemctl start in background and `wait` for it so that the trap
 # will run immediately when signal is received:
 systemctl start $unitname --quiet &
-wait
+wait $!

--- a/src/cmd/flux-run-housekeeping.in
+++ b/src/cmd/flux-run-housekeeping.in
@@ -18,4 +18,4 @@ printenv >@X_RUNSTATEDIR@/${unitname}.env
 # Run systemctl start in background and `wait` for it so that the trap
 # will run immediately when signal is received:
 systemctl start $unitname --quiet &
-wait
+wait $!

--- a/src/cmd/flux-run-prolog.in
+++ b/src/cmd/flux-run-prolog.in
@@ -18,4 +18,4 @@ printenv >@X_RUNSTATEDIR@/${unitname}.env
 # Run systemctl start in background and `wait` for it so that the trap
 # will run immediately when signal is received:
 systemctl start $unitname --quiet &
-wait
+wait $!


### PR DESCRIPTION
Problem: flux-run-{prolog,epilog,housekeeping} scripts do not fail if systemctl start fails.

Replace "wait" with "wait $!".
The former always returns success.