### PR TITLE
job-exec: only adjust timelimit for jobs when start delay exceeds a configurable percent of job duration

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -82,6 +82,17 @@ barrier-timeout
    nodes on which the barrier is waiting.  To disable the barrier timeout,
    set this value to ``"0"``. (Default: ``30m``).
 
+max-start-delay-percent
+   (optional) Specify the maximum allowed delay, as a percentage of a job's
+   duration, between when a job is allocated (i.e. the starttime recorded
+   in _R_) and when the execution system receives the start request from
+   the job manager. If the delay exceeds this percentage, then extend the
+   job's effective expiration by the delay. This prevents short duration
+   jobs from having their runtime significantly reduced, while avoiding a
+   differential between the actual resource set expiration and the time
+   at which a ``timeout`` exception is raised for longer running jobs,
+   where any runtime impact will be negligible. The default is 25 percent.
+
 testexec
    (options) A table of keys (see :ref:`testexec`) for configuring the
    **job-exec** test execution implementation (used in mainly for testing).

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1640,12 +1640,18 @@ static json_t *running_job_stats (struct job_exec_ctx *ctx)
         json_t *entry;
         char *critical_ranks;
         json_t *impl_stats = NULL;
+        double expiration = 0.;
 
         if (!(critical_ranks = idset_encode (job->critical_ranks,
                                              IDSET_FLAG_RANGE)))
             goto error;
 
-        entry = json_pack ("{s:s s:s s:s s:i s:i s:i s:i s:i s:i s:f s:i s:i}",
+        if (job->expiration_timer)
+            expiration = flux_watcher_next_wakeup (job->expiration_timer);
+
+
+        entry = json_pack ("{s:s s:s s:s s:i s:i s:i s:i s:i s:i"
+                           " s:f s:f s:i s:i}",
                            "implementation",
                            job->impl ? job->impl->name : "none",
                            "ns", job->ns,
@@ -1656,6 +1662,7 @@ static json_t *running_job_stats (struct job_exec_ctx *ctx)
                            "started", job->started,
                            "running", job->running,
                            "finalizing", job->finalizing,
+                           "expiration", expiration,
                            "kill_timeout", job->kill_timeout,
                            "kill_count", job->kill_count,
                            "kill_shell_count", job->kill_shell_count);


### PR DESCRIPTION
Problem: When the job execution system receives a start request for a job with a time limit, it always adjusts the actual job time limit by the difference between the starttime in R and the time at which the start request is received. For jobs that are instances of Flux, this causes a discrepancy between the time at which the execution system will raise a timeout exception and the expiration used by the scheduler in the subinstance. This results in an arbitrary amount of time between when jobs in the instance can no longer run because the resources are expired, and the subinstance itself is finally terminated by the timeout exception.

It is probably unnecessary to provide the grace time in the execution system for the difference between the `alloc` and `start` events for jobs of any meaningful length. It is more important that the execution system timeout matches the expiration of resources in the subinstance. Therefore, only make this adjustment if the delta that would be applied is greater than 25% of the total job duration. This keeps the behavior for short jobs, where the difference would meaningfully effect the actual job runtime, but ensures longer jobs are not affected by the timeout discrepancy.

Fixes #6781