### PR TITLE
add `-S, --setattr` and `-c, --config-path` options directly to `flux start`

### DIFF
--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -122,6 +122,15 @@ as long as the Flux instance is running.  It covers the following use cases:
 
 OPTIONS
 =======
+.. option:: -S, --setattr=ATTR=VAL
+
+   Set broker attribute *ATTR* to *VAL*. This is equivalent to
+   :option:`-o,-SATTR=VAL`.
+
+.. option:: -c, --config-path=PATH
+
+   Set the *PATH* for broker configuration. See :man1:`flux-broker` for
+   option details. This is equivalent to :option:`-o,-cPATH`.
 
 .. option:: -o, --broker-opts=OPTIONS
 
@@ -282,7 +291,7 @@ If :program:`flux start` appears to hang, the following tips may be helpful:
    See :man7:`flux-environment`.
 
 #. More logging can be enabled by adding the
-   :option:`flux start -o,-Slog-stderr-level=7` option, which instructs the
+   :option:`flux start -Slog-stderr-level=7` option, which instructs the
    broker to forward its internal log buffer to stderr.  See
    :man7:`flux-broker-attributes`.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -936,3 +936,5 @@ cgroups
 fs
 misconfigured
 aTGTz
+cPATH
+SATTR

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -99,6 +99,9 @@ const char *default_statedir = "/var/lib/flux";
 
 const char *usage_msg = "[OPTIONS] command ...";
 static struct optparse_option opts[] = {
+    { .name = "setattr",    .key = 'S', .has_arg = 1, .arginfo = "ATTR=VAL",
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .usage = "Set broker attribute", },
     { .name = "recovery",   .key = 'r', .has_arg = 2, .arginfo = "[TARGET]",
       .flags = OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG,
       .usage = "Start instance in recovery mode with dump file or statedir", },
@@ -615,6 +618,7 @@ int add_args_common (char **argz,
         errno = ENOMEM;
         return -1;
     }
+    add_args_list (argz, argz_len, ctx.opts, "setattr", "-S");
     add_args_list (argz, argz_len, ctx.opts, "broker-opts", "");
 
     if (optparse_hasopt (ctx.opts, "recovery"))

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -102,6 +102,8 @@ static struct optparse_option opts[] = {
     { .name = "setattr",    .key = 'S', .has_arg = 1, .arginfo = "ATTR=VAL",
       .flags = OPTPARSE_OPT_AUTOSPLIT,
       .usage = "Set broker attribute", },
+    { .name = "config-path",.key = 'c', .has_arg = 1, .arginfo = "PATH",
+      .usage = "Set broker config from PATH (default: none)", },
     { .name = "recovery",   .key = 'r', .has_arg = 2, .arginfo = "[TARGET]",
       .flags = OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG,
       .usage = "Start instance in recovery mode with dump file or statedir", },
@@ -612,6 +614,7 @@ int add_args_common (char **argz,
                      const char *broker_path)
 {
     bool system_recovery = false;
+    const char *config_path = NULL;
 
     add_args_list (argz, argz_len, ctx.opts, "wrap", "");
     if (argz_add (argz, argz_len, broker_path) != 0) {
@@ -625,7 +628,16 @@ int add_args_common (char **argz,
         process_recovery_option (argz, argz_len, &system_recovery);
 
     if (system_recovery || optparse_hasopt (ctx.opts, "sysconfig"))
-        add_argzf (argz, argz_len, "-c%s", default_config_path);
+        config_path = default_config_path;
+    if (optparse_hasopt (ctx.opts, "config-path")) {
+        const char *conf = optparse_get_str (ctx.opts, "config-path", NULL);
+        if (config_path)
+            log_msg ("Warning: overriding recovery/--sysconfig path with %s",
+                     conf);
+        config_path = conf;
+    }
+    if (config_path)
+        add_argzf (argz, argz_len, "-c%s", config_path);
 
     return 0;
 }

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -309,7 +309,9 @@ char *find_broker (const char *searchpath)
     return dir ? xstrdup (path) : NULL;
 }
 
-void exit_timeout (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+void exit_timeout (flux_reactor_t *r,
+                   flux_watcher_t *w,
+                   int revents, void *arg)
 {
     struct client *cli;
 
@@ -455,7 +457,7 @@ void add_args_list (char **argz,
     const char *arg;
     optparse_getopt_iterator_reset (opt, name);
     while ((arg = optparse_getopt_next (opt, name)))
-        if (argz_add  (argz, argz_len, arg) != 0)
+        if (argz_add (argz, argz_len, arg) != 0)
             log_err_exit ("argz_add");
 }
 
@@ -674,7 +676,7 @@ struct client *client_create (const char *broker_path,
 {
     struct client *cli = xzmalloc (sizeof (*cli));
     char *arg;
-    char * argz = NULL;
+    char *argz = NULL;
     size_t argz_len = 0;
 
     cli->rank = rank;
@@ -684,8 +686,8 @@ struct client *client_create (const char *broker_path,
 
     add_argzf (&argz, &argz_len, "--setattr=rundir=%s", rundir);
 
-    if (rank == 0 && cmd_argz)
-        argz_append (&argz, &argz_len, cmd_argz, cmd_argz_len); /* must be last arg */
+    if (rank == 0 && cmd_argz) /* must be last arg */
+        argz_append (&argz, &argz_len, cmd_argz, cmd_argz_len);
 
     if (!(cli->cmd = flux_cmd_create (0, NULL, environ)))
         goto fail;
@@ -748,7 +750,9 @@ void client_dumpargs (struct client *cli)
 void pmi_server_initialize (int flags)
 {
     struct taskmap *map;
-    const char *mode = optparse_get_str (ctx.opts, "test-pmi-clique", "single");
+    const char *mode = optparse_get_str (ctx.opts,
+                                         "test-pmi-clique",
+                                         "single");
     struct pmi_simple_ops ops = {
         .abort = pmi_abort,
         .kvs_put = pmi_kvs_put,
@@ -1098,8 +1102,10 @@ int start_session (const char *cmd_argz,
     if (!(ctx.reactor = flux_reactor_create (FLUX_REACTOR_SIGCHLD)))
         log_err_exit ("flux_reactor_create");
     if (!(ctx.timer = flux_timer_watcher_create (ctx.reactor,
-                                                 ctx.exit_timeout, 0.,
-                                                 exit_timeout, NULL)))
+                                                 ctx.exit_timeout,
+                                                 0.,
+                                                 exit_timeout,
+                                                 NULL)))
         log_err_exit ("flux_timer_watcher_create");
     if (!(ctx.clients = zlist_new ()))
         log_err_exit ("zlist_new");

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -449,18 +449,6 @@ void channel_cb (flux_subprocess_t *p, const char *stream)
     }
 }
 
-void add_args_list (char **argz,
-                    size_t *argz_len,
-                    optparse_t *opt,
-                    const char *name)
-{
-    const char *arg;
-    optparse_getopt_iterator_reset (opt, name);
-    while ((arg = optparse_getopt_next (opt, name)))
-        if (argz_add (argz, argz_len, arg) != 0)
-            log_err_exit ("argz_add");
-}
-
 void add_argzf (char **argz, size_t *argz_len, const char *fmt, ...)
 {
     va_list ap;
@@ -471,6 +459,18 @@ void add_argzf (char **argz, size_t *argz_len, const char *fmt, ...)
     va_end (ap);
     if (argz_add (argz, argz_len, arg) != 0)
         log_err_exit ("argz_add");
+}
+
+void add_args_list (char **argz,
+                    size_t *argz_len,
+                    optparse_t *opt,
+                    const char *name,
+                    const char *prepend)
+{
+    const char *arg;
+    optparse_getopt_iterator_reset (opt, name);
+    while ((arg = optparse_getopt_next (opt, name)))
+        add_argzf (argz, argz_len, "%s%s", prepend, arg);
 }
 
 char *create_rundir (void)
@@ -610,12 +610,12 @@ int add_args_common (char **argz,
 {
     bool system_recovery = false;
 
-    add_args_list (argz, argz_len, ctx.opts, "wrap");
+    add_args_list (argz, argz_len, ctx.opts, "wrap", "");
     if (argz_add (argz, argz_len, broker_path) != 0) {
         errno = ENOMEM;
         return -1;
     }
-    add_args_list (argz, argz_len, ctx.opts, "broker-opts");
+    add_args_list (argz, argz_len, ctx.opts, "broker-opts", "");
 
     if (optparse_hasopt (ctx.opts, "recovery"))
         process_recovery_option (argz, argz_len, &system_recovery);

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -457,13 +457,15 @@ void channel_cb (flux_subprocess_t *p, const char *stream)
 void add_argzf (char **argz, size_t *argz_len, const char *fmt, ...)
 {
     va_list ap;
-    char arg[1024];
+    char *arg = NULL;
 
     va_start (ap, fmt);
-    (void)vsnprintf (arg, sizeof (arg), fmt, ap);
+    if (vasprintf (&arg, fmt, ap) < 0)
+        log_err_exit ("vasprintf");
     va_end (ap);
     if (argz_add (argz, argz_len, arg) != 0)
         log_err_exit ("argz_add");
+    free (arg);
 }
 
 void add_args_list (char **argz,

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -682,9 +682,7 @@ struct client *client_create (const char *broker_path,
     if (add_args_common (&argz, &argz_len, broker_path) < 0)
         goto fail;
 
-    char *dir_arg = xasprintf ("--setattr=rundir=%s", rundir);
-    argz_add (&argz, &argz_len, dir_arg);
-    free (dir_arg);
+    add_argzf (&argz, &argz_len, "--setattr=rundir=%s", rundir);
 
     if (rank == 0 && cmd_argz)
         argz_append (&argz, &argz_len, cmd_argz, cmd_argz_len); /* must be last arg */

--- a/t/fluxometer.lua
+++ b/t/fluxometer.lua
@@ -133,7 +133,7 @@ function fluxTest.init (...)
     end
 
     test.log_file = "lua-"..test.prog..".broker.log"
-    test.start_args = { "-o,-Slog-filename=" .. test.log_file }
+    test.start_args = { "-Slog-filename=" .. test.log_file }
 
     local path = fluxTest.fluxbindir .. "/flux"
     local mode = posix.stat (path, 'mode')

--- a/t/issues/t3906-job-exec-exception.sh
+++ b/t/issues/t3906-job-exec-exception.sh
@@ -7,7 +7,7 @@
 #  3. Ensure job exception is raised and includes appropriate error note
 #
 export startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
-SHELL=/bin/sh flux start -s 4 -o,-Stbon.topo=kary:4 --test-exit-mode=leader '\
+SHELL=/bin/sh flux start -s 4 -Stbon.topo=kary:4 --test-exit-mode=leader '\
    id=$(flux submit -n4 -N4 sleep 300) \
 && flux job wait-event $id start \
 && $startctl kill 3 9 \

--- a/t/issues/t3960-job-exec-ehostunreach.sh
+++ b/t/issues/t3960-job-exec-ehostunreach.sh
@@ -12,7 +12,7 @@
 #
 #
 export startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
-SHELL=/bin/sh flux start -s 4 -o,-Stbon.topo=kary:4 --test-exit-mode=leader '\
+SHELL=/bin/sh flux start -s 4 -Stbon.topo=kary:4 --test-exit-mode=leader '\
    id=$(flux submit -n4 -N4 sleep 300) \
 && flux job wait-event $id start \
 && $startctl kill 3 19 \

--- a/t/issues/t4182-resource-rerank.sh
+++ b/t/issues/t4182-resource-rerank.sh
@@ -40,7 +40,7 @@ echo "resource.noverify = true" >t4182-resource.toml
 
 #  ensure R rerank failure is ignored (i.e. job completes successfully)
 flux run -o per-resource.type=node -o cpu-affinity=off -n 11 \
-	flux start -o,--config-path=t4182-resource.toml \
+	flux start --config-path=t4182-resource.toml \
 	flux getattr hostlist
 
 #  ensure R is reranked based on hostlist attribute:

--- a/t/issues/t4465-job-list-use-after-free.sh
+++ b/t/issues/t4465-job-list-use-after-free.sh
@@ -22,10 +22,10 @@ mkdir ${STATEDIR}
 # a different order than submitted, hence number of jobs submitted equals
 # number of broker ranks.
 #
-flux start --test-size=8 -o,-Sstatedir=${STATEDIR} \
+flux start --test-size=8 -Sstatedir=${STATEDIR} \
     bash -c "flux submit --cc 1-8 --quiet /bin/true && flux queue drain"
 
-flux start --test-size=1 -o,-Sstatedir=${STATEDIR} \
+flux start --test-size=1 -Sstatedir=${STATEDIR} \
     --wrap=libtool,e,${VALGRIND} \
     --wrap=--tool=memcheck \
     --wrap=--trace-children=no \

--- a/t/issues/t4482-flush-list-corruption.sh
+++ b/t/issues/t4482-flush-list-corruption.sh
@@ -38,6 +38,6 @@ EOF
 chmod +x t4482.sh
 
 flux start -s 1 \
-    -o,--setattr=broker.rc1_path= \
-    -o,--setattr=broker.rc3_path= \
+    --setattr=broker.rc1_path= \
+    --setattr=broker.rc3_path= \
     ./t4482.sh

--- a/t/issues/t4583-free-range-test.sh
+++ b/t/issues/t4583-free-range-test.sh
@@ -31,7 +31,7 @@ if test "$FREE_RANGE_TEST_ACTIVE" != "t"; then
     exec flux start -s 4 \
         --test-exit-mode=leader \
         --test-pmi-clique=per-broker \
-        -o -Stbon.topo=kary:0 $0
+        -Stbon.topo=kary:0 $0
 fi
 
 #  Start a job with tbon.topo=kary:0

--- a/t/issues/t4852-t_submit-legacy.sh
+++ b/t/issues/t4852-t_submit-legacy.sh
@@ -41,9 +41,9 @@ STATEDIR=issue4852-statedir
 mkdir issue4852-statedir
 
 flux start -s 1 \
-    -o,--setattr=statedir=${STATEDIR} \
+    --setattr=statedir=${STATEDIR} \
     ./t4852setup.sh
 
 flux start -s 1 \
-    -o,--setattr=statedir=${STATEDIR} \
+    --setattr=statedir=${STATEDIR} \
     ./t4852test.sh

--- a/t/issues/t5892-shutdown-no-epilog.sh
+++ b/t/issues/t5892-shutdown-no-epilog.sh
@@ -12,7 +12,7 @@ plugins = [
 command = [ "touch", "t5892-epilog-flag" ]
 EOF
 
-flux start -o,--config-path=t5892.toml \
+flux start --config-path=t5892.toml \
 	flux submit sleep inf
 
 rc=0

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -60,10 +60,10 @@ def rerun_under_flux(size=1, personality="full"):
         for rc_num in [1, 3]:
             attr = "broker.rc{}_path".format(rc_num)
             if personality == "minimal":
-                command.append("-o,-S{}=".format(attr))
+                command.append("-S{}=".format(attr))
             else:
                 path = "{}/t/rc/rc{}-{}".format(srcdir, rc_num, personality)
-                command.append("-o,-S{}={}".format(attr, path))
+                command.append("-S{}={}".format(attr, path))
                 if not is_exe(path):
                     print("cannot execute {}".format(path), file=sys.stderr)
                     sys.exit(1)

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -118,14 +118,14 @@ make_bootstrap_config() {
 	    path = "$workdir/R"
 	    noverify = true
 	EOT2
-    echo "--test-hosts=$fakehosts -o,-c$workdir/conf.d"
+    echo "--test-hosts=$fakehosts -c$workdir/conf.d"
     echo "--test-exit-mode=${TEST_UNDER_FLUX_EXIT_MODE:-leader}"
     echo "--test-exit-timeout=${TEST_UNDER_FLUX_EXIT_TIMEOUT:-0}"
-    echo "-o,-Sbroker.quorum=${TEST_UNDER_FLUX_QUORUM:-$size}"
+    echo "-Sbroker.quorum=${TEST_UNDER_FLUX_QUORUM:-$size}"
     echo "--test-start-mode=${TEST_UNDER_FLUX_START_MODE:-all}"
-    echo "-o,-Stbon.topo=${TEST_UNDER_FLUX_TOPO:-custom}"
-    echo "-o,-Stbon.zmqdebug=1"
-    echo "-o,-Sstatedir=$workdir/state"
+    echo "-Stbon.topo=${TEST_UNDER_FLUX_TOPO:-custom}"
+    echo "-Stbon.zmqdebug=1"
+    echo "-Sstatedir=$workdir/state"
 }
 
 #
@@ -263,7 +263,7 @@ test_under_flux() {
         # Set log_path for ASan o/w errors from broker may be lost
         ASAN_OPTIONS=${ASAN_OPTIONS}:log_path=${TEST_NAME}.asan
     fi
-    logopts="-o -Slog-filename=${log_file},-Slog-forward-level=7"
+    logopts="-o -Slog-filename=${log_file} -Slog-forward-level=7"
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
     TEST_UNDER_FLUX_PERSONALITY="${personality:-default}" \

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -286,7 +286,8 @@ test_expect_success 'module: remove testmod if loaded' '
 '
 test_expect_success 'module: load without unload causes broker failure' '
 	test_must_fail flux start \
-	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+	    -Sbroker.rc1_path= \
+	    -Sbroker.rc3_path= \
 	    flux module load content 2>nounload.err
 '
 test_expect_success 'module: module name is called out' '

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -333,36 +333,36 @@ test_expect_success 'reload module with no options and verify modes' '
 
 
 test_expect_success 'run flux without statedir and verify modes' '
-	flux start -o,-Sbroker.rc1_path=$rc1_kvs,-Sbroker.rc3_path=$rc3_kvs \
+	flux start -Sbroker.rc1_path=$rc1_kvs -Sbroker.rc3_path=$rc3_kvs \
 	    flux dmesg >logs3 &&
 	grep "journal_mode=OFF synchronous=OFF" logs3
 '
 test_expect_success 'run flux with statedir and verify modes' '
-	flux start -o,-Sbroker.rc1_path=$rc1_kvs,-Sbroker.rc3_path=$rc3_kvs \
-	    -o,-Sstatedir=$(pwd) flux dmesg >logs4  &&
+	flux start -Sbroker.rc1_path=$rc1_kvs -Sbroker.rc3_path=$rc3_kvs \
+	    -Sstatedir=$(pwd) flux dmesg >logs4  &&
 	grep "journal_mode=WAL synchronous=NORMAL" logs4
 '
 test_expect_success 'run flux without statedir and verify config' '
-	flux start -o,-Sbroker.rc1_path=$rc1_kvs,-Sbroker.rc3_path=$rc3_kvs \
+	flux start -Sbroker.rc1_path=$rc1_kvs -Sbroker.rc3_path=$rc3_kvs \
 	    flux module stats content-sqlite >stats1 &&
 	$jq -e ".config.journal_mode == \"OFF\"" < stats1 &&
 	$jq -e ".config.synchronous == \"OFF\"" < stats1
 '
 test_expect_success 'run flux with statedir and verify config' '
-	flux start -o,-Sbroker.rc1_path=$rc1_kvs,-Sbroker.rc3_path=$rc3_kvs \
-	    -o,-Sstatedir=$(pwd) flux module stats content-sqlite >stats2  &&
+	flux start -Sbroker.rc1_path=$rc1_kvs -Sbroker.rc3_path=$rc3_kvs \
+	    -Sstatedir=$(pwd) flux module stats content-sqlite >stats2  &&
 	$jq -e ".config.journal_mode == \"WAL\"" < stats2 &&
 	$jq -e ".config.synchronous == \"NORMAL\"" < stats2
 '
 test_expect_success 'flux fails with invalid journal_mode config' '
-	flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+	flux start -Sbroker.rc1_path= -Sbroker.rc3_path= \
 	    "flux module load content; \
 	    flux module load content-sqlite journal_mode=FOO; \
 	    flux module remove content" > invalid1.out 2> invalid1.err &&
 	grep "content-sqlite: Invalid argument" invalid1.err
 '
 test_expect_success 'flux fails with invalid synchronous config' '
-	flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+	flux start -Sbroker.rc1_path= -Sbroker.rc3_path= \
 	    "flux module load content; \
 	    flux module load content-sqlite synchronous=BAR; \
 	    flux module remove content" > invalid2.out 2> invalid2.err &&
@@ -374,8 +374,8 @@ test_expect_success 'test config via config file works' '
 	journal_mode = "PERSIST"
 	synchronous = "EXTRA"
 	EOT
-	flux start -o,--config-path=$(pwd) \
-	   -o,-Sbroker.rc1_path=$rc1_kvs,-Sbroker.rc3_path=$rc3_kvs \
+	flux start --config-path=$(pwd) \
+	   -Sbroker.rc1_path=$rc1_kvs -Sbroker.rc3_path=$rc3_kvs \
 	   flux module stats content-sqlite > configstats.out &&
 	$jq -e ".config.journal_mode == \"PERSIST\"" < configstats.out &&
 	$jq -e ".config.synchronous == \"EXTRA\"" < configstats.out &&
@@ -387,8 +387,8 @@ test_expect_success 'invalid config fails (journal_mode)' '
 	journal_mode = "FOO"
 	synchronous = "EXTRA"
 	EOT
-	test_must_fail flux start -o,--config-path=$(pwd) \
-	   -o,-Sbroker.rc1_path=$rc1_kvs,-Sbroker.rc3_path=$rc3_kvs \
+	test_must_fail flux start --config-path=$(pwd) \
+	   -Sbroker.rc1_path=$rc1_kvs -Sbroker.rc3_path=$rc3_kvs \
 	   flux module stats content-sqlite &&
 	rm content-sqlite.toml
 '
@@ -398,8 +398,8 @@ test_expect_success 'invalid config fails (synchronous)' '
 	journal_mode = "PERSIST"
 	synchronous = "BAR"
 	EOT
-	test_must_fail flux start -o,--config-path=$(pwd) \
-	   -o,-Sbroker.rc1_path=$rc1_kvs,-Sbroker.rc3_path=$rc3_kvs \
+	test_must_fail flux start --config-path=$(pwd) \
+	   -Sbroker.rc1_path=$rc1_kvs -Sbroker.rc3_path=$rc3_kvs \
 	   flux module stats content-sqlite &&
 	rm content-sqlite.toml
 '
@@ -408,8 +408,8 @@ test_expect_success 'invalid config fails (synchronous)' '
 # Will create in WAL mode since statedir is set
 recreate_database()
 {
-	flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
-	    -o,-Sstatedir=$(pwd) bash -c \
+	flux start -Sbroker.rc1_path= -Sbroker.rc3_path= \
+	    -Sstatedir=$(pwd) bash -c \
 	    "flux module load content &&
 	    flux module load content-sqlite truncate && \
 	    flux module remove content-sqlite && \
@@ -417,8 +417,8 @@ recreate_database()
 }
 load_module_xfail()
 {
-	flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
-	    -o,-Sstatedir=$(pwd) bash -c \
+	flux start -Sbroker.rc1_path= -Sbroker.rc3_path= \
+	    -Sstatedir=$(pwd) bash -c \
 	    "flux module load content; \
 	    flux module load content-sqlite; \
 	    rc=\$?; \
@@ -443,7 +443,7 @@ test_expect_success 'module load fails with corrupt database' '
 	test_must_fail load_module_xfail
 '
 test_expect_success 'full instance start fails corrupt database' '
-	test_must_fail flux start -o,-Sstatedir=$(pwd) /bin/true
+	test_must_fail flux start -Sstatedir=$(pwd) /bin/true
 '
 
 test_expect_success 'flux module stats content-sqlite is open to guests' '

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -154,7 +154,7 @@ test_expect_success '[bootstrap] config with with unknown parent' '
 	]
 	EOT
 	test_must_fail flux start --test-size=1 --test-hosts=fake0 \
-	    -o,-c conf4d /bin/true
+	    -c conf4d /bin/true
 '
 
 test_expect_success '[bootstrap] config with with impossible parent' '
@@ -166,7 +166,7 @@ test_expect_success '[bootstrap] config with with impossible parent' '
 	]
 	EOT
 	test_must_fail flux start --test-size=1 --test-hosts=fake0 \
-	    -o,-c conf4e /bin/true
+	    -c conf4e /bin/true
 '
 
 test_expect_success '[bootstrap] config with hostname not found' '
@@ -226,8 +226,8 @@ test_expect_success 'start size=2 instance with ipc://' '
 	host = "fake1"
 	EOT
 	flux start -s2 --test-hosts=fake[0-1] \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
-		-o,--config-path=conf8 \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= \
+		--config-path=conf8 \
 		./attrdump.sh >ipc.out &&
 	cat <<-EXP >ipc.exp &&
 	2
@@ -256,8 +256,8 @@ test_expect_success 'start size=3 instance with ipc:// and custom topology' '
 	parent = "fake1"
 	EOT
 	flux start --test-size=3 --test-hosts=fake[0-2] \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
-		-o,--config-path=conf8a \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= \
+		--config-path=conf8a \
 		flux getattr tbon.maxlevel >conf8a.out &&
 	echo 2 >conf8a.exp &&
 	test_cmp conf8a.exp conf8a.out
@@ -288,7 +288,7 @@ test_expect_success NO_CHAIN_LINT 'a warning is printed when upstream URI has un
 	host = "fake1"
 	EOT
 	FLUX_FAKE_HOSTNAME=fake1 \
-		flux broker -vv -Sbroker.rc1_path=,-Sbroker.rc3_path= \
+		flux broker -vv -Sbroker.rc1_path= -Sbroker.rc3_path= \
 		--config-path=conf8b 2>warn.err &
 	echo $! >warn.pid &&
 	waitgrep "unable to resolve upstream peer" warn.err 30
@@ -324,8 +324,8 @@ test_expect_success 'start size=4 instance with tcp://' '
 	host = "fake[2-3]"
 	EOT
 	flux start -s4 --test-hosts=fake[0-3] \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
-		-o,--config-path=conf9 \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= \
+		--config-path=conf9 \
 		./attrdump.sh >tcp.out &&
 	cat <<-EXP >tcp.exp &&
 	4
@@ -519,7 +519,7 @@ test_expect_success 'tbon.zmq_io_threads config only applies to rank 0' '
 	0: 4
 	1: 1
 	EOT2
-	flux start -s2 -o,--config-path=zmq_io_threads.toml \
+	flux start -s2 --config-path=zmq_io_threads.toml \
 		flux exec --label-io flux getattr tbon.zmq_io_threads \
 		| sort >t4.out &&
 	test_cmp t4.exp t4.out
@@ -530,8 +530,8 @@ test_expect_success 'tbon.zmq_io_threads broker attr overrides' '
 	1: 1
 	EOT2
 	flux start -s2 \
-		-o,--config-path=zmq_io_threads.toml \
-		-o,-Stbon.zmq_io_threads=2 \
+		--config-path=zmq_io_threads.toml \
+		-Stbon.zmq_io_threads=2 \
 		flux exec --label-io flux getattr tbon.zmq_io_threads \
 		| sort >t2.out &&
 	test_cmp t2.exp t2.out

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -9,15 +9,15 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile --debug
 . `dirname $0`/sharness.sh
 
 test_expect_success 'initial program is run when rc1/rc3 are nullified' '
-	flux start -o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+	flux start -Slog-stderr-level=6 \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= \
 		/bin/true 2>normal.log
 '
 
 test_expect_success 'rc1 failure causes instance failure' '
 	test_expect_code 1 flux start \
-		-o,-Sbroker.rc1_path=/bin/false,-Sbroker.rc3_path= \
-		-o,-Slog-stderr-level=6 \
+		-Sbroker.rc1_path=/bin/false -Sbroker.rc3_path= \
+		-Slog-stderr-level=6 \
 		sleep 3600 2>rc1_failure.log
 '
 
@@ -25,8 +25,8 @@ test_expect_success 'rc1 bad path handled same as failure' '
 	(
 	  SHELL=/bin/sh &&
 	  test_expect_code 127 flux start \
-		-o,-Sbroker.rc1_path=rc1-nonexist,-Sbroker.rc3_path= \
-		-o,-Slog-stderr-level=6 \
+		-Sbroker.rc1_path=rc1-nonexist -Sbroker.rc3_path= \
+		-Slog-stderr-level=6 \
 		/bin/true 2>bad1.log
 	)
 '
@@ -34,79 +34,79 @@ test_expect_success 'rc1 bad path handled same as failure' '
 test_expect_success 'default initial program is $SHELL' '
 	run_timeout --env=SHELL=/bin/sh 60 \
 		flux $SHARNESS_TEST_SRCDIR/scripts/runpty.py -i none \
-		flux start -o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+		flux start -Slog-stderr-level=6 \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= \
 		>shell.log &&
 	grep "rc2.0: /bin/sh Exited" shell.log
 '
 
 test_expect_success 'rc2 failure if stdin not a tty' '
 	test_expect_code 1 \
-		flux start -o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+		flux start -Slog-stderr-level=6 \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= \
                 2>shell-notty.log &&
 	grep "not a tty" shell-notty.log
 '
 
 test_expect_success 'rc3 failure causes instance failure' '
 	test_expect_code 1 flux start \
-		-o,-Sbroker.rc3_path=/bin/false \
-		-o,-Slog-stderr-level=6 \
+		-Sbroker.rc3_path=/bin/false \
+		-Slog-stderr-level=6 \
 		/bin/true 2>rc3_failure.log
 '
 
 test_expect_success 'broker.rc2_none terminates by signal without error' '
 	for timeout in 0.5 1 2 4; do
 	    run_timeout -s ALRM $timeout flux start \
-		-o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Sbroker.rc2_none &&
+		-Slog-stderr-level=6 \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= -Sbroker.rc2_none &&
 	    break
 	done
 '
 
 test_expect_success 'flux admin cleanup-push /bin/true works' '
-	flux start -o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+	flux start -Slog-stderr-level=6 \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= \
 		flux admin cleanup-push /bin/true
 '
 
 test_expect_success 'flux admin cleanup-push /bin/false causes instance failure' '
-	test_expect_code 1 flux start -o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+	test_expect_code 1 flux start -Slog-stderr-level=6 \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= \
 		flux admin cleanup-push /bin/false
 '
 
 test_expect_success 'cleanup does not run if rc1 fails' '
-	test_expect_code 1 flux start -o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path=/bin/false,-Sbroker.rc3_path= \
+	test_expect_code 1 flux start -Slog-stderr-level=6 \
+		-Sbroker.rc1_path=/bin/false -Sbroker.rc3_path= \
 		flux admin cleanup-push memorable-string 2>nocleanup.err && \
 	test_must_fail grep memorable-string nocleanup.err
 '
 
 test_expect_success 'flux admin cleanup-push (empty) fails' '
 	test_expect_code 1 flux start \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= \
 		flux admin cleanup-push "" 2>push.err &&
 	grep "cannot push an empty command line" push.err
 '
 
 test_expect_success 'flux admin cleanup-push with no commands fails' '
 	test_expect_code 1 flux start \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= \
 		flux admin cleanup-push </dev/null 2>push2.err &&
 	grep "commands array is empty" push2.err
 '
 
 test_expect_success 'flux admin cleanup-push (stdin) works' '
-	echo /bin/true | flux start -o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+	echo /bin/true | flux start -Slog-stderr-level=6 \
+		-Sbroker.rc1_path= -Sbroker.rc3_path= \
 		flux admin cleanup-push 2>push-stdin.err &&
 	grep cleanup.0 push-stdin.err
 '
 
 test_expect_success 'flux admin cleanup-push (stdin) retains cmd block order' '
-	flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
-		-o,-Slog-stderr-level=6 \
+	flux start -Sbroker.rc1_path= -Sbroker.rc3_path= \
+		-Slog-stderr-level=6 \
 		flux admin cleanup-push <<-EOT 2>hello.err &&
 	echo Hello world
 	echo Hello solar system
@@ -117,9 +117,9 @@ test_expect_success 'flux admin cleanup-push (stdin) retains cmd block order' '
 
 test_expect_success 'capture the environment for all three rc scripts' '
 	SLURM_FOO=42 flux start \
-		-o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path="bash -c printenv >rc1.env" \
-		-o,-Sbroker.rc3_path="bash -c printenv >rc3.env" \
+		-Slog-stderr-level=6 \
+		-Sbroker.rc1_path="bash -c printenv >rc1.env" \
+		-Sbroker.rc3_path="bash -c printenv >rc3.env" \
 		"bash -c printenv >rc2.env"
 '
 
@@ -163,9 +163,9 @@ test_expect_success 'job environment is not set in rc scripts' '
 
 test_expect_success 'capture the environment for instance run as a job' '
 	flux start flux run flux start \
-		-o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path="bash -c printenv >rc1.env2" \
-		-o,-Sbroker.rc3_path="bash -c printenv >rc3.env2" \
+		-Slog-stderr-level=6 \
+		-Sbroker.rc1_path="bash -c printenv >rc1.env2" \
+		-Sbroker.rc3_path="bash -c printenv >rc3.env2" \
 		"bash -c printenv >rc2.env2"
 '
 

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -6,7 +6,7 @@ test_description='Test content-files backing store service'
 
 . `dirname $0`/sharness.sh
 
-test_under_flux 1 minimal -o,-Sstatedir=$(pwd)
+test_under_flux 1 minimal -Sstatedir=$(pwd)
 
 BLOBREF=${FLUX_BUILD_DIR}/t/kvs/blobref
 RPC=${FLUX_BUILD_DIR}/t/request/rpc

--- a/t/t0019-tbon-config.t
+++ b/t/t0019-tbon-config.t
@@ -7,13 +7,13 @@ test_description='Test the brokers tbon.* configuration'
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
-ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
+ARGS="-Sbroker.rc1_path= -Sbroker.rc3_path="
 
 test_expect_success 'flux-start with size 2 works with tbon.zmqdebug' '
-	flux start ${ARGS} -o,-Stbon.zmqdebug=1 -s2 /bin/true
+	flux start ${ARGS} -Stbon.zmqdebug=1 -s2 /bin/true
 '
 test_expect_success 'flux-start with non-integer tbon.zmqdebug fails' '
-	test_must_fail flux start ${ARGS} -o,-Stbon.zmqdebug=foo /bin/true
+	test_must_fail flux start ${ARGS} -Stbon.zmqdebug=foo /bin/true
 '
 test_expect_success 'tbon.endpoint can be read' '
 	ATTR_VAL=`flux start ${ARGS} -s2 flux getattr tbon.endpoint` &&
@@ -30,25 +30,25 @@ test_expect_success 'tbon.endpoint uses tcp:// if process mapping unavailable' '
 	grep "^tcp" endpoint2.out
 '
 test_expect_success 'tbon.endpoint uses tcp:// if tbon.prefertcp is set' '
-	flux start ${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+	flux start ${ARGS} -s2 -Stbon.prefertcp=1 \
 		flux getattr tbon.endpoint >endpoint2.out &&
 	grep "^tcp" endpoint2.out
 '
 test_expect_success 'FLUX_IPADDR_INTERFACE=lo works' '
 	FLUX_IPADDR_INTERFACE=lo flux start \
-		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+		${ARGS} -s2 -Stbon.prefertcp=1 \
 		flux getattr tbon.endpoint >endpoint3.out &&
 	grep "127.0.0.1" endpoint3.out
 '
 test_expect_success 'tbon.interface-hint=lo works' '
-	flux start -o,-Stbon.interface-hint=lo \
-		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+	flux start -Stbon.interface-hint=lo \
+		${ARGS} -s2 -Stbon.prefertcp=1 \
 		flux getattr tbon.endpoint >endpoint3a.out &&
 	grep "127.0.0.1" endpoint3a.out
 '
 test_expect_success 'tbon.interface-hint=127.0.0.0/8 works' '
-	flux start -o,-Stbon.interface-hint=127.0.0.0/8 \
-		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+	flux start -Stbon.interface-hint=127.0.0.0/8 \
+		${ARGS} -s2 -Stbon.prefertcp=1 \
 		flux getattr tbon.endpoint >endpoint3b.out &&
 	grep "127.0.0.1" endpoint3b.out
 '
@@ -56,8 +56,8 @@ test_expect_success 'TOML tbon.interface-hint=127.0.0.0/8 works' '
 	cat >hint.toml <<-EOT &&
 	tbon.interface-hint = "127.0.0.0/8"
 	EOT
-	flux start -o,--config-path=hint.toml \
-		${ARGS} -s2 -o,-Stbon.prefertcp=1 \
+	flux start --config-path=hint.toml \
+		${ARGS} -s2 -Stbon.prefertcp=1 \
 		flux getattr tbon.endpoint >endpoint3c.out &&
 	grep "127.0.0.1" endpoint3c.out
 '
@@ -65,19 +65,19 @@ test_expect_success 'TOML tbon.interface-hint=wrong type fails' '
 	cat >badhint.toml <<-EOT &&
 	tbon.interface-hint = 42
 	EOT
-	test_must_fail flux start -o,--config-path=badhint.toml ${ARGS} true
+	test_must_fail flux start --config-path=badhint.toml ${ARGS} true
 '
 test_expect_success 'tbon.interface-hint=badiface fails' '
 	test_must_fail_or_be_terminated flux start \
-		-o,-Stbon.interface-hint=badiface \
-		${ARGS} -s2 -o,-Stbon.prefertcp=1 true
+		-Stbon.interface-hint=badiface \
+		${ARGS} -s2 -Stbon.prefertcp=1 true
 '
 test_expect_success 'tbon.interface-hint=default-route works' '
-	flux start -o,-Stbon.interface-hint=default-route,-Stbon.prefertcp=1 \
+	flux start -Stbon.interface-hint=default-route -Stbon.prefertcp=1 \
 		${ARGS} -s2 true
 '
 test_expect_success 'tbon.interface-hint=hostname works' '
-	flux start -o,-Stbon.interface-hint=hostname,-Stbon.prefertcp=1 \
+	flux start -Stbon.interface-hint=hostname -Stbon.prefertcp=1 \
 		${ARGS} -s2 true
 '
 test_expect_success 'tbon.interface-hint defaults to default-router' '
@@ -85,19 +85,19 @@ test_expect_success 'tbon.interface-hint defaults to default-router' '
 	grep default-route defhint.out
 '
 test_expect_success 'tbon.interface-hint default comes from parent' '
-	flux start -o,-Stbon.interface-hint=hostname \
+	flux start -Stbon.interface-hint=hostname \
 	    flux alloc -N1 flux getattr tbon.interface-hint >childhint.out &&
 	grep hostname childhint.out
 '
 test_expect_success 'tbon.interface-hint from parent can be overridden' '
-	flux start -o,-Stbon.interface-hint=hostname \
+	flux start -Stbon.interface-hint=hostname \
 	    flux alloc -N1 --broker-opts=-Stbon.interface-hint=default-router \
 	    flux getattr tbon.interface-hint >childhint2.out &&
 	grep default-router childhint2.out
 '
 test_expect_success 'tbon.endpoint cannot be set' '
 	test_must_fail_or_be_terminated flux start ${ARGS} -s2 \
-		-o,--setattr=tbon.endpoint=ipc:///tmp/customflux /bin/true
+		--setattr=tbon.endpoint=ipc:///tmp/customflux /bin/true
 '
 test_expect_success 'tbon.parent-endpoint cannot be read on rank 0' '
 	test_must_fail flux start ${ARGS} -s2 flux getattr tbon.parent-endpoint
@@ -108,28 +108,28 @@ test_expect_success 'tbon.parent-endpoint can be read on not rank 0' '
 '
 test_expect_success 'broker -Stbon.fanout=4 is an alias for tbon.topo=kary:4' '
 	echo kary:4 >fanout.exp &&
-	flux start ${ARGS} -o,-Stbon.fanout=4 \
+	flux start ${ARGS} -Stbon.fanout=4 \
 		flux getattr tbon.topo >fanout.out &&
 	test_cmp fanout.exp fanout.out
 '
 test_expect_success 'broker -Stbon.topo=kary:8 option works' '
 	echo kary:8 >topo.exp &&
-	flux start ${ARGS} -o,-Stbon.topo=kary:8 \
+	flux start ${ARGS} -Stbon.topo=kary:8 \
 		flux getattr tbon.topo >topo.out &&
 	test_cmp topo.exp topo.out
 '
 test_expect_success 'broker -Stbon.topo=kary:0 works' '
-	flux start ${ARGS} -o,-Stbon.topo=kary:0 /bin/true
+	flux start ${ARGS} -Stbon.topo=kary:0 /bin/true
 '
 test_expect_success 'broker -Stbon.topo=custom option works' '
 	echo custom >topo2.exp &&
-	flux start ${ARGS} -o,-Stbon.topo=custom \
+	flux start ${ARGS} -Stbon.topo=custom \
 		flux getattr tbon.topo >topo2.out &&
 	test_cmp topo2.exp topo2.out
 '
 test_expect_success 'broker -Stbon.topo=binomial option works' '
 	echo binomial >topo_binomial.exp &&
-	flux start ${ARGS} -o,-Stbon.topo=binomial \
+	flux start ${ARGS} -Stbon.topo=binomial \
 		flux getattr tbon.topo >topo_binomial.out &&
 	test_cmp topo_binomial.exp topo_binomial.out
 '

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -347,14 +347,14 @@ EOF
 '
 
 test_expect_success 'run instance with content-s3 module loaded' '
-	flux start -o,--setattr=broker.rc1_path=$(pwd)/rc1-content-s3 \
-                   -o,--setattr=broker.rc3_path=$(pwd)/rc3-content-s3 \
+	flux start --setattr=broker.rc1_path=$(pwd)/rc1-content-s3 \
+                   --setattr=broker.rc3_path=$(pwd)/rc3-content-s3 \
 	           flux kvs put testkey=43
 '
 
 test_expect_success 're-run instance with content-s3 module loaded' '
-	flux start -o,--setattr=broker.rc1_path=$(pwd)/rc1-content-s3 \
-                   -o,--setattr=broker.rc3_path=$(pwd)/rc3-content-s3 \
+	flux start --setattr=broker.rc1_path=$(pwd)/rc1-content-s3 \
+                   --setattr=broker.rc3_path=$(pwd)/rc3-content-s3 \
 	           flux kvs get testkey >gets3.out
 '
 
@@ -364,8 +364,8 @@ test_expect_success 'content from previous instance survived (s3)' '
 '
 
 test_expect_success 're-run instance, verify checkpoint date saved (s3)' '
-	flux start -o,--setattr=broker.rc1_path=$(pwd)/rc1-content-s3 \
-                   -o,--setattr=broker.rc3_path=$(pwd)/rc3-content-s3 \
+	flux start --setattr=broker.rc1_path=$(pwd)/rc1-content-s3 \
+                   --setattr=broker.rc3_path=$(pwd)/rc3-content-s3 \
 	           flux dmesg >dmesgs3.out
 '
 

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -9,7 +9,7 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 SRPC=${FLUX_BUILD_DIR}/t/request/rpc_stream
-ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
+ARGS="-Sbroker.rc1_path= -Sbroker.rc3_path="
 GROUPSCMD="flux python ${SHARNESS_TEST_SRCDIR}/scripts/groups.py"
 
 test_expect_success 'quorum reached on instance with 1 TBON level' '
@@ -31,28 +31,28 @@ test_expect_success 'quorum reached on instance with 3 TBON levels' '
 '
 
 test_expect_success 'broker.quorum can be set on the command line' '
-	flux start -s3 ${ARGS} -o,-Sbroker.quorum=3 \
+	flux start -s3 ${ARGS} -Sbroker.quorum=3 \
 		${GROUPSCMD} get broker.online >full1_explicit.out &&
 	test_cmp full1.exp full1_explicit.out
 '
 
 test_expect_success 'broker fails with malformed broker.quorum' '
 	test_must_fail flux start ${ARGS} \
-		-o,-Sbroker.quorum=9-10 /bin/true 2>qmalformed.err &&
+		-Sbroker.quorum=9-10 /bin/true 2>qmalformed.err &&
 	grep "Error parsing broker.quorum attribute" qmalformed.err
 '
 
 test_expect_success 'broker fails with broker.quorum that exceeds size' '
 	test_must_fail flux start ${ARGS} \
-		-o,-Sbroker.quorum=99 /bin/true 2>qtoobig.err &&
+		-Sbroker.quorum=99 /bin/true 2>qtoobig.err &&
 	grep "Error parsing broker.quorum attribute" qtoobig.err
 '
 test_expect_success 'broker.quorum can be 0 for compatibility' '
-	flux start ${ARGS} -o,-Sbroker.quorum=0 /bin/true 2>compat1.err &&
+	flux start ${ARGS} -Sbroker.quorum=0 /bin/true 2>compat1.err &&
 	grep assuming compat1.err
 '
 test_expect_success 'broker.quorum can be 0-1 (size=2) for compatibility' '
-	flux start -s2 ${ARGS} -o,-Sbroker.quorum=0-1 /bin/true 2>compat2.err &&
+	flux start -s2 ${ARGS} -Sbroker.quorum=0-1 /bin/true 2>compat2.err &&
 	grep assuming compat2.err
 '
 test_expect_success 'create rc1 that blocks on FIFO for rank != 0' '
@@ -81,10 +81,10 @@ test_expect_success 'instance functions with late-joiner' '
 	mkfifo fifo &&
 	run_timeout 60 \
 		flux start -s2 \
-		-o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path="$(pwd)/rc1_block" \
-		-o,-Sbroker.rc3_path= \
-		-o,-Sbroker.quorum=1 \
+		-Slog-stderr-level=6 \
+		-Sbroker.rc1_path="$(pwd)/rc1_block" \
+		-Sbroker.rc3_path= \
+		-Sbroker.quorum=1 \
 		$(pwd)/rc2_unblock >late.out &&
 	test_cmp late.exp late.out
 '
@@ -114,8 +114,8 @@ test_expect_success 'create rc script that prints current state' '
 test_expect_success 'monitor reports INIT(2) in rc1' '
 	echo 2 >rc1.exp &&
 	flux start \
-		-o,-Sbroker.rc1_path=$(pwd)/rc_getstate \
-		-o,-Sbroker.rc3_path= \
+		-Sbroker.rc1_path=$(pwd)/rc_getstate \
+		-Sbroker.rc3_path= \
 		/bin/true &&
 	test_cmp rc1.exp rc.out
 '
@@ -123,8 +123,8 @@ test_expect_success 'monitor reports INIT(2) in rc1' '
 test_expect_success 'monitor reports RUN(4) in rc2' '
 	echo 4 >rc2.exp &&
 	flux start \
-		-o,-Sbroker.rc1_path= \
-		-o,-Sbroker.rc3_path= \
+		-Sbroker.rc1_path= \
+		-Sbroker.rc3_path= \
 		$(pwd)/rc_getstate &&
 	test_cmp rc2.exp rc.out
 '
@@ -132,8 +132,8 @@ test_expect_success 'monitor reports RUN(4) in rc2' '
 test_expect_success 'monitor reports CLEANUP(5) in cleanup script' '
 	echo 5 >cleanup.exp &&
 	flux start \
-		-o,-Sbroker.rc1_path= \
-		-o,-Sbroker.rc3_path= \
+		-Sbroker.rc1_path= \
+		-Sbroker.rc3_path= \
 		bash -c "echo $(pwd)/rc_getstate | flux admin cleanup-push" &&
 	test_cmp cleanup.exp rc.out
 '
@@ -141,14 +141,14 @@ test_expect_success 'monitor reports CLEANUP(5) in cleanup script' '
 test_expect_success 'monitor reports FINALIZE(7) in rc3' '
 	echo 7 >rc3.exp &&
 	flux start \
-		-o,-Sbroker.rc1_path= \
-		-o,-Sbroker.rc3_path=$(pwd)/rc_getstate \
+		-Sbroker.rc1_path= \
+		-Sbroker.rc3_path=$(pwd)/rc_getstate \
 		/bin/true &&
 	test_cmp rc3.exp rc.out
 '
 
 test_expect_success 'capture state transitions from size=1 instance' '
-	flux start ${ARGS} -o,-Slog-filename=states.log /bin/true
+	flux start ${ARGS} -Slog-filename=states.log /bin/true
 '
 
 test_expect_success 'all expected events and state transitions occurred' '
@@ -165,7 +165,7 @@ test_expect_success 'all expected events and state transitions occurred' '
 
 test_expect_success 'capture state transitions from size=2 instance' '
 	flux start ${ARGS} --test-size=2 \
-		-o,-Slog-stderr-level=6,-Slog-stderr-mode=local \
+		-Slog-stderr-level=6 -Slog-stderr-mode=local \
 		/bin/true 2>states2.log
 '
 
@@ -195,9 +195,9 @@ test_expect_success 'all expected events and state transitions occurred on rank 
 
 test_expect_success 'capture state transitions from instance with rc1 failure' '
 	test_expect_code 1 flux start \
-	    -o,-Slog-filename=states_rc1.log \
-	    -o,-Sbroker.rc1_path=/bin/false \
-	    -o,-Sbroker.rc3_path= \
+	    -Slog-filename=states_rc1.log \
+	    -Sbroker.rc1_path=/bin/false \
+	    -Sbroker.rc3_path= \
 	    /bin/true
 '
 
@@ -212,7 +212,7 @@ test_expect_success 'all expected events and state transitions occurred' '
 
 test_expect_success 'capture state transitions from instance with rc2 failure' '
 	test_expect_code 1 flux start \
-	    -o,-Slog-filename=states_rc2.log \
+	    -Slog-filename=states_rc2.log \
 	    ${ARGS} \
 	    /bin/false
 '
@@ -231,9 +231,9 @@ test_expect_success 'all expected events and state transitions occurred' '
 
 test_expect_success 'capture state transitions from instance with rc3 failure' '
 	test_expect_code 1 flux start \
-	    -o,-Slog-filename=states_rc3.log \
-	    -o,-Sbroker.rc1_path= \
-	    -o,-Sbroker.rc3_path=/bin/false \
+	    -Slog-filename=states_rc3.log \
+	    -Sbroker.rc1_path= \
+	    -Sbroker.rc3_path=/bin/false \
 	    /bin/true
 '
 
@@ -251,21 +251,21 @@ test_expect_success 'all expected events and state transitions occurred' '
 
 test_expect_success 'instance rc1 failure exits with norestart code' '
 	test_expect_code 99 flux start \
-	    -o,-Sbroker.exit-norestart=99 \
-	    -o,-Sbroker.rc1_path=/bin/false \
-	    -o,-Sbroker.rc3_path= \
+	    -Sbroker.exit-norestart=99 \
+	    -Sbroker.rc1_path=/bin/false \
+	    -Sbroker.rc3_path= \
 	    /bin/true
 '
 
 test_expect_success 'broker.quorum-timeout=none is accepted' '
-	flux start ${ARGS} -o,-Sbroker.quorum-timeout=none /bin/true
+	flux start ${ARGS} -Sbroker.quorum-timeout=none /bin/true
 '
 
 test_expect_success 'broker.quorum-timeout=3h is accepted' '
-	flux start ${ARGS} -o,-Sbroker.quorum-timeout=3h /bin/true
+	flux start ${ARGS} -Sbroker.quorum-timeout=3h /bin/true
 '
 test_expect_success 'broker.quorum-timeout=x fails' '
-	test_must_fail flux start ${ARGS} -o,-Sbroker.quorum-timeout=x /bin/true
+	test_must_fail flux start ${ARGS} -Sbroker.quorum-timeout=x /bin/true
 '
 test_expect_success 'create rc1 that sleeps for 2s on rank != 0' '
 	cat <<-EOT >rc1_sleep &&
@@ -277,9 +277,9 @@ test_expect_success 'create rc1 that sleeps for 2s on rank != 0' '
 '
 test_expect_success 'broker.quorum-timeout works' '
 	flux start -s2 ${ARGS} \
-		-o,-Slog-filename=timeout.log \
-		-o,-Sbroker.rc1_path="$(pwd)/rc1_sleep" \
-		-o,-Sbroker.quorum-timeout=1s /bin/true
+		-Slog-filename=timeout.log \
+		-Sbroker.rc1_path="$(pwd)/rc1_sleep" \
+		-Sbroker.quorum-timeout=1s /bin/true
 '
 test_expect_success 'logs contain quorum delayed/reached messages' '
 	grep "quorum delayed" timeout.log &&
@@ -297,7 +297,7 @@ test_expect_success 'broker.cleanup-timeout default is none' '
 
 test_expect_success 'broker.cleanup-timeout=3h is accepted' '
 	flux start ${ARGS} \
-		-o,-Sbroker.cleanup-timeout=3h \
+		-Sbroker.cleanup-timeout=3h \
 		flux getattr broker.cleanup-timeout >cto2.out &&
 	cat >cto2.exp <<-EOT &&
 	3h
@@ -306,7 +306,7 @@ test_expect_success 'broker.cleanup-timeout=3h is accepted' '
 '
 test_expect_success 'broker.cleanup-timeout=x fails' '
 	test_must_fail flux start ${ARGS} \
-		-o,-Sbroker.cleanup-timeout=x true
+		-Sbroker.cleanup-timeout=x true
 '
 test_expect_success 'create rc1 that hangs in cleanup' '
 	cat <<-EOT >rc1_cleanup &&
@@ -328,9 +328,9 @@ test_expect_success 'create initial program that SIGTERMs broker' '
 '
 test_expect_success 'cleanup gets SIGHUP after broker.cleanup-timeout expires' '
 	test_expect_code 129 flux start -s2 ${ARGS} \
-		-o,-Slog-filename=cleanup.log \
-		-o,-Sbroker.rc1_path="$(pwd)/rc1_cleanup" \
-		-o,-Sbroker.cleanup-timeout=1s \
+		-Slog-filename=cleanup.log \
+		-Sbroker.rc1_path="$(pwd)/rc1_cleanup" \
+		-Sbroker.cleanup-timeout=1s \
 		./killbroker 15 60
 '
 

--- a/t/t0028-content-backing-none.t
+++ b/t/t0028-content-backing-none.t
@@ -85,7 +85,7 @@ test_expect_success 'unload kvs' '
 '
 
 test_expect_success 'content.backing-module input of none works' '
-        flux start -o,-Scontent.backing-module=none /bin/true
+        flux start -Scontent.backing-module=none /bin/true
 '
 
 test_expect_success 'removedcontent module' '

--- a/t/t0090-content-enospc.t
+++ b/t/t0090-content-enospc.t
@@ -27,8 +27,8 @@ test_expect_success 'flux still operates with content-sqlite running out of spac
 	rm -rf /test/tmpfs-1m/* &&
 	mkdir /test/tmpfs-1m/statedir &&
 	test_must_fail flux start \
-	    -o,-Scontent.backing-module=content-sqlite \
-	    -o,-Sstatedir=/test/tmpfs-1m/statedir \
+	    -Scontent.backing-module=content-sqlite \
+	    -Sstatedir=/test/tmpfs-1m/statedir \
 	    "./fillstatedir.sh; flux dmesg; flux run echo helloworld" > sql.out 2> sql.err &&
 	grep -q "No space left on device" sql.out &&
 	grep "helloworld" sql.out
@@ -39,8 +39,8 @@ test_expect_success 'flux still operates with content-files running out of space
 	rm -rf /test/tmpfs-1m/* &&
 	mkdir /test/tmpfs-1m/statedir &&
 	test_must_fail flux start \
-	    -o,-Scontent.backing-module=content-files \
-	    -o,-Sstatedir=/test/tmpfs-1m/statedir \
+	    -Scontent.backing-module=content-files \
+	    -Sstatedir=/test/tmpfs-1m/statedir \
 	    "./fillstatedir.sh; flux dmesg; flux run echo helloworld" > files.out 2> files.err &&
 	grep -q "No space left on device" files.out &&
 	grep "helloworld" files.out
@@ -51,8 +51,8 @@ test_expect_success 'content flush returns error on ENOSPC' '
 	rm -rf /test/tmpfs-1m/* &&
 	mkdir /test/tmpfs-1m/statedir &&
 	test_must_fail flux start \
-	    -o,-Scontent.backing-module=content-sqlite \
-	    -o,-Sstatedir=/test/tmpfs-1m/statedir \
+	    -Scontent.backing-module=content-sqlite \
+	    -Sstatedir=/test/tmpfs-1m/statedir \
 	    "./fillstatedir.sh; flux dmesg; flux content flush" > flush.out 2> flush.err &&
 	grep -q "No space left on device" flush.out &&
 	grep "content.flush: No space left on device" flush.err

--- a/t/t2004-hydra.t
+++ b/t/t2004-hydra.t
@@ -7,7 +7,7 @@ test_description='Test that MPICH Hydra can launch Flux'
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 PMI_INFO=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi_info
-ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
+ARGS="-Sbroker.rc1_path= -Sbroker.rc3_path="
 
 if ! which mpiexec.hydra 2>/dev/null; then
     skip_all='skipping hydra-launching-flux tests, mpiexec.hydra unavailable'

--- a/t/t2008-althash.t
+++ b/t/t2008-althash.t
@@ -18,21 +18,21 @@ if test -n "$S3_ACCESS_KEY_ID"; then
 fi
 
 test_expect_success 'Started instance with content.hash=sha1' '
-	OUT=$(flux start -o,-Scontent.hash=sha1 \
+	OUT=$(flux start -Scontent.hash=sha1 \
 	    flux getattr content.hash) &&
 	test "$OUT" = "sha1"
 '
 
 test_expect_success 'Started instance with content.hash=sha256' '
-	OUT=$(flux start -o,-Scontent.hash=sha256 \
+	OUT=$(flux start -Scontent.hash=sha256 \
 	    flux getattr content.hash) &&
 	test "$OUT" = "sha256"
 '
 
 test_expect_success 'Started instance with content.hash=sha256,content-files' '
-	OUT=$(flux start -o,-Scontent.hash=sha256 \
-	    -o,-Scontent.backing-module=content-files \
-	    -o,-Sstatedir=$(pwd) \
+	OUT=$(flux start -Scontent.hash=sha256 \
+	    -Scontent.backing-module=content-files \
+	    -Sstatedir=$(pwd) \
 	    flux getattr content.hash) &&
 	test "$OUT" = "sha256" &&
 	ls -1 content.files | tail -1 | grep sha256
@@ -58,20 +58,20 @@ test_expect_success S3 'create content-s3.toml from env' '
 '
 
 test_expect_success S3 'Started instance with content.hash=sha256,content-s3' '
-	OUT=$(flux start -o,-Scontent.hash=sha256 \
-	    -o,-Scontent.backing-module=content-s3 \
+	OUT=$(flux start -Scontent.hash=sha256 \
+	    -Scontent.backing-module=content-s3 \
 	    flux getattr content.hash) &&
 	test "$OUT" = "sha256"
 '
 test_expect_success S3 'Content store nil returns correct hash for sha256' '
-	OUT=$(flux start -o,-Scontent.hash=sha256 \
-	    -o,-Scontent.backing-module=content-s3 \
+	OUT=$(flux start -Scontent.hash=sha256 \
+	    -Scontent.backing-module=content-s3 \
 	    flux content store </dev/null) &&
 	test "$OUT" = "$nil256"
 '
 
 test_expect_success 'Attempt to start instance with invalid hash fails hard' '
-	test_must_fail flux start -o,-Scontent.hash=wronghash /bin/true
+	test_must_fail flux start -Scontent.hash=wronghash /bin/true
 '
 
 test_done

--- a/t/t2010-kvs-snapshot-restore.t
+++ b/t/t2010-kvs-snapshot-restore.t
@@ -16,7 +16,7 @@ CHANGECHECKPOINT=${FLUX_SOURCE_DIR}/t/kvs/change-checkpoint.py
 #
 
 test_expect_success 'run instance with statedir set (sqlite)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 		   flux kvs put --sequence testkey=42 \
 		   > start_sequence_sqlite.out
 '
@@ -27,7 +27,7 @@ test_expect_success 'content.sqlite file exists after instance exited' '
 '
 
 test_expect_success 're-run instance with statedir set (sqlite)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 		   flux kvs get testkey >getsqlite.out
 '
 
@@ -41,7 +41,7 @@ test_expect_success 'content from previous instance survived (sqlite)' '
 # increase over several restarts
 
 test_expect_success 're-run instance, get sequence number 1 (sqlite)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 		   flux kvs version > restart_version_sqlite1.out
 '
 
@@ -52,7 +52,7 @@ test_expect_success 'restart sequence number increasing 1 (sqlite)' '
 '
 
 test_expect_success 're-run instance, get sequence number 2 (sqlite)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 		   flux kvs version > restart_version_sqlite2.out
 '
 
@@ -63,7 +63,7 @@ test_expect_success 'restart sequence number increasing 2 (sqlite)' '
 '
 
 test_expect_success 're-run instance, verify checkpoint date saved (sqlite)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 		   flux dmesg >dmesgsqlite1.out
 '
 
@@ -74,7 +74,7 @@ test_expect_success 'verify date in flux logs (sqlite)' '
 '
 
 test_expect_success 're-run instance, get rootref (sqlite)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 		   flux kvs getroot -b > getrootsqlite.out
 '
 
@@ -84,7 +84,7 @@ test_expect_success 'write rootref to checkpoint path, emulating checkpoint vers
 '
 
 test_expect_success 're-run instance, verify checkpoint correctly loaded (sqlite)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 		   flux dmesg >dmesgsqlite2.out
 '
 
@@ -114,9 +114,9 @@ EOF
 '
 
 test_expect_success 'run instance with statedir set (files)' '
-	flux start -o,--setattr=statedir=$(pwd) \
-		   -o,--setattr=broker.rc1_path=$(pwd)/rc1-content-files \
-		   -o,--setattr=broker.rc3_path=$(pwd)/rc3-content-files \
+	flux start --setattr=statedir=$(pwd) \
+		   --setattr=broker.rc1_path=$(pwd)/rc1-content-files \
+		   --setattr=broker.rc3_path=$(pwd)/rc3-content-files \
 		   flux kvs put --sequence testkey=43 > start_sequence_files.out
 '
 
@@ -126,9 +126,9 @@ test_expect_success 'content.files dir and kvs-primary exist after instance exit
 '
 
 test_expect_success 're-run instance with statedir set (files)' '
-	flux start -o,--setattr=statedir=$(pwd) \
-		   -o,--setattr=broker.rc1_path=$(pwd)/rc1-content-files \
-		   -o,--setattr=broker.rc3_path=$(pwd)/rc3-content-files \
+	flux start --setattr=statedir=$(pwd) \
+		   --setattr=broker.rc1_path=$(pwd)/rc1-content-files \
+		   --setattr=broker.rc3_path=$(pwd)/rc3-content-files \
 		   flux kvs get testkey >getfiles.out
 '
 
@@ -142,7 +142,7 @@ test_expect_success 'content from previous instance survived (files)' '
 # increase over several restarts
 
 test_expect_success 're-run instance, get sequence number 1 (files)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 		   flux kvs version > restart_version_files1.out
 '
 
@@ -153,7 +153,7 @@ test_expect_success 'restart sequence number increasing 1 (files)' '
 '
 
 test_expect_success 're-run instance, get sequence number 2 (files)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 		   flux kvs version > restart_version_files2.out
 '
 
@@ -164,9 +164,9 @@ test_expect_success 'restart sequence number increasing 2 (files)' '
 '
 
 test_expect_success 're-run instance, verify checkpoint date saved (files)' '
-	flux start -o,--setattr=statedir=$(pwd) \
-		   -o,--setattr=broker.rc1_path=$(pwd)/rc1-content-files \
-		   -o,--setattr=broker.rc3_path=$(pwd)/rc3-content-files \
+	flux start --setattr=statedir=$(pwd) \
+		   --setattr=broker.rc1_path=$(pwd)/rc1-content-files \
+		   --setattr=broker.rc3_path=$(pwd)/rc3-content-files \
 		   flux dmesg >dmesgfiles.out
 '
 

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -8,7 +8,7 @@ test_description='Test job manager jobtap plugin interface'
 
 mkdir -p config
 
-test_under_flux 4 job -o,--config-path=$(pwd)/config
+test_under_flux 4 job --config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 
@@ -85,7 +85,7 @@ test_expect_success 'job-manager: plugins can be loaded by configuration' '
 	  { load = "${PLUGINPATH}/args.so" },
 	]
 	EOF
-	flux start -o,-c $(pwd)/testconf flux jobtap list > confplugins.out &&
+	flux start -c $(pwd)/testconf flux jobtap list > confplugins.out &&
 	test_debug "cat confplugins.out" &&
 	grep args confplugins.out &&
 	grep test confplugins.out
@@ -110,7 +110,7 @@ test_expect_success 'job-manager: bad plugins config is detected' '
 	EOF
 	test_must_fail \
 	    flux bulksubmit -n1 --watch --log=badconf.{}.log \
-	        flux start -o,-c$(pwd)/badconf/{} /bin/true ::: a b c d &&
+	        flux start -c$(pwd)/badconf/{} /bin/true ::: a b c d &&
 	test_debug "echo a:; cat badconf.a.log" &&
 	grep "config must be an array" badconf.a.log &&
 	test_debug "echo b:; cat badconf.b.log" &&

--- a/t/t2219-job-manager-restart.t
+++ b/t/t2219-job-manager-restart.t
@@ -9,13 +9,13 @@ DUMPS=${SHARNESS_TEST_SRCDIR}/job-manager/dumps
 export FLUX_DISABLE_JOB_CLEANUP=t
 
 test_expect_success 'start instance with empty kvs, run one job, and dump' '
-	flux start -o,-Scontent.dump=dump.tar \
+	flux start -Scontent.dump=dump.tar \
 	    flux run --env-remove=* /bin/true &&
 	test -f $(pwd)/dump.tar
 '
 
 restart_flux() {
-	flux start -o,-Scontent.restore=$1 \
+	flux start -Scontent.restore=$1 \
 		flux module stats job-manager
 }
 
@@ -23,7 +23,7 @@ restart_flux() {
 # "not replayed" warnings were logged
 restart_with_job_warning() {
 	local out=$(basename $1).dmesg
-	flux start -o,-Scontent.restore=$1 /bin/true 2>$out
+	flux start -Scontent.restore=$1 /bin/true 2>$out
 	result=$?
 	cat $out
 	test $result -eq 0 && grep -q "not replayed:" $out
@@ -67,17 +67,17 @@ test_expect_success 'purging all jobs triggers jobid checkpoint update' '
 '
 
 test_expect_success 'verify that anon queue disable persists across restart' '
-	flux start -o,-Scontent.dump=dump_dis.tar \
+	flux start -Scontent.dump=dump_dis.tar \
 	    flux queue disable disable-restart-test &&
-	flux start -o,-Scontent.restore=dump_dis.tar \
+	flux start -Scontent.restore=dump_dis.tar \
 	    flux queue status >dump_dis.out &&
 	grep "disabled: disable-restart-test" dump_dis.out
 '
 
 test_expect_success 'verify that anon queue stopped persists across restart' '
-	flux start -o,-Scontent.dump=dump_stopped.tar \
+	flux start -Scontent.dump=dump_stopped.tar \
 	    flux queue stop stop-restart-test &&
-	flux start -o,-Scontent.restore=dump_stopped.tar \
+	flux start -Scontent.restore=dump_stopped.tar \
 	    flux queue status >dump_stopped.out &&
 	grep "stopped: stop-restart-test" dump_stopped.out
 '
@@ -88,24 +88,24 @@ test_expect_success 'verify that named queue enable/disable persists across rest
 	[queues.debug]
 	[queues.batch]
 	EOT
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.dump=dump_queue_enable1.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.dump=dump_queue_enable1.tar \
 	    flux queue status >dump_queue_enable_1.out &&
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.restore=dump_queue_enable1.tar \
-	    -o,-Scontent.dump=dump_queue_enable2.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.restore=dump_queue_enable1.tar \
+	    -Scontent.dump=dump_queue_enable2.tar \
 	    flux queue disable --queue=batch xyzzy &&
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.restore=dump_queue_enable2.tar \
-	    -o,-Scontent.dump=dump_queue_enable3.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.restore=dump_queue_enable2.tar \
+	    -Scontent.dump=dump_queue_enable3.tar \
 	    flux queue status >dump_queue_enable_2.out &&
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.restore=dump_queue_enable3.tar \
-	    -o,-Scontent.dump=dump_queue_enable4.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.restore=dump_queue_enable3.tar \
+	    -Scontent.dump=dump_queue_enable4.tar \
 	    flux queue enable --queue=batch &&
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.restore=dump_queue_enable4.tar \
-	    -o,-Scontent.dump=dump_queue_enable5.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.restore=dump_queue_enable4.tar \
+	    -Scontent.dump=dump_queue_enable5.tar \
 	    flux queue status >dump_queue_enable_3.out &&
 	grep "^debug: Job submission is enabled" dump_queue_enable_1.out &&
 	grep "^batch: Job submission is enabled" dump_queue_enable_1.out &&
@@ -118,7 +118,7 @@ test_expect_success 'verify that named queue enable/disable persists across rest
 # N.B. no named queues configured in this test, so anon queue is what
 # is tested
 test_expect_success 'verify that instance can restart after config change' '
-	flux start -o,-Scontent.restore=dump_queue_enable5.tar \
+	flux start -Scontent.restore=dump_queue_enable5.tar \
 	    flux queue status >dump_queue_reconf.out &&
 	grep "^Job submission is enabled" dump_queue_reconf.out
 '
@@ -129,24 +129,24 @@ test_expect_success 'verify that named queue start/stop persists across restart'
 	[queues.debug]
 	[queues.batch]
 	EOT
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.dump=dump_queue_start1.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.dump=dump_queue_start1.tar \
 	    flux queue status >dump_queue_start_1.out &&
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.restore=dump_queue_start1.tar \
-	    -o,-Scontent.dump=dump_queue_start2.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.restore=dump_queue_start1.tar \
+	    -Scontent.dump=dump_queue_start2.tar \
 	    flux queue start --queue=batch &&
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.restore=dump_queue_start2.tar \
-	    -o,-Scontent.dump=dump_queue_start3.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.restore=dump_queue_start2.tar \
+	    -Scontent.dump=dump_queue_start3.tar \
 	    flux queue status >dump_queue_start_2.out &&
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.restore=dump_queue_start3.tar \
-	    -o,-Scontent.dump=dump_queue_start4.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.restore=dump_queue_start3.tar \
+	    -Scontent.dump=dump_queue_start4.tar \
 	    flux queue stop --queue=batch xyzzy &&
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.restore=dump_queue_start4.tar \
-	    -o,-Scontent.dump=dump_queue_start5.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.restore=dump_queue_start4.tar \
+	    -Scontent.dump=dump_queue_start5.tar \
 	    flux queue status >dump_queue_start_3.out &&
 	grep "^debug: Scheduling is stopped" dump_queue_start_1.out &&
 	grep "^batch: Scheduling is stopped" dump_queue_start_1.out &&
@@ -162,14 +162,14 @@ test_expect_success 'checkpointed queue no longer configured on restart is ignor
 	[queues.debug]
 	[queues.batch]
 	EOT
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.dump=dump_queue_missing.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.dump=dump_queue_missing.tar \
 	    flux queue disable --queue batch xyzzy &&
 	cat >conf.d/queues.toml <<-EOT &&
 	[queues.debug]
 	EOT
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.restore=dump_queue_missing.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.restore=dump_queue_missing.tar \
 	    flux queue status >dump_queue_missing.out &&
 	grep "^debug: Job submission is enabled" dump_queue_missing.out &&
 	grep "^debug: Scheduling is stopped" dump_queue_missing.out &&
@@ -182,15 +182,15 @@ test_expect_success 'new queue configured on restart uses defaults' '
 	[queues.debug]
 	[queues.batch]
 	EOT
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.dump=dump_queue_ignored.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.dump=dump_queue_ignored.tar \
 	    flux queue disable --queue batch xyzzy &&
 	cat >conf.d/queues.toml <<-EOT &&
 	[queues.debug]
 	[queues.newqueue]
 	EOT
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.restore=dump_queue_ignored.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.restore=dump_queue_ignored.tar \
 	    flux queue status >dump_queue_ignored.out &&
 	grep "^debug: Job submission is enabled" dump_queue_ignored.out &&
 	grep "^debug: Scheduling is stopped" dump_queue_ignored.out &&
@@ -200,7 +200,7 @@ test_expect_success 'new queue configured on restart uses defaults' '
 
 test_expect_success 'bad job directory is moved to lost+found' '
 	flux start \
-	    -o,-Scontent.restore=${DUMPS}/warn/dump-shorteventlog.tar.bz2 \
+	    -Scontent.restore=${DUMPS}/warn/dump-shorteventlog.tar.bz2 \
 	    flux kvs dir -R lost+found
 '
 

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -127,12 +127,12 @@ test_expect_success 'flux-queue: status reports no reason for stop' '
 
 test_expect_success 'flux-queue: stop with --nocheckpoint works' '
 	flux start \
-	    -o,-Scontent.dump=dump_queue_nocheckpoint1.tar \
+	    -Scontent.dump=dump_queue_nocheckpoint1.tar \
 	    flux queue stop &&
 	tar -xvf dump_queue_nocheckpoint1.tar &&
 	cat checkpoint/job-manager | jq -e ".queue[0].start == false" &&
 	flux start \
-	    -o,-Scontent.dump=dump_queue_nocheckpoint2.tar \
+	    -Scontent.dump=dump_queue_nocheckpoint2.tar \
 	    flux queue stop --nocheckpoint &&
 	tar -xvf dump_queue_nocheckpoint2.tar &&
 	cat checkpoint/job-manager | jq -e ".queue[0].start == true"
@@ -547,14 +547,14 @@ test_expect_success 'flux-queue: stop with named queues and --nocheckpoint works
 	EOT
 	chmod +x ./stopqueues.sh &&
 	chmod +x ./stopqueuesnocheckpoint.sh &&
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.dump=dump_queue_named_nocheckpoint1.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.dump=dump_queue_named_nocheckpoint1.tar \
 	    ./stopqueues.sh &&
 	tar -xvf dump_queue_named_nocheckpoint1.tar &&
 	cat checkpoint/job-manager | jq -e ".queue[0].start == false" &&
 	cat checkpoint/job-manager | jq -e ".queue[1].start == false" &&
-	flux start -o,--config-path=$(pwd)/conf.d \
-	    -o,-Scontent.dump=dump_queue_named_nocheckpoint2.tar \
+	flux start --config-path=$(pwd)/conf.d \
+	    -Scontent.dump=dump_queue_named_nocheckpoint2.tar \
 	    ./stopqueuesnocheckpoint.sh &&
 	tar -xvf dump_queue_named_nocheckpoint2.tar &&
 	cat checkpoint/job-manager | jq -e ".queue[0].start == true" &&

--- a/t/t2245-policy-config.t
+++ b/t/t2245-policy-config.t
@@ -180,7 +180,7 @@ test_expect_success 'a bad config is detected at initialization too' '
 	cat >badconf.toml <<-EOT &&
 	policy.foo = 1
 	EOT
-	test_must_fail flux start -o,--config-path=badconf.toml true
+	test_must_fail flux start --config-path=badconf.toml true
 '
 
 test_done

--- a/t/t2273-job-alloc-bypass.t
+++ b/t/t2273-job-alloc-bypass.t
@@ -130,14 +130,14 @@ test_expect_success 'generate a script to submit a testexec+alloc-bypass job' '
 '
 test_expect_success 'run test job in a persistent instance' '
 	FLUX_DISABLE_JOB_CLEANUP=t flux start -s1 \
-	    -o,--config-path=config.toml \
-	    -o,-Sstatedir=$(pwd) \
+	    --config-path=config.toml \
+	    -Sstatedir=$(pwd) \
 	    ./prog.sh
 '
 test_expect_success 'restart that instance and get the resource alloc count' '
 	FLUX_DISABLE_JOB_CLEANUP=t flux start -s1 \
-	    -o,--config-path=config.toml \
-	    -o,-Sstatedir=$(pwd) \
+	    --config-path=config.toml \
+	    -Sstatedir=$(pwd) \
 	    sh -c "flux jobs -no {state} \$(flux job last); \
 	        FLUX_RESOURCE_LIST_RPC=sched.resource-status \
 		flux resource list -s allocated -no {nnodes}" >restart.out
@@ -151,8 +151,8 @@ test_expect_success 'the job was running and resources were not allocated' '
 '
 test_expect_success 'restart that instance and cancel the job' '
 	flux start -s1 \
-	    -o,--config-path=config.toml \
-	    -o,-Sstatedir=$(pwd) \
+	    --config-path=config.toml \
+	    -Sstatedir=$(pwd) \
 	    sh -c "flux cancel \$(flux job last); \
 	    flux job wait-event -vvv \$(flux job last) clean"
 '

--- a/t/t2312-resource-exclude.t
+++ b/t/t2312-resource-exclude.t
@@ -10,7 +10,7 @@ exclude = "0"
 EOT
 
 SIZE=4
-test_under_flux $SIZE full -o,--config-path=$(pwd)/exclude.toml
+test_under_flux $SIZE full --config-path=$(pwd)/exclude.toml
 
 # Usage: waitup N
 #   where N is a count of online ranks
@@ -56,7 +56,7 @@ test_expect_success 'config with bad exclude idset fails' '
 	[resource]
 	exclude = "xxzz"
 	EOT
-	test_must_fail flux start -o,--config-path=resource.toml true
+	test_must_fail flux start --config-path=resource.toml true
 '
 
 test_expect_success 'config with out of range exclude idset fails' '
@@ -64,7 +64,7 @@ test_expect_success 'config with out of range exclude idset fails' '
 	[resource]
 	exclude = "1"
 	EOT
-	test_must_fail flux start -o,--config-path=resource.toml true
+	test_must_fail flux start --config-path=resource.toml true
 '
 
 # See flux-framework/flux-core#5337
@@ -73,7 +73,7 @@ test_expect_success 'test instance can exclude ranks' '
 	[resource]
 	exclude = "1"
 	EOT
-	test $(flux start -s2 -o,--config-path=exclude.toml \
+	test $(flux start -s2 --config-path=exclude.toml \
 	    flux resource status -s exclude -no {nnodes}) -eq 1
 '
 test_expect_success 'test instance fails to exclude hostnames' '
@@ -81,7 +81,7 @@ test_expect_success 'test instance fails to exclude hostnames' '
 	[resource]
 	exclude = "$(hostname -s)"
 	EOT
-	test_must_fail flux start -s2 -o,--config-path=exclude2.toml \
+	test_must_fail flux start -s2 --config-path=exclude2.toml \
 	    /bin/true 2>exclude2.err &&
 	grep "R is unavailable" exclude2.err
 '
@@ -94,7 +94,7 @@ test_expect_success 'instance with configured R can exclude hostnames' '
 	hosts = "$(hostname -s)"
 	cores = "0"
 	EOT
-	test $(flux start -s1 -o,--config-path=exclude3.toml \
+	test $(flux start -s1 --config-path=exclude3.toml \
 	    flux resource status -s exclude -no {nnodes}) -eq 1
 '
 test_expect_success 'incorrect excluded hostnames raises correct error' '
@@ -106,7 +106,7 @@ test_expect_success 'incorrect excluded hostnames raises correct error' '
 	hosts = "$(hostname -s)"
 	cores = "0"
 	EOT
-	test_must_fail flux start -o,--config-path=exclude4.toml true \
+	test_must_fail flux start --config-path=exclude4.toml true \
 		2>exclude4.err &&
 	test_debug "cat exclude4.err" &&
 	grep "invalid hosts: badhost" exclude4.err

--- a/t/t2313-resource-acquire.t
+++ b/t/t2313-resource-acquire.t
@@ -10,7 +10,7 @@ exclude = "0"
 EOT
 
 SIZE=4
-test_under_flux $SIZE full -o,--config-path=$(pwd)/exclude.toml
+test_under_flux $SIZE full --config-path=$(pwd)/exclude.toml
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 RPC_STREAM=${FLUX_BUILD_DIR}/t/request/rpc_stream

--- a/t/t2403-job-exec-conf.t
+++ b/t/t2403-job-exec-conf.t
@@ -24,7 +24,7 @@ test_expect_success 'job-exec: kill-timeout can be set in exec conf' '
 	[exec]
 	kill-timeout = ".5m"
 	EOF
-	flux start -o,--config-path=${name}.toml -s1 \
+	flux start --config-path=${name}.toml -s1 \
 		flux module stats job-exec > ${name}.json 2>&1 &&
 	test_debug "jq -S . < ${name}.json" &&
 	cat ${name}.json | jq ".[\"kill-timeout\"] == 30"
@@ -41,7 +41,7 @@ test_expect_success 'job-exec: bad kill-timeout config causes module failure' '
 	[exec]
 	kill-timeout = "foo"
 	EOF
-	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
+	test_must_fail flux start --config-path=${name}.toml -s1 \
 		flux dmesg > ${name}.log 2>&1 &&
 	grep "invalid kill-timeout: foo" ${name}.log
 '
@@ -87,7 +87,7 @@ test_expect_success 'job-exec: term/kill-signal can be set in exec conf' '
 	kill-signal = "SIGINT"
 	term-signal = "SIGHUP"
 	EOF
-	flux start -o,--config-path=${name}.toml -s1 \
+	flux start --config-path=${name}.toml -s1 \
 		flux module stats job-exec > ${name}.json 2>&1 &&
 	cat ${name}.json | jq ".[\"kill-signal\"] == \"SIGINT\"" &&
 	cat ${name}.json | jq ".[\"term-signal\"] == \"SIGTERM\""
@@ -98,7 +98,7 @@ test_expect_success 'job-exec: bad term/kill-signal config causes module failure
 	[exec]
 	kill-signal = "foo"
 	EOF
-	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
+	test_must_fail flux start --config-path=${name}.toml -s1 \
 		flux dmesg > ${name}.log 2>&1 &&
 	grep "invalid kill-signal: foo" ${name}.log
 '
@@ -127,7 +127,7 @@ test_expect_success 'job-exec: job-shell can be set in exec conf' '
 	[exec]
 	job-shell = "my-flux-shell"
 	EOF
-	flux start -o,--config-path=${name}.toml -s1 \
+	flux start --config-path=${name}.toml -s1 \
 		flux module stats -p bulk-exec.config.default_job_shell job-exec > ${name}.out 2>&1 &&
 	grep "my-flux-shell" ${name}.out
 '
@@ -137,7 +137,7 @@ test_expect_success 'job-exec: bad job-shell config causes module failure' '
 	[exec]
 	job-shell = 42
 	EOF
-	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
+	test_must_fail flux start --config-path=${name}.toml -s1 \
 		flux dmesg > ${name}.log 2>&1 &&
 	grep "error reading config value exec.job-shell" ${name}.log
 '
@@ -178,7 +178,7 @@ test_expect_success 'job-exec: imp path can be set in exec conf' '
 	[exec]
 	imp = "my-flux-imp"
 	EOF
-	flux start -o,--config-path=${name}.toml -s1 \
+	flux start --config-path=${name}.toml -s1 \
 		flux module stats -p bulk-exec.config.flux_imp_path job-exec > ${name}.out 2>&1 &&
 	grep "my-flux-imp" ${name}.out
 '
@@ -188,7 +188,7 @@ test_expect_success 'job-exec: bad imp config causes module failure' '
 	[exec]
 	imp = 42
 	EOF
-	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
+	test_must_fail flux start --config-path=${name}.toml -s1 \
 		flux dmesg > ${name}.log 2>&1 &&
 	grep "error reading config value exec.imp" ${name}.log
 '
@@ -230,7 +230,7 @@ test_expect_success 'job-exec: exec service can be set in exec conf' '
 	[exec]
 	service = "bar"
 	EOF
-	flux start -o,--config-path=${name}.toml -s1 \
+	flux start --config-path=${name}.toml -s1 \
 		flux module stats -p bulk-exec.config.exec_service job-exec > ${name}.out 2>&1 &&
 	grep "bar" ${name}.out
 '
@@ -268,7 +268,7 @@ test_expect_success 'job-exec: exec service override can be set in exec conf' '
 	service = "bar"
 	service-override = true
 	EOF
-	flux start -o,--config-path=${name}.toml -s1 \
+	flux start --config-path=${name}.toml -s1 \
 		flux module stats -p bulk-exec.config.exec_service_override job-exec > ${name}.out 2>&1 &&
 	val=$(cat ${name}.out) &&
 	test $val -eq 1
@@ -298,7 +298,7 @@ test_expect_success 'job-exec: sdexex properties can be set in exec conf' '
 	MemoryHigh = "200M"
 	MemoryMax = "100M"
 	EOF
-	flux start -o,--config-path=${name}.toml -s1 \
+	flux start --config-path=${name}.toml -s1 \
 		flux module stats -p bulk-exec.config.sdexec_properties job-exec > ${name}.out 2>&1 &&
 	jq -e ".MemoryHigh == \"200M\"" < ${name}.out &&
 	jq -e ".MemoryMax == \"100M\"" < ${name}.out
@@ -310,7 +310,7 @@ test_expect_success 'job-exec: bad sdexec properties causes module failure (type
 	service = "sdexec"
 	sdexec-properties = 42
 	EOF
-	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
+	test_must_fail flux start --config-path=${name}.toml -s1 \
 		flux dmesg > ${name}.log 2>&1 &&
 	grep "exec.sdexec-properties is not a table" ${name}.log
 '
@@ -322,7 +322,7 @@ test_expect_success 'job-exec: bad sdexec properties causes module failure (type
 	[exec.sdexec-properties]
 	MemoryHigh = 42
 	EOF
-	test_must_fail flux start -o,--config-path=${name}.toml -s1 \
+	test_must_fail flux start --config-path=${name}.toml -s1 \
 		flux dmesg > ${name}.log 2>&1 &&
 	grep "exec.sdexec-properties.MemoryHigh is not a string" ${name}.log
 '

--- a/t/t2408-sdbus-recovery.t
+++ b/t/t2408-sdbus-recovery.t
@@ -24,7 +24,7 @@ cat >config/config.toml <<EOF
 sdbus-debug = true
 EOF
 
-test_under_flux 1 minimal -o,--config-path=$(pwd)/config
+test_under_flux 1 minimal --config-path=$(pwd)/config
 
 flux setattr log-stderr-level 1
 

--- a/t/t2410-sdexec-memlimit.t
+++ b/t/t2410-sdexec-memlimit.t
@@ -57,7 +57,7 @@ if ! $(pwd)/getcg.sh cgroup.controllers | grep memory; then
 	test_done
 fi
 
-test_under_flux 1 full -o,--config-path=$(pwd)/config
+test_under_flux 1 full --config-path=$(pwd)/config
 
 flux setattr log-stderr-level 7
 

--- a/t/t2411-sdexec-job.t
+++ b/t/t2411-sdexec-job.t
@@ -26,7 +26,7 @@ sdexec-debug = true
 service-override = true
 EOT
 
-test_under_flux 2 full -o,--config-path=$(pwd)/config
+test_under_flux 2 full --config-path=$(pwd)/config
 
 flux exec flux setattr log-stderr-level 7
 

--- a/t/t2806-config-cmd.t
+++ b/t/t2806-config-cmd.t
@@ -23,7 +23,7 @@ f = [ "fubar", "barfu" ]
 a = true
 EOF
 
-test_under_flux 1 minimal -o,--config-path=$(pwd)/config
+test_under_flux 1 minimal --config-path=$(pwd)/config
 
 runas_guest() {
         local userid=$(($(id -u)+1))

--- a/t/t2807-dump-cmd.t
+++ b/t/t2807-dump-cmd.t
@@ -4,7 +4,7 @@ test_description='Test flux dump/restore'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 1 minimal -o,-Sstatedir=$(pwd)
+test_under_flux 1 minimal -Sstatedir=$(pwd)
 
 QUERYCMD="flux python ${FLUX_SOURCE_DIR}/t/scripts/sqlite-query.py"
 
@@ -193,14 +193,14 @@ test_expect_success 'restore --no-cache with no backing store fails' '
 '
 test_expect_success 'run a flux instance, preserving content.sqlite' '
 	mkdir test &&
-	flux start -o,-Sstatedir=$(pwd)/test /bin/true
+	flux start -Sstatedir=$(pwd)/test /bin/true
 '
 
 reader() {
 	local dbdir=$1
-        flux start -o,-Sbroker.rc1_path= \
-                -o,-Sbroker.rc3_path=\
-                -o,-Sstatedir=$dbdir\
+        flux start -Sbroker.rc1_path= \
+                -Sbroker.rc3_path=\
+                -Sstatedir=$dbdir\
                 bash -c "\
                         flux module load content && \
                         flux module load content-sqlite && \
@@ -212,9 +212,9 @@ reader() {
 
 writer() {
 	local dbdir=$1
-        flux start -o,-Sbroker.rc1_path= \
-                -o,-Sbroker.rc3_path= \
-                -o,-Sstatedir=$dbdir \
+        flux start -Sbroker.rc1_path= \
+                -Sbroker.rc3_path= \
+                -Sstatedir=$dbdir \
                 bash -c "\
                         flux module load content && \
                         flux module load content-sqlite && \
@@ -231,7 +231,7 @@ test_expect_success 'perform offline garbage collection with dump/restore' '
 '
 
 test_expect_success 'restart flux instance and try to run a job' '
-	flux start -o,-Sstatedir=test \
+	flux start -Sstatedir=test \
 		flux run /bin/true
 '
 
@@ -260,7 +260,7 @@ test_expect_success 'restore bigdump.tar with size limit' '
 test_expect_success 'rc1 skips blob that exceeds 100M limit' '
 	dd if=/dev/zero of=big/hugeblob bs=1048576 count=120 &&
 	tar cvf bigdump2.tar big &&
-	flux start -o,-Scontent.restore=bigdump2.tar \
+	flux start -Scontent.restore=bigdump2.tar \
 		/bin/true 2>bigdump3.err &&
 	grep "exceeds" bigdump3.err
 '

--- a/t/t2808-shutdown-cmd.t
+++ b/t/t2808-shutdown-cmd.t
@@ -81,7 +81,7 @@ test_expect_success 'cancel that job' '
 
 test_expect_success 'run instance with no initial program and wait for it to start' '
 	flux submit --wait-event=start \
-		flux start -o,-Sbroker.rc2_none >jobid3 &&
+		flux start -Sbroker.rc2_none >jobid3 &&
 	run_timeout 30 bash -c "while ! flux uri $(cat jobid3) >uri3; do \
 		sleep 0.1; \
 	done"

--- a/t/t2809-job-purge.t
+++ b/t/t2809-job-purge.t
@@ -252,7 +252,7 @@ test_expect_success 'new instance with bad config fails to start' '
 	[job-manager]
 	inactive-num-limit = -42
 	EOT
-	test_must_fail flux start -o,--config-path=$(pwd)/config \
+	test_must_fail flux start --config-path=$(pwd)/config \
 		/bin/true 2>badnum2.err &&
 	grep "must be >= 0" badnum2.err
 '

--- a/t/t2810-kvs-garbage-collect.t
+++ b/t/t2810-kvs-garbage-collect.t
@@ -17,9 +17,9 @@ test_expect_success 'create test script' '
 '
 test_expect_success 'run instance that leaves an auto dump' '
 	mkdir -p state &&
-	flux start -o,-Sstatedir=state \
-	    -o,-Scontent.dump=auto \
-	    -o,-Slog-filename=dmesg.log \
+	flux start -Sstatedir=state \
+	    -Scontent.dump=auto \
+	    -Slog-filename=dmesg.log \
 	    ./runjobs.sh >object_count
 '
 test_expect_success 'broker logs report dump activity' '
@@ -31,9 +31,9 @@ test_expect_success 'dump exists and RESTORE symlink is valid' '
 	test -f $(cat archive)
 '
 test_expect_success 'restart instance with auto restore' '
-	flux start -o,-Sstatedir=state \
-	    -o,-Scontent.restore=auto \
-	    -o,-Slog-filename=dmesg2.log \
+	flux start -Sstatedir=state \
+	    -Scontent.restore=auto \
+	    -Slog-filename=dmesg2.log \
 	    flux module stats \
 	        --type int --parse object_count content-sqlite >object_count2
 '
@@ -59,9 +59,9 @@ test_expect_success 'archive file remains' '
 # - explicitly named dump file (not auto)
 #
 test_expect_success 'run instance that leaves a named dump' '
-	flux start -o,-Slog-filename=dmesg3.log \
-	    -o,-Scontent.dump=foo.tgz \
-	    -o,-Scontent.backing-module=content-files \
+	flux start -Slog-filename=dmesg3.log \
+	    -Scontent.dump=foo.tgz \
+	    -Scontent.backing-module=content-files \
 	    ./runjobs.sh >object_count3
 '
 test_expect_success 'broker logs report dump activity' '
@@ -74,9 +74,9 @@ test_expect_success 'no RESTORE link was created because path is explicit' '
 	test_must_fail test -h dump/RESTORE
 '
 test_expect_success 'restart instance and restore' '
-	flux start -o,-Slog-filename=dmesg4.log \
-	    -o,-Scontent.restore=foo.tgz \
-	    -o,-Scontent.backing-module=content-files \
+	flux start -Slog-filename=dmesg4.log \
+	    -Scontent.restore=foo.tgz \
+	    -Scontent.backing-module=content-files \
 	    flux module stats \
 	        --type int --parse object_count content-files >object_count4
 '

--- a/t/t2812-flux-job-last.t
+++ b/t/t2812-flux-job-last.t
@@ -42,7 +42,7 @@ test_expect_success 'flux-job last lists inactive jobs after instance restart' '
 	flux job last "[:]" >lastdump.exp &&
 	flux queue idle &&
 	flux dump dump.tgz &&
-	flux start -o,-Scontent.restore=dump.tgz \
+	flux start -Scontent.restore=dump.tgz \
 		flux job last "[:]" >lastdump.out &&
 	test_cmp lastdump.exp lastdump.out
 '

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -10,7 +10,7 @@ SIZE=$(test_size_large)
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"
 
-ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
+ARGS="-Sbroker.rc1_path= -Sbroker.rc3_path="
 test_expect_success "flux can run flux instance as a job" '
 	run_timeout 60 flux run -n1 -N1 \
 		flux start ${ARGS} flux getattr size >size.out &&

--- a/t/t3200-instance-restart.t
+++ b/t/t3200-instance-restart.t
@@ -13,22 +13,22 @@ if test -n "$S3_ACCESS_KEY_ID"; then
 fi
 
 test_expect_success 'run a job in persistent instance' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 	           flux submit /bin/true >id1.out
 '
 
 test_expect_success 'restart instance and run another job' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 	           flux submit /bin/true >id2.out
 '
 
 test_expect_success 'restart instance and run another job' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 	           flux submit /bin/true >id3.out
 '
 
 test_expect_success 'restart instance and list inactive jobs' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 	           flux jobs --no-header --format={id} \
 		   	--filter=INACTIVE >list.out
 '
@@ -45,7 +45,7 @@ test_expect_success 'job IDs were issued in ascending order' '
 '
 
 test_expect_success 'restart instance and capture startlog' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 	           flux startlog >startlog.out
 '
 test_expect_success 'startlog shows 5 run periods' '
@@ -56,14 +56,14 @@ test_expect_success 'most recent period is still running' '
 '
 
 test_expect_success 'doctor startlog to look like a crash' '
-	flux start -o,--setattr=statedir=$(pwd) \
-		-o,-Sbroker.rc1_path=$SHARNESS_TEST_SRCDIR/rc/rc1-kvs \
-		-o,-Sbroker.rc3_path=$SHARNESS_TEST_SRCDIR/rc/rc3-kvs \
+	flux start --setattr=statedir=$(pwd) \
+		-Sbroker.rc1_path=$SHARNESS_TEST_SRCDIR/rc/rc1-kvs \
+		-Sbroker.rc3_path=$SHARNESS_TEST_SRCDIR/rc/rc3-kvs \
 		flux startlog --post-start-event
 '
 test_expect_success 'run flux and capture logs on stderr' '
-	flux start -o,--setattr=statedir=$(pwd) \
-		-o,--setattr=log-stderr-level=6 \
+	flux start --setattr=statedir=$(pwd) \
+		--setattr=log-stderr-level=6 \
 		/bin/true 2>improper.err
 '
 test_expect_success 'improper shutdown was logged' '
@@ -72,14 +72,14 @@ test_expect_success 'improper shutdown was logged' '
 
 test_expect_success 'run a job in persistent instance (content-files)' '
 	flux start \
-	    -o,-Scontent.backing-module=content-files \
-	    -o,-Sstatedir=$(pwd) \
+	    -Scontent.backing-module=content-files \
+	    -Sstatedir=$(pwd) \
 	    flux submit /bin/true >files_id1.out
 '
 test_expect_success 'restart instance and list inactive jobs' '
 	flux start \
-	    -o,-Scontent.backing-module=content-files \
-	    -o,-Sstatedir=$(pwd) \
+	    -Scontent.backing-module=content-files \
+	    -Sstatedir=$(pwd) \
 	    flux jobs --no-header --format={id} \
 	        --filter=INACTIVE >files_list.out
 '
@@ -108,12 +108,12 @@ test_expect_success S3 'create content-s3.toml from env' '
 
 test_expect_success S3 'run a job in persistent instance (content-s3)' '
 	flux start \
-	    -o,-Scontent.backing-module=content-s3 \
+	    -Scontent.backing-module=content-s3 \
 	    flux submit /bin/true >files_id2.out
 '
 test_expect_success S3 'restart instance and list inactive jobs' '
 	flux start \
-	    -o,-Scontent.backing-module=content-s3 \
+	    -Scontent.backing-module=content-s3 \
 	    flux jobs --no-header --format={id} \
 	        --filter=INACTIVE >files_list2.out
 '

--- a/t/t3201-crontabs.t
+++ b/t/t3201-crontabs.t
@@ -9,21 +9,21 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 
 test_expect_success 'empty cron.directory works' '
 	mkdir cron.d &&
-	flux start -o,-Scron.directory=cron.d /bin/true
+	flux start -Scron.directory=cron.d /bin/true
 '
 test_expect_success 'non-existent cron.directory works' '
-	flux start -o,-Scron.directory=noexist /bin/true
+	flux start -Scron.directory=noexist /bin/true
 '
 test_expect_success 'cron.directory with subdirectory works' '
 	rm -rf cron.d &&
 	mkdir -p cron.d/subdir &&
-	flux start -o,-Scron.directory=cron.d /bin/true
+	flux start -Scron.directory=cron.d /bin/true
 '
 test_expect_success 'cron.directory with non-crontab file fails' '
 	rm -rf cron.d &&
 	mkdir cron.d &&
 	echo zzz >cron.d/badtab &&
-	test_must_fail flux start -o,-Scron.directory=cron.d \
+	test_must_fail flux start -Scron.directory=cron.d \
 		/bin/true 2>bad.err &&
 	grep "could not load crontab" bad.err
 '
@@ -32,7 +32,7 @@ test_expect_success 'cron.directory with good crontab files works' '
 	mkdir cron.d &&
 	echo "10 * * * * /bin/true" >cron.d/goodtab &&
 	echo "20 * * * * hostname" >cron.d/goodtab2 &&
-	flux start -o,-Scron.directory=cron.d flux cron list >list.out &&
+	flux start -Scron.directory=cron.d flux cron list >list.out &&
 	grep /bin/true list.out &&
 	grep hostname list.out
 '

--- a/t/t3202-instance-restart-testexec.t
+++ b/t/t3202-instance-restart-testexec.t
@@ -9,7 +9,7 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 export FLUX_DISABLE_JOB_CLEANUP=t
 
 test_expect_success 'run a testexec job in persistent instance (long run)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 	     flux submit \
 	       --flags=debug \
 	       --setattr=system.exec.test.run_duration=100s \
@@ -17,7 +17,7 @@ test_expect_success 'run a testexec job in persistent instance (long run)' '
 '
 
 test_expect_success 'restart instance, reattach to running job, cancel it (long run)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 	     sh -c "flux job eventlog $(cat id1.out) > eventlog_long1.out; \
 		    flux jobs -n > jobs_long1.out; \
 		    flux cancel $(cat id1.out)" &&
@@ -27,7 +27,7 @@ test_expect_success 'restart instance, reattach to running job, cancel it (long 
 '
 
 test_expect_success 'restart instance, job completed (long run)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 	     sh -c "flux job eventlog $(cat id1.out) > eventlog_long2.out; \
 		    flux jobs -n > jobs_long2.out" &&
 	grep "finish" eventlog_long2.out | grep status &&
@@ -38,7 +38,7 @@ test_expect_success 'restart instance, job completed (long run)' '
 # right after reattach, emulating a job that finished before the
 # instance restarted
 test_expect_success 'run a testexec job in persistent instance (exit run)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 	     flux submit \
 	       --flags=debug \
 	       --setattr=system.exec.test.reattach_finish=1 \
@@ -47,7 +47,7 @@ test_expect_success 'run a testexec job in persistent instance (exit run)' '
 '
 
 test_expect_success 'restart instance, reattach to running job, its finished (exit run)' '
-	flux start -o,--setattr=statedir=$(pwd) \
+	flux start --setattr=statedir=$(pwd) \
 	     sh -c "flux job eventlog $(cat id2.out) > eventlog_exit1.out" &&
 	grep "reattach-start" eventlog_exit1.out &&
 	grep "reattach-finish" eventlog_exit1.out &&

--- a/t/t3203-instance-recovery.t
+++ b/t/t3203-instance-recovery.t
@@ -14,7 +14,7 @@ runpty="flux ${SHARNESS_TEST_SRCDIR}/scripts/runpty.py"
 test_expect_success 'start a persistent instance of size 4' '
 	mkdir -p test1 &&
 	flux start --test-size=4 --test-exit-timeout=300s \
-		-o,-Sstatedir=$(pwd)/test1 /bin/true
+		-Sstatedir=$(pwd)/test1 /bin/true
 '
 test_expect_success 'expected broker attributes are set in recovery mode' '
 	cat >recov_attrs.exp <<-EOT &&
@@ -23,8 +23,8 @@ test_expect_success 'expected broker attributes are set in recovery mode' '
 	5
 	EOT
 	flux start --recovery=$(pwd)/test1 \
-	    -o,-Sbroker.rc1_path= \
-	    -o,-Sbroker.rc3_path= \
+	    -Sbroker.rc1_path= \
+	    -Sbroker.rc3_path= \
 	    bash -c " \
 		flux getattr broker.recovery-mode && \
 	        flux getattr broker.quorum && \
@@ -34,24 +34,24 @@ test_expect_success 'expected broker attributes are set in recovery mode' '
 test_expect_success 'banner message is printed in interactive recovery mode' '
 	run_timeout --env=SHELL=/bin/sh 120 \
 	    $runpty -i none flux start \
-	        -o,-Sbroker.rc1_path= \
-	        -o,-Sbroker.rc3_path= \
+	        -Sbroker.rc1_path= \
+	        -Sbroker.rc3_path= \
 	        --recovery=$(pwd)/test1 >banner.out &&
 	grep "Entering Flux recovery mode" banner.out
 '
 test_expect_success '--recovery is not ignored if --test-size is specified' '
 	run_timeout --env=SHELL=/bin/sh 120 \
 	    $runpty -i none flux start \
-	        -o,-Sbroker.rc1_path= \
-	        -o,-Sbroker.rc3_path= \
+	        -Sbroker.rc1_path= \
+	        -Sbroker.rc3_path= \
 	    	--test-size=1 \
 	        --recovery=$(pwd)/test1 >banner.out &&
 	grep "Entering Flux recovery mode" banner.out
 '
 test_expect_success 'rc1 failure is ignored in recovery mode' '
 	flux start --recovery=$(pwd)/test1 \
-	    -o,-Sbroker.rc1_path=/bin/false \
-	    -o,-Sbroker.rc3_path= \
+	    -Sbroker.rc1_path=/bin/false \
+	    -Sbroker.rc3_path= \
 	    echo "hello world" >hello.out &&
 	grep hello hello.out
 '
@@ -73,8 +73,8 @@ test_expect_success 'recovery mode also works with dump file' '
 test_expect_success 'banner message warns changes are not persistent' '
 	run_timeout --env=SHELL=/bin/sh 120 \
 	    $runpty -i none flux start \
-	        -o,-Sbroker.rc1_path= \
-	        -o,-Sbroker.rc3_path= \
+	        -Sbroker.rc1_path= \
+	        -Sbroker.rc3_path= \
 	        --recovery=$(pwd)/test1.tar >banner2.out &&
 	grep "changes will not be preserved" banner2.out
 '

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -51,7 +51,7 @@ test_expect_success \
 	run_timeout 300 \
 	flux start -s ${VALGRIND_NBROKERS} \
 		--test-exit-timeout=120 \
-		-o,--config-path=valgrind.toml \
+		--config-path=valgrind.toml \
 		--wrap=libtool,e,${VALGRIND} \
 		--wrap=--tool=memcheck \
 		--wrap=--leak-check=full \


### PR DESCRIPTION
I kept getting annoyed that the common broker options for configuration path and setting attributes have to be passed through `flux start`'s `-o, --broker-opts` option. `flux start` is used solely to start brokers, so why can't it just support these common options directly? So, submitted for your consideration is a PR that adds `-S, --setattr` and `-c, --config-path` options directly to `flux start`. If used, these options are just passed along to the broker(s) being started.

WIP because there's no tests or documentation updates in case there's some reason I'm not thinking of that this was a bad idea.