### PR TITLE
convert ISO timestamp output from UTC to local time + offset in `flux dmesg` and eventlog commands

### DIFF
--- a/doc/man1/flux-dmesg.rst
+++ b/doc/man1/flux-dmesg.rst
@@ -15,7 +15,7 @@ DESCRIPTION
 .. program:: flux dmesg
 
 Each broker rank maintains a circular buffer of log entries
-which can be printed using :program`flux dmesg`.
+which can be printed using :program:`flux dmesg`.
 
 
 OPTIONS

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -108,7 +108,7 @@ static const char *months[] = {
     NULL
 };
 
-void print_iso_timestamp (struct dmesg_ctx *ctx, struct stdlog_header hdr)
+void print_iso_timestamp (struct dmesg_ctx *ctx, struct stdlog_header *hdr)
 {
     struct tm tm;
     struct timeval tv;
@@ -121,13 +121,13 @@ void print_iso_timestamp (struct dmesg_ctx *ctx, struct stdlog_header hdr)
      * - getting current timezone offset fails
      * - timestamp_tzoffset() returns "Z" (hdr timestamp already in Zulu time)
      */
-    if (timestamp_parse (hdr.timestamp, &tm, &tv) < 0
+    if (timestamp_parse (hdr->timestamp, &tm, &tv) < 0
         || strftime (buf, len, "%Y-%m-%dT%T", &tm) == 0
         || timestamp_tzoffset (&tm, tz, sizeof (tz)) < 0
         || streq (tz, "Z")) {
         printf ("%s%s%s ",
                 dmesg_color (ctx, DMESG_COLOR_TIME),
-                hdr.timestamp,
+                hdr->timestamp,
                 dmesg_color_reset (ctx));
         return;
     }
@@ -139,14 +139,14 @@ void print_iso_timestamp (struct dmesg_ctx *ctx, struct stdlog_header hdr)
             dmesg_color_reset (ctx));
 }
 
