### PR TITLE
accept target queue as non-option parameter in most `flux queue` subcommands

### DIFF
--- a/doc/man1/flux-queue.rst
+++ b/doc/man1/flux-queue.rst
@@ -9,14 +9,14 @@ flux-queue(1)
 SYNOPSIS
 ========
 
-| **flux** **queue** **list** [-n] [-o FORMAT]
-| **flux** **queue** **status** [*-q* *NAME* | *-a*] [*-v*]
+| **flux** **queue** **list** [*-q* *QUEUES,...*] [*-n*] [*-o* *FORMAT*]
+| **flux** **queue** **status** [*-a*] [*-v*] [*QUEUE*]
 
-| **flux** **queue** **disable** [*-q* *NAME* | *-a*] [*-v*] [*--quiet*] [*--nocheckpoint*] *reason*
-| **flux** **queue** **enable** [*-q* *NAME* | *-a*] [*-v*] [*--quiet*]
+| **flux** **queue** **disable** [*-a*] [*-v*] [*--quiet*] [*--nocheckpoint*] [*-m* *reason*] [*QUEUE*]
+| **flux** **queue** **enable** [*-a*] [*-v*] [*--quiet*] [*QUEUE*]
 
-| **flux** **queue** **stop** [*-q* *NAME* | *-a*] [*-v*] [*--quiet*] [*--nocheckpoint*] *reason*
-| **flux** **queue** **start** [*-q* *NAME* | *-a*] [*-v*] [*--quiet*]
+| **flux** **queue** **stop** [*-a*] [*-v*] [*--quiet*] [*--nocheckpoint*] [*-m* *reason*] [*QUEUE*]
+| **flux** **queue** **start** [*-a*] [*-v*] [*--quiet*] [*QUEUE*]
 
 | **flux** **queue** **drain** [*--timeout=DURATION*]
 | **flux** **queue** **idle** [*--timeout=DURATION*]
@@ -77,12 +77,8 @@ disable
 
 .. program:: flux queue disable
 
-Prevent jobs from being submitted to the queue, with a reason that is
+Prevent jobs from being submitted to the queue, with an optional reason that is
 shown to submitting users.
-
-.. option:: -q, --queue=NAME
-
-   Select a queue by name.
 
 .. option:: -a, --all
 
@@ -98,7 +94,12 @@ shown to submitting users.
 
 .. option:: --nocheckpoint
 
-   Do not preserve the new queue stop state across a Flux instance restart.
+   Do not preserve the new queue disabled state across a Flux instance restart.
+
+.. options:: -m, --message=REASON
+
+   Add a reason that the queue is disabled. This will be shown to users
+   who attempt to submit to the queue.
 
 enable
 ------
@@ -132,10 +133,6 @@ Stop allocating resources to jobs.  Pending jobs remain enqueued, and
 running jobs continue to run, but no new jobs are allocated
 resources.
 
-.. option:: -q, --queue=NAME
-
-   Select a queue by name.
-
 .. option:: -a, --all
 
    Select all queues.
@@ -152,16 +149,17 @@ resources.
 
    Do not preserve the new queue stop state across a Flux instance restart.
 
+.. options:: -m, --message=REASON
+
+   Add a reason that the queue is stopped. This message will be displayed
+   in the output of :command:`flux queue status`.
+
 start
 -----
 
 .. program:: flux queue start
 
 Start allocating resources to jobs.
-
-.. option:: -q, --queue=NAME
-
-   Select a queue by name.
 
 .. option:: -a, --all
 

--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -391,7 +391,7 @@ def enable(args):
 
 
 def disable(args):
-    reason = None
+    reason = "disabled by administrator"
     if args.message:
         reason = " ".join(args.message)
     handle = flux.Flux()

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -322,7 +322,7 @@ test_expect_success 'job-manager: still no jobs in the queue' '
 '
 
 test_expect_success 'job-manager: flux queue disable works' '
-	flux queue disable system is fubar
+	flux queue disable --message="system is fubar"
 '
 
 test_expect_success 'job-manager: flux job submit receives custom error' '

