### PR TITLE
add flux module stats --rusage=[self|children|thread] optional argument

### DIFF
--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -105,10 +105,11 @@ the object may be customized on a module basis.
   Multiply the returned (int or double) value by the specified
   floating point value.
 
-.. option:: -R, --rusage
+.. option:: -R, --rusage=[self|children|thread]
 
   Return a JSON object representing an *rusage* structure
-  returned by :linux:man2:`getrusage`.
+  returned by :linux:man2:`getrusage`.  If specified, the optional argument
+  specifies the query target (default: self).
 
 .. option:: -c, --clear
 

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -184,25 +184,21 @@ test_expect_success 'flux module stats --scale works' '
 	test "$EVENT_TX2" -eq $((${EVENT_TX}*2))
 '
 
-
 test_expect_success 'flux module stats --rusage works' '
-	flux module stats --rusage $REALMOD >rusage.stats &&
-	grep -q utime rusage.stats &&
-	grep -q stime rusage.stats &&
-	grep -q maxrss rusage.stats &&
-	grep -q ixrss rusage.stats &&
-	grep -q idrss rusage.stats &&
-	grep -q isrss rusage.stats &&
-	grep -q minflt rusage.stats &&
-	grep -q majflt rusage.stats &&
-	grep -q nswap rusage.stats &&
-	grep -q inblock rusage.stats &&
-	grep -q oublock rusage.stats &&
-	grep -q msgsnd rusage.stats &&
-	grep -q msgrcv rusage.stats &&
-	grep -q nsignals rusage.stats &&
-	grep -q nvcsw rusage.stats &&
-	grep -q nivcsw rusage.stats
+	flux module stats --rusage $REALMOD
+'
+test_expect_success 'flux module stats -Rself works' '
+	flux module stats -Rself $REALMOD
+'
+test_expect_success 'flux module stats --rusage=children works' '
+	flux module stats --rusage=children $REALMOD
+'
+# RUSAGE_THREAD is a non-portable GNU extension
+test_expect_success 'flux module stats --rusage=thread might work :-)' '
+	test_might_fail flux module stats --rusage=thread $REALMOD
+'
+test_expect_success 'flux module stats --rusage=badopt fails' '
+	test_must_fail flux module stats --rusage=badopt $REALMOD
 '
 
 test_expect_success 'flux module stats --rusage --parse maxrss works' '


### PR DESCRIPTION
Problem: `getrusage(2)` accepts multiple `who` targets, but flux hard codes the non-portable RUSAGE_THREAD.

Switch the default to RUSAGE_SELF, which is portable.

Add a `who` key to the RPC and change `flux module stats --rusage` so it takes an optional argument of `self`, `children`, or `thread`.

Update docs and add a few tests.