### PR TITLE
fix multiple issues in the `flux job attach` statusline

### DIFF
--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -1158,6 +1158,9 @@ void attach_event_continuation (flux_future_t *f, void *arg)
                          "severity", &severity,
                          "note", &note) < 0)
             log_err_exit ("error decoding exception context");
+
+        if (ctx->statusline)
+            fprintf (stderr, "\r\033[K");
         fprintf (stderr, "%.3fs: job.exception type=%s severity=%d %s\n",
                          event->timestamp - ctx->timestamp_zero,
                          type,

--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -1010,6 +1010,16 @@ static const char *attach_notify_msg (struct attach_ctx *ctx,
     else if (streq (event->name, "start")) {
         msg = "started";
     }
+    else if (streq (event->name, "jobspec-update")) {
+        /* Keep existing status msg, but clear current queue name in case
+         * the queue was updated. This will force current queue and its
+         * status to be refreshed.
+         */
+        msg = ctx->status_msg;
+        free (ctx->queue);
+        ctx->queue = NULL;
+        ctx->queue_stopped = false;
+    }
     else {
         /* Keep existing status msg for any event not handled above
          */

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -109,7 +109,7 @@ test_expect_success 'attach: exit code reflects cancellation' '
 	! flux job attach $(cat jobid2)
 '
 test_expect_success 'attach: reports task exit code with nonzero exit' '
-	id=$(flux submit sh -c 'exit 42') &&
+	id=$(flux submit sh -c "exit 42") &&
 	test_must_fail flux job attach $id 2>exited.err &&
 	test_debug "cat exited.err" &&
 	grep "exited with exit code 42" exited.err


### PR DESCRIPTION
This PR is largely a rewrite of the "statusline" implementation in `flux job attach` to address multiple issues:

 - the status message displayed "canceling due to exception" even for non-fatal exceptions
 - the status message did not properly account for prolog-start and finish events due to the implementation
 - the status message was overwritten by text when `flux job attach` logs a `job.exception` message