### PR TITLE
WIP: flux-content: support new checkpoints list command

### DIFF
--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -14,6 +14,7 @@
 #include "builtin.h"
 
 #include <unistd.h>
+#include <jansson.h>
 
 #include "src/common/libutil/blobref.h"
 #include "src/common/libutil/read_all.h"
@@ -168,6 +169,49 @@ static int internal_content_dropcache (optparse_t *p, int ac, char *av[])
     return (0);
 }
 
+static int internal_checkpoints (optparse_t *p, int ac, char *av[])
+{
+    flux_t *h;
+    int optindex = optparse_option_index (p);
+    char *key;
+    int index = 0;
+
+    if (optindex != (ac - 1)) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    key = av[optindex];
+
+    if (!(h = builtin_get_flux_handle (p)))
+        log_err_exit ("flux_open");
+
+    while (true) {
+        flux_future_t *f = NULL;
+        char *s;
+        json_t *o;
+        if (!(f = flux_rpc_pack (h,
+                                 "content.checkpoint-get",
+                                 0,
+                                 0,
+                                 "{s:s s:i}",
+                                 "key", key,
+                                 "index", index)))
+            log_err_exit ("content.checkpoint-get");
+        if (flux_rpc_get_unpack (f, "{s:o}", "value", &o) < 0) {
+            if (errno == ENOENT)
+                break;
+            log_err_exit ("content.checkpoint-get");
+        }
+        s = json_dumps (o, JSON_COMPACT);
+        printf ("%s\n", s);
+        free (s);
+        flux_future_destroy (f);
+        index++;
+    }
+    flux_close (h);
+    return (0);
+}
+
 int cmd_content (optparse_t *p, int ac, char *av[])
 {
     log_init ("flux-content");
@@ -217,6 +261,13 @@ static struct optparse_subcommand content_subcmds[] = {
       NULL,
       "Flush dirty entries from local content cache",
       internal_content_flush,
+      0,
+      NULL,
+    },
+    { "checkpoints",
+      "key",
+      "List checkpoint(s)",
+      internal_checkpoints,
       0,
       NULL,
     },

--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -208,14 +208,24 @@ void checkpoint_get_cb (flux_t *h,
 {
     struct content_files *ctx = arg;
     const char *key;
+    int offset = 0;
     void *data = NULL;
     size_t size;
     json_t *o = NULL;
     const char *errstr = NULL;
     json_error_t error;
 
-    if (flux_request_unpack (msg, NULL, "{s:s}", "key", &key) < 0)
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s?i}",
+                             "key", &key,
+                             "index", &offset) < 0)
         goto error;
+    /* content-files only supports a single checkpoint */
+    if (offset) {
+        errno = ENOENT;
+        goto error;
+    }
     if (filedb_get (ctx->dbpath, key, &data, &size, &errstr) < 0)
         goto error;
     /* recovery from version 0 checkpoint blobref not supported */

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -342,13 +342,23 @@ void checkpoint_get_cb (flux_t *h,
     const char *errstr = NULL;
     struct content_s3 *ctx = arg;
     const char *key;
+    int offset = 0;
     void *data = NULL;
     size_t size;
     json_t *o = NULL;
     json_error_t error;
 
-    if (flux_request_unpack (msg, NULL, "{s:s}", "key", &key) < 0)
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s?i}",
+                             "key", &key,
+                             "index", &offset) < 0)
+         goto error;
+    /* content-s3 only supports a single checkpoint */
+    if (offset) {
+        errno = ENOENT;
         goto error;
+    }
 
     if (s3_get (ctx->cfg, key, &data, &size, &errstr) < 0)
         goto error;

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -67,7 +67,8 @@ const char *sql_create_table_checkpt =
     "     (strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime')) NOT NULL"
     ");";
 const char *sql_checkpt_get = "SELECT value FROM checkpt"
-                              "  WHERE key = ?1 ORDER BY ts DESC LIMIT 1";
+                              "  WHERE key = ?1"
+                              "  ORDER BY ts DESC LIMIT 1 OFFSET ?2";
 const char *sql_checkpt_put = "INSERT INTO checkpt (key,value) "
                               "  values (?1, ?2)";
 const char *sql_checkpt_prune =
