### PR TITLE
broker: add 'mincrit' topology

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -177,12 +177,30 @@ TREE BASED OVERLAY NETWORK
 ==========================
 
 tbon.topo [Updates: C]
-   URI describing the TBON tree topology such as ``kary:16``.  The ``kary``
-   scheme selects a complete, k-ary tree with fanout *k*, with ``kary:0``
-   meaning that rank 0 is the parent of all other ranks by convention.  The
-   ``binomial`` scheme selects a binomial tree topology of the minimum order
-   that fits the instance size.  Default: ``kary:32``, unless bootstrapping by
-   TOML configuration, then see :man5:`flux-config-bootstrap`.
+   A URI describing the TBON tree topology.  The following schemes are
+   available:
+
+   kary:k
+      A complete, k-ary tree with fanout *k*.  By convention, ``kary:0``
+      indicates that rank 0 is the parent of all other ranks.
+
+   mincrit[:k]
+      Minimize critical ranks.  The tree height is limited to three.
+      If *k* is specified, it sets the number of router (interior) ranks,
+      making the number of critical ranks *k* plus one.  The fanout from
+      routers to leaves is determined by the instance size.  If *k* is
+      unspecified, *k* is set to a value that avoids exceeding a fanout of
+      1024 at any level.  If that cannot be achieved in three levels,
+      then rank 0 is overloaded.
+
+   binomial
+      Binomial tree topology of the minimum order that fits the instance size.
+
+   custom
+      The topology is set by TOML configuration.
+      See :man5:`flux-config-bootstrap`.
+
+   The default value is ``kary:32``.
 
 tbon.descendants
    Number of descendants "below" this node of the tree based

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -969,3 +969,4 @@ YQ
 composable
 orchestrator
 fsck
+mincrit

--- a/src/broker/test/topology.c
+++ b/src/broker/test/topology.c
@@ -250,6 +250,24 @@ struct internal_ranks_test internal_ranks_tests[] = {
     { 4,  "binomial","0,2" },
     { 8,  "binomial","0,2,4,6" },
     { 16, "binomial","0,2,4,6,8,10,12,14" },
+    { 4096, "mincrit:0", "0" },
+    { 1, "mincrit:2", "" },
+    { 2, "mincrit:2", "0" },
+    { 3, "mincrit:2", "0" },
+    { 4, "mincrit:2", "0-1" },
+    { 5, "mincrit:2", "0-2" },
+    { 6, "mincrit:2", "0-2" },
+    { 7, "mincrit:2", "0-2" },
+    { 1024, "mincrit:2", "0-2" },
+    { 512, "mincrit", "0" },
+    // leader has 1024 children at size=1024+1=1025
+    { 1025, "mincrit", "0" },
+    { 1026, "mincrit", "0-2" },
+    // 2 routers have 1024 children each at size=1024+1024+3=2051
+    { 2051, "mincrit", "0-2" },
+    { 2052, "mincrit", "0-3" },
+    // a large el capitan run
+    { 10800, "mincrit", "0-11" },
     { -1, NULL, NULL  }
 };
 

--- a/src/broker/test/topology.c
+++ b/src/broker/test/topology.c
@@ -637,6 +637,60 @@ void test_binomial5 (void)
     topology_decref (topo);
 }
 
