### PR TITLE
recursively update instead of replacing tables when loading Flux configuration

### DIFF
--- a/config/x_ac_jansson.m4
+++ b/config/x_ac_jansson.m4
@@ -30,6 +30,8 @@ AC_DEFUN([X_AC_JANSSON], [
         AC_MSG_ERROR([flux cannot be built on a system with 16 bit ints])
     ])
 
+    AC_REPLACE_FUNCS(json_object_update_recursive)
+
     LIBS="$ac_save_LIBS"
     CFLAGS="$ac_save_CFLAGS"
   ]

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -20,6 +20,9 @@
 #include <glob.h>
 #include <jansson.h>
 #include <flux/core.h>
+#if !HAVE_JSON_OBJECT_UPDATE_RECURSIVE
+#include "src/common/libmissing/json_object_update_recursive.h"
+#endif
 
 #include "src/common/libutil/intree.h"
 #include "src/common/libutil/errno_safe.h"
@@ -234,7 +237,7 @@ static int conf_update_obj (flux_conf_t *conf,
                             json_t *obj,
                             flux_error_t *error)
 {
-    if (json_object_update (conf->obj, obj) < 0) {
+    if (json_object_update_recursive (conf->obj, obj) < 0) {
         errprintf (error,
                    "%s: updating JSON object: out of memory",
                    filename);

--- a/src/common/libflux/test/conf.c
+++ b/src/common/libflux/test/conf.c
@@ -48,6 +48,10 @@ const char *tab3 = \
 const char *tab3_json = \
 "{\"tab3\": {\"id\": 4}}";
 
+const char *tab4 = \
+"[tab]\n" \
+"added = \"bar\"";
+
 
 static void
 create_test_file (const char *dir,
@@ -109,6 +113,7 @@ void test_basic (void)
     char path1[PATH_MAX + 1];
     char path2[PATH_MAX + 1];
     char path3[PATH_MAX + 1];
+    char path4[PATH_MAX + 1];
     char pathj[PATH_MAX + 1];
     char invalid[PATH_MAX + 1];
     flux_error_t error;
@@ -136,6 +141,7 @@ void test_basic (void)
     create_test_file (dir, "01", "toml", path1, sizeof (path1), t1);
     create_test_file (dir, "02", "toml", path2, sizeof (path2), tab2);
     create_test_file (dir, "03", "toml", path3, sizeof (path3), tab3);
+    create_test_file (dir, "04", "toml", path4, sizeof (path4), tab4);
     create_test_file (NULL, "03", "json", pathj, sizeof (pathj), tab3_json);
 
     /* Parse of one file works
@@ -242,6 +248,18 @@ void test_basic (void)
     ok (rc == 0 && i == 42,
         "unpacked integer from [tab] and got expected value");
 
+    /* Check that tab was updated with added value from tab4
+     */
+    rc = flux_conf_unpack (conf,
+                           &error,
+                           "{s:{s:s}}",
+                           "tab",
+                           "added", &s);
+    diag ("added = %s", s);
+    ok (rc == 0 && streq (s, "bar"),
+        "unpacked added string from [tab] and got expected value");
+
+
     /* Check table from second toml file
      */
     i = 0;
@@ -331,6 +349,7 @@ void test_basic (void)
     if (   (unlink (path1) < 0)
         || (unlink (path2) < 0)
         || (unlink (path3) < 0)
+        || (unlink (path4) < 0)
         || (unlink (pathj) < 0)
         || (unlink (invalid) < 0) )
         BAIL_OUT ("unlink: %s", strerror (errno));

--- a/src/common/libmissing/Makefile.am
+++ b/src/common/libmissing/Makefile.am
@@ -49,4 +49,5 @@ EXTRA_libmissing_la_SOURCES = \
 	envz.h \
 	envz.c \
 	macros.h \
-	strerrorname_np.h
+	strerrorname_np.h \
+	json_object_update_recursive.h

--- a/src/common/libmissing/json_object_update_recursive.c
+++ b/src/common/libmissing/json_object_update_recursive.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2009-2016 Petri Lehtinen <petri@digip.org>
+ *
+ * Jansson is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT license. See LICENSE for details.
+ */
+
+#include <jansson.h>
+
+/* Taken from jansson v2.13 source. This version does not do a loop
+ * check as is done in later versions of this function. The loop check
+ * requires access to jansson internals.
+ */
+int json_object_update_recursive (json_t *object, json_t *other)
+{
+    const char *key;
+    json_t *value;
+
+    if (!json_is_object (object) || !json_is_object (other))
+        return -1;
+
+    json_object_foreach (other, key, value) {
+        json_t *v = json_object_get (object, key);
+
+        if (json_is_object (v) && json_is_object (value))
+            json_object_update_recursive (v, value);
+        else
+            json_object_set_nocheck (object, key, value);
+    }
+
+    return 0;
+}

--- a/src/common/libmissing/json_object_update_recursive.h
+++ b/src/common/libmissing/json_object_update_recursive.h
@@ -1,0 +1,24 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef LIBMISSING_JANNSON_UPDATE_RECURSIVE_H
+#define LIBMISSING_JANNSON_UPDATE_RECURSIVE_H 1
+
+/* Like json_object_update(), but object values in *other* are
+ * recursively merged the corresponding values in *object* if they
+ * are also objects, instead of overwriting them. Returns a 0 on
+ * successs or -1 on error.
+ *
+ * Note: This version doesn't detect cycles like the version found
+ * in jansson >= 2.13.1.
+ */
+int json_object_update_recursive (json_t *object, json_t *other);
+
+#endif


### PR DESCRIPTION
This PR updates the `json_object_update()` call to use `json_object_update_recursive()` when "updating" a Flux config object with another config fragment loaded from a file. This makes it so that table values in the new config object update tables in the existing config, instead of replacing tables (see #6396).

Since `json_object_update_recursive()` is not present until jansson v2.13, add a simple implementation to libmissing if necessary. Note that the upstream jansson version of this function detects cycles, whereas the libmissing version does not, but that is unlikely to be an issue for Flux.