### PR TITLE
testsuite: reduce parallelism in `t4000-issues-test-driver.t` for test reliability

### DIFF
--- a/t/t4000-issues-test-driver.t
+++ b/t/t4000-issues-test-driver.t
@@ -10,8 +10,13 @@ if test_have_prereq ASAN; then
     test_done
 fi
 
+# Note: use test_under_flux "job" personality so that only 2 cores per fake
+# node are configured in the test instance. This ensures a maximum of 4
+# issues test scripts (invoked as jobs below) run simultaneously, instead
+# of 1 per real core, which could cause test failures on overloaded systems.
+#
 SIZE=2
-test_under_flux ${SIZE}
+test_under_flux ${SIZE} job
 echo "# $0: flux session size will be ${SIZE}"
 
 if test -z "$T4000_ISSUES_GLOB"; then


### PR DESCRIPTION
Problem: The issues tests in t4000-issues-test-driver.t are run as jobs in a test instance of size=2, but the instance inherits the total number of cores from the system, which means up to 2*ncores issues tests could be run at the same time. On some systems, this causes failures in the tests due to overloading the system.

Switch to the "job" personality of test_under_flux, which will configure the test instance with only 2 fake cores per rank, keeping the parallelism of the tests to 4, which is probably a safe number.

Fixes #6856