### PR TITLE
add `flux.conf_builtin.conf_builtin_get()` to give Python access to compiled-in config values

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -11,6 +11,7 @@ nobase_fluxpy_PYTHON = \
 	memoized_property.py \
 	debugged.py \
 	importer.py \
+	conf_builtin.py \
 	cli/__init__.py \
 	cli/base.py \
 	cli/alloc.py \

--- a/src/bindings/python/flux/conf_builtin.py
+++ b/src/bindings/python/flux/conf_builtin.py
@@ -1,0 +1,64 @@
+###############################################################
+# Copyright 2024 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import threading
+from pathlib import Path
+
+from flux.core.inner import raw
+
+tls = threading.local()
+tls.FLUX_CONF_AUTO_FLAG = None
+
+
+def _conf_builtin_get_flag():
+    """Simulate the use of FLUX_CONF_AUTO for Python
+
+    FLUX_CONF_AUTO will not work from Python since the executable will
+    be python and not something part of the Flux build tree or installed
+    by Flux. This function simulates FLUX_CONF_AUTO by returning the
+    correct FLUX_CONF_FLAG based on whether this module is under the
+    in tree PYTHONPATH or not.
+    """
+    if tls.FLUX_CONF_AUTO_FLAG is None:
+        # Resolve builtin installed python path:
+        pythonpath = conf_builtin_get("python_path", which="intree").split(":")
+        for path in pythonpath:
+            if Path(path).resolve() in Path(__file__).resolve().parents:
+                # If path is one of this module's parents,
+                # then this module is in tree:
+                tls.FLUX_CONF_AUTO_FLAG = raw.FLUX_CONF_INTREE
+                return tls.FLUX_CONF_AUTO_FLAG
+        # O/w, assume we're installed
+        tls.FLUX_CONF_AUTO_FLAG = raw.FLUX_CONF_INSTALLED
+    return tls.FLUX_CONF_AUTO_FLAG
+
+
+def conf_builtin_get(name, which="auto"):
+    """Get builtin (compiled-in) configuration values from libflux
+
+    Args:
+        name (str): name of config value
+        which (str): one of "installed", "intree", or "auto" to return
+            the installed path, in tree path, or automatically determine
+            which to use. default=auto.
+    """
+    if which == "auto":
+        flag = _conf_builtin_get_flag()
+    elif which == "installed":
+        flag = raw.FLUX_CONF_INSTALLED
+    elif which == "intree":
+        flag = raw.FLUX_CONF_INTREE
+    else:
+        raise ValueError("which must be one of auto, installed, or intree")
+
+    try:
+        return raw.flux_conf_builtin_get(name, flag).decode("utf-8")
+    except OSError:
+        raise ValueError(f"No builtin config value for '{name}'")

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -48,6 +48,11 @@ static const char *conf_auxkey = "flux::conf_object";
 
 static struct builtin builtin_tab[] = {
     {
+        .key = "confdir",
+        .val_installed = FLUXCONFDIR,
+        .val_intree = ABS_TOP_SRCDIR "/etc",
+    },
+    {
         .key = "lua_cpath_add",
         .val_installed = LUAEXECDIR "/?.so",
         .val_intree = ABS_TOP_BUILDDIR "/src/bindings/lua/?.so",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -288,6 +288,7 @@ TESTSCRIPTS = \
 	python/t0028-compat36.py \
 	python/t0029-fileref.py \
 	python/t0030-journal.py \
+	python/t0031-conf-builtin.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0031-conf-builtin.py
+++ b/t/python/t0031-conf-builtin.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2024 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+
+import subflux  # noqa: F401
+from flux.conf_builtin import conf_builtin_get
+from pycotap import TAPTestRunner
+
+
+class TestConfBuiltin(unittest.TestCase):
+
+    def test_conf_builtin_get(self):
+        with self.assertRaises(ValueError):
+            conf_builtin_get("foo")
+
+        with self.assertRaises(ValueError):
+            conf_builtin_get("confdir", which="badarg")
+
+        self.assertIsNotNone(conf_builtin_get("confdir"))
+        self.assertIsNotNone(conf_builtin_get("confdir", which="intree"))
+        self.assertIsNotNone(conf_builtin_get("confdir", which="installed"))
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
Currently, Python programs have no way to query libflux for compiled-in config values, but this could be useful if they want to find the current config directory. This could possibly be derived from broker attributes, but in some cases the broker attributes could be set to nothing, so this is not ideal.

Calling in to `flux_conf_builtin_get()` with `FLUX_CONF_AUTO`  using ffi doesn't work, because the "executable" for Python programs is always going to be a `python` binary installed in the system (or elsewhere), so the libflux intree detection doesn't work.

This PR introduces a wrapper for `flux_conf_builtin_get()` for Python that reimplements intree detection using the path to module itself compared to the intree python_path.

Since the motivating use case is to determine the current appropriate Flux confdir from a Python program, this PR also adds a new builtin config key `confdir` for this purpose.
