### PR TITLE
add `ResourceJournalConsumer` and `EventLogFormatter` classes and use them to standardize `flux resource eventlog` 

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -22,7 +22,7 @@ SYNOPSIS
 | **flux** **resource** **reload** [-f] [--xml] *path*
 
 | **flux** **resource** **acquire-mute**
-| **flux** **resource** **eventlog** [*-w* *EVENT*] [*-F*]
+| **flux** **resource** **eventlog** [*-w* *EVENT*] [*-f* *FORMAT*] [*-T* *FORMAT*] [*-L* [*WHEN*]] [*-H*] [*-F*]
 
 DESCRIPTION
 ===========
@@ -363,6 +363,26 @@ eventlog
 .. program:: flux resource eventlog
 
 Watch the resource journal, which is described in RFC 44.
+
+.. option:: -f, --format=FORMAT
+
+  Specify the eventlog output format. Valid choices are *text* (the default)
+  or *json*.
+
+.. option:: -T, --time-format=FORMAT
+
+  Specify the timestamp format. Valid choices are *raw* (the default), *iso*,
+  *offset*, and *human*.
+
+.. option:: -H, --human
+
+  Display human-readable output. Equivalent to :option:`-T human -f text`.
+
+.. option:: -L, --color[=WHEN]
+
+  Control color output. The optional argument *WHEN* can be one of *auto*,
+  *never*, or *always*. If *WHEN* is omitted, it defaults to *always*.
+  Otherwise the default is *auto*.
 
 .. option:: -F, --follow
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -942,3 +942,4 @@ SATTR
 myprogram
 unref
 sigprocmask
+iso

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -523,7 +523,7 @@ _flux_submit_commands()
 # flux-resource(1) completions
 _flux_resource()
 {
-    local subcmds="drain undrain status list R info reload"
+    local subcmds="drain undrain status list R info reload eventlog"
     local cmd=$1
     local split=false
     local states
@@ -570,15 +570,35 @@ _flux_resource()
         -q --queue= \
         -i --include= \
     "
+    local eventlog_OPTS="\
+        -h --help \
+        -f --format= \
+        -T --time-format=
+        -L --color= \
+        -F --follor \
+        -w --wait-event= \
+    "
+
     _flux_split_longopt && split=true
     case $prev in
         --queue | -!(-*)q)
             _flux_complete_queue
             return
             ;;
-        --format | -!(-*)o)
-            _flux_complete_format_name flux resource $cmd
-            return
+        --format | -!(-*)o | -!(-*)f)
+            case $cmd in
+                eventlog)
+                    COMPREPLY=( $(compgen -W "text json" -- "$cur") )
+                    return
+                    ;;
+                *)
+                    # Only eventlog takes -f as format
+                    if test "$prev" != "-f"; then
+                        _flux_complete_format_name flux resource $cmd
+                        return
+                    fi
+                    ;;
+            esac
             ;;
         --states | -!(-*)s)
             case $cmd in

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -60,6 +60,7 @@ nobase_fluxpy_PYTHON = \
 	resource/ResourceSet.py \
 	resource/list.py \
 	resource/status.py \
+	resource/journal.py \
 	hostlist.py \
 	idset.py \
 	progress.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -72,6 +72,8 @@ nobase_fluxpy_PYTHON = \
 	constraint/parser.py \
 	constraint/parsetab.py \
 	constraint/__init__.py \
+	abc/journal.py \
+	abc/__init__.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -11,6 +11,7 @@ nobase_fluxpy_PYTHON = \
 	memoized_property.py \
 	debugged.py \
 	importer.py \
+	eventlog.py \
 	conf_builtin.py \
 	cli/__init__.py \
 	cli/base.py \

--- a/src/bindings/python/flux/abc/__init__.py
+++ b/src/bindings/python/flux/abc/__init__.py
@@ -1,0 +1,13 @@
+###############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from flux.abc.journal import JournalConsumerBase, JournalEventBase
+
+__all__ = ["JournalConsumerBase", "JournalEventBase"]

