### PR TITLE
content: remove checkpoint key 

### DIFF
--- a/src/modules/content/checkpoint.c
+++ b/src/modules/content/checkpoint.c
@@ -96,8 +96,10 @@ error:
     return -1;
 }
 
-void content_checkpoint_get_request (flux_t *h, flux_msg_handler_t *mh,
-                                     const flux_msg_t *msg, void *arg)
+void content_checkpoint_get_request (flux_t *h,
+                                     flux_msg_handler_t *mh,
+                                     const flux_msg_t *msg,
+                                     void *arg)
 {
     struct content_checkpoint *checkpoint = arg;
     const char *key;
@@ -164,7 +166,10 @@ static int checkpoint_put_forward (struct content_checkpoint *checkpoint,
         rank = 0;
     }
 
-    if (!(f = flux_rpc_pack (checkpoint->h, topic, rank, 0,
+    if (!(f = flux_rpc_pack (checkpoint->h,
+                             topic,
+                             rank,
+                             0,
                              "{s:s s:O}",
                              "key", key,
                              "value", value))
@@ -190,8 +195,10 @@ error:
     return -1;
 }
 
-void content_checkpoint_put_request (flux_t *h, flux_msg_handler_t *mh,
-                                     const flux_msg_t *msg, void *arg)
+void content_checkpoint_put_request (flux_t *h,
+                                     flux_msg_handler_t *mh,
+                                     const flux_msg_t *msg,
+                                     void *arg)
 {
     struct content_checkpoint *checkpoint = arg;
     const char *key;

--- a/src/modules/content/checkpoint.c
+++ b/src/modules/content/checkpoint.c
@@ -34,13 +34,9 @@ static void checkpoint_get_continuation (flux_future_t *f, void *arg)
 {
     struct content_checkpoint *checkpoint = arg;
     const flux_msg_t *msg = flux_future_aux_get (f, "msg");
-    const char *key;
     json_t *value = NULL;
 
     assert (msg);
-
-    if (flux_request_unpack (msg, NULL, "{s:s}", "key", &key) < 0)
-        goto error;
 
     if (flux_rpc_get_unpack (f, "{s:o}", "value", &value) < 0)
         goto error;

--- a/t/content/content-helper.sh
+++ b/t/content/content-helper.sh
@@ -4,43 +4,43 @@
 # content module test helper functions
 
 # Get RPC message contents for checkpoint put
-# Usage: checkpoint_put_msg key rootref
+# Usage: checkpoint_put_msg rootref
 checkpoint_put_msg() {
-	o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
+	o="{value:{version:1,rootref:\"$1\",timestamp:2.2}}"
 	echo ${o}
 }
 
-# checkpoint rootref at specific key
-# Usage: checkpoint_put key rootref
+# checkpoint rootref
+# Usage: checkpoint_put rootref
 checkpoint_put() {
-	o=$(checkpoint_put_msg $1 $2)
+	o=$(checkpoint_put_msg $1)
 	jq -j -c -n ${o} | $RPC content.checkpoint-put
 }
 
 # Get RPC message contents for checkpoint get
-# Usage: checkpoint_get_msg key
+# Usage: checkpoint_get_msg
 checkpoint_get_msg() {
-	o="{key:\"$1\"}"
+	o="{}"
 	echo ${o}
 }
 
-# get checkpoint rootref at key
-# Usage: checkpoint_get key
+# get checkpoint rootref
+# Usage: checkpoint_get
 checkpoint_get() {
-	o=$(checkpoint_get_msg $1)
+	o=$(checkpoint_get_msg)
 	jq -j -c -n ${o} | $RPC content.checkpoint-get
 }
 
 # Identical to checkpoint_put(), but go directly to backing store
-# Usage: checkpoint_put key rootref
+# Usage: checkpoint_put rootref
 checkpoint_backing_put() {
-	o=$(checkpoint_put_msg $1 $2)
+	o=$(checkpoint_put_msg $1)
 	jq -j -c -n ${o} | $RPC content-backing.checkpoint-put
 }
 
 # Identical to checkpoint_get(), but go directly to backing store
-# Usage: checkpoint_get key
+# Usage: checkpoint_get
 checkpoint_backing_get() {
-	o=$(checkpoint_get_msg $1)
+	o=$(checkpoint_get_msg)
 	jq -j -c -n ${o} | $RPC content-backing.checkpoint-get
 }

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -128,24 +128,24 @@ test_expect_success 'fill the cache with more data for later purging' '
 	${SPAMUTIL} 10000 200 >/dev/null
 '
 
-test_expect_success 'checkpoint-put foo w/ rootref bar' '
-	checkpoint_put foo bar
+test_expect_success 'checkpoint-put w/ rootref bar' '
+	checkpoint_put bar
 '
 
-test_expect_success 'checkpoint-get foo returned rootref bar' '
+test_expect_success 'checkpoint-get returned rootref bar' '
 	echo bar >rootref.exp &&
-	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
+	checkpoint_get | jq -r .value | jq -r .rootref >rootref.out &&
 	test_cmp rootref.exp rootref.out
 '
 
 test_expect_success 'checkpoint-put on rank 1 forwards to rank 0' '
-       o=$(checkpoint_put_msg rankone rankref) &&
+       o=$(checkpoint_put_msg rankref) &&
        jq -j -c -n ${o} | flux exec -r 1 ${RPC} content.checkpoint-put
 '
 
 test_expect_success 'checkpoint-get on rank 1 forwards to rank 0' '
        echo rankref >rankref.exp &&
-       o=$(checkpoint_get_msg rankone) &&
+       o=$(checkpoint_get_msg kvs-primary) &&
        jq -j -c -n ${o} \
 	   | flux exec -r 1 ${RPC} content.checkpoint-get \
 	   | jq -r .value | jq -r .rootref > rankref.out &&
@@ -153,18 +153,18 @@ test_expect_success 'checkpoint-get on rank 1 forwards to rank 0' '
 '
 
 # use grep instead of compare, incase of floating point rounding
-test_expect_success 'checkpoint-get foo returned correct timestamp' '
-        checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
+test_expect_success 'checkpoint-get returned correct timestamp' '
+        checkpoint_get | jq -r .value | jq -r .timestamp >timestamp.out &&
         grep 2.2 timestamp.out
 '
 
-test_expect_success 'checkpoint-put updates foo rootref to baz' '
-	checkpoint_put foo baz
+test_expect_success 'checkpoint-put updates rootref to baz' '
+	checkpoint_put baz
 '
 
-test_expect_success 'checkpoint-get foo returned rootref baz' '
+test_expect_success 'checkpoint-get returned rootref baz' '
 	echo baz >rootref2.exp &&
-	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
+	checkpoint_get | jq -r .value | jq -r .rootref >rootref2.out &&
 	test_cmp rootref2.exp rootref2.out
 '
 
@@ -173,33 +173,28 @@ test_expect_success 'flush + reload content-sqlite module on rank 0' '
 	flux module reload content-sqlite
 '
 
-test_expect_success 'checkpoint-get foo still returns rootref baz' '
+test_expect_success 'checkpoint-get still returns rootref baz' '
 	echo baz >rootref3.exp &&
-	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
+	checkpoint_get | jq -r .value | jq -r .rootref >rootref3.out &&
 	test_cmp rootref3.exp rootref3.out
 '
 
-test_expect_success 'checkpoint-backing-get foo returns rootref baz' '
+test_expect_success 'checkpoint-backing-get returns rootref baz' '
 	echo baz >rootref_backing.exp &&
-	checkpoint_backing_get foo \
+	checkpoint_backing_get \
             | jq -r .value \
             | jq -r .rootref >rootref_backing.out &&
 	test_cmp rootref_backing.exp rootref_backing.out
 '
 
-test_expect_success 'checkpoint-backing-put foo w/ rootref boof' '
-	checkpoint_backing_put foo boof
+test_expect_success 'checkpoint-backing-put w/ rootref boof' '
+	checkpoint_backing_put boof
 '
 
-test_expect_success 'checkpoint-get foo returned rootref boof' '
+test_expect_success 'checkpoint-get returned rootref boof' '
 	echo boof >rootref4.exp &&
-	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
+	checkpoint_get | jq -r .value | jq -r .rootref >rootref4.out &&
 	test_cmp rootref4.exp rootref4.out
-'
-
-test_expect_success 'checkpoint-get noexist fails with No such...' '
-	test_must_fail checkpoint_get noexist 2>badkey.err &&
-	grep "No such file or directory" badkey.err
 '
 
 test_expect_success 'content-backing.load wrong size hash fails with EPROTO' '
@@ -227,8 +222,8 @@ test_expect_success 'remove content-sqlite module on rank 0' '
 	flux module remove content-sqlite
 '
 
-test_expect_success 'checkpoint-put foo w/ rootref spoon fails without backing' '
-	test_must_fail checkpoint_put foo spoon
+test_expect_success 'checkpoint-put w/ rootref spoon fails without backing' '
+	test_must_fail checkpoint_put spoon
 '
 
 test_expect_success 'remove heartbeat module' '

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -162,29 +162,29 @@ test_expect_success 'flux module stats reports zero object count' '
 	    --type int --parse object_count content-files) -eq 0
 '
 
-test_expect_success 'checkpoint-put foo w/ rootref bar' '
-	checkpoint_put foo bar
+test_expect_success 'checkpoint-put w/ rootref bar' '
+	checkpoint_put bar
 '
 
-test_expect_success 'checkpoint-get foo returned rootref bar' '
+test_expect_success 'checkpoint-get returned rootref bar' '
         echo bar >rootref.exp &&
-        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
+        checkpoint_get | jq -r .value | jq -r .rootref >rootref.out &&
         test_cmp rootref.exp rootref.out
 '
 
 # use grep instead of compare, incase of floating point rounding
-test_expect_success 'checkpoint-get foo returned correct timestamp' '
-        checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
+test_expect_success 'checkpoint-get returned correct timestamp' '
+        checkpoint_get | jq -r .value | jq -r .timestamp >timestamp.out &&
         grep 2.2 timestamp.out
 '
 
-test_expect_success 'checkpoint-put updates foo rootref to baz' '
-        checkpoint_put foo baz
+test_expect_success 'checkpoint-put updates rootref to baz' '
+        checkpoint_put baz
 '
 
-test_expect_success 'checkpoint-get foo returned rootref baz' '
+test_expect_success 'checkpoint-get returned rootref baz' '
         echo baz >rootref2.exp &&
-        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
+        checkpoint_get | jq -r .value | jq -r .rootref >rootref2.out &&
         test_cmp rootref2.exp rootref2.out
 '
 
@@ -192,58 +192,54 @@ test_expect_success 'reload content-files module' '
 	flux module reload content-files
 '
 
-test_expect_success 'checkpoint-get foo still returns rootref baz' '
+test_expect_success 'checkpoint-get still returns rootref baz' '
         echo baz >rootref3.exp &&
-        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
+        checkpoint_get | jq -r .value | jq -r .rootref >rootref3.out &&
         test_cmp rootref3.exp rootref3.out
 '
 
-test_expect_success 'checkpoint-put updates foo rootref with longer rootref' '
-        checkpoint_put foo abcdefghijklmnopqrstuvwxyz
+test_expect_success 'checkpoint-put updates rootref with longer rootref' '
+        checkpoint_put abcdefghijklmnopqrstuvwxyz
 '
 
-test_expect_success 'checkpoint-get foo returned rootref with longer rootref' '
+test_expect_success 'checkpoint-get returned rootref with longer rootref' '
         echo abcdefghijklmnopqrstuvwxyz >rootref4.exp &&
-        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
+        checkpoint_get | jq -r .value | jq -r .rootref >rootref4.out &&
         test_cmp rootref4.exp rootref4.out
 '
 
-test_expect_success 'checkpoint-put updates foo rootref to shorter rootref' '
-        checkpoint_put foo foobar
+test_expect_success 'checkpoint-put updates rootref to shorter rootref' '
+        checkpoint_put foobar
 '
 
-test_expect_success 'checkpoint-get foo returned rootref with shorter rootref' '
+test_expect_success 'checkpoint-get returned rootref with shorter rootref' '
         echo foobar >rootref5.exp &&
-        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref5.out &&
+        checkpoint_get | jq -r .value | jq -r .rootref >rootref5.out &&
         test_cmp rootref5.exp rootref5.out
 '
 
-test_expect_success 'checkpoint-put updates foo rootref to boof' '
-        checkpoint_put foo boof
+test_expect_success 'checkpoint-put updates rootref to boof' '
+        checkpoint_put boof
 '
 
-test_expect_success 'checkpoint-backing-get foo returns rootref boof' '
+test_expect_success 'checkpoint-backing-get returns rootref boof' '
         echo boof >rootref_backing.exp &&
-        checkpoint_backing_get foo \
+        checkpoint_backing_get \
             | jq -r .value \
             | jq -r .rootref >rootref_backing.out &&
         test_cmp rootref_backing.exp rootref_backing.out
 '
 
-test_expect_success 'checkpoint-backing-put foo w/ rootref poof' '
-        checkpoint_backing_put foo poof
+test_expect_success 'checkpoint-backing-put w/ rootref poof' '
+        checkpoint_backing_put poof
 '
 
-test_expect_success 'checkpoint-get foo returned rootref boof' '
+test_expect_success 'checkpoint-get returned rootref boof' '
         echo poof >rootref6.exp &&
-        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref6.out &&
+        checkpoint_get | jq -r .value | jq -r .rootref >rootref6.out &&
         test_cmp rootref6.exp rootref6.out
 '
 
-test_expect_success 'checkpoint-get bad request fails with EPROTO' '
-	test_must_fail $RPC content.checkpoint-get </dev/null 2>badget.err &&
-	grep "Protocol error" badget.err
-'
 test_expect_success 'checkpoint-put bad request fails with EPROTO' '
 	test_must_fail $RPC content.checkpoint-put </dev/null 2>badput.err &&
 	grep "Protocol error" badput.err
@@ -258,8 +254,8 @@ test_expect_success 'remove content-files module' '
 	flux module remove content-files
 '
 
-test_expect_success 'checkpoint-put foo w/ rootref spoon fails without backing' '
-       test_must_fail checkpoint_put foo spoon
+test_expect_success 'checkpoint-put w/ rootref spoon fails without backing' '
+       test_must_fail checkpoint_put spoon
 '
 
 test_expect_success 'remove content module' '


### PR DESCRIPTION
Problem: In the content backing modules, checkpoints are allowed to take a key.  However, the singular "kvs-primary" key is the
only key used.  Only testing uses alternate keys.  The flexible key makes some future modifications to checkpointing more difficult.

Make "kvs-primary" the only valid key for checkpointing.