### PR TITLE
testsuite: fix non-bourne shell test failure

### DIFF
--- a/t/t2317-resource-shrink.t
+++ b/t/t2317-resource-shrink.t
@@ -7,6 +7,9 @@ test_description='Test resource shrink when not using resource configuration'
 SIZE=4
 test_under_flux $SIZE full --test-exit-mode=leader
 export FLUX_URI_RESOLVE_LOCAL=t
+# set bourne-shell to protect against non-bourne shells being executed by
+# flux proxy in tests
+export SHELL=/bin/sh
 
 # Usage: waitup N
 #   where N is a count of online ranks


### PR DESCRIPTION
Problem: Tests in t2317-resource-shrink.t failed because of quoting/escaping issues with non-bourne shells.

Solution: Set SHELL to /bin/sh in tests.

Fixes #6685