### PR TITLE
indicate held jobs in the` INFO` column of `flux jobs` output

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -524,11 +524,13 @@ the state of the job or other context:
 
 **contextual_info**
    Returns selected information based on the job's current state.  If the
-   job is in PRIORITY state, then the string ``priority-wait`` is returned,
-   if the job is in DEPEND state, then a list of outstanding  dependencies
-   is returned, if the job is in SCHED state then an estimated time the
-   job will run is returned (if the scheduler supports it). Otherwise,
-   the assigned nodelist is returned (if resources were assigned).
+   job is in PRIORITY state, then the string ``priority-wait`` is returned.
+   If the job is in DEPEND state, then a list of outstanding dependencies
+   is returned. If the job is in SCHED state and its priority is currently
+   0, then one of ``held`` or ``priority-hold`` will be printed depending
+   on if urgency is also 0, otherwise an estimated time the job will run is
+   returned (if supported by the scheduler). In other states, the assigned
+   nodelist is returned (if resources were assigned).
 
 **contextual_info**
    Returns the job runtime for jobs in RUN state or later, otherwise the

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -133,7 +133,7 @@ test_expect_success 'submit jobs for job list testing' '
 	#
 	#  Submit a set of jobs with non-default urgencies
 	#
-	for u in 31 25 20 15 10 5; do
+	for u in 31 25 20 15 10 5 0; do
 		flux job submit --urgency=$u sleeplong.json >> sched.ids
 	done &&
 	listjobs > active.ids &&
@@ -552,6 +552,7 @@ test_expect_success 'flux-jobs --format={urgency},{priority} works' '
 	echo 15,15 >> urgency_priority.exp &&
 	echo 10,10 >> urgency_priority.exp &&
 	echo 5,5 >> urgency_priority.exp &&
+	echo 0,0 >> urgency_priority.exp &&
 	for i in `seq 1 $(job_list_state_count run)`; do
 		echo "16,16" >> urgency_priority.exp
 	done &&
@@ -559,6 +560,18 @@ test_expect_success 'flux-jobs --format={urgency},{priority} works' '
 		echo "16,16" >> urgency_priority.exp
 	done &&
 	test_cmp urgency_priority.out urgency_priority.exp
+'
+
+test_expect_success 'flux-jobs --format={contextual_info} shows held job' '
+	flux jobs -no {urgency}:{contextual_info} | grep 0:held
+'
+
+# There is no simple way to create a job with urgency > 0 and priority == 0,
+# so test priority-hold using --from-stdin:
+test_expect_success 'flux-jobs {contextual_info} shows priority-hold job' '
+	echo "{\"id\":195823665152,\"state\":8,\"priority\":0,\"urgency\":16}" \
+		| flux jobs --from-stdin -no {priority}:{contextual_info} \
+		| grep 0:priority-hold
 '
 
 test_expect_success 'flux-jobs --format={state},{state_single} works' '


### PR DESCRIPTION
This PR implements @ryanday36's suggestion in #6426. It extends the `flux jobs` `{contextual_info}` field (`INFO`) to check for a priority of 0 and prints `held` if `urgency` is also zero, otherwise `priority-hold`.