### PR TITLE
flux-proxy: fall back to `/tmp` when `TMPDIR` is invalid

### DIFF
--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -352,6 +352,14 @@ static int comms_error (flux_t *h, void *arg)
     return 0;
 }
 
+static bool is_directory (const char *path)
+{
+    struct stat st;
+    if (stat (path, &st) < 0)
+        return 0;
+    return S_ISDIR (st.st_mode);
+}
+
 static int cmd_proxy (optparse_t *p, int ac, char *av[])
 {
     struct proxy_command ctx;
@@ -404,6 +412,11 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
 
     /* Create socket directory.
      */
+    if (tmpdir && !is_directory (tmpdir)) {
+        log_msg ("TMPDIR (%s) is not a directory. Using /tmp instead",
+                 tmpdir);
+        tmpdir = "/tmp";
+    }
     if (snprintf (workpath,
                   sizeof (workpath),
                   "%s/flux-proxy-XXXXXX",

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -178,4 +178,10 @@ test_expect_success NO_CHAIN_LINT 'flux-proxy sends SIGHUP to children without -
 	grep "\[\?25h" pty.out &&
 	grep "SIGHUP" pty.out
 '
+test_expect_success 'flux-proxy falls back to /tmp with invalid TMPDIR' '
+	id=$(flux batch -n1 --wrap sleep inf) &&
+	flux proxy ${id}?local flux uptime &&
+	flux cancel $id &&
+	flux job wait-event -Hvt 60 $id clean
+'
 test_done


### PR DESCRIPTION
This PR fixes #6737 by having `flux proxy` fall back to `/tmp` with a warning when `TMPDIR` is not a valid directory.