--- a/t/t2219-job-manager-restart.t
+++ b/t/t2219-job-manager-restart.t
@@ -68,7 +68,7 @@ test_expect_success 'purging all jobs triggers jobid checkpoint update' '
 
 test_expect_success 'verify that anon queue disable persists across restart' '
 	flux start -Scontent.dump=dump_dis.tar \
-	    flux queue disable disable-restart-test &&
+	    flux queue disable --message=disable-restart-test &&
 	flux start -Scontent.restore=dump_dis.tar \
 	    flux queue status >dump_dis.out &&
 	grep "disabled: disable-restart-test" dump_dis.out
@@ -76,7 +76,7 @@ test_expect_success 'verify that anon queue disable persists across restart' '
 
 test_expect_success 'verify that anon queue stopped persists across restart' '
 	flux start -Scontent.dump=dump_stopped.tar \
-	    flux queue stop stop-restart-test &&
+	    flux queue stop -m stop-restart-test &&
 	flux start -Scontent.restore=dump_stopped.tar \
 	    flux queue status >dump_stopped.out &&
 	grep "stopped: stop-restart-test" dump_stopped.out
@@ -94,7 +94,7 @@ test_expect_success 'verify that named queue enable/disable persists across rest
 	flux start --config-path=$(pwd)/conf.d \
 	    -Scontent.restore=dump_queue_enable1.tar \
 	    -Scontent.dump=dump_queue_enable2.tar \
-	    flux queue disable --queue=batch xyzzy &&
+	    flux queue disable batch &&
 	flux start --config-path=$(pwd)/conf.d \
 	    -Scontent.restore=dump_queue_enable2.tar \
 	    -Scontent.dump=dump_queue_enable3.tar \
@@ -110,7 +110,8 @@ test_expect_success 'verify that named queue enable/disable persists across rest
 	grep "^debug: Job submission is enabled" dump_queue_enable_1.out &&
 	grep "^batch: Job submission is enabled" dump_queue_enable_1.out &&
 	grep "^debug: Job submission is enabled" dump_queue_enable_2.out &&
-	grep "^batch: Job submission is disabled: xyzzy" dump_queue_enable_2.out &&
+	grep "^batch: Job submission is disabled: disabled by administrator" \
+		dump_queue_enable_2.out &&
 	grep "^debug: Job submission is enabled" dump_queue_enable_3.out &&
 	grep "^batch: Job submission is enabled" dump_queue_enable_3.out
 '
@@ -143,7 +144,7 @@ test_expect_success 'verify that named queue start/stop persists across restart'
 	flux start --config-path=$(pwd)/conf.d \
 	    -Scontent.restore=dump_queue_start3.tar \
 	    -Scontent.dump=dump_queue_start4.tar \
-	    flux queue stop --queue=batch xyzzy &&
+	    flux queue stop --queue=batch -m xyzzy &&
 	flux start --config-path=$(pwd)/conf.d \
 	    -Scontent.restore=dump_queue_start4.tar \
 	    -Scontent.dump=dump_queue_start5.tar \
@@ -164,7 +165,7 @@ test_expect_success 'checkpointed queue no longer configured on restart is ignor
 	EOT
 	flux start --config-path=$(pwd)/conf.d \
 	    -Scontent.dump=dump_queue_missing.tar \
-	    flux queue disable --queue batch xyzzy &&
+	    flux queue disable batch &&
 	cat >conf.d/queues.toml <<-EOT &&
 	[queues.debug]
 	EOT
@@ -184,7 +185,7 @@ test_expect_success 'new queue configured on restart uses defaults' '
 	EOT
 	flux start --config-path=$(pwd)/conf.d \
 	    -Scontent.dump=dump_queue_ignored.tar \
-	    flux queue disable --queue batch xyzzy &&
+	    flux queue disable batch &&
 	cat >conf.d/queues.toml <<-EOT &&
 	[queues.debug]
 	[queues.newqueue]

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -292,7 +292,7 @@ test_expect_success 'flux-queue: start queue and drain' '
 '
 
 test_expect_success 'flux-queue: quiet option works' '
