### PR TITLE
update clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@ BinPackParameters : false
 BinPackArguments : false
 AllowAllParametersOfDeclarationOnNextLine : false
 AlignTrailingComments : true
-ColumnLimit : 88
+ColumnLimit : 80
 
 # do not put all arguments on one line unless it's the same line as the call
 PenaltyBreakBeforeFirstCallParameter : 10000000

--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,17 @@
 BasedOnStyle : google
 SpaceBeforeParens : Always
 IndentWidth : 4
-BreakBeforeBraces : Linux
+BreakBeforeBraces : Custom
+BraceWrapping :
+  BeforeElse : true
+  AfterFunction : true
 UseTab: Never
 AllowShortIfStatementsOnASingleLine : false
 ConstructorInitializerAllOnOneLineOrOnePerLine : true
 AllowShortFunctionsOnASingleLine : false
 AllowShortLoopsOnASingleLine : false
 BinPackParameters : false
+BinPackArguments : false
 AllowAllParametersOfDeclarationOnNextLine : false
 AlignTrailingComments : true
 ColumnLimit : 88
@@ -17,9 +21,103 @@ PenaltyBreakBeforeFirstCallParameter : 10000000
 PenaltyReturnTypeOnItsOwnLine : 65000
 PenaltyBreakString : 10
 
+# Preserve the hand-authored layout of jansson-style pack/unpack calls.
+# This must be a literal list -- clang-format does not accept a regex here.
+# The names are the pack/unpack-family functions that take a jansson format
+# string; regenerate after adding/removing such a function by running the
+# command below and pruning the non-jansson matches (czmq zhash/zhashx/zlistx
+# _pack/_unpack, treeobj_unpack, pty_data_unpack, dependencies_unpack,
+# test_pack, and the bare "unpack" comment hit):
+#   grep -rhoE '\b[A-Za-z_][A-Za-z0-9_]*(pack|unpack)(_ex)?\b *\(' \
+#       --include=*.c --include=*.h src | sed -E 's/ *\(//' | sort -u
+WhitespaceSensitiveMacros :
+- cred_msg_pack
+- event_job_post_pack
+- event_job_post_vpack
+- eventlog_entry_pack
+- eventlog_entry_vpack
+- eventlogger_append_pack
+- eventlogger_append_vpack
+- flux_conf_pack
+- flux_conf_unpack
+- flux_conf_vpack
+- flux_conf_vunpack
+- flux_event_pack
+- flux_event_publish_pack
+- flux_event_unpack
+- flux_event_vpack
+- flux_event_vunpack
+- flux_job_result_get_unpack
+- flux_jobspec1_attr_pack
+- flux_jobspec1_attr_unpack
+- flux_jobtap_event_post_pack
+- flux_jobtap_jobspec_update_id_pack
+- flux_jobtap_jobspec_update_pack
+- flux_kvs_lookup_get_unpack
+- flux_kvs_txn_pack
+- flux_kvs_txn_vpack
+- flux_msg_pack
+- flux_msg_unpack
+- flux_msg_vpack
+- flux_msg_vunpack
+- flux_plugin_arg_pack
+- flux_plugin_arg_unpack
+- flux_plugin_arg_vpack
+- flux_plugin_arg_vunpack
+- flux_plugin_conf_unpack
+- flux_request_unpack
+- flux_request_vunpack
+- flux_respond_pack
+- flux_respond_vpack
+- flux_rpc_get_unpack
+- flux_rpc_get_vunpack
+- flux_rpc_pack
+- flux_rpc_vpack
+- flux_shell_getopt_unpack
+- flux_shell_info_unpack
+- flux_shell_info_vunpack
+- flux_shell_jobspec_info_unpack
+- flux_shell_jobspec_info_vunpack
+- flux_shell_rank_info_unpack
+- flux_shell_rank_info_vunpack
+- flux_shell_rpc_pack
+- flux_shell_setopt_pack
+- flux_shell_task_info_unpack
+- flux_shell_task_info_vunpack
+- jobinfo_emit_event_pack
+- jobinfo_emit_event_vpack
+- jobinfo_shell_rpc_pack
+- json_pack
+- json_pack_ex
+- json_unpack
+- json_unpack_ex
+- json_vpack_ex
+- json_vunpack_ex
+- reslog_post_pack
+- schedutil_alloc_respond_annotate_pack
+- schedutil_alloc_respond_pack
+- schedutil_alloc_respond_success_pack
+- sdexec_property_dict_unpack
+- sdexec_property_get_unpack
+- server_auth_unpack
+- shell_eventlogger_context_vpack
+- shell_svc_vpack
+- test_eventlog_entry_vpack
+
+# treat foreach macros as for loops
+ForEachMacros :
+- json_array_foreach
+- json_object_foreach
+
 # These improve formatting results but require clang 3.6/7 or higher
