### PR TITLE
heartbeat: add optional timeout

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -363,7 +363,8 @@ MAN5_FILES_PRIMARY = \
 	man5/flux-config-ingest.5 \
 	man5/flux-config-kvs.5 \
 	man5/flux-config-policy.5 \
-	man5/flux-config-queues.5
+	man5/flux-config-queues.5 \
+	man5/flux-config-heartbeat.5
 
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)

--- a/doc/man5/flux-config-heartbeat.rst
+++ b/doc/man5/flux-config-heartbeat.rst
@@ -1,0 +1,48 @@
+========================
+flux-config-heartbeat(5)
+========================
+
+
+DESCRIPTION
+===========
+
+The ``heartbeat`` table may be used to tune the configuration of the
+Flux heartbeat module, which publishes periodic ``heartbeat.pulse`` messages
+for synchronization.
+
+It may contain the following keys:
+
+
+KEYS
+====
+
+period
+   (optional) The interval (in RFC 23 Flux Standard Duration format) between
+   the publication of heartbeat messages.  Default: ``"2s"``.
+
+
+EXAMPLE
+=======
+
+::
+
+   [heartbeat]
+   period = "5s"
+
+
+RESOURCES
+=========
+
+.. include:: common/resources.rst
+
+
+FLUX RFC
+========
+
+:doc:`rfc:spec_23`
+
+
+SEE ALSO
+========
+
+:man5:`flux-config`

--- a/doc/man5/flux-config-heartbeat.rst
+++ b/doc/man5/flux-config-heartbeat.rst
@@ -6,20 +6,30 @@ flux-config-heartbeat(5)
 DESCRIPTION
 ===========
 
-The ``heartbeat`` table may be used to tune the configuration of the
-Flux heartbeat module, which publishes periodic ``heartbeat.pulse`` messages
-for synchronization.
+The Flux heartbeat service publishes periodic ``heartbeat.pulse`` messages
+from the leader broker for synchronization.  Follower brokers subscribe
+to these messages and may optionally force a disconnect from their overlay
+network parent when they are are missed for a configurable period.
 
-It may contain the following keys:
-
+The ``heartbeat`` table may be used to tune the heartbeat service.  It may
+contain the following keys:
 
 KEYS
 ====
 
 period
    (optional) The interval (in RFC 23 Flux Standard Duration format) between
-   the publication of heartbeat messages.  Default: ``"2s"``.
+   the publication of heartbeat messages.  Default: *2s*.
 
+timeout
+   (optional) The period (in RFC 23 Flux Standard Duration format) after
+   which a follower broker will forcibly disconnect from its overlay network
+   parent if it hasn't received a heartbeat message.  Set to *0* or *infinity*
+   to disable.  Default: *5m*.
+
+warn_thresh
+  (optional) The number of missed heartbeat periods after which a warning
+  message will be logged.  Default: 3.
 
 EXAMPLE
 =======
@@ -28,7 +38,43 @@ EXAMPLE
 
    [heartbeat]
    period = "5s"
+   timeout = "1m"
+   warn_thresh = 3
 
