### PR TITLE
t: add checkpoint integrity test

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -108,6 +108,7 @@ TESTSCRIPTS = \
 	t1009-kvs-copy.t \
 	t1010-kvs-commit-sync.t \
 	t1011-kvs-checkpoint-period.t \
+	t1012-kvs-checkpoint.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \
@@ -435,6 +436,7 @@ check_PROGRAMS = \
 	kvs/watch_disconnect \
 	kvs/watch_stream \
 	kvs/commit \
+	kvs/loop_append \
 	kvs/transactionmerge \
 	kvs/lookup_invalid \
 	kvs/commit_order \
@@ -637,6 +639,11 @@ kvs_commit_SOURCES = kvs/commit.c
 kvs_commit_CPPFLAGS = $(test_cppflags)
 kvs_commit_LDADD = $(test_ldadd)
 kvs_commit_LDFLAGS = $(test_ldflags)
+
+kvs_loop_append_SOURCES = kvs/loop_append.c
+kvs_loop_append_CPPFLAGS = $(test_cppflags)
+kvs_loop_append_LDADD = $(test_ldadd)
+kvs_loop_append_LDFLAGS = $(test_ldflags)
 
 kvs_transactionmerge_SOURCES = kvs/transactionmerge.c
 kvs_transactionmerge_CPPFLAGS = $(test_cppflags)

