### PR TITLE
kvs-watch: subscribe/unsubscribe to events asynchronously

### DIFF
--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -1271,8 +1271,10 @@ struct ns_monitor *namespace_monitor (struct watch_ctx *ctx,
             zhashx_delete (ctx->namespaces, ns);
             return NULL;
         }
-        if (flux_future_then (nsm->getrootf, -1.,
-                              namespace_getroot_continuation, nsm) < 0) {
+        if (flux_future_then (nsm->getrootf,
+                              -1.,
+                              namespace_getroot_continuation,
+                              nsm) < 0) {
             zhashx_delete (ctx->namespaces, ns);
             return NULL;
         }

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -74,6 +74,7 @@ struct ns_monitor {
     char *topic;                // topic string for subscription
     bool subscribed;            // subscription active
     flux_future_t *getrootf;    // initial getroot future
+    flux_future_t *eventsubf;   // for event subscription
 };
 
 /* Module state.
@@ -176,6 +177,7 @@ static void namespace_destroy (void **data)
         free (nsm->topic);
         free (nsm->ns_name);
         flux_future_destroy (nsm->getrootf);
+        flux_future_destroy (nsm->eventsubf);
         free (nsm);
         errno = saved_errno;
     }
@@ -201,31 +203,8 @@ static struct ns_monitor *namespace_create (struct watch_ctx *ctx,
     zlistx_set_destructor (nsm->watchers, watcher_destructor);
     if (!(nsm->ns_name = strdup (ns)))
         goto error;
-    /* We are subscribing to the kvs.namespace-<NS> substring.
-     *
-     * This substring encompasses four events at the moment.
-     *
-     * kvs.namespace-<NS>-setroot
-     * kvs.namespace-<NS>-error
-     * kvs.namespace-<NS>-removed
-     * kvs.namespace-<NS>-created
-     *
-     * This module only has callbacks for the "setroot", "removed", and
-     * "created" events. "error" events are dropped.
-     *
-     * While dropped events are "bad" performance wise, "error" events
-     * are presumably rare and it is a net win on performance to limit
-     * the number of calls to the flux_event_subscribe() function.
-     *
-     * See issue #2779 for more information.
-     */
-    if (asprintf (&nsm->topic, "kvs.namespace-%s", ns) < 0)
-        goto error;
     nsm->owner = FLUX_USERID_UNKNOWN;
     nsm->ctx = ctx;
-    if (flux_event_subscribe (ctx->h, nsm->topic) < 0)
-        goto error;
-    nsm->subscribed = true;
     return nsm;
 error:
     namespace_destroy ((void **)&nsm);
@@ -247,9 +226,9 @@ static void watcher_cleanup (struct ns_monitor *nsm, struct watcher *w)
     /* wait for all in flight lookups to complete before destroying watcher */
     if (zlist_size (w->lookups) == 0 && zlist_size (w->loads) == 0)
         zlistx_delete (nsm->watchers, w->handle);
-    /* under extremely racy scenarios, it is possible getroot in flight and
-     * not complete, but we will destroy namespace_monitor if there are no
-     * watchers.
+    /* under extremely racy scenarios, it is possible getroot or
+     * event_subscribe is in flight and not complete, but we will destroy
+     * namespace_monitor if there are no watchers.
      */
     if (zlistx_size (nsm->watchers) == 0)
         zhashx_delete (nsm->ctx->namespaces, nsm->ns_name);
@@ -1246,6 +1225,27 @@ done:
     watcher_respond_ns (nsm);
 }
 
