### PR TITLE
shell: determine node & core resource counts from R during init

### DIFF
--- a/src/shell/jobspec.c
+++ b/src/shell/jobspec.c
@@ -35,33 +35,6 @@ static void set_error (json_error_t *error, const char *fmt, ...)
     }
 }
 
-static int parse_res_level (json_t *o,
-                            int level,
-                            struct res_level *resp,
-                            json_error_t *error)
-{
-    json_error_t loc_error;
-    struct res_level res;
-
-    if (o == NULL) {
-        set_error (error, "level %d: missing", level);
-        return -1;
-    }
-    res.with = NULL;
-    /* For jobspec version 1, expect exactly one array element per level.
-     */
-    if (json_unpack_ex (o, &loc_error, 0,
-                        "{s:s s:i s?o}",
-                        "type", &res.type,
-                        "count", &res.count,
-                        "with", &res.with) < 0) {
-        set_error (error, "level %d: %s", level, loc_error.text);
-        return -1;
-    }
-    *resp = res;
-    return 0;
-}
-
 void jobspec_destroy (struct jobspec *job)
 {
     if (job) {
@@ -71,145 +44,6 @@ void jobspec_destroy (struct jobspec *job)
         json_decref (job->jobspec);
         free (job);
     }
-}
-
-static int recursive_parse_helper (struct jobspec *job,
-                                  json_t *curr_resource,
-                                  json_error_t *error,
-                                  int level,
-                                  int with_multiplier)
-{
-    size_t index;
-    json_t *value;
-    size_t size = json_array_size (curr_resource);
-    struct res_level res;
-    int curr_multiplier;
-
-    if (size == 0) {
-        set_error (error, "Malformed jobspec: resource entry is not a list");
-        return -1;
-    }
-
-    json_array_foreach (curr_resource, index, value) {
-        if (parse_res_level (value, level, &res, error) < 0) {
-            return -1;
-        }
-
-        curr_multiplier = with_multiplier * res.count;
-
-        if (streq (res.type, "node")) {
-            if (job->slot_count > 0) {
-                set_error (error, "node resource encountered after slot resource");
-                return -1;
-            }
-            if (job->cores_per_slot > 0) {
-                set_error (error, "node resource encountered after core resource");
-                return -1;
-            }
-            if (job->node_count > 0) {
-                set_error (error, "node resource encountered after node resource");
-                return -1;
-            }
-
-            job->node_count = curr_multiplier;
-        } else if (streq (res.type, "slot")) {
-            if (job->cores_per_slot > 0) {
-                set_error (error, "slot resource encountered after core resource");
-                return -1;
-            }
-            if (job->slot_count > 0) {
-                set_error (error, "slot resource encountered after slot resource");
-                return -1;
-            }
-
-            job->slot_count = curr_multiplier;
-
-            // Reset the multiplier since we are now looking
-            // to calculate the cores_per_slot value
-            curr_multiplier = 1;
-
-            // Check if we already encountered the `node` resource
-            if (job->node_count > 0) {
-                // N.B.: with a strictly enforced ordering of node then slot
-                // (with arbitrary non-core resources in between)
-                // the slots_per_node will always be a perfectly round integer
-                // (i.e., job->slot_count % job->node_count == 0)
-                job->slots_per_node = job->slot_count / job->node_count;
-            }
-        } else if (streq (res.type, "core")) {
-            if (job->slot_count < 1) {
-                set_error (error, "core resource encountered before slot resource");
-                return -1;
-            }
-            if (job->cores_per_slot > 0) {
-                set_error (error, "core resource encountered after core resource");
-                return -1;
-            }
-
-            job->cores_per_slot = curr_multiplier;
-            // N.B.: despite having found everything we were looking for (i.e.,
-            // node, slot, and core resources), we have to keep recursing to
-            // make sure their aren't additional erroneous node/slot/core
-            // resources in the jobspec
-        }
-
-        if (res.with != NULL) {
-            if (recursive_parse_helper (job,
-                                        res.with,
-                                        error,
-                                        level+1,
-                                        curr_multiplier)
-                < 0) {
-                return -1;
-            }
-        }
-
-        if (streq (res.type, "node")) {
-            if ((job->slot_count <= 0) || (job->cores_per_slot <= 0)) {
-                set_error (error,
-                           "node encountered without slot&core below it");
-                return -1;
-            }
-        } else if (streq (res.type, "slot")) {
-            if (job->cores_per_slot <= 0) {
-                set_error (error, "slot encountered without core below it");
-                return -1;
-            }
-        }
-    }
-    return 0;
-}
-
-/* This function requires that the jobspec resource ordering is the same as the
- * ordering specified in V1, but it allows additional resources before and in
- * between the V1 resources (i.e., node, slot, and core).  In shorthand, it
- * requires that the jobspec follows the form ...->[node]->...->slot->...->core.
- * Where `node` is optional, and `...` represents any non-V1
- * resources. Additionally, this function also allows multiple resources at any
- * level, as long as there is only a single node, slot, and core within the
- * entire jobspec.
- */
-static int recursive_parse_jobspec_resources (struct jobspec *job,
-                                              json_t *curr_resource,
-                                              json_error_t *error)
-{
-    if (curr_resource == NULL) {
-        set_error (error, "jobspec top-level resources empty");
-        return -1;
-    }
-
-    // Set node-related values to -1 ahead of time, if the recursive descent
-    // encounters node in the jobspec, it will overwrite these values
-    job->slots_per_node = -1;
-    job->node_count = -1;
-
-    int rc = recursive_parse_helper (job, curr_resource, error, 0, 1);
-
-    if ((rc == 0) && (job->cores_per_slot < 1)) {
-        set_error (error, "Missing core resource");
-        return -1;
-    }
-    return rc;
 }
 
 /* This function requires that the jobspec resource ordering is the same as the
@@ -338,28 +172,23 @@ struct jobspec *jobspec_parse (const char *jobspec, rcalc_t *r, json_error_t *er
         goto error;
     }
 
-    if (r) {
-        if (recursive_get_slot_count (&job->slot_count,
-                                      resources,
-                                      error,
-                                      &is_node_specified,
-                                      0) < 0) {
-            // recursive_get_slot_count calls set_error
-            goto error;
-        }
-        if (is_node_specified) {
-            job->node_count = rcalc_total_nodes (r);
-            job->slots_per_node = job->slot_count;
-            job->slot_count *= job->node_count;
-        } else {
-            job->node_count = -1;
-            job->slots_per_node = -1;
-        }
-        job->cores_per_slot = rcalc_total_cores (r) / job->slot_count;
-    } else if (recursive_parse_jobspec_resources (job, resources, error) < 0) {
-        // recursive_parse_jobspec_resources calls set_error
+    if (recursive_get_slot_count (&job->slot_count,
+                                  resources,
+                                  error,
+                                  &is_node_specified,
+                                  0) < 0) {
+        // recursive_get_slot_count calls set_error
         goto error;
     }
+    if (is_node_specified) {
+        job->node_count = rcalc_total_nodes (r);
+        job->slots_per_node = job->slot_count;
+        job->slot_count *= job->node_count;
+    } else {
+        job->node_count = -1;
+        job->slots_per_node = -1;
+    }
+    job->cores_per_slot = rcalc_total_cores (r) / job->slot_count;
 
     /* Set job->task_count
      */

