### PR TITLE
github: upgrade codecov-action to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,7 +225,7 @@ jobs:
       if: success() && matrix.coverage
       env:
         DOCKER_REPO:
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: ${{matrix.coverage_flags}}


### PR DESCRIPTION
Problem: codecov-action released v5.4.0 on 2025-02-26, but flux-core is still on v4.

Upgrade the version.