### PR TITLE
content-sqlite: store history of checkpoints

### DIFF
--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -371,7 +371,7 @@ void checkpoint_get_cb (flux_t *h,
                         void *arg)
 {
     struct content_sqlite *ctx = arg;
-    char *s;
+    const char *s;
     json_t *o = NULL;
     const char *errstr = NULL;
     json_error_t error;
@@ -389,7 +389,7 @@ void checkpoint_get_cb (flux_t *h,
         errno = ENOENT;
         goto error;
     }
-    s = (char *)sqlite3_column_text (ctx->checkpt_get_stmt, 0);
+    s = (const char *)sqlite3_column_text (ctx->checkpt_get_stmt, 0);
     if (!(o = json_loads (s, 0, &error))) {
         /* recovery from version 0 checkpoint blobref not supported */
         errstr = error.text;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -82,6 +82,7 @@ TESTSCRIPTS = \
 	t0032-directives-parser.t \
 	t0033-filemap-cmd.t \
 	t0034-broker-getenv.t \
+	t0035-content-sqlite-checkpoints.t \
 	t0025-broker-state-machine.t \
 	t0027-broker-groups.t \
 	t0013-config-file.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -400,6 +400,7 @@ dist_check_SCRIPTS = \
 	scripts/dmesg-grep.py \
 	scripts/stats-listen.py \
 	scripts/sqlite-query.py \
+	scripts/sqlite-write.py \
 	scripts/pipe.py \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \

--- a/t/scripts/sqlite-query.py
+++ b/t/scripts/sqlite-query.py
@@ -22,6 +22,9 @@ if __name__ == "__main__":
         "-t", "--timeout", type=str, metavar="MS", help="Set busytimeout"
     )
     parser.add_argument(
+        "--nokey", action="store_true", help="don't output key, just value"
+    )
+    parser.add_argument(
         "dbpath", type=str, metavar="DBPATH", nargs=1, help="database path"
     )
     parser.add_argument("query", type=str, metavar="QUERY", nargs=1, help="query")
@@ -58,7 +61,10 @@ if __name__ == "__main__":
     for row in rows:
         for key in row.keys():
             val = row[key]
-            print(f"{key} = {val}", file=utf8out)
+            if args.nokey:
+                print(f"{val}", file=utf8out)
+            else:
+                print(f"{key} = {val}", file=utf8out)
 
     con.close()
     sys.exit(0)

--- a/t/scripts/sqlite-query.py
+++ b/t/scripts/sqlite-query.py
@@ -10,7 +10,7 @@
 
 # Query a sqlite db for testing purposes
 
-# Usage: flux python query.py [OPTIONS] dbpath query
+# Usage: flux python sqlite-query.py [OPTIONS] dbpath query
 
 import argparse
 import sqlite3

--- a/t/scripts/sqlite-write.py
+++ b/t/scripts/sqlite-write.py
@@ -1,0 +1,57 @@
+###############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# write to a sqlite db for testing purposes
+
+# Usage: flux python sqlite-write.py [OPTIONS] dbpath query
+
+import argparse
+import sqlite3
+import sys
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-t", "--timeout", type=str, metavar="MS", help="Set busytimeout"
+    )
+    parser.add_argument(
+        "dbpath", type=str, metavar="DBPATH", nargs=1, help="database path"
+    )
+    parser.add_argument("query", type=str, metavar="QUERY", nargs=1, help="query")
+    args = parser.parse_args()
+
+    try:
+        #  Required in non-utf-8 locale if dbpath contains multibyte
+        #   characters. Prevents Python from whining about surrogates
+        #   not allowed. Really there must be a better way, but this works:
+        dbpath = args.dbpath[0].encode("utf-8", errors="surrogateescape").decode()
+        dburi = "file:" + dbpath + "?mode=rw"
+        con = sqlite3.connect(dburi, uri=True)
+    except sqlite3.Error as e:
+        print(e)
+        sys.exit(1)
+
+    if args.timeout:
+        con.execute("PRAGMA busy_wait = " + args.timeout)
+
+    con.row_factory = sqlite3.Row
+    cursor = con.cursor()
+
+    try:
+        cursor.execute(args.query[0])
+    except sqlite3.Error as e:
+        print(e)
+        sys.exit(1)
+
+    con.commit()
+    con.close()
+    sys.exit(0)
+
+# vim: tabstop=4 shiftwidth=4 expandtab

