### PR TITLE
job-manager: clean up queue code

### DIFF
--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -189,7 +189,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating purge context");
         goto done;
     }
-    if (!(ctx.queue = queue_create (&ctx))) {
+    if (!(ctx.queue = queue_ctx_create (&ctx))) {
         flux_log_error (h, "error creating queue context");
         goto done;
     }
@@ -258,7 +258,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     rc = 0;
 done:
     flux_msg_handler_delvec (ctx.handlers);
-    queue_destroy (ctx.queue);
+    queue_ctx_destroy (ctx.queue);
     purge_destroy (ctx.purge);
     journal_ctx_destroy (ctx.journal);
     annotate_ctx_destroy (ctx.annotate);

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -34,7 +34,7 @@ struct job_manager {
     struct annotate *annotate;
     struct journal *journal;
     struct purge *purge;
-    struct queue *queue;
+    struct queue_ctx *queue;
     struct update *update;
     struct jobtap *jobtap;
 };

--- a/src/modules/job-manager/queue.h
+++ b/src/modules/job-manager/queue.h
@@ -15,17 +15,17 @@
 
 #include "job-manager.h"
 
-struct queue *queue_create (struct job_manager *ctx);
-void queue_destroy (struct queue *queue);
+struct queue_ctx *queue_ctx_create (struct job_manager *ctx);
+void queue_ctx_destroy (struct queue_ctx *qctx);
 
-json_t *queue_save_state (struct queue *queue);
-int queue_restore_state (struct queue *queue, int version, json_t *o);
+json_t *queue_ctx_save (struct queue_ctx *qctx);
+int queue_ctx_restore (struct queue_ctx *qctx, int version, json_t *o);
 
-int queue_submit_check (struct queue *queue,
+int queue_submit_check (struct queue_ctx *qctx,
                         json_t *jobspec,
                         flux_error_t *error);
 
-bool queue_started (struct queue *queue, struct job *job);
+bool queue_started (struct queue_ctx *qctx, struct job *job);
 
 #endif /* ! _FLUX_JOB_MANAGER_QUEUE_H */
 

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -311,7 +311,7 @@ int restart_save_state_to_txn (struct job_manager *ctx, flux_kvs_txn_t *txn)
 {
     json_t *queue;
 
-    if (!(queue = queue_save_state (ctx->queue)))
+    if (!(queue = queue_ctx_save (ctx->queue)))
         return -1;
     if (flux_kvs_txn_pack (txn,
                            0,
@@ -368,7 +368,7 @@ static int restart_restore_state (struct job_manager *ctx)
     if (ctx->max_jobid < id)
         ctx->max_jobid = id;
     if (queue) {
-        if (queue_restore_state (ctx->queue, version, queue) < 0)
+        if (queue_ctx_restore (ctx->queue, version, queue) < 0)
             goto error;
     }
     flux_future_destroy (f);


### PR DESCRIPTION
Problem: queues in the job manager are a bit strange(!) and the code is not well documented.

This is some gratuitous cleanup based on my experience revisiting the code after a long haitus.  Hopefully it makes things a little more clear for the next visitor.