### PR TITLE
skip "empty" lines of output in `flux resource list` with `--skip-empty` or `--include`

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -106,6 +106,15 @@ all
   hostlist form. It is not an error to specify ranks, nodes, or hosts which
   do not exist.
 
+.. option:: --skip-empty
+
+  Skip lines with empty resource sets in output. This is the default when
+  `-i, --include` is used.
+
+.. options:: --no-skip-empty
+
+  Do not skip empty resource sets in output, even with `-i, --include`.
+
 .. option:: -o, --format=FORMAT
 
   Customize the output format (See the `OUTPUT FORMAT`_ section below).

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -543,6 +543,8 @@ _flux_resource()
         -n --no-header \
         -q --queue= \
         -i --include= \
+        --skip-empty \
+        --no-skip-empty \
     "
     local status_OPTS="\
         ${list_OPTS} \

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -693,7 +693,7 @@ def list_handler(args):
         resources, args.states, formatter, config, queues=args.queue
     )
     items = sort_output(args, lines.values())
-    if args.skip_empty:
+    if args.skip_empty or (args.include and not args.no_skip_empty):
         items = [x for x in items if x.ranks]
     formatter.print_items(items, no_header=args.no_header)
 
@@ -906,7 +906,12 @@ def main():
     list_parser.add_argument(
         "--skip-empty",
         action="store_true",
-        help="Skip empty lines",
+        help="Skip empty lines. This is the default with -i, --include.",
+    )
+    list_parser.add_argument(
+        "--no-skip-empty",
+        action="store_true",
+        help="Do not skip empty lines, even with --include.",
     )
     list_parser.add_argument(
         "-n", "--no-header", action="store_true", help="Suppress header output"
@@ -952,7 +957,9 @@ def main():
         action="store_true",
         help=argparse.SUPPRESS,
     )
-
+    info_parser.add_argument(
+        "--no-skip-empty", action="store_true", help=argparse.SUPPRESS
+    )
     info_parser.set_defaults(func=info)
 
     reload_parser = subparsers.add_parser(

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -693,6 +693,8 @@ def list_handler(args):
         resources, args.states, formatter, config, queues=args.queue
     )
     items = sort_output(args, lines.values())
+    if args.skip_empty:
+        items = [x for x in items if x.ranks]
     formatter.print_items(items, no_header=args.no_header)
 
 
@@ -902,6 +904,11 @@ def main():
         help="Include only specified queues in output",
     )
     list_parser.add_argument(
+        "--skip-empty",
+        action="store_true",
+        help="Skip empty lines",
+    )
+    list_parser.add_argument(
         "-n", "--no-header", action="store_true", help="Suppress header output"
     )
     list_parser.add_argument(
@@ -939,6 +946,13 @@ def main():
         "--from-stdin", action="store_true", help=argparse.SUPPRESS
     )
     info_parser.add_argument("--config-file", help=argparse.SUPPRESS)
