### PR TITLE
libflux: support ancestor paths as alternative to URI in `flux_open(3)` and `flux_open_ex(3)`

### DIFF
--- a/doc/man3/flux_open.rst
+++ b/doc/man3/flux_open.rst
@@ -33,10 +33,18 @@ to communicate with the Flux message broker. :func:`flux_open_ex` takes an
 optional pointer to a :type:`flux_error_t` structure which, when non-NULL, will
 be used to store any errors which may have otherwise gone to :var:`stderr`.
 
-The :var:`uri` scheme (before "://") specifies the "connector" that will be used
-to establish the connection. The :var:`uri` path (after "://") is parsed by the
-connector. If :var:`uri` is NULL, the value of :envvar:`FLUX_URI` is used.  If
-:envvar:`FLUX_URI` is not set, a compiled-in default URI is used.
+When set, the :var:`uri` argument may be a valid native URI, e.g. as
+returned from the :man1:`flux-uri` command or found in the :var:`local-uri`
+and :var:`parent-uri` broker attributes, or a path-like string referencing
+a possible instance ancestor like "/" for the top-level or root instance,
+or ".." for the parent instance. See `ANCESTOR PATHS`_ below.
+
+If :var:`uri` is NULL, the value of :envvar:`FLUX_URI` is used.
+If :envvar:`FLUX_URI` is not set, a compiled-in default URI is used.
+
+When :var:`uri` contains a native URI, the scheme (before "://") specifies
+the "connector" that will be used to establish the connection. The :var:`uri`
+path (after "://") is parsed by the connector.
 
 *flags* is the logical "or" of zero or more of the following flags:
 
@@ -88,6 +96,20 @@ original handle.
 :func:`flux_close` destroys a :type:`flux_t` handle, closing its connection with
 the Flux message broker.
 
+
+ANCESTOR PATHS
+==============
+
+As an alternative to a URI, the :func:`flux_open` and :func:`flux_open_ex`
+functions also take a path-like string indicating that a handle to an ancestor
+instance should be opened. This string follows the following rules:
+
+ - One or more ".." separated by "/" refer to a parent instance
+   (possibly multiple levels up the hierarchy)
+ - "." indicates the current instance
+ - A single slash ("/") indicates the root instance
+ - ".." at the root is not an error, it just returns a handle to the root
+   instance
 
 RETURN VALUE
 ============

--- a/doc/man3/flux_open.rst
+++ b/doc/man3/flux_open.rst
@@ -92,7 +92,7 @@ the Flux message broker.
 RETURN VALUE
 ============
 
-:func:`flux_open` and :func:`flux_clone` return a :type:`flux_t`` handle on
+:func:`flux_open` and :func:`flux_clone` return a :type:`flux_t` handle on
 success.  On error, NULL is returned, with :var:`errno` set.
 
 

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -32,6 +32,15 @@ class Flux(Wrapper):
     Example:
         >>> flux.Flux()
         <flux.core.Flux object at 0x...>
+
+    Args:
+        uri (str): A fully-qualified native path as returned by
+            :man1:`flux-uri`, or a path-like string that references any
+            ancestor in the current hierarchy, e.g. ``/`` refers to
+            the root instance, ``..`` refers to the parent, ``../..``
+            the parent's parent and so on. See :man3:`flux_open` for more
+            details.
+        flags (int): flags as described in :man3:`flux_open`.
     """
 
     #  Thread local storage to hold a reactor_running boolean, indicating

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -106,4 +106,47 @@ test_expect_success 'flux can launch multiple brokers per node (R lookup fallbac
 		--conf=resource.no-update-watch=true \
 		flux resource info
 '
+test_expect_success 'flux_open("/") works at top-level' '
+	flux python -c "import flux; print(flux.Flux(\"/\").attr_get(\"instance-level\"));"
+'
+test_expect_success 'flux_open(3) accepts path-like URIs: "/", "../.." etc' '
+	cat <<-EOF >flux_open.py &&
+	import unittest
+	import flux
+	import sys
+	from collections import namedtuple
+
+	Test = namedtuple("Test", ["arg", "level"])
+	tests = [
+	    Test(None, 3),
+	    Test(".", 3),
+	    Test("./", 3),
+	    Test("..", 2),
+	    Test("../", 2),
+	    Test("./..", 2),
+	    Test("../..", 1),
+	    Test("..//..", 1),
+	    Test("../../", 1),
+	    Test(".././..", 1),
+	    Test("../../..", 0),
+	    Test("../../../..", 0),
+	    Test("../../../../../../../", 0),
+	    Test("/", 0),
+	]
+
+	class TestFluxOpen(unittest.TestCase):
+	    def test_pathlike_uris(self):
+	        for test in tests:
+	            l = flux.Flux(test.arg).attr_get("instance-level")
+	            self.assertEqual(int(l), test.level)
+
+	    def test_pathlike_bad_arg(self):
+	        for arg in ("/.", "//", "../f", "../f/.."):
+	            with self.assertRaises(OSError, msg=f"arg={arg}"):
+	                h = flux.Flux(arg)
+	                print(h.attr_get("instance-level"))
+	unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))
+	EOF
+	flux alloc -n1 flux alloc -n1 flux alloc -n1 flux python ./flux_open.py
+'
 test_done

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -54,7 +54,7 @@ test_expect_success "flux --root works in subinstance" '
 	id=$(flux batch -n1 --wrap \
 		flux run flux start ${ARGS} \
 		flux --root getattr instance-level) &&
-	flux job wait-event -vt 30 $id clean &&
+	flux job wait-event -vt 60 $id clean &&
 	test_debug "cat flux-${id}.out" &&
 	test "$(cat flux-${id}.out)" -eq 0
 '


### PR DESCRIPTION
This PR adds support for path-like shorthand arguments to `flux_open(3)` and `flux_open_ex(3)` to refer easily to ancestor Flux instances using a familiar filesystem idiom. The string ".." refers to the parent, "../.." its parent, and so on. "/" can be used to refer directly to the root instance, and for completeness "." indicates the current instance (and is therefore ignored as a path element). It is not an error to specify ".." at the root, so specifying more ".." elements than parents just returns a handle to the root instance.

I did my best in the documentation, but feel free to make suggestions.