### PR TITLE
build macos with homebrew lua that is not deprecated

### DIFF
--- a/scripts/install-deps-macos.sh
+++ b/scripts/install-deps-macos.sh
@@ -22,13 +22,11 @@ brew install \
   libarchive \
   hwloc \
   sqlite \
-  lua@5.3 \
+  lua \
   python3 \
   cffi \
   libyaml \
   jq
-
-brew link lua@5.3
 
 python3 -m venv macos-venv
 source macos-venv/bin/activate


### PR DESCRIPTION
Problem: macos ci builds are failing (that didn't take long!) because apparently the lua I chose was about to be deprecated, and now is.

This fixes that.