### PR TITLE
libsubprocess: fix error path bug

### DIFF
--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -396,8 +396,10 @@ static void server_exec_cb (flux_t *h,
      * environment.
      */
     if (env[0] == NULL) {
-        if (cmd_set_env (cmd, environ) < 0)
+        if (cmd_set_env (cmd, environ) < 0) {
             errmsg = "error setting up command environment";
+            goto error;
+        }
     }
     /* Ensure FLUX_URI points to the local broker (overwrite).
      */


### PR DESCRIPTION
Problem: the subprocess server ignores failure of `cmd_set_env()`.

This was introduced by #6661 which was just merged.  Oops!

Fix error path.