### PR TITLE
kvs: support configuration of max operations count

### DIFF
--- a/doc/man5/flux-config-kvs.rst
+++ b/doc/man5/flux-config-kvs.rst
@@ -29,6 +29,13 @@ gc-threshold
    point. (Default: garbage collection must be manually requested with
    `flux-shutdown --gc`).
 
+transaction-max-ops
+   (optional) Sets the maximum number of transactions that can be
+   performed in a single KVS commit.  This configuration is to prevent
+   a single transaction from taking up too much of the KVS's time
+   (i.e. to prevent a denial-of-service from a large transaction).  By
+   default the maximum is 16384.
+
 
 EXAMPLE
 =======

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1039,3 +1039,4 @@ EPEL
 pubkey
 builtins
 ignorefail
+KVS's


### PR DESCRIPTION
Per discussion in #6125, denial-of-service attacks could be made against the KVS by very very large KVS transactions.

Support two configurations for capping the number of transactions made by users.  One for each individual transaction made by a caller and one for the combined total of operations from a fence.

For the time being, I made the default 64K for the transaction cap and 1M for the fence cap.

I made this WIP only b/c those defaults may be tweaked depending on what stats we get from the prior PR #6556.  I would like to merge only after we gather a bit of data, although I'd be quite shocked if we have to adjust the defaults.  Edit: Or alternately, if we'd like to just get the code in, we could default the max to LLONG_MAX and lower the default at a later time.

Only other thought is I decided to return the errno E2BIG if we went across a max cap boundary.  It's possible there is a superior errno for this, I picked it b/c I thought "ehhh that's not bad".
