### PR TITLE
flux-fsck: fix error message output

### DIFF
--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -147,7 +147,7 @@ static void fsck_valref (flux_t *h, const char *path, json_t *treeobj)
     if (fvd.errorcount) {
         /* each invalid blobref will be output in verbose mode */
         if (!verbose) {
-            if (errno == ENOENT)
+            if (fvd.errnum == ENOENT)
                 read_error ("%s: missing blobref(s)", path);
             else
                 read_error ("%s: error retrieving blobref(s): %s",

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -90,6 +90,7 @@ test_expect_success 'unload kvs' '
 # line count includes extra diagnostic messages
 test_expect_success 'flux-fsck detects errors' '
 	test_must_fail flux fsck 2> fsckerrors1.out &&
+	test_debug "cat fsckerrors1.out" &&
 	count=$(cat fsckerrors1.out | wc -l) &&
 	test $count -eq 3 &&
 	grep "dir\.b" fsckerrors1.out | grep "missing blobref(s)" &&
@@ -97,11 +98,13 @@ test_expect_success 'flux-fsck detects errors' '
 '
 test_expect_success 'flux-fsck --verbose outputs details' '
 	test_must_fail flux fsck --verbose 2> fsckerrors1V.out &&
+	test_debug "cat fsckerrors1V.out" &&
 	grep "dir\.b" fsckerrors1V.out | grep "missing blobref" | grep "index=1" &&
 	grep "Total errors: 1" fsckerrors1V.out
 '
 test_expect_success 'flux-fsck no output with --quiet' '
 	test_must_fail flux fsck --quiet 2> fsckerrors2.out &&
+	test_debug "cat fsckerrors2.out" &&
 	count=$(cat fsckerrors2.out | wc -l) &&
 	test $count -eq 0
 '
@@ -122,6 +125,7 @@ test_expect_success 'unload kvs' '
 # line count includes extra diagnostic messages
 test_expect_success 'flux-fsck detects errors' '
 	test_must_fail flux fsck 2> fsckerrors3.out &&
+	test_debug "cat fsckerrors3.out" &&
 	count=$(cat fsckerrors3.out | wc -l) &&
 	test $count -eq 4 &&
 	grep "dir\.b" fsckerrors3.out | grep "missing blobref(s)" &&
@@ -130,6 +134,7 @@ test_expect_success 'flux-fsck detects errors' '
 '
 test_expect_success 'flux-fsck --verbose outputs details' '
 	test_must_fail flux fsck --verbose 2> fsckerrors3V.out &&
+	test_debug "cat fsckerrors3V.out" &&
 	grep "dir\.b" fsckerrors3V.out | grep "missing blobref" | grep "index=1" &&
 	grep "dir\.c" fsckerrors3V.out | grep "missing blobref" | grep "index=1" &&
 	grep "dir\.c" fsckerrors3V.out | grep "missing blobref" | grep "index=2" &&
@@ -137,6 +142,7 @@ test_expect_success 'flux-fsck --verbose outputs details' '
 '
 test_expect_success 'flux-fsck no output with --quiet' '
 	test_must_fail flux fsck --quiet 2> fsckerrors4.out &&
+	test_debug "cat fsckerrors4.out" &&
 	count=$(cat fsckerrors4.out | wc -l) &&
 	test $count -eq 0
 '

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -39,12 +39,12 @@ test_expect_success 'save some treeobjs for later' '
 test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
-test_expect_success 'flux-fsck works' '
+test_expect_success 'flux-fsck works (simple)' '
 	flux fsck 2> simple.out &&
 	grep "Checking integrity" simple.out &&
 	grep "Total errors: 0" simple.out
 '
-test_expect_success 'flux-fsck verbose works' '
+test_expect_success 'flux-fsck verbose works (simple)' '
 	flux fsck --verbose 2> verbose.out &&
 	grep "dir\.a" verbose.out &&
 	grep "dir\.b" verbose.out &&
@@ -66,7 +66,7 @@ test_expect_success LONGTEST 'call sync to ensure we have checkpointed' '
 test_expect_success LONGTEST 'unload kvs' '
        flux module remove kvs
 '
-test_expect_success LONGTEST 'flux-fsck works' '
+test_expect_success LONGTEST 'flux-fsck works (big)' '
 	flux fsck --verbose 2> bigval.out &&
 	grep "Checking integrity" bigval.out &&
 	grep "bigval" bigval.out &&
@@ -77,7 +77,7 @@ test_expect_success 'load kvs' '
 '
 # unfortunately we don't have a `flux content remove` command, so we'll corrupt
 # a valref by overwriting a treeobj with a bad reference
-test_expect_success 'make a reference invalid' '
+test_expect_success 'make a reference invalid (dir.b)' '
 	cat dirb.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > dirbbad.out &&
 	flux kvs put --treeobj dir.b="$(cat dirbbad.out)"
 '
@@ -88,7 +88,7 @@ test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
 # line count includes extra diagnostic messages
-test_expect_success 'flux-fsck detects errors' '
+test_expect_success 'flux-fsck detects errors (dir.b)' '
 	test_must_fail flux fsck 2> fsckerrors1.out &&
 	test_debug "cat fsckerrors1.out" &&
 	count=$(cat fsckerrors1.out | wc -l) &&
@@ -96,13 +96,13 @@ test_expect_success 'flux-fsck detects errors' '
 	grep "dir\.b" fsckerrors1.out | grep "missing blobref(s)" &&
 	grep "Total errors: 1" fsckerrors1.out
 '
-test_expect_success 'flux-fsck --verbose outputs details' '
+test_expect_success 'flux-fsck --verbose outputs details (dir.b)' '
 	test_must_fail flux fsck --verbose 2> fsckerrors1V.out &&
 	test_debug "cat fsckerrors1V.out" &&
 	grep "dir\.b" fsckerrors1V.out | grep "missing blobref" | grep "index=1" &&
 	grep "Total errors: 1" fsckerrors1V.out
 '
-test_expect_success 'flux-fsck no output with --quiet' '
+test_expect_success 'flux-fsck no output with --quiet (dir.b)' '
 	test_must_fail flux fsck --quiet 2> fsckerrors2.out &&
 	test_debug "cat fsckerrors2.out" &&
 	count=$(cat fsckerrors2.out | wc -l) &&
@@ -111,7 +111,7 @@ test_expect_success 'flux-fsck no output with --quiet' '
 test_expect_success 'load kvs' '
 	flux module load kvs
 '
-test_expect_success 'make a reference invalid' '
+test_expect_success 'make a reference invalid (dir.c)' '
 	cat dirc.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > dircbad1.out &&
 	cat dircbad1.out | jq -c .data[2]=\"sha1-1234567890123456789012345678901234567890\" > dircbad2.out &&
 	flux kvs put --treeobj dir.c="$(cat dircbad2.out)"
@@ -123,7 +123,7 @@ test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
 # line count includes extra diagnostic messages
-test_expect_success 'flux-fsck detects errors' '
+test_expect_success 'flux-fsck detects errors (dir.b & c)' '
 	test_must_fail flux fsck 2> fsckerrors3.out &&
 	test_debug "cat fsckerrors3.out" &&
 	count=$(cat fsckerrors3.out | wc -l) &&
@@ -132,7 +132,7 @@ test_expect_success 'flux-fsck detects errors' '
 	grep "dir\.c" fsckerrors3.out | grep "missing blobref(s)" &&
 	grep "Total errors: 2" fsckerrors3.out
 '
-test_expect_success 'flux-fsck --verbose outputs details' '
+test_expect_success 'flux-fsck --verbose outputs details (dir.b & c)' '
 	test_must_fail flux fsck --verbose 2> fsckerrors3V.out &&
 	test_debug "cat fsckerrors3V.out" &&
 	grep "dir\.b" fsckerrors3V.out | grep "missing blobref" | grep "index=1" &&
@@ -140,7 +140,7 @@ test_expect_success 'flux-fsck --verbose outputs details' '
 	grep "dir\.c" fsckerrors3V.out | grep "missing blobref" | grep "index=2" &&
 	grep "Total errors: 2" fsckerrors3V.out
 '
-test_expect_success 'flux-fsck no output with --quiet' '
+test_expect_success 'flux-fsck no output with --quiet (dir.b & c)' '
 	test_must_fail flux fsck --quiet 2> fsckerrors4.out &&
 	test_debug "cat fsckerrors4.out" &&
 	count=$(cat fsckerrors4.out | wc -l) &&


### PR DESCRIPTION
Problem: An error check inadvertently checks `errno` when it should check the stored errnum in a data structure.  This leads to an invalid error message output.

Fix the error check to ensure the correct error message is output.

Fixes #6860