### PR TITLE
fix handling of `\n` in submission cli `--add-file=` option

### DIFF
--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -969,7 +969,10 @@ class MiniCmd:
 
     def handle_add_file_arg(self, jobspec, arg):
         """Process a single argument to --add-file=ARG."""
-        name, _, data = arg.partition("=")
+        #  Note: Replace any newline escaped by the shell with literal '\n'
+        #  so that newline detection below works for file data passed on
+        #  on the command line:
+        name, _, data = arg.replace("\\n", "\n").partition("=")
         if not data:
             # No '=' implies path-only argument (no multiline allowed)
             if "\n" in name:

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -967,6 +967,20 @@ class MiniCmd:
         """
         raise NotImplementedError()
 
+    def handle_add_file_arg(self, jobspec, arg):
+        """Process a single argument to --add-file=ARG."""
+        name, _, data = arg.partition("=")
+        if not data:
+            # No '=' implies path-only argument (no multiline allowed)
+            if "\n" in name:
+                raise ValueError("--add-file: file name missing")
+            data = name
+            name = basename(data)
+        try:
+            jobspec.add_file(name, data)
+        except (TypeError, ValueError, OSError) as exc:
+            raise ValueError(f"--add-file={arg}: {exc}") from None
+
     # pylint: disable=too-many-branches,too-many-statements
     def jobspec_create(self, args):
         """
@@ -1081,17 +1095,7 @@ class MiniCmd:
 
         if args.add_file is not None:
             for arg in args.add_file:
-                name, _, data = arg.partition("=")
-                if not data:
-                    # No '=' implies path-only argument (no multiline allowed)
-                    if "\n" in name:
-                        raise ValueError("--add-file: file name missing")
-                    data = name
-                    name = basename(data)
-                try:
-                    jobspec.add_file(name, data)
-                except (TypeError, ValueError, OSError) as exc:
-                    raise ValueError(f"--add-file={arg}: {exc}") from None
+                self.handle_add_file_arg(jobspec, arg)
 
         return jobspec
 

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -526,7 +526,7 @@ class Jobspec(object):
             raise TypeError("data must be a Mapping or string")
 
         files = self.jobspec["attributes"]["system"].get("files", {})
-        if "\n" in data and encoding is None:
+        if encoding is None and "\n" in data:
             #  Use default encoding of utf-8 if data contains newlines,
             #  since this is presumed to be file content.
             encoding = "utf-8"

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -335,6 +335,11 @@ test_expect_success 'flux submit --add-file=name=file works' '
 		cp {{tmpdir}}/myfile . &&
 	test_cmp file.txt myfile
 '
+test_expect_success 'flux submit --add-file=name=data works' '
+	flux submit -n1 --watch --add-file=add-file.test="this is a test\n" \
+		cp {{tmpdir}}/add-file.test . &&
+	grep "this is a test" add-file.test
+'
 test_expect_success 'flux submit --add-file complains for non-regular files' '
 	test_must_fail flux submit -n1 --add-file=/tmp hostname
 '


### PR DESCRIPTION
This PR fixes a small bug in the submission cli `--add-file=[NAME=]DATA` option. The option is documented to allow file data on the command line if `DATA` contains a `\n`. However, any `\n` passed on the command line ends up quoted, so this doesn't actually work:
```console
$ flux submit --add-file=test='this is a test\n' hostname
flux-submit: ERROR: --add-file=test=this is a test\n: [Errno 2] No such file or directory: 'this is a test\\n'
```

This PR just unescapes in newlines in `DATA` so that newline detection works (and the newlines appear as newlines in the resulting fileref data).