--- a/t/t0035-content-sqlite-checkpoints.t
+++ b/t/t0035-content-sqlite-checkpoints.t
@@ -91,4 +91,67 @@ test_expect_success 'remove content module' '
 	flux exec flux module remove content
 '
 
+#
+# test conversion from checkpt 1.0 database
+#
+
+test_expect_success 'run an instance to create a checkpt_v2 table' '
+	statedir=$(mktemp -d --tmpdir=${TMPDIR:-/tmp}) &&
+	flux start --setattr=statedir=${statedir} "flux kvs put --sync foo=bar"
+'
+
+test_expect_success 'get most recent checkpoint' '
+        $QUERYCMD -t 100 --nokey ${statedir}/content.sqlite \
+                "select value from checkpt_v2 ORDER BY id DESC LIMIT 1" > checkptvalue.out &&
+        cat checkptvalue.out | jq .rootref > checkptvaluerootref.out
+'
+
+test_expect_success 'drop checkpt_v2 table' '
+        $WRITECMD -t 100 ${statedir}/content.sqlite \
+                "DROP TABLE IF EXISTS checkpt_v2" &&
+        $QUERYCMD -t 100 ${statedir}/content.sqlite \
+                "select tbl_name from sqlite_master where type = \"table\"" > tables1.out &&
+        test_must_fail grep checkpt_v2 tables1.out
+'
+
+test_expect_success 'create checkpt v1 table' '
+        $WRITECMD -t 100 ${statedir}/content.sqlite \
+                "create table checkpt(key TEXT, value TEXT)" &&
+        $QUERYCMD -t 100 ${statedir}/content.sqlite \
+                "select tbl_name from sqlite_master where type = \"table\"" > tables2.out &&
+        grep "checkpt$" tables2.out
+'
+
+# setup insert outside of test to avoid tons of escape json text trickery
+value=$(cat checkptvalue.out)
+insert="insert into checkpt (key, value) values ('kvs-primary', '${value}')"
+test_expect_success 'put checkpoint into checkpt v1 table' '
+        $WRITECMD -t 100 ${statedir}/content.sqlite "${insert}" &&
+        $QUERYCMD -t 100 ${statedir}/content.sqlite \
+             "select * from checkpt" > checkpt.out &&
+        grep $(cat checkptvaluerootref.out) checkpt.out
+'
+
+test_expect_success 'instance loads from v1 checkpt and converts to v2 checkpt table' '
+	flux start --setattr=statedir=${statedir} "flux kvs get foo" > restart.out &&
+        grep bar restart.out &&
+        $QUERYCMD -t 100 ${statedir}/content.sqlite \
+                "select tbl_name from sqlite_master where type = \"table\"" > tables3.out &&
+        grep "checkpt_v2" tables3.out
+'
+
+test_expect_success 'old checkpoint is in v2 table' '
+        $QUERYCMD -t 100 --nokey ${statedir}/content.sqlite \
+                "select * from checkpt_v2" > checkptvalues.out &&
+        grep $(cat checkptvaluerootref.out) checkptvalues.out
+'
+
+test_expect_success 'new checkpoint is storing multiple checkpoints' '
+	flux start --setattr=statedir=${statedir} "flux kvs sync" &&
+        $QUERYCMD -t 100 --nokey ${statedir}/content.sqlite \
+                "select * from checkpt_v2" > checkptvalues2.out &&
+	count=`grep rootref checkptvalues2.out | wc -l` &&
+	test $count -gt 1
+'
+
 test_done

