### PR TITLE
fix macos portability issues

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,9 @@ EXTRA_DIST = \
 	NEWS.md \
 	scripts/requirements-dev.txt \
 	scripts/install-deps-deb.sh \
-	scripts/install-deps-rpm.sh
+	scripts/install-deps-rpm.sh \
+	scripts/install-deps-macos.sh \
+	scripts/configure-macos.sh
 
 ACLOCAL_AMFLAGS = -I config
 

--- a/configure.ac
+++ b/configure.ac
@@ -187,6 +187,7 @@ AC_CHECK_HEADERS( \
   xlocale.h \
   endian.h \
   inttypes.h \
+  link.h \
 )
 
 ##

--- a/configure.ac
+++ b/configure.ac
@@ -241,6 +241,7 @@ X_AC_CHECK_COND_LIB(rt, clock_gettime)
 X_AC_CHECK_COND_LIB(dl, dlerror)
 X_AC_MALLOC
 AC_CHECK_LIB(m, floor)
+AC_SEARCH_LIBS(epoll, libepoll-shim)
 
 AC_ARG_ENABLE([docs],
 	      AS_HELP_STRING([--disable-docs], [disable building docs]))

--- a/configure.ac
+++ b/configure.ac
@@ -234,6 +234,7 @@ AC_REPLACE_FUNCS( \
   envz_add \
   strerrorname_np \
   pipe2 \
+  mempcpy \
 )
 X_AC_CHECK_PTHREADS
 X_AC_CHECK_COND_LIB(rt, clock_gettime)

--- a/configure.ac
+++ b/configure.ac
@@ -233,6 +233,7 @@ AC_REPLACE_FUNCS( \
   argz_add \
   envz_add \
   strerrorname_np \
+  pipe2 \
 )
 X_AC_CHECK_PTHREADS
 X_AC_CHECK_COND_LIB(rt, clock_gettime)

--- a/doc/man3/flux_future_get.rst
+++ b/doc/man3/flux_future_get.rst
@@ -118,7 +118,7 @@ ETIMEDOUT
    A timeout passed to :func:`flux_future_wait_for` expired before the future
    was fulfilled.
 
-EDEADLOCK
+EDEADLOCK (or EDEADLK on BSD systems)
    :func:`flux_future_wait_for` would likely deadlock due to an
    improperly initialized future.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -625,6 +625,8 @@ gc
 tgz
 tmpfiles
 EDEADLOCK
+EDEADLK
+BSD
 setpgrp
 nosetpgrp
 checkpointed

--- a/scripts/configure-macos.sh
+++ b/scripts/configure-macos.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+die() {
+    echo "$(basename $0): $@" >&2
+    exit 1
+}
+
+DEPS_SCRIPT=scripts/install-deps-macos.sh
+
+test -f $DEPS_SCRIPT || die "please run from the top level of the source tree"
+test -d macos-venv || die "please run $DEPS_SCRIPT first"
+
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+CPPFLAGS=-I${HOMEBREW_PREFIX}/include/lua
+CPPFLAGS="-I$(brew --prefix epoll-shim)/include/libepoll-shim ${CPPFLAGS}"
+LDFLAGS=-L${HOMEBREW_PREFIX}/lib
+
+PKG_CONFIG_PATH=$(pkg-config --variable pc_path pkg-config)
+PKG_CONFIG_PATH=$(brew --prefix libarchive)/lib/pkgconfig:${PKG_CONFIG_PATH}
+
+PATH=$(brew --prefix libtool)/libexec/gnubin:$PATH
+
+source macos-venv/bin/activate
+
+./autogen.sh
+
+CPPFLAGS=$CPPFLAGS LDFLAGS=$LDFLAGS PKG_CONFIG_PATH=$PKG_CONFIG_PATH \
+  ./configure