--- a/src/bindings/python/flux/abc/journal.py
+++ b/src/bindings/python/flux/abc/journal.py
@@ -1,0 +1,359 @@
+###############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Abstract classes for journal consumer interfaces"""
+
+import errno
+import time
+from abc import ABC, abstractmethod
+from collections import deque
+
+from flux.constants import FLUX_RPC_NORESPONSE, FLUX_RPC_STREAMING
+from flux.eventlog import EventLogEvent
+
+
+class JournalEventBase(EventLogEvent):
+    """A container for an event from a journal RPC interface
+
+    Attributes:
+        name (str): event name (Possible event names will depend on the
+            journal service being consumed)
+        timestamp (float): event timestamp in seconds since the epoch
+            with sub-millisecond precision.
+        context (dict): context dictionary
+        context_string (str): context dict converted to comma separated
+            key=value string.
+    """
+
+    def __init__(self, event):
+        # If no timestamp, then capture the time now
+        if "timestamp" not in event:
+            event["timestamp"] = time.time()
+        super().__init__(event)
+
+    def is_empty(self):
+        """Return True if this event is an empty journal event"""
+        return "name" not in self
+
+    def __str__(self):
+        if self.is_empty():
+            return f"{self.timestamp:<0.5f} End of historical data stream"
+        return " ".join(
+            [
+                f"{self.timestamp:<0.5f}",
+                self.name,
+                self.context_string,
+            ]
+        )
+
+
+class JournalConsumerBase(ABC):
+    """Base class for consuming events from a journal-style RPC
+
+    This base class implements a wrapper around journal style RPCs
+    which allow clients to obtain a stream of events, possibly including
+    historical data.
+
+    Subclasses of :obj`JournalConsumerBase` should be implemented to more
+    completely handle the specifics of a given interface, but all such
+    subclasses will follow the interface documented here.
+
+    A journal consumer is created by passing the constructor an open
+    :obj:`~flux.Flux` handle, the topic string of the journal service along
+    with any other optional parameters described below. The :func:`start`
+    method should then be called, which sends the initial RPC. To stop the
+    stream of events, call the :func:`stop` method. After all events have
+    been processed :func:`poll` or the registered callback will return None.
+
+    When the consumer is first started, historical data (events in the past)
+    will be sent from the journal service unless *full* is set to False.
+    These events are stored until all historical events are processed,
+    then are time ordered before returning them via :func:`poll` or to
+    the callback registered by :func:`set_callback`.
+
+    To avoid processing previously seen events with a new instance of this
+    class, the timestamp of the newest processed event can be passed via the
+    *since* parameter. Timestamps should be unique so :func:`poll` or the
+    callback will start with the newest event after the *since* timestamp.
+
+    When *full* is True, a compliant journal service sends a sentinel
+    event in the journal stream to demarcate the transition between
+    history and current events. If *include_sentinel* is set to True,
+    then an empty event will be returned by :func:`poll` or the
+    registered callback to represent the sentinel. An empty event
+    can be compared to :data:`self.SENTINEL_EVENT` or by using the
+    :func:`JournalEventBase.is_empty` method. The default behavior is to
+    suppress the sentinel.
+
+    Subclasses of :obj:`JournalConsumerBase` must implement the following
+    abstract methods, see method documentation for details:
+
+      * :meth:`flux.abc.JournalConsumerBase.process_response`, in which a
+        single response from the journal service is processed and a dictionary
+        of kwargs is returned.
+      * :meth:`flux.abc.JournalConsumerBase.create_event`, which is passed
+        one event entry from the same response and the `**kwargs` obtained
+        from above, and should return an object of a class derived from
+         :obj:`JournalEventBase`
+
+    Subclasses may optionally implement the following methods:
+
+      * :meth:`flux.abc.JournalConsumerBase.is_empty_response`, which is
+        used to determine if a journal response message is to be considered
+        the "empty" sentinel response.
+
+    Finally, subclasses may optionally override the following properties:
+
+      * :data:`request_payload`, which is the payload of a journal request
+        (the default is an empty payload)
+
+      * :data:`SENTINEL_EVENT`, which is a class constant representing the
+        sentinel event for this class.
+
+    """
+
+    SENTINEL_EVENT = JournalEventBase({})
+
+    def __init__(
+        self,
+        flux_handle,
+        topic,
+        cancel_topic=None,
+        full=True,
+        since=0.0,
+        include_sentinel=False,
+    ):
+        """Initialize a :obj:`JournalConsumerBase` instance
+
+        Args:
+            flux_handle (:obj:`~flux.Flux`): A Flux handle
+            topic (str): The journal RPC topic string
+            cancel_topic (:obj:`str`, optional): The RPC topic string to cancel
+                an active journal request. If not set, it will defuault to
+                topic + "-cancel".
+            full (bool, optional): Whether to return full history, if the
+                journal interface supports it. Defaults to True.
+            since (float, optional): Return only events that have a timestamp
+                greater than ``since``.
+            include_sentinel (bool, optional): Return an empty event upon
+                receipt of the sentinel from the journal service. The default
+                is to suppress this event.
+        """
+        self.handle = flux_handle
+        self.topic = topic
+        self.cancel_topic = cancel_topic
+
+        if self.cancel_topic is None:
+            self.cancel_topic = f"{self.topic}-cancel"
+
+        self.backlog = deque()
+        self.full = full
+        self.since = since
+        self.rpc = None
+        self.cb = None
+        self.cb_args = []
+        self.cb_kwargs = {}
+        self.processing_inactive = self.full
+        self.include_sentinel = include_sentinel
+
+    def __sort_backlog(self):
+        self.processing_inactive = False
+        self.backlog = deque(sorted(self.backlog, key=lambda x: x.timestamp))
+        if self.include_sentinel:
+            self.backlog.append(self.SENTINEL_EVENT)
+
+    @abstractmethod
+    def process_response(self, resp):
+        """Process a journal response.
+
+        This method may return a dictionary which is then passed as
+        ``*kwargs`` to :meth:`create_event` below.
+
+        Args:
+            resp (dict): The payload of a single journal response (converted
+                from json to a dict)
+        Returns:
+            dict
+        """
+        return {}
+
+    @abstractmethod
+    def create_event(self, entry, **kwargs):
+        """Return a journal event object from a response entry
+
+        This method should return an event object given an individual eventlog
+        entry and ``**kwargs`` returned from :meth:`process_response`.
+
+        Args:
+            entry (dict): An individual event dictionary from the ``events``
+                array of a journal response.
+            **kwargs : Additional keyword arguments returned from the
+                :meth:`process_response` method.
+
+        Returns:
+            :obj:`JournalEventBase` or a subclass
+
+        """
+        return JournalEventBase(entry)
+
+    def __enqueue_response(self, resp, *args):
+        if resp is None:
+            # End of data, enqueue None:
+            self.backlog.append(None)
+            return
+
+        kwargs = self.process_response(resp)
+        for entry in resp["events"]:
+            event = self.create_event(entry, **kwargs)
+            if event.timestamp > self.since:
+                self.backlog.append(event)
+
+    def __next_event(self):
+        return self.backlog.popleft()
+
+    def __set_then_cb(self):
+        if self.rpc is not None and self.cb is not None:
+            try:
+                self.rpc.then(self.__cb)
+            except OSError as exc:
+                if exc.errno == errno.EINVAL:
+                    # then callback is already set
+                    pass
+
+    def is_empty_response(self, resp):
+        """Return True if resp is "empty" """
+        return len(resp["events"]) == 0
+
+    @property
+    def request_payload(self):
+        """Approprioate request payload for this journal RPC"""
+        return {}
+
+    def start(self):
+        """Start the stream of events by sending a request
+
+        This function initiates the stream of events for a journal
+        consumer by sending the initial request to the configured journal
+        service endpoint.
+
+        .. note::
+            If :func:`start` is called more than once the stream of events
+            will be restarted using the original options passed to the
+            constructor. This may cause duplicate events, or missed events
+            if *full* is False since no history will be included.
+        """
+        self.rpc = self.handle.rpc(
+            self.topic, self.request_payload, 0, FLUX_RPC_STREAMING
+        )
+        #  Need to call self.rpc.then() if a user cb is registered:
+        self.__set_then_cb()
+
+        return self
+
+    def stop(self):
+        """Cancel the journal RPC
+
+        Cancel the RPC. This will eventually stop the stream of events to
+        either :func:`poll` or the defined callback. After all events have
+        been processed an *event* of None will be returned by :func:`poll`
+        or the defined callback.
+        """
+        self.handle.rpc(
+            self.cancel_topic,
+            {"matchtag": self.rpc.pimpl.get_matchtag()},
+            0,
+            FLUX_RPC_NORESPONSE,
+        )
+
+    def poll(self, timeout=-1.0):
+        """Synchronously get the next journal event
+
+        if *full* is True, then this call will not return until all
+        historical events have been processed. Historical events will sorted
+        in time order and returned once per :func:`poll` call.
+
+        :func:`start` must be called before this function.
+
+        Args:
+            timeout (float): Only wait *timeout* seconds for the next event.
+                If the timeout expires then a :exc:`TimeoutError` is raised.
+                A *timeout* of -1.0 disables any timeout.
+        Raises:
+            RuntimeError:  :func:`poll` was called before :func:`start`.
+        """
+        if self.rpc is None:
+            raise RuntimeError("poll() called before start()")
+
+        if self.processing_inactive:
+            # process backlog. Time order events once done:
+            while self.processing_inactive:
+                resp = self.rpc.wait_for(timeout).get()
+                if self.is_empty_response(resp):
+                    self.__sort_backlog()
+                else:
+                    self.__enqueue_response(resp)
+                self.rpc.reset()
+
+        while not self.backlog:
+            try:
+                resp = self.rpc.wait_for(timeout).get()
+            except OSError as exc:
+                if exc.errno != errno.ENODATA:
+                    raise
+                resp = None
+            self.__enqueue_response(resp)
+            self.rpc.reset()
+
+        return self.__next_event()
+
+    def __user_cb_flush(self):
+        if self.processing_inactive:
+            #  all events are accumulated in the backlog while we're still
+            #  processing history so that those events can be sorted in
+            #  timestamp order:
+            return
+        while self.backlog:
+            self.cb(self.__next_event(), *self.cb_args, **self.cb_kwargs)
+
+    def __cb(self, future):
+        try:
+            resp = future.get()
+            if self.processing_inactive and self.is_empty_response(resp):
+                self.__sort_backlog()
+            else:
+                self.__enqueue_response(resp)
+            self.__user_cb_flush()
+        except OSError as exc:
+            if exc.errno == errno.ENODATA:
+                self.__enqueue_response(None)
+        finally:
+            future.reset()
+
+    def set_callback(self, event_cb, *args, **kwargs):
+        """Register callback *event_cb* to be called for each journal event
+
+        If provided, ``*args``, and ``**kwargs`` are passed along to
+        *event_cb*, whose only required argument is an *event*, e.g.
+
+        >>> def event_cb(event)
+        >>>     # do something with event
+
+        After a :obj:`JournalConsumer` is stopped and the final event is
+        received, *event_cb* will be called with an *event* of None, which
+        signals the end of the event stream.
+        """
+        self.cb = event_cb
+        self.cb_args = args
+        self.cb_kwargs = kwargs
+        self.__set_then_cb()
+        return self
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/eventlog.py
+++ b/src/bindings/python/flux/eventlog.py
@@ -1,0 +1,50 @@
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import json
+
+
+class EventLogEvent(dict):
+    """
+    wrapper class for a single KVS EventLog entry
+    """
+
+    def __init__(self, event):
+        """
+        "Initialize from a string or dict eventlog event
+        """
+        if isinstance(event, str):
+            event = json.loads(event)
+        super().__init__(event)
+        if "context" not in self:
+            self["context"] = {}
+
+    def __str__(self):
+        return "{0.timestamp:<0.5f}: {0.name} {0.context}".format(self)
+
+    @property
+    def name(self):
+        return self["name"]
+
+    @property
+    def timestamp(self):
+        return self["timestamp"]
+
+    @property
+    def context(self):
+        return self["context"]
+
+    @property
+    def context_string(self):
+        if not self.context:
+            return ""
+        return json.dumps(
+            self.context, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        )

