### PR TITLE
add --full option to display payloads in message tracing programs

### DIFF
--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -12,7 +12,7 @@ SYNOPSIS
 | **flux** **module** **list** [*-l*]
 | **flux** **module** **stats** [*-R*] [*--clear*] *name*
 | **flux** **module** **debug** [*--setbit=VAL*] [*--clearbit=VAL*] [*--set=MASK*] [*--clear=MASK*] *name*
-| **flux** **module** **trace** [*-t TYPE,...*] [-T *topic-glob*] *name...*
+| **flux** **module** **trace** [-f] [*-t TYPE,...*] [-T *topic-glob*] *name...*
 
 
 
@@ -150,6 +150,11 @@ trace
 
 Display message summaries for messages transmitted and received by the
 named modules.
+
+.. option:: -f, --full
+
+   Include JSON payload in output, if any.  Payloads that are not JSON are
+   not displayed.
 
 .. option:: -T, --topic=GLOB
 

--- a/doc/man1/flux-overlay.rst
+++ b/doc/man1/flux-overlay.rst
@@ -14,7 +14,7 @@ SYNOPSIS
 | **flux** **overlay** **lookup** *target*
 | **flux** **overlay** **parentof** *rank*
 | **flux** **overlay** **disconnect** [*--parent=RANK*] *target*
-| **flux** **overlay** **trace** [*-r rank*] [*-t TYPE,...*] [*topic-glob*]
+| **flux** **overlay** **trace** [-f] [*-r rank*] [*-t TYPE,...*] [*topic-glob*]
 
 
 DESCRIPTION
@@ -129,6 +129,11 @@ trace
 Display message summaries for messages transmitted and received on the
 overlay network.  A topic string glob pattern may be supplied as a positional
 argument.
+
+.. option:: -f, --full
+
+   Include JSON payload in output, if any.  Payloads that are not JSON are
+   not displayed.
 
 .. option:: -r, --rank=NODEID
 

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -1168,6 +1168,7 @@ _flux_overlay()
         -L --color= \
         -H --human \
         -d --delta \
+        -f --full \
     "
     _flux_split_longopt && split=true
     case $prev in
@@ -1305,6 +1306,7 @@ _flux_module()
         -L --color= \
         -H --human \
         -d --delta \
+        -f --full \
     "
     if [[ $cmd != "module" ]]; then
 

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -93,6 +93,9 @@ static struct optparse_option trace_opts[] = {
     { .name = "rank", .key = 'r', .has_arg = 1, .arginfo = "NODEID",
       .usage = "Filter output by peer rank",
     },
+    { .name = "full", .key = 'f', .has_arg = 0,
+      .usage = "Show JSON message payload, if any",
+    },
     { .name = "type", .key = 't', .has_arg = 1,
       .flags = OPTPARSE_OPT_AUTOSPLIT,
       .arginfo = "TYPE,...",
@@ -1208,12 +1211,15 @@ static void trace_print_human_timestamp (struct trace_ctx *ctx,
 static void trace_print_human (struct trace_ctx *ctx,
                                double timestamp,
                                int message_type,
-                               const char *s)
+                               const char *s,
+                               const char *payload_str)
 {
     trace_print_human_timestamp (ctx, timestamp);
-    printf (" %s%s%s\n",
+    printf (" %s%s%s%s%s\n",
             trace_color (ctx, message_type),
             s,
+            payload_str ? "\n" : "",
+            payload_str ? payload_str : "",
             trace_color_reset (ctx));
 }
 
@@ -1236,12 +1242,15 @@ static void trace_print_timestamp (struct trace_ctx *ctx, double timestamp)
 static void trace_print (struct trace_ctx *ctx,
                          double timestamp,
                          int message_type,
-                         const char *s)
+                         const char *s,
+                         const char *payload_str)
 {
     trace_print_timestamp (ctx, timestamp);
-    printf (" %s%s%s\n",
+    printf (" %s%s%s%s%s\n",
             trace_color (ctx, message_type),
             s,
+            payload_str ? "\n" : "",
+            payload_str ? payload_str : "",
             trace_color_reset (ctx));
 }
 
@@ -1302,10 +1311,11 @@ static int subcmd_trace (optparse_t *p, int ac, char *av[])
                              "overlay.trace",
                              FLUX_NODEID_ANY,
                              FLUX_RPC_STREAMING,
-                             "{s:i s:s s:i}",
+                             "{s:i s:s s:i s:b}",
                              "typemask", ctx.match.typemask,
                              "topic_glob", ctx.match.topic_glob,
-                             "nodeid", ctx.nodeid)))
+                             "nodeid", ctx.nodeid,
+                             "full", optparse_hasopt (p, "full") ? 1 : 0)))
         log_err_exit ("error sending overlay.trace request");
     do {
         double timestamp;
@@ -1314,17 +1324,23 @@ static int subcmd_trace (optparse_t *p, int ac, char *av[])
         int type;
         const char *topic;
         int payload_size;
+        json_t *payload_json = json_null ();
+        char *payload_str = NULL;
         char buf[160];
 
         if (flux_rpc_get_unpack (f,
-                                 "{s:F s:s s:i s:i s:s s:i}",
+                                 "{s:F s:s s:i s:i s:s s:i s?o}",
                                  "timestamp", &timestamp,
                                  "prefix", &prefix,
                                  "rank", &rank,
                                  "type", &type,
                                  "topic", &topic,
-                                 "payload_size", &payload_size) < 0)
+                                 "payload_size", &payload_size,
+                                 "payload", &payload_json) < 0)
             log_err_exit ("%s", future_strerror (f, errno));
