### PR TITLE
jobtap: fix issues at restart with dependent jobs

### DIFF
--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1918,6 +1918,10 @@ static int jobtap_emit_dependency_event (struct jobtap *jobtap,
         errno = EINVAL;
         return -1;
     }
+    /* Avoid duplicate dependency-add events on restart
+     */
+    if (add && grudgeset_contains (job->dependencies, description))
+        return 0;
     return event_job_post_pack (jobtap->ctx->event,
                                 job,
                                 event,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -380,6 +380,7 @@ dist_check_SCRIPTS = \
 	issues/t5657-kvs-getroot-namespace.sh \
 	issues/t5892-shutdown-no-epilog.sh \
 	issues/t2492-shell-lost.sh \
+	issues/t6773-multiple-dependency-add.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t6773-multiple-dependency-add.sh
+++ b/t/issues/t6773-multiple-dependency-add.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+#
+#  Jobs with dependencies are mishandled during instance restart because
+#  jobtap callbacks are made multiple times per job
+
+
+cat <<EOF >t6773.py
+import flux
+import flux.job
+
+handle = flux.Flux()
+print("stopping queue")
+handle.rpc(
+    "job-manager.queue-start",
+    {"start": False, "all": True, "nocheckpoint": False},
+    nodeid=0,
+).get()
+
+print("submitting sleep job")
+jobspec = flux.job.JobspecV1.from_command(["/bin/true"])
+jobid = flux.job.submit(handle, jobspec)
+scheme = "afterany"
+print("submitting chain of 9 dependent jobs")
+for i in range(9):
+    dependency = [{"scheme": f"{scheme}", "value": f"{jobid}"}]
+    jobspec.setattr("attributes.system.dependencies", dependency)
+    jobspec.setattr("attributes.system.job.name", f"{scheme}-{i}")
+    jobid = flux.job.submit(handle, jobspec)
+
+EOF
+
+# Run restartable instance and submit 10 dependent jobs:
+rm -rf statedir.t6773
+mkdir -p statedir.t6773
+
+echo "Running restartable instance"
+flux start -Sstatedir=statedir.t6773 flux python t6773.py
+
+# Create script for restarted instance that:
+# - starts the queue
+# - walks all jobs ensuring they ran and had only one dependency-add and
+#   one flux-restart event each.
+cat <<-'EOF' >t6773.sh
+#!/bin/sh
+RC=0
+flux queue start
+flux watch --all || RC=1
+let count=0
+for id in $(flux jobs -ano {id}); do
+    flux job status -vvv $id || RC=1
+    test $(flux job eventlog $id | grep -c flux-restart) -le 1 || RC=1
+    test $(flux job eventlog $id | grep -c dependency-add) -le 1 || RC=1
+    let count++
+done
+echo processed $count jobs
+exit $RC
+EOF
+chmod +x t6773.sh
+
+flux start -Sstatedir=statedir.t6773 ./t6773.sh
+


### PR DESCRIPTION
This PR addresses the reproducible issues described in #6773 by preventing jobs from being iterated multiple times during job manager restart. 

Also, a commit is added to prevent multiple `dependency-add` events in a job eventlog. This is necessary because dependency plugins are called in the same manner during restart as when the job is submitted. Rather than trying to force dependency plugins to detect this condition, we just make `flux_jobtap_dependency_add(3)` detect existing identical dependencies and prevent the event.

Fixes #6773