### PR TITLE
flux-hostlist: add `-F, --find=HOSTS` option

### DIFF
--- a/doc/man1/flux-hostlist.rst
+++ b/doc/man1/flux-hostlist.rst
@@ -70,6 +70,12 @@ OPTIONS
   '0-1' will return the first and second, '-1' returns the last host).  The
   command will fail if any id in *IDS* is not a valid index.
 
+.. option:: -F, --find=HOSTS
+
+  Output a list of space-separated indices of *HOSTS* in the result hostlist,
+  where *HOSTS* should be one or more hosts in hostlist form. The command
+  will fail if any host in *HOSTS* is not found.
+
 .. option:: -L, --limit=N
 
   Output at most *N* hosts (*-N* to output the last *N* hosts).

--- a/src/cmd/flux-hostlist.py
+++ b/src/cmd/flux-hostlist.py
@@ -73,6 +73,14 @@ def parse_args():
         help="Output hosts at indices in idset IDS (-IDS to index from end)",
     )
     parser.add_argument(
+        "-F",
+        "--find",
+        type=str,
+        metavar="HOSTS",
+        help="Output indices of HOSTS in target in hostlist."
+        + " Fails if any host is not found.",
+    )
+    parser.add_argument(
         "-L",
         "--limit",
         metavar="N",
@@ -394,7 +402,9 @@ def main():
         else:
             hl = hl[IDset(args.nth)]
 
-    if args.count:
+    if args.find:
+        print(" ".join(map(str, hl.index(args.find))))
+    elif args.count:
         print(f"{hl.count()}")
     elif args.expand:
         # Convert '\n' specified on command line to actual newline char

--- a/t/t2814-hostlist-cmd.t
+++ b/t/t2814-hostlist-cmd.t
@@ -115,6 +115,15 @@ test_expect_success 'flux-hostlist -n errors with invalid index' '
 	test_must_fail flux hostlist -n 10 foo[1-10] &&
 	test_must_fail flux hostlist -n 1,10 foo[1-10]
 '
+test_expect_success 'flux-hostlist -F, --find=HOSTS works' '
+	test "$(flux hostlist -F foo1 foo[1-10])" = "0" &&
+	test "$(flux hostlist -F foo10 foo[1-10])" = "9" &&
+	test "$(flux hostlist -F foo[1-2] foo[1-10])" = "0 1"
+'
+test_expect_success 'flux-hostlist -F, --find=HOSTS fails if host not found' '
+	test_must_fail flux hostlist -F foo1 foo[2-10] &&
+	test_must_fail flux hostlist -F foo[1-10] foo[2-10]
+'
 test_expect_success 'flux-hostlist -x, --exclude works' '
 	test "$(flux hostlist -x foo1 foo[0-10])" = "foo[0,2-10]" &&
 	test "$(flux hostlist -x foo[0-9] foo[0-10])" = "foo10"


### PR DESCRIPTION
This simply adds a `-F, --find=HOSTS` option to `flux hostlist`, which allows getting the index of one or more hosts in the target hostlist.
