### PR TITLE
use local ipc for TBON when brokers are co-located

### DIFF
--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -207,8 +207,8 @@ OPTIONS
    Set the pmi clique mode, which determines how ``PMI_process_mapping`` is set
    in the PMI server used to bootstrap the brokers.  If ``none``, the mapping
    is not created.  If ``single``, all brokers are placed in one clique. If
-   ``per-broker``, each broker is placed in its own clique.
-   Default: ``single``.
+   ``per-broker``, each broker is placed in its own clique.  Otherwise the
+   option argument is interpreted as an RFC 34 taskmap.  Default: ``single``.
 
 .. option:: -r, --recovery=[TARGET]
 

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -91,7 +91,8 @@ TESTS = test_attr.t \
 	test_boot_config.t \
 	test_runat.t \
 	test_overlay.t \
-	test_topology.t
+	test_topology.t \
+	test_bizcard.t
 
 test_ldadd = \
 	$(builddir)/libbroker.la \
@@ -148,5 +149,10 @@ test_topology_t_SOURCES = test/topology.c
 test_topology_t_CPPFLAGS = $(test_cppflags)
 test_topology_t_LDADD = $(test_ldadd)
 test_topology_t_LDFLAGS = $(test_ldflags)
+
+test_bizcard_t_SOURCES = test/bizcard.c
+test_bizcard_t_CPPFLAGS = $(test_cppflags)
+test_bizcard_t_LDADD = $(test_ldadd)
+test_bizcard_t_LDFLAGS = $(test_ldflags)
 
 EXTRA_DIST = README.md

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -36,6 +36,8 @@ libbroker_la_SOURCES = \
 	modservice.h \
 	overlay.h \
 	overlay.c \
+	bizcard.h \
+	bizcard.c \
 	service.h \
 	service.c \
 	attr.h \

