### PR TITLE
libschedutil: use preprocessor symbols for flags

### DIFF
--- a/src/common/libschedutil/init.h
+++ b/src/common/libschedutil/init.h
@@ -21,10 +21,10 @@ extern "C" {
 
 typedef struct schedutil_ctx schedutil_t;
 
-enum schedutil_flags {
-    SCHEDUTIL_FREE_NOLOOKUP = 1, // now the default so this flag is ignored
-    SCHEDUTIL_HELLO_PARTIAL_OK = 2,
-};
+/* schedutil_create() flags values
+ */
+#define SCHEDUTIL_FREE_NOLOOKUP 1 // now the default so this flag is ignored
+#define SCHEDUTIL_HELLO_PARTIAL_OK 2
 
 /* Create a handle for the schedutil convenience library.
  *


### PR DESCRIPTION
Problem: its laborious to test flux-core for the existence of schedutil flags because they are anonymous enums.

Convert to preprocessor symbols that can be easily checked with an #ifdef in the scheduler.