### PR TITLE
python: support relative and absolute path-like targets in jobid URI resolver

### DIFF
--- a/doc/man1/flux-uri.rst
+++ b/doc/man1/flux-uri.rst
@@ -89,14 +89,21 @@ URI SCHEMES
 
 The following URI schemes are included by default:
 
-jobid:ID[/ID...]
+jobid:PATH
    This scheme attempts to get the URI for a Flux instance running as a
    job in the current enclosing instance. This is the assumed scheme if no
    ``scheme:`` is provided in *TARGET* passed to :program:`flux uri`, so the
-   ``jobid:`` prefix is optional. A hierarchy of Flux jobids is supported,
-   so ``f1234/f3456`` will resolve the URI for job ``f3456`` running in
-   job ``f1234`` in the current instance. This scheme will raise an error
-   if the target job is not running.
+   ``jobid:`` prefix is optional. *PATH* is a hierarchical path expression
+   that may contain an optional leading slash (``/``) (which references
+   the top-level, root instance explicitly), followed by zero or more job
+   IDs separated by slashes. The special IDs ``.`` and ``..`` indicate
+   the current instance (within the hierarchy) and its parent, respectively.
+   This allows resolution of a single job running in the current instance
+   via ``f1234``, explicitly within the root instance via ``/f2345``, or
+   a job running within another job via ``f3456/f789``. Completely relative
+   paths can also be used such as ``..`` to get the URI of the current
+   parent, or ``../..`` to get the URI of the parent's parent. Finally,
+   a single slash (``/``) may be used to get the root instance URI.
 
    The ``jobid`` scheme supports the optional query parameter ``?wait``, which
    causes the resolver to wait until a URI has been posted to the job eventlog
@@ -149,6 +156,13 @@ Get the URI of a nested job:
    With  the ``jobid`` resolver, ``?local`` only needs to be placed on
    the last component of the jobid "path" or hierarchy. This will resolve
    each URI in turn as a local URI.
+
+Get the URI of the root instance from within a job running at any depth:
+
+::
+
+   $ flux uri /
+   local:///run/flux/local
 
 Get the URI of a local flux-broker
 

--- a/t/python/t0025-uri.py
+++ b/t/python/t0025-uri.py
@@ -45,6 +45,20 @@ class TestJobURI(unittest.TestCase):
         self.assertEqual(uri.fragment, "")
         self.assertEqual(uri.params, "")
 
+    def test_parse_local_with_remote_hostname(self):
+        hostname = "fakehost"
+        uri = JobURI("local:///tmp/foo", remote_hostname=hostname)
+        self.assertEqual(uri.uri, "local:///tmp/foo")
+        self.assertEqual(str(uri), "local:///tmp/foo")
+        self.assertEqual(uri.remote, f"ssh://{hostname}/tmp/foo")
+        self.assertEqual(uri.local, "local:///tmp/foo")
+        self.assertEqual(uri.scheme, "local")
+        self.assertEqual(uri.netloc, "")
+        self.assertEqual(uri.path, "/tmp/foo")
+        self.assertEqual(uri.query, "")
+        self.assertEqual(uri.fragment, "")
+        self.assertEqual(uri.params, "")
+
     def test_parse_errors(self):
         with self.assertRaises(ValueError):
             JobURI("foo:///tmp/bar").remote

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -108,6 +108,23 @@ test_expect_success 'flux uri resolves hierarchical jobids with ?local' '
 	test_debug "echo ${jobid}/${jobid2}?local is ${uri}"
 
 '
+test_expect_success 'flux uri works with relative paths' '
+	root_uri=$(FLUX_SSH=$testssh flux uri --local .) &&
+	job1_uri=$(FLUX_SSH=$testssh flux uri --local ${jobid}) &&
+	job2_uri=$(FLUX_SSH=$testssh flux uri --local ${jobid}/${jobid2}) &&
+	uri=$(FLUX_SSH=$testssh flux proxy $job2_uri flux uri /) &&
+	test_debug "echo flux uri / got ${uri} expected ${root_uri}" &&
+	test "$uri" = "$root_uri" &&
+	uri=$(FLUX_SSH=$testssh flux proxy $job2_uri flux uri ../..) &&
+	test_debug "echo flux uri ../.. got ${uri} expected ${root_uri}" &&
+	test "$uri" = "$root_uri" &&
+	uri=$(FLUX_SSH=$testssh flux proxy $job2_uri flux uri ..) &&
+	test_debug "echo flux uri .. got ${uri} expected ${job1_uri}" &&
+	test "$uri" = "$job1_uri" &&
+	uri=$(FLUX_SSH=$testssh flux proxy $job2_uri flux uri .) &&
+	test_debug "echo flux uri . got ${uri} expected ${job2_uri}" &&
+	test "$uri" = "$job2_uri"
+'
 test_expect_success 'flux uri --wait can resolve URI for pending job' '
 	uri=$(flux uri --wait $(flux batch -n1 --wrap hostname)) &&
 	flux job wait-event -vt 30 $(flux job last) clean  &&


### PR DESCRIPTION
This PR adds support for path-like expressions in the `jobid` URI resolver. Notably, `/`  now refers to the root instance, `..` refers to the parent of the current instance, and for completeness `.` indicates the current instance. These special targets can be combined with a slash as expected, e.g. `../..` refers to the parent of the current instance's parent, and `/f1234` would refer directly to job `f1234` in the root instance, and so on.

This gives users of `flux-uri(1)`, the `FluxURIResolver` class, and the internal `uri_resolve()` function (`flux proxy`, `flux top` and `flux shutdown`) an easy way to refer to the root instance or parent instances from within a batch/alloc job.

I've made this PR a WIP because other folks may not agree with the approach. 

One other idea I had was to directly support `/` and `..` in `flux_open(3)`, but that kind of breaks the abstraction that `flux_open()` only takes a native URI. The approach in this PR does have the drawback that it only helps shell and Python users, not necessarily users of the C API.

So just throwing this out there for consideration.