--- a/src/bindings/python/flux/eventlog.py
+++ b/src/bindings/python/flux/eventlog.py
@@ -9,6 +9,8 @@
 ###############################################################
 
 import json
+import sys
+from datetime import datetime, timedelta
 
 
 class EventLogEvent(dict):
@@ -48,3 +50,150 @@ class EventLogEvent(dict):
         return json.dumps(
             self.context, ensure_ascii=False, separators=(",", ":"), sort_keys=True
         )
+
+
+class EventLogFormatter:
+    """Formatter for eventlog event entries
+
+    This class is used by utilities to format eventlog entries in
+    with optional formatting such as colorization, human-readable and
+    offset timestamps, etc.
+    """
+
+    BOLD = "\033[1m"
+    YELLOW = "\033[33m"
+    GREEN = "\033[32m"
+    BLUE = "\033[34m"
+    MAGENTA = "\033[35m"
+    GRAY = "\033[37m"
+    RED = "\033[31m"
+
+    eventlog_colors = {
+        "name": YELLOW,
+        "time": GREEN,
+        "timebreak": BOLD + GREEN,
+        "key": BLUE,
+        "value": MAGENTA,
+        "number": GRAY,
+        "exception": BOLD + RED,
+    }
+
+    def __init__(self, format="text", timestamp_format="raw", color="auto"):
+        """Initialize an eventlog formatter
+
+        Args:
+            format (str): The format to use for the eventlog entry. Valid
+                values include "text" (default), or "json".
+            timestamp_format (str): The format of the timestamp. Valid values
+                include "raw" (default), "iso", "offset", "human"
+            color (str): When to use color. Valid values include "auto" (the
+                default, "always" or "never".
+        """
+
+        self.t0 = None
+        self.last_dt = None
+        self.last_ts = None
+
+        if format not in ("text", "json"):
+            raise ValueError(f"Invalid entry_fmt: {format}")
+        self.entry_format = format
+
+        if timestamp_format not in ("raw", "human", "reltime", "iso", "offset"):
+            raise ValueError(f"Invalid timestamp_fmt: {timestamp_format}")
+        if timestamp_format == "reltime":
+            timestamp_format = "human"
+        self.timestamp_format = timestamp_format
+
+        if color not in ("always", "never", "auto"):
+            raise ValueError(f"Invalid color: {color}")
+        if color == "always":
+            self.color = True
+        elif color == "never":
+            self.color = False
+        elif color == "auto":
+            self.color = sys.stdout.isatty()
+
+    def _color(self, name):
+        if self.color:
+            return self.eventlog_colors[name]
+        return ""
+
+    def _reset(self):
+        if self.color:
+            return "\033[0m"
+        return ""
+
+    def _timestamp_human(self, ts):
+        dt = datetime.fromtimestamp(ts)
+
+        if self.last_dt is not None:
+            delta = dt - self.last_dt
+            if delta < timedelta(minutes=1):
+                sec = delta.total_seconds()
+                return self._color("time") + f"[{sec:>+11.6f}]" + self._reset()
+        # New minute. Save last timestamp, print dt
+        self.last_ts = ts
+        self.last_dt = dt
+
+        mday = dt.astimezone().strftime("%b%d %H:%M")
+        return self._color("timebreak") + f"[{mday}]" + self._reset()
+
+    def _timestamp(self, ts):
+        if self.t0 is None:
+            self.t0 = ts
+
+        if self.timestamp_format == "human":
+            return self._timestamp_human(ts)
+
+        if self.timestamp_format == "raw":
+            result = f"{ts:11.6f}"
+        elif self.timestamp_format == "iso":
+            dt = datetime.fromtimestamp(ts).astimezone()
+            tz = dt.strftime("%z").replace("+0000", "Z")
+            us = int((ts - int(ts)) * 1e6)
+            result = dt.astimezone().strftime("%Y-%m-%dT%T.") + f"{us:06d}" + tz
+        else:  # offset
+            ts -= self.t0
+            result = f"{ts:15.6f}"
+
+        return self._color("time") + result + self._reset()
+
+    def _format_text(self, entry):
+        ts = self._timestamp(entry.timestamp)
+        if entry.name == "exception":
+            name = self._color("exception") + entry.name + self._reset()
+        else:
+            name = self._color("name") + entry.name + self._reset()
+        context = ""
+        for key, val in entry.context.items():
+            key = self._color("key") + key + self._reset()
+            if type(val) in (int, float):
+                color = self._color("number")
+            else:
+                color = self._color("value")
+            val = color + json.dumps(val, separators=(",", ":")) + self._reset()
+            context += f" {key}={val}"
+
+        return f"{ts} {name}{context}"
+
+    def _format_json(self, entry):
+        # remove context if it is empty
+        if "context" in entry and not entry["context"]:
+            entry = {k: v for k, v in entry.items() if k != "context"}
+        return json.dumps(entry, separators=(",", ":"))
+
+    def format(self, entry):
+        """Format an eventlog entry
+        Args:
+            entry (:obj:`dict` or :obj:`EventLogEntry`): The entry to format.
+                If a :obj:`dict`, then the entry must conform to RFC 18.
+
+        Returns:
+            str: The formatted eventlog entry as a string.
+        """
+
+        if not isinstance(entry, EventLogEvent):
+            entry = EventLogEvent(entry)
+        if self.entry_format == "json":
+            return self._format_json(entry)
+        return self._format_text(entry)

