### PR TITLE
test: fix checks-lib script

### DIFF
--- a/src/test/checks-lib.sh
+++ b/src/test/checks-lib.sh
@@ -41,7 +41,7 @@ checks_die() {
     local MSG="$1"
     shift 1
     printf "::error::$MSG\n"
-    if $# -gt 0; then
+    if [ $# -gt 0 ]; then
         eval "$@"
     fi
     exit 1


### PR DESCRIPTION
Problem: the checks-lib script has an incorrect `if` statement, leading to errors.

Fix it.