### PR TITLE
ci: add macos builder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,22 @@ jobs:
         cd flux-pam &&
         src/test/docker/docker-run-checks.sh -j 4 -i el8
 
+  build-macos:
+    needs: [python-lint]
+    name: macos build only
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - name: Install dependencies
+      run: scripts/install-deps-macos.sh
+    - name: autogen, configure
+      run: scripts/configure-macos.sh
+    - name: make, including test programs
+      run: make check -j4 TESTS=
+
   generate-matrix:
     # https://stackoverflow.com/questions/59977364
     name: Generate build matrix

--- a/src/common/libsdexec/test/start.c
+++ b/src/common/libsdexec/test/start.c
@@ -21,6 +21,8 @@
 #include "src/common/libutil/jpath.h"
 #include "start.h"
 
+extern char **environ;
+
 void test_inval (void)
 {
     char *av[] = { "/bin/ls", NULL };

--- a/src/modules/job-manager/test/kill.c
+++ b/src/modules/job-manager/test/kill.c
@@ -26,8 +26,8 @@ int main (int argc, char **argv)
         "kill_check_signal signum=SIGKILL works");
     ok (kill_check_signal (-1) < 0,
         "kill_check_signal signum=-1 fails");
-    ok (kill_check_signal (SIGRTMAX + 1) < 0,
-        "kill_check_signal signum=SIGRTMAX+1 fails");
+    ok (kill_check_signal (NSIG) < 0,
+        "kill_check_signal signum=NSIG fails");
 
     done_testing ();
 

--- a/src/modules/kvs/test/cache.c
+++ b/src/modules/kvs/test/cache.c
@@ -14,6 +14,10 @@
 #include <stdbool.h>
 #include <jansson.h>
 
+#ifndef EBADE
+#define EBADE EINVAL
+#endif
+
 #include "src/common/libkvs/treeobj.h"
 #include "src/common/libutil/tstat.h"
 #include "src/common/libtap/tap.h"


### PR DESCRIPTION
Problem: recent macos portability fixes are not being tested

Add a macos builder that just runs `make check TESTS=` to build all the code.

It doesn't run any tests because we are not there yet
- #6485

Fix a couple minor compilation issues that were missed before.