### PR TITLE
set `exit-timeout=none` by default in `flux alloc` and `flux batch`

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -349,10 +349,14 @@ plugins include:
 
 .. option:: exit-timeout=VALUE
 
-  A fatal exception is raised on the job 30s after the first task exits.
-  The timeout period may be altered by providing a different value in
-  Flux Standard Duration form.  A value of ``none`` disables generation of
-  the exception.
+  When the first task in a job exits, and exit-timeout is not set to
+  ``none``, a timer is initiated with a duration specified by *VALUE*. If the
+  timer expires, a fatal exception is raised on the job. The timeout
+  duration can be adjusted by specifying a new *VALUE* in Flux Standard
+  Duration format. Setting the value to "none" disables both the timer
+  and the exception. The default timeout is "30s" for normal parallel jobs
+  (:man1:`flux-submit` and :man1:`flux-run`) and "none" for jobs that are
+  instances of Flux (:man1:`flux-batch` and :man1:`flux-alloc`).
 
 .. option:: exit-on-error
 

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -1042,6 +1042,8 @@ class JobspecV1(Jobspec):
         )
         jobspec.setattr_shell_option("per-resource.type", "node")
         jobspec.setattr_shell_option("mpi", "none")
+        #  Default exit-timeout=none
+        jobspec.setattr_shell_option("exit-timeout", "none")
         if conf is not None:
             jobspec.add_file("conf.json", conf)
         return jobspec

--- a/t/issues/t4583-free-range-test.sh
+++ b/t/issues/t4583-free-range-test.sh
@@ -36,7 +36,7 @@ fi
 
 #  Start a job with tbon.topo=kary:0
 log "Starting a child instance with flat topology\n"
-jobid=$(flux alloc -N4 -o exit-timeout=none --bg --broker-opts=-Stbon.topo=kary:0)
+jobid=$(flux alloc -N4 --bg --broker-opts=-Stbon.topo=kary:0)
 
 log "Started job $jobid\n"
 

--- a/t/t2317-resource-shrink.t
+++ b/t/t2317-resource-shrink.t
@@ -22,7 +22,7 @@ force_down () {
 groups="flux python ${SHARNESS_TEST_SRCDIR}/scripts/groups.py"
 
 test_expect_success 'submit a resilient job using all ranks' '
-	jobid=$(flux alloc --bg -xN4 -o exit-timeout=none --conf=tbon.topo=kary:0) &&
+	jobid=$(flux alloc --bg -xN4 --conf=tbon.topo=kary:0) &&
 	flux proxy $jobid flux overlay status
 '
 # tbon.torpid_min should be >= sync_min (1s hardwired)

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -39,6 +39,14 @@ test_expect_success 'flux alloc -N2 requests 2 nodes exclusively' '
 test_expect_success 'flux alloc --exclusive works' '
 	flux alloc -N1 -n1 --exclusive --dry-run hostname | jq -S ".resources[0]" | jq -e ".type == \"node\" and .exclusive"
 '
+test_expect_success 'flux alloc disables exit timeout by default' '
+	flux alloc -n1 --dry-run myapp | \
+	    jq -e ".attributes.system.shell.options[\"exit-timeout\"] == \"none\""
+'
+test_expect_success 'flux alloc allows exit-timeout to be overridden' '
+	flux alloc -n1 -o exit-timeout=20s --dry-run myapp | \
+	    jq -e ".attributes.system.shell.options[\"exit-timeout\"] == \"20s\""
+'
 test_expect_success 'flux alloc fails if N > n' '
 	test_expect_code 1 flux alloc -N2 -n1 --dry-run hostname
 '

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -63,6 +63,14 @@ test_expect_success 'flux batch --wrap option works on stdin' '
 	EOF
 	test_cmp stdin-wrap.expected stdin-wrap.out
 '
+test_expect_success 'flux batch disables exit-timeout by default' '
+	flux batch -n1 --wrap --dry-run true | \
+	    jq -e ".attributes.system.shell.options[\"exit-timeout\"] == \"none\""
+'
+test_expect_success 'flux batch allows exit-timeout to be overridden' '
+	flux batch -n1 -o exit-timeout=30s --wrap --dry-run true | \
+	    jq -e ".attributes.system.shell.options[\"exit-timeout\"] == \"30s\""
+'
 test_expect_success 'flux batch fails for binary file' '
 	test_expect_code 1 flux batch -n1 $(which hostname)
 '


### PR DESCRIPTION
This PR modifies `flux.job.Jobspec.from_nest_command()` to set the shell option `exit-timeout` to `none` by default, the main effect of which is to disable the exit-timeout for `flux batch` and `flux alloc`.  Tests and documentation are updated.

The explanation for this change is documented in #6304.