### PR TITLE
sched-simple: improve unsupported resource type exception

### DIFF
--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -127,7 +127,7 @@ jobreq_create (const flux_msg_t *msg)
     else if (job->jj.slot_gpus > 0) {
         snprintf (job->jj.error,
                   sizeof (job->jj.error),
-                  "Unsupported resource type 'gpu'");
+                  "sched-simple does not support resource type 'gpu'");
         errno = EINVAL;
         job->errnum = errno;
     }

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -63,7 +63,8 @@ test_expect_success 'sched-simple: unsatisfiable request is canceled' '
 test_expect_success 'sched-simple: gpu request is canceled' '
 	jobid=$(flux run -n1 -g1 --dry-run hostname | flux job submit) &&
 	flux job wait-event --timeout=5.0 $jobid exception &&
-	flux job eventlog $jobid | grep  "Unsupported resource type .gpu."
+	flux job eventlog $jobid \
+		| grep  "sched-simple does not support resource type .gpu."
 '
 Y2J="flux python ${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py"
 SPEC=${SHARNESS_TEST_SRCDIR}/jobspec/valid/basic.yaml


### PR DESCRIPTION
Problem: The exception raised by sched-simple when it receives a job request including GPUs can be confusing. Especially when users expect that a different scheduler is loaded, or do not know that sched-simple does not support scheduling GPUs.

Improve the exception message to say explicitly

 sched-simple does not support resource type 'gpu'

to make it clear that sched-simple is loaded and does not support GPUs.