### PR TITLE
rlist and shell: record nslots in allocated Rv1 for use in shell init

### DIFF
--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -26,6 +26,8 @@
 struct rlist {
     int total;
     int avail;
+    int nslots;
+
     zlistx_t *nodes;
 
     zhashx_t *rank_index;

--- a/src/shell/rcalc.c
+++ b/src/shell/rcalc.c
@@ -49,6 +49,7 @@ struct rcalc {
     int ncores;
     int ngpus;
     int ntasks;
+    int nslots;
     struct rankinfo *ranks;
     struct allocinfo *alloc;
 };
@@ -223,10 +224,11 @@ rcalc_t * rcalc_create_json (json_t *o)
         return (NULL);
     r->json = json_incref (o);
     if (json_unpack_ex (o, NULL, 0,
-                        "{s:i s:{s:o}}",
+                        "{s:i s:{s:o s?i}}",
                         "version", &version,
                         "execution",
-                        "R_lite", &r->R_lite) < 0)
+                            "R_lite", &r->R_lite,
+                            "nslots", &r->nslots) < 0)
         goto fail;
     if (version != 1) {
         errno = EINVAL;
@@ -287,6 +289,11 @@ int rcalc_total_gpus (rcalc_t *r)
 int rcalc_total_ntasks (rcalc_t *r)
 {
     return r->ntasks;
+}
+
+int rcalc_total_slots (rcalc_t *r)
+{
+    return r->nslots;
 }
 
 int rcalc_total_nodes_used (rcalc_t *r)

--- a/src/shell/rcalc.h
+++ b/src/shell/rcalc.h
@@ -44,6 +44,8 @@ int rcalc_total_ntasks (rcalc_t *r);
 int rcalc_total_cores (rcalc_t *r);
 /*  Return # of total gpus asssigned to rcalc object */
 int rcalc_total_gpus (rcalc_t *r);
+/*  Return total # of slots in rcalc object */
+int rcalc_total_slots (rcalc_t *r);
 /*  Return total # of nodes/ranks in rcalc object */
 int rcalc_total_nodes (rcalc_t *r);
 /*  Return the total # of nodes/ranks with at least 1 task assigned */

--- a/src/shell/test/jobspec.c
+++ b/src/shell/test/jobspec.c
@@ -99,6 +99,7 @@ struct output good_output[] = {
 };
 struct input bad_input[] = {
     { "empty object", "{}",  "{}" },
+    { "invalid JSON", "{]",  "{}" },
     {
         "missing version",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
@@ -178,6 +179,11 @@ struct input bad_input[] = {
         "missing resource type",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": \"hostname\", \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"label\": \"task\", \"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}]}]}",
         "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
+    },
+    {
+        "invalid resource type",
+        "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": 1, \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}], \"nslots\": 1}}",
     },
     {
         "(node->slot->core,slot->core)",


### PR DESCRIPTION
This is my initial attempt to investigate what is required to enable resource ranges in jobspec à la RFC 14. Very rough at this point (in particular there is lots of work to do on the testsuite) but I am interested in discussion about some potential design considerations that have come up. The code to this point allows jobspec with ranges that is otherwise V1 compliant to be allocated and run successfully, but at least the job-list service still issues a non-fatal error, and I've just ignored sched-simple at this point.

(update: the discussion in this paragraph has now been addressed by #6682)
Firstly, because flux-sched already largely supports ranges, once a couple of explicit version checks are tweaked in libjob and shell, we can already get back a resource set allocation from fluxion. From a design perspective, my personal opinion about these version checks is that it should be exclusively the remit of the validator to actually fail jobspec purely based on the version number. If a jobspec passes validation, then it seems to me that other components should at most warn about unsupported version numbers, but otherwise try their best to handle the rest of the jobspec (in future, I suppose a version check could also determine different code pathways for different versions). This would allow someone in future to define an extension of a supported version and not have other components arbitrarily fail even when all the information they require is present and conformant.

Secondly, the lack of information about slots in RFC 20 resource sets is problematic. In short, in my opinion the shell really shouldn't have to parse the jobspec resource section at all to determine what resources it will run on, it should just be able to consult the R allocation returned by the scheduler. flux-sched can already handle ranges for any/all of the resources in V1 jobspec, but if a range is used for the slot resource then the slot count decided by the scheduler is not recorded in R. If a fixed count was used for the cores then the slot count can be determined fairly easily in V1, but if a range was also used for the cores then the shell has to re-determine (guess, really) what the chosen slot and core counts should be (e.g. if 6 cores are allocated per node in R, then you could potentially have slot:core counts of 1:6, 2:3, 3:2, or 6:1).

In my mind the ideal long-term solution is to have slot information included in the allocated resource set; I know it's a "virtual" resource, but it's still part of the scheduler's decision making, and especially looking ahead to more complicated possibilities of canonical jobspec it seems like it will definitely be important to preserve the slot information in the resource graph allocated by the scheduler.

For now, I've added infrastructure to the shell initialization that ~~guesses~~ resolves a slot:core count combination if needed, but it perhaps raises the question of whether it even makes sense to allow ranges for both slot and core resources simultaneously? Philosophically, I generally prefer having fewer restrictions, lest some future user come up with a strange use case one never predicted, but requiring a fixed count for at least one of the slot or core resources does greatly simplify things at this point, and it doesn't seem too restrictive to forbid leaving it entirely to the scheduler to decide what combination of number of slots and cores are allocated!