### PR TITLE
update multi-user signaling to track flux-security 0.13.0 IMP changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -399,7 +399,7 @@ AS_IF([test x$enable_code_coverage = xyes], [
 AC_ARG_WITH([flux-security], AS_HELP_STRING([--with-flux-security],
              [Build with flux-security]))
 AS_IF([test "x$with_flux_security" = "xyes"], [
-    PKG_CHECK_MODULES([FLUX_SECURITY], [flux-security >= 0.9.0],
+    PKG_CHECK_MODULES([FLUX_SECURITY], [flux-security >= 0.13.0],
                       [flux_sec_incdir=`$PKG_CONFIG --variable=includedir flux-security`],
                       [flux_sec_incdir=;])
     AS_IF([test "x$flux_sec_incdir" = x],

--- a/doc/man1/flux-exec.rst
+++ b/doc/man1/flux-exec.rst
@@ -95,11 +95,7 @@ OPTIONS
 
    Prepend the full path to :program:`flux-imp run` to *COMMAND*. This option
    is mostly meant for testing or as a convenience to execute a configured
-   ``prolog`` or ``epilog`` command under the IMP. Note: When this option is
-   used, or if :program:`flux-imp` is detected as the first argument of
-   *COMMAND*, :program:`flux exec` will use :program:`flux-imp kill` to
-   signal remote commands instead of the normal builtin subprocess signaling
-   mechanism.
+   ``prolog`` or ``epilog`` command under the IMP.
 
 CAVEATS
 =======

--- a/src/common/libsubprocess/bulk-exec.h
+++ b/src/common/libsubprocess/bulk-exec.h
@@ -60,11 +60,6 @@ int bulk_exec_aux_set (struct bulk_exec *exec,
  */
 int bulk_exec_set_max_per_loop (struct bulk_exec *exec, int max);
 
-/*  Set path to an IMP to use for bulk_exec_kill().
- */
-int bulk_exec_set_imp_path (struct bulk_exec *exec,
-                            const char *imp_path);
-
 void bulk_exec_destroy (struct bulk_exec *exec);
 
 int bulk_exec_push_cmd (struct bulk_exec *exec,

--- a/src/common/libsubprocess/test/bulk-exec-einval.c
+++ b/src/common/libsubprocess/test/bulk-exec-einval.c
@@ -27,16 +27,12 @@ int main (int argc, char *argv[])
         "bulk_exec_aux_set (NULL, ..) returns EINVAL");
     ok (bulk_exec_set_max_per_loop (NULL, 1) < 0 && errno == EINVAL,
         "bulk_exec_set_max_per_loop (NULL, 1) returns EINVAL");
-    ok (bulk_exec_set_imp_path (NULL, NULL) < 0 && errno == EINVAL,
-        "bulk_exec_set_imp_path (NULL, NULL) returns EINVAL");
     ok (bulk_exec_push_cmd (NULL, NULL, NULL, 0) < 0 && errno == EINVAL,
         "bulk_exec_push_cmd (NULL, ...) returns EINVAL");
     ok (bulk_exec_start (NULL, NULL) < 0 && errno == EINVAL,
         "bulk_exec_start (NULL, NULL) returns EINVAL");
     ok (bulk_exec_kill (NULL, NULL, 0) == NULL && errno == EINVAL,
         "bulk_exec_kill (NULL, NULL, 0) returns EINVAL");
-    ok (bulk_exec_imp_kill (NULL, NULL, NULL, 0) == NULL && errno == EINVAL,
-        "bulk_exec_imp_kill (NULL, NULL, NULL, 0) returns EINVAL");
     ok (bulk_exec_cancel (NULL) < 0 && errno == EINVAL,
         "bulk_exec_cancel (NULL) returns EINVAL");
     ok (bulk_exec_rc (NULL) < 0 && errno == EINVAL,

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -560,10 +560,6 @@ static int exec_init (struct jobinfo *job)
         flux_log_error (job->h, "exec_init: bulk_exec_create");
         goto err;
     }
-    if (job->multiuser && bulk_exec_set_imp_path (exec, imp_path)) {
-        flux_log_error (job->h, "exec_ctx_create: bulk_exec_set_imp_path");
-        goto err;
-    }
     if (!(ctx = exec_ctx_create (job, ranks, &error))) {
         flux_log (job->h, LOG_ERR, "exec_ctx_create: %s", error.text);
         goto err;

--- a/src/modules/job-manager/housekeeping.c
+++ b/src/modules/job-manager/housekeeping.c
@@ -190,8 +190,6 @@ static struct allocation *allocation_create (struct housekeeping *hk,
                                               id,
                                               "housekeeping",
                                                a))
-        || (hk->imp_path
-            && bulk_exec_set_imp_path (a->bulk_exec, hk->imp_path) < 0)
         || update_cmd_env (hk->cmd, id, userid) < 0
         || bulk_exec_push_cmd (a->bulk_exec, a->pending, hk->cmd, 0) < 0) {
         allocation_destroy (a);

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -827,15 +827,6 @@ static struct perilog_proc *procdesc_run (flux_t *h,
                         idf58 (id));
         goto error;
     }
-    /*  If using IMP, push path to IMP into bulk_exec for IMP kill support:
-     */
-    if (pd->uses_imp
-        && bulk_exec_set_imp_path (bulk_exec, perilog_config.imp_path) < 0) {
-        flux_log_error (h,
-                        "%s: failed to set IMP path",
-                        perilog_proc_name (proc));
-        goto error;
-    }
     if (bulk_exec_start (h, bulk_exec) < 0) {
         flux_log_error (h, "%s: bulk_exec_start", perilog_proc_name (proc));
         goto error;

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -16,7 +16,7 @@ JOBS=2
 MOUNT_HOME_ARGS="--volume=$HOME:$HOME -e HOME"
 
 if test "$PROJECT" = "flux-core"; then
-  FLUX_SECURITY_VERSION=0.11.0
+  FLUX_SECURITY_VERSION=0.13.0
   POISON=t
 fi
 

--- a/t/job-exec/imp-fail.sh
+++ b/t/job-exec/imp-fail.sh
@@ -14,16 +14,6 @@ case "$cmd" in
         printf "test-imp: Going to fail on rank 1\n" >&2
         if test $(flux getattr rank) = 1; then exit 0; fi
         exec "$@" ;;
-    kill)
-        #  Note: kill must be implemented in test since job-exec
-        #  module will run `flux-imp kill PID`.
-        #
-        signal=$2;
-        pid=$3;
-        printf "test-imp: kill -$signal $pid\n" >&2
-        shift 3;
-        printf "test-imp: Kill pid $pid signal $signal\n" >&2
-        kill -$signal $pid ;;
     *)
         printf "test-imp: Fatal: Unknown cmd=$cmd\n" >&2; exit 1 ;;
 esac

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -81,7 +81,7 @@ test_expect_success 'job-exec: reconfig and reload module' '
 	flux config reload &&
 	flux module reload -f job-exec
 '
-test_expect_success NO_ASAN 'job-exec: kill multiuser job uses the IMP' '
+test_expect_success NO_ASAN 'job-exec: kill multiuser job works' '
 	FAKE_USERID=42 &&
 	flux run --dry-run -n2 -N2 sleep 1000 | \
 		flux python ${SIGN_AS} ${FAKE_USERID} > sleep-job.signed &&
@@ -91,8 +91,7 @@ test_expect_success NO_ASAN 'job-exec: kill multiuser job uses the IMP' '
 	jq -e ".userid == 42" < ${id}.json &&
 	flux job wait-event -p exec -vt 30 ${id} shell.start &&
 	flux cancel ${id} &&
-	test_expect_code 143 run_timeout 30 flux job status -v ${id} &&
-	flux dmesg | grep "test-imp: Kill .*signal 15"
+	test_expect_code 143 run_timeout 30 flux job status -v ${id}
 '
 
 #  Configure failing IMP


### PR DESCRIPTION
Problem: job-exec uses `flux imp kill` to deliver SIGKILL to the flux-shell when shell signaling methods fail to clean up a multi-user job, but the `flux imp kill` sub-command is being deprecated in favor of having the IMP forward signals (per RFC 15).

This changes job-exec to send SIGUSR1 (which RFC 15 defines as a proxy for SIGKILL) directly to the IMP in that case.

To make it easier to coordinate the flux-core and flux-security changes, we'll add the #6409 fix here as well.

