### PR TITLE
support resource counts in `flux queue list` output, display effective limits by default

### DIFF
--- a/doc/man1/flux-queue.rst
+++ b/doc/man1/flux-queue.rst
@@ -254,6 +254,21 @@ The following field names can be specified:
 **limits.range.ngpus**
    range of gpus that can be requested for this queue
 
+**limits.range.effective.nnodes**
+   effective range of nodes that can be requested for this queue.
+   The upper end of the range will display the smaller of the policy
+   limit and the total nodes currently assigned to the queue.
+
+**limits.range.effective.ncores**
+   effective range of cores that can be requested for this queue.
+   The upper end of the range will display the smaller of the policy
+   limit and the total cores currently assigned to the queue.
+
+**limits.range.effective.ngpus**
+   effective range of gpus that can be requested for this queue.
+   The upper end of the range will display the smaller of the policy
+   limit and the total gpus currently assigned to the queue.
+
 **limits.min.nnodes**
    minimum number of nodes that must be requested for this queue
 
@@ -272,6 +287,9 @@ The following field names can be specified:
 **limits.max.ngpus**
    maximum number of gpus that can be requested for this queue
 
+**resources.{all,free,allocated,up,down}.{nnodes,ncores,ngpus}**
+   Counts of resources in various states (all available, currently free,
+   currently allocated, up, and down) for this queue.
 
 RESOURCES
 =========

--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -114,6 +114,19 @@ class FluxQueueConfig(UtilConfig):
                 "{color_started}{started:>2}{color_off} "
                 "{defaults.timelimit!F:>8} "
                 "{limits.timelimit!F:>8} "
+                "{limits.range.effective.nnodes:>10} "
+                "{limits.range.effective.ncores:>10} "
+                "{limits.range.effective.ngpus:>10}"
+            ),
+        },
+        "policy": {
+            "description": "flux-queue list with policy limits only",
+            "format": (
+                "?:{queuem:<8.8} "
+                "{color_enabled}{enabled:>2}{color_off} "
+                "{color_started}{started:>2}{color_off} "
+                "{defaults.timelimit!F:>8} "
+                "{limits.timelimit!F:>8} "
                 "{limits.range.nnodes:>10} "
                 "{limits.range.ncores:>10} "
                 "{limits.range.ngpus:>10}"

--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -132,6 +132,19 @@ class FluxQueueConfig(UtilConfig):
                 "{limits.range.ngpus:>10}"
             ),
         },
+        "nodes": {
+            "description": "Show queue status plus all/up/allocated/free nodes",
+            "format": (
+                "?:{queuem:<8.8} "
+                "{color_enabled}{enabled:>2}{color_off} "
+                "{color_started}{started:>2}{color_off} "
+                "{resources.all.nnodes:>6} "
+                "{resources.up.nnodes:>10} "
+                "{resources.down.nnodes:>10} "
+                "{resources.allocated.nnodes:>11} "
+                "{resources.free.nnodes:>10}"
+            ),
+        },
     }
 
     def __init__(self, subcommand):
@@ -262,6 +275,17 @@ class QueueInfoWrapper:
         return AltField("✔", "y") if self.is_started else AltField("✗", "n")
 
 
+def generate_resource_headings():
+    headings = {}
+    for item in ("nnodes", "ncores", "ngpus"):
+        for state in ("all", "free", "allocated", "up", "down"):
+            heading = item[1:].upper()
+            if state != "all":
+                heading += f":{state[:5].upper()}"
+            headings[f"resources.{state}.{item}"] = heading
+    return headings
+
+
 def list(args):
     headings = {
         "queue": "QUEUE",
@@ -290,6 +314,8 @@ def list(args):
         "limits.min.ngpus": "MINGPUS",
         "limits.max.ngpus": "MAXGPUS",
     }
+    headings.update(generate_resource_headings())
+
     fmt = FluxQueueConfig("list").load().get_format_string(args.format)
     formatter = flux.util.OutputFormat(fmt, headings=headings)
 


### PR DESCRIPTION
This PR leverages the `resources` attribute of `QueueInfo` in `flux queue list` to support emitting _effective_ queue limits in `flux queue list` as mentioned in #6724. 

Then, headers are added for the other `resources.{all,up,down.free,allocated}.{nnodes,ncores,ngpus}` fields so that these are available in output formats. Because it might be useful, a `nodes` output now shows the states of all nodes in the various queues in `flux queue list`:

```
$ src/cmd/flux queue list -o nodes
QUEUE    EN ST  NODES   NODES:UP NODES:DOWN NODES:ALLOC NODES:FREE
pbatch*   ✔  ✔    972        946         26         911         36
pdebug    ✔  ✔     40         40          0           5         35
pci       ✔  ✔      4          4          0           0          4
pall      ✔  ✗   1144       1118         26        1044         75
```

The new `flux queue list` default output now looks like:
```
QUEUE    EN ST TDEFAULT   TLIMIT     NNODES     NCORES      NGPUS
pbatch*   ✔  ✔      12h       1d      0-972    0-93312     0-3888
pdebug    ✔  ✔      30m       1h       0-40     0-3840      0-160
pci       ✔  ✔       1h       4h        0-1      0-384       0-16
pall      ✔  ✗      12h       1d     0-1144   0-109824     0-4576
```

Fixes #6724

