### PR TITLE
libsubprocess: support flow control on writes via credits

### DIFF
--- a/src/common/libsubprocess/client.h
+++ b/src/common/libsubprocess/client.h
@@ -22,6 +22,7 @@ enum {
     SUBPROCESS_REXEC_STDOUT = 1,
     SUBPROCESS_REXEC_STDERR = 2,
     SUBPROCESS_REXEC_CHANNEL = 4,
+    SUBPROCESS_REXEC_WRITE_CREDIT = 8,
 };
 
 flux_future_t *subprocess_rexec (flux_t *h,
@@ -39,6 +40,7 @@ bool subprocess_rexec_is_output (flux_future_t *f,
                                  const char **buf,
                                  int *len,
                                  bool *eof);
+bool subprocess_rexec_is_add_credit (flux_future_t *f, json_t **channels);
 
 int subprocess_write (flux_future_t *f,
                       const char *stream,

--- a/src/common/libsubprocess/ev_fbuf_write.h
+++ b/src/common/libsubprocess/ev_fbuf_write.h
@@ -30,6 +30,7 @@ struct ev_fbuf_write {
     bool              eof;      /* flag, eof written             */
     bool              closed;   /* flag, fd has been closed      */
     int               close_errno;  /* errno from close          */
+    bool              initial_space; /* flag, initial space notified */
     void              *data;
 };
 

--- a/src/common/libsubprocess/fbuf.h
+++ b/src/common/libsubprocess/fbuf.h
@@ -85,8 +85,7 @@ int fbuf_write_from_fd (struct fbuf *fb, int fd, int len);
 typedef void (*fbuf_notify_f) (struct fbuf *fb, void *arg);
 
 /* Set notify callback for internal use by fbuf watchers.
- * The callback is invoked when the buffer transitions from empty
- * or from full.
+ * The callback is invoked when the amount of data in the buffer has changed.
  */
 void fbuf_set_notify (struct fbuf *fb, fbuf_notify_f cb, void *arg);
 

--- a/src/common/libsubprocess/fbuf_watcher.h
+++ b/src/common/libsubprocess/fbuf_watcher.h
@@ -51,6 +51,7 @@ void fbuf_read_watcher_decref (flux_watcher_t *w);
  *
  * - data from buffer written to fd
  * - callback triggered after:
+ *   - buffer space available (FLUX_POLLOUT)
  *   - fbuf_write_watcher_close() was called AND any buffered data has
  *     been written out (FLUX_POLLOUT)
  *   - error (FLUX_POLLERR)

--- a/src/common/libsubprocess/fbuf_watcher.h
+++ b/src/common/libsubprocess/fbuf_watcher.h
@@ -50,7 +50,10 @@ void fbuf_read_watcher_decref (flux_watcher_t *w);
 /* write watcher
  *
  * - data from buffer written to fd
- * - callback triggered after fd closed (FLUX_POLLOUT) or error (FLUX_POLLERR)
+ * - callback triggered after:
+ *   - fbuf_write_watcher_close() was called AND any buffered data has
+ *     been written out (FLUX_POLLOUT)
+ *   - error (FLUX_POLLERR)
  */
 flux_watcher_t *fbuf_write_watcher_create (flux_reactor_t *r,
                                            int fd,

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -699,6 +699,7 @@ int flux_subprocess_write (flux_subprocess_t *p,
             log_err ("fbuf_write");
             return -1;
         }
+        c->buffer_space -= ret;
     }
     else {
         if (p->state != FLUX_SUBPROCESS_INIT

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -84,6 +84,9 @@ typedef void (*flux_subprocess_output_f) (flux_subprocess_t *p,
                                           const char *stream);
 typedef void (*flux_subprocess_state_f) (flux_subprocess_t *p,
                                          flux_subprocess_state_t state);
+typedef void (*flux_subprocess_credit_f) (flux_subprocess_t *p,
+                                          const char *stream,
+                                          int bytes);
 typedef void (*flux_subprocess_hook_f) (flux_subprocess_t *p, void *arg);
 
 /*
@@ -93,6 +96,8 @@ typedef void (*flux_subprocess_hook_f) (flux_subprocess_t *p, void *arg);
  *  flux_subprocess_read_line() and similar functions should be used
  *  to read buffered data.  If this is not done, it can lead to
  *  excessive callbacks and code "spinning".
+ *
+ *  The first call to on_credit will contain the full buffer size.
  *
  */
 typedef struct {
@@ -104,6 +109,7 @@ typedef struct {
     flux_subprocess_output_f on_channel_out; /* Read from channel when ready */
     flux_subprocess_output_f on_stdout; /* Read of stdout is ready           */
     flux_subprocess_output_f on_stderr; /* Read of stderr is ready           */
+    flux_subprocess_credit_f on_credit; /* Write buffer space available      */
 } flux_subprocess_ops_t;
 
 /*

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -36,6 +36,8 @@ struct subprocess_channel {
     int parent_fd;
     int child_fd;
     flux_watcher_t *buffer_write_w;
+    int buffer_space;
+    bool initial_credits_sent;     /* accounting for on_credit callback */
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is
      * stopped.  We need to put something into the reactor so we know

--- a/src/common/libsubprocess/test/fbuf.c
+++ b/src/common/libsubprocess/test/fbuf.c
@@ -195,26 +195,26 @@ void notify_callback (void)
     ok (fbuf_write (fb, "foo", 3) == 3,
         "fbuf_write 3 bytes");
 
-    ok (count == 1,
-        "notify was not called again");
+    ok (count == 2,
+        "notify was called again");
 
     ok (fbuf_write (fb, "1234567", 7) == 7,
         "fbuf_write 7 bytes success");
 
-    ok (count == 1,
-        "notify was not called again on transition to full");
+    ok (count == 3,
+        "notify was called again on transition to full");
 
     ok (fbuf_read (fb, 1, &len) != NULL && len == 1,
         "fbuf_read cleared one byte");
 
-    ok (count == 2,
+    ok (count == 4,
         "notify was called again on transition from full");
 
     ok (fbuf_read (fb, -1, &len) != NULL && len == 15,
         "fbuf_read cleared all data");
 
-    ok (count == 2,
-        "notify was not called on transition to empty");
+    ok (count == 5,
+        "notify was called on transition to empty");
 
     fbuf_destroy (fb);
 }

--- a/t/reactor/reactorcat.c
+++ b/t/reactor/reactorcat.c
@@ -42,6 +42,7 @@ static void write_cb (flux_reactor_t *r, flux_watcher_t *w,
             fprintf (stderr, "error: close: %s\n", strerror (errnum));
         flux_watcher_stop (w);
     }
+    /* else ignore reports of buffer space changes */
 }
 
 static void read_cb (flux_reactor_t *r, flux_watcher_t *w,


### PR DESCRIPTION
Per https://github.com/flux-framework/rfc/pull/427 and discussion in #4572.

Some minor tweaks to the `add-credit` RPC.  I think the design in the RFC assumed multiple channels would return credits at the same time, but I think that is impractical, so it's just credits for each channel.

Haven't tested that this works by adding support in `flux-exec` yet.  Just thought I'd post this initial work.  May split off the cleanup into another PR.