### PR TITLE
doc: correct flux_future_set_reactor() prototype

### DIFF
--- a/doc/man3/flux_future_create.rst
+++ b/doc/man3/flux_future_create.rst
@@ -38,7 +38,7 @@ SYNOPSIS
                             void *aux,
                             flux_free_f destroy);
 
-   void flux_future_set_reactor (flux_future_t *f, flux_t *h);
+   void flux_future_set_reactor (flux_future_t *f, flux_reactor_t *r);
 
    flux_reactor_t *flux_future_get_reactor (flux_future_t *f);
 


### PR DESCRIPTION
Problem: The documented function prototype for flux_future_set_reactor(3) is incorrect, likely due to a cut and paste error.

Correct the function prototype.