-	flux queue disable --quiet foof > disable_quiet.out &&
+	flux queue disable --quiet > disable_quiet.out &&
 	test_must_fail grep submission disable_quiet.out &&
 	flux queue enable --quiet > enable_quiet.out &&
 	test_must_fail grep submission enable_quiet.out &&
@@ -303,7 +303,7 @@ test_expect_success 'flux-queue: quiet option works' '
 '
 
 test_expect_success 'flux-queue: verbose option works' '
-	flux queue disable --verbose foof > disable_verbose.out &&
+	flux queue disable --verbose > disable_verbose.out &&
 	test $(grep -c "submission is disabled" disable_verbose.out) -eq 1 &&
 	flux queue enable --verbose > enable_verbose.out &&
 	test $(grep -c "submission is enabled" enable_verbose.out) -eq 1 &&
@@ -563,7 +563,7 @@ test_expect_success 'flux-queue: stop with named queues and --nocheckpoint works
 '
 
 test_expect_success 'flux-queue: quiet option works with one queue' '
-	flux queue disable -q batch --quiet foof > mqdisable_quiet.out &&
+	flux queue disable -q batch --quiet > mqdisable_quiet.out &&
 	test_must_fail grep submission mqdisable_quiet.out &&
 	flux queue enable -q batch --quiet > mqenable_quiet.out &&
 	test_must_fail grep submission mqenable_quiet.out &&
@@ -574,7 +574,7 @@ test_expect_success 'flux-queue: quiet option works with one queue' '
 '
 
 test_expect_success 'flux-queue: verbose option works with one queue' '
-	flux queue disable -q batch --verbose foof > mqdisable_verbose.out &&
+	flux queue disable -q batch --verbose > mqdisable_verbose.out &&
 	test $(grep -c "submission is disabled" mqdisable_verbose.out) -eq 1 &&
 	test $(grep -c "submission is enabled" mqdisable_verbose.out) -eq 1 &&
 	flux queue enable -q batch --verbose > mqenable_verbose.out &&

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -19,21 +19,6 @@ test_expect_success 'flux-queue: missing sub-command fails with usage message' '
 	grep -i usage: usage2.out
 '
 
-test_expect_success 'flux-queue: disable with no reason fails' '
-	test_must_fail flux queue submit disable 2>usage3.out &&
-	grep -i usage: usage3.out
-'
-
-test_expect_success 'flux-queue: enable with extra free args fails' '
-	test_must_fail flux queue enable xyz 2>usage4.out &&
-	grep -i usage: usage4.out
-'
-
-test_expect_success 'flux-queue: status with extra free args fails' '
-	test_must_fail flux queue status xyz 2>usage5.out &&
-	grep -i usage: usage5.out
-'
-
 test_expect_success 'flux-queue: drain with extra free args fails' '
 	test_must_fail flux queue drain xyz 2>usage6.out &&
 	grep -i usage: usage6.out
@@ -65,7 +50,7 @@ test_expect_success 'flux-queue: idle with bad broker connection fails' '
 '
 
 test_expect_success 'flux-queue: disable works' '
-	flux queue disable system is fubar > disable.out &&
+	flux queue disable --message="system is fubar" > disable.out &&
 	grep "^Job submission is disabled" disable.out &&
 	grep "system is fubar" disable.out
 '
@@ -91,13 +76,8 @@ test_expect_success 'flux-queue: start with bad broker connection fails' '
 	! FLUX_URI=/wrong flux queue start
 '
 
-test_expect_success 'flux-queue: start with extra free args fails' '
-	test_must_fail flux queue start xyz 2>start_xargs.err &&
-	grep -i usage: start_xargs.err
-'
-
 test_expect_success 'flux-queue: stop works' '
-	flux queue stop my unique message > stop.out &&
+	flux queue stop --message="my unique message" > stop.out &&
 	grep "^Scheduling is stopped" stop.out &&
 	grep "my unique message" stop.out
 '
