### PR TITLE
increase default prolog kill-timeout from 10s to 1m

### DIFF
--- a/doc/man5/flux-config-job-manager.rst
+++ b/doc/man5/flux-config-job-manager.rst
@@ -128,7 +128,7 @@ prolog
       sending it a SIGTERM signal. ``kill-timeout`` is the number of
       seconds to wait until any nodes with prolog tasks that are still
       active will be drained. The drain reason will include the string
-      "canceled then timed out". The default is 10.
+      "canceled then timed out". The default is 60.
    cancel-on-exception
       (optional) A boolean indicating whether a fatal job exception raised
       while the prolog is active terminates the prolog. The default is true.

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -122,6 +122,10 @@ struct perilog_proc {
     char *failed_ranks;
 };
 
+/* The default time (sec) to wait for the prolog to terminate after SIGTERM.
+ */
+static double default_kill_timeout = 60.;
+
 static struct perilog_proc *procdesc_run (flux_t *h,
                                           flux_plugin_t *p,
                                           struct perilog_procdesc *pd,
@@ -250,7 +254,7 @@ static struct perilog_procdesc *perilog_procdesc_create (json_t *o,
     }
 
     pd->cmd = cmd;
-    pd->kill_timeout = kill_timeout > 0. ? kill_timeout : 10.;
+    pd->kill_timeout = kill_timeout > 0. ? kill_timeout : default_kill_timeout;
     pd->per_rank = per_rank;
     pd->prolog = prolog;
     pd->uses_imp = uses_imp;


### PR DESCRIPTION
Problem: on a slow system, the prolog kill timeout may be exceeded due to reasons other than an intransigent prolog process.
    
Increase the timeout from 10s to 1m.
    
Fixes #6420
