### PR TITLE
shell: fix signal plugin to work with Fluxion scheduler

### DIFF
--- a/src/shell/signal.c
+++ b/src/shell/signal.c
@@ -87,7 +87,7 @@ static int set_timeleft_watcher (struct shell_signal *sig)
     double remaining;
 
     if (flux_shell_info_unpack (sig->shell,
-                                "{s:{s:{s:f}}}",
+                                "{s:{s:{s:F}}}",
                                 "R",
                                 "execution",
                                 "expiration", &expiration) < 0) {


### PR DESCRIPTION
Problem: The shell signal plugin doesn't work with Fluxion because it expects a float value for expiration in R and Fluxion encodes an integer.

Update the format specifier in the signal plugin's use of json_unpack on R to use `s:F` instead of `s:f` so that the plugin works with Fluxion.

Fixes #6521