### PR TITLE
shell: fix incorrect assignment of shell rank ids when broker ranks appear unordered in R

### DIFF
--- a/t/shell/input/out-of-order-ranks.json
+++ b/t/shell/input/out-of-order-ranks.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "execution": {
+    "R_lite": [
+     {
+        "rank": "1",
+        "children": {
+          "core": "0-7"
+        }
+      },
+      {
+        "rank": "0",
+        "children": {
+          "core": "0-1"
+        }
+      }
+    ],
+    "starttime": 0,
+    "expiration": 0,
+    "nodelist": [
+      "f[0-1]"
+    ]
+  }
+}

--- a/t/shell/output/out-of-order-ranks.10.expected
+++ b/t/shell/output/out-of-order-ranks.10.expected
@@ -1,0 +1,4 @@
+Distributing 10 tasks across 2 nodes with 10 cores
+Used 2 nodes
+0: rank=0 ntasks=2 cores=0-1
+1: rank=1 ntasks=8 cores=0-7


### PR DESCRIPTION
This PR should fix #6582. The rcalc code in the shell currently assigns shell ranks based on the order broker ranks appear in `R_lite` in the job's R. This breaks an assumption elsewhere that rcalc derived shell ranks match the order of broker ranks and the R nodelist.

This PR simply sorts the rcalc->ranks array and reassigns shell rank ids if necessary.

A test is added to ensure out of order ranks in `R_lite` still produce the expected task layout and rank assignment.