+    # Options required in `info` because they are also present in `list`:
+    info_parser.add_argument(
+        "--skip-empty",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+
     info_parser.set_defaults(func=info)
 
     reload_parser = subparsers.add_parser(

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -76,6 +76,13 @@ for input in ${SHARNESS_TEST_SRCDIR}/flux-resource/list/*.json; do
         test_debug "cat $name.output" &&
         test_cmp ${base}.expected $name.output
     '
+    test_expect_success "flux-resource list --skip-empty: $testname" '
+        awk "\$3!=0 {print}" ${base}.expected > skip-empty.${name}.expected &&
+        flux resource list -o "$FORMAT" \
+            --skip-empty \
+            --from-stdin < $input > skip-empty.${name}.output 2>&1 &&
+        test_cmp skip-empty.${name}.expected skip-empty.${name}.output
+    '
     test_expect_success "flux-resource info input check: $testname" '
         flux resource info --from-stdin < $input > ${name}-info.output 2>&1 &&
         test_debug "cat ${name}-info.output" &&
@@ -178,6 +185,11 @@ test_expect_success 'flux-resource list supports --include' '
 	test $(wc -l <list-include.output) -eq 1
 '
 INPUT=${SHARNESS_TEST_SRCDIR}/flux-resource/list/normal-new.json
+test_expect_success 'flux-resource list --include skips empty lines by default' '
+	flux resource list -s all -ni 0 --from-stdin < $INPUT >skip-empty.out &&
+	test_debug "cat skip-empty.out" &&
+	test $(wc -l <skip-empty.out) -eq 1
+'
 test_expect_success 'flux-resource list: --include works with ranks' '
 	flux resource list -s all -o "{nnodes} {ranks}" -ni 0,3 --from-stdin \
 	    --no-skip-empty \

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -96,12 +96,13 @@ for input in ${SHARNESS_TEST_SRCDIR}/flux-resource/list/*.json; do
     name=$(basename $base) &&
     test_expect_success "flux-resource list input --include check: $name" '
         flux resource list -o "{ranks} {nodelist}" --include=0 \
+	    --no-skip-empty \
             --from-stdin < $input >$name-include.output 2>&1 &&
         test_debug "cat $name-include.output" &&
         grep "^0[^,-]" $name-include.output
     '
     test_expect_success "flux-resource info input --include check: $testname" '
-        flux resource info --from-stdin -i0 < $input \
+        flux resource info --from-stdin --no-skip-empty -i0 < $input \
             > ${name}-info-include.output 2>&1 &&
         test_debug "cat ${name}-info-include.output" &&
 	grep "1 Node" ${name}-info-include.output
@@ -172,13 +173,14 @@ test_expect_success 'flux-resource -q, --queue reports invalid queue' '
 	grep "foo: no such queue" badqueue.err
 '
 test_expect_success 'flux-resource list supports --include' '
-	flux resource list -s all -ni 0 >list-include.output &&
+	flux resource list -s all -ni 0 --no-skip-empty >list-include.output &&
 	test_debug "cat list-include.output" &&
 	test $(wc -l <list-include.output) -eq 1
 '
 INPUT=${SHARNESS_TEST_SRCDIR}/flux-resource/list/normal-new.json
 test_expect_success 'flux-resource list: --include works with ranks' '
 	flux resource list -s all -o "{nnodes} {ranks}" -ni 0,3 --from-stdin \
+	    --no-skip-empty \
 		< $INPUT >include-ranks.out &&
 	test_debug "cat include-ranks.out" &&
 	grep "^2 0,3" include-ranks.out
@@ -270,7 +272,8 @@ test_expect_success 'flux-resource list: -i works with excluded hosts #5266' '
 '
 test_expect_success 'flux-resource list: --include works with invalid host' '
 	flux resource list -s all -o "{nnodes} {nodelist}" -ni pi7 \
-		--from-stdin < $INPUT >include-invalid-hosts.out &&
+		--from-stdin --no-skip-empty \
+		< $INPUT >include-invalid-hosts.out &&
 	test_debug "cat include-invalid-hosts.out" &&
 	grep "^0" include-invalid-hosts.out
 '


### PR DESCRIPTION
We didn't really come to a resolution in issue #6275 - however, it is clear that this output is surprising and wrong:
```console
$ flux resource list --include=corona171
     STATE QUEUE   NNODES NCORES NGPUS NODELIST
      free pdebug       1     48     8 corona171
 allocated pbatch       0      0     0 
 allocated pdebug       0      0     0 
 allocated pnvmeof      0      0     0 
      down pbatch       0      0     0 
      down pdebug       0      0     0 
      down pnvmeof      0      0     0 
```

This PR adds a `--skip-empty` option to `flux resource list` to skip all lines that represent empty resource sets, then makes this the default for `-i, --include` (which is probably the expected and least surprising behavior). So, instead of the above, we get:
```console
$ src/cmd/flux resource list --include=corona171
     STATE QUEUE  NNODES NCORES NGPUS NODELIST
      free pdebug      1     48     8 corona171
```

There is also now a `--no-skip-empty` option which disables the option with `--include`.