+USE CASES
+=========
+
+Heartbeats may be used to synchronize Flux activities across brokers to
+reduce the operating system jitter that affects some sensitive bulk-synchronous
+applications.  :man3:`flux_sync_create` provides a way to invoke work that
+is synchronized with the heartbeat.
+
+.. note::
+  The efficacy of heartbeats to mitigate noise is limited by the propagation
+  delay of published messages through the tree based overlay network;  however,
+  this may be reduced in the future with a side channel transport such as
+  TCP multicast, hardware collectives, or quantum entanglement.
+
+The heartbeat timeout may be used to work around a peculiarity of ZeroMQ,
+the software layer underpinning the overlay network.  When a Flux broker
+loses the TCP connection to its overlay parent without a shutdown (for example,
+if the parent crashes or there is a network partition and TCP times out),
+ZeroMQ tries indefinitely to re-establish the connection without informing
+the broker.  The child broker remains in RUN state with any upstream RPCs
+blocked until the parent returns to service, after which it is forced to
+disconnect and shut down, which causes the RPCs to fail.  A heartbeat timeout
+forces the broker to "fail fast", with the same net effect, but arriving
+at a steady state sooner.
+
+The effect of a follower broker shutdown depends on its role.  If it is
+not a leaf node, the effect applies to its entire subtree.  In a system
+instance, systemd restarts brokers that shut down this way.  Upon restart,
+the brokers remain in JOIN state until the parent returns to service.
+The heartbeat service is not loaded until after the parent connection is
+established, so heartbeat timeouts do not apply in this phase.  In a user
+allocation where brokers are not restarted, the outcome depends on whether
+or not the broker is one of the *critical ranks* described in
+:man7:`flux-broker-attributes`.
 
 RESOURCES
 =========

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -358,6 +358,7 @@ man_pages = [
     ('man5/flux-config-queues', 'flux-config-queues', 'configure Flux job queues', [author], 5),
     ('man5/flux-config-job-manager', 'flux-config-job-manager', 'configure Flux job manager service', [author], 5),
     ('man5/flux-config-kvs', 'flux-config-kvs', 'configure Flux kvs service', [author], 5),
+    ('man5/flux-config-heartbeat', 'flux-config-heartbeat', 'configure Flux heartbeat service', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),
     ('man7/flux-environment', 'flux-environment', 'Flux environment overview', [author], 7),

--- a/etc/rc1
+++ b/etc/rc1
@@ -86,7 +86,7 @@ fi
 
 modload all job-ingest
 modload 0 job-exec
-modload 0 heartbeat
+modload all heartbeat
 
 core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}

--- a/etc/rc3
+++ b/etc/rc3
@@ -27,7 +27,7 @@ for rcdir in $all_dirs; do
     done
 done
 
-modrm 0 heartbeat
+modrm all heartbeat
 modrm 0 sched-simple
 modrm all resource
 modrm 0 job-exec

--- a/src/modules/heartbeat/heartbeat.c
+++ b/src/modules/heartbeat/heartbeat.c
@@ -31,25 +31,18 @@ struct heartbeat {
     flux_future_t *f;
 };
 
-static void heartbeat_get_cb (flux_t *h,
-                              flux_msg_handler_t *mh,
-                              const flux_msg_t *msg,
-                              void *arg)
+static void heartbeat_stats_cb (flux_t *h,
+                                flux_msg_handler_t *mh,
+                                const flux_msg_t *msg,
+                                void *arg)
 {
     struct heartbeat *hb = arg;
 
-    if (flux_request_decode (msg, NULL, NULL) < 0)
-        goto error;
     if (flux_respond_pack (h,
                            msg,
                            "{s:f}",
-                           "period",
-                           hb->period) < 0)
-        flux_log_error (h, "error responding to heartbeat.get request");
-    return;
-error:
-    if (flux_respond_error (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "error responding to heartbeat.get request");
+                           "period", hb->period) < 0)
+        flux_log_error (h, "error responding to stats-get request");
 }
 
 static void publish_continuation (flux_future_t *f, void *arg)
@@ -106,10 +99,11 @@ inval:
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    {   FLUX_MSGTYPE_REQUEST,
-        "heartbeat.get",
-        heartbeat_get_cb,
-        FLUX_ROLE_USER
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "heartbeat.stats-get",
+        heartbeat_stats_cb,
+        0,
     },
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/src/modules/heartbeat/heartbeat.c
+++ b/src/modules/heartbeat/heartbeat.c
@@ -9,27 +9,44 @@
 \************************************************************/
 
 /* heartbeat.c - publish regular heartbeat messages
+ *
+ * Heartbeats are published on rank 0 (leader)
+ * Heartbeats are subscribed to on rank > 0 (followers)
+ *
+ * By default, if a follower broker does not receive heartbeats within
+ * a timeout window (5m), it forces an overlay parent disconnect.
  */
 
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-
+#include <unistd.h>
 #include <flux/core.h>
+#include <jansson.h>
+#include <math.h>
 
 #include "src/common/libutil/fsd.h"
 #include "src/common/libutil/errprintf.h"
 #include "ccan/str/str.h"
 
 static const double default_period = 2.0;
