### PR TITLE
ci: update pre-commit and fix spurious flake8 error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ files: '^(src/bindings/python/flux|src/cmd|t/python/.*\.py|t/scripts/.*\.py)'
 exclude: "^(src/bindings/python/_flux/|src/bindings/python/flux/utils/|t/python/tap)"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -38,7 +38,7 @@ repos:
         types: [python]
         entry: ./scripts/run_mypy.sh
   - repo: https://github.com/netromdk/vermin
-    rev: v1.5.1
+    rev: v1.6.0
     hooks:
       - id: vermin
         args: ['-t=3.6-', '--violations']

--- a/src/bindings/python/flux/cli/fortune.py
+++ b/src/bindings/python/flux/cli/fortune.py
@@ -134,7 +134,7 @@ class FortuneCmd(base.MiniCmd):
         Check if we are within a few weeks of Valentine's Day
         """
         global fortunes
-        global valentines
+        global valentines  # noqa: F824
         now = datetime.now()
 
         # End of January or start of February


### PR DESCRIPTION
The pre-commit run in ci recently started complaining that it was using deprecated config with the suggestion to run
```
 pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks
```

This PR is the result of that.

Also, a spurious flake8 error starting showing up, so workaround that too with a `# noqa:` comment.