### PR TITLE
testsuite: fix flux-proxy TMPDIR test

### DIFF
--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -180,7 +180,8 @@ test_expect_success NO_CHAIN_LINT 'flux-proxy sends SIGHUP to children without -
 '
 test_expect_success 'flux-proxy falls back to /tmp with invalid TMPDIR' '
 	id=$(flux batch -n1 --wrap sleep inf) &&
-	flux proxy ${id}?local flux uptime &&
+	uri=$(flux uri --local --wait $id) &&
+	TMPDIR=/foo flux proxy $uri flux uptime &&
 	flux cancel $id &&
 	flux job wait-event -Hvt 60 $id clean
 '


### PR DESCRIPTION
Problem: The test for handling an invalid TMPDIR in flux-proxy contains a race: The batch instance may not have posted the uri memo by the time flux-proxy runs. Not only that, but somehow setting the invalid TMPDIR value was dropped at some point, so the test doesn't even test anything.

Fix the race condition using `flux uri --wait`.

Restore the invalid TMPDIR so the test checks the intended behavior.