### PR TITLE
add more arguments to Python `JobspecV1` factory methods

### DIFF
--- a/src/bindings/python/flux/cli/alloc.py
+++ b/src/bindings/python/flux/cli/alloc.py
@@ -59,6 +59,12 @@ class AllocCmd(base.BatchAllocCmd):
             broker_opts=base.list_split(args.broker_opts),
             exclusive=args.exclusive,
             conf=args.conf.config,
+            duration=args.time_limit,
+            name=args.job_name,
+            cwd=args.cwd if args.cwd is not None else os.getcwd(),
+            unbuffered=args.unbuffered,
+            queue=args.queue,
+            bank=args.bank,
         )
 
         self.update_jobspec_common(args, jobspec)

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -1023,7 +1023,6 @@ class MiniCmd:
             # shell options dict and will be processed by the shell.
             jobspec.setattr_shell_option("env-expand", env_expand)
 
-        jobspec.cwd = args.cwd if args.cwd is not None else os.getcwd()
         rlimits = get_filtered_rlimits(args.rlimit)
         if rlimits:
             jobspec.setattr_shell_option("rlimit", rlimits)
@@ -1050,42 +1049,6 @@ class MiniCmd:
                 )
             except ConstraintSyntaxError as exc:
                 raise ValueError(f"--requires='{constraint}': {exc}")
-        if args.time_limit is not None:
-            #  With no units, time_limit is in minutes, but jobspec.duration
-            #  takes seconds or FSD by default, so convert here if necessary.
-            try:
-                limit = float(args.time_limit)
-                args.time_limit = limit * 60
-            except ValueError:
-                pass
-            jobspec.duration = args.time_limit
-
-        if args.job_name is not None:
-            jobspec.setattr("system.job.name", args.job_name)
-
-        if args.input is not None:
-            #  Note: temporary stopgap until per-task input is supported
-            #  by the job shell:
-            #  Check if --input specified an IDset. If not, then assume
-            #  a file, otherwise, do not modify jobspec, input will be
-            #  handled by `flux job attach`.
-            try:
-                IDset(args.input)
-            except (ValueError, OSError):
-                jobspec.stdin = args.input
-
-        if args.output is not None and args.output not in ["none", "kvs"]:
-            jobspec.stdout = args.output
-            if args.label_io:
-                jobspec.setattr_shell_option("output.stdout.label", True)
-
-        if args.error is not None:
-            jobspec.stderr = args.error
-            if args.label_io:
-                jobspec.setattr_shell_option("output.stderr.label", True)
-
-        if args.unbuffered:
-            jobspec.unbuffered = True
 
         if args.setopt is not None:
             for keyval in args.setopt:
@@ -1098,12 +1061,6 @@ class MiniCmd:
         if debugged.get_mpir_being_debugged() == 1:
             # if stop-tasks-in-exec is present, overwrite
             jobspec.setattr_shell_option("stop-tasks-in-exec", json.loads("1"))
-
-        if args.queue is not None:
-            jobspec.setattr("system.queue", args.queue)
-
-        if args.bank is not None:
-            jobspec.setattr("system.bank", args.bank)
 
         if args.setattr is not None:
             for keyval in args.setattr:
@@ -1279,6 +1236,26 @@ class SubmitBaseCmd(MiniCmd):
         if args.command[0] == "--":
             args.command.pop(0)
 
+        #  Time limit in cli submission commands defaults to minutes if
+        #  no units are given, but JobspecV1 duration is in seconds or FSD,
+        #  so convert if necessary:
+        if args.time_limit is not None:
+            try:
+                limit = float(args.time_limit)
+                args.time_limit = limit * 60
+            except ValueError:
+                pass
+
+        #  Check if --input specified an IDset. If not, then assume a file,
+        #  otherwise do not modify jobspec, input will be handled by
+        #  `flux job attach`:
+        stdin = None
+        if args.input is not None:
+            try:
+                IDset(args.input)
+            except (ValueError, OSError):
+                stdin = args.input
+
         #  Ensure integer args are converted to int() here.
         #  This is done because we do not use type=int in argparse in order
         #   to allow these options to be mutable for bulksubmit:
@@ -1361,6 +1338,16 @@ class SubmitBaseCmd(MiniCmd):
                 per_resource_count=per_resource_count,
                 gpus_per_node=args.gpus_per_node,
                 exclusive=args.exclusive,
+                duration=args.time_limit,
+                cwd=args.cwd if args.cwd is not None else os.getcwd(),
+                name=args.job_name,
+                input=stdin,
+                output=args.output,
+                error=args.error,
+                label_io=args.label_io,
+                unbuffered=args.unbuffered,
+                queue=args.queue,
+                bank=args.bank,
             )
 
         #  If ntasks not set, then set it to node count, with
