### PR TITLE
flux-housekeeping: add `-i, --include=TARGETS` option to `flux housekeeping list`

### DIFF
--- a/doc/man1/flux-housekeeping.rst
+++ b/doc/man1/flux-housekeeping.rst
@@ -42,6 +42,12 @@ list
 
 :program:`flux housekeeping list` lists active housekeeping tasks by jobid.
 
+.. option:: -i, --include=TARGETS
+
+  Filter results to only include resources matching *TARGETS*, which may
+  be specified either as an idset of broker ranks or a list of hosts in
+  hostlist form. It is not an error to specify ranks or hosts that do not
+  exist.
 
 .. option:: -o, --format=FORMAT
 

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -2048,6 +2048,7 @@ _flux_housekeeping()
     local subcmds="list kill"
     local split=false
     list_OPTS="\
+        -i --include= \
         -o --format= \
         -n --no-header \
     "

--- a/src/cmd/flux-housekeeping.py
+++ b/src/cmd/flux-housekeeping.py
@@ -78,8 +78,18 @@ class HousekeepingSet:
 
     def __init__(self, ranks, hostlist):
         self.ranks = IDset(ranks)
-        self.nnodes = len(self.ranks)
-        self.nodelist = hostlist[self.ranks]
+        self.hostlist = hostlist
+
+    @property
+    def nnodes(self):
+        return self.ranks.count()
+
+    @property
+    def nodelist(self):
+        return self.hostlist[self.ranks]
+
+    def update(self, other):
+        self.ranks += other.ranks
 
 
 class HousekeepingJob:

--- a/t/t2226-housekeeping.t
+++ b/t/t2226-housekeeping.t
@@ -310,6 +310,18 @@ test_expect_success 'flux housekeeping list shows 4 jobs' '
 	test_debug "flux housekeeping list" &&
 	test $(flux housekeeping list -n | wc -l) -eq 4
 '
+test_expect_success 'flux housekeeping list -i, --include works' '
+	flux housekeeping list -i 0  &&
+	test "$(flux housekeeping list -i 0 -no {ranks})" = 0 &&
+	flux housekeeping list -i 0,3 &&
+	test "$(flux housekeeping list -i 0,3 -no {ranks})" = "0,3"
+'
+test_expect_success 'flux housekeeping list -i, --include works with hostname'  '
+	flux housekeeping list -i $(hostname)
+'
+test_expect_success 'flux housekeeping list -i, --include fails with bad hostlist' '
+	test_must_fail flux housekeeping list -i "foo["
+'
 test_expect_success 'send SIGTERM to the nodes by rank' '
 	kill_ranks 0-3 15
 '


### PR DESCRIPTION
This PR adds a `-i, --include=TARGETS` option to `flux housekeeping list` as requested in #6375.