+SortIncludes : false
 BreakBeforeBinaryOperators : NonAssignment
-AlignAfterOpenBracket: true
-BinPackArguments : false
+AlignAfterOpenBracket: Align
 AlignOperands : true
 BreakBeforeTernaryOperators : true
+SpaceBeforeSquareBrackets: false
+IndentPPDirectives: None
+
+#
+# vi:tabstop=4 shiftwidth=4 expandtab ft=yaml
+#

--- a/.clang-format
+++ b/.clang-format
@@ -117,6 +117,9 @@ BreakBeforeTernaryOperators : true
 SpaceBeforeSquareBrackets: false
 IndentPPDirectives: None
 
+# will appear in clang-20
+AlignConsecutiveMacros: true
+
 #
 # vi:tabstop=4 shiftwidth=4 expandtab ft=yaml
 #

--- a/.clang-format
+++ b/.clang-format
@@ -109,7 +109,6 @@ ForEachMacros :
 - json_array_foreach
 - json_object_foreach
 
-# These improve formatting results but require clang 3.6/7 or higher
 SortIncludes : false
 BreakBeforeBinaryOperators : NonAssignment
 AlignAfterOpenBracket: Align

--- a/scripts/check-format
+++ b/scripts/check-format
@@ -10,6 +10,17 @@ function filter_pyfiles() {
     done
 }
 
