### PR TITLE
job-info: avoid error response on failed rpc

### DIFF
--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -706,9 +706,9 @@ static int main_namespace_lookup (struct guest_watch_ctx *gw)
         goto error;
 
     if (!(gw->main_namespace_lookup_f = flux_rpc_message (gw->ctx->h,
-                                                         msg,
-                                                         FLUX_NODEID_ANY,
-                                                         0))) {
+                                                          msg,
+                                                          FLUX_NODEID_ANY,
+                                                          0))) {
         flux_log_error (gw->ctx->h, "%s: flux_rpc_message", __FUNCTION__);
         goto error;
     }


### PR DESCRIPTION
Problem: Common usage in flux-core is to not respond with an RPC error
(such as through flux_respond_error()) if a prior RPC attempt fails (such
as through flux_respond_pack()).  This pattern is violated in several
places in job-info.

Solution: If flux_respond_pack() fails, do not call flux_respond_error()
in error handling paths.

Fixes #6498