### PR TITLE
add `resource.rediscover` config key to force rediscovery of subinstance resources

### DIFF
--- a/doc/man5/flux-config-resource.rst
+++ b/doc/man5/flux-config-resource.rst
@@ -75,6 +75,10 @@ noverify
    (optional) If true, disable the draining of nodes when there is a
    discrepancy between configured resources and HWLOC-probed resources.
 
+rediscover
+   (optional) If true, force rediscovery of resources using HWLOC, rather
+   then using the R and HWLOC XML from the enclosing instance.
+
 Note that updates to the resource table are ignored until the next Flux
 restart.
 

--- a/src/modules/resource/inventory.c
+++ b/src/modules/resource/inventory.c
@@ -595,7 +595,11 @@ static int start_resource_watch (struct inventory *inv,
     }
     flux_future_reset (f);
     inv->R_watch_f = f;
-    if (R) { // R = NULL if no conversion possible (fall through to discovery)
+
+    /* If R == NULL (no conversion possible) or rediscover == true, then
+     * we will fall through to dynamic discovery.
+     */
+    if (R && !config->rediscover) {
         if (inventory_put (inv, R, "job-info") < 0)
             goto done;
         if (flux_future_then (f,

--- a/src/modules/resource/inventory.h
+++ b/src/modules/resource/inventory.h
@@ -12,12 +12,11 @@
 #define _FLUX_RESOURCE_INVENTORY_H
 
 /* Create resource inventory.
- * R is configured resource object, if any (ref taken).
+ * config->R is configured resource object, if any (ref taken).
  * R is obtained from enclosing Flux instance or probed dynamically otherwise.
  */
 struct inventory *inventory_create (struct resource_ctx *ctx,
-                                    json_t *R,
-                                    bool no_update_watch);
+                                    struct resource_config *config);
 void inventory_destroy (struct inventory *inv);
 
 /* Get resource object.

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -57,6 +57,10 @@
  * no-update-watch = false
  *   For testing purposes, simulate missing job-info.update-watch service
  *   in parent instance by sending to an invalid service name.
+ *
+ * rediscover = false
+ *   Force rediscovery of local resources via hwloc. Do not fetch R or hwloc
+ *   XML from the enclosing instance.
  */
 static int parse_config (struct resource_ctx *ctx,
                          const flux_conf_t *conf,
@@ -70,12 +74,13 @@ static int parse_config (struct resource_ctx *ctx,
     int noverify = 0;
     int norestrict = 0;
     int no_update_watch = 0;
+    int rediscover = 0;
     json_t *o = NULL;
     json_t *config = NULL;
 
     if (flux_conf_unpack (conf,
                           &error,
-                          "{s?{s?s s?s s?o s?s s?b s?b s?b !}}",
+                          "{s?{s?s s?s s?o s?s s?b s?b s?b s?b !}}",
                           "resource",
                             "path", &path,
                             "scheduling", &scheduling_path,
@@ -83,7 +88,8 @@ static int parse_config (struct resource_ctx *ctx,
                             "exclude", &exclude,
                             "norestrict", &norestrict,
                             "noverify", &noverify,
-                            "no-update-watch", &no_update_watch) < 0) {
+                            "no-update-watch", &no_update_watch,
+                            "rediscover", &rediscover) < 0) {
         errprintf (errp,
                    "error parsing [resource] configuration: %s",
                    error.text);
@@ -144,6 +150,7 @@ static int parse_config (struct resource_ctx *ctx,
         rconfig->noverify = noverify ? true : false;
         rconfig->norestrict = norestrict ? true : false;
         rconfig->no_update_watch = no_update_watch ? true : false;
+        rconfig->rediscover = rediscover ? true : false;
         rconfig->R = o;
     }
     else

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -347,9 +347,7 @@ int mod_main (flux_t *h, int argc, char **argv)
      *  Create inventory on all ranks first, since it is required by
      *  the exclude and drain subsystems on rank 0.
      */
-    if (!(ctx->inventory = inventory_create (ctx,
-                                             config.R,
-                                             config.no_update_watch)))
+    if (!(ctx->inventory = inventory_create (ctx, &config)))
         goto error;
 
     if (ctx->rank == 0) {
@@ -382,7 +380,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     /*  topology is initialized after exclude/drain etc since this
      *  rank may attempt to drain itself due to a topology mismatch.
      */
-    if (!(ctx->topology = topo_create (ctx, config.noverify, config.norestrict)))
+    if (!(ctx->topology = topo_create (ctx, &config)))
         goto error;
     if (!(ctx->monitor = monitor_create (ctx,
                                          inventory_get_size (ctx->inventory),

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -60,11 +60,7 @@
  */
 static int parse_config (struct resource_ctx *ctx,
                          const flux_conf_t *conf,
-                         const char **excludep,
-                         json_t **R,
-                         bool *noverifyp,
-                         bool *norestrictp,
-                         bool *no_update_watchp,
+                         struct resource_config *rconfig,
                          flux_error_t *errp)
 {
     flux_error_t error;
@@ -143,16 +139,13 @@ static int parse_config (struct resource_ctx *ctx,
             return -1;
         }
     }
-    if (excludep)
-        *excludep = exclude;
-    if (noverifyp)
-        *noverifyp = noverify ? true : false;
-    if (norestrictp)
-        *norestrictp = norestrict ? true : false;
-    if (no_update_watchp)
-        *no_update_watchp = no_update_watch ? true : false;
-    if (R)
-        *R = o;
+    if (rconfig) {
+        rconfig->exclude_idset = exclude;
+        rconfig->noverify = noverify ? true : false;
+        rconfig->norestrict = norestrict ? true : false;
+        rconfig->no_update_watch = no_update_watch ? true : false;
+        rconfig->R = o;
+    }
     else
         json_decref (o);
     return 0;
@@ -174,7 +167,7 @@ static void config_reload_cb (flux_t *h,
 
     if (flux_conf_reload_decode (msg, &conf) < 0)
         goto error;
-    if (parse_config (ctx, conf, NULL, NULL, NULL, NULL, NULL, &error) < 0) {
+    if (parse_config (ctx, conf, NULL, &error) < 0) {
         errstr = error.text;
         goto error;
     }
@@ -305,12 +298,9 @@ error:
     return -1;
 }
 
-int parse_args (flux_t *h,
-                int argc,
+int parse_args (flux_t *h, int argc,
                 char **argv,
-                bool *monitor_force_up,
-                bool *noverify,
-                bool *no_update_watch)
+                struct resource_config *config)
 {
     int i;
     for (i = 0; i < argc; i++) {
@@ -318,9 +308,9 @@ int parse_args (flux_t *h,
          * 'restart' event posted to resource.eventlog.
          */
         if (streq (argv[i], "monitor-force-up"))
-            *monitor_force_up = true;
+            config->monitor_force_up = true;
         else if (streq (argv[i], "noverify"))
-            *noverify = true;
+            config->noverify = true;
         else  {
             flux_log (h, LOG_ERR, "unknown option: %s", argv[i]);
             errno = EINVAL;
@@ -335,13 +325,8 @@ int mod_main (flux_t *h, int argc, char **argv)
 {
     struct resource_ctx *ctx;
     flux_error_t error;
-    const char *exclude_idset;
     json_t *eventlog = NULL;
-    bool monitor_force_up = false;
-    bool noverify = false;
-    bool norestrict = false;
-    bool no_update_watch = false;
-    json_t *R_from_config;
+    struct resource_config config = {0};
 
     if (!(ctx = resource_ctx_create (h)))
         goto error;
@@ -349,38 +334,24 @@ int mod_main (flux_t *h, int argc, char **argv)
         goto error;
     if (flux_get_rank (h, &ctx->rank) < 0)
         goto error;
-    if (parse_config (ctx,
-                      flux_get_conf (h),
-                      &exclude_idset,
-                      &R_from_config,
-                      &noverify,
-                      &norestrict,
-                      &no_update_watch,
-                      &error) < 0) {
+    if (parse_config (ctx, flux_get_conf (h), &config, &error) < 0) {
         flux_log (h, LOG_ERR, "%s", error.text);
         goto error;
     }
-    if (parse_args (h,
-                    argc,
-                    argv,
-                    &monitor_force_up,
-                    &noverify,
-                    &no_update_watch) < 0)
+    if (parse_args (h, argc, argv, &config) < 0)
         goto error;
     if (flux_attr_get (ctx->h, "broker.recovery-mode"))
-        noverify = true;
+        config.noverify = true;
 
     /*  Note: Order of creation of resource subsystems is important.
      *  Create inventory on all ranks first, since it is required by
      *  the exclude and drain subsystems on rank 0.
      */
     if (!(ctx->inventory = inventory_create (ctx,
-                                             R_from_config,
-                                             no_update_watch)))
+                                             config.R,
+                                             config.no_update_watch)))
         goto error;
-    /*  Done with R_from_config now, so free it.
-     */
-    json_decref (R_from_config);
+
     if (ctx->rank == 0) {
         /*  Create reslog and reload eventlog before initializing
          *  acquire, exclude, and drain subsystems, since these
@@ -403,7 +374,7 @@ int mod_main (flux_t *h, int argc, char **argv)
          *  the exclude idset to ensure drained ranks that are now
          *  excluded are ignored.
          */
-        if (!(ctx->exclude = exclude_create (ctx, exclude_idset)))
+        if (!(ctx->exclude = exclude_create (ctx, config.exclude_idset)))
             goto error;
         if (!(ctx->drain = drain_create (ctx, eventlog)))
             goto error;
@@ -411,11 +382,11 @@ int mod_main (flux_t *h, int argc, char **argv)
     /*  topology is initialized after exclude/drain etc since this
      *  rank may attempt to drain itself due to a topology mismatch.
      */
-    if (!(ctx->topology = topo_create (ctx, noverify, norestrict)))
+    if (!(ctx->topology = topo_create (ctx, config.noverify, config.norestrict)))
         goto error;
     if (!(ctx->monitor = monitor_create (ctx,
                                          inventory_get_size (ctx->inventory),
-                                         monitor_force_up)))
+                                         config.monitor_force_up)))
         goto error;
     if (!(ctx->status = status_create (ctx)))
         goto error;
@@ -427,10 +398,12 @@ int mod_main (flux_t *h, int argc, char **argv)
     }
     resource_ctx_destroy (ctx);
     json_decref (eventlog);
+    json_decref (config.R);
     return 0;
 error:
     resource_ctx_destroy (ctx);
     ERRNO_SAFE_WRAP (json_decref, eventlog);
+    ERRNO_SAFE_WRAP (json_decref, config.R);
     return -1;
 }
 

--- a/src/modules/resource/resource.h
+++ b/src/modules/resource/resource.h
@@ -14,6 +14,7 @@
 struct resource_config {
     json_t *R;
     const char *exclude_idset;
+    bool rediscover;
     bool noverify;
     bool norestrict;
     bool no_update_watch;

--- a/src/modules/resource/resource.h
+++ b/src/modules/resource/resource.h
@@ -11,6 +11,15 @@
 #ifndef _FLUX_RESOURCE_H
 #define _FLUX_RESOURCE_H
 
+struct resource_config {
+    json_t *R;
+    const char *exclude_idset;
+    bool noverify;
+    bool norestrict;
+    bool no_update_watch;
+    bool monitor_force_up;
+};
+
 struct resource_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;

--- a/src/modules/resource/topo.c
+++ b/src/modules/resource/topo.c
@@ -284,7 +284,8 @@ static char *topo_get_local_xml (struct resource_ctx *ctx,
     const char *xml;
 
     errno = 0;
-    if (!(parent_h = resource_parent_handle_open (ctx))
+    if (config->rediscover
+        || !(parent_h = resource_parent_handle_open (ctx))
         || !(f = flux_rpc (parent_h,
                            "resource.topo-get",
                            NULL,

--- a/src/modules/resource/topo.h
+++ b/src/modules/resource/topo.h
@@ -12,8 +12,7 @@
 #define _FLUX_RESOURCE_TOPO_H
 
 struct topo *topo_create (struct resource_ctx *ctx,
-                          bool no_verify,
-                          bool no_restrict);
+                          struct resource_config *config);
 void topo_destroy (struct topo *topo);
 
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -179,6 +179,7 @@ TESTSCRIPTS = \
 	t2313-resource-acquire.t \
 	t2314-resource-monitor.t \
 	t2315-resource-system.t \
+	t2315-resource-rediscover.t \
 	t2350-resource-list.t \
 	t2351-resource-status-input.t \
 	t2352-resource-cmd-config.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -179,7 +179,7 @@ TESTSCRIPTS = \
 	t2313-resource-acquire.t \
 	t2314-resource-monitor.t \
 	t2315-resource-system.t \
-	t2315-resource-rediscover.t \
+	t2316-resource-rediscover.t \
 	t2350-resource-list.t \
 	t2351-resource-status-input.t \
 	t2352-resource-cmd-config.t \

--- a/t/t2316-resource-rediscover.t
+++ b/t/t2316-resource-rediscover.t
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+test_description='Test resource module forced rediscovery'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+if which hwloc-bind > /dev/null; then
+	NCORES=$(hwloc-bind --get | hwloc-calc --number-of core | tail -n 1)
+	test $NCORES = 1 || test_set_prereq MULTICORE
+fi
+
+if ! test_have_prereq MULTICORE; then
+   skip_all='skipping rediscovery testing without MULTICORE'
+   test_done
+fi
+
+test_under_flux 2
+
+test_expect_success 'resource: resource.rediscover forces hwloc discovery' '
+	NCORES=$(flux alloc -n1 -o cpu-affinity=off \
+	         flux resource list -no {ncores}) &&
+	test $NCORES -eq 1 &&
+	NCORES2=$(flux alloc -n1 -o cpu-affinity=off \
+	          --conf=resource.rediscover=true \
+	          flux resource list -no {ncores}) &&
+	test_debug "echo got ncores=$NCORES2 with resource.rediscover" &&
+	test $NCORES2 -gt $NCORES
+'
+test_expect_success 'resource: resource.rediscover works with multiple nodes' '
+	NCORES=$(flux alloc -N2 -n2 -o cpu-affinity=off \
+	         flux resource list -no {ncores}) &&
+	test $NCORES -eq 2 &&
+	NCORES3=$(flux alloc -N2 -n2 -o cpu-affinity=off \
+	          --conf=resource.rediscover=true \
+	          flux resource list -no {ncores}) &&
+	test_debug "echo got ncores=$NCORES3 with rediscover on 2 nodes" &&
+	test $NCORES3 -gt $NCORES &&
+	test $NCORES3 -eq $(($NCORES2*2))
+'
+test_done


### PR DESCRIPTION
This PR adds an optional `rediscover` key to  the `[resource]` config table which, when true, forces rediscovery of local resources via hwloc, rather than using the job's R and enclosing instance hwloc XML.

This could be used in combination with a prolog option to change the GPU compute partition mode so the child instance can see the newly reconfigured GPUs.

Fixes #6418.