### PR TITLE
kvs-watch: support FLUX_KVS_STREAM flag

### DIFF
--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -141,6 +141,13 @@ the value is zero length.
   replaced.  The :option:`--full` option ensures these changes are reported
   as well, at greater overhead.
 
+.. option:: -S, --stream
+
+  Return potentially large values in multiple responses.  This may improve
+  response times of very large values in the KVS.
+
+  Will not work in combination with :option:`--watch`.
+
 put
 ---
 
@@ -505,6 +512,13 @@ Display the contents of an RFC 18 KVS eventlog referred to by *key*.
   Control output colorization. The optional argument *WHEN* can be one of
   'auto', 'never', or 'always'. The default value of *WHEN* if omitted is
   'always'. The default is 'auto' if the option is unused.
+
+.. option:: -S, --stream
+
+  Return potentially large eventlogs in multiple responses.  This may improve
+  response times of very large eventlogs in the KVS.
+
+  Will not work in combination with :option:`--watch`.
 
 eventlog append
 ---------------

--- a/doc/man3/flux_kvs_lookup.rst
+++ b/doc/man3/flux_kvs_lookup.rst
@@ -170,6 +170,10 @@ FLUX_KVS_WAITCREATE
    fulfilled with an ENODATA error to ensure the cancel request has been
    received and processed.
 
+FLUX_KVS_STREAM
+   Return a potentially large value in multiple responses terminated
+   by an ENODATA error response.
+
 
 RETURN VALUE
 ============

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -35,7 +35,8 @@ enum kvs_op {
     FLUX_KVS_APPEND = 32,
     FLUX_KVS_WATCH_FULL = 64,
     FLUX_KVS_WATCH_UNIQ = 128,
-    FLUX_KVS_WATCH_APPEND = 256
+    FLUX_KVS_WATCH_APPEND = 256,
+    FLUX_KVS_STREAM = 512
 };
 
 /* Namespace

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -385,7 +385,11 @@ static int handle_initial_response (flux_t *h,
             errprintf (&err,
                        "%s cannot be watched with WATCH_APPEND",
                        treeobj_type_name (val));
-            errno = EINVAL;
+            if (treeobj_is_dir (val)
+                || treeobj_is_dirref (val))
+                errno = EISDIR;
+            else
+                errno = EINVAL;
             goto error_respond;
         }
 
@@ -537,7 +541,11 @@ static int handle_append_response (flux_t *h,
             errprintf (&err,
                        "%s cannot be watched with WATCH_APPEND",
                        treeobj_type_name (val));
-            errno = EINVAL;
+            if (treeobj_is_dir (val)
+                || treeobj_is_dirref (val))
+                errno = EISDIR;
+            else
+                errno = EINVAL;
             goto error_respond;
         }
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -422,6 +422,7 @@ check_PROGRAMS = \
 	kvs/dtree \
 	kvs/blobref \
 	kvs/watch_disconnect \
+	kvs/watch_stream \
 	kvs/commit \
 	kvs/fence_api \
 	kvs/transactionmerge \
@@ -665,6 +666,11 @@ kvs_watch_disconnect_SOURCES = kvs/watch_disconnect.c
 kvs_watch_disconnect_CPPFLAGS = $(test_cppflags)
 kvs_watch_disconnect_LDADD = $(test_ldadd)
 kvs_watch_disconnect_LDFLAGS = $(test_ldflags)
+
+kvs_watch_stream_SOURCES = kvs/watch_stream.c
+kvs_watch_stream_CPPFLAGS = $(test_cppflags)
+kvs_watch_stream_LDADD = $(test_ldadd)
+kvs_watch_stream_LDFLAGS = $(test_ldflags)
 
 kvs_issue1760_SOURCES = kvs/issue1760.c
 kvs_issue1760_CPPFLAGS = $(test_cppflags)

--- a/t/kvs/watch_stream.c
+++ b/t/kvs/watch_stream.c
@@ -1,0 +1,71 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <unistd.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+
+static void usage (void)
+{
+    fprintf (stderr, "Usage: watch_stream <key>\n");
+    exit (1);
+}
+
+void stream_continuation (flux_future_t *f, void *arg)
+{
+    const char *value;
+    int *replycount = arg;
+    if (flux_kvs_lookup_get (f, &value) < 0) {
+        if (errno != ENODATA)
+            log_err_exit ("flux_kvs_lookup_get");
+        flux_future_destroy (f);
+        return;
+    }
+    printf ("%d: %s\n", ++(*replycount), value);
+    flux_future_reset (f);
+}
+
+int main (int argc, char **argv)
+{
+    flux_t *h;
+    flux_future_t *f;
+    const char *key;
+    int replycount = 0;
+
+    if (argc != 2)
+        usage();
+
+    key = argv[1];
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!(f = flux_kvs_lookup (h, NULL, FLUX_KVS_STREAM, key)))
+        log_err_exit ("flux_kvs_lookup");
+
+    if (flux_future_then (f, -1., stream_continuation, &replycount) < 0)
+        log_err_exit ("flux_future_then");
+
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        log_err_exit ("flux_reactor_run");
+
+    flux_close (h);
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
Problem: It would be convenient if there was a way to stream large data from the KVS by their individual content blobs, rather than getting a very large piece of content in one response.  Such a response can be slow and give the appearance that something is hanging.  For example, this ability would be useful for a large amount of standard output stored in the KVS.

Support a new FLUX_KVS_STREAM flag.  It will use the mechanisms built into the kvs-watch module and the FLUX_KVS_WATCH_APPEND flag to stream each content blob to the user.  Once all the content is streamed, it will return ENODATA to indicate the stream is complete.