### PR TITLE
resource: only read `resource.scheduling` config on rank 0

### DIFF
--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -116,7 +116,10 @@ static int parse_config (struct resource_ctx *ctx,
             return -1;
         }
     }
-    if (scheduling_path) {
+    /* resource.scheduling key, if configured, is only required on rank 0,
+     * since by definition it is used only by the scheduler.
+     */
+    if (scheduling_path && ctx->rank == 0) {
         json_t *scheduling;
         json_error_t e;
         if (!o) {


### PR DESCRIPTION
Problem: The Rv1 scheduling key as JGF can be large and time-consuming to generate and distribute, but currently it is required on all nodes. Since the key is really only used by the scheduler on rank 0, it would be ideal resource.scheduling was only read on rank 0.

Only process the resource.scheduling config key on rank 0.

Fixes #6480