--- a/src/bindings/python/flux/job/event.py
+++ b/src/bindings/python/flux/job/event.py
@@ -8,9 +8,9 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 import errno
-import json
 
 from _flux._core import ffi
+from flux.eventlog import EventLogEvent
 from flux.job._wrapper import _RAW as RAW
 from flux.kvs import WatchImplementation
 
@@ -33,45 +33,6 @@ MAIN_EVENTS = frozenset(
         "exception",
     }
 )
-
-
-class EventLogEvent(dict):
-    """
-    wrapper class for a single KVS EventLog entry
-    """
-
-    def __init__(self, event):
-        """
-        "Initialize from a string or dict eventlog event
-        """
-        if isinstance(event, str):
-            event = json.loads(event)
-        super().__init__(event)
-        if "context" not in self:
-            self["context"] = {}
-
-    def __str__(self):
-        return "{0.timestamp:<0.5f}: {0.name} {0.context}".format(self)
-
-    @property
-    def name(self):
-        return self["name"]
-
-    @property
-    def timestamp(self):
-        return self["timestamp"]
-
-    @property
-    def context(self):
-        return self["context"]
-
-    @property
-    def context_string(self):
-        if not self.context:
-            return ""
-        return json.dumps(
-            self.context, ensure_ascii=False, separators=(",", ":"), sort_keys=True
-        )
 
 
 class JobEventWatchFuture(WatchImplementation):

