### PR TITLE
python: make FluxExecutor catch submission errors

### DIFF
--- a/src/bindings/python/flux/job/event.py
+++ b/src/bindings/python/flux/job/event.py
@@ -142,7 +142,7 @@ class JobException(Exception):
         self.type = event.context["type"]
         self.note = event.context["note"]
         self.severity = event.context["severity"]
-        super().__init__(self)
+        super().__init__()
 
     def __str__(self):
         return f"job.exception: type={self.type}: {self.note}"

--- a/src/bindings/python/flux/job/executor.py
+++ b/src/bindings/python/flux/job/executor.py
@@ -349,7 +349,7 @@ class FluxExecutorFuture(concurrent.futures.Future):
         except concurrent.futures.TimeoutError:
             # set jobid to something
             self._set_jobid(
-                None, RuntimeError(f"job could not be submitted due to {exception}")
+                None, RuntimeError(f"job could not be submitted due to {exception!r}")
             )
         return super().set_exception(exception)
 


### PR DESCRIPTION
Problem: as reported in #6698, sometimes the `submit_get_id` function can return errors, but the FluxExecutor has no handling for this.

Add exception handling, and for `get_event` as well for safety.