--- a/t/t0035-content-sqlite-checkpoints.t
+++ b/t/t0035-content-sqlite-checkpoints.t
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+test_description='Test content-sqlite checkpointing'
+
+. `dirname $0`/content/content-helper.sh
+
+. `dirname $0`/sharness.sh
+
+SIZE=1
+export FLUX_CONF_DIR=$(pwd)
+test_under_flux ${SIZE} minimal
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+QUERYCMD="flux python ${FLUX_SOURCE_DIR}/t/scripts/sqlite-query.py"
+WRITECMD="flux python ${FLUX_SOURCE_DIR}/t/scripts/sqlite-write.py"
+
+test_expect_success 'load content module' '
+	flux module load content
+'
+
+test_expect_success 'load content-sqlite with invalid max-checkpoints config' '
+	cat >maxcheckpoints.toml <<-EOT &&
+	[content-sqlite]
+	max_checkpoints = -1
+	EOT
+	flux config load maxcheckpoints.toml &&
+	test_must_fail flux module load content-sqlite
+'
+
+test_expect_success 'load content-sqlite with valid max-checkpoints config' '
+	cat >maxcheckpoints.toml <<-EOT &&
+	[content-sqlite]
+	max_checkpoints = 5
+	EOT
+	flux config load maxcheckpoints.toml &&
+	flux module load content-sqlite
+'
+
+test_expect_success 'remove content-sqlite & content module' '
+	flux module remove content-sqlite &&
+	flux module remove content
+'
+
+test_expect_success 'load content module' '
+	flux module load content
+'
+
+test_expect_success 'load content-sqlite module with invalid max-checkpoints' '
+	test_must_fail flux module load content-sqlite max-checkpoints=-1
+'
+
+test_expect_success 'load content-sqlite module with max-checkpoints' '
+	flux module load content-sqlite max-checkpoints=5
+'
+
+test_expect_success 'checkpoint-put w/ different rootrefs' '
+	checkpoint_put ref1 &&
+	checkpoint_put ref2 &&
+	checkpoint_put ref3 &&
+	checkpoint_put ref4 &&
+	checkpoint_put ref5 &&
+	checkpoint_put ref6
+'
+
+test_expect_success 'checkpoint-get returns most recent checkpoint' '
+	echo ref6 >rootref.exp &&
+	checkpoint_get | jq -r .value | jq -r .rootref >rootref.out &&
+	test_cmp rootref.exp rootref.out
+'
+
+test_expect_success 'content-sqlite stores only max of 5 checkpoints' '
+	count=`flux module stats content-sqlite | jq ".checkpoints | length"` &&
+	test $count -eq 5
+'
+
+test_expect_success 'content-sqlite the first checkpoint is the most recent' '
+	flux module stats content-sqlite | jq ".checkpoints[0].value" | grep ref6
+'
+
+test_expect_success 'content-sqlite the oldest checkpoint is not listed' '
+	flux module stats content-sqlite | jq ".checkpoints" > checkpoints.out &&
+	test_must_fail grep ref1 checkpoints.out
+'
+
+test_expect_success 'remove content-sqlite module' '
+	flux module remove content-sqlite
+'
+
+test_expect_success 'remove content module' '
+	flux exec flux module remove content
+'
+
+test_done


### PR DESCRIPTION
Problem: The content-sqlite backend only stores one checkpoint for each key, overwriting older keys/checkpoints.  If anything
goes wrong with a checkpoint, there is no information stored to allow a recovery from an earlier point in time.

Instead of overwriting checkpoints, store a rolling history of the checkpoints.  Support configuration of the maximum number of checkpoints via a new configuration parameter.  The default maximum number of checkpoints is 100 per key.

Fixes #6629

----

notes:

- for this PR the new tests are in `t0012-content-sqlite-checkpoints.t` b/c I didn't want to create new numbered content-sqlite test files super far away from `t0012-content-sqlite.t` ... but maybe I should.  Or should we do a good re-numbering on tests and shifting everything down.

- you'll notice a big comment that discusses why we use a string timestamp rather than a numeric timestamp in SQL.  I can't help but wonder if prior discussions of vendoring sqlite and bringing it into flux-core could be warranted (https://sqlite.org/amalgamation.html).

