### PR TITLE
build: use -Wl,--gc-sections when appropriate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -166,6 +166,20 @@ AC_PATH_PROGS(SSH, [rsh ssh], [/usr/bin/rsh])
 AC_DEFINE_UNQUOTED([PATH_SSH], "$SSH",
           [Define remote shell program to be used by the ssh:// connector])
 
+# macos linker doesn't support --gc-sections
+saved_LDFLAGS="$LDFLAGS"
+LDFLAGS="-Wl,--gc-sections $LDFLAGS"
+AC_MSG_CHECKING([whether ld supports --gc-sections])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([])], [
+  AC_MSG_RESULT([yes])
+  ld_gc_sections="-Wl,--gc-sections"
+  AS_VAR_SET(ld_gc_sections, $ld_gc_sections)
+  AC_SUBST(ld_gc_sections)
+  ],[
+  AC_MSG_RESULT([no])
+])
+LDFLAGS=$saved_LDFLAGS
+
 LT_INIT
 AC_PROG_AWK
 


### PR DESCRIPTION
Problem: libflux-optparse.so has unresolved jansson symbols on focal.

A recent macos portability change dropped the linker option to garbage collect unused sections, resulting in unresolved json_* symbols in libflux-optparse.so from libmissing.la on focal.

The change, introduced in flux-framework/flux-core#6476, was supposed to set a make variable $ld_gc_sections when that option is available, but the change was incomplete and the variable was never set.

Add the missing configure logic.

Confirmed:
- json_ symbols are no longer unresolved in libflux-optparse.so on focal
- macos still builds, and json_ symbols do not appear there

Fixes #6496