### PR TITLE
kvs: remove dropcache

### DIFF
--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -14,7 +14,6 @@ SYNOPSIS
 | **flux** **kvs** **link** *target* *linkname*
 | **flux** **kvs** **readlink** *key...*
 | **flux** **kvs** **mkdir** *key...*
-| **flux** **kvs** **dropcache**
 
 | **flux** **kvs** **copy** *source* *destination*
 | **flux** **kvs** **move** *source* *destination*
@@ -360,18 +359,6 @@ Create an empty directory. If *key* exists, it is overwritten.
 
    After the commit has completed, display the new root sequence number
    or "version".
-
-dropcache
----------
-
-.. program:: flux kvs dropcache
-
-Tell the local KVS to drop any cache it is holding.
-
-.. option:: -a, --all
-
-  Publish an event across the Flux instance instructing the KVS module on
-  all ranks to drop their caches.
 
 copy
 ----

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -1027,7 +1027,6 @@ _flux_kvs()
         mkdir
         copy
         move
-        dropcache
         version
         wait
         getroot
@@ -1105,9 +1104,6 @@ _flux_kvs()
     "
     move_OPTS="\
         ${copy_OPTS}
-    "
-    dropcache_OPTS="\
-        -a --all
     "
     version_OPTS="\
         -N --namespace= \

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -366,17 +366,6 @@ def namespace_list(flux_handle):
     return nslist
 
 
