### PR TITLE
WIP job-manager: use subprocess kill not flux imp kill

### DIFF
--- a/src/modules/job-manager/housekeeping.c
+++ b/src/modules/job-manager/housekeeping.c
@@ -190,8 +190,6 @@ static struct allocation *allocation_create (struct housekeeping *hk,
                                               id,
                                               "housekeeping",
                                                a))
-        || (hk->imp_path
-            && bulk_exec_set_imp_path (a->bulk_exec, hk->imp_path) < 0)
         || update_cmd_env (hk->cmd, id, userid) < 0
         || bulk_exec_push_cmd (a->bulk_exec, a->pending, hk->cmd, 0) < 0) {
         allocation_destroy (a);

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -819,15 +819,6 @@ static struct perilog_proc *procdesc_run (flux_t *h,
                         idf58 (id));
         goto error;
     }
-    /*  If using IMP, push path to IMP into bulk_exec for IMP kill support:
-     */
-    if (pd->uses_imp
-        && bulk_exec_set_imp_path (bulk_exec, perilog_config.imp_path) < 0) {
-        flux_log_error (h,
-                        "%s: failed to set IMP path",
-                        perilog_proc_name (proc));
-        goto error;
-    }
     if (bulk_exec_start (h, bulk_exec) < 0) {
         flux_log_error (h, "%s: bulk_exec_start", perilog_proc_name (proc));
         goto error;


### PR DESCRIPTION
Problem: housekeeping and perilog use 'flux imp kill' to implement send signals to housekeeping and prolog/epilog processes, but the 'flux imp kill' subcommand is being deprecated in favor of having the IMP forwarding signals.

Don't configure bulk-exec with the imp path so that bulk_exec_kill() will use flux_subprocess_kill().

Fixes #6409

(don't merge before we have a flux-security release with flux-framework/flux-security#188 in it)