@@ -1384,6 +1371,16 @@ class SubmitBaseCmd(MiniCmd):
             gpus_per_task=args.gpus_per_task,
             num_nodes=args.nodes,
             exclusive=args.exclusive,
+            duration=args.time_limit,
+            cwd=args.cwd if args.cwd is not None else os.getcwd(),
+            name=args.job_name,
+            input=stdin,
+            output=args.output,
+            error=args.error,
+            label_io=args.label_io,
+            unbuffered=args.unbuffered,
+            queue=args.queue,
+            bank=args.bank,
         )
 
     def run_and_exit(self):
@@ -1756,6 +1753,13 @@ class BatchAllocCmd(MiniCmd):
                 1, nbrokers
             )
             args.conf.update(f'resource.exclude="{exclude}"')
+
+        if args.time_limit is not None:
+            try:
+                limit = float(args.time_limit)
+                args.time_limit = limit * 60
+            except ValueError:
+                pass
 
     def update_jobspec_common(self, args, jobspec):
         """Common jobspec update code for batch/alloc"""

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -63,7 +63,7 @@ def decode_signal(val):
     try:
         return getattr(signal, f"SIG{val}")
     except AttributeError:
-        pass
+        pass  # Fall through to raise ValueError
     raise ValueError(f"signal '{val}' is invalid")
 
 
@@ -742,6 +742,7 @@ def parse_jobspec_keyval(label, keyval):
         try:
             val = json.loads(val)
         except (json.JSONDecodeError, TypeError):
+            # val was not a JSON string, keep as is
             pass
     return key, val
 
@@ -1244,6 +1245,7 @@ class SubmitBaseCmd(MiniCmd):
                 limit = float(args.time_limit)
                 args.time_limit = limit * 60
             except ValueError:
+                # no conversion necessary
                 pass
 
         #  Check if --input specified an IDset. If not, then assume a file,
@@ -1759,6 +1761,7 @@ class BatchAllocCmd(MiniCmd):
                 limit = float(args.time_limit)
                 args.time_limit = limit * 60
             except ValueError:
+                # no conversion necessary
                 pass
 
     def update_jobspec_common(self, args, jobspec):

--- a/src/bindings/python/flux/cli/batch.py
+++ b/src/bindings/python/flux/cli/batch.py
@@ -10,6 +10,7 @@
 
 import argparse
 import logging
+import os
 import sys
 
 import flux
@@ -100,6 +101,8 @@ class BatchCmd(base.BatchAllocCmd):
             else:
                 args.job_name = "batch"
 
+        output = args.output if args.output is not None else "flux-{{id}}.out"
+
         jobspec = flux.job.JobspecV1.from_batch_command(
             script=self.script,
             jobname=args.job_name,
@@ -111,14 +114,18 @@ class BatchCmd(base.BatchAllocCmd):
             broker_opts=base.list_split(args.broker_opts),
             exclusive=args.exclusive,
             conf=args.conf.config,
+            duration=args.time_limit,
+            cwd=args.cwd if args.cwd is not None else os.getcwd(),
+            input=args.input,
+            output=output,
+            error=args.error,
+            label_io=args.label_io,
+            unbuffered=args.unbuffered,
+            queue=args.queue,
+            bank=args.bank,
         )
 
         self.update_jobspec_common(args, jobspec)
-
-        # Default output is flux-{{jobid}}.out
-        # overridden by either --output=none or --output=kvs
-        if not args.output:
-            jobspec.stdout = "flux-{{id}}.out"
         return jobspec
 
     def main(self, args):

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -425,7 +425,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(jobspec.getattr("shell.options.output.batch-timeout"), 1.0)
 
     def test_22_from_batch_command(self):
-        """Test that `from_batch_command` produces a valid jobspec"""
+        """Test that `from_nest_command` produces a valid jobspec"""
         jobid = job.submit(
             self.fh, JobspecV1.from_batch_command("#!/bin/sh\nsleep 0", "nested sleep")
         )


### PR DESCRIPTION
This PR adds some more arguments to the `JobspecV1` factory methods as described in #6833 so that more fully formed jobspec can be instantiated with a single method call.

This PR doesn't go as far as adding _all_ the options offered by the submission CLI commands. However, job parameters that are an annoyance to set after the fact like the environment and cwd are there, as well as output, error, and input paths, etc.

One thing I didn't do was move support for some of the more user-friendly aspects of the CLI into the Python methods. For instance, the `environment` and `rlimits` arguments just take straight mappings, instead the "rule" based expressions supported by the CLI. We could change that, but I wasn't sure if it was necessary in the Python API.

Also, some other missing parameters include `--dependency`, `--requires`, and `--begin-time` -- all of which actually are mostly implemented in the CLI, and I wasn't sure exactly if those should go in the factory methods. They could be added later I guess.

Fixes #6833