-void print_human_timestamp (struct dmesg_ctx *ctx, struct stdlog_header hdr)
+void print_human_timestamp (struct dmesg_ctx *ctx, struct stdlog_header *hdr)
 {
     struct tm tm;
     struct timeval tv;
-    if (timestamp_parse (hdr.timestamp, &tm, &tv) < 0) {
+    if (timestamp_parse (hdr->timestamp, &tm, &tv) < 0) {
         printf ("%s[%s]%s ",
                 dmesg_color (ctx, DMESG_COLOR_TIME),
-                hdr.timestamp,
+                hdr->timestamp,
                 dmesg_color_reset (ctx));
     }
     if (tm.tm_year == ctx->last_tm.tm_year
@@ -200,7 +200,7 @@ static const char *severity_color (struct dmesg_ctx *ctx, int severity)
 }
 
 typedef void (*timestamp_print_f) (struct dmesg_ctx *ctx,
-                                   struct stdlog_header hdr);
+                                   struct stdlog_header *hdr);
 
 void dmesg_print (struct dmesg_ctx *ctx,
                   const char *buf,
@@ -217,7 +217,7 @@ void dmesg_print (struct dmesg_ctx *ctx,
     else {
         nodeid = strtoul (hdr.hostname, NULL, 10);
         severity = STDLOG_SEVERITY (hdr.pri);
-        (*timestamp_print) (ctx, hdr);
+        (*timestamp_print) (ctx, &hdr);
         printf ("%s%s.%s[%" PRIu32 "]%s: %s%.*s%s\n",
                 dmesg_color (ctx, DMESG_COLOR_NAME),
                 hdr.appname,

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -108,6 +108,37 @@ static const char *months[] = {
     NULL
 };
 
+void print_iso_timestamp (struct dmesg_ctx *ctx, struct stdlog_header hdr)
+{
+    struct tm tm;
+    struct timeval tv;
+    char buf[128];
+    char tz[16];
+    int len = sizeof (buf);
+
+    /* Fall back to using the hdr timestamp string if
+     * - the timestamp fails to parse
+     * - getting current timezone offset fails
+     * - timestamp_tzoffset() returns "Z" (hdr timestamp already in Zulu time)
+     */
+    if (timestamp_parse (hdr.timestamp, &tm, &tv) < 0
+        || strftime (buf, len, "%Y-%m-%dT%T", &tm) == 0
+        || timestamp_tzoffset (&tm, tz, sizeof (tz)) < 0
+        || streq (tz, "Z")) {
+        printf ("%s%s%s ",
+                dmesg_color (ctx, DMESG_COLOR_TIME),
+                hdr.timestamp,
+                dmesg_color_reset (ctx));
+        return;
+    }
+    printf ("%s%s.%.6lu%s%s ",
+            dmesg_color (ctx, DMESG_COLOR_TIME),
+            buf,
+            tv.tv_usec,
+            tz,
+            dmesg_color_reset (ctx));
+}
+
 void print_human_timestamp (struct dmesg_ctx *ctx, struct stdlog_header hdr)
 {
     struct tm tm;
@@ -168,7 +199,13 @@ static const char *severity_color (struct dmesg_ctx *ctx, int severity)
     return "";
 }
 
-void dmesg_print_human (struct dmesg_ctx *ctx, const char *buf, int len)
+typedef void (*timestamp_print_f) (struct dmesg_ctx *ctx,
+                                   struct stdlog_header hdr);
+
+void dmesg_print (struct dmesg_ctx *ctx,
+                  const char *buf,
+                  int len,
+                  timestamp_print_f timestamp_print)
 {
     struct stdlog_header hdr;
     const char *msg;
@@ -180,35 +217,8 @@ void dmesg_print_human (struct dmesg_ctx *ctx, const char *buf, int len)
     else {
         nodeid = strtoul (hdr.hostname, NULL, 10);
         severity = STDLOG_SEVERITY (hdr.pri);
-        print_human_timestamp (ctx, hdr);
-        printf ("%s%s[%" PRIu32 "]%s: %s%.*s%s\n",
-                 dmesg_color (ctx, DMESG_COLOR_NAME),
-                 hdr.appname,
-                 nodeid,
-                 dmesg_color_reset (ctx),
-                 severity_color (ctx, severity),
-                 msglen, msg,
-                 dmesg_color_reset (ctx));
-    }
-    fflush (stdout);
-}
-
-void dmesg_print (struct dmesg_ctx *ctx, const char *buf, int len)
-{
-    struct stdlog_header hdr;
-    const char *msg;
-    int msglen, severity;
-    uint32_t nodeid;
-
-    if (stdlog_decode (buf, len, &hdr, NULL, NULL, &msg, &msglen) < 0)
-        printf ("%.*s\n", len, buf);
-    else {
-        nodeid = strtoul (hdr.hostname, NULL, 10);
-        severity = STDLOG_SEVERITY (hdr.pri);
-        printf ("%s%s%s %s%s.%s[%" PRIu32 "]%s: %s%.*s%s\n",
-                dmesg_color (ctx, DMESG_COLOR_TIME),
-                hdr.timestamp,
-                dmesg_color_reset (ctx),
+        (*timestamp_print) (ctx, hdr);
+        printf ("%s%s.%s[%" PRIu32 "]%s: %s%.*s%s\n",
                 dmesg_color (ctx, DMESG_COLOR_NAME),
                 hdr.appname,
                 stdlog_severity_to_string (severity),
@@ -278,10 +288,10 @@ static int cmd_dmesg (optparse_t *p, int ac, char *av[])
                                  "nobacklog", optparse_hasopt (p, "new"))))
             log_err_exit ("error sending log.dmesg request");
         while (flux_rpc_get (f, &buf) == 0) {
+            timestamp_print_f ts_print = print_iso_timestamp;
             if (optparse_hasopt (p, "human"))
-                dmesg_print_human (&ctx, buf, strlen (buf));
-            else
-                dmesg_print (&ctx, buf, strlen (buf));
+                ts_print = print_human_timestamp;
+            dmesg_print (&ctx, buf, strlen (buf), ts_print);
             flux_future_reset (f);
         }
         if (errno != ENODATA)

--- a/src/common/libutil/test/timestamp.c
+++ b/src/common/libutil/test/timestamp.c
@@ -276,6 +276,18 @@ static void test_all ()
     }
 }
 
+void test_tzoffset (void)
+{
+    struct tm tm;
+
+    ok (timestamp_tzoffset (NULL, NULL, 0) < 0 && errno == EINVAL,
+        "timestamp_tzoffset (NULL, NULL, 0) returns EINVAL");
+
+    memset (&tm, 0, sizeof (tm));
+    ok (timestamp_tzoffset (&tm, NULL, 0) < 0 && errno == EINVAL,
+        "timestamp_tzoffset (&tm, NULL, 0) returns EINVAL");
+}
+
 int main (int argc, char *argv[])
 {
 
@@ -286,6 +298,7 @@ int main (int argc, char *argv[])
 
     test_all ();
     test_invalid ();
+    test_tzoffset ();
 
     done_testing ();
 }

--- a/src/common/libutil/timestamp.h
+++ b/src/common/libutil/timestamp.h
@@ -40,6 +40,15 @@ int timestamp_parse (const char *s,
  */
 int timestamp_from_double (double ts, struct tm *tm, struct timeval *tv);
 
+/* Get the current timezone offset for `tm` in the form [+-]HH:MM
+ * and place it into the supplied buffer. As a special case, +00:00
+ * is converted to "Z" (Zulu time) for backwards compatibility when
+ * the current timezone is UTC.
+ *
+ * Returns -1 on failure, 0 for success.
+ */
+int timestamp_tzoffset (struct tm *tm, char *buf, int size);
+
 #endif /* !_UTIL_TIMESTAMP_H */
 
 /*

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -117,6 +117,21 @@ test_expect_success 'logged non-ascii printable characters are unmodified' '
 test_expect_success 'dmesg request with empty payload fails with EPROTO(71)' '
 	${RPC} log.dmesg 71 </dev/null
 '
+# Note: TZ=UTC is set by default for sharness
+test_expect_success 'dmesg with TZ=UTC uses "Z" as offset' '
+	flux dmesg \
+	    | grep -E \
+	    "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z"
+'
+
+test "$(TZ=America/Los_Angeles date +%z)" != "+0000" &&
+  test "$(TZ=America/Los_Angeles date +%Z)" != "UTC" &&
+  test_set_prereq HAVE_TZ
+test_expect_success HAVE_TZ 'dmesg with TZ=America/Los_Angeles uses tz offset' '
+	TZ=America/Los_Angeles flux dmesg >dmesgLA.out &&
+	test_debug "cat dmesgLA.out" &&
+	grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+-[0-9]{2}:[0-9]{2}" dmesgLA.out
+'
 test_expect_success 'dmesg -H, --human works' '
 	#
 	#  Note: --human option should format first timestamp of dmesg output

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -176,6 +176,19 @@ test_expect_success 'flux job eventlog --time-format=iso works' '
 	get_timestamp_field submit eventlog_time_format2.out | grep T | grep Z
 '
 
+test "$(TZ=America/Los_Angeles date +%z)" != "+0000" &&
+  test "$(TZ=America/Los_Angeles date +%Z)" != "UTC" &&
+  test_set_prereq HAVE_TZ
+test_expect_success HAVE_TZ 'flux job eventlog --time-format=iso uses local time' '
+	jobid=$(submit_job) &&
+	TZ=America/Los_Angeles \
+	    flux job eventlog --time-format=iso $jobid > tzlocal.out &&
+	test_debug "cat tzlocal.out" &&
+	get_timestamp_field submit tzlocal.out \
+	    | grep -E \
+	    "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+-[0-9]{2}:[0-9]{2}"
+'
+
 test_expect_success 'flux job eventlog --time-format=offset works' '
 	jobid=$(submit_job) &&
 	flux job eventlog --time-format=offset $jobid > eventlog_time_format3.out &&


### PR DESCRIPTION
This PR changes the default timestamp display for `flux dmesg` and the "iso" time format for `flux job eventlog` `flux kvs eventlog` and `flux job wait-event`  to use local time instead of UTC. This better matches the behavior of most other system utilities and logfiles, and the old behavior can easily be restored if desired by setting `TZ=UTC`.

Fixes #6421