+function filter_cfiles() {
+    # echo C/C++ files; clang-format-flux skips vendored/copied code itself
+    for infile in "$@"; do
+        case $infile in
+            *.c|*.h)
+                [[ -f $infile ]] && echo "$infile"
+                ;;
+        esac
+    done
+}
+
 if command -v black 2>&1 > /dev/null ; then
     if [[ $# -eq 0 ]]; then
         # awk cmd copied from:
@@ -21,9 +32,22 @@ if command -v black 2>&1 > /dev/null ; then
             -exec awk ' /^#!.*python/{print FILENAME} {nextfile}' {} + \) \
             | xargs black --check --diff
     else
-        filter_pyfiles "$@" | xargs black --check --diff
+        filter_pyfiles "$@" | xargs --no-run-if-empty black --check --diff
     fi
 else
   echo "black not found, failing"
+  exit 1
+fi
+
+if command -v clang-format 2>&1 > /dev/null ; then
+    if [[ $# -eq 0 ]]; then
+        # clang-format-flux skips vendored/copied code itself.
+        find src -type f \( -name "*.c" -o -name "*.h" \) -print \
+            | xargs scripts/clang-format-flux --check
+    else
+        filter_cfiles "$@" | xargs --no-run-if-empty scripts/clang-format-flux --check
+    fi
+else
+  echo "clang-format not found, failing"
   exit 1
 fi

--- a/scripts/clang-format-flux
+++ b/scripts/clang-format-flux
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Run clang-format on C files, then repair one construct it gets wrong.
+
+Flux's .clang-format uses WhitespaceSensitiveMacros to preserve the
+hand-authored layout of jansson-style pack/unpack calls.  A side effect
+(present since clang-format 14) is that a comparison operator following a
+*multi-line* call is peeled onto its own line:
+
+    if (flux_request_unpack (msg, "{s:s}",
+                             "topic_glob", &match.topic_glob)
+        < 0)
+
+Flux style attaches the comparison to the closing paren instead.  The
+single BreakBeforeBinaryOperators knob can't express this: NonAssignment
+(which we need, so that && / || break *before* the operator per flux
+style) also forces comparisons before the operator.  So we reattach the
+comparison here as a post-pass.
+
+Only a lone comparison operator (< <= > >= == !=) with a simple operand
+is reattached, and only when the joined line stays within the column
+limit.  Logical operators (&& ||) are never touched, and overflowing
+joins are left peeled -- both match existing flux source.
+
+Usage:
+    clang-format-flux [--check] FILE...
+
+--check prints a unified diff of what would change and exits non-zero if
+any file is not already formatted; without it, files are edited in place.
+"""
+import difflib
+import fnmatch
+import re
+import subprocess
+import sys
+
+COLUMN_LIMIT = 80
+
+# Vendored or copied code that is maintained upstream, not to flux style.
+# Kept in sync with the exclusion lists in Makefile.am and .typos.toml.
+# Patterns are matched against the path as given on the command line, with
+# any leading "./" stripped, using shell-glob semantics ('*' spans '/').
+EXCLUDE = [
+    "*src/common/libccan/*",
+    "*src/common/libczmqcontainers/*",
+    "*src/common/libev/*",
+    "*src/common/liblsd/*",
+    "*src/common/libmissing/*",
+    "*src/common/liboptparse/getopt*",
+    "*src/common/libtap/*",
+    "*src/common/libtomlc99/*",
+    "*src/common/libyuarel/*",
+    "*src/bindings/python/_flux/*",
+    # individually copied files (no directory of their own)
+    "*src/common/libutil/sha1.c",
+    "*src/common/libutil/test/sha1.c",
+    "*src/common/libutil/test/blobref.c",
+    "*src/common/libutil/test/levenshtein.c",
+]
+
+
+def is_excluded(path):
+    """True if path is vendored/copied code that must not be reformatted."""
+    norm = path[2:] if path.startswith("./") else path
+    return any(fnmatch.fnmatch(norm, pat) for pat in EXCLUDE)
+
+
+# A line that is nothing but a comparison operator, a simple operand, an
+# optional run of closing parens, and an optional trailing ';' or ','.
+# Deliberately excludes && and || -- flux breaks *before* those.
+_OP_LINE = re.compile(
+    r"^(?P<indent>\s*)"
+    r"(?P<op><=|>=|==|!=|<|>)\s+"
+    r"(?P<operand>[A-Za-z_][A-Za-z0-9_]*|-?[0-9]+)"
+    r"(?P<close>\)*)"
+    r"(?P<tail>\s*[;,])?\s*$"
+)
+
+
+def reattach(text):
+    """Reattach peeled comparison operators to the preceding line."""
+    lines = text.split("\n")
+    out = []
+    for line in lines:
+        m = _OP_LINE.match(line)
+        if m and out and out[-1].rstrip().endswith(")"):
+            prev = out[-1].rstrip()
+            tail = m.group("tail") or ""
+            joined = "{} {} {}{}{}".format(
+                prev,
+                m.group("op"),
+                m.group("operand"),
+                m.group("close"),
+                tail,
+            )
+            if len(joined) <= COLUMN_LIMIT:
+                out[-1] = joined
+                continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def format_text(path, text):
+    """Return clang-format output for text, with the reattach fixup."""
+    r = subprocess.run(
+        ["clang-format", "--assume-filename=" + path],
+        input=text,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return reattach(r.stdout)
+
+
+def main():
+    args = sys.argv[1:]
+    check = False
+    if args and args[0] == "--check":
+        check = True
+        args = args[1:]
+    if not args:
+        print("usage: clang-format-flux [--check] FILE...", file=sys.stderr)
+        return 2
+
+    rc = 0
+    for path in args:
+        if is_excluded(path):
+            continue
+        with open(path) as f:
+            original = f.read()
+        formatted = format_text(path, original)
+        if check:
+            if formatted != original:
+                rc = 1
+                sys.stdout.writelines(
+                    difflib.unified_diff(
+                        original.splitlines(keepends=True),
+                        formatted.splitlines(keepends=True),
+                        fromfile=path,
+                        tofile=path + " (formatted)",
+                    )
+                )
+        elif formatted != original:
+            with open(path, "w") as f:
+                f.write(formatted)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/format
+++ b/scripts/format
@@ -12,3 +12,11 @@ if command -v black 2>&1 > /dev/null ; then
 else
   echo "black not found, python left unformatted"
 fi
+
+if command -v clang-format 2>&1 > /dev/null ; then
+    # clang-format-flux skips vendored/copied code itself.
+    find src -type f \( -name "*.c" -o -name "*.h" \) -print \
+        | xargs scripts/clang-format-flux
+else
+  echo "clang-format not found, C/C++ left unformatted"
+fi


### PR DESCRIPTION
Salvage the improvements to our `.clang-format` file from #4694 which was out of date.