### PR TITLE
shell: support more mustache tags

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -402,6 +402,7 @@ $(RST_FILES): \
 	man1/common/job-other-batch.rst \
 	man1/common/job-other-run.rst \
 	man1/common/job-shell-options.rst \
+	man1/common/job-mustache-templates.rst \
 	man3/common/resources.rst \
 	man3/common/experimental.rst \
 	man3/common/json_pack.rst \
@@ -496,6 +497,7 @@ EXTRA_DIST = \
 	man1/common/job-other-batch.rst \
 	man1/common/job-other-run.rst \
 	man1/common/job-shell-options.rst \
+	man1/common/job-mustache-templates.rst \
 	man3/common/resources.rst \
 	man3/common/experimental.rst \
 	man3/index.rst \

--- a/doc/man1/common/job-mustache-templates.rst
+++ b/doc/man1/common/job-mustache-templates.rst
@@ -1,0 +1,76 @@
+
+Submission commands support a simplified version of mustache templates
+in select options (e.g., :option:`--output`, :option:`--error`,
+:option:`--dump`), and job commands/arguments. These templates are replaced
+by job details once available. A mustache template is a tag in double
+braces, like *{{tag}}*.
+
+The following is a list of currently supported tags:
+
+.. note::
+   The template system in the job shell allows plugins to extend the set
+   of supported mustache tags. Check with your installation of Flux to
+   determine if extra tags are available locally.
+
+Job mustache tags:
+
+*{{id}}* or *{{jobid}}*
+  Expands to the current jobid in F58 encoding. If needed, an alternate
+  encoding may be selected by using a subkey with the name of the
+  desired encoding, e.g. *{{id.dec}}*. Supported encodings include *f58*
+  (the default), *dec*, *hex*, *dothex*, and *words*.
+
+*{{name}}*
+  Expands to the current job name. If a name is not set for the job,
+  then the basename of the command will be used.
+
+*{{nnodes}}*
+  Expands to the number of nodes allocated to the job.
+
+*{{size}}* or *{{ntasks}}*
+  Expands to the job size, or total number of tasks in the job.
+
+Node-specific tags are prefixed with *node.*, and support any of the
+keys present in the object returned by :man3:`flux_shell_get_rank_info`,
+these include:
+
+*{{node.id}}*
+  Expands to the current node index within the job (0 - nnodes-1).
+
+*{{node.name}}*
+  Expands to the hostname of the current node.
+
+*{{node.broker_rank}}*
+  Expands to the broker rank of the enclosing instance on this node.
+
+*{{node.cores}}*
+  Expands to the core id list assigned to the current node in idset
+  form. For example, ``0-3`` or ``1``
+
+*{{node.gpus}}*
+  Expands to the GPU id list assigned to the job on this node
+  in idset form, e.g. ``0-1`` or ``4``
+
+*{{node.ncores}}*
+  Expands to the number of cores allocated to the job on this node.
+
+Task-specific tags are prefixed with *task.*, with the special case of
+*{{taskid}}*, which is an alias for *{{task.id}}*.
+
+.. note::
+   The :option:`--output` and :option:`--error` options do not support
+   task-specific tags at this time.
+
+*{{task.id}}*, *{{task.rank}}*, or *{{taskid}}*
+  Expands to the global rank for the current task.
+
+*{{task.index}}* or *{{task.localid}}*
+  Expands to the local rank for the current task.
+
+Other tags:
+
+*{{tmpdir}}*
+  Expands to the path to the job temporary directory on the local system.
+
+If an unknown mustache tag is encountered, an error message may be displayed,
+and the unknown template will appear in the result.

--- a/doc/man1/common/job-standard-io.rst
+++ b/doc/man1/common/job-standard-io.rst
@@ -13,18 +13,8 @@
 .. option:: --output=TEMPLATE
 
    Specify the filename *TEMPLATE* for stdout redirection, bypassing
-   the KVS.  *TEMPLATE* may be a mustache template which supports the
-   following tags:
-
-   *{{id}}* or *{{jobid}}*
-     Expands to the current jobid in the F58 encoding. If needed, an
-     alternate encoding may be selected by using a subkey with the name
-     of the desired encoding, e.g. *{{id.dec}}*. Supported encodings
-     include *f58* (the default), *dec*, *hex*, *dothex*, and *words*.
-
-   *{{name}}*
-     Expands to the current job name. If a name is not set for the job,
-     then the basename of the command will be used.
+   the KVS.  *TEMPLATE* may be a mustache template.
+   See `MUSTACHE TEMPLATES`_ below for more information.
 
 .. option:: --error=TEMPLATE
 

