### PR TITLE
rename broker quorum and shutdown warn period attributes

### DIFF
--- a/doc/guide/admin.rst
+++ b/doc/guide/admin.rst
@@ -1181,7 +1181,7 @@ Try to start the leader (rank 0) broker on the management node.
        Memory: 26.6M
           CPU: 3.506s
        CGroup: /system.slice/flux.service
-               └─287739 broker --config-path=/etc/flux/system/conf.d -Scron.directory=/etc/flux/system/cron.d -Srundir=/run/flux -Sstatedir=/var/lib/flux -Slocal-uri=local:///run/flux/local -Slog-stderr-level=6 -Slog-stderr-mode=local -Sbroker.rc2_none -Sbroker.quorum=1 -Sbroker.quorum-timeout=none -Sbroker.exit-norestart=42 -Sbroker.sd-notify=1 -Scontent.dump=auto -Scontent.restore=auto
+               └─287739 broker --config-path=/etc/flux/system/conf.d -Scron.directory=/etc/flux/system/cron.d -Srundir=/run/flux -Sstatedir=/var/lib/flux -Slocal-uri=local:///run/flux/local -Slog-stderr-level=6 -Slog-stderr-mode=local -Sbroker.rc2_none -Sbroker.quorum=1 -Sbroker.quorum-warn=none -Sbroker.exit-norestart=42 -Sbroker.sd-notify=1 -Scontent.dump=auto -Scontent.restore=auto
 
   Apr 23 07:36:46 test0 flux[287739]: sched-fluxion-resource.info[0]: version 0.33.1-40-g24255b38
   Apr 23 07:36:46 test0 flux[287739]: sched-fluxion-qmanager.info[0]: version 0.33.1-40-g24255b38

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -115,6 +115,11 @@ broker.quorum-warn [Updates: C]
    rank 0 broker waits for the ``broker.quorum`` set to come online before
    warning of slow joiners.   Default: ``60s``.
 
+broker.shutdown-warn [Updates: C]
+   During shutdown, the amount of time (in RFC 23 Flux Standard Duration
+   format) that a broker waits for its TBON children to disconnect before
+   warning of slow peers.  Default: ``60s``.
+
 broker.cleanup-timeout [Updates: C]
    The amount of time (in RFC 23 Flux Standard Duration format) that the
    rank 0 broker waits for cleanup actions to complete when the broker has

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -110,10 +110,10 @@ broker.quorum [Updates: C]
    broker enters the RUN state and starts the initial program, if any.
    Default: instance size.
 
-broker.quorum-timeout [Updates: C]
+broker.quorum-warn [Updates: C]
    The amount of time (in RFC 23 Flux Standard Duration format) that the
    rank 0 broker waits for the ``broker.quorum`` set to come online before
-   aborting the Flux instance.   Default: ``60s``.
+   warning of slow joiners.   Default: ``60s``.
 
 broker.cleanup-timeout [Updates: C]
    The amount of time (in RFC 23 Flux Standard Duration format) that the

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -20,7 +20,7 @@ ExecStart=/bin/bash -c '\
   -Slog-stderr-mode=local \
   -Sbroker.rc2_none \
   -Sbroker.quorum=1 \
-  -Sbroker.quorum-timeout=none \
+  -Sbroker.quorum-warn=none \
   -Sbroker.cleanup-timeout=45 \
   -Sbroker.exit-norestart=42 \
   -Sbroker.sd-notify=1 \

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -1268,22 +1268,26 @@ static void disconnect_cb (flux_t *h,
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    {    FLUX_MSGTYPE_REQUEST,
+    {
+        FLUX_MSGTYPE_REQUEST,
         "state-machine.monitor",
         state_machine_monitor_cb,
-        0
+        0,
     },
-    {   FLUX_MSGTYPE_REQUEST,
+    {
+        FLUX_MSGTYPE_REQUEST,
         "state-machine.wait",
         state_machine_wait_cb,
-        FLUX_ROLE_USER
+        FLUX_ROLE_USER,
     },
-    {   FLUX_MSGTYPE_REQUEST,
+    {
+        FLUX_MSGTYPE_REQUEST,
         "state-machine.disconnect",
         disconnect_cb,
-        0
+        0,
     },
-    {    FLUX_MSGTYPE_REQUEST,
+    {
+        FLUX_MSGTYPE_REQUEST,
         "state-machine.get",
         state_machine_get_cb,
         FLUX_ROLE_USER,

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -257,15 +257,15 @@ test_expect_success 'instance rc1 failure exits with norestart code' '
 	    true
 '
 
-test_expect_success 'broker.quorum-timeout=none is accepted' '
-	flux start ${ARGS} -Sbroker.quorum-timeout=none true
+test_expect_success 'broker.quorum-warn=none is accepted' '
+	flux start ${ARGS} -Sbroker.quorum-warn=none true
 '
 
-test_expect_success 'broker.quorum-timeout=3h is accepted' '
-	flux start ${ARGS} -Sbroker.quorum-timeout=3h true
+test_expect_success 'broker.quorum-warn=3h is accepted' '
+	flux start ${ARGS} -Sbroker.quorum-warn=3h true
 '
-test_expect_success 'broker.quorum-timeout=x fails' '
-	test_must_fail flux start ${ARGS} -Sbroker.quorum-timeout=x true
+test_expect_success 'broker.quorum-warn=x fails' '
+	test_must_fail flux start ${ARGS} -Sbroker.quorum-warn=x true
 '
 test_expect_success 'create rc1 that sleeps for 2s on rank != 0' '
 	cat <<-EOT >rc1_sleep &&
@@ -275,11 +275,11 @@ test_expect_success 'create rc1 that sleeps for 2s on rank != 0' '
 	EOT
 	chmod +x rc1_sleep
 '
-test_expect_success 'broker.quorum-timeout works' '
+test_expect_success 'broker.quorum-warn works' '
 	flux start -s2 ${ARGS} \
 		-Slog-filename=timeout.log \
 		-Sbroker.rc1_path="$(pwd)/rc1_sleep" \
-		-Sbroker.quorum-timeout=1s true
+		-Sbroker.quorum-warn=1s true
 '
 test_expect_success 'logs contain quorum delayed/reached messages' '
 	grep "quorum delayed" timeout.log &&

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -344,12 +344,12 @@ test_expect_success 'create hanging rc3 for rank > 0' '
 	chmod +x rc3_hang
 '
 
-test_expect_success 'run instance with short shutdown timeout' '
+test_expect_success 'run instance with short shutdown warn period' '
 	flux start -s3 \
 		-Slog-filename=shutdown.log \
 		-Sbroker.rc1_path= \
 		-Sbroker.rc3_path="$(pwd)/rc3_hang" \
-		-Sbroker.shutdown-timeout=1s \
+		-Sbroker.shutdown-warn=1s \
 		true
 '
 test_expect_success 'appropriate message was logged' '


### PR DESCRIPTION
Problem: The `broker.quorum-timeout` and `broker.shutdown-timeout` just control the timing of warning messages, but their names imply otherwise.  Documentation is wrong for the former and missing for the latter.

Rename these to `broker.quorum-warn` and `broker.shutdown-warn`, respectively, and update documentation and tests.