### PR TITLE
flux-jobs: filter against all users with --include

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -56,7 +56,8 @@ OPTIONS
    List only jobs where the assigned resources intersect with the supplied
    argument, which may be specified either as an RFC 22 idset of broker ranks
    or an RFC 29 hostlist of host names. It is not an error to specify ranks or
-   hosts which do not exist.
+   hosts which do not exist.  This option implies :option:`-A` unless a specific
+   user has been selected via the :option:`-u, --user` option.
 
 .. option:: -c, --count=N
 

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -244,6 +244,13 @@ class FilterActionSetUpdate(argparse.Action):
         getattr(namespace, self.dest).update(values)
 
 
+class FilterActionUser(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, "filtered", True)
+        setattr(namespace, "filtereduser", True)
+        setattr(namespace, self.dest, values)
+
+
 # pylint: disable=redefined-builtin
 class FilterTrueAction(argparse.Action):
     def __init__(

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -24,6 +24,7 @@ from flux.job.stats import JobStats
 from flux.util import (
     FilterAction,
     FilterActionSetUpdate,
+    FilterActionUser,
     FilterTrueAction,
     UtilConfig,
     help_formatter,
@@ -167,6 +168,9 @@ def fetch_jobs_flux(args, fields, flux_handle=None):
                 constraint = {"hostlist": [Hostlist(args.include).encode()]}
             except ValueError:
                 raise ValueError(f"-i/--include: invalid targets: {args.include}")
+        # --include implies check against all user jobs
+        if not args.filtereduser:
+            args.user = str(flux.constants.FLUX_USERID_UNKNOWN)
 
     jobs_rpc = JobList(
         flux_handle,
@@ -261,7 +265,7 @@ def parse_args():
     parser.add_argument(
         "-u",
         "--user",
-        action=FilterAction,
+        action=FilterActionUser,
         type=str,
         metavar="[USERNAME|UID]",
         default=str(os.getuid()),
@@ -368,6 +372,7 @@ def parse_args():
     # Hidden '--from-stdin' option for testing only.
     parser.add_argument("--from-stdin", action="store_true", help=argparse.SUPPRESS)
     parser.set_defaults(filtered=False)
+    parser.set_defaults(filtereduser=False)
     return parser.parse_args()
 
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -225,6 +225,7 @@ TESTSCRIPTS = \
 	t2715-python-cli-cancel.t \
 	t2716-python-cli-batch-conf.t \
 	t2800-jobs-cmd.t \
+	t2800-jobs-cmd-multiuser.t \
 	t2800-jobs-recursive.t \
 	t2800-jobs-instance-info.t \
 	t2800-jobs-config.t \

--- a/t/t2800-jobs-cmd-multiuser.t
+++ b/t/t2800-jobs-cmd-multiuser.t
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+test_description='Test flux jobs command with multiple user jobs'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+if ! flux version | grep -q libflux-security; then
+    skip_all='libflux-security not built, skipping'
+    test_done
+fi
+
+flux setattr log-stderr-level 1
+
+submit_job_altuser()
+{
+        USERID=$1
+        flux run --dry-run --setattr=exec.test.run_duration=0.1s hostname | \
+            flux python ${SHARNESS_TEST_SRCDIR}/scripts/sign-as.py $USERID \
+                 >job.signed
+        FLUX_HANDLE_USERID=$USERID \
+            flux job submit --flags=signed job.signed
+}
+
+test_expect_success 'configure guest access to test exec' '
+        flux config load <<-EOF
+	[exec.testexec]
+	allow-guests = true
+	EOF
+'
+
+myid=$(id -u)
+id1=$(($myid + 1))
+id2=$(($myid + 2))
+
+test_expect_success 'submit jobs as several different users' '
+	jobid=$(submit_job_altuser $myid) &&
+	flux job wait-event -t 30s $jobid clean &&
+	jobid=$(submit_job_altuser $id1) &&
+	flux job wait-event -t 30s $jobid clean &&
+	jobid=$(submit_job_altuser $id2) &&
+	flux job wait-event -t 30s $jobid clean
+'
+test_expect_success 'default only shows current user jobs' '
+        flux jobs -a -n -o "{id},{userid}" > default.out &&
+        test $(wc -l < default.out) -eq 1 &&
+        grep $myid default.out
+'
+test_expect_success '-u option works with specific users' '
+        flux jobs -a -n -u $id1 -o "{id},{userid}" > user1.out &&
+        test $(wc -l < user1.out) -eq 1 &&
+        grep $id1 user1.out &&
+        flux jobs -a -n -u $id2 -o "{id},{userid}" > user2.out &&
+        test $(wc -l < user2.out) -eq 1 &&
+        grep $id2 user2.out
+'
+test_expect_success '-u all option shows all jobs' '
+        flux jobs -a -n -u all -o "{id},{userid}" > userall.out &&
+        test $(wc -l < userall.out) -eq 3
+'
+test_expect_success '-A option shows all jobs' '
+        flux jobs -a -n -A -o "{id},{userid}" > optionA.out &&
+        test $(wc -l < optionA.out) -eq 3
+'
+test_done

--- a/t/t2800-jobs-cmd-multiuser.t
+++ b/t/t2800-jobs-cmd-multiuser.t
@@ -63,4 +63,16 @@ test_expect_success '-A option shows all jobs' '
         flux jobs -a -n -A -o "{id},{userid}" > optionA.out &&
         test $(wc -l < optionA.out) -eq 3
 '
+test_expect_success '--include defaults to work against all user jobs' '
+        flux jobs -a -n -i $(hostname) -o "{id},{userid},{nodelist}" > includeall.out &&
+        test $(wc -l < includeall.out) -eq 3
+'
+test_expect_success '--include w/ -u only lists user jobs' '
+        flux jobs -a -n -i $(hostname) -u $id1 -o "{id},{userid}" > include1.out &&
+        test $(wc -l < include1.out) -eq 1 &&
+        grep $id1 include1.out &&
+        flux jobs -a -n -i $(hostname) -u $id2 -o "{id},{userid}" > include2.out &&
+        test $(wc -l < include2.out) -eq 1 &&
+        grep $id2 include2.out
+'
 test_done


### PR DESCRIPTION
Problem: The --include option is predominantly used for finding jobs on specific hosts.  This implies that the -A option is set (i.e.
filter on all user jobs) but it is currently not.  This can be confusing to users wondering why --include isn't finding any jobs running on specific hosts.

Solution: If the user did not specify filtering on a specific user with --user, then assume all user jobs (i.e. -A or --user=all) will be checked when --include is specified.

---- 

side note, the 1 tricky part was how to tell if the user specified `--user=X` on the command line so we didn't assume "-A" when `--include` was specified.  I setup a new filter action that sets a argparse flag "filtereduser".  There were probably other ways of doing this, but went with this approach.