--- a/src/bindings/python/flux/resource/__init__.py
+++ b/src/bindings/python/flux/resource/__init__.py
@@ -12,3 +12,4 @@ from flux.resource.Rlist import Rlist
 from flux.resource.ResourceSet import ResourceSet
 from flux.resource.list import resource_list, SchedResourceList
 from flux.resource.status import resource_status, ResourceStatus
+from flux.resource.journal import ResourceJournalConsumer

--- a/src/bindings/python/flux/resource/journal.py
+++ b/src/bindings/python/flux/resource/journal.py
@@ -1,0 +1,69 @@
+###############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from flux.abc import JournalConsumerBase, JournalEventBase
+
+
+class ResourceJournalEvent(JournalEventBase):
+    """A container for an event from the resource journal
+
+    Attributes:
+        name (str): event name (See :rfc:`21` for possible event names)
+        timestamp (float): event timestamp in seconds since the epoch
+            with sub-millisecond precision.
+        context (dict): context dictionary
+            (See `RFC 21: Event Descriptions <https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_21.html#event-descriptions>`_.)
+        context_string (str): context dict converted to comma separated
+            key=value string.
+        R (dict): For resource-define events, the instance R (See :rfc:`20`)
+    """
+
+    def __init__(self, event, R=None):
+        super().__init__(event)
+        self.R = R
+
+    def __str__(self):
+        if self.is_empty():
+            return f"{self.timestamp:<0.5f} End of historical data stream"
+        return " ".join(
+            [
+                f"{self.timestamp:<0.5f}",
+                self.name,
+                self.context_string,
+            ]
+        )
+
+
+class ResourceJournalConsumer(JournalConsumerBase):
+    """Class for consuming the resource journal
+
+    See :obj:`journal.JournalConsumerBase` for documentation of the
+    journal consumer interface.
+    """
+
+    def __init__(self, flux_handle, since=0.0, include_sentinel=False):
+        super().__init__(
+            flux_handle,
+            "resource.journal",
+            full=True,
+            since=since,
+            include_sentinel=include_sentinel,
+        )
+
+    def process_response(self, resp):
+        """Process a single response from the resource journal"""
+        return {"R": resp.get("R")}
+
+    def create_event(self, entry, R=None):
+        """Create a ResourceJournalEvent from one event entry in a response"""
+        return ResourceJournalEvent(entry, R)
+
+
+# vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -292,6 +292,7 @@ TESTSCRIPTS = \
 	python/t0029-fileref.py \
 	python/t0030-journal.py \
 	python/t0031-conf-builtin.py \
+	python/t0032-resource-journal.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -293,6 +293,7 @@ TESTSCRIPTS = \
 	python/t0030-journal.py \
 	python/t0031-conf-builtin.py \
 	python/t0032-resource-journal.py \
