### PR TITLE
fix failure to signal a process group after the process group leader exits

### DIFF
--- a/src/common/libsubprocess/test/test_fork_sleep.c
+++ b/src/common/libsubprocess/test/test_fork_sleep.c
@@ -20,6 +20,10 @@ main (int argc, char *argv[])
 {
     int len = 30;
     pid_t pid;
+    int nowait = 0;
+
+    if (getenv ("TEST_FORK_SLEEP_NOWAIT"))
+        nowait = 1;
 
     if (argv[1] != NULL) {
         len = atoi (argv[1]);
@@ -37,6 +41,8 @@ main (int argc, char *argv[])
         printf ("%d\n", getpid ());
         printf ("%d\n", pid);
         fflush (stdout);
+        if (nowait)
+            exit (0);
         wait (NULL);
     }
 


### PR DESCRIPTION
This PR fixes the main issue described in #6712. In this case, a child forked from the job shell kept the subprocess "active" (waiting for stdio to close) after the shell was sent SIGTERM (the process was inadvertently ignoring SIGTERM). When the job exec module attempted to SIGKILL, this was a noop since bulk-exec and libsubprocess do not allow sending a signal to a subprocess that has exited.

Fix the issue by allowing signals to be sent to any active subprocess if that subprocess was spawned in a process group.
