### PR TITLE
add FLUX_JOB_ID_PATH to the job environment

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -25,6 +25,13 @@ The following are set in the environment of each task spawned by
 
       NUMERIC_JOB_ID=$(flux job id $FLUX_JOB_ID)
 
+.. envvar:: FLUX_JOB_ID_PATH
+
+   A list of Flux jobids in F58 form, beginning with the separator ``/``,
+   that uniquely identifies the job's position in the Flux instance hierarchy.
+   For example, a job submitted to a batch job on a Flux system instance might
+   have a path of ``/ƒD2e73NP/ƒDCB6RV``.
+
 .. envvar:: FLUX_ENCLOSING_ID
 
    The jobid of the enclosing Flux instance, if it has one. The enclosing

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -970,3 +970,4 @@ composable
 orchestrator
 fsck
 mincrit
+DCB

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -668,6 +668,13 @@ static void init_attrs_post_boot (attr_t *attrs)
             log_err_exit ("setattr parent-kvs-namespace");
     }
     unsetenv ("FLUX_KVS_NAMESPACE");
+
+    val = getenv ("FLUX_JOB_ID_PATH");
+    if (!val || !instance_is_job)
+        val = "/";
+    if (attr_add (attrs, "jobid-path", val, ATTR_IMMUTABLE) < 0)
+        log_err_exit ("setattr jobid-path");
+    unsetenv ("FLUX_JOB_ID_PATH");
 }
 
 static void init_attrs (attr_t *attrs, pid_t pid, struct flux_msg_cred *cred)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1222,7 +1222,7 @@ static int execute_parental_notifications (struct broker *ctx)
         goto out;
 
     /*  Note: not an error if rpc to set critical ranks fails, but
-     *  issue an error notifying user that no criitcal ranks are set.
+     *  issue an error notifying user that no critical ranks are set.
      */
     if (!(f2 = set_critical_ranks (h, id, ctx->attrs)))
         log_msg ("Unable to get critical ranks, all ranks will be critical");

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1755,17 +1755,25 @@ static int shell_setup_environment (flux_shell_t *shell)
 {
     const char *uri;
     const char *namespace;
+    const char *jobid_path;
 
     (void) flux_shell_unsetenv (shell, "FLUX_PROXY_REMOTE");
 
     if (!(uri = getenv ("FLUX_URI"))
         || !(namespace = getenv ("FLUX_KVS_NAMESPACE"))
+        || !(jobid_path = flux_attr_get (shell->h, "jobid-path"))
         || flux_shell_setenvf (shell, 1, "FLUX_URI", "%s", uri) < 0
         || flux_shell_setenvf (shell,
                                1,
                                "FLUX_KVS_NAMESPACE",
                                "%s",
                                namespace) < 0
+        || flux_shell_setenvf (shell,
+                               1,
+                               "FLUX_JOB_ID_PATH",
+                               "%s/%s",
+                               streq (jobid_path, "/") ? "" : jobid_path,
+                               idf58 (shell->info->jobid)) < 0
         || flux_shell_setenvf (shell,
                                1,
                                "FLUX_JOB_SIZE",

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -153,6 +153,7 @@ test_expect_success 'FLUX_URI is set in rc scripts' '
 
 test_expect_success 'job environment is not set in rc scripts' '
 	var_is_unset FLUX_JOB_ID *.env &&
+	var_is_unset FLUX_JOB_ID_PATH *.env &&
 	var_is_unset FLUX_JOB_SIZE *.env &&
 	var_is_unset FLUX_JOB_NNODES *.env &&
 	var_is_unset FLUX_JOB_TMPDIR *.env &&
@@ -175,6 +176,7 @@ test_expect_success 'capture the environment for instance run as a job' '
 
 test_expect_success 'job environment is not set in rcs of subinstance' '
 	var_is_unset FLUX_JOB_ID *.env2 &&
+	var_is_unset FLUX_JOB_ID_PATH *.env2 &&
 	var_is_unset FLUX_JOB_SIZE *.env2 &&
 	var_is_unset FLUX_JOB_NNODES *.env2 &&
 	var_is_unset FLUX_JOB_TMPDIR *.env2 &&

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -106,6 +106,18 @@ test_expect_success 'flux can launch multiple brokers per node (R lookup fallbac
 		--conf=resource.no-update-watch=true \
 		flux resource info
 '
+test_expect_success 'broker flux jobid-path=/' '
+	val=$(flux getattr jobid-path) &&
+	test $val = /
+'
+test_expect_success 'child broker jobid-path=/id' '
+	val=$(flux run flux start ${ARGS} flux getattr jobid-path) &&
+	test $val = /$(flux job last)
+'
+test_expect_success 'job FLUX_JOB_ID_PATH=/id' '
+	val=$(flux run printenv FLUX_JOB_ID_PATH) &&
+	test $val = /$(flux job last)
+'
 test_expect_success 'flux_open("/") works at top-level' '
 	flux python -c "import flux; print(flux.Flux(\"/\").attr_get(\"instance-level\"));"
 '


### PR DESCRIPTION
Problem: Flux jobs run in sub-instances do not have a unique ID like slurm's jobid.step.

Add the FLUX_JOB_PATH environment variable to the job environment.  The path consists of job IDs separated by `/` characters, with `/` designating the top level instance.  For example, a job run in a batch job of a system instance might have a FLUX_JOB_PATH of  `/ƒD1oBT5/ƒDCB6RV`.

I hope it is not going too far to put this in the environment of every job.   In #6876 I had proposed just adding a broker attribute and passing it through PMI.  This was simpler and felt more complete.  We can go back to the other plan if there is disagreement on this approach.