+	python/t0033-eventlog-formatter.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0032-resource-journal.py
+++ b/t/python/t0032-resource-journal.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+
+import flux
+from flux.resource import ResourceJournalConsumer, ResourceSet
+from subflux import rerun_under_flux
+
+
+def __flux_size():
+    return 4
+
+
+class TestResourceJournalConsumer(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        self.fh = flux.Flux()
+
+    def test_history(self):
+        consumer = ResourceJournalConsumer(self.fh).start()
+
+        events = []
+        while True:
+            # Read events until we see resource-define
+            event = consumer.poll(timeout=5.0)
+            events.append(event)
+            if event.name == "resource-define":
+                break
+        consumer.stop()
+
+        # events are ordered
+        self.assertTrue(
+            all(
+                events[index].timestamp < events[index + 1].timestamp
+                for index in range(len(events) - 1)
+            )
+        )
+
+        # get timestamp of arbitrary event in history:
+        seq = 1
+        timestamp = events[seq].timestamp
+
+        # new consumer with since timestamp
+        consumer = ResourceJournalConsumer(self.fh, since=timestamp).start()
+        events2 = []
+        while True:
+            event = consumer.poll(timeout=5.0)
+            events2.append(event)
+            if event.timestamp == events[-1].timestamp:
+                break
+
+        consumer.stop()
+
+        # events2 should be equal to the events[seq+1:]:
+        self.assertListEqual(events2, events[seq + 1 :])
+
+        # ensure JournalEvent can be converted to a string:
+        print(f"{events[-1]}")
+
+    def test_async(self):
+        events = []
+        test_arg2 = 42
+        test_kw_arg = "foo"
+
+        count = [0]
+
+        def test_cb(event, arg2, kw_arg=None):
+            events.append(event)
+            self.assertEqual(arg2, test_arg2)
+            self.assertEqual(kw_arg, test_kw_arg)
+            count[0] += 1
+            if count[0] == 4:
+                # do not stop consumer here. Adding a new callback on
+                # an active consumer is tested below
+                self.fh.reactor_stop()
+
+        consumer = ResourceJournalConsumer(self.fh).start()
+        consumer.set_callback(test_cb, test_arg2, kw_arg=test_kw_arg)
+
+        self.fh.reactor_run()
+
+        # historical events are ordered
+        self.assertTrue(
+            all(
+                events[index].timestamp < events[index + 1].timestamp
+                for index in range(len(events) - 1)
+            )
+        )
+
+        new_events = []
+
+        def new_cb(event):
+            if event.name == "drain":
+                consumer.stop()
+                self.fh.reactor_stop()
+            new_events.append(event)
+
+        # Reset callback to append to new_events
+        consumer.set_callback(new_cb)
+
+        # drain a node to append a new event to resource eventlog
+        self.fh.rpc("resource.drain", {"targets": "0", "reason": "test"}).get()
+        self.fh.reactor_run()
+
+        for event in new_events:
+            self.assertTrue(event.name == "drain")
+
+        # restore state
+        self.fh.rpc("resource.undrain", {"targets": "0"}).get()
+
+        # stop consumer
+        consumer.stop()
+
+    def test_sentinel(self):
+        self.assertTrue(ResourceJournalConsumer.SENTINEL_EVENT.is_empty())
+
+        # Ensure empty event can be converted to a string:
+        print(ResourceJournalConsumer.SENTINEL_EVENT)
+
+        consumer = ResourceJournalConsumer(self.fh, include_sentinel=True)
+        consumer.start()
+        while True:
+            event = consumer.poll(0.1)
+            if event == consumer.SENTINEL_EVENT:
+                break
+
+    def test_sentinel_async(self):
+
+        def cb(event):
+            if event is None:
+                self.fh.reactor_stop()
+            if event.is_empty():
+                consumer.stop()
+
+        consumer = ResourceJournalConsumer(self.fh, include_sentinel=True)
+        consumer.start()
+        consumer.set_callback(cb)
+        self.fh.reactor_run()
+
+    def test_poll_timeout(self):
+
+        consumer = ResourceJournalConsumer(self.fh).start()
+        with self.assertRaises(TimeoutError):
+            while True:
+                consumer.poll(timeout=0.1)
+        consumer.stop()
+
+    def test_poll_ENODATA(self):
+
+        consumer = ResourceJournalConsumer(self.fh, include_sentinel=True).start()
+        while True:
+            event = consumer.poll(0.1)
+            if event.is_empty():
+                consumer.stop()
+                break
+        self.assertIsNone(consumer.poll(timeout=5.0))
+
+    def test_poll_RuntimeError(self):
+
+        with self.assertRaises(RuntimeError):
+            ResourceJournalConsumer(self.fh).poll(5.0)
+
+    def test_poll_cb_set_before_start(self):
+
+        def cb(event):
+            if event.is_empty():
+                consumer.stop()
+                self.fh.reactor_stop()
+
+        consumer = ResourceJournalConsumer(self.fh, include_sentinel=True)
+        consumer.set_callback(cb)
+        consumer.start()
+        self.fh.reactor_run()
+
+    def test_poll_cb_reset(self):
+        """test that the consumer callback can be reset"""
+
+        def cb(event):
+            self.fail("incorrect callback called")
+
+        def cb2(event):
+            if event is None:
+                self.fh.reactor_stop()
+            if event.is_empty():
+                consumer.stop()
+
+        consumer = ResourceJournalConsumer(self.fh, include_sentinel=True)
+        consumer.set_callback(cb)
+        consumer.start()
+        consumer.set_callback(cb2)
+        self.fh.reactor_run()
+
+    def test_R_in_resource_define_event(self):
+        """test that R is available in resource-define event"""
+        consumer = ResourceJournalConsumer(self.fh).start()
+        while True:
+            event = consumer.poll()
+            if event is None:
+                break
+            if event.name == "resource-define":
+                self.assertTrue(hasattr(event, "R"))
+                R = ResourceSet(event.R)
+                self.assertEqual(R.nnodes, 4)
+                consumer.stop()
+
+    def test_event_after_history(self):
+        """Test that a consumer gets new events after history is processed"""
+
+        def cb(event, wait):
+            if event.is_empty():
+                # history processed, now drain a rank
+                print("got sentinel event, draining rank 0")
+                self.fh.rpc(
+                    "resource.drain", {"targets": "0", "reason": "history-test"}
+                ).get()
+            elif (
+                event.name == "drain"
+                and "reason" in event.context
+                and event.context["reason"] == "history-test"
+            ):
+                print("got drain event, undraining rank 0")
+                self.fh.rpc("resource.undrain", {"targets": "0"}).get()
+                wait[0] = True
+            elif wait[0] and event.name == "undrain":
+                print("got undrain event, stopping consumer")
+                consumer.stop()
+
+        consumer = ResourceJournalConsumer(self.fh, include_sentinel=True)
+        consumer.set_callback(cb, wait=[False])
+        consumer.start()
+        self.fh.reactor_run()
+
+
+if __name__ == "__main__":
+    if rerun_under_flux(__flux_size()):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner(), buffer=False)

