### PR TITLE
libflux: update API to use size_t where appropriate

### DIFF
--- a/doc/man3/flux_event_decode.rst
+++ b/doc/man3/flux_event_decode.rst
@@ -18,7 +18,7 @@ SYNOPSIS
    int flux_event_decode_raw (const flux_msg_t *msg,
                               const char **topic,
                               const void **data,
-                              int *len);
+                              size_t *len);
 
    int flux_event_unpack (const flux_msg_t *msg,
                           const char **topic,
@@ -29,7 +29,7 @@ SYNOPSIS
 
    flux_msg_t *flux_event_encode_raw (const char *topic,
                                       const void *data,
-                                      int len);
+                                      size_t len);
 
    flux_msg_t *flux_event_pack (const char *topic,
                                 const char *fmt,

--- a/doc/man3/flux_event_publish.rst
+++ b/doc/man3/flux_event_publish.rst
@@ -26,7 +26,7 @@ SYNOPSIS
                                           const char *topic,
                                           int flags,
                                           const void *data,
-                                          int len);
+                                          size_t len);
 
    int flux_event_publish_get_seq (flux_future_t *f, int *seq);
 

--- a/doc/man3/flux_kvs_lookup.rst
+++ b/doc/man3/flux_kvs_lookup.rst
@@ -29,7 +29,7 @@ SYNOPSIS
 
    int flux_kvs_lookup_get_raw (flux_future_t *f,
                                 const void **data
-                                int *len);
+                                size_t *len);
 
    int flux_kvs_lookup_get_dir (flux_future_t *f,
                                 const flux_kvsdir_t **dir);

--- a/doc/man3/flux_kvs_txn_create.rst
+++ b/doc/man3/flux_kvs_txn_create.rst
@@ -50,7 +50,7 @@ SYNOPSIS
                              int flags,
                              const char *key,
                              const void *data,
-                             int len);
+                             size_t len);
 
    int flux_kvs_txn_put_treeobj (flux_kvs_txn_t *txn,
                                  int flags,

--- a/doc/man3/flux_request_decode.rst
+++ b/doc/man3/flux_request_decode.rst
@@ -23,7 +23,7 @@ SYNOPSIS
    int flux_request_decode_raw (const flux_msg_t *msg,
                                 const char **topic,
                                 const void **data,
-                                int *len);
+                                size_t *len);
 
 Link with :command:`-lflux-core`.
 

--- a/doc/man3/flux_request_encode.rst
+++ b/doc/man3/flux_request_encode.rst
@@ -15,7 +15,7 @@ SYNOPSIS
 
    flux_msg_t *flux_request_encode_raw (const char *topic,
                                         void *data,
-                                        int len);
+                                        size_t len);
 
 Link with :command:`-lflux-core`.
 

--- a/doc/man3/flux_respond.rst
+++ b/doc/man3/flux_respond.rst
@@ -23,7 +23,7 @@ SYNOPSIS
    int flux_respond_raw (flux_t *h,
                          const flux_msg_t *request,
                          const void *data,
-                         int length);
+                         size_t length);
 
    int flux_respond_error (flux_t *h,
                            const flux_msg_t *request,

--- a/doc/man3/flux_response_decode.rst
+++ b/doc/man3/flux_response_decode.rst
@@ -18,7 +18,7 @@ SYNOPSIS
    int flux_response_decode_raw (const flux_msg_t *msg,
                                  const char **topic,
                                  const void **data,
-                                 int *len);
+                                 size_t *len);
 
    int flux_response_decode_error (const flux_msg_t *msg,
                                    const char *errstr);

--- a/doc/man3/flux_rpc.rst
+++ b/doc/man3/flux_rpc.rst
@@ -27,7 +27,7 @@ SYNOPSIS
    flux_future_t *flux_rpc_raw (flux_t *h,
                                 const char *topic,
                                 const void *data,
-                                int len,
+                                size_t len,
                                 uint32_t nodeid,
                                 int flags);
 
@@ -42,7 +42,7 @@ SYNOPSIS
 
    int flux_rpc_get_raw (flux_future_t *f,
                          const void **data,
-                         int *len);
+                         size_t *len);
 
    uint32_t flux_rpc_get_matchtag (flux_future_t *f);
 

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -527,7 +527,7 @@ static void append_request_cb (flux_t *h,
     logbuf_t *logbuf = arg;
     uint32_t matchtag;
     const char *buf;
-    int len;
+    size_t len;
 
     if (flux_msg_get_matchtag (msg, &matchtag) < 0) {
         log_msg ("%s: malformed log request", __FUNCTION__);

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -286,15 +286,18 @@ static int attr_set_log (const char *name, const char *val, void *arg)
         int level = strtol (val, NULL, 10);
         if (logbuf_set_forward_level (logbuf, level) < 0)
             goto done;
-    } else if (streq (name, "log-critical-level")) {
+    }
+    else if (streq (name, "log-critical-level")) {
         int level = strtol (val, NULL, 10);
         if (logbuf_set_critical_level (logbuf, level) < 0)
             goto done;
-    } else if (streq (name, "log-stderr-level")) {
+    }
+    else if (streq (name, "log-stderr-level")) {
         int level = strtol (val, NULL, 10);
         if (logbuf_set_stderr_level (logbuf, level) < 0)
             goto done;
-    } else if (streq (name, "log-stderr-mode")) {
+    }
+    else if (streq (name, "log-stderr-mode")) {
         if (streq (val, "leader"))
             logbuf->stderr_mode = MODE_LEADER;
         else if (streq (val, "local"))
@@ -303,18 +306,22 @@ static int attr_set_log (const char *name, const char *val, void *arg)
             errno = EINVAL;
             goto done;
         }
-    } else if (streq (name, "log-ring-size")) {
+    }
+    else if (streq (name, "log-ring-size")) {
         int size = strtol (val, NULL, 10);
         if (logbuf_set_ring_size (logbuf, size) < 0)
             goto done;
-    } else if (streq (name, "log-filename")) {
+    }
+    else if (streq (name, "log-filename")) {
         if (logbuf_set_filename (logbuf, val) < 0)
             goto done;
-    } else if (streq (name, "log-level")) {
+    }
+    else if (streq (name, "log-level")) {
         int level = strtol (val, NULL, 10);
         if (logbuf_set_level (logbuf, level) < 0)
             goto done;
-    } else {
+    }
+    else {
         errno = ENOENT;
         goto done;
     }
@@ -331,32 +338,61 @@ static int logbuf_register_attrs (logbuf_t *logbuf, attr_t *attrs)
      * Only allowed to be set on rank 0 (ignore initial value on rank > 0).
      */
     if (logbuf->rank == 0) {
-        if (attr_add_active (attrs, "log-filename", 0,
-                             attr_get_log, attr_set_log, logbuf) < 0)
+        if (attr_add_active (attrs,
+                             "log-filename",
+                             0,
+                             attr_get_log,
+                             attr_set_log,
+                             logbuf) < 0)
             goto done;
-    } else {
+    }
+    else {
         (void)attr_delete (attrs, "log-filename", true);
         if (attr_add (attrs, "log-filename", NULL, ATTR_IMMUTABLE) < 0)
             goto done;
     }
 
-    if (attr_add_active (attrs, "log-stderr-level", 0,
-                         attr_get_log, attr_set_log, logbuf) < 0)
+    if (attr_add_active (attrs,
+                         "log-stderr-level",
+                         0,
+                         attr_get_log,
+                         attr_set_log,
+                         logbuf) < 0)
         goto done;
-    if (attr_add_active (attrs, "log-stderr-mode", 0,
-                         attr_get_log, attr_set_log, logbuf) < 0)
+    if (attr_add_active (attrs,
+                         "log-stderr-mode",
+                         0,
+                         attr_get_log,
+                         attr_set_log,
+                         logbuf) < 0)
         goto done;
-    if (attr_add_active (attrs, "log-level", 0,
-                         attr_get_log, attr_set_log, logbuf) < 0)
+    if (attr_add_active (attrs,
+                         "log-level",
+                         0,
+                         attr_get_log,
+                         attr_set_log,
+                         logbuf) < 0)
         goto done;
-    if (attr_add_active (attrs, "log-forward-level", 0,
-                         attr_get_log, attr_set_log, logbuf) < 0)
+    if (attr_add_active (attrs,
+                         "log-forward-level",
+                         0,
+                         attr_get_log,
+                         attr_set_log,
+                         logbuf) < 0)
         goto done;
-    if (attr_add_active (attrs, "log-critical-level", 0,
-                         attr_get_log, attr_set_log, logbuf) < 0)
+    if (attr_add_active (attrs,
+                         "log-critical-level",
+                         0,
+                         attr_get_log,
+                         attr_set_log,
+                         logbuf) < 0)
         goto done;
-    if (attr_add_active (attrs, "log-ring-size", 0,
-                         attr_get_log, attr_set_log, logbuf) < 0)
+    if (attr_add_active (attrs,
+                         "log-ring-size",
+                         0,
+                         attr_get_log,
+                         attr_set_log,
+                         logbuf) < 0)
         goto done;
     rc = 0;
 done:
@@ -366,8 +402,12 @@ done:
 static int logbuf_forward (logbuf_t *logbuf, const char *buf, int len)
 {
     flux_future_t *f;
-    if (!(f = flux_rpc_raw (logbuf->h, "log.append", buf, len,
-                              FLUX_NODEID_UPSTREAM, FLUX_RPC_NORESPONSE)))
+    if (!(f = flux_rpc_raw (logbuf->h,
+                            "log.append",
+                            buf,
+                            len,
+                            FLUX_NODEID_UPSTREAM,
+                            FLUX_RPC_NORESPONSE)))
         return -1;
     flux_future_destroy (f);
     return 0;
@@ -408,11 +448,13 @@ static void log_fp (FILE *fp, int flags, const char *buf, int len)
             nodeid = strtoul (hdr.hostname, NULL, 10);
             severity = STDLOG_SEVERITY (hdr.pri);
             log_timestamp (fp, &hdr, flags);
-            fprintf (fp, "%s.%s[%" PRIu32 "]: %.*s\n",
+            fprintf (fp,
+                     "%s.%s[%" PRIu32 "]: %.*s\n",
                      hdr.appname,
                      stdlog_severity_to_string (severity),
                      nodeid,
-                     msglen, msg);
+                     msglen,
+                     msg);
         }
     }
     fflush (fp);
@@ -438,8 +480,8 @@ static int logbuf_append (logbuf_t *logbuf, const char *buf, int len)
                 rc = -1;
         }
         if (severity <= logbuf->critical_level
-                    || (severity <= logbuf->stderr_level
-                    && logbuf->stderr_mode == MODE_LOCAL)) {
+            || (severity <= logbuf->stderr_level
+            && logbuf->stderr_mode == MODE_LOCAL)) {
             int flags = 0;
             if (logbuf->stderr_mode == MODE_LOCAL)
                 flags |= LOG_NO_TIMESTAMP; // avoid dup in syslog journal
@@ -450,15 +492,17 @@ static int logbuf_append (logbuf_t *logbuf, const char *buf, int len)
     if (severity <= logbuf->forward_level) {
         if (logbuf->rank == 0) {
             log_fp (logbuf->f, 0, buf, len);
-        } else {
+        }
+        else {
             if (logbuf_forward (logbuf, buf, len) < 0)
                 rc = -1;
         }
     }
-    if (!logged_stderr && severity <= logbuf->stderr_level
-                       && logbuf->stderr_mode == MODE_LEADER
-                       && logbuf->rank == 0) {
-            log_fp (stderr, 0, buf, len);
+    if (!logged_stderr
+        && severity <= logbuf->stderr_level
+        && logbuf->stderr_mode == MODE_LEADER
+        && logbuf->rank == 0) {
+        log_fp (stderr, 0, buf, len);
     }
     return rc;
 }
@@ -475,8 +519,10 @@ static void logbuf_append_redirect (const char *buf, int len, void *arg)
 
 /* N.B. log requests have no response.
  */
-static void append_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                               const flux_msg_t *msg, void *arg)
+static void append_request_cb (flux_t *h,
+                               flux_msg_handler_t *mh,
+                               const flux_msg_t *msg,
+                               void *arg)
 {
     logbuf_t *logbuf = arg;
     uint32_t matchtag;
@@ -503,8 +549,10 @@ error:
     }
 }
 
