### PR TITLE
doc: improve housekeeping documentation

### DIFF
--- a/doc/man1/flux-housekeeping.rst
+++ b/doc/man1/flux-housekeeping.rst
@@ -15,7 +15,7 @@ DESCRIPTION
 
 .. program:: flux housekeeping
 
-The `EXPERIMENTAL`_ housekeeping service provides similar functionality to
+The housekeeping service provides similar functionality to
 a job epilog, with a few advantages
 
  - Housekeeping runs after the job, which is then allowed to exit CLEANUP
@@ -126,11 +126,6 @@ The following field names can be specified for
 
 **pending.ranks**
    The list of nodes that still need to complete housekeeping.
-
-EXPERIMENTAL
-============
-
-.. include:: common/experimental.rst
 
 RESOURCES
 =========

--- a/doc/man5/flux-config-job-manager.rst
+++ b/doc/man5/flux-config-job-manager.rst
@@ -34,7 +34,7 @@ plugins
 
 housekeeping
    (optional) Table of configuration for the job-manager housekeeping
-   service. The housekeeping service is an `EXPERIMENTAL`_ alternative for
+   service. The housekeeping service is an alternative for
    handling administrative job epilog workloads. If enabled, resources are
    released by jobs to housekeeping, which runs a command or a systemd unit
    and releases resources to the scheduler on completion. See configuration
@@ -198,11 +198,6 @@ EXAMPLE
    [job-manager.housekeeping]
    release-after = "1m"
 
-
-EXPERIMENTAL
-============
-
-.. include:: common/experimental.rst
 
 RESOURCES
 =========

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -932,3 +932,5 @@ minnodes
 cgroup
 cgroups
 fs
+misconfigured
+aTGTz


### PR DESCRIPTION
Problem: the admin guide does not discuss housekeeping, and the flux-housekeeping(1) and flux-config-job-manager(5) man pages list housekeeping as EXPERIMENTAL.

I think we're past the EXPERIMENTAL phase at this point.  Drop that.

Add a TROUBLESHOOTING section to flux-housekeeping(1).

Rework the prolog/epilog section of the admin guide to include housekeeping and a general intro that describes the roles of the three scripts.