### PR TITLE
resolve perilog plugin issue that lets a job start after prolog timeout when cancellation fails

### DIFF
--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -1026,10 +1026,11 @@ static void proc_kill_timeout_cb (flux_reactor_t *r,
 {
     struct perilog_proc *proc = arg;
     flux_t *h = flux_jobtap_get_flux (proc->p);
-    flux_log_error (h,
-                    "%s: timed out waiting for SIGTERM to terminate %s",
-                    idf58 (proc->id),
-                    perilog_proc_name (proc));
+    flux_log (h,
+              LOG_ERR,
+              "%s: timed out waiting for SIGTERM to terminate %s",
+              idf58 (proc->id),
+              perilog_proc_name (proc));
     /*  Drain active ranks and post finish event
      */
     proc->cancel_timeout = true;


### PR DESCRIPTION
This PR fixes an issue discovered while testing recent flux-security changes.

If the prolog times out and the resulting cancel (SIGTERM) then times out, affected ranks are drained, but no job exception is raised so the job continues to start. Not only does this result in a job starting when it isn't supposed to, but additionally the epilog may be run _twice_: once when the prolog fails and again when the `finish` event is posted.

This PR fixes the issue by adding a new flag cancel_timeout to the `perilog_proc` struct which then results in a specific exception being raised. The exception then prevents the job from starting and of course the extra `finish` event, etc.

A test that reproduced the issue is also added.