### PR TITLE
support `sort:` prefix for format strings and `--sort` option to `flux jobs`

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -101,6 +101,13 @@ OPTIONS
    configuration snippet for an existing named format may be generated with
    :option:`--format=get-config=NAME`.
 
+.. option:: --sort=[-]KEY,..
+
+   Sort jobs based on a list of comma separated keys. If a KEY is preceded
+   by a dash ``-``, then the sort order is reversed. Supported keys match
+   output field names, e.g. ``id``, ``t_run``, etc. This option overrides
+   any ``sort:`` prefix specified in the current format.
+
 .. option:: --json
 
    Emit data for selected jobs in JSON format. The data for multiple
@@ -227,6 +234,12 @@ following is the format used for the default format:
    {id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} \
    {status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} \
    {contextual_time!F:>8h} {contextual_info}
+
+If the format string begins with ``sort:k1[,k2,...]``, then ``k1[,k2,...]``
+will be taken to be a comma-separated list of keys on which to sort
+the displayed output. If a sort key starts with ``-``, then the key
+will be sorted in reverse order. The sort order embedded in the format
+ may be overridden on the command line by the :option:`--sort` option.
 
 If a format field is preceded by the special string ``?:`` this will
 cause the field to be removed entirely from output if the result would

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -301,6 +301,13 @@ def parse_args():
         + " or a defined format by name (use 'help' to get a list of names)",
     )
     parser.add_argument(
+        "--sort",
+        type=str,
+        default="",
+        metavar="KEY,...",
+        help="Specify sort order",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Output jobs in JSON instead of formatted output",
@@ -519,6 +526,9 @@ def main():
         )
         if args.stats_only:
             sys.exit(0 if stats.active else 1)
+
+    if args.sort:
+        formatter.set_sort_keys(args.sort)
 
     jobs = fetch_jobs(args, formatter.fields)
     sformatter = JobInfoFormat(formatter.filter(jobs))

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1575,5 +1575,30 @@ test_expect_success 'flux-jobs --stats works after jobs purged (defaultqueue)' '
 	head -1 statspurgeqdefault.output > statspurgeqdefault.actual &&
 	test_cmp statspurgeqdefault.expected statspurgeqdefault.actual
 '
-
+test_expect_success 'flux-jobs allows sorting order in format' '
+	flux jobs -ano "{ncores}	{t_submit}	{id.f58}" \
+		| sort -k1,2n \
+		| cut -f 3 >sort1.expected &&
+	flux jobs -ano "sort:ncores,t_submit {id.f58}" >sort1.out &&
+	test_cmp sort1.expected sort1.out
+'
+test_expect_success 'flux-jobs allows sorting order via --sort' '
+	flux jobs -ano "{ntasks}	{t_submit}	{id.f58}" \
+		| sort -k1n,2rn \
+		| cut -f 3 >sort2.expected &&
+	flux jobs -an --sort=ntasks,-t_submit -o "{id.f58}" >sort2.out &&
+	test_cmp sort2.expected sort2.out
+'
+test_expect_success 'flux-jobs --sort overrides sort: in format' '
+	flux jobs -ano "{ntasks}	{t_submit}	{id.f58}" \
+		| sort -k1n,2rn \
+		| cut -f 3 >sort3.expected &&
+	flux jobs -an --sort=ntasks,-t_submit -o "sort:t_submit {id.f58}" \
+		>sort3.out &&
+	test_cmp sort3.expected sort3.out
+'
+test_expect_success 'flux-jobs invalid sort key throws exception' '
+	test_must_fail flux jobs -a --sort=foo 2>sort.error &&
+	grep "Invalid sort key: foo" sort.error
+'
 test_done


### PR DESCRIPTION
This PR adds support for adding sort keys directly to format strings in the `flux.util.OutputFormat` class via a `sort:` prefix, e.g. `sort:t_run {id.f58}`. The sort is done in the `OutputFormat.print_items()` method, so all utilities that use that method get this form of sort support automatically.

Then, a `--sort` option is added to `flux jobs` to set the sort keys, overriding any existing  sort stored with the format.

Admittedly, it is a bit strange to do it this way, it isn't immediately obvious that a class ostensibly handling an output format string should support sort keys. However, I started work on another branch where I added sort directly to `flux jobs` and it ended up being more complicated because 1. the sort keys need to be included in the "fields" that `flux jobs` uses to determine which attributes to fetch from `job-list`, and 2. this would require more duplication of code/effort when adding sort capability to other commands.

A couple benefits of doing it this way:

 - the sort order can be defined along with custom formats in config files (Admittedly, this could also be done with a new `sort` key in the config TOML)
 - all utilities that use `OutputFormat.print_items()` automatically get sort support
 
 Fixes #6322 