### PR TITLE
flux-version: report hwloc.api=x.y.z instead of hwloc=x.y.z

### DIFF
--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -64,7 +64,7 @@ static int cmd_version (optparse_t *p, int ac, char *av[])
 #if HAVE_LIBSYSTEMD
     printf ("+systemd");
 #endif
-    printf ("+hwloc==%d.%d.%d",
+    printf ("+hwloc.api==%d.%d.%d",
             HWLOC_API_VERSION >> 16 & 0x000000ff,
             HWLOC_API_VERSION >>  8 & 0x000000ff,
             HWLOC_API_VERSION       & 0x000000ff


### PR DESCRIPTION
Problem: The hwloc version reported by `flux version` is the build time libhwloc API version, not the actual libhwloc version. This can cause confusion for users that are expecting this string to report the library version.

Hint that the HWLOC version reported is an API version by changing the string to `hwloc.api`.

Fixes #6637