### PR TITLE
WIP: truncate resource journal at a configurable size

### DIFF
--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -46,7 +46,8 @@ libresource_la_SOURCES = \
 
 TESTS = \
 	test_rutil.t \
-	test_drainset.t
+	test_drainset.t \
+	test_truncate.t
 
 test_ldadd = \
 	$(builddir)/libresource.la \
@@ -80,3 +81,8 @@ test_drainset_t_SOURCES = test/drainset.c
 test_drainset_t_CPPFLAGS = $(test_cppflags)
 test_drainset_t_LDADD = $(test_ldadd)
 test_drainset_t_LDFLAGS = $(test_ldflags)
+
+test_truncate_t_SOURCES = test/truncate.c
+test_truncate_t_CPPFLAGS = $(test_cppflags)
+test_truncate_t_LDADD = $(test_ldadd)
+test_truncate_t_LDFLAGS = $(test_ldflags)

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -40,7 +40,9 @@ libresource_la_SOURCES = \
 	drainset.h \
 	drainset.c \
 	upgrade.h \
-	upgrade.c
+	upgrade.c \
+	truncate.h \
+	truncate.c
 
 TESTS = \
 	test_rutil.t \

--- a/src/modules/resource/drainset.h
+++ b/src/modules/resource/drainset.h
@@ -25,6 +25,15 @@ int drainset_drain_rank (struct drainset *dset,
                          double timestamp,
                          const char *reason);
 
+int drainset_drain_ex (struct drainset *dset,
+                       unsigned int rank,
+                       double timestamp,
+                       const char *reason,
+                       int overwrite);
+
+int drainset_undrain (struct drainset *dset,
+                      unsigned int rank);
+
 json_t *drainset_to_json (struct drainset *dset);
 
 struct drainset *drainset_from_json (json_t *o);

