### PR TITLE
kvs: remove unused internal transaction request API code

### DIFF
--- a/src/common/libkvs/kvs_txn_compact.c
+++ b/src/common/libkvs/kvs_txn_compact.c
@@ -42,7 +42,7 @@
  *
  * append "A"
  * write "B"
- * append "c"
+ * append "C"
  *
  * we cannot combine the appends of "A" and "C".  In this scenario, we
  * generate an EINVAL error to the caller, indicating that the

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1780,8 +1780,8 @@ static void commit_request_cb (flux_t *h,
         goto error;
     }
 
-    if (!(tr = treq_create_rank (ctx->rank, ctx->seq++, flags))) {
-        flux_log_error (h, "%s: treq_create_rank", __FUNCTION__);
+    if (!(tr = treq_create (ctx->rank, ctx->seq++, flags))) {
+        flux_log_error (h, "%s: treq_create", __FUNCTION__);
         goto error;
     }
     if (treq_mgr_add_transaction (root->trm, tr) < 0) {

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1803,11 +1803,6 @@ static void commit_request_cb (flux_t *h,
     }
 
     if (ctx->rank == 0) {
-        /* we use this flag to indicate if a treq has been added to
-         * the ready queue.
-         */
-        treq_mark_processed (tr);
-
         if (kvstxn_mgr_add_transaction (root->ktm,
                                         treq_get_name (tr),
                                         ops,

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1780,7 +1780,7 @@ static void commit_request_cb (flux_t *h,
         goto error;
     }
 
-    if (!(tr = treq_create_rank (ctx->rank, ctx->seq++, 1, flags))) {
+    if (!(tr = treq_create_rank (ctx->rank, ctx->seq++, flags))) {
         flux_log_error (h, "%s: treq_create_rank", __FUNCTION__);
         goto error;
     }
@@ -1801,8 +1801,7 @@ static void commit_request_cb (flux_t *h,
 
     if (ctx->rank == 0) {
         /* we use this flag to indicate if a treq has been added to
-         * the ready queue.  We don't need to call
-         * treq_count_reached() b/c this is a commit and nprocs is 1
+         * the ready queue.
          */
         treq_mark_processed (tr);
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1780,7 +1780,11 @@ static void commit_request_cb (flux_t *h,
         goto error;
     }
 
-    if (!(tr = treq_create (ctx->rank, ctx->seq++, flags))) {
+    /* save copy of request, will be used later via
+     * finalize_transaction_bynames() to send error code to original
+     * send.
+     */
+    if (!(tr = treq_create (msg, ctx->rank, ctx->seq++, flags))) {
         flux_log_error (h, "%s: treq_create", __FUNCTION__);
         goto error;
     }
@@ -1791,13 +1795,6 @@ static void commit_request_cb (flux_t *h,
         errno = saved_errno;
         goto error;
     }
-
-    /* save copy of request, will be used later via
-     * finalize_transaction_bynames() to send error code to original
-     * send.
-     */
-    if (treq_add_request_copy (tr, msg) < 0)
-        goto error;
 
     if (ctx->rank == 0) {
         /* we use this flag to indicate if a treq has been added to

--- a/src/modules/kvs/test/treq.c
+++ b/src/modules/kvs/test/treq.c
@@ -47,17 +47,17 @@ void treq_basic_tests (void)
     const char *name;
     int count = 0;
 
-    ok (treq_create (NULL, 0) == NULL,
-        "treq_create fails on bad input");
-
-    ok ((tr = treq_create ("foo", 3)) != NULL,
+    ok ((tr = treq_create (214, 3577, 3)) != NULL,
         "treq_create works");
 
     ok ((name = treq_get_name (tr)) != NULL,
         "treq_get_name works");
 
-    ok (streq (name, "foo"),
-        "treq_get_name returns the correct name");
+    ok (strstr (name, "214") != NULL,
+        "treq_get_name returns name with rank in it");
+
+    ok (strstr (name, "3577") != NULL,
+        "treq_get_name returns name with seq in it");
 
     ok (treq_get_flags (tr) == 3,
         "treq_get_flags works");
@@ -106,20 +106,6 @@ void treq_basic_tests (void)
     flux_msg_destroy (request);
 
     treq_destroy (tr);
-
-    ok ((tr = treq_create_rank (214, 3577, 4)) != NULL,
-        "treq_create_rank works");
-
-    ok ((name = treq_get_name (tr)) != NULL,
-        "treq_get_name works");
-
-    ok (strstr (name, "214") != NULL,
-        "treq_get_name returns name with rank in it");
-
-    ok (strstr (name, "3577") != NULL,
-        "treq_get_name returns name with seq in it");
-
-    treq_destroy (tr);
 }
 
 void treq_ops_tests (void)
@@ -128,7 +114,7 @@ void treq_ops_tests (void)
     json_t *ops;
     json_t *o;
 
-    ok ((tr = treq_create ("foo", 3)) != NULL,
+    ok ((tr = treq_create (214, 3577, 3)) != NULL,
         "treq_create works");
 
     ok (treq_add_request_ops (tr, NULL) == 0,
@@ -173,7 +159,7 @@ void treq_request_tests (void)
     flux_msg_t *request;
     int count = 0;
 
-    ok ((tr = treq_create ("foo", 3)) != NULL,
+    ok ((tr = treq_create (214, 3577, 3)) != NULL,
         "treq_create works");
 
     ok (treq_iter_request_copies (tr, msg_cb, &count) == 0,
@@ -214,6 +200,8 @@ void treq_mgr_basic_tests (void)
 {
     treq_mgr_t *trm;
     treq_t *tr, *tmp_tr;
+    const char *tmp_name;
+    char *name;
 
     ok ((trm = treq_mgr_create ()) != NULL,
         "treq_mgr_create works");
@@ -221,8 +209,14 @@ void treq_mgr_basic_tests (void)
     ok (treq_mgr_transactions_count (trm) == 0,
         "treq_mgr_transactions_count returns 0 when no transactions added");
 
-    ok ((tr = treq_create ("treq1", 0)) != NULL,
+    ok ((tr = treq_create (214, 3577, 3)) != NULL,
         "treq_create works");
+
+    ok ((tmp_name = treq_get_name (tr)) != NULL,
+        "treq_get_name works");
+
+    if (!(name = strdup (tmp_name)))
+        BAIL_OUT ("strdup");
 
     ok (treq_mgr_add_transaction (trm, tr) == 0,
         "treq_mgr_add_transaction works");
@@ -230,7 +224,7 @@ void treq_mgr_basic_tests (void)
     ok (treq_mgr_add_transaction (trm, tr) < 0,
         "treq_mgr_add_transaction fails on duplicate treq");
 
-    ok ((tmp_tr = treq_mgr_lookup_transaction (trm, "treq1")) != NULL,
+    ok ((tmp_tr = treq_mgr_lookup_transaction (trm, name)) != NULL,
         "treq_mgr_lookup_transaction works");
 
     ok (tr == tmp_tr,
@@ -242,15 +236,16 @@ void treq_mgr_basic_tests (void)
     ok (treq_mgr_transactions_count (trm) == 1,
         "treq_mgr_transactions_count returns 1 when treq submitted");
 
-    treq_mgr_remove_transaction (trm, "treq1");
+    treq_mgr_remove_transaction (trm, name);
 
     ok (treq_mgr_transactions_count (trm) == 0,
         "treq_mgr_transactions_count returns 0 after treq remove");
 
-    ok (treq_mgr_lookup_transaction (trm, "treq1") == NULL,
+    ok (treq_mgr_lookup_transaction (trm, name) == NULL,
         "treq_mgr_lookup_transaction can't find removed treq");
 
     treq_mgr_destroy (trm);
+    free (name);
 }
 
 int treq_count_cb (treq_t *tr, void *data)
@@ -273,7 +268,8 @@ int treq_add_error_cb (treq_t *tr, void *data)
     treq_mgr_t *trm = data;
     treq_t *tr2;
 
-    tr2 = treq_create ("foobar", 0);
+    if (!(tr2 = treq_create (123, 456, 7)))
+        BAIL_OUT ("treq_create");
 
     if (treq_mgr_add_transaction (trm, tr2) < 0) {
         treq_destroy (tr2);
@@ -301,7 +297,7 @@ void treq_mgr_iter_tests (void)
         && count == 0,
         "treq_mgr_iter_transactions success when no transactions submitted");
 
-    ok ((tr = treq_create ("treq1", 0)) != NULL,
+    ok ((tr = treq_create (214, 3577, 3)) != NULL,
         "treq_create works");
 
     ok (treq_mgr_add_transaction (trm, tr) == 0,

--- a/src/modules/kvs/test/treq.c
+++ b/src/modules/kvs/test/treq.c
@@ -41,8 +41,6 @@ int msg_cb_error (treq_t *tr, const flux_msg_t *req, void *data)
 void treq_basic_tests (void)
 {
     treq_t *tr;
-    json_t *ops;
-    json_t *o;
     flux_msg_t *request;
     const char *name;
     int count = 0;
@@ -65,21 +63,6 @@ void treq_basic_tests (void)
     ok (treq_get_flags (tr) == 3,
         "treq_get_flags works");
 
-    /* for test ops can be anything */
-    ops = json_array ();
-    json_array_append_new (ops, json_string ("A"));
-
-    ok (treq_add_request_ops (tr, ops) == 0,
-        "initial treq_add_request_ops add works");
-
-    ok ((o = treq_get_ops (tr)) != NULL,
-        "initial treq_get_ops call works");
-
-    ok (json_equal (ops, o) == true,
-        "initial treq_get_ops match");
-
-    json_decref (ops);
-
     ok (treq_iter_request_copies (tr, msg_cb, &count) == 0,
         "second treq_iter_request_copies works");
 
@@ -95,51 +78,6 @@ void treq_basic_tests (void)
         "treq_get_processed returns true");
 
     flux_msg_destroy (request);
-
-    treq_destroy (tr);
-}
-
-void treq_ops_tests (void)
-{
-    treq_t *tr;
-    json_t *ops;
-    json_t *o;
-
-    ok ((tr = treq_create (NULL, 214, 3577, 3)) != NULL,
-        "treq_create works");
-
-    ok (treq_add_request_ops (tr, NULL) == 0,
-        "treq_add_request_ops works with NULL ops");
-
-    /* for test ops can be anything */
-    ops = json_array ();
-    json_array_append_new (ops, json_string ("A"));
-
-    ok (treq_add_request_ops (tr, ops) == 0,
-        "treq_add_request_ops add works");
-
-    json_decref (ops);
-
-    /* for test ops can be anything */
-    ops = json_array ();
-    json_array_append_new (ops, json_string ("B"));
-
-    ok (treq_add_request_ops (tr, ops) == 0,
-        "treq_add_request_ops add works");
-
-    json_decref (ops);
-
-    ok ((o = treq_get_ops (tr)) != NULL,
-        "initial treq_get_ops call works");
-
-    ops = json_array ();
-    json_array_append_new (ops, json_string ("A"));
-    json_array_append_new (ops, json_string ("B"));
-
-    ok (json_equal (ops, o) == true,
-        "treq_get_ops match");
-
-    json_decref (ops);
 
     treq_destroy (tr);
 }
@@ -308,7 +246,6 @@ int main (int argc, char *argv[])
     plan (NO_PLAN);
 
     treq_basic_tests ();
-    treq_ops_tests ();
     treq_request_tests ();
     treq_mgr_basic_tests ();
     treq_mgr_iter_tests ();

--- a/src/modules/kvs/test/treq.c
+++ b/src/modules/kvs/test/treq.c
@@ -56,14 +56,6 @@ void treq_basic_tests (void)
     ok (streq (topic, "mytopic"),
         "treq_get_request returned correct request");
 
-    ok (treq_get_processed (tr) == false,
-        "treq_get_processed returns false initially");
-
-    treq_mark_processed (tr);
-
-    ok (treq_get_processed (tr) == true,
-        "treq_get_processed returns true");
-
     flux_msg_destroy (request);
 
     treq_destroy (tr);

--- a/src/modules/kvs/test/treq.c
+++ b/src/modules/kvs/test/treq.c
@@ -47,23 +47,17 @@ void treq_basic_tests (void)
     const char *name;
     int count = 0;
 
-    ok (treq_create (NULL, 0, 0) == NULL,
+    ok (treq_create (NULL, 0) == NULL,
         "treq_create fails on bad input");
 
-    ok ((tr = treq_create ("foo", 1, 3)) != NULL,
+    ok ((tr = treq_create ("foo", 3)) != NULL,
         "treq_create works");
-
-    ok (treq_count_reached (tr) == false,
-        "initial treq_count_reached() is false");
 
     ok ((name = treq_get_name (tr)) != NULL,
         "treq_get_name works");
 
     ok (streq (name, "foo"),
         "treq_get_name returns the correct name");
-
-    ok (treq_get_nprocs (tr) == 1,
-        "treq_get_nprocs works");
 
     ok (treq_get_flags (tr) == 3,
         "treq_get_flags works");
@@ -80,10 +74,6 @@ void treq_basic_tests (void)
 
     ok (json_equal (ops, o) == true,
         "initial treq_get_ops match");
-
-    ok (treq_add_request_ops (tr, ops) < 0
-        && errno == EOVERFLOW,
-        "treq_add_request_ops fails with EOVERFLOW when exceeding nprocs");
 
     json_decref (ops);
 
@@ -105,9 +95,6 @@ void treq_basic_tests (void)
     ok (count == 1,
         "second treq_iter_request_copies count is 1");
 
-    ok (treq_count_reached (tr) == true,
-        "later treq_count_reached() is true");
-
     ok (treq_get_processed (tr) == false,
         "treq_get_processed returns false initially");
 
@@ -120,10 +107,7 @@ void treq_basic_tests (void)
 
     treq_destroy (tr);
 
-    ok (treq_create_rank (1, 2, -1, 0) == NULL,
-        "treq_create_rank fails on bad input");
-
-    ok ((tr = treq_create_rank (214, 3577, 2, 4)) != NULL,
+    ok ((tr = treq_create_rank (214, 3577, 4)) != NULL,
         "treq_create_rank works");
 
     ok ((name = treq_get_name (tr)) != NULL,
@@ -144,17 +128,11 @@ void treq_ops_tests (void)
     json_t *ops;
     json_t *o;
 
-    ok ((tr = treq_create ("foo", 3, 3)) != NULL,
+    ok ((tr = treq_create ("foo", 3)) != NULL,
         "treq_create works");
-
-    ok (treq_count_reached (tr) == false,
-        "initial treq_count_reached() is false");
 
     ok (treq_add_request_ops (tr, NULL) == 0,
         "treq_add_request_ops works with NULL ops");
-
-    ok (treq_count_reached (tr) == false,
-        "treq_count_reached() is still false");
 
     /* for test ops can be anything */
     ops = json_array ();
@@ -165,9 +143,6 @@ void treq_ops_tests (void)
 
     json_decref (ops);
 
-    ok (treq_count_reached (tr) == false,
-        "treq_count_reached() is still false");
-
     /* for test ops can be anything */
     ops = json_array ();
     json_array_append_new (ops, json_string ("B"));
@@ -176,9 +151,6 @@ void treq_ops_tests (void)
         "treq_add_request_ops add works");
 
     json_decref (ops);
-
-    ok (treq_count_reached (tr) == true,
-        "treq_count_reached() is true");
 
     ok ((o = treq_get_ops (tr)) != NULL,
         "initial treq_get_ops call works");
@@ -201,7 +173,7 @@ void treq_request_tests (void)
     flux_msg_t *request;
     int count = 0;
 
-    ok ((tr = treq_create ("foo", 1, 3)) != NULL,
+    ok ((tr = treq_create ("foo", 3)) != NULL,
         "treq_create works");
 
     ok (treq_iter_request_copies (tr, msg_cb, &count) == 0,
@@ -249,7 +221,7 @@ void treq_mgr_basic_tests (void)
     ok (treq_mgr_transactions_count (trm) == 0,
         "treq_mgr_transactions_count returns 0 when no transactions added");
 
-    ok ((tr = treq_create ("treq1", 1, 0)) != NULL,
+    ok ((tr = treq_create ("treq1", 0)) != NULL,
         "treq_create works");
 
     ok (treq_mgr_add_transaction (trm, tr) == 0,
@@ -301,7 +273,7 @@ int treq_add_error_cb (treq_t *tr, void *data)
     treq_mgr_t *trm = data;
     treq_t *tr2;
 
-    tr2 = treq_create ("foobar", 1, 0);
+    tr2 = treq_create ("foobar", 0);
 
     if (treq_mgr_add_transaction (trm, tr2) < 0) {
         treq_destroy (tr2);
@@ -329,7 +301,7 @@ void treq_mgr_iter_tests (void)
         && count == 0,
         "treq_mgr_iter_transactions success when no transactions submitted");
 
-    ok ((tr = treq_create ("treq1", 1, 0)) != NULL,
+    ok ((tr = treq_create ("treq1", 0)) != NULL,
         "treq_create works");
 
     ok (treq_mgr_add_transaction (trm, tr) == 0,

--- a/src/modules/kvs/test/treq.c
+++ b/src/modules/kvs/test/treq.c
@@ -47,7 +47,10 @@ void treq_basic_tests (void)
     const char *name;
     int count = 0;
 
-    ok ((tr = treq_create (214, 3577, 3)) != NULL,
+    ok ((request = flux_request_encode ("mytopic", "{ bar : 1 }")) != NULL,
+        "flux_request_encode works");
+
+    ok ((tr = treq_create (request, 214, 3577, 3)) != NULL,
         "treq_create works");
 
     ok ((name = treq_get_name (tr)) != NULL,
@@ -78,18 +81,6 @@ void treq_basic_tests (void)
     json_decref (ops);
 
     ok (treq_iter_request_copies (tr, msg_cb, &count) == 0,
-        "initial treq_iter_request_copies works");
-
-    ok (count == 0,
-        "initial treq_iter_request_copies count is 0");
-
-    ok ((request = flux_request_encode ("mytopic", "{ bar : 1 }")) != NULL,
-        "flux_request_encode works");
-
-    ok (treq_add_request_copy (tr, request) == 0,
-        "initial treq_add_request_copy call works");
-
-    ok (treq_iter_request_copies (tr, msg_cb, &count) == 0,
         "second treq_iter_request_copies works");
 
     ok (count == 1,
@@ -114,7 +105,7 @@ void treq_ops_tests (void)
     json_t *ops;
     json_t *o;
 
-    ok ((tr = treq_create (214, 3577, 3)) != NULL,
+    ok ((tr = treq_create (NULL, 214, 3577, 3)) != NULL,
         "treq_create works");
 
     ok (treq_add_request_ops (tr, NULL) == 0,
@@ -159,28 +150,11 @@ void treq_request_tests (void)
     flux_msg_t *request;
     int count = 0;
 
-    ok ((tr = treq_create (214, 3577, 3)) != NULL,
-        "treq_create works");
-
-    ok (treq_iter_request_copies (tr, msg_cb, &count) == 0,
-        "initial treq_iter_request_copies works");
-
-    ok (count == 0,
-        "initial treq_iter_request_copies count is 0");
-
     ok ((request = flux_request_encode ("mytopic", "{ A : 1 }")) != NULL,
         "flux_request_encode works");
 
-    ok (treq_add_request_copy (tr, request) == 0,
-        "treq_add_request_copy works");
-
-    flux_msg_destroy (request);
-
-    ok ((request = flux_request_encode ("mytopic", "{ B : 1 }")) != NULL,
-        "flux_request_encode works");
-
-    ok (treq_add_request_copy (tr, request) == 0,
-        "treq_add_request_copy works");
+    ok ((tr = treq_create (request, 214, 3577, 3)) != NULL,
+        "treq_create works");
 
     flux_msg_destroy (request);
 
@@ -190,8 +164,8 @@ void treq_request_tests (void)
     ok (treq_iter_request_copies (tr, msg_cb, &count) == 0,
         "second treq_iter_request_copies works");
 
-    ok (count == 2,
-        "treq_iter_request_copies count is 2");
+    ok (count == 1,
+        "treq_iter_request_copies count is 1");
 
     treq_destroy (tr);
 }
@@ -209,7 +183,7 @@ void treq_mgr_basic_tests (void)
     ok (treq_mgr_transactions_count (trm) == 0,
         "treq_mgr_transactions_count returns 0 when no transactions added");
 
-    ok ((tr = treq_create (214, 3577, 3)) != NULL,
+    ok ((tr = treq_create (NULL, 214, 3577, 3)) != NULL,
         "treq_create works");
 
     ok ((tmp_name = treq_get_name (tr)) != NULL,
@@ -268,7 +242,7 @@ int treq_add_error_cb (treq_t *tr, void *data)
     treq_mgr_t *trm = data;
     treq_t *tr2;
 
-    if (!(tr2 = treq_create (123, 456, 7)))
+    if (!(tr2 = treq_create (NULL, 123, 456, 7)))
         BAIL_OUT ("treq_create");
 
     if (treq_mgr_add_transaction (trm, tr2) < 0) {
@@ -297,7 +271,7 @@ void treq_mgr_iter_tests (void)
         && count == 0,
         "treq_mgr_iter_transactions success when no transactions submitted");
 
-    ok ((tr = treq_create (214, 3577, 3)) != NULL,
+    ok ((tr = treq_create (NULL, 214, 3577, 3)) != NULL,
         "treq_create works");
 
     ok (treq_mgr_add_transaction (trm, tr) == 0,

--- a/src/modules/kvs/test/treq.c
+++ b/src/modules/kvs/test/treq.c
@@ -121,94 +121,12 @@ void treq_mgr_basic_tests (void)
     free (name);
 }
 
-int treq_count_cb (treq_t *tr, void *data)
-{
-    int *count = data;
-    (*count)++;
-    return 0;
-}
-
-int treq_remove_cb (treq_t *tr, void *data)
-{
-    treq_mgr_t *trm = data;
-
-    treq_mgr_remove_transaction (trm, treq_get_name (tr));
-    return 0;
-}
-
-int treq_add_error_cb (treq_t *tr, void *data)
-{
-    treq_mgr_t *trm = data;
-    treq_t *tr2;
-
-    if (!(tr2 = treq_create (NULL, 123, 456, 7)))
-        BAIL_OUT ("treq_create");
-
-    if (treq_mgr_add_transaction (trm, tr2) < 0) {
-        treq_destroy (tr2);
-        return -1;
-    }
-    return 0;
-}
-
-int treq_error_cb (treq_t *tr, void *data)
-{
-    return -1;
-}
-
-void treq_mgr_iter_tests (void)
-{
-    treq_mgr_t *trm;
-    treq_t *tr;
-    int count;
-
-    ok ((trm = treq_mgr_create ()) != NULL,
-        "treq_mgr_create works");
-
-    count = 0;
-    ok (treq_mgr_iter_transactions (trm, treq_count_cb, &count) == 0
-        && count == 0,
-        "treq_mgr_iter_transactions success when no transactions submitted");
-
-    ok ((tr = treq_create (NULL, 214, 3577, 3)) != NULL,
-        "treq_create works");
-
-    ok (treq_mgr_add_transaction (trm, tr) == 0,
-        "treq_mgr_add_transaction works");
-
-    ok (treq_mgr_transactions_count (trm) == 1,
-        "treq_mgr_transactions_count returns correct count of transactions");
-
-    ok (treq_mgr_iter_transactions (trm, treq_error_cb, NULL) < 0,
-        "treq_mgr_iter_transactions error on callback error");
-
-    ok (treq_mgr_iter_transactions (trm, treq_add_error_cb, trm) < 0
-        && errno == EAGAIN,
-        "treq_mgr_iter_transactions error on callback error trying to add treq");
-
-    ok (treq_mgr_iter_transactions (trm, treq_remove_cb, trm) == 0,
-        "treq_mgr_iter_transactions success on remove");
-
-    count = 0;
-    ok (treq_mgr_iter_transactions (trm, treq_count_cb, &count) == 0,
-        "treq_mgr_iter_transactions success on count");
-
-    ok (count == 0,
-        "treq_mgr_iter_transactions returned correct count of transactions");
-
-    ok (treq_mgr_transactions_count (trm) == 0,
-        "treq_mgr_transactions_count returns correct count of transactions");
-
-    treq_mgr_destroy (trm);
-}
-
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
 
     treq_basic_tests ();
     treq_mgr_basic_tests ();
-    treq_mgr_iter_tests ();
 
     done_testing ();
     return (0);

--- a/src/modules/kvs/treq.c
+++ b/src/modules/kvs/treq.c
@@ -179,7 +179,9 @@ void treq_destroy (treq_t *tr)
     }
 }
 
-static treq_t *treq_create_common (int flags)
+treq_t *treq_create (uint32_t rank,
+                     unsigned int seq,
+                     int flags)
 {
     treq_t *tr = NULL;
     int saved_errno;
@@ -193,59 +195,12 @@ static treq_t *treq_create_common (int flags)
         saved_errno = ENOMEM;
         goto error;
     }
-    tr->flags = flags;
-    tr->processed = false;
-
-    return tr;
-error:
-    treq_destroy (tr);
-    errno = saved_errno;
-    return NULL;
-}
-
-treq_t *treq_create (const char *name, int flags)
-{
-    treq_t *tr = NULL;
-    int saved_errno;
-
-    if (!name) {
-        saved_errno = EINVAL;
-        goto error;
-    }
-
-    if (!(tr = treq_create_common (flags))) {
-        saved_errno = EINVAL;
-        goto error;
-    }
-
-    if (!(tr->name = strdup (name))) {
-        saved_errno = errno;
-        goto error;
-    }
-
-    return tr;
-error:
-    treq_destroy (tr);
-    errno = saved_errno;
-    return NULL;
-}
-
-treq_t *treq_create_rank (uint32_t rank,
-                          unsigned int seq,
-                          int flags)
-{
-    treq_t *tr = NULL;
-    int saved_errno;
-
-    if (!(tr = treq_create_common (flags))) {
-        saved_errno = EINVAL;
-        goto error;
-    }
-
     if (asprintf (&(tr->name), "treq.%u.%u", rank, seq) < 0) {
         saved_errno = errno;
         goto error;
     }
+    tr->flags = flags;
+    tr->processed = false;
 
     return tr;
 error:

--- a/src/modules/kvs/treq.c
+++ b/src/modules/kvs/treq.c
@@ -219,11 +219,9 @@ int treq_get_flags (treq_t *tr)
     return tr->flags;
 }
 
-int treq_iter_request_copies (treq_t *tr, treq_msg_cb cb, void *data)
+const flux_msg_t *treq_get_request (treq_t *tr)
 {
-    if (cb (tr, tr->request, data) < 0)
-        return -1;
-    return 0;
+    return tr->request;
 }
 
 bool treq_get_processed (treq_t *tr)

--- a/src/modules/kvs/treq.c
+++ b/src/modules/kvs/treq.c
@@ -35,7 +35,6 @@ struct treq_mgr {
 struct treq {
     char *name;
     const flux_msg_t *request;
-    json_t *ops;
     int flags;
     bool processed;
 };
@@ -173,7 +172,6 @@ void treq_destroy (treq_t *tr)
 {
     if (tr) {
         free (tr->name);
-        json_decref (tr->ops);
         flux_msg_decref (tr->request);
         free (tr);
     }
@@ -189,10 +187,6 @@ treq_t *treq_create (const flux_msg_t *request,
 
     if (!(tr = calloc (1, sizeof (*tr)))) {
         saved_errno = errno;
-        goto error;
-    }
-    if (!(tr->ops = json_array ())) {
-        saved_errno = ENOMEM;
         goto error;
     }
     if (request) {
@@ -223,28 +217,6 @@ const char *treq_get_name (treq_t *tr)
 int treq_get_flags (treq_t *tr)
 {
     return tr->flags;
-}
-
-json_t *treq_get_ops (treq_t *tr)
-{
-    return tr->ops;
-}
-
-int treq_add_request_ops (treq_t *tr, json_t *ops)
-{
-    json_t *op;
-    int i;
-
-    if (ops) {
-        for (i = 0; i < json_array_size (ops); i++) {
-            if ((op = json_array_get (ops, i)))
-                if (json_array_append (tr->ops, op) < 0) {
-                    errno = ENOMEM;
-                    return -1;
-                }
-        }
-    }
-    return 0;
 }
 
 int treq_iter_request_copies (treq_t *tr, treq_msg_cb cb, void *data)

--- a/src/modules/kvs/treq.c
+++ b/src/modules/kvs/treq.c
@@ -34,7 +34,6 @@ struct treq {
     char *name;
     const flux_msg_t *request;
     int flags;
-    bool processed;
 };
 
 /*
@@ -138,7 +137,6 @@ treq_t *treq_create (const flux_msg_t *request,
         goto error;
     }
     tr->flags = flags;
-    tr->processed = false;
 
     return tr;
 error:
@@ -160,16 +158,6 @@ int treq_get_flags (treq_t *tr)
 const flux_msg_t *treq_get_request (treq_t *tr)
 {
     return tr->request;
-}
-
-bool treq_get_processed (treq_t *tr)
-{
-    return tr->processed;
-}
-
-void treq_mark_processed (treq_t *tr)
-{
-    tr->processed = true;
 }
 
 /*

--- a/src/modules/kvs/treq.h
+++ b/src/modules/kvs/treq.h
@@ -63,13 +63,6 @@ void treq_destroy (treq_t *tr);
 const char *treq_get_name (treq_t *tr);
 int treq_get_flags (treq_t *tr);
 
-json_t *treq_get_ops (treq_t *tr);
-
-/* treq_add_request_ops() should be called with ops on each
- * request, even if ops is NULL
- */
-int treq_add_request_ops (treq_t *tr, json_t *ops);
-
 /* Call callback for each request message copy stored internally via
  * treq_add_request_copy().
  *

--- a/src/modules/kvs/treq.h
+++ b/src/modules/kvs/treq.h
@@ -50,8 +50,11 @@ int treq_mgr_transactions_count (treq_mgr_t *trm);
  * treq_t API
  */
 
-/* will create transaction name based on rank & seq */
-treq_t *treq_create (uint32_t rank,
+/* will create transaction name based on rank & seq
+ * - request copy saved in transaction for retrieval later
+ */
+treq_t *treq_create (const flux_msg_t *request,
+                     uint32_t rank,
                      unsigned int seq,
                      int flags);
 
@@ -66,11 +69,6 @@ json_t *treq_get_ops (treq_t *tr);
  * request, even if ops is NULL
  */
 int treq_add_request_ops (treq_t *tr, json_t *ops);
-
-/* copy the request message into the transaction, where it can be
- * retrieved later.
- */
-int treq_add_request_copy (treq_t *tr, const flux_msg_t *request);
 
 /* Call callback for each request message copy stored internally via
  * treq_add_request_copy().

--- a/src/modules/kvs/treq.h
+++ b/src/modules/kvs/treq.h
@@ -57,11 +57,6 @@ const char *treq_get_name (treq_t *tr);
 int treq_get_flags (treq_t *tr);
 const flux_msg_t *treq_get_request (treq_t *tr);
 
-/* convenience processing flag
- */
-bool treq_get_processed (treq_t *tr);
-void treq_mark_processed (treq_t *tr);
-
 #endif /* !_FLUX_KVS_TREQ_H */
 
 /*

--- a/src/modules/kvs/treq.h
+++ b/src/modules/kvs/treq.h
@@ -51,21 +51,16 @@ int treq_mgr_transactions_count (treq_mgr_t *trm);
  */
 
 /* treq_create - name is passed in */
-treq_t *treq_create (const char *name, int nprocs, int flags);
+treq_t *treq_create (const char *name, int flags);
 
 /* treq_create_rank - internally will create name based on rank & seq */
 treq_t *treq_create_rank (uint32_t rank,
                           unsigned int seq,
-                          int nprocs,
                           int flags);
 
 void treq_destroy (treq_t *tr);
 
-/* if number of calls to treq_add_request_ops() is == nprocs */
-bool treq_count_reached (treq_t *tr);
-
 const char *treq_get_name (treq_t *tr);
-int treq_get_nprocs (treq_t *tr);
 int treq_get_flags (treq_t *tr);
 
 json_t *treq_get_ops (treq_t *tr);

--- a/src/modules/kvs/treq.h
+++ b/src/modules/kvs/treq.h
@@ -19,8 +19,6 @@ typedef struct treq treq_t;
 
 typedef int (*treq_itr_f)(treq_t *tr, void *data);
 
-typedef int (*treq_msg_cb)(treq_t *tr, const flux_msg_t *req, void *data);
-
 /*
  * treq_mgr_t API
  */
@@ -62,14 +60,7 @@ void treq_destroy (treq_t *tr);
 
 const char *treq_get_name (treq_t *tr);
 int treq_get_flags (treq_t *tr);
-
-/* Call callback for each request message copy stored internally via
- * treq_add_request_copy().
- *
- * If cb returns < 0 on a message, this function was quit and return
- * -1.
- */
-int treq_iter_request_copies (treq_t *tr, treq_msg_cb cb, void *data);
+const flux_msg_t *treq_get_request (treq_t *tr);
 
 /* convenience processing flag
  */

--- a/src/modules/kvs/treq.h
+++ b/src/modules/kvs/treq.h
@@ -17,8 +17,6 @@ typedef struct treq_mgr treq_mgr_t;
 
 typedef struct treq treq_t;
 
-typedef int (*treq_itr_f)(treq_t *tr, void *data);
-
 /*
  * treq_mgr_t API
  */
@@ -34,9 +32,6 @@ int treq_mgr_add_transaction (treq_mgr_t *trm, treq_t *tr);
 /* Lookup a transaction previously stored via
  * treq_mgr_add_transaction(), via name */
 treq_t *treq_mgr_lookup_transaction (treq_mgr_t *trm, const char *name);
-
-/* Iterate through all transactions */
-int treq_mgr_iter_transactions (treq_mgr_t *trm, treq_itr_f cb, void *data);
 
 /* remove a transaction from the treq manager */
 int treq_mgr_remove_transaction (treq_mgr_t *trm, const char *name);

--- a/src/modules/kvs/treq.h
+++ b/src/modules/kvs/treq.h
@@ -50,13 +50,10 @@ int treq_mgr_transactions_count (treq_mgr_t *trm);
  * treq_t API
  */
 
-/* treq_create - name is passed in */
-treq_t *treq_create (const char *name, int flags);
-
-/* treq_create_rank - internally will create name based on rank & seq */
-treq_t *treq_create_rank (uint32_t rank,
-                          unsigned int seq,
-                          int flags);
+/* will create transaction name based on rank & seq */
+treq_t *treq_create (uint32_t rank,
+                     unsigned int seq,
+                     int flags);
 
 void treq_destroy (treq_t *tr);
 


### PR DESCRIPTION
With the removal of KVS fence support in #6592, a large amount of the transaction request ("treq") API is no longer needed.  Remove that code and code that uses it.

As a side note, you may notice the "treq" API is now very simple.  Here's the internal structs

```
struct treq_mgr {
    zhash_t *transactions;
};

struct treq {
    char *name;
    const flux_msg_t *request;
    int flags;
};
```

So I hope I can "squash" this into the kvsroot/kvstxn API, but that is for a follow up PR.  This PR is just for the "obvious" removal of dead code.
