### PR TITLE
require Lua `posix` in `configure` and document some tips for running the testsuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,13 @@ are available for [redhat](scripts/install-deps-rpm.sh) and
 ```
 ./autogen.sh   # skip if building from a release tarball
 ./configure
-make
-make check
+make -jN
+make -jN check
 ```
+
+> [!TIP]
+> `make check` runs many tests. Use of `-jN` recommended.
+> For more details about the testsuite, see the [README](t/README.md).
 
 ##### VSCode Dev Containers
 

--- a/configure.ac
+++ b/configure.ac
@@ -390,6 +390,13 @@ AM_CONDITIONAL([ENABLE_PYLINT], [test "x$PYLINT" = "xpylint"])
 AX_PROG_LUA([5.1],[5.5])
 AX_LUA_HEADERS
 AX_LUA_LIBS
+AC_MSG_CHECKING([for luaposix])
+if $LUA -l posix -e ''; then
+  AC_MSG_RESULT([yes])
+else
+  AC_MSG_RESULT([no])
+  AC_MSG_FAILURE([Could not find required Lua posix module])
+fi
 X_AC_ZEROMQ
 X_AC_JANSSON
 PKG_CHECK_MODULES([LIBSYSTEMD], [libsystemd >= 0.23],

--- a/scripts/install-deps-macos.sh
+++ b/scripts/install-deps-macos.sh
@@ -24,6 +24,7 @@ brew install \
   hwloc \
   sqlite \
   lua \
+  luarocks \
   python3 \
   cffi \
   libyaml \
@@ -34,5 +35,8 @@ source macos-venv/bin/activate
 
 pip3 install setuptools
 pip3 install -r scripts/requirements-dev.txt
+
+# luaposix now required for configure:
+luarocks install luaposix
 
 echo "Now run scripts/configure-macos.sh"

--- a/t/README.md
+++ b/t/README.md
@@ -124,6 +124,10 @@ running the testsuite against an installed version of flux-core.
 The environment variable `FLUX_TEST_VALGRIND` may be set to `t`
 to run tests under valgrind.
 
+The environment variable `FLUX_TESTS_LOGFILE` may be set to `t` to force
+most tests to generate a verbose log as `$TEST_NAME.output` when debugging
+tests.
+
 
 Skipping Tests
 --------------


### PR DESCRIPTION
This PR addresses some issues described by @ocaisa in #6835.

We now just go ahead and fail in configure if `luaposix` is not found to avoid confusion.

Also, a couple extra tips re: the testsuite are added to the top-level README.