+void test_mincrit5 (void)
+{
+    struct topology *topo;
+    flux_error_t error;
+
+    topo = topology_create ("mincrit:zz", 5, &error);
+    if (!topo)
+        diag ("%s", error.text);
+    ok (topo == NULL,
+        "mincrit topology fails with unknown path");
+
+    topo = topology_create ("mincrit:2", 5, &error);
+    ok (topo != NULL,
+        "mincrit:2 topology of size=5 works");
+
+    ok (topology_set_rank (topo, 1) == 0,
+        "set rank to 1");
+    ok (topology_get_parent (topo) == 0,
+        "rank 1 parent is 0");
+    ok (topology_get_child_ranks (topo, NULL, 0) == 1,
+        "rank 1 has one child");
+    ok (topology_get_level (topo) == 1,
+        "rank 1 level is 1");
+
+    ok (topology_set_rank (topo, 2) == 0,
+        "set rank to 2");
+    ok (topology_get_parent (topo) == 0,
+        "rank 2 parent is 0");
+    ok (topology_get_child_ranks (topo, NULL, 0) == 1,
+        "rank 2 has one child");
+    ok (topology_get_level (topo) == 1,
+        "rank 2 level is 1");
+
+    ok (topology_set_rank (topo, 3) == 0,
+        "set rank to 3");
+    ok (topology_get_parent (topo) == 1,
+        "rank 3 parent is 1");
+    ok (topology_get_child_ranks (topo, NULL, 0) == 0,
+        "rank 3 has no children");
+    ok (topology_get_level (topo) == 2,
+        "rank 3 level is 2");
+
+    ok (topology_set_rank (topo, 4) == 0,
+        "set rank to 4");
+    ok (topology_get_parent (topo) == 2,
+        "rank 4 parent is 2");
+    ok (topology_get_child_ranks (topo, NULL, 0) == 0,
+        "rank 4 has no children");
+    ok (topology_get_level (topo) == 2,
+        "rank 4 level is 2");
+
+    topology_decref (topo);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -650,6 +704,7 @@ int main (int argc, char *argv[])
     test_custom ();
     test_rank_aux ();
     test_binomial5 ();
+    test_mincrit5 ();
 
     done_testing ();
 }

--- a/t/t0019-tbon-config.t
+++ b/t/t0019-tbon-config.t
@@ -168,4 +168,23 @@ test_expect_success 'broker -Stbon.topo=binomial option works' '
 		flux getattr tbon.topo >topo_binomial.out &&
 	test_cmp topo_binomial.exp topo_binomial.out
 '
+test_expect_success 'broker -Stbon.topo=mincrit option works' '
+	echo mincrit >topo_mincrit.exp &&
+	flux start ${ARGS} -Stbon.topo=mincrit \
+		flux getattr tbon.topo >topo_mincrit.out &&
+	test_cmp topo_mincrit.exp topo_mincrit.out
+'
+test_expect_success 'broker -Stbon.topo=mincrit:2 option works' '
+	echo 2 >topo_crit2.exp &&
+	flux start -s5 ${ARGS} -Stbon.topo=mincrit:2 \
+		flux getattr tbon.maxlevel >topo_crit2.out &&
+	test_cmp topo_crit2.exp topo_crit2.out
+'
+test_expect_success 'broker -Stbon.topo=mincrit is flat for small size' '
+	echo 1 >topo_critsmall.exp &&
+	flux start -s5 ${ARGS} -Stbon.topo=mincrit \
+		flux getattr tbon.maxlevel >topo_critsmall.out &&
+	test_cmp topo_critsmall.exp topo_critsmall.out
+'
+
 test_done


### PR DESCRIPTION
Problem: `kary:0` usefully minimizes critical nodes for batch jobs but may not perform well.
    
 Add a new TBON topology `mincrit[:K]` for defining a 3 level tree where the fanout from leader to routers is K, and the fanout from routers to leaves is dependent on the size.
    
If K is unspecified, a value is chosen that keeps the fanout to the leaves at or below 1024.  If there are 1025 nodes or less, a flat topology is used.
    
Example:
```
$ flux start -o,-Stbon.topo=mincrit:2 --test-size=11 flux overlay status
0 system76-pc: full
├─ 1 system76-pc: full
│  ├─ 3 system76-pc: full
│  ├─ 5 system76-pc: full
│  ├─ 7 system76-pc: full
│  └─ 9 system76-pc: full
└─ 2 system76-pc: full
   ├─ 4 system76-pc: full
   ├─ 6 system76-pc: full
   ├─ 8 system76-pc: full
   └─ 10 system76-pc: full
 ```   
Fixes #6807
