### PR TITLE
libsubprocess: remove confusing `flux_future_push: Invalid argument` error message in bulk-exec

### DIFF
--- a/src/common/libsubprocess/bulk-exec.c
+++ b/src/common/libsubprocess/bulk-exec.c
@@ -696,12 +696,14 @@ flux_future_t *bulk_exec_kill (struct bulk_exec *exec,
                         flux_future_fulfill_error (cf, err, "Internal error");
                 }
             }
-            (void) snprintf (s,
-                             sizeof (s)-1,
-                             "%u",
-                             flux_subprocess_rank (p));
-            if (flux_future_push (cf, s, f) < 0)
-                flux_future_destroy (f);
+            if (f) {
+                (void) snprintf (s,
+                                 sizeof (s)-1,
+                                 "%u",
+                                flux_subprocess_rank (p));
+                if (flux_future_push (cf, s, f) < 0)
+                    flux_future_destroy (f);
+            }
         }
         p = zlist_next (exec->processes);
     }

--- a/src/common/libsubprocess/bulk-exec.c
+++ b/src/common/libsubprocess/bulk-exec.c
@@ -331,14 +331,9 @@ static struct exec_cmd *exec_cmd_create (const struct idset *ranks,
     struct exec_cmd *c = calloc (1, sizeof (*c));
     if (!c)
         return NULL;
-    if (!(c->ranks = idset_copy (ranks))) {
-        fprintf (stderr, "exec_cmd_create: idset_copy failed");
+    if (!(c->ranks = idset_copy (ranks))
+        || !(c->cmd = flux_cmd_copy (cmd)))
         goto err;
-    }
-    if (!(c->cmd = flux_cmd_copy (cmd))) {
-        fprintf (stderr, "exec_cmd_create: flux_cmd_copy failed");
-        goto err;
-    }
     /* bulk-exec always uses unbuffered reads for performance */
     c->flags = flags | FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF;
     return (c);
@@ -705,10 +700,8 @@ flux_future_t *bulk_exec_kill (struct bulk_exec *exec,
                              sizeof (s)-1,
                              "%u",
                              flux_subprocess_rank (p));
-            if (flux_future_push (cf, s, f) < 0) {
-                fprintf (stderr, "flux_future_push: %s\n", strerror (errno));
+            if (flux_future_push (cf, s, f) < 0)
                 flux_future_destroy (f);
-            }
         }
         p = zlist_next (exec->processes);
     }


### PR DESCRIPTION
This PR removes some stray debug `fprintf` calls in bulk-exec, and also prevents calling `flux_future_push()` with a `NULL` future in `bulk_exec_kill()`.

Fixes #6776 