-static void clear_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                              const flux_msg_t *msg, void *arg)
+static void clear_request_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
 {
     logbuf_t *logbuf = arg;
 
@@ -513,8 +561,10 @@ static void clear_request_cb (flux_t *h, flux_msg_handler_t *mh,
     return;
 }
 
-static void dmesg_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                              const flux_msg_t *msg, void *arg)
+static void dmesg_request_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
 {
     logbuf_t *logbuf = arg;
     struct logbuf_entry *e;

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -438,7 +438,8 @@ static void log_fp (FILE *fp, int flags, const char *buf, int len)
 {
     struct stdlog_header hdr;
     const char *msg;
-    int msglen, severity;
+    size_t msglen;
+    int severity;
     uint32_t nodeid;
 
     if (fp) {
@@ -453,7 +454,7 @@ static void log_fp (FILE *fp, int flags, const char *buf, int len)
                      hdr.appname,
                      stdlog_severity_to_string (severity),
                      nodeid,
-                     msglen,
+                     (int)msglen,
                      msg);
         }
     }

--- a/src/broker/shutdown.c
+++ b/src/broker/shutdown.c
@@ -65,7 +65,7 @@ static int forward_logbuf (flux_t *h,
 {
     struct stdlog_header hdr;
     const char *txt;
-    int txtlen;
+    size_t txtlen;
     char buf[FLUX_MAX_LOGBUF];
     int loglevel;
 
@@ -86,7 +86,7 @@ static int forward_logbuf (flux_t *h,
                      hdr.appname,
                      stdlog_severity_to_string (STDLOG_SEVERITY (hdr.pri)),
                      strtoul (hdr.hostname, NULL, 10),
-                     txtlen,
+                     (int)txtlen,
                      txt) >= sizeof (buf))
         return 0;
     return flux_respond_pack (h, request, "{s:s}", "log", buf);

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -683,7 +683,8 @@ void diag_logger (const char *buf, int len, void *arg)
 {
     struct stdlog_header hdr;
     const char *msg;
-    int msglen, severity;
+    size_t msglen;
+    int severity;
     char *s;
 
     if (stdlog_decode (buf, len, &hdr, NULL, NULL, &msg, &msglen) < 0)
@@ -692,7 +693,7 @@ void diag_logger (const char *buf, int len, void *arg)
     if (asprintf (&s,
                   "%s: %.*s\n",
                   stdlog_severity_to_string (severity),
-                  msglen,
+                  (int)msglen,
                   msg) < 0)
         BAIL_OUT ("asprintf failed");
     diag (s);

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -692,7 +692,8 @@ void diag_logger (const char *buf, int len, void *arg)
     if (asprintf (&s,
                   "%s: %.*s\n",
                   stdlog_severity_to_string (severity),
-                  msglen, msg) < 0)
+                  msglen,
+                  msg) < 0)
         BAIL_OUT ("asprintf failed");
     diag (s);
     if (zlist_append (logs, s) < 0)

--- a/src/broker/test/runat.c
+++ b/src/broker/test/runat.c
@@ -245,7 +245,8 @@ void diag_logger (const char *buf, int len, void *arg)
 {
     struct stdlog_header hdr;
     const char *msg;
-    int msglen, severity;
+    size_t msglen;
+    int severity;
     char *s;
 
     if (stdlog_decode (buf, len, &hdr, NULL, NULL, &msg, &msglen) < 0)
@@ -254,7 +255,7 @@ void diag_logger (const char *buf, int len, void *arg)
     if (asprintf (&s,
                   "%s: %.*s\n",
                   stdlog_severity_to_string (severity),
-                  msglen,
+                  (int)msglen,
                   msg) < 0)
         BAIL_OUT ("asprintf failed");
     diag (s);

--- a/src/broker/test/runat.c
+++ b/src/broker/test/runat.c
@@ -254,7 +254,8 @@ void diag_logger (const char *buf, int len, void *arg)
     if (asprintf (&s,
                   "%s: %.*s\n",
                   stdlog_severity_to_string (severity),
-                  msglen, msg) < 0)
+                  msglen,
+                  msg) < 0)
         BAIL_OUT ("asprintf failed");
     diag (s);
     if (zlist_append (logs, s) < 0)