--- a/src/shell/jobspec.h
+++ b/src/shell/jobspec.h
@@ -14,6 +14,8 @@
 #include <flux/core.h>
 #include <jansson.h>
 
+#include "rcalc.h"
+
 struct jobspec {
     json_t *jobspec;
     int version;                // jobspec version
@@ -28,7 +30,7 @@ struct jobspec {
     json_t *options;            // attributes.system.shell.options, if any
 };
 
-struct jobspec *jobspec_parse (const char *jobspec, json_error_t *error);
+struct jobspec *jobspec_parse (const char *jobspec, rcalc_t *r, json_error_t *error);
 void jobspec_destroy (struct jobspec *job);
 
 #endif /* !_SHELL_JOBSPEC_H */

--- a/src/shell/test/jobspec.c
+++ b/src/shell/test/jobspec.c
@@ -200,7 +200,7 @@ int main (int argc, char **argv)
     int i;
 
     for (i = 0; good_input[i].desc; i++) {
-        js = jobspec_parse (good_input[i].s, &error);
+        js = jobspec_parse (good_input[i].s, NULL, &error);
         ok (js != NULL, "good.%d (%s) works", i, good_input[i].desc);
         if (!js) {
             diag ("%s", error.text);
@@ -235,7 +235,7 @@ int main (int argc, char **argv)
     }
 
     for (i = 0; bad_input[i].desc; i++) {
-        js = jobspec_parse (bad_input[i].s, &error);
+        js = jobspec_parse (bad_input[i].s, NULL, &error);
         ok (js == NULL, "bad.%d (%s) fails", i, bad_input[i].desc);
         if (!js)
             diag ("%s", error.text);

--- a/src/shell/test/jobspec.c
+++ b/src/shell/test/jobspec.c
@@ -14,12 +14,14 @@
 #include <jansson.h>
 
 #include "jobspec.h"
+#include "rcalc.h"
 
 #include "src/common/libtap/tap.h"
 
 struct input {
     const char *desc;
-    const char *s;
+    const char *j;
+    const char *r;
 };
 
 struct output {
@@ -33,55 +35,59 @@ struct input good_input[] = {
     {
         "slot->core",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
         "slot->core (different version number)",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 256, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
         "node->socket->slot->core",
         "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"socket\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}], \"label\": \"task\"}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
-    },
-    {
-        "node[2]->socket[3]->slot[5]->core[3]",
-        "{\"resources\": [{\"type\": \"node\", \"count\": 2, \"with\": [{\"type\": \"socket\", \"count\": 3, \"with\": [{\"type\": \"slot\", \"count\": 5, \"with\": [{\"type\": \"core\", \"count\": 3}], \"label\": \"task\"}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
         "slot[5]->socket[2]->core[3]",
         "{\"resources\": [{\"type\": \"slot\", \"count\": 5, \"label\": \"task\", \"with\": [{\"type\": \"socket\", \"count\": 2, \"with\": [{\"type\": \"core\", \"count\": 3}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1-30\"}}]}}",
     },
     {
         "node->socket->slot->(core[2],gpu)",
         "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"socket\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 2}, {\"type\": \"gpu\", \"count\": 1}]}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1-2\", \"gpu\": \"1\"}}]}}",
     },
     {
         "node->socket->slot->(gpu,core)",
         "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"socket\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"gpu\", \"count\": 1}, {\"type\": \"core\", \"count\": 1}]}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\", \"gpu\": \"1\"}}]}}",
     },
     {
         "node->socket->slot->(core[2]->PU,gpu)",
         "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"socket\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 2, \"with\": [{\"type\": \"PU\", \"count\": 1}]}, {\"type\": \"gpu\", \"count\": 1}]}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1-2\", \"gpu\": \"1\"}}]}}",
     },
     {
         "node[2]->(storage,slot[3]->core[5])",
         "{\"resources\": [{\"type\": \"node\", \"count\": 2, \"with\": [{\"type\": \"storage\", \"count\": 1}, {\"type\": \"slot\", \"label\": \"task\", \"count\": 3, \"with\": [{\"type\": \"core\", \"count\": 5}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1-2\", \"children\": {\"core\": \"1-15\"}}]}}",
     },
     {
         "(storage,node->slot->core)",
         "{\"version\": 1, \"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"default\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}]}]}, {\"type\": \"storage\", \"count\": 1562, \"exclusive\": true}], \"attributes\": {\"system\": {\"duration\": 57600}}, \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"default\", \"count\": {\"per_slot\": 1}}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
         "cluster->(storage,node->slot->core)",
         "{\"version\": 1, \"resources\": [{\"type\": \"cluster\", \"count\": 1, \"with\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"default\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}]}]}, {\"type\": \"storage\", \"count\": 1562, \"exclusive\": true}]}], \"attributes\": {\"system\": {\"duration\": 57600}}, \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"default\", \"count\": {\"per_slot\": 1}}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
-    { NULL, NULL },
+    { NULL, NULL, NULL },
 };