--- a/src/modules/resource/drainset.h
+++ b/src/modules/resource/drainset.h
@@ -27,6 +27,8 @@ int drainset_drain_rank (struct drainset *dset,
 
 json_t *drainset_to_json (struct drainset *dset);
 
+struct drainset *drainset_from_json (json_t *o);
+
 #endif /* ! _FLUX_RESOURCE_DRAINSET_H */
 
 /*

--- a/src/modules/resource/reslog.c
+++ b/src/modules/resource/reslog.c
@@ -412,6 +412,12 @@ static void entry_destructor (void **item)
     }
 }
 
+void reslog_set_journal_max (struct reslog *reslog, int max)
+{
+    if (reslog)
+        reslog->journal_max = max;
+}
+
 struct reslog *reslog_create (struct resource_ctx *ctx,
                               json_t *eventlog,
                               int journal_max)

--- a/src/modules/resource/reslog.c
+++ b/src/modules/resource/reslog.c
@@ -37,6 +37,7 @@ struct reslog {
     zlist_t *pending;       // list of pending futures
     zlist_t *watchers;
     zlistx_t *eventlog;
+    int journal_max;
     struct flux_msglist *consumers;
     flux_msg_handler_t **handlers;
 };
@@ -411,13 +412,16 @@ static void entry_destructor (void **item)
     }
 }
 
-struct reslog *reslog_create (struct resource_ctx *ctx, json_t *eventlog)
+struct reslog *reslog_create (struct resource_ctx *ctx,
+                              json_t *eventlog,
+                              int journal_max)
 {
     struct reslog *reslog;
 
     if (!(reslog = calloc (1, sizeof (*reslog))))
         return NULL;
     reslog->ctx = ctx;
+    reslog->journal_max = journal_max;
     if (!(reslog->pending = zlist_new ())
         || !(reslog->watchers = zlist_new ()))
         goto nomem;

--- a/src/modules/resource/reslog.h
+++ b/src/modules/resource/reslog.h
@@ -27,6 +27,8 @@ struct reslog *reslog_create (struct resource_ctx *ctx,
                               int journal_max);
 void reslog_destroy (struct reslog *reslog);
 
+void reslog_set_journal_max (struct reslog *reslog, int max);
+
 /* Post an event to the eventlog.  This function returns immediately,
  * and the commit to the eventlog completes asynchronously.
  * If 'request' is non-NULL, a success/fail response is sent upon commit

--- a/src/modules/resource/reslog.h
+++ b/src/modules/resource/reslog.h
@@ -22,7 +22,9 @@ typedef void (*reslog_cb_f)(struct reslog *reslog,
                             json_t *context,
                             void *arg);
 
-struct reslog *reslog_create (struct resource_ctx *ctx, json_t *eventlog);
+struct reslog *reslog_create (struct resource_ctx *ctx,
+                              json_t *eventlog,
+                              int journal_max);
 void reslog_destroy (struct reslog *reslog);
 
 /* Post an event to the eventlog.  This function returns immediately,

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -178,13 +178,15 @@ static void config_reload_cb (flux_t *h,
     const flux_conf_t *conf;
     flux_error_t error;
     const char *errstr = NULL;
+    struct resource_config config = {0};
 
     if (flux_conf_reload_decode (msg, &conf) < 0)
         goto error;
-    if (parse_config (ctx, conf, NULL, &error) < 0) {
+    if (parse_config (ctx, conf, &config, &error) < 0) {
         errstr = error.text;
         goto error;
     }
+    reslog_set_journal_max (ctx->reslog, config.journal_max);
     if (flux_set_conf (h, flux_conf_incref (conf)) < 0) {
         errstr = "error updating cached configuration";
         goto error;

--- a/src/modules/resource/resource.h
+++ b/src/modules/resource/resource.h
@@ -19,6 +19,7 @@ struct resource_config {
     bool norestrict;
     bool no_update_watch;
     bool monitor_force_up;
+    int journal_max;
 };
 
 struct resource_ctx {

--- a/src/modules/resource/test/drainset.c
+++ b/src/modules/resource/test/drainset.c
@@ -28,6 +28,7 @@ static void check_drainset (struct drainset *ds,
     char *s;
     json_t *o = drainset_to_json (ds);
     json_t *expected = json_loads (json_str, 0, NULL);
+    struct drainset *ds2;
     if (!o || !expected)
         BAIL_OUT ("drainset_to_json failed");
     if (!(s = json_dumps (o, JSON_COMPACT)))
@@ -36,8 +37,21 @@ static void check_drainset (struct drainset *ds,
     diag ("expected =         %s", json_str);
     ok (json_equal (expected, o),
         "drainset_to_json got expected result");
-    json_decref (expected);
+
+    if (!(ds2 = drainset_from_json (o)))
+        BAIL_OUT ("drainset_from_json failed");
     json_decref (o);
+
+    ok (true, "drainset_from_json worked");
+    if (!(o = drainset_to_json (ds2)))
+        BAIL_OUT ("drainset_to_json failed");
+
+    ok (json_equal (expected, o),
+        "drainset_to_json after from_json got expected result");
+
+    drainset_destroy (ds2);
+    json_decref (o);
+    json_decref (expected);
     free (s);
 }
 

--- a/src/modules/resource/test/truncate.c
+++ b/src/modules/resource/test/truncate.c
@@ -1,0 +1,330 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <errno.h>
+#include <string.h>
+
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libeventlog/eventlog.h"
+
+#include "src/modules/resource/truncate.h"
+
+static char *drain_idset (json_t *drain)
+{
+    char *result = NULL;
+    const char *key;
+    json_t *val;
+    struct idset *ids = idset_create (0, IDSET_FLAG_AUTOGROW);
+    if (!ids)
+        return NULL;
+
+    json_object_foreach (drain, key, val) {
+        if (idset_decode_add (ids, key, -1, NULL) < 0)
+            goto out;
+    }
+    result = idset_encode (ids, IDSET_FLAG_RANGE);
+out:
+    idset_destroy (ids);
+    return result;
+}
+
+static void check_truncate (struct truncate_info *ti,
+                            double expected_timestamp,
+                            const char *expected_online,
+                            const char *expected_torpid,
+                            const char *expected_drained,
+                            const char *expected_method)
+{
+    double timestamp;
+    const char *online;
+    const char *torpid;
+    const char *method = NULL;
+    const char *ranks = NULL;
+    const char *nodelist = NULL;
+    char *drained = NULL;
+    json_t *drain;
+    json_t *o = truncate_info_event (ti);
+
+    if (!o)
+        BAIL_OUT ("truncate_info_event failed!");
+
+    if (json_unpack (o,
+                     "{s:f s:{s:s s:s s:o s?s s?s s?s}}",
+                     "timestamp", &timestamp,
+                     "context",
+                      "online", &online,
+                      "torpid", &torpid,
+                      "drain", &drain,
+                      "ranks", &ranks,
+                      "nodelist", &nodelist,
+                      "discovery-method", &method) < 0)
+        BAIL_OUT ("json_unpack of truncate event failed");
+
+    is (online, expected_online,
+        "got expected online \"%s\"=\"%s\"",
+        online,
+        expected_online);
+    is (torpid, expected_torpid,
+        "got expected torpid \"%s\"=\"%s\"",
+        torpid,
+        expected_torpid);
+    if (!(drained = drain_idset (drain)))
+        BAIL_OUT ("failed to get drained ranks from drain object");
+    is (drained, expected_drained,
+        "got expected drained ranks \"%s\"=\"%s\"",
+        drained,
+        expected_drained);
+    if (expected_method)
+        is (method, expected_method,
+            "got expected discovery-method \"%s\"=\"%s\"",
+            method,
+            expected_method);
+    if (expected_timestamp > 0.)
+        ok (timestamp == expected_timestamp,
+            "got expected timestamp");
+
+    json_decref (o);
+    free (drained);
+}
+
+static void test_empty ()
+{
+    struct truncate_info *ti = truncate_info_create ();
+    if (!ti)
+        BAIL_OUT ("truncate_info_create()/event() failed!");
+    ok (true, "created empty truncate object");
+    check_truncate (ti, -1., "", "", "", NULL);
+    truncate_info_destroy (ti);
+}
+
+static void test_invalid ()
+{
+    json_t *event;
+    struct truncate_info *ti = truncate_info_create ();
+
+    ok (truncate_info_event (NULL) == NULL && errno == EINVAL,
+        "truncate_info_event (NULL) returns EINVAL");
+
+    ok (truncate_info_update (NULL, NULL) < 0 && errno == EINVAL,
+        "truncate_info_update (NULL, NULL) returns EINVAL");
+    ok (truncate_info_update (ti, NULL) < 0 && errno == EINVAL,
+        "truncate_info_update (ti, NULL) returns EINVAL");
+
+    /* create bad event (empty JSON object)
+     */
+    if (!(event = json_object ()))
+        BAIL_OUT ("failed to create bad event for testing");
+    ok (truncate_info_update (ti, event) < 0 && errno == EINVAL,
+        "truncate_info_update with bad event returns EINVAL");
+    json_decref (event);
+
+    /* create good event, bad event name
+     */
+    if (!(event = eventlog_entry_create (0., "foo", NULL)))
+        BAIL_OUT ("eventlog_entry_create (foo)");
+    ok (truncate_info_update (ti, event) < 0 && errno == ENOENT,
+        "truncate_info_update with unknown event name returns ENOENT");
+    json_decref (event);
+
+    truncate_info_destroy (ti);
+}
+
+struct test_entry {
+    const char *name;
+    const char *context;
+    const char *online;
+    const char *torpid;
+    const char *drained;
+    const char *method;
+};
+
+/* Sequence of basic resource events and expected online, torpid, etc.
+ * from the truncate object.
+ */
+struct test_entry tests[] = {
+    { .name = "restart",
+      .context= "{\"ranks\":\"0-3\","
+                 "\"nodelist\":\"foo[0-3]\","
+                 "\"online\":\"\",\"torpid\":\"\"}",
+      .online = "",
+      .torpid = "",
+      .drained = "",
+      .method = NULL
+    },
+    { .name = "online",
+      .context= "{\"idset\":\"0\"}",
+      .online = "0",
+      .torpid = "",
+      .drained = "",
+      .method = NULL
+    },
+    { .name = "online",
+      .context= "{\"idset\":\"1-3\"}",
+      .online = "0-3",
+      .torpid = "",
+      .drained = "",
+      .method = NULL
+    },
+    { .name = "resource-define",
+      .context= "{\"method\":\"dynamic-discovery\"}",
+      .online = "0-3",
+      .torpid = "",
+      .drained = "",
+      .method = "dynamic-discovery",
+    },
+    { .name = "torpid",
+      .context= "{\"idset\":\"3\"}",
+      .online = "0-3",
+      .torpid = "3",
+      .drained = "",
+      .method = "dynamic-discovery",
+    },
+    { .name = "lively",
+      .context= "{\"idset\":\"3\"}",
+      .online = "0-3",
+      .torpid = "",
+      .drained = "",
+      .method = "dynamic-discovery",
+    },
+    { .name = "offline",
+      .context= "{\"idset\":\"3\"}",
+      .online = "0-2",
+      .torpid = "",
+      .drained = "",
+      .method = "dynamic-discovery",
+    },
+    { .name = "drain",
+      .context= "{\"idset\":\"1\","
+                 "\"nodelist\":\"foo1\","
+                 "\"overwrite\":0}",
+      .online = "0-2",
+      .torpid = "",
+      .drained = "1",
+      .method = "dynamic-discovery",
+    },
+    /* Flux allows drain event with overwrite=0 if there
+     * is no reason.
+     */
+    { .name = "drain",
+      .context= "{\"idset\":\"1\","
+                 "\"nodelist\":\"foo1\","
+                 "\"overwrite\":0}",
+      .online = "0-2",
+      .torpid = "",
+      .drained = "1",
+      .method = "dynamic-discovery",
+    },
+    { .name = "undrain",
+      .context= "{\"idset\":\"1\"}",
+      .online = "0-2",
+      .torpid = "",
+      .drained = "",
+      .method = "dynamic-discovery",
+    },
+    { .name = "drain",
+      .context= "{\"idset\":\"0\","
+                 "\"nodelist\":\"foo0\","
+                 "\"reason\":\"test\","
+                 "\"overwrite\":0}",
+      .online = "0-2",
+      .torpid = "",
+      .drained = "0",
+      .method = "dynamic-discovery",
+    },
+    { .name = "drain",
+      .context= "{\"idset\":\"1\","
+                 "\"nodelist\":\"foo0\","
+                 "\"reason\":\"test\","
+                 "\"overwrite\":0}",
+      .online = "0-2",
+      .torpid = "",
+      .drained = "0-1",
+      .method = "dynamic-discovery",
+    },
+    { .name = "undrain",
+      .context= "{\"idset\":\"0\"}",
+      .online = "0-2",
+      .torpid = "",
+      .drained = "1",
+      .method = "dynamic-discovery",
+    },
+    { NULL, NULL, NULL, NULL, NULL, NULL },
+};
+
+static void test_simple ()
+{
+    struct test_entry *t = tests;
+    json_t *event;
+    struct truncate_info *ti = truncate_info_create ();
+
+    if (!ti)
+        BAIL_OUT ("Failed to create truncate info object");
+
+    while (t->name) {
+        if (!(event = eventlog_entry_create (0., t->name, t->context)))
+            BAIL_OUT ("failed to create %s event context", t->name);
+        ok (truncate_info_update (ti, event) == 0,
+            "truncate_info_update '%s' worked",
+            t->name);
+        json_decref (event);
+        check_truncate (ti, -1., t->online, t->torpid, t->drained, t->method);
+        ++t;
+    }
+
+    truncate_info_destroy (ti);
+}
+
+static void test_from_truncate ()
+{
+    json_t *event;
+    const char *context =
+        "{\"online\":\"0-3\","
+         "\"torpid\":\"\","
+         "\"ranks\":\"0-3\","
+         "\"nodelist\":\"foo[0-3]\","
+         "\"drain\":{\"0-1\":{\"reason\":\"foo\",\"timestamp\":1.0}},"
+         "\"discovery-method\":\"dynamic-discovery\"}";
+
+    struct truncate_info *ti = truncate_info_create ();
+    if (!ti)
+        BAIL_OUT ("truncate_info_create failed");
+
+    if (!(event = eventlog_entry_create (0., "truncate", context)))
+        BAIL_OUT ("failed to create truncate event: %s", strerror (errno));
+
+    ok (truncate_info_update (ti, event) == 0,
+        "truncate_info_update 'truncate' worked");
+
+    check_truncate (ti, -1., "0-3", "", "0-1", "dynamic-discovery");
+
+    json_decref (event);
+    truncate_info_destroy (ti);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+    test_empty ();
+    test_invalid ();
+    test_simple ();
+    test_from_truncate ();
+    done_testing ();
+    return (0);
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/resource/truncate.c
+++ b/src/modules/resource/truncate.c
@@ -1,0 +1,293 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libeventlog/eventlog.h"
+#include "ccan/str/str.h"
+
+#include "truncate.h"
+#include "drainset.h"
+//#include "inventory.h"
+
+/* Truncate event needs to hold dropped information due to
+ * truncation of the resource eventlog.
+ *
+ * Most items are updated directly in the context, which is initialized
+ * from the first dropped event (possibly itself a truncate event), then
+ * updated with each event as they are dropped during a truncate operation.
+ */
+struct truncate_info {
+    double timestamp;
+
+    /* Only online+torpid idsets and drain info is actively tracked.
+     * Other data is held and updated in the event context to avoid
+     * unnecessary decode/encode:
+     */
+    struct idset *online;
+    struct idset *torpid;
+    struct drainset *drainset;
+
+    json_t *context;
+};
+
+void truncate_info_destroy (struct truncate_info *ti)
+{
+    if (ti) {
+        int saved_errno = errno;
+        idset_destroy (ti->online);
+        idset_destroy (ti->torpid);
+        json_decref (ti->context);
+        drainset_destroy (ti->drainset);
+        free (ti);
+        errno = saved_errno;
+    }
+}
+
+struct truncate_info *truncate_info_create (void)
+{
+    struct truncate_info *ti;
+
+    if (!(ti = calloc (1, sizeof (*ti)))
+        || !(ti->context = json_object ())
+        || !(ti->online = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || !(ti->torpid = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || !(ti->drainset = drainset_create ()))
+        goto error;
+    return ti;
+error:
+    truncate_info_destroy (ti);
+    return NULL;
+}
+
+static int add_idset_from_context (struct idset *idset,
+                                   const char *key,
+                                   json_t *context)
+{
+    char *ids;
+    if (json_unpack (context, "{s:s}", key, &ids) < 0
+        || idset_decode_add (idset, ids, -1, NULL) < 0)
+        return -1;
+    return 0;
+}
+
+static int subtract_idset_from_context (struct idset *idset,
+                                        const char *key,
+                                        json_t *context)
+{
+    char *ids;
+    if (json_unpack (context, "{s:s}", key, &ids) < 0
+        || idset_decode_subtract (idset, ids, -1, NULL) < 0)
+        return -1;
+    return 0;
+}
+
+static int truncate_reset_idsets (struct truncate_info *ti)
+{
+    if (idset_clear_all (ti->online) < 0
+        || idset_clear_all (ti->torpid) < 0)
+        return -1;
+    return 0;
+}
+
+/* Update truncate info with restart event:
+ * - update context with restart event context (updates rank, nodelist, online)
+ * - then reinitialize ti->online from context.online
+ * - clear torpid ranks
+ */
+static int process_restart (struct truncate_info *ti, json_t *context)
+{
+    if (json_object_update (ti->context, context) < 0
+        || truncate_reset_idsets (ti) < 0
+        || add_idset_from_context (ti->online, "online", context) < 0)
+        return -1;
+
+    /* No need to update "torpid" in context (if it exists) since the
+     * key will be replaced on encode.
+     */
+    return 0;
+}
+
+static int process_truncate (struct truncate_info *ti, json_t *context)
+{
+    json_t *drain;
+    struct drainset *ds = NULL;
+
+    if (json_object_update (ti->context, context) < 0
+        || truncate_reset_idsets (ti) < 0
+        || add_idset_from_context (ti->online, "online", context) < 0
+        || add_idset_from_context (ti->torpid, "torpid", context) < 0
+        || json_unpack (context, "{s:o}", "drain", &drain) < 0
+        || !(ds = drainset_from_json (drain)))
+        return -1;
+
+    drainset_destroy (ti->drainset);
+    ti->drainset = ds;
+
+    return 0;
+}
+
+static int process_undrain (struct truncate_info *ti, json_t *context)
+{
+    struct idset *ranks = NULL;
+    unsigned int rank;
+    const char *ids;
+    int rc = -1;
+
+    if (json_unpack (context, "{s:s}", "idset", &ids) < 0
+        || !(ranks = idset_decode (ids)))
+        return -1;
+
+    rank = idset_first (ranks);
+    while (rank != IDSET_INVALID_ID) {
+        if (drainset_undrain (ti->drainset, rank) < 0)
+            goto out;
+        rank = idset_next (ranks, rank);
+    }
+
+    rc = 0;
+out:
+    idset_destroy (ranks);
+    return rc;
+}
+
+static int process_drain (struct truncate_info *ti, json_t *context)
+{
+    struct idset *ranks = NULL;
+    int overwrite;
+    const char *ids;
+    const char *reason = "";
+    unsigned int rank;
+    int rc = -1;
+
+    if (json_unpack (context,
+                     "{s:s s?s s:i}",
+                     "idset", &ids,
+                     "reason", &reason,
+                     "overwrite", &overwrite) < 0)
+        return -1;
+
+    if (!(ranks = idset_decode (ids))
+        || overwrite < 0
+        || overwrite > 2)
+        goto out;
+
+    rank = idset_first (ranks);
+    while (rank != IDSET_INVALID_ID) {
+        if (drainset_drain_ex (ti->drainset,
+                               rank,
+                               ti->timestamp,
+                               reason,
+                               overwrite) < 0)
+            if (errno != EEXIST)
+                goto out;
+        rank = idset_next (ranks, rank);
+    }
+    rc = 0;
+out:
+    idset_destroy (ranks);
+    return rc;
+}
+
+static int process_resource_define (struct truncate_info *ti,
+                                    json_t *context)
+{
+    /* Add method and R to context */
+    // TODO: json_t *R = json_incref (inventory_get (reslog->ctx->inventory));
+    json_t *method;
+
+    if (!(method = json_object_get (context, "method"))) {
+        errno = EPROTO;
+        return -1;
+    }
+    if (json_object_set (ti->context, "discovery-method", method) < 0)
+        return -1;
+    return 0;
+}
+
+int truncate_info_update (struct truncate_info *ti, json_t *event)
+{
+    const char *name;
+    json_t *context;
+    int rc = -1;
+
+    if (!ti || !event) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (eventlog_entry_parse (event, &ti->timestamp, &name, &context) < 0)
+        return -1;
+
+    if (streq (name, "truncate"))
+        rc = process_truncate (ti, context);
+    else if (streq (name, "restart"))
+        rc = process_restart (ti, context);
+    else if (streq (name, "resource-define"))
+        rc = process_resource_define (ti, context);
+    else if (streq (name, "drain"))
+        rc = process_drain (ti, context);
+    else if (streq (name, "undrain"))
+        rc = process_undrain (ti, context);
+    else if (streq (name, "online"))
+        rc = add_idset_from_context (ti->online, "idset", context);
+    else if (streq (name, "offline"))
+        rc = subtract_idset_from_context (ti->online, "idset", context);
+    else if (streq (name, "torpid"))
+        rc = add_idset_from_context (ti->torpid, "idset", context);
+    else if (streq (name, "lively"))
+        rc = subtract_idset_from_context (ti->torpid, "idset", context);
+    else
+        errno = ENOENT;
+
+    if (rc < 0)
+        fprintf (stderr, "truncate_info_update %s failed\n", name);
+    return rc;
+}
+
+json_t *truncate_info_event (struct truncate_info *ti)
+{
+    char *online = NULL;
+    char *torpid = NULL;
+    json_t *drainset = NULL;
+    json_t *entry = NULL;
+    json_t *o = NULL;
+
+    if (!ti) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (!(online = idset_encode (ti->online, IDSET_FLAG_RANGE))
+        || !(torpid = idset_encode (ti->torpid, IDSET_FLAG_RANGE))
+        || !(drainset = drainset_to_json (ti->drainset))
+        || !(o = json_pack ("{s:s s:s s:O}",
+                            "online", online,
+                            "torpid", torpid,
+                            "drain", drainset))
+        || json_object_update (ti->context, o) < 0)
+        goto error;
+    entry = eventlog_entry_pack (ti->timestamp, "truncate", "O", ti->context);
+error:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    ERRNO_SAFE_WRAP (json_decref, drainset);
+    ERRNO_SAFE_WRAP (free, torpid);
+    ERRNO_SAFE_WRAP (free, online);
+    return entry;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/truncate.h
+++ b/src/modules/resource/truncate.h
@@ -1,0 +1,29 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_TRUNCATE_H
+#define _FLUX_RESOURCE_TRUNCATE_H
+
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/idset.h>
+
+struct truncate_info *truncate_info_create ();
+void truncate_info_destroy (struct truncate_info *ti);
+int truncate_info_update (struct truncate_info *ti, json_t *event);
+
+json_t *truncate_info_event (struct truncate_info *ti);
+
+#endif /* ! _FLUX_RESOURCE_TRUNCATE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This PR adds support for truncation of the in-memory resource eventlog, including addition of the `truncate` event proposed for RFC 44 which holds a summary of information lost by the truncation.

The current limit here is an arbitrarily chosen 100,000 entries. The implementation actually allows the eventlog to grow to `journal-max` + 1% before truncating, at which point enough entries are dropped to bring the size back to the limit. This is to avoid truncating on every event appended to the log once it has reached the limit. 

The journal limit can be altered via the `resource.journal-max` configuration key. A live update immediately truncates the event if it exceeds the max + 1% water mark.

This is a WIP because maintaining the truncated "state" ended a bit more complex than I originally thought, though it is perhaps 95% complete here. However, if there's no actual need for a resource journal consumer to reconstruct state at this point, it might be worth dropping the `truncate` event context which would make this PR trivial.

Items that are still TODO if we keep the current approach:
 - add a method to the `truncate_info` object to allow _R_ to be pushed into the context on a `resource-define` event.
 - add a handler to the truncate class for the `resource-update` event
 - better error handling and error messages (there are none now)
 - further testing
 
 If we decide to drop the truncate event context which summarizes lost state, most of the above TODO items could be dropped. The truncate event would just notify the consumer that the log has been truncated and record the timestamp of the most recently dropped event.
 
 Maybe I'll work up a PR that does this 2nd part only, then make all the context keys in the RFC 44 proposal set to OPTIONAL. We could always tack the extra truncate event context handling on in another PR (I should have thought of this before, sorry!)
 
 I'll still leave this here for consideration.
 
 An example:
 ```console
$ flux resource eventlog -H
[Feb12 19:53] restart ranks="0-7" online="" nodelist="corona[212,212,212,212,212,212,212,212]"
[  +1.242239] online idset="0"
[  +2.321909] online idset="1"
[  +3.363048] online idset="2"
[  +4.437279] online idset="3"
[  +5.504496] online idset="4"
[  +6.550387] online idset="5"
[  +7.554111] resource-define method="dynamic-discovery"
[  +7.610144] online idset="6"
[  +8.653062] online idset="7"
$ echo resource.journal-max=4 | flux config load
$ flux resource eventlog -H
[Feb12 19:53] truncate ranks="0-7" online="0-5" nodelist="corona[212,212,212,212,212,212,212,212]" torpid="" drain={}
[  +1.003724] resource-define method="dynamic-discovery"
[  +1.059757] online idset="6"
[  +2.102675] online idset="7"
$ flux resource drain 0
$ flux resource eventlog -H
[Feb12 19:53] truncate ranks="0-7" online="0-5" nodelist="corona[212,212,212,212,212,212,212,212]" torpid="" drain={} discovery-method="dynamic-discovery"
[  +0.056033] online idset="6"
[  +1.098951] online idset="7"
[Feb12 20:01] drain idset="0" nodelist="corona212" overwrite=0
$ flux resource drain 1
$ flux resource eventlog -H
[Feb12 19:53] truncate ranks="0-7" online="0-6" nodelist="corona[212,212,212,212,212,212,212,212]" torpid="" drain={} discovery-method="dynamic-discovery"
[  +1.042918] online idset="7"
[Feb12 20:01] drain idset="0" nodelist="corona212" overwrite=0
[ +18.420785] drain idset="1" nodelist="corona212" overwrite=0
$ echo resource.journal-max=1 | flux config load
$ flux resource eventlog -H
[Feb12 20:02] truncate ranks="0-7" online="0-7" nodelist="corona[212,212,212,212,212,212,212,212]" torpid="" drain={"1":{"timestamp":1739419321.7013323,"reason":""},"0":{"timestamp":1739419303.2805471,"reason":""}} discovery-method="dynamic-discovery"
```