### PR TITLE
docker: add missing tag of flux-core el8 image

### DIFF
--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -308,6 +308,17 @@ matrix.add_build(
     args="--enable-broken-locale-mode",
 )
 
+# el8 - test install
+matrix.add_build(
+    name="el8 - test-install",
+    image="el8",
+    env=dict(
+        TEST_INSTALL="t",
+    ),
+    args="--with-flux-security",
+    docker_tag=True,
+)
+
 # RHEL8 clone, system, coverage
 matrix.add_build(
     name="el8 - system,coverage",


### PR DESCRIPTION
Problem: Recent updates to the flux-core ci workflow dropped the deployment of the  fluxrm/flux-core:el8 image, but several projects depend on this image representing the current version of flux-core.

Add a new el8 test-install builder to CI and tag the image for docker deployment.