### PR TITLE
flux-queue: correct some comment grammar

### DIFF
--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -171,8 +171,9 @@ class FluxQueueConfig(UtilConfig):
 
 class QueueLimitsEffectiveRange:
     """
-    QueueLimits wrapper which supports a effective range (configured minimum
-    to effective maximum minimum of limit or all resources in queue).
+    QueueLimits wrapper which supports an effective range (configured minimum
+    to effective maximum, which is the minimum of limit or all resources in
+    queue).
     """
 
     def __init__(self, limits, resources):


### PR DESCRIPTION
Problem: A comment about the new QueueLimitsEffectiveRange class has some English typos / grammer issues.

Fix up the comment.

---

Fixing up the typos that were missed in #6726 