### PR TITLE
fix housekeeping reconfiguration problem

### DIFF
--- a/src/modules/job-manager/housekeeping.c
+++ b/src/modules/job-manager/housekeeping.c
@@ -613,6 +613,7 @@ json_t *housekeeping_get_stats (struct housekeeping *hk)
     json_t *running;
     json_t *stats = NULL;
     struct allocation *a;
+    char *command = NULL;
 
     if (!(running = json_object ()))
         goto nomem;
@@ -626,11 +627,19 @@ json_t *housekeeping_get_stats (struct housekeeping *hk)
         }
         a = zlistx_next (hk->allocations);
     }
-    if (!(stats = json_pack ("{s:O}", "running", running)))
+    if (hk->cmd)
+        command = flux_cmd_stringify (hk->cmd);
+    if (!(stats = json_pack ("{s:O, s{s:f s:s}}",
+                             "running", running,
+                             "config",
+                               "release-after", hk->release_after,
+                               "command", command ? command : "")))
         goto nomem;
+    free (command);
     json_decref (running);
     return stats;
 nomem:
+    free (command);
     json_decref (running);
     errno = ENOMEM;
     return NULL;

--- a/t/t2226-housekeeping.t
+++ b/t/t2226-housekeeping.t
@@ -395,4 +395,23 @@ test_expect_success 'one node is allocated' '
 	test $(FLUX_RESOURCE_LIST_RPC=sched.resource-status \
 		flux resource list -s allocated -no {nnodes}) -eq 1
 '
+# issue #6596
+test_expect_success 'release-after is 0 from last test' '
+	flux module stats job-manager | \
+		jq -e .housekeeping.config >config1.json &&
+	jq -e ".\"release-after\" == 0" config1.json
+'
+test_expect_success 'reconfigure housekeeping with default release-after' '
+	flux config load <<-EOT
+	[job-manager.housekeeping]
+	command = [ "true" ]
+	# NOTE: release-after was "0" before, now it should be unset
+	EOT
+'
+test_expect_success 'release-after is -1 after reconfig' '
+	flux module stats job-manager | \
+		jq -e .housekeeping.config >config2.json &&
+	jq -e ".\"release-after\" == -1" config2.json
+'
+
 test_done


### PR DESCRIPTION
Problem: as noted in #6596, when housekeeping is reconfigured, it retains the old value of `release-after` unless the key is explicitly set.

And the only way to disable partial release is to not set it.

This fixes the config callback so that release-after is set to the default if not mentioned.