### PR TITLE
support partially allocated jobs across scheduler reload

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -138,7 +138,8 @@ libflux_idset_la_LDFLAGS = \
 libflux_schedutil_la_SOURCES =
 libflux_schedutil_la_LIBADD = \
 	$(builddir)/libschedutil/libschedutil.la \
-	$(builddir)/libczmqcontainers/libczmqcontainers.la \
+	$(builddir)/librlist/librlist.la \
+	libflux-internal.la \
 	libflux-core.la \
 	$(JANSSON_LIBS)
 libflux_schedutil_la_LDFLAGS = \

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -78,16 +78,20 @@ int schedutil_hello (schedutil_t *util)
 {
     flux_future_t *f;
     int rc = -1;
+    int partial_ok = 0;
 
     if (!util || !util->ops->hello) {
         errno = EINVAL;
         return -1;
     }
-    if (!(f = flux_rpc (util->h,
-                        "job-manager.sched-hello",
-                        NULL,
-                        FLUX_NODEID_ANY,
-                        FLUX_RPC_STREAMING)))
+    if ((util->flags & SCHEDUTIL_HELLO_PARTIAL_OK))
+        partial_ok = 1;
+    if (!(f = flux_rpc_pack (util->h,
+                             "job-manager.sched-hello",
+                             FLUX_NODEID_ANY,
+                             FLUX_RPC_STREAMING,
+                             "{s:b}",
+                             "partial-ok", partial_ok)))
         return -1;
     while (1) {
         const flux_msg_t *msg;

--- a/src/common/libschedutil/init.h
+++ b/src/common/libschedutil/init.h
@@ -23,6 +23,7 @@ typedef struct schedutil_ctx schedutil_t;
 
 enum schedutil_flags {
     SCHEDUTIL_FREE_NOLOOKUP = 1, // now the default so this flag is ignored
+    SCHEDUTIL_HELLO_PARTIAL_OK = 2,
 };
 
 /* Create a handle for the schedutil convenience library.

--- a/src/modules/job-manager/housekeeping.h
+++ b/src/modules/job-manager/housekeeping.h
@@ -31,7 +31,9 @@ int housekeeping_start (struct housekeeping *hk,
  * It should inform the scheduler about resources that are still allocated,
  * but no longer directly held by jobs.
  */
-int housekeeping_hello_respond (struct housekeeping *hk, const flux_msg_t *msg);
+int housekeeping_hello_respond (struct housekeeping *hk,
+                                const flux_msg_t *msg,
+                                bool partial_ok);
 
 json_t *housekeeping_get_stats (struct housekeeping *hk);
 

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -576,7 +576,7 @@ static int hello_cb (flux_t *h,
     }
     s = rlist_dumps (alloc);
     if ((rc = rlist_set_allocated (ss->rlist, alloc)) < 0)
-        flux_log_error (h, "hello: rlist_remove (%s)", s);
+        flux_log_error (h, "hello: alloc %s", s);
     else
         flux_log (h, LOG_DEBUG, "hello: alloc %s", s);
     free (s);

--- a/t/t2226-housekeeping.t
+++ b/t/t2226-housekeeping.t
@@ -332,8 +332,7 @@ test_expect_success 'flux resource list shows 0 nodes allocated' '
 	test $(flux resource list -s allocated -no {nnodes}) -eq 0
 '
 # The following tests exercise recovery from RFC 27 hello protocol
-# with partial release. Once partial release is added to RFC 27, these
-# tests should be removed or changed.
+# with partial release.
 test_expect_success 'configure housekeeping with immediate release' '
 	flux config load <<-EOT
 	[job-manager.housekeeping]
@@ -347,9 +346,9 @@ test_expect_success 'run job that uses 4 nodes to trigger housekeeping' '
 test_expect_success 'housekeeping is running for 1 job' '
 	wait_for_running 1
 '
-test_expect_success 'reload scheduler' '
+test_expect_success 'reload scheduler without partial hello capability' '
 	flux dmesg -C &&
-	flux module reload -f sched-simple &&
+	flux module reload -f sched-simple test-hello-nopartial &&
 	flux dmesg -H
 '
 test_expect_success 'wait for housekeeping to finish' '

--- a/t/t2226-housekeeping.t
+++ b/t/t2226-housekeeping.t
@@ -27,6 +27,11 @@ kill_ranks () {
 	flux housekeeping kill --targets=$1 --signal=$2
 }
 
+# Usage: straggler_count
+straggler_count () {
+	flux housekeeping list -no {nnodes}
+}
+
 # Note: the hand off of resources to housekeeping occurs just before the job
 # becomes inactive, therefore it is safe to assume that housekeeping has run
 # for the job if it is enclosed between successful 'wait_for_running 0' calls.
@@ -36,6 +41,16 @@ kill_ranks () {
 wait_for_running () {
 	count=0
 	while test $(list_jobs | wc -l) -ne $1; do
+		count=$(($count+1));
+		test $count -eq 300 && return 1 # max 300 * 0.1s sleep = 30s
+		sleep 0.1
+	done
+}
+
+# Usage: wait_for_straggler_count count
+wait_for_straggler_count () {
+	count=0
+	while test $(straggler_count) -gt $1; do
 		count=$(($count+1));
 		test $count -eq 300 && return 1 # max 300 * 0.1s sleep = 30s
 		sleep 0.1
@@ -343,8 +358,9 @@ test_expect_success 'configure housekeeping with immediate release' '
 test_expect_success 'run job that uses 4 nodes to trigger housekeeping' '
 	flux run -N4 true
 '
-test_expect_success 'housekeeping is running for 1 job' '
-	wait_for_running 1
+test_expect_success 'housekeeping completed except for one straggler' '
+	wait_for_running 1 &&
+	wait_for_straggler_count 1
 '
 test_expect_success 'reload scheduler without partial hello capability' '
 	flux dmesg -C &&
@@ -356,5 +372,27 @@ test_expect_success 'wait for housekeeping to finish' '
 '
 test_expect_success 'housekeeping jobs were terminated due to sched reload' '
 	flux dmesg | grep "housekeeping:.*will be terminated"
+'
+test_expect_success 'no node are allocated' '
+	test $(flux resource list -s allocated -no {nnodes}) -eq 0 &&
+	test $(FLUX_RESOURCE_LIST_RPC=sched.resource-status \
+		flux resource list -s allocated -no {nnodes}) -eq 0
+'
+test_expect_success 'run job that uses 4 nodes to trigger housekeeping' '
+	flux run -N4 true
+'
+test_expect_success 'housekeeping completed except for one straggler' '
+	wait_for_running 1 &&
+	wait_for_straggler_count 1
+'
+test_expect_success 'reload scheduler WITH partial hello capability' '
+	flux dmesg -C &&
+	flux module reload -f sched-simple &&
+	flux dmesg -H
+'
+test_expect_success 'one node is allocated' '
+	test $(flux resource list -s allocated -no {nnodes}) -eq 1 &&
+	test $(FLUX_RESOURCE_LIST_RPC=sched.resource-status \
+		flux resource list -s allocated -no {nnodes}) -eq 1
 '
 test_done


### PR DESCRIPTION
This is a proof of concept implementation of the changes to the scheduler hello protocol proposed in flux-framework/rfc#433, in which support is added for reloading the scheduler with housekeeping running and some nodes of job(s) already released.

The scheduler indicates it supports this by calling `schedutil_create()` with the SCHEDUTIL_HELLO_PARTIAL_OK flag.  When it sets that, it agrees to parse an optional `allocated` key in each hello response.  The `allocated` key is set to an idset representing the subset of ranks of R that are actually allocated.  If missing, all ranks are assumed to be allocated.

We need to get some feedback from @milroy, @trws, et al to make sure this approach works for fluxion.  I thought working through this with sched-simple would be helpful to illustrate the idea.