### PR TITLE
sdexec: add stop timeout to handle unkillable processes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -433,7 +433,7 @@ AS_IF([test x$enable_code_coverage = xyes], [
 AC_ARG_WITH([flux-security], AS_HELP_STRING([--with-flux-security],
              [Build with flux-security]))
 AS_IF([test "x$with_flux_security" = "xyes"], [
-    PKG_CHECK_MODULES([FLUX_SECURITY], [flux-security >= 0.13.0],
+    PKG_CHECK_MODULES([FLUX_SECURITY], [flux-security >= 0.14.0],
       [flux_sec_incdir=`$PKG_CONFIG --variable=includedir flux-security`])
     AS_IF([test "x$flux_sec_incdir" = x],
           [AC_MSG_ERROR([couldn't find flux-security include directory])])

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Mark A. Grondona <mark.grondona@gmail.com>
 Standards-Version: 4.1.2
 Build-Depends:
   debhelper (>= 10),
-  flux-security (>= 0.13.0),
+  flux-security (>= 0.14.0),
   libsystemd-dev (>= 0.23),
   libarchive-dev,
   uuid-dev,

--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -38,6 +38,21 @@ sdexec-properties
    (optional) A table of systemd properties to set for all jobs.  All values
    must be strings. See :ref:`sdexec_properties` below.
 
+sdexec-stop-timer-sec
+   (optional) Configure the length of time in seconds after a unit enters
+   deactivating state when it will be sent the sdexec-stop-timer-signal.
+   Deactivating state is entered by ``imp-shell`` units when the
+   :man1:`flux-shell` terminates.  The unit may remain there as long as
+   user processes remain in the unit's cgroup.
+
+   After the same length of time, if the unit hasn't terminated, for example
+   due to unkillable processes, the unit is abandoned and the node is drained.
+   Default 30.
+
+sdexec-stop-timer-signal
+   (optional) Configure the signal used by the stop timer.  By default,
+   10 (SIGUSR1, the IMP proxy for SIGKILL) is used.
+
 kill-timeout
    (optional) The amount of time in FSD to wait after ``SIGTERM`` is
    sent to a job before sending ``SIGKILL``. The default is "5s". See

--- a/src/common/libsdexec/start.c
+++ b/src/common/libsdexec/start.c
@@ -285,6 +285,21 @@ static int prop_add (json_t *prop, const char *name, const char *val)
         if (prop_add_bool (prop, name, value) < 0)
             return -1;
     }
+    else if (streq (name, "TimeoutStopUSec")) {
+        if (streq (val, "infinity")) {
+            if (prop_add_u64 (prop, name, UINT64_MAX) < 0)
+                return -1;
+        }
+        else {
+            errno = 0;
+            char *endptr;
+            uint64_t u = strtoull (val, &endptr, 10);
+            if (errno != 0 || *endptr != '\0')
+                return -1;
+            if (prop_add_u64 (prop, name, u) < 0)
+                return -1;
+        }
+    }
     else {
         if (prop_add_string (prop, name, val) < 0)
             return -1;

--- a/src/common/libsdexec/start.h
+++ b/src/common/libsdexec/start.h
@@ -21,8 +21,6 @@
  * and systemd.service(5) for more info on mode and type parameters.
  * mode may be one of:
      replace, fail, isolate, ignore-dependencies, ignore-requirements
- * type may be one of:
- *   simple, exec, forking, oneshot, dbus, notify, notify-reload, idle
  *
  * stdin_fd, stdout_fd, and stderr_fd are file descriptors to be duped and
  * passed to the new unit.  The dup should be complete on first fulfillment
@@ -50,7 +48,6 @@
 flux_future_t *sdexec_start_transient_unit (flux_t *h,
                                             uint32_t rank,
                                             const char *mode,
-                                            const char *type,
                                             json_t *cmd,
                                             int stdin_fd,
                                             int stdout_fd,

--- a/src/common/libsdexec/test/start.c
+++ b/src/common/libsdexec/test/start.c
@@ -57,7 +57,6 @@ void test_inval (void)
     ok (sdexec_start_transient_unit (NULL,      // h
                                      0,         // rank
                                      "fail",    // mode
-                                     "simple",  // type
                                      cmd_o,     // cmd
                                      -1, -1, -1, // *_fd
                                      &error) == NULL
@@ -70,7 +69,6 @@ void test_inval (void)
     ok (sdexec_start_transient_unit (h,         // h
                                      0,         // rank
                                      NULL,      // mode
-                                     "simple",  // type
                                      cmd_o,     // cmd
                                      -1, -1, -1, // *_fd
                                      &error) == NULL
@@ -83,20 +81,6 @@ void test_inval (void)
     ok (sdexec_start_transient_unit (h,         // h
                                      0,         // rank
                                      "fail",    // mode
-                                     NULL,      // type
-                                     cmd_o,     // cmd
-                                     -1, -1, -1, // *_fd
-                                     &error) == NULL
-        && errno == EINVAL,
-        "sdexec_start_transient_unit type=NULL fails with EINVAL");
-    diag ("%s", error.text);
-
-    errno = 0;
-    error.text[0] = '\0';
-    ok (sdexec_start_transient_unit (h,         // h
-                                     0,         // rank
-                                     "fail",    // mode
-                                     "simple",  // type
                                      NULL,      // cmd
                                      -1, -1, -1, // *_fd
                                      &error) == NULL
@@ -109,7 +93,6 @@ void test_inval (void)
     ok (sdexec_start_transient_unit (h,         // h
                                      0,         // rank
                                      "fail",    // mode
-                                     "simple",  // type
                                      cmd_o_noname, // cmd
                                      -1, -1, -1, // *_fd
                                      &error) == NULL
@@ -122,7 +105,6 @@ void test_inval (void)
     ok (sdexec_start_transient_unit (h,         // h
                                      0,         // rank
                                      "fail",    // mode
-                                     "simple",  // type
                                      cmd_o_badprop, // cmd
                                      -1, -1, -1, // *_fd
                                      &error) == NULL

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -519,6 +519,7 @@ static int parse_service_option (json_t *jobspec,
     return 0;
 }
 
+
 static struct bulk_exec_ops exec_ops = {
     .on_start =     start_cb,
     .on_exit =      exit_cb,
@@ -604,14 +605,27 @@ static int exec_init (struct jobinfo *job)
             goto err;
         }
         /* The systemd user instance running as user flux is not privileged
-         * to signal guest processes, therefore only signal the IMP and
-         * never use SIGKILL.  See flux-framework/flux-core#6399
+         * to signal guest processes, therefore:
+         * - Set the KillMode=process so only the IMP is signaled
+         * - Use Type=notify in conjunction with IMP calling sd_notify(3) so
+         *   the unit transitions to deactivating when the shell exits.
+         * - Set TimeoutStopUsec=infinity to disable systemd's stop timeout.
+         * - Enable sdexec's stop timeout which is armed at deactivating,
+         *   delivers SIGUSR1 (proxy for SIGKILL) after 30s, then abandons
+         *   the unit and terminates the exec RPC after another 30s.
          */
         if (streq (service, "sdexec")) {
             if (flux_cmd_setopt (cmd, "SDEXEC_PROP_KillMode", "process") < 0
+                || flux_cmd_setopt (cmd, "SDEXEC_PROP_Type", "notify") < 0
                 || flux_cmd_setopt (cmd,
-                                    "SDEXEC_PROP_SendSIGKILL",
-                                    "off") < 0) {
+                                    "SDEXEC_PROP_TimeoutStopUSec",
+                                    "infinity") < 0
+                || flux_cmd_setopt (cmd,
+                                    "SDEXEC_STOP_TIMER_SIGNAL",
+                                    config_get_sdexec_stop_timer_signal ()) < 0
+                || flux_cmd_setopt (cmd,
+                                    "SDEXEC_STOP_TIMER_SEC",
+                                    config_get_sdexec_stop_timer_sec ()) < 0) {
                 flux_log_error (job->h,
                                 "Unable to set multiuser sdexec options");
                 return -1;

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -38,6 +38,10 @@ double config_get_default_barrier_timeout (void);
 
 int config_get_stats (json_t **config_stats);
 
+const char *config_get_sdexec_stop_timer_sec (void);
+
+const char *config_get_sdexec_stop_timer_signal (void);
+
 int config_setup (flux_t *h,
                   const flux_conf_t *conf,
                   int argc,

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -57,6 +57,20 @@ struct sdexec_ctx {
     struct flux_msglist *kills;
 };
 
+enum stop_timer_state {
+    STOP_TIMER_OFF,
+    STOP_TIMER_SIGKILL,
+    STOP_TIMER_ABANDON,
+};
+
+struct stop_timer {
+    flux_watcher_t *timer;
+    enum stop_timer_state state;
+    int kill_signal;
+    int timeout_sec;
+    bool timed_out;
+};
+
 struct sdproc {
     const flux_msg_t *msg;
     json_t *cmd;
@@ -74,12 +88,16 @@ struct sdproc {
     uint8_t out_eof_sent:1;
     uint8_t err_eof_sent:1;
 
+    struct stop_timer stop;
+
     int errnum;
     const char *errstr;
     flux_error_t error;
 
     struct sdexec_ctx *ctx;
 };
+
+static const int default_stop_timeout_sec = -1; // disabled by default
 
 static bool sdexec_debug;
 
@@ -174,7 +192,13 @@ static void exec_respond_error (struct sdproc *proc,
  */
 static void finalize_exec_request_if_done (struct sdproc *proc)
 {
-    if (sdexec_unit_state (proc->unit) == STATE_INACTIVE
+    if (proc->stop.timed_out) {
+        exec_respond_error (proc,
+                            EDEADLK,
+                            "Processes did not respond to SIGKILL."
+                            " Abandoning unit as is.");
+    }
+    else if (sdexec_unit_state (proc->unit) == STATE_INACTIVE
         && sdexec_unit_substate (proc->unit) == SUBSTATE_DEAD
         && (!proc->out || proc->out_eof_sent)
         && (!proc->err || proc->err_eof_sent)) {
@@ -205,6 +229,51 @@ static void finalize_exec_request_if_done (struct sdproc *proc)
         }
         else
             exec_respond_error (proc, ENODATA, NULL);
+    }
+}
+
+static void stop_timer_start (struct stop_timer *stop,
+                              enum stop_timer_state state)
+{
+    if (stop->timeout_sec < 0)
+        return; // stop timer is disabled
+    stop->state = state;
+    flux_timer_watcher_reset (stop->timer, (double)stop->timeout_sec, 0.);
+    flux_watcher_start (stop->timer);
+}
+
+static void stop_timer_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
+{
+    struct sdproc *proc = arg;
+
+    switch (proc->stop.state) {
+        case STOP_TIMER_SIGKILL:
+            sdexec_log_debug (proc->ctx->h,
+                              "%s: killing after %ds stop timeout",
+                              sdexec_unit_name (proc->unit),
+                              proc->stop.timeout_sec);
+            flux_future_t *f = NULL;
+            f = sdexec_kill_unit (proc->ctx->h,
+                                  proc->ctx->rank,
+                                  sdexec_unit_name (proc->unit),
+                                  "main",
+                                  proc->stop.kill_signal);
+            flux_future_destroy (f);
+            stop_timer_start (&proc->stop, STOP_TIMER_ABANDON);
+            break;
+        case STOP_TIMER_ABANDON:
+            sdexec_log_debug (proc->ctx->h,
+                              "%s: abandoning after %ds stop timeout",
+                              sdexec_unit_name (proc->unit),
+                              proc->stop.timeout_sec * 2);
+            proc->stop.timed_out = true;
+            finalize_exec_request_if_done (proc); // destroys proc
+            break;
+        case STOP_TIMER_OFF:
+            break;
     }
 }
 
@@ -313,6 +382,13 @@ static void property_changed_continuation (flux_future_t *f, void *arg)
             }
             proc->f_stop = f2;
         }
+    }
+    /* If the unit reaches deactivating state, start the stop timer.
+     * The stop timer is necessary to help imp-shell make progress if the
+     * shell has exited but processes remain in the cgroup.
+     */
+    if (sdexec_unit_state (proc->unit) == STATE_DEACTIVATING) {
+        stop_timer_start (&proc->stop, STOP_TIMER_SIGKILL);
     }
     /* If the unit reaches failed.failed call ResetFailedUnit to cause stdout
      * and stderr to reach eof, and the unit to transition to inactive.dead.
@@ -460,6 +536,7 @@ static void sdproc_destroy (struct sdproc *proc)
         flux_future_destroy (proc->f_start);
         flux_future_destroy (proc->f_stop);
         sdexec_unit_destroy (proc->unit);
+        flux_watcher_destroy (proc->stop.timer);
         json_decref (proc->cmd);
         flux_msglist_destroy (proc->write_requests);
         free (proc);
@@ -519,6 +596,26 @@ static int get_dict (json_t *o,
         return -1;
     }
     *vp = v;
+    return 0;
+}
+
+static int get_dict_int (json_t *o,
+                         const char *name,
+                         const char *k,
+                         int *vp)
+{
+    const char *v;
+    if (get_dict (o, name, k, &v) < 0)
+        return -1;
+
+    char *endptr;
+    errno = 0;
+    int i = strtol (v, &endptr, 10);
+    if (errno != 0 || *endptr != '\0') {
+        errno = EINVAL;
+        return -1;
+    }
+    *vp = i;
     return 0;
 }
 
@@ -593,6 +690,7 @@ static struct sdproc *sdproc_create (struct sdexec_ctx *ctx,
         | SUBPROCESS_REXEC_CHANNEL;
     const char *name;
     char *tmp = NULL;
+    flux_reactor_t *reactor = flux_get_reactor (ctx->h);
 
     if ((flags & ~valid_flags) != 0) {
         errno = EINVAL;
@@ -602,10 +700,31 @@ static struct sdproc *sdproc_create (struct sdexec_ctx *ctx,
         return NULL;
     proc->ctx = ctx;
     proc->flags = flags;
+    if (!(proc->stop.timer = flux_timer_watcher_create (reactor,
+                                                        0,
+                                                        0,
+                                                        stop_timer_cb,
+                                                        proc)))
+        goto error;
     if (!(proc->cmd = json_deep_copy (cmd))) {
         errno = ENOMEM;
         goto error;
     }
+    /* Enable the stop timer by setting the SDEXEC_STOP_TIMER_SEC option to
+     * a value in seconds.  The stop timer is disabled by default.
+     * sOptionally set SDEXEC_STOP_TIMER_SIGNAL to a numerical signal
+     * value to use instead of SIGKILL.
+     */
+    if (get_dict_int (proc->cmd,
+                      "opts",
+                      "SDEXEC_STOP_TIMER_SEC",
+                      &proc->stop.timeout_sec) < 0)
+        proc->stop.timeout_sec = default_stop_timeout_sec;
+    if (get_dict_int (proc->cmd,
+                      "opts",
+                      "SDEXEC_STOP_TIMER_SIGNAL",
+                      &proc->stop.kill_signal) < 0)
+        proc->stop.kill_signal = SIGKILL;
     /* Set SDEXEC_NAME for sdexec_start_transient_unit().
      * If unset, use a truncated uuid as the name.
      */

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -726,7 +726,6 @@ static void exec_cb (flux_t *h,
     if (!(proc->f_start = sdexec_start_transient_unit (h,
                                              ctx->rank,
                                              "fail", // mode
-                                             "exec", // type
                                              proc->cmd,
                                              sdexec_channel_get_fd (proc->in),
                                              sdexec_channel_get_fd (proc->out),

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -16,7 +16,7 @@ JOBS=2
 MOUNT_HOME_ARGS="--volume=$HOME:$HOME -e HOME"
 
 if test "$PROJECT" = "flux-core"; then
-  FLUX_SECURITY_VERSION=0.13.0
+  FLUX_SECURITY_VERSION=0.14.0
   POISON=t
 fi
 

--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -218,6 +218,32 @@ test_expect_success 'setting TimeoutStopUSec to an invalid value fails' '
 	    $true 2>timeoutstop_badval.err &&
 	grep "error setting property" timeoutstop_badval.err
 '
+test_expect_success 'sdexec Type defaults exec' '
+	cat >typedefault.exp <<-EOT &&
+	Type=exec
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-typedefault.service" \
+	    $systemctl --user show --property Type \
+	        t2409-typedefault.service >typedefault.out &&
+	test_cmp typedefault.exp typedefault.out
+'
+test_expect_success 'sdexec can set unit Type to simple' '
+	cat >typesimple.exp <<-EOT &&
+	Type=simple
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-typesimple.service" \
+	    --setopt=SDEXEC_PROP_Type=simple \
+	    $systemctl --user show --property Type \
+	        t2409-typesimple.service >typesimple.out &&
+	test_cmp typesimple.exp typesimple.out
+'
+test_expect_success 'setting Type to an invalid value fails' '
+	test_must_fail $sdexec -r 0 --setopt=SDEXEC_PROP_Type=zzz \
+	    $true 2>type_badval.err &&
+	grep "Invalid Type" type_badval.err
+'
 # Check that we can set resource control attributes on our transient units,
 # Check that we can set resource control attributes on our transient units,
 # but expect resource control testing to occur elsewhere.

--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -191,6 +191,34 @@ test_expect_success 'sdexec can set unit KillMode property to process' '
 	        t2409-killmode.service >killmode.out &&
 	test_cmp killmode.exp killmode.out
 '
+test_expect_success 'sdexec can set unit TimeoutStopUSec property to infinity' '
+	cat >timeoutstop.exp <<-EOT &&
+	TimeoutStopUSec=infinity
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-timeoutstop.service" \
+	    --setopt=SDEXEC_PROP_TimeoutStopUSec=infinity \
+	    $systemctl --user show --property TimeoutStopUSec \
+	        t2409-timeoutstop.service >timeoutstop.out &&
+	test_cmp timeoutstop.exp timeoutstop.out
+'
+test_expect_success 'sdexec can set unit TimeoutStopUSec to a numerical value' '
+	cat >timeoutstop2.exp <<-EOT &&
+	TimeoutStopUSec=42us
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-timeoutstop2.service" \
+	    --setopt=SDEXEC_PROP_TimeoutStopUSec=42 \
+	    $systemctl --user show --property TimeoutStopUSec \
+	        t2409-timeoutstop2.service >timeoutstop2.out &&
+	test_cmp timeoutstop2.exp timeoutstop2.out
+'
+test_expect_success 'setting TimeoutStopUSec to an invalid value fails' '
+	test_must_fail $sdexec -r 0 --setopt=SDEXEC_PROP_TimeoutStopUSec=zzz \
+	    $true 2>timeoutstop_badval.err &&
+	grep "error setting property" timeoutstop_badval.err
+'
+# Check that we can set resource control attributes on our transient units,
 # Check that we can set resource control attributes on our transient units,
 # but expect resource control testing to occur elsewhere.
 # See also:


### PR DESCRIPTION
Problem: in a system instance using sdexec, jobs may remain in R state when the shell exits with unkillable processes.

This is because the IMP doesn't exit until the unit cgroup is empty, and the IMP must exit for sdexec to collect the shell's exit status.

This PR, in conjunction with flux-framework/flux-security#201, arranges for the unit to enter deactivating state once the shell exits.  An sdexec timeout begins at that point.  If after a configurable period, the unit has not stopped, SIGUSR1 (IMP proxy for SIGKILL) is sent to the unit.  If after another period the unit still has not stopped, it is abandoned and the subprocess protocol is terminated so  the job can advance and release resources.

The abandoned unit remains in deactivating state indefinitely, and can be picked up by the `sdmon` montoring service proposed in #6616