--- a/doc/man1/flux-batch.rst
+++ b/doc/man1/flux-batch.rst
@@ -213,7 +213,10 @@ override those in the submission script, e.g.: ::
    $ flux jobs -no {name} ƒ112345
    test-name
 
+MUSTACHE TEMPLATES
+==================
 
+.. include:: common/job-mustache-templates.rst
 
 RESOURCES
 =========

--- a/doc/man1/flux-bulksubmit.rst
+++ b/doc/man1/flux-bulksubmit.rst
@@ -238,6 +238,11 @@ Usage: :option:`flux bulksubmit -o NAME[=ARG]`.
 .. include:: common/job-shell-options.rst
 .. program:: flux bulksubmit
 
+MUSTACHE TEMPLATES
+==================
+
+.. include:: common/job-mustache-templates.rst
+
 RESOURCES
 =========
 

--- a/doc/man1/flux-run.rst
+++ b/doc/man1/flux-run.rst
@@ -154,6 +154,11 @@ Usage: :option:`flux run -o NAME[=ARG]`.
 .. include:: common/job-shell-options.rst
 .. program:: flux run
 
+MUSTACHE TEMPLATES
+==================
+
+.. include:: common/job-mustache-templates.rst
+
 RESOURCES
 =========
 

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -610,13 +610,17 @@ supported. Job shell specific functions and tables are described below:
   then the current rank is used.  Returns a table of rank-specific
   information including:
 
+  **id**
+    The current shell rank (matches ``shell_rank`` input parameter)
+  **name**
+    The host name for ``shell_rank``
   **broker_rank**
     The broker rank on which ``shell_rank`` is running.
   **ntasks**
     The number of local tasks assigned to ``shell_rank``.
   **resources**
     A table of resources by name (e.g. "core", "gpu") assigned to
-    ``shell_rank``, e.g. ``{ core = "0-1", gpu = "0" }``.
+    ``shell_rank``, e.g. ``{ ncores = 2, core = "0-1", gpu = "0" }``.
 
 **shell.log(msg)**, **shell.debug(msg)**, **shell.log_error(msg)**
   Log messages to the shell log facility at INFO, DEBUG, and ERROR

--- a/doc/man1/flux-submit.rst
+++ b/doc/man1/flux-submit.rst
@@ -154,6 +154,11 @@ Usage: :option:`flux submit -o NAME[=ARG]`.
 .. include:: common/job-shell-options.rst
 .. program:: flux submit
 
+MUSTACHE TEMPLATES
+==================
+
+.. include:: common/job-mustache-templates.rst
+
 RESOURCES
 =========
 

--- a/doc/man3/flux_shell_get_info.rst
+++ b/doc/man3/flux_shell_get_info.rst
@@ -53,12 +53,15 @@ string with the following layout:
 
 ::
 
+   "id":i,
+   "name":s,
    "broker_rank":i,
    "ntasks":i
    "taskids":s
-   "resources": { "cores":s, ... }
+   "resources": { "ncores":i, "cores":s, ... }
 
-where :var:`broker_rank` is the broker rank on which the target shell rank
+where :var:`id` is the shell rank, :var:`name` is the hostname of that shell
+rank, :var:`broker_rank` is the broker rank on which the target shell rank
 of the query is running, :var:`ntasks` is the number of tasks running under
 that shell rank, :var:`taskids` is a list of task id assignments for those
 tasks (an RFC 22 idset string), and :var:`resources` is a dictionary of

--- a/src/shell/mustache.c
+++ b/src/shell/mustache.c
@@ -20,8 +20,6 @@
 
 struct mustache_renderer {
     mustache_tag_f tag_f;
-    void *tag_arg;
-
     mustache_log_f llog;
     void *llog_data;
 };
@@ -32,8 +30,7 @@ void mustache_renderer_destroy (struct mustache_renderer *mr)
 }
 
 