--- a/t/kvs/loop_append.c
+++ b/t/kvs/loop_append.c
@@ -1,0 +1,180 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* loop_append - infinite appends for testing kvs checkpointing.
+ *
+ * - count - stop after count appends
+ * - batch-count - how many eventlog entries to append per commit
+ * - threads - each thread writes to a different key
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <assert.h>
+#include <getopt.h>
+#include <pthread.h>
+#include <inttypes.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/xzmalloc.h"
+#include "src/common/libeventlog/eventlog.h"
+
+#define OPTIONS "c:b:t:"
+static const struct option longopts[] = {
+   {"count", required_argument, 0, 'c'},
+   {"batch-count", required_argument, 0, 'b'},
+   {"threads", required_argument, 0, 't'},
+   {0, 0, 0, 0},
+};
+
+static int count = -1;
+static int threads = 1;
+static int batch_count = 10;
+static const char *key = NULL;
+
+static void usage (void)
+{
+    fprintf (stderr,
+"Usage: loop_append [--count=N] [--batch-count=N] [--threads=N] <key>\n"
+);
+    exit (1);
+}
+
+typedef struct {
+    pthread_t t;
+    pthread_attr_t attr;
+    int n;
+    char *key;
+} thd_t;
+
+void *thread (void *arg)
+{
+    thd_t *t = arg;
+    flux_t *h = NULL;
+    char eventname[64];
+    int i = 0;
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    snprintf (eventname, sizeof (eventname), "test%d", t->n);
+
+    while (count < 0 || (i < count)) {
+        flux_future_t *f;
+        flux_kvs_txn_t *txn;
+        json_t *o;
+        char *str;
+        int j = 0;
+        if (!(txn = flux_kvs_txn_create ()))
+            log_err_exit ("flux_kvs_txn_create");
+        for (j = 0; j < batch_count && (count < 0 || i < count); j++) {
+            if (!(o = eventlog_entry_pack (i, eventname, "{s:i}", "count", i)))
+                log_err_exit ("eventlog_entry_pack");
+            if (!(str = eventlog_entry_encode (o)))
+                log_err_exit ("eventlog_encode");
+            if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, t->key, str) < 0)
+                log_err_exit ("%s", key);
+            json_decref (o);
+            free (str);
+            i++;
+        }
+        if (!(f = flux_kvs_commit (h, NULL, 0, txn)))
+            log_err_exit ("flux_kvs_commit");
+        if (flux_future_get (f, NULL) < 0)
+            log_err_exit ("commit %d", i);
+        flux_future_destroy (f);
+        flux_kvs_txn_destroy (txn);
+    }
+    flux_close (h);
+    return NULL;
+}
+
+int main (int argc, char *argv[])
+{
+    thd_t *thd;
+    flux_t *h = NULL;
+    flux_future_t *f;
+    flux_kvs_txn_t *txn;
+    int i, ch, rc;
+
+    log_init (argv[0]);
+
+    while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
+        switch (ch) {
+            case 'c':
+                count = strtoul (optarg, NULL, 10);
+                if (!count)
+                    log_msg_exit ("count must be > 0");
+                break;
+            case 'b':
+                batch_count = strtoul (optarg, NULL, 10);
+                if (!batch_count)
+                    log_msg_exit ("batch count must be > 0");
+                break;
+            case 't':
+                threads = strtoul (optarg, NULL, 10);
+                if (!threads)
+                    log_msg_exit ("threads must be > 0");
+                break;
+            default:
+                usage ();
+        }
+    }
+    if ((argc - optind) != 1)
+        usage ();
+    key = argv[optind];
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    /* first unlink old one if it's there */
+    if (!(txn = flux_kvs_txn_create ()))
+        log_err_exit ("flux_kvs_txn_create");
+    if (flux_kvs_txn_unlink (txn, 0, key) < 0)
+        log_err_exit ("flux_kvs_txn_unlink");
+    if (!(f = flux_kvs_commit (h, NULL, 0, txn))
+        || flux_future_get (f, NULL) < 0) {
+        if (errno != ENOENT)
+            log_err_exit ("flux_kvs_commit");
+    }
+
+    thd = xzmalloc (sizeof (*thd) * threads);
+
+    for (i = 0; i < threads; i++) {
+        thd[i].n = i;
+        if ((rc = pthread_attr_init (&thd[i].attr)))
+            log_errn (rc, "pthread_attr_init");
+        if (asprintf ((&thd[i].key), "%s%d", key, i) < 0)
+            log_errn (rc, "asprintf");
+        if ((rc = pthread_create (&thd[i].t, &thd[i].attr, thread, &thd[i])))
+            log_errn (rc, "pthread_create");
+    }
+
+    for (i = 0; i < threads; i++) {
+        if ((rc = pthread_join (thd[i].t, NULL)))
+            log_errn (rc, "pthread_join");
+    }
+
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+    for (i = 0; i < threads; i++)
+        free (thd[i].key);
+    free (thd);
+    flux_close (h);
+    log_fini ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t1012-kvs-checkpoint.t
+++ b/t/t1012-kvs-checkpoint.t
@@ -1,0 +1,76 @@
+#!/bin/sh
+#
+
+test_description='Test kvs checkpointing works'
+
+. `dirname $0`/kvs/kvs-helper.sh
+
+. `dirname $0`/sharness.sh
+
+if ! test "$TEST_LONG" = "t" && ! test "$LONGTEST" = "t"; then
+    skip_all='kvs checkpoint valid only run under LONGTEST'
+    test_done
+fi
+
+LOOPAPPEND=${FLUX_BUILD_DIR}/t/kvs/loop_append
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+THREADS=16
+
+export FLUX_CONF_DIR=$(pwd)
+
+test_expect_success 'configure checkpoint-period, place initial value' '
+	cat >kvs.toml <<-EOT
+	[kvs]
+	checkpoint-period = "5s"
+	EOT
+'
+
+# N.B. if wish to hand test with more "stress", incrase threads,
+# batchcount, and/or sleep.
+
+test_expect_success NO_CHAIN_LINT 'kvs: start instance that creates tons of appended data' '
+	statedir=$(mktemp -d --tmpdir=${TMPDIR:-/tmp}) &&
+	echo $statedir &&
+	flux start --setattr=statedir=${statedir} ${LOOPAPPEND} --batch-count=50 --threads=${THREADS} mydata &
+	pid=$! &&
+	sleep 60 &&
+	kill -s 9 $pid
+'
+
+test_expect_success 'kvs: create get checkpoint script' '
+	cat >checkpointget.sh <<-EOT &&
+	jq -j -c -n  "{key:\"kvs-primary\"}" | $RPC content.checkpoint-get
+	EOT
+	chmod 700 checkpointget.sh
+'
+
+test_expect_success 'kvs: make sure there was atleast one checkpoint' '
+	flux start --recovery=${statedir} ./checkpointget.sh
+'
+
+test_expect_success 'kvs: create get data script' '
+	cat >dataget.sh <<-EOT &&
+	N=\$((${THREADS} - 1))
+	for i in \$(seq 0 \${N})
+	do
+		flux kvs get mydata\${i} > ${statedir}/data\${i}.out 2> ${statedir}/data\${i}.err
+		if [[ \$? -ne 0 ]]
+		then
+			exit 1
+		fi
+	done
+	EOT
+	chmod 700 dataget.sh
+'
+
+test_expect_success 'kvs: make sure we can get all the data' '
+	flux start --recovery=${statedir} ./dataget.sh &&
+	num=$(wc -l ${statedir}/data*.out | tail -n 1 | awk "{print \$1}") &&
+	echo "total output lines = $num" &&
+	test ${num} -ne 0 &&
+	num=$(wc -l ${statedir}/data*.err | tail -n 1 | awk "{print \$1}") &&
+	echo "total error lines = $num" &&
+	test ${num} -eq 0
+'
+
+test_done


### PR DESCRIPTION
Problem: There are no tests to ensure that checkpoints work as intended when the broker is killed or it suddenly crashes.

Add some testing in a new t1012-kvs-checkpoint.t test.

Closes #6718