### PR TITLE
broker: ensure `parent-uri` and `parent-kvs-namespace` are only set for jobs

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -638,9 +638,11 @@ static void init_attrs_post_boot (attr_t *attrs)
      */
     unsetenv ("FLUX_PROXY_REMOTE");
 
-    val = getenv ("FLUX_KVS_NAMESPACE");
-    if (attr_add (attrs, "parent-kvs-namespace", val, ATTR_IMMUTABLE) < 0)
-        log_err_exit ("setattr parent-kvs-namespace");
+    if (instance_is_job) {
+        val = getenv ("FLUX_KVS_NAMESPACE");
+        if (attr_add (attrs, "parent-kvs-namespace", val, ATTR_IMMUTABLE) < 0)
+            log_err_exit ("setattr parent-kvs-namespace");
+    }
     unsetenv ("FLUX_KVS_NAMESPACE");
 }
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -611,12 +611,21 @@ static void init_attrs_starttime (attr_t *attrs, double starttime)
 static void init_attrs_post_boot (attr_t *attrs)
 {
     const char *val;
+    bool instance_is_job;
+
+    /* Use the jobid attribute instead of FLUX_JOB_ID in the current
+     * environment to determine if this instance was run as a job. This
+     * is because the jobid attribute is only set by PMI, whereas
+     * FLUX_JOB_ID could leak from the calling environment, e.g.
+     * `flux run flux start --test-size=2`.
+     */
+    instance_is_job = attr_get (attrs, "jobid", NULL, NULL) == 0;
 
     /* Set the parent-uri attribute IFF this instance was run as a job
      * in the enclosing instance.  "parent" in this context reflects
      * a hierarchy of resource allocation.
      */
-    if (getenv ("FLUX_JOB_ID"))
+    if (instance_is_job)
         val = getenv ("FLUX_URI");
     else
         val = NULL;

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -557,7 +557,17 @@ test_expect_success 'broker broker.pid attribute is readable' '
 	test -n "$BROKERPID" &&
 	test "$BROKERPID" -eq "$BROKERPID"
 '
-
+test_expect_success 'broker sets parent-uri attribute only for jobs' '
+	flux start flux run flux start flux getattr parent-uri &&
+	test_must_fail \
+		flux start flux run flux start -s1 flux getattr parent-uri
+'
+test_expect_success 'broker sets parent-kvs-namespace attribute only for jobs' '
+	flux start flux run flux start flux getattr parent-kvs-namespace &&
+	test_must_fail \
+		flux start flux run \
+			flux start -s1 flux getattr parent-kvs-namespace
+'
 test_expect_success 'local-uri override works' '
 	sockdir=$(mktemp -d) &&
 	newsock=local://$sockdir/meep &&


### PR DESCRIPTION
This PR fixes #6560 by delaying initialization of the mentioned attributes until after bootstrap. Then the `jobid` attribute instead of `FLUX_JOB_ID` is used since this more correctly indicates if the current instance is a job or not.

Fixes #6560