### PR TITLE
support `afterexc` dependency scheme

### DIFF
--- a/doc/man1/common/job-dependencies.rst
+++ b/doc/man1/common/job-dependencies.rst
@@ -50,6 +50,11 @@ afternotok:JOBID
    This dependency is satisfied after JOBID enters the INACTIVE state
    with an unsuccessful result.
 
+afterexcept:JOBID
+   This dependency is satisfied when JOBID enters the INACTIVE state
+   and a fatal job exception caused the transition to CLEANUP (e.g.,
+   node failure, timeout, cancel, etc.).
+
 begin-time:TIMESTAMP
    This dependency is satisfied after TIMESTAMP, which is specified in
    floating point seconds since the UNIX epoch. See the ``--begin-time``

--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -91,6 +91,7 @@ urgency    i    current urgency
 priority   I    current priority
 t_submit   f    submit timestamp in floating point seconds
 entry      o    posted eventlog entry, including context
+end_event  o    copy of event that cause transition to CLEANUP, if available
 ========== ==== ==========================================
 
 Return arguments can be packed using the ``FLUX_PLUGIN_ARG_OUT`` and

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -529,6 +529,7 @@ reprioritization
 afterany
 afterok
 afternotok
+afterexcept
 parsedatetime
 cancelall
 raiseall

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1969,10 +1969,8 @@ static struct job * jobtap_lookup_jobid (flux_plugin_t *p, flux_jobid_t id)
         return NULL;
     }
     job = current_job (jobtap);
-    if (id == FLUX_JOBTAP_CURRENT_JOB || (job && id == job->id)) {
-        errno = EINVAL;
+    if (id == FLUX_JOBTAP_CURRENT_JOB || (job && id == job->id))
         return job;
-    }
     return lookup_job (jobtap->ctx, id);
 }
 

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -198,6 +198,12 @@ static flux_plugin_arg_t *jobtap_args_create (struct jobtap *jobtap,
                                   "R", job->R_redacted) < 0)
             goto error;
     }
+    if (job->end_event)
+        if (flux_plugin_arg_pack (args,
+                                  FLUX_PLUGIN_ARG_IN,
+                                  "{s:O}",
+                                  "end_event", job->end_event) < 0)
+        goto error;
     /*
      *  Always start with empty OUT args. This allows unpack of OUT
      *   args to work without error, even if plugin does not set any


### PR DESCRIPTION
This PR adds support for an `afterexc` dependency scheme as suggested in #6564.
This is similar to `afternotok`, but the dependency is only satisfied if a fatal job exception was the event the caused the job to transition to the CLENAUP state.