### PR TITLE
libflux: support setting prep watcher priority

### DIFF
--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -525,6 +525,12 @@ double flux_watcher_next_wakeup (flux_watcher_t *w)
 
 /* Prepare
  */
+
+static void prepare_set_priority (flux_watcher_t *w, int priority)
+{
+    ev_set_priority ((ev_prepare *)w->data, priority);
+}
+
 static void prepare_start (flux_watcher_t *w)
 {
     ev_prepare_start (w->r->loop, (ev_prepare *)w->data);
@@ -543,6 +549,7 @@ static void prepare_cb (struct ev_loop *loop, ev_prepare *pw, int revents)
 }
 
 static struct flux_watcher_ops prepare_watcher = {
+    .set_priority = prepare_set_priority,
     .start = prepare_start,
     .stop = prepare_stop,
     .destroy = NULL,


### PR DESCRIPTION
Problem: Watcher priorities are only configurable in check watchers, but would be useful in prepare watchers as well.

Add support for prepare watcher priorities.  Add unit tests.

----

split out from #6353.  the "initial credits" from a subprocess should be sent immediately after the subprocess is returned to the caller.  So we want to make the "initial credits" prepare watcher the first thing to be called.