### PR TITLE
add method to request extra brokers on node 0

### DIFF
--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -547,7 +547,6 @@ class Xcmd:
         "flags": "--flags=",
         "begin_time": "--begin-time=",
         "signal": "--signal=",
-        "taskmap": "--taskmap=",
     }
 
     class Xinput:

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -40,7 +40,7 @@ from flux.constraint.parser import ConstraintParser, ConstraintSyntaxError
 from flux.idset import IDset
 from flux.job import JobspecV1, JobWatcher
 from flux.progress import ProgressBar
-from flux.util import dict_merge, set_treedict
+from flux.util import dict_merge, get_treedict, set_treedict
 
 LOGGER = logging.getLogger("flux")
 
@@ -495,6 +495,12 @@ class BatchConfig:
         if extension in (".toml", ".json"):
             return self.update_file(value, extension)
         return self.update_named_config(value)
+
+    def get(self, key, default=None):
+        """
+        Get a value from the current config using dotted key form
+        """
+        return get_treedict(self.config or {}, key, default=default)
 
 
 class ConfAction(argparse.Action):


### PR DESCRIPTION
This PR is a WIP pending tests. I'm not sure if the solution proposed here is the best we can come up with, but I thought I'd post it now to get feedback.

This PR implements a hidden `--add-brokers=N` option to `flux batch` and `flux alloc` that can be used to force N extra brokers on nodeid 0. This is hidden for now because I'm not sure it is a great long-term approach, but it allows us to give select users a way to supplement their jobs with these extra brokers.

The option should be paired with an appropriate `tbon.topo` such that all critical ranks of the job are placed on node rank 0. The extra ranks are automatically excluded. Users may choose to also exclude or drain rank 0 since it will have more flux-broker processes on it.

Simple example:
```console
$ src/cmd/flux alloc -N4 --add-brokers=1 --conf=tbon.topo=kary:2
$ flux resource status 
       STATE UP NNODES NODELIST
       avail  ✔      4 pi[3,1-2,4]
     exclude  ✔      1 pi3
$ flux resource list
     STATE NNODES NCORES NGPUS NODELIST
      free      4     24     0 pi[3,1-2,4]
 allocated      0      0     0 
      down      0      0     0 
$ flux overlay status
0 pi3: full
├─ 1 pi3: full
│  ├─ 3 pi2: full
│  └─ 4 pi4: full
└─ 2 pi1: full
```

Note that `flux jobs` properly reports this instance has 5 tasks running on 4 nodes:
```console
$ flux --parent jobs
       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
ƒ29BhqUNKg3H grondo   flux        R      5      4   39.94m pi[3,1-2,4]
```
```
