### PR TITLE
modernize code formatting

### DIFF
--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -491,7 +491,10 @@ int flux_conf_reload_decode (const flux_msg_t *msg, const flux_conf_t **confp)
             return -1;
         json_decref (conf->obj);
         conf->obj = json_incref (o);
-        if (flux_msg_aux_set (msg, auxkey, (flux_conf_t *)conf, (flux_free_f)flux_conf_decref) < 0) {
+        if (flux_msg_aux_set (msg,
+                              auxkey,
+                              (flux_conf_t *)conf,
+                              (flux_free_f)flux_conf_decref) < 0) {
             flux_conf_decref (conf);
             return -1;
         }

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -68,7 +68,8 @@ int flux_conf_vunpack (const flux_conf_t *conf,
 
 int flux_conf_unpack (const flux_conf_t *conf,
                       flux_error_t *error,
-                      const char *fmt, ...);
+                      const char *fmt,
+                      ...);
 
 #ifdef __cplusplus
 }

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -107,7 +107,8 @@ done:
 }
 
 
-int flux_event_decode (const flux_msg_t *msg, const char **topicp,
+int flux_event_decode (const flux_msg_t *msg,
+                       const char **topicp,
                        const char **sp)
 {
     const char *topic, *s;
@@ -126,8 +127,10 @@ done:
     return rc;
 }
 
-int flux_event_decode_raw (const flux_msg_t *msg, const char **topicp,
-                           const void **datap, int *lenp)
+int flux_event_decode_raw (const flux_msg_t *msg,
+                           const char **topicp,
+                           const void **datap,
+                           int *lenp)
 {
     const char *topic;
     const void *data = NULL;
@@ -154,8 +157,10 @@ done:
     return rc;
 }
 
-static int flux_event_vunpack (const flux_msg_t *msg, const char **topic,
-                               const char *fmt, va_list ap)
+static int flux_event_vunpack (const flux_msg_t *msg,
+                               const char **topic,
+                               const char *fmt,
+                               va_list ap)
 {
     const char *ts;
     int rc = -1;
@@ -171,8 +176,10 @@ done:
     return rc;
 }
 
-int flux_event_unpack (const flux_msg_t *msg, const char **topic,
-                       const char *fmt, ...)
+int flux_event_unpack (const flux_msg_t *msg,
+                       const char **topic,
+                       const char *fmt,
+                       ...)
 {
     va_list ap;
     int rc;
@@ -216,7 +223,8 @@ error:
 }
 
 flux_msg_t *flux_event_encode_raw (const char *topic,
-                                   const void *data, int len)
+                                   const void *data,
+                                   int len)
 {
     flux_msg_t *msg = flux_event_create (topic);
     if (!msg)
@@ -230,7 +238,8 @@ error:
 }
 
 static flux_msg_t *flux_event_vpack (const char *topic,
-                                     const char *fmt, va_list ap)
+                                     const char *fmt,
+                                     va_list ap)
 {
     flux_msg_t *msg = flux_event_create (topic);
     if (!msg)
@@ -255,8 +264,10 @@ flux_msg_t *flux_event_pack (const char *topic, const char *fmt, ...)
 }
 
 static flux_future_t *wrap_event_rpc (flux_t *h,
-                                      const char *topic, int flags,
-                                      const void *src, int srclen)
+                                      const char *topic,
+                                      int flags,
+                                      const void *src,
+                                      int srclen)
 {
     flux_future_t *f;
 
@@ -270,10 +281,14 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
             errno = EPROTO;
             return NULL;
         }