-def dropcache(flux_handle):
-    """Drop KVS cache entries
-
-    Inform KVS module to drop cache entries without a reference.
-
-    Args:
-        flux_handle: A Flux handle obtained from flux.Flux()
-    """
-    RAW.flux_kvs_dropcache(flux_handle)
-
-
 class KVSTxn:
     """KVS Transaction Object
 

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -42,7 +42,6 @@ int cmd_readlink (optparse_t *p, int argc, char **argv);
 int cmd_mkdir (optparse_t *p, int argc, char **argv);
 int cmd_version (optparse_t *p, int argc, char **argv);
 int cmd_wait (optparse_t *p, int argc, char **argv);
-int cmd_dropcache (optparse_t *p, int argc, char **argv);
 int cmd_copy (optparse_t *p, int argc, char **argv);
 int cmd_move (optparse_t *p, int argc, char **argv);
 int cmd_dir (optparse_t *p, int argc, char **argv);
@@ -180,13 +179,6 @@ static struct optparse_option ls_opts[] =  {
     },
     { .name = "classify", .key = 'F', .has_arg = 0,
       .usage = "Append indicator (one of .@) to entries",
-    },
-    OPTPARSE_TABLE_END
-};
-
-static struct optparse_option dropcache_opts[] =  {
-    { .name = "all", .key = 'a', .has_arg = 0,
-      .usage = "Drop KVS across all ranks",
     },
     OPTPARSE_TABLE_END
 };
@@ -359,13 +351,6 @@ static struct optparse_subcommand subcommands[] = {
       cmd_move,
       0,
       copy_opts
-    },
-    { "dropcache",
-      "[--all]",
-      "Tell KVS to drop its cache",
-      cmd_dropcache,
-      0,
-      dropcache_opts
     },
     { "version",
       "[-N ns]",
@@ -1209,27 +1194,6 @@ int cmd_wait (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_open");
     if (flux_kvs_wait_version (h, ns, vers) < 0)
         log_err_exit ("flux_kvs_wait_version");
-    flux_close (h);
-    return (0);
-}
-
-int cmd_dropcache (optparse_t *p, int argc, char **argv)
-{
-    flux_t *h;
-
-    if (!(h = flux_open (NULL, 0)))
-        log_err_exit ("flux_open");
-
-    if (optparse_hasopt (p, "all")) {
-        flux_msg_t *msg = flux_event_encode ("kvs.dropcache", NULL);
-        if (!msg || flux_send (h, msg, 0) < 0)
-            log_err_exit ("flux_send");
-        flux_msg_destroy (msg);
-    }
-    else {
-        if (flux_kvs_dropcache (h) < 0)
-            log_err_exit ("flux_kvs_dropcache");
-    }
     flux_close (h);
     return (0);
 }

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -162,21 +162,6 @@ done:
     return ret;
 }
 
-int flux_kvs_dropcache (flux_t *h)
-{
-    flux_future_t *f;
-    int rc = -1;
-
-    if (!(f = flux_rpc (h, "kvs.dropcache", NULL, FLUX_NODEID_ANY, 0)))
-        goto done;
-    if (flux_future_get (f, NULL) < 0)
-        goto done;
-    rc = 0;
-done:
-    flux_future_destroy (f);
-    return rc;
-}
-
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -66,12 +66,6 @@ flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *ns);
 int flux_kvs_get_version (flux_t *h, const char *ns, int *versionp);
 int flux_kvs_wait_version (flux_t *h, const char *ns, int version);
 
-/* Garbage collect the cache.  Drop all data that doesn't have a
- * reference in the namespace.
- * Returns -1 on error (errno set), 0 on success.
- */
-int flux_kvs_dropcache (flux_t *h);
-
 #ifdef __cplusplus
 }
 #endif

--- a/t/issues/t1760-kvs-use-after-free.sh
+++ b/t/issues/t1760-kvs-use-after-free.sh
@@ -1,6 +1,34 @@
 #!/bin/sh -e
 # dropcache, do a put that misses a references, unlink a dir, the reference
 # should not be missing.
+#
+# N.B. the reason this test is split across two flux starts is we need the
+# internal KVS cache to be empty
 
-TEST=issue1760
-${FLUX_BUILD_DIR}/t/kvs/issue1760 a
+cat <<-EOF >t1760setup.sh
+#!/bin/sh -e
+
+flux kvs mkdir foo
+
+EOF
+
+cat <<-EOF >t1760test.sh
+#!/bin/sh -e
+
+${FLUX_BUILD_DIR}/t/kvs/issue1760 foo
+
+EOF
+
+chmod +x t1760setup.sh
+chmod +x t1760test.sh
+
+STATEDIR=issue1760-statedir
+mkdir issue1760-statedir
+
+flux start -s 1 \
+    --setattr=statedir=${STATEDIR} \
+    ./t1760setup.sh
+
+flux start -s 1 \
+    --setattr=statedir=${STATEDIR} \
+    ./t1760test.sh

--- a/t/kvs/issue1760.c
+++ b/t/kvs/issue1760.c
@@ -8,7 +8,13 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-/* issue1760.c - make kvs module sad */
+/* issue1760.c - make kvs module sad
+ *
+ * - it is assumed the directory passed in under argv[1] has already
+ * been created.  The command line `flux kvs` command does not allow
+ * a put & unlink to be done under a single transaction, thus the need
+ * for this utility test.
+ */
 
 /* Failure mode 1:
 ./issue1760 a
@@ -51,24 +57,6 @@ int main (int argc, char *argv[])
 
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
-
-    /* Mkdir <dir>
-     */
-    if (!(txn = flux_kvs_txn_create ()))
-        log_err_exit ("flux_kvs_txn_create");
-    if (flux_kvs_txn_mkdir (txn, 0, dir) < 0)
-        log_err_exit ("flux_kvs_txn_mkdir");
-    if (!(f = flux_kvs_commit (h, NULL, 0, txn)))
-        log_err_exit ("flux_kvs_commit");
-    if (flux_future_get (f, NULL) < 0)
-        log_err_exit ("flux_future_get");
-    flux_future_destroy (f);
-    flux_kvs_txn_destroy (txn);
-
-    /* Expire internal kvs cache
-     */
-    if (flux_kvs_dropcache (h) < 0)
-        log_err_exit ("flux_kvs_dropcache");
 
     /* Commit the following:
      * put <dir>.a

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -1165,17 +1165,6 @@ test_expect_success 'kvs: --sequence on write ops works' '
 '
 
 #
-# dropcache tests
-#
-
-test_expect_success 'kvs: dropcache works' '
-	flux kvs dropcache
-'
-test_expect_success 'kvs: dropcache --all works' '
-	flux kvs dropcache --all
-'
-
-#
 # version/wait tests
 #
 

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -379,12 +379,6 @@ test_expect_success 'kvs: guest cannot make a symlink in the test ns on rank 1' 
 # Basic tests, user can't perform non-namespace operations
 #
 
-test_expect_success 'kvs: dropcache fails (user)' '
-        set_userid 9999 &&
-        ! flux kvs dropcache &&
-        unset_userid
-'
-
 test_expect_success 'kvs: stats works (user)' '
         set_userid 9999 &&
         flux module stats kvs >/dev/null &&


### PR DESCRIPTION
Problem: KVS dropcache code was added very early on in KVS prototyping for testing.  It is basically not used anymore.  If we want to test something that requires a "clean" slate for the KVS, we can just start a new instance and test with that.

Solution: Remove all KVS dropcache code.  Remove all associated tests.  Update one regression test to be accomplished through two instances rather than one to emulate an emptying of the cache.

Fixes #6608