### PR TITLE
add `FLUX_ENCLOSING_ID` to initial program environment for instances with a `jobid` broker attribute

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -25,6 +25,22 @@ The following are set in the environment of each task spawned by
 
       NUMERIC_JOB_ID=$(flux job id $FLUX_JOB_ID)
 
+.. envvar:: FLUX_ENCLOSING_ID
+
+   The jobid of the enclosing Flux instance, if it has one. The enclosing
+   Flux instance is the one that ran :envvar:`FLUX_JOB_ID`. Depending on
+   how the enclosing Flux instance was started, it may or may not have
+   a jobid. If it was not launched by Flux, :envvar:`FLUX_ENCLOSING_ID`
+   is not set.
+
+   Example 1: A batch job that runs one MPI job is submitted to a Flux system
+   instance. In the environment of the MPI job, :envvar:`FLUX_ENCLOSING_ID`
+   refers to the batch jobid in the system instance.
+
+   Example 2: An MPI job is submitted directly to a Flux system
+   instance. Since the Flux system instance was not launched by Flux,
+   :envvar:`FLUX_ENCLOSING_ID` is not set in the environment of the MPI job.
+
 .. envvar:: FLUX_JOB_SIZE
 
    The number of tasks in the current job.
@@ -170,8 +186,9 @@ environment in other workload managers, for example:
    BATCH_NCORES=$(flux resource list -n -o {ncores})
    BATCH_NGPUS=$(flux resource list -n -o {ngpus})
    BATCH_HOSTLIST=$(flux getattr hostlist)
-   BATCH_JOBID=$(flux getattr jobid)
 
+Additionally, :envvar:`FLUX_ENCLOSING_ID` is set to the jobid of the
+enclosing instance, if it has one.
 
 PMI CLIENT
 ==========

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -700,8 +700,12 @@ static int create_runat_rc2 (struct runat *r, const char *argz, size_t argz_len)
 
 static int create_runat_phases (broker_ctx_t *ctx)
 {
+    const char *jobid = NULL;
     const char *rc1, *rc3, *local_uri;
     bool rc2_none = false;
+
+    /* jobid may be NULL */
+    (void) attr_get (ctx->attrs, "jobid", &jobid, NULL);
 
     if (attr_get (ctx->attrs, "local-uri", &local_uri, NULL) < 0) {
         log_err ("local-uri is not set");
@@ -718,7 +722,10 @@ static int create_runat_phases (broker_ctx_t *ctx)
     if (attr_get (ctx->attrs, "broker.rc2_none", NULL, NULL) == 0)
         rc2_none = true;
 
-    if (!(ctx->runat = runat_create (ctx->h, local_uri, ctx->sd_notify))) {
+    if (!(ctx->runat = runat_create (ctx->h,
+                                     local_uri,
+                                     jobid,
+                                     ctx->sd_notify))) {
         log_err ("runat_create");
         return -1;
     }

--- a/src/broker/runat.h
+++ b/src/broker/runat.h
@@ -27,7 +27,11 @@ typedef void (*runat_completion_f)(struct runat *r,
                                    const char *name,
                                    void *arg);
 
-struct runat *runat_create (flux_t *h, const char *local_uri, bool sdnotify);
+struct runat *runat_create (flux_t *h,
+                            const char *local_uri,
+                            const char *jobid,
+                            bool sdnotify);
+
 void runat_destroy (struct runat *r);
 
 /* Push command, to be run under shell -c, onto named list.

--- a/src/broker/test/runat.c
+++ b/src/broker/test/runat.c
@@ -68,7 +68,7 @@ void basic (flux_t *h)
 
     ctx.h = h;
 
-    r = runat_create (h, "local://notreally", false);
+    r = runat_create (h, "local://notreally", "f1234", false);
     ok (r != NULL,
         "runat_create works");
 
@@ -268,7 +268,7 @@ void badinput (flux_t *h)
     struct runat *r;
     int rc;
 
-    if (!(r = runat_create (h, NULL, false)))
+    if (!(r = runat_create (h, NULL, NULL, false)))
         BAIL_OUT ("runat_create failed");
 
     ok (runat_is_defined (NULL, "foo") == false,

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -116,7 +116,7 @@ test_expect_success 'flux admin cleanup-push (stdin) retains cmd block order' '
 '
 
 test_expect_success 'capture the environment for all three rc scripts' '
-	SLURM_FOO=42 flux start \
+	SLURM_FOO=42 FLUX_ENCLOSING_ID=66 flux start \
 		-Slog-stderr-level=6 \
 		-Sbroker.rc1_path="bash -c printenv >rc1.env" \
 		-Sbroker.rc3_path="bash -c printenv >rc3.env" \
@@ -161,6 +161,10 @@ test_expect_success 'job environment is not set in rc scripts' '
 	var_is_unset FLUX_KVS_NAMESPACE *.env
 '
 
+test_expect_success 'FLUX_ENCLOSING_ID not set if instance is not a job' '
+	var_is_unset FLUX_ENCLOSING_ID *.env
+'
+
 test_expect_success 'capture the environment for instance run as a job' '
 	flux start flux run flux start \
 		-Slog-stderr-level=6 \
@@ -177,6 +181,10 @@ test_expect_success 'job environment is not set in rcs of subinstance' '
 	var_is_unset FLUX_TASK_RANK *.env2 &&
 	var_is_unset FLUX_TASK_LOCAL_ID *.env2 &&
 	var_is_unset FLUX_KVS_NAMESPACE *.env2
+'
+
+test_expect_success 'FLUX_ENCLOSING_ID is set if instance is a job' '
+	var_is_set FLUX_ENCLOSING_ID *.env2
 '
 
 test_done


### PR DESCRIPTION
This PR adds a `FLUX_ENCLOSING_ID` environment variable as an alternative to the broker `jobid` attribute. If an instance does not have a `jobid` attribute, then `FLUX_ENCLOSING_ID` is unset.

This environment variable can be used to refer to the jobid of the enclosing batch or alloc instance from the initial program or a job within that instance (since it will be inherited by jobs).