### PR TITLE
docs: fix constraints negation in man pages

### DIFF
--- a/doc/man1/common/job-constraints.rst
+++ b/doc/man1/common/job-constraints.rst
@@ -32,8 +32,8 @@
    properties
      Require the set of specified properties. Properties may be
      comma-separated, in which case all specified properties are required.
-     As a convenience, if a property starts with ``^`` then a matching
-     resource must not have the specified property. In these commands,
+     As a convenience, if a property starts with ``-`` then a matching
+     resource must *not* have the specified property. In these commands,
      the ``properties`` operator is the default, so that ``a,b`` is equivalent
      to ``properties:a,b``.
 


### PR DESCRIPTION
Problem: the docs on constraint negation is wrong, it has '^' as the negation token but it is actually '-' both in practice and in RFC 35.

Change it.