### PR TITLE
resource: only mark nodes lost that transition from `online` to `offline` 

### DIFF
--- a/src/modules/resource/monitor.c
+++ b/src/modules/resource/monitor.c
@@ -202,11 +202,12 @@ static int post_join_leave (struct monitor *monitor,
         goto error;
 
     /* Update the set of lost ranks. These are only the ranks that have
-     * left the online group (not ranks that never joined).
+     * left the online group monitor->up (not ranks that never joined).
      */
-    if (idset_add (monitor->lost, leave) < 0
-        || idset_subtract (monitor->lost, join) < 0) {
-        goto error;
+    if (oldset == monitor->up) {
+        if (idset_add (monitor->lost, leave) < 0
+            || idset_subtract (monitor->lost, join) < 0)
+            goto error;
     }
 
     rc = 0;

--- a/t/t2317-resource-shrink.t
+++ b/t/t2317-resource-shrink.t
@@ -8,7 +8,6 @@ SIZE=4
 test_under_flux $SIZE full --test-exit-mode=leader
 export FLUX_URI_RESOLVE_LOCAL=t
 
-
 # Usage: waitup N
 #   where N is a count of online ranks
 waitup () {
@@ -17,10 +16,40 @@ waitup () {
 force_down () {
 	flux python -c "import flux; flux.Flux().rpc(\"resource.monitor-force-down\", {\"ranks\":\"$1\"}).get()"
 }
+groups="flux python ${SHARNESS_TEST_SRCDIR}/scripts/groups.py"
 
 test_expect_success 'submit a resilient job using all ranks' '
 	jobid=$(flux alloc --bg -xN4 -o exit-timeout=none --conf=tbon.topo=kary:0) &&
 	flux proxy $jobid flux overlay status
+'
+# tbon.torpid_min should be >= sync_min (1s hardwired)
+test_expect_success 'reduce tbon.torpid max/min values in subinstance for testing' '
+        flux proxy $jobid flux exec flux setattr tbon.torpid_min 1s &&
+        flux proxy $jobid flux exec flux setattr tbon.torpid_max 2s
+'
+test_expect_success 'kill -STOP broker 3' '
+	pid=$(flux proxy $jobid flux exec -r 3 flux getattr broker.pid) &&
+	test_debug "echo Sending SIGSTOP to $pid" &&
+	kill -STOP $pid
+'
+test_expect_success  'wait for rank 3 to become torpid' '
+	flux proxy $jobid $groups waitfor --count=1 broker.torpid &&
+	test_debug "flux proxy $jobid flux dmesg -H" &&
+	test_debug "flux proxy $jobid flux overlay errors"
+'
+test_expect_success 'kill -CONT broker 3' '
+	kill -CONT $pid
+'
+test_expect_success  'rank 3 is no longer torpid' '
+	flux proxy $jobid $groups waitfor --count=0 broker.torpid
+'
+test_expect_success 'subinstance did not shrink due to lively->torpid->lively' '
+	flux proxy $jobid flux resource list &&
+	test $(flux proxy $jobid flux resource list -s all -no {nnodes}) -eq 4
+'
+test_expect_success 'restore tbon.torpid max/min values in subinstance' '
+        flux proxy $jobid flux exec flux setattr tbon.torpid_min 5s &&
+        flux proxy $jobid flux exec flux setattr tbon.torpid_max 30s
 '
 test_expect_success 'disconnect rank 3' '
 	flux overlay disconnect 3


### PR DESCRIPTION
This PR fixes #6675 and adds a set of tests to ensure torpid/lively events don't cause resource removal (shrink).

Thanks for finding this one @garlick!