-struct output good_output[] =
-    {
+struct output good_output[] = {
      {1, 1, 1, -1},
      {1, 1, 1, -1},
      {1, 1, 1, 1},
-     {30, 30, 3, 15},
      {5, 5, 6, -1},
      {1, 1, 2, 1},
      {1, 1, 1, 1},
@@ -92,103 +98,98 @@ struct output good_output[] =
      {0, 0, 0, 0},
 };
 struct input bad_input[] = {
-    {
-        "empty object",
-        "{}",
-    },
+    { "empty object", "{}",  "{}" },
     {
         "missing version",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
         "missing resources",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1}",
+        "{}",
     },
     {
         "missing tasks",
         "{\"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 256, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
         "environment not an object",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"environment\":42, \"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
         "cwd not a string",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": 42}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
         "no slot resource",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"meep\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
-        "missing count",
+        "missing task count",
         "{\"tasks\": [{\"slot\": \"task\", \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
-        "empty count",
+        "empty task count",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
-        "multiple keys in count",
+        "multiple keys in task count",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1, \"total\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
         "per_resource",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_resource\": {\"type\": \"core\", \"count\": 1}}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
         "per_slot > 1",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 2}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
         "missing command",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
-        "slot->node->core",
-        "{\"resources\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+        "slot count not an integer",
+        "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": {\"min\": 1}, \"with\": [{\"count\": 1, \"type\": \"core\"}]}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1-2\"}}]}}",
     },
     {
-        "node->core->slot",
-        "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+        "resources not an array",
+        "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": {\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}]}}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
-        "node->(storage,slot->PU)",
-        "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"storage\", \"count\": 1}, {\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"PU\", \"count\": 1}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+        "command not an array",
+        "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": \"hostname\", \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}]}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
-        "node->slot->(PU,gpu)",
-        "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"PU\", \"count\": 1}, {\"type\": \"gpu\", \"count\": 1}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+        "missing resource type",
+        "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": \"hostname\", \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"label\": \"task\", \"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}]}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1\"}}]}}",
     },
     {
-        "node->(storage->core,slot->PU)",
-        "{\"version\": 1, \"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"storage\", \"count\": 1562, \"exclusive\": true, \"with\": [{\"type\": \"core\", \"count\": 1}]}, {\"type\": \"slot\", \"label\": \"default\", \"count\": 1, \"with\": [{\"type\": \"PU\", \"count\": 1}]}]}], \"attributes\": {\"system\": {\"duration\": 57600}}, \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"default\", \"count\": {\"per_slot\": 1}}]}",
+        "(node->slot->core,slot->core)",
+        "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}]}]}, {\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}]}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1\", \"children\": {\"core\": \"1-2\"}}]}}",
     },
     {
-        "node->(slot,core)",
-        "{\"version\": 1, \"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"default\", \"count\": 1}, {\"type\": \"core\", \"count\": 1}]}], \"attributes\": {\"system\": {\"duration\": 57600}}, \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"default\", \"count\": {\"per_slot\": 1}}]}",
+        "(node->slot->core,node)",
+        "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}]}]}, {\"type\": \"node\", \"count\": 1}]}",
+        "{\"version\": 1, \"execution\": {\"R_lite\": [{\"rank\": \"1-2\", \"children\": {\"core\": \"1\"}}]}}",
     },
