### PR TITLE
job-info: index watchers for quick cancels

### DIFF
--- a/src/modules/job-info/guest_watch.h
+++ b/src/modules/job-info/guest_watch.h
@@ -29,6 +29,8 @@ void guest_watchers_cancel (struct info_ctx *ctx,
                             const flux_msg_t *msg,
                             bool cancel);
 
+int guest_watch_setup (struct info_ctx *ctx);
+
 void guest_watch_cleanup (struct info_ctx *ctx);
 
 #endif /* ! _FLUX_JOB_INFO_GUEST_WATCH_H */

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -112,23 +112,10 @@ static void info_ctx_destroy (struct info_ctx *ctx)
         int saved_errno = errno;
         flux_msg_handler_delvec (ctx->handlers);
         lru_cache_destroy (ctx->owner_lru);
-        /* freefn set on lookup entries will destroy list entries */
-        if (ctx->lookups)
-            zlist_destroy (&ctx->lookups);
-        if (ctx->watchers) {
-            watch_cleanup (ctx);
-            zlist_destroy (&ctx->watchers);
-        }
-        if (ctx->guest_watchers) {
-            guest_watch_cleanup (ctx);
-            zlist_destroy (&ctx->guest_watchers);
-        }
-        if (ctx->update_watchers) {
-            update_watch_cleanup (ctx);
-            zlist_destroy (&ctx->update_watchers);
-        }
-        if (ctx->index_uw)
-            zhashx_destroy (&ctx->index_uw);
+        lookup_cleanup (ctx);
+        watch_cleanup (ctx);
+        guest_watch_cleanup (ctx);
+        update_watch_cleanup (ctx);
         free (ctx);
         errno = saved_errno;
     }
@@ -145,17 +132,13 @@ static struct info_ctx *info_ctx_create (flux_t *h)
     if (!(ctx->owner_lru = lru_cache_create (OWNER_LRU_MAXSIZE)))
         goto error;
     lru_cache_set_free_f (ctx->owner_lru, (lru_cache_free_f)free);
-    if (!(ctx->lookups = zlist_new ()))
+    if (lookup_setup (ctx) < 0)
         goto error;
-    if (!(ctx->watchers = zlist_new ()))
+    if (watch_setup (ctx) < 0)
         goto error;
-    if (!(ctx->guest_watchers = zlist_new ()))
+    if (guest_watch_setup (ctx) < 0)
         goto error;
-    if (!(ctx->update_watchers = zlist_new ()))
-        goto error;
-    /* no destructor for index_uw, destruction handled on
-     * update_watchers list */
-    if (!(ctx->index_uw = zhashx_new ()))
+    if (update_watch_setup (ctx) < 0)
         goto error;
     return ctx;
 error:

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -39,9 +39,9 @@ static void stats_cb (flux_t *h,
                       void *arg)
 {
     struct info_ctx *ctx = arg;
-    int lookups = zlist_size (ctx->lookups);
-    int watchers = zlist_size (ctx->watchers);
-    int guest_watchers = zlist_size (ctx->guest_watchers);
+    int lookups = zlistx_size (ctx->lookups);
+    int watchers = zlistx_size (ctx->watchers);
+    int guest_watchers = zlistx_size (ctx->guest_watchers);
     int update_lookups = 0;     /* no longer supported */
     int update_watchers = update_watch_count (ctx);
     if (flux_respond_pack (h,

--- a/src/modules/job-info/job-info.h
+++ b/src/modules/job-info/job-info.h
@@ -19,13 +19,21 @@
 
 #define OWNER_LRU_MAXSIZE 1000
 
+/* N.B. zlistx_t is predominantly use for storage b/c we need to
+ * iterate and remove entries while iterating.  This cannot be done
+ * with a zhashx_t unless we use the relatively costly zhashx_keys().
+ * So a number of lists are supplemented with a hash for when a
+ * quick lookup would be advantageous.
+ */
 struct info_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;
     lru_cache_t *owner_lru; /* jobid -> owner LRU */
     zlistx_t *lookups;
     zlistx_t *watchers;
+    zhashx_t *watchers_matchtags; /* matchtag + uuid -> watcher */
     zlistx_t *guest_watchers;
+    zhashx_t *guest_watchers_matchtags; /* matchtag + uuid -> guest_watcher */
     zlistx_t *update_watchers;
     zhashx_t *index_uw;        /* jobid + key -> update_watcher lookup */
 };

--- a/src/modules/job-info/job-info.h
+++ b/src/modules/job-info/job-info.h
@@ -23,10 +23,10 @@ struct info_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;
     lru_cache_t *owner_lru; /* jobid -> owner LRU */
-    zlist_t *lookups;
-    zlist_t *watchers;
-    zlist_t *guest_watchers;
-    zlist_t *update_watchers;
+    zlistx_t *lookups;
+    zlistx_t *watchers;
+    zlistx_t *guest_watchers;
+    zlistx_t *update_watchers;
     zhashx_t *index_uw;        /* jobid + key -> update_watcher lookup */
 };
 

--- a/src/modules/job-info/job-info.h
+++ b/src/modules/job-info/job-info.h
@@ -27,7 +27,7 @@ struct info_ctx {
     zlist_t *watchers;
     zlist_t *guest_watchers;
     zlist_t *update_watchers;
-    zhashx_t *index_uw;        /* update_watchers lookup */
+    zhashx_t *index_uw;        /* jobid + key -> update_watcher lookup */
 };
 
 #endif /* _FLUX_JOB_INFO_H */

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -646,6 +646,19 @@ error:
     json_decref (keys);
 }
 
