### PR TITLE
libfileref: fix segfault for files >2G

### DIFF
--- a/src/common/libfilemap/fileref.c
+++ b/src/common/libfilemap/fileref.c
@@ -98,7 +98,7 @@ static json_t *blobvec_create (int fd,
 #endif
         if (offset < size) {
             off_t notdata;
-            int blobsize;
+            size_t blobsize;
 
 #ifdef SEEK_HOLE
             // N.B. returns size if there are no more holes


### PR DESCRIPTION
Problem: 'flux archive create' segfaults when it tries to archive files with size >2G.

Change a local variable from int to size_t.

Fixes #6461