### PR TITLE
flux-fsck: parallelize valref blobref checks

### DIFF
--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -67,8 +67,13 @@ test_expect_success 'flux-fsck detects errors' '
 	test_must_fail flux fsck 2> fsckerrors1.out &&
 	count=$(cat fsckerrors1.out | wc -l) &&
 	test $count -eq 3 &&
-	grep "dir\.b" fsckerrors1.out | grep "missing blobref" | grep "index=1" &&
+	grep "dir\.b" fsckerrors1.out | grep "missing blobref(s)" &&
 	grep "Total errors: 1" fsckerrors1.out
+'
+test_expect_success 'flux-fsck --verbose outputs details' '
+	test_must_fail flux fsck --verbose 2> fsckerrors1V.out &&
+	grep "dir\.b" fsckerrors1V.out | grep "missing blobref" | grep "index=1" &&
+	grep "Total errors: 1" fsckerrors1V.out
 '
 test_expect_success 'flux-fsck no output with --quiet' '
 	test_must_fail flux fsck --quiet 2> fsckerrors2.out &&
@@ -90,9 +95,15 @@ test_expect_success 'flux-fsck detects errors' '
 	test_must_fail flux fsck 2> fsckerrors3.out &&
 	count=$(cat fsckerrors3.out | wc -l) &&
 	test $count -eq 4 &&
-	grep "dir\.b" fsckerrors3.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" fsckerrors3.out | grep "missing blobref" | grep "index=2" &&
+	grep "dir\.b" fsckerrors3.out | grep "missing blobref(s)" &&
+	grep "dir\.c" fsckerrors3.out | grep "missing blobref(s)" &&
 	grep "Total errors: 2" fsckerrors3.out
+'
+test_expect_success 'flux-fsck --verbose outputs details' '
+	test_must_fail flux fsck --verbose 2> fsckerrors3V.out &&
+	grep "dir\.b" fsckerrors3V.out | grep "missing blobref" | grep "index=1" &&
+	grep "dir\.c" fsckerrors3V.out | grep "missing blobref" | grep "index=2" &&
+	grep "Total errors: 2" fsckerrors3V.out
 '
 test_expect_success 'flux-fsck no output with --quiet' '
 	test_must_fail flux fsck --quiet 2> fsckerrors4.out &&

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -41,8 +41,8 @@ test_expect_success 'unload kvs' '
 '
 test_expect_success 'flux-fsck works' '
 	flux fsck 2> simple.out &&
-        grep "Checking integrity" simple.out &&
-        grep "Total errors: 0" simple.out
+	grep "Checking integrity" simple.out &&
+	grep "Total errors: 0" simple.out
 '
 test_expect_success 'flux-fsck verbose works' '
 	flux fsck --verbose 2> verbose.out &&
@@ -68,7 +68,7 @@ test_expect_success 'flux-fsck detects errors' '
 	count=$(cat fsckerrors1.out | wc -l) &&
 	test $count -eq 3 &&
 	grep "dir\.b" fsckerrors1.out | grep "missing blobref" &&
-        grep "Total errors: 1" fsckerrors1.out
+	grep "Total errors: 1" fsckerrors1.out
 '
 test_expect_success 'flux-fsck no output with --quiet' '
 	test_must_fail flux fsck --quiet 2> fsckerrors2.out &&
@@ -92,7 +92,7 @@ test_expect_success 'flux-fsck detects errors' '
 	test $count -eq 4 &&
 	grep "dir\.b" fsckerrors3.out | grep "missing blobref" &&
 	grep "dir\.c" fsckerrors3.out | grep "missing blobref" &&
-        grep "Total errors: 2" fsckerrors3.out
+	grep "Total errors: 2" fsckerrors3.out
 '
 test_expect_success 'flux-fsck no output with --quiet' '
 	test_must_fail flux fsck --quiet 2> fsckerrors4.out &&

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -81,6 +81,9 @@ test_expect_success 'make a reference invalid' '
 	cat dirb.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > dirbbad.out &&
 	flux kvs put --treeobj dir.b="$(cat dirbbad.out)"
 '
