### PR TITLE
doc: remove `jinja2<3.1`, `sphinx<6.0.0` requirements

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -2,4 +2,3 @@ sphinx<6.0.0
 sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18
 urllib3<2
-jinja2<3.1.0

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,4 +1,3 @@
-sphinx<6.0.0
 sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18
 urllib3<2


### PR DESCRIPTION
#### Problem

GitHub dependabot is reporting moderate security vulnerabilities detected with `jinja2 < 3.1.4`, but flux-core has `jinja2<3.1.0` listed in its `requirements-doc.txt` file.

The `requirements-doc.txt` file for flux-core documentation requires `sphinx < 6.0.0`, but we would like to upgrade sphinx to the latest version.

---

This PR drops both the `jinja2` and `sphinx` version requirements from the `requirements-doc.txt` file.