### PR TITLE
execute rc2 in same process group as broker and send `SIGHUP` before broker exit

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -134,6 +134,12 @@ broker.rc3_path [Updates: C]
 broker.rc2_none [Updates: C]
    If set, do not run an initial program.
 
+broker.rc2_pgrp [Updates: C]
+   By default, rc2 will be placed in the same process group as the
+   broker whenever the broker is itself a process group leader. If the
+   ``broker.rc2_pgrp`` attribute is set, then rc2 will always be placed
+   in its own process group.
+
 broker.exit-restart [Updates: C, R]
    A numeric exit code that the broker uses to indicate that it should not be
    restarted.  This is set by the systemd unit file.  Default: unset.

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -131,6 +131,9 @@ broker.rc1_path [Updates: C]
 broker.rc3_path [Updates: C]
    The path to the broker's rc3 script.  Default: ``${prefix}/etc/flux/rc3``.
 
+broker.rc2_none [Updates: C]
+   If set, do not run an initial program.
+
 broker.exit-restart [Updates: C, R]
    A numeric exit code that the broker uses to indicate that it should not be
    restarted.  This is set by the systemd unit file.  Default: unset.

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -948,3 +948,4 @@ backoff
 unkillable
 Feitelson
 TimeoutStopSec
+pgrp

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -354,10 +354,12 @@ static struct runat_command *runat_command_create (char **env, int flags)
         cmd->flags |= FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH;
     if (flags & RUNAT_FLAG_FORK_EXEC)
         cmd->flags |= FLUX_SUBPROCESS_FLAGS_FORK_EXEC;
-    /*
-     * N.B. By default subprocesses call setpgrp() before exec(2).  So
-     * any processes spawned by command are also signaled by
-     * flux_subprocess_signal()
+    if (flags & RUNAT_FLAG_NO_SETPGRP)
+        cmd->flags |= FLUX_SUBPROCESS_FLAGS_NO_SETPGRP;
+
+    /* N.B. if !RUNAT_FLAG_NO_SETPGRP then cmd will be in its own
+     * process group and flux_subprocess_kill() will use killpg(2).
+     * Otherwise, cmd shares a process group with the broker.
      */
     if (!(cmd->cmd = flux_cmd_create (0, NULL, env)))
         goto error;

--- a/src/broker/runat.h
+++ b/src/broker/runat.h
@@ -19,6 +19,7 @@ enum {
                                  * combine w/ broker) */
     RUNAT_FLAG_FORK_EXEC = 2,  /* require use of fork/exec, not
                                 * posix_spawn */
+    RUNAT_FLAG_NO_SETPGRP = 4,  /* Do not run process in its own pgrp */
 };
 
 struct runat;

--- a/t/issues/t5105-signal-propagation.sh
+++ b/t/issues/t5105-signal-propagation.sh
@@ -30,7 +30,7 @@ flux job kill -s SIGUSR1 $id
 
 $waitfile -t 100 -v -p "got SIGUSR1" log
 
-flux job status --json -v $id
+flux job status --json -v $id || true
 
 # vi: ts=4 sw=4 expandtab
 


### PR DESCRIPTION
This PR addresses #6725 and #6729, which both involve how the broker manages rc2 and associated processes.

The main change here is that rc2 (the broker initial program) is run in the same process group as the broker when the broker is a process group leader. This change addresses #6729 since the job shell uses `killpg(2)`, so signals are delivered to the broker _and_ the initial program/batch script. In case this ends up being a problem for some use cases, the old behavior can be restored by setting the `broker.rc2_pgrp` broker attribute.

#6725 is then addressed by having the broker send `SIGHUP` to its own process group on exit. This is similar to what the kernel would do when a session leader exits to cleanup processes still using a terminal. This effectively terminates any background processes that were launched from a batch script or initial program.

It may have been better to have these two changes in two separate PRs, but it turns out that just the first change makes the test suite less reliable, particularly the `t2808-shutdown` test, so it seems better if we take both changes at once.