+int lookup_setup (struct info_ctx *ctx)
+{
+    if (!(ctx->lookups = zlist_new ()))
+        return -1;
+    return 0;
+}
+
+void lookup_cleanup (struct info_ctx *ctx)
+{
+    if (ctx->lookups)
+        zlist_destroy (&ctx->lookups);
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-info/lookup.h
+++ b/src/modules/job-info/lookup.h
@@ -24,6 +24,10 @@ void update_lookup_cb (flux_t *h,
                        const flux_msg_t *msg,
                        void *arg);
 
+int lookup_setup (struct info_ctx *ctx);
+
+void lookup_cleanup (struct info_ctx *ctx);
+
 #endif /* ! _FLUX_JOB_INFO_LOOKUP_H */
 
 /*

--- a/src/modules/job-info/lookup.h
+++ b/src/modules/job-info/lookup.h
@@ -13,6 +13,8 @@
 
 #include <flux/core.h>
 
+void lookup_ctx_destroy_wrapper (void **data);
+
 void lookup_cb (flux_t *h,
                 flux_msg_handler_t *mh,
                 const flux_msg_t *msg,

--- a/src/modules/job-info/update.h
+++ b/src/modules/job-info/update.h
@@ -38,6 +38,8 @@ void update_watchers_cancel (struct info_ctx *ctx,
                              const flux_msg_t *msg,
                              bool cancel);
 
+int update_watch_setup (struct info_ctx *ctx);
+
 void update_watch_cleanup (struct info_ctx *ctx);
 
 int update_watch_count (struct info_ctx *ctx);

--- a/src/modules/job-info/util.c
+++ b/src/modules/job-info/util.c
@@ -152,6 +152,47 @@ void apply_updates_jobspec (flux_t *h,
     }
 }
 
+char *create_matchtag_key (flux_t *h, const flux_msg_t *msg)
+{
+    char *matchtag_key;
+    uint32_t matchtag;
+    const char *uuid;
+
+    if (flux_msg_get_matchtag (msg, &matchtag) < 0) {
+        flux_log_error (h, "failed to get matchtag");
+        return NULL;
+    }
+    if (!(uuid = flux_msg_route_first (msg))) {
+        flux_log_error (h, "failed to get uuid");
+        return NULL;
+    }
+    if (asprintf (&matchtag_key, "%s:%u", uuid, matchtag) < 0)
+        return NULL;
+    return matchtag_key;
+}
+
+int get_matchtag_key (flux_t *h,
+                      const flux_msg_t *msg,
+                      char *buf,
+                      size_t bufsize)
+{
+    uint32_t matchtag;
+    const char *uuid;
+    if (flux_msg_unpack (msg, "{s:i}", "matchtag", &matchtag) < 0) {
+        flux_log_error (h, "failed to get matchtag");
+        return -1;
+    }
+    if (!(uuid = flux_msg_route_first (msg))) {
+        flux_log_error (h, "failed to get uuid");
+        return -1;
+    }
+    if (snprintf (buf, bufsize, "%s:%u", uuid, matchtag) >= bufsize) {
+        flux_log_error (h, "failed to create matchtag key");
+        return -1;
+    }
+    return 0;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-info/util.h
+++ b/src/modules/job-info/util.h
@@ -50,6 +50,13 @@ void apply_updates_jobspec (flux_t *h,
                             json_t *jobspec,
                             json_t *context);
 
+char *create_matchtag_key (flux_t *h, const flux_msg_t *msg);
+
+int get_matchtag_key (flux_t *h,
+                      const flux_msg_t *msg,
+                      char *buf,
+                      size_t bufsize);
+
 #endif /* ! _FLUX_JOB_INFO_UTIL_H */
 
 /*

--- a/src/modules/job-info/watch.h
+++ b/src/modules/job-info/watch.h
@@ -31,6 +31,8 @@ void watchers_cancel (struct info_ctx *ctx,
                       const flux_msg_t *msg,
                       bool cancel);
 
+int watch_setup (struct info_ctx *ctx);
+
 void watch_cleanup (struct info_ctx *ctx);
 
 #endif /* ! _FLUX_JOB_INFO_WATCH_H */


### PR DESCRIPTION
Problem: In watchers_cancel() and guest_watchers_cancel(), every
watcher is iterated over to try and match a cancellation request.
This can slow down performance when the list grows larger and larger
over time.  For example, when monitoring jobs (i.e. watching
eventlogs of jobs) this can lead to very long lists.

Solution: Create an index that will map request uuids & matchtags
to their respective watchers, which will allow quick lookups for
cancellation requests.

---

With more and more performance fixes up in master, the gap between "master" and my PRs shrinks, we gotta get to 64K jobs to show the big improvement.

Current master

```
Running throughput.py 2048 jobs per iteration, 1 iterations
throughput:     198.6 job/s (script: 192.1 job/s)
1: 11 seconds
Total of 11 seconds for everything
Running throughput.py 4096 jobs per iteration, 1 iterations
throughput:     183.4 job/s (script: 181.2 job/s)
1: 23 seconds
Total of 23 seconds for everything
Running throughput.py 8192 jobs per iteration, 1 iterations
throughput:     180.2 job/s (script: 178.7 job/s)
1: 46 seconds
Total of 46 seconds for everything
Running throughput.py 16384 jobs per iteration, 1 iterations
throughput:     162.8 job/s (script: 162.1 job/s)
1: 101 seconds
Total of 101 seconds for everything
Running throughput.py 32768 jobs per iteration, 1 iterations
throughput:     131.9 job/s (script: 131.7 job/s)
1: 249 seconds
Total of 249 seconds for everything
Running throughput.py 65536 jobs per iteration, 1 iterations
throughput:     43.6 job/s (script:  43.6 job/s)
1: 1503 seconds
Total of 1503 seconds for everything

```

this branch

```
Running throughput.py 2048 jobs per iteration, 1 iterations
throughput:     197.4 job/s (script: 191.2 job/s)
1: 11 seconds
Total of 11 seconds for everything
Running throughput.py 4096 jobs per iteration, 1 iterations
throughput:     180.3 job/s (script: 178.2 job/s)
1: 23 seconds
Total of 23 seconds for everything
Running throughput.py 8192 jobs per iteration, 1 iterations
throughput:     176.0 job/s (script: 174.5 job/s)
1: 48 seconds
Total of 48 seconds for everything
Running throughput.py 16384 jobs per iteration, 1 iterations
throughput:     161.6 job/s (script: 161.0 job/s)
1: 102 seconds
Total of 102 seconds for everything
Running throughput.py 32768 jobs per iteration, 1 iterations
throughput:     137.0 job/s (script: 136.7 job/s)
1: 240 seconds
Total of 240 seconds for everything
Running throughput.py 65536 jobs per iteration, 1 iterations
throughput:     68.4 job/s (script:  68.4 job/s)
1: 960 seconds
Total of 960 seconds for everything
```

so through 32K jobs, not too much of a difference, but a significant difference at 64K.