### PR TITLE
Support new flux-fsck tool to check integrity of content store

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -26,6 +26,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-getattr.1 \
 	man1/flux-dmesg.1 \
 	man1/flux-dump.1 \
+	man1/flux-fsck.1 \
 	man1/flux-archive.1 \
 	man1/flux-content.1 \
 	man1/flux-config.1 \

--- a/doc/man1/flux-fsck.rst
+++ b/doc/man1/flux-fsck.rst
@@ -1,0 +1,65 @@
+============
+flux-fsck(1)
+============
+
+
+SYNOPSIS
+========
+
+**flux** **fsck** [*OPTIONS*]
+
+
+DESCRIPTION
+===========
+
+.. program flux fsck
+
+The :program:`flux fsck` checks the integrity of the KVS backing
+store, starting with the most recent checkpoint (root version) written
+to the backing store.
+
+
+OPTIONS
+=======
+
+.. option:: -h, --help
+
+   Summarize available options.
+
+.. option:: -v, --verbose
+
+   List keys on stderr as they are validated.
+
+.. option:: -q, --quiet
+
+   Don't output diagnostic messages and discovered errors.
+
+
+EXIT STATUS
+===========
+
+0
+  Content store valid
+
+1
+  One or more errors were discovered
+
+
+RESOURCES
+=========
+
+.. include:: common/resources.rst
+
+
+FLUX RFC
+========
+
+:doc:`rfc:spec_10`
+
+:doc:`rfc:spec_11`
+
+
+SEE ALSO
+========
+
+:man1:`flux-content`, :man1:`flux-kvs`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -30,6 +30,7 @@ man_pages = [
     ('man1/flux-cron', 'flux-cron', 'Cron-like utility for Flux', [author], 1),
     ('man1/flux-dmesg', 'flux-dmesg', 'access broker ring buffer', [author], 1),
     ('man1/flux-dump', 'flux-dump', 'Write KVS snapshot to portable archive', [author], 1),
+    ('man1/flux-fsck', 'flux-fsck', 'Check integrity of KVS backing store', [author], 1),
     ('man1/flux-env', 'flux-env', 'Print the flux environment or execute a command inside it', [author], 1),
     ('man1/flux-event', 'flux-event', 'Send and receive Flux events', [author], 1),
     ('man1/flux-exec', 'flux-exec', 'Execute processes across flux ranks', [author], 1),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -968,3 +968,4 @@ UWjZ
 YQ
 composable
 orchestrator
+fsck

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -79,7 +79,8 @@ flux_SOURCES = \
 	builtin/archive.c \
 	builtin/pmi.c \
 	builtin/shutdown.c \
-	builtin/lptest.c
+	builtin/lptest.c \
+	builtin/fsck.c
 nodist_flux_SOURCES = \
 	builtin-cmds.c
 dist_bin_SCRIPTS = flux-python

--- a/src/cmd/builtin/dump.c
+++ b/src/cmd/builtin/dump.c
@@ -64,22 +64,20 @@ void read_error (const char *fmt, ...)
 
 static void progress_notify (flux_t *h)
 {
-    if (sd_notify_flag) {
-        flux_future_t *f;
-        char buf[64];
+    flux_future_t *f;
+    char buf[64];
 
-        snprintf (buf,
-                  sizeof (buf),
-                  "flux-dump(1) has archived %d keys",
-                  keycount);
-        f = flux_rpc_pack (h,
-                           "state-machine.sd-notify",
-                           FLUX_NODEID_ANY,
-                           FLUX_RPC_NORESPONSE,
-                           "{s:s}",
-                           "status", buf);
-        flux_future_destroy (f);
-    }
+    snprintf (buf,
+              sizeof (buf),
+              "flux-dump(1) has archived %d keys",
+              keycount);
+    f = flux_rpc_pack (h,
+                       "state-machine.sd-notify",
+                       FLUX_NODEID_ANY,
+                       FLUX_RPC_NORESPONSE,
+                       "{s:s}",
+                       "status", buf);
+    flux_future_destroy (f);
 }
 
 static void progress (flux_t *h, int delta_keys)

--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -1,0 +1,305 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+#include <unistd.h>
+#include <stdarg.h>
+#include <jansson.h>
+#include <time.h>
+#include <stdarg.h>
+
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libkvs/treeobj.h"
+#include "src/common/libkvs/kvs_checkpoint.h"
+#include "src/common/libutil/fsd.h"
+#include "src/common/libutil/timestamp.h"
+#include "src/common/libutil/blobref.h"
+#include "src/common/libcontent/content.h"
+#include "ccan/str/str.h"
+
+#include "builtin.h"
+
+static void fsck_treeobj (flux_t *h,
+                          const char *path,
+                          json_t *treeobj);
+
+static bool verbose;
+static bool quiet;
+static int errorcount;
+
+static void read_verror (const char *fmt, va_list ap)
+{
+    char buf[128];
+    vsnprintf (buf, sizeof (buf), fmt, ap);
+    fprintf (stderr, "%s\n", buf);
+}
+
+static __attribute__ ((format (printf, 1, 2)))
+void read_error (const char *fmt, ...)
+{
+    va_list ap;
+    if (quiet)
+        return;
+    va_start (ap, fmt);
+    read_verror (fmt, ap);
+    va_end (ap);
+}
+
+static void fsck_valref (flux_t *h,
+                         const char *path,
+                         json_t *treeobj)
+{
+    int count = treeobj_get_count (treeobj);
+    const void *buf;
+    size_t buflen;
+
+    for (int i = 0; i < count; i++) {
+        flux_future_t *f;
+        if (!(f = content_load_byblobref (h,
+                                          treeobj_get_blobref (treeobj, i),
+                                          CONTENT_FLAG_CACHE_BYPASS))
+            || content_load_get (f, &buf, &buflen) < 0) {
+            if (errno == ENOENT)
+                read_error ("%s: missing blobref index=%d",
+                            path,
+                            i);
+            else
+                read_error ("%s: error retrieving blobref index=%d: %s",
+                            path,
+                            i,
+                            future_strerror (f, errno));
+            errorcount++;
+            flux_future_destroy (f);
+            return;
+        }
+        flux_future_destroy (f);
+    }
+}
+
+static void fsck_val (flux_t *h,
+                      const char *path,
+                      json_t *treeobj)
+{
+    /* Do nothing for now */
+}
+
+static void fsck_symlink (flux_t *h,
+                          const char *path,
+                          json_t *treeobj)
+{
+    /* Do nothing for now */
+}
+
+static void fsck_dir (flux_t *h,
+                      const char *path,
+                      json_t *treeobj)
+{
+    json_t *dict = treeobj_get_data (treeobj);
+    const char *name;
+    json_t *entry;
+
+    json_object_foreach (dict, name, entry) {
+        char *newpath;
+        if (asprintf (&newpath, "%s.%s", path, name) < 0)
+            log_msg_exit ("out of memory");
+        fsck_treeobj (h, newpath, entry); // recurse
+        free (newpath);
+    }
+}
+
+static void fsck_dirref (flux_t *h,
+                         const char *path,
+                         json_t *treeobj)
+{
+    flux_future_t *f = NULL;
+    const void *buf;
+    size_t buflen;
+    json_t *treeobj_deref = NULL;
+    int count;
+
+    count = treeobj_get_count (treeobj);
+    if (count != 1) {
+        read_error ("%s: invalid dirref treeobj count=%d",
+                    path,
+                    count);
+        errorcount++;
+        return;
+    }
+    if (!(f = content_load_byblobref (h,
+                                      treeobj_get_blobref (treeobj, 0),
+                                      CONTENT_FLAG_CACHE_BYPASS))
+        || content_load_get (f, &buf, &buflen) < 0) {
+        if (errno == ENOENT)
+            read_error ("%s: missing dirref blobref", path);
+        else
+            read_error ("%s: error retrieving dirref blobref: %s",
+                        path,
+                        future_strerror (f, errno));
+        errorcount++;
+        flux_future_destroy (f);
+        return;
+    }
+    if (!(treeobj_deref = treeobj_decodeb (buf, buflen))) {
+        read_error ("%s: could not decode directory", path);
+        errorcount++;
+        goto cleanup;
+    }
+    if (!treeobj_is_dir (treeobj_deref)) {
+        read_error ("%s: dirref references non-directory", path);
+        errorcount++;
+        goto cleanup;
+    }
+    fsck_dir (h, path, treeobj_deref); // recurse
+cleanup:
+    json_decref (treeobj_deref);
+    flux_future_destroy (f);
+}
+
+static void fsck_treeobj (flux_t *h,
+                          const char *path,
+                          json_t *treeobj)
+{
+    if (treeobj_validate (treeobj) < 0) {
+        read_error ("%s: invalid tree object", path);
+        errorcount++;
+        return;
+    }
+    if (treeobj_is_symlink (treeobj)) {
+        if (verbose)
+            fprintf (stderr, "%s\n", path);
+        fsck_symlink (h, path, treeobj);
+    }
+    else if (treeobj_is_val (treeobj)) {
+        if (verbose)
+            fprintf (stderr, "%s\n", path);
+        fsck_val (h, path, treeobj);
+    }
+    else if (treeobj_is_valref (treeobj)) {
+        if (verbose)
+            fprintf (stderr, "%s\n", path);
+        fsck_valref (h, path, treeobj);
+    }
+    else if (treeobj_is_dirref (treeobj)) {
+        fsck_dirref (h, path, treeobj); // recurse
+    }
+    else if (treeobj_is_dir (treeobj)) {
+        fsck_dir (h, path, treeobj); // recurse
+    }
+}
+
+static void fsck_blobref (flux_t *h, const char *blobref)
+{
+    flux_future_t *f;
+    const void *buf;
+    size_t buflen;
+    json_t *treeobj;
+    json_t *dict;
+    const char *key;
+    json_t *entry;
+
+    if (!(f = content_load_byblobref (h, blobref, CONTENT_FLAG_CACHE_BYPASS))
+        || content_load_get (f, &buf, &buflen) < 0) {
+        read_error ("cannot load root tree object: %s",
+                    future_strerror (f, errno));
+        errorcount++;
+        flux_future_destroy (f);
+        return;
+    }
+    if (!(treeobj = treeobj_decodeb (buf, buflen)))
+        log_err_exit ("cannot decode root tree object");
+    if (treeobj_validate (treeobj) < 0)
+        log_msg_exit ("invalid root tree object");
+    if (!treeobj_is_dir (treeobj))
+        log_msg_exit ("root tree object is not a directory");
+
+    dict = treeobj_get_data (treeobj);
+    json_object_foreach (dict, key, entry) {
+        fsck_treeobj (h, key, entry);
+    }
+    json_decref (treeobj);
+    flux_future_destroy (f);
+}
+
+static int cmd_fsck (optparse_t *p, int ac, char *av[])
+{
+    int optindex =  optparse_option_index (p);
+    flux_future_t *f;
+    const char *blobref;
+    double timestamp;
+    flux_t *h;
+
+    log_init ("flux-fsck");
+
+    if (optindex != ac) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+
+    if (optparse_hasopt (p, "verbose"))
+        verbose = true;
+    if (optparse_hasopt (p, "quiet"))
+        quiet = true;
+
+    h = builtin_get_flux_handle (p);
+
+    if (!(f = kvs_checkpoint_lookup (h,
+                                     NULL,
+                                     KVS_CHECKPOINT_FLAG_CACHE_BYPASS))
+        || kvs_checkpoint_lookup_get_timestamp (f, &timestamp) < 0
+        || kvs_checkpoint_lookup_get_rootref (f, &blobref) < 0)
+        log_msg_exit ("error fetching checkpoint: %s",
+                      future_strerror (f, errno));
+    if (!quiet) {
+        char buf[64] = "";
+        struct tm tm;
+        if (!timestamp_from_double (timestamp, &tm, NULL))
+            strftime (buf, sizeof (buf), "%Y-%m-%dT%T", &tm);
+        fprintf (stderr,
+                 "Checking integrity of checkpoint from %s\n",
+                 buf);
+    }
+
+    fsck_blobref (h, blobref);
+
+    flux_future_destroy (f);
+
+    flux_close (h);
+
+    if (!quiet)
+        fprintf (stderr, "Total errors: %d\n", errorcount);
+    return (errorcount ? -1 : 0);
+}
+
+static struct optparse_option fsck_opts[] = {
+    { .name = "verbose", .key = 'v', .has_arg = 0,
+      .usage = "List keys as they are being validated",
+    },
+    { .name = "quiet", .key = 'q', .has_arg = 0,
+      .usage = "Don't output diagnostic messages and discovered errors",
+    },
+    OPTPARSE_TABLE_END
+};
+
+int subcommand_fsck_register (optparse_t *p)
+{
+    optparse_err_t e;
+    e = optparse_reg_subcommand (p,
+        "fsck",
+        cmd_fsck,
+        "[OPTIONS]",
+        "check integrity of content store data",
+        0,
+        fsck_opts);
+    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -246,6 +246,7 @@ TESTSCRIPTS = \
 	t2813-flux-watch.t \
 	t2814-hostlist-cmd.t \
 	t2815-post-job-event.t \
+	t2816-fsck-cmd.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -1,0 +1,107 @@
+#!/bin/sh
+
+test_description='Test flux fsck command'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 minimal
+
+test_expect_success 'load content and content-sqlite module' '
+	flux module load content &&
+	flux module load content-sqlite
+'
+test_expect_success 'load kvs' '
+	flux module load kvs
+'
+test_expect_success 'create some kvs content' '
+	flux kvs put dir.a=test &&
+	flux kvs put dir.b=test1 &&
+	flux kvs put --append dir.b=test2 &&
+	flux kvs put --append dir.b=test3 &&
+	flux kvs put --append dir.b=test4 &&
+	flux kvs put dir.c=testA &&
+	flux kvs put --append dir.c=testB &&
+	flux kvs put --append dir.c=testC &&
+	flux kvs put --append dir.c=testD &&
+	flux kvs link dir alink &&
+	flux kvs namespace create testns &&
+	flux kvs put --namespace=testns dir.a=testns
+'
+# N.B. startlog commands in rc scripts normally ensures a checkpoint
+# exists but we do this just to be extra sure
+test_expect_success 'call --sync to ensure we have checkpointed' '
+	flux kvs put --sync dir.sync=foo
+'
+test_expect_success 'save some treeobjs for later' '
+	flux kvs get --treeobj dir.b > dirb.out &&
+	flux kvs get --treeobj dir.c > dirc.out
+'
+test_expect_success 'unload kvs' '
+	flux module remove kvs
+'
+test_expect_success 'flux-fsck works' '
+	flux fsck 2> simple.out &&
+        grep "Checking integrity" simple.out &&
+        grep "Total errors: 0" simple.out
+'
+test_expect_success 'flux-fsck verbose works' '
+	flux fsck --verbose 2> verbose.out &&
+	grep "dir\.a" verbose.out &&
+	grep "dir\.b" verbose.out &&
+	grep "alink" verbose.out
+'
+test_expect_success 'load kvs' '
+	flux module load kvs
+'
+# unfortunately we don't have a `flux content remove` command, so we'll corrupt
+# a valref by overwriting a treeobj with a bad reference
+test_expect_success 'make a reference invalid' '
+	cat dirb.out | jq -c .data[2]=\"sha1-1234567890123456789012345678901234567890\" > dirbbad.out &&
+	flux kvs put --treeobj dir.b="$(cat dirbbad.out)"
+'
+test_expect_success 'unload kvs' '
+	flux module remove kvs
+'
+# line count includes extra diagnostic messages
+test_expect_success 'flux-fsck detects errors' '
+	test_must_fail flux fsck 2> fsckerrors1.out &&
+	count=$(cat fsckerrors1.out | wc -l) &&
+	test $count -eq 3 &&
+	grep "dir\.b" fsckerrors1.out | grep "missing blobref" &&
+        grep "Total errors: 1" fsckerrors1.out
+'
+test_expect_success 'flux-fsck no output with --quiet' '
+	test_must_fail flux fsck --quiet 2> fsckerrors2.out &&
+	count=$(cat fsckerrors2.out | wc -l) &&
+	test $count -eq 0
+'
+test_expect_success 'load kvs' '
+	flux module load kvs
+'
+test_expect_success 'make a reference invalid' '
+	cat dirc.out | jq -c .data[2]=\"sha1-1234567890123456789012345678901234567890\" > dircbad.out &&
+	flux kvs put --treeobj dir.c="$(cat dircbad.out)"
+'
+test_expect_success 'unload kvs' '
+	flux module remove kvs
+'
+# line count includes extra diagnostic messages
+test_expect_success 'flux-fsck detects errors' '
+	test_must_fail flux fsck 2> fsckerrors3.out &&
+	count=$(cat fsckerrors3.out | wc -l) &&
+	test $count -eq 4 &&
+	grep "dir\.b" fsckerrors3.out | grep "missing blobref" &&
+	grep "dir\.c" fsckerrors3.out | grep "missing blobref" &&
+        grep "Total errors: 2" fsckerrors3.out
+'
+test_expect_success 'flux-fsck no output with --quiet' '
+	test_must_fail flux fsck --quiet 2> fsckerrors4.out &&
+	count=$(cat fsckerrors4.out | wc -l) &&
+	test $count -eq 0
+'
+test_expect_success 'remove content & content-sqlite modules' '
+	flux module remove content-sqlite &&
+	flux module remove content
+'
+
+test_done


### PR DESCRIPTION
There is no way to check if the data in the content store is valid and doesn't have corruption.  Support a `flux-fsck` tool to check it.

This tool is largely based on `flux-dump`, walking the content store tree and making sure all references are valid and retrievable.

This is very basic start to the `flux-fsck` and it doesn't do much beyond the trivial check.  Future work will include.

A) check different checkpoints (i.e. related to work in #6772)

B) update primary checkpoint if we are "rolling back" to an earlier one

Edit: it's worth noting that this has no dependencies on other recent PRs (#6772, #6775).  