+/* event.subscribe response for initial namespace creation */
+static void namespace_event_subscribe_continuation (flux_future_t *f, void *arg)
+{
+    struct ns_monitor *nsm = arg;
+
+    if (flux_rpc_get (f, NULL) < 0) {
+        flux_log_error (nsm->ctx->h, "%s: event subscribe", __FUNCTION__);
+        nsm->errnum = errno;
+        goto cleanup;
+    }
+    flux_future_destroy (f);
+    nsm->eventsubf = NULL;
+    nsm->subscribed = true;
+    return;
+
+cleanup:
+    flux_future_destroy (f);
+    nsm->eventsubf = NULL;
+    watcher_respond_ns (nsm);
+}
+
 /* Create 'nsm' if not already monitoring this namespace, and
  * send a getroot RPC to the kvs so first response need not wait
  * for the next commit to occur in the arbitrarily distant future.
@@ -1259,21 +1259,49 @@ struct ns_monitor *namespace_monitor (struct watch_ctx *ctx,
         if (!(nsm = namespace_create (ctx, ns)))
             return NULL;
         (void)zhashx_insert (ctx->namespaces, ns, nsm);
-        /* store future in namespace, so namespace can be destroyed
+        /* store futures in namespace, so namespace can be destroyed
          * appropriately to avoid matchtag leak */
-        if (!(nsm->getrootf = flux_kvs_getroot (ctx->h, ns, 0))) {
-            zhashx_delete (ctx->namespaces, ns);
-            return NULL;
-        }
+        if (!(nsm->getrootf = flux_kvs_getroot (ctx->h, ns, 0)))
+            goto cleanup;
         if (flux_future_then (nsm->getrootf,
                               -1.,
                               namespace_getroot_continuation,
-                              nsm) < 0) {
-            zhashx_delete (ctx->namespaces, ns);
-            return NULL;
-        }
+                              nsm) < 0)
+            goto cleanup;
+        /* We are subscribing to the kvs.namespace-<NS> substring.
+         *
+         * This substring encompasses four events at the moment.
+         *
+         * kvs.namespace-<NS>-setroot
+         * kvs.namespace-<NS>-error
+         * kvs.namespace-<NS>-removed
+         * kvs.namespace-<NS>-created
+         *
+         * This module only has callbacks for the "setroot", "removed", and
+         * "created" events. "error" events are dropped.
+         *
+         * While dropped events are "bad" performance wise, "error" events
+         * are presumably rare and it is a net win on performance to limit
+         * the number of calls to subscribe to events.
+         *
+         * See issue #2779 for more information.
+         */
+        if (asprintf (&nsm->topic, "kvs.namespace-%s", ns) < 0)
+            goto cleanup;
+        if (!(nsm->eventsubf = flux_event_subscribe_ex (ctx->h,
+                                                        nsm->topic,
+                                                        0)))
+            goto cleanup;
+        if (flux_future_then (nsm->eventsubf,
+                              -1.,
+                              namespace_event_subscribe_continuation,
+                              nsm) < 0)
+            goto cleanup;
     }
     return nsm;
+cleanup:
+    zhashx_delete (ctx->namespaces, ns);
+    return NULL;
 }
 
 static void lookup_cb (flux_t *h,

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -260,7 +260,7 @@ static int event_unsubscribe (struct kvs_ctx *ctx, const char *ns)
             goto cleanup;
 
         if (flux_event_unsubscribe (ctx->h, topic) < 0) {
-            flux_log_error (ctx->h, "flux_event_subscribe");
+            flux_log_error (ctx->h, "flux_event_unsubscribe");
             goto cleanup;
         }
     }


### PR DESCRIPTION
Per discussion in #6690 and #6694.  It's a nice job throughput bump.  

Before
```
Running throughput.py 2048 jobs
throughput:     147.0 job/s (script: 142.6 job/s)
Total of 14 seconds
Running throughput.py 4096 jobs
throughput:     131.3 job/s (script: 129.9 job/s)
Total of 32 seconds
Running throughput.py 8192 jobs
throughput:     67.5 job/s (script:  11.6 job/s)
Total of 703 seconds
Running throughput.py 16384 jobs
throughput:     33.3 job/s (script:   6.7 job/s)
Total of 2456 seconds
```

After
```
Running throughput.py 2048 jobs
throughput:     196.4 job/s (script: 191.9 job/s)
Total of 11 seconds for everything
Running throughput.py 4096 jobs
throughput:     169.8 job/s (script: 168.0 job/s)
Total of 25 seconds for everything
Running throughput.py 8192 jobs
throughput:     173.1 job/s (script: 171.8 job/s)
Total of 48 seconds for everything
Running throughput.py 16384 jobs
throughput:     152.7 job/s (script: 152.1 job/s)
Total of 109 seconds for everything
```

Fixes #6694 