### PR TITLE
python: call shutdown() on executor in job validator

### DIFF
--- a/src/bindings/python/flux/job/validator/validator.py
+++ b/src/bindings/python/flux/job/validator/validator.py
@@ -191,6 +191,10 @@ class JobValidator:
         )
         return self
 
+    def stop(self):
+        """Stop the validator."""
+        self.executor.shutdown()
+
     def validate(self, jobinfo):
         """Validate jobinfo using all loaded validators
 

--- a/src/cmd/flux-job-validator.py
+++ b/src/cmd/flux-job-validator.py
@@ -110,6 +110,8 @@ def main():
             result = validator.validate(line)
         print(result, flush=True)
 
+    validator.stop()
+
     sys.exit(exitcode)
 
 


### PR DESCRIPTION
Problem: The concurrent.futures ThreadPoolExecutor is not explicitly shut down when exiting flux-job-validator. This MAY be causing the program to occasionally hang at exit.

Add a stop() method to the JobValidator class which calls the shutdown() method of the executor. Call validator.stop() from flux-job-validator(1) before exit.

Fixes #6434