### PR TITLE
job-exec: fix confusing "job shell exec error" log message

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -379,12 +379,12 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
         }
         else {
             jobinfo_fatal_error (job,
-                                 errnum,
+                                 0,
                                  "%s on broker %s (rank %d): %s",
                                  "job shell exec error",
                                  hostname,
                                  rank,
-                                 flux_cmd_arg (cmd, 0));
+                                 flux_subprocess_fail_error (p));
         }
     }
     else

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -204,20 +204,4 @@ test_expect_success FLUX_SECURITY \
 	flux job wait-event -vHt 15s $jobid clean &&
 	flux job status -vvv $jobid
 '
-
-if ! grep 'release 7' /etc/centos-release >/dev/null 2>&1 \
-   && ! grep 'release 7' /etc/redhat-release >/dev/null 2>&1
-then
-   test_set_prereq NOT_DISTRO7
-fi
-
-# The following test does not work on CentOS 7 / RHEL7 since exec errno does
-#  not work with job-exec (for as yet unknown reason). Skip the test on
-#  these distros:
-test_expect_success NOT_DISTRO7 'job-exec: path to shell is emitted on exec error' '
-	test_expect_code 127 flux run \
-	  --setattr=exec.job_shell=/foo/flux-shell hostname 2>exec.err &&
-	test_debug "cat exec.err" &&
-	grep /foo/flux-shell exec.err
-'
 test_done


### PR DESCRIPTION
Problem: When the job-exec module detects an exec error for a job shell it emits a confusing error message that includes either the path to the job shell or the IMP (if a multiuser job), and only the result of `strerror()` for the errno returned from libsubprocess. When using sdexec, this errno is always `ENOENT`, resulting in a confusing error message that seems to indicate that `flux-imp` was not found.

It is unhelpful to include `argv[0]` in this error message. It will always be the job shell or the IMP and we all know it. Drop this from the log message.

Also, sdexec will provide extra information in the subprocess error string available from `flux_subprocess_fail_error (p)`. Log this instead of `strerror (errno)`.

Fixes #6568