### PR TITLE
t: fix potential race in backgrounded processes

### DIFF
--- a/t/issues/t3432-python-sigint.sh
+++ b/t/issues/t3432-python-sigint.sh
@@ -27,7 +27,7 @@ def ping_cb(rpc, do_sync=False):
        print("ready.")
        sys.stdout.flush()
 
-do_sync = len(sys.argv) > 1 and sys.argv[1] == "sync" 
+do_sync = len(sys.argv) > 1 and sys.argv[1] == "sync"
 
 h = flux.Flux()
 

--- a/t/job-exec/imp.sh
+++ b/t/job-exec/imp.sh
@@ -7,7 +7,7 @@ cd $SHARNESS_TRASH_DIRECTORY
 
 case "$cmd" in
     exec)
-        shift; 
+        shift;
         #  Copy IMP's input to a file so tests can check result:
         ${FLUX_IMP_EXEC_HELPER:-cat} >imp-$(flux job id $2).input
         printf "test-imp: Running $* \n" >&2

--- a/t/kvs/torture.c
+++ b/t/kvs/torture.c
@@ -43,7 +43,7 @@ static void fill (char *s, int i, int len);
 
 void usage (void)
 {
-    fprintf (stderr, 
+    fprintf (stderr,
 "Usage: torture [--quiet|--verbose] [--prefix NAME] [--size BYTES] [--count N]\n"
 );
     exit (1);

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -52,7 +52,7 @@ test_expect_success 'flux dmesg -c prints and clears' '
 	! flux dmesg | grep -q hello_dmesg_pc
 '
 test_expect_success NO_CHAIN_LINT 'flux dmesg -f works' '
-	flux logger hello_last &&
+	flux logger hello_last
 	flux dmesg -f > dmesg.out &
 	pid=$! &&
 	$waitfile -t 20 -p hello_last dmesg.out &&
@@ -61,7 +61,7 @@ test_expect_success NO_CHAIN_LINT 'flux dmesg -f works' '
 	kill $pid
 '
 test_expect_success NO_CHAIN_LINT 'flux dmesg -f --new works' '
-	flux logger hello_old &&
+	flux logger hello_old
 	flux dmesg -f --new > dmesg2.out &
 	pid=$! &&
 	for i in $(seq 1 10); do flux logger hello_new; done &&

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -278,7 +278,7 @@ waitgrep() {
 # RFC 2606 reserves the .invalid domain for testing
 test_expect_success NO_CHAIN_LINT 'a warning is printed when upstream URI has unknown host' '
 	mkdir conf8b &&
-	cat <<-EOT >conf8b/bootstrap.toml &&
+	cat <<-EOT >conf8b/bootstrap.toml
 	[bootstrap]
 	curve_cert = "testcert"
 	[[bootstrap.hosts]]

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -519,7 +519,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: ENOSYS returned on unfinished requests o
 	WAITCOUNT=$(flux module stats --parse namespace.primary.#versionwaiters kvs) &&
 	WAITCOUNT=$(($WAITCOUNT+1))
 	VERS=$(flux kvs version) &&
-	VERSWAIT=$(($VERS+10)) &&
+	VERSWAIT=$(($VERS+10))
 	flux kvs wait ${VERSWAIT} 2> enosys.err &
 	pid=$! &&
 	wait_versionwaiters ${WAITCOUNT} &&

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -410,7 +410,7 @@ test_expect_success 'kvs: wait fails on invalid namespace on rank 1' '
 test_expect_success NO_CHAIN_LINT 'kvs: wait recognizes removed namespace' '
         flux kvs namespace create $NAMESPACETMP-REMOVE-WAIT &&
         VERS=$(flux kvs version --namespace=$NAMESPACETMP-REMOVE-WAIT) &&
-        VERS=$((VERS + 1)) &&
+        VERS=$((VERS + 1))
         flux kvs wait --namespace=$NAMESPACETMP-REMOVE-WAIT $VERS > wait_out 2>&1 &
         waitpid=$! &&
         wait_versionwaiters_nonzero $NAMESPACETMP-REMOVE-WAIT &&

--- a/t/t1007-kvs-lookup-watch.t
+++ b/t/t1007-kvs-lookup-watch.t
@@ -34,7 +34,7 @@ test_expect_success 'kvs-watch stats reports no namespaces when there are no wat
 '
 
 test_expect_success NO_CHAIN_LINT 'kvs-watch stats reports active watcher' '
-       flux kvs put test.stats=0 &&
+       flux kvs put test.stats=0
        flux kvs get --watch --count=2 test.stats >activewatchers.out &
        pid=$! &&
        $waitfile --count=1 --timeout=10 --pattern="[0-9]+" activewatchers.out &&
@@ -59,7 +59,7 @@ test_monotonicity() {
 }
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch returns commit order' '
-	flux kvs put test.c=1 &&
+	flux kvs put test.c=1
 	flux kvs get --watch --count=20 test.c >seq.out &
 	pid=$! &&
 	$waitfile --count=1 --timeout=10 \
@@ -86,7 +86,7 @@ test_expect_success 'flux kvs get --watch fails on nonexistent namespace' '
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch terminated by key removal' '
-	flux kvs put test.e=1 &&
+	flux kvs put test.e=1
 	flux kvs get --watch test.e >seq2.out &
 	pid=$! &&
 	$waitfile --count=1 --timeout=10 \
@@ -97,7 +97,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --watch terminated by key remova
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch terminated by namespace removal' '
 	flux kvs namespace create testns2 &&
-	flux kvs put --namespace=testns2 meep=1 &&
+	flux kvs put --namespace=testns2 meep=1
 	flux kvs get --namespace=testns2 --watch meep >seq4.out &
 	pid=$! &&
 	$waitfile --count=1 --timeout=10 \
@@ -107,8 +107,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --watch terminated by namespace 
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch sees duplicate committed values' '
-	flux kvs put test.f=1 &&
-
+	flux kvs put test.f=1
 	flux kvs get --count=20 --watch test.f >seq3.out &
 	pid=$! &&
 	$waitfile --count=1 --timeout=10 \
@@ -121,8 +120,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --watch sees duplicate committed
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch and --uniq do not see duplicate committed values' '
-	flux kvs put test.f=1 &&
-
+	flux kvs put test.f=1
 	flux kvs get --count=3 --watch --uniq test.f >seq4.out &
 	pid=$! &&
 	$waitfile --count=1 --timeout=10 \
@@ -157,7 +155,7 @@ test_expect_success 'flux kvs get --waitcreate works on existing key' '
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --waitcreate works on non-existent key' '
-        ! flux kvs get test.waitcreate2 &&
+        ! flux kvs get test.waitcreate2
         flux kvs get --waitcreate test.waitcreate2 > waitcreate2.out &
         pid=$! &&
         wait_watcherscount_nonzero primary &&
@@ -168,7 +166,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --waitcreate works on non-existe
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --waitcreate works on non-existent namespace' '
-        ! flux kvs get --namespace=ns_waitcreate test.waitcreate3 &&
+        ! flux kvs get --namespace=ns_waitcreate test.waitcreate3
         flux kvs get --namespace=ns_waitcreate --waitcreate \
                      test.waitcreate3 > waitcreate3.out &
         pid=$! &&
@@ -188,7 +186,7 @@ test_expect_success 'flux_kvs_lookup with waitcreate can be canceled' '
 # ensure background watcher has started, otherwise test can be racy
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get, basic --watch & --waitcreate works' '
-        ! flux kvs get --watch test.create_later &&
+        ! flux kvs get --watch test.create_later
         flux kvs get --watch --waitcreate --count=1 \
                      test.create_later > waitcreate.out &
         pid=$! &&
@@ -200,7 +198,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get, basic --watch & --waitcreate wo
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate & remove key works' '
-        ! flux kvs get --watch test.create_and_remove &&
+        ! flux kvs get --watch test.create_and_remove
         flux kvs get --watch --waitcreate --count=2 \
                      test.create_and_remove > waitcreate2.out 2>&1 &
         pid=$! &&
@@ -214,7 +212,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate & remove
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, create & remove namespace works' '
-        ! flux kvs get --namespace=ns_create_and_remove --watch test.ns_create_and_remove &&
+        ! flux kvs get --namespace=ns_create_and_remove --watch test.ns_create_and_remove
         flux kvs get --namespace=ns_create_and_remove --watch --waitcreate --count=2 \
                      test.ns_create_and_remove > waitcreate4.out 2>&1 &
         pid=$! &&
@@ -230,7 +228,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, create 
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, doesnt work on removed namespace' '
         flux kvs namespace create ns_remove &&
-        ! flux kvs get --namespace=ns_remove --watch test.ns_remove &&
+        ! flux kvs get --namespace=ns_remove --watch test.ns_remove
         flux kvs get --namespace=ns_remove --watch --waitcreate --count=1 \
                      test.ns_remove > waitcreate5.out 2>&1 &
         pid=$! &&
@@ -246,7 +244,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, doesnt 
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: basic --watch & --append works' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc" &&
+        flux kvs put test.append.test="abc"
         flux kvs get --watch --append --count=4 \
                      test.append.test > append1.out 2>&1 &
         pid=$! &&
@@ -271,7 +269,7 @@ largeval="abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr
 test_expect_success NO_CHAIN_LINT 'flux kvs get: basic --watch & --append works (initial valref)' '
         flux kvs unlink -Rf test &&
         echo -n ${largeval} | flux kvs put --raw test.append.test=- &&
-        flux kvs get --treeobj test.append.test | grep valref &&
+        flux kvs get --treeobj test.append.test | grep valref
         flux kvs get --watch --append --count=4 \
                      test.append.test > append1.out 2>&1 &
         pid=$! &&
@@ -291,7 +289,7 @@ abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzab
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append works with empty string' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc" &&
+        flux kvs put test.append.test="abc"
         flux kvs get --watch --append --count=4 \
                      test.append.test > append2.out 2>&1 &
         pid=$! &&
@@ -309,7 +307,7 @@ e
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append works with --waitcreate' '
-        flux kvs unlink -Rf test &&
+        flux kvs unlink -Rf test
         flux kvs get --watch --waitcreate --append --count=4 \
                      test.append.test > append3.out 2>&1 &
         pid=$! &&
@@ -329,7 +327,7 @@ f
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append works with multiple appends in a transaction' '
-        flux kvs unlink -Rf test &&
+        flux kvs unlink -Rf test
         flux kvs get --watch --waitcreate --append --count=7 \
                      test.append.test > append4.out 2>&1 &
         pid=$! &&
@@ -358,7 +356,7 @@ test_expect_success 'flux kvs get: --append fails on non-value' '
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append & --waitcreate fails on non-value' '
-        flux kvs unlink -Rf test &&
+        flux kvs unlink -Rf test
         flux kvs get --watch --waitcreate --append --count=1 test.append &
         pid=$! &&
         wait_watcherscount_nonzero primary &&
@@ -368,7 +366,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get: --append & --waitcreate fails o
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append fails on removed key' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc" &&
+        flux kvs put test.append.test="abc"
         flux kvs get --watch --append --count=4 \
                      test.append.test > append5.out 2>&1 &
         pid=$! &&
@@ -389,7 +387,7 @@ flux-kvs: test.append.test: No such file or directory
 # N.B. valref treeobj expected, but treeobj is now a dirref
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append fails on change to non-value' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc" &&
+        flux kvs put test.append.test="abc"
         flux kvs get --watch --append --count=4 \
                      test.append.test > append6.out 2>&1 &
         pid=$! &&
@@ -410,7 +408,7 @@ flux-kvs: test.append.test: Invalid argument
 # N.B. valref treeobj expected, but treeobj is now a val
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append fails on fake append' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc" &&
+        flux kvs put test.append.test="abc"
         flux kvs get --watch --append --count=4 \
                      test.append.test > append7.out 2>&1 &
         pid=$! &&
@@ -424,7 +422,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get: --append fails on fake append' 
 # N.B. valref treeobj now has fewer entries
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append fails on fake append (valref)' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc" &&
+        flux kvs put test.append.test="abc"
         flux kvs get --watch --append --count=4 \
                      test.append.test > append7.out 2>&1 &
         pid=$! &&
@@ -460,7 +458,7 @@ wait_kvs_value() {
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/o --full doesnt detect change' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.dir_orig.a="abc" &&
+        flux kvs put test.dir_orig.a="abc"
         flux kvs get --watch --count=2 test.dir_orig.a > full1.out 2>&1 &
         pid=$! &&
         wait_watcherscount_nonzero primary &&
@@ -491,7 +489,7 @@ wait_kvs_enoent() {
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/o --full doesnt detect ENOENT' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.dir_orig.a="abc" &&
+        flux kvs put test.dir_orig.a="abc"
         flux kvs get --watch --count=2 test.dir_orig.a > full2.out 2>&1 &
         pid=$! &&
         wait_watcherscount_nonzero primary &&
@@ -507,7 +505,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/o --full doesnt detect
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full detects change' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.dir_orig.a="abc" &&
+        flux kvs put test.dir_orig.a="abc"
         flux kvs get --watch --full --count=2 test.dir_orig.a > full3.out 2>&1 &
         pid=$! &&
         wait_watcherscount_nonzero primary &&
@@ -521,7 +519,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full detects change
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full detects ENOENT' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.dir_orig.a="abc" &&
+        flux kvs put test.dir_orig.a="abc"
         flux kvs get --watch --full --count=2 test.dir_orig.a > full4.out 2>&1 &
         pid=$! &&
         wait_watcherscount_nonzero primary &&
@@ -533,7 +531,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full detects ENOENT
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full works with changing data sizes' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.dir.a="abc" &&
+        flux kvs put test.dir.a="abc"
         flux kvs get --watch --full --count=5 test.dir.a > full5.out 2>&1 &
         pid=$! &&
         wait_watcherscount_nonzero primary &&
@@ -554,7 +552,7 @@ abc
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full doesnt work with non-changing data' '
         flux kvs unlink -Rf test &&
-        flux kvs put test.dir.a="abc" &&
+        flux kvs put test.dir.a="abc"
         flux kvs get --watch --full --count=3 test.dir.a > full6.out 2>&1 &
         pid=$! &&
         wait_watcherscount_nonzero primary &&
@@ -572,7 +570,7 @@ xyz
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full & --waitcreate works' '
-        flux kvs unlink -Rf test &&
+        flux kvs unlink -Rf test
         flux kvs get --watch --full --waitcreate --count=3 test.dir.a > full7.out 2>&1 &
         pid=$! &&
         wait_watcherscount_nonzero primary &&
@@ -592,7 +590,7 @@ xyz
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch, normalized key matching works ' '
 	flux kvs namespace create testnorm1 &&
-        flux kvs put --namespace=testnorm1 testnormkey1.a=1 &&
+        flux kvs put --namespace=testnorm1 testnormkey1.a=1
         flux kvs get --namespace=testnorm1 --watch --count=2 \
                      testnormkey1...a > norm1.out &
         pid=$! &&
@@ -660,7 +658,7 @@ test_expect_success 'flux kvs get --stream and --waitcreate works on existing ke
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --stream and --waitcreate works on non-existent key' '
-	! flux kvs get test.stream.b &&
+	! flux kvs get test.stream.b
 	flux kvs get --stream --waitcreate test.stream.b > stream7.out &
 	pid=$! &&
 	wait_watcherscount_nonzero primary &&
@@ -671,7 +669,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --stream and --waitcreate works 
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --stream and --waitcreate works on non-existent namespace' '
-	! flux kvs get --namespace=ns_stream test.stream.c &&
+	! flux kvs get --namespace=ns_stream test.stream.c
 	flux kvs get --namespace=ns_stream --waitcreate \
 		     test.stream.c > stream8.out &
 	pid=$! &&
@@ -700,7 +698,7 @@ test_expect_success 'flux kvs eventlog get --stream and --waitcreate works on ex
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs eventlog get --stream and --waitcreate works on non-existent key' '
-	! flux kvs eventlog get test.stream.log2 &&
+	! flux kvs eventlog get test.stream.log2
 	flux kvs eventlog get --stream --waitcreate test.stream.log2 > stream12.out &
 	pid=$! &&
 	wait_watcherscount_nonzero primary &&

--- a/t/t1008-kvs-eventlog.t
+++ b/t/t1008-kvs-eventlog.t
@@ -13,10 +13,10 @@ waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
 test_expect_success 'flux kvs eventlog append --timestamp works' '
 	flux kvs eventlog append --timestamp=1 test.a name {\"data\":\"foo\"} &&
 	flux kvs eventlog get --unformatted test.a >get_a.out &&
-        echo "{\"timestamp\":1.0,\"name\":\"name\",\"context\":{\"data\":\"foo\"}}" \
-             >get_a.exp &&
-        flux kvs get test.a &&
-        test_cmp get_a.exp get_a.out
+	echo "{\"timestamp\":1.0,\"name\":\"name\",\"context\":{\"data\":\"foo\"}}" \
+	     >get_a.exp &&
+	flux kvs get test.a &&
+	test_cmp get_a.exp get_a.out
 '
 
 test_expect_success 'flux kvs eventlog append works w/o context' '
@@ -29,7 +29,7 @@ test_expect_success 'flux kvs eventlog append works w/ context' '
 	flux kvs eventlog append test.c foo {\"data\":\"bar\"} &&
 	flux kvs eventlog get test.c >get_c.out &&
 	grep -q foo get_c.out &&
-        grep -q "data=\"bar\"" get_c.out
+	grep -q "data=\"bar\"" get_c.out
 '
 
 test_expect_success 'flux kvs eventlog get --human works' '
@@ -62,8 +62,8 @@ test_expect_success 'flux kvs eventlog wait-event --human works' '
 
 has_color() {
 	# To grep for ansi escape we need the help of the non-shell builtin
-  	# printf(1), so run under env(1) so we don't get shell builtin:
-        grep "$(env printf "\x1b\[")" $1 >/dev/null
+	# printf(1), so run under env(1) so we don't get shell builtin:
+	grep "$(env printf "\x1b\[")" $1 >/dev/null
 }
 test_expect_success 'flux kvs eventlog get/wait-event reject invalid --color' '
 	test_must_fail flux kvs eventlog get --color=foo test.human &&
@@ -119,7 +119,7 @@ test_expect_success 'flux kvs eventlog get --watch --count=N works' '
 		get --watch --unformatted --count=2 test.d >get_d.out &&
 	echo "{\"timestamp\":42.0,\"name\":\"foo\"}" >get_d.exp &&
 	echo "{\"timestamp\":43.0,\"name\":\"bar\"}" >>get_d.exp &&
-        test_cmp get_d.exp get_d.out
+	test_cmp get_d.exp get_d.out
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs eventlog get --watch returns append order' '
@@ -129,17 +129,17 @@ test_expect_success NO_CHAIN_LINT 'flux kvs eventlog get --watch returns append 
 	pid=$! &&
 	for i in $(seq 2 20); do \
 		flux kvs eventlog append --timestamp=$i test.e foo "{\"data\":\"bar\"}"; \
-    	        echo "{\"timestamp\":$i.0,\"name\":\"foo\",\"context\":{\"data\":\"bar\"}}" >>get_e.exp
+		echo "{\"timestamp\":$i.0,\"name\":\"foo\",\"context\":{\"data\":\"bar\"}}" >>get_e.exp
 	done &&
 	wait $pid &&
 	test_cmp get_e.exp get_e.out
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs eventlog get --waitcreate works' '
-        test_must_fail flux kvs eventlog get --unformatted test.f &&
+	test_must_fail flux kvs eventlog get --unformatted test.f &&
 	flux kvs eventlog get --unformatted --waitcreate test.f >get_f.out &
 	pid=$! &&
-        wait_watcherscount_nonzero primary &&
+	wait_watcherscount_nonzero primary &&
 	flux kvs eventlog append --timestamp=1 test.f foo "{\"data\":\"bar\"}" &&
 	echo "{\"timestamp\":1.0,\"name\":\"foo\",\"context\":{\"data\":\"bar\"}}" >get_f.exp
 	wait $pid &&
@@ -147,63 +147,63 @@ test_expect_success NO_CHAIN_LINT 'flux kvs eventlog get --waitcreate works' '
 '
 
 test_expect_success 'flux kvs eventlog append and work on alternate namespaces' '
-        flux kvs namespace create EVENTLOGTESTNS &&
-        flux kvs eventlog append test.ns main &&
-        flux kvs eventlog append --namespace=EVENTLOGTESTNS test.ns guest &&
-        flux kvs eventlog get test.ns > get_f1.out &&
-        grep main get_f1.out &&
-        flux kvs eventlog get --namespace=EVENTLOGTESTNS test.ns > get_f2.out &&
-        grep guest get_f2.out
+	flux kvs namespace create EVENTLOGTESTNS &&
+	flux kvs eventlog append test.ns main &&
+	flux kvs eventlog append --namespace=EVENTLOGTESTNS test.ns guest &&
+	flux kvs eventlog get test.ns > get_f1.out &&
+	grep main get_f1.out &&
+	flux kvs eventlog get --namespace=EVENTLOGTESTNS test.ns > get_f2.out &&
+	grep guest get_f2.out
 '
 
 test_expect_success 'flux kvs eventlog wait-event detects eventlog with event' '
 	flux kvs eventlog append --timestamp=42 test.wait_event.a foo &&
 	flux kvs eventlog append --timestamp=43 test.wait_event.a bar &&
-        flux kvs eventlog wait-event --unformatted test.wait_event.a foo > wait_event_a1.out &&
-        grep foo wait_event_a1.out &&
-        test_must_fail grep bar wait_event_a1.out &&
-        flux kvs eventlog wait-event --unformatted test.wait_event.a bar > wait_event_a2.out &&
-        test_must_fail grep foo wait_event_a2.out &&
-        grep bar wait_event_a2.out
+	flux kvs eventlog wait-event --unformatted test.wait_event.a foo > wait_event_a1.out &&
+	grep foo wait_event_a1.out &&
+	test_must_fail grep bar wait_event_a1.out &&
+	flux kvs eventlog wait-event --unformatted test.wait_event.a bar > wait_event_a2.out &&
+	test_must_fail grep foo wait_event_a2.out &&
+	grep bar wait_event_a2.out
 '
 
 test_expect_success 'flux kvs eventlog wait-event outputs more events with -v' '
 	flux kvs eventlog append --timestamp=42 test.wait_event.b foo &&
 	flux kvs eventlog append --timestamp=43 test.wait_event.b bar &&
-        flux kvs eventlog wait-event --unformatted -v test.wait_event.b foo > wait_event_b1.out &&
-        grep foo wait_event_b1.out &&
-        test_must_fail grep bar wait_event_b1.out &&
-        flux kvs eventlog wait-event --unformatted -v test.wait_event.b bar > wait_event_b2.out &&
-        grep foo wait_event_b2.out &&
-        grep bar wait_event_b2.out
+	flux kvs eventlog wait-event --unformatted -v test.wait_event.b foo > wait_event_b1.out &&
+	grep foo wait_event_b1.out &&
+	test_must_fail grep bar wait_event_b1.out &&
+	flux kvs eventlog wait-event --unformatted -v test.wait_event.b bar > wait_event_b2.out &&
+	grep foo wait_event_b2.out &&
+	grep bar wait_event_b2.out
 '
 
 test_expect_success 'flux kvs eventlog wait-event doesnt output events with -q' '
 	flux kvs eventlog append --timestamp=42 test.wait_event.c foo &&
 	flux kvs eventlog append --timestamp=43 test.wait_event.c bar &&
-        flux kvs eventlog wait-event --unformatted -q test.wait_event.c foo > wait_event_c1.out &&
-        test_must_fail grep foo wait_event_c1.out &&
-        test_must_fail grep bar wait_event_c1.out &&
-        flux kvs eventlog wait-event --unformatted -q test.wait_event.c bar > wait_event_c2.out &&
-        test_must_fail grep foo wait_event_c2.out &&
-        test_must_fail grep bar wait_event_c2.out
+	flux kvs eventlog wait-event --unformatted -q test.wait_event.c foo > wait_event_c1.out &&
+	test_must_fail grep foo wait_event_c1.out &&
+	test_must_fail grep bar wait_event_c1.out &&
+	flux kvs eventlog wait-event --unformatted -q test.wait_event.c bar > wait_event_c2.out &&
+	test_must_fail grep foo wait_event_c2.out &&
+	test_must_fail grep bar wait_event_c2.out
 '
 
 test_expect_success 'flux kvs eventlog wait-event fails on eventlog without event' '
 	flux kvs eventlog append --timestamp=42 test.wait_event.d foo &&
 	flux kvs eventlog append --timestamp=43 test.wait_event.d bar &&
-        test_expect_code 137 run_timeout 0.1 flux kvs eventlog wait-event test.wait_event.d foobar
+	test_expect_code 137 run_timeout 0.1 flux kvs eventlog wait-event test.wait_event.d foobar
 '
 
 test_expect_success 'flux kvs eventlog wait-event fails on non-existent eventlog' '
-        test_must_fail flux kvs eventlog wait-event test.wait_event.e foo
+	test_must_fail flux kvs eventlog wait-event test.wait_event.e foo
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs eventlog wait-event --waitcreate works' '
-        test_must_fail flux kvs eventlog get --unformatted test.wait_event.f &&
+	test_must_fail flux kvs eventlog get --unformatted test.wait_event.f &&
 	flux kvs eventlog wait-event --waitcreate --unformatted test.wait_event.f foo >wait_event_f.out &
 	pid=$! &&
-        wait_watcherscount_nonzero primary &&
+	wait_watcherscount_nonzero primary &&
 	flux kvs eventlog append --timestamp=1 test.wait_event.f foo "{\"data\":\"bar\"}" &&
 	echo "{\"timestamp\":1.0,\"name\":\"foo\",\"context\":{\"data\":\"bar\"}}" >wait_event_f.exp
 	wait $pid &&

--- a/t/t1008-kvs-eventlog.t
+++ b/t/t1008-kvs-eventlog.t
@@ -210,7 +210,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs eventlog wait-event --waitcreate wor
 	test_cmp wait_event_f.exp wait_event_f.out
 '
 
-test_expect_success NO_CHAIN_LINT 'flux kvs eventlog wait-event --timeout works' '
+test_expect_success 'flux kvs eventlog wait-event --timeout works' '
 	flux kvs eventlog append --timestamp=42 test.wait_event.g foo &&
 	flux kvs eventlog append --timestamp=43 test.wait_event.g bar &&
 	test_must_fail flux kvs eventlog wait-event --timeout=0.1 test.wait_event.g baz

--- a/t/t1008-kvs-eventlog.t
+++ b/t/t1008-kvs-eventlog.t
@@ -136,7 +136,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs eventlog get --watch returns append 
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs eventlog get --waitcreate works' '
-	test_must_fail flux kvs eventlog get --unformatted test.f &&
+	test_must_fail flux kvs eventlog get --unformatted test.f
 	flux kvs eventlog get --unformatted --waitcreate test.f >get_f.out &
 	pid=$! &&
 	wait_watcherscount_nonzero primary &&
@@ -200,7 +200,7 @@ test_expect_success 'flux kvs eventlog wait-event fails on non-existent eventlog
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs eventlog wait-event --waitcreate works' '
-	test_must_fail flux kvs eventlog get --unformatted test.wait_event.f &&
+	test_must_fail flux kvs eventlog get --unformatted test.wait_event.f
 	flux kvs eventlog wait-event --waitcreate --unformatted test.wait_event.f foo >wait_event_f.out &
 	pid=$! &&
 	wait_watcherscount_nonzero primary &&

--- a/t/t1012-kvs-checkpoint.t
+++ b/t/t1012-kvs-checkpoint.t
@@ -30,7 +30,7 @@ test_expect_success 'configure checkpoint-period, place initial value' '
 
 test_expect_success NO_CHAIN_LINT 'kvs: start instance that creates tons of appended data' '
 	statedir=$(mktemp -d --tmpdir=${TMPDIR:-/tmp}) &&
-	echo $statedir &&
+	echo $statedir
 	flux start --setattr=statedir=${statedir} ${LOOPAPPEND} --batch-count=50 --threads=${THREADS} mydata &
 	pid=$! &&
 	sleep 60 &&

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -248,7 +248,7 @@ test_expect_success NO_CHAIN_LINT 'flux job eventlog -F, --follow works' '
 '
 #
 #  Color and human-readable output tests for flux job eventlog/wait-event
-#  
+#
 test_expect_success 'flux job eventlog -H, --human works' '
 	#
         #  Note: --human option should format first timestamp of eventlog

--- a/t/t2274-manager-perilog-per-rank.t
+++ b/t/t2274-manager-perilog-per-rank.t
@@ -165,7 +165,7 @@ test_expect_success 'perilog: stdout was copied to dmesg log' '
 	flux dmesg -H | grep "$jobid: prolog:.*rank 0.*stdout: 0" &&
 	flux dmesg -H | grep "$jobid: prolog:.*rank 1.*stdout: 1" &&
 	flux dmesg -H | grep "$jobid: prolog:.*rank 2.*stdout: 2" &&
-	flux dmesg -H | grep "$jobid: prolog:.*rank 3.*stdout: 3" 
+	flux dmesg -H | grep "$jobid: prolog:.*rank 3.*stdout: 3"
 '
 test_expect_success 'perilog: load a basic per-rank prolog config' '
 	flux config load <<-EOF &&

--- a/t/t2408-sdbus-recovery.t
+++ b/t/t2408-sdbus-recovery.t
@@ -78,7 +78,7 @@ test_expect_success 'print logs' '
 test_expect_success 'force another bus reconnect' '
 	bus_reconnect
 '
-test_expect_success NO_CHAIN_LINT 'background subscription fails with EAGAIN' '
+test_expect_success 'background subscription fails with EAGAIN' '
 	pid=$(cat signals.pid) &&
 	test_must_fail wait $pid &&
 	grep "Errno 11" signals.err
@@ -94,7 +94,7 @@ test_expect_success 'get systemd version to ensure reconnect has occurred' '
 test_expect_success 'remove sdbus module' '
 	flux module remove sdbus
 '
-test_expect_success NO_CHAIN_LINT 'background subscription fails with ENOSYS' '
+test_expect_success 'background subscription fails with ENOSYS' '
 	pid=$(cat signals2.pid) &&
 	test_must_fail wait $pid &&
 	grep "Errno 38" signals2.err

--- a/t/t2603-job-shell-initrc.t
+++ b/t/t2603-job-shell-initrc.t
@@ -40,7 +40,6 @@ test_expect_success 'flux-shell: initrc: plugin.searchpath set via broker attr' 
 	test_debug "cat print-searchpath.out" &&
 	grep "plugin.searchpath = /test/foo" print-searchpath.out &&
 	flux setattr conf.shell_pluginpath "${old_pluginpath}"
-	
 '
 test_expect_success 'flux-shell: default initrc obeys FLUX_SHELL_RC_PATH' '
 	mkdir test-dir.d &&
@@ -127,7 +126,7 @@ test_expect_success 'flux-shell: initrc: assignment to shell method fails' '
 test_expect_success 'flux-shell: initrc: return false from plugin aborts shell' '
 	name=failed-return &&
 	cat >${name}.lua <<-EOT &&
-	    plugin.register { 
+	    plugin.register {
               name = "$name",
               handlers = {
 		{ topic="*", fn = function () return false end }

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -323,7 +323,7 @@ test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output 
         id=$(flux submit -n1 \
              --output=out27 --error=err27 \
              sleep 60)
-        flux job wait-event $id start &&
+        flux job wait-event $id start
         flux job attach -E -X ${id} 2> attach27.err &
         pid=$! &&
         flux cancel $id &&
@@ -334,7 +334,7 @@ test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output 
         id=$(flux submit -n2 \
              --output=out28 --error=err28 \
              sleep 60)
-        flux job wait-event $id start &&
+        flux job wait-event $id start
         flux job attach -E -X ${id} 2> attach28.err &
         pid=$! &&
         flux cancel $id &&

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -17,7 +17,7 @@ runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast"
 waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
 
 shell_leader_rank() {
-    flux job wait-event -f json -p exec $1 shell.init | 
+    flux job wait-event -f json -p exec $1 shell.init |
         jq '.context["leader-rank"]'
 }
 shell_service() {

--- a/t/t2621-job-shell-plugin-fork.t
+++ b/t/t2621-job-shell-plugin-fork.t
@@ -9,7 +9,7 @@ test_under_flux 2 job
 
 FORK_PLUGIN="${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs/fork.so"
 test_expect_success 'create shell initrc to load fork.so plugin' '
-	cat <<-EOF >fork.lua 
+	cat <<-EOF >fork.lua
 	plugin.load { file = "$FORK_PLUGIN" }
 	EOF
 '

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -116,7 +116,7 @@ test_expect_success NO_CHAIN_LINT 'flux alloc --bg can be interrupted' '
 '
 test_expect_success NO_CHAIN_LINT 'flux alloc --bg errors when job is canceled' '
 	flux queue stop &&
-	test_when_finished "flux queue start" &&
+	test_when_finished "flux queue start"
 	flux alloc --bg -n1 -v >canceled.log 2>&1 &
 	pid=$! &&
 	$waitfile -t 180 -v -p waiting canceled.log &&

--- a/t/t2815-post-job-event.t
+++ b/t/t2815-post-job-event.t
@@ -20,12 +20,12 @@ test_expect_success 'flux-post-job-event can post a simple event' '
 '
 test_expect_success 'flux-post-job-event can post an event with context' '
 	flux post-job-event $JOBID test note=testing  &&
-	flux job wait-event -m note=testing -t15 $JOBID test 
+	flux job wait-event -m note=testing -t15 $JOBID test
 '
 test_expect_success 'flux-post-job-event can post multiple context keys' '
 	flux post-job-event $JOBID test note=test2 status=0  &&
 	flux job wait-event -m note=test2 -t15 $JOBID test  &&
-	flux job wait-event -m status=0 -t15 $JOBID test 
+	flux job wait-event -m status=0 -t15 $JOBID test
 '
 test_expect_success 'flux-post-job-event fails for invalid job' '
 	test_must_fail flux post-job-event f123 test note="test event"

--- a/t/test-inception.sh
+++ b/t/test-inception.sh
@@ -8,7 +8,7 @@ stats() {
     while :; do
        echo === $(flux jobs --stats-only) ===
        sleep 5
-    done 
+    done
 }
 
 stats &
@@ -31,7 +31,7 @@ for id in $(flux jobs -f failed -no {id}); do
     name=$(flux jobs -no {name} ${id})
     flux job attach $id > ${name/.t}.log 2>&1
 done
- 
+
 # print failed jobs listing to stdout
 flux jobs -f failed
 


### PR DESCRIPTION
Problem: The following pattern exists in a number of tests

do-something &&
do-something &&
run_a_process_in_background &
pid=$! &&
...
wait $pid / kill $pid / etc.

This is racy and unsafe.  In bash $! returns the pid of the most
recent backgrounded process, but with the previous line being && chained,
it is possible the backgrounding of the process has not yet occurred and
an incorrect PID is picked up by $!.

Solution:  Remove the && chain for any command before a backgrounded
process.  In one situation, remove the workaround put in place to work
around this.

Fixes #6745