### PR TITLE
librlist: avoid unnecessary hwloc dependencies

### DIFF
--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -128,7 +128,6 @@ _idset_la_LIBADD = $(common_libs)
 nodist__rlist_la_SOURCES = _rlist.c
 _rlist_la_LIBADD = \
 	$(top_builddir)/src/common/librlist/librlist.la \
-	$(HWLOC_LIBS) \
 	$(common_libs)
 
 if HAVE_FLUX_SECURITY

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -21,14 +21,12 @@ AM_CPPFLAGS = \
 
 fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
-	$(top_builddir)/src/common/librlist/librlist-hwloc.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(FLUX_SECURITY_LIBS) \
 	$(LIBPTHREAD) \
-	$(HWLOC_LIBS) \
 	$(JANSSON_LIBS)
 
 LDADD = $(fluxcmd_ldadd)
@@ -197,6 +195,7 @@ flux_terminus_LDADD = \
 
 flux_R_LDADD = \
 	$(fluxcmd_ldadd) \
+	$(top_builddir)/src/common/librlist/librlist-hwloc.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libhostlist/libhostlist.la \

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -21,6 +21,7 @@ AM_CPPFLAGS = \
 
 fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
+	$(top_builddir)/src/common/librlist/librlist-hwloc.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/common/librlist/Makefile.am
+++ b/src/common/librlist/Makefile.am
@@ -15,7 +15,8 @@ AM_CPPFLAGS = \
 	$(HWLOC_CFLAGS)
 
 noinst_LTLIBRARIES = \
-	librlist.la
+	librlist.la \
+	librlist-hwloc.la
 
 librlist_la_SOURCES = \
 	rnode.h \
@@ -24,6 +25,9 @@ librlist_la_SOURCES = \
 	match.c \
 	rlist.c \
 	rlist.h \
+	rlist_private.h
+
+librlist_hwloc_la_SOURCES = \
 	rhwloc.c \
 	rhwloc.h
 
@@ -85,6 +89,7 @@ test_rhwloc_t_CPPFLAGS = \
 	$(test_cppflags)
 test_rhwloc_t_LDADD = \
 	librlist.la \
+	librlist-hwloc.la \
 	$(test_ldadd)
 test_rhwloc_t_LDFLAGS = \
 	$(test_ldflags)

--- a/src/common/librlist/Makefile.am
+++ b/src/common/librlist/Makefile.am
@@ -35,8 +35,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(LIBPTHREAD) \
-	$(JANSSON_LIBS) \
-	$(HWLOC_LIBS)
+	$(JANSSON_LIBS)
 
 test_cppflags = \
 	$(AM_CPPFLAGS)
@@ -90,6 +89,7 @@ test_rhwloc_t_CPPFLAGS = \
 test_rhwloc_t_LDADD = \
 	librlist.la \
 	librlist-hwloc.la \
-	$(test_ldadd)
+	$(test_ldadd) \
+	$(HWLOC_LIBS)
 test_rhwloc_t_LDFLAGS = \
 	$(test_ldflags)

--- a/src/common/librlist/rhwloc.h
+++ b/src/common/librlist/rhwloc.h
@@ -48,4 +48,8 @@ char * rhwloc_core_idset_string (hwloc_topology_t topo);
  */
 char * rhwloc_gpu_idset_string (hwloc_topology_t topo);
 
+/*  Return rlist object from local hwloc topology, or from xml if non-NULL.
+ */
+struct rlist *rlist_from_hwloc (int my_rank, const char *xml);
+
 #endif /* !HAVE_UTIL_RHWLOC */

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -225,8 +225,6 @@ struct rlist *rlist_from_R (const char *R);
  */
 struct rlist *rlist_from_json (json_t *o, json_error_t *err);
 
-struct rlist *rlist_from_hwloc (int my_rank, const char *xml);
-
 /*  Verify resources in rlist 'actual' meet or exceed resources in
  *   matching ranks of rlist 'expected'
  *  Returns:
@@ -288,5 +286,6 @@ int rlist_assign_properties (struct rlist *rl,
 char *rlist_properties_encode (const struct rlist *rl);
 
 struct rlist *rlist_from_config (json_t *conf, flux_error_t *errp);
+
 
 #endif /* !HAVE_SCHED_RLIST_H */

--- a/src/common/librlist/rlist_private.h
+++ b/src/common/librlist/rlist_private.h
@@ -1,0 +1,16 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_SCHED_RLIST_PRIVATE_H
+#define HAVE_SCHED_RLIST_PRIVATE_H 1
+
+int rlist_add_rnode (struct rlist *rl, struct rnode *n);
+
+#endif /* !HAVE_SCHED_RLIST_PRIVATE_H */

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -168,8 +168,7 @@ job_info_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libjob/libjob.la \
-	$(JANSSON_LIBS) \
-	$(HWLOC_LIBS)
+	$(JANSSON_LIBS)
 job_info_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 job_list_la_SOURCES =
@@ -184,8 +183,7 @@ job_list_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
-	$(JANSSON_LIBS) \
-	$(HWLOC_LIBS)
+	$(JANSSON_LIBS)
 job_list_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 job_ingest_la_SOURCES =
@@ -211,8 +209,7 @@ job_manager_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
-	$(JANSSON_LIBS) \
-	$(HWLOC_LIBS)
+	$(JANSSON_LIBS)
 job_manager_la_LDFLAGS = \
 	$(fluxlib_ldflags) \
 	-avoid-version \
@@ -265,8 +262,7 @@ sched_simple_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
-	$(JANSSON_LIBS) \
-	$(HWLOC_LIBS)
+	$(JANSSON_LIBS)
 sched_simple_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 sdexec_la_SOURCES = \

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -245,6 +245,7 @@ resource_la_CPPFLAGS = \
 	$(HWLOC_CFLAGS)
 resource_la_LIBADD = \
 	$(builddir)/resource/libresource.la \
+	$(top_builddir)/src/common/librlist/librlist-hwloc.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/job-list/Makefile.am
+++ b/src/modules/job-list/Makefile.am
@@ -50,8 +50,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(JANSSON_LIBS) \
-	$(HWLOC_LIBS)
+	$(JANSSON_LIBS)
 
 test_cppflags = \
 	$(AM_CPPFLAGS)

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -136,8 +136,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(LIBPTHREAD) \
-	$(JANSSON_LIBS) \
-	$(HWLOC_LIBS)
+	$(JANSSON_LIBS)
 
 test_cppflags = \
 	$(AM_CPPFLAGS)

--- a/src/modules/resource/inventory.c
+++ b/src/modules/resource/inventory.c
@@ -89,7 +89,8 @@
 #include <jansson.h>
 #include <flux/core.h>
 
-#include <src/common/librlist/rlist.h>
+#include "src/common/librlist/rlist.h"
+#include "src/common/librlist/rhwloc.h"
 #include "src/common/libidset/idset.h"
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/errprintf.h"

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -106,6 +106,7 @@ flux_shell_LDADD = \
 	$(builddir)/libshell.la \
 	$(builddir)/libmpir.la \
 	$(top_builddir)/src/common/libjob/libjob.la \
+	$(top_builddir)/src/common/librlist/librlist-hwloc.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/bindings/lua/libfluxlua.la \
 	$(top_builddir)/src/common/libflux-core.la \


### PR DESCRIPTION
Problem: the librlist.la convenience library includes code that requires hwloc, but often the hwloc bits are not needed.

Split the hwloc parts into a separate convenience library, `librlist-hwloc.la`.

This also drops the ffi python binding for `rlist_from_hwloc()`, which probably is fine.