### PR TITLE
flux-queue: do not default to --all with configured queues

### DIFF
--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -448,12 +448,13 @@ test_expect_success 'flux-queue stop --all affects all queues' '
 	flux queue status >mqstatus_stop.out &&
 	test $(grep -c "Scheduling is stopped: test reasons" mqstatus_stop.out) -eq 2
 '
-test_expect_success 'flux-queue stop w/o --all affects all queues but outputs warning' '
+test_expect_success 'flux-queue stop with multiple queues fails with warning' '
 	flux queue start --all &&
-	flux queue stop test reasons 2>mqstatus_stop2.err &&
-	grep "warning" mqstatus_stop2.err &&
-	flux queue status >mqstatus_stop2.out &&
-	test $(grep -c "Scheduling is stopped: test reasons" mqstatus_stop2.out) -eq 2
+	test_must_fail flux queue stop test reasons 2>mqstatus_stop2.err &&
+	grep "Named queues" mqstatus_stop2.err
+'
+test_expect_success 'stop queues' '
+	flux queue stop --all
 '
 test_expect_success 'jobs may be submitted to either queue' '
 	flux submit --wait-event=priority -q batch true > job_batch1.id &&
@@ -495,14 +496,14 @@ test_expect_success 'submitted jobs ran and completed' '
 	wait_state $(cat job_debug1.id) INACTIVE &&
 	flux jobs -n -o "{state}" $(cat job_debug1.id) | grep INACTIVE
 '
-test_expect_success 'flux-queue start w/o --all affects all queues but outputs warning' '
+test_expect_success 'flux-queue start with multiple queues emits warning' '
 	flux queue stop --all &&
-	flux queue start 2>mqstatus_start2.err &&
-	grep "warning" mqstatus_start2.err &&
-	flux queue status >mqstatus_start2.out &&
-	test $(grep -c "Scheduling is started" mqstatus_start2.out) -eq 2
+	test_must_fail flux queue start 2>mqstatus_start2.err &&
+	grep "Named queues" mqstatus_start2.err
 '
-
+test_expect_success 'start all queues' '
+	flux queue start --all
+'
 test_expect_success 'flux-queue stop can do one queue' '
 	flux queue stop -q batch nobatch > mqstop_batch.out &&
 	test $(grep -c "Scheduling is" mqstop_batch.out) -eq 1 &&


### PR DESCRIPTION
Problem: The default behavior of `flux queue start|stop` to apply to all queues when named queues are configured is confusing and potentially dangerous.

Issue an error instead of a warning when this is the case.

If there are no configured queues, then `flux queue start` and `flux queue stop` will still work as expected.

Update tests.

Fixes #6674

I'm going to submit a separate PR that will further change `flux queue start|stop` to take one more queues in the free arguments (and move the stop "reason" to a `-m, --message` option). Since this is a breaking change I figured it should be considered separately.