### PR TITLE
flux-kvs: support sync command

### DIFF
--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -21,6 +21,7 @@ SYNOPSIS
 | **flux** **kvs** **getroot**
 | **flux** **kvs** **version**
 | **flux** **kvs** **wait** *version*
+| **flux** **kvs** **sync**
 
 | **flux** **kvs** **namespace** **create** [*-o owner*] *name...*
 | **flux** **kvs** **namespace** **remove** *name...*
@@ -434,6 +435,16 @@ wait
 Block until the KVS version reaches *version* or greater. A simple form
 of synchronization between peers is: node A puts a value, commits it,
 reads version, sends version to node B. Node B waits for version, gets value.
+
+sync
+----
+
+.. program:: flux kvs sync
+
+Flush pending content and checkpoints to disk to ensure data persists
+across a Flux instance crash.  This command is identical to the
+:command:`flux kvs put` :option:`--sync` option, but does not require
+any data to be written.
 
 namespace create
 ----------------

--- a/t/t1010-kvs-commit-sync.t
+++ b/t/t1010-kvs-commit-sync.t
@@ -33,7 +33,7 @@ test_expect_success 'kvs: no checkpoint of kvs-primary should exist yet' '
         test_must_fail checkpoint_get kvs-primary
 '
 
-test_expect_success 'kvs: put some data to kvs and sync it' '
+test_expect_success 'kvs: put some data to kvs and sync it (flux kvs put)' '
         flux kvs put --blobref --sync c=3 > syncblob.out
 '
 
@@ -44,6 +44,16 @@ test_expect_success 'kvs: checkpoint of kvs-primary should exist now' '
 test_expect_success 'kvs: checkpoint of kvs-primary should match rootref' '
         checkpoint_get kvs-primary | jq -r .value.rootref > checkpoint.out &&
         test_cmp syncblob.out checkpoint.out
+'
+
+test_expect_success 'kvs: put some data to kvs and sync it (flux kvs sync)' '
+        flux kvs put --blobref d=4 > syncblob2.out &&
+        flux kvs sync
+'
+
+test_expect_success 'kvs: checkpoint of kvs-primary should match rootref' '
+        checkpoint_get kvs-primary | jq -r .value.rootref > checkpoint2.out &&
+        test_cmp syncblob2.out checkpoint2.out
 '
 
 test_expect_success 'kvs: sync fails against non-primary namespace' '

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -29,8 +29,8 @@ test_expect_success 'create some kvs content' '
 '
 # N.B. startlog commands in rc scripts normally ensures a checkpoint
 # exists but we do this just to be extra sure
-test_expect_success 'call --sync to ensure we have checkpointed' '
-	flux kvs put --sync dir.sync=foo
+test_expect_success 'call sync to ensure we have checkpointed' '
+	flux kvs sync
 '
 test_expect_success 'save some treeobjs for later' '
 	flux kvs get --treeobj dir.b > dirb.out &&


### PR DESCRIPTION
Problem: The only way to perform a sync is through the `flux kvs put` command, which inherently requires the user to
also write data at the same time.  This isn't necessarily always desired.

Support a new `flux kvs sync` command.  It is largely identical to `flux kvs put --sync`, but does not require additional data to be written.

Fixes #6814