### PR TITLE
flux-job: forward some signals to jobs in `flux job attach`

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -55,6 +55,14 @@ A job can be interactively attached to via :program:`flux job attach`.  This is
 typically used to watch stdout/stderr while a job is running or after it has
 completed.  It can also be used to feed stdin to a job.
 
+By default SIGTERM, SIGHUP, SIGALRM, SIGUSR1 and SIGUSR2 are forwarded to the
+job when received by :program:`flux job attach`. To disable this behavior,
+use the :option:`--read-only` option.
+
+When :program:`flux job attach` receives two SIGINT (Ctrl-C) signals within 2s
+it will cancel the job. A Ctrl-C followed by Ctrl-Z detaches from the job.
+This behavior is also disabled with :option:`--read-only`.
+
 When :program:`flux job attach` is run interactively -- that is all of
 ``stdout``, ``stderr`` and ``stdin`` are attached to a tty -- the command may
 display a status line while the job is pending, e.g

--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -204,7 +204,8 @@ void print_eventlog_entry (struct attach_ctx *ctx,
         if (!(context_s = json_dumps (event->context, JSON_COMPACT)))
             log_err_exit ("%s: error re-encoding context", __func__);
     }
-    fprintf (stderr, "%.3fs: %s%s%s%s%s\n",
+    fprintf (stderr,
+             "%.3fs: %s%s%s%s%s\n",
              event->timestamp - ctx->timestamp_zero,
              prefix ? prefix : "",
              prefix ? "." : "",
@@ -260,17 +261,19 @@ static void handle_output_redirect (struct attach_ctx *ctx, json_t *context)
     const char *path = NULL;
     if (!ctx->output_header_parsed)
         log_msg_exit ("stream redirect read before header");
-    if (json_unpack (context, "{ s:s s:s s?s }",
-                              "stream", &stream,
-                              "rank", &rank,
-                              "path", &path) < 0)
+    if (json_unpack (context,
+                     "{ s:s s:s s?s }",
+                     "stream", &stream,
+                     "rank", &rank,
+                     "path", &path) < 0)
         log_msg_exit ("malformed redirect context");
     if (!optparse_hasopt (ctx->p, "quiet"))
-        fprintf (stderr, "%s: %s redirected%s%s\n",
-                         rank,
-                         stream,
-                         path ? " to " : "",
-                         path ? path : "");
+        fprintf (stderr,
+                 "%s: %s redirected%s%s\n",
+                 rank,
+                 stream,
+                 path ? " to " : "",
+                 path ? path : "");
 }
 
 /*  Level prefix strings. Nominally, output log event 'level' integers
@@ -293,7 +296,9 @@ static void handle_output_log (struct attach_ctx *ctx,
     int level = -1;
     json_error_t err;
 
-    if (json_unpack_ex (context, &err, 0,
+    if (json_unpack_ex (context,
+                        &err,
+                        0,
                         "{ s?i s:i s:s s?s s?s s?i }",
                         "rank", &rank,
                         "level", &level,
@@ -395,8 +400,10 @@ void attach_cancel_continuation (flux_future_t *f, void *arg)
  * If the user types ctrl-C twice within 2s, cancel the job.
  * If the user types ctrl-C then ctrl-Z within 2s, detach from the job.
  */
-void attach_signal_cb (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg)
+void attach_signal_cb (flux_reactor_t *r,
+                       flux_watcher_t *w,
+                       int revents,
+                       void *arg)
 {
     struct attach_ctx *ctx = arg;
     flux_future_t *f;
@@ -409,7 +416,8 @@ void attach_signal_cb (flux_reactor_t *r, flux_watcher_t *w,
             log_msg ("one more ctrl-C within 2s to cancel or ctrl-Z to detach");
         }
         else {
-            if (!(f = flux_job_cancel (ctx->h, ctx->id,
+            if (!(f = flux_job_cancel (ctx->h,
+                                       ctx->id,
                                        "interrupted by ctrl-C")))
                 log_err_exit ("flux_job_cancel");
             if (flux_future_then (f, -1, attach_cancel_continuation, NULL) < 0)
@@ -506,8 +514,10 @@ static int attach_send_shell (struct attach_ctx *ctx,
 }
 
 /* Handle std input from user */
-void attach_stdin_cb (flux_reactor_t *r, flux_watcher_t *w,
-                      int revents, void *arg)
+void attach_stdin_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
 {
     struct attach_ctx *ctx = arg;
     const char *ptr;
@@ -541,7 +551,8 @@ void attach_output_start (struct attach_ctx *ctx)
                                                 0)))
         log_err_exit ("flux_job_event_watch");
 
-    if (flux_future_then (ctx->output_f, -1.,
+    if (flux_future_then (ctx->output_f,
+                          -1.,
                           attach_output_continuation,
                           ctx) < 0)
         log_err_exit ("flux_future_then");
@@ -714,7 +725,9 @@ void handle_exec_log_msg (struct attach_ctx *ctx, double ts, json_t *context)
     size_t len = 0;
     json_error_t err;
 
-    if (json_unpack_ex (context, &err, 0,
+    if (json_unpack_ex (context,
+                        &err,
+                        0,
                         "{s:s s:s s:s s:s%}",
                         "rank", &rank,
                         "component", &component,
@@ -1109,8 +1122,10 @@ static void attach_notify (struct attach_ctx *ctx,
     }
 }
 
-void attach_notify_cb (flux_reactor_t *r, flux_watcher_t *w,
-                       int revents, void *arg)
+void attach_notify_cb (flux_reactor_t *r,
+                       flux_watcher_t *w,
+                       int revents,
+                       void *arg)
 {
     struct attach_ctx *ctx = arg;
     ctx->statusline = true;
@@ -1156,7 +1171,8 @@ void attach_event_continuation (flux_future_t *f, void *arg)
         int severity;
         const char *note;
 
-        if (json_unpack (event->context, "{s:s s:i s:s}",
+        if (json_unpack (event->context,
+                         "{s:s s:i s:s}",
                          "type", &type,
                          "severity", &severity,
                          "note", &note) < 0)

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -185,6 +185,21 @@ test_expect_success 'attach: detached job was not canceled' '
 	flux cancel $(cat jobid4)
 '
 
+test_expect_success 'attach: SIGTERM is forwarded to job' '
+	run_attach 5 &&
+	pid=$(cat pid5) &&
+	kill -TERM $pid &&
+	test_must_fail_or_be_terminated wait $pid &&
+	grep Terminated attach5.err
+'
+test_expect_success 'attach: SIGUSR1 is forwarded to job' '
+	run_attach 6 &&
+	pid=$(cat pid6) &&
+	kill -USR1 $pid &&
+	! wait $pid &&
+	grep "User defined"  attach6.err
+'
+
 # Make sure live output occurs by seeing output "before" sleep, but no
 # data "after" a sleep.
 #


### PR DESCRIPTION
It seems like perhaps an oversight that `flux job attach` gets terminated by signals like `SIGTERM`, `SIGHUP`, `SIGALRM` and `SIGUSR[12]` instead of forwarding them to jobs. 

If changes proposed in #6725 and #6729 go into effect, we don't want a `flux job attach` to just exit immediately when a user sends SIGUSR1 to their batch job. Instead, this PR lets `flux job attach` handle the signal and forward it to the job. This is probably the expected behavior for this particular command.