+
+        if (!json_is_null (payload_json))
+            payload_str = json_dumps (payload_json, JSON_INDENT(2));
 
         char rankstr[16];
         if (rank < 0)
@@ -1342,10 +1358,12 @@ static int subcmd_trace (optparse_t *p, int ac, char *av[])
                   encode_size (payload_size));
 
         if (optparse_hasopt (p, "human"))
-            trace_print_human (&ctx, timestamp, type, buf);
+            trace_print_human (&ctx, timestamp, type, buf, payload_str);
         else
-            trace_print (&ctx, timestamp, type, buf);
+            trace_print (&ctx, timestamp, type, buf, payload_str);
         fflush (stdout);
+
+        free (payload_str);
 
         flux_future_reset (f);
     } while (1);

--- a/t/t3400-overlay-trace.t
+++ b/t/t3400-overlay-trace.t
@@ -24,8 +24,15 @@ test_expect_success NO_CHAIN_LINT 'start background trace' '
 	flux overlay trace >trace.out &
 	echo $! >trace.pid
 '
+test_expect_success NO_CHAIN_LINT 'start second background trace with --full' '
+	flux overlay trace --full >trace2.out &
+	echo $! >trace2.pid
+'
 test_expect_success NO_CHAIN_LINT 'heartbeat.pulse event was captured' '
 	$waitfile -t 60 -p heartbeat.pulse trace.out
+'
+test_expect_success NO_CHAIN_LINT 'heartbeat.pulse event was captured with --full' '
+	$waitfile -t 60 -p heartbeat.pulse trace2.out
 '
 test_expect_success NO_CHAIN_LINT 'send one kvs.ping to rank 1' '
 	flux ping -r 1 -c 1 kvs
@@ -33,7 +40,17 @@ test_expect_success NO_CHAIN_LINT 'send one kvs.ping to rank 1' '
 test_expect_success NO_CHAIN_LINT 'kvs.ping request/response was captured' '
 	$waitfile -t 60 -c 2 -p kvs.ping trace.out
 '
+test_expect_success NO_CHAIN_LINT 'kvs.ping request/response was captured with --full' '
+	$waitfile -t 60 -c 2 -p kvs.ping trace2.out
+'
 test_expect_success NO_CHAIN_LINT 'stop background trace' '
-	kill -15 $(cat trace.pid); wait || true
+	pid=$(cat trace.pid) &&
+	kill -15 $pid &&
+	wait $pid || true
+'
+test_expect_success NO_CHAIN_LINT 'stop second background trace' '
+	pid=$(cat trace2.pid) &&
+	kill -15 $pid &&
+	wait $pid || true
 '
 test_done

--- a/t/t3401-module-trace.t
+++ b/t/t3401-module-trace.t
@@ -24,8 +24,15 @@ test_expect_success NO_CHAIN_LINT 'start background trace' '
 	flux module trace kvs >trace.out &
 	echo $! >trace.pid
 '
+test_expect_success NO_CHAIN_LINT 'start second background trace with --full' '
+	flux module trace --full kvs >trace1a.out &
+	echo $! >trace1a.pid
+'
 test_expect_success NO_CHAIN_LINT 'heartbeat.pulse event was captured' '
 	$waitfile -t 60 -p heartbeat.pulse trace.out
+'
+test_expect_success NO_CHAIN_LINT 'heartbeat.pulse event was captured with --full' '
+	$waitfile -t 60 -p heartbeat.pulse trace1a.out
 '
 test_expect_success NO_CHAIN_LINT 'send one kvs.ping' '
 	flux ping -c 1 kvs