+static const double default_timeout = 300.;
+
+static const int default_warn_thresh = 3; // number of heartbeat periods
 
 struct heartbeat {
     flux_t *h;
     uint32_t rank;
     double period;
+    double timeout;
     flux_watcher_t *timer;
     flux_msg_handler_t **handlers;
     flux_future_t *f;
+    flux_future_t *sync;
+    json_int_t count;
+    double t_stamp;
+    int warn_thresh;
+    bool over_warn_thresh;
 };
 
 static void heartbeat_stats_cb (flux_t *h,
@@ -41,9 +58,45 @@ static void heartbeat_stats_cb (flux_t *h,
 
     if (flux_respond_pack (h,
                            msg,
-                           "{s:f}",
-                           "period", hb->period) < 0)
+                           "{s:f s:f s:I s:i}",
+                           "period", hb->period,
+                           "timeout", hb->timeout,
+                           "count", hb->count,
+                           "warn_thresh", hb->warn_thresh) < 0)
         flux_log_error (h, "error responding to stats-get request");
+}
+
+static void sync_cb (flux_future_t *f, void *arg)
+{
+    struct heartbeat *hb = arg;
+    double now = flux_reactor_now (flux_get_reactor (hb->h));
+
+    if (flux_future_get (f, NULL) < 0) {
+        if (errno != ETIMEDOUT) {
+            flux_log_error (hb->h, "unexpected sync error");
+            goto done;
+        }
+        char buf[64] = "unknown period";
+        char msg[128];
+        (void)fsd_format_duration_ex (buf, sizeof (buf), now - hb->t_stamp, 2);
+        snprintf (msg, sizeof (msg), "no heartbeat for %s", buf);
+
+        flux_future_t *f2;
+        if (!(f2 = flux_rpc_pack (hb->h,
+                                  "overlay.disconnect-parent",
+                                  FLUX_NODEID_ANY,
+                                  FLUX_RPC_NORESPONSE,
+                                  "{s:s}",
+                                  "reason", msg)))
+            flux_log_error (hb->h, "overlay.disconnect-parent");
+        flux_future_destroy (f2);
+    }
+    else {
+        hb->count++;
+        hb->t_stamp = now;
+    }
+done:
+    flux_future_reset (f);
 }
 
 static void publish_continuation (flux_future_t *f, void *arg)
@@ -57,15 +110,9 @@ static void publish_continuation (flux_future_t *f, void *arg)
     hb->f = NULL;
 }
 
