### PR TITLE
testsuite: fix flaky test for handling of invalid `tbon.topo`

### DIFF
--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -598,8 +598,8 @@ test_expect_success 'tbon.topo with unknown scheme fails' '
 	[tbon]
 	topo = "notascheme:42"
 	EOT
-	test_must_fail flux broker ${ARGS} -c conf23 \
-		true 2>badscheme.err &&
+	test_must_fail flux broker ${ARGS} -Sbroker.boot-method=single \
+	        -c conf23 true 2>badscheme.err &&
 	grep "unknown topology scheme" badscheme.err
 '
 test_expect_success 'tbon.topo is kary:32 by default' '


### PR DESCRIPTION
Problem: on systems where a non-flux libpmi is loaded first, and in some of our CI systems, t0013's test of unknown tbon.topo schemes fails with SIGKILL.

Force the test to run as singletons so libpmi is not used. Fixes #6655