### PR TITLE
job-ingest: improve cleanup and stats output

### DIFF
--- a/src/modules/job-ingest/workcrew.c
+++ b/src/modules/job-ingest/workcrew.c
@@ -256,12 +256,14 @@ json_t *workcrew_stats_get (struct workcrew *crew)
         int requests = 0;
         int errors = 0;
         int backlog = 0;
+        int trash = 0;
         json_t *pids = json_array ();
 
         for (int i = 0; i < WORKCREW_SIZE; i++) {
             running += worker_is_running (crew->worker[i]) ? 1 : 0;
             requests += worker_request_count (crew->worker[i]);
             errors += worker_error_count (crew->worker[i]);
+            trash += worker_trash_count (crew->worker[i]);
             backlog += worker_queue_depth (crew->worker[i]);
             if (pids) {
                 json_t *pid = json_integer (worker_pid (crew->worker[i]));
@@ -269,10 +271,11 @@ json_t *workcrew_stats_get (struct workcrew *crew)
                     json_decref (pid);
             }
         }
-        o = json_pack ("{s:i s:i s:i s:i s:O}",
+        o = json_pack ("{s:i s:i s:i s:i s:i s:O}",
                        "running", running,
                        "requests", requests,
                        "errors", errors,
+                       "trash", trash,
                        "backlog", backlog,
                        "pids", pids ? pids : json_null ());
         json_decref (pids);

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -396,6 +396,11 @@ int worker_error_count (struct worker *w)
     return w ? w->error_count : 0;
 }
 
+int worker_trash_count (struct worker *w)
+{
+    return w ? zlist_size (w->trash) : 0;
+}
+
 bool worker_is_running (struct worker *w)
 {
     return (w && w->p ? true : false);

--- a/src/modules/job-ingest/worker.h
+++ b/src/modules/job-ingest/worker.h
@@ -24,6 +24,7 @@ flux_future_t *worker_request (struct worker *w, const char *s);
 int worker_queue_depth (struct worker *w);
 int worker_request_count (struct worker *w);
 int worker_error_count (struct worker *w);
+int worker_trash_count (struct worker *w);
 bool worker_is_running (struct worker *w);
 pid_t worker_pid (struct worker *w);
 

--- a/t/t2113-job-ingest-pipeline.t
+++ b/t/t2113-job-ingest-pipeline.t
@@ -91,4 +91,14 @@ test_expect_success 'job was validated but not frobbed' '
 	test_cmp frob3.count frob4.count &&
 	test_must_fail test_cmp val3.count val4.count
 '
+test_expect_success 'stop validator 0' '
+	valpid=$(jq -r ".pipeline.validator.pids[0]" <stats8.out) &&
+	kill -STOP $valpid
+'
+test_expect_success 'remove job-ingest to trigger cleanup' '
+	flux setattr log-stderr-level 7 &&
+	flux module remove job-ingest &&
+	flux setattr log-stderr-level 1
+'
+
 test_done


### PR DESCRIPTION
This adds a count of "trash" processes for each work crew to the `flux module stats job-ingest` output, so that there is some indication that the module is tracking subprocesses whose input has been closed, but that have not yet exited.

While in there I noticed that the cleanup code that sends SIGKILL to running workers doesn't signal workers that are lingering in the trash list.  Add code to signal those too and a test.