### PR TITLE
flux-job: do not override `-L, --color` when `-H, --human` is used in `eventlog` and `wait-event` subcommands

### DIFF
--- a/src/cmd/job/eventlog.c
+++ b/src/cmd/job/eventlog.c
@@ -146,7 +146,6 @@ static void formatter_parse_options (optparse_t *p,
     if (optparse_hasopt (p, "human")) {
         format = "text",
         time_format = "human";
-        when = "auto";
     }
 
     if (eventlog_formatter_set_format (evf, format) < 0)

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -282,7 +282,7 @@ test_expect_success 'flux job eventlog/wait-event reject invalid --color' '
         test_must_fail flux job eventlog --color=foo $jobid &&
         test_must_fail flux job wait-event --color=foo $jobid
 '
-for opt in "-L" "-Lalways" "--color" "--color=always"; do
+for opt in "-HL" "-L" "-Lalways" "--color" "--color=always"; do
         test_expect_success "flux job eventlog $opt forces color on" '
                 name=notty${opt##--color=} &&
                 outfile=color-${name:-default}.out &&


### PR DESCRIPTION
While working on something else I discovered that `flux job eventlog -HL ...` wasn't forcing color on like it should. This is because `-H, --human` forces `color = auto`, overwriting the user's command line choice.

`auto` is already the default. Stop doing that.

Add a test.