--- a/src/broker/bizcard.c
+++ b/src/broker/bizcard.c
@@ -1,0 +1,191 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/errno_safe.h"
+#include "ccan/str/str.h"
+
+#include "bizcard.h"
+
+struct bizcard {
+    json_t *obj;
+    char *encoded;
+    size_t cursor;
+    int refcount;
+};
+
+void bizcard_decref (struct bizcard *bc)
+{
+    if (bc && --bc->refcount == 0) {
+        int saved_errno = errno;
+        json_decref (bc->obj);
+        free (bc->encoded);
+        free (bc);
+        errno = saved_errno;
+    }
+}
+
+struct bizcard *bizcard_incref (struct bizcard *bc)
+{
+    if (bc)
+        bc->refcount++;
+    return bc;
+}
+
+struct bizcard *bizcard_create (const char *hostname, const char *pubkey)
+{
+    struct bizcard *bc;
+
+    if (!hostname || !pubkey) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(bc = calloc (1, sizeof (*bc))))
+        return NULL;
+    bc->refcount = 1;
+    if (!(bc->obj = json_pack ("{s:s s:s s:[]}",
+                               "host", hostname,
+                               "pubkey", pubkey,
+                               "uri"))) {
+        errno = ENOMEM;
+        bizcard_decref (bc);
+        return NULL;
+    }
+    return bc;
+}
+
+const char *bizcard_encode (const struct bizcard *bc_const)
+{
+    struct bizcard *bc = (struct bizcard *)bc_const;
+    if (!bc) {
+        errno = EINVAL;
+        return NULL;
+    }
+    char *s;
+    if (!(s = json_dumps (bc->obj, JSON_COMPACT))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    free (bc->encoded);
+    bc->encoded = s;
+    return bc->encoded;
+}
+
+struct bizcard *bizcard_decode (const char *s, flux_error_t *error)
+{
+    struct bizcard *bc;
+    json_error_t jerror;
+
+    if (!(bc = calloc (1, sizeof (*bc))))
+        return NULL;
+    bc->refcount = 1;
+    if (!(bc->obj = json_loads (s, 0, &jerror))) {
+        errprintf (error, "%s", jerror.text);
+        errno = EINVAL;
+        goto error;
+    }
+    if (json_unpack_ex (bc->obj,
+                        &jerror,
+                        JSON_VALIDATE_ONLY,
+                        "{s:s s:s s:o}",
+                        "host",
+                        "pubkey",
+                        "uri") < 0) {
+        errprintf (error, "%s", jerror.text);
+        errno = EINVAL;
+        goto error;
+    }
+    return bc;
+error:
+    bizcard_decref (bc);
+    return NULL;
+}
+
+int bizcard_uri_append (struct bizcard *bc, const char *uri)
+{
+    json_t *a;
+    json_t *o;
+
+    if (!bc
+        || !uri
+        || !strstr (uri, "://")
+        || !(a = json_object_get (bc->obj, "uri"))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(o = json_string (uri)) || json_array_append_new (a, o) < 0) {
+        json_decref (o);
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+const char *bizcard_uri_next (const struct bizcard *bc_const)
+{
+    struct bizcard *bc = (struct bizcard *)bc_const;
+    json_t *a;
+    json_t *o;
+    const char *s;
+
+    if (!bc
+        || !(a = json_object_get (bc->obj, "uri"))
+        || !(o = json_array_get (a, bc->cursor))
+        || !(s = json_string_value (o)))
+        return NULL;
+    bc->cursor++;
+    return s;
+}
+
+const char *bizcard_uri_first (const struct bizcard *bc_const)
+{
+    struct bizcard *bc = (struct bizcard *)bc_const;
+    if (bc)
+        bc->cursor = 0;
+    return bizcard_uri_next (bc);
+}
+
+const char *bizcard_uri_find (const struct bizcard *bc, const char *scheme)
+{
+    const char *uri;
+
+    uri = bizcard_uri_first (bc);
+    while (uri) {
+        if (!scheme || strstarts (uri, scheme))
+            return uri;
+        uri = bizcard_uri_next (bc);
+    }
+    return NULL;
+}
+
+const char *bizcard_pubkey (const struct bizcard *bc)
+{
+    const char *s;
+    if (!bc || json_unpack (bc->obj, "{s:s}", "pubkey", &s) < 0)
+        return NULL;
+    return s;
+}
+
+const char *bizcard_hostname (const struct bizcard *bc)
+{
+    const char *s;
+    if (!bc || json_unpack (bc->obj, "{s:s}", "host", &s) < 0)
+        return NULL;
+    return s;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/broker/bizcard.h
+++ b/src/broker/bizcard.h
@@ -1,0 +1,33 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef BROKER_BIZCARD_H
+#define BROKER_BIZCARD_H
+
+#include <flux/core.h>
+
+struct bizcard *bizcard_create (const char *hostname, const char *pubkey);
+struct bizcard *bizcard_incref (struct bizcard *bc);
+void bizcard_decref (struct bizcard *bc);
+
+const char *bizcard_encode (const struct bizcard *bc);
+struct bizcard *bizcard_decode (const char *s, flux_error_t *error);
+
+int bizcard_uri_append (struct bizcard *bc, const char *uri);
+const char *bizcard_uri_first (const struct bizcard *bc);
+const char *bizcard_uri_next (const struct bizcard *bc);
+const char *bizcard_uri_find (const struct bizcard *bc, const char *scheme);
+
+const char *bizcard_pubkey (const struct bizcard *bc);
+const char *bizcard_hostname (const struct bizcard *bc);
+
+#endif /* BROKER_BIZCARD_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -614,7 +614,7 @@ int boot_config (flux_t *h,
                                        bind_uri,
                                        sizeof (bind_uri)) < 0)
             goto error;
-        if (overlay_bind (overlay, bind_uri) < 0)
+        if (overlay_bind (overlay, bind_uri, NULL) < 0)
             goto error;
         if (overlay_authorize (overlay,
                                overlay_cert_name (overlay),

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -464,7 +464,7 @@ int boot_pmi (const char *hostname, struct overlay *overlay, attr_t *attrs)
 
         if (format_bind_uri (buf, sizeof (buf), attrs, info.rank) < 0)
             goto error;
-        if (overlay_bind (overlay, buf) < 0)
+        if (overlay_bind (overlay, buf, NULL) < 0)
             goto error;
     }
     /* Each broker writes a business card consisting of hostname,

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1494,7 +1494,7 @@ static int bind_uri (struct overlay *ov, const char *uri)
     return 0;
 }
 
-int overlay_bind (struct overlay *ov, const char *uri)
+int overlay_bind (struct overlay *ov, const char *uri, const char *uri2)
 {
     if (!ov->h || ov->rank == FLUX_NODEID_ANY || ov->bind_zsock) {
         errno = EINVAL;
@@ -1552,6 +1552,10 @@ int overlay_bind (struct overlay *ov, const char *uri)
     }
     if (bind_uri (ov, uri) < 0) {
         log_err ("error binding to %s", uri);
+        return -1;
+    }
+    if (uri2 && bind_uri (ov, uri2) < 0) {
+        log_err ("error binding to %s", uri2);
         return -1;
     }
     if (!(ov->bind_w = zmqutil_watcher_create (ov->reactor,

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -136,9 +136,9 @@ bool overlay_peer_is_torpid (struct overlay *ov, uint32_t rank);
 
 /* Broker should call overlay_bind() if there are children.  This may happen
  * before any peers are authorized as long as they are authorized before they
- * try to connect.
+ * try to connect.  Note: uri2 (a secondary endpoint) MAY be NULL
  */
-int overlay_bind (struct overlay *ov, const char *uri);
+int overlay_bind (struct overlay *ov, const char *uri, const char *uri2);
 
 /* Broker should call overlay_connect(), after overlay_set_parent_uri()
  * and overlay_set_parent_pubkey(), if there is a parent.

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -16,6 +16,7 @@
 
 #include "attr.h"
 #include "topology.h"
+#include "bizcard.h"
 
 typedef enum {
     OVERLAY_ANY = 0,
@@ -98,6 +99,7 @@ int overlay_get_child_peer_count (struct overlay *ov);
 struct idset *overlay_get_child_peer_idset (struct overlay *ov);
 const char *overlay_get_bind_uri (struct overlay *ov);
 const char *overlay_get_parent_uri (struct overlay *ov);
+const struct bizcard *overlay_get_bizcard (struct overlay *ov);
 int overlay_set_parent_uri (struct overlay *ov, const char *uri);
 bool overlay_parent_error (struct overlay *ov);
 void overlay_set_version (struct overlay *ov, int version); // test only

--- a/src/broker/test/bizcard.c
+++ b/src/broker/test/bizcard.c
@@ -1,0 +1,194 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "ccan/str/str.h"
+#include "src/common/libtap/tap.h"
+#include "bizcard.h"
+
+bool streq_safe (const char *s1, const char *s2)
+{
+    if (!s1 && !s2)
+        return true;
+    if (!s1 || !s1)
+        return false;
+    return streq (s1, s2);
+}
+
+bool test_bizcard_equiv (const struct bizcard *bc1,
+                         const struct bizcard *bc2)
+{
+    if (!streq (bizcard_hostname (bc1), bizcard_hostname (bc2)))
+        return false;
+    if (!streq (bizcard_pubkey (bc1), bizcard_pubkey (bc2)))
+        return false;
+    if (!streq_safe (bizcard_uri_first (bc1), bizcard_uri_first (bc2)))
+        return false;
+    do {
+        if (!streq_safe (bizcard_uri_next (bc1), bizcard_uri_next (bc2)))
+            return false;
+    } while (bizcard_uri_next (bc1) != NULL);
+    return true;
+}
+
+void test_simple (void)
+{
+    struct bizcard *bc;
+    struct bizcard *bc2;
+    const char *s;
+
+    ok ((bc = bizcard_create ("hostname", "pubkey")) != NULL,
+        "bizcard_create works");
+    ok ((s = bizcard_hostname (bc)) != NULL
+        && streq (s, "hostname"),
+        "bizcard_hostname works");
+    ok ((s = bizcard_pubkey (bc)) != NULL
+        && streq (s, "pubkey"),
+        "bizcard_pubkey works");
+    ok (bizcard_uri_first (bc) == NULL,
+        "bizcard_uri_first returns NULL");
+    ok (bizcard_uri_next (bc) == NULL,
+        "bizcard_uri_next returns NULL");
+    ok (bizcard_uri_find (bc, NULL) == NULL,
+        "bizcard_uri_find scheme=NULL returns NULL");
+    ok (bizcard_uri_find (bc, "ipc") == NULL,
+        "bizcard_uri_find scheme=ipc returns NULL");
+
+    ok (bizcard_uri_append (bc, "ipc:///foo/bar") == 0,
+        "bizcard_uri_append uri=ipc:///foo/bar works");
+    ok ((s = bizcard_uri_first (bc)) != NULL
+        && streq (s, "ipc:///foo/bar"),
+        "bizcard_uri_first returns URI");
+    ok (bizcard_uri_next (bc) == NULL,
+        "bizcard_uri_next returns NULL");
+    ok ((s = bizcard_uri_find (bc, NULL)) != NULL
+        && streq (s, "ipc:///foo/bar"),
+        "bizcard_uri_find scheme=NULL returns URI");
+    ok ((s = bizcard_uri_find (bc, "ipc://")) != NULL
+        && streq (s, "ipc:///foo/bar"),
+        "bizcard_uri_find scheme=ipc:// returns URI");
+    ok (bizcard_uri_find (bc, "tcp://") == NULL,
+        "bizcard_uri_find scheme=tcp:// returns NULL");
+
+    ok (bizcard_uri_append (bc, "tcp://192.168.1.1:1234") == 0,
+        "bizcard_uri_append uri=tcp://192.168.1.1:1234 works");
+    ok ((s = bizcard_uri_first (bc)) != NULL
+        && streq (s, "ipc:///foo/bar"),
+        "bizcard_uri_first returns ipc URI");
+    ok ((s = bizcard_uri_next (bc)) != NULL
+        && streq (s, "tcp://192.168.1.1:1234"),
+        "bizcard_uri_next returns tcp URI");
+    ok (bizcard_uri_next (bc) == NULL,
+        "bizcard_uri_next returns NULL");
+    ok ((s = bizcard_uri_find (bc, "ipc://")) != NULL
+        && streq (s, "ipc:///foo/bar"),
+        "bizcard_uri_find scheme=ipc:// returns ipc URI");
+    ok ((s = bizcard_uri_find (bc, "tcp://")) != NULL
+        && streq (s, "tcp://192.168.1.1:1234"),
+        "bizcard_uri_find scheme=tcp:// returns tcp URI");
+
+    ok ((s = bizcard_encode (bc)) != NULL,
+        "bizcard_encode works");
+    ok ((bc2 = bizcard_decode (s, NULL)) != NULL,
+        "bizcard_decode works");
+    ok (test_bizcard_equiv (bc, bc2),
+        "new bizcard is same as the old one");
+
+    bizcard_incref (bc);
+    bizcard_decref (bc);
+
+    bizcard_decref (bc);
+    bizcard_decref (bc2);
+}
+
+void test_inval (void)
+{
+    flux_error_t error;
+    struct bizcard *bc;
+
+    errno = 0;
+    ok (bizcard_create (NULL, "pubkey") == NULL && errno == EINVAL,
+        "bizcard_create hostname=NULL fails with EINVAL");
+    errno = 0;
+    ok (bizcard_create ("hostname", NULL) == NULL && errno == EINVAL,
+        "bizcard_create pubkey=NULL fails with EINVAL");
+
+    lives_ok ({bizcard_decref (NULL);},
+              "bizcard_decref NULL doesn't crash");
+    lives_ok ({bizcard_incref (NULL);},
+              "bizcard_incref NULL doesn't crash");
+
+    errno = 0;
+    ok (bizcard_encode (NULL) == NULL && errno == EINVAL,
+        "bizcard_encode NULL fails with EINVAL");
+    errno = 0;
+
+    error.text[0] = '\0';
+    ok (bizcard_decode (NULL, &error) == NULL
+        && errno == EINVAL
+        && error.text[0] != '\0',
+        "bizcard_decode NULL fails with EINVAL and sets error");
+    diag ("%s", error.text);
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (bizcard_decode ("badinput", &error) == NULL
+        && errno == EINVAL
+        && error.text[0] != '\0',
+        "bizcard_decode badinput fails with EINVAL and sets error");
+    diag ("%s", error.text);
+
+    errno = 0;
+    error.text[0] = '\0';
+    ok (bizcard_decode ("{}", &error) == NULL
+        && errno == EINVAL
+        && error.text[0] != '\0',
+        "bizcard_decode {} fails with EINVAL and sets error");
+    diag ("%s", error.text);
+
+    if (!(bc = bizcard_create ("foo", "bar")))
+        BAIL_OUT ("bizcard_create failed");
+
+    errno = 0;
+    ok (bizcard_uri_append (NULL, "foo://bar") < 0 && errno == EINVAL,
+        "bizcard_uri_append bc=NULL fails with EINVAL");
+    errno = 0;
+    ok (bizcard_uri_append (bc, NULL) < 0 && errno == EINVAL,
+        "bizcard_uri_append uri=NULL fails with EINVAL");
+
+    ok (bizcard_uri_first (NULL) == NULL,
+        "bizcard_uri_first NULL returns NULL");
+    ok (bizcard_uri_next (NULL) == NULL,
+        "bizcard_uri_next NULL returns NULL");
+    ok (bizcard_uri_find (NULL, NULL) == NULL,
+        "bizcard_uri_next bc=NULL returns NULL");
+    ok (bizcard_pubkey (NULL) == NULL,
+        "bizcard_pubkey NULL returns NULL");
+    ok (bizcard_hostname (NULL) == NULL,
+        "bizcard_hostname NULL returns NULL");
+
+    bizcard_decref (bc);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_simple ();
+    test_inval ();
+
+    done_testing ();
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -294,7 +294,7 @@ void trio (flux_t *h)
         "%s: overlay_cert_pubkey works", ctx[0]->name);
 
     snprintf (parent_uri, sizeof (parent_uri), "ipc://@%s", ctx[0]->name);
-    ok (overlay_bind (ctx[0]->ov, parent_uri) == 0,
+    ok (overlay_bind (ctx[0]->ov, parent_uri, NULL) == 0,
         "%s: overlay_bind %s works", ctx[0]->name, parent_uri);
 
     ctx[1] = ctx_create (h, size, 1, "kary:2", recv_cb);
@@ -441,7 +441,8 @@ void trio (flux_t *h)
      * fails to initialize because its endpoint is already bound.
      */
     errno = 0;
-    ok (overlay_bind (ctx[1]->ov, "ipc://@foo") < 0 && errno == EADDRINUSE,
+    ok (overlay_bind (ctx[1]->ov, "ipc://@foo", NULL) < 0
+        && errno == EADDRINUSE,
         "%s: second overlay_bind in proc fails with EADDRINUSE", ctx[0]->name);
 
     /* Various tests of rank 2 without proper authorization.
@@ -523,7 +524,7 @@ void test_create (flux_t *h,
              * handler, and overlay_authorize() will fail if it doesn't
              * exist.
              */
-            if (overlay_bind (ctx[0]->ov, uri) < 0)
+            if (overlay_bind (ctx[0]->ov, uri, NULL) < 0)
                 BAIL_OUT ("%s: overlay_bind failed", ctx[0]->name);
         }
         else {
@@ -669,7 +670,7 @@ void wrongness (flux_t *h)
         BAIL_OUT ("overlay_create failed");
 
     errno = 0;
-    ok (overlay_bind (ov, "ipc://@foobar") < 0 && errno == EINVAL,
+    ok (overlay_bind (ov, "ipc://@foobar", NULL) < 0 && errno == EINVAL,
         "overlay_bind fails if called before rank is known");
 
     ok (!flux_msg_is_local (NULL),

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -293,8 +293,7 @@ test_expect_success 'flux-start --test-pmi-clique=none works' "
 test_expect_success 'flux-start --test-pmi-clique=badmode fails' "
 	test_must_fail flux start ${ARGS} --test-size=1 \
 		--test-pmi-clique=badmode \
-		true 2>badmode.err &&
-	grep unsupported badmode.err
+		true
 "
 test_expect_success 'flux-start embedded server works from initial program' "
 	flux start -v ${ARGS} -s1 flux python ${startctl} status \


### PR DESCRIPTION
This allows IPC to be used instead of TCP between brokers when they are co-located on the same node.
Using @grondo's custom taskmap from the description of #6815, this starts a flux instance with several ranks on the first node and the rest on their own nodes:
```
$ flux run -q batch -N4 -n8 --taskmap=manual:"[[0,1,5,1],[1,3,1,1]]" -o pty.interactive flux start
$ flux exec -x 0 --label-io flux getattr tbon.parent-endpoint
5: tcp://[::ffff:192.168.88.246]:45175
6: tcp://[::ffff:192.168.88.246]:45175
7: tcp://[::ffff:192.168.88.246]:45175
2: ipc:///tmp/flux-jWd8Pr/tbon-0
3: ipc:///tmp/flux-jWd8Pr/tbon-0
4: ipc:///tmp/flux-jWd8Pr/tbon-0
1: ipc:///tmp/flux-jWd8Pr/tbon-0
```

WIP because this needs tests and I'm struggling with how that might be done.  Since its EOD I figured I'd get this posted for now and return for another look with a fresh brain.

Note this PR did require significant refactoring in the broker's PMI client.  I think it's more readable now though  overall.