### PR TITLE
add `flux --root` option

### DIFF
--- a/doc/man1/flux.rst
+++ b/doc/man1/flux.rst
@@ -37,6 +37,11 @@ OPTIONS
    :envvar:`FLUX_KVS_NAMESPACE` if current instance is confined to a KVS
    namespace in the parent. This option may be specified multiple times.
 
+.. option:: -r, --root
+
+   Like :option:`--parent`, but connect to the top-level, or root, instance.
+   This overrides any other uses of the :option:`--parent` option.
+
 .. option:: -v, --verbose
 
    Display command environment, and the path search for *CMD*.

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -393,7 +393,7 @@ void exec_subcommand (const char *searchpath, bool vopt, int argc, char *argv[])
     }
 }
 
-static flux_t *flux_open_internal (optparse_t *p, const char *uri)
+static flux_t *flux_open_internal (optparse_t *p)
 {
     flux_t *h = NULL;
     if ((h = optparse_get_data (p, "flux_t")))
@@ -416,7 +416,7 @@ static void push_parent_environment (optparse_t *p, struct environment *env)
 {
     const char *uri;
     const char *ns;
-    flux_t *h = flux_open_internal (p, NULL);
+    flux_t *h = flux_open_internal (p);
 
     if (h == NULL)
         log_err_exit ("flux_open");
@@ -440,7 +440,7 @@ static void push_parent_environment (optparse_t *p, struct environment *env)
     /*  Now close current handle and connect to parent URI.
      */
     flux_close_internal (p);
-    if (!(h = flux_open_internal (p, uri)))
+    if (!(h = flux_open_internal (p)))
         log_err_exit ("flux_open (parent)");
 }
 
@@ -454,7 +454,7 @@ static void print_environment (struct environment *env)
 
 flux_t *builtin_get_flux_handle (optparse_t *p)
 {
-    return flux_open_internal (p, NULL);
+    return flux_open_internal (p);
 }
 
 static void register_builtin_subcommands (optparse_t *p)

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -437,11 +437,10 @@ static void push_parent_environment (optparse_t *p, struct environment *env)
     else
         environment_unset (env, "FLUX_KVS_NAMESPACE");
 
-    /*  Now close current handle and connect to parent URI.
+    /*  Now close current handle. Next call to `flux_open()` will
+     *  have FLUX_URI set to parent after environment_apply() is called.
      */
     flux_close_internal (p);
-    if (!(h = flux_open_internal (p)))
-        log_err_exit ("flux_open (parent)");
 }
 
 static void print_environment (struct environment *env)

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -40,13 +40,19 @@ static void register_builtin_subcommands (optparse_t *p);
 static void push_parent_environment (optparse_t *p, struct environment *env);
 
 static struct optparse_option opts[] = {
-    { .name = "verbose",         .key = 'v', .has_arg = 0,
+    { .name = "verbose",
+      .key = 'v',
+      .has_arg = 0,
       .usage = "Be verbose about environment and command search",
     },
-    { .name = "version",         .key = 'V', .has_arg = 0,
+    { .name = "version",
+      .key = 'V',
+      .has_arg = 0,
       .usage = "Display command and component versions",
     },
-    { .name = "parent",         .key = 'p', .has_arg = 0,
+    { .name = "parent",
+      .key = 'p',
+      .has_arg = 0,
       .usage = "Set environment of parent instead of current instance",
     },
     OPTPARSE_TABLE_END
@@ -64,7 +70,8 @@ void usage (optparse_t *p)
     const char *val = getenv ("FLUX_CMDHELP_PATTERN");
     const char *def = default_cmdhelp_pattern (p);
 
-    if (asprintf (&help_pattern, "%s%s%s",
+    if (asprintf (&help_pattern,
+                  "%s%s%s",
                   def ? def : "",
                   val ? ":" : "",
                   val ? val : "") < 0)
@@ -317,8 +324,10 @@ void setup_path (struct environment *env, const char *argv0)
 /* Check for a flux-<command>.py in dir and execute it under the configured
  * PYTHON_INTERPRETER if found.
  */
-void exec_subcommand_py (bool vopt, const char *dir,
-                         int argc, char *argv[],
+void exec_subcommand_py (bool vopt,
+                         const char *dir,
+                         int argc,
+                         char *argv[],
 	                     const char *prefix)
 {
     char *path = xasprintf ("%s%s%s%s.py",
@@ -345,13 +354,16 @@ void exec_subcommand_py (bool vopt, const char *dir,
     free (path);
 }
 
-void exec_subcommand_dir (bool vopt, const char *dir, char *argv[],
-        const char *prefix)
+void exec_subcommand_dir (bool vopt,
+                          const char *dir,
+                          char *argv[],
+                          const char *prefix)
 {
     char *path = xasprintf ("%s%s%s%s",
                             dir ? dir : "",
                             dir ? "/" : "",
-                            prefix ? prefix : "", argv[0]);
+                            prefix ? prefix : "",
+                            argv[0]);
     if (vopt)
         log_msg ("trying to exec %s", path);
     execvp (path, argv); /* no return if successful */

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -50,6 +50,19 @@ test_expect_success "flux --parent --parent works in subinstance" '
 	test_cmp guest2.test.exp guest2.test
 '
 
+test_expect_success "flux --root works in subinstance" '
+	id=$(flux batch -n1 --wrap \
+		flux run flux start ${ARGS} \
+		flux --root getattr instance-level) &&
+	flux job wait-event -vt 30 $id clean &&
+	test_debug "cat flux-${id}.out" &&
+	test "$(cat flux-${id}.out)" -eq 0
+'
+
+test_expect_success 'flux --root returns current instance at depth 0' '
+	test $(flux --root getattr instance-level) -eq 0
+'
+
 test_expect_success "instance-level attribute = 0 in new standalone instance" '
 	flux start ${ARGS} flux getattr instance-level >level_new.out &&
 	echo 0 >level_new.exp &&


### PR DESCRIPTION
Since `flux --parent [--parent] COMMAND ARGS...` is supported to connect to parent (grandparent, etc.), it seems neglectful that a method to connect to the top-level or _root_ instance is not also provided. Instead, users have to supply the `--parent` option at least `instance-level` times: an admittedly awkward interface.

This PR adds a `--root` option to `flux(1)` that behaves exactly as if `--parent` had been specified `instance-level` times. If `instance-level` is `0`, this option has no effect (same as `--parent`).