--- a/scripts/install-deps-macos.sh
+++ b/scripts/install-deps-macos.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+die() {
+    echo "$(basename $0): $@" >&2
+    exit 1
+}
+
+test -f scripts/requirements-dev.txt || die "Please run from top of source tree"
+
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+brew install \
+  autoconf \
+  automake \
+  libtool \
+  make \
+  pkg-config \
+  epoll-shim \
+  zeromq \
+  jansson \
+  lz4 \
+  libarchive \
+  hwloc \
+  sqlite \
+  lua@5.3 \
+  python3 \
+  cffi \
+  libyaml \
+  jq
+
+brew link lua@5.3
+
+python3 -m venv macos-venv
+source macos-venv/bin/activate
+
+pip3 install setuptools
+pip3 install -r scripts/requirements-dev.txt
+
+echo "Now run scripts/configure-macos.sh"

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -11,7 +11,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <sys/param.h>
+#include <limits.h>
 #include <unistd.h>
 #include <jansson.h>
 #include <flux/hostlist.h>
@@ -164,7 +164,7 @@ static int format_bind_uri (char *buf, int bufsz, attr_t *attrs, int rank)
             goto overflow;
     }
     else {
-        char ipaddr[HOST_NAME_MAX + 1];
+        char ipaddr[_POSIX_HOST_NAME_MAX + 1];
         flux_error_t error;
         int flags = 0;
         const char *interface = NULL;

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -11,7 +11,7 @@
 #ifndef _BROKER_H
 #define _BROKER_H
 
-#include <sys/param.h>
+#include <limits.h>
 #include <flux/optparse.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -23,7 +23,7 @@ struct broker {
     flux_watcher_t *w_internal;
     flux_reactor_t *reactor;
     optparse_t *opts;
-    char hostname[MAXHOSTNAMELEN + 1];
+    char hostname[_POSIX_HOST_NAME_MAX + 1];
 
     struct overlay *overlay;
     uint32_t rank;

--- a/src/cmd/builtin/relay.c
+++ b/src/cmd/builtin/relay.c
@@ -36,7 +36,7 @@
 #include "builtin.h"
 #include <unistd.h>
 #include <sys/types.h>
-#include <sys/param.h>
+#include <limits.h>
 #include <stdio.h>
 #include <glob.h>
 #include <ctype.h>
@@ -131,7 +131,7 @@ static int cmd_relay (optparse_t *p, int ac, char *av[])
     flux_t *h;
     int optindex;
     char *uri;
-    char hostname [HOST_NAME_MAX + 1];
+    char hostname [_POSIX_HOST_NAME_MAX + 1];
 
     /*  If possible, initialize logging prefix as local hostname. (In the
      *  unlikely event gethostname(3) fails, use "unknown-host".)

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -18,6 +18,10 @@
 #include <assert.h>
 #include <flux/core.h>
 
+#ifndef EDEADLOCK
+#define EDEADLOCK EDEADLK
+#endif
+
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/aux.h"
 

--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -16,6 +16,10 @@
 #include <string.h>
 #include <flux/core.h>
 
+#ifndef EDEADLOCK
+#define EDEADLOCK EDEADLK
+#endif
+
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libtap/tap.h"

--- a/src/common/libhostlist/hostlist.c
+++ b/src/common/libhostlist/hostlist.c
@@ -41,12 +41,6 @@
 /* max number of ranges that will be processed between brackets */
 #define MAX_RANGES    10240    /* 10K Ranges */
 
-/* size of internal hostname buffer (+ some slop), hostnames will probably
- * be truncated if longer than MAXHOSTNAMELEN */
-#ifndef MAXHOSTNAMELEN
-#define MAXHOSTNAMELEN    64
-#endif
-
 /* max size of internal hostrange buffer */
 #define MAXHOSTRANGELEN 1024
 

--- a/src/common/libhostlist/hostrange.c
+++ b/src/common/libhostlist/hostrange.c
@@ -18,7 +18,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <ctype.h>
-#include <sys/param.h>
+#include <limits.h>
 #include <unistd.h>
 #include <stdbool.h>
 
@@ -30,13 +30,6 @@
 
 /* max number of ranges that will be processed between brackets */
 #define MAX_RANGES    10240    /* 10K Ranges */
-
-/* size of internal hostname buffer (+ some slop), hostnames will probably
- * be truncated if longer than MAXHOSTNAMELEN
- */
-#ifndef MAXHOSTNAMELEN
-#define MAXHOSTNAMELEN    64
-#endif
 
 /* max size of internal hostrange buffer */
 #define MAXHOSTRANGELEN 1024
@@ -457,7 +450,7 @@ size_t hostrange_numstr (struct hostrange * hr, size_t n, char *buf)
 
 char * hostrange_host_tostring (struct hostrange * hr, int depth)
 {
-    char buf[MAXHOSTNAMELEN + 16];
+    char buf[_POSIX_HOST_NAME_MAX + 16];
     int len;
 
     if (!hr || depth < 0) {
@@ -475,7 +468,7 @@ char * hostrange_host_tostring (struct hostrange * hr, int depth)
             errno = ERANGE;
             return NULL;
         }
-        snprintf (buf+len, MAXHOSTNAMELEN+15 - len, "%0*lu",
+        snprintf (buf+len, sizeof (buf) - len, "%0*lu",
                  hr->width, hr->lo + depth);
     }
     return strdup (buf);

--- a/src/common/libkvs/test/kvs_checkpoint.c
+++ b/src/common/libkvs/test/kvs_checkpoint.c
@@ -16,6 +16,10 @@
 #include <errno.h>
 #include <flux/core.h>
 
+#ifndef EDEADLOCK
+#define EDEADLOCK EDEADLK
+#endif
+
 #include "src/common/libtap/tap.h"
 
 #include "kvs_checkpoint.h"

--- a/src/common/libmissing/Makefile.am
+++ b/src/common/libmissing/Makefile.am
@@ -50,4 +50,5 @@ EXTRA_libmissing_la_SOURCES = \
 	envz.c \
 	macros.h \
 	strerrorname_np.h \
-	json_object_update_recursive.h
+	json_object_update_recursive.h \
+	pipe2.h

--- a/src/common/libmissing/Makefile.am
+++ b/src/common/libmissing/Makefile.am
@@ -51,4 +51,5 @@ EXTRA_libmissing_la_SOURCES = \
 	macros.h \
 	strerrorname_np.h \
 	json_object_update_recursive.h \
-	pipe2.h
+	pipe2.h \
+	mempcpy.h

--- a/src/common/libmissing/argz.c
+++ b/src/common/libmissing/argz.c
@@ -22,7 +22,9 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-
+#ifndef HAVE_MEMPCPY
+#include "mempcpy.h"
+#endif
 
 
 /* Add BUF, of length BUF_LEN to the argz vector in ARGZ & ARGZ_LEN.  */

--- a/src/common/libmissing/mempcpy.c
+++ b/src/common/libmissing/mempcpy.c
@@ -1,0 +1,24 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <errno.h>
+
+#include "mempcpy.h"
+
+void *mempcpy (void *dest, const void *src, size_t len)
+{
+    return memcpy (dest, src, len) + len;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libmissing/mempcpy.h
+++ b/src/common/libmissing/mempcpy.h
@@ -1,0 +1,16 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _MEMPCPY_H
+#define _MEMPCPY_H 1
+
+void *mempcpy (void *dest, const void *src, size_t len);
+
+#endif // !_MEMPCPY

--- a/src/common/libmissing/pipe2.c
+++ b/src/common/libmissing/pipe2.c
@@ -1,0 +1,46 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include "pipe2.h"
+
+static int setflags (int fd, int flags)
+{
+    int oflags;
+    if ((oflags = fcntl (fd, F_GETFL)) < 0
+        || fcntl (fd, F_SETFL, oflags | flags) < 0)
+        return -1;
+    return 0;
+}
+
+int pipe2 (int pipefd[2], int flags)
+{
+    int pfd[2];
+    if (pipe (pfd) < 0)
+        return -1;
+    if (setflags (pfd[0], flags) < 0 || setflags (pfd[1], flags) < 0) {
+        int saved_errno = errno;
+        (void)close (pfd[0]);
+        (void)close (pfd[1]);
+        errno = saved_errno;
+        return -1;
+    }
+    pipefd[0] = pfd[0];
+    pipefd[1] = pfd[1];
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libmissing/pipe2.h
+++ b/src/common/libmissing/pipe2.h
@@ -1,0 +1,16 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PIPE2_H
+#define _PIPE2_H 1
+
+int pipe2 (int pipefd[2], int flags);
+
+#endif // !_PIPE2_H

--- a/src/common/liboptparse/getopt.c
+++ b/src/common/liboptparse/getopt.c
@@ -65,6 +65,10 @@
 
 #include <string.h>
 
+#ifndef HAVE_MEMPCPY
+#include "src/common/libmissing/mempcpy.h"
+#endif
+
 #ifdef VMS
 # include <unixlib.h>
 #endif

--- a/src/common/libpmi/upmi_libpmi.c
+++ b/src/common/libpmi/upmi_libpmi.c
@@ -14,7 +14,9 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <dlfcn.h>
+#if HAVE_LINK_H
 #include <link.h>
+#endif
 
 #include "src/common/libutil/errprintf.h"
 #include "ccan/array_size/array_size.h"
@@ -46,10 +48,13 @@ static const char *plugin_name = "libpmi";
 
 static const char *dlinfo_name (void *dso)
 {
-    struct link_map *p;
-    if (dlinfo (dso, RTLD_DI_LINKMAP, &p) < 0)
-        return NULL;
-    return p->l_name;
+#if HAVE_LINK_H
+    struct link_map *p = NULL;
+    (void)dlinfo (dso, RTLD_DI_LINKMAP, &p);
+    if (p && p->l_name)
+        return p->l_name;
+#endif
+    return "unknown";
 }
 
 static int dlopen_wrap (const char *path,
@@ -303,9 +308,6 @@ static int op_preinit (flux_plugin_t *p,
     int result;
     int spawned;
     const char *name = dlinfo_name (ctx->dso);
-
-    if (!name)
-        name = "unknown";
 
     result = ctx->init (&spawned);
     if (result != PMI_SUCCESS)

--- a/src/common/librouter/test/sendfd.c
+++ b/src/common/librouter/test/sendfd.c
@@ -15,6 +15,10 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#ifndef HAVE_PIPE2
+#include "src/common/libmissing/pipe2.h"
+#endif
+
 
 #include <flux/core.h>
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -13,7 +13,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
-	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
+	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\" \
+	$(JANSSON_CFLAGS)
 
 noinst_LTLIBRARIES = libutil.la
 

--- a/src/common/libutil/fdwalk.c
+++ b/src/common/libutil/fdwalk.c
@@ -93,6 +93,7 @@ struct linux_dirent64
 
 #include "fdwalk.h"
 
+#ifdef __linux__
 // Parses a file descriptor number in base 10, requiring the strict format used
 // in /proc/*/fd. Returns the value, or -1 if not a valid string.
 static int parse_fd(const char *s) {
@@ -111,6 +112,7 @@ static int parse_fd(const char *s) {
     } while (*s);
     return val;
 }
+#endif /* __linux__ */
 
 int _fdwalk_portable (void (*func)(void *, int), void *data)
 {
@@ -121,15 +123,16 @@ int _fdwalk_portable (void (*func)(void *, int), void *data)
 
 }
 
-int fdwalk (void (*func)(void *, int), void *data) {
-    int fd;
-    int rc = 0;
+int fdwalk (void (*func)(void *, int), void *data){
 
     /* On Linux use getdents64 to avoid malloc in opendir() and
      *  still walk only open fds. If not on linux or open() of /proc/self
      *  fails, fall back to iterating over all possible fds.
      */
 #ifdef __linux__
+    int fd;
+    int rc = 0;
+
     int dir_fd = open ("/proc/self/fd", O_RDONLY | O_DIRECTORY);
     if (dir_fd >= 0) {
         char buf [4096];

--- a/src/common/libutil/ipaddr.c
+++ b/src/common/libutil/ipaddr.c
@@ -11,7 +11,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <sys/param.h>
+#include <limits.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -178,7 +178,7 @@ static int getprimary_hostaddr (char *buf,
                                 int prefer_family,
                                 flux_error_t *error)
 {
-    char hostname[HOST_NAME_MAX + 1];
+    char hostname[_POSIX_HOST_NAME_MAX + 1];
     struct addrinfo hints, *res = NULL;
     struct addrinfo *rp;
     int e;

--- a/src/common/libutil/popen2.c
+++ b/src/common/libutil/popen2.c
@@ -22,6 +22,9 @@
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>
+#ifndef HAVE_PIPE2
+#include "src/common/libmissing/pipe2.h"
+#endif
 
 #include "popen2.h"
 #include "fdwalk.h"

--- a/src/common/libutil/sigutil.c
+++ b/src/common/libutil/sigutil.c
@@ -55,7 +55,9 @@ static const struct signal_info signals[] = {
     SIGDEF(SIGPIPE),
     SIGDEF(SIGALRM),
     SIGDEF(SIGTERM),
+#ifdef SIGSTKFLT
     SIGDEF(SIGSTKFLT),
+#endif
     SIGDEF(SIGCHLD),
     SIGDEF(SIGCONT),
     SIGDEF(SIGSTOP),
@@ -69,11 +71,13 @@ static const struct signal_info signals[] = {
     SIGDEF(SIGPROF),
     SIGDEF(SIGWINCH),
     SIGDEF(SIGIO),
+#ifdef SIGPWR
     SIGDEF(SIGPWR),
+#endif
     SIGDEF(SIGSYS),
 };
 
-static bool isnumber (const char *s, int *result)
+static bool strisnumber (const char *s, int *result)
 {
     char *endptr;
     long int l;
@@ -94,7 +98,7 @@ int sigutil_signum (const char *s)
         errno = EINVAL;
         return -1;
     }
-    if (isnumber (s, &signum)) {
+    if (strisnumber (s, &signum)) {
         if (signum <= 0) {
             errno = EINVAL;
             return -1;

--- a/src/common/libutil/test/getaddr.c
+++ b/src/common/libutil/test/getaddr.c
@@ -11,7 +11,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <sys/param.h>
+#include <limits.h>
 #include <flux/core.h>
 
 #include "src/common/libutil/ipaddr.h"
@@ -20,7 +20,7 @@
 
 int main(int argc, char** argv)
 {
-    char buf[MAXHOSTNAMELEN + 1];
+    char buf[_POSIX_HOST_NAME_MAX + 1];
     flux_error_t error;
     char *name = getenv ("FLUX_IPADDR_INTERFACE");
     int flags = 0;

--- a/src/common/libutil/test/ipaddr.c
+++ b/src/common/libutil/test/ipaddr.c
@@ -11,7 +11,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <sys/param.h>
+#include <limits.h>
 #include <flux/core.h>
 
 #include "src/common/libtap/tap.h"
@@ -20,7 +20,7 @@
 
 int main(int argc, char** argv)
 {
-    char host[MAXHOSTNAMELEN + 1];
+    char host[_POSIX_HOST_NAME_MAX + 1];
     flux_error_t error;
     int n;
 

--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -14,7 +14,7 @@
 #include <flux/core.h>
 #include <flux/optparse.h>
 #include <flux/shell.h>
-#include <sys/param.h>
+#include <limits.h>
 
 #include "src/common/libutil/aux.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -27,7 +27,7 @@ struct flux_shell {
     flux_jobid_t jobid;
     int broker_rank;
     uid_t broker_owner;
-    char hostname [MAXHOSTNAMELEN + 1];
+    char hostname [_POSIX_HOST_NAME_MAX + 1];
     int protocol_fd[2];
 
     optparse_t *p;


### PR DESCRIPTION
Here's a bit of work towards portability of flux-core to macos.  This has been going on at a low level for some time, documented in #2892.

Instructions for preschool level macos user like me:

0) install xcode (eh, I typed `git` and a dialog box did the rest)
1) install homebrew (download pkg from homebrew site)
2) run `scripts/install-deps-macos.sh`
3) run `scripts/configure-macos.sh`
4) make

I am moving on to other things today.  The current status is compilation fails in libev:
```
Making all in libev
  CC       ev.lo
ev.c:3036:21: error: variable has incomplete type 'struct itimerspec'
 3036 |   struct itimerspec its = { 0 };
      |                     ^
/opt/homebrew/opt/epoll-shim/include/libepoll-shim/sys/timerfd.h:17:8: note: forward declaration of 'struct itimerspec'
   17 | struct itimerspec;
      |        ^
1 error generated.
```
