### PR TITLE
doc: update link to flux-accounting guide

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -81,7 +81,7 @@ currently:
    * - flux-accounting - Bank accounting and fair share priority
      - `Github <https://github.com/flux-framework/flux-accounting>`_
 
-       `Flux Accounting Guide <https://flux-framework.readthedocs.io/en/latest/guides/accounting-guide.html>`_
+       `Flux Accounting Guide <https://flux-framework.readthedocs.io/projects/flux-accounting/en/latest/guide/accounting-guide.html>`_
 
    * - flux-pmix - OpenMPI support
      - `Github <https://github.com/flux-framework/flux-pmix>`_


### PR DESCRIPTION
#### Problem

The hyper-link to the flux-accounting guide on flux-core's front page no longer works because the guide was moved from flux-docs to flux-accounting, which now has its own ReadTheDocs site.

---

This PR just updates the link to the flux-accounting guide.