### PR TITLE
job-exec: make job signaling more configurable and fix documentation

### DIFF
--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -76,6 +76,9 @@ test_expect_success 'job-exec: job exception uses SIGKILL after kill-timeout' '
 	test_debug "cat kill.output" &&
 	grep "trap-sigterm got SIGTERM" kill.output
 '
+test_expect_success 'job-exec: kill_shell_delay is multiple of kill_timeout' '
+	flux module stats job-exec | jq -e ".[\"kill-shell-delay\"] == 1.0"
+'
 test_expect_success 'job-exec: job shell eventually killed by SIGKILL' '
 	id=$(flux submit --wait-event=start -n1 \
 	     sh -c "trap \"\" SIGTERM;

--- a/t/t2406-job-exec-cleanup.t
+++ b/t/t2406-job-exec-cleanup.t
@@ -32,7 +32,7 @@ test_expect_success 'job-exec: ensure cancellation kills job' '
 	test_debug "echo Canceling $id" &&
 	flux cancel $id &&
 	test_debug "flux job attach -vEX $id || :" &&
-	test_expect_code 137 flux job status $id &&
+	test_expect_code 143 flux job status $id &&
 	test_must_fail ps -q $pid
 '
 # Note: increase max-kill-count here to ensure job doesn't disappear from


### PR DESCRIPTION
This PR adds a couple tunables to the job-exec module for how it signals jobs and then fixes the documentation to actually describe how jobs are terminated. I'm not super happy with the result, but it is an improvement over what's there now because it fixes a couple glaring issues:

 - the time between when the execution system starts signaling a job and when it transitions to killing the job shell is not configurable
 - the execution system sent `SIGTERM` to a job at most once (none in the case of a timeout exception).

This PR adds two new tunables `kill-shell-delay` (default: 5 * `kill-timeout`) and `max-term-count` (default: 2) to fix the above issues.

Additionally, the documentation in the `flux-config-exec(5)`  `JOB TERMINATION` section was incorrect. This is now fixed to correctly describe the new termination process given the changes above.

Fixes #6784