### PR TITLE
support `singleton` dependency scheme in job submission

### DIFF
--- a/doc/man1/common/job-dependencies.rst
+++ b/doc/man1/common/job-dependencies.rst
@@ -55,6 +55,14 @@ afterexcept:JOBID
    and a fatal job exception caused the transition to CLEANUP (e.g.,
    node failure, timeout, cancel, etc.).
 
+singleton
+   This dependency is satisfied when there are no other active jobs
+   of the same userid and job name which are not already held with
+   a singleton dependency. That is, a singleton can be the only
+   job with the same userid and job name in the SCHED state or later.
+   The singleton scheme requires an explicit job name using the
+   ``--job-name`` option.
+
 begin-time:TIMESTAMP
    This dependency is satisfied after TIMESTAMP, which is specified in
    floating point seconds since the UNIX epoch. See the ``--begin-time``

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -74,6 +74,7 @@ libjob_manager_la_SOURCES = \
 	plugins/limit-job-size.c \
 	plugins/limit-duration.c \
 	plugins/dependency-after.c \
+	plugins/dependency-singleton.c \
 	plugins/begin-time.c \
 	plugins/update-duration.c \
 	plugins/validate-duration.c \

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -48,6 +48,7 @@ extern int priority_default_plugin_init (flux_plugin_t *p);
 extern int limit_job_size_plugin_init (flux_plugin_t *p);
 extern int limit_duration_plugin_init (flux_plugin_t *p);
 extern int after_plugin_init (flux_plugin_t *p);
+extern int singleton_plugin_init (flux_plugin_t *p);
 extern int begin_time_plugin_init (flux_plugin_t *p);
 extern int validate_duration_plugin_init (flux_plugin_t *p);
 extern int update_duration_plugin_init (flux_plugin_t *p);
