### PR TITLE
ci: ensure unit tests are run during coverage

### DIFF
--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -144,6 +144,7 @@ if test "$COVERAGE" = "t"; then
 	export ENABLE_USER_SITE=1 && \
 	export COVERAGE_PROCESS_START=$(pwd)/coverage.rc && \
 	${MAKE} -j $JOBS check TESTS= && \
+	(cd src && ${MAKE} -j $JOBS check) && \
 	(cd t && ${MAKE} -j $JOBS check ${SYSTEM:+TESTS=\"$SYSTEM_TESTS\"})"
 	POSTCHECKCMDS="\
 	${MAKE} code-coverage-capture &&


### PR DESCRIPTION
Problem: Unit tests are no longer being run as part of the coverage ci build after 69c1691b6a5f0f1e7ee8d66a152ef22059dc6a1a replaced `make check-prep` with `make check TESTS=`. This is because the former actually ran all unit tests while the latter does not.

Ensure unit tests are executed during the coverage build by adding

 (cd src && make check)

to the set of commands run during coverage.