### PR TITLE
python: add `unbuffered` getter and setter to `Jobspec` class

### DIFF
--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -1085,11 +1085,7 @@ class MiniCmd:
                 jobspec.setattr_shell_option("output.stderr.label", True)
 
         if args.unbuffered:
-            #  For output, set the buffer.type to none and reduce the configured
-            #  event batch-timeout to something very small.
-            jobspec.setattr_shell_option("output.stdout.buffer.type", "none")
-            jobspec.setattr_shell_option("output.stderr.buffer.type", "none")
-            jobspec.setattr_shell_option("output.batch-timeout", 0.05)
+            jobspec.unbuffered = True
 
         if args.setopt is not None:
             for keyval in args.setopt:

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -24,7 +24,7 @@ import stat
 import sys
 import threading
 import traceback
-from collections import namedtuple
+from collections import abc, namedtuple
 from datetime import datetime, timedelta
 from operator import attrgetter
 from pathlib import Path, PurePosixPath
@@ -203,6 +203,32 @@ def set_treedict(in_dict, key, val):
         set_treedict(in_dict.setdefault(path[0], {}), path[1], val)
     else:
         in_dict[key] = val
+
+
+def del_treedict(in_dict, key, remove_empty=False):
+    """
+    ``del_treedict(d, "a.b.c")`` is like ``del d[a][b][c]``
+
+    Args:
+        in_dict (Mapping): dict in which to remove ``key``
+        key (str): dotted key to remove
+        remove_empty (bool): If True, remove empty dictionaries that result
+            from deletion of ``key``.
+
+    Raises:
+        KeyError: a path component of ``key`` does not exist.
+    """
+    path = key.split(".", 1)
+    if len(path) == 2:
+        del_treedict(in_dict[path[0]], path[1], remove_empty=remove_empty)
+        if (
+            remove_empty
+            and isinstance(in_dict[path[0]], abc.Mapping)
+            and len(in_dict[path[0]]) == 0
+        ):
+            del in_dict[path[0]]
+    else:
+        del in_dict[key]
 
 
 class TreedictAction(argparse.Action):

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -401,6 +401,29 @@ class TestJob(unittest.TestCase):
             with self.assertRaises(TypeError):
                 setattr(jobspec, stream, None)
 
+        with self.assertRaises(TypeError):
+            jobspec.unbuffered = 1
+
+        jobspec.unbuffered = True
+        self.assertTrue(jobspec.unbuffered)
+        self.assertEqual(
+            jobspec.getattr("shell.options.output.stderr.buffer.type"), "none"
+        )
+        self.assertEqual(
+            jobspec.getattr("shell.options.output.stdout.buffer.type"), "none"
+        )
+        self.assertEqual(jobspec.getattr("shell.options.output.batch-timeout"), 0.05)
+
+        jobspec.unbuffered = False
+        self.assertFalse(jobspec.unbuffered)
+
+        # jobspec.unbuffered = True keeps modified batch-timeout
+        jobspec.unbuffered = True
+        jobspec.setattr_shell_option("output.batch-timeout", 1.0)
+        jobspec.unbuffered = False
+        self.assertFalse(jobspec.unbuffered)
+        self.assertEqual(jobspec.getattr("shell.options.output.batch-timeout"), 1.0)
+
     def test_22_from_batch_command(self):
         """Test that `from_batch_command` produces a valid jobspec"""
         jobid = job.submit(

--- a/t/python/t0024-util.py
+++ b/t/python/t0024-util.py
@@ -17,7 +17,13 @@ from collections import namedtuple
 from datetime import datetime
 
 import subflux  # noqa: F401 - To set up PYTHONPATH
-from flux.util import OutputFormat, UtilDatetime, parse_datetime
+from flux.util import (
+    OutputFormat,
+    UtilDatetime,
+    del_treedict,
+    parse_datetime,
+    set_treedict,
+)
 from pycotap import TAPTestRunner
 
 
@@ -280,6 +286,27 @@ class TestOutputFormat(unittest.TestCase):
             fmt.copy(nullify_expansion=True).get_format_prepended(""),
             "{s} {i:4d} {f:.2f}",
         )
+
+    def test_del_treedict(self):
+        d = {}
+        set_treedict(d, "a.b.c", 42)
+        self.assertEqual(d, {"a": {"b": {"c": 42}}})
+
+        del_treedict(d, "a.b.c")
+        self.assertEqual(d, {"a": {"b": {}}})
+
+        set_treedict(d, "a.b.c", 42)
+        del_treedict(d, "a.b.c", remove_empty=True)
+        self.assertEqual(d, {})
+
+        set_treedict(d, "a.b.c", 42)
+        del_treedict(d, "a.b")
+        self.assertEqual(d, {"a": {}})
+
+        # missing key raises KeyError
+        set_treedict(d, "a.b.c", 42)
+        with self.assertRaises(KeyError):
+            del_treedict(d, "a.b.d")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds an `unbuffered` getter and setter property to the Python `Jobspec` class as suggested by @trws in #6858.

based on top of #6874.