### PR TITLE
flux-jobs(1): document unlimited --count value

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -60,7 +60,7 @@ OPTIONS
 
 .. option:: -c, --count=N
 
-   Limit output to N jobs (default 1000)
+   Limit output to N jobs. N=0 means unlimited. (default 1000)
 
 .. option:: --since=WHEN
 


### PR DESCRIPTION
Problem: flux jobs --count=0 means "unlimited" but that is not documented in the man page.

Add it.

Fixes #6363