### PR TITLE
flux-module: require argument for flux module stats

### DIFF
--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -648,11 +648,11 @@ int cmd_stats (optparse_t *p, int argc, char **argv)
     flux_future_t *f = NULL;
     flux_t *h;
 
-    if ((n = optparse_option_index (p)) < argc - 1) {
+    if ((n = optparse_option_index (p)) != (argc - 1)) {
         optparse_print_usage (p);
         exit (1);
     }
-    service = n < argc ? argv[n++] : "broker";
+    service = argv[n];
     nodeid = FLUX_NODEID_ANY;
 
     if (!(h = flux_open (NULL, 0)))

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -206,6 +206,11 @@ test_expect_success 'flux module stats --rusage --parse maxrss works' '
 	test "$RSS" -gt 0
 '
 
+test_expect_success 'flux module stats with no args is an error' '
+	test_must_fail flux module stats 2> usage.out &&
+	grep -i "usage" usage.out
+'
+
 # try to hit some error cases
 
 test_expect_success 'flux module with no arguments prints usage and fails' '


### PR DESCRIPTION
Problem: The default target for flux module stats points to a RPC
target that no longer exists.

Require a stats target with flux module stats.

Fixes #6636

---

As an aside, the manpage for `flux-module(1)` and the `--help` output already documents this input as required.  So no need to fix those up.