### PR TITLE
add resource journal

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -22,6 +22,7 @@ SYNOPSIS
 | **flux** **resource** **reload** [-f] [--xml] *path*
 
 | **flux** **resource** **acquire-mute**
+| **flux** **resource** **eventlog** [*-w* *EVENT*] [*-F*]
 
 DESCRIPTION
 ===========
@@ -356,6 +357,24 @@ Tell the resource module to stop sending RFC 28 ``resource.acquire`` responses
 to the scheduler.  This is used during Flux instance shutdown to avoid asking
 the scheduler to needlessly process OFFLINE updates.
 
+eventlog
+--------
+
+.. program:: flux resource eventlog
+
+Watch the resource journal, which is described in RFC 44.
+
+.. option:: -F, --follow
+
+  After printing the current eventlog, wait for new events and print
+  them as they arrive.
+
+.. option:: -w, --wait=EVENT
+
+  Wait for the specified event to be posted, print it, then quit.
+  The current set of valid events events is *restart*, *resource-define*,
+  *online*, *offline*, *drain*, *undrain*, *torpid*, and *lively*.
+
 OUTPUT FORMAT
 =============
 
@@ -520,3 +539,4 @@ FLUX RFC
 | :doc:`rfc:spec_22`
 | :doc:`rfc:spec_27`
 | :doc:`rfc:spec_29`
+| :doc:`rfc:spec_44`

--- a/src/modules/resource/reslog.h
+++ b/src/modules/resource/reslog.h
@@ -22,7 +22,7 @@ typedef void (*reslog_cb_f)(struct reslog *reslog,
                             json_t *context,
                             void *arg);
 
-struct reslog *reslog_create (flux_t *h);
+struct reslog *reslog_create (struct resource_ctx *ctx);
 void reslog_destroy (struct reslog *reslog);
 
 /* Post an event to the eventlog.  This function returns immediately,

--- a/src/modules/resource/reslog.h
+++ b/src/modules/resource/reslog.h
@@ -22,7 +22,7 @@ typedef void (*reslog_cb_f)(struct reslog *reslog,
                             json_t *context,
                             void *arg);
 
-struct reslog *reslog_create (struct resource_ctx *ctx);
+struct reslog *reslog_create (struct resource_ctx *ctx, json_t *eventlog);
 void reslog_destroy (struct reslog *reslog);
 
 /* Post an event to the eventlog.  This function returns immediately,

--- a/src/modules/resource/reslog.h
+++ b/src/modules/resource/reslog.h
@@ -47,6 +47,8 @@ int reslog_sync (struct reslog *reslog);
 int reslog_add_callback (struct reslog *reslog, reslog_cb_f cb, void *arg);
 void reslog_remove_callback (struct reslog *reslog, reslog_cb_f cb, void *arg);
 
+void reslog_disconnect (struct reslog *reslog, const flux_msg_t *msg);
+
 #define RESLOG_KEY "resource.eventlog"
 
 #endif /* !_FLUX_RESOURCE_RESLOG_H */

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -362,8 +362,6 @@ int mod_main (flux_t *h, int argc, char **argv)
          *  acquire, exclude, and drain subsystems, since these
          *  are required by acquire and exclude.
          */
-        if (!(ctx->reslog = reslog_create (ctx)))
-            goto error;
         if (reload_eventlog (h, &eventlog) < 0)
             goto error;
         /* One time only: purge the eventlog (including KVS) of
@@ -372,7 +370,7 @@ int mod_main (flux_t *h, int argc, char **argv)
          */
         if (upgrade_eventlog (h, &eventlog) < 0)
             goto error;
-        if (!(ctx->reslog = reslog_create (ctx)))
+        if (!(ctx->reslog = reslog_create (ctx, eventlog)))
             goto error;
         if (!(ctx->acquire = acquire_create (ctx)))
             goto error;

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -362,7 +362,7 @@ int mod_main (flux_t *h, int argc, char **argv)
          *  acquire, exclude, and drain subsystems, since these
          *  are required by acquire and exclude.
          */
-        if (!(ctx->reslog = reslog_create (h)))
+        if (!(ctx->reslog = reslog_create (ctx)))
             goto error;
         if (reload_eventlog (h, &eventlog) < 0)
             goto error;
@@ -371,6 +371,8 @@ int mod_main (flux_t *h, int argc, char **argv)
          * See flux-framework/flux-core#5931.
          */
         if (upgrade_eventlog (h, &eventlog) < 0)
+            goto error;
+        if (!(ctx->reslog = reslog_create (ctx)))
             goto error;
         if (!(ctx->acquire = acquire_create (ctx)))
             goto error;

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -203,6 +203,8 @@ static void disconnect_cb (flux_t *h,
         acquire_disconnect (ctx->acquire, msg);
     if (ctx->status)
         status_disconnect (ctx->status, msg);
+    if (ctx->reslog)
+        reslog_disconnect (ctx->reslog, msg);
 }
 
 flux_t *resource_parent_handle_open (struct resource_ctx *ctx)

--- a/src/modules/resource/upgrade.c
+++ b/src/modules/resource/upgrade.c
@@ -42,6 +42,7 @@
 #include "src/common/libeventlog/eventlog.h"
 #include "ccan/str/str.h"
 
