### PR TITLE
libeventlog: cleanup failed batch in eventlogger

### DIFF
--- a/src/common/libeventlog/eventlogger.c
+++ b/src/common/libeventlog/eventlogger.c
@@ -136,6 +136,8 @@ static void eventlog_batch_error (struct eventlog_batch *batch, int errnum)
         (*ev->ops.err) (ev, ev->arg, errnum, entry);
         entry = zlist_next (batch->entries);
     }
+    /*  zlist_remove destroys batch */
+    zlist_remove (ev->pending, batch);
 }
 
 static void commit_cb (flux_future_t *f, void *arg)


### PR DESCRIPTION
Problem: If a batch commit fails in the eventlogger the batch is never cleaned up until the eventlogger is destroyed.  It sits on the pending list forever.

Cleanup the batch in eventlogger_batch_error() to reclaim that memory.

Fixes #6754

----

Side note, this was found only via code review.   Also, #6755 is not required to be merged first, as this is independent of that.  However, #6755 will ensure one more case of "batch error" is handled correctly.