### PR TITLE
t: fix race in job info update watch test

### DIFF
--- a/t/t2233-job-info-update.t
+++ b/t/t2233-job-info-update.t
@@ -268,11 +268,11 @@ test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (multi
 	${UPDATE_WATCH} $jobid R > watch10A.out &
 	watchpidA=$! &&
 	wait_update_watchers $((watchers+1)) &&
-	update1=$(expiration_add $jobid 100)
+	update1=$(expiration_add $jobid 100) &&
+	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch10A.out
 	${UPDATE_WATCH} $jobid R > watch10B.out &
 	watchpidB=$! &&
 	wait_update_watchers $((watchers+2)) &&
-	${WAITFILE} --count=2 --timeout=30 --pattern="expiration" watch10A.out &&
 	${WAITFILE} --count=1 --timeout=30 --pattern="expiration" watch10B.out &&
 	kill -s USR1 $watchpidA &&
 	wait $watchpidA &&

--- a/t/t2233-job-info-update.t
+++ b/t/t2233-job-info-update.t
@@ -284,7 +284,7 @@ test_expect_success NO_CHAIN_LINT 'job-info: update watch can be canceled (multi
 	test $(cat watch10A.out | wc -l) -eq 2 &&
 	test $(cat watch10B.out | wc -l) -eq 1 &&
 	head -n1 watch10A.out | jq -e ".execution.expiration == 0.0" &&
-	tail -n1 watch10B.out | jq -e ".execution.expiration == ${update1}" &&
+	tail -n1 watch10A.out | jq -e ".execution.expiration == ${update1}" &&
 	cat watch10B.out | jq -e ".execution.expiration == ${update1}"
 '
 


### PR DESCRIPTION
Problem: In a test in t2233-job-info-update.t there is a small race possibility.  An update watcher assumes that an update
has "propogated" and that an earlier value of that update cannot be seen.  However, a recent test failure indicates that the earlier
value can be seen.

Solution: Move one of the "waits" earlier in the test to ensure the updated value has fully "propogated".  This ensures later watchers will only get the updated value.

Fixes #6838
