### PR TITLE
fix compile issue with GCC13.2.0 on Zen4

### DIFF
--- a/src/common/libutil/basemoji.c
+++ b/src/common/libutil/basemoji.c
@@ -176,8 +176,8 @@ int uint64_basemoji_encode (uint64_t id, char *buf, int buflen)
     /* Copy 4-byte emojis back in order so that most significant bits are
      * on the left:
      */
-    for (int i = count - 4; i >= 0; i-=4) {
-        memcpy (buf+n, reverse+i, 4);
+    for (int i = 0; i < count; i+=4) {
+        memcpy (buf+n, reverse+(count-4-i), 4);
         n+=4;
     }
     return 0;


### PR DESCRIPTION
Fixes #6854 

A compiler error was raised for the specific case of GCC 13.2.0 with Zen4, 
```
basemoji.c: In function 'uint64_basemoji_encode':
basemoji.c:180:9: error: 'reverse' may be used uninitialized [-Werror=maybe-uninitialized]
  180 |         memcpy (buf+n, reverse+i, 4);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
basemoji.c:150:10: note: 'reverse' declared here
  150 |     char reverse[BASEMOJI_MAXLEN+1];
      |          ^~~~~~~
cc1: all warnings being treated as errors
```
Compiler seemed to have trouble figuring out the loop that uses this array was safe.  Replaced the loop with a more compiler friendly version.