### PR TITLE
add support for undrain reason

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -17,7 +17,7 @@ SYNOPSIS
 
 | **flux** **resource** **drain** [*-n*] [*-o* *FORMAT*] [*-i* *TARGETS*]
 | **flux** **resource** **drain** [*-f*] [*-u*] [*targets*] [*reason*]
-| **flux** **resource** **undrain** [*-f*] *targets*
+| **flux** **resource** **undrain** [*-f*] *targets* [*reason*]
 
 | **flux** **resource** **reload** [-f] [--xml] *path*
 
@@ -323,6 +323,7 @@ undrain
 .. program:: flux resource undrain
 
 Undrain the nodes specified by the *targets* argument (IDSET or HOSTLIST).
+Any remaining free arguments are recorded as a reason for the undrain event.
 
 This command is restricted to the Flux instance owner.
 

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -22,7 +22,7 @@ SYNOPSIS
 | **flux** **resource** **reload** [-f] [--xml] *path*
 
 | **flux** **resource** **acquire-mute**
-| **flux** **resource** **eventlog** [*-w* *EVENT*] [*-f* *FORMAT*] [*-T* *FORMAT*] [*-L* [*WHEN*]] [*-H*] [*-F*]
+| **flux** **resource** **eventlog** [*-w* *EVENT*] [*-f* *FORMAT*] [*-T* *FORMAT*] [*-L* [*WHEN*]] [*-H*] [*-F*] [*-i* *TARGETS*]
 
 DESCRIPTION
 ===========
@@ -395,6 +395,12 @@ Watch the resource journal, which is described in RFC 44.
   Wait for the specified event to be posted, print it, then quit.
   The current set of valid events events is *restart*, *resource-define*,
   *online*, *offline*, *drain*, *undrain*, *torpid*, and *lively*.
+
+.. option:: -i, --include=TARGETS
+
+  Filter events to only include those that apply to  *TARGETS*, which is
+  normally one or more hostnames in RFC 29 hostlist form. TARGETS can also
+  be broker ranks in RFC 22 idset form, useful mainly in test.
 
 OUTPUT FORMAT
 =============

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -166,6 +166,8 @@ def undrain(args):
     payload = {"targets": args.targets}
     if args.force:
         payload["mode"] = "force"
+    if args.reason:
+        payload["reason"] = " ".join(args.reason)
     RPC(flux.Flux(), "resource.undrain", payload, nodeid=0).get()
 
 
@@ -840,6 +842,7 @@ def main():
     undrain_parser.add_argument(
         "targets", help="List of targets to resume (IDSET or HOSTLIST)"
     )
+    undrain_parser.add_argument("reason", help="Reason", nargs=argparse.REMAINDER)
     undrain_parser.set_defaults(func=undrain)
 
     status_parser = subparsers.add_parser(

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -159,15 +159,17 @@ test_expect_success 'two nodes are still drained' '
 	test $(flux resource list -n -s down -o {nnodes}) -eq 2
 '
 
-test_expect_success 'undrain remaining nodes' '
-	flux resource undrain 1-2 &&
+test_expect_success 'undrain remaining nodes with a reason' '
+	flux resource undrain 1-2 "reason for undrain" &&
 	test $(flux resource list -n -s down -o {nnodes}) -eq 0
 '
 
 test_expect_success 'resource.eventlog has three undrain events' '
 	test $(has_resource_event undrain | wc -l) -eq 3
 '
-
+test_expect_success 'final undrain event has a reason' '
+	flux resource eventlog -H | tail -1 | grep "reason for undrain"
+'
 test_expect_success 'reload resource module to simulate instance restart' '
 	flux module remove sched-simple &&
 	flux module reload resource noverify &&


### PR DESCRIPTION
This PR adds support for an undrain reason. Currently there is not a utility to display the undrain reason, it is just entered into the resource eventlog. Therefore, to make the undrain reason a bit more useful, a new `-i, --include=TARGETS` option is added to `flux resource eventlog` so admins can easily see the "history" of a node or set of nodes. (Actually, this could be moved to  a separate PR if preferred.)

Fixes #6599