### PR TITLE
    broker/test: avoid race in zeromq cleanup

### DIFF
--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -725,6 +725,15 @@ int main (int argc, char *argv[])
     trio (h);
     clear_list (logs);
 
+    /* trio() and check_monitor() tests will bind to the same address
+     * in their tests.  Test can be racy and fail with EADDRINUSE if
+     * prior tests did not complete cleanup.  To ensure there are no
+     * issues, destroy & recreate zctx.  See issue 6404.
+     */
+    zmq_ctx_term (zctx);
+    if (!(zctx = zmq_ctx_new ()))
+        BAIL_OUT ("failed to recreate zmq context");
+
     check_monitor (h);
     clear_list (logs);
 


### PR DESCRIPTION
Problem: There is a small chance of receiving EADDRINUSE from an overlay_bind() call if a prior test has not fully cleaned itself up.

Retry overlay_bind() if EADDRINUSE is hit.

Fixes #6404