--- a/src/broker/trace.c
+++ b/src/broker/trace.c
@@ -54,7 +54,7 @@ static void trace_msg (flux_t *h,
     int type = 0;
     char buf[64];
     const char *topic = NULL;
-    int payload_size = 0;
+    size_t payload_size = 0;
     json_t *payload_json = NULL;
     int errnum = 0;
     const char *errstr = NULL;

--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -23,7 +23,7 @@ static void load_to_fd (flux_t *h, int fd, const char *blobref, int flags)
 {
     flux_future_t *f;
     const uint8_t *data;
-    int size;
+    size_t size;
 
     if (!(f = content_load_byblobref (h, blobref, flags))
         || content_load_get (f, (const void **)&data, &size) < 0)

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -209,7 +209,8 @@ void dmesg_print (struct dmesg_ctx *ctx,
 {
     struct stdlog_header hdr;
     const char *msg;
-    int msglen, severity;
+    size_t msglen;
+    int severity;
     uint32_t nodeid;
 
     if (stdlog_decode (buf, len, &hdr, NULL, NULL, &msg, &msglen) < 0)
@@ -225,7 +226,7 @@ void dmesg_print (struct dmesg_ctx *ctx,
                 nodeid,
                 dmesg_color_reset (ctx),
                 severity_color (ctx, severity),
-                msglen,
+                (int)msglen,
                 msg,
                 dmesg_color_reset (ctx));
     }

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -225,7 +225,8 @@ void dmesg_print (struct dmesg_ctx *ctx,
                 nodeid,
                 dmesg_color_reset (ctx),
                 severity_color (ctx, severity),
-                msglen, msg,
+                msglen,
+                msg,
                 dmesg_color_reset (ctx));
     }
     fflush (stdout);

--- a/src/cmd/builtin/dump.c
+++ b/src/cmd/builtin/dump.c
@@ -154,7 +154,7 @@ static void dump_valref (struct archive *ar,
     int total_size = 0;
     struct archive_entry *entry;
     const void *data;
-    int len;
+    size_t len;
 
     /* We need the total size before we start writing archive data,
      * so make a first pass, saving the data for writing later.
@@ -220,7 +220,7 @@ static void dump_val (struct archive *ar,
 {
     struct archive_entry *entry;
     void *data;
-    int len;
+    size_t len;
 
     if (treeobj_decode_val (treeobj, &data, &len) < 0)
         log_err_exit ("%s: invalid value object", path);
@@ -296,7 +296,7 @@ static void dump_dirref (struct archive *ar,
 {
     flux_future_t *f;
     const void *buf;
-    int buflen;
+    size_t buflen;
     json_t *treeobj_deref = NULL;
 
     if (treeobj_get_count (treeobj) != 1)
@@ -356,7 +356,7 @@ static void dump_blobref (struct archive *ar,
 {
     flux_future_t *f;
     const void *buf;
-    int buflen;
+    size_t buflen;
     json_t *treeobj;
     json_t *dict;
     const char *key;

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -256,7 +256,7 @@ static int event_pub (optparse_t *p, int argc, char **argv)
                 log_err_exit ("flux_recv error");
             if (optparse_hasopt (p, "raw")) {
                 const void *data;
-                int len;
+                size_t len;
                 if ((flux_event_decode_raw (msg, NULL, &data, &len) == 0
                     && match_payload_raw (payload, payloadsz, data, len)))
                     received = true;
@@ -350,7 +350,7 @@ static void event_cb (flux_t *h,
     int max_count = optparse_get_int (p, "count", 0);
     static int recv_count = 0;
     const char *payload;
-    int payloadsz;
+    size_t payloadsz;
     const char *topic;
 
     if (flux_event_decode (msg, &topic, &payload) == 0)

--- a/src/cmd/flux-event.c
+++ b/src/cmd/flux-event.c
@@ -73,8 +73,10 @@ static bool match_payload (const char *s1, const char *s2)
     return streq (s1, s2);
 }
 
-static bool match_payload_raw (const void *p1, int p1sz,
-                               const char *p2, int p2sz)
+static bool match_payload_raw (const void *p1,
+                               int p1sz,
+                               const char *p2,
+                               int p2sz)
 {
     if (!p1 && !p2)
         return true;
@@ -83,8 +85,11 @@ static bool match_payload_raw (const void *p1, int p1sz,
     return !memcmp (p1, p2, p1sz);
 }
 
-static int publish_raw_sync (flux_t *h, const char *topic, int flags,
-                             char *payload, int payloadsz)
+static int publish_raw_sync (flux_t *h,
+                             const char *topic,
+                             int flags,
+                             char *payload,
+                             int payloadsz)
 {
     flux_future_t *f;
     int seq;
@@ -100,8 +105,11 @@ done:
     return rc;
 }
 
-static int publish_raw (flux_t *h, const char *topic, int flags,
-                        char *payload, int payloadsz)
+static int publish_raw (flux_t *h,
+                        const char *topic,
+                        int flags,
+                        char *payload,
+                        int payloadsz)
 {
     flux_msg_t *msg;
     int rc = -1;
@@ -118,7 +126,9 @@ done:
     return rc;
 }
 
-static int publish_json_sync (flux_t *h, const char *topic, int flags,
+static int publish_json_sync (flux_t *h,
+                              const char *topic,
+                              int flags,
                               char *payload)
 {
     flux_future_t *f;
@@ -136,7 +146,9 @@ done:
     return rc;
 }
 
-static int publish_json (flux_t *h, const char *topic, int flags,
+static int publish_json (flux_t *h,
+                         const char *topic,
+                         int flags,
                          char *payload)
 {
     flux_msg_t *msg;
@@ -172,8 +184,12 @@ static struct optparse_option pub_opts[] = {
 
 static void event_pub_register (optparse_t *parent)
 {
-    if (optparse_reg_subcommand (parent, "pub", event_pub,
-                                 "[OPTIONS] topic [payload]", NULL, 0,
+    if (optparse_reg_subcommand (parent,
+                                 "pub",
+                                 event_pub,
+                                 "[OPTIONS] topic [payload]",
+                                 NULL,
+                                 0,
                                  pub_opts) != OPTPARSE_SUCCESS)
         log_err_exit ("optparse_reg_subcommand");
 }
@@ -242,13 +258,13 @@ static int event_pub (optparse_t *p, int argc, char **argv)
                 const void *data;
                 int len;
                 if ((flux_event_decode_raw (msg, NULL, &data, &len) == 0
-                        && match_payload_raw (payload, payloadsz, data, len)))
+                    && match_payload_raw (payload, payloadsz, data, len)))
                     received = true;
             }
             else {
                 const char *json_str;
                 if ((flux_event_decode (msg, NULL, &json_str) == 0
-                        && match_payload (payload, json_str)))
+                    && match_payload (payload, json_str)))
                     received = true;
             }
             flux_msg_destroy (msg);
@@ -315,14 +331,20 @@ static const struct optparse_option sub_opts [] = {
 
 void event_sub_register (optparse_t *parent)
 {
-    if (optparse_reg_subcommand (parent, "sub", event_sub,
-                                 "[OPTIONS] [topic...]", NULL, 0,
+    if (optparse_reg_subcommand (parent,
+                                 "sub",
+                                 event_sub,
+                                 "[OPTIONS] [topic...]",
+                                 NULL,
+                                 0,
                                  sub_opts) != OPTPARSE_SUCCESS)
         log_err_exit ("optparse_reg_subcommand");
 }
 
-static void event_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+static void event_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     optparse_t *p = arg;
     int max_count = optparse_get_int (p, "count", 0);
@@ -333,8 +355,10 @@ static void event_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_event_decode (msg, &topic, &payload) == 0)
         printf ("%s\t%s\n", topic, payload ? payload : "");
-    else if (flux_event_decode_raw (msg, &topic, (const void **)&payload,
-                                                          &payloadsz) == 0) {
+    else if (flux_event_decode_raw (msg,
+                                    &topic,
+                                    (const void **)&payload,
+                                    &payloadsz) == 0) {
         int maxlen = payloadsz; // no truncation
         char *s = make_printable (payload, payloadsz, maxlen);
         printf ("%s\t%s\n", topic, s);

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -712,7 +712,7 @@ void lookup_continuation (flux_future_t *f, void *arg)
     }
     else if (optparse_hasopt (ctx->p, "raw")) {
         const void *data;
-        int len;
+        size_t len;
         if (flux_kvs_lookup_get_raw (f, &data, &len) < 0)
             log_err_exit ("%s", key);
         if (optparse_hasopt (ctx->p, "label"))
@@ -1291,7 +1291,7 @@ static void dump_kvs_dir (const flux_kvsdir_t *dir, int maxcol,
             if (!dopt) {
                 const char *value;
                 const void *buf;
-                int len;
+                size_t len;
                 if (rootref) {
                     if (!(f = flux_kvs_lookupat (h, 0, key, rootref)))
                         log_err_exit ("%s", key);
@@ -1303,7 +1303,7 @@ static void dump_kvs_dir (const flux_kvsdir_t *dir, int maxcol,
                 if (flux_kvs_lookup_get (f, &value) == 0) // null terminated
                     dump_kvs_val (key, maxcol, value);
                 else if (flux_kvs_lookup_get_raw  (f, &buf, &len) == 0)
-                    kv_printf (key, maxcol, "%.*s", len, (char *)buf);
+                    kv_printf (key, maxcol, "%.*s", (int)len, (char *)buf);
                 else
                     log_err_exit ("%s", key);
                 flux_future_destroy (f);

--- a/src/common/libcontent/content.c
+++ b/src/common/libcontent/content.c
@@ -23,7 +23,7 @@
 
 flux_future_t *content_load_byhash (flux_t *h,
                                     const void *hash,
-                                    int hash_size,
+                                    size_t hash_size,
                                     int flags)
 {
     const char *topic = "content.load";
@@ -47,19 +47,19 @@ flux_future_t *content_load_byblobref (flux_t *h,
                                        int flags)
 {
     uint32_t hash[BLOBREF_MAX_DIGEST_SIZE];
-    int hash_size;
+    ssize_t hash_size;
 
     if ((hash_size = blobref_strtohash (blobref, hash, sizeof (hash))) < 0)
         return NULL;
     return content_load_byhash (h, hash, hash_size, flags);
 }
 
-int content_load_get (flux_future_t *f, const void **buf, int *len)
+int content_load_get (flux_future_t *f, const void **buf, size_t *len)
 {
     return flux_rpc_get_raw (f, buf, len);
 }
 
-flux_future_t *content_store (flux_t *h, const void *buf, int len, int flags)
+flux_future_t *content_store (flux_t *h, const void *buf, size_t len, int flags)
 {
     const char *topic = "content.store";
     uint32_t rank = FLUX_NODEID_ANY;
@@ -73,10 +73,12 @@ flux_future_t *content_store (flux_t *h, const void *buf, int len, int flags)
     return flux_rpc_raw (h, topic, buf, len, rank, 0);
 }
 
-int content_store_get_hash (flux_future_t *f, const void **hash, int *hash_size)
+int content_store_get_hash (flux_future_t *f,
+                            const void **hash,
+                            size_t *hash_size)
 {
     const void *buf;
-    int buf_size;
+    size_t buf_size;
 
     if (flux_rpc_get_raw (f, &buf, &buf_size) < 0)
         return -1;
@@ -96,7 +98,7 @@ int content_store_get_blobref (flux_future_t *f,
 
     if (!(result = flux_future_aux_get (f, auxkey))) {
         const void *hash;
-        int hash_len;
+        size_t hash_len;
         char buf[BLOBREF_MAX_STRING_SIZE];
         char *cpy = NULL;
 

--- a/src/common/libcontent/content.h
+++ b/src/common/libcontent/content.h
@@ -21,7 +21,7 @@ enum {
  */
 flux_future_t *content_load_byhash (flux_t *h,
                                     const void *hash,
-                                    int hash_len,
+                                    size_t hash_len,
                                     int flags);
 flux_future_t *content_load_byblobref (flux_t *h,
                                        const char *blobref,
@@ -32,17 +32,22 @@ flux_future_t *content_load_byblobref (flux_t *h,
  * Storage for 'buf' belongs to 'f' and is valid until 'f' is destroyed.
  * Returns 0 on success, -1 on failure with errno set.
  */
-int content_load_get (flux_future_t *f, const void **buf, int *len);
+int content_load_get (flux_future_t *f, const void **buf, size_t *len);
 
 /* Send request to store blob.
  */
-flux_future_t *content_store (flux_t *h, const void *buf, int len, int flags);
+flux_future_t *content_store (flux_t *h,
+                              const void *buf,
+                              size_t len,
+                              int flags);
 
 /* Get result of store request (hash or blobref).
  * Storage belongs to 'f' and is valid until 'f' is destroyed.
  * Returns 0 on success, -1 on failure with errno set.
  */
-int content_store_get_hash (flux_future_t *f, const void **hash, int *hash_len);
+int content_store_get_hash (flux_future_t *f,
+                            const void **hash,
+                            size_t *hash_len);
 int content_store_get_blobref (flux_future_t *f,
                                const char *hash_name,
                                const char **blobref);

--- a/src/common/libfilemap/filemap.c
+++ b/src/common/libfilemap/filemap.c
@@ -82,7 +82,7 @@ static int extract_blob (flux_t *h,
     } entry;
     flux_future_t *f;
     const void *buf;
-    int size;
+    size_t size;
 
     if (json_unpack (o,
                      "[I,I,s]",

--- a/src/common/libfilemap/filemap.c
+++ b/src/common/libfilemap/filemap.c
@@ -37,7 +37,7 @@
 static int decode_data (const char *s, void **data, size_t *data_size)
 {
     if (s) {
-        int len = strlen (s);
+        size_t len = strlen (s);
         size_t bufsize = base64_decoded_length (len);
         void *buf;
         ssize_t n;

--- a/src/common/libfilemap/fileref.c
+++ b/src/common/libfilemap/fileref.c
@@ -75,7 +75,7 @@ static json_t *blobvec_create (int fd,
                                const void *mapbuf,
                                size_t size,
                                const char *hashtype,
-                               int chunksize)
+                               size_t chunksize)
 {
     json_t *blobvec;
     off_t offset = 0;
@@ -154,7 +154,7 @@ static json_t *fileref_create_blobvec (const char *path,
                                        void *mapbuf,
                                        struct stat *sb,
                                        const char *hashtype,
-                                       int chunksize,
+                                       size_t chunksize,
                                        flux_error_t *error)
 {
     json_t *blobvec;
@@ -336,9 +336,7 @@ json_t *fileref_create_ex (const char *path,
     int saved_errno;
 
     if (param) {
-        if (param->chunksize < 0
-            || param->hashtype == NULL
-            || param->small_file_threshold < 0) {
+        if (param->hashtype == NULL) {
             errprintf (error, "invalid blobvec encoding parameters");
             goto inval;
         }
@@ -380,7 +378,7 @@ json_t *fileref_create_ex (const char *path,
     else if (S_ISREG (sb.st_mode)
         && param != NULL
         && sb.st_size > param->small_file_threshold) {
-        int chunksize;
+        size_t chunksize;
 
         mapinfo.size = sb.st_size;
         mapinfo.base = mmap (NULL, mapinfo.size, PROT_READ, MAP_PRIVATE, fd, 0);

--- a/src/common/libfilemap/fileref.h
+++ b/src/common/libfilemap/fileref.h
@@ -19,9 +19,9 @@
 
 struct blobvec_param {
     const char *hashtype;
-    int chunksize;              // maximum size of each blob
-    int small_file_threshold;   // no blobvec encoding for regular files of
-};                              //  size <= thresh (0=always blobvec)
+    size_t chunksize;              // maximum size of each blob
+    size_t small_file_threshold;   // no blobvec encoding for regular files of
+};                                 //  size <= thresh (0=always blobvec)
 
 struct blobvec_mapinfo {
     void *base;

--- a/src/common/libfilemap/test/fileref.c
+++ b/src/common/libfilemap/test/fileref.c
@@ -656,26 +656,6 @@ void test_expfail (void)
     ok (o == NULL && errno == EINVAL,
         "fileref_create_ex param.hashtype=smurfette fails with EINVAL");
 
-    errno = 0;
-    param.chunksize = -1;
-    param.hashtype = "sha1";
-    param.small_file_threshold = 0;
-    o = fileref_create_ex (mkpath ("test"), &param, NULL, &error);
-    if (!o)
-        diag ("%s", error.text);
-    ok (o == NULL && errno == EINVAL,
-        "fileref_create_ex param.chunksize=-1 fails with EINVAL");
-
-    errno = 0;
-    param.chunksize = 1024;
-    param.hashtype = "sha1";
-    param.small_file_threshold = -1;
-    o = fileref_create_ex (mkpath ("test"), &param, NULL, &error);
-    if (!o)
-        diag ("%s", error.text);
-    ok (o == NULL && errno == EINVAL,
-        "fileref_create_ex param.small_file_threshold=-1 fails with EINVAL");
-
     rmfile ("test");
 }
 

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -130,11 +130,11 @@ done:
 int flux_event_decode_raw (const flux_msg_t *msg,
                            const char **topicp,
                            const void **datap,
-                           int *lenp)
+                           size_t *lenp)
 {
     const char *topic;
     const void *data = NULL;
-    int len = 0;
+    size_t len = 0;
     int rc = -1;
 
     if (!datap || !lenp) {
@@ -224,7 +224,7 @@ error:
 
 flux_msg_t *flux_event_encode_raw (const char *topic,
                                    const void *data,
-                                   int len)
+                                   size_t len)
 {
     flux_msg_t *msg = flux_event_create (topic);
     if (!msg)
@@ -267,7 +267,7 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
                                       const char *topic,
                                       int flags,
                                       const void *src,
-                                      int srclen)
+                                      size_t srclen)
 {
     flux_future_t *f;
 
@@ -371,7 +371,7 @@ flux_future_t *flux_event_publish_raw (flux_t *h,
                                        const char *topic,
                                        int flags,
                                        const void *data,
-                                       int len)
+                                       size_t len)
 {
     if (!h || !topic || (flags & ~(FLUX_MSGFLAG_PRIVATE)) != 0) {
         errno = EINVAL;

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -63,7 +63,7 @@ flux_msg_t *flux_event_pack (const char *topic, const char *fmt, ...);
  */
 flux_msg_t *flux_event_encode_raw (const char *topic,
                                    const void *data,
-                                   int len);
+                                   size_t len);
 
 /* Decode an event message, with optional raw payload.
  * If topic is non-NULL, assign the event topic string.
@@ -74,7 +74,7 @@ flux_msg_t *flux_event_encode_raw (const char *topic,
 int flux_event_decode_raw (const flux_msg_t *msg,
                            const char **topic,
                            const void **data,
-                           int *len);
+                           size_t *len);
 
 /* Publish an event with optional string payload.
  * The future is fulfilled once the event has been assigned a sequence number,
@@ -99,7 +99,7 @@ flux_future_t *flux_event_publish_raw (flux_t *h,
                                        const char *topic,
                                        int flags,
                                        const void *data,
-                                       int len);
+                                       size_t len);
 
 /* Obtain the event sequence number from the fulfilled
  * flux_event_publish() future.

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -99,7 +99,7 @@ const char *flux_strerror (int errnum)
     return strerror (errnum);
 }
 
-static int log_rpc (flux_t *h, const char *buf, int len)
+static int log_rpc (flux_t *h, const char *buf, size_t len)
 {
     flux_msg_t *msg;
 
@@ -116,7 +116,8 @@ int flux_vlog (flux_t *h, int level, const char *fmt, va_list ap)
     logctx_t *ctx;
     int saved_errno = errno;
     uint32_t rank;
-    int len;
+    int n;
+    size_t len;
     char timestamp[WALLCLOCK_MAXLEN];
     char hostname[STDLOG_MAX_HOSTNAME + 1];
     struct stdlog_header hdr;
@@ -148,10 +149,13 @@ int flux_vlog (flux_t *h, int level, const char *fmt, va_list ap)
     hdr.appname = ctx->appname;
     hdr.procid = ctx->procid;
 
-    len = stdlog_vencodef (ctx->buf, sizeof (ctx->buf), &hdr,
-                           STDLOG_NILVALUE, fmt, ap);
-    if (len >= sizeof (ctx->buf))
-        len = sizeof (ctx->buf);
+    n = stdlog_vencodef (ctx->buf,
+                         sizeof (ctx->buf),
+                         &hdr,
+                         STDLOG_NILVALUE,
+                         fmt,
+                         ap);
+    len = n >= sizeof (ctx->buf) ? sizeof (ctx->buf) : n;
     /* If log message contains multiple lines, log the first
      * line and save the rest.
      */

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -842,7 +842,7 @@ static bool payload_overlap (flux_msg_t *msg, const void *b)
          && (char *)b <  (char *)msg->payload + msg->payload_size);
 }
 
-int flux_msg_set_payload (flux_msg_t *msg, const void *buf, int size)
+int flux_msg_set_payload (flux_msg_t *msg, const void *buf, size_t size)
 {
     if (msg_validate (msg) < 0)
         return -1;
@@ -968,7 +968,7 @@ int flux_msg_pack (flux_msg_t *msg, const char *fmt, ...)
     return rc;
 }
 
-int flux_msg_get_payload (const flux_msg_t *msg, const void **buf, int *size)
+int flux_msg_get_payload (const flux_msg_t *msg, const void **buf, size_t *size)
 {
     if (msg_validate (msg) < 0)
         return -1;
@@ -1003,7 +1003,7 @@ int flux_msg_get_string (const flux_msg_t *msg, const char **s)
 {
     const char *buf;
     const char *result;
-    int size;
+    size_t size;
 
     if (msg_validate (msg) < 0)
         return -1;
@@ -1366,7 +1366,7 @@ void flux_msg_fprint_ts (FILE *f, const flux_msg_t *msg, double timestamp)
     if (flux_msg_has_payload (msg)) {
         const char *s;
         const void *buf;
-        int size;
+        size_t size;
         if (flux_msg_get_string (msg, &s) == 0)
             fprintf (f, "%s %s\n", prefix, s);
         else if (flux_msg_get_payload (msg, &buf, &size) == 0) {

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -166,8 +166,10 @@ int flux_msg_get_topic (const flux_msg_t *msg, const char **topic);
  * Any old payload is deleted.
  * flux_msg_get_payload returns pointer to msg-owned buf.
  */
-int flux_msg_get_payload (const flux_msg_t *msg, const void **buf, int *size);
-int flux_msg_set_payload (flux_msg_t *msg, const void *buf, int size);
+int flux_msg_get_payload (const flux_msg_t *msg,
+                          const void **buf,
+                          size_t *size);
+int flux_msg_set_payload (flux_msg_t *msg, const void *buf, size_t size);
 bool flux_msg_has_payload (const flux_msg_t *msg);
 
 /* Test/set/clear message flags

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -63,11 +63,11 @@ done:
 int flux_request_decode_raw (const flux_msg_t *msg,
                              const char **topic,
                              const void **data,
-                             int *len)
+                             size_t *len)
 {
     const char *ts;
     const void *d = NULL;
-    int l = 0;
+    size_t l = 0;
     int rc = -1;
 
     if (!data || !len) {
@@ -162,7 +162,7 @@ error:
 
 flux_msg_t *flux_request_encode_raw (const char *topic,
                                      const void *data,
-                                     int len)
+                                     size_t len)
 {
     flux_msg_t *msg = request_encode (topic);
 

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -42,7 +42,7 @@ int flux_request_unpack (const flux_msg_t *msg,
 int flux_request_decode_raw (const flux_msg_t *msg,
                              const char **topic,
                              const void **data,
-                             int *len);
+                             size_t *len);
 
 /* Encode a request message with optional string payload.
  * If s is non-NULL, assign the string payload.
@@ -55,7 +55,7 @@ flux_msg_t *flux_request_encode (const char *topic, const char *s);
  */
 flux_msg_t *flux_request_encode_raw (const char *topic,
                                      const void *data,
-                                     int len);
+                                     size_t len);
 
 #ifdef __cplusplus
 }

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -71,11 +71,11 @@ done:
 int flux_response_decode_raw (const flux_msg_t *msg,
                               const char **topic,
                               const void **data,
-                              int *len)
+                              size_t *len)
 {
     const char *ts;
     const void *d = NULL;
-    int l = 0;
+    size_t l = 0;
     int rc = -1;
 
     if (!data || !len) {
@@ -167,7 +167,7 @@ error:
 
 flux_msg_t *flux_response_encode_raw (const char *topic,
                                       const void *data,
-                                      int len)
+                                      size_t len)
 {
     flux_msg_t *msg;
 

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -38,7 +38,7 @@ int flux_response_decode (const flux_msg_t *msg,
 int flux_response_decode_raw (const flux_msg_t *msg,
                               const char **topic,
                               const void **data,
-                              int *len);
+                              size_t *len);
 
 /* If failed response includes an error string payload, assign to 'errstr',
  * otherwise fail.
@@ -55,7 +55,7 @@ flux_msg_t *flux_response_encode (const char *topic, const char *s);
  */
 flux_msg_t *flux_response_encode_raw (const char *topic,
                                       const void *data,
-                                      int len);
+                                      size_t len);
 
 /* Encode an error response with 'errnum' (must be nonzero) and
  * if non-NULL, an error string payload.

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -123,7 +123,7 @@ done:
     return rc;
 }
 
-int flux_rpc_get_raw (flux_future_t *f, const void **data, int *len)
+int flux_rpc_get_raw (flux_future_t *f, const void **data, size_t *len)
 {
     const flux_msg_t *msg;
     int rc = -1;
@@ -331,7 +331,7 @@ flux_future_t *flux_rpc (flux_t *h,
 flux_future_t *flux_rpc_raw (flux_t *h,
                              const char *topic,
                              const void *data,
-                             int len,
+                             size_t len,
                              uint32_t nodeid,
                              int flags)
 {

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -43,7 +43,7 @@ flux_future_t *flux_rpc_vpack (flux_t *h,
 flux_future_t *flux_rpc_raw (flux_t *h,
                              const char *topic,
                              const void *data,
-                             int len,
+                             size_t len,
                              uint32_t nodeid,
                              int flags);
 
@@ -56,7 +56,7 @@ int flux_rpc_get (flux_future_t *f, const char **s);
 
 int flux_rpc_get_unpack (flux_future_t *f, const char *fmt, ...);
 
-int flux_rpc_get_raw (flux_future_t *f, const void **data, int *len);
+int flux_rpc_get_raw (flux_future_t *f, const void **data, size_t *len);
 
 /* Accessor for RPC matchtag (see RFC 6).
  */

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -25,8 +25,8 @@ void test_codec (void)
     const char data[] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     int len = strlen (data);
     const void *d;
-    int l;
-    int i;
+    size_t l;
+    size_t i;
 
     /* no topic is an error */
     errno = 0;

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -39,7 +39,7 @@ void check_cornercase (void)
     uint32_t tag;
     const char *topic;
     const void *payload;
-    int payload_size;
+    size_t payload_size;
 
     errno = 0;
     ok (flux_msg_create (0xFFFF) == NULL && errno == EINVAL,
@@ -634,7 +634,8 @@ void check_payload (void)
     flux_msg_t *msg;
     const void *buf;
     void *pay[1024];
-    int plen = sizeof (pay), len;
+    size_t plen = sizeof (pay);
+    size_t len;
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
        "flux_msg_create works");
@@ -995,7 +996,7 @@ void check_copy (void)
     flux_msg_t *msg, *cpy;
     int type;
     const char *topic;
-    int cpylen;
+    size_t cpylen;
     const char buf[] = "xxxxxxxxxxxxxxxxxx";
     const void *cpybuf;
     const char *s;

--- a/src/common/libflux/test/request.c
+++ b/src/common/libflux/test/request.c
@@ -25,7 +25,9 @@ int main (int argc, char *argv[])
     const char *json_str = "{\"a\":42}";
     const void *d;
     const char data[] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-    int i, l, len = strlen (data);
+    size_t i;
+    size_t l;
+    size_t len = strlen (data);
 
     plan (NO_PLAN);
 

--- a/src/common/libflux/test/response.c
+++ b/src/common/libflux/test/response.c
@@ -27,7 +27,8 @@ int main (int argc, char *argv[])
     const char *json_str = "{\"a\":42}";
     const void *d;
     const char data[] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-    int l, len = strlen (data);
+    size_t l;
+    size_t len = strlen (data);
     int errnum;
 
     plan (NO_PLAN);

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -124,7 +124,7 @@ void rpctest_rawecho_cb (flux_t *h,
                          void *arg)
 {
     const void *d = NULL;
-    int l = 0;
+    size_t l = 0;
 
     if (flux_request_decode_raw (msg, NULL, &d, &l) < 0)
         goto error;
@@ -494,7 +494,7 @@ void test_encoding (flux_t *h)
     /* working with-payload RPC (raw) */
     const void *d;
     const char data[] = "aaaaaaaaaaaaaaaaaaaa";
-    int l, len = strlen (data);
+    size_t l, len = strlen (data);
     ok ((r = flux_rpc_raw (h,
                            "rpctest.rawecho",
                            data,

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -24,8 +24,10 @@
 
 
 /* increment integer and send it back */
-void rpctest_incr_cb (flux_t *h, flux_msg_handler_t *mh,
-                     const flux_msg_t *msg, void *arg)
+void rpctest_incr_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     int i;
 
@@ -40,8 +42,10 @@ error:
 }
 
 /* request nodeid and flags returned in response */
-void rpctest_nodeid_cb (flux_t *h, flux_msg_handler_t *mh,
-                        const flux_msg_t *msg, void *arg)
+void rpctest_nodeid_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
 {
     uint32_t nodeid;
 
@@ -49,9 +53,11 @@ void rpctest_nodeid_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     if (flux_msg_get_nodeid (msg, &nodeid) < 0)
         goto error;
-    if (flux_respond_pack (h, msg, "s:i s:i",
-                                   "nodeid", (int)nodeid,
-                                   "flags", msg->proto.flags) < 0)
+    if (flux_respond_pack (h,
+                           msg,
+                           "s:i s:i",
+                           "nodeid", (int)nodeid,
+                           "flags", msg->proto.flags) < 0)
         BAIL_OUT ("flux_respond_pack: %s", flux_strerror (errno));
     return;
 error:
@@ -60,8 +66,10 @@ error:
 }
 
 /* request payload echoed in response */
-void rpctest_echo_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+void rpctest_echo_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     const char *s;
 
@@ -80,14 +88,19 @@ error:
 }
 
 /* request payload sets error response content */
-void rpctest_echo_error_cb (flux_t *h, flux_msg_handler_t *mh,
-                            const flux_msg_t *msg, void *arg)
+void rpctest_echo_error_cb (flux_t *h,
+                            flux_msg_handler_t *mh,
+                            const flux_msg_t *msg,
+                            void *arg)
 {
     int errnum;
     const char *errstr = NULL;
 
-    if (flux_request_unpack (msg, NULL, "{s:i s?s}",
-                             "errnum", &errnum, "errstr", &errstr) < 0)
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:i s?s}",
+                             "errnum", &errnum,
+                             "errstr", &errstr) < 0)
         goto error;
     if (errstr) {
         if (flux_respond_error (h, msg, errnum, errstr) < 0)
@@ -105,8 +118,10 @@ error:
 
 
 /* raw request payload echoed in response */
-void rpctest_rawecho_cb (flux_t *h, flux_msg_handler_t *mh,
-                         const flux_msg_t *msg, void *arg)
+void rpctest_rawecho_cb (flux_t *h,
+                         flux_msg_handler_t *mh,
+                         const flux_msg_t *msg,
+                         void *arg)
 {
     const void *d = NULL;
     int l = 0;
@@ -122,8 +137,10 @@ error:
 }
 
 /* no-payload response */
-void rpctest_hello_cb (flux_t *h, flux_msg_handler_t *mh,
-                       const flux_msg_t *msg, void *arg)
+void rpctest_hello_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
 {
     const char *s;
 
@@ -141,8 +158,10 @@ error:
         BAIL_OUT ("flux_respond_error: %s", flux_strerror (errno));
 }
 
-void rpcftest_hello_cb (flux_t *h, flux_msg_handler_t *mh,
-                        const flux_msg_t *msg, void *arg)
+void rpcftest_hello_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
 {
     if (flux_request_unpack (msg, NULL, "{ ! }") < 0)
         goto error;
@@ -156,14 +175,19 @@ error:
 
 /* Send back the requested number of responses followed an ENODATA error.
  */
-void rpctest_multi_cb (flux_t *h, flux_msg_handler_t *mh,
-                       const flux_msg_t *msg, void *arg)
+void rpctest_multi_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
 {
     int i, count;
     int noterm;
 
-    if (flux_request_unpack (msg, NULL, "{s:i s:i}", "count", &count,
-                                                     "noterm", &noterm) < 0)
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:i s:i}",
+                             "count", &count,
+                             "noterm", &noterm) < 0)
         goto error;
     if (!flux_msg_is_streaming (msg)) {
         errno = EPROTO;
@@ -366,7 +390,10 @@ void test_error (flux_t *h)
 
     /* Error response with error message payload.
      */
-    f = flux_rpc_pack (h, "rpctest.echoerr", FLUX_NODEID_ANY, 0,
+    f = flux_rpc_pack (h,
+                       "rpctest.echoerr",
+                       FLUX_NODEID_ANY,
+                       0,
                        "{s:i s:s}",
                        "errnum", 69,
                        "errstr", "Hello world");
@@ -385,7 +412,10 @@ void test_error (flux_t *h)
 
     /* Error response with no error message payload.
      */
-    f = flux_rpc_pack (h, "rpctest.echoerr", FLUX_NODEID_ANY, 0,
+    f = flux_rpc_pack (h,
+                       "rpctest.echoerr",
+                       FLUX_NODEID_ANY,
+                       0,
                        "{s:i}",
                        "errnum", ENOTDIR);
     ok (f != NULL,
@@ -465,8 +495,12 @@ void test_encoding (flux_t *h)
     const void *d;
     const char data[] = "aaaaaaaaaaaaaaaaaaaa";
     int l, len = strlen (data);
-    ok ((r = flux_rpc_raw (h, "rpctest.rawecho", data, len,
-                          FLUX_NODEID_ANY, 0)) != NULL,
+    ok ((r = flux_rpc_raw (h,
+                           "rpctest.rawecho",
+                           data,
+                           len,
+                           FLUX_NODEID_ANY,
+                           0)) != NULL,
         "flux_rpc_raw with payload when payload is expected works");
     d = NULL;
     l = -1;
@@ -478,8 +512,12 @@ void test_encoding (flux_t *h)
 
     /* use newish pack/unpack payload interfaces */
     int i = 0;
-    ok ((r = flux_rpc_pack (h, "rpctest.incr", FLUX_NODEID_ANY, 0,
-                            "{s:i}", "n", 107)) != NULL,
+    ok ((r = flux_rpc_pack (h,
+                            "rpctest.incr",
+                            FLUX_NODEID_ANY,
+                            0,
+                            "{s:i}",
+                            "n", 107)) != NULL,
         "flux_rpc_pack works");
     ok (flux_rpc_get_unpack (r, NULL) < 0
         && errno == EINVAL,
@@ -491,8 +529,12 @@ void test_encoding (flux_t *h)
     flux_future_destroy (r);
 
     /* cause remote EPROTO (unexpected payload) - will be picked up in _getf() */
-    ok ((r = flux_rpc_pack (h, "rpcftest.hello", FLUX_NODEID_ANY, 0,
-                            "{ s:i }", "foo", 42)) != NULL,
+    ok ((r = flux_rpc_pack (h,
+                            "rpcftest.hello",
+                            FLUX_NODEID_ANY,
+                            0,
+                            "{ s:i }",
+                            "foo", 42)) != NULL,
         "flux_rpc_pack with payload when none is expected works, at first");
     errno = 0;
     ok (flux_rpc_get_unpack (r, "{}") < 0
@@ -501,7 +543,11 @@ void test_encoding (flux_t *h)
     flux_future_destroy (r);
 
     /* cause local EPROTO (user incorrectly expects payload) */
-    ok ((r = flux_rpc_pack (h, "rpcftest.hello", FLUX_NODEID_ANY, 0, "{}")) != NULL,
+    ok ((r = flux_rpc_pack (h,
+                            "rpcftest.hello",
+                            FLUX_NODEID_ANY,
+                            0,
+                            "{}")) != NULL,
         "flux_rpc_pack with empty payload works");
     errno = 0;
     ok (flux_rpc_get_unpack (r, "{ s:i }", "foo", &i) < 0
@@ -511,7 +557,12 @@ void test_encoding (flux_t *h)
 
     /* cause local EPROTO (user incorrectly expects empty payload) */
     errno = 0;
-    ok ((r = flux_rpc_pack (h, "rpctest.echo", FLUX_NODEID_ANY, 0, "{ s:i }", "foo", 42)) != NULL,
+    ok ((r = flux_rpc_pack (h,
+                            "rpctest.echo",
+                            FLUX_NODEID_ANY,
+                            0,
+                            "{ s:i }",
+                            "foo", 42)) != NULL,
         "flux_rpc_pack with payload works");
     errno = 0;
     ok (flux_rpc_get_unpack (r, "{ ! }") < 0
@@ -576,13 +627,20 @@ void test_multi_response (flux_t *h)
     int t1, t2;
     const flux_msg_t *response;
 
-    f = flux_rpc_pack (h, "rpctest.multi", FLUX_NODEID_ANY, FLUX_RPC_STREAMING,
-                          "{s:i s:i}", "count", 3, "noterm", 0);
+    f = flux_rpc_pack (h,
+                       "rpctest.multi",
+                       FLUX_NODEID_ANY,
+                       FLUX_RPC_STREAMING,
+                       "{s:i s:i}",
+                       "count", 3,
+                       "noterm", 0);
     if (!f)
         BAIL_OUT ("flux_rpc_pack failed");
     errno = 0;
-    while (flux_rpc_get_unpack (f, "{s:i s:i}", "seq", &seq,
-                                                "flags", &inflags) == 0) {
+    while (flux_rpc_get_unpack (f,
+                                "{s:i s:i}",
+                                "seq", &seq,
+                                "flags", &inflags) == 0) {
         if (flux_future_get (f, (const void **)&response) == 0)
             outflags = response->proto.flags;
         count++;
@@ -613,8 +671,13 @@ void test_multi_response_noterm (flux_t *h)
     int t1, t2;
 
     // service will send two responses: seq=0, ENODATA
-    f = flux_rpc_pack (h, "rpctest.multi", FLUX_NODEID_ANY, FLUX_RPC_STREAMING,
-                          "{s:i s:i}", "count", 1, "noterm", 0);
+    f = flux_rpc_pack (h,
+                       "rpctest.multi",
+                       FLUX_NODEID_ANY,
+                       FLUX_RPC_STREAMING,
+                       "{s:i s:i}",
+                       "count", 1,
+                       "noterm", 0);
     if (!f)
         BAIL_OUT ("flux_rpc_pack failed");
     // consume seq=0 response
@@ -638,8 +701,13 @@ void test_multi_response_server_noterm (flux_t *h)
     flux_future_t *f;
 
     // service will send only seq=0 (not ENODATA).
-    f = flux_rpc_pack (h, "rpctest.multi", FLUX_NODEID_ANY, FLUX_RPC_STREAMING,
-                          "{s:i s:i}", "count", 1, "noterm", 1);
+    f = flux_rpc_pack (h,
+                       "rpctest.multi",
+                       FLUX_NODEID_ANY,
+                       FLUX_RPC_STREAMING,
+                       "{s:i s:i}",
+                       "count", 1,
+                       "noterm", 1);
     if (!f)
         BAIL_OUT ("flux_rpc_pack failed");
     flux_future_destroy (f);
@@ -674,8 +742,13 @@ void test_multi_response_then (flux_t *h)
 {
     flux_future_t *f;
 
-    f = flux_rpc_pack (h, "rpctest.multi", FLUX_NODEID_ANY, FLUX_RPC_STREAMING,
-                          "{s:i s:i}", "count", 3, "noterm", 0);
+    f = flux_rpc_pack (h,
+                       "rpctest.multi",
+                       FLUX_NODEID_ANY,
+                       FLUX_RPC_STREAMING,
+                       "{s:i s:i}",
+                       "count", 3,
+                       "noterm", 0);
     if (!f)
         BAIL_OUT ("flux_rpc_pack failed");
     ok (flux_future_then (f, -1., multi_then_cb, NULL) == 0,
@@ -726,8 +799,13 @@ void test_multi_response_then_chain (flux_t *h)
 {
     flux_future_t *f;
 
-    f = flux_rpc_pack (h, "rpctest.multi", FLUX_NODEID_ANY, FLUX_RPC_STREAMING,
-                          "{s:i s:i}", "count", 3, "noterm", 0);
+    f = flux_rpc_pack (h,
+                       "rpctest.multi",
+                       FLUX_NODEID_ANY,
+                       FLUX_RPC_STREAMING,
+                       "{s:i s:i}",
+                       "count", 3,
+                       "noterm", 0);
     if (!f)
         BAIL_OUT ("flux_rpc_pack failed");
     ok (flux_future_then (f, -1., multi_then_first_cb, NULL) == 0,

--- a/src/common/libflux/test/rpcscale.c
+++ b/src/common/libflux/test/rpcscale.c
@@ -29,7 +29,7 @@ void ping_cb (flux_t *h,
               void *arg)
 {
     const void *payload;
-    int payload_len;
+    size_t payload_len;
 
     if (flux_request_decode_raw (msg, NULL, &payload, &payload_len) < 0)
         goto error;

--- a/src/common/libkvs/kvs_lookup.c
+++ b/src/common/libkvs/kvs_lookup.c
@@ -31,7 +31,7 @@ struct lookup_ctx {
     json_t *treeobj;
     char *treeobj_str; // json_dumps of tree object returned from lookup
     void *val_data;    // result of base64 decode of val object data
-    int val_len;
+    size_t val_len;
     bool val_valid;
     json_t *val_obj;
     flux_kvsdir_t *dir;
@@ -333,7 +333,7 @@ int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...)
     return rc;
 }
 
-int flux_kvs_lookup_get_raw (flux_future_t *f, const void **data, int *len)
+int flux_kvs_lookup_get_raw (flux_future_t *f, const void **data, size_t *len)
 {
     struct lookup_ctx *ctx;
 

--- a/src/common/libkvs/kvs_lookup.h
+++ b/src/common/libkvs/kvs_lookup.h
@@ -26,7 +26,7 @@ flux_future_t *flux_kvs_lookupat (flux_t *h,
 
 int flux_kvs_lookup_get (flux_future_t *f, const char **value);
 int flux_kvs_lookup_get_unpack (flux_future_t *f, const char *fmt, ...);
-int flux_kvs_lookup_get_raw (flux_future_t *f, const void **data, int *len);
+int flux_kvs_lookup_get_raw (flux_future_t *f, const void **data, size_t *len);
 int flux_kvs_lookup_get_treeobj (flux_future_t *f, const char **treeobj);
 int flux_kvs_lookup_get_dir (flux_future_t *f, const flux_kvsdir_t **dir);
 int flux_kvs_lookup_get_symlink (flux_future_t *f,

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -101,7 +101,7 @@ int flux_kvs_txn_put_raw (flux_kvs_txn_t *txn,
                           int flags,
                           const char *key,
                           const void *data,
-                          int len)
+                          size_t len)
 {
     json_t *dirent = NULL;
     int saved_errno;

--- a/src/common/libkvs/kvs_txn.h
+++ b/src/common/libkvs/kvs_txn.h
@@ -43,7 +43,7 @@ int flux_kvs_txn_put_raw (flux_kvs_txn_t *txn,
                           int flags,
                           const char *key,
                           const void *data,
-                          int len);
+                          size_t len);
 
 int flux_kvs_txn_put_treeobj (flux_kvs_txn_t *txn,
                               int flags,

--- a/src/common/libkvs/kvs_txn_compact.c
+++ b/src/common/libkvs/kvs_txn_compact.c
@@ -51,7 +51,7 @@
 
 struct append_data {
     void *data;
-    int len;
+    size_t len;
 };
 
 struct compact_key {

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -37,7 +37,7 @@ void jdiag (json_t *o)
 int check_null_value (json_t *dirent)
 {
     char *data = "";
-    int len = -1;
+    size_t len = 42;
 
     if (treeobj_decode_val (dirent, (void **)&data, &len) < 0) {
         diag ("%s: initial base64 decode failed", __FUNCTION__);
@@ -56,7 +56,8 @@ int check_null_value (json_t *dirent)
 int check_int_value (json_t *dirent, int expected)
 {
     char *data;
-    int rc, len, i;
+    int rc, i;
+    size_t len;
     json_t *val;
 
     if (treeobj_decode_val (dirent, (void **)&data, &len) < 0) {
@@ -89,7 +90,8 @@ int check_int_value (json_t *dirent, int expected)
 int check_string_value (json_t *dirent, const char *expected)
 {
     char *data;
-    int rc, len;
+    int rc;
+    size_t len;
     const char *s;
     json_t *val;
 
@@ -121,7 +123,7 @@ int check_string_value (json_t *dirent, const char *expected)
 int check_raw_value (json_t *dirent, const char *expected, int expected_len)
 {
     char *data;
-    int len;
+    size_t len;
 
     if (treeobj_decode_val (dirent, (void **)&data, &len) < 0) {
         diag ("%s: initial base64 decode failed", __FUNCTION__);
@@ -304,7 +306,8 @@ void test_raw_values (void)
     char buf[13], *nbuf;
     json_t *entry, *dirent;
     const char *key;
-    int flags, nlen;
+    int flags;
+    size_t nlen;
 
     memset (buf, 'c', sizeof (buf));
 

--- a/src/common/libkvs/test/kvs_txn_compact.c
+++ b/src/common/libkvs/test/kvs_txn_compact.c
@@ -29,7 +29,7 @@
 int check_null_value (json_t *dirent)
 {
     char *data = "";
-    int len = -1;
+    size_t len = 42;
 
     if (treeobj_decode_val (dirent, (void **)&data, &len) < 0) {
         diag ("%s: initial base64 decode failed", __FUNCTION__);
@@ -45,7 +45,7 @@ int check_null_value (json_t *dirent)
 int check_raw_value (json_t *dirent, const char *expected, int expected_len)
 {
     char *data = NULL;
-    int len;
+    size_t len;
     int rc = -1;
 
     if (treeobj_decode_val (dirent, (void **)&data, &len) < 0) {

--- a/src/common/libkvs/test/treeobj.c
+++ b/src/common/libkvs/test/treeobj.c
@@ -191,7 +191,7 @@ void test_val (void)
     json_t *val, *val2;
     char buf[32];
     char *outbuf;
-    int outlen;
+    size_t outlen;
 
     memset (buf, 'x', sizeof (buf));
 
@@ -720,7 +720,7 @@ void test_corner_cases (void)
     json_t *val, *valref, *dir, *symlink;
     json_t *array, *object;
     char *outbuf;
-    int outlen;
+    size_t outlen;
 
     val = treeobj_create_val ("a", 1);
     if (!val)

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -218,7 +218,7 @@ int treeobj_get_symlink (const json_t *obj,
     return 0;
 }
 
-int treeobj_decode_val (const json_t *obj, void **dp, int *lp)
+int treeobj_decode_val (const json_t *obj, void **dp, size_t *lp)
 {
     const char *type, *xdatastr;
     const json_t *xdata;
@@ -517,9 +517,9 @@ json_t *treeobj_create_symlink (const char *ns, const char *target)
     return obj;
 }
 
-json_t *treeobj_create_val (const void *data, int len)
+json_t *treeobj_create_val (const void *data, size_t len)
 {
-    int xlen;
+    ssize_t xlen;
     char *xdata;
     json_t *obj = NULL;
 

--- a/src/common/libkvs/treeobj.h
+++ b/src/common/libkvs/treeobj.h
@@ -24,7 +24,7 @@
  * Return JSON object on success, NULL on failure with errno set.
  */
 json_t *treeobj_create_symlink (const char *ns, const char *target);
-json_t *treeobj_create_val (const void *data, int len);
+json_t *treeobj_create_val (const void *data, size_t len);
 json_t *treeobj_create_valref (const char *blobref);
 json_t *treeobj_create_dir (void);
 json_t *treeobj_create_dirref (const char *blobref);
@@ -67,7 +67,7 @@ int treeobj_get_symlink (const json_t *obj,
  * If len > 0, data will be followed by an extra NULL byte in memory.
  * Caller must free returned data.
  */
-int treeobj_decode_val (const json_t *obj, void **data, int *len);
+int treeobj_decode_val (const json_t *obj, void **data, size_t *len);
 
 /* get type-specific count.
  * For dirref/valref, this is the number of blobrefs.

--- a/src/common/librouter/test/sendfd.c
+++ b/src/common/librouter/test/sendfd.c
@@ -68,7 +68,7 @@ void test_large (void)
     char buf[8192];
     const char *topic;
     const void *buf2;
-    int buf2len;
+    size_t buf2len;
 #if defined(F_GETPIPE_SZ)
     int min_size = 16384;
     int size;
@@ -280,7 +280,7 @@ void test_nonblock (int size, int count)
     while ((msg = zlist_pop (ior->queue))) {
         const char *topic;
         const void *buf2;
-        int buf2len;
+        size_t buf2len;
 
         if (flux_request_decode_raw (msg, &topic, &buf2, &buf2len) < 0) {
             diag ("flux_request_decode_raw: %s", flux_strerror (errno));

--- a/src/common/librouter/test/usock_echo.c
+++ b/src/common/librouter/test/usock_echo.c
@@ -139,7 +139,7 @@ static bool equal_message (const flux_msg_t *m1, const flux_msg_t *m2)
     int type1, type2;
     const char *topic1, *topic2;
     const void *buf1, *buf2;
-    int len1, len2;
+    size_t len1, len2;
 
     if (flux_msg_get_type (m1, &type1) < 0)
         return false;

--- a/src/common/libutil/blobref.c
+++ b/src/common/libutil/blobref.c
@@ -47,21 +47,21 @@
 #endif
 
 static void sha1_hash (const void *data,
-                       int data_len,
+                       size_t data_len,
                        void *hash,
-                       int hash_len);
+                       size_t hash_len);
 static void sha256_hash (const void *data,
-                         int data_len,
+                         size_t data_len,
                          void *hash,
-                         int hash_len);
+                         size_t hash_len);
 
 struct blobhash {
     char *name;
-    int hashlen;
+    size_t hashlen;
     void (*hashfun)(const void *data,
-                    int data_len,
+                    size_t data_len,
                     void *hash,
-                    int hash_len);
+                    size_t hash_len);
 };
 
 static struct blobhash blobtab[] = {
@@ -77,9 +77,9 @@ static struct blobhash blobtab[] = {
 };
 
 static void sha1_hash (const void *data,
-                       int data_len,
+                       size_t data_len,
                        void *hash,
-                       int hash_len)
+                       size_t hash_len)
 {
     SHA1_CTX ctx;
 
@@ -90,9 +90,9 @@ static void sha1_hash (const void *data,
 }
 
 static void sha256_hash (const void *data,
-                         int data_len,
+                         size_t data_len,
                          void *hash,
-                         int hash_len)
+                         size_t hash_len)
 {
     SHA256_CTX ctx;
 
@@ -131,11 +131,11 @@ static bool isxdigit_lower (char c)
     return false;
 }
 
-int blobref_strtohash (const char *blobref, void *hash, int size)
+ssize_t blobref_strtohash (const char *blobref, void *hash, size_t size)
 {
     struct blobhash *bh;
-    int len = strlen (blobref);
-    int offset;
+    size_t len = strlen (blobref);
+    size_t offset;
 
     if (!(bh = lookup_blobhash (blobref)) || size < bh->hashlen)
         goto inval;
@@ -152,16 +152,16 @@ inval:
 
 static int hashtostr (struct blobhash *bh,
                       const void *hash,
-                      int len,
+                      size_t len,
                       char *blobref,
-                      int blobref_len)
+                      size_t blobref_len)
 {
-    int offset;
+    size_t offset;
 
     if (len != bh->hashlen || !blobref)
         goto inval;
     offset = strlen (bh->name) + 1;
-    if (blobref_len - offset + 1 < (int)hex_str_size (bh->hashlen))
+    if (blobref_len < hex_str_size (bh->hashlen) + offset - 1)
         goto inval;
     strcpy (blobref, bh->name);
     strcat (blobref, "-");
@@ -175,9 +175,9 @@ inval:
 
 int blobref_hashtostr (const char *hashtype,
                        const void *hash,
-                       int len,
+                       size_t len,
                        void *blobref,
-                       int blobref_len)
+                       size_t blobref_len)
 {
     struct blobhash *bh;
 
@@ -191,9 +191,9 @@ int blobref_hashtostr (const char *hashtype,
 
 int blobref_hash (const char *hashtype,
                   const void *data,
-                  int len,
+                  size_t len,
                   void *blobref,
-                  int blobref_len)
+                  size_t blobref_len)
 {
     struct blobhash *bh;
     uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
@@ -206,11 +206,11 @@ int blobref_hash (const char *hashtype,
     return hashtostr (bh, hash, bh->hashlen, blobref, blobref_len);
 }
 
-int blobref_hash_raw (const char *hashtype,
-                      const void *data,
-                      int len,
-                      void *hash,
-                      int hash_len)
+ssize_t blobref_hash_raw (const char *hashtype,
+                          const void *data,
+                          size_t len,
+                          void *hash,
+                          size_t hash_len)
 {
     struct blobhash *bh;
 
@@ -228,8 +228,8 @@ int blobref_hash_raw (const char *hashtype,
 int blobref_validate (const char *blobref)
 {
     struct blobhash *bh;
-    int len;
-    int offset;
+    size_t len;
+    size_t offset;
 
     if (!blobref || !(bh = lookup_blobhash (blobref)))
         goto inval;

--- a/src/common/libutil/blobref.h
+++ b/src/common/libutil/blobref.h
@@ -20,7 +20,9 @@
  * The hash algorithm is selected by the blobref prefix.
  * Returns hash length on success, or -1 on error, with errno set.
  */
-int blobref_strtohash (const char *blobref, void *hash, int size);
+ssize_t blobref_strtohash (const char *blobref,
+                           void *hash,
+                           size_t size);
 
 /* Convert a hash digest to null-terminated blobref string in 'blobref'.
  * The hash algorithm is selected by 'hashtype', e.g. "sha1".
@@ -28,9 +30,9 @@ int blobref_strtohash (const char *blobref, void *hash, int size);
  */
 int blobref_hashtostr (const char *hashtype,
                        const void *hash,
-                       int len,
+                       size_t len,
                        void *blobref,
-                       int blobref_len);
+                       size_t blobref_len);
 
 /* Compute hash over data and return null-terminated blobref string in
  * 'blobref'.  The hash algorithm is selected by 'hashtype', e.g. "sha1".
@@ -38,19 +40,19 @@ int blobref_hashtostr (const char *hashtype,
  */
 int blobref_hash (const char *hashtype,
                   const void *data,
-                  int len,
+                  size_t len,
                   void *blobref,
-                  int blobref_len);
+                  size_t blobref_len);
 
 /* Compute hash over data and store it in 'hash'.
  * The hash algorithm is selected by 'hashtype', e.g. "sha1".
  * Returns hash size on success, -1 on error with errno set.
  */
-int blobref_hash_raw (const char *hashtype,
-                      const void *data,
-                      int len,
-                      void *hash,
-                      int hash_len);
+ssize_t blobref_hash_raw (const char *hashtype,
+                          const void *data,
+                          size_t len,
+                          void *hash,
+                          size_t hash_len);
 
 /* Check validity of blobref string.
  */

--- a/src/common/libutil/stdlog.c
+++ b/src/common/libutil/stdlog.c
@@ -52,8 +52,11 @@ static int next_str (char **p, char **result)
     return 0;
 }
 
-static int next_structured_data (const char *buf, int len, int *offp,
-                                 const char **sp, int *slenp)
+static int next_structured_data (const char *buf,
+                                 int len,
+                                 int *offp,
+                                 const char **sp,
+                                 int *slenp)
 {
     int off = *offp;
     int this = *offp;
@@ -78,9 +81,13 @@ static int next_structured_data (const char *buf, int len, int *offp,
     return 0;
 }
 
-int stdlog_decode (const char *buf, int len, struct stdlog_header *hdr,
-                   const char **sdp, int *sdlenp,
-                   const char **msgp, int *msglenp)
+int stdlog_decode (const char *buf,
+                   int len,
+                   struct stdlog_header *hdr,
+                   const char **sdp,
+                   int *sdlenp,
+                   const char **msgp,
+                   int *msglenp)
 {
     int hdr_len = STDLOG_MAX_HEADER;
     char *p = &hdr->buf[0];
@@ -158,19 +165,31 @@ char *stdlog_split_message (const char *buf, int *len, const char *sep)
     return xtra;
 }
 
-int stdlog_vencodef (char *buf, int len, struct stdlog_header *hdr,
-                     const char *sd, const char *fmt, va_list ap)
+int stdlog_vencodef (char *buf,
+                     int len,
+                     struct stdlog_header *hdr,
+                     const char *sd,
+                     const char *fmt,
+                     va_list ap)
 {
     int m, n, i;
     int rc; // includes any overflow
 
-    m = snprintf (buf, len, "<%d>%d %.*s %.*s %.*s %.*s %.*s %s ",
-                  hdr->pri, hdr->version,
-                  STDLOG_MAX_TIMESTAMP, hdr->timestamp,
-                  STDLOG_MAX_HOSTNAME, hdr->hostname,
-                  STDLOG_MAX_APPNAME, hdr->appname,
-                  STDLOG_MAX_PROCID, hdr->procid,
-                  STDLOG_MAX_MSGID, hdr->msgid,
+    m = snprintf (buf,
+                  len,
+                  "<%d>%d %.*s %.*s %.*s %.*s %.*s %s ",
+                  hdr->pri,
+                  hdr->version,
+                  STDLOG_MAX_TIMESTAMP,
+                  hdr->timestamp,
+                  STDLOG_MAX_HOSTNAME,
+                  hdr->hostname,
+                  STDLOG_MAX_APPNAME,
+                  hdr->appname,
+                  STDLOG_MAX_PROCID,
+                  hdr->procid,
+                  STDLOG_MAX_MSGID,
+                  hdr->msgid,
                   sd);
     rc = m;
     if (m > len)
@@ -189,8 +208,12 @@ int stdlog_vencodef (char *buf, int len, struct stdlog_header *hdr,
     return rc;
 }
 
-int stdlog_encodef (char *buf, int len, struct stdlog_header *hdr,
-                    const char *sd, const char *fmt, ...)
+int stdlog_encodef (char *buf,
+                    int len,
+                    struct stdlog_header *hdr,
+                    const char *sd,
+                    const char *fmt,
+                    ...)
 {
     va_list ap;
     int rc;
@@ -201,8 +224,11 @@ int stdlog_encodef (char *buf, int len, struct stdlog_header *hdr,
     return rc;
 }
 
-int stdlog_encode (char *buf, int len, struct stdlog_header *hdr,
-                   const char *sd, const char *msg)
+int stdlog_encode (char *buf,
+                   int len,
+                   struct stdlog_header *hdr,
+                   const char *sd,
+                   const char *msg)
 {
     return stdlog_encodef (buf, len, hdr, sd, "%s", msg);
 }

--- a/src/common/libutil/stdlog.c
+++ b/src/common/libutil/stdlog.c
@@ -53,13 +53,13 @@ static int next_str (char **p, char **result)
 }
 
 static int next_structured_data (const char *buf,
-                                 int len,
-                                 int *offp,
+                                 size_t len,
+                                 size_t *offp,
                                  const char **sp,
-                                 int *slenp)
+                                 size_t *slenp)
 {
-    int off = *offp;
-    int this = *offp;
+    size_t off = *offp;
+    size_t this = *offp;
     int level = 0;
 
     while (off < len) {
@@ -82,17 +82,17 @@ static int next_structured_data (const char *buf,
 }
 
 int stdlog_decode (const char *buf,
-                   int len,
+                   size_t len,
                    struct stdlog_header *hdr,
                    const char **sdp,
-                   int *sdlenp,
+                   size_t *sdlenp,
                    const char **msgp,
-                   int *msglenp)
+                   size_t *msglenp)
 {
-    int hdr_len = STDLOG_MAX_HEADER;
+    size_t hdr_len = STDLOG_MAX_HEADER;
     char *p = &hdr->buf[0];
     const char *sd;
-    int off, sdlen;
+    size_t off, sdlen;
 
     if (hdr_len > len)
         hdr_len = len;
@@ -133,14 +133,14 @@ int stdlog_decode (const char *buf,
     return 0;
 }
 
-char *stdlog_split_message (const char *buf, int *len, const char *sep)
+char *stdlog_split_message (const char *buf, size_t *len, const char *sep)
 {
     struct stdlog_header hdr;
     const char *msg;
-    int msglen;
-    int off;
+    size_t msglen;
+    size_t off;
     char *xtra;
-    int xtra_len;
+    size_t xtra_len;
 
     if (stdlog_decode (buf, *len, &hdr, NULL, NULL, &msg, &msglen) < 0)
         return NULL;
@@ -166,7 +166,7 @@ char *stdlog_split_message (const char *buf, int *len, const char *sep)
 }
 
 int stdlog_vencodef (char *buf,
-                     int len,
+                     size_t len,
                      struct stdlog_header *hdr,
                      const char *sd,
                      const char *fmt,
@@ -209,7 +209,7 @@ int stdlog_vencodef (char *buf,
 }
 
 int stdlog_encodef (char *buf,
-                    int len,
+                    size_t len,
                     struct stdlog_header *hdr,
                     const char *sd,
                     const char *fmt,
@@ -225,7 +225,7 @@ int stdlog_encodef (char *buf,
 }
 
 int stdlog_encode (char *buf,
-                   int len,
+                   size_t len,
                    struct stdlog_header *hdr,
                    const char *sd,
                    const char *msg)

--- a/src/common/libutil/stdlog.h
+++ b/src/common/libutil/stdlog.h
@@ -43,17 +43,33 @@ struct stdlog_header {
     char *msgid;
 };
 
-int stdlog_decode (const char *buf, int len, struct stdlog_header *hdr,
-                   const char **sd, int *sdlen, const char **msg, int *msglen);
+int stdlog_decode (const char *buf,
+                   int len,
+                   struct stdlog_header *hdr,
+                   const char **sd,
+                   int *sdlen,
+                   const char **msg,
+                   int *msglen);
 
-int stdlog_encode (char *buf, int len, struct stdlog_header *hdr,
-                   const char *sd, const char *msg);
+int stdlog_encode (char *buf,
+                   int len,
+                   struct stdlog_header *hdr,
+                   const char *sd,
+                   const char *msg);
 
-int stdlog_vencodef (char *buf, int len, struct stdlog_header *hdr,
-                     const char *sd, const char *fmt, va_list ap);
+int stdlog_vencodef (char *buf,
+                     int len,
+                     struct stdlog_header *hdr,
+                     const char *sd,
+                     const char *fmt,
+                     va_list ap);
 
-int stdlog_encodef (char *buf, int len, struct stdlog_header *hdr,
-                    const char *sd, const char *fmt, ...);
+int stdlog_encodef (char *buf,
+                    int len,
+                    struct stdlog_header *hdr,
+                    const char *sd,
+                    const char *fmt,
+                    ...);
 
 /* If encoded stdlog message in buf, *len contains chars from 'sep'
  * (in the message part), truncate the original message and return

--- a/src/common/libutil/stdlog.h
+++ b/src/common/libutil/stdlog.h
@@ -44,28 +44,28 @@ struct stdlog_header {
 };
 
 int stdlog_decode (const char *buf,
-                   int len,
+                   size_t len,
                    struct stdlog_header *hdr,
                    const char **sd,
-                   int *sdlen,
+                   size_t *sdlen,
                    const char **msg,
-                   int *msglen);
+                   size_t *msglen);
 
 int stdlog_encode (char *buf,
-                   int len,
+                   size_t len,
                    struct stdlog_header *hdr,
                    const char *sd,
                    const char *msg);
 
 int stdlog_vencodef (char *buf,
-                     int len,
+                     size_t len,
                      struct stdlog_header *hdr,
                      const char *sd,
                      const char *fmt,
                      va_list ap);
 
 int stdlog_encodef (char *buf,
-                    int len,
+                    size_t len,
                     struct stdlog_header *hdr,
                     const char *sd,
                     const char *fmt,
@@ -77,7 +77,7 @@ int stdlog_encodef (char *buf,
  * Returns NULL if no 'sep' chars or on alloc failure.
  * If non-NULL, caller must free returned value.
  */
-char *stdlog_split_message (const char *buf, int *len, const char *sep);
+char *stdlog_split_message (const char *buf, size_t *len, const char *sep);
 
 void stdlog_init (struct stdlog_header *hdr);
 

--- a/src/common/libutil/test/stdlog.c
+++ b/src/common/libutil/test/stdlog.c
@@ -100,8 +100,11 @@ int main(int argc, char** argv)
     plan (NO_PLAN);
 
     stdlog_init (&hdr);
-    len = stdlog_encode (buf, sizeof (buf), &hdr,
-                         STDLOG_NILVALUE, STDLOG_NILVALUE);
+    len = stdlog_encode (buf,
+                         sizeof (buf),
+                         &hdr,
+                         STDLOG_NILVALUE,
+                         STDLOG_NILVALUE);
     ok (len >= 0,
         "stdlog_init encoded defaults");
     diag ("%.*s", len, buf);

--- a/src/common/libutil/test/stdlog.c
+++ b/src/common/libutil/test/stdlog.c
@@ -48,17 +48,19 @@ void test_split (void)
     char buf[2048];
     char *xtra;
     struct stdlog_header hdr;
-    int len;
-    int msglen;
+    int n;
+    size_t len;
+    size_t msglen;
     const char *msg;
 
     stdlog_init (&hdr);
 
     /* orig=foo\nbar\nbaz */
-    len = stdlog_encode (buf, sizeof (buf), &hdr, STDLOG_NILVALUE,
+    n = stdlog_encode (buf, sizeof (buf), &hdr, STDLOG_NILVALUE,
                          "foo\nbar\nbaz");
-    ok (len >= 0,
+    ok (n >= 0,
         "stdlog_encode encoded foo\\nbar\\nbaz");
+    len = n;
     xtra = stdlog_split_message (buf, &len, "\r\n");
     ok (xtra != NULL && streq (xtra, "bar\nbaz"),
         "stdlog_split_message got bar\\nbaz");
@@ -67,9 +69,10 @@ void test_split (void)
         "and truncated orig message to foo");
 
     /* xtra=bar\nbaz */
-    len = stdlog_encode (buf, sizeof (buf), &hdr, STDLOG_NILVALUE, xtra);
-    ok (len >= 0,
+    n = stdlog_encode (buf, sizeof (buf), &hdr, STDLOG_NILVALUE, xtra);
+    ok (n >= 0,
         "stdlog_encode encoded bar\\nbaz");
+    len = n;
     free (xtra);
     xtra = stdlog_split_message (buf, &len, "\r\n");
     ok (xtra != NULL && streq (xtra, "baz"),
@@ -80,9 +83,10 @@ void test_split (void)
         "and truncated orig message to bar");
 
     /* xtra=baz */
-    len = stdlog_encode (buf, sizeof (buf), &hdr, STDLOG_NILVALUE, xtra);
-    ok (len >= 0,
+    n = stdlog_encode (buf, sizeof (buf), &hdr, STDLOG_NILVALUE, xtra);
+    ok (n >= 0,
         "stdlog_encode encoded baz");
+    len = n;
     free (xtra);
     xtra = stdlog_split_message (buf, &len, "\r\n");
     ok (xtra == NULL,
@@ -93,9 +97,10 @@ int main(int argc, char** argv)
 {
     char buf[2048];
     struct stdlog_header hdr, cln;
-    int n, len;
+    int n;
+    size_t len;
     const char *sd, *msg;
-    int sdlen, msglen;
+    size_t sdlen, msglen;
 
     plan (NO_PLAN);
 

--- a/src/common/libzmqutil/mpart.c
+++ b/src/common/libzmqutil/mpart.c
@@ -102,7 +102,7 @@ static int mpart_append (zlist_t *mpart, zmq_msg_t *part)
     return 0;
 }
 
-int mpart_addmem (zlist_t *mpart, const void *buf, int size)
+int mpart_addmem (zlist_t *mpart, const void *buf, size_t size)
 {
     zmq_msg_t *part;
 

--- a/src/common/libzmqutil/mpart.h
+++ b/src/common/libzmqutil/mpart.h
@@ -20,7 +20,7 @@
  */
 void mpart_destroy (zlist_t *mpart);
 zlist_t *mpart_create (void);
-int mpart_addmem (zlist_t *mpart, const void *buf, int size);
+int mpart_addmem (zlist_t *mpart, const void *buf, size_t size);
 int mpart_addstr (zlist_t *mpart, const char *s);
 zlist_t *mpart_recv (void *sock);
 int mpart_send (void *sock, zlist_t *mpart);

--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -122,7 +122,7 @@ static void load_cb (flux_t *h,
 {
     struct content_files *ctx = arg;
     const void *hash;
-    int hash_size;
+    size_t hash_size;
     char blobref[BLOBREF_MAX_STRING_SIZE];
     void *data = NULL;
     size_t size;
@@ -164,7 +164,7 @@ void store_cb (flux_t *h,
 {
     struct content_files *ctx = arg;
     const void *data;
-    int size;
+    size_t size;
     char blobref[BLOBREF_MAX_STRING_SIZE];
     char hash[BLOBREF_MAX_DIGEST_SIZE];
     int hash_size;

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -256,7 +256,7 @@ static void load_cb (flux_t *h, flux_msg_handler_t *mh, const flux_msg_t *msg, v
 {
     struct content_s3 *ctx = arg;
     const void *hash;
-    int hash_size;
+    size_t hash_size;
     char blobref[BLOBREF_MAX_STRING_SIZE];
     void *data = NULL;
     size_t size;
@@ -300,7 +300,7 @@ void store_cb (flux_t *h,
 {
     struct content_s3 *ctx = arg;
     const void *data;
-    int size;
+    size_t size;
     char blobref[BLOBREF_MAX_STRING_SIZE];
     uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
     int hash_size;

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -305,7 +305,7 @@ static void load_cb (flux_t *h,
 {
     struct content_sqlite *ctx = arg;
     const void *hash;
-    int hash_size;
+    size_t hash_size;
     const void *data;
     int size;
     struct timespec t0;
@@ -339,7 +339,7 @@ void store_cb (flux_t *h,
 {
     struct content_sqlite *ctx = arg;
     const void *data;
-    int size;
+    size_t size;
     uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
     int hash_size;
     struct timespec t0;

--- a/src/modules/content/cache.c
+++ b/src/modules/content/cache.c
@@ -62,7 +62,7 @@ struct msgstack {
 
 struct cache_entry {
     const void *data;
-    int len;
+    size_t len;
     void *data_container;
     void *hash;                     // key storage is contiguous with struct
     uint8_t valid:1;                // entry contains valid data
@@ -417,7 +417,7 @@ static void content_load_request (flux_t *h,
 {
     struct content_cache *cache = arg;
     const void *hash;
-    int hash_size;
+    size_t hash_size;
     struct cache_entry *e;
     const char *errmsg = NULL;
 
@@ -535,7 +535,7 @@ static void cache_store_continuation (flux_future_t *f, void *arg)
     struct content_cache *cache = arg;
     struct cache_entry *e = flux_future_aux_get (f, "entry");
     const void *hash;
-    int hash_size;
+    size_t hash_size;
 
     e->store_pending = 0;
     assert (cache->flush_batch_count > 0);
@@ -630,7 +630,7 @@ static void content_store_request (flux_t *h,
 {
     struct content_cache *cache = arg;
     const void *data;
-    int len;
+    size_t len;
     struct cache_entry *e = NULL;
     uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
     int hash_size;

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -255,7 +255,7 @@ static void handle_load_response (flux_future_t *f, struct watcher *w)
 {
     flux_t *h = flux_future_get_flux (f);
     const void *data;
-    int size;
+    size_t size;
     flux_error_t err;
 
     if (content_load_get (f, &data, &size) < 0) {

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -182,7 +182,8 @@ void cache_entry_decref (struct cache_entry *entry)
         entry->refcount--;
 }
 
-int cache_entry_get_raw (struct cache_entry *entry, const void **data,
+int cache_entry_get_raw (struct cache_entry *entry,
+                         const void **data,
                          int *len)
 {
     if (!entry || !entry->valid)

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -86,7 +86,8 @@ void cache_entry_decref (struct cache_entry *entry);
  * cache_entry_set_raw() & cache_entry_clear_data()
  * return -1 on error, 0 on success
  */
-int cache_entry_get_raw (struct cache_entry *entry, const void **data,
+int cache_entry_get_raw (struct cache_entry *entry,
+                         const void **data,
                          int *len);
 int cache_entry_set_raw (struct cache_entry *entry, const void *data, int len);
 
@@ -148,8 +149,11 @@ int cache_expire_entries (struct cache *cache, double max_age);
 /* Obtain statistics on the cache.
  * Returns -1 on error, 0 on success
  */
-int cache_get_stats (struct cache *cache, tstat_t *ts, int *size,
-                     int *incomplete, int *dirty);
+int cache_get_stats (struct cache *cache,
+                     tstat_t *ts,
+                     int *size,
+                     int *incomplete,
+                     int *dirty);
 
 /* Destroy wait_t's on the waitqueue_t of any cache entry
  * if they meet match criteria.

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -501,7 +501,7 @@ static void content_load_completion (flux_future_t *f, void *arg)
 {
     struct kvs_ctx *ctx = arg;
     const void *data;
-    int size;
+    size_t size;
     const char *blobref;
     struct cache_entry *entry;
 

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -305,7 +305,8 @@ void null_request_cb (flux_t *h,
 {
     t_req_ctx_t *ctx = arg;
     const char *topic;
-    int type, size;
+    int type;
+    size_t size;
     const void *buf;
     uint32_t nodeid;
 
@@ -349,7 +350,7 @@ void null_request_cb (flux_t *h,
     if (flux_msg_get_payload (msg, &buf, &size) == 0) {
         flux_log (h,
                   LOG_ERR,
-                  "%s: unexpected payload size %d",
+                  "%s: unexpected payload size %zu",
                   __FUNCTION__,
                   size);
         goto error;

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -74,20 +74,26 @@ error:
 
 /* Return number of queued clog requests
  */
-void count_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                       const flux_msg_t *msg, void *arg)
+void count_request_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
 {
     t_req_ctx_t *ctx = getctx (h);
 
-    if (flux_respond_pack (h, msg, "{s:i}",
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:i}",
                            "count", zlist_size (ctx->clog_requests)) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
 }
 
 /* Don't reply to request - just queue it for later.
  */
-void clog_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+void clog_request_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     t_req_ctx_t *ctx = getctx (h);
     flux_msg_t *cpy = flux_msg_copy (msg, true);
@@ -98,8 +104,10 @@ void clog_request_cb (flux_t *h, flux_msg_handler_t *mh,
 
 /* Reply to all queued requests.
  */
-void flush_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                       const flux_msg_t *msg, void *arg)
+void flush_request_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
 {
     t_req_ctx_t *ctx = getctx (h);
     flux_msg_t *req;
@@ -117,8 +125,10 @@ void flush_request_cb (flux_t *h, flux_msg_handler_t *mh,
 /* Accept a json payload, verify it and return error if it doesn't
  * match expected.
  */
-void sink_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+void sink_request_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     double d;
 
@@ -138,8 +148,10 @@ error:
 
 /* Return a fixed json payload
  */
-void src_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                     const flux_msg_t *msg, void *arg)
+void src_request_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
 {
     if (flux_respond_pack (h, msg, "{s:i}", "wormz", 42) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
@@ -147,8 +159,10 @@ void src_request_cb (flux_t *h, flux_msg_handler_t *mh,
 
 /* Return 'n' sequenced responses.
  */
-void nsrc_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+void nsrc_request_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     int i, count;
 
@@ -166,8 +180,10 @@ error:
 
 /* Always return an error 42
  */
-void err_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                     const flux_msg_t *msg, void *arg)
+void err_request_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
 {
     if (flux_respond_error (h, msg, 42, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
@@ -175,8 +191,10 @@ void err_request_cb (flux_t *h, flux_msg_handler_t *mh,
 
 /* Echo a json payload back to requestor.
  */
-void echo_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+void echo_request_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     const char *json_str;
 
@@ -196,8 +214,10 @@ error:
 
 /* Proxy ping.
  */
-void xping_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                       const flux_msg_t *msg, void *arg)
+void xping_request_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
 {
     t_req_ctx_t *ctx = arg;
     int rank, seq = ctx->ping_seq++;
@@ -205,16 +225,23 @@ void xping_request_cb (flux_t *h, flux_msg_handler_t *mh,
     char *hashkey = NULL;
     flux_msg_t *cpy;
 
-    if (flux_request_unpack (msg, NULL, "{s:i s:s}", "rank", &rank,
-                                                     "service", &service) < 0)
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:i s:s}",
+                             "rank", &rank,
+                             "service", &service) < 0)
         goto error;
     flux_log (h, LOG_DEBUG, "Rxping rank=%d service=%s", rank, service);
 
     flux_log (h, LOG_DEBUG, "Tping seq=%d %d!%s", seq, rank, service);
 
     flux_future_t *f;
-    if (!(f = flux_rpc_pack (h, service, rank, 0,
-                             "{s:i}", "seq", seq)))
+    if (!(f = flux_rpc_pack (h,
+                             service,
+                             rank,
+                             0,
+                             "{s:i}",
+                             "seq", seq)))
         goto error;
     flux_future_destroy (f);
     if (!(cpy = flux_msg_copy (msg, true)))
@@ -232,8 +259,10 @@ error:
 /* Handle ping response for proxy ping.
  * Match it with a request and respond to that request.
  */
-void ping_response_cb (flux_t *h, flux_msg_handler_t *mh,
-                       const flux_msg_t *msg, void *arg)
+void ping_response_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
 {
     t_req_ctx_t *ctx = arg;
     int seq;
@@ -248,8 +277,7 @@ void ping_response_cb (flux_t *h, flux_msg_handler_t *mh,
         return;
     }
     if (!json_str || !(o = json_loads (json_str, 0, NULL))
-            || json_unpack (o, "{s:i s:s}", "seq", &seq,
-                                            "route", &route) < 0) {
+        || json_unpack (o, "{s:i s:s}", "seq", &seq, "route", &route) < 0) {
         flux_log (h, LOG_ERR, "%s: error decoding payload", __FUNCTION__);
         goto done;
     }
@@ -270,8 +298,10 @@ done:
 /* Handle the simplest possible request.
  * Verify that everything is as expected; log it and stop the reactor if not.
  */
-void null_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+void null_request_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     t_req_ctx_t *ctx = arg;
     const char *topic;
@@ -288,7 +318,10 @@ void null_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
     if (type != FLUX_MSGTYPE_REQUEST) {
-        flux_log (h, LOG_ERR, "%s: unexpected type %s", __FUNCTION__,
+        flux_log (h,
+                  LOG_ERR,
+                  "%s: unexpected type %s",
+                  __FUNCTION__,
                   flux_msg_typestr (type));
         goto error;
     }
@@ -297,7 +330,10 @@ void null_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
     if (nodeid != ctx->rank && nodeid != FLUX_NODEID_ANY) {
-        flux_log (h, LOG_ERR, "%s: unexpected nodeid: %"PRIu32"", __FUNCTION__,
+        flux_log (h,
+                  LOG_ERR,
+                  "%s: unexpected nodeid: %"PRIu32"",
+                  __FUNCTION__,
                   nodeid);
         goto error;
     }
@@ -311,12 +347,18 @@ void null_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
     if (flux_msg_get_payload (msg, &buf, &size) == 0) {
-        flux_log (h, LOG_ERR, "%s: unexpected payload size %d", __FUNCTION__,
+        flux_log (h,
+                  LOG_ERR,
+                  "%s: unexpected payload size %d",
+                  __FUNCTION__,
                   size);
         goto error;
     }
     if (errno != EPROTO) {
-        flux_log (h, LOG_ERR, "%s: get nonexistent payload: %s", __FUNCTION__,
+        flux_log (h,
+                  LOG_ERR,
+                  "%s: get nonexistent payload: %s",
+                  __FUNCTION__,
                   strerror (errno));
         goto error;
     }

--- a/t/request/rpc.c
+++ b/t/request/rpc.c
@@ -41,7 +41,7 @@ int main (int argc, char *argv[])
     ssize_t inlen;
     void *inbuf;
     const char *outbuf;
-    int outlen;
+    size_t outlen;
     int expected_errno = -1;
     int ch;
     bool raw_request = false;


### PR DESCRIPTION
Problem: some libflux interfaces use the C `int` type to represent buffer and I/O sizes, but `size_t`, as an unsigned type with more range, is more appropriate in public interfaces.
    
Convert the following public API interfaces to use `size_t`:
 ```c
    flux_msg_get_payload()
    flux_msg_set_payload()
    flux_request_decode_raw()
    flux_request_encode_raw()
    flux_response_decode_raw()
    flux_response_encode_raw()
    flux_respond_raw()
    flux_event_encode_raw()
    flux_event_decode_raw()
    flux_event_publish_raw()
    flux_rpc_raw()
    flux_rpc_get_raw()
    flux_kvs_lookup_get_raw()
    flux_kvs_txn_put_raw()
```
Update tests and in-tree users, where appropriate.
