### PR TITLE
job-exec: improve drain message for unkillable procs

### DIFF
--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -425,7 +425,7 @@ static int drain_active_ranks (struct jobinfo *job, struct idset *active_ranks)
     }
     rc = jobinfo_drain_ranks (job,
                               ranks,
-                              "unkillable processes for job %s",
+                              "unkillable user processes for job %s",
                               idf58 (job->id));
     ERRNO_SAFE_WRAP (free, ranks);
     return rc;

--- a/t/t2406-job-exec-cleanup.t
+++ b/t/t2406-job-exec-cleanup.t
@@ -102,7 +102,7 @@ test_expect_success 'job-exec: cancel test job to start kill timer' '
 test_expect_success 'job-exec: wait for job to be terminated by max-kill-count' '
 	flux job wait-event -vt 15 $jobid clean &&
 	flux dmesg -H | grep "exceeded max kill count" &&
-	flux resource drain -no {reason} | grep "unkillable processes"
+	flux resource drain -no {reason} | grep "unkillable user processes"
 '
 test_expect_success 'job-exec: kill orphan sleep PID' '
 	kill $sleep_pid


### PR DESCRIPTION
Problem: The drain message issued by the job-exec module when it gives up trying to kill user processes in the job is not clear.

Note that the unkillable job procesess were user processes to avoid confusion that epilog or housekeeping processes were at fault.

Update one test that attempts to match the old error message.

Fixes #6495