@@ -33,8 +40,18 @@ test_expect_success NO_CHAIN_LINT 'send one kvs.ping' '
 test_expect_success NO_CHAIN_LINT 'kvs.ping request/response was captured' '
 	$waitfile -t 60 -c 2 -p kvs.ping trace.out
 '
+test_expect_success NO_CHAIN_LINT 'kvs.ping request/response was captured with --full' '
+	$waitfile -t 60 -c 2 -p kvs.ping trace1a.out
+'
 test_expect_success NO_CHAIN_LINT 'stop background trace' '
-	kill -15 $(cat trace.pid); wait || true
+	pid=$(cat trace.pid) &&
+	kill -15 $pid &&
+	wait $pid || true
+'
+test_expect_success NO_CHAIN_LINT 'stop second background trace' '
+	pid=$(cat trace1a.pid) &&
+	kill -15 $pid &&
+	wait $pid || true
 '
 
 test_expect_success NO_CHAIN_LINT 'start background trace on multiple modules' '


### PR DESCRIPTION
Look, payloads can be displayed now in `flux overlay trace` and `flux module trace`.   Here's an example of the latter when running `flux run hostname`.

Note that non-json payloads are not displayed.  The log message at the end is a good example - we encode those in RFC 5424 format.
```
$ flux module trace --full sched-simple
2024-10-03T17:39:29.131 sched-simple rx > sched.alloc [478]
{
  "id": 1098219782144,
  "priority": 16,
  "userid": 5588,
  "t_submit": 1728002369.1095428,
  "jobspec": {
    "resources": [
      {
        "type": "slot",
        "count": 1,
        "with": [
          {
            "type": "core",
            "count": 1
          }
        ],
        "label": "task"
      }
    ],
    "tasks": [
      {
        "command": [
          "hostname"
        ],
        "slot": "task",
        "count": {
          "per_slot": 1
        }
      }
    ],
    "attributes": {
      "system": {
        "duration": 0,
        "cwd": "/home/garlick/proj/flux-core",
        "shell": {
          "options": {
            "rlimit": {
              "cpu": -1,
              "fsize": -1,
              "data": -1,
              "stack": 8388608,
              "core": 0,
              "nofile": 1048576,
              "as": -1,
              "rss": -1,
              "nproc": 159594
            }
          }
        }
      }
    },
    "version": 1
  }
}
2024-10-03T17:39:29.131 sched-simple tx > log.append [102]
2024-10-03T17:39:29.131 sched-simple tx > kvs.commit [326]
{
  "namespace": "primary",
  "flags": 0,
  "ops": [
    {
      "key": "job.0000.00ff.b300.0000.R",
      "flags": 0,
      "dirent": {
        "ver": 1,
        "type": "val",
        "data": "eyJ2ZXJzaW9uIjoxLCJleGVjdXRpb24iOnsiUl9saXRlIjpbeyJyYW5rIjoiMCIsImNoaWxkcmVuIjp7ImNvcmUiOiIwIn19XSwic3RhcnR0aW1lIjoxNzI4MDAyMzY5LjEzMTg3MTIsImV4cGlyYXRpb24iOjAuMCwibm9kZWxpc3QiOlsicG9wLW9zIl19fQ=="
      }
    }
  ]
}
2024-10-03T17:39:29.132 sched-simple tx > log.append [90]
2024-10-03T17:39:29.132 sched-simple rx < kvs.commit [73]
{
  "rootref": "sha1-feb9a5c263da15114560ec806e8a4415931ca59e",
  "rootseq": 13
}
2024-10-03T17:39:29.132 sched-simple tx < sched.alloc [279]
{
  "id": 1098219782144,
  "type": 0,
  "annotations": {
    "sched": {
      "resource_summary": "rank0/core0",
      "reason_pending": null,
      "jobs_ahead": null
    }
  },
  "R": {
    "version": 1,
    "execution": {
      "R_lite": [
        {
          "rank": "0",
          "children": {
            "core": "0"
          }
        }
      ],
      "starttime": 1728002369.1318712,
      "expiration": 0.0,
      "nodelist": [
        "pop-os"
      ]
    }
  }
}
2024-10-03T17:39:29.153 sched-simple rx > sched.free [184]
{
  "id": 1098219782144,
  "R": {
    "version": 1,
    "execution": {
      "R_lite": [
        {
          "rank": "0",
          "children": {
            "core": "0"
          }
        }
      ],
      "starttime": 1728002369.1318712,
      "expiration": 0.0,
      "nodelist": [
        "pop-os"
      ]
    }
  },
  "final": true
}
2024-10-03T17:39:29.153 sched-simple tx > log.append [96]

