### PR TITLE
support `flux uri --wait JOBID`

### DIFF
--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -938,3 +938,4 @@ misconfigured
 aTGTz
 cPATH
 SATTR
+myprogram

--- a/src/bindings/python/flux/uri/resolvers/jobid.py
+++ b/src/bindings/python/flux/uri/resolvers/jobid.py
@@ -20,13 +20,23 @@ def filter_slash(iterable):
     return list(filter(lambda x: "/" not in x, iterable))
 
 
+def wait_for_uri(flux_handle, jobid):
+    """Wait for memo event containing job uri, O/w finish event"""
+    for event in flux.job.event_watch(flux_handle, jobid):
+        if event.name == "memo" and "uri" in event.context:
+            return event.context["uri"]
+        if event.name == "finish":
+            return None
+    return None
+
+
 class URIResolver(URIResolverPlugin):
     """A URI resolver that attempts to fetch the remote_uri for a job"""
 
     def describe(self):
         return "Get URI for a given Flux JOBID"
 
-    def _do_resolve(self, uri, flux_handle, force_local=False):
+    def _do_resolve(self, uri, flux_handle, force_local=False, wait=False):
         #
         #  Convert a possible hierarchy of jobids to a list, dropping any
         #   extraneous '/' (e.g. //id0/id1 -> [ "id0", "id1" ]
@@ -39,18 +49,21 @@ class URIResolver(URIResolverPlugin):
         except OSError as exc:
             raise ValueError(f"{arg} is not a valid jobid")
 
-        #  Fetch the jobinfo object for this job
         try:
-            job = job_list_id(
-                flux_handle, jobid, attrs=["state", "annotations"]
-            ).get_jobinfo()
-            if job.state != "RUN":
-                raise ValueError(f"jobid {arg} is not running")
-            uri = job.user.uri
+            if wait:
+                uri = wait_for_uri(flux_handle, jobid)
+            else:
+                #  Fetch the jobinfo object for this job
+                job = job_list_id(
+                    flux_handle, jobid, attrs=["state", "annotations"]
+                ).get_jobinfo()
+                if job.state != "RUN":
+                    raise ValueError(f"jobid {arg} is not running")
+                uri = job.user.uri
         except FileNotFoundError as exc:
             raise ValueError(f"jobid {arg} not found") from exc
 
-        if str(uri) == "":
+        if uri is None or str(uri) == "":
             raise ValueError(f"URI not found for job {arg}")
 
         #  If there are more jobids in the hierarchy to resolve, resolve
@@ -67,6 +80,9 @@ class URIResolver(URIResolverPlugin):
 
     def resolve(self, uri):
         force_local = False
+        wait = False
         if "local" in uri.query_dict or "FLUX_URI_RESOLVE_LOCAL" in os.environ:
             force_local = True
-        return self._do_resolve(uri, flux.Flux(), force_local=force_local)
+        if "wait" in uri.query_dict:
+            wait = True
+        return self._do_resolve(uri, flux.Flux(), force_local=force_local, wait=wait)

--- a/src/cmd/flux-uri.py
+++ b/src/cmd/flux-uri.py
@@ -48,12 +48,19 @@ def main():
         default=os.environ.get("FLUX_URI_RESOLVE_LOCAL"),
     )
     parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="wait for a URI to become available, if supported",
+    )
+    parser.add_argument(
         "uri",
         metavar="TARGET",
         help="A Flux jobid or URI in scheme:argument form (e.g. jobid:f1234)",
     )
 
     args = parser.parse_args()
+    if args.wait:
+        args.uri = args.uri + "?wait"
     uri = resolver.resolve(args.uri)
     if args.remote:
         print(uri.remote)

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -108,6 +108,11 @@ test_expect_success 'flux uri resolves hierarchical jobids with ?local' '
 	test_debug "echo ${jobid}/${jobid2}?local is ${uri}"
 
 '
+test_expect_success 'flux uri --wait can resolve URI for pending job' '
+	uri=$(flux uri --wait $(flux batch -n1 --wrap hostname)) &&
+	flux job wait-event -vt 30 $(flux job last) clean  &&
+	test "$uri" = "$(flux jobs -no {uri} $(flux job last))"
+'
 test_expect_success 'terminate batch job cleanly' '
 	flux proxy $(flux uri --local ${jobid}) flux cancel --all &&
 	flux job wait-event -vt 30 ${jobid} clean


### PR DESCRIPTION
This PR adds support for a `?wait` query parameter to the `jobid` URI resolver, and a new `--wait` option to `flux-uri` to pass that parameter down to the resolver.

This supports waiting until the URI is available for pending or starting jobs, as opposed to the resolver returning "job is not running".

If the `wait` parameter is used with a job that isn't an instance of Flux, then it waits until the `finish` event before giving up and returning "URI not found".

