### PR TITLE
sdexec: set KillMode=process SendSIGKILL=no for multi-user jobs

### DIFF
--- a/src/common/libsdexec/start.c
+++ b/src/common/libsdexec/start.c
@@ -155,6 +155,26 @@ static int prop_add_bool (json_t *prop, const char *name, int val)
     return 0;
 }
 
+// per systemd.syntax(7), boolean values are: 1|yes|true|on, 0|no|false|off
+static bool is_true (const char *s)
+{
+    if (streq (s, "1")
+        || !strcasecmp (s, "yes")
+        || !strcasecmp (s, "true")
+        || !strcasecmp (s, "on"))
+        return true;
+    return false;
+}
+static bool is_false (const char *s)
+{
+    if (streq (s, "0")
+        || !strcasecmp (s, "no")
+        || !strcasecmp (s, "false")
+        || !strcasecmp (s, "off"))
+        return true;
+    return false;
+}
+
 static int prop_add_u32 (json_t *prop, const char *name, uint32_t val)
 {
     json_int_t i = val;
@@ -253,6 +273,17 @@ static int prop_add (json_t *prop, const char *name, const char *val)
             return -1;
         }
         free (bitmap);
+    }
+    else if (streq (name, "SendSIGKILL")) {
+        bool value;
+        if (is_false (val))
+            value = false;
+        else if (is_true (val))
+            value = true;
+        else
+            return -1;
+        if (prop_add_bool (prop, name, value) < 0)
+            return -1;
     }
     else {
         if (prop_add_string (prop, name, val) < 0)

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -824,8 +824,6 @@ static void kill_continuation (flux_future_t *f, void *arg)
  * only the pids of units started with sdexec.exec since the sdexec module
  * was loaded.  Since this sends an sdbus RPC, the response is handled in
  * kill_continuation() when the sdbus response is received.
- * N.B. in a typical system instance, job-exec would remotely execute
- * flux-imp kill and this would not be used.
  */
 static void kill_cb (flux_t *h,
                      flux_msg_handler_t *mh,

--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -164,6 +164,33 @@ test_expect_success 'sdexec can set unit Description property' '
 	        t2409-desc.service >desc.out &&
 	test_cmp desc.exp desc.out
 '
+test_expect_success 'sdexec can set unit SendSIGKILL property to no' '
+	cat >sigkill.exp <<-EOT &&
+	SendSIGKILL=no
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-sigkill.service" \
+	    --setopt=SDEXEC_PROP_SendSIGKILL=no \
+	    $systemctl --user show --property SendSIGKILL \
+	        t2409-sigkill.service >sigkill.out &&
+	test_cmp sigkill.exp sigkill.out
+'
+test_expect_success 'setting SendSIGKILL to an invalid value fails' '
+	test_must_fail $sdexec -r 0 --setopt=SDEXEC_PROP_SendSIGKILL=zzz \
+	    $true 2>sigkill_badval.err &&
+	grep "error setting property" sigkill_badval.err
+'
+test_expect_success 'sdexec can set unit KillMode property to process' '
+	cat >killmode.exp <<-EOT &&
+	KillMode=process
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-killmode.service" \
+	    --setopt=SDEXEC_PROP_KillMode=process \
+	    $systemctl --user show --property KillMode \
+	        t2409-killmode.service >killmode.out &&
+	test_cmp killmode.exp killmode.out
+'
 # Check that we can set resource control attributes on our transient units,
 # but expect resource control testing to occur elsewhere.
 # See also:


### PR DESCRIPTION
Problem: For multi-user jobs spawned via SDEXEC, the systemd user instance running as the flux user does not have permission to kill guest processes, yet it does try and in the process may kill off the only process that does have permission to continue cleanup efforts, the IMP.
    
When the job is run by the IMP and sdexec, Set `KillMode=process` so that systemd only delivers signals to the IMP, which it should forward to the shell and/or cgroup per RFC 15.
    
Also set `SendSIGKILL=off` so that SIGKILL is never deployed against the IMP.
    
Fixes #6399

This _should_ be OK even without the forthcoming changes to job-exec and the IMP to forward signals and avoid using SIGKILL, however I still need to give this a sanity check on my test cluster as the conditional use of these properties for IMP jobs is not tested by CI.  I think we can still get a review going however so I'll not set WIP.