### PR TITLE
python: usability improvements for `JournalConsumer` class

### DIFF
--- a/src/bindings/python/flux/job/journal.py
+++ b/src/bindings/python/flux/job/journal.py
@@ -180,11 +180,17 @@ class JournalConsumer:
         historical events have been processed. Historical events will sorted
         in time order and returned once per :func:`poll` call.
 
+        :func:`start` must be called before this function.
+
         Args:
             timeout (float): Only wait *timeout* seconds for the next event.
                 If the timeout expires then a :exc:`TimeoutError` is raised.
                 A *timeout* of -1.0 disables any timeout.
+        Raises:
+            RuntimeError:  :func:`poll` was called before :func:`start`.
         """
+        if self.rpc is None:
+            raise RuntimeError("poll() called before start()")
 
         if self.processing_inactive:
             # process backlog. Time order events once done:

--- a/src/bindings/python/flux/job/journal.py
+++ b/src/bindings/python/flux/job/journal.py
@@ -161,6 +161,12 @@ class JournalConsumer:
 
         This function sends the job-manager.events-journal RPC to the
         job manager. It must be called to start the stream of events.
+
+        .. note::
+            If :func:`start` is called more than once the stream of events
+            will be restarted using the original options passed to the
+            constructor. This may cause duplicate events, or missed events
+            if *full* is False since no history will be included.
         """
         self.rpc = self.handle.rpc(
             "job-manager.events-journal", {"full": self.full}, 0, FLUX_RPC_STREAMING


### PR DESCRIPTION
@wihobbs had pointed out some usability issues with the `JournalConsumer` class yesterday after the PR was merged. This PR tackles those issues.

 - Document that `poll()` must be called after `start()`.
 - handle the above case better by raising a specific `RuntimeException` when the `JournalConsumer` isn't started before `poll()` is called
 - allow `set_callback()` to be called before `start()` - there's no reason not to allow it.
 - add tests accordingly. 