### PR TITLE
testsuite: don't assume /bin/true and /bin/false

### DIFF
--- a/src/broker/test/runat.c
+++ b/src/broker/test/runat.c
@@ -78,8 +78,8 @@ void basic (flux_t *h)
         "runat_is_defined name=test1 returns false");
     ok (runat_is_completed (r, "test1") == false,
         "runat_is_completed name=test1 returns false");
-    ok (runat_push_shell_command (r, "test1", "/bin/true", 0) == 0
-        && runat_push_shell_command (r, "test1", "/bin/true", 0) == 0,
+    ok (runat_push_shell_command (r, "test1", "true", 0) == 0
+        && runat_push_shell_command (r, "test1", "true", 0) == 0,
         "pushed true;true");
     ok (runat_is_defined (r, "test1") == true,
         "runat_is_defined name=test1 returns true after creation");
@@ -101,8 +101,8 @@ void basic (flux_t *h)
 
     /* run false;true */
     clear_list (logs);
-    ok (runat_push_shell_command (r, "test2", "/bin/true", 0) == 0
-        && runat_push_shell_command (r, "test2", "/bin/false", 0) == 0,
+    ok (runat_push_shell_command (r, "test2", "true", 0) == 0
+        && runat_push_shell_command (r, "test2", "false", 0) == 0,
         "pushed true;true");
     ok (runat_start (r, "test2", test_completion, &ctx) == 0,
         "runat_start works");
@@ -119,8 +119,8 @@ void basic (flux_t *h)
 
     /* run true;false */
     clear_list (logs);
-    ok (runat_push_command (r, "test3", "/bin/false", 11, 0) == 0
-        && runat_push_command (r, "test3", "/bin/true", 10, 0) == 0,
+    ok (runat_push_command (r, "test3", "false", 6, 0) == 0
+        && runat_push_command (r, "test3", "true", 5, 0) == 0,
         "pushed true;true");
     ok (runat_start (r, "test3", test_completion, &ctx) == 0,
         "runat_start works");
@@ -221,9 +221,9 @@ void basic (flux_t *h)
 #if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 24)
     flags |= RUNAT_FLAG_FORK_EXEC;
 #endif
-    ok (runat_push_shell_command (r, "test7", "/bin/true", flags) == 0
+    ok (runat_push_shell_command (r, "test7", "true", flags) == 0
             && runat_push_shell_command (r, "test7", "sleep 3600", flags) == 0,
-        "pushed /bin/true;sleep 3600");
+        "pushed true;sleep 3600");
     ok (runat_start (r, "test7", test_completion, &ctx) == 0,
         "runat_start works");
     ok (runat_abort (r, "test7") == 0,

--- a/src/common/libsubprocess/test/channel.c
+++ b/src/common/libsubprocess/test/channel.c
@@ -384,7 +384,7 @@ void channel_nul_terminate_cb (flux_subprocess_t *p, const char *stream)
 
 void test_bufsize (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
 
@@ -427,7 +427,7 @@ void test_bufsize (flux_reactor_t *r)
 
 void test_bufsize_error (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
     flux_subprocess_ops_t ops = {

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -58,7 +58,7 @@ extern char **environ;
 
 void corner_case_test (flux_t *h)
 {
-    char *true_av[] = { "/bin/true", NULL };
+    char *true_av[] = { "true", NULL };
     flux_subprocess_t *p;
     flux_cmd_t *cmd;
 
@@ -243,7 +243,7 @@ void simple_test (flux_t *h)
 {
     struct simple_scorecard exp;
 
-    char *true_av[] = { "/bin/true", NULL };
+    char *true_av[] = { "true", NULL };
     memset (&exp, 0, sizeof (exp));
     exp.running = 1;
     exp.exited = 1;
@@ -251,12 +251,12 @@ void simple_test (flux_t *h)
     exp.stdout_eof = 1;
     exp.stderr_eof = 1;
     simple_run_check (h,
-                      "/bin/true",
+                      "true",
                       ARRAY_SIZE (true_av) - 1,
                       true_av,
                       &exp);
 
-    char *false_av[] = { "/bin/false", NULL };
+    char *false_av[] = { "false", NULL };
     memset (&exp, 0, sizeof (exp));
     exp.running = 1;
     exp.exited = 1;
@@ -265,7 +265,7 @@ void simple_test (flux_t *h)
     exp.stdout_eof = 1;
     exp.stderr_eof = 1;
     simple_run_check (h,
-                      "/bin/false",
+                      "false",
                       ARRAY_SIZE (false_av) - 1,
                       false_av,
                       &exp);

--- a/src/common/libsubprocess/test/stdio.c
+++ b/src/common/libsubprocess/test/stdio.c
@@ -1085,7 +1085,7 @@ void test_line_buffer_disable (flux_reactor_t *r)
 
 void test_line_buffer_error (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
 

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -68,7 +68,7 @@ void completion_cb (flux_subprocess_t *p)
 void test_corner_cases (flux_reactor_t *r)
 {
     flux_t *h = NULL;
-    char *avgood[] = { "/bin/true", NULL };
+    char *avgood[] = { "true", NULL };
     char *avbad[] = { NULL };
     flux_cmd_t *cmd;
 
@@ -106,7 +106,7 @@ void test_corner_cases (flux_reactor_t *r)
     flux_cmd_destroy (cmd);
 
     ok ((cmd = flux_cmd_create (1, avgood, NULL)) != NULL,
-        "flux_cmd_create with /bin/true works");
+        "flux_cmd_create with true works");
     ok (flux_rexec (h, -10, 0, cmd, NULL) == NULL
         && errno == EINVAL,
         "flux_rexec fails with cmd with invalid rank");
@@ -174,7 +174,7 @@ void test_corner_cases (flux_reactor_t *r)
         "flux_subprocess_aux_get fails with NULL pointer input");
 
     ok ((cmd = flux_cmd_create (1, avgood, NULL)) != NULL,
-        "flux_cmd_create with /bin/true works");
+        "flux_cmd_create with true works");
     ok (flux_local_exec (r,
                          FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF,
                          cmd,
@@ -188,7 +188,7 @@ void test_corner_cases (flux_reactor_t *r)
 
 void test_post_exec_errors (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
 
@@ -256,7 +256,7 @@ void test_post_exec_errors (flux_reactor_t *r)
 
 void test_basic (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd, *cmd2;
     flux_reactor_t *r2;
     flux_subprocess_t *p = NULL;
@@ -301,7 +301,7 @@ void completion_fail_cb (flux_subprocess_t *p)
 
 void test_basic_fail (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/false", NULL };
+    char *av[] = { "false", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
 
@@ -326,7 +326,7 @@ void test_basic_fail (flux_reactor_t *r)
 
 void test_flag_no_setpgrp (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
 
@@ -351,7 +351,7 @@ void test_flag_no_setpgrp (flux_reactor_t *r)
 
 void test_flag_fork_exec (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
 
@@ -651,7 +651,7 @@ void state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 
 void test_state_change (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
 
@@ -771,7 +771,7 @@ void test_exec_fail (flux_reactor_t *r)
 
 void test_context (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
     char *extra = "mydata";
@@ -804,7 +804,7 @@ void test_context (flux_reactor_t *r)
 
 void test_refcount (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
     char *extra = "mydata";
@@ -849,7 +849,7 @@ void shmem_hook_cb (flux_subprocess_t *p, void *arg)
 
 void test_pre_exec_hook (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
     int *shmem_count;
@@ -900,7 +900,7 @@ void count_hook_cb (flux_subprocess_t *p, void *arg)
 
 void test_post_fork_hook (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd;
     flux_subprocess_t *p = NULL;
     int hook_count = 0;
@@ -940,7 +940,7 @@ void destroy_in_completion_cb (flux_subprocess_t *p)
 
 void test_destroy_in_completion (flux_reactor_t *r)
 {
-    char *av[] = { "/bin/true", NULL };
+    char *av[] = { "true", NULL };
     flux_cmd_t *cmd, *cmd2;
     flux_reactor_t *r2;
     flux_subprocess_t *p = NULL;

--- a/src/common/libutil/test/popen2.c
+++ b/src/common/libutil/test/popen2.c
@@ -97,8 +97,8 @@ int main(int argc, char** argv)
         "popen2 /noexist failed with ENOENT");
 
     /* open/close (child exit error) */
-    ok ((p = popen2 ("/bin/false", (char*[]){ "/bin/false", NULL }, 0)) != NULL,
-        "popen2 /bin/false OK");
+    ok ((p = popen2 ("false", (char*[]){ "false", NULL }, 0)) != NULL,
+        "popen2 false OK");
     ok (pclose2 (p) == 0x100,
         "pclose2 returns child exit code 1");
 

--- a/t/issues/t4465-job-list-use-after-free.sh
+++ b/t/issues/t4465-job-list-use-after-free.sh
@@ -23,7 +23,7 @@ mkdir ${STATEDIR}
 # number of broker ranks.
 #
 flux start --test-size=8 -Sstatedir=${STATEDIR} \
-    bash -c "flux submit --cc 1-8 --quiet /bin/true && flux queue drain"
+    bash -c "flux submit --cc 1-8 --quiet true && flux queue drain"
 
 flux start --test-size=1 -Sstatedir=${STATEDIR} \
     --wrap=libtool,e,${VALGRIND} \

--- a/t/issues/t4852-t_submit-legacy.sh
+++ b/t/issues/t4852-t_submit-legacy.sh
@@ -7,7 +7,7 @@
 cat <<-EOF >t4852setup.sh
 #!/bin/sh -e
 
-jobid=\$(flux submit --wait /bin/true)
+jobid=\$(flux submit --wait true)
 
 kvspath=\$(flux job id --to=kvs \$jobid)
 

--- a/t/issues/t5308-kvsdir-initial-path.py
+++ b/t/issues/t5308-kvsdir-initial-path.py
@@ -9,7 +9,7 @@ import flux.job
 from flux.job import JobspecV1
 
 handle = flux.Flux()
-jobspec = JobspecV1.from_command(command=["/bin/true"], num_tasks=1, num_nodes=1)
+jobspec = JobspecV1.from_command(command=["true"], num_tasks=1, num_nodes=1)
 jobid = flux.job.submit(handle, jobspec, waitable=True)
 flux.job.wait(handle, jobid=jobid)
 jobdir = flux.job.job_kvs(handle, jobid)

--- a/t/job-manager/submit-sliding-window.py
+++ b/t/job-manager/submit-sliding-window.py
@@ -29,7 +29,7 @@ if len(sys.argv) == 3:
 # Open connection to broker
 h = flux.Flux()
 
-jobspec = JobspecV1.from_command(["/bin/true"])
+jobspec = JobspecV1.from_command(["true"])
 done = 0
 running = 0
 

--- a/t/job-manager/submit-wait.py
+++ b/t/job-manager/submit-wait.py
@@ -27,16 +27,16 @@ else:
 h = flux.Flux()
 
 # Submit njobs test jobs (half will fail)
-jobspec = JobspecV1.from_command(["/bin/true"])
-jobspec_fail = JobspecV1.from_command(["/bin/false"])
+jobspec = JobspecV1.from_command(["true"])
+jobspec_fail = JobspecV1.from_command(["false"])
 jobs = []
 for i in range(njobs):
     if i < njobs / 2:
         jobid = job.submit(h, jobspec, waitable=True)
-        print("submit: {} /bin/true".format(jobid))
+        print("submit: {} true".format(jobid))
     else:
         jobid = job.submit(h, jobspec_fail, waitable=True)
-        print("submit: {} /bin/false".format(jobid))
+        print("submit: {} false".format(jobid))
     jobs.append(jobid)
 
 # Wait for each job in turn

--- a/t/job-manager/submit-waitany.py
+++ b/t/job-manager/submit-waitany.py
@@ -27,15 +27,15 @@ else:
 h = flux.Flux()
 
 # Submit njobs test jobs (half will fail)
-jobspec = JobspecV1.from_command(["/bin/true"])
-jobspec_fail = JobspecV1.from_command(["/bin/false"])
+jobspec = JobspecV1.from_command(["true"])
+jobspec_fail = JobspecV1.from_command(["false"])
 for i in range(njobs):
     if i < njobs / 2:
         jobid = job.submit(h, jobspec, waitable=True)
-        print("submit: {} /bin/true".format(jobid))
+        print("submit: {} true".format(jobid))
     else:
         jobid = job.submit(h, jobspec_fail, waitable=True)
-        print("submit: {} /bin/false".format(jobid))
+        print("submit: {} false".format(jobid))
 
 
 # Wait for njobs jobs

--- a/t/job-manager/wait-interrupted.py
+++ b/t/job-manager/wait-interrupted.py
@@ -28,11 +28,11 @@ else:
 h = flux.Flux()
 
 # Submit njobs test jobs
-jobspec = JobspecV1.from_command(["/bin/true"])
+jobspec = JobspecV1.from_command(["true"])
 jobs = []
 for i in range(njobs):
     jobid = job.submit(h, jobspec, waitable=True)
-    print("submit: {} /bin/true".format(jobid))
+    print("submit: {} true".format(jobid))
     jobs.append(jobid)
 
 # Async wait which we immediately abandon

--- a/t/system/0004-recovery.t
+++ b/t/system/0004-recovery.t
@@ -6,16 +6,16 @@ test_expect_success 'dump the last checkpoint' '
         sudo -u flux flux dump --checkpoint /tmp/dump.tar
 '
 test_expect_success 'flux start --recover fails when instance is running' '
-	test_must_fail sudo -u flux flux start --recover /bin/true
+	test_must_fail sudo -u flux flux start --recover true
 '
 test_expect_success 'stop the system instance' '
 	sudo flux shutdown
 '
 test_expect_success 'flux start --recover works' '
-	sudo -u flux flux start --recover /bin/true
+	sudo -u flux flux start --recover true
 '
 test_expect_success 'flux start --recover works from dump file' '
-	sudo -u flux flux start --recover=/tmp/dump.tar --sysconfig /bin/true
+	sudo -u flux flux start --recover=/tmp/dump.tar --sysconfig true
 '
 test_expect_success 'restart flux' '
         sudo systemctl start flux

--- a/t/system/0005-exec.t
+++ b/t/system/0005-exec.t
@@ -7,16 +7,16 @@ test_expect_success 'start a long-running guest job' '
 	jobid=$(flux job last)
 '
 test_expect_success 'flux exec --jobid fails as guest' '
-	test_must_fail flux exec --jobid=$jobid /bin/true
+	test_must_fail flux exec --jobid=$jobid true
 '
 test_expect_success 'flux exec --jobid fails as instance owner' '
-	test_must_fail sudo -u flux flux exec --jobid=$jobid /bin/true
+	test_must_fail sudo -u flux flux exec --jobid=$jobid true
 '
 test_expect_success 'flux exec without --jobid works as instance owner' '
-	sudo -u flux flux exec -r 0 /bin/true
+	sudo -u flux flux exec -r 0 true
 '
 test_expect_success 'flux exec without --jobid fails as guest' '
-	test_must_fail flux exec -r 0 /bin/true
+	test_must_fail flux exec -r 0 true
 '
 test_expect_success 'cancel long-running job' '
 	flux cancel $jobid

--- a/t/t0000-sharness.t
+++ b/t/t0000-sharness.t
@@ -461,7 +461,7 @@ test_expect_success 'empty sharness.d directory does not cause failure' '
 		test_description="sharness works"
 		. ./sharness.sh
 		test_expect_success "test success" "
-			/bin/true
+			true
 		"
 		test_done
 		EOF

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -39,7 +39,7 @@ test_expect_success 'run_timeout works' '
 	test_expect_code 142 run_timeout -s ALRM 0.001 sleep 2
 '
 test_expect_success 'test run_timeout with success' '
-	run_timeout 1 /bin/true
+	run_timeout 1 true
 '
 test_expect_success 'run_timeout fails if exec fails' '
 	test_must_fail run_timeout 1 /nonexistent/executable
@@ -177,7 +177,7 @@ test_expect_success 'or forced by setting FLUX_PMI_CLIENT_METHODS' "
 "
 test_expect_success 'start fails when broker.boot-method=unknown' "
 	test_must_fail flux start ${ARGS} -Sbroker.boot-method=unknown \
-		/bin/true
+		true
 "
 test_expect_success 'flux-start in subprocess/pmi mode works (size 2)' "
 	flux start ${ARGS} -s2 flux getattr size | grep -x 2
@@ -195,10 +195,10 @@ test_expect_success 'flux-start with size 2 has rank 1 peer' '
 	test_cmp child2.exp child2.out
 '
 test_expect_success 'flux-start fails with unknown option' "
-	test_must_fail flux start ${ARGS} --unknown /bin/true
+	test_must_fail flux start ${ARGS} --unknown true
 "
 test_expect_success 'flux-start fails with --verbose=badopt' "
-	test_must_fail flux start ${ARGS} --verbose=badopt /bin/true
+	test_must_fail flux start ${ARGS} --verbose=badopt true
 "
 test_expect_success 'create bad broker shell script' '
 	cat >flux-broker <<-EOT &&
@@ -207,7 +207,7 @@ test_expect_success 'create bad broker shell script' '
 	chmod +x flux-broker
 '
 test_expect_success 'flux-start exec fails on bad broker shell script' "
-	test_must_fail bash -c 'FLUX_EXEC_PATH_PREPEND=. flux start /bin/true'
+	test_must_fail bash -c 'FLUX_EXEC_PATH_PREPEND=. flux start true'
 "
 test_expect_success 'flux-start test exec fails on bad broker shell script' "
 	#
@@ -215,10 +215,10 @@ test_expect_success 'flux-start test exec fails on bad broker shell script' "
 	# might fail with exit code 127, which test_must_fail does not
 	# accept, so we use ! here since any failure is acceptable here
 	#
-	! bash -c 'FLUX_EXEC_PATH_PREPEND=. flux start -s1 /bin/true'
+	! bash -c 'FLUX_EXEC_PATH_PREPEND=. flux start -s1 true'
 "
 test_expect_success 'flux-start -s1 works' "
-	flux start ${ARGS} -s1 /bin/true
+	flux start ${ARGS} -s1 true
 "
 test_expect_success 'flux-start -s1 sets broker.mapping to expected value' "
 	cat >mapping_1.exp <<-EOT &&
@@ -228,72 +228,72 @@ test_expect_success 'flux-start -s1 sets broker.mapping to expected value' "
 	test_cmp mapping_1.exp mapping_1.out
 "
 test_expect_success 'flux-start --test-rundir without --test-size fails' "
-	test_must_fail flux start ${ARGS} --test-rundir=$(pwd) /bin/true
+	test_must_fail flux start ${ARGS} --test-rundir=$(pwd) true
 "
 test_expect_success 'flux-start --test-pmi-clique without --test-size fails' "
-	test_must_fail flux start ${ARGS} --test-pmi-clique=none /bin/true
+	test_must_fail flux start ${ARGS} --test-pmi-clique=none true
 "
 test_expect_success 'flux-start --test-hosts without --test-size fails' "
-	test_must_fail flux start ${ARGS} --test-hosts=foo /bin/true
+	test_must_fail flux start ${ARGS} --test-hosts=foo true
 "
 test_expect_success 'flux-start --test-hosts with insufficient hosts fails' "
-	test_must_fail flux start ${ARGS} -s2 --test-hosts=foo /bin/true
+	test_must_fail flux start ${ARGS} -s2 --test-hosts=foo true
 "
 test_expect_success 'flux-start --test-hosts with garbled hosts fails' "
-	test_must_fail flux start ${ARGS} -s2 --test-hosts=foo] /bin/true
+	test_must_fail flux start ${ARGS} -s2 --test-hosts=foo] true
 "
 test_expect_success 'flux-start --test-exit-timeout without --test-size fails' "
-	test_must_fail flux start ${ARGS} --test-exit-timeout=10s /bin/true
+	test_must_fail flux start ${ARGS} --test-exit-timeout=10s true
 "
 test_expect_success 'flux-start --test-exit-timeout fails with bad FSD' "
-	test_must_fail flux start ${ARGS} -s1 --test-exit-timeout=-1 /bin/true
+	test_must_fail flux start ${ARGS} -s1 --test-exit-timeout=-1 true
 "
 test_expect_success 'flux-start --test-exit-mode without --test-size fails' "
-	test_must_fail flux start ${ARGS} --test-exit-mode=any /bin/true
+	test_must_fail flux start ${ARGS} --test-exit-mode=any true
 "
 test_expect_success 'flux-start --test-exit-mode=leader is accepted' "
-	flux start ${ARGS} -s1 --test-exit-mode=leader /bin/true
+	flux start ${ARGS} -s1 --test-exit-mode=leader true
 "
 test_expect_success 'flux-start --test-exit-mode=badmode fails' "
-	test_must_fail flux start ${ARGS} -s1 --test-exit-mode=badmode /bin/true
+	test_must_fail flux start ${ARGS} -s1 --test-exit-mode=badmode true
 "
 test_expect_success 'flux-start --test-start-mode without --test-size fails' "
-	test_must_fail flux start ${ARGS} --test-start-mode=all /bin/true
+	test_must_fail flux start ${ARGS} --test-start-mode=all true
 "
 test_expect_success 'flux-start --test-start-mode=all is accepted' "
-	flux start ${ARGS} -s1 --test-start-mode=all /bin/true
+	flux start ${ARGS} -s1 --test-start-mode=all true
 "
 test_expect_success 'flux-start --test-start-mode=badmode fails' "
-	test_must_fail flux start ${ARGS} -s1 --test-start-mode=badmode /bin/true
+	test_must_fail flux start ${ARGS} -s1 --test-start-mode=badmode true
 "
 test_expect_success 'flux-start --test-rundir-cleanup without --test-size fails' "
-	test_must_fail flux start ${ARGS} --test-rundir-cleanup /bin/true
+	test_must_fail flux start ${ARGS} --test-rundir-cleanup true
 "
 test_expect_success 'flux-start --verbose=2 enables PMI tracing' "
 	flux start ${ARGS} \
 		--test-size=1 --verbose=2 \
-		/bin/true 2>&1 | grep pmi_version
+		true 2>&1 | grep pmi_version
 "
 test_expect_success 'flux-start -vv also does' "
 	flux start ${ARGS} \
 		--test-size=1 -vv \
-		/bin/true 2>&1 | grep pmi_version
+		true 2>&1 | grep pmi_version
 "
 test_expect_success 'flux-start --test-pmi-clique=single works' "
 	flux start ${ARGS} \
 		--test-size=1 \
 		--test-pmi-clique=single \
-		/bin/true
+		true
 "
 test_expect_success 'flux-start --test-pmi-clique=none works' "
 	flux start ${ARGS} --test-size=1 \
 		--test-pmi-clique=single \
-		/bin/true
+		true
 "
 test_expect_success 'flux-start --test-pmi-clique=badmode fails' "
 	test_must_fail flux start ${ARGS} --test-size=1 \
 		--test-pmi-clique=badmode \
-		/bin/true 2>badmode.err &&
+		true 2>badmode.err &&
 	grep unsupported badmode.err
 "
 test_expect_success 'flux-start embedded server works from initial program' "
@@ -311,10 +311,10 @@ test_expect_success 'flux-start embedded server logs disconnect notification' "
 	grep 'disconnect from' startctl.err
 "
 test_expect_success 'flux-start in exec mode passes through errors from command' "
-	test_must_fail flux start ${ARGS} /bin/false
+	test_must_fail flux start ${ARGS} false
 "
 test_expect_success 'flux-start in subprocess/pmi mode passes through errors from command' "
-	test_must_fail flux start ${ARGS} -s1 /bin/false
+	test_must_fail flux start ${ARGS} -s1 false
 "
 test_expect_success 'flux-start in exec mode passes exit code due to signal' "
 	test_expect_code 130 flux start ${ARGS} 'kill -INT \$\$'
@@ -336,10 +336,10 @@ test_expect_success 'flux-start in subprocess/pmi mode works as initial program'
 test_expect_success 'flux-start works with non-errexit clean BASH_ENV' '
 	cat >testbashrc <<-EOT &&
 	command -v ls >/dev/null || :
-	/bin/false
-	/bin/true
+	false
+	true
 	EOT
-	BASH_ENV=testbashrc flux start /bin/true
+	BASH_ENV=testbashrc flux start true
 '
 
 test_expect_success 'flux-start works with multiple files in rc1.d' '
@@ -383,7 +383,7 @@ test_expect_success 'flux-start dies gracefully when run from removed dir' '
 	mkdir foo && (
 	 cd foo &&
 	 rmdir ../foo &&
-	 test_must_fail flux start /bin/true )
+	 test_must_fail flux start true )
 '
 
 command -v hwloc-ls >/dev/null && test_set_prereq HWLOC_LS
@@ -484,14 +484,14 @@ test_expect_success 'flux start --test-rundir --test-rundir-cleanup works' '
 test_expect_success 'flux start --test-rundir with missing directory fails' '
 	test_must_fail flux start ${ARGS} --test-size=1 \
 		--test-rundir=/noexist \
-		/bin/true 2>noexist_rundir.err &&
+		true 2>noexist_rundir.err &&
 	grep "/noexist: No such file or directory" noexist_rundir.err
 '
 test_expect_success 'flux start --test-rundir with not-directory fails' '
 	touch notdir &&
 	test_must_fail flux start ${ARGS} --test-size=1 \
 		--test-rundir=notdir \
-		/bin/true 2>notdir_rundir.err &&
+		true 2>notdir_rundir.err &&
 	grep "notdir: not a directory" notdir_rundir.err
 '
 test_expect_success 'rundir override works' '
@@ -509,30 +509,30 @@ test_expect_success 'rundir override creates nonexistent dirs and cleans up' '
 '
 test_expect_success 'broker fails gracefully when rundir buffer overflows' '
 	longstring=$(head -c 1024 < /dev/zero | tr \\0 D) &&
-	! TMPDIR=$longstring flux start ${ARGS} /bin/true 2>overflow.err &&
+	! TMPDIR=$longstring flux start ${ARGS} true 2>overflow.err &&
 	grep overflow overflow.err
 '
 test_expect_success 'broker fails gracefully on nonexistent TMPDIR' '
-	! TMPDIR=/noexist flux start ${ARGS} /bin/true 2>noexist.err &&
+	! TMPDIR=/noexist flux start ${ARGS} true 2>noexist.err &&
 	grep "cannot create directory in /noexist" noexist.err
 '
 test_expect_success 'broker fails gracefully on non-directory rundir' '
 	touch notdir &&
 	test_must_fail flux start ${ARGS} -Srundir=notdir \
-		/bin/true 2>notdir.err &&
+		true 2>notdir.err &&
 	grep "Not a directory" notdir.err
 '
 test_expect_success 'broker fails gracefully on unwriteable rundir' '
 	mkdir -p privdir &&
 	chmod u-w privdir &&
 	test_must_fail flux start ${ARGS} -Srundir=privdir \
-		/bin/true 2>privdir.err &&
+		true 2>privdir.err &&
 	grep "permissions" privdir.err
 '
 # statedir created here is reused in the next several tests
 test_expect_success 'broker statedir is not cleaned up' '
 	mkdir -p statedir &&
-	flux start ${ARGS} -Sstatedir=$(pwd)/statedir /bin/true &&
+	flux start ${ARGS} -Sstatedir=$(pwd)/statedir true &&
 	test -d statedir
 '
 test_expect_success 'broker statedir cannot be changed at runtime' '
@@ -548,7 +548,7 @@ test_expect_success 'broker statedir cannot be set at runtime' '
 test_expect_success 'broker fails when statedir does not exist' '
 	rm -rf statedir &&
 	test_must_fail flux start ${ARGS} -Sstatedir=$(pwd)/statedir \
-		/bin/true 2>nostatedir.err &&
+		true 2>nostatedir.err &&
 	grep "cannot stat" nostatedir.err
 '
 # Use -eq hack to test that BROKERPID is a number
@@ -570,25 +570,25 @@ test_expect_success 'local-uri override works' '
 '
 test_expect_success 'broker fails gracefully when local-uri is malformed' '
 	test_must_fail flux start ${ARGS} -Slocal-uri=baduri \
-		/bin/true 2>baduri.err &&
+		true 2>baduri.err &&
 	grep malformed baduri.err
 '
 test_expect_success 'broker fails gracefully when local-uri buffer overflows' '
 	longuri="local://$(head -c 1024 < /dev/zero | tr \\0 D)" &&
 	test_must_fail flux start ${ARGS} -Slocal-uri=${longuri} \
-		/bin/true 2>longuri.err &&
+		true 2>longuri.err &&
 	grep "buffer overflow" longuri.err
 '
 test_expect_success 'broker fails gracefully when local-uri in missing dir' '
 	test_must_fail flux start ${ARGS} -Slocal-uri=local:///noexist/x \
-		/bin/true 2>nodiruri.err &&
+		true 2>nodiruri.err &&
 	grep "cannot stat" nodiruri.err
 '
 test_expect_success 'broker fails gracefully when local-uri in non-dir' '
 	touch urinotdir &&
 	test_must_fail flux start ${ARGS} \
 		-Slocal-uri=local://$(pwd)/urinotdir/x \
-		/bin/true 2>urinotdir.err &&
+		true 2>urinotdir.err &&
 	grep "Not a directory" urinotdir.err
 '
 test_expect_success 'broker fails gracefully when local-uri in unwritable dir' '
@@ -596,20 +596,20 @@ test_expect_success 'broker fails gracefully when local-uri in unwritable dir' '
 	chmod u-w privdir &&
 	test_must_fail flux start ${ARGS} \
 		-Slocal-uri=local://$(pwd)/privdir/x \
-		/bin/true 2>uriprivdir.err &&
+		true 2>uriprivdir.err &&
 	grep "permissions" uriprivdir.err
 '
 test_expect_success 'broker broker.pid attribute is immutable' '
 	test_must_fail flux start ${ARGS} --setattr=broker.pid=1234 flux getattr broker.pid
 '
 test_expect_success 'broker --verbose option works' '
-	flux start ${ARGS} -o,-v /bin/true
+	flux start ${ARGS} -o,-v true
 '
 test_expect_success 'broker fails on invalid broker.critical-ranks option' '
 	test_must_fail flux start ${ARGS} -Sbroker.critical-ranks=0-1
 '
 test_expect_success 'broker fails on unknown option' '
-	test_must_fail flux start ${ARGS} -o,--not-an-option /bin/true
+	test_must_fail flux start ${ARGS} -o,--not-an-option true
 '
 test_expect_success 'flux-help command list can be extended' '
 	mkdir help.d &&
@@ -733,7 +733,7 @@ test_expect_success 'setting rundir to a long directory fails (#3925)' '
 	mkdir -p $longdir &&
 	test_must_fail flux start ${ARGS} \
 		-Srundir=$longdir \
-		/bin/true 2>longrun.err &&
+		true 2>longrun.err &&
 	grep "exceeds max" longrun.err
 '
 
@@ -742,7 +742,7 @@ test_expect_success 'setting local-uri to a long path fails (#3925)' '
 	mkdir -p $longdir &&
 	test_must_fail flux start ${ARGS} \
 		-Slocal-uri=local://$longdir/local-0 \
-		/bin/true 2>longuri.err &&
+		true 2>longuri.err &&
 	grep "exceeds max" longuri.err
 '
 

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -18,19 +18,19 @@ invalid_rank() {
 TMPDIR=$(cd /tmp && $(which pwd))
 
 test_expect_success 'basic exec functionality' '
-	flux exec -n /bin/true
+	flux exec -n true
 '
 
 test_expect_success 'exec to specific rank' '
-	flux exec -n -r 0 /bin/true
+	flux exec -n -r 0 true
 '
 
 test_expect_success 'exec to "all" ranks' '
-	flux exec -n -r all /bin/true
+	flux exec -n -r all true
 '
 
 test_expect_success 'exec to subset of ranks' '
-	flux exec -n -r 2-3 /bin/true
+	flux exec -n -r 2-3 true
 '
 
 test_expect_success 'exec to all except a set of ranks' '
@@ -50,7 +50,7 @@ test_expect_success 'configure access.allow-guest-user = true' '
 	EOT
 '
 test_expect_success 'exec to rank 0 from another rank is an error' '
-	test_must_fail flux exec -n -r 1 flux exec -n -r 0 /bin/true
+	test_must_fail flux exec -n -r 1 flux exec -n -r 0 true
 '
 test_expect_success 'configure access.allow-guest-user = false' '
 	flux config load <<-EOT
@@ -58,19 +58,19 @@ test_expect_success 'configure access.allow-guest-user = false' '
 	EOT
 '
 test_expect_success 'exec to rank 0 from another rank works' '
-	flux exec -n -r 1 flux exec -n -r 0 /bin/true
+	flux exec -n -r 1 flux exec -n -r 0 true
 '
 
 test_expect_success 'exec to non-existent rank is an error' '
-	test_must_fail flux exec -n -r $(invalid_rank) /bin/true
+	test_must_fail flux exec -n -r $(invalid_rank) true
 '
 
 test_expect_success 'exec to empty idset is an error' '
-	test_must_fail flux exec -n -r 0-1 -x 0-1 /bin/true
+	test_must_fail flux exec -n -r 0-1 -x 0-1 true
 '
 
 test_expect_success 'test_on_rank works' '
-	test_on_rank 1 /bin/true
+	test_on_rank 1 true
 '
 
 test_expect_success 'test_on_rank sends to correct rank' '

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -16,11 +16,11 @@ rexec_script="flux python ${SHARNESS_TEST_SRCDIR}/scripts/rexec.py"
 rexec="${FLUX_BUILD_DIR}/t/rexec/rexec"
 
 test_expect_success 'basic rexec functionality (process success)' '
-	$rexec /bin/true
+	$rexec true
 '
 
 test_expect_success 'basic rexec functionality (process fail)' '
-	! $rexec /bin/false
+	! $rexec false
 '
 
 test_expect_success 'basic rexec - cwd correct' '
@@ -57,7 +57,7 @@ test_expect_success 'basic rexec functionality (echo stdout/err)' '
 '
 
 test_expect_success 'basic rexec invalid rank' '
-	test_must_fail $rexec -r 32 /bin/true > output 2>&1 &&
+	test_must_fail $rexec -r 32 true > output 2>&1 &&
 	grep -q "$(strerror_symbol EHOSTUNREACH)" output
 '
 
@@ -77,14 +77,14 @@ test_expect_success 'basic rexec fail exec() ENOENT' '
 '
 
 test_expect_success 'basic rexec propagates exit code()' '
-	test_expect_code 0 $rexec /bin/true &&
-	test_expect_code 1 $rexec /bin/false &&
+	test_expect_code 0 $rexec true &&
+	test_expect_code 1 $rexec false &&
 	test_expect_code 2 $rexec sh -c "exit 2" &&
 	test_expect_code 3 $rexec sh -c "exit 3"
 '
 
 test_expect_success 'basic rexec functionality (check state changes)' '
-	$rexec -s /bin/true > output &&
+	$rexec -s true > output &&
 	echo "Running" > expected &&
 	echo "Exited" >> expected &&
 	test_cmp expected output
@@ -253,13 +253,13 @@ test_expect_success 'get URI for rank 1 and check that it works' '
 	test $(FLUX_URI=$(cat uri1) flux getattr rank) -eq 1
 '
 test_expect_success 'rexec from rank 0 to rank 1 works' '
-	$rexec -r 0 /bin/true
+	$rexec -r 0 true
 '
 test_expect_success 'rexec from rank 1 to rank 1 works' '
-	(FLUX_URI=$(cat uri1) $rexec -r 1 /bin/true)
+	(FLUX_URI=$(cat uri1) $rexec -r 1 true)
 '
 test_expect_success 'rexec from rank 1 to rank 0 is restricted' '
-	(FLUX_URI=$(cat uri1) test_must_fail $rexec -r 0 /bin/true)
+	(FLUX_URI=$(cat uri1) test_must_fail $rexec -r 0 true)
 '
 
 test_expect_success NO_CHAIN_LINT 'ps, kill work locally on rank 0' '
@@ -288,7 +288,7 @@ test_expect_success 'configure access.allow-guest-user = false' '
 	EOT
 '
 test_expect_success 'rexec from rank 1 to rank 0 works' '
-	(FLUX_URI=$(cat uri1) $rexec -r 0 /bin/true)
+	(FLUX_URI=$(cat uri1) $rexec -r 0 true)
 '
 
 test_expect_success NO_CHAIN_LINT 'kill fails with ESRCH when pid is unknown' '

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -443,7 +443,7 @@ test_expect_success 'module load fails with corrupt database' '
 	test_must_fail load_module_xfail
 '
 test_expect_success 'full instance start fails corrupt database' '
-	test_must_fail flux start -Sstatedir=$(pwd) /bin/true
+	test_must_fail flux start -Sstatedir=$(pwd) true
 '
 
 test_expect_success 'flux module stats content-sqlite is open to guests' '

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -66,7 +66,7 @@ test_expect_success 'FLUX_CONF_DIR also works to specify config dir' '
 '
 
 test_expect_success 'flux broker fails with specified config directory missing' "
-	test_must_fail flux broker ${ARGS} -c noexist /bin/true
+	test_must_fail flux broker ${ARGS} -c noexist true
 "
 
 test_expect_success 'broker fails with invalid TOML' '
@@ -75,7 +75,7 @@ test_expect_success 'broker fails with invalid TOML' '
 	[bootstrap]
 	bad-toml
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf1 /bin/true
+	test_must_fail flux broker ${ARGS} -c conf1 true
 '
 
 test_expect_success 'broker fails with invalid TOML file' '
@@ -83,7 +83,7 @@ test_expect_success 'broker fails with invalid TOML file' '
 	[bootstrap]
 	bad-toml
 	EOT
-	test_must_fail flux broker ${ARGS} -c invalid.toml /bin/true
+	test_must_fail flux broker ${ARGS} -c invalid.toml true
 '
 #
 # [bootstrap] tests
@@ -98,7 +98,7 @@ test_expect_success '[bootstrap] config with bad hosts array' '
 	[bootstrap]
 	hosts = 42
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf3 /bin/true
+	test_must_fail flux broker ${ARGS} -c conf3 true
 '
 
 test_expect_success '[bootstrap] config with bad hosts array element' '
@@ -109,7 +109,7 @@ test_expect_success '[bootstrap] config with bad hosts array element' '
 	    42
 	]
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf4 /bin/true
+	test_must_fail flux broker ${ARGS} -c conf4 true
 '
 
 test_expect_success '[bootstrap] config with hosts array element with extra key' '
@@ -120,7 +120,7 @@ test_expect_success '[bootstrap] config with hosts array element with extra key'
 	    { host = "xyz", extrakey = 42 },
 	]
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf4a /bin/true
+	test_must_fail flux broker ${ARGS} -c conf4a true
 '
 
 test_expect_success '[bootstrap] config with hosts array element missing host' '
@@ -131,7 +131,7 @@ test_expect_success '[bootstrap] config with hosts array element missing host' '
 	    { },
 	]
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf4b /bin/true
+	test_must_fail flux broker ${ARGS} -c conf4b true
 '
 
 test_expect_success '[bootstrap] config with bad hostlist' '
@@ -142,7 +142,7 @@ test_expect_success '[bootstrap] config with bad hostlist' '
 	    { host = "foo[0-254}" },
 	]
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf4c /bin/true
+	test_must_fail flux broker ${ARGS} -c conf4c true
 '
 
 test_expect_success '[bootstrap] config with with unknown parent' '
@@ -154,7 +154,7 @@ test_expect_success '[bootstrap] config with with unknown parent' '
 	]
 	EOT
 	test_must_fail flux start --test-size=1 --test-hosts=fake0 \
-	    -c conf4d /bin/true
+	    -c conf4d true
 '
 
 test_expect_success '[bootstrap] config with with impossible parent' '
@@ -166,7 +166,7 @@ test_expect_success '[bootstrap] config with with impossible parent' '
 	]
 	EOT
 	test_must_fail flux start --test-size=1 --test-hosts=fake0 \
-	    -c conf4e /bin/true
+	    -c conf4e true
 '
 
 test_expect_success '[bootstrap] config with hostname not found' '
@@ -179,7 +179,7 @@ test_expect_success '[bootstrap] config with hostname not found' '
 	    { host = "matchnobody" },
 	]
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf5 /bin/true
+	test_must_fail flux broker ${ARGS} -c conf5 true
 '
 
 test_expect_success '[bootstrap] hosts array can be missing' '
@@ -345,7 +345,7 @@ test_expect_success '[bootstrap] curve_cert is required for size > 1' '
 	    { host = "foo2" }
 	]
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf10 /bin/true
+	test_must_fail flux broker ${ARGS} -c conf10 true
 '
 
 test_expect_success '[bootstrap] curve_cert must exist' '
@@ -354,7 +354,7 @@ test_expect_success '[bootstrap] curve_cert must exist' '
 	[bootstrap]
 	curve_cert = "conf11/cert"
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf11 /bin/true
+	test_must_fail flux broker ${ARGS} -c conf11 true
 '
 
 test_expect_success '[bootstrap] curve_cert file must contain valid cert' '
@@ -365,7 +365,7 @@ test_expect_success '[bootstrap] curve_cert file must contain valid cert' '
 	[bootstrap]
 	curve_cert = "conf12/cert"
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf12 /bin/true
+	test_must_fail flux broker ${ARGS} -c conf12 true
 '
 
 test_expect_success '[bootstrap] curve_cert file must be mode g-r' '
@@ -376,7 +376,7 @@ test_expect_success '[bootstrap] curve_cert file must be mode g-r' '
 	[bootstrap]
 	curve_cert = "conf13/cert"
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf13 /bin/true
+	test_must_fail flux broker ${ARGS} -c conf13 true
 '
 
 test_expect_success '[bootstrap] curve_cert file must be mode o-r' '
@@ -387,7 +387,7 @@ test_expect_success '[bootstrap] curve_cert file must be mode o-r' '
 	[bootstrap]
 	curve_cert = "conf14/cert"
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf14 /bin/true
+	test_must_fail flux broker ${ARGS} -c conf14 true
 '
 
 #
@@ -427,7 +427,7 @@ test_expect_success MAXRT 'tbon.tcp_user_timeout command line overrides config' 
 test_expect_success MAXRT 'tbon.tcp_user_timeout with bad FSD on command line fails' '
 	test_must_fail flux broker ${ARGS} \
 		-Stbon.tcp_user_timeout=zzz \
-		/bin/true 2>badattr.err &&
+		true 2>badattr.err &&
 	grep "Error parsing" badattr.err
 '
 test_expect_success MAXRT 'tbon.tcp_user_timeout with bad FSD configured fails' '
@@ -437,7 +437,7 @@ test_expect_success MAXRT 'tbon.tcp_user_timeout with bad FSD configured fails' 
 	tcp_user_timeout = 42
 	EOT
 	test_must_fail flux broker ${ARGS} -c conf16 \
-		/bin/true 2>badconf.err &&
+		true 2>badconf.err &&
 	grep "Config file error" badconf.err
 '
 test_expect_success NOMAXRT 'tbon.tcp_user_timeout config cannot be set with old zeromq' '
@@ -447,13 +447,13 @@ test_expect_success NOMAXRT 'tbon.tcp_user_timeout config cannot be set with old
 	tcp_user_timeout = "30s"
 	EOT
 	test_must_fail flux broker ${ARGS} -c conf17 \
-		/bin/true 2>noconf.err &&
+		true 2>noconf.err &&
 	grep "unsupported by this zeromq version" noconf.err
 '
 test_expect_success NOMAXRT 'tbon.tcp_user_timeout attr cannot be set with old zeromq' '
 	test_must_fail flux broker ${ARGS} \
 		-Stbon.tcp_user_timeout=30s \
-		/bin/true 2>noattr.err &&
+		true 2>noattr.err &&
 	grep "unsupported by this zeromq version" noattr.err
 '
 
@@ -481,7 +481,7 @@ test_expect_success 'tbon.zmqdebug can be configured' '
 test_expect_success MAXRT 'tbon.zmqdebug with bad value on command line fails' '
 	test_must_fail flux broker ${ARGS} \
 		-Stbon.zmqdebug=zzz \
-		/bin/true 2>zbadattr.err &&
+		true 2>zbadattr.err &&
 	grep "value must be an integer" zbadattr.err
 '
 test_expect_success MAXRT 'tbon.zmqdebug configured with wrong type fails' '
@@ -491,7 +491,7 @@ test_expect_success MAXRT 'tbon.zmqdebug configured with wrong type fails' '
 	zmqdebug = "notint"
 	EOT
 	test_must_fail flux broker ${ARGS} -c conf19 \
-		/bin/true 2>zbadconf.err &&
+		true 2>zbadconf.err &&
 	grep "Expected integer" zbadconf.err
 '
 test_expect_success MAXRT 'tbon.zmqdebug configured with wrong type fails' '
@@ -501,7 +501,7 @@ test_expect_success MAXRT 'tbon.zmqdebug configured with wrong type fails' '
 	zmqdebug = "notint"
 	EOT
 	test_must_fail flux broker ${ARGS} -c conf20 \
-		/bin/true 2>zbadconf.err &&
+		true 2>zbadconf.err &&
 	grep "Expected integer" zbadconf.err
 '
 test_expect_success 'tbon.zmq_io_threads is 1 by default' '
@@ -589,7 +589,7 @@ test_expect_success 'tbon.torpid_max configured with wrong type fails' '
 	torpid_max = 5
 	EOT
 	test_must_fail flux broker ${ARGS} -c conf22 \
-		/bin/true 2>badtorpid.err &&
+		true 2>badtorpid.err &&
 	grep "Expected string" badtorpid.err
 '
 test_expect_success 'tbon.topo with unknown scheme fails' '
@@ -599,7 +599,7 @@ test_expect_success 'tbon.topo with unknown scheme fails' '
 	topo = "notascheme:42"
 	EOT
 	test_must_fail flux broker ${ARGS} -c conf23 \
-		/bin/true 2>badscheme.err &&
+		true 2>badscheme.err &&
 	grep "unknown topology scheme" badscheme.err
 '
 test_expect_success 'tbon.topo is kary:32 by default' '
@@ -671,13 +671,13 @@ test_expect_success NOCONNTO 'tbon.connect_timeout config cannot be set with old
 	connect_timeout = "35s"
 	EOT
 	test_must_fail flux broker ${ARGS} -c conf27 \
-		/bin/true 2>noconnto_conf.err &&
+		true 2>noconnto_conf.err &&
 	grep "unsupported by this zeromq version" noconnto_conf.err
 '
 test_expect_success NOCONNTO 'tbon.connect_timeout attr cannot be set with old zeromq' '
 	test_must_fail flux broker ${ARGS} \
 		-Stbon.connect_timeout=10s \
-		/bin/true 2>noconnto_attr.err &&
+		true 2>noconnto_attr.err &&
 	grep "unsupported by this zeromq version" noconnto_attr.err
 '
 test_expect_success CONNTO 'tbon.connect_timeout config can be set to 0' '

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -11,12 +11,12 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile --debug
 test_expect_success 'initial program is run when rc1/rc3 are nullified' '
 	flux start -Slog-stderr-level=6 \
 		-Sbroker.rc1_path= -Sbroker.rc3_path= \
-		/bin/true 2>normal.log
+		true 2>normal.log
 '
 
 test_expect_success 'rc1 failure causes instance failure' '
 	test_expect_code 1 flux start \
-		-Sbroker.rc1_path=/bin/false -Sbroker.rc3_path= \
+		-Sbroker.rc1_path=false -Sbroker.rc3_path= \
 		-Slog-stderr-level=6 \
 		sleep 3600 2>rc1_failure.log
 '
@@ -27,7 +27,7 @@ test_expect_success 'rc1 bad path handled same as failure' '
 	  test_expect_code 127 flux start \
 		-Sbroker.rc1_path=rc1-nonexist -Sbroker.rc3_path= \
 		-Slog-stderr-level=6 \
-		/bin/true 2>bad1.log
+		true 2>bad1.log
 	)
 '
 
@@ -50,9 +50,9 @@ test_expect_success 'rc2 failure if stdin not a tty' '
 
 test_expect_success 'rc3 failure causes instance failure' '
 	test_expect_code 1 flux start \
-		-Sbroker.rc3_path=/bin/false \
+		-Sbroker.rc3_path=false \
 		-Slog-stderr-level=6 \
-		/bin/true 2>rc3_failure.log
+		true 2>rc3_failure.log
 '
 
 test_expect_success 'broker.rc2_none terminates by signal without error' '
@@ -64,21 +64,21 @@ test_expect_success 'broker.rc2_none terminates by signal without error' '
 	done
 '
 
-test_expect_success 'flux admin cleanup-push /bin/true works' '
+test_expect_success 'flux admin cleanup-push true works' '
 	flux start -Slog-stderr-level=6 \
 		-Sbroker.rc1_path= -Sbroker.rc3_path= \
-		flux admin cleanup-push /bin/true
+		flux admin cleanup-push true
 '
 
-test_expect_success 'flux admin cleanup-push /bin/false causes instance failure' '
+test_expect_success 'flux admin cleanup-push false causes instance failure' '
 	test_expect_code 1 flux start -Slog-stderr-level=6 \
 		-Sbroker.rc1_path= -Sbroker.rc3_path= \
-		flux admin cleanup-push /bin/false
+		flux admin cleanup-push false
 '
 
 test_expect_success 'cleanup does not run if rc1 fails' '
 	test_expect_code 1 flux start -Slog-stderr-level=6 \
-		-Sbroker.rc1_path=/bin/false -Sbroker.rc3_path= \
+		-Sbroker.rc1_path=false -Sbroker.rc3_path= \
 		flux admin cleanup-push memorable-string 2>nocleanup.err && \
 	test_must_fail grep memorable-string nocleanup.err
 '
@@ -98,7 +98,7 @@ test_expect_success 'flux admin cleanup-push with no commands fails' '
 '
 
 test_expect_success 'flux admin cleanup-push (stdin) works' '
-	echo /bin/true | flux start -Slog-stderr-level=6 \
+	echo true | flux start -Slog-stderr-level=6 \
 		-Sbroker.rc1_path= -Sbroker.rc3_path= \
 		flux admin cleanup-push 2>push-stdin.err &&
 	grep cleanup.0 push-stdin.err

--- a/t/t0019-tbon-config.t
+++ b/t/t0019-tbon-config.t
@@ -10,10 +10,10 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 ARGS="-Sbroker.rc1_path= -Sbroker.rc3_path="
 
 test_expect_success 'flux-start with size 2 works with tbon.zmqdebug' '
-	flux start ${ARGS} -Stbon.zmqdebug=1 -s2 /bin/true
+	flux start ${ARGS} -Stbon.zmqdebug=1 -s2 true
 '
 test_expect_success 'flux-start with non-integer tbon.zmqdebug fails' '
-	test_must_fail flux start ${ARGS} -Stbon.zmqdebug=foo /bin/true
+	test_must_fail flux start ${ARGS} -Stbon.zmqdebug=foo true
 '
 test_expect_success 'tbon.endpoint can be read' '
 	ATTR_VAL=`flux start ${ARGS} -s2 flux getattr tbon.endpoint` &&
@@ -97,7 +97,7 @@ test_expect_success 'tbon.interface-hint from parent can be overridden' '
 '
 test_expect_success 'tbon.endpoint cannot be set' '
 	test_must_fail_or_be_terminated flux start ${ARGS} -s2 \
-		--setattr=tbon.endpoint=ipc:///tmp/customflux /bin/true
+		--setattr=tbon.endpoint=ipc:///tmp/customflux true
 '
 test_expect_success 'tbon.parent-endpoint cannot be read on rank 0' '
 	test_must_fail flux start ${ARGS} -s2 flux getattr tbon.parent-endpoint
@@ -119,7 +119,7 @@ test_expect_success 'broker -Stbon.topo=kary:8 option works' '
 	test_cmp topo.exp topo.out
 '
 test_expect_success 'broker -Stbon.topo=kary:0 works' '
-	flux start ${ARGS} -Stbon.topo=kary:0 /bin/true
+	flux start ${ARGS} -Stbon.topo=kary:0 true
 '
 test_expect_success 'broker -Stbon.topo=custom option works' '
 	echo custom >topo2.exp &&

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -38,21 +38,21 @@ test_expect_success 'broker.quorum can be set on the command line' '
 
 test_expect_success 'broker fails with malformed broker.quorum' '
 	test_must_fail flux start ${ARGS} \
-		-Sbroker.quorum=9-10 /bin/true 2>qmalformed.err &&
+		-Sbroker.quorum=9-10 true 2>qmalformed.err &&
 	grep "Error parsing broker.quorum attribute" qmalformed.err
 '
 
 test_expect_success 'broker fails with broker.quorum that exceeds size' '
 	test_must_fail flux start ${ARGS} \
-		-Sbroker.quorum=99 /bin/true 2>qtoobig.err &&
+		-Sbroker.quorum=99 true 2>qtoobig.err &&
 	grep "Error parsing broker.quorum attribute" qtoobig.err
 '
 test_expect_success 'broker.quorum can be 0 for compatibility' '
-	flux start ${ARGS} -Sbroker.quorum=0 /bin/true 2>compat1.err &&
+	flux start ${ARGS} -Sbroker.quorum=0 true 2>compat1.err &&
 	grep assuming compat1.err
 '
 test_expect_success 'broker.quorum can be 0-1 (size=2) for compatibility' '
-	flux start -s2 ${ARGS} -Sbroker.quorum=0-1 /bin/true 2>compat2.err &&
+	flux start -s2 ${ARGS} -Sbroker.quorum=0-1 true 2>compat2.err &&
 	grep assuming compat2.err
 '
 test_expect_success 'create rc1 that blocks on FIFO for rank != 0' '
@@ -116,7 +116,7 @@ test_expect_success 'monitor reports INIT(2) in rc1' '
 	flux start \
 		-Sbroker.rc1_path=$(pwd)/rc_getstate \
 		-Sbroker.rc3_path= \
-		/bin/true &&
+		true &&
 	test_cmp rc1.exp rc.out
 '
 
@@ -143,12 +143,12 @@ test_expect_success 'monitor reports FINALIZE(7) in rc3' '
 	flux start \
 		-Sbroker.rc1_path= \
 		-Sbroker.rc3_path=$(pwd)/rc_getstate \
-		/bin/true &&
+		true &&
 	test_cmp rc3.exp rc.out
 '
 
 test_expect_success 'capture state transitions from size=1 instance' '
-	flux start ${ARGS} -Slog-filename=states.log /bin/true
+	flux start ${ARGS} -Slog-filename=states.log true
 '
 
 test_expect_success 'all expected events and state transitions occurred' '
@@ -166,7 +166,7 @@ test_expect_success 'all expected events and state transitions occurred' '
 test_expect_success 'capture state transitions from size=2 instance' '
 	flux start ${ARGS} --test-size=2 \
 		-Slog-stderr-level=6 -Slog-stderr-mode=local \
-		/bin/true 2>states2.log
+		true 2>states2.log
 '
 
 test_expect_success 'all expected events and state transitions occurred on rank 0' '
@@ -196,9 +196,9 @@ test_expect_success 'all expected events and state transitions occurred on rank 
 test_expect_success 'capture state transitions from instance with rc1 failure' '
 	test_expect_code 1 flux start \
 	    -Slog-filename=states_rc1.log \
-	    -Sbroker.rc1_path=/bin/false \
+	    -Sbroker.rc1_path=false \
 	    -Sbroker.rc3_path= \
-	    /bin/true
+	    true
 '
 
 test_expect_success 'all expected events and state transitions occurred' '
@@ -214,7 +214,7 @@ test_expect_success 'capture state transitions from instance with rc2 failure' '
 	test_expect_code 1 flux start \
 	    -Slog-filename=states_rc2.log \
 	    ${ARGS} \
-	    /bin/false
+	    false
 '
 
 test_expect_success 'all expected events and state transitions occurred' '
@@ -233,8 +233,8 @@ test_expect_success 'capture state transitions from instance with rc3 failure' '
 	test_expect_code 1 flux start \
 	    -Slog-filename=states_rc3.log \
 	    -Sbroker.rc1_path= \
-	    -Sbroker.rc3_path=/bin/false \
-	    /bin/true
+	    -Sbroker.rc3_path=false \
+	    true
 '
 
 test_expect_success 'all expected events and state transitions occurred' '
@@ -252,20 +252,20 @@ test_expect_success 'all expected events and state transitions occurred' '
 test_expect_success 'instance rc1 failure exits with norestart code' '
 	test_expect_code 99 flux start \
 	    -Sbroker.exit-norestart=99 \
-	    -Sbroker.rc1_path=/bin/false \
+	    -Sbroker.rc1_path=false \
 	    -Sbroker.rc3_path= \
-	    /bin/true
+	    true
 '
 
 test_expect_success 'broker.quorum-timeout=none is accepted' '
-	flux start ${ARGS} -Sbroker.quorum-timeout=none /bin/true
+	flux start ${ARGS} -Sbroker.quorum-timeout=none true
 '
 
 test_expect_success 'broker.quorum-timeout=3h is accepted' '
-	flux start ${ARGS} -Sbroker.quorum-timeout=3h /bin/true
+	flux start ${ARGS} -Sbroker.quorum-timeout=3h true
 '
 test_expect_success 'broker.quorum-timeout=x fails' '
-	test_must_fail flux start ${ARGS} -Sbroker.quorum-timeout=x /bin/true
+	test_must_fail flux start ${ARGS} -Sbroker.quorum-timeout=x true
 '
 test_expect_success 'create rc1 that sleeps for 2s on rank != 0' '
 	cat <<-EOT >rc1_sleep &&
@@ -279,7 +279,7 @@ test_expect_success 'broker.quorum-timeout works' '
 	flux start -s2 ${ARGS} \
 		-Slog-filename=timeout.log \
 		-Sbroker.rc1_path="$(pwd)/rc1_sleep" \
-		-Sbroker.quorum-timeout=1s /bin/true
+		-Sbroker.quorum-timeout=1s true
 '
 test_expect_success 'logs contain quorum delayed/reached messages' '
 	grep "quorum delayed" timeout.log &&

--- a/t/t0028-content-backing-none.t
+++ b/t/t0028-content-backing-none.t
@@ -85,7 +85,7 @@ test_expect_success 'unload kvs' '
 '
 
 test_expect_success 'content.backing-module input of none works' '
-        flux start -Scontent.backing-module=none /bin/true
+        flux start -Scontent.backing-module=none true
 '
 
 test_expect_success 'removedcontent module' '

--- a/t/t1102-cmddriver.t
+++ b/t/t1102-cmddriver.t
@@ -99,7 +99,7 @@ test_expect_success 'cmddriver adds its own path to PATH' '
 	mkdir bin &&
 	cat <<-EOF >bin/flux &&
 	#!/bin/sh
-	/bin/true
+	true
 	EOF
 	chmod +x bin/flux &&
 	fluxcmd=$(command -v flux) &&

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -27,8 +27,8 @@ test_expect_success 'flux-proxy cleans up socket' '
 '
 
 test_expect_success 'flux-proxy exits with command return code' '
-	flux proxy $TEST_URI /bin/true &&
-	! flux proxy $TEST_URI /bin/false
+	flux proxy $TEST_URI true &&
+	! flux proxy $TEST_URI false
 '
 
 test_expect_success 'flux-proxy forwards getattr request' '
@@ -95,10 +95,10 @@ test_expect_success 'set bogus broker version' '
 	flux setattr version 0.0.0
 '
 test_expect_success 'flux-proxy fails with version mismatch' '
-	test_must_fail flux proxy $FLUX_URI /bin/true
+	test_must_fail flux proxy $FLUX_URI true
 '
 test_expect_success 'flux-proxy --force works with version mismatch' '
-	flux proxy --force $FLUX_URI /bin/true
+	flux proxy --force $FLUX_URI true
 '
 test_expect_success 'restore real broker version' '
 	flux setattr version $(cat realversion)

--- a/t/t1200-stats-basic.t
+++ b/t/t1200-stats-basic.t
@@ -49,13 +49,13 @@ test_expect_success 'nothing received with no endpoint' '
 
 test_expect_success 'FLUX_FRIPP_STATSD with colectomy' '
 	FLUX_FRIPP_STATSD=localhost \
-		flux start true sleep 1 2>colon.err &&
+		flux start true 2>colon.err &&
 	grep "parse error" colon.err
 '
 
 test_expect_success 'FLUX_FRIPP_STATSD with invalid hostname' '
 	FLUX_FRIPP_STATSD=thiscantpossiblybevalid:9000 \
-		flux start true sleep 1 2>host.err &&
+		flux start true 2>host.err &&
 	grep "parse error" host.err
 '
 

--- a/t/t1200-stats-basic.t
+++ b/t/t1200-stats-basic.t
@@ -49,13 +49,13 @@ test_expect_success 'nothing received with no endpoint' '
 
 test_expect_success 'FLUX_FRIPP_STATSD with colectomy' '
 	FLUX_FRIPP_STATSD=localhost \
-		flux start /bin/true sleep 1 2>colon.err &&
+		flux start true sleep 1 2>colon.err &&
 	grep "parse error" colon.err
 '
 
 test_expect_success 'FLUX_FRIPP_STATSD with invalid hostname' '
 	FLUX_FRIPP_STATSD=thiscantpossiblybevalid:9000 \
-		flux start /bin/true sleep 1 2>host.err &&
+		flux start true sleep 1 2>host.err &&
 	grep "parse error" host.err
 '
 

--- a/t/t2008-althash.t
+++ b/t/t2008-althash.t
@@ -71,7 +71,7 @@ test_expect_success S3 'Content store nil returns correct hash for sha256' '
 '
 
 test_expect_success 'Attempt to start instance with invalid hash fails hard' '
-	test_must_fail flux start -Scontent.hash=wronghash /bin/true
+	test_must_fail flux start -Scontent.hash=wronghash true
 '
 
 test_done

--- a/t/t2100-job-ingest.t
+++ b/t/t2100-job-ingest.t
@@ -89,7 +89,7 @@ test_expect_success 'job-ingest: jobspec stored accurately in KVS' '
 '
 
 test_expect_success 'job-ingest: submit a job with environment' '
-	flux run --env=-* --env=FOO=bar --dry-run /bin/true \
+	flux run --env=-* --env=FOO=bar --dry-run true \
 	    >jobspec_env.json &&
 	jobid=$(flux job submit jobspec_env.json) &&
 	kvsdir=$(flux job id --to=kvs $jobid) &&

--- a/t/t2113-job-ingest-pipeline.t
+++ b/t/t2113-job-ingest-pipeline.t
@@ -13,7 +13,7 @@ test_expect_success 'no workers are running at the start' '
 	jq -e ".pipeline.validator.running == 0" <stats.out
 '
 test_expect_success 'run a job with no ingest configuration' '
-	flux run /bin/true
+	flux run true
 '
 test_expect_success 'one validator, no frobnicator started' '
 	flux module stats job-ingest >stats2.out &&
@@ -29,7 +29,7 @@ test_expect_success 'configure frobnicator' '
 	EOT
 '
 test_expect_success 'run a job with unspecified duration' '
-	flux submit /bin/true >jobid1
+	flux submit true >jobid1
 '
 test_expect_success 'one validator, one frobnicator started' '
 	flux module stats job-ingest >stats3.out &&
@@ -47,7 +47,7 @@ test_expect_success 'force module config update' '
 	flux config get | flux config load
 '
 test_expect_success 'run a job to trigger work crew with new config' '
-	flux submit /bin/true
+	flux submit true
 '
 test_expect_success 'workers were restarted' '
 	flux module stats job-ingest >stats5.out &&
@@ -59,7 +59,7 @@ test_expect_success 'workers were restarted' '
 test_expect_success 'run a job with novalidate flag' '
 	jq -r ".pipeline.frobnicator.requests" <stats5.out >frob.count &&
 	jq -r ".pipeline.validator.requests" <stats5.out >val.count &&
-	flux run --flags novalidate /bin/true
+	flux run --flags novalidate true
 '
 test_expect_success 'job was frobbed but not validated' '
 	flux module stats job-ingest >stats6.out &&
@@ -72,7 +72,7 @@ test_expect_success 'reconfig with null config' '
 	flux config load </dev/null
 '
 test_expect_success 'run a job with novalidate flag' '
-	flux run --flags novalidate /bin/true
+	flux run --flags novalidate true
 '
 test_expect_success 'job was neither frobbed nor validated' '
 	flux module stats job-ingest >stats7.out &&
@@ -82,7 +82,7 @@ test_expect_success 'job was neither frobbed nor validated' '
 	test_cmp val2.count val3.count
 '
 test_expect_success 'run a job' '
-	flux run /bin/true
+	flux run true
 '
 test_expect_success 'job was validated but not frobbed' '
 	flux module stats job-ingest >stats8.out &&

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -30,7 +30,7 @@ flux setattr log-stderr-level 1
 
 # Other tests may refer to $(cat inactivejob) for inactive job id
 test_expect_success 'create one inactive job' '
-	flux submit /bin/true >inactivejob &&
+	flux submit true >inactivejob &&
 	flux queue drain
 '
 

--- a/t/t2208-job-manager-wait.t
+++ b/t/t2208-job-manager-wait.t
@@ -31,24 +31,24 @@ test_expect_success "python FLUX_JOBID_ANY matches job.h" '
 '
 
 test_expect_success "wait works on waitable job run with flux submit" '
-	JOBID=$(flux submit --flags waitable /bin/true) &&
+	JOBID=$(flux submit --flags waitable true) &&
 	flux job wait ${JOBID}
 '
 
 test_expect_success "wait works on waitable job run with flux-job" '
-	flux submit --dry-run /bin/true >true.jobspec &&
+	flux submit --dry-run true >true.jobspec &&
 	JOBID=$(flux job submit --flags=waitable true.jobspec) &&
 	flux job wait ${JOBID}
 '
 
 test_expect_success "wait works on inactive,waitable job" '
-	JOBID=$(flux submit --flags waitable /bin/true) &&
+	JOBID=$(flux submit --flags waitable true) &&
 	flux job wait-event ${JOBID} clean &&
 	flux job wait ${JOBID}
 '
 
 test_expect_success "waitable inactive jobs are listed as zombies" '
-	JOBID=$(flux submit --flags waitable /bin/true) &&
+	JOBID=$(flux submit --flags waitable true) &&
 	echo ${JOBID} >id1.out &&
 	flux job wait-event ${JOBID} clean &&
 	${list_jobs} >list1.out &&
@@ -63,18 +63,18 @@ test_expect_success "zombies go away after they are waited for" '
 '
 
 test_expect_success "wait works on three waitable jobs in reverse order" '
-	JOB1=$(flux submit --flags waitable /bin/true) &&
-	JOB2=$(flux submit --flags waitable /bin/true) &&
-	JOB3=$(flux submit --flags waitable /bin/true) &&
+	JOB1=$(flux submit --flags waitable true) &&
+	JOB2=$(flux submit --flags waitable true) &&
+	JOB3=$(flux submit --flags waitable true) &&
 	flux job wait ${JOB3} &&
 	flux job wait ${JOB2} &&
 	flux job wait ${JOB1}
 '
 
 test_expect_success "wait FLUX_JOBID_ANY works on three waitable jobs" '
-	flux submit --flags waitable /bin/true >jobs.out &&
-	flux submit --flags waitable /bin/true >>jobs.out &&
-	flux submit --flags waitable /bin/true >>jobs.out &&
+	flux submit --flags waitable true >jobs.out &&
+	flux submit --flags waitable true >>jobs.out &&
+	flux submit --flags waitable true >>jobs.out &&
 	flux job wait >wait.out &&
 	flux job wait >>wait.out &&
 	flux job wait >>wait.out &&
@@ -118,7 +118,7 @@ test_expect_success "wait works when job terminated by exception" '
 '
 
 test_expect_success "wait works when job tasks exit 1" '
-	JOBID=$(flux submit --flags waitable /bin/false) &&
+	JOBID=$(flux submit --flags waitable false) &&
 	test_expect_code 1 flux job wait ${JOBID} 2>false.out &&
 	grep exit false.out
 '
@@ -133,31 +133,31 @@ test_expect_success "wait --all works with no waitable jobs" '
 '
 
 test_expect_success "wait --all works with one job" '
-	flux submit --flags waitable /bin/true &&
+	flux submit --flags waitable true &&
 	test_job_count 1 &&
 	flux job wait --all &&
 	test_job_count 0
 '
 
 test_expect_success "wait --all works with two jobs" '
-	flux submit --flags waitable /bin/true &&
-	flux submit --flags waitable /bin/true &&
+	flux submit --flags waitable true &&
+	flux submit --flags waitable true &&
 	test_job_count 2 &&
 	flux job wait --all &&
 	test_job_count 0
 '
 
 test_expect_success "wait --all fails when first job fails" '
-	flux submit --flags waitable /bin/false &&
-	flux submit --flags waitable /bin/true &&
+	flux submit --flags waitable false &&
+	flux submit --flags waitable true &&
 	test_job_count 2 &&
 	test_must_fail flux job wait --all &&
 	test_job_count 0
 '
 
 test_expect_success "wait --all fails when second job fails" '
-	flux submit --flags waitable /bin/true &&
-	flux submit --flags waitable /bin/false &&
+	flux submit --flags waitable true &&
+	flux submit --flags waitable false &&
 	test_job_count 2 &&
 	test_must_fail flux job wait --all &&
 	test_job_count 0
@@ -165,9 +165,9 @@ test_expect_success "wait --all fails when second job fails" '
 
 
 test_expect_success "wait --all --verbose emits one line per successful job" '
-	flux submit --flags waitable /bin/true &&
-	flux submit --flags waitable /bin/true &&
-	flux submit --flags waitable /bin/false &&
+	flux submit --flags waitable true &&
+	flux submit --flags waitable true &&
+	flux submit --flags waitable false &&
 	test_must_fail flux job wait --all --verbose 2>verbose.err &&
 	test $(wc -l <verbose.err) -eq 3
 '
@@ -182,7 +182,7 @@ test_expect_success "wait fails on non-waitable, active job" '
 '
 
 test_expect_success "wait fails on non-waitable, inactive job" '
-	JOBID=$(flux submit /bin/true) &&
+	JOBID=$(flux submit true) &&
 	flux job wait-event ${JOBID} clean &&
 	test_expect_code 2 flux job wait ${JOBID}
 '
@@ -194,7 +194,7 @@ test_expect_success "a second wait fails on waitable, active job" '
 '
 
 test_expect_success "a second wait fails on waitable, inactive job" '
-	JOBID=$(flux submit --flags waitable /bin/true) &&
+	JOBID=$(flux submit --flags waitable true) &&
 	flux job wait-event ${JOBID} clean &&
 	flux job wait ${JOBID} &&
 	test_expect_code 2 flux job wait ${JOBID}
@@ -202,12 +202,12 @@ test_expect_success "a second wait fails on waitable, inactive job" '
 
 test_expect_success "guest cannot submit job with WAITABLE flag" '
 	export FLUX_HANDLE_ROLEMASK=0x2 &&
-	test_must_fail flux submit --flags waitable /bin/true &&
+	test_must_fail flux submit --flags waitable true &&
 	unset FLUX_HANDLE_ROLEMASK
 '
 
 test_expect_success "guest cannot wait on a job" '
-	JOBID=$(flux submit --flags waitable /bin/true) &&
+	JOBID=$(flux submit --flags waitable true) &&
 	export FLUX_HANDLE_ROLEMASK=0x2 &&
 	test_expect_code 1 flux job wait ${JOBID} &&
 	unset FLUX_HANDLE_ROLEMASK

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -110,7 +110,7 @@ test_expect_success 'job-manager: bad plugins config is detected' '
 	EOF
 	test_must_fail \
 	    flux bulksubmit -n1 --watch --log=badconf.{}.log \
-	        flux start -c$(pwd)/badconf/{} /bin/true ::: a b c d &&
+	        flux start -c$(pwd)/badconf/{} true ::: a b c d &&
 	test_debug "echo a:; cat badconf.a.log" &&
 	grep "config must be an array" badconf.a.log &&
 	test_debug "echo b:; cat badconf.b.log" &&
@@ -233,11 +233,11 @@ test_expect_success 'job-manager: load jobtap_api test plugin' '
 	id=$(flux submit sleep 1000) &&
 	flux run -vvv \
 		--setattr=system.lookup-id=$(flux job id $id) \
-		/bin/true &&
+		true &&
 	flux cancel $id &&
 	id=$(flux submit \
 		--setattr=system.expected-result=failed \
-		/bin/false) &&
+		false) &&
 	test_expect_code 1 flux job attach -vEX $id &&
 	test_must_fail flux job wait-event $id exception &&
 	id=$(flux submit -t 0.1s \
@@ -246,7 +246,7 @@ test_expect_success 'job-manager: load jobtap_api test plugin' '
 	test_must_fail flux job wait-event -vm type=test $id exception &&
 	id=$(flux submit --urgency=hold \
 		--setattr=system.expected-result=canceled \
-		/bin/true) &&
+		true) &&
 	flux cancel $id &&
 	test_must_fail flux job wait-event -vm type=test $id exception
 '

--- a/t/t2219-job-manager-restart.t
+++ b/t/t2219-job-manager-restart.t
@@ -10,7 +10,7 @@ export FLUX_DISABLE_JOB_CLEANUP=t
 
 test_expect_success 'start instance with empty kvs, run one job, and dump' '
 	flux start -Scontent.dump=dump.tar \
-	    flux run --env-remove=* /bin/true &&
+	    flux run --env-remove=* true &&
 	test -f $(pwd)/dump.tar
 '
 
@@ -23,7 +23,7 @@ restart_flux() {
 # "not replayed" warnings were logged
 restart_with_job_warning() {
 	local out=$(basename $1).dmesg
-	flux start -Scontent.restore=$1 /bin/true 2>$out
+	flux start -Scontent.restore=$1 true 2>$out
 	result=$?
 	cat $out
 	test $result -eq 0 && grep -q "not replayed:" $out
@@ -61,7 +61,7 @@ test_expect_success 'and max_jobid is still greater than zero' '
 '
 
 test_expect_success 'purging all jobs triggers jobid checkpoint update' '
-	flux start bash -c "flux run --env-remove=* /bin/true && \
+	flux start bash -c "flux run --env-remove=* true && \
 	    flux job purge -f --num-limit=0 && \
 	    flux kvs get checkpoint.job-manager"
 '

--- a/t/t2220-job-manager-R.t
+++ b/t/t2220-job-manager-R.t
@@ -21,7 +21,7 @@ json_diff() {
 flux setattr log-stderr-level 1
 
 test_expect_success 'submit job' '
-	flux submit -t 10s --wait-event=clean /bin/true | flux job id >jobid
+	flux submit -t 10s --wait-event=clean true | flux job id >jobid
 '
 test_expect_success 'job-manager getattr of R works' '
 	job_manager_getattr $(cat jobid) R  >R.out

--- a/t/t2221-job-manager-limit-duration.t
+++ b/t/t2221-job-manager-limit-duration.t
@@ -21,11 +21,11 @@ test_expect_success 'configure a valid duration limit' '
 	EOT
 '
 test_expect_success 'a job that exceeds policy.limits.duration is rejected' '
-	test_must_fail flux submit -t 1h /bin/true 2>duration.err &&
+	test_must_fail flux submit -t 1h true 2>duration.err &&
 	grep "exceeds policy limit of 1m" duration.err
 '
 test_expect_success 'a job that is under policy.limits.duration is accepted' '
-	flux submit -t 30s /bin/true
+	flux submit -t 30s true
 '
 test_expect_success 'configure policy.limits.duration and queue duration' '
 	flux config load <<-EOT &&
@@ -40,37 +40,37 @@ test_expect_success 'configure policy.limits.duration and queue duration' '
 	flux queue start --all
 '
 test_expect_success 'a job that exceeds policy.limits.duration is rejected' '
-	test_must_fail flux submit --queue=debug -t 2h /bin/true
+	test_must_fail flux submit --queue=debug -t 2h true
 '
 test_expect_success 'a job with no limit is also rejected' '
-	test_must_fail flux submit --queue=debug -t 0 /bin/true
+	test_must_fail flux submit --queue=debug -t 0 true
 '
 test_expect_success 'but is accepted by a queue with higher limit' '
 	flux submit \
 	    --queue=batch \
 	    -t 2h \
-	    /bin/true
+	    true
 '
 test_expect_success 'and is rejected when it exceeds the queue limit' '
 	test_must_fail flux submit \
 	    --queue=batch \
 	    -t 16h \
-	    /bin/true
+	    true
 '
 test_expect_success 'no limit is also rejected as exceeding the queue limit' '
 	test_must_fail flux submit \
 	    --queue=batch \
 	    -t 0 \
-	    /bin/true
+	    true
 '
 test_expect_success 'a job that is under policy.limits.duration is accepted' '
-	flux submit --queue=debug -t 1h /bin/true
+	flux submit --queue=debug -t 1h true
 '
 test_expect_success 'but is rejected on a queue with lower limit' '
 	test_must_fail flux submit \
 	    --queue=short \
 	    -t 1h \
-	    /bin/true
+	    true
 '
 test_expect_success 'configure policy.limits.duration and an unlimited queue' '
 	flux config load <<-EOT
@@ -82,17 +82,17 @@ test_expect_success 'configure policy.limits.duration and an unlimited queue' '
 	EOT
 '
 test_expect_success 'a job that is over policy.limits.duration is rejected' '
-	test_must_fail flux submit --queue=debug -t 2h /bin/true
+	test_must_fail flux submit --queue=debug -t 2h true
 '
 test_expect_success 'but is accepted by the unlimited queue' '
 	flux submit \
 	    --queue=batch \
-	    -t 2h /bin/true
+	    -t 2h true
 '
 test_expect_success 'a job that sets no explicit duration is accepted by the unlimited queue' '
 	flux submit \
 	    --queue=batch \
-	    /bin/true
+	    true
 '
 test_expect_success 'configure an invalid duration limit' '
 	test_must_fail flux config load <<-EOT

--- a/t/t2222-job-manager-limit-job-size.t
+++ b/t/t2222-job-manager-limit-job-size.t
@@ -22,15 +22,15 @@ test_expect_success 'configure valid job-size.*.nnodes limits' '
 	EOT
 '
 test_expect_success 'a job that exceeds job-size.max.nnodes is rejected' '
-	test_must_fail flux submit -N 3 /bin/true 2>max-nnodes.err &&
+	test_must_fail flux submit -N 3 true 2>max-nnodes.err &&
 	grep "exceeds policy limit of 2" max-nnodes.err
 '
 test_expect_success 'a job that is under job-size.min.nnodes is rejected' '
-	test_must_fail flux submit -N 1 /bin/true 2>min-nnodes.err &&
+	test_must_fail flux submit -N 1 true 2>min-nnodes.err &&
 	grep "is under policy limit of 2" min-nnodes.err
 '
 test_expect_success 'a job that is between both of those is accepted' '
-	flux submit -N 2 /bin/true
+	flux submit -N 2 true
 '
 test_expect_success 'configure job-size.*.ncores limits' '
 	flux config load <<-EOT
@@ -40,15 +40,15 @@ test_expect_success 'configure job-size.*.ncores limits' '
 	EOT
 '
 test_expect_success 'a job that exceeds job-size.max.ncores is rejected' '
-	test_must_fail flux submit -n 3 /bin/true 2>max-ncores.err &&
+	test_must_fail flux submit -n 3 true 2>max-ncores.err &&
 	grep "exceeds policy limit of 2" max-ncores.err
 '
 test_expect_success 'a job that is under job-size.min.ncores is rejected' '
-	test_must_fail flux submit -n 1 /bin/true 2>min-ncores.err &&
+	test_must_fail flux submit -n 1 true 2>min-ncores.err &&
 	grep "is under policy limit of 2" min-ncores.err
 '
 test_expect_success 'a job that is between both of those is accepted' '
-	flux submit -n 2 /bin/true
+	flux submit -n 2 true
 '
 test_expect_success 'configure job-size.*.ngpus limits' '
 	flux config load <<-EOT
@@ -58,15 +58,15 @@ test_expect_success 'configure job-size.*.ngpus limits' '
 	EOT
 '
 test_expect_success 'a job that exceeds job-size.max.ngpus is rejected' '
-	test_must_fail flux submit -g 3 /bin/true 2>max-ngpus.err &&
+	test_must_fail flux submit -g 3 true 2>max-ngpus.err &&
 	grep "exceeds policy limit of 2" max-ngpus.err
 '
 test_expect_success 'a job that is under job-size.min.ngpus is rejected' '
-	test_must_fail flux submit -g 1 /bin/true 2>min-ngpus.err &&
+	test_must_fail flux submit -g 1 true 2>min-ngpus.err &&
 	grep "is under policy limit of 2" min-ngpus.err
 '
 test_expect_success 'a job that is between both of those is accepted' '
-	flux submit -g 2 /bin/true
+	flux submit -g 2 true
 '
 test_expect_success 'configure job-size.max.ngpus and queue with unlimited' '
 	flux config load <<-EOT &&
@@ -79,13 +79,13 @@ test_expect_success 'configure job-size.max.ngpus and queue with unlimited' '
 	flux queue start --all
 '
 test_expect_success 'a job is accepted if under general gpu limit' '
-	flux submit --queue=debug -n1 /bin/true
+	flux submit --queue=debug -n1 true
 '
 test_expect_success 'a job is rejected if over gpu limit' '
-	test_must_fail flux submit --queue=debug -n1 -g1 /bin/true
+	test_must_fail flux submit --queue=debug -n1 -g1 true
 '
 test_expect_success 'same job is accepted with unlimited queue override' '
-	flux submit --queue=batch -n1 -g1 /bin/true
+	flux submit --queue=batch -n1 -g1 true
 '
 test_expect_success 'configure an invalid job-size object' '
 	test_must_fail flux config load <<-EOT

--- a/t/t2226-housekeeping.t
+++ b/t/t2226-housekeeping.t
@@ -166,7 +166,7 @@ test_expect_success 'configuring housekeeping with no cmd or exec.imp fails' '
 test_expect_success 'but is accepted if exec.imp is defined' '
 	flux config load <<-EOT
 	[exec]
-	imp = "/bin/true"
+	imp = "/bin/echo"
 	[job-manager.housekeeping]
 	EOT
 '
@@ -174,7 +174,7 @@ test_expect_success 'deprecated use-systemd-unit is ignored with log warning' '
 	flux dmesg -C &&
 	flux config load <<-EOT &&
 	[exec]
-	imp = "/bin/true"
+	imp = "/bin/echo"
 	[job-manager.housekeeping]
 	use-systemd-unit = true
 	EOT
@@ -183,7 +183,7 @@ test_expect_success 'deprecated use-systemd-unit is ignored with log warning' '
 test_expect_success 'configuring housekeeping with bad fsd fails' '
 	test_must_fail flux config load 2>load2.err <<-EOT &&
 	[job-manager.housekeeping]
-	command = [ "/bin/true" ]
+	command = [ "/bin/echo" ]
 	release-after = "foo"
 	EOT
 	grep "FSD parse error" load2.err

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -71,7 +71,7 @@ test_expect_success 'flux-queue: disable works' '
 '
 
 test_expect_success 'flux-queue: job submit fails with queue disabled' '
-	test_must_fail flux run /bin/true
+	test_must_fail flux run true
 '
 
 test_expect_success 'flux-queue: enable works' '
@@ -80,7 +80,7 @@ test_expect_success 'flux-queue: enable works' '
 '
 
 test_expect_success 'flux-queue: flux run works after enable' '
-	run_timeout 60 flux run /bin/true
+	run_timeout 60 flux run true
 '
 
 test_expect_success 'flux-queue: stop with bad broker connection fails' '
@@ -139,7 +139,7 @@ test_expect_success 'flux-queue: stop with --nocheckpoint works' '
 '
 
 test_expect_success 'flux-queue: submit some jobs' '
-	flux submit --cc 1-3 --wait-event=priority /bin/true
+	flux submit --cc 1-3 --wait-event=priority true
 '
 
 test_expect_success 'flux-queue: start scheduling' '
@@ -159,7 +159,7 @@ test_expect_success 'flux-queue: start long job that uses all cores' '
 '
 
 test_expect_success 'flux-queue: submit a job and make sure alloc sent' '
-	id=$(flux submit --flags debug /bin/true) &&
+	id=$(flux submit --flags debug true) &&
 	flux job wait-event ${id} debug.alloc-request
 '
 
@@ -195,7 +195,7 @@ test_expect_success 'flux-queue: unload scheduler' '
 '
 
 test_expect_success 'flux-queue: submit a job to ping scheduler' '
-	flux submit --flags debug /bin/true
+	flux submit --flags debug true
 '
 
 wait_for_sched_offline() {
@@ -244,8 +244,8 @@ test_expect_success 'flux-queue: submit a long job that uses all cores' '
 '
 
 test_expect_success 'flux-queue: submit 2 more jobs' '
-	flux submit /bin/true &&
-	flux submit /bin/true
+	flux submit true &&
+	flux submit true
 '
 
 test_expect_success 'flux-queue: there are 3 active jobs' '
@@ -392,8 +392,8 @@ test_expect_success 'start queues' '
 	test $(grep -c "Scheduling is started" mqstatus_initial.out) -eq 2
 '
 test_expect_success 'jobs may be submitted to either queue' '
-	flux submit -q batch /bin/true &&
-	flux submit -q debug /bin/true
+	flux submit -q batch true &&
+	flux submit -q debug true
 '
 test_expect_success 'flux-queue status can show one queue' '
 	flux queue status -q debug >mqstatus_debug.out &&
@@ -409,8 +409,8 @@ test_expect_success 'flux-queue disable --all affects all queues' '
 	test $(grep -c "submission is disabled: test reason" mqstatus_dis.out) -eq 2
 '
 test_expect_success 'jobs may not be submitted to either queue' '
-	test_must_fail flux submit -q batch /bin/true &&
-	test_must_fail flux submit -q debug /bin/true
+	test_must_fail flux submit -q batch true &&
+	test_must_fail flux submit -q debug true
 '
 test_expect_success 'flux-queue enable without --queue or --all fails' '
 	test_must_fail flux queue enable
@@ -428,8 +428,8 @@ test_expect_success 'flux-queue disable can do one queue' '
 	flux queue status >mqstatus_batchdis.out &&
 	test $(grep -c "submission is enabled" mqstatus_batchdis.out) -eq 1 &&
 	test $(grep -c "submission is disabled: nobatch" mqstatus_batchdis.out) -eq 1 &&
-	test_must_fail flux submit -q batch /bin/true &&
-	flux submit -q debug /bin/true
+	test_must_fail flux submit -q batch true &&
+	flux submit -q debug true
 '
 test_expect_success 'flux-queue enable can do one queue' '
 	flux queue enable -q batch > mqenable_batch.out &&
@@ -437,8 +437,8 @@ test_expect_success 'flux-queue enable can do one queue' '
 	test $(grep -c "submission is enabled" mqenable_batch.out) -eq 1 &&
 	flux queue status >mqstatus_batchena.out &&
 	test $(grep -c "submission is enabled" mqstatus_batchena.out) -eq 2 &&
-	flux submit -q batch /bin/true &&
-	flux submit -q debug /bin/true
+	flux submit -q batch true &&
+	flux submit -q debug true
 '
 
 
@@ -456,8 +456,8 @@ test_expect_success 'flux-queue stop w/o --all affects all queues but outputs wa
 	test $(grep -c "Scheduling is stopped: test reasons" mqstatus_stop2.out) -eq 2
 '
 test_expect_success 'jobs may be submitted to either queue' '
-	flux submit --wait-event=priority -q batch /bin/true > job_batch1.id &&
-	flux submit --wait-event=priority -q debug /bin/true > job_debug1.id
+	flux submit --wait-event=priority -q batch true > job_batch1.id &&
+	flux submit --wait-event=priority -q debug true > job_debug1.id
 '
 
 wait_state() {
@@ -510,8 +510,8 @@ test_expect_success 'flux-queue stop can do one queue' '
 	flux queue status >mqstatus_batchstop.out &&
 	test $(grep -c "Scheduling is started" mqstatus_batchstop.out) -eq 1 &&
 	test $(grep -c "Scheduling is stopped: nobatch" mqstatus_batchstop.out) -eq 1 &&
-	flux submit -q batch /bin/true > job_batch2.id &&
-	flux submit -q debug /bin/true > job_debug2.id
+	flux submit -q batch true > job_batch2.id &&
+	flux submit -q debug true > job_debug2.id
 '
 test_expect_success 'check one job ran, other job didnt' '
 	wait_state $(cat job_debug2.id) INACTIVE &&

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -1303,7 +1303,7 @@ test_expect_success 'verify job names preserved across restart' '
 
 test_expect_success 'flux job list outputs cwd' '
 	pwd=$(pwd) &&
-	jobid=`flux submit --wait /bin/true | flux job id` &&
+	jobid=`flux submit --wait true | flux job id` &&
 	echo $jobid > jobcwd.id &&
 	wait_jobid_state $jobid inactive &&
 	flux job list -s inactive | grep $jobid | jq -e ".cwd == \"${pwd}\""
@@ -1323,7 +1323,7 @@ test_expect_success 'verify job cwd preserved across restart' '
 #
 
 test_expect_success 'flux job list output no queue if queue not set' '
-	jobid=`flux submit --wait /bin/true | flux job id` &&
+	jobid=`flux submit --wait true | flux job id` &&
 	echo $jobid > jobqueue1.id &&
 	wait_jobid_state $jobid inactive &&
 	flux job list -s inactive | grep $jobid | jq -e ".queue == null"
@@ -1337,7 +1337,7 @@ test_expect_success 'reconfigure with one queue' '
 '
 
 test_expect_success 'flux job list outputs queue' '
-	jobid=`flux submit --wait --queue=foo /bin/true | flux job id` &&
+	jobid=`flux submit --wait --queue=foo true | flux job id` &&
 	echo $jobid > jobqueue2.id &&
 	wait_jobid_state $jobid inactive &&
 	flux job list -s inactive | grep $jobid | jq -e ".queue == \"foo\""
@@ -1367,7 +1367,7 @@ test_expect_success 'support jobspec updates of project and bank' '
 '
 
 test_expect_success 'flux job list outputs no project and bank by default' '
-	jobid=`flux submit --wait /bin/true | flux job id` &&
+	jobid=`flux submit --wait true | flux job id` &&
 	echo $jobid > jobprojectbank1.id &&
 	wait_jobid_state $jobid inactive &&
 	flux job list -s inactive | grep $jobid | jq -e ".project == null" &&
@@ -1375,7 +1375,7 @@ test_expect_success 'flux job list outputs no project and bank by default' '
 '
 # initially put job on hold, jobspec-updates don't matter after the job is running
 test_expect_success 'flux job list outputs project and bank if one set' '
-	jobid=`flux submit --urgency=hold /bin/true | flux job id` &&
+	jobid=`flux submit --urgency=hold true | flux job id` &&
 	echo $jobid > jobprojectbank2.id &&
 	flux update $jobid project=foo &&
 	flux update $jobid bank=bar &&
@@ -2374,7 +2374,7 @@ test_expect_success 'load jobspec-update test plugin' '
 '
 
 test_expect_success 'run job in the default queue' '
-	flux submit -q defaultqueue --wait /bin/true | flux job id > update1.id &&
+	flux submit -q defaultqueue --wait true | flux job id > update1.id &&
 	wait_id_inactive $(cat update1.id)
 '
 
@@ -2657,10 +2657,10 @@ test_expect_success 'configure batch,debug queues' '
 '
 
 test_expect_success 'run some jobs in the batch,debug queues' '
-	flux submit -q batch --wait /bin/true | flux job id > stats1.id &&
-	flux submit -q debug --wait /bin/true | flux job id > stats2.id &&
-	flux submit -q batch --wait /bin/false | flux job id > stats3.id &&
-	flux submit -q debug --wait /bin/false | flux job id > stats4.id &&
+	flux submit -q batch --wait true | flux job id > stats1.id &&
+	flux submit -q debug --wait true | flux job id > stats2.id &&
+	flux submit -q batch --wait false | flux job id > stats3.id &&
+	flux submit -q debug --wait false | flux job id > stats4.id &&
 	wait_id_inactive $(cat stats1.id) &&
 	wait_id_inactive $(cat stats2.id) &&
 	wait_id_inactive $(cat stats3.id) &&

--- a/t/t2262-job-list-stats.t
+++ b/t/t2262-job-list-stats.t
@@ -37,7 +37,7 @@ test_expect_success NO_CHAIN_LINT 'start monitoring job-stats and wait for first
 	$waitfile stats.log
 '
 test_expect_success NO_CHAIN_LINT 'run a job to completion' '
-	flux run /bin/true
+	flux run true
 '
 test_expect_success NO_CHAIN_LINT 'wait until job-stats produces at least one more response' '
 	$waitfile --count=2 stats.log

--- a/t/t2280-job-memo.t
+++ b/t/t2280-job-memo.t
@@ -26,7 +26,7 @@ test_expect_success 'memo: error on invalid jobid' '
 	test_expect_code 1 flux job memo f1 foo=bar
 '
 test_expect_success 'memo: create one inactive job' '
-	flux submit /bin/true >inactivejob &&
+	flux submit true >inactivejob &&
 	flux queue drain
 '
 test_expect_success 'memo: submit a running and pending job' '

--- a/t/t2304-sched-simple-alloc-check.t
+++ b/t/t2304-sched-simple-alloc-check.t
@@ -25,7 +25,7 @@ test_expect_success 'a regular job fails with an alloc-check exception' '
 	test_expect_code 1 \
 	    run_timeout 30 flux submit --flags=waitable -vvv \
 	    --wait-event=exception \
-	    -N1 /bin/true >bypass.jobid
+	    -N1 true >bypass.jobid
 '
 test_expect_success 'flux job wait says the job failed' '
 	test_must_fail flux job wait -v $(cat bypass.jobid)

--- a/t/t2312-resource-exclude.t
+++ b/t/t2312-resource-exclude.t
@@ -82,7 +82,7 @@ test_expect_success 'test instance fails to exclude hostnames' '
 	exclude = "$(hostname -s)"
 	EOT
 	test_must_fail flux start -s2 --config-path=exclude2.toml \
-	    /bin/true 2>exclude2.err &&
+	    true 2>exclude2.err &&
 	grep "R is unavailable" exclude2.err
 '
 test_expect_success 'instance with configured R can exclude hostnames' '

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -108,7 +108,7 @@ test_expect_success 'job-exec: test exec start override works' '
 '
 test_expect_success 'job-exec: override only works on jobs with flag set' '
 	jobid=$(flux submit \
-		--setattr=system.exec.test.run_duration=0. /bin/true) &&
+		--setattr=system.exec.test.run_duration=0. true) &&
 	flux job wait-event -t 5 ${jobid} alloc &&
 	test_must_fail flux job-exec-override start ${jobid} &&
 	flux cancel ${jobid} &&

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -89,7 +89,7 @@ test_expect_success 'job-exec: job shell eventually killed by SIGKILL' '
 	flux module reload job-exec
 '
 test_expect_success 'job-exec: invalid job shell generates exception' '
-	id=$(flux run --dry-run /bin/true \
+	id=$(flux run --dry-run true \
 		| $jq ".attributes.system.exec.job_shell = \"/notthere\"" \
 		| flux job submit) &&
 	flux job wait-event -vt 5 $id clean

--- a/t/t2411-sdexec-job.t
+++ b/t/t2411-sdexec-job.t
@@ -36,7 +36,7 @@ rkill="flux python ${SHARNESS_TEST_SRCDIR}/scripts/rexec.py kill -s sdexec"
 
 test_expect_success 'job gets exception if sdexec requested but not loaded' '
 	test_must_fail flux run --setattr system.exec.bulkexec.service=sdexec \
-	    -N1 /bin/true 2>except.err &&
+	    -N1 true 2>except.err &&
 	grep "sdexec service is not loaded" except.err
 '
 test_expect_success 'load sdbus,sdexec modules' '
@@ -48,18 +48,18 @@ test_expect_success 'clear broker logs' '
 '
 test_expect_success 'incorrect bulkexec.service fails' '
 	test_must_fail flux run --setattr system.exec.bulkexec.service=zzz \
-	    -N1 /bin/true
+	    -N1 true
 '
 test_expect_success '1-node job works' '
 	flux run --setattr system.exec.bulkexec.service=sdexec \
-	    -N1 /bin/true
+	    -N1 true
 '
 test_expect_success 'dump broker logs' '
         flux dmesg >dmesg.out
 '
 test_expect_success '2-node job works' '
 	flux run --setattr system.exec.bulkexec.service=sdexec \
-	    -N2 /bin/true
+	    -N2 true
 '
 test_expect_success 'create a shell userrc that dumps data to stderr' '
 	cat >userrc.lua <<-EOT

--- a/t/t2501-job-status.t
+++ b/t/t2501-job-status.t
@@ -7,8 +7,8 @@ test_description='Test flux job status'
 test_under_flux 2 job
 
 test_expect_success 'status: submit a series of jobs' '
-	zero=$(flux submit /bin/true) &&
-	one=$(flux submit /bin/false) &&
+	zero=$(flux submit true) &&
+	one=$(flux submit false) &&
 	sigint=$(flux submit sh -c "kill -INT \$$") &&
 	shell_sigquit=$(flux submit sh -c "kill -QUIT \$PPID") &&
 	unsatisfiable=$(flux submit -n 1024 hostname) &&

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -20,7 +20,7 @@ test_expect_success 'job-shell: errors on unknown argument' '
 
 test_expect_success 'job-shell: reads J not jobspec' '
 	id=$(flux submit --wait-event=priority \
-		-n1 --urgency=hold /bin/true) &&
+		-n1 --urgency=hold true) &&
 	flux job info ${id} jobspec \
 		| jq ".tasks[0].command[0] = \"false\"" >jobspec.new &&
 	flux kvs put \
@@ -31,7 +31,7 @@ test_expect_success 'job-shell: reads J not jobspec' '
 
 test_expect_success 'job-shell: fails on modified J' '
 	id=$(flux submit --wait-event=priority \
-		-n1 --urgency=hold /bin/true) &&
+		-n1 --urgency=hold true) &&
 	flux job info ${id} J | sed s/./%/85 > J.new &&
 	flux kvs put \
 		$(flux job id --to=kvs ${id}).J="$(cat J.new)" &&
@@ -71,13 +71,13 @@ test_expect_success 'job-shell: execute 2 tasks per rank' '
 	flux kvs dir ${kvsdir}.guest.test2 | sort >test2.out &&
 	test_cmp test2.exp test2.out
 '
-test_expect_success 'job-shell: /bin/true exit code propagated' '
-	id=$(flux submit /bin/true) &&
+test_expect_success 'job-shell: true exit code propagated' '
+	id=$(flux submit true) &&
 	flux job wait-event $id finish >true.finish.out &&
 	grep status=0 true.finish.out
 '
-test_expect_success 'job-shell: /bin/false exit code propagated' '
-	id=$(flux submit /bin/false) &&
+test_expect_success 'job-shell: false exit code propagated' '
+	id=$(flux submit false) &&
 	flux job wait-event $id finish >false.finish.out &&
 	grep status=256 false.finish.out
 '
@@ -340,7 +340,7 @@ test_expect_success 'job-shell: FLUX_JOB_TMPDIR is created in TMPDIR' '
 test_expect_success 'job-shell: job fails if FLUX_JOB_TMPDIR cannot be created' '
 	chmod u-w mytmpdir &&
 	! TMPDIR=$(pwd)/mytmpdir \
-		flux run /bin/true 2>badjobtmp.err &&
+		flux run true 2>badjobtmp.err &&
 	grep exception badjobtmp.err
 '
 

--- a/t/t2603-job-shell-initrc.t
+++ b/t/t2603-job-shell-initrc.t
@@ -24,7 +24,7 @@ test_expect_success 'flux-shell: initrc: conf.shell_initrc can be set' '
 	EOF
 	initrc_old=$(flux getattr conf.shell_initrc) &&
 	flux setattr conf.shell_initrc $(pwd)/test-initrc.lua &&
-	flux run /bin/true > test-initrc.output 2>&1 &&
+	flux run true > test-initrc.output 2>&1 &&
 	test_debug "cat test-initrc.output" &&
 	grep "loaded test-initrc" test-initrc.output &&
 	flux setattr conf.shell_initrc "${initrc_old}"
@@ -35,7 +35,7 @@ test_expect_success 'flux-shell: initrc: plugin.searchpath set via broker attr' 
 	EOF
 	old_pluginpath=$(flux getattr conf.shell_pluginpath) &&
 	flux setattr conf.shell_pluginpath /test/foo &&
-	flux run -o initrc=$(pwd)/print-searchpath.lua /bin/true \
+	flux run -o initrc=$(pwd)/print-searchpath.lua true \
 		>print-searchpath.out 2>&1 &&
 	test_debug "cat print-searchpath.out" &&
 	grep "plugin.searchpath = /test/foo" print-searchpath.out &&

--- a/t/t2609-job-shell-events.t
+++ b/t/t2609-job-shell-events.t
@@ -12,7 +12,7 @@ INITRC_TESTDIR="${SHARNESS_TEST_SRCDIR}/shell/initrc"
 INITRC_PLUGINPATH="${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs"
 
 test_expect_success 'flux-shell: 1N: init and start shell events are emitted' '
-	id=$(flux submit -n1 -N1 /bin/true)  &&
+	id=$(flux submit -n1 -N1 true)  &&
 	flux job wait-event -vt 5 -p exec \
 		-m leader-rank=0 ${id} shell.init &&
 	flux job wait-event -vt 5 -p exec \
@@ -21,7 +21,7 @@ test_expect_success 'flux-shell: 1N: init and start shell events are emitted' '
 		${id} shell.start
 '
 test_expect_success 'flux-shell: 2N: init and start shell events are emitted' '
-	id=$(flux submit -n4 -N2 /bin/true)  &&
+	id=$(flux submit -n4 -N2 true)  &&
 	flux job wait-event -vt 5 -p exec \
 		-m leader-rank=0  ${id} shell.init &&
 	flux job wait-event -vt 5 -p exec \

--- a/t/t2610-job-shell-mpir.t
+++ b/t/t2610-job-shell-mpir.t
@@ -26,7 +26,7 @@ for test in 1:1 2:2 2:4 4:4 4:8 4:7; do
     NODES=${test%:*}
     test_expect_success "flux-shell: ${NODES}N/${TASKS}P: trace+mpir works" '
 	id=$(flux submit -o stop-tasks-in-exec \
-	    -n${TASKS} -N${NODES} /bin/true)  &&
+	    -n${TASKS} -N${NODES} true)  &&
 	flux job wait-event -vt 5 -p exec -m sync=true ${id} shell.start &&
 	${mpir} -r $(shell_leader_rank $id) -s $(shell_service $id) &&
 	flux job kill -s CONT ${id} &&
@@ -36,7 +36,7 @@ done
 
 
 test_expect_success 'flux-shell: test security of proctable method' '
-	id=$(flux submit -o stop-tasks-in-exec /bin/true) &&
+	id=$(flux submit -o stop-tasks-in-exec true) &&
 	flux job wait-event -vt 5 -p exec -m sync=true ${id} shell.start &&
 	shell_rank=$(shell_leader_rank $id) &&
 	shell_service=$(shell_service $id) &&
@@ -49,7 +49,7 @@ test_expect_success 'flux-shell: test security of proctable method' '
 	flux job attach ${id}
 '
 test_expect_success 'mpir: tool launch is supported' '
-	id=$(flux submit -N4 -n8 -o stop-tasks-in-exec /bin/true) &&
+	id=$(flux submit -N4 -n8 -o stop-tasks-in-exec true) &&
 	flux job wait-event -vt 5 -p exec -m sync=true $id shell.start &&
 	shell_rank=$(shell_leader_rank $id) &&
 	shell_service=$(shell_service $id) &&
@@ -68,7 +68,7 @@ test_expect_success 'mpir: tool launch is supported' '
 # on broker rank 0 to ensure this configuration works with tool launch
 test_expect_success 'mpir: tool launch works with empty MPIR_server_arguments' '
 	id=$(flux submit --requires=rank:1,3 \
-	     -N2 -n2 -o stop-tasks-in-exec /bin/true) &&
+	     -N2 -n2 -o stop-tasks-in-exec true) &&
 	flux job wait-event -vt 5 -p exec -m sync=true $id shell.start &&
 	shell_rank=$(shell_leader_rank $id) &&
 	shell_service=$(shell_service $id) &&
@@ -82,7 +82,7 @@ test_expect_success 'mpir: tool launch works with empty MPIR_server_arguments' '
 	flux job attach $id
 '
 test_expect_success 'mpir: tool launch reports errors' '
-	id=$(flux submit -N2 -n2 -o stop-tasks-in-exec /bin/true) &&
+	id=$(flux submit -N2 -n2 -o stop-tasks-in-exec true) &&
 	flux job wait-event -vt 5 -p exec -m sync=true $id shell.start &&
 	shell_rank=$(shell_leader_rank $id) &&
 	shell_service=$(shell_service $id) &&

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -7,7 +7,7 @@ test_description='Test flux-shell task exit support'
 test_under_flux 2 job
 
 test_expect_success 'flux-shell: first task exit posts shell.task-exit event' '
-	jobid=$(flux submit /bin/true) &&
+	jobid=$(flux submit true) &&
 	run_timeout 10 flux job wait-event -p exec \
 		$jobid shell.task-exit
 '
@@ -60,19 +60,19 @@ test_expect_success 'flux-shell: exit-on-error catches lost shell' '
 		-n2 -N2 -o exit-on-error ./test2.sh
 '
 test_expect_success 'flux-shell: exit-timeout=aaa is rejected' '
-	test_must_fail flux run -o exit-timeout=aaa /bin/true
+	test_must_fail flux run -o exit-timeout=aaa true
 '
 test_expect_success 'flux-shell: exit-timeout=false is rejected' '
-	test_must_fail flux run -o exit-timeout=false /bin/true
+	test_must_fail flux run -o exit-timeout=false true
 '
 test_expect_success 'flux-shell: exit-timeout=none is accepted' '
-	flux run -o exit-timeout=none /bin/true
+	flux run -o exit-timeout=none true
 '
 test_expect_success 'flux-shell: exit-timeout=100 is accepted' '
-	flux run -o exit-timeout=100 /bin/true
+	flux run -o exit-timeout=100 true
 '
 test_expect_success 'flux-shell: exit-timeout=42.34 is accepted' '
-	flux run -o exit-timeout=42.34 /bin/true
+	flux run -o exit-timeout=42.34 true
 '
 
 test_done

--- a/t/t2615-job-shell-rlimit.t
+++ b/t/t2615-job-shell-rlimit.t
@@ -25,10 +25,10 @@ test_expect_success 'flux-shell: works when no specific rlimit propagated' '
 	test "$(cat ulimit-n.out)" = "123"
 '
 test_expect_success 'flux-shell: nonfatal rlimit errors are logged' '
-	flux run --output=nofile.out --rlimit nofile=inf /bin/true &&
+	flux run --output=nofile.out --rlimit nofile=inf true &&
 	grep "nofile exceeds current max"  nofile.out
 '
 test_expect_success 'flux-shell: invalid rlimit option is fatal error' '
-	test_must_fail flux run -o rlimit.foo=1234 /bin/true
+	test_must_fail flux run -o rlimit.foo=1234 true
 '
 test_done

--- a/t/t2617-job-shell-stage-in.t
+++ b/t/t2617-job-shell-stage-in.t
@@ -59,10 +59,10 @@ test_expect_success 'and deprecation warning was printed' '
 	grep deprecated depr.err
 '
 test_expect_success 'verify that stage-in fails with unknown option' '
-	test_must_fail flux run -N1 -ostage-in.badopt /bin/true
+	test_must_fail flux run -N1 -ostage-in.badopt true
 '
 test_expect_success 'verify that stage-in fails with unknown archive name' '
-	test_must_fail flux run -N1 -ostage-in.names=badarchive /bin/true
+	test_must_fail flux run -N1 -ostage-in.names=badarchive true
 '
 test_expect_success 'verify that stage-in.pattern works' '
 	flux run -N1 \
@@ -79,33 +79,33 @@ test_expect_success 'verify that stage-in.destination works' '
 	mkdir testdest &&
 	flux run -N1 \
 	    -o stage-in.destination=$(pwd)/testdest \
-	    /bin/true &&
+	    true &&
 	test -f testdest/main/hello
 '
 test_expect_success 'verify that stage-in.destination=local:path works' '
 	rm -rf testdest/main &&
 	flux run -N1 \
 	    -o stage-in.destination=local:$(pwd)/testdest \
-	    /bin/true &&
+	    true &&
 	test -f testdest/main/hello
 '
 test_expect_success 'verify that stage-in.destination=global:path works' '
 	rm -rf testdest/main &&
 	flux run -N2 \
 	    -o stage-in.destination=global:$(pwd)/testdest \
-	    /bin/true &&
+	    true &&
 	test -f testdest/main/hello
 '
 test_expect_success 'verify that stage-in.destination fails on bad dir' '
 	test_must_fail flux run -N1 \
 	    -o stage-in.destination=/noexist \
-	    /bin/true
+	    true
 '
 test_expect_success 'verify that stage-in.destination fails on bad prefix' '
 	rm -rf testdest/main &&
 	test_must_fail flux run -N1 \
 	    -o stage-in.destination=wrong:$(pwd)/testdest \
-	    /bin/true
+	    true
 '
 test_expect_success 'remove archives' '
 	flux archive remove &&
@@ -125,7 +125,7 @@ test_expect_success 'modify mapped test file without reducing its size' '
         dd if=/dev/zero of=foo bs=4096 count=1 conv=notrunc
 '
 test_expect_success 'content change should cause an error' '
-        test_must_fail flux run -N1 -o stage-in /bin/true 2>changed.err &&
+        test_must_fail flux run -N1 -o stage-in true 2>changed.err &&
 	grep changed changed.err
 '
 test_expect_success 'Create files for example 2 of flux-archive(1)' '

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -59,11 +59,11 @@ test_expect_success 'flux submit --flags debug,waitable works' '
 	flux job eventlog $jobid | grep submit | grep flags=6
 '
 test_expect_success 'flux submit --flags=novalidate works' '
-	jobid=$(flux submit --flags novalidate /bin/true) &&
+	jobid=$(flux submit --flags novalidate true) &&
 	flux job eventlog $jobid | grep submit | grep flags=8
 '
 test_expect_success 'flux submit with bad flags fails' '
-	test_must_fail flux submit --flags notaflag /bin/true
+	test_must_fail flux submit --flags notaflag true
 '
 test_expect_success 'flux submit --time-limit=5d works' '
 	flux submit --dry-run --time-limit=5d hostname >t5d.out &&

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -62,7 +62,7 @@ test_expect_success 'flux alloc --bg option works' '
 	flux job wait-event $jobid clean
 '
 test_expect_success 'flux alloc --bg option works with a command' '
-	jobid=$(flux alloc -n1 -v --bg /bin/true) &&
+	jobid=$(flux alloc -n1 -v --bg true) &&
 	flux job wait-event -t 180 -v $jobid finish &&
 	flux job attach $jobid
 '
@@ -160,7 +160,7 @@ test_expect_success 'flux alloc: no duplication of output with pty.capture' '
 test_expect_success 'flux alloc: instance can bootstrap without update-watch RPC' '
 	flux alloc -N2 \
 	  --broker-opts=-Slog-stderr-level=7 \
-	  --conf=resource.no-update-watch=true /bin/true >alloc.log 2>&1 &&
+	  --conf=resource.no-update-watch=true true >alloc.log 2>&1 &&
 	test_debug "cat alloc.log" &&
 	grep "falling back to job-info.lookup" alloc.log
 '

--- a/t/t2800-jobs-instance-info.t
+++ b/t/t2800-jobs-instance-info.t
@@ -21,9 +21,9 @@ waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
 #     jobs.
 #
 test_expect_success 'start a set of Flux instances' '
-	id=$(flux submit flux start /bin/true) &&
+	id=$(flux submit flux start true) &&
 	id2=$(flux submit -N2 -n2 -c1 flux start \
-		"flux run /bin/false ; \
+		"flux run false ; \
 		 flux submit --cc=1-4 sleep 300 && \
 		 touch ready && \
 		 flux queue idle") &&

--- a/t/t2800-jobs-recursive.t
+++ b/t/t2800-jobs-recursive.t
@@ -36,7 +36,7 @@ submit_fake_user_instance()
 #   the sleep job to finish.
 #
 test_expect_success 'start a recursive job' '
-	id=$(flux submit flux start /bin/true) &&
+	id=$(flux submit flux start true) &&
 	rid=$(flux submit -n2 \
 		flux start \
 		flux submit --wait --cc=1-2 flux start \

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -76,7 +76,7 @@ test_expect_success 'flux-top does not display FLUX_JOBID_ANY jobid in title' '
 	test_must_fail grep jpXCZedGfVQ nojobs.out
 '
 test_expect_success 'run a test job to completion' '
-	flux submit --wait -n1 flux start /bin/true >jobid &&
+	flux submit --wait -n1 flux start true >jobid &&
 	job_list_wait_state $(cat jobid) INACTIVE
 '
 test_expect_success 'flux-top summary shows one completed job' '

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -72,7 +72,7 @@ test_expect_success NO_CHAIN_LINT 'flux-uri pid scheme fails for non-flux pid' '
 	kill $pid
 '
 test_expect_success 'flux uri fails for completed job' '
-	complete_id=$(flux submit --wait flux start /bin/true) &&
+	complete_id=$(flux submit --wait flux start true) &&
 	test_expect_code 1 flux uri ${complete_id} 2>jobid-notrunning.log &&
 	test_debug "cat jobid-notrunning.log" &&
 	grep "not running" jobid-notrunning.log

--- a/t/t2803-flux-pstree.t
+++ b/t/t2803-flux-pstree.t
@@ -67,7 +67,7 @@ test_expect_success 'flux-pstree -x --skip-root=no works in empty instance' '
 #   the sleep job to finish.
 #
 test_expect_success 'start a recursive job' '
-	id=$(flux submit flux start /bin/true) &&
+	id=$(flux submit flux start true) &&
 	rid=$(flux submit -n2 \
 		flux start \
 		flux submit --wait --cc=1-2 flux start \

--- a/t/t2807-dump-cmd.t
+++ b/t/t2807-dump-cmd.t
@@ -193,7 +193,7 @@ test_expect_success 'restore --no-cache with no backing store fails' '
 '
 test_expect_success 'run a flux instance, preserving content.sqlite' '
 	mkdir test &&
-	flux start -Sstatedir=$(pwd)/test /bin/true
+	flux start -Sstatedir=$(pwd)/test true
 '
 
 reader() {
@@ -232,7 +232,7 @@ test_expect_success 'perform offline garbage collection with dump/restore' '
 
 test_expect_success 'restart flux instance and try to run a job' '
 	flux start -Sstatedir=test \
-		flux run /bin/true
+		flux run true
 '
 
 # Cover --size-limit
@@ -261,7 +261,7 @@ test_expect_success 'rc1 skips blob that exceeds 100M limit' '
 	dd if=/dev/zero of=big/hugeblob bs=1048576 count=120 &&
 	tar cvf bigdump2.tar big &&
 	flux start -Scontent.restore=bigdump2.tar \
-		/bin/true 2>bigdump3.err &&
+		true 2>bigdump3.err &&
 	grep "exceeds" bigdump3.err
 '
 

--- a/t/t2808-shutdown-cmd.t
+++ b/t/t2808-shutdown-cmd.t
@@ -34,7 +34,7 @@ test_expect_success 'flux-shutdown fails if job argument is unknown' '
 '
 
 test_expect_success 'run a test job to completion' '
-	flux submit --wait -n1 flux start /bin/true >jobid
+	flux submit --wait -n1 flux start true >jobid
 '
 test_expect_success 'flux-shutdown fails if job is not running' '
 	test_must_fail flux shutdown $(cat jobid) 2>notrun.err &&
@@ -141,7 +141,7 @@ test_expect_success 'submit batch script and wait for it to start' '
 	rm -f job6-has-started &&
 	cat >batch6.sh <<-EOT &&
 	#!/bin/sh
-	flux run /bin/true
+	flux run true
 	touch job6-has-started
 	sleep 300
 	EOT
@@ -200,7 +200,7 @@ test_expect_success 'submit batch script and wait for it to start (1)' '
 	rm -f job7-has-started &&
 	cat >batch7.sh <<-EOT &&
 	#!/bin/sh
-	flux run /bin/true
+	flux run true
 	touch job7-has-started
 	sleep 300
 	EOT

--- a/t/t2809-job-purge.t
+++ b/t/t2809-job-purge.t
@@ -48,7 +48,7 @@ test_expect_success 'reload heartbeat module with fast rate' '
         flux module reload heartbeat period=0.1s
 '
 test_expect_success 'create 10 inactive jobs' '
-	flux submit --cc=1-10 /bin/true >jobids &&
+	flux submit --cc=1-10 true >jobids &&
 	flux queue drain
 '
 test_expect_success 'verify job KVS eventlogs exist' '
@@ -110,9 +110,9 @@ test_expect_success 'verify job KVS eventlogs do not exist' '
 	done
 '
 test_expect_success 'create 2 inactive jobs with known completion order' '
-	flux submit /bin/true >jobid1 &&
+	flux submit true >jobid1 &&
 	flux job wait-event $(cat jobid1) clean &&
-	flux submit /bin/true >jobid2 &&
+	flux submit true >jobid2 &&
 	flux job wait-event $(cat jobid2) clean
 '
 test_expect_success 'purge the oldest job - youngest is still there' '
@@ -127,7 +127,7 @@ test_expect_success 'purge the last job' '
 # purge w/ job ids tests
 #
 test_expect_success 'create 4 inactive jobs and 1 active job and save their jobids' '
-	flux submit --cc=1-4 /bin/true > inactive.ids &&
+	flux submit --cc=1-4 true > inactive.ids &&
 	flux queue drain &&
 	flux submit sleep inf > active.id
 '
@@ -192,7 +192,7 @@ test_expect_success 'cleanup running job' '
 # do the following "auto purge" tests last, as they could affect earlier tests
 #
 test_expect_success 'create 10 inactive jobs' '
-	flux submit --cc=1-10 /bin/true &&
+	flux submit --cc=1-10 true &&
 	flux queue drain
 '
 test_expect_success 'reconfigure job manager with inactive-num-limit=5' '
@@ -253,7 +253,7 @@ test_expect_success 'new instance with bad config fails to start' '
 	inactive-num-limit = -42
 	EOT
 	test_must_fail flux start --config-path=$(pwd)/config \
-		/bin/true 2>badnum2.err &&
+		true 2>badnum2.err &&
 	grep "must be >= 0" badnum2.err
 '
 

--- a/t/t2810-kvs-garbage-collect.t
+++ b/t/t2810-kvs-garbage-collect.t
@@ -8,7 +8,7 @@ test_expect_success 'create test script' '
 	cat >runjobs.sh <<-EOT &&
 	#!/bin/bash -e
 	trap "" SIGHUP
-	flux submit --cc=1-10 /bin/true >/dev/null
+	flux submit --cc=1-10 true >/dev/null
 	flux queue drain
 	backingmod=\$(flux getattr content.backing-module)
 	flux module stats --type int --parse object_count \$backingmod

--- a/t/t2812-flux-job-last.t
+++ b/t/t2812-flux-job-last.t
@@ -18,7 +18,7 @@ test_expect_success 'flux-job last fails when no jobs have been submitted' '
 
 '
 test_expect_success 'submit some jobs' '
-	flux submit --cc=0-9 /bin/true >jobids
+	flux submit --cc=0-9 true >jobids
 '
 test_expect_success 'flux job last lists the most recently submitted job' '
 	id=$(flux job last) &&

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -63,16 +63,16 @@ test_expect_success 'flux run -o pmi=off does not set FLUX_PMI_LIBRARY_PATH' '
 	test_must_fail flux run -o pmi=off printenv FLUX_PMI_LIBRARY_PATH
 '
 test_expect_success 'flux run -o pmi.badopt fails' '
-	test_must_fail flux run -o pmi.badopt /bin/true
+	test_must_fail flux run -o pmi.badopt true
 '
 test_expect_success 'flux run -o pmi-simple.exchange.badopt fails' '
-	test_must_fail flux run -o pmi-simple.exchange.badopt /bin/true
+	test_must_fail flux run -o pmi-simple.exchange.badopt true
 '
 test_expect_success 'flux run -o pmi-simple.exchange.k=foo fails' '
-	test_must_fail flux run -o pmi-simple.exchange.k=foo /bin/true
+	test_must_fail flux run -o pmi-simple.exchange.k=foo true
 '
 test_expect_success 'flux run -o pmi-simple.nomap=foo fails' '
-	test_must_fail flux run -o pmi-simple.nomap=foo /bin/true
+	test_must_fail flux run -o pmi-simple.nomap=foo true
 '
 
 test_expect_success 'pmi_info works' '
@@ -262,7 +262,7 @@ test_expect_success 'flux-pmi --libpmi-noflux fails w/ flux libpmi.so' '
 test_expect_success 'flux broker refuses the Flux libpmi.so and goes single' '
 	FLUX_PMI_DEBUG=1 FLUX_PMI_CLIENT_METHODS="libpmi single" \
 	    LD_LIBRARY_PATH=$(dirname $(cat libpmi)) \
-            flux start /bin/true 2>debug.err &&
+            flux start true 2>debug.err &&
 	grep single debug.err
 '
 # method=libpmi2
@@ -309,7 +309,7 @@ test_expect_success 'flux-pmi --libpmi-noflux fails w/ flux libpmi2.so' '
 test_expect_success 'flux broker refuses the Flux pmi lib and goes single' '
 	FLUX_PMI_DEBUG=1 FLUX_PMI_CLIENT_METHODS="libpmi2 single" \
 	    LD_LIBRARY_PATH=$(dirname $(cat libpmi2)) \
-            flux start /bin/true 2>debug.err &&
+            flux start true 2>debug.err &&
 	grep single debug.err
 '
 # method=single

--- a/t/t3200-instance-restart.t
+++ b/t/t3200-instance-restart.t
@@ -14,17 +14,17 @@ fi
 
 test_expect_success 'run a job in persistent instance' '
 	flux start --setattr=statedir=$(pwd) \
-	           flux submit /bin/true >id1.out
+	           flux submit true >id1.out
 '
 
 test_expect_success 'restart instance and run another job' '
 	flux start --setattr=statedir=$(pwd) \
-	           flux submit /bin/true >id2.out
+	           flux submit true >id2.out
 '
 
 test_expect_success 'restart instance and run another job' '
 	flux start --setattr=statedir=$(pwd) \
-	           flux submit /bin/true >id3.out
+	           flux submit true >id3.out
 '
 
 test_expect_success 'restart instance and list inactive jobs' '
@@ -64,7 +64,7 @@ test_expect_success 'doctor startlog to look like a crash' '
 test_expect_success 'run flux and capture logs on stderr' '
 	flux start --setattr=statedir=$(pwd) \
 		--setattr=log-stderr-level=6 \
-		/bin/true 2>improper.err
+		true 2>improper.err
 '
 test_expect_success 'improper shutdown was logged' '
 	grep "Flux was not shut down properly" improper.err
@@ -74,7 +74,7 @@ test_expect_success 'run a job in persistent instance (content-files)' '
 	flux start \
 	    -Scontent.backing-module=content-files \
 	    -Sstatedir=$(pwd) \
-	    flux submit /bin/true >files_id1.out
+	    flux submit true >files_id1.out
 '
 test_expect_success 'restart instance and list inactive jobs' '
 	flux start \
@@ -109,7 +109,7 @@ test_expect_success S3 'create content-s3.toml from env' '
 test_expect_success S3 'run a job in persistent instance (content-s3)' '
 	flux start \
 	    -Scontent.backing-module=content-s3 \
-	    flux submit /bin/true >files_id2.out
+	    flux submit true >files_id2.out
 '
 test_expect_success S3 'restart instance and list inactive jobs' '
 	flux start \

--- a/t/t3201-crontabs.t
+++ b/t/t3201-crontabs.t
@@ -9,31 +9,31 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 
 test_expect_success 'empty cron.directory works' '
 	mkdir cron.d &&
-	flux start -Scron.directory=cron.d /bin/true
+	flux start -Scron.directory=cron.d true
 '
 test_expect_success 'non-existent cron.directory works' '
-	flux start -Scron.directory=noexist /bin/true
+	flux start -Scron.directory=noexist true
 '
 test_expect_success 'cron.directory with subdirectory works' '
 	rm -rf cron.d &&
 	mkdir -p cron.d/subdir &&
-	flux start -Scron.directory=cron.d /bin/true
+	flux start -Scron.directory=cron.d true
 '
 test_expect_success 'cron.directory with non-crontab file fails' '
 	rm -rf cron.d &&
 	mkdir cron.d &&
 	echo zzz >cron.d/badtab &&
 	test_must_fail flux start -Scron.directory=cron.d \
-		/bin/true 2>bad.err &&
+		true 2>bad.err &&
 	grep "could not load crontab" bad.err
 '
 test_expect_success 'cron.directory with good crontab files works' '
 	rm -rf cron.d &&
 	mkdir cron.d &&
-	echo "10 * * * * /bin/true" >cron.d/goodtab &&
+	echo "10 * * * * true" >cron.d/goodtab &&
 	echo "20 * * * * hostname" >cron.d/goodtab2 &&
 	flux start -Scron.directory=cron.d flux cron list >list.out &&
-	grep /bin/true list.out &&
+	grep true list.out &&
 	grep hostname list.out
 '
 

--- a/t/t3203-instance-recovery.t
+++ b/t/t3203-instance-recovery.t
@@ -14,7 +14,7 @@ runpty="flux ${SHARNESS_TEST_SRCDIR}/scripts/runpty.py"
 test_expect_success 'start a persistent instance of size 4' '
 	mkdir -p test1 &&
 	flux start --test-size=4 --test-exit-timeout=300s \
-		-Sstatedir=$(pwd)/test1 /bin/true
+		-Sstatedir=$(pwd)/test1 true
 '
 test_expect_success 'expected broker attributes are set in recovery mode' '
 	cat >recov_attrs.exp <<-EOT &&
@@ -50,7 +50,7 @@ test_expect_success '--recovery is not ignored if --test-size is specified' '
 '
 test_expect_success 'rc1 failure is ignored in recovery mode' '
 	flux start --recovery=$(pwd)/test1 \
-	    -Sbroker.rc1_path=/bin/false \
+	    -Sbroker.rc1_path=false \
 	    -Sbroker.rc3_path= \
 	    echo "hello world" >hello.out &&
 	grep hello hello.out

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -43,12 +43,12 @@ test_expect_success 'resource status shows no drained nodes' '
 '
 
 test_expect_success 'flux exec -r 1 fails with EHOSTUNREACH' '
-	test_must_fail run_timeout 30 flux exec -r 1 /bin/true 2>unreach.err &&
+	test_must_fail run_timeout 30 flux exec -r 1 true 2>unreach.err &&
 	grep "$(strerror_symbol EHOSTUNREACH)" unreach.err
 '
 
 test_expect_success 'single node job can run with only rank 0 up' '
-	run_timeout 30 flux run -n1 /bin/true
+	run_timeout 30 flux run -n1 true
 '
 
 test_expect_success 'two node job is accepted although it cannot run yet' '

--- a/t/t3304-system-rpctrack-down.t
+++ b/t/t3304-system-rpctrack-down.t
@@ -77,7 +77,7 @@ test_expect_success NO_CHAIN_LINT 'broker 0 tracked child rpc count is nonzero' 
 
 test_expect_success 'stop broker 1 hard and wait for it to exit' '
 	$startctl kill 1 9 &&
-	($startctl wait 1 || /bin/true)
+	($startctl wait 1 || true)
 '
 
 # Ensure an EHOSTUNREACH is encountered on the socket to trigger connected

--- a/t/t3306-system-routercrash.t
+++ b/t/t3306-system-routercrash.t
@@ -123,7 +123,7 @@ test_expect_success 'ping broker 2 via broker 0' '
 # Side effect: let rc1 on rank 2 finish loading resource module
 # before shutdown begins, or it will complain
 test_expect_success 'run a 3 node job' '
-        flux run -n3 -N3 /bin/true
+        flux run -n3 -N3 true
 '
 
 

--- a/t/t3307-system-leafcrash.t
+++ b/t/t3307-system-leafcrash.t
@@ -57,7 +57,7 @@ test_expect_success 'and child returned to service' '
 # Side effect: let rc1 on rank 1 finish loading resource module
 # before shutdown begins, or it will complain
 test_expect_success 'run a 2 node job' '
-	flux run -n2 -N2 /bin/true
+	flux run -n2 -N2 true
 '
 
 test_done

--- a/t/valgrind/workload.d/job-info
+++ b/t/valgrind/workload.d/job-info
@@ -4,7 +4,7 @@ set -x
 
 # Test info fetch
 
-id=$(flux submit -n 1 /bin/true)
+id=$(flux submit -n 1 true)
 flux job attach ${id}
 
 flux job info ${id} eventlog >/dev/null

--- a/t/valgrind/workload.d/job-list
+++ b/t/valgrind/workload.d/job-list
@@ -5,7 +5,7 @@ set -x
 # Test job list
 
 # launch a few jobs just to ensure there are jobs to list
-flux submit -n 1 /bin/true
-flux submit -n 1 /bin/false
+flux submit -n 1 true
+flux submit -n 1 false
 
 flux jobs -a -A

--- a/t/valgrind/workload.d/job-wait
+++ b/t/valgrind/workload.d/job-wait
@@ -4,9 +4,9 @@ set -x
 
 # Test job wait
 
-id=$(flux submit --flags waitable /bin/true)
+id=$(flux submit --flags waitable true)
 flux job wait ${id}
 
 # No leaks if zombie persists
-id=$(flux submit --flags waitable /bin/true)
+id=$(flux submit --flags waitable true)
 flux job wait-event ${id} clean


### PR DESCRIPTION
Problem: tests that hard code `/bin/true` or `/bin/false` fail on macos, where those programs are in `/usr/bin`.

When PATH is already being searched, don't specify a fully qualfied path.