### PR TITLE
configure: relax flux-security version check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -433,7 +433,7 @@ AS_IF([test x$enable_code_coverage = xyes], [
 AC_ARG_WITH([flux-security], AS_HELP_STRING([--with-flux-security],
              [Build with flux-security]))
 AS_IF([test "x$with_flux_security" = "xyes"], [
-    PKG_CHECK_MODULES([FLUX_SECURITY], [flux-security >= 0.14.0],
+    PKG_CHECK_MODULES([FLUX_SECURITY], [flux-security >= 0.13.0],
       [flux_sec_incdir=`$PKG_CONFIG --variable=includedir flux-security`])
     AS_IF([test "x$flux_sec_incdir" = x],
           [AC_MSG_ERROR([couldn't find flux-security include directory])])

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -316,6 +316,29 @@ test_columns_variable_preserved() {
 	test "$cols" = "12"
 }
 
+#  flux-security version check. If flux is built with flux-security,
+#  check that version >= x.y.z:
+#
+#  Usage: test_flux_security_version x.y.z
+#
+#  Sets FLUX_SECURITY_VERSION environment variable for use after return
+#  Note this function always succeeds if flux is not built with flux-security.
+#  If a test requires flux-security, that should be separately tested.
+#
+test_flux_security_version() {
+    req_major=$(echo $1 | cut -d. -f1)
+    req_minor=$(echo $1 | cut -d. -f2)
+    req_patch=$(echo $1 | cut -d. -f3)
+    FLUX_SECURITY_VERSION=$(flux version | awk '/security:/ {print $2}')
+    if test -z "$FLUX_SECURITY_VERSION"; then
+        return 0
+    fi
+    major=$(echo $FLUX_SECURITY_VERSION | cut -d. -f1)
+    minor=$(echo $FLUX_SECURITY_VERSION | cut -d. -f2)
+    patch=$(echo $FLUX_SECURITY_VERSION | cut -d. -f3)
+    test $major -ge $req_major -a $minor -ge $req_minor -a $patch -ge $req_patch
+}
+
 #  Export a shorter name for this test
 TEST_NAME=$SHARNESS_TEST_NAME
 export TEST_NAME

--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -17,6 +17,10 @@ if ! busctl --user status >/dev/null; then
 	skip_all="user dbus is not running"
 	test_done
 fi
+if ! test_flux_security_version 0.14.0; then
+	skip_all="requires flux-security >= v0.14, got ${FLUX_SECURITY_VERSION}"
+	test_done
+fi
 
 test_under_flux 2 minimal
 

--- a/t/t2410-sdexec-memlimit.t
+++ b/t/t2410-sdexec-memlimit.t
@@ -29,6 +29,10 @@ if ! systemctl show user@$(id -u) -p DelegateControllers | grep memory; then
 	skip_all="cgroups memory controller is not delegated"
 	test_done
 fi
+if ! test_flux_security_version 0.14.0; then
+	skip_all="requires flux-security >= v0.14, got ${FLUX_SECURITY_VERSION}"
+	test_done
+fi
 if stress=$(which stress); then
 	test_set_prereq STRESS
 fi

--- a/t/t2411-sdexec-job.t
+++ b/t/t2411-sdexec-job.t
@@ -17,6 +17,10 @@ if ! busctl --user status >/dev/null; then
 	skip_all="user dbus is not running"
 	test_done
 fi
+if ! test_flux_security_version 0.14.0; then
+	skip_all="requires flux-security >= v0.14, got ${FLUX_SECURITY_VERSION}"
+	test_done
+fi
 
 mkdir -p config
 cat >config/config.toml <<EOT


### PR DESCRIPTION
This PR relaxes the flux-security version check from v0.14.0 back to v0.13.0 since v0.14.0 is only required for the sdexec module when used to launch jobs in a system instance.

A test is added to the sdexec module to abort if a sufficient flux-security version isn't found at runtime, and a version check added to affected tests.

This allows flux-core to continue to be built on TOSS systems with flux-security v0.13.0 installed. We'll probably have to run with this version for a month at least, and it is nice to be able to build test versions of flux `--with-flux-security`.

Fixes #6672