### PR TITLE
shell: ignore SIGPIPE

### DIFF
--- a/src/shell/signals.c
+++ b/src/shell/signals.c
@@ -16,6 +16,7 @@
  * SIGINT  - forward to all local tasks
  * SIGTERM - forward
  * SIGALRM - forward
+ * SIGPIPE - ignore
  *
  * Notes:
  *
@@ -82,6 +83,9 @@ static int signals_init (flux_plugin_t *p,
         || trap_signal (shell, SIGTERM) < 0
         || trap_signal (shell, SIGALRM) < 0)
         shell_log_errno ("failed to set up signal watchers");
+
+    /* ignore SIGPIPE */
+    signal (SIGPIPE, SIG_IGN);
     return 0;
 }
 


### PR DESCRIPTION
This PR fixes #6487 by ignoring `SIGPIPE` in the job shell.

At attempt at adding a test was made, but the test is inherently racy, because if the data is sent from the shell to the task before stdin is actually closed, the issue wouldn't reproduce (and also there's no way to synchronize on the job shell actually writing the data to the task, so the job could get canceled before any data is written) However, it seem sufficient for now.