### PR TITLE
doc: add note on use of flux queue drain

### DIFF
--- a/doc/man1/flux-queue.rst
+++ b/doc/man1/flux-queue.rst
@@ -186,6 +186,10 @@ be taken down for maintenance.
 
    Limit the time that the command` will block.
 
+.. note::
+   :program:`flux queue drain` can be used as a simple mechanism to wait for
+   all submitted jobs to complete in :command:`flux-batch` scripts.
+
 idle
 ----
 
@@ -307,4 +311,4 @@ FLUX RFC
 SEE ALSO
 ========
 
-:man1:`flux-jobs`, :man1:`flux-submit`
+:man1:`flux-jobs`, :man1:`flux-submit`, :man1:`flux-batch`


### PR DESCRIPTION
Problem: It is common to use `flux queue drain` to wait for all submitted jobs to finish in flux-batch(1) scripts.  However, this may not be obvious to new flux users.

Add a note about this in flux-queue(1) if users look for information on why this is used in flux batch scripts.

----

just an idea based on an e-mail thread