@@ -292,7 +272,7 @@ test_expect_success 'flux-queue: start queue and drain' '
 '
 
 test_expect_success 'flux-queue: quiet option works' '
-	flux queue disable --quiet > disable_quiet.out &&
+	flux queue disable --quiet -m foof > disable_quiet.out &&
 	test_must_fail grep submission disable_quiet.out &&
 	flux queue enable --quiet > enable_quiet.out &&
 	test_must_fail grep submission enable_quiet.out &&
@@ -333,7 +313,7 @@ test_expect_success 'flux-queue: start denied for guest' '
 '
 
 test_expect_success 'flux-queue: disable denied for guest' '
-	test_must_fail runas_guest flux queue disable foo 2>guest_dis.err &&
+	test_must_fail runas_guest flux queue disable 2>guest_dis.err &&
 	grep "requires owner credentials" guest_dis.err
 '
 
@@ -371,6 +351,22 @@ test_expect_success 'flux queue start --queue fails with no queues' '
 test_expect_success 'flux queue stop --queue fails with no queues' '
 	test_must_fail flux queue stop --queue=batch
 '
+test_expect_success 'flux queue status queue fails with no queues' '
+	test_must_fail flux queue status batch
+'
+test_expect_success 'flux queue enable queue fails with no queues' '
+	test_must_fail flux queue enable batch
+'
+test_expect_success 'flux queue disable queue fails with no queues' '
+	test_must_fail flux queue disable batch
+'
+test_expect_success 'flux queue start queue fails with no queues' '
+	test_must_fail flux queue start batch
+'
+test_expect_success 'flux queue stop queue fails with no queues' '
+	test_must_fail flux queue stop batch
+'
+
 test_expect_success 'ensure instance is drained' '
 	flux queue drain &&
 	flux queue status -v
@@ -396,14 +392,14 @@ test_expect_success 'jobs may be submitted to either queue' '
 	flux submit -q debug true
 '
 test_expect_success 'flux-queue status can show one queue' '
-	flux queue status -q debug >mqstatus_debug.out &&
+	flux queue status debug >mqstatus_debug.out &&
 	test_must_fail grep batch mqstatus_debug.out
 '
-test_expect_success 'flux-queue disable without --queue or --all fails' '
-	test_must_fail flux queue disable test reasons
+test_expect_success 'flux-queue disable without queue or --all fails' '
+	test_must_fail flux queue disable --message="test reasons"
 '
 test_expect_success 'flux-queue disable --all affects all queues' '
-	flux queue disable --all test reasons > mqdisable.out &&
+	flux queue disable --all --message="test reasons" > mqdisable.out &&
 	test $(grep -c "submission is disabled: test reason" mqdisable.out) -eq 2 &&
 	flux queue status >mqstatus_dis.out &&
 	test $(grep -c "submission is disabled: test reason" mqstatus_dis.out) -eq 2
@@ -412,7 +408,7 @@ test_expect_success 'jobs may not be submitted to either queue' '
 	test_must_fail flux submit -q batch true &&
 	test_must_fail flux submit -q debug true
 '
-test_expect_success 'flux-queue enable without --queue or --all fails' '
+test_expect_success 'flux-queue enable without queue or --all fails' '
 	test_must_fail flux queue enable
 '
 test_expect_success 'flux-queue enable --all affects all queues' '
@@ -422,7 +418,7 @@ test_expect_success 'flux-queue enable --all affects all queues' '
 	test $(grep -c "submission is enabled" mqstatus_ena.out) -eq 2
 '
 test_expect_success 'flux-queue disable can do one queue' '
-	flux queue disable -q batch nobatch > mqdisable_batch.out &&
+	flux queue disable --message=nobatch batch > mqdisable_batch.out &&
 	test $(grep -c "submission is" mqdisable_batch.out) -eq 1 &&
 	test $(grep -c "submission is disabled: nobatch" mqdisable_batch.out) -eq 1 &&
 	flux queue status >mqstatus_batchdis.out &&
