### PR TITLE
shell: clear signal mask and handlers in shell for plugins that call `fork(2)`

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -495,6 +495,7 @@ check_LTLIBRARIES = \
 	shell/plugins/test-event.la \
 	shell/plugins/jobspec-info.la \
 	shell/plugins/taskmap-reverse.la \
+	shell/plugins/fork.la \
 	job-manager/plugins/priority-wait.la \
 	job-manager/plugins/priority-invert.la \
 	job-manager/plugins/args.la \
@@ -874,6 +875,13 @@ shell_plugins_taskmap_reverse_la_CPPFLAGS = $(test_cppflags)
 shell_plugins_taskmap_reverse_la_LDFLAGS = \
 	$(fluxplugin_ldflags) -module -rpath /nowhere
 shell_plugins_taskmap_reverse_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+shell_plugins_fork_la_SOURCES = shell/plugins/fork.c
+shell_plugins_fork_la_CPPFLAGS = $(test_cppflags)
+shell_plugins_fork_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+shell_plugins_fork_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
 
 job_manager_plugins_priority_wait_la_SOURCES = \

--- a/t/shell/plugins/fork.c
+++ b/t/shell/plugins/fork.c
@@ -1,0 +1,46 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME "fork"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <stdio.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+
+static int init_cb (flux_plugin_t *p,
+                    const char *topic,
+                    flux_plugin_arg_t *args,
+                    void *data)
+{
+    if (fork () == 0) {
+        /* Just pause in child to simulate a worker process spawned by
+         * a shell plugin.
+         */
+        pause ();
+        exit (0);
+    }
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    if (flux_plugin_add_handler (p, "shell.init", init_cb, NULL) < 0)
+        return -1;
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -53,6 +53,8 @@ test_expect_success 'job-exec: job exception kills job shells' '
 	flux job eventlog $id | grep -E "status=(15|36608)"
 '
 test_expect_success 'job-exec: job exception uses SIGKILL after kill-timeout' '
+	flux cancel --all &&
+	(flux watch --all || true) &&
 	flux module reload job-exec kill-timeout=0.2 &&
 	cat <<-EOF >trap-sigterm.sh &&
 	#!/bin/sh

--- a/t/t2621-job-shell-plugin-fork.t
+++ b/t/t2621-job-shell-plugin-fork.t
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+test_description='Test flux-shell behavior when plugin calls fork(2)'
+
+. `dirname $0`/sharness.sh
+
+
+test_under_flux 2 job
+
+FORK_PLUGIN="${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs/fork.so"
+test_expect_success 'create shell initrc to load fork.so plugin' '
+	cat <<-EOF >fork.lua 
+	plugin.load { file = "$FORK_PLUGIN" }
+	EOF
+'
+test_expect_success 'submit sleep job with fork plugin' '
+	id=$(flux submit -o userrc=fork.lua -N2 sleep 120)
+'
+test_expect_success 'cancel sleep job' '
+	flux cancel $id
+'
+test_expect_success 'job should exit without hanging due to shell child' '
+	flux job wait-event -vt 60 $id clean
+'
+test_expect_success 'submit hostname job with fork plugin and wait it to exit' '
+	id=$(flux submit -o userrc=fork.lua -n1 hostname) &&
+	flux job wait-event -Hp exec $id shell.task-exit
+'
+test_expect_success 'cancel hostname job' '
+	flux cancel $id
+'
+test_expect_success 'job should complete without hanging due to shell child' '
+	flux job wait-event -vt 60 $id clean
+'
+
+test_done


### PR DESCRIPTION
This PR adds an atfork handler to the job shell that clears the signal mask and resets signal handlers in the case a shell plugin calls `fork()`. This allows SIGTERM sent by the job execution system to terminate these extra child processes of the shell (unless the plugin installs its own handler to deal with SIGTERM more gracefully)

