### PR TITLE
prevent log message truncation

### DIFF
--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -26,6 +26,8 @@
 #include "src/common/libutil/stdlog.h"
 #include "src/common/libutil/errno_safe.h"
 
+#define FLUX_MAX_LOGBUF     2048
+
 typedef struct {
     char appname[STDLOG_MAX_APPNAME + 1];
     char procid[STDLOG_MAX_PROCID + 1];

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -20,9 +20,6 @@
 extern "C" {
 #endif
 
-
-#define FLUX_MAX_LOGBUF     2048
-
 typedef void (*flux_log_f)(const char *buf, int len, void *arg);
 
 /* Set log appname for handle instance.

--- a/src/common/libflux/test/log.c
+++ b/src/common/libflux/test/log.c
@@ -20,6 +20,8 @@
 int main (int argc, char *argv[])
 {
     flux_t *h;
+    char *s;
+    int truncation_size = 3073;
 
     plan (NO_PLAN);
 
@@ -41,6 +43,14 @@ int main (int argc, char *argv[])
     ok (flux_log (NULL, LOG_INFO, "# flux_t=NULL") == 0,
        "flux_log h=NULL works");
 
+    if (!(s = calloc (1, truncation_size)))
+        BAIL_OUT ("Failed to allocate memory for truncation test");
+    memset (s, 'a', truncation_size - 2);
+
+    ok (flux_log (NULL, LOG_INFO, "# %s", s) == 0,
+        "flux_log h=NULL works with long message");
+
+    free (s);
     test_server_stop (h);
     flux_close (h);
     done_testing();

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -171,4 +171,11 @@ test_expect_success 'dmesg with invalid --color option fails' '
 	test_must_fail flux dmesg --color=foo
 '
 
+test_expect_success 'dmesg: long lines are not truncated' '
+	python3 -c "print(\"x\"*3000)" | flux logger --appname=truncate &&
+	result=$(flux dmesg | sed -n "/truncate/s/^.*: //p" | wc -c) &&
+	test_debug "echo logged 3001 characters, got $result" &&
+	test $result -eq 3001
+'
+
 test_done


### PR DESCRIPTION
This fixes #6545 by falling back to a malloc'd buffer if truncation is detected when handling log messages.

Since the internal fixed buffer size is no longer relevant, the definition of `FLUX_MAX_LOGBUF` is also removed from the public interface. However, I'm fine dropping that commit if it goes too far.

Fixes #6545.