### PR TITLE
build: remove unnecssary `check-prep` target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,11 +57,6 @@ CODE_COVERAGE_LCOV_OPTIONS =
 # recursive checks.
 check-local: all
 
-check-prep: all
-	cd src && $(MAKE) check
-	cd doc && $(MAKE) check
-	cd t && $(MAKE) check-prep
-
 export DEB_BUILD_OPTIONS ?= nocheck terse
 deb: debian scripts/debbuild.sh
 	+@$(top_srcdir)/scripts/debbuild.sh $(abs_top_srcdir)

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -16,7 +16,7 @@
 #  DISTCHECK     Run `make distcheck` if set
 #  RECHECK       Run `make recheck` if `make check` fails the first time
 #  UNIT_TEST_ONLY Only run `make check` under ./src
-#  QUICK_CHECK   Run only `make check-prep` and a simple test
+#  QUICK_CHECK   Run only `make TESTS=` and a simple test
 #  PRELOAD       Set as LD_PRELOAD for make and tests
 #  POISON        Install poison libflux and flux(1) in image
 #  INCEPTION     Run tests under a flux instance
@@ -143,7 +143,7 @@ if test "$COVERAGE" = "t"; then
 	CHECKCMDS="\
 	export ENABLE_USER_SITE=1 && \
 	export COVERAGE_PROCESS_START=$(pwd)/coverage.rc && \
-	${MAKE} -j $JOBS check-prep && \
+	${MAKE} -j $JOBS check TESTS= && \
 	(cd t && ${MAKE} -j $JOBS check ${SYSTEM:+TESTS=\"$SYSTEM_TESTS\"})"
 	POSTCHECKCMDS="\
 	${MAKE} code-coverage-capture &&
@@ -163,7 +163,7 @@ elif test "$TEST_INSTALL" = "t"; then
 
 # Run checks as Flux jobs:
 elif test "$INCEPTION" = "t"; then
-	CHECKCMDS="make -j ${JOBS} check-prep && \
+	CHECKCMDS="make -j ${JOBS} check TESTS= && \
 	           cd t && ../src/cmd/flux start -s1 ./test-inception.sh && \
 	           cd .."
 fi
@@ -177,7 +177,7 @@ if test -n "$UNIT_TEST_ONLY"; then
 fi
 
 if test -n "$QUICK_CHECK"; then
-  CHECKCMDS="make -j ${JOBS} check-prep && \
+  CHECKCMDS="make -j ${JOBS} check TESTS= && \
 	     src/cmd/flux start -s 2 flux submit --cc=1-5 --watch -vvv hostname"
 fi
 

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -50,7 +50,7 @@ Options:\n\
  -d, --distcheck               Run 'make distcheck' instead of 'make check'\n\
  -r, --recheck                 Run 'make recheck' after failure\n\
  -u, --unit-test-only          Only run unit tests\n\
-     --quick-check             Only run check-prep and one basic test\n\
+     --quick-check             Only run 'make check TESTS=' and one basic test\n\
  -P, --no-poison               Do not install poison libflux and flux(1)\n\
  -D, --build-directory=DIRNAME Name of a subdir to build in, will be made\n\
      --workdir=PATH            Use PATH as working directory for build\n\

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -514,9 +514,6 @@ check_LTLIBRARIES = \
 	stats/stats-basic.la \
 	stats/stats-immediate.la
 
-check-prep:
-	$(MAKE) $(check_PROGRAMS) $(check_LTLIBRARIES)
-
 dist_check_DATA = \
 	hwloc-data/sierra2/0.xml \
 	hwloc-data/sierra2/1.xml \


### PR DESCRIPTION
This PR removes `make check-prep` in preference to the method @garlick used to build `check` prereqs in the macos build: `make check TESTS=`.