### PR TITLE
improve error message on invalid formatting of shell options

### DIFF
--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -422,7 +422,10 @@ class BatchConfig:
             value = json.loads(value)
         except json.decoder.JSONDecodeError:
             value = str(value)
-        set_treedict(self.config, key, value)
+        try:
+            set_treedict(self.config, key, value)
+        except TypeError as e:
+            raise TypeError(f"failed to set {key} to {value}: {e}")
         return self
 
     def update_file(self, path, extension=".toml"):

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -564,7 +564,10 @@ class Jobspec(object):
             if not key.startswith(("user.", "system.")):
                 key = "system." + key
             key = "attributes." + key
-        set_treedict(self.jobspec, key, val)
+        try:
+            set_treedict(self.jobspec, key, val)
+        except TypeError as e:
+            raise TypeError(f"failed to set {key} to {val}: {e}")
 
     def setattr_shell_option(self, key, val):
         """

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -125,6 +125,12 @@ test_expect_success 'flux alloc: mpi option can be overridden' '
 	flux alloc -o mpi=foo -N1 --dry-run hostname | \
 		jq -e ".attributes.system.shell.options.mpi = \"foo\""
 '
+test_expect_success 'flux alloc: -o foo.bar cannot override -o foo' '
+	test_must_fail flux alloc -o foo -N1 -o foo.bar=hi --dry-run hostname >shellopt.out 2>&1 &&
+	test_debug "cat shellopt.out" &&
+	grep "failed to set attributes.system.shell.options.foo.bar to hi" shellopt.out
+'
+
 test_expect_success 'flux alloc: MPI vars are not set in initial program' '
 	flux queue start &&
 	unset OMPI_MCA_pmix &&


### PR DESCRIPTION
Problem: When submitting a job through the command line, a shell option `-o KEY[=VAL]` is not required to have a value. If one is not provided, then `attributes.system.shell.KEY` is set to 1. If a user later provides a sub-key of this shell option, such as `-o KEY.foo=bar`, the error message returned by Python is not particularly helpful.

Wrap `set_treedict()` in a try/except where user input might provide an invalid key and raise a useful error message.

Fixes #6678