### PR TITLE
kvs: remove stats clearing

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -226,8 +226,7 @@ static int event_subscribe (struct kvs_ctx *ctx, const char *ns)
         /* These belong to all namespaces, subscribe once the first
          * time we init a namespace */
 
-        if (flux_event_subscribe (ctx->h, "kvs.stats.clear") < 0
-            || flux_event_subscribe (ctx->h, "kvs.dropcache") < 0) {
+        if (flux_event_subscribe (ctx->h, "kvs.dropcache") < 0) {
             flux_log_error (ctx->h, "flux_event_subscribe");
             goto cleanup;
         }
@@ -2176,44 +2175,6 @@ error:
     json_decref (nsstats);
 }
 
-static int stats_clear_root_cb (struct kvsroot *root, void *arg)
-{
-    kvstxn_mgr_clear_noop_stores (root->ktm);
-    return 0;
-}
-
-static void stats_clear (struct kvs_ctx *ctx)
-{
-    ctx->faults = 0;
-    memset (&ctx->txn_commit_stats, '\0', sizeof (ctx->txn_commit_stats));
-
-    if (kvsroot_mgr_iter_roots (ctx->krm, stats_clear_root_cb, NULL) < 0)
-        flux_log_error (ctx->h, "%s: kvsroot_mgr_iter_roots", __FUNCTION__);
-}
-
-static void stats_clear_event_cb (flux_t *h,
-                                  flux_msg_handler_t *mh,
-                                  const flux_msg_t *msg,
-                                  void *arg)
-{
-    struct kvs_ctx *ctx = arg;
-
-    stats_clear (ctx);
-}
-
-static void stats_clear_request_cb (flux_t *h,
-                                    flux_msg_handler_t *mh,
-                                    const flux_msg_t *msg,
-                                    void *arg)
-{
-    struct kvs_ctx *ctx = arg;
-
-    stats_clear (ctx);
-
-    if (flux_respond (h, msg, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
-}
-
 static int namespace_create (struct kvs_ctx *ctx,
                              const char *ns,
                              const char *rootref,
@@ -2620,18 +2581,6 @@ static const struct flux_msg_handler_spec htab[] = {
         "kvs.stats-get",
         stats_get_cb,
         FLUX_ROLE_USER
-    },
-    {
-        FLUX_MSGTYPE_REQUEST,
-        "kvs.stats-clear",
-        stats_clear_request_cb,
-        0
-    },
-    {
-        FLUX_MSGTYPE_EVENT,
-        "kvs.stats-clear",
-        stats_clear_event_cb,
-        0
     },
     {
         FLUX_MSGTYPE_EVENT,

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -221,10 +221,6 @@ static int event_subscribe (struct kvs_ctx *ctx, const char *ns)
      * See issue #2779 for more information.
      */
 
-    /* do not want to subscribe to events that are not within our
-     * namespace, so we subscribe to only specific ones.
-     */
-
     if (!(ctx->events_init)) {
 
         /* These belong to all namespaces, subscribe once the first

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -1343,11 +1343,6 @@ int kvstxn_mgr_get_noop_stores (kvstxn_mgr_t *ktm)
     return ktm->noop_stores;
 }
 
-void kvstxn_mgr_clear_noop_stores (kvstxn_mgr_t *ktm)
-{
-    ktm->noop_stores = 0;
-}
-
 int kvstxn_mgr_ready_transaction_count (kvstxn_mgr_t *ktm)
 {
     return zlist_size (ktm->ready);

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -201,7 +201,6 @@ void kvstxn_mgr_remove_transaction (kvstxn_mgr_t *ktm,
                                     bool fallback);
 
 int kvstxn_mgr_get_noop_stores (kvstxn_mgr_t *ktm);
-void kvstxn_mgr_clear_noop_stores (kvstxn_mgr_t *ktm);
 
 /* return count of ready transactions */
 int kvstxn_mgr_ready_transaction_count (kvstxn_mgr_t *ktm);

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -228,8 +228,6 @@ void kvstxn_mgr_basic_tests (void)
     ok (kvstxn_mgr_get_noop_stores (ktm) == 0,
         "kvstxn_mgr_get_noop_stores works");
 
-    kvstxn_mgr_clear_noop_stores (ktm);
-
     ok (kvstxn_mgr_ready_transaction_count (ktm) == 0,
         "kvstxn_mgr_ready_transaction_count is initially 0");
 

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -397,12 +397,6 @@ test_expect_success 'kvs-watch: stats works (user)' '
         unset_userid
 '
 
-test_expect_success 'kvs: stats clear fails (user)' '
-        set_userid 9999 &&
-        ! flux module stats -c kvs &&
-        unset_userid
-'
-
 #
 # ensure no lingering pending requests
 #


### PR DESCRIPTION
Problem: KVS stats clearing code was added very early on in KVS prototyping for testing.  It is basically not used anymore.  If we
want to test something that requires a "clean" slate for the KVS, we can just start a new instance and test with that.

Solution: Remove all KVS stats clearing code.  Remove all associated tests.

Fixes #6607