### PR TITLE
broker: detect mismatched bootstrap.hosts configuration

### DIFF
--- a/src/broker/boot_config.h
+++ b/src/broker/boot_config.h
@@ -20,7 +20,10 @@
  *   tbon.endpoint (w)
  *   instance-level (w)
  */
-int boot_config (flux_t *h, struct overlay *overlay, attr_t *attrs);
+int boot_config (flux_t *h,
+                 const char *hostname,
+                 struct overlay *overlay,
+                 attr_t *attrs);
 
 /* The following is exported for unit testing.
  */
@@ -51,7 +54,7 @@ int boot_config_getrankbyname (json_t *hosts,
 int boot_config_parse (const flux_conf_t *cf,
                        struct boot_conf *conf,
                        json_t **hosts);
-int boot_config_attr (attr_t *attrs, json_t *hosts);
+int boot_config_attr (attr_t *attrs, const char *hostname, json_t *hosts);
 int boot_config_format_uri (char *buf,
                             int bufsz,
                             const char *fmt,

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -239,14 +239,13 @@ static void trace_upmi (void *arg, const char *text)
     fprintf (stderr, "boot_pmi: %s\n", text);
 }
 
-int boot_pmi (struct overlay *overlay, attr_t *attrs)
+int boot_pmi (const char *hostname, struct overlay *overlay, attr_t *attrs)
 {
     const char *topo_uri;
     flux_error_t error;
     json_error_t jerror;
     char key[64];
     char *val;
-    char hostname[MAXHOSTNAMELEN + 1];
     char *bizcard = NULL;
     struct hostlist *hl = NULL;
     json_t *o;
@@ -308,10 +307,6 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs)
     if (topology_set_rank (topo, info.rank) < 0
         || overlay_set_topology (overlay, topo) < 0)
         goto error;
-    if (gethostname (hostname, sizeof (hostname)) < 0) {
-        log_err ("gethostname");
-        goto error;
-    }
     if (!(hl = hostlist_create ())) {
         log_err ("hostlist_create");
         goto error;

--- a/src/broker/boot_pmi.h
+++ b/src/broker/boot_pmi.h
@@ -16,7 +16,7 @@
 #include "attr.h"
 #include "overlay.h"
 
-int boot_pmi (struct overlay *overlay, attr_t *attrs);
+int boot_pmi (const char *hostname, struct overlay *overlay, attr_t *attrs);
 
 #endif /* BROKER_BOOT_PMI_H */
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -330,6 +330,7 @@ int main (int argc, char *argv[])
     }
 
     if (!(ctx.overlay = overlay_create (ctx.h,
+                                        ctx.hostname,
                                         ctx.attrs,
                                         NULL,
                                         overlay_recv_cb,

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -234,6 +234,12 @@ int main (int argc, char *argv[])
 
     init_attrs (ctx.attrs, getpid (), &ctx.cred);
 
+    const char *hostname = getenv ("FLUX_FAKE_HOSTNAME");
+    if (hostname)
+        strlcpy (ctx.hostname, hostname, sizeof (ctx.hostname));
+    else if (gethostname (ctx.hostname, sizeof (ctx.hostname)) < 0)
+        log_err_exit ("gethostname");
+
     parse_command_line_arguments (argc, argv, &ctx);
 
     /* Block all signals but those that we want to generate core dumps.
@@ -364,13 +370,13 @@ int main (int argc, char *argv[])
             method = NULL;
     }
     if (!method || !streq (method, "config")) {
-        if (boot_pmi (ctx.overlay, ctx.attrs) < 0) {
+        if (boot_pmi (ctx.hostname, ctx.overlay, ctx.attrs) < 0) {
             log_msg ("bootstrap failed");
             goto cleanup;
         }
     }
     else {
-        if (boot_config (ctx.h, ctx.overlay, ctx.attrs) < 0) {
+        if (boot_config (ctx.h, ctx.hostname, ctx.overlay, ctx.attrs) < 0) {
             log_msg ("bootstrap failed");
             goto cleanup;
         }
@@ -1035,20 +1041,16 @@ out:
 }
 
 static flux_future_t *set_uri_job_memo (flux_t *h,
+                                        const char *hostname,
                                         flux_jobid_t id,
                                         attr_t *attrs)
 {
     const char *local_uri = NULL;
     const char *path;
     char uri [1024];
-    char hostname [MAXHOSTNAMELEN + 1];
 
     if (attr_get (attrs, "local-uri", &local_uri, NULL) < 0) {
         log_err ("Unexpectedly unable to fetch local-uri attribute");
-        return NULL;
-    }
-    if (gethostname (hostname, sizeof (hostname)) < 0) {
-        log_err ("gethostname failure");
         return NULL;
     }
     path = local_uri + 8; /* forward past "local://" */
@@ -1165,7 +1167,7 @@ static int execute_parental_notifications (struct broker *ctx)
     }
 
     /*  Perform any RPCs to parent in parallel */
-    if (!(f = set_uri_job_memo (h, id, ctx->attrs)))
+    if (!(f = set_uri_job_memo (h, ctx->hostname, id, ctx->attrs)))
         goto out;
 
     /*  Note: not an error if rpc to set critical ranks fails, but

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -11,6 +11,7 @@
 #ifndef _BROKER_H
 #define _BROKER_H
 
+#include <sys/param.h>
 #include <flux/optparse.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -22,6 +23,7 @@ struct broker {
     flux_watcher_t *w_internal;
     flux_reactor_t *reactor;
     optparse_t *opts;
+    char hostname[MAXHOSTNAMELEN + 1];
 
     struct overlay *overlay;
     uint32_t rank;

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -43,6 +43,7 @@ typedef int (*overlay_recv_f)(flux_msg_t **msg,
  * Note: If zctx is NULL, it is created/destroyed on demand internally.
  */
 struct overlay *overlay_create (flux_t *h,
+                                const char *hostname,
                                 attr_t *attrs,
                                 void *zctx,
                                 overlay_recv_f cb,

--- a/src/broker/test/boot_config.c
+++ b/src/broker/test/boot_config.c
@@ -481,7 +481,7 @@ void test_attr (const char *dir)
     if (attrs == NULL)
         BAIL_OUT ("cannot continue without attrs");
 
-    rc = boot_config_attr (attrs, NULL);
+    rc = boot_config_attr (attrs, "localhost", NULL);
     ok (rc == 0,
         "boot_config_attr works NULL hosts");
     ok (attr_get (attrs, "hostlist", NULL, NULL) == 0,
@@ -494,7 +494,7 @@ void test_attr (const char *dir)
     hosts = json_array ();
     if (hosts == NULL)
         BAIL_OUT ("cannot continue without empty hosts array");
-    rc = boot_config_attr (attrs, hosts);
+    rc = boot_config_attr (attrs, "localhost", hosts);
     ok (rc == 0,
         "boot_config_attr works empty hosts");
     ok (attr_get (attrs, "hostlist", NULL, NULL) == 0,
@@ -512,7 +512,7 @@ void test_attr (const char *dir)
     attrs = attr_create ();
     if (!attrs)
         BAIL_OUT ("attr_create failed");
-    rc = boot_config_attr (attrs, hosts);
+    rc = boot_config_attr (attrs, "foo0", hosts);
     ok (rc == 0,
         "boot_config_attr works on input hosts");
     ok (attr_get (attrs, "hostlist", &val, &flags) == 0

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -382,7 +382,8 @@ void trio (flux_t *h)
     ok (rmsg != NULL,
         "%s: response was received by overlay", ctx[0]->name);
     ok (!flux_msg_is_local (rmsg),
-        "%s: flux_msg_is_local returns false for response from child");
+        "%s: flux_msg_is_local returns false for response from child",
+        ctx[0]->name);
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && streq (topic, "m000"),
         "%s: received message has expected topic", ctx[0]->name);
     ok (flux_msg_route_count (rmsg) == 0,
@@ -402,7 +403,8 @@ void trio (flux_t *h)
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && streq (topic, "eeek"),
         "%s: received message has expected topic", ctx[0]->name);
     ok (!flux_msg_is_local (rmsg),
-        "%s: flux_msg_is_local returns false for event from child");
+        "%s: flux_msg_is_local returns false for event from child",
+        ctx[0]->name);
 
     /* Response 0->1
      */

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -109,7 +109,7 @@ struct context *ctx_create (flux_t *h,
     ctx->size = size;
     ctx->rank = rank;
     snprintf (ctx->name, sizeof (ctx->name), "test%d", rank);
-    if (!(ctx->ov = overlay_create (h, ctx->attrs, zctx, cb, ctx)))
+    if (!(ctx->ov = overlay_create (h, ctx->name, ctx->attrs, zctx, cb, ctx)))
         BAIL_OUT ("overlay_create");
     if (!(ctx->uuid = overlay_get_uuid (ctx->ov)))
         BAIL_OUT ("overlay_get_uuid failed");
@@ -654,18 +654,18 @@ void wrongness (flux_t *h)
     if (!(attrs = attr_create ()))
         BAIL_OUT ("attr_create failed");
     errno = 0;
-    ok (overlay_create (NULL, attrs, zctx, NULL, NULL) == NULL
+    ok (overlay_create (NULL, "test0", attrs, zctx, NULL, NULL) == NULL
         && errno == EINVAL,
         "overlay_create h=NULL fails with EINVAL");
     errno = 0;
-    ok (overlay_create (h, NULL, zctx, NULL, NULL) == NULL
+    ok (overlay_create (h, "test0", NULL, zctx, NULL, NULL) == NULL
         && errno == EINVAL,
         "overlay_create attrs=NULL fails with EINVAL");
     attr_destroy (attrs);
 
     if (!(attrs = attr_create ()))
         BAIL_OUT ("attr_create failed");
-    if (!(ov = overlay_create (h, attrs, zctx, NULL, NULL)))
+    if (!(ov = overlay_create (h, "test0", attrs, zctx, NULL, NULL)))
         BAIL_OUT ("overlay_create failed");
 
     errno = 0;

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -240,7 +240,7 @@ int main (int argc, char *argv[])
             if (opts[i].name
                 && strstarts (opts[i].name, "test-")
                 && optparse_hasopt (ctx.opts, opts[i].name))
-                log_msg_exit ("%s only works with --test-size", opts[0].name);
+                log_msg_exit ("--%s only works with --test-size", opts[i].name);
         }
     }
 

--- a/src/common/libhostlist/hostlist.c
+++ b/src/common/libhostlist/hostlist.c
@@ -466,7 +466,13 @@ static int append_range_list_with_suffix (struct hostlist *hl,
         for (j = rng->lo; j <= rng->hi; j++) {
             char host[size];
             struct hostrange * hr;
-            sprintf (host, "%s%0*lu%s", pfx, rng->width, j, sfx);
+            snprintf (host,
+                      sizeof (host),
+                      "%s%0*lu%s",
+                      pfx,
+                      rng->width,
+                      j,
+                      sfx);
             if (!(hr = hostrange_create_single (host)))
                 return -1;
             hostlist_append_range (hl, hr);

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -5,7 +5,7 @@ test_description='Test resource drain/undrain'
 . `dirname $0`/sharness.sh
 
 SIZE=4
-test_under_flux $SIZE full -o,-Shostlist=fake[0-3]
+test_under_flux $SIZE full --test-hosts=fake[0-3]
 
 
 # Usage: waitup N


### PR DESCRIPTION
Problem: as noted in #6389, a mismatched `bootstrap.hosts` config can result in two hosts ping-ponging back and forth, connecting and causing the the other to be disconnected with a misleading message.

This adds the hostname to the `overlay.hello` RPC.  The rank was already there.  If the `hostlist` broker attribute does not confirm the rank to host mapping, deny the connection.

Marking as a WIP for now  pending inspiration on how to adapt the issue test for  #4182 (resource module re-ranking).