-static void timer_cb (flux_reactor_t *r,
-                      flux_watcher_t *w,
-                      int revents,
-                      void *arg)
+static void heartbeat_publish (struct heartbeat *hb)
 {
-    struct heartbeat *hb = arg;
-
     flux_future_destroy (hb->f);
-
     if (!(hb->f = flux_event_publish (hb->h, "heartbeat.pulse", 0, NULL))) {
         flux_log_error (hb->h, "error sending publish request");
         return;
@@ -75,6 +122,58 @@ static void timer_cb (flux_reactor_t *r,
         flux_future_destroy (hb->f);
         hb->f = NULL;
     }
+    hb->count++;
+}
+
+static void heartbeat_warn (struct heartbeat *hb)
+{
+    double now = flux_reactor_now (flux_get_reactor (hb->h));
+    bool over_thresh = false;
+
+    if (now - hb->t_stamp > hb->period * hb->warn_thresh)
+        over_thresh = true;
+
+    if (over_thresh && !hb->over_warn_thresh) {
+        flux_log (hb->h, LOG_WARNING, "heartbeat overdue");
+        hb->over_warn_thresh = true;
+    }
+    else if (!over_thresh && hb->over_warn_thresh) {
+        flux_log (hb->h, LOG_WARNING, "heartbeat received");
+        hb->over_warn_thresh = false;
+    }
+}
+
+static void timer_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
+{
+    struct heartbeat *hb = arg;
+
+    if (hb->rank == 0)
+        heartbeat_publish (hb);
+    else
+        heartbeat_warn (hb);
+}
+
+static void heartbeat_period_adjust (struct heartbeat *hb, double period)
+{
+    if (hb->timer) {
+        flux_timer_watcher_reset (hb->timer, 0., period);
+        flux_timer_watcher_again (hb->timer);
+    }
+}
+
+static int heartbeat_timeout_adjust (struct heartbeat *hb, double timeout)
+{
+    if (hb->sync) {
+        flux_future_t *f;
+        if (!(f = flux_sync_create (hb->h, 0.))
+            || flux_future_then (f, timeout, sync_cb, hb) < 0)
+            return -1;
+        hb->sync = f;
+    }
+    return 0;
 }
 
 static int heartbeat_parse_args (struct heartbeat *hb,
@@ -110,13 +209,18 @@ static int heartbeat_parse_config (struct heartbeat *hb,
 {
     flux_error_t conf_error;
     const char *period_fsd = NULL;
+    const char *timeout_fsd = NULL;
     double new_period = default_period;
+    double new_timeout = default_timeout;
+    int new_warn_thresh = default_warn_thresh;
 
     if (flux_conf_unpack (conf,
                           &conf_error,
-                          "{s?{s?s !}}",
+                          "{s?{s?s s?s s?i !}}",
                           "heartbeat",
-                            "period", &period_fsd) < 0) {
+                            "period", &period_fsd,
+                            "timeout", &timeout_fsd,
+                            "warn_thresh", &new_warn_thresh) < 0) {
         errprintf (error,
                    "error reading [heartbeat] config table: %s",
                    conf_error.text);
@@ -133,13 +237,38 @@ static int heartbeat_parse_config (struct heartbeat *hb,
             return -1;
         }
     }
-    if (new_period != hb->period) {
-        hb->period = new_period;
-        if (hb->timer) {
-            flux_timer_watcher_reset (hb->timer, 0., hb->period);
-            flux_timer_watcher_again (hb->timer);
+    if (timeout_fsd) {
+        if (fsd_parse_duration (timeout_fsd, &new_timeout) < 0) {
+            errprintf (error, "error parsing heartbeat.timeout FSD value");
+            return -1;
         }
+        if (new_timeout == 0 || new_timeout == INFINITY)
+            new_timeout = -1;
     }
+    if (new_timeout < new_period * 2 && new_timeout != -1) {
+            errprintf (error,
+                       "heartbeat.timeout must be >= 2*heartbeat.period,"
+                       " infinity, or 0");
+            errno = EINVAL;
+            return -1;
+    }
+    if (new_period != hb->period) {
+        heartbeat_period_adjust (hb, new_period);
+        hb->period = new_period;
+    }
+    if (new_timeout != hb->timeout) {
+        if (heartbeat_timeout_adjust (hb, new_timeout) < 0) {
+            errprintf (error, "error adjusting timeout: %s", strerror (errno));
+            return -1;
+        }
+        hb->timeout = new_timeout;
+    }
+    if (new_warn_thresh <= 0) {
+        errprintf (error, "heartbeat.warn_thresh must be positive");
+        errno = EINVAL;
+        return -1;
+    }
+    hb->warn_thresh = new_warn_thresh;
     return 0;
 }
 
@@ -192,6 +321,7 @@ static void heartbeat_destroy (struct heartbeat *hb)
 {
     if (hb) {
         int saved_errno = errno;
+        flux_future_destroy (hb->sync);
         flux_future_destroy (hb->f);
         flux_msg_handler_delvec (hb->handlers);
         flux_watcher_destroy (hb->timer);
@@ -208,6 +338,9 @@ static struct heartbeat *heartbeat_create (flux_t *h)
         return NULL;
     hb->h = h;
     hb->period = default_period;
+    hb->timeout = default_timeout;
+    hb->t_stamp = flux_reactor_now (flux_get_reactor (h));
+    hb->warn_thresh = default_warn_thresh;
     if (flux_get_rank (h, &hb->rank) < 0
         || flux_msg_handler_addvec (hb->h, htab, hb, &hb->handlers) < 0)
         goto error;
@@ -230,14 +363,17 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log (h, LOG_ERR, "%s", error.text);
         goto error;
     }
-    if (hb->rank == 0) {
-        if (!(hb->timer = flux_timer_watcher_create (r,
-                                                     0.,
-                                                     hb->period,
-                                                     timer_cb,
-                                                     hb)))
+    if (!(hb->timer = flux_timer_watcher_create (r,
+                                                 0.,
+                                                 hb->period,
+                                                 timer_cb,
+                                                 hb)))
+        goto error;
+    flux_watcher_start (hb->timer);
+    if (hb->rank > 0) {
+        if (!(hb->sync = flux_sync_create (h, 0))
+            || flux_future_then (hb->sync, hb->timeout, sync_cb, hb) < 0)
             goto error;
-        flux_watcher_start (hb->timer);
     }
     if (flux_reactor_run (r, 0) < 0) {
         flux_log_error (h, "flux_reactor_run");

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -261,6 +261,7 @@ TESTSCRIPTS = \
 	t3307-system-leafcrash.t \
 	t3308-system-torpid.t \
 	t3309-system-reconnect.t \
+	t3310-system-heartbeat.t \
 	t3400-overlay-trace.t \
 	t3401-module-trace.t \
 	lua/t0001-send-recv.t \

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -39,7 +39,7 @@ modload all job-ingest
 modload all job-info
 modload 0 job-list
 modload all barrier
-modload 0 heartbeat
+modload all heartbeat
 
 if test $RANK -eq 0; then
     # Set fake resources for testing

--- a/t/rc/rc1-kvs
+++ b/t/rc/rc1-kvs
@@ -14,4 +14,4 @@ modload all content blob-size-limit=1048576
 modload 0 content-sqlite
 modload all kvs
 modload all kvs-watch
-modload 0 heartbeat
+modload all heartbeat

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -14,7 +14,7 @@ if [ "${TEST_UNDER_FLUX_NO_EXEC}" != "y" ]
 then
     modrm 0 job-exec
 fi
-modrm 0 heartbeat
+modrm all heartbeat
 modrm 0 sched-simple
 modrm all resource
 modrm 0 job-list

--- a/t/rc/rc3-kvs
+++ b/t/rc/rc3-kvs
@@ -11,7 +11,7 @@ modrm() {
 }
 
 
-modrm 0 heartbeat
+modrm all heartbeat
 modrm all kvs-watch
 modrm all kvs
 

--- a/t/t1107-heartbeat.t
+++ b/t/t1107-heartbeat.t
@@ -8,28 +8,86 @@ SIZE=1
 test_under_flux ${SIZE} minimal
 
 
-test_expect_success 'load heartbeat' '
-	flux module load heartbeat
+test_expect_success 'load heartbeat, period is 2s' '
+	flux module load heartbeat &&
+	flux module stats heartbeat | jq -r -e ".period == 2"
 '
-
-test_expect_success 'reload heartbeat with period=10s and verify' '
-	period1=$(flux module stats heartbeat | jq -r -e .period) &&
+test_expect_success 'reload heartbeat with period=10s' '
 	flux module reload heartbeat period=10s &&
-	period2=$(flux module stats heartbeat | jq -r -e .period) &&
-	echo period changed from $period1 to $period2 &&
-	test "$period1" != "$period2"
+	flux module stats heartbeat | jq -r -e ".period == 10"
 '
-
+test_expect_success 'reconfig with period=5s' '
+	flux config load <<-EOT &&
+	[heartbeat]
+	period = "5s"
+	EOT
+	flux module stats heartbeat | jq -r -e ".period == 5"
+'
+test_expect_success 'reconfig with wrong period type, period is still 5s' '
+	test_must_fail flux config load <<-EOT &&
+	[heartbeat]
+	period = 4
+	EOT
+	flux module stats heartbeat | jq -r -e ".period == 5"
+'
+test_expect_success 'reconfig with bad period FSD, period is still 5s' '
+	test_must_fail flux config load <<-EOT &&
+	[heartbeat]
+	period = "zzz"
+	EOT
+	flux module stats heartbeat | jq -r -e ".period == 5"
+'
+test_expect_success 'reconfig with bad key' '
+	test_must_fail flux config load <<-EOT
+	[heartbeat]
+	z = 42
+	EOT
+'
+test_expect_success 'reconfig with empty table, period is 2s' '
+	flux config load <<-EOT &&
+	[heartbeat]
+	EOT
+	flux module stats heartbeat | jq -r -e ".period == 2"
+'
 test_expect_success 'unload heartbeat' '
 	flux module unload heartbeat
 '
-
+test_expect_success 'reconfig period of 0 (unchecked)' '
+	flux config load <<-EOT
+	[heartbeat]
+	period = "0"
+	EOT
+'
+test_expect_success 'loading heartbeat fails with bad config' '
+	test_must_fail flux module load heartbeat
+'
+test_expect_success 'reconfig with empty [heartbeat] table' '
+	flux config load <<-EOT
+	[heartbeat]
+	EOT
+'
+test_expect_success 'load heartbeat, period is 2s' '
+	flux module load heartbeat &&
+	flux module stats heartbeat | jq -r -e ".period == 2"
+'
+test_expect_success 'unload heartbeat' '
+	flux module unload heartbeat
+'
 test_expect_success 'reload heartbeat with period=bad fsd' '
 	test_must_fail flux module load heartbeat period=1x
 '
 
 test_expect_success 'reload heartbeat with bad option' '
 	test_must_fail flux module load heartbeat foo=42
+'
+test_expect_success 'load heartbeat with period=1s' '
+	flux module load heartbeat period=1s
+'
+test_expect_success 'period is 1s' '
+	flux module stats heartbeat | jq -r -e ".period == 1"
+'
+test_expect_success 'unload heartbeat' '
+	flux module unload heartbeat
 '
 
 test_done

--- a/t/t1107-heartbeat.t
+++ b/t/t1107-heartbeat.t
@@ -8,19 +8,14 @@ SIZE=1
 test_under_flux ${SIZE} minimal
 
 
-get_heartbeat() {
-	flux python -c \
-	    "import flux; print(flux.Flux().rpc(\"heartbeat.get\").get_str())"
-}
-
 test_expect_success 'load heartbeat' '
 	flux module load heartbeat
 '
 
 test_expect_success 'reload heartbeat with period=10s and verify' '
-	period1=$(get_heartbeat | jq -r -e .period) &&
+	period1=$(flux module stats heartbeat | jq -r -e .period) &&
 	flux module reload heartbeat period=10s &&
-	period2=$(get_heartbeat | jq -r -e .period) &&
+	period2=$(flux module stats heartbeat | jq -r -e .period) &&
 	echo period changed from $period1 to $period2 &&
 	test "$period1" != "$period2"
 '

--- a/t/t1107-heartbeat.t
+++ b/t/t1107-heartbeat.t
@@ -4,12 +4,11 @@
 test_description='Test heartbeat module'
 
 . `dirname $0`/sharness.sh
-SIZE=1
+SIZE=2
 test_under_flux ${SIZE} minimal
 
-
 test_expect_success 'load heartbeat, period is 2s' '
-	flux module load heartbeat &&
+	flux exec flux module load heartbeat &&
 	flux module stats heartbeat | jq -r -e ".period == 2"
 '
 test_expect_success 'reload heartbeat with period=10s' '
@@ -86,8 +85,90 @@ test_expect_success 'load heartbeat with period=1s' '
 test_expect_success 'period is 1s' '
 	flux module stats heartbeat | jq -r -e ".period == 1"
 '
-test_expect_success 'unload heartbeat' '
-	flux module unload heartbeat
-'
 
+# Cover heartbeat.timeout
+
+test_expect_success 'reconfig with timeout=infinity works' '
+	flux config load <<-EOT &&
+	[heartbeat]
+	timeout = "infinity"
+	EOT
+	flux module stats heartbeat | jq -r -e ".timeout == -1"
+'
+test_expect_success 'reconfig with timeout=0 works' '
+	flux config load <<-EOT &&
+	[heartbeat]
+	timeout = "0"
+	EOT
+	flux module stats heartbeat | jq -r -e ".timeout == -1"
+'
+test_expect_success 'reconfig with timeout=1m works' '
+	flux config load <<-EOT &&
+	[heartbeat]
+	period = "2s"
+	timeout = "1m"
+	EOT
+	flux module stats heartbeat | jq -r -e ".timeout == 60"
+'
+test_expect_success 'reconfig with wrong timeout type fails' '
+	test_must_fail flux config load <<-EOT &&
+	[heartbeat]
+	period = "2s"
+	timeout = 42
+	EOT
+	flux module stats heartbeat | jq -r -e ".timeout == 60"
+'
+test_expect_success 'reconfig with bad timeout FSD fails' '
+	test_must_fail flux config load <<-EOT &&
+	[heartbeat]
+	period = "2s"
+	timeout = "42z"
+	EOT
+	flux module stats heartbeat | jq -r -e ".timeout == 60"
+'
+test_expect_success 'reconfig with timeout < period fails' '
+	test_must_fail flux config load <<-EOT &&
+	[heartbeat]
+	period = "2s"
+	timeout = "1s"
+	EOT
+	flux module stats heartbeat | jq -r -e ".timeout == 60"
+'
+test_expect_success 'reconfig with warn_thresh=-1 fails' '
+	test_must_fail flux config load <<-EOT
+	[heartbeat]
+	warn_thresh = -1
+	EOT
+'
+test_expect_success 'reconfig with warn_thresh=10 works' '
+	flux config load <<-EOT &&
+	[heartbeat]
+	warn_thresh = 10
+	EOT
+	flux module stats heartbeat | jq -r -e ".warn_thresh == 10"
+'
+test_expect_success 'reload with period=0.1s timeout=infinity warn_thresh=3' '
+	flux exec flux setattr log-stderr-level 4 &&
+	flux exec -r 1 flux dmesg -C &&
+	flux exec -r 1 flux config load <<-EOT &&
+	[heartbeat]
+	period = "0.1s"
+	timeout = "infinity"
+	warn_thresh = 3
+	EOT
+	flux exec -r 1 flux module reload heartbeat &&
+	flux exec -r 1 flux module stats heartbeat
+'
+test_expect_success 'stop leader broker and get follower log messages' '
+	flux module remove heartbeat &&
+	sleep 2 &&
+	flux module load heartbeat &&
+	flux exec -r 1 flux dmesg -H >dmesg.log
+'
+test_expect_success 'heartbeat overdue was logged' '
+	grep -q "heartbeat overdue" dmesg.log
+'
+test_expect_success 'unload heartbeat' '
+	flux exec flux module unload heartbeat
+'
 test_done

--- a/t/t3310-system-heartbeat.t
+++ b/t/t3310-system-heartbeat.t
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+
+test_description='Deprive a leaf node of heartbeats and make it sad'
+
+. `dirname $0`/sharness.sh
+
+startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+
+test_under_flux 2 system
+
+test_expect_success 'ensure child is online' '
+	flux overlay status --timeout=0 --wait full
+'
+
+test_expect_success 'tell brokers to log to stderr' '
+	flux exec flux setattr log-stderr-mode local
+'
+test_expect_success 'configure heartbeat' '
+	flux exec flux config load <<-EOT
+	[heartbeat]
+	period = "0.1s"
+	timeout = "0.5s"
+	EOT
+'
+test_expect_success 'stop heartbeat' '
+	flux module remove heartbeat
+'
+test_expect_success 'wait for rank 1 to exit' '
+	test_expect_code 1 $startctl wait 1
+'
+test_expect_success 'start heartbeat' '
+	flux module load heartbeat
+'
+test_expect_success 'wait for degraded status' '
+	flux overlay status --timeout=0 --wait=degraded
+'
+
+test_done


### PR DESCRIPTION
As discussed in #6626, this adds a timeout option to the heartbeat module.

- heartbeat is loaded on all ranks
- heartbeat on leader rank publishes heartbeats, as before
- heartbeat on follower ranks subscribes to heartbeats
- if a heartbeat does not arrive within a configurable timeout, follower logs a LOG_CRIT message and calls `_exit(1)`.
- the timeout value and whether to merely log or log+exit is configurable

My initial inclination was to just log (no exit) on timeout by default, but I wasn't sure this would get used if we didn't enable it by default, so in the first proposal it is enabled, the default is to log+exit after a 5m timeout.  I'm happy to change that if it seems inappropriate.  Since it is enabled by default, it applies to all instances including user allocations on el cap that are using the slingshot. :shrug: 