--- a/t/python/t0033-eventlog-formatter.py
+++ b/t/python/t0033-eventlog-formatter.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import json
+import os
+import time
+import unittest
+
+import subflux  # noqa: F401
+from flux.eventlog import EventLogFormatter
+from pycotap import TAPTestRunner
+
+TEST_EVENTLOG = """\
+{"timestamp":1738774194.078433,"name":"submit","context":{"userid":1001,"urgency":16,"flags":0,"version":1}}
+{"timestamp":1738774194.0947378,"name":"validate"}
+{"timestamp":1738774194.1073177,"name":"depend"}
+{"timestamp":1738774194.107436,"name":"priority","context":{"priority":16}}
+{"timestamp":1738774194.110116,"name":"alloc","context":{"annotations":{"sched":{"resource_summary":"rank[0-3]/core[0-7]"}}}}
+{"timestamp":1738774194.1177957,"name":"start"}
+{"timestamp":1738774194.1820674,"name":"finish","context":{"status":0}}
+{"timestamp":1738774194.1853716,"name":"release","context":{"ranks":"all","final":true}}
+{"timestamp":1738774194.1854134,"name":"free"}
+{"timestamp":1738774194.1854289,"name":"clean"}
+"""
+
+TEST_EVENTLOG_OUTPUT = """\
+1738774194.078433 submit userid=1001 urgency=16 flags=0 version=1
+1738774194.094738 validate
+1738774194.107318 depend
+1738774194.107436 priority priority=16
+1738774194.110116 alloc annotations={"sched":{"resource_summary":"rank[0-3]/core[0-7]"}}
+1738774194.117796 start
+1738774194.182067 finish status=0
+1738774194.185372 release ranks="all" final=true
+1738774194.185413 free
+1738774194.185429 clean
+"""
+
+TEST_EVENTLOG_OUTPUT_HUMAN_UTC = """\
+[Feb05 16:49] submit userid=1001 urgency=16 flags=0 version=1
+[  +0.016305] validate
+[  +0.028885] depend
+[  +0.029003] priority priority=16
+[  +0.031683] alloc annotations={"sched":{"resource_summary":"rank[0-3]/core[0-7]"}}
+[  +0.039363] start
+[  +0.103634] finish status=0
+[  +0.106939] release ranks="all" final=true
+[  +0.106980] free
+[  +0.106996] clean
+"""
+TEST_EVENTLOG_OUTPUT_HUMAN_COLOR = """\
+[1m[32m[Feb05 16:49][0m [33msubmit[0m [34muserid[0m=[37m1001[0m [34murgency[0m=[37m16[0m [34mflags[0m=[37m0[0m [34mversion[0m=[37m1[0m
+[32m[  +0.016305][0m [33mvalidate[0m
+[32m[  +0.028885][0m [33mdepend[0m
+[32m[  +0.029003][0m [33mpriority[0m [34mpriority[0m=[37m16[0m
+[32m[  +0.031683][0m [33malloc[0m [34mannotations[0m=[35m{"sched":{"resource_summary":"rank[0-3]/core[0-7]"}}[0m
+[32m[  +0.039363][0m [33mstart[0m
+[32m[  +0.103634][0m [33mfinish[0m [34mstatus[0m=[37m0[0m
+[32m[  +0.106939][0m [33mrelease[0m [34mranks[0m=[35m"all"[0m [34mfinal[0m=[35mtrue[0m
+[32m[  +0.106980][0m [33mfree[0m
+[32m[  +0.106996][0m [33mclean[0m
+"""
+
+TEST_EVENTLOG_OUTPUT_OFFSET = """\
+0.000000 submit userid=1001 urgency=16 flags=0 version=1
+0.016305 validate
+0.028885 depend
+0.029003 priority priority=16
+0.031683 alloc annotations={"sched":{"resource_summary":"rank[0-3]/core[0-7]"}}
+0.039363 start
+0.103634 finish status=0
+0.106939 release ranks="all" final=true
+0.106980 free
+0.106996 clean
+"""
+
+TEST_EVENTLOG_OUTPUT_ISO_ZULU = """\
+2025-02-05T16:49:54.078433Z submit userid=1001 urgency=16 flags=0 version=1
+2025-02-05T16:49:54.094737Z validate
+2025-02-05T16:49:54.107317Z depend
+2025-02-05T16:49:54.107435Z priority priority=16
+2025-02-05T16:49:54.110116Z alloc annotations={"sched":{"resource_summary":"rank[0-3]/core[0-7]"}}
+2025-02-05T16:49:54.117795Z start
+2025-02-05T16:49:54.182067Z finish status=0
+2025-02-05T16:49:54.185371Z release ranks="all" final=true
+2025-02-05T16:49:54.185413Z free
+2025-02-05T16:49:54.185428Z clean
+"""
+
+test_eventlog_json = [x for x in TEST_EVENTLOG.splitlines()]
+test_eventlog = [json.loads(x) for x in TEST_EVENTLOG.splitlines()]
+test_eventlog_raw = [x for x in TEST_EVENTLOG_OUTPUT.splitlines()]
+test_eventlog_human = [x for x in TEST_EVENTLOG_OUTPUT_HUMAN_UTC.splitlines()]
+test_eventlog_human_color = [x for x in TEST_EVENTLOG_OUTPUT_HUMAN_COLOR.splitlines()]
+test_eventlog_offset = [x for x in TEST_EVENTLOG_OUTPUT_OFFSET.splitlines()]
+test_eventlog_iso_zulu = [x for x in TEST_EVENTLOG_OUTPUT_ISO_ZULU.splitlines()]
+
+
+class TestEventLogFormatter(unittest.TestCase):
+
+    def test_invalid_args(self):
+        with self.assertRaises(ValueError):
+            EventLogFormatter(format="foo")
+        with self.assertRaises(ValueError):
+            EventLogFormatter(timestamp_format="foo")
+        with self.assertRaises(ValueError):
+            EventLogFormatter(color="foo")
+
+    def test_raw(self):
+        evf = EventLogFormatter()
+        for entry, expected in zip(test_eventlog, test_eventlog_raw):
+            self.assertEqual(evf.format(entry).strip(), expected)
+
+    def test_human(self):
+        evf = EventLogFormatter(timestamp_format="human")
+        for entry, expected in zip(test_eventlog, test_eventlog_human):
+            self.assertEqual(evf.format(entry).strip(), expected)
+
+    def test_offset(self):
+        evf = EventLogFormatter(timestamp_format="offset")
+        for entry, expected in zip(test_eventlog, test_eventlog_offset):
+            self.assertEqual(evf.format(entry).strip(), expected)
+
+    def test_iso(self):
+        evf = EventLogFormatter(timestamp_format="iso")
+        for entry, expected in zip(test_eventlog, test_eventlog_iso_zulu):
+            self.assertEqual(evf.format(entry).strip(), expected)
+
+    def test_json(self):
+        evf = EventLogFormatter(format="json")
+        for entry, expected in zip(test_eventlog, test_eventlog_json):
+            self.assertEqual(evf.format(entry).strip(), expected)
+
+    def test_color(self):
+        evf = EventLogFormatter(timestamp_format="human", color="always")
+        for entry, expected in zip(test_eventlog, test_eventlog_human_color):
+            self.assertEqual(evf.format(entry).strip(), expected)
+
+
+if __name__ == "__main__":
+    os.environ["TZ"] = "UTC"
+    time.tzset()
+    unittest.main(testRunner=TAPTestRunner(), buffer=False)

