### PR TITLE
broker: let a upmi client relay extra bootstrap info

### DIFF
--- a/src/common/libpmi/test/upmi.c
+++ b/src/common/libpmi/test/upmi.c
@@ -13,6 +13,7 @@
 #endif
 #include <stdlib.h>
 #include <string.h>
+#include <jansson.h>
 
 #include "src/common/libtap/tap.h"
 #include "ccan/str/str.h"
@@ -39,8 +40,11 @@ void test_single (void)
     ok (upmi != NULL,
         "upmi_create spec=single works");
 
+    info.dict = json_true ();
     ok (upmi_initialize (upmi, &info, &error) == 0,
         "upmi_initialize works");
+    ok (info.dict == NULL,
+        "upmi_initialize sets info.dict to NULL by default");
     ok (info.size == 1 && info.rank == 0,
         "info rank==0, size==1");
     is (info.name, "single",

--- a/src/common/libpmi/upmi.c
+++ b/src/common/libpmi/upmi.c
@@ -428,12 +428,14 @@ int upmi_initialize (struct upmi *upmi,
         upmi_trace (upmi, "initialize: %s", error.text);
         return -1;
     }
+    info.dict = NULL;
     if (flux_plugin_arg_unpack (upmi->args,
                                 FLUX_PLUGIN_ARG_OUT,
-                                "{s:i s:s s:i}",
+                                "{s:i s:s s:i s?o}",
                                 "rank", &info.rank,
                                 "name", &name,
-                                "size", &info.size) < 0) {
+                                "size", &info.size,
+                                "dict", &info.dict) < 0) {
         errprintf (errp, "%s", flux_plugin_arg_strerror (upmi->args));
         return -1;
     }

--- a/src/common/libpmi/upmi.h
+++ b/src/common/libpmi/upmi.h
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <stdarg.h>
 #include <stdbool.h>
+#include <jansson.h>
 
 #include "src/common/libflux/types.h"
 
@@ -27,6 +28,7 @@ struct upmi_info {
     int rank;
     int size;
     const char *name;
+    json_t *dict; // may be NULL and is invalidated by the next upmi API call
 };
 
 typedef void (*upmi_trace_f)(void *arg, const char *text);


### PR DESCRIPTION
Problem:  there is no way for a upmi client to relay auxiliary bootstrap
information through the broker to applications.

Add an optional dict plugin OUT argument that can be set by the
upmi_initialize() implementation.  A new dict member is added to
struct pmi_info that is set to a json dictionary when the implementation
sets  the OUT argument.  In the broker, any key-value pairs in the dict are
directly set as broker attributes.