### PR TITLE
job-manager/history: optimize list insertion

### DIFF
--- a/src/modules/job-manager/plugins/history.c
+++ b/src/modules/job-manager/plugins/history.c
@@ -165,13 +165,13 @@ static int jobtap_cb (flux_plugin_t *p,
             job_entry_destroy (entry);
             return 0;
         }
-        if (!hola_list_insert (hist->users, key, entry, false)) {
+        if (!hola_list_insert (hist->users, key, entry, true)) {
             job_entry_destroy (entry);
             return -1;
         }
     }
     else if (streq (topic, "job.new")) {
-        if (!hola_list_insert (hist->users, key, entry, false)) {
+        if (!hola_list_insert (hist->users, key, entry, true)) {
             job_entry_destroy (entry);
             return -1;
         }


### PR DESCRIPTION
Problem: Internal job history lists are sorted with larger t_submit values at the front of the list.  When new jobs are inserted (i.e. jobs with bigger t_submit values), they are inserted with a search starting at the back of the list. This is the opposite of what should be done and leads to a slowdown in job throughput over time.

Insert into the job history list starting at the front.

Fixes #6419