### PR TITLE
idset: add round-robin allocation flag

### DIFF
--- a/doc/man3/idset_alloc.rst
+++ b/doc/man3/idset_alloc.rst
@@ -30,12 +30,15 @@ The idset must have been created with IDSET_FLAG_INITFULL.
 
 .. note::
   Unallocated is defined as "in the set" so that allocation can use the
-  constant-time *first* operation to find the next available id.  Defining
+  constant-time *first* operation to find the first available id.  Defining
   unallocated as "not in the set" would mean that iteration would
-  be required to find the next available id.
+  be required to find the next available id.  This advantage is lost when
+  the set is created with IDSET_FLAG_ALLOC_RR.
 
-:func:`idset_alloc` takes the next available id out of the set.
+:func:`idset_alloc` takes the first available id out of the set.
 This is implemented as :func:`idset_first` and :func:`idset_clear` internally.
+If the set was created with IDSET_FLAG_ALLOC_RR, it takes the *next*
+available id after the most recently allocated one, using :func:`idset_next`.
 If there are no more ids available and the set was created with
 IDSET_FLAG_AUTOGROW, the set is expanded in order to fulfill the request.
 

--- a/doc/man3/idset_create.rst
+++ b/doc/man3/idset_create.rst
@@ -106,6 +106,10 @@ IDSET_FLAG_INITFULL
    The idset is created full instead of empty.  If specified with
    IDSET_FLAG_AUTOGROW, new portions that are added are also filled.
 
+IDSET_FLAG_ALLOC_RR
+   Change :func:`idset_alloc` to begin searching for an id after the
+   most recently allocated one, rather than taking the first available.
+
 IDSET_FLAG_COUNT_LAZY
    The running count is not maintained and :func:`idset_count` uses a slower
    iteration method.  Not maintaining the count makes set/clear operations

--- a/src/common/libidset/idset.h
+++ b/src/common/libidset/idset.h
@@ -30,6 +30,7 @@ enum idset_flags {
     IDSET_FLAG_INITFULL = 8, // initilize/grow idset with all ids set
     IDSET_FLAG_COUNT_LAZY = 16, // disable running count, which speeds up
                              //  idset_set/clear, but slows down idset_count()
+    IDSET_FLAG_ALLOC_RR = 32, // idset_alloc() allocates using round-robin
 };
 
 typedef struct {

--- a/src/common/libidset/idset_private.h
+++ b/src/common/libidset/idset_private.h
@@ -23,6 +23,7 @@ struct idset {
     size_t count;
     Veb T;
     int flags;
+    unsigned int alloc_rr_last;
 };
 
 #define IDSET_ENCODE_CHUNK 1024

--- a/src/common/libidset/test/idset.c
+++ b/src/common/libidset/test/idset.c
@@ -941,6 +941,37 @@ void test_alloc (int flags)
     idset_destroy (idset);
 }
 
+void test_alloc_rr (void)
+{
+    unsigned int id;
+    struct idset *idset;
+
+    idset = idset_create (2, IDSET_FLAG_INITFULL | IDSET_FLAG_ALLOC_RR);
+    if (!idset)
+        BAIL_OUT ("could not create idset");
+    diag ("alloc_rr: created set size=2");
+    ok (idset_alloc (idset, &id) == 0 && id == 0,
+        "alloc_rr: allocated 0");
+    idset_free (idset, 0);
+    diag ("alloc_rr: freed 0");
+    ok (idset_alloc (idset, &id) == 0 && id == 1,
+        "alloc_rr: allocated 1");
+    idset_free (idset, 1);
+    diag ("alloc_rr: freed 1");
+    ok (idset_alloc (idset, &id) == 0 && id == 0,
+        "alloc_rr: allocated 0");
+    ok (idset_alloc (idset, &id) == 0 && id == 1,
+        "alloc_rr: allocated 1");
+    ok (idset_alloc (idset, &id) < 0,
+        "alloc_rr: failed");
+    idset_free (idset, 0);
+    diag ("alloc_rr: freed 0");
+    ok (idset_alloc (idset, &id) == 0 && id == 0,
+        "alloc_rr: allocated 0");
+
+    idset_destroy (idset);
+}
+
 void test_alloc_badparam (void)
 {
     unsigned int id;
@@ -1209,8 +1240,13 @@ int main (int argc, char *argv[])
     issue_2336 ();
     test_ops ();
     test_initfull();
+    diag ("idset_alloc test flags=0");
     test_alloc (0);
+    diag ("idset_alloc test flags=COUNT_LAZY");
     test_alloc (IDSET_FLAG_COUNT_LAZY);
+    diag ("idset_alloc test flags=ALLOC_RR");
+    test_alloc (IDSET_FLAG_ALLOC_RR);
+    test_alloc_rr ();
     test_alloc_badparam();
     test_decode_ex ();
     test_decode_empty ();


### PR DESCRIPTION
Problem: in working on VNI support for flux-coral2, I found it would be handy to have something like `idset_alloc(3)` and `idset_free(3)` to allocate form a configurable VNI pool, except not immediately re-use a VNI after it is freed, in case there are race conditions in VNI cleanup.

This adds a FLUX_IDSET_ALLOC_RR flag to select "round robin" allocation for `idset_alloc(3)`.   If we wanted to we could use this for matchtags, although it does raise the complexity of an allocation from O(1) to O(log(n)) and matchtag handling is pretty well tested at this point.
