### PR TITLE
add `FLUX_JOB_RANKS` environment variable to prolog and epilog

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -333,6 +333,17 @@ then the following are set to allow Flux commands to work from the script:
 - :envvar:`FLUX_EXEC_PATH`
 - :envvar:`FLUX_CONNECTOR_PATH`
 
+In addition, the following extra environment variables are set in the
+prolog and epilog for convenience:
+
+- :envvar:`FLUX_JOB_RANKS` - the broker ranks which were assigned to the
+  job for which the current prolog or epilog is running. This can be
+  used in conjunction with the ``hostlist`` attribute to construct the
+  job hostlist. For example:
+
+  .. code-block:: shell
+
+   FLUX_JOB_HOSTLIST=$(flux hostlist --nth=${FLUX_JOB_RANKS} instance)
 
 TESTING
 =======

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -933,7 +933,7 @@ static int run_command (flux_plugin_t *p,
     return 0;
 error:
     perilog_proc_destroy (proc);
-    return 01;
+    return -1;
 }
 
 static int run_cb (flux_plugin_t *p,

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -63,6 +63,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/fsd.h"
+#include "src/common/libutil/errno_safe.h"
 #include "ccan/str/str.h"
 #include "src/broker/state_machine.h" // for STATE_CLEANUP
 #include "src/common/libsubprocess/bulk-exec.h"
@@ -809,7 +810,9 @@ static struct perilog_proc *procdesc_run (flux_t *h,
                                           json_t *R)
 {
     struct perilog_proc *proc = NULL;
+    struct idset *job_ranks = NULL;
     struct idset *ranks = NULL;
+    char *rank_str = NULL;
     struct bulk_exec *bulk_exec = NULL;
     double timeout;
 
@@ -819,7 +822,16 @@ static struct perilog_proc *procdesc_run (flux_t *h,
                         pd->prolog ? "prolog" : "epilog");
         goto error;
     }
+    if (!(job_ranks = ranks_from_R (R))
+        || !(rank_str = idset_encode (job_ranks, IDSET_FLAG_RANGE))) {
+            flux_log (h,
+                      LOG_ERR,
+                      "%s: %s: failed to decode ranks from R",
+                      idf58 (id),
+                      perilog_proc_name (proc));
+    }
     if (flux_cmd_setenvf (pd->cmd, 1, "FLUX_JOB_ID", "%s", idf58 (id)) < 0
+        || flux_cmd_setenvf (pd->cmd, 1, "FLUX_JOB_RANKS", "%s", rank_str) < 0
         || flux_cmd_setenvf (pd->cmd, 1, "FLUX_JOB_USERID", "%u", userid) < 0) {
         flux_log_error (h,
                         "%s: flux_cmd_create",
@@ -827,10 +839,10 @@ static struct perilog_proc *procdesc_run (flux_t *h,
         goto error;
     }
     if (pd->per_rank) {
-        if (!(ranks = ranks_from_R (R))) {
+        if (!(ranks = idset_copy (job_ranks))) {
             flux_log (h,
                       LOG_ERR,
-                      "%s: %s: failed to decode ranks from R",
+                      "%s: %s: failed to copy job ranks",
                       idf58 (id),
                       perilog_proc_name (proc));
             goto error;
@@ -889,9 +901,13 @@ static struct perilog_proc *procdesc_run (flux_t *h,
 
     /* proc now has ownership of bulk_exec, ranks
      */
+    free (rank_str);
+    idset_destroy (job_ranks);
     return proc;
 error:
     idset_destroy (ranks);
+    idset_destroy (job_ranks);
+    ERRNO_SAFE_WRAP (free, rank_str);
     bulk_exec_destroy (bulk_exec);
     perilog_proc_destroy (proc);
     return NULL;

--- a/t/t2274-manager-perilog-per-rank.t
+++ b/t/t2274-manager-perilog-per-rank.t
@@ -426,6 +426,18 @@ test_expect_success 'perilog: job does not start when prolog cancel times out' '
 	test_must_fail grep "start$" prolog-cancel-eventlog.out &&
 	grep epilog-start prolog-cancel-eventlog.out
 '
+test_expect_success 'perilog: prolog has FLUX_JOB_RANKS environment variable' '
+	undrain_all &&
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	per-rank = true
+	command = [ "sh", "-c", "test \$FLUX_JOB_RANKS\" = \"0-3\"" ]
+	EOF
+	jobid=$(flux submit -N4 hostname) &&
+	flux job wait-event -vHt 30 $jobid prolog-start &&
+	flux job wait-event -vHt 30 $jobid clean
+'
+
 test_expect_success 'perilog: log-ignore works' '
 	undrain_all &&
 	flux config load <<-EOF &&


### PR DESCRIPTION
As noted in #6668 it would be useful to supply the job prolog and epilog with enough information for these scripts to determine on what node of the job they're running. 

This PR adds a `FLUX_JOB_RANKS` environment variable for this purpose. While there's no flux utility for manipulating idsets, `FLUX_JOB_RANKS` can be used along with the `hostlist` attribute to get the job hostlist, from which the script can test if it is running on a specific rank. (I plan to add a `-F, --find=HOST` option to `flux hostlist` soon to make this a bit more useful.