### PR TITLE
kvs: support initial-rootref option

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2818,23 +2818,15 @@ int mod_main (flux_t *h, int argc, char **argv)
         if (checkpoint_get (h, rootref, sizeof (rootref), &seq) < 0)
             memcpy (rootref, empty_dir_rootref, sizeof (empty_dir_rootref));
 
-        /* primary namespace must always be there and not marked
-         * for removal
-         */
-        if (!(root = kvsroot_mgr_lookup_root_safe (ctx->krm,
-                                                   KVS_PRIMARY_NAMESPACE))) {
-
-            if (!(root = kvsroot_mgr_create_root (ctx->krm,
-                                                  ctx->cache,
-                                                  ctx->hash_name,
-                                                  KVS_PRIMARY_NAMESPACE,
-                                                  owner,
-                                                  0))) {
-                flux_log_error (h, "kvsroot_mgr_create_root");
-                goto done;
-            }
+        if (!(root = kvsroot_mgr_create_root (ctx->krm,
+                                              ctx->cache,
+                                              ctx->hash_name,
+                                              KVS_PRIMARY_NAMESPACE,
+                                              owner,
+                                              0))) {
+            flux_log_error (h, "kvsroot_mgr_create_root");
+            goto done;
         }
-
         setroot (ctx, root, rootref, seq);
 
         if (event_subscribe (ctx, KVS_PRIMARY_NAMESPACE) < 0) {

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -73,6 +73,8 @@ struct kvs_ctx {
     flux_watcher_t *idle_w;
     flux_watcher_t *check_w;
     int transaction_merge;
+    char initial_rootref[BLOBREF_MAX_STRING_SIZE];
+    bool initial_rootref_set;
     bool events_init;            /* flag */
     char *hash_name;
     unsigned int seq;           /* for commit transactions */
@@ -2641,6 +2643,16 @@ static int process_args (struct kvs_ctx *ctx, int ac, char **av)
                 return -1;
             }
         }
+        else if (strstarts (av[i], "initial-rootref=")) {
+            char *ptr = av[i] + 16;
+            if (strlen (ptr) > BLOBREF_MAX_STRING_SIZE
+                || blobref_validate (ptr) < 0) {
+                errno = EINVAL;
+                return -1;
+            }
+            memcpy (ctx->initial_rootref, ptr, strlen (ptr));
+            ctx->initial_rootref_set = true;
+        }
         else {
             flux_log (ctx->h, LOG_ERR, "Unknown option `%s'", av[i]);
             errno = EINVAL;
@@ -2811,12 +2823,19 @@ int mod_main (flux_t *h, int argc, char **argv)
             goto done;
         }
 
-        /* Look for a checkpoint and use it if found.
-         * Otherwise start the primary root namespace with an empty directory
-         * and seq = 0.
-         */
-        if (checkpoint_get (h, rootref, sizeof (rootref), &seq) < 0)
-            memcpy (rootref, empty_dir_rootref, sizeof (empty_dir_rootref));
+        if (ctx->initial_rootref_set) {
+            memcpy (rootref,
+                    ctx->initial_rootref,
+                    sizeof (ctx->initial_rootref));
+        }
+        else {
+            /* Look for a checkpoint and use it if found.  Otherwise
+             * start the primary root namespace with an empty
+             * directory and seq = 0.
+             */
+            if (checkpoint_get (h, rootref, sizeof (rootref), &seq) < 0)
+                memcpy (rootref, empty_dir_rootref, sizeof (empty_dir_rootref));
+        }
 
         if (!(root = kvsroot_mgr_create_root (ctx->krm,
                                               ctx->cache,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -108,6 +108,7 @@ TESTSCRIPTS = \
 	t1010-kvs-commit-sync.t \
 	t1011-kvs-checkpoint-period.t \
 	t1012-kvs-checkpoint.t \
+	t1013-kvs-initial-rootref.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \

--- a/t/t1013-kvs-initial-rootref.t
+++ b/t/t1013-kvs-initial-rootref.t
@@ -1,0 +1,74 @@
+#!/bin/sh
+#
+
+test_description='Test kvs module initial-rootref option'
+
+. `dirname $0`/kvs/kvs-helper.sh
+
+. `dirname $0`/sharness.sh
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+export FLUX_CONF_DIR=$(pwd)
+SIZE=4
+test_under_flux ${SIZE} minimal -Sstatedir=$(pwd)
+
+test_expect_success 'load content, content-sqlite, and kvs' '
+	flux module load content &&
+	flux module load content-sqlite &&
+	flux module load kvs
+'
+
+test_expect_success 'kvs: put some data to kvs' '
+	flux kvs put --blobref data=1 > blob1.out &&
+	flux kvs put --blobref data=2 > blob2.out &&
+	flux kvs put --blobref data=3 > blob3.out &&
+	flux kvs put --blobref data=4 > blob4.out &&
+	flux kvs put --blobref data=5 > blob5.out
+'
+
+test_expect_success 'kvs: reload kvs' '
+	flux module reload kvs
+'
+
+test_expect_success 'kvs: data should be last written' '
+	echo "5" > data1.exp &&
+	flux kvs get data > data1.out &&
+	test_cmp data1.out data1.exp
+'
+
+test_expect_success 'kvs: root should be last one' '
+	flux kvs getroot -b > getroot1.out &&
+	test_cmp getroot1.out blob5.out
+'
+
+test_expect_success 'kvs: reload kvs with different initial rootref' '
+        ref=$(cat blob3.out) &&
+	flux module reload kvs initial-rootref="$ref"
+'
+
+test_expect_success 'kvs: data should be previous one' '
+	echo "3" > data2.exp &&
+	flux kvs get data > data2.out &&
+	test_cmp data2.out data2.exp
+'
+
+test_expect_success 'kvs: root should be previous one' '
+	flux kvs getroot -b > getroot2.out &&
+	test_cmp getroot2.out blob3.out
+'
+
+test_expect_success 'kvs: remove kvs module' '
+	flux module remove kvs
+'
+
+test_expect_success 'kvs: load kvs with bad rootref' '
+	test_must_fail flux module reload kvs initial-rootref="abcdefghijklmnop"
+'
+
+test_expect_success 'kvs: remove modules' '
+	flux module remove content-sqlite &&
+	flux module remove content
+'
+
+test_done


### PR DESCRIPTION
Problem: The only way for the KVS to start with a non-default root reference is to read a root reference from the content module's checkpoint service.  There is no way to initialize the KVS with a specific root reference.  Allowing users to select an initial root reference could be useful for debugging and testing, especially when multiple checkpoints exist.
    
Support a initial-rootref option.