@@ -432,7 +428,7 @@ test_expect_success 'flux-queue disable can do one queue' '
 	flux submit -q debug true
 '
 test_expect_success 'flux-queue enable can do one queue' '
-	flux queue enable -q batch > mqenable_batch.out &&
+	flux queue enable batch > mqenable_batch.out &&
 	test $(grep -c "submission is" mqenable_batch.out) -eq 1 &&
 	test $(grep -c "submission is enabled" mqenable_batch.out) -eq 1 &&
 	flux queue status >mqstatus_batchena.out &&
@@ -443,14 +439,14 @@ test_expect_success 'flux-queue enable can do one queue' '
 
 
 test_expect_success 'flux-queue stop --all affects all queues' '
-	flux queue stop --all test reasons > mqstop.out &&
+	flux queue stop --all -m "test reasons"> mqstop.out &&
 	test $(grep -c "Scheduling is stopped: test reasons" mqstop.out) -eq 2 &&
 	flux queue status >mqstatus_stop.out &&
 	test $(grep -c "Scheduling is stopped: test reasons" mqstatus_stop.out) -eq 2
 '
 test_expect_success 'flux-queue stop with multiple queues fails with warning' '
 	flux queue start --all &&
-	test_must_fail flux queue stop test reasons 2>mqstatus_stop2.err &&
+	test_must_fail flux queue stop 2>mqstatus_stop2.err &&
 	grep "Named queues" mqstatus_stop2.err
 '
 test_expect_success 'stop queues' '
@@ -505,7 +501,7 @@ test_expect_success 'start all queues' '
 	flux queue start --all
 '
 test_expect_success 'flux-queue stop can do one queue' '
-	flux queue stop -q batch nobatch > mqstop_batch.out &&
+	flux queue stop --message="nobatch" batch > mqstop_batch.out &&
 	test $(grep -c "Scheduling is" mqstop_batch.out) -eq 1 &&
 	test $(grep -c "Scheduling is stopped: nobatch" mqstop_batch.out) -eq 1 &&
 	flux queue status >mqstatus_batchstop.out &&
@@ -521,7 +517,7 @@ test_expect_success 'check one job ran, other job didnt' '
 	flux jobs -n -o "{state}" $(cat job_batch2.id) | grep SCHED
 '
 test_expect_success 'flux-queue start can do one queue' '
-	flux queue start -q batch > mqstart_batch.out &&
+	flux queue start batch > mqstart_batch.out &&
 	test $(grep -c "Scheduling is" mqstart_batch.out) -eq 1 &&
 	test $(grep -c "Scheduling is started" mqstart_batch.out) -eq 1 &&
 	flux queue status >mqstatus_batchstart.out &&
@@ -563,43 +559,43 @@ test_expect_success 'flux-queue: stop with named queues and --nocheckpoint works
 '
 
 test_expect_success 'flux-queue: quiet option works with one queue' '
-	flux queue disable -q batch --quiet > mqdisable_quiet.out &&
+	flux queue disable --quiet -m foof batch > mqdisable_quiet.out &&
 	test_must_fail grep submission mqdisable_quiet.out &&
-	flux queue enable -q batch --quiet > mqenable_quiet.out &&
+	flux queue enable --quiet batch > mqenable_quiet.out &&
 	test_must_fail grep submission mqenable_quiet.out &&
-	flux queue stop -q batch --quiet > mqstop_quiet.out &&
+	flux queue stop --quiet batch > mqstop_quiet.out &&
 	test_must_fail grep Scheduling mqstop_quiet.out &&
-	flux queue start -q batch --quiet > mqstart_quiet.out &&
+	flux queue start --quiet batch > mqstart_quiet.out &&
 	test_must_fail grep Scheduling mqstart_quiet.out
 '
 
 test_expect_success 'flux-queue: verbose option works with one queue' '
-	flux queue disable -q batch --verbose > mqdisable_verbose.out &&
+	flux queue disable --verbose -m foof batch > mqdisable_verbose.out &&
 	test $(grep -c "submission is disabled" mqdisable_verbose.out) -eq 1 &&
 	test $(grep -c "submission is enabled" mqdisable_verbose.out) -eq 1 &&
