### PR TITLE
allow mustache templates in job environment variables

### DIFF
--- a/doc/man1/common/job-env-rules.rst
+++ b/doc/man1/common/job-env-rules.rst
@@ -31,8 +31,13 @@ via a set of *RULE* expressions. The currently supported rules are
      * Advanced parameter substitution is not allowed, e.g. ``${var:-foo}``
        will raise an error.
 
+   ``VAL`` may also contain a mustache template, in which case the template
+   will be substituted in the job shell with the corresponding value before
+   launching job tasks. See `MUSTACHE TEMPLATES`_ for more information.
+
    Examples:
-       ``PATH=/bin``, ``PATH=$PATH:/bin``, ``FOO=${BAR}something``
+       ``PATH=/bin``, ``PATH=$PATH:/bin``, ``FOO=${BAR}something``,
+       ``PATH=${PATH}:/{{tmpdir}}/bin``
 
  * Otherwise, the rule is considered a pattern from which to match
    variables from the process environment if they do not exist in

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -99,7 +99,8 @@ flux_shell_SOURCES = \
 	signal.c \
 	files.c \
 	hwloc.c \
-	rexec.c
+	rexec.c \
+	env-expand.c
 
 if HAVE_INOTIFY
 flux_shell_SOURCES += oom.c

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -56,6 +56,7 @@ extern struct shell_builtin builtin_signal;
 extern struct shell_builtin builtin_oom;
 extern struct shell_builtin builtin_hwloc;
 extern struct shell_builtin builtin_rexec;
