### PR TITLE
shell: make shell tasks available in `shell.init` callback

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -255,14 +255,13 @@ static void output_cb (struct bulk_exec *exec,
     const char *cmd = flux_cmd_arg (flux_subprocess_get_cmd (p), 0);
     int rank = flux_subprocess_rank (p);
 
-    if (streq (stream, "stdout")) {
-        if (len == 6
-            && strncmp (data, "enter\n", 6) == 0
-            && exec_barrier_enter (exec, rank) < 0) {
+    if (streq (stream, "stdout")
+        && len == 6
+        && strncmp (data, "enter\n", 6) == 0) {
+        if (exec_barrier_enter (exec, rank) < 0)
             jobinfo_fatal_error (job,
                                  errno,
                                  "Failed to handle barrier");
-        }
         return;
     }
     jobinfo_log_output (job,

--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -334,6 +334,7 @@ void shell_info_destroy (struct shell_info *info)
         rcalc_destroy (info->rcalc);
         taskmap_destroy (info->taskmap);
         idset_destroy (info->taskids);
+        hostlist_destroy (info->hostlist);
         free (info->hwloc_xml);
         free (info);
         errno = saved_errno;

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -457,14 +457,16 @@ static void shell_output_log (struct shell_output *out, json_t *context)
     int fd = out->stderr_file.fdp->fd;
     json_error_t error;
 
-    if (json_unpack_ex (context, &error, 0,
-                     "{ s?i s:i s:s s?s s?s s?i }",
-                     "rank", &rank,
-                     "level", &level,
-                     "message", &msg,
-                     "component", &component,
-                     "file", &file,
-                     "line", &line) < 0) {
+    if (json_unpack_ex (context,
+                        &error,
+                        0,
+                        "{ s?i s:i s:s s?s s?s s?i }",
+                        "rank", &rank,
+                        "level", &level,
+                        "message", &msg,
+                        "component", &component,
+                        "file", &file,
+                        "line", &line) < 0) {
         /*  Ignore log messages that cannot be unpacked so we don't
          *   log an error while logging.
          */
@@ -729,7 +731,8 @@ static int shell_output_handler (flux_plugin_t *p,
     const void *data;
     size_t len;
 
-    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
                                 "{s:s s:i s:s%}",
                                 "stream", &stream,
                                 "rank", &rank,
@@ -1163,8 +1166,10 @@ static int log_output (flux_plugin_t *p,
     int level = -1;
     json_t *context = NULL;
 
-    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
-                                "{s:i}", "level", &level) < 0)
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:i}",
+                                "level", &level) < 0)
         return -1;
     if (level > FLUX_SHELL_NOTICE + out->shell->verbose)
         return 0;
@@ -1487,8 +1492,10 @@ static int shell_output_init (flux_plugin_t *p,
     struct shell_output *out = shell_output_create (shell);
     if (!out)
         return -1;
-    if (flux_plugin_aux_set (p, "builtin.output", out,
-                            (flux_free_f) shell_output_destroy) < 0) {
+    if (flux_plugin_aux_set (p,
+                             "builtin.output",
+                             out,
+                             (flux_free_f) shell_output_destroy) < 0) {
         shell_output_destroy (out);
         return -1;
     }

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -380,8 +380,11 @@ nomem:
     return -1;
 }
 
-int flux_shell_setenvf (flux_shell_t *shell, int overwrite,
-                        const char *name, const char *fmt, ...)
+int flux_shell_setenvf (flux_shell_t *shell,
+                        int overwrite,
+                        const char *name,
+                        const char *fmt,
+                        ...)
 {
     json_t *env;
     va_list ap;
@@ -1142,7 +1145,9 @@ static int mustache_render_name (flux_shell_t *shell,
 {
     const char *jobname = NULL;
     json_error_t error;
-    if (json_unpack_ex (shell->info->jobspec->jobspec, &error, 0,
+    if (json_unpack_ex (shell->info->jobspec->jobspec,
+                        &error,
+                        0,
                         "{s:{s:{s?{s?s}}}}",
                         "attributes",
                          "system",
@@ -1440,7 +1445,8 @@ static int load_initrc (flux_shell_t *shell, const char *default_rcfile)
     shell_debug ("Loading %s", rcfile);
 
     if (shell_rc (shell, rcfile) < 0) {
-        shell_die (1, "loading rc file %s%s%s",
+        shell_die (1,
+                   "loading rc file %s%s%s",
                    rcfile,
                    errno ? ": " : "",
                    errno ? strerror (errno) : "");
@@ -1665,13 +1671,17 @@ static int shell_register_event_context (flux_shell_t *shell)
         return 0;
     o = taskmap_encode_json (shell->info->taskmap, TASKMAP_ENCODE_WRAPPED);
     if (o == NULL
-        || flux_shell_add_event_context (shell, "shell.init", 0,
+        || flux_shell_add_event_context (shell,
+                                         "shell.init",
+                                         0,
                                          "{s:i s:i}",
                                          "leader-rank",
                                          shell->info->rankinfo.rank,
                                          "size",
                                          shell->info->shell_size) < 0
-        || flux_shell_add_event_context (shell, "shell.start", 0,
+        || flux_shell_add_event_context (shell,
+                                         "shell.start",
+                                         0,
                                          "{s:O}",
                                          "taskmap", o) < 0)
         goto out;
@@ -1768,7 +1778,8 @@ int main (int argc, char *argv[])
 
     /* Set no_process_group if nosetpgrp option is set */
     if (flux_shell_getopt_unpack (&shell,
-                                  "nosetpgrp", "i",
+                                  "nosetpgrp",
+                                  "i",
                                   &shell.nosetpgrp) < 0)
         shell_die (1, "failed to parse attributes.system.shell.nosetpgrp");
 
@@ -1861,7 +1872,8 @@ int main (int argc, char *argv[])
                 ec = 126;
             else if (errno == ENOENT)
                 ec = 127;
-            shell_die (ec, "task %d (host %s): start failed: %s: %s",
+            shell_die (ec,
+                       "task %d (host %s): start failed: %s: %s",
                        task->rank,
                        shell.hostname,
                        flux_cmd_arg (task->cmd, 0),

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -87,8 +87,10 @@ int flux_shell_get_environ (flux_shell_t *shell, char **json_str);
 
 /*  Set an environment variable in the global job environment
  */
-int flux_shell_setenvf (flux_shell_t *shell, int overwrite,
-                        const char *name, const char *fmt, ...)
+int flux_shell_setenvf (flux_shell_t *shell,
+                        int overwrite,
+                        const char *name,
+                        const char *fmt, ...)
                         __attribute__ ((format (printf, 4, 5)));
 
 /*  Unset an environment variable in the global job environment

--- a/t/job-exec/dummy.sh
+++ b/t/job-exec/dummy.sh
@@ -150,8 +150,8 @@ test_mock_failure() {
 
 barrier() {
     if [[ ${NNODES} -gt 1 ]]; then
-        echo enter >&${FLUX_EXEC_PROTOCOL_FD:-1}
-        read -u ${FLUX_EXEC_PROTOCOL_FD:-0} line
+        echo enter >&1
+        read -u 0 line
         if [[ ${line##*=} -ne 0 ]]; then
             exit ${line##*=}
         fi

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -209,10 +209,6 @@ static int shell_cb (flux_plugin_t *p,
         errno = 0;
         ok (flux_shell_current_task (shell) == NULL && errno == 0,
             "flux_shell_current_task returns no task in shell.init");
-        ok (flux_shell_task_first (shell) == NULL && errno == EAGAIN,
-            "flux_shell_task_first (shell) in shell.init returns EAGAIN");
-        ok (flux_shell_task_next (shell) == NULL && errno == EAGAIN,
-            "flux_shell_task_next (shell) in shell.init returns EAGAIN");
     }
     if (streq (topic, "shell.exit"))
         return exit_status () == 0 ? 0 : -1;

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -38,6 +38,9 @@ static int shell_cb (flux_plugin_t *p,
     char *json_str;
     flux_shell_t *shell = flux_plugin_get_shell (p);
 
+    if (streq (topic, "shell.log"))
+        return 0;
+
     diag ("invalid-args: %s", topic);
     if (!shell)
         return die ("flux_plugin_get_shell: %s\n", strerror (errno));

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -347,19 +347,6 @@ test_expect_success 'job-shell: job fails if FLUX_JOB_TMPDIR cannot be created' 
 test_expect_success 'job-shell: restore rundir writability' '
 	chmod 700 $(flux getattr rundir)
 '
-
-test_expect_success 'job-shell: fails if FLUX_EXEC_PROTOCOL_FD incorrect' '
-	cat <<-EOF >shell2.sh &&
-	#!/bin/sh
-	export FLUX_EXEC_PROTOCOL_FD=foo
-	exec ${FLUX_BUILD_DIR}/src/shell/flux-shell "\$@"
-	EOF
-	chmod +x shell2.sh &&
-	test_must_fail flux run \
-		--setattr=system.exec.job_shell=$(pwd)/shell2.sh \
-		-n2 -N2 hostname 2>protocol_fd_invalid.err &&
-	grep FLUX_EXEC_PROTOCOL_FD protocol_fd_invalid.err
-'
 test_expect_success 'job-shell: corrects HOSTNAME environment variable' '
 	HOSTNAME=incorrect \
 		flux run -n1 printenv HOSTNAME >hostname.out &&


### PR DESCRIPTION
The main purpose of this PR is to create the shell task list earlier in initialization so that tasks can be iterated in the `shell.init` callback. This may be convenient in some scenarios where some per-task work is being done and that work may fail. With this change, the failure would occur during `shell.init` and cleanup will be simplified since no tasks have been started yet.

Other fixes that were discovered along the way are included here.

