### PR TITLE
docs: rfc flux-config-bootstrap diagram

### DIFF
--- a/doc/man5/flux-config-bootstrap.rst
+++ b/doc/man5/flux-config-bootstrap.rst
@@ -215,6 +215,22 @@ create a tree topology with three levels.
    parent = "test128"
 
 
+Note that the first block of hosts defines the entire tree, with nodes test0 through test255. The second block has a comma instead of a dash, indicating a group of two members (1 and 128) and not a range. The resulting tree looks like this. The numbers on the left indicate the level of the tree.
+
+::
+
+        ┌───────┐                          
+    1)  │ test0 │                          
+        └───┬───┴──────────┐               
+            │              │               
+        ┌───┴───┐     ┌────┴────┐          
+    2)  │ test1 │     │ test128 │          
+        └───┬───┘     └────┬────┘          
+            │              │               
+        ┌───┴─────────┐   ┌┴──────────────┐
+    3)  │ test[2-127] │   │ test[129-255] │
+        └─────────────┘   └───────────────┘
+    
 RESOURCES
 =========
 


### PR DESCRIPTION
I've been trying to make different topology designs this weekend, and this was the only example I could find of a slightly interesting tree in the flux config. I spent a ton of time confused not because the tree was complex, but because I mistook a comma for a dash (meaning I was reading `test[1-128]` instead of `test[1,128]`, and didn't see it until I sat down with pen and paper to draw it out. To save others the time of also making this mistake, I'm adding a diagram to the docs here that explicitly shows the tree and describes some of the components in text.

Problem: It is really easy to miss the subtle comma (instead of a dash) for one of the bootstrap directives, resulting in a lot of confusion trying to figure out how the tree makes sense.
Solution: Provide a visual diagram of the tree and some additional explanation to make it explicitly clear.

![image](https://github.com/user-attachments/assets/8854e9bb-76a7-4777-8249-3fd4d9f663b5)
