### PR TITLE
ensure only jobs that entered the RUN state can satisfy `--dependency=afterany|afternotok`

### DIFF
--- a/doc/man1/common/job-dependencies.rst
+++ b/doc/man1/common/job-dependencies.rst
@@ -28,6 +28,13 @@ The following dependency schemes are built-in:
    has been submitted, then the submission will be rejected with an error
    that the target job cannot be found.
 
+.. note::
+   The ``after*`` dependency schemes below only satisfy dependencies for
+   jobs that entered the RUN state. A job that is canceled while pending
+   does not satisfy the `afterany` or `afternotok` dependencies. Thus,
+   canceling a job with a chain of dependencies causes all jobs in the
+   chain to be canceled.
+
 after:JOBID
    This dependency is satisfied after JOBID starts.
 

--- a/src/modules/job-manager/plugins/dependency-after.c
+++ b/src/modules/job-manager/plugins/dependency-after.c
@@ -475,18 +475,20 @@ static void release_all (flux_plugin_t *p, zlistx_t *l, int typemask)
 /*
  *  Raise exceptions for all unhandled depednencies in list `l`.
  */
-static void raise_exceptions (flux_plugin_t *p, zlistx_t *l)
+static void raise_exceptions (flux_plugin_t *p, zlistx_t *l, const char *msg)
 {
     if (l) {
         struct after_info *after;
+        if (!msg)
+            msg = "can never be satisfied";
         FOREACH_ZLISTX (l, after) {
             if (flux_jobtap_raise_exception (p,
                                              after->depid,
                                              "dependency",
                                              0,
-                                             "%s %s can never be satisfied",
-                                             "dependency",
-                                             after->description) < 0)
+                                             "dependency %s %s",
+                                             after->description,
+                                             msg) < 0)
                 flux_log_error (flux_jobtap_get_flux (p),
                                 "id=%s: unable to raise exception for %s",
                                 idf58 (after->depid),
@@ -558,7 +560,7 @@ static int release_dependent_jobs (flux_plugin_t *p, zlistx_t *l)
     /*  Any remaining dependencies can't now be satisfied.
      *   Raise exceptions on any remaining members of list `l`
      */
-    raise_exceptions (p, l);
+    raise_exceptions (p, l, "can never be satisfied");
 
     return 0;
 }

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -63,7 +63,7 @@ test_expect_success 'dependency=after works' '
 	test_debug "echo checking that job ${depid} is in DEPEND state" &&
 	test "$(flux jobs -no {state} $depid)" = "DEPEND" &&
 	flux job urgency $jobid default &&
-	flux job wait-event -vt 15 $depid clean 
+	flux job wait-event -vt 15 $depid clean
 '
 test_expect_success 'dependency=after does not release job until start event' '
 	jobid=$(flux submit \
@@ -96,7 +96,7 @@ test_expect_success 'dependency=after generates exception for failed job' '
 	test_debug "echo checking that job ${depid} is in DEPEND state" &&
 	test "$(flux jobs -no {state} $depid)" = "DEPEND" &&
 	flux cancel $jobid &&
-	flux job wait-event -m type=dependency -vt 15 $depid exception 
+	flux job wait-event -m type=dependency -vt 15 $depid exception
 '
 test_expect_success 'dependency=afterany works' '
 	flux bulksubmit \
@@ -205,7 +205,7 @@ test_expect_success 'dependency=afterok works for INACTIVE job' '
 		flux run --dependency=afterok:${job1} \
 		echo afterok:${job1} &&
 	test_must_fail flux run --dependency=afterok:${job2} hostname &&
-	test_must_fail flux run --dependency=afterok:${job3} hostname 
+	test_must_fail flux run --dependency=afterok:${job3} hostname
 '
 test_expect_success 'dependency=afternotok works for INACTIVE job' '
 	run_timeout 15 \


### PR DESCRIPTION
This PR updates the `dependency-after` plugin to only allow jobs that entered the RUN state to satisfy any of the `after*` dependencies (which really only affects the `afterany` and `afternotok` types). This changes existing behavior, since pending jobs that are canceled would currently cause `after{any,notok}` dependent jobs to be released. This probably isn't what users want though, and it fixes the use case described in #6555, so it is probably the right approach.