### PR TITLE
fix possible truncation of strings with "expandable" output fields

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -741,7 +741,7 @@ class OutputFormat:
 
             # Also adjust precision if necessary (only for string type)
             if (
-                self.type in (None, "s")
+                self.type in (None, "s", "")
                 and self.precision
                 and self.precision < self.width
             ):

--- a/t/python/t0024-util.py
+++ b/t/python/t0024-util.py
@@ -207,9 +207,9 @@ class TestOutputFormat(unittest.TestCase):
         self.assertEqual(fmt, "{i:>8} {f:8.2}")
 
         fmt = OutputFormat(
-            "?+:{i:>7} ?:{s:>6} ?+:{f:.2}", headings=self.headings
+            "?+:{i:>7} ?:{s:>6} ?+:{f:.2f}", headings=self.headings
         ).filter(items)
-        self.assertEqual(fmt, "{i:>8} {f:3.2}")
+        self.assertEqual(fmt, "{i:>8} {f:3.2f}")
 
     def test_sort(self):
         a = Item("a", 0, 2.2)

--- a/t/python/t0024-util.py
+++ b/t/python/t0024-util.py
@@ -250,6 +250,17 @@ class TestOutputFormat(unittest.TestCase):
         formatter.sort_items(items)
         self.assertListEqual(items, [z, d, a])
 
+    def test_issue6530(self):
+        a = Item("1234567890", 0, 2.2)
+        b = Item("abcdefghijklmnop", 2, 13)
+        c = Item("c", 4, 5.0)
+
+        items = [a, b, c]
+        fmt = OutputFormat(
+            "+:{s:5.5} +:{i:4d} +:{f:.2f}", headings=self.headings
+        ).filter(items)
+        self.assertEqual(fmt, "{s:16.16} {i:4d} {f:3.2f}")
+
 
 if __name__ == "__main__":
     unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
This PR fixes truncation of strings in output formats that use the `+:` sentinel, when the field width is greater than the minimum precision (e.g. `+:{field:10.10}` and the maximum width > 10)