### PR TITLE
fix incorrect combination of lines in `flux resource status` for expandable fields that differ past the minimum width

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -1135,7 +1135,9 @@ class Deduplicator:
     """
 
     def __init__(self, formatter, except_fields=None, combine=None):
-        self.formatter = formatter.copy(except_fields=except_fields)
+        self.formatter = formatter.copy(
+            except_fields=except_fields, nullify_expansion=True
+        )
         self.combine = combine
         self.hash = {}
         self.items = []

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -833,7 +833,10 @@ class OutputFormat:
             # Skip this field if it is in except_fields
             if field in except_fields:
                 # Preserve any format "prefix" (i.e. the text):
-                lst.append(text)
+                # Unless it is whitespace or a sentinel (+:,  etc):
+                result = text.strip()
+                if result and result not in ("+:", "?:", "?+:"):
+                    lst.append(text)
                 continue
             # If field doesn't have 'prepend' then add it
             if field and not field.startswith(prepend):

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -45,7 +45,7 @@ class FluxResourceConfig(UtilConfig):
             "description": "Long flux-resource status format string",
             "format": (
                 "{state:>12} {color_up}{up:>2}{color_off} "
-                "{nnodes:>6} +:{reason:<30.30+} {nodelist}"
+                "{nnodes:>6} +:{reason:<30.30} {nodelist}"
             ),
         },
     }
@@ -54,7 +54,7 @@ class FluxResourceConfig(UtilConfig):
             "description": "Long flux-resource drain format string",
             "format": (
                 "{timestamp!d:%b%d %R::<12} {state:<8.8} {ranks:<8.8+} "
-                "+:{reason:<30.30+} {nodelist}"
+                "+:{reason:<30.30} {nodelist}"
             ),
         },
         "default": {

--- a/t/python/t0024-util.py
+++ b/t/python/t0024-util.py
@@ -261,6 +261,26 @@ class TestOutputFormat(unittest.TestCase):
         ).filter(items)
         self.assertEqual(fmt, "{s:16.16} {i:4d} {f:3.2f}")
 
+    def test_copy(self):
+        original = "+:{s:5.5} {i:4d} {f:.2f}"
+
+        fmt = OutputFormat(original, headings=self.headings)
+        self.assertEqual(fmt.get_format_prepended(""), original)
+
+        # copy preserves original fmt
+        self.assertEqual(fmt.copy().get_format_prepended(""), original)
+
+        # except_fields can remove fields
+        self.assertEqual(
+            fmt.copy(except_fields=["s", "f"]).get_format_prepended(""), " {i:4d}"
+        )
+
+        # nullify_expansion removes formatting on +: fields
+        self.assertEqual(
+            fmt.copy(nullify_expansion=True).get_format_prepended(""),
+            "{s} {i:4d} {f:.2f}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main(testRunner=TAPTestRunner())

--- a/t/t2354-resource-status.t
+++ b/t/t2354-resource-status.t
@@ -43,6 +43,17 @@ test_expect_success 'cancel running jobs' '
 	flux cancel --all &&
 	flux queue idle
 '
+# issue#6625:
+test_expect_success 'flux-resource status does not combine dissimilar drain reasons' '
+	test_when_finished "flux resource undrain -f 0-3" &&
+	flux resource drain -f 0-3 xxxxxxxx &&
+	flux resource drain -f 0   xxxxxxxxyy &&
+	flux resource status -no "{state:>12} {ranks:>6} +:{reason:<5.5+}" \
+		> drain.1 &&
+	flux resource status -no "{state:>12} {ranks:>6} {reason:<10}" \
+		> drain.2 &&
+	test_cmp drain.1 drain.2
+'
 test_expect_success 'flux-resource status shows housekeeping by default' '
 	flux config load <<-EOF &&
 	[job-manager.housekeeping]


### PR DESCRIPTION
This PR fixes #6625. Expandable width fields (those with the `+:` or `?+:` prefix sentinel) are passed to the `Deduplicator` class before the final maximum width is known, so comparison only occurs up to the _minimum_ width. This was causing drain reasons that differ past the 30 character minimum width to be incorrectly combined.

The fix here strips the field widths from expandable fields in the `Deduplicator` so that the entire field is compared.