### PR TITLE
python: unify behavior of `Jobspec` `getattr` and `setattr` methods

### DIFF
--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -132,6 +132,19 @@ def validate_jobspec(jobspec, require_version=None):
     return True
 
 
+def _attr_key_prepend(key):
+    """
+    Amend a key provided to setattr, getattr, etc. to prepend ``attributes.``
+    or ``attributes.system.`` if the key does not already start with one of
+    those key prefixes.
+    """
+    if not key.startswith("attributes."):
+        if not key.startswith(("user.", "system.")):
+            key = "system." + key
+        key = "attributes." + key
+    return key
+
+
 class Jobspec(object):
     top_level_keys = set(["resources", "tasks", "version", "attributes"])
 
@@ -558,8 +571,7 @@ class Jobspec(object):
 
         Raises KeyError if a component of key does not exist.
         """
-        if not key.startswith("attributes."):
-            key = "attributes." + key
+        key = _attr_key_prepend(key)
         value = self.jobspec
         for attr in key.split("."):
             value = value.get(attr)
@@ -571,11 +583,8 @@ class Jobspec(object):
         """
         set job attribute
         """
-        if not key.startswith("attributes."):
-            if not key.startswith(("user.", "system.")):
-                key = "system." + key
-            key = "attributes." + key
         try:
+            key = _attr_key_prepend(key)
             set_treedict(self.jobspec, key, val)
         except TypeError as e:
             raise TypeError(f"failed to set {key} to {val}: {e}")

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -810,18 +810,24 @@ class TestJob(unittest.TestCase):
         jobspec.setattr("attributes.system.chicken", 4)
         jobspec.setattr("attributes.user.duck", 5)
         jobspec.setattr("attributes.goat", 6)
-        # N.B. setattr defaults "key" to "attributes.system.key"
-        # but getattr defaults "key" to "attributes.key"
+        self.assertEqual(jobspec.getattr("cow"), 1)
         self.assertEqual(jobspec.getattr("system.cow"), 1)
         self.assertEqual(jobspec.getattr("attributes.system.cow"), 1)
+
+        self.assertEqual(jobspec.getattr("cat"), 2)
         self.assertEqual(jobspec.getattr("system.cat"), 2)
         self.assertEqual(jobspec.getattr("attributes.system.cat"), 2)
+
         self.assertEqual(jobspec.getattr("user.dog"), 3)
         self.assertEqual(jobspec.getattr("attributes.user.dog"), 3)
+
+        self.assertEqual(jobspec.getattr("chicken"), 4)
         self.assertEqual(jobspec.getattr("system.chicken"), 4)
         self.assertEqual(jobspec.getattr("attributes.system.chicken"), 4)
+
         self.assertEqual(jobspec.getattr("user.duck"), 5)
         self.assertEqual(jobspec.getattr("attributes.user.duck"), 5)
+
         self.assertEqual(jobspec.getattr("attributes.goat"), 6)
 
     def test_36_str(self):


### PR DESCRIPTION
This PR makes a tweak to the behavior of the `Jobspec.getattr` method so that it is consistent with the behavior of `Jobspec.setattr`. That is,  keys that do not start with `user.`, `system.` or `attributes.` default to  `attributes.system.`