### PR TITLE
kvs: report error to all fence requests

### DIFF
--- a/src/common/libkvs/kvs_txn_compact.c
+++ b/src/common/libkvs/kvs_txn_compact.c
@@ -42,7 +42,7 @@
  *
  * append "A"
  * write "B"
- * append "c"
+ * append "C"
  *
  * we cannot combine the appends of "A" and "C".  In this scenario, we
  * generate an EINVAL error to the caller, indicating that the


### PR DESCRIPTION
Problem: When an error occurs in a fence request, the error is
only reported to the requestor.  In most cases, this is fine, but
the error should be reported to all members of the fence in some
cases.  Most notably, it should be reported to all members of the
fence when the fence count has been reached and an error has
occurred after this point.

Solution: In fence_request_cb() return an error via
the kvs function error_event_send_to_name() when it is appropriate.

----

Spliting these few commits out of #6581 since it is an actual bug right now, no need to wait for #6581 to go in to fix it.