@@ -397,12 +398,20 @@ void checkpoint_get_cb (flux_t *h,
 {
     struct content_sqlite *ctx = arg;
     const char *key;
+    int offset = 0;
     char *s;
     json_t *o = NULL;
     const char *errstr = NULL;
     json_error_t error;
 
-    if (flux_request_unpack (msg, NULL, "{s:s}", "key", &key) < 0)
+    /* N.B. SQL OFFSET means "skip" this number of rows, which is
+     * basically identical to 0 index array logic
+     */
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s?i}",
+                             "key", &key,
+                             "index", &offset) < 0)
         goto error;
     if (sqlite3_bind_text (ctx->checkpt_get_stmt,
                            1,
@@ -410,6 +419,13 @@ void checkpoint_get_cb (flux_t *h,
                            strlen (key),
                            SQLITE_STATIC) != SQLITE_OK) {
         log_sqlite_error (ctx, "checkpt_get: binding key");
+        set_errno_from_sqlite_error (ctx);
+        goto error;
+    }
+    if (sqlite3_bind_int (ctx->checkpt_get_stmt,
+                          2,
+                          offset) != SQLITE_OK) {
+        log_sqlite_error (ctx, "checkpt_get: binding offset");
         set_errno_from_sqlite_error (ctx);
         goto error;
     }

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -46,14 +46,35 @@ const char *sql_store = "INSERT INTO objects (hash,size,object) "
                         "  values (?1, ?2, ?3)";
 const char *sql_objects_count = "SELECT count(1) FROM objects";
 
-const char *sql_create_table_checkpt = "CREATE TABLE if not exists checkpt("
-                                       "  key TEXT UNIQUE,"
-                                       "  value TEXT"
-                                       ");";
+/* N.B. the timestamp for checkpoints would preferably be
+ *
+ * ts REAL PRIMARY KEY DEFAULT (unixepoch('now', 'subsecond', 'localtime') NOT NULL
+ *
+ * however unixepoch() is only supported in sqlite 3.38, as of this writing
+ * most distros are at 3.26.
+ *
+ * We could go with non-subsecond epochs under the assumption no one would
+ * ever do checkpoints < 1s apart except in testing.  Other trickery could be
+ * done too, but we elect to just go with TEXT strftime() with subseconds, going
+ * with the assumption checkpointing is rare and the strftime() has virtually no
+ * impact on performance.
+ */
+const char *sql_create_table_checkpt =
+    "CREATE TABLE if not exists checkpt("
+    "  key TEXT,"
+    "  value TEXT,"
+    "  ts TIMESTAMP PRIMARY KEY DEFAULT "
+    "     (strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime')) NOT NULL"
+    ");";
 const char *sql_checkpt_get = "SELECT value FROM checkpt"
-                              "  WHERE key = ?1";
-const char *sql_checkpt_put = "REPLACE INTO checkpt (key,value) "
+                              "  WHERE key = ?1 ORDER BY ts DESC LIMIT 1";
+const char *sql_checkpt_put = "INSERT INTO checkpt (key,value) "
                               "  values (?1, ?2)";
+const char *sql_checkpt_prune =
+    "DELETE FROM checkpt WHERE key = ?1 AND ts IN "
+    "  (SELECT ts FROM checkpt ORDER BY ts DESC LIMIT -1 OFFSET ?2);";
+
+#define MAX_CHECKPOINTS_DEFAULT 100
 
 struct content_stats {
     tstat_t load;
@@ -68,6 +89,7 @@ struct content_sqlite {
     sqlite3_stmt *store_stmt;
     sqlite3_stmt *checkpt_get_stmt;
     sqlite3_stmt *checkpt_put_stmt;
+    sqlite3_stmt *checkpt_prune_stmt;
     flux_t *h;
     char *hashfun;
     int hash_size;
@@ -76,6 +98,7 @@ struct content_sqlite {
     struct content_stats stats;
     char *journal_mode;
     char *synchronous;
+    int max_checkpoints;
     bool truncate;
 };
 
@@ -471,15 +494,36 @@ void checkpoint_put_cb (flux_t *h,
         set_errno_from_sqlite_error (ctx);
         goto error;
     }
+    if (sqlite3_bind_text (ctx->checkpt_prune_stmt,
+                           1,
+                           (char *)key,
+                           strlen (key),
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "checkpt_prune: binding key");
+        goto error;
+    }
+    if (sqlite3_bind_int (ctx->checkpt_prune_stmt,
+                          2,
+                          ctx->max_checkpoints) != SQLITE_OK) {
+        log_sqlite_error (ctx, "checkpt_prune: binding count");
+        goto error;
+    }
+    if (sqlite3_step (ctx->checkpt_prune_stmt) != SQLITE_DONE) {
+        log_sqlite_error (ctx, "checkpt_prune: executing stmt");
+        set_errno_from_sqlite_error (ctx);
+        goto error;
+    }
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "flux_respond");
     (void )sqlite3_reset (ctx->checkpt_put_stmt);
+    (void )sqlite3_reset (ctx->checkpt_prune_stmt);
     free (value);
     return;
 error:
     if (flux_respond_error (h, msg, errno, errstr) < 0)
         flux_log_error (h, "flux_respond_error");
     (void )sqlite3_reset (ctx->checkpt_put_stmt);
+    (void )sqlite3_reset (ctx->checkpt_prune_stmt);
     free (value);
 }
 
@@ -502,6 +546,10 @@ static void content_sqlite_closedb (struct content_sqlite *ctx)
         if (ctx->checkpt_put_stmt) {
             if (sqlite3_finalize (ctx->checkpt_put_stmt) != SQLITE_OK)
                 log_sqlite_error (ctx, "sqlite_finalize checkpt_put_stmt");
+        }
+        if (ctx->checkpt_prune_stmt) {
+            if (sqlite3_finalize (ctx->checkpt_prune_stmt) != SQLITE_OK)
+                log_sqlite_error (ctx, "sqlite_finalize checkpt_prune_stmt");
         }
         if (ctx->db) {
             if (sqlite3_close (ctx->db) != SQLITE_OK)
@@ -707,6 +755,14 @@ static int content_sqlite_opendb (struct content_sqlite *ctx, bool truncate)
         log_sqlite_error (ctx, "preparing checkpt_put stmt");
         goto error;
     }
+    if (sqlite3_prepare_v2 (ctx->db,
+                            sql_checkpt_prune,
+                            -1,
+                            &ctx->checkpt_prune_stmt,
+                            NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "preparing checkpt prune stmt");
+        goto error;
+    }
     if (sqlite3_exec (ctx->db,
                       sql_objects_count,
                       set_count,
@@ -771,6 +827,7 @@ static struct content_sqlite *content_sqlite_create (flux_t *h)
         goto error;
     if (set_config (&ctx->synchronous, "NORMAL") < 0)
         goto error;
+    ctx->max_checkpoints = MAX_CHECKPOINTS_DEFAULT;
 
     /* Some tunables:
      * - the hash function, e.g. sha1, sha256
@@ -851,13 +908,15 @@ static int process_config (struct content_sqlite *ctx,
     flux_error_t error;
     const char *journal_mode = NULL;
     const char *synchronous = NULL;
+    int tmp_max_checkpoints = ctx->max_checkpoints;
 
     if (flux_conf_unpack (conf,
                           &error,
-                          "{s?{s?s s?s}}",
+                          "{s?{s?s s?s s?i}}",
                           "content-sqlite",
                             "journal_mode", &journal_mode,
-                            "synchronous", &synchronous) < 0) {
+                            "synchronous", &synchronous,
+                            "max_checkpoints", &tmp_max_checkpoints) < 0) {
         flux_log_error (ctx->h, "%s", error.text);
         return -1;
     }
@@ -879,6 +938,12 @@ static int process_config (struct content_sqlite *ctx,
         if (set_config (&ctx->synchronous, synchronous) < 0)
             return -1;
     }
+    if (tmp_max_checkpoints <= 0) {
+        flux_log (ctx->h, LOG_ERR, "invalid max_checkpoints config");
+        errno = EINVAL;
+        return -1;
+    }
+    ctx->max_checkpoints = tmp_max_checkpoints;
     return 0;
 }
 
@@ -906,6 +971,20 @@ static int process_args (struct content_sqlite *ctx,
             }
             if (set_config (&ctx->synchronous, argv[i] + 12) < 0)
                 return -1;
+        }
+        else if (strstarts (argv[i], "max-checkpoints=")) {
+            char *endptr;
+            int tmp_max_checkpoints;
+            errno = 0;
+            tmp_max_checkpoints = strtoul (argv[i] + 16, &endptr, 10);
+            if (errno != 0
+                || *endptr != '\0'
+                || tmp_max_checkpoints <= 0) {
+                flux_log (ctx->h, LOG_ERR, "invalid max-checkpoints specified");
+                errno = EINVAL;
+                return -1;
+            }
+            ctx->max_checkpoints = tmp_max_checkpoints;
         }
         else if (streq ("truncate", argv[i])) {
             *truncate = true;

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -74,6 +74,8 @@ const char *sql_checkpt_prune =
     "DELETE FROM checkpt WHERE key = ?1 AND ts IN "
     "  (SELECT ts FROM checkpt ORDER BY ts DESC LIMIT -1 OFFSET ?2);";
 
+const char *sql_checkpt_get_all = "SELECT * FROM checkpt ORDER BY ts DESC";
+
 #define MAX_CHECKPOINTS_DEFAULT 100
 
 struct content_stats {
@@ -90,6 +92,7 @@ struct content_sqlite {
     sqlite3_stmt *checkpt_get_stmt;
     sqlite3_stmt *checkpt_put_stmt;
     sqlite3_stmt *checkpt_prune_stmt;
+    sqlite3_stmt *checkpt_get_all_stmt;
     flux_t *h;
     char *hashfun;
     int hash_size;
@@ -527,6 +530,70 @@ error:
     free (value);
 }
 
+static json_t *stats_checkpoints (struct content_sqlite *ctx)
+{
+    json_t *checkpts = NULL;
+    int ret;
+
+    if (!(checkpts = json_object ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+
+    ret = sqlite3_step (ctx->checkpt_get_all_stmt);
+    if (ret != SQLITE_DONE && ret != SQLITE_ROW) {
+        log_sqlite_error (ctx, "checkpt_get_all: executing stmt");
+        set_errno_from_sqlite_error (ctx);
+        goto error;
+    }
+
+    while (ret == SQLITE_ROW) {
+        const char *key;
+        const char *value;
+        const char *timestamp;
+        json_t *keycheckpts;
+        json_t *o;
+        sqlite3_stmt *stmt = ctx->checkpt_get_all_stmt;
+
+        /* index 0 - key
+         * index 1 - value
+         * index 2 - timestamp
+         */
+        if (!(key = (char *)sqlite3_column_text (stmt, 0))
+            || !(value = (char *)sqlite3_column_text (stmt, 1))
+            || !(timestamp = (char *)sqlite3_column_text (stmt, 2))) {
+            log_sqlite_error (ctx, "checkpt_get_all: getting values");
+            set_errno_from_sqlite_error (ctx);
+            goto error;
+        }
+        if (!(keycheckpts = json_object_get (checkpts, key))) {
+            if (!(keycheckpts = json_array ())
+                || json_object_set_new (checkpts, key, keycheckpts) < 0) {
+                json_decref (keycheckpts);
+                errno = ENOMEM;
+                goto error;
+            }
+        }
+
+        if (!(o = json_pack ("{s:s s:s}",
+                             "value", value,
+                             "timestamp", timestamp))
+            || json_array_append_new (keycheckpts, o) < 0) {
+            json_decref (o);
+            errno = ENOMEM;
+            goto error;
+        }
+
+        ret = sqlite3_step (ctx->checkpt_get_all_stmt);
+    }
+
+    return checkpts;
+
+error:
+    ERRNO_SAFE_WRAP (json_decref, checkpts);
+    return NULL;
+}
+
 static void content_sqlite_closedb (struct content_sqlite *ctx)
 {
     if (ctx) {
@@ -550,6 +617,10 @@ static void content_sqlite_closedb (struct content_sqlite *ctx)
         if (ctx->checkpt_prune_stmt) {
             if (sqlite3_finalize (ctx->checkpt_prune_stmt) != SQLITE_OK)
                 log_sqlite_error (ctx, "sqlite_finalize checkpt_prune_stmt");
+        }
+        if (ctx->checkpt_get_all_stmt) {
+            if (sqlite3_finalize (ctx->checkpt_get_all_stmt) != SQLITE_OK)
+                log_sqlite_error (ctx, "sqlite_finalize checkpt_get_all_stmt");
         }
         if (ctx->db) {
             if (sqlite3_close (ctx->db) != SQLITE_OK)
@@ -623,6 +694,7 @@ void stats_get_cb (flux_t *h,
     const char *errmsg = NULL;
     json_t *load_time = NULL;
     json_t *store_time = NULL;
+    json_t *checkpoints = NULL;
 
     if (sqlite3_exec (ctx->db,
                       sql_objects_count,
@@ -636,9 +708,11 @@ void stats_get_cb (flux_t *h,
     if (!(load_time = pack_tstat (&ctx->stats.load))
         || !(store_time = pack_tstat (&ctx->stats.store)))
         goto error;
+    if (!(checkpoints = stats_checkpoints (ctx)))
+        goto error;
     if (flux_respond_pack (h,
                            msg,
-                           "{s:i s:I s:I s:O s:O s:{s:s s:s}}",
+                           "{s:i s:I s:I s:O s:O s:{s:s s:s} s:O}",
                            "object_count", count,
                            "dbfile_size", get_file_size (ctx->dbfile),
                            "dbfile_free", get_fs_free (ctx->dbfile),
@@ -646,16 +720,19 @@ void stats_get_cb (flux_t *h,
                            "store_time", store_time,
                            "config",
                              "journal_mode", ctx->journal_mode,
-                             "synchronous", ctx->synchronous) < 0)
+                             "synchronous", ctx->synchronous,
+                           "checkpoints", checkpoints) < 0)
         flux_log_error (h, "error responding to stats-get request");
     json_decref (load_time);
     json_decref (store_time);
+    json_decref (checkpoints);
     return;
 error:
     if (flux_respond_error (h, msg, errno, errmsg) < 0)
         flux_log_error (h, "error responding to stats-get request");
     json_decref (load_time);
     json_decref (store_time);
+    json_decref (checkpoints);
 }
 
 /* Open the database file ctx->dbfile and set up the database.
@@ -761,6 +838,14 @@ static int content_sqlite_opendb (struct content_sqlite *ctx, bool truncate)
                             &ctx->checkpt_prune_stmt,
                             NULL) != SQLITE_OK) {
         log_sqlite_error (ctx, "preparing checkpt prune stmt");
+        goto error;
+    }
+    if (sqlite3_prepare_v2 (ctx->db,
+                            sql_checkpt_get_all,
+                            -1,
+                            &ctx->checkpt_get_all_stmt,
+                            NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "preparing checkpt get_all stmt");
         goto error;
     }
     if (sqlite3_exec (ctx->db,

--- a/src/modules/content/checkpoint.c
+++ b/src/modules/content/checkpoint.c
@@ -60,6 +60,7 @@ error:
 static int checkpoint_get_forward (struct content_checkpoint *checkpoint,
                                    const flux_msg_t *msg,
                                    const char *key,
+                                   int index,
                                    const char **errstr)
 {
     const char *topic = "content.checkpoint-get";
@@ -76,8 +77,9 @@ static int checkpoint_get_forward (struct content_checkpoint *checkpoint,
                              topic,
                              rank,
                              0,
-                             "{s:s}",
-                             "key", key))
+                             "{s:s s:i}",
+                             "key", key,
+                             "index", index))
         || flux_future_then (f,
                              -1,
                              checkpoint_get_continuation,
@@ -105,6 +107,7 @@ void content_checkpoint_get_request (flux_t *h, flux_msg_handler_t *mh,
 {
     struct content_checkpoint *checkpoint = arg;
     const char *key;
+    int index = 0;
     const char *errstr = NULL;
 
     if (checkpoint->rank == 0
@@ -114,12 +117,17 @@ void content_checkpoint_get_request (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (flux_request_unpack (msg, NULL, "{s:s}", "key", &key) < 0)
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s?i}",
+                             "key", &key,
+                             "index", &index) < 0)
         goto error;
 
     if (checkpoint_get_forward (checkpoint,
                                 msg,
                                 key,
+                                index,
                                 &errstr) < 0)
         goto error;
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -76,6 +76,7 @@ TESTSCRIPTS = \
 	t0010-generic-utils.t \
 	t0011-content-cache.t \
 	t0012-content-sqlite.t \
+	t0012-content-sqlite-checkpoints.t \
 	t0024-content-s3.t \
 	t0029-archive-mmap.t \
 	t0030-marshall.t \

--- a/t/t0012-content-sqlite-checkpoints.t
+++ b/t/t0012-content-sqlite-checkpoints.t
@@ -1,0 +1,122 @@
+#!/bin/sh
+
+test_description='Test content-sqlite checkpointing'
+
+. `dirname $0`/content/content-helper.sh
+
+. `dirname $0`/sharness.sh
+
+SIZE=1
+export FLUX_CONF_DIR=$(pwd)
+test_under_flux ${SIZE} minimal
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+test_expect_success 'load content module' '
+	flux module load content
+'
+
+test_expect_success 'load content-sqlite with invalid max-checkpoints config' '
+	cat >maxcheckpoints.toml <<-EOT &&
+	[content-sqlite]
+	max_checkpoints = -1
+	EOT
+	flux config load maxcheckpoints.toml &&
+	test_must_fail flux module load content-sqlite
+'
+
+test_expect_success 'load content-sqlite with valid max-checkpoints config' '
+	cat >maxcheckpoints.toml <<-EOT &&
+	[content-sqlite]
+	max_checkpoints = 5
+	EOT
+	flux config load maxcheckpoints.toml &&
+	flux module load content-sqlite
+'
+
+test_expect_success 'remove content-sqlite & content module' '
+	flux module remove content-sqlite
+	flux module remove content
+'
+
+test_expect_success 'load content module' '
+	flux module load content
+'
+
+test_expect_success 'load content-sqlite module with invalid max-checkpoints' '
+	test_must_fail flux module load content-sqlite max-checkpoints=-1
+'
+
+test_expect_success 'load content-sqlite module with max-checkpoints' '
+	flux module load content-sqlite max-checkpoints=5
+'
+
+test_expect_success 'checkpoint-put w/ different rootrefs (key1)' '
+	checkpoint_put key1 ref1 &&
+	checkpoint_put key1 ref2 &&
+	checkpoint_put key1 ref3 &&
+	checkpoint_put key1 ref4 &&
+	checkpoint_put key1 ref5 &&
+	checkpoint_put key1 ref6
+'
+
+test_expect_success 'checkpoint-get returns most recent checkpoint (key1)' '
+	echo ref6 >rootrefkey1.exp &&
+	checkpoint_get key1 | jq -r .value | jq -r .rootref >rootrefkey1.out &&
+	test_cmp rootrefkey1.exp rootrefkey1.out
+'
+
+test_expect_success 'content-sqlite stores only max of 5 checkpoints (key1)' '
+	count=`flux module stats content-sqlite | jq ".checkpoints.key1 | length"`
+	test $count -eq 5
+'
+
+test_expect_success 'content-sqlite the first checkpoint is the most recent (key1)' '
+	flux module stats content-sqlite | jq ".checkpoints.key1[0].value" | grep ref6
+'
+
+test_expect_success 'content-sqlite the oldest checkpoint is not listed (key1)' '
+	flux module stats content-sqlite | jq ".checkpoints.key1" > key1checkpoints.out &&
+	test_must_fail grep ref1 key1checkpoints.out
+'
+
+test_expect_success 'checkpoint-put w/ different rootrefs (key2)' '
+	checkpoint_put key2 ref10 &&
+	checkpoint_put key2 ref11 &&
+	checkpoint_put key2 ref12 &&
+	checkpoint_put key2 ref13 &&
+	checkpoint_put key2 ref14 &&
+	checkpoint_put key2 ref15
+'
+
+test_expect_success 'checkpoint-get returns most recent checkpoint (key2)' '
+	echo ref15 >rootrefkey2.exp &&
+	checkpoint_get key2 | jq -r .value | jq -r .rootref >rootrefkey2.out &&
+	test_cmp rootrefkey2.exp rootrefkey2.out
+'
+
+test_expect_success 'checkpoint-get still returns most recent checkpoint (key1)' '
+	echo ref6 >rootrefkey1B.exp &&
+	checkpoint_get key1 | jq -r .value | jq -r .rootref >rootrefkey1B.out &&
+	test_cmp rootrefkey1B.exp rootrefkey1B.out
+'
+
+test_expect_success 'content-sqlite stores only max of 5 checkpoints (key2)' '
+	count=`flux module stats content-sqlite | jq ".checkpoints.key2 | length"`
+	test $count -eq 5
+'
+
+test_expect_success 'content-sqlite still stores only max of 5 checkpoints (key1)' '
+	count=`flux module stats content-sqlite | jq ".checkpoints.key1 | length"`
+	test $count -eq 5
+'
+
+test_expect_success 'remove content-sqlite module' '
+	flux module remove content-sqlite
+'
+
+test_expect_success 'remove content module' '
+	flux exec flux module remove content
+'
+
+test_done

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -158,6 +158,13 @@ test_expect_success 'checkpoint-get foo returned correct timestamp' '
         grep 2.2 timestamp.out
 '
 
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints1.out &&
+        count=$(cat checkpoints1.out | wc -l) &&
+        test $count -eq 1 &&
+        grep bar checkpoints1.out
+'
+
 test_expect_success 'checkpoint-put updates foo rootref to baz' '
 	checkpoint_put foo baz
 '
@@ -187,6 +194,13 @@ test_expect_success 'checkpoint-backing-get foo returns rootref baz' '
 	test_cmp rootref_backing.exp rootref_backing.out
 '
 
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints2.out &&
+        count=$(cat checkpoints2.out | wc -l) &&
+        test $count -eq 2 &&
+        head -n 1 checkpoints2.out | grep baz
+'
+
 test_expect_success 'checkpoint-backing-put foo w/ rootref boof' '
 	checkpoint_backing_put foo boof
 '
@@ -195,6 +209,13 @@ test_expect_success 'checkpoint-get foo returned rootref boof' '
 	echo boof >rootref4.exp &&
 	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
 	test_cmp rootref4.exp rootref4.out
+'
+
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints2.out &&
+        count=$(cat checkpoints2.out | wc -l) &&
+        test $count -eq 3 &&
+        head -n 1 checkpoints2.out | grep boof
 '
 
 test_expect_success 'checkpoint-get noexist fails with No such...' '

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -178,6 +178,13 @@ test_expect_success 'checkpoint-get foo returned correct timestamp' '
         grep 2.2 timestamp.out
 '
 
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints1.out &&
+        count=$(cat checkpoints1.out | wc -l) &&
+        test $count -eq 1 &&
+        grep bar checkpoints1.out
+'
+
 test_expect_success 'checkpoint-put updates foo rootref to baz' '
         checkpoint_put foo baz
 '
@@ -186,6 +193,13 @@ test_expect_success 'checkpoint-get foo returned rootref baz' '
         echo baz >rootref2.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
         test_cmp rootref2.exp rootref2.out
+'
+
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints2.out &&
+        count=$(cat checkpoints2.out | wc -l) &&
+        test $count -eq 1 &&
+        grep baz checkpoints2.out
 '
 
 test_expect_success 'reload content-files module' '
@@ -208,6 +222,13 @@ test_expect_success 'checkpoint-get foo returned rootref with longer rootref' '
         test_cmp rootref4.exp rootref4.out
 '
 
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints3.out &&
+        count=$(cat checkpoints3.out | wc -l) &&
+        test $count -eq 1 &&
+        grep abcdefghijklmnopqrstuvwxyz checkpoints3.out
+'
+
 test_expect_success 'checkpoint-put updates foo rootref to shorter rootref' '
         checkpoint_put foo foobar
 '
@@ -216,6 +237,13 @@ test_expect_success 'checkpoint-get foo returned rootref with shorter rootref' '
         echo foobar >rootref5.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref5.out &&
         test_cmp rootref5.exp rootref5.out
+'
+
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints4.out &&
+        count=$(cat checkpoints4.out | wc -l) &&
+        test $count -eq 1 &&
+        grep foobar checkpoints4.out
 '
 
 test_expect_success 'checkpoint-put updates foo rootref to boof' '
@@ -230,6 +258,13 @@ test_expect_success 'checkpoint-backing-get foo returns rootref boof' '
         test_cmp rootref_backing.exp rootref_backing.out
 '
 
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints5.out &&
+        count=$(cat checkpoints5.out | wc -l) &&
+        test $count -eq 1 &&
+        grep boof checkpoints5.out
+'
+
 test_expect_success 'checkpoint-backing-put foo w/ rootref poof' '
         checkpoint_backing_put foo poof
 '
@@ -238,6 +273,13 @@ test_expect_success 'checkpoint-get foo returned rootref boof' '
         echo poof >rootref6.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref6.out &&
         test_cmp rootref6.exp rootref6.out
+'
+
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints6.out &&
+        count=$(cat checkpoints6.out | wc -l) &&
+        test $count -eq 1 &&
+        grep poof checkpoints6.out
 '
 
 test_expect_success 'checkpoint-get bad request fails with EPROTO' '

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -137,6 +137,13 @@ test_expect_success 'checkpoint-get foo returned correct timestamp' '
         grep 2.2 timestamp.out
 '
 
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints1.out &&
+        count=$(cat checkpoints1.out | wc -l) &&
+        test $count -eq 1 &&
+        grep bar checkpoints1.out
+'
+
 test_expect_success 'checkpoint-put updates foo rootref to baz' '
         checkpoint_put foo baz
 '
@@ -145,6 +152,13 @@ test_expect_success 'checkpoint-get foo returned rootref baz' '
         echo baz >rootref2.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
         test_cmp rootref2.exp rootref2.out
+'
+
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints2.out &&
+        count=$(cat checkpoints2.out | wc -l) &&
+        test $count -eq 1 &&
+        grep baz checkpoints2.out
 '
 
 test_expect_success 'reload content-s3 module' '
@@ -189,6 +203,13 @@ test_expect_success 'checkpoint-get foo returned rootref boof' '
 	echo boof >rootref4.exp &&
 	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
 	test_cmp rootref4.exp rootref4.out
+'
+
+test_expect_success 'flux content checkpoints lists correct checkpoint' '
+        flux content checkpoints foo > checkpoints3.out &&
+        count=$(cat checkpoints3.out | wc -l) &&
+        test $count -eq 1 &&
+        grep boof checkpoints3.out
 '
 
 test_expect_success 'config: reload config does not take effect immediately' '


### PR DESCRIPTION
Built on top of #6772.  So I'll list this as WIP for the time being.

Problem: There is currently no way to get multiple checkpoints from the content modules.

Support an optional "index" key when getting content checkpoints.  If the index is not available, return ENOENT to the caller.  Support a new "flux-content checkpoints" command.