-struct mustache_renderer * mustache_renderer_create (mustache_tag_f tagfn,
-                                                     void *arg)
+struct mustache_renderer * mustache_renderer_create (mustache_tag_f tagfn)
 {
     struct mustache_renderer *mr = NULL;
 
@@ -44,7 +41,6 @@ struct mustache_renderer * mustache_renderer_create (mustache_tag_f tagfn,
     if (!(mr = calloc (1, sizeof (*mr))))
         return NULL;
     mr->tag_f = tagfn;
-    mr->tag_arg = arg;
     return (mr);
 }
 
@@ -58,7 +54,9 @@ void mustache_renderer_set_log (struct mustache_renderer *mr,
     }
 }
 
-char *mustache_render (struct mustache_renderer *mr, const char *template)
+char *mustache_render (struct mustache_renderer *mr,
+                       const char *template,
+                       void *arg)
 {
     char name [1024];
     size_t size;
@@ -120,7 +118,7 @@ char *mustache_render (struct mustache_renderer *mr, const char *template)
         len = end - start;
         memcpy (name, start, len);
         name[len] = '\0';
-        if ((*mr->tag_f) (fp, name, mr->tag_arg) < 0) {
+        if ((*mr->tag_f) (fp, name, arg) < 0) {
             /*  If callback fails, just fail to expand the current mustache tag.
              */
             fprintf (fp, "{{%s}}", name);

--- a/src/shell/mustache.h
+++ b/src/shell/mustache.h
@@ -38,8 +38,7 @@ struct mustache_renderer;
 /*  Create a mustache renderer, with mustache tags expanded by tag
  *   callback `cb`. (See callback definition above).
  */
-struct mustache_renderer *mustache_renderer_create (mustache_tag_f cb,
-                                                    void *arg);
+struct mustache_renderer *mustache_renderer_create (mustache_tag_f cb);
 
 void mustache_renderer_destroy (struct mustache_renderer *mr);
 
@@ -48,10 +47,13 @@ void mustache_renderer_destroy (struct mustache_renderer *mr);
 void mustache_renderer_set_log (struct mustache_renderer *mr,
                                 mustache_log_f log,
                                 void *log_data);
-                                
+
 /*  Render the mustache template 'template' with renderer 'mr'.
+ *  The opaque argument 'arg' will be passed to the tag callback(s).
  */
-char * mustache_render (struct mustache_renderer *mr, const char *template);
+char * mustache_render (struct mustache_renderer *mr,
+                        const char *template,
+                        void *arg);
 
 #endif /* !_SHELL_MUSTACHE_H */
 

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1175,7 +1175,7 @@ static int mustache_render_jobid (flux_shell_t *shell,
 
     if (strlen (name) > 2) {
         if (name[2] != '.') {
-            shell_log_error ("Unknown mustache tag '%s'", name);
+            errno = ENOENT;
             return -1;
         }
         type = name+3;
@@ -1246,7 +1246,7 @@ static int mustache_cb (FILE *fp, const char *name, void *arg)
                                 "{s:s}",
                                 "result", &result) < 0
         || result == NULL) {
-        shell_log_error ("Unknown mustache tag '%s'", name);
+        errno = ENOENT;
         goto out;
     }
     if (fputs (result, fp) < 0) {

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1030,7 +1030,7 @@ char *flux_shell_mustache_render (flux_shell_t *shell, const char *fmt)
         errno = EINVAL;
         return NULL;
     }
-    return mustache_render (shell->mr, fmt);
+    return mustache_render (shell->mr, fmt, shell);
 }
 
 static int mustache_render_name (flux_shell_t *shell,
@@ -1161,7 +1161,7 @@ static void shell_initialize (flux_shell_t *shell)
         shell_die_errno (1, "zhashx_new");
     zhashx_set_destructor (shell->completion_refs, item_free);
 
-    if (!(shell->mr = mustache_renderer_create (mustache_cb, shell)))
+    if (!(shell->mr = mustache_renderer_create (mustache_cb)))
         shell_die_errno (1, "mustache_renderer_create");
     mustache_renderer_set_log (shell->mr, shell_llog, NULL);
 

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1217,6 +1217,10 @@ static int mustache_cb (FILE *fp, const char *name, void *arg)
         return mustache_render_jobid (shell, name, fp);
     if (streq (name, "name"))
         return mustache_render_name (shell, name, fp);
+    if (streq (name, "nnodes"))
+        return fprintf (fp, "%d", shell->info->shell_size);
+    if (streq (name, "ntasks") || streq (name, "size"))
+        return fprintf (fp, "%d", shell->info->total_ntasks);
     if (strstarts (name, "task."))
         return mustache_render_task (shell, shell->current_task, name, fp);
     if (strstarts (name, "node."))

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -131,9 +131,11 @@ int flux_shell_info_unpack (flux_shell_t *shell,
 /*  Return rank and task info for given shell rank as JSON string.
  *  {
  *   "broker_rank":i,
+ *   "id":i,      // same as shell_rank parameter
+ *   "name":s,    // hostname of this shell_rank
  *   "ntasks":i
  *   "taskids": s // task id list for this rank in RFC 22 idset form.
- *   "resources": { "cores":s, ... }
+ *   "resources": { "ncores":i, "cores":s, ... }
  *  }
  */
 int flux_shell_get_rank_info (flux_shell_t *shell,

--- a/src/shell/test/mustache.c
+++ b/src/shell/test/mustache.c
@@ -68,22 +68,22 @@ int main (int argc, char **argv)
 
     plan (NO_PLAN);
 
-    mr = mustache_renderer_create (NULL, NULL);
+    mr = mustache_renderer_create (NULL);
     ok (mr == NULL && errno == EINVAL,
         "mustache_renderer_create fails with invalid callback");
 
     /*  Pass tests as tag_f argument so we have something non-NULL to test
      *   in the callback
      */
-    mr = mustache_renderer_create (cb, tests);
+    mr = mustache_renderer_create (cb);
     ok (mr != NULL,
         "mustache_renderer_create");
 
-    ok (mustache_render (mr, NULL) == NULL && errno == EINVAL,
+    ok (mustache_render (mr, NULL, tests) == NULL && errno == EINVAL,
         "mustache_render (mr, NULL) returns EINVAL");
 
     while (mp->template != NULL) {
-        char * result = mustache_render (mr, mp->template);
+        char * result = mustache_render (mr, mp->template, tests);
         if (mp->expected == NULL)
             ok (result == NULL && errno == mp->errnum,
                 "mustache_render '%s' failed with errno = %d",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -216,6 +216,7 @@ TESTSCRIPTS = \
 	t2617-job-shell-stage-in.t \
 	t2618-job-shell-signal.t \
 	t2619-job-shell-hwloc.t \
+	t2620-job-shell-mustache.t \
 	t2710-python-cli-submit.t \
 	t2711-python-cli-run.t \
 	t2713-python-cli-bulksubmit.t \

--- a/t/t2604-job-shell-affinity.t
+++ b/t/t2604-job-shell-affinity.t
@@ -117,9 +117,23 @@ test_expect_success 'flux-shell: load alloc-bypass jobtap plugin' '
 '
 test_expect_success 'flux-shell: create multi-gpu R' '
 	cat >R.gpu <<-EOF
-	        {"version": 1, "execution":{ "R_lite":[
-                { "children": { "core": "0-1", "gpu": "0-3" }, "rank": "0" }
-        ]}}
+	{
+	  "version": 1,
+	  "execution": {
+	    "R_lite": [
+	      {
+		"children": {
+		  "core": "0-1",
+		  "gpu": "0-3"
+		},
+		"rank": "0"
+	      }
+	    ],
+	    "nodelist": [
+	      "$(hostname)"
+	    ]
+	  }
+	}
 	EOF
 '
 test_expect_success 'flux-shell: gpu-affinity works by default' '

--- a/t/t2620-job-shell-mustache.t
+++ b/t/t2620-job-shell-mustache.t
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+test_description='Test flux-shell mustache template rendering'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 2 job
+
+test_expect_success 'mustache: templates are rendered in job arguments' '
+	flux run -N2 -n4 \
+	  echo {{id.words}}: size={{size}} nnodes={{nnodes}} name={{name}} \
+	  >output.1 &&
+	test_debug "cat output.1" &&
+	grep "size=4 nnodes=2 name=echo" output.1
+'
+test_expect_success 'mustache: per-task tags work' '
+	flux run -N2 -n4 --label-io \
+	  echo {{taskid}}: rank={{task.rank}} index={{task.index}} \
+	  | sort >output.2 &&
+	test_debug "cat output.2" &&
+	cat <<-EOF >expected.2 &&
+	0: 0: rank=0 index=0
+	1: 1: rank=1 index=1
+	2: 2: rank=2 index=0
+	3: 3: rank=3 index=1
+	EOF
+	test_cmp expected.2 output.2
+'
+test_expect_success 'mustache: per-node tags work' '
+	flux run -N2 -n2 --label-io \
+	  echo id={{node.id}} name={{node.name}} cores={{node.cores}}[{{node.ncores}}] \
+	  | sort >output.3 &&
+	test_debug "cat output.3" &&
+	cat <<-EOF >expected.3 &&
+	0: id=0 name=$(hostname) cores=0[1]
+	1: id=1 name=$(hostname) cores=0[1]
+	EOF
+	test_cmp expected.3 output.3
+'
+test_expect_success 'mustache: node.resources renders as JSON' '
+	flux run -N2 -n2 echo {{node.resources}} | jq
+'
+test_expect_success 'mustache: unsupported tag is left alone' '
+	flux run echo {{foo}} {{node.foo}} {{task.foo}} >output.4 &&
+	test_debug "cat output.4" &&
+	test "$(cat output.4)" = "{{foo}} {{node.foo}} {{task.foo}}"
+'
+
+test_done


### PR DESCRIPTION
This PR adds new mustache tags specific to tasks and nodes (shell rank, really), formatted as `{{task.*}}` and `{{node.*}}`, with a couple special cases. The node tags use the "rank info" object in the shell to render results, which has been updated with additional items for mustache tag use.

Since there are many more supported tags to document, a new _MUSTACHE TEMPLATES_ section is added to the job submission ccommands' manual pages, pasted here since it contains the set of supported tags:

## MUSTACHE TEMPLATES

Submission commands support a simplified version of mustache templates in select options (e.g., `--output`, `--error`, `--dump`), and job commands/arguments. These templates are replaced by job details once available. A mustache template is a tag in double braces, like `{{tag}}`.

The following is a list of currently supported tags:

> **Note**  
> The template system in the job shell allows plugins to extend the set of supported mustache tags. Check with your installation of Flux to determine if extra tags are available locally.

### Job mustache tags:

- `{{id}}` or `{{jobid}}`  
  Expands to the current jobid in F58 encoding. If needed, an alternate encoding may be selected by using a subkey with the name of the desired encoding, e.g., `{{id.dec}}`. Supported encodings include `f58` (the default), `dec`, `hex`, `dothex`, and `words`.

- `{{name}}`  
  Expands to the current job name. If a name is not set for the job, then the basename of the command will be used.

- `{{nnodes}}`  
  Expands to the number of nodes allocated to the job.

- `{{size}}` or `{{ntasks}}`  
  Expands to the job size, or total number of tasks in the job.

### Node-specific tags

Node-specific tags are prefixed with `node.`, and support any of the keys present in the object returned by `flux_shell_get_rank_info`. These include:

- `{{node.id}}`  
  Expands to the current node index within the job (0 - nnodes-1).

- `{{node.name}}`  
  Expands to the hostname of the current node.

- `{{node.broker_rank}}`  
  Expands to the broker rank of the enclosing instance on this node.

- `{{node.cores}}`  
  Expands to the core id list assigned to the current node in idset form. For example, `0-3` or `1`.

- `{{node.gpus}}`  
  Expands to the GPU id list assigned to the job on this node in idset form, e.g., `0-1` or `4`.

- `{{node.ncores}}`  
  Expands to the number of cores allocated to the job on this node.

### Task-specific tags

Task-specific tags are prefixed with `task.`, with the special case of `{{taskid}}`, which is an alias for `{{task.id}}`.

> **Note**  
> The `--output` and `--error` options do not support task-specific tags at this time.

- `{{task.id}}`, `{{task.rank}}`, or `{{taskid}}`  
  Expands to the global rank for the current task

- `{{task.index}}` or `{{task.localid}}`
  Expands to the local rank for the current task
  
### Other tags:

- `{{tmpdir}}`
  Expands to the path of the job temporary directory on the local system.
  
If an unknown mustache tag is encountered, an error message may be displayed and the unknown template will appear in the result.