### PR TITLE
enable daily backups of system KVS

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -7,10 +7,13 @@ systemdsystemunit_DATA = \
 #endif
 
 tmpfilesdir = $(prefix)/lib/tmpfiles.d
+crondir = $(fluxconfdir)/system/cron.d
 fluxrc1dir = $(fluxconfdir)/rc1.d
 
 tmpfiles_DATA = flux.conf
 
+dist_cron_DATA = \
+	kvs-backup.cron
 
 dist_fluxconf_SCRIPTS = \
         rc1 \

--- a/etc/flux.conf
+++ b/etc/flux.conf
@@ -1,4 +1,4 @@
 # See tmpfiles.d(5)
-# remove Flux dump files older than 30 days
+# remove old Flux dump files
 
-e /var/lib/flux/dump - - - 30d
+e /var/lib/flux/dump - - - 7d

--- a/etc/kvs-backup.cron
+++ b/etc/kvs-backup.cron
@@ -1,0 +1,1 @@
+0 3 * * * sh -c "flux dump --quiet --ignore-failed-read $(flux getattr statedir)/dump/$(date +%Y%m%d_%H%M%S).tgz"


### PR DESCRIPTION
Problem: the kvs and its content storage layer currently have some reliability issues, especially in long running system instances of Flux.
    
As a stopgap while those issues are being worked, add a nightly KVS dump for the system instance of Flux.  Backups will accumulate in `/var/lib/flux/dump` using the same naming convention as the automatic dumps taken at shutdown.  The existing tmpfiles configuration removes old dump files, keeping storage usage in check.
    
Fixes #6759