-        if (!(f = flux_rpc_pack (h, "event.publish", 0, 0,
-                                 "{s:s s:i s:s}", "topic", topic,
-                                                  "flags", flags,
-                                                  "payload", dst))) {
+        if (!(f = flux_rpc_pack (h,
+                                 "event.publish",
+                                 0,
+                                 0,
+                                 "{s:s s:i s:s}",
+                                 "topic", topic,
+                                 "flags", flags,
+                                 "payload", dst))) {
             int saved_errno = errno;
             free (dst);
             errno = saved_errno;
@@ -282,9 +297,13 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
         free (dst);
     }
     else {
-        if (!(f = flux_rpc_pack (h, "event.publish", 0, 0,
-                                    "{s:s s:i}", "topic", topic,
-                                                 "flags", flags))) {
+        if (!(f = flux_rpc_pack (h,
+                                 "event.publish",
+                                 0,
+                                 0,
+                                 "{s:s s:i}",
+                                 "topic", topic,
+                                 "flags", flags))) {
             return NULL;
         }
     }
@@ -292,7 +311,8 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
 }
 
 flux_future_t *flux_event_publish (flux_t *h,
-                                   const char *topic, int flags,
+                                   const char *topic,
+                                   int flags,
                                    const char *json_str)
 {
     int len = 0;
@@ -306,8 +326,10 @@ flux_future_t *flux_event_publish (flux_t *h,
 }
 
 flux_future_t *flux_event_publish_pack (flux_t *h,
-                                        const char *topic, int flags,
-                                        const char *fmt, ...)
+                                        const char *topic,
+                                        int flags,
+                                        const char *fmt,
+                                        ...)
 {
     va_list ap;
     json_t *o;
@@ -331,8 +353,11 @@ flux_future_t *flux_event_publish_pack (flux_t *h,
         return NULL;
     }
     json_decref (o);
-    if (!(f = wrap_event_rpc (h,  topic, flags,
-                              json_str, strlen (json_str) + 1))) {
+    if (!(f = wrap_event_rpc (h,
+                              topic,
+                              flags,
+                              json_str,
+                              strlen (json_str) + 1))) {
         int saved_errno = errno;
         free (json_str);
         errno = saved_errno;
@@ -343,8 +368,10 @@ flux_future_t *flux_event_publish_pack (flux_t *h,
 }
 
 flux_future_t *flux_event_publish_raw (flux_t *h,
-                                       const char *topic, int flags,
-                                       const void *data, int len)
+                                       const char *topic,
+                                       int flags,
+                                       const void *data,
+                                       int len)
 {
     if (!h || !topic || (flags & ~(FLUX_MSGFLAG_PRIVATE)) != 0) {
         errno = EINVAL;

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -35,14 +35,16 @@ flux_future_t *flux_event_unsubscribe_ex (flux_t *h,
  * If s is non-NULL, assign string payload or set to NULL if none
  * exists.  Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_event_decode (const flux_msg_t *msg, const char **topic,
+int flux_event_decode (const flux_msg_t *msg,
+                       const char **topic,
                        const char **s);
 
 /* Decode an event message with required JSON payload.  These functions use
  * jansson unpack style variable arguments for decoding the JSON object
  * payload directly.  Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_event_unpack (const flux_msg_t *msg, const char **topic,
+int flux_event_unpack (const flux_msg_t *msg,
+                       const char **topic,
                        const char *fmt, ...);
 
 /* Encode an event message with optional string payload.
@@ -60,7 +62,8 @@ flux_msg_t *flux_event_pack (const char *topic, const char *fmt, ...);
 /* Encode an event message with raw payload.
  */
 flux_msg_t *flux_event_encode_raw (const char *topic,
-                                   const void *data, int len);
+                                   const void *data,
+                                   int len);
 
 /* Decode an event message, with optional raw payload.
  * If topic is non-NULL, assign the event topic string.
@@ -68,28 +71,35 @@ flux_msg_t *flux_event_encode_raw (const char *topic,
  * If there is no payload, they will be assigned NULL and zero.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_event_decode_raw (const flux_msg_t *msg, const char **topic,
-                           const void **data, int *len);
+int flux_event_decode_raw (const flux_msg_t *msg,
+                           const char **topic,
+                           const void **data,
+                           int *len);
 
 /* Publish an event with optional string payload.
  * The future is fulfilled once the event has been assigned a sequence number,
  * and does not indicate that the event has yet reached all subscribers.
  */
 flux_future_t *flux_event_publish (flux_t *h,
-                                   const char *topic, int flags,
+                                   const char *topic,
+                                   int flags,
                                    const char *s);
 
 /* Publish an event with JSON payload.
  */
 flux_future_t *flux_event_publish_pack (flux_t *h,
-                                        const char *topic, int flags,
-                                        const char *fmt, ...);
+                                        const char *topic,
+                                        int flags,
+                                        const char *fmt,
+                                        ...);
 
 /* Publish an event with optional raw payload.
  */
 flux_future_t *flux_event_publish_raw (flux_t *h,
-                                       const char *topic, int flags,
-                                       const void *data, int len);
+                                       const char *topic,
+                                       int flags,
+                                       const void *data,
+                                       int len);
 
 /* Obtain the event sequence number from the fulfilled
  * flux_event_publish() future.

--- a/src/common/libflux/fripp.c
+++ b/src/common/libflux/fripp.c
@@ -227,9 +227,12 @@ int fripp_gauge (struct fripp_ctx *ctx,
         return 0;
 
     if (ctx->period == 0)
-        return fripp_sendf (ctx, inc && value > 0 ?
-                            "%s.%s:+%zd|g\n" : "%s.%s:%zd|g\n",
-                            ctx->prefix, name, value);
+        return fripp_sendf (ctx,
+                            "%s.%s:%s%zd|g\n",
+                            ctx->prefix,
+                            name,
+                            inc && value > 0 ? "+" : "",
+                            value);
 
     struct metric *m;
 
@@ -310,7 +313,7 @@ static void timer_cb (flux_reactor_t *r,
 
     FOREACH_ZHASHX (ctx->metrics, name, m) {
         if ((m->type == BRUBECK_COUNTER || m->type == BRUBECK_GAUGE)
-                && m->cur.l == m->prev.l) {
+            && m->cur.l == m->prev.l) {
             zlist_append (ctx->done, (void *) name);
             continue;
         }

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -70,12 +70,18 @@ struct flux_future {
     int refcount;
 };
 
-static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
-                      int revents, void *arg);
-static void now_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
-                          int revents, void *arg);
-static void then_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
-                           int revents, void *arg);
+static void check_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg);
+static void now_timer_cb (flux_reactor_t *r,
+                          flux_watcher_t *w,
+                          int revents,
+                          void *arg);
+static void then_timer_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg);
 
 /* "now" reactor context - used for flux_future_wait_on()
  * This is set up lazily; wait until the user calls flux_future_wait_on().
@@ -107,15 +113,19 @@ error:
 }
 
 static int now_context_set_timeout (struct now_context *now,
-                                    double timeout, void *arg)
+                                    double timeout,
+                                    void *arg)
 {
     if (now) {
         if (timeout < 0.)       // disable
             flux_watcher_stop (now->timer);
         else {
             if (!now->timer) {  // set
-                now->timer = flux_timer_watcher_create (now->r, timeout, 0.,
-                                                        now_timer_cb, arg);
+                now->timer = flux_timer_watcher_create (now->r,
+                                                        timeout,
+                                                        0.,
+                                                        now_timer_cb,
+                                                        arg);
                 if (!now->timer)
                     return -1;
             }
@@ -179,7 +189,8 @@ static void then_context_stop (struct then_context *then)
 }
 
 static int then_context_set_timeout (struct then_context *then,
-                                     double timeout, void *arg)
+                                     double timeout,
+                                     void *arg)
 {
     if (then) {
         then->timeout = timeout;
@@ -187,8 +198,11 @@ static int then_context_set_timeout (struct then_context *then,
             flux_watcher_stop (then->timer);
         else {
             if (!then->timer) {
-                then->timer = flux_timer_watcher_create (then->r, 0., timeout,
-                                                         then_timer_cb, arg);
+                then->timer = flux_timer_watcher_create (then->r,
+                                                         0.,
+                                                         timeout,
+                                                         then_timer_cb,
+                                                         arg);
                 if (!then->timer)
                     return -1;
             }
@@ -216,7 +230,8 @@ static void clear_result (struct future_result *fs)
     init_result (fs);
 }
 
-static void set_result_value (struct future_result *fs, void *value,
+static void set_result_value (struct future_result *fs,
+                              void *value,
                               flux_free_f value_free)
 {
     assert (fs->is_error == false);
@@ -224,7 +239,8 @@ static void set_result_value (struct future_result *fs, void *value,
     fs->value_free = value_free;
 }
 
-static int set_result_errnum (struct future_result *fs, int errnum,
+static int set_result_errnum (struct future_result *fs,
+                              int errnum,
                               const char *errstr)
 {
     assert (!fs->value && !fs->value_free);
@@ -537,8 +553,10 @@ int flux_future_get (flux_future_t *f, const void **result)
  * Lazily set up the "then" reactor context.
  * If timer expires, fulfill the future with ETIMEDOUT error.
  */
-int flux_future_then (flux_future_t *f, double timeout,
-                      flux_continuation_f cb, void *arg)
+int flux_future_then (flux_future_t *f,
+                      double timeout,
+                      flux_continuation_f cb,
+                      void *arg)
 {
     if (!f || !f->r || !cb) {
         errno = EINVAL;
@@ -577,8 +595,10 @@ void *flux_future_aux_get (flux_future_t *f, const char *name)
 
 /* Store 'aux' object by name.
  */
-int flux_future_aux_set (flux_future_t *f, const char *name,
-                         void *aux, flux_free_f destroy)
+int flux_future_aux_set (flux_future_t *f,
+                         const char *name,
+                         void *aux,
+                         flux_free_f destroy)
 {
     if (!f) {
         errno = EINVAL;
@@ -635,7 +655,8 @@ void flux_future_fulfill (flux_future_t *f, void *result, flux_free_f free_fn)
     }
 }
 
-void flux_future_fulfill_error (flux_future_t *f, int errnum,
+void flux_future_fulfill_error (flux_future_t *f,
+                                int errnum,
                                 const char *errstr)
 {
     if (f) {
@@ -692,8 +713,9 @@ int flux_future_fulfill_with (flux_future_t *f, flux_future_t *p)
     if (p->fatal_errnum_valid)
         flux_future_fatal_error (f, p->fatal_errnum, p->fatal_errnum_string);
     else if (p->result.is_error)
-        flux_future_fulfill_error (f, p->result.errnum,
-                                      p->result.errnum_string);
+        flux_future_fulfill_error (f,
+                                   p->result.errnum,
+                                   p->result.errnum_string);
     else {
         /*  Nornal result, if result has a free_fn registered, then we have
          *   to steal the reference for the result. We do this by copying
@@ -767,8 +789,10 @@ const char *flux_future_error_string (flux_future_t *f)
 /* timer - for flux_future_then() timeout
  * fulfill the future with an error
  */
-static void then_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
-                           int revents, void *arg)
+static void then_timer_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
 {
     flux_future_t *f = arg;
     flux_future_fulfill_error (f, ETIMEDOUT, NULL);
@@ -777,8 +801,10 @@ static void then_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
 /* timer - for flux_future_wait_for() timeout
  * stop the reactor but don't fulfill the future
  */
-static void now_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
-                          int revents, void *arg)
+static void now_timer_cb (flux_reactor_t *r,
+                          flux_watcher_t *w,
+                          int revents,
+                          void *arg)
 {
     errno = ETIMEDOUT;
     flux_reactor_stop_error (r);
@@ -786,8 +812,10 @@ static void now_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
 
 /* check - if results are ready, call the continuation
  */
-static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
-                      int revents, void *arg)
+static void check_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
 {
     flux_future_t *f = arg;
 

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -21,8 +21,10 @@ extern "C" {
 
 typedef void (*flux_continuation_f)(flux_future_t *f, void *arg);
 
-int flux_future_then (flux_future_t *f, double timeout,
-                      flux_continuation_f cb, void *arg);
+int flux_future_then (flux_future_t *f,
+                      double timeout,
+                      flux_continuation_f cb,
+                      void *arg);
 
 int flux_future_wait_for (flux_future_t *f, double timeout);
 
@@ -33,8 +35,10 @@ void flux_future_reset (flux_future_t *f);
 void flux_future_destroy (flux_future_t *f);
 
 void *flux_future_aux_get (flux_future_t *f, const char *name);
-int flux_future_aux_set (flux_future_t *f, const char *name,
-                         void *aux, flux_free_f destroy);
+int flux_future_aux_set (flux_future_t *f,
+                         const char *name,
+                         void *aux,
+                         flux_free_f destroy);
 
 /* Functions primarily used by implementors of classes that return futures.
  * See flux_future_create(3).
@@ -47,7 +51,9 @@ flux_future_t *flux_future_create (flux_future_init_f cb, void *arg);
 int flux_future_get (flux_future_t *f, const void **result);
 
 void flux_future_fulfill (flux_future_t *f, void *result, flux_free_f free_fn);
-void flux_future_fulfill_error (flux_future_t *f, int errnum, const char *errstr);
+void flux_future_fulfill_error (flux_future_t *f,
+                                int errnum,
+                                const char *errstr);
 
 int flux_future_fulfill_with (flux_future_t *f, flux_future_t *p);
 
@@ -96,13 +102,15 @@ flux_future_t *flux_future_get_child (flux_future_t *cf, const char *name);
  *  has been used.
  */
 flux_future_t *flux_future_and_then (flux_future_t *f,
-                                     flux_continuation_f cb, void *arg);
+                                     flux_continuation_f cb,
+                                     void *arg);
 
 /* Like flux_future_and_then(3), but run the continuation `cb` when
  *  future `f` is fulfilled with an error.
  */
 flux_future_t *flux_future_or_then (flux_future_t *f,
-                                    flux_continuation_f cb, void *arg);
+                                    flux_continuation_f cb,
+                                    void *arg);
 
 /* Set the next future for the chained future `prev` to `f`.
  *  This function steals a reference to `f` and thus flux_future_destroy()
@@ -114,7 +122,8 @@ int flux_future_continue (flux_future_t *prev, flux_future_t *f);
 /*  Set the next future for the chained future `prev` to be fulfilled
  *   with an error `errnum` and an optional error string.
  */
-void flux_future_continue_error (flux_future_t *prev, int errnum,
+void flux_future_continue_error (flux_future_t *prev,
+                                 int errnum,
                                  const char *errstr);
 
 /*  Fulfill the next future in the chain immediately with a result.

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1417,8 +1417,8 @@ int msg_frames (const flux_msg_t *msg)
 }
 
 struct flux_match flux_match_init (int typemask,
-                                     uint32_t matchtag,
-                                     const char *topic_glob)
+                                   uint32_t matchtag,
+                                   const char *topic_glob)
 {
     struct flux_match m = {typemask, matchtag, topic_glob};
     return m;

--- a/src/common/libflux/msg_handler.c
+++ b/src/common/libflux/msg_handler.c
@@ -47,8 +47,10 @@ struct flux_msg_handler {
     uint8_t running:1;
 };
 
-static void handle_cb (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg);
+static void handle_cb (flux_reactor_t *r,
+                       flux_watcher_t *w,
+                       int revents,
+                       void *arg);
 static void free_msg_handler (flux_msg_handler_t *mh);
 
 static size_t matchtag_hasher (const void *key);
@@ -578,7 +580,8 @@ void flux_msg_handler_destroy (flux_msg_handler_t *mh)
 
 flux_msg_handler_t *flux_msg_handler_create (flux_t *h,
                                              const struct flux_match match,
-                                             flux_msg_handler_f cb, void *arg)
+                                             flux_msg_handler_f cb,
+                                             void *arg)
 {
     struct dispatch *d;
     flux_msg_handler_t *mh;

--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -256,8 +256,10 @@ const char * flux_plugin_get_path (flux_plugin_t *p)
     return NULL;
 }
 
-int flux_plugin_aux_set (flux_plugin_t *p, const char *key,
-                         void *val, aux_free_f free_fn)
+int flux_plugin_aux_set (flux_plugin_t *p,
+                         const char *key,
+                         void *val,
+                         aux_free_f free_fn)
 {
     return aux_set (&p->aux, key, val, free_fn);
 }
@@ -323,9 +325,11 @@ int flux_plugin_set_conf (flux_plugin_t *p, const char *json_str)
     if (!p || !json_str)
         return plugin_seterror (p, EINVAL, NULL);
     if (!(p->conf = json_loads (json_str, 0, &err))) {
-        return plugin_seterror (p, errno,
+        return plugin_seterror (p,
+                                errno,
                                 "parse error: col %d: %s",
-                                 err.column, err.text);
+                                err.column,
+                                err.text);
     }
     if (p->conf_str) {
         free (p->conf_str);
@@ -455,18 +459,22 @@ int flux_plugin_register (flux_plugin_t *p,
     return 0;
 }
 
-static int arg_seterror (flux_plugin_arg_t *arg, int errnum,
-                         const char *fmt, ...)
+static int arg_seterror (flux_plugin_arg_t *arg,
+                         int errnum,
+                         const char *fmt,
+                         ...)
 {
     if (fmt) {
         va_list ap;
         va_start (ap, fmt);
         vsnprintf (arg->error.text, sizeof (arg->error.text), fmt, ap);
         va_end (ap);
-    } else if (arg) {
+    }
+    else if (arg) {
         snprintf (arg->error.text,
                   sizeof (arg->error.text),
-                  "%s", strerror (errno));
+                  "%s",
+                  strerror (errno));
     }
     errno = errnum;
     return -1;
@@ -547,8 +555,10 @@ int flux_plugin_arg_get (flux_plugin_arg_t *args, int flags, char **json_str)
     return 0;
 }
 
-int flux_plugin_arg_vpack (flux_plugin_arg_t *args, int flags,
-                           const char *fmt, va_list ap)
+int flux_plugin_arg_vpack (flux_plugin_arg_t *args,
+                           int flags,
+                           const char *fmt,
+                           va_list ap)
 {
     json_t *o;
     arg_clear_error (args);
@@ -559,8 +569,10 @@ int flux_plugin_arg_vpack (flux_plugin_arg_t *args, int flags,
     return arg_set (args, flags, o);
 }
 
-int flux_plugin_arg_pack (flux_plugin_arg_t *args, int flags,
-                          const char *fmt, ...)
+int flux_plugin_arg_pack (flux_plugin_arg_t *args,
+                          int flags,
+                          const char *fmt,
+                          ...)
 {
     int rc;
     va_list ap;
@@ -570,8 +582,10 @@ int flux_plugin_arg_pack (flux_plugin_arg_t *args, int flags,
     return rc;
 }
 
-int flux_plugin_arg_vunpack (flux_plugin_arg_t *args, int flags,
-                             const char *fmt, va_list ap)
+int flux_plugin_arg_vunpack (flux_plugin_arg_t *args,
+                             int flags,
+                             const char *fmt,
+                             va_list ap)
 {
     json_t **op;
     arg_clear_error (args);
@@ -581,8 +595,10 @@ int flux_plugin_arg_vunpack (flux_plugin_arg_t *args, int flags,
     return json_vunpack_ex (*op, &args->error, 0, fmt, ap);
 }
 
-int flux_plugin_arg_unpack (flux_plugin_arg_t *args, int flags,
-                            const char *fmt, ...)
+int flux_plugin_arg_unpack (flux_plugin_arg_t *args,
+                            int flags,
+                            const char *fmt,
+                            ...)
 {
     int rc;
     va_list ap;
@@ -592,7 +608,8 @@ int flux_plugin_arg_unpack (flux_plugin_arg_t *args, int flags,
     return rc;
 }
 
-int flux_plugin_call (flux_plugin_t *p, const char *string,
+int flux_plugin_call (flux_plugin_t *p,
+                      const char *string,
                       flux_plugin_arg_t *args)
 {
     const struct flux_plugin_handler *h = NULL;

--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -154,15 +154,22 @@ int flux_plugin_arg_get (flux_plugin_arg_t *args,
 
 /*  Pack/unpack arguments into plugin arg object using jansson pack style args
  */
-int flux_plugin_arg_pack (flux_plugin_arg_t *args, int flags,
+int flux_plugin_arg_pack (flux_plugin_arg_t *args,
+                          int flags,
                           const char *fmt, ...);
-int flux_plugin_arg_vpack (flux_plugin_arg_t *args, int flags,
-                           const char *fmt, va_list ap);
+int flux_plugin_arg_vpack (flux_plugin_arg_t *args,
+                           int flags,
+                           const char *fmt,
+                           va_list ap);
 
-int flux_plugin_arg_unpack (flux_plugin_arg_t *args, int flags,
-                            const char *fmt, ...);
-int flux_plugin_arg_vunpack (flux_plugin_arg_t *args, int flags,
-                             const char *fmt, va_list ap);
+int flux_plugin_arg_unpack (flux_plugin_arg_t *args,
+                            int flags,
+                            const char *fmt,
+                            ...);
+int flux_plugin_arg_vunpack (flux_plugin_arg_t *args,
+                             int flags,
+                             const char *fmt,
+                             va_list ap);
 
 /*  Call first plugin callback matching 'name', passing optional plugin
  *   arguments in 'args'.
@@ -171,7 +178,8 @@ int flux_plugin_arg_vunpack (flux_plugin_arg_t *args, int flags,
  *   called with return value < 0, and 1 if callback was called with
  *   return value >= 0.
  */
-int flux_plugin_call (flux_plugin_t *p, const char *name,
+int flux_plugin_call (flux_plugin_t *p,
+                      const char *name,
                       flux_plugin_arg_t *args);
 
 /*  Load a plugin from a shared object found in 'path'

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -40,7 +40,8 @@ done:
     return rc;
 }
 
-int flux_request_decode (const flux_msg_t *msg, const char **topicp,
+int flux_request_decode (const flux_msg_t *msg,
+                         const char **topicp,
                          const char **sp)
 {
     const char *topic, *s;
@@ -59,8 +60,10 @@ done:
     return rc;
 }
 
-int flux_request_decode_raw (const flux_msg_t *msg, const char **topic,
-                             const void **data, int *len)
+int flux_request_decode_raw (const flux_msg_t *msg,
+                             const char **topic,
+                             const void **data,
+                             int *len)
 {
     const char *ts;
     const void *d = NULL;
@@ -87,8 +90,10 @@ done:
     return rc;
 }
 
-static int flux_request_vunpack (const flux_msg_t *msg, const char **topic,
-                                 const char *fmt, va_list ap)
+static int flux_request_vunpack (const flux_msg_t *msg,
+                                 const char **topic,
+                                 const char *fmt,
+                                 va_list ap)
 {
     const char *ts;
     int rc = -1;
@@ -108,8 +113,10 @@ done:
     return rc;
 }
 
-int flux_request_unpack (const flux_msg_t *msg, const char **topic,
-                         const char *fmt, ...)
+int flux_request_unpack (const flux_msg_t *msg,
+                         const char **topic,
+                         const char *fmt,
+                         ...)
 {
     va_list ap;
     int rc;
@@ -154,7 +161,8 @@ error:
 }
 
 flux_msg_t *flux_request_encode_raw (const char *topic,
-                                     const void *data, int len)
+                                     const void *data,
+                                     int len)
 {
     flux_msg_t *msg = request_encode (topic);
 

--- a/src/common/libflux/request.h
+++ b/src/common/libflux/request.h
@@ -20,15 +20,18 @@ extern "C" {
  * If s is non-NULL, assign the string payload or set to NULL if none
  * exists.  Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_request_decode (const flux_msg_t *msg, const char **topic,
+int flux_request_decode (const flux_msg_t *msg,
+                         const char **topic,
                          const char **s);
 
 /* Decode a request message with required json payload.  These functions use
  * jansson unpack style variable arguments for decoding the JSON object
  * payload directly.  Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_request_unpack (const flux_msg_t *msg, const char **topic,
-                         const char *fmt, ...);
+int flux_request_unpack (const flux_msg_t *msg,
+                         const char **topic,
+                         const char *fmt,
+                         ...);
 
 /* Decode a request message with optional raw payload.
  * If topic is non-NULL, assign the request topic string.
@@ -36,8 +39,10 @@ int flux_request_unpack (const flux_msg_t *msg, const char **topic,
  * If there is no payload, they will be assigned NULL and zero.
  * Returns 0 on success, or -1 on failure with errno set.
  */
-int flux_request_decode_raw (const flux_msg_t *msg, const char **topic,
-                             const void **data, int *len);
+int flux_request_decode_raw (const flux_msg_t *msg,
+                             const char **topic,
+                             const void **data,
+                             int *len);
 
 /* Encode a request message with optional string payload.
  * If s is non-NULL, assign the string payload.
@@ -49,7 +54,8 @@ flux_msg_t *flux_request_encode (const char *topic, const char *s);
  * Otherwise there will be no payload.
  */
 flux_msg_t *flux_request_encode_raw (const char *topic,
-                                     const void *data, int len);
+                                     const void *data,
+                                     int len);
 
 #ifdef __cplusplus
 }

--- a/src/common/libflux/service.c
+++ b/src/common/libflux/service.c
@@ -19,8 +19,12 @@ flux_future_t *flux_service_register (flux_t *h, const char *name)
         errno = EINVAL;
         return NULL;
     }
-    return flux_rpc_pack (h, "service.add", FLUX_NODEID_ANY, 0,
-                          "{s:s}", "service", name);
+    return flux_rpc_pack (h,
+                          "service.add",
+                          FLUX_NODEID_ANY,
+                          0,
+                          "{s:s}",
+                          "service", name);
 }
 
 flux_future_t *flux_service_unregister (flux_t *h, const char *name)
@@ -29,8 +33,12 @@ flux_future_t *flux_service_unregister (flux_t *h, const char *name)
         errno = EINVAL;
         return NULL;
     }
-    return flux_rpc_pack (h, "service.remove", FLUX_NODEID_ANY, 0,
-                          "{s:s}", "service", name);
+    return flux_rpc_pack (h,
+                          "service.remove",
+                          FLUX_NODEID_ANY,
+                          0,
+                          "{s:s}",
+                          "service", name);
 }
 
 /*

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -26,8 +26,10 @@
 
 static const size_t fdwriter_bufsize = 10*1024*1024;
 
-static void fdwriter (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg)
+static void fdwriter (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
 {
     int fd = flux_fd_watcher_get_fd (w);
     static char *buf = NULL;
@@ -42,9 +44,10 @@ static void fdwriter (flux_reactor_t *r, flux_watcher_t *w,
     }
     if (revents & FLUX_POLLOUT) {
         if ((n = write (fd, buf + count, fdwriter_bufsize - count)) < 0
-                                && errno != EWOULDBLOCK && errno != EAGAIN) {
+            && errno != EWOULDBLOCK && errno != EAGAIN) {
             fprintf (stderr, "%s: write failed: %s\n",
-                     __FUNCTION__, strerror (errno));
+                     __FUNCTION__,
+                     strerror (errno));
             goto error;
         }
         if (n > 0) {
@@ -59,8 +62,10 @@ static void fdwriter (flux_reactor_t *r, flux_watcher_t *w,
 error:
     flux_reactor_stop_error (r);
 }
-static void fdreader (flux_reactor_t *r, flux_watcher_t *w,
-                      int revents, void *arg)
+static void fdreader (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
 {
     int fd = flux_fd_watcher_get_fd (w);
     static char *buf = NULL;
@@ -75,9 +80,10 @@ static void fdreader (flux_reactor_t *r, flux_watcher_t *w,
     }
     if (revents & FLUX_POLLIN) {
         if ((n = read (fd, buf + count, fdwriter_bufsize - count)) < 0
-                            && errno != EWOULDBLOCK && errno != EAGAIN) {
+            && errno != EWOULDBLOCK && errno != EAGAIN) {
             fprintf (stderr, "%s: read failed: %s\n",
-                     __FUNCTION__, strerror (errno));
+                     __FUNCTION__,
+                     strerror (errno));
             goto error;
         }
         if (n > 0) {
@@ -121,8 +127,10 @@ static void test_fd (flux_reactor_t *reactor)
 }
 
 static int repeat_countdown = 10;
-static void repeat (flux_reactor_t *r, flux_watcher_t *w,
-                    int revents, void *arg)
+static void repeat (flux_reactor_t *r,
+                    flux_watcher_t *w,
+                    int revents,
+                    void *arg)
 {
     repeat_countdown--;
     if (repeat_countdown == 0)
@@ -131,8 +139,10 @@ static void repeat (flux_reactor_t *r, flux_watcher_t *w,
 
 static int oneshot_runs = 0;
 static int oneshot_errno = 0;
-static void oneshot (flux_reactor_t *r, flux_watcher_t *w,
-                     int revents, void *arg)
+static void oneshot (flux_reactor_t *r,
+                     flux_watcher_t *w,
+                     int revents,
+                     void *arg)
 {
     oneshot_runs++;
     if (oneshot_errno != 0) {
@@ -221,8 +231,10 @@ static void test_timer (flux_reactor_t *reactor)
 
 /* A reactor callback that immediately stops reactor without error */
 static bool do_stop_callback_ran = false;
-static void do_stop_reactor (flux_reactor_t *r, flux_watcher_t *w,
-                     int revents, void *arg)
+static void do_stop_reactor (flux_reactor_t *r,
+                             flux_watcher_t *w,
+                             int revents,
+                             void *arg)
 {
     do_stop_callback_ran = true;
     flux_reactor_stop (r);
@@ -288,8 +300,12 @@ static void test_periodic (flux_reactor_t *reactor)
     flux_watcher_destroy (w);
 
     repeat_countdown = 5;
-    ok ((w = flux_periodic_watcher_create (reactor, 0.01, 0.01,
-                                           NULL, repeat, NULL)) != NULL,
+    ok ((w = flux_periodic_watcher_create (reactor,
+                                           0.01,
+                                           0.01,
+                                           NULL,
+                                           repeat,
+                                           NULL)) != NULL,
         "periodic: creating 10ms interval works");
     flux_watcher_start (w);
     ok (flux_reactor_run (reactor, 0) == 0,
@@ -307,8 +323,12 @@ static void test_periodic (flux_reactor_t *reactor)
     flux_watcher_stop (w);
     flux_watcher_destroy (w);
 
-    ok ((w = flux_periodic_watcher_create (reactor, 0, 0, resched_cb,
-                                           do_stop_reactor, reactor)) != NULL,
+    ok ((w = flux_periodic_watcher_create (reactor,
+                                           0,
+                                           0,
+                                           resched_cb,
+                                           do_stop_reactor,
+                                           reactor)) != NULL,
         "periodic: creating with resched callback works");
     flux_watcher_start (w);
     ok (flux_reactor_run (reactor, 0) >= 0,
@@ -320,8 +340,12 @@ static void test_periodic (flux_reactor_t *reactor)
     flux_watcher_destroy (w);
 
     do_stop_callback_ran = false;
-    ok ((w = flux_periodic_watcher_create (reactor, 0, 0, resched_cb_negative,
-                                           do_stop_reactor, reactor)) != NULL,
+    ok ((w = flux_periodic_watcher_create (reactor,
+                                           0,
+                                           0,
+                                           resched_cb_negative,
+                                           do_stop_reactor,
+                                           reactor)) != NULL,
         "periodic: create watcher with misconfigured resched callback");
     flux_watcher_start (w);
     ok (flux_reactor_run (reactor, 0) == 0,
@@ -333,8 +357,10 @@ static void test_periodic (flux_reactor_t *reactor)
 }
 
 static int idle_count = 0;
-static void idle_cb (flux_reactor_t *r, flux_watcher_t *w,
-                     int revents, void *arg)
+static void idle_cb (flux_reactor_t *r,
+                     flux_watcher_t *w,
+                     int revents,
+                     void *arg)
 {
     if (++idle_count == 42)
         flux_watcher_stop (w);
@@ -361,22 +387,28 @@ static void test_idle (flux_reactor_t *reactor)
 }
 
 static int prepare_count = 0;
-static void prepare_cb (flux_reactor_t *r, flux_watcher_t *w,
-                        int revents, void *arg)
+static void prepare_cb (flux_reactor_t *r,
+                        flux_watcher_t *w,
+                        int revents,
+                        void *arg)
 {
     prepare_count++;
 }
 
 static int check_count = 0;
-static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
-                      int revents, void *arg)
+static void check_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
 {
     check_count++;
 }
 
 static int prepchecktimer_count = 0;
-static void prepchecktimer_cb (flux_reactor_t *r, flux_watcher_t *w,
-                               int revents, void *arg)
+static void prepchecktimer_cb (flux_reactor_t *r,
+                               flux_watcher_t *w,
+                               int revents,
+                               void *arg)
 {
     if (++prepchecktimer_count == 8)
         flux_reactor_stop (r);
@@ -388,8 +420,11 @@ static void test_prepcheck (flux_reactor_t *reactor)
     flux_watcher_t *prep;
     flux_watcher_t *chk;
 
-    w = flux_timer_watcher_create (reactor, 0.01, 0.01,
-                                   prepchecktimer_cb, NULL);
+    w = flux_timer_watcher_create (reactor,
+                                   0.01,
+                                   0.01,
+                                   prepchecktimer_cb,
+                                   NULL);
     ok (w != NULL,
         "created timer watcher that fires every 0.01s");
     ok (!flux_watcher_is_active (w),
@@ -412,8 +447,10 @@ static void test_prepcheck (flux_reactor_t *reactor)
         "reactor ran successfully");
     ok (prepchecktimer_count == 8,
         "timer fired 8 times, then reactor was stopped");
-    diag ("prep %d check %d timer %d", prepare_count, check_count,
-                                       prepchecktimer_count);
+    diag ("prep %d check %d timer %d",
+          prepare_count,
+          check_count,
+          prepchecktimer_count);
     ok (prepare_count >= 8,
         "prepare watcher ran at least once per timer");
     ok (check_count >= 8,
@@ -425,15 +462,19 @@ static void test_prepcheck (flux_reactor_t *reactor)
 }
 
 static int sigusr1_count = 0;
-static void sigusr1_cb (flux_reactor_t *r, flux_watcher_t *w,
-                        int revents, void *arg)
+static void sigusr1_cb (flux_reactor_t *r,
+                        flux_watcher_t *w,
+                        int revents,
+                        void *arg)
 {
     if (++sigusr1_count == 8)
         flux_reactor_stop (r);
 }
 
-static void sigidle_cb (flux_reactor_t *r, flux_watcher_t *w,
-                        int revents, void *arg)
+static void sigidle_cb (flux_reactor_t *r,
+                        flux_watcher_t *w,
+                        int revents,
+                        void *arg)
 {
     if (kill (getpid (), SIGUSR1) < 0)
         flux_reactor_stop_error (r);
@@ -468,8 +509,10 @@ static void test_signal (flux_reactor_t *reactor)
 }
 
 static pid_t child_pid = -1;
-static void child_cb (flux_reactor_t *r, flux_watcher_t *w,
-                      int revents, void *arg)
+static void child_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
 {
     int pid = flux_child_watcher_get_rpid (w);
     int rstatus = flux_child_watcher_get_rstatus (w);
@@ -521,8 +564,10 @@ struct stat_ctx {
     int stat_nlink;
     enum { STAT_APPEND, STAT_WAIT, STAT_UNLINK } state;
 };
-static void stat_cb (flux_reactor_t *r, flux_watcher_t *w,
-                     int revents, void *arg)
+static void stat_cb (flux_reactor_t *r,
+                     flux_watcher_t *w,
+                     int revents,
+                     void *arg)
 {
     struct stat_ctx *ctx = arg;
     struct stat new, old;
@@ -542,8 +587,10 @@ static void stat_cb (flux_reactor_t *r, flux_watcher_t *w,
     }
 }
 
-static void stattimer_cb (flux_reactor_t *r, flux_watcher_t *w,
-                          int revents, void *arg)
+static void stattimer_cb (flux_reactor_t *r,
+                          flux_watcher_t *w,
+                          int revents,
+                          void *arg)
 {
     struct stat_ctx *ctx = arg;
     if (ctx->state == STAT_APPEND) {
@@ -578,8 +625,11 @@ static void test_stat (flux_reactor_t *reactor)
     ok (flux_watcher_is_active (w),
         "flux_watcher_is_active() returns true after flux_watcher_start()");
 
-    tw = flux_timer_watcher_create (reactor, 0.01, 0.01,
-                                    stattimer_cb, &ctx);
+    tw = flux_timer_watcher_create (reactor,
+                                    0.01,
+                                    0.01,
+                                    stattimer_cb,
+                                    &ctx);
     ok (tw != NULL,
         "created timer watcher");
     flux_watcher_start (tw);

--- a/src/common/libkvs/kvs_dir.c
+++ b/src/common/libkvs/kvs_dir.c
@@ -55,8 +55,10 @@ void flux_kvsdir_destroy (flux_kvsdir_t *dir)
 
 flux_kvsdir_t *flux_kvsdir_copy (const flux_kvsdir_t *dir)
 {
-    return kvsdir_create_fromobj (dir->handle, dir->rootref,
-                                  dir->key, dir->dirobj);
+    return kvsdir_create_fromobj (dir->handle,
+                                  dir->rootref,
+                                  dir->key,
+                                  dir->dirobj);
 }
 
 /* If rootref is non-NULL, the kvsdir records the root reference
@@ -236,8 +238,10 @@ flux_kvsdir_t *kvsdir_create_fromobj (flux_t *handle,
 {
     flux_kvsdir_t *dir = NULL;
 
-    if (!key || !treeobj || treeobj_validate (treeobj) < 0
-                         || !treeobj_is_dir (treeobj)) {
+    if (!key
+        || !treeobj
+        || treeobj_validate (treeobj) < 0
+        || !treeobj_is_dir (treeobj)) {
         errno = EINVAL;
         goto error;
     }

--- a/src/common/libutil/blobref.c
+++ b/src/common/libutil/blobref.c
@@ -46,13 +46,22 @@
 #error BLOBREF_MAX_DIGEST_SIZE is too small
 #endif
 
-static void sha1_hash (const void *data, int data_len, void *hash, int hash_len);
-static void sha256_hash (const void *data, int data_len, void *hash, int hash_len);
+static void sha1_hash (const void *data,
+                       int data_len,
+                       void *hash,
+                       int hash_len);
+static void sha256_hash (const void *data,
+                         int data_len,
+                         void *hash,
+                         int hash_len);
 
 struct blobhash {
     char *name;
     int hashlen;
-    void (*hashfun)(const void *data, int data_len, void *hash, int hash_len);
+    void (*hashfun)(const void *data,
+                    int data_len,
+                    void *hash,
+                    int hash_len);
 };
 
 static struct blobhash blobtab[] = {
@@ -67,7 +76,10 @@ static struct blobhash blobtab[] = {
     { NULL, 0, 0 },
 };
 
-static void sha1_hash (const void *data, int data_len, void *hash, int hash_len)
+static void sha1_hash (const void *data,
+                       int data_len,
+                       void *hash,
+                       int hash_len)
 {
     SHA1_CTX ctx;
 
@@ -77,7 +89,10 @@ static void sha1_hash (const void *data, int data_len, void *hash, int hash_len)
     SHA1_Final (&ctx, hash);
 }
 
-static void sha256_hash (const void *data, int data_len, void *hash, int hash_len)
+static void sha256_hash (const void *data,
+                         int data_len,
+                         void *hash,
+                         int hash_len)
 {
     SHA256_CTX ctx;
 
@@ -136,8 +151,10 @@ inval:
 }
 
 static int hashtostr (struct blobhash *bh,
-                      const void *hash, int len,
-                      char *blobref, int blobref_len)
+                      const void *hash,
+                      int len,
+                      char *blobref,
+                      int blobref_len)
 {
     int offset;
 
@@ -157,8 +174,10 @@ inval:
 }
 
 int blobref_hashtostr (const char *hashtype,
-                       const void *hash, int len,
-                       void *blobref, int blobref_len)
+                       const void *hash,
+                       int len,
+                       void *blobref,
+                       int blobref_len)
 {
     struct blobhash *bh;
 
@@ -171,8 +190,10 @@ int blobref_hashtostr (const char *hashtype,
 
 
 int blobref_hash (const char *hashtype,
-                  const void *data, int len,
-                  void *blobref, int blobref_len)
+                  const void *data,
+                  int len,
+                  void *blobref,
+                  int blobref_len)
 {
     struct blobhash *bh;
     uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
@@ -186,8 +207,10 @@ int blobref_hash (const char *hashtype,
 }
 
 int blobref_hash_raw (const char *hashtype,
-                      const void *data, int len,
-                      void *hash, int hash_len)
+                      const void *data,
+                      int len,
+                      void *hash,
+                      int hash_len)
 {
     struct blobhash *bh;
 

--- a/src/common/libutil/blobref.h
+++ b/src/common/libutil/blobref.h
@@ -27,24 +27,30 @@ int blobref_strtohash (const char *blobref, void *hash, int size);
  * Returns 0 on success, -1 on error, with errno set.
  */
 int blobref_hashtostr (const char *hashtype,
-                       const void *hash, int len,
-                       void *blobref, int blobref_len);
+                       const void *hash,
+                       int len,
+                       void *blobref,
+                       int blobref_len);
 
 /* Compute hash over data and return null-terminated blobref string in
  * 'blobref'.  The hash algorithm is selected by 'hashtype', e.g. "sha1".
  * Returns 0 on success, -1 on error with errno set.
  */
 int blobref_hash (const char *hashtype,
-                  const void *data, int len,
-                  void *blobref, int blobref_len);
+                  const void *data,
+                  int len,
+                  void *blobref,
+                  int blobref_len);
 
 /* Compute hash over data and store it in 'hash'.
  * The hash algorithm is selected by 'hashtype', e.g. "sha1".
  * Returns hash size on success, -1 on error with errno set.
  */
 int blobref_hash_raw (const char *hashtype,
-                      const void *data, int len,
-                      void *hash, int hash_len);
+                      const void *data,
+                      int len,
+                      void *hash,
+                      int hash_len);
 
 /* Check validity of blobref string.
  */


### PR DESCRIPTION
Problem: some older code violates RFC 7 whitespace guidelines.

Break long parameter lists to one per line.

This chunk of whitespace cleanup was peeled off of #6467