-    {
-        "(node,slot->core)",
-        "{\"version\": 1, \"resources\": [{\"type\": \"node\", \"count\": 1}, {\"type\": \"slot\", \"label\": \"default\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}]}], \"attributes\": {\"system\": {\"duration\": 57600}}, \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"default\", \"count\": {\"per_slot\": 1}}]}",
-    },
-    {
-        "cluster->(node->slot->core,node)",
-        "{\"version\": 1, \"resources\": [{\"type\": \"cluster\", \"count\": 1, \"with\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"default\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}]}]}, {\"type\": \"node\", \"count\": 1}]}], \"attributes\": {\"system\": {\"duration\": 57600}}, \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"default\", \"count\": {\"per_slot\": 1}}]}",
-    },
-    {
-        "cluster->(slot->core,node)",
-        "{\"version\": 1, \"resources\": [{\"type\": \"cluster\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"default\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}]}, {\"type\": \"node\", \"count\": 1}]}], \"attributes\": {\"system\": {\"duration\": 57600}}, \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"default\", \"count\": {\"per_slot\": 1}}]}",
-    },
-    {
-        "cluster->(slot->core,slot->core)",
-        "{\"version\": 1, \"resources\": [{\"type\": \"cluster\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"default\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}]}, {\"type\": \"slot\", \"label\": \"default\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}]}]}], \"attributes\": {\"system\": {\"duration\": 57600}}, \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"default\", \"count\": {\"per_slot\": 1}}]}",
-    },
-    {
-        "node->(slot->core,storage->core)",
-        "{\"version\": 1, \"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"default\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}]}, {\"type\": \"storage\", \"count\": 1562, \"exclusive\": true, \"with\": [{\"type\": \"core\", \"count\": 1}]}]}], \"attributes\": {\"system\": {\"duration\": 57600}}, \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"default\", \"count\": {\"per_slot\": 1}}]}",
-    },
-    { NULL, NULL },
+    { NULL, NULL, NULL },
 };
 
 int main (int argc, char **argv)