@@ -70,6 +71,7 @@ static struct jobtap_builtin jobtap_builtins [] = {
     { ".limit-job-size", limit_job_size_plugin_init },
     { ".limit-duration", limit_duration_plugin_init },
     { ".dependency-after", after_plugin_init },
+    { ".dependency-singleton", singleton_plugin_init },
     { ".begin-time", &begin_time_plugin_init },
     { ".validate-duration", &validate_duration_plugin_init },
     { ".update-duration", &update_duration_plugin_init },

--- a/src/modules/job-manager/plugins/dependency-singleton.c
+++ b/src/modules/job-manager/plugins/dependency-singleton.c
@@ -1,0 +1,369 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* dependency-singleton.c
+ *
+ * Support singleton dependency scheme which places a dependency
+ * on a job which is only released when there are no other active
+ * jobs of the same userid and job name which are not also already
+ * held with a singleton dependency.
+ *
+ * Notes:
+ * - counts of active jobs with the same userid/job-name are maintained
+ *   in a global hash
+ * - jobs without an explicit name are ignored
+ * - jobs submitted with dependency=singleton are placed on a list, also
+ *   hashed by userid/job-name
+ * - when the active job count for a userid/job-name is decremented and
+ *   equals the count of singletons for that same pair, a singleton job
+ *   is released and removed from the list
+ * - it is an error to submit a singleton job without an explicit job name
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+#include "src/common/libjob/idf58.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/hola.h"
+#include "ccan/str/str.h"
+#include "ccan/ptrint/ptrint.h"
+
+struct singleton_ctx {
+    zhashx_t *counts; // uid:job-name => ACTIVE job counts
+                      // (with or without singleton dep)
+    struct hola *singletons; // uid:job-name => list of struct singleton
+                             // (jobs with singleton dep)
+};
+
+struct singleton {
+    flux_jobid_t id;
+};
+
+static struct singleton_ctx *global_ctx = NULL;
+
+static void singleton_ctx_destroy (struct singleton_ctx *sctx)
+{
+    if (sctx) {
+        int saved_errno = errno;
+        zhashx_destroy (&sctx->counts);
+        hola_destroy (sctx->singletons);
+        free (sctx);
+        errno = saved_errno;
+    }
+}
+
+static struct singleton_ctx *singleton_ctx_create (void)
+{
+    struct singleton_ctx *sctx;
+    int flags = HOLA_AUTOCREATE | HOLA_AUTODESTROY;
+
+    if (!(sctx = malloc (sizeof (*sctx)))
+        || !(sctx->counts = zhashx_new ())
+        || !(sctx->singletons = hola_create (flags)))
+        goto error;
+    return sctx;
+error:
+    singleton_ctx_destroy (sctx);
+    return NULL;
+}
+
+static int singleton_key_create (char *key,
+                                 size_t len,
+                                 uint32_t userid,
+                                 const char *name)
+{
+    if (snprintf (key, len, "%u:%s", userid, name) >= len)
+        return -1;
+    return 0;
+}
+
+static int singleton_list_push (flux_plugin_t *p,
+                                struct singleton_ctx *sctx,
+                                const char *key,
+                                flux_jobid_t id)
+{
+    struct singleton *s;
+
+    if (!(s = calloc (1, sizeof (*s)))
+        || flux_jobtap_job_aux_set (p, id, NULL, s, (flux_free_f) free) < 0) {
+        free (s);
+        return -1;
+    }
+    s->id = id;
+    if (!(hola_list_add_end (sctx->singletons, key, s)))
+        return -1;
+
+    return 0;
+}
+
+static struct singleton *singleton_list_pop (struct singleton_ctx *sctx,
+                                             const char *key)
+{
+    struct singleton *s = hola_list_first (sctx->singletons, key);
+    if (s) {
+        hola_list_delete (sctx->singletons,
+                          key,
+                          hola_list_cursor (sctx->singletons, key));
+    }
+    return s;
+}
+
+static size_t singleton_list_count (struct singleton_ctx *sctx,
+                                    const char *key)
+{
+    return hola_list_size (sctx->singletons, key);
+}
+
+/* Return the current count of ACTIVE jobs with same uid:job-name
+ */
+static int get_current_active_count (struct singleton_ctx *sctx,
+                                     const char *key)
+{
+    return ptr2int (zhashx_lookup (sctx->counts, key));
+}
+
+/* Set the current count of ACTIVE jobs for key (uid:job-name)
+ */
+static void set_current_active_count (struct singleton_ctx *sctx,
+                                      const char *key,
+                                      int count)
+{
+    if (count > 0)
+        zhashx_update (sctx->counts, key, int2ptr (count));
+    else
+        zhashx_delete (sctx->counts, key);
+}
+
+/* Update singleton userid:name hash counts with value (1 or -1)
+ */
+static int singleton_count_update (struct singleton_ctx *sctx,
+                                   flux_plugin_t *p,
+                                   flux_plugin_arg_t *args,
+                                   int value)
+{
+    flux_jobid_t id;
+    struct singleton *s;
+    uint32_t userid;
+    const char *name = NULL;
+    char key [1024];
+    int count;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I s:i s:{s:{s:{s?{s?s}}}}}",
+                                "id", &id,
+                                "userid", &userid,
+                                "jobspec",
+                                 "attributes",
+                                  "system",
+                                   "job",
+                                    "name", &name) < 0)
+        return -1;
+
+    /* Only track jobs with an explicit name */
+    if (name == NULL)
+        return 0;
+
+    if (singleton_key_create (key, sizeof (key), userid, name) < 0)
+        return -1;
+
+    count = get_current_active_count (sctx, key) + value;
+    if (count == singleton_list_count (sctx, key)
+        && (s = singleton_list_pop (sctx, key))) {
+        /*  All active jobs of this uid/name pair are waiting on a singleton
+         *  dependency. Pop the next job on the list and release it:
+         */
+        if (flux_jobtap_dependency_remove (p, s->id, "singleton") < 0) {
+            flux_jobtap_raise_exception (p,
+                                         s->id,
+                                         "dependency",
+                                         0,
+                                         "failed to remove singleton dependency");
+        }
+    }
+    set_current_active_count (sctx, key, count);
+    return 0;
+}
+
+static int new_cb (flux_plugin_t *p,
+                    const char *topic,
+                    flux_plugin_arg_t *args,
+                    void *data)
+{
+    return singleton_count_update (global_ctx, p, args, 1);
+}
+
+static int inactive_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *data)
+{
+    return singleton_count_update (global_ctx, p, args, -1);
+}
+
+
+static int dependency_singleton_cb (flux_plugin_t *p,
+                                    const char *topic,
+                                    flux_plugin_arg_t *args,
+                                    void *data)
+{
+    struct singleton_ctx *sctx = global_ctx;
+    flux_jobid_t id;
+    uint32_t userid;
+    const char *name = NULL;
+    char key [1024];
+    int count;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I s:i s:{s:{s:{s?{s?s}}}}}",
+                                "id", &id,
+                                "userid", &userid,
+                                "jobspec",
+                                 "attributes",
+                                  "system",
+                                   "job",
+                                    "name", &name) < 0)
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "failed to unpack plugin args: %s",
+                                       flux_plugin_arg_strerror (args));
+    if (name == NULL)
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "singleton jobs require a job name");
+
+    if (singleton_key_create (key, sizeof (key), userid, name) < 0)
+        return flux_jobtap_reject_job (p, args, "error creating singleton key");
+
+    /* Get current count of matching jobs in PRIORITY|SCHED|RUN|CLEANUP state.
+     * If there are no other matching jobs then release this one immediately.
+     *
+     * Note: The current job is not included in the `counts` hash yet since
+     * `job.dependency.*` callbacks run before `job.new`, which is only called
+     * on valid jobs.
+     */
+    if ((count = get_current_active_count (sctx, key)) == 0)
+        return 0;
+
+    if (flux_jobtap_dependency_add (p, id, "singleton") < 0)
+        return flux_jobtap_reject_job (p, args, "failed to add dependency");
+
+    return singleton_list_push (p, sctx, key, id);
+}
+
+static json_t *singleton_list_to_json (const char *key)
+{
+    json_t *o;
+    zlistx_t *l;
+    struct singleton *s;
+
+    if (!(o = json_array ()))
+        return NULL;
+
+    if (!(l = hola_hash_lookup (global_ctx->singletons, key)))
+        return o;
+
+    s = zlistx_first (l);
+    while (s) {
+        json_t *id = json_integer (s->id);
+        if (!id || json_array_append_new (o, id)) {
+            json_decref (id);
+            goto error;
+        }
+        s = zlistx_next (l);
+    }
+    return o;
+error:
+    json_decref (o);
+    return NULL;
+}
+
+static json_t *singletons_to_json (void)
+{
+    json_t *o = NULL;
+    zlistx_t *keys = NULL;
+    const char *key;
+
+    if (!(keys = zhashx_keys (global_ctx->counts))
+        || !(o = json_object ()))
+        goto error;
+
+    key = zlistx_first (keys);
+    while (key) {
+        json_t *singletons;
+        json_t *entry = NULL;
+        int count = get_current_active_count (global_ctx, key);
+
+        if (!(singletons = singleton_list_to_json (key))
+            || !(entry = json_pack ("{s:i s:O}",
+                                    "count", count,
+                                    "singletons", singletons))
+            || json_object_set_new (o, key, entry) < 0) {
+            json_decref (entry);
+            json_decref (singletons);
+            goto error;
+        }
+        json_decref (singletons);
+        key = zlistx_next (keys);
+    }
+    zlistx_destroy (&keys);
+    return o;
+error:
+    json_decref (o);
+    zlistx_destroy (&keys);
+    return NULL;
+}
+
+static int query_cb (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *data)
+{
+    int rc;
+    json_t *o;
+    if (!(o = singletons_to_json ()))
+        return -1;
+    rc = flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT, "O", o);
+    json_decref (o);
+    return rc;
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.dependency.singleton",  dependency_singleton_cb, NULL },
+    { "job.new",                   new_cb,                  NULL },
+    { "job.state.inactive",        inactive_cb,             NULL },
+    { "plugin.query",              query_cb,                NULL },
+    { 0 },
+};
+
+int singleton_plugin_init (flux_plugin_t *p)
+{
+    if (!(global_ctx = singleton_ctx_create ())
+        || flux_plugin_aux_set (p,
+                                NULL,
+                                global_ctx,
+                                (flux_free_f) singleton_ctx_destroy) < 0) {
+        singleton_ctx_destroy (global_ctx);
+        return -1;
+    }
+    return flux_plugin_register (p, ".dependency-singleton", tab);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -165,6 +165,7 @@ TESTSCRIPTS = \
 	t2274-manager-perilog-per-rank.t \
 	t2275-job-duration-validator.t \
 	t2276-job-requires.t \
+	t2277-dependency-singleton.t \
 	t2280-job-memo.t \
 	t2290-job-update.t \
 	t2291-job-update-queue.t \

--- a/t/t2277-dependency-singleton.t
+++ b/t/t2277-dependency-singleton.t
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+test_description='Test job dependency singleton support'
+
+. $(dirname $0)/sharness.sh
+
+
+flux version | grep -q libflux-security && test_set_prereq FLUX_SECURITY
+
+test_under_flux 2 job
+
+flux setattr log-stderr-level 1
+
+submit_as_alternate_user()
+{
+	FAKE_USERID=42
+	flux run --dry-run "$@" | \
+		flux python ${SHARNESS_TEST_SRCDIR}/scripts/sign-as.py $FAKE_USERID \
+		>job.signed
+	FLUX_HANDLE_USERID=$FAKE_USERID \
+		flux job submit --flags=signed job.signed
+}
+
+test_expect_success 'dependency=singleton rejects job with no job name' '
+	test_expect_code 1 flux submit --dependency=singleton true 2>s1.err &&
+	grep "require a job name" s1.err
+'
+test_expect_success 'jobs without a dependency run' '
+	flux run true
+'
+test_expect_success 'submit 5 singleton jobs at once' '
+	flux submit -n1 --watch --quiet --cc=1-5 --job-name=test \
+		--dependency=singleton echo {cc} > 5jobs.out &&
+	test_debug "cat 5jobs.out" &&
+	test_seq 1 5 >5jobs.expected &&
+	test_cmp 5jobs.expected 5jobs.out
+'
+test_expect_success 'submit a held job' '
+	heldid=$(flux submit -n1 --urgency=hold --job-name=foo hostname)
+'
+test_expect_success 'singleton job is stuck in DEPEND state' '
+	id=$(flux submit -n1 --job-name=foo --dependency=singleton true) &&
+	flux job wait-event -vt 30 $id dependency-add &&
+	test $(flux jobs -no {state} $id) = DEPEND
+'
+test_expect_success 'jobtap plugin query works' '
+	flux jobtap query .dependency-singleton | jq &&
+	flux jobtap query .dependency-singleton \
+		| jq -e ".[\"$(id -u):foo\"].count == 2"
+'
+test_expect_success 'singleton job with a different name runs' '
+	id2=$(flux submit -n1 --job-name=bar --dependency=singleton true) &&
+	flux job wait-event -vt 30 $id2 clean
+'
+test_expect_success FLUX_SECURITY 'allow guest access to testexec' '
+	echo exec.testexec.allow-guests=true | flux config load
+'
+test_expect_success FLUX_SECURITY 'singleton job as another user with same name runs' '
+	id3=$(submit_as_alternate_user -n1 --job-name=foo \
+	      --dependency=singleton -Sexec.test.run_duration=0.1s true) &&
+	echo "submitted $id3" &&
+	flux job wait-event -vt 30 $id3 clean
+'
+test_expect_success 'release held job, singleton should now run' '
+	test $(flux jobs -no {state} $id) = DEPEND &&
+	flux job urgency $heldid default &&
+	flux job wait-event -vt30 $id clean
+'
+test_done


### PR DESCRIPTION
This PR adds a very simple implementation of a `singleton` dependency scheme as described in #6804.

In order to support the requirement of "a singleton job is not eligible to run until all jobs of the same userid and job name have become inactive", the plugin has to track a count of _all_ jobs by userid,name pair, even when no singleton jobs are being submitted. In practice, this seems to have little impact on throughput, so perhaps this is ok. Note that, for simplicity, jobs without an explicit name are ignored by the plugin (i.e. first argument does not count as the job name).

Singleton jobs are then placed on a list in submission order and are only released when the count of active jobs with the same userid and job name equal the number of currently held singletons.