### PR TITLE
support specification of file permissions in `--add-file` submission option

### DIFF
--- a/doc/man1/common/job-other-options.rst
+++ b/doc/man1/common/job-other-options.rst
@@ -58,20 +58,22 @@
    character, then VAL is interpreted as a file, which must be valid JSON,
    to use as the attribute value.
 
-.. option:: --add-file=[NAME=]ARG
+.. option:: --add-file=[NAME[:PERMS]=]ARG
 
    Add a file to the RFC 37 file archive in jobspec before submission. Both
    the file metadata and content are stored in the archive, so modification
    or deletion of a file after being processed by this option will have no
-   effect on the job. If no ``NAME`` is provided, then ``ARG`` is assumed to
-   be the path to a local file and the basename of the file will be used as
-   ``NAME``.  Otherwise, if ``ARG`` contains a newline, then it is assumed
-   to be the raw file data to encode. The file will be extracted by the
-   job shell into the job temporary directory and may be referenced as
-   ``{{tmpdir}}/NAME`` on the command line, or ``$FLUX_JOB_TMPDIR/NAME``
-   in a batch script.  This option may be specified multiple times to
-   encode multiple files.  Note: As documented in RFC 14, the file names
-   ``script`` and ``conf.json`` are both reserved.
+   effect on the job. If no ``NAME`` is provided, then ``ARG`` is assumed
+   to be the path to a local file and the basename of the file will be
+   used as ``NAME``.  Otherwise, if ``ARG`` contains a newline, then it
+   is assumed to be the raw file data to encode. If ``PERMS`` is provided
+   and is a valid octal integer, then this will override the default file
+   permissions of 0600.  The file will be extracted by the job shell into
+   the job temporary directory and may be referenced as ``{{tmpdir}}/NAME``
+   on the command line, or ``$FLUX_JOB_TMPDIR/NAME`` in a batch script.
+   This option may be specified multiple times to encode multiple files.
+   Note: As documented in RFC 14, the file names ``script`` and ``conf.json``
+   are both reserved.
 
    .. note::
       This option should only be used for small files such as program input

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -503,7 +503,7 @@ class Jobspec(object):
         self.setattr_shell_option("{}.{}.type".format(iotype, stream_name), "file")
         self.setattr_shell_option("{}.{}.path".format(iotype, stream_name), path)
 
-    def add_file(self, path, data, perms=0o0600, encoding=None):
+    def add_file(self, path, data, perms=None, encoding=None):
         """
         Add a file to the RFC 14 "files" dictionary in Jobspec. If
         ``data`` contains newlines or an encoding is explicitly provided,
@@ -524,6 +524,9 @@ class Jobspec(object):
         """
         if not (isinstance(data, abc.Mapping) or isinstance(data, str)):
             raise TypeError("data must be a Mapping or string")
+
+        if perms is None:
+            perms = 0o600
 
         files = self.jobspec["attributes"]["system"].get("files", {})
         if encoding is None and "\n" in data:

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -340,6 +340,15 @@ test_expect_success 'flux submit --add-file=name=data works' '
 		cp {{tmpdir}}/add-file.test . &&
 	grep "this is a test" add-file.test
 '
+test_expect_success 'flux submit --add-file=name:perms=data works' '
+	flux submit -n1 --watch --add-file=test:0700="#!/bin/sh\ntrue\n" \
+		{{tmpdir}}/test
+'
+test_expect_success 'flux submit --add-file allows colon in name' '
+	flux submit -n1 --watch --add-file=add-file:test="this is a test\n" \
+		cp {{tmpdir}}/add-file:test . &&
+	grep "this is a test" add-file:test
+'
 test_expect_success 'flux submit --add-file complains for non-regular files' '
 	test_must_fail flux submit -n1 --add-file=/tmp hostname
 '


### PR DESCRIPTION
This PR adds support for specifying file permissions in the `--add-file` option in Flux submission command. (Presently, all files added with content directly provided on the command like get the default permissions of 0600)

Example:
```
$ flux submit --add-file=test:700='#!/bin/sh\ntrue\n' -n1 {{tmpdir}}/test
```