### PR TITLE
flux-kvs: improve eventlog error messages

### DIFF
--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -2019,8 +2019,11 @@ void eventlog_get_continuation (flux_future_t *f, void *arg)
     if (flux_kvs_lookup_get (f, &s) < 0)
         log_err_exit ("flux_kvs_lookup_get");
 
-    if (!(a = eventlog_decode (s)))
+    if (!(a = eventlog_decode (s))) {
+        if (errno == EINVAL)
+            log_msg_exit ("cannot decode improperly formatted eventlog");
         log_err_exit ("eventlog_decode");
+    }
 
     json_array_foreach (a, index, value) {
         if (optparse_hasopt (ctx->p, "watch")) {
@@ -2135,8 +2138,11 @@ void eventlog_wait_event_continuation (flux_future_t *f, void *arg)
             log_err_exit ("flux_kvs_lookup_get");
     }
 
-    if (!(a = eventlog_decode (s)))
+    if (!(a = eventlog_decode (s))) {
+        if (errno == EINVAL)
+            log_msg_exit ("cannot decode improperly formatted eventlog");
         log_err_exit ("eventlog_decode");
+    }
 
     json_array_foreach (a, index, value) {
         const char *name;

--- a/t/t1008-kvs-eventlog.t
+++ b/t/t1008-kvs-eventlog.t
@@ -224,6 +224,12 @@ test_expect_success 'flux kvs eventlog get fails on bad input' '
 	test_must_fail flux kvs eventlog get
 '
 
+test_expect_success 'flux kvs eventlog get fails on not an eventlog' '
+	flux kvs put test.noteventlog=foo &&
+	test_must_fail flux kvs eventlog get test.noteventlog 2> noteventlog1.err &&
+	grep "cannot decode" noteventlog1.err
+'
+
 test_expect_success 'flux kvs eventlog append fails on bad input' '
 	test_must_fail flux kvs eventlog append
 '
@@ -234,6 +240,11 @@ test_expect_success 'flux kvs eventlog append fails with invalid context' '
 
 test_expect_success 'flux kvs eventlog wait-event fails on bad input' '
 	test_must_fail flux kvs eventlog wait-event
+'
+
+test_expect_success 'flux kvs eventlog wait-event fails on not an eventlog' '
+	test_must_fail flux kvs eventlog wait-event test.noteventlog foo 2> noteventlog2.err &&
+	grep "cannot decode" noteventlog2.err
 '
 
 #


### PR DESCRIPTION
Problem: When an improperly formatted eventlog is input into eventlog commands, a non-useful error message is output.

Output a better error message.

