### PR TITLE
arm64 Docker cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
 
   ci-checks:
     needs: [generate-matrix]
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.runner}}
     env:
       TAP_DRIVER_QUIET: 1
       FLUX_TEST_TIMEOUT: 300
@@ -210,10 +210,6 @@ jobs:
     - name: docker buildx
       uses: docker/setup-buildx-action@v3
       if: matrix.needs_buildx
-
-    - name: setup qemu-user-static
-      run: |
-        docker run --rm --privileged aptman/qus -s -- -p --credential aarch64
 
     - name: docker-run-checks
       timeout-minutes: ${{matrix.timeout_minutes}}

--- a/src/test/docker/README.md
+++ b/src/test/docker/README.md
@@ -65,8 +65,8 @@ Docker buildx extensions, see
 
 and run
 ```
-$  docker buildx build --push --platform=linux/arm64,linux/amd64 --tag fluxrm/testenv:jammy src/test/docker/jammy
-$  docker buildx build --push --platform=linux/386,linux/amd64,linux/arm64 --tag fluxrm/testenv:bookworm src/test/docker/bookworm
+$  docker buildx build --push --platform=linux/arm64,linux/amd64 --tag fluxrm/testenv:jammy -f src/test/docker/jammy/Dockerfile .
+$  docker buildx build --push --platform=linux/386,linux/amd64,linux/arm64 --tag fluxrm/testenv:bookworm -f src/test/docker/bookworm/Dockerfile .
 ```
 
 to build and push images to docker hub.

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -31,8 +31,9 @@ DEFAULT_MULTIARCH_PLATFORMS = {
         "suffix": " - arm64",
         "command_args": "--install-only ",
         "timeout_minutes": 90,
+        "runner": "ubuntu-24.04-arm",
     },
-    "linux/amd64": {"when": lambda _: True},
+    "linux/amd64": {"when": lambda _: True, "runner": "ubuntu-latest"},
 }
 
 
@@ -94,6 +95,7 @@ class BuildMatrix:
         platform=None,
         command_args="",
         timeout_minutes=60,
+        runner="ubuntu-latest",
     ):
         """Add a build to the matrix.include array"""
 
@@ -144,6 +146,7 @@ class BuildMatrix:
                 "env": env,
                 "command": command,
                 "image": image,
+                "runner": runner,
                 "tag": self.tag,
                 "branch": self.branch,
                 "coverage": coverage,
@@ -175,6 +178,7 @@ class BuildMatrix:
                     image=image if image is not None else name,
                     command_args=args.get("command_args", ""),
                     timeout_minutes=args.get("timeout_minutes", 30),
+                    runner=args["runner"],
                     **kwargs,
                 )
 
@@ -189,7 +193,11 @@ matrix = BuildMatrix()
 
 # Multi-arch builds, arm only builds on
 bookworm_platforms = deepcopy(DEFAULT_MULTIARCH_PLATFORMS)
-bookworm_platforms["linux/386"] = {"when": lambda _: True, "suffix": " - 32 bit"}
+bookworm_platforms["linux/386"] = {
+    "when": lambda _: True,
+    "suffix": " - 32 bit",
+    "runner": "ubuntu-latest",
+}
 common_args = (
     "--prefix=/usr"
     " --sysconfdir=/etc"

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -239,17 +239,15 @@ matrix.add_multiarch_build(
         TEST_INSTALL="t",
     ),
 )
-# single arch builds that still produce a container
-matrix.add_build(
-    name="fedora40 - test-install",
-    image="fedora40",
+matrix.add_multiarch_build(
+    name="fedora40",
+    default_suffix=" - test-install",
     args=common_args,
     env=dict(
         TEST_INSTALL="t",
     ),
-    docker_tag=True,
 )
-
+# single arch builds that still produce a container
 # Ubuntu: TEST_INSTALL
 matrix.add_build(
     name="jammy - test-install",

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -8,6 +8,11 @@ if ! test_have_prereq NO_ASAN; then
     test_done
 fi
 
+if test "$(uname -m)" = "aarch64" ; then
+    skip_all='skipping faketime cron tests on aarch64'
+    test_done
+fi
+
 # allow libfaketime to be found on ubuntu, centos
 if test -d /usr/lib/x86_64-linux-gnu/faketime ; then
   export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/faketime"


### PR DESCRIPTION
This is related to flux-framework/flux-sched#1328. The problem over there started because of a single-arch push to the alpine tag, which I'm guessing was a small mistake in a buildx command.  In investigating that, I realized our documented commands don't work, so this fixes that.  Also this includes commits to fix an issue in the docker entrypoint script, and port over the arm64 runner changes developed in the above sched PR.

NOTE: the last commit in here is mainly there so we can test the arm64 runners before merging anything.  If it works well, we might want to run some of the tests on arm all the time, or at least _run the tests after the builds on merge_.  Either way, we need to resolve that before this can be considered ready to merge.