+#include "resource.h"
 #include "reslog.h"
 #include "upgrade.h"
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -185,6 +185,7 @@ TESTSCRIPTS = \
 	t2352-resource-cmd-config.t \
 	t2353-resource-eventlog.t \
 	t2354-resource-status.t \
+	t2355-resource-journal.t \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
 	t2402-job-exec-dummy.t \

--- a/t/t2355-resource-journal.t
+++ b/t/t2355-resource-journal.t
@@ -1,0 +1,99 @@
+#!/bin/sh
+
+test_description='Test the resource event journal'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 2
+
+test_expect_success 'unload the scheduler' '
+	flux module remove sched-simple
+'
+
+test_expect_success 'flux resource eventlog --wait works' '
+	flux resource eventlog --wait=resource-define | tee eventlog
+'
+test_expect_success '1st event: restart online=""' '
+	head -1 eventlog | tee eventlog.1 &&
+	jq -e ".name == \"restart\"" eventlog.1 &&
+	jq -e ".context.ranks == \"0-1\"" eventlog.1 &&
+	jq -e ".context.online == \"\"" eventlog.1
+'
+test_expect_success 'that event was not posted to the KVS' '
+	flux kvs get resource.eventlog >kvs &&
+	test_must_fail grep -q restart kvs
+'
+test_expect_success 'last event: resource-define method=dynamic-discovery' '
+	tail -1 eventlog | tee eventlog.2 &&
+	jq -e ".name == \"resource-define\"" eventlog.2 &&
+	jq -e ".context.method == \"dynamic-discovery\"" eventlog.2
+'
+test_expect_success 'resource-define event was posted to the KVS' '
+	flux kvs get resource.eventlog >kvs &&
+	grep -q resource-define kvs
+'
+
+test_expect_success 'reload resource with monitor-force-up' '
+	flux module reload resource monitor-force-up
+'
+test_expect_success 'flux resource eventlog works' '
+	flux resource eventlog --wait=resource-define >forcelog
+'
+test_expect_success '1st event: restart online=0-1' '
+	head -1 forcelog >forcelog.1 &&
+	jq -e ".name == \"restart\"" forcelog.1 &&
+	jq -e ".context.ranks == \"0-1\"" forcelog.1 &&
+	jq -e ".context.online == \"0-1\"" forcelog.1
+'
+
+test_expect_success '2nd event: resource-define method=kvs' '
+	head -2 forcelog | tail -1 | tee forcelog.2 &&
+	jq -e ".name == \"resource-define\"" forcelog.2 &&
+	jq -e ".context.method == \"kvs\"" forcelog.2
+'
+
+test_expect_success 'that event WAS posted to the KVS' '
+	flux kvs get resource.eventlog >kvs2 &&
+	test $(grep resource-define kvs2 | wc -l) -eq 2
+'
+test_expect_success NO_CHAIN_LINT 'watch eventlog in the background waiting on drain' '
+	flux resource eventlog -F --wait=drain >bgeventlog &
+	echo $! >bgpid
+'
+test_expect_success NO_CHAIN_LINT 'drain rank 1' '
+	flux resource drain 1
+'
+test_expect_success NO_CHAIN_LINT 'background watcher completed successfully' '
+	wait $(cat bgpid)
+'
+
+test_expect_success 'run restartable flux instance, drain 0' '
+	flux start --setattr=statedir=$(pwd) \
+	    sh -c "flux resource eventlog --wait=resource-define \
+	    	&& flux resource drain 0 testing"
+'
+test_expect_success 'restart flux instance, dump eventlog' '
+	flux start --setattr=statedir=$(pwd) \
+	    flux resource eventlog --wait=resource-define | tee restartlog
+'
+test_expect_success '1st event: drain idset=0 reason=testing' '
+	head -1 restartlog | tee restartlog.1 &&
+	jq -e ".name == \"drain\"" restartlog.1 &&
+	jq -e ".context.idset == \"0\"" restartlog.1 &&
+	jq -e ".context.reason == \"testing\"" restartlog.1
+'
+test_expect_success '2nd event: restart' '
+	head -2 restartlog | tail -1 | tee restartlog.2 &&
+	jq -e ".name == \"restart\"" restartlog.2
+'
+test_expect_success 'last event: resource-define method=kvs' '
+	tail -1 restartlog | tee restartlog.3 &&
+	jq -e ".name == \"resource-define\"" restartlog.3 &&
+	jq -e ".context.method == \"kvs\"" restartlog.3
+'
+
+test_expect_success 'reload the scheduler' '
+	flux module load sched-simple
+'
+
+test_done


### PR DESCRIPTION
This adds a resource journal streaming RPC similar the one offered by the job manager.  Just a first cut at this point.

This doesn't change what's posted to the persistent `resource.eventlog` in the KVS but does add one new event called `restart` that's only for journal consumption.  It provides a baseline for mapping execution targets to hostnames in the current instance, and sets the initial `online` set after a restart.

Unlike the job manager journal, this doesn't have as much volume to deal with so no options for event filtering or skipping historical data are provided as yet.

`flux resource eventlog` can be used to dump and optionally follow this log.  This is not currently polished at all - it just dumps the events in JSON form, one per line.

For more detail on what's in this log and how the journal is formatted, see the proposed RFC:
- flux-framework/rfc#440