+test_expect_success 'call sync to ensure we have checkpointed' '
+	flux kvs sync
+'
 test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
@@ -109,6 +112,9 @@ test_expect_success 'make a reference invalid' '
 	cat dirc.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > dircbad1.out &&
 	cat dircbad1.out | jq -c .data[2]=\"sha1-1234567890123456789012345678901234567890\" > dircbad2.out &&
 	flux kvs put --treeobj dir.c="$(cat dircbad2.out)"
+'
+test_expect_success 'call sync to ensure we have checkpointed' '
+	flux kvs sync
 '
 test_expect_success 'unload kvs' '
 	flux module remove kvs

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -84,8 +84,9 @@ test_expect_success 'load kvs' '
 	flux module load kvs
 '
 test_expect_success 'make a reference invalid' '
-	cat dirc.out | jq -c .data[2]=\"sha1-1234567890123456789012345678901234567890\" > dircbad.out &&
-	flux kvs put --treeobj dir.c="$(cat dircbad.out)"
+	cat dirc.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > dircbad1.out &&
+	cat dircbad1.out | jq -c .data[2]=\"sha1-1234567890123456789012345678901234567890\" > dircbad2.out &&
+	flux kvs put --treeobj dir.c="$(cat dircbad2.out)"
 '
 test_expect_success 'unload kvs' '
 	flux module remove kvs
@@ -102,6 +103,7 @@ test_expect_success 'flux-fsck detects errors' '
 test_expect_success 'flux-fsck --verbose outputs details' '
 	test_must_fail flux fsck --verbose 2> fsckerrors3V.out &&
 	grep "dir\.b" fsckerrors3V.out | grep "missing blobref" | grep "index=1" &&
+	grep "dir\.c" fsckerrors3V.out | grep "missing blobref" | grep "index=1" &&
 	grep "dir\.c" fsckerrors3V.out | grep "missing blobref" | grep "index=2" &&
 	grep "Total errors: 2" fsckerrors3V.out
 '

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -56,7 +56,7 @@ test_expect_success 'load kvs' '
 # unfortunately we don't have a `flux content remove` command, so we'll corrupt
 # a valref by overwriting a treeobj with a bad reference
 test_expect_success 'make a reference invalid' '
-	cat dirb.out | jq -c .data[2]=\"sha1-1234567890123456789012345678901234567890\" > dirbbad.out &&
+	cat dirb.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > dirbbad.out &&
 	flux kvs put --treeobj dir.b="$(cat dirbbad.out)"
 '
 test_expect_success 'unload kvs' '
@@ -67,7 +67,7 @@ test_expect_success 'flux-fsck detects errors' '
 	test_must_fail flux fsck 2> fsckerrors1.out &&
 	count=$(cat fsckerrors1.out | wc -l) &&
 	test $count -eq 3 &&
-	grep "dir\.b" fsckerrors1.out | grep "missing blobref" &&
+	grep "dir\.b" fsckerrors1.out | grep "missing blobref" | grep "index=1" &&
 	grep "Total errors: 1" fsckerrors1.out
 '
 test_expect_success 'flux-fsck no output with --quiet' '
@@ -90,8 +90,8 @@ test_expect_success 'flux-fsck detects errors' '
 	test_must_fail flux fsck 2> fsckerrors3.out &&
 	count=$(cat fsckerrors3.out | wc -l) &&
 	test $count -eq 4 &&
-	grep "dir\.b" fsckerrors3.out | grep "missing blobref" &&
-	grep "dir\.c" fsckerrors3.out | grep "missing blobref" &&
+	grep "dir\.b" fsckerrors3.out | grep "missing blobref" | grep "index=1" &&
+	grep "dir\.c" fsckerrors3.out | grep "missing blobref" | grep "index=2" &&
 	grep "Total errors: 2" fsckerrors3.out
 '
 test_expect_success 'flux-fsck no output with --quiet' '


### PR DESCRIPTION
Problem: The values in a valref blobref array are checked synchronously one by one.  This can be quite slow.

Parallelize the valref blobref array verification by making each blobref lookup asynchronous.