### PR TITLE
broker: avoid malloc in event distribution critical path

### DIFF
--- a/src/common/libflux/message_route.h
+++ b/src/common/libflux/message_route.h
@@ -11,9 +11,11 @@
 #ifndef _FLUX_CORE_MESSAGE_ROUTE_H
 #define _FLUX_CORE_MESSAGE_ROUTE_H
 
+#include "ccan/list/list.h"
+
 struct route_id {
     struct list_node route_id_node;
-    char id[0];                 /* variable length id stored at end of struct */
+    char *id;                   /* variable length id stored at end of struct */
 };
 
 int msg_route_push (flux_msg_t *msg,
@@ -27,6 +29,13 @@ int msg_route_append (flux_msg_t *msg,
 void msg_route_clear (flux_msg_t *msg);
 
 int msg_route_delete_last (flux_msg_t *msg);
+
+typedef int (*msg_route_send_f)(const flux_msg_t *msg, void *arg);
+
+int msg_route_sendto (const flux_msg_t *msg,
+                      const char *id,
+                      msg_route_send_f cb,
+                      void *arg);
 
 #endif /* !_FLUX_CORE_MESSAGE_ROUTE_H */
 


### PR DESCRIPTION
Problem: when the broker distributes event messages to overlay peers, it does a malloc/free per peer as it pushes and pops the peer id onto the message route stack.

This adds a (private) helper function to the message layer to streamline this case, avoiding the dynamic memory allocation.

This might not be worth the extra complexity, so marking WIP for now.