### PR TITLE
flux-jobs: output message if results truncated

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -36,7 +36,8 @@ OPTIONS
 
 .. option:: -n, --no-header
 
-   For default output, do not output column headers.
+   For default output, do not output column headers and truncation
+   warnings.
 
 .. option:: -u, --user=[USERNAME|UID]
 

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -433,6 +433,14 @@ test_expect_success 'flux-jobs --count works' '
 	test $count -eq 8
 '
 
+test_expect_success 'flux-jobs outputs message if results limit reached' '
+	count=`flux jobs --no-header -a --count=0 | wc -l` &&
+        flux jobs -a --count=${count} 2> limit1.out &&
+	test_must_fail grep -i "output truncated" limit1.out &&
+        flux jobs -a --count=8 2> limit2.out &&
+	grep -i "output truncated" limit2.out
+'
+
 #
 # -i, --include tests
 #


### PR DESCRIPTION
Simple attempt at the issue raised in #6794, all done in `flux-jobs`.

Only interesting oddity is i cheated and used the `no-header` flag to also not output the warning message.  Results in zero need to change any tests in sharness.