--- a/t/t2355-resource-journal.t
+++ b/t/t2355-resource-journal.t
@@ -11,7 +11,7 @@ test_expect_success 'unload the scheduler' '
 '
 
 test_expect_success 'flux resource eventlog --wait works' '
-	flux resource eventlog --wait=resource-define | tee eventlog
+	flux resource eventlog -f json --wait=resource-define | tee eventlog
 '
 test_expect_success '1st event: restart online=""' '
 	head -1 eventlog | tee eventlog.1 &&
@@ -37,7 +37,7 @@ test_expect_success 'reload resource with monitor-force-up' '
 	flux module reload resource monitor-force-up
 '
 test_expect_success 'flux resource eventlog works' '
-	flux resource eventlog --wait=resource-define >forcelog
+	flux resource eventlog -f json --wait=resource-define >forcelog
 '
 test_expect_success '1st event: restart online=0-1' '
 	head -1 forcelog >forcelog.1 &&
@@ -74,7 +74,7 @@ test_expect_success 'run restartable flux instance, drain 0' '
 '
 test_expect_success 'restart flux instance, dump eventlog' '
 	flux start --setattr=statedir=$(pwd) \
-	    flux resource eventlog --wait=resource-define | tee restartlog
+	    flux resource eventlog -f json --wait=resource-define | tee restartlog
 '
 test_expect_success '1st event: drain idset=0 reason=testing' '
 	head -1 restartlog | tee restartlog.1 &&

--- a/t/t2355-resource-journal.t
+++ b/t/t2355-resource-journal.t
@@ -39,6 +39,68 @@ test_expect_success 'reload resource with monitor-force-up' '
 test_expect_success 'flux resource eventlog works' '
 	flux resource eventlog -f json --wait=resource-define >forcelog
 '
+test_expect_success 'flux resource eventlog formats as text by default' '
+	flux resource eventlog | grep method=
+'
+test_expect_success 'flux resource eventlog --time-format=raw works' '
+	flux resource eventlog --time-format=raw > out.raw &&
+	test_debug "cat out.raw" &&
+	grep resource-define out.raw | awk "{print \$1}" \
+		| grep "^[^.]*\.[^.]*$"
+'
+test_expect_success 'flux resource eventlog --time-format=iso works' '
+	TZ=UTC flux resource eventlog --time-format=iso > out.iso &&
+	test_debug "cat out.iso" &&
+	grep resource-define out.iso | awk "{print \$1}" | grep "Z$"
+'
+test_expect_success 'flux resource eventlog --time-format=offset works' '
+	TZ=UTC flux resource eventlog --time-format=offset > out.offset &&
+	test_debug "cat out.offset" &&
+	head -n1 out.offset | awk "{print \$1}" | grep "^ *0\.0"
+'
+test_expect_success 'flux resource eventlog --time-format=human works' '
+	TZ=UTC flux resource eventlog --time-format=human > out.Thuman &&
+	test_debug "cat out.Thuman" &&
+	head -n1 out.Thuman | grep "^\[...[0-9][0-9] [0-9][0-9]:[0-9][0-9]\]"
+'
+test_expect_success 'flux resource eventlog --human works' '
+	TZ=UTC flux resource eventlog --human > out.human &&
+	test_debug "cat out.human" &&
+	head -n1 out.human | grep "^\[...[0-9][0-9] [0-9][0-9]:[0-9][0-9]\]"
+'
+has_color() {
+        # To grep for ansi escape we need the help of the non-shell builtin
+        # printf(1), so run under env(1) so we don't get shell builtin:
+        grep "$(env printf "\x1b\[")" $1 >/dev/null
+}
+for opt in "-HL" "-L" "-Lalways" "--color" "--color=always"; do
+        test_expect_success "flux resource eventlog $opt forces color on" '
+                name=notty${opt##--color=} &&
+                outfile=color-${name:-default}.out &&
+                flux resource eventlog ${opt} >$outfile &&
+                test_debug "cat $outfile" &&
+                has_color $outfile
+        '
+done
+for opt in "" "--color" "--color=always" "--color=auto" "-H"; do
+        test_expect_success "flux resource eventlog $opt shows color on tty" '
+                name=${opt##--color=} &&
+                outfile=color-${name:-default}.out &&
+                runpty.py flux resource eventlog ${opt} $jobid >$outfile &&
+                test_debug "cat $outfile" &&
+                has_color $outfile
+        '
+done
+for opt in "-HLnever" "-Lnever" "--color=never"; do
+	test_expect_success "flux resource eventlog $opt disables color on tty" '
+		name=${opt##--color=} &&
+		outfile=color-${name:-default}.out &&
+		runpty.py flux resource eventlog ${opt} >$outfile &&
+		test_debug "cat $outfile" &&
+		test_must_fail has_color $outfile
+	'
+done
+
 test_expect_success '1st event: restart online=0-1' '
 	head -1 forcelog >forcelog.1 &&
 	jq -e ".name == \"restart\"" forcelog.1 &&


### PR DESCRIPTION
The main purpose of this PR is to add the Python `ResourceJournalConsumer` class, which mimics the existing job manager `JournalConsumer` class. In fact, most of the original `JournalConsumer` class implementation is moved to an abstract `JournalConsumerBase` class, then both the job manager `JournalConsumer` and `ResourceJournalConsumer` classes inherit from that.

In addition, the `flux resource eventlog` utility is modified to have similar options to the rest of the `eventlog` utilities in Flux (`--format`, `--time-format`, `--color`, `--human`)using a new `EventLogFormatter` class  and the newly added `ResourceJournalConsumer` class. 