### PR TITLE
kvs: add transaction stats

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2448,7 +2448,7 @@ static void stats_get_cb (flux_t *h,
                            "{ s:O s:O s:{s:O s:O} s:i }",
                            "cache", cstats,
                            "namespace", nsstats,
-                           "transactions",
+                           "transaction-opcount",
                              "commit", txncstats,
                              "fence", txnfstats,
                            "pending_requests", zhashx_size (ctx->requests)) < 0)

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2371,12 +2371,12 @@ static void stats_get_cb (flux_t *h,
             goto error;
     }
 
-    if (!(tstats = json_pack ("{ s:i s:f s:f s:f s:f }",
+    if (!(tstats = json_pack ("{ s:i s:I s:f s:f s:I }",
                               "count", tstat_count (&ts),
-                              "min", tstat_min (&ts)*scale,
+                              "min", (json_int_t)tstat_min (&ts)*scale,
                               "mean", tstat_mean (&ts)*scale,
                               "stddev", tstat_stddev (&ts)*scale,
-                              "max", tstat_max (&ts)*scale)))
+                              "max", (json_int_t)tstat_max (&ts)*scale)))
         goto nomem;
 
     if (!(cstats = json_pack ("{ s:f s:O s:i s:i s:i }",

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -462,36 +462,6 @@ test_expect_success 'kvs: read-your-writes consistency on alt namespace' '
 '
 
 #
-# test clear of stats
-#
-
-# each store of largeval will increase the noop store count, b/c we
-# know that the identical large value will be cached as raw data
-
-test_expect_success 'kvs: clear stats locally' '
-	flux kvs unlink -Rf $DIR &&
-	flux module stats -c kvs &&
-	flux module stats --parse "namespace.primary.#no-op stores" kvs | grep -q 0 &&
-	flux kvs put $DIR.largeval1=$largeval &&
-	flux kvs put $DIR.largeval2=$largeval &&
-	! flux module stats --parse "namespace.primary.#no-op stores" kvs | grep -q 0 &&
-	flux module stats -c kvs &&
-	flux module stats --parse "namespace.primary.#no-op stores" kvs | grep -q 0
-'
-
-test_expect_success NO_ASAN 'kvs: clear stats globally' '
-	flux kvs unlink -Rf $DIR &&
-	flux module stats -C kvs &&
-	flux exec -n sh -c "flux module stats --parse \"namespace.primary.#no-op stores\" kvs | grep -q 0" &&
-	for i in `seq 0 $((${SIZE} - 1))`; do
-	    flux exec -n -r $i sh -c "flux kvs put $DIR.$i.largeval1=$largeval $DIR.$i.largeval2=$largeval"
-	done &&
-	! flux exec -n sh -c "flux module stats --parse \"namespace.primary.#no-op stores\" kvs | grep -q 0" &&
-	flux module stats -C kvs &&
-	flux exec -n sh -c "flux module stats --parse \"namespace.primary.#no-op stores\" kvs | grep -q 0"
-'
-
-#
 # test fence api
 #
 
@@ -532,6 +502,36 @@ test_expect_success 'kvs: 1 pending requests at end of tests before module remov
 	test $pendingcount -eq 1 &&
 	pendingcount1=$(flux exec -n -r 1 sh -c "flux module stats -p pending_requests kvs") &&
 	test $pendingcount1 -eq 1
+'
+
+#
+# test clear of stats
+#
+
+# each store of largeval will increase the noop store count, b/c we
+# know that the identical large value will be cached as raw data
+
+test_expect_success 'kvs: clear stats locally' '
+	flux kvs unlink -Rf $DIR &&
+	flux module stats -c kvs &&
+	flux module stats --parse "namespace.primary.#no-op stores" kvs | grep -q 0 &&
+	flux kvs put $DIR.largeval1=$largeval &&
+	flux kvs put $DIR.largeval2=$largeval &&
+	! flux module stats --parse "namespace.primary.#no-op stores" kvs | grep -q 0 &&
+	flux module stats -c kvs &&
+	flux module stats --parse "namespace.primary.#no-op stores" kvs | grep -q 0
+'
+
+test_expect_success NO_ASAN 'kvs: clear stats globally' '
+	flux kvs unlink -Rf $DIR &&
+	flux module stats -C kvs &&
+	flux exec -n sh -c "flux module stats --parse \"namespace.primary.#no-op stores\" kvs | grep -q 0" &&
+	for i in `seq 0 $((${SIZE} - 1))`; do
+	    flux exec -n -r $i sh -c "flux kvs put $DIR.$i.largeval1=$largeval $DIR.$i.largeval2=$largeval"
+	done &&
+	! flux exec -n sh -c "flux module stats --parse \"namespace.primary.#no-op stores\" kvs | grep -q 0" &&
+	flux module stats -C kvs &&
+	flux exec -n sh -c "flux module stats --parse \"namespace.primary.#no-op stores\" kvs | grep -q 0"
 '
 
 #

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -505,6 +505,25 @@ test_expect_success 'kvs: 1 pending requests at end of tests before module remov
 '
 
 #
+# transaction module stats
+#
+
+test_expect_success 'kvs: module stats returns reasonable transaction stats' '
+        commitdata=$(flux module stats -p transaction-opcount.commit kvs) &&
+        echo $commitdata | jq -e ".count > 0" &&
+        echo $commitdata | jq -e ".min > 0" &&
+        echo $commitdata | jq -e ".max > 0" &&
+        echo $commitdata | jq -e ".mean > 0.0" &&
+        echo $commitdata | jq -e ".stddev >= 0.0" &&
+        fencedata=$(flux module stats -p transaction-opcount.fence kvs) &&
+        echo $fencedata | jq -e ".count > 0" &&
+        echo $fencedata | jq -e ".min > 0" &&
+        echo $fencedata | jq -e ".max > 0" &&
+        echo $fencedata | jq -e ".mean > 0.0" &&
+        echo $fencedata | jq -e ".stddev >= 0.0"
+'
+
+#
 # test clear of stats
 #
 
@@ -520,6 +539,21 @@ test_expect_success 'kvs: clear stats locally' '
 	! flux module stats --parse "namespace.primary.#no-op stores" kvs | grep -q 0 &&
 	flux module stats -c kvs &&
 	flux module stats --parse "namespace.primary.#no-op stores" kvs | grep -q 0
+'
+
+test_expect_success 'kvs: clear of transaction stats works' '
+        commitdata=$(flux module stats -p transaction-opcount.commit kvs) &&
+        echo $commitdata | jq -e ".count == 0" &&
+        echo $commitdata | jq -e ".min == 0" &&
+        echo $commitdata | jq -e ".max == 0" &&
+        echo $commitdata | jq -e ".mean == 0.0" &&
+        echo $commitdata | jq -e ".stddev == 0.0" &&
+        fencedata=$(flux module stats -p transaction-opcount.fence kvs) &&
+        echo $fencedata | jq -e ".count == 0" &&
+        echo $fencedata | jq -e ".min == 0" &&
+        echo $fencedata | jq -e ".max == 0" &&
+        echo $fencedata | jq -e ".mean == 0.0" &&
+        echo $fencedata | jq -e ".stddev == 0.0"
 '
 
 test_expect_success NO_ASAN 'kvs: clear stats globally' '


### PR DESCRIPTION
Problem: In the future we would like to put a cap on the maximum number
of operations in a transaction.  However, we do not have any stat tracking
of operations in a transaction.

Add transaction stats for commits and fences in the kvs module.

---

This is really a "prep" for #6125.  I decided to split out the stats for commits & fences, since they are quite different.  For example, if every process in an job did a fenced KVS transaction with a single op, this scales up with the size of cluster.  So we want to count that differently than each op individually.

Note that I could have done "stats per namespace", but that wasn't really the information that we want.  We mostly want to know what is the average and what is the max.  So I did it "globally" vs per namespace.