-	flux queue enable -q batch --verbose > mqenable_verbose.out &&
+	flux queue enable --verbose batch > mqenable_verbose.out &&
 	test $(grep -c "submission is enabled" mqenable_verbose.out) -eq 2 &&
-	flux queue stop -q batch --verbose > mqstop_verbose.out &&
+	flux queue stop --verbose batch > mqstop_verbose.out &&
 	test $(grep -c "Scheduling is stopped" mqstop_verbose.out) -eq 1 &&
 	test $(grep -c "Scheduling is started" mqstop_verbose.out) -eq 1 &&
-	flux queue start -q batch --verbose > mqstart_verbose.out &&
+	flux queue start --verbose batch > mqstart_verbose.out &&
 	test $(grep -c "Scheduling is started" mqstart_verbose.out) -eq 2
 '
 
 test_expect_success 'flux-queue start fails on unknown queue' '
-	test_must_fail flux queue start -q notaqueue
+	test_must_fail flux queue start notaqueue
 '
 test_expect_success 'flux-queue stop fails on unknown queue' '
-	test_must_fail flux queue stop -q notaqueue
+	test_must_fail flux queue stop notaqueue
 '
 test_expect_success 'flux-queue enable fails on unknown queue' '
-	test_must_fail flux queue enable -q notaqueue
+	test_must_fail flux queue enable notaqueue
 '
 test_expect_success 'flux-queue disable fails on unknown queue' '
-	test_must_fail flux queue disable -q notaqueue
+	test_must_fail flux queue disable notaqueue
 '
 test_expect_success 'flux-queue status fails on unknown queue' '
-	test_must_fail flux queue status -q notaqueue
+	test_must_fail flux queue status notaqueue
 '
 
 test_done

--- a/t/t2241-queue-cmd-list.t
+++ b/t/t2241-queue-cmd-list.t
@@ -88,7 +88,7 @@ test_expect_success 'flux-queue: queue is enabled/stopped' '
 	test "$(flux queue list -no {started})" = "✗"
 '
 test_expect_success 'flux-queue: disable anonymous queue' '
-	flux queue disable testing
+	flux queue disable
 '
 test_expect_success 'flux-queue: queue is disabled/stopped' '
 	test_debug "flux queue list" &&

--- a/t/t2804-uptime-cmd.t
+++ b/t/t2804-uptime-cmd.t
@@ -24,7 +24,7 @@ test_expect_success 'flux-uptime reports correct size' '
 	flux uptime | grep "size 4"
 '
 test_expect_success 'flux-uptime reports submit disabled' '
-	flux queue disable "testing" &&
+	flux queue disable -m "testing" &&
 	flux uptime | grep "submit disabled"
 '
 test_expect_success 'flux-uptime reports scheduler stopped' '

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -54,7 +54,7 @@ test_expect_success "flux --root works in subinstance" '
 	id=$(flux batch -n1 --wrap \
 		flux run flux start ${ARGS} \
 		flux --root getattr instance-level) &&
-	flux job wait-event -vt 60 $id clean &&
+	flux job wait-event -vt 120 $id clean &&
 	test_debug "cat flux-${id}.out" &&
 	test "$(cat flux-${id}.out)" -eq 0
 '


### PR DESCRIPTION
This PR reworks the argument handling in many `flux queue` subcommands so that the target queue name is given as the first non-option parameter (aka free arguments), since this is probably what most users expect. The `-q, --queue=NAME` options are still supported, but are now hidden and undocumented and could be deprecated in a future release.

The "reason" in `flux queue disable` is now optional, and a new `-m, --message=REASON` option is provided for both `flux queue disable` and `flux queue stop` for specifying the reason now that it is not specified in the free arguments. This should allow old usage to immediately fail with "No such queue" if someone uses the old method `flux queue stop -q batch reason` since queue "reason" won't likely exist.

We should get @kkier and @ryanday36 to sign off on these changes since scripts and admin behavior may need to change.