### PR TITLE
Remove version check from libjob and change to pass with warning in shell

### DIFF
--- a/src/common/libjob/jj.c
+++ b/src/common/libjob/jj.c
@@ -124,13 +124,8 @@ int jj_get_counts_json (json_t *jobspec, struct jj_counts *jj)
         errno = EINVAL;
         return -1;
     }
-    if (version != 1) {
-        snprintf (jj->error, sizeof (jj->error) - 1,
-                 "Invalid version: expected 1, got %d", version);
-        errno = EINVAL;
-        return -1;
-    }
-    /* N.B. attributes.system is generally optional, but
+    /* jobspec version check omitted as discussed in #6632 and #6682
+     * N.B. attributes.system is generally optional, but
      * attributes.system.duration is required in jobspec version 1 */
     if (json_unpack_ex (jobspec, &error, 0, "{s:{s:{s:F}}}",
                         "attributes",

--- a/src/modules/job-list/test/job_data.c
+++ b/src/modules/job-list/test/job_data.c
@@ -37,7 +37,7 @@ struct test_jobspec_corner_case {
     { TEST_SRCDIR "/jobspec/invalid_command_string.jobspec", -1 },
     { TEST_SRCDIR "/jobspec/invalid_per_resource_missing_type.jobspec", -1 },
     { TEST_SRCDIR "/jobspec/missing_version.jobspec", -1 },
-    { TEST_SRCDIR "/jobspec/invalid_version.jobspec", -1 },
+    { TEST_SRCDIR "/jobspec/invalid_version.jobspec", 0 },
     { TEST_SRCDIR "/jobspec/missing_resources.jobspec", -1 },
     { TEST_SRCDIR "/jobspec/invalid_resources.jobspec", -1 },
     { TEST_SRCDIR "/jobspec/invalid_resources_missing_type.jobspec", -1 },

--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -175,6 +175,10 @@ static int shell_init_jobinfo (flux_shell_t *shell, struct shell_info *info)
         shell_log_error ("error parsing jobspec: %s", error.text);
         goto out;
     }
+    if (info->jobspec->version != 1) {
+        shell_warn ("Unsupported jobspec version: expected 1 got %d",
+                    info->jobspec->version);
+    }
 
     /*  Synchronously get initial version of R from first job-info
      *  watch response:

--- a/src/shell/jobspec.c
+++ b/src/shell/jobspec.c
@@ -248,11 +248,6 @@ struct jobspec *jobspec_parse (const char *jobspec, json_error_t *error)
                                 "shell", "options", &job->options) < 0) {
         goto error;
     }
-    if (job->version != 1) {
-        set_error (error, "Invalid jobspec version: expected 1 got %d",
-                   job->version);
-        goto error;
-    }
     if (job->environment && !json_is_object (job->environment)) {
         set_error (error, "attributes.system.environment is not object type");
         goto error;

--- a/src/shell/test/jobspec.c
+++ b/src/shell/test/jobspec.c
@@ -35,6 +35,10 @@ struct input good_input[] = {
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
     },
     {
+        "slot->core (different version number)",
+        "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 256, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+    },
+    {
         "node->socket->slot->core",
         "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"socket\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}], \"label\": \"task\"}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
     },
@@ -75,6 +79,7 @@ struct input good_input[] = {
 struct output good_output[] =
     {
      {1, 1, 1, -1},
+     {1, 1, 1, -1},
      {1, 1, 1, 1},
      {30, 30, 3, 15},
      {5, 5, 6, -1},
@@ -90,10 +95,6 @@ struct input bad_input[] = {
     {
         "empty object",
         "{}",
-    },
-    {
-        "wrong version",
-        "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 256, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
     },
     {
         "missing version",

--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -7,12 +7,12 @@ test_description='Test json-jobspec *cough* parser *cough*'
 jj=${FLUX_BUILD_DIR}/t/sched-simple/jj-reader
 y2j="flux python ${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py"
 
-test_expect_success 'jj-reader: unexpected version throws error' '
+test_expect_success 'jj-reader: unexpected version continues without error' '
 	flux run --dry-run hostname \
 		| jq ".version = 2" >input.$test_count &&
-	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
+	test_expect_code 0 $jj<input.$test_count >out.$test_count 2>&1 &&
 	cat >expected.$test_count <<-EOF &&
-	jj-reader: Invalid version: expected 1, got 2
+	nnodes=0 nslots=1 slot_size=1 slot_gpus=0 exclusive=false duration=0.0
 	EOF
 	test_cmp expected.$test_count out.$test_count
 '

--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -226,7 +226,7 @@ test_expect_success 'flux-shell: stdout/err from task.exec works' '
 test_expect_success 'flux-shell: early fatal errors are captured in eventlog' '
 	flux jobtap load alloc-bypass.so &&
 	id=$(flux run --dry-run -Salloc-bypass.R="$(flux resource R -i0)" true | \
-	     jq .version=2 | \
+	     jq '.attributes.system.environment=1' | \
 	     flux job submit --flags=novalidate) &&
 	echo jobid=$id &&
 	flux job wait-event -Hvt 30 $id clean &&


### PR DESCRIPTION
Problem: version checks in libjob and shell trigger fatal errors if jobspec `version != 1` but this interferes with implementing further features of canonical jobspec and (IMHO) should be the remit of the validator.

The version checks are changed to issue warnings about unsupported jobspec versions but otherwise allow execution to continue.

This is separated off from #6632 (with a bit of tweaking/polishing) to hopefully create a more digestible, standalone PR.