+extern struct shell_builtin builtin_env_expand;
 
 static struct shell_builtin * builtins [] = {
     &builtin_tmpdir,
@@ -86,6 +87,7 @@ static struct shell_builtin * builtins [] = {
 #endif
     &builtin_hwloc,
     &builtin_rexec,
+    &builtin_env_expand,
     &builtin_list_end,
 };
 

--- a/src/shell/env-expand.c
+++ b/src/shell/env-expand.c
@@ -1,0 +1,113 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#define FLUX_SHELL_PLUGIN_NAME "env-expand"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <jansson.h>
+
+#include <flux/shell.h>
+
+#include "builtins.h"
+
+static int env_expand (flux_plugin_t *p,
+                       const char *topic,
+                       flux_plugin_arg_t *args,
+                       void *data)
+{
+    json_t *to_expand = NULL;
+    json_t *value;
+    void *tmp;
+    const char *key;
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+
+    if (!(shell = flux_plugin_get_shell (p)))
+        return shell_log_errno ("unable to get shell handle");
+    if (flux_shell_getopt_unpack (shell, "env-expand", "o", &to_expand) != 1)
+        return 0;
+    json_object_foreach_safe (to_expand, tmp, key, value) {
+        const char *s = json_string_value (value);
+        char *result;
+        if (s == NULL) {
+            shell_log_error ("invalid value for env var %s", key);
+            continue;
+        }
+        result = flux_shell_mustache_render (shell, s);
+
+        /*  If mustache render was successful, then set it for the job and
+         *  remove the key from the env-expand object internally, so it isn't
+         *  expanded again in task_env_expand():
+         */
+        if (result && !strstr (result, "{{")) {
+            if (flux_shell_setenvf (shell, 1, key, "%s", result) < 0)
+                shell_log_errno ("failed to set %s=%s", key, result);
+            else
+                (void) json_object_del (to_expand, key);
+        }
+        free (result);
+    }
+    return 0;
+}
+
+/* Per-task environment variable mustache substitution.
+ * N.B.: Only templates that were not fully rendered by env_expand() above
+ * should remain in the `env-expand` shell options object.
+ */
+static int task_env_expand (flux_plugin_t *p,
+                            const char *topic,
+                            flux_plugin_arg_t *args,
+                            void *data)
+{
+    json_t *to_expand = NULL;
+    json_t *value;
+    const char *key;
+    flux_shell_t *shell;
+    flux_shell_task_t *task;
+    flux_cmd_t *cmd;
+
+    if (!(shell = flux_plugin_get_shell (p)))
+        return shell_log_errno ("unable to get shell handle");
+    if (flux_shell_getopt_unpack (shell, "env-expand", "o", &to_expand) != 1)
+        return 0;
+
+    if (!(task = flux_shell_current_task (shell))
+        || !(cmd = flux_shell_task_cmd (task)))
+        return -1;
+
+    json_object_foreach (to_expand, key, value) {
+        const char *s = json_string_value (value);
+        char *result;
+        if (s == NULL) {
+            shell_log_error ("invalid value for env var %s", key);
+            continue;
+        }
+        if (!(result = flux_shell_mustache_render (shell, s))) {
+            shell_log_errno ("failed to expand env var %s=%s", key, s);
+            continue;
+        }
+        if (flux_cmd_setenvf (cmd, 1, key, "%s", result) < 0)
+            shell_log_errno ("failed to set %s=%s", key, result);
+        free (result);
+    }
+    return 0;
+}
+
+struct shell_builtin builtin_env_expand = {
+    .name = FLUX_SHELL_PLUGIN_NAME,
+    .init = env_expand,
+    .task_init = task_env_expand,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t2620-job-shell-mustache.t
+++ b/t/t2620-job-shell-mustache.t
@@ -45,5 +45,18 @@ test_expect_success 'mustache: unsupported tag is left alone' '
 	test_debug "cat output.4" &&
 	test "$(cat output.4)" = "{{foo}} {{node.foo}} {{task.foo}}"
 '
-
+test_expect_success 'mustache: mustache templates can be rendered in env' '
+	flux run --env=TEST={{tmpdir}} -N2 \
+		sh -c "test \$TEST = \$FLUX_JOB_TMPDIR"
+'
+test_expect_success 'mustache: env variables can have per-task tags' '
+	flux run --env=TEST={{taskid}} -N2 -n4 \
+		sh -c "test \$TEST = \$FLUX_TASK_RANK" &&
+	flux run --env=T1={{size}} --env=T2={{taskid}} -N2 -n4 \
+		sh -c "test \$T1 -eq 4 -a \$T2 = \$FLUX_TASK_RANK"
+'
+test_expect_success 'mustache: invalid tags in env vars are left unexpanded' '
+	flux run --env=TEST={{task.foo}} \
+		sh -c "test \$TEST = {{task.foo}}"
+'
 test_done


### PR DESCRIPTION
The job shell expands mustache templates for input/output filenames as well as in command arguments. It would also be useful to support this template expansion in environment variables, but currently this is not supported. It probably isn't efficient to wholesale expand mustache templates in all environment variables, since the common case would be no variables to expand. Also, some environment variables may happen to contain mustache templates which should not be expanded.

This PR introduces a new `env-expand` shell builtin plugin which applies mustache expansion to any environment variables in a new `env-expand` shell options key in jobspec.

On the cli side, the `get_filtered_environment()` function is extended to look for environment variable values specified on the command line and pass these back in a dictionary separate from the main environment. This dictionary is then saved in the `attributes.system.shell.options.env-expand` key for use by the shell plugin.

This means that only environment variables specified on the command line or in a file as `VAR=TEMPLATE` where `TEMPLATE` contains `{{}}` will be expanded. Variables in the environment that already do contain `{{}}` pass through the normal environment dictionary unmodified. Additionally, the `env-expand` shell plugin only has to process the minimum number of variables.

This is a WIP so I can get feedback on the approach before writing tests.

The current use case here is to place files in the job's tmpdir and set environment variables in the job to point to these files, e.g. to extend rc1:

```
flux alloc --add-file=rc1.d/rc1:700=`#!/bin/sh\nflux exec dosomething` --env=FLUX_RC_EXTRA={{tmpdir}}
```