### PR TITLE
testsuite: fix flaky test in t0019-tbon-config.t

### DIFF
--- a/t/t0019-tbon-config.t
+++ b/t/t0019-tbon-config.t
@@ -95,8 +95,12 @@ test_expect_success 'tbon.interface-hint from parent can be overridden' '
 	    flux getattr tbon.interface-hint >childhint2.out &&
 	grep default-router childhint2.out
 '
+# Note: the following test has been observed to fail (as expected) in more
+# ways than just nonzero exit or terminated by SIGKILL/SIGTERM (in CI the
+# test sometimes fails with SIGPIPE). Therefore, use the blanket `!` here
+# since we just want to test failure, we don't care how it fails.
 test_expect_success 'tbon.endpoint cannot be set' '
-	test_must_fail_or_be_terminated flux start ${ARGS} -s2 \
+	! flux start ${ARGS} -s2 \
 		--setattr=tbon.endpoint=ipc:///tmp/customflux true
 '
 test_expect_success 'tbon.parent-endpoint cannot be read on rank 0' '


### PR DESCRIPTION
Problem: The test `tbon.endpoint cannot be set` in t0019-tbon-config.t fails occasionally in ci because the `flux start` command reports it is terminated by SIGPIPE rather than SIGKILL/SIGTERM.

The test is just meant to detect an expected failure of the command, it does not matter how the command fails. Just use `!` to detect failure. Add a note to explain why `test_must_fail` or similar is not used here.

Fixes #6336