@@ -196,11 +197,13 @@ int main (int argc, char **argv)
     plan (NO_PLAN);
     struct jobspec *js;
     struct output *expect;
+    rcalc_t *rs;
     json_error_t error;
     int i;
 
     for (i = 0; good_input[i].desc; i++) {
-        js = jobspec_parse (good_input[i].s, NULL, &error);
+        rs = rcalc_create (good_input[i].r);
+        js = jobspec_parse (good_input[i].j, rs, &error);
         ok (js != NULL, "good.%d (%s) works", i, good_input[i].desc);
         if (!js) {
             diag ("%s", error.text);
@@ -232,15 +235,18 @@ int main (int argc, char **argv)
                 expect->slots_per_node);
             jobspec_destroy (js);
         }
+        rcalc_destroy (rs);
     }
 
     for (i = 0; bad_input[i].desc; i++) {
-        js = jobspec_parse (bad_input[i].s, NULL, &error);
+        rs = rcalc_create (bad_input[i].r);
+        js = jobspec_parse (bad_input[i].j, rs, &error);
         ok (js == NULL, "bad.%d (%s) fails", i, bad_input[i].desc);
         if (!js)
             diag ("%s", error.text);
         else
             jobspec_destroy (js);
+        rcalc_destroy (rs);
     }
 
     done_testing ();


### PR DESCRIPTION
Problem: counts for resources are currently being parsed only from jobspec, but if/once ranges are used then values cannot be determined.

Modify shell init data flow to use the actual allocation from the scheduler in R, if present, to determine resource counts for nodes & cores in `jobspec_parse`.

As a first step, this checks whether a resource set struct was passed to `jobspec_parse`, and otherwise leaves the original codepath unchanged. The slot count must still be parsed from the jobspec regardless, because it is missing from R.

The concept for this is also essentially separated off from #6632, albeit with a fair bit of re-working to keep the changes as minimal as possible. Because `flux-sched` already has basic support for ranges, this PR already allows jobspec with ranges for nodes and/or cores to run successfully.