### PR TITLE
add flux module remove --cancel option

### DIFF
--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -71,6 +71,15 @@ Remove module *name*.
 
   Suppress failure if module *name* is not loaded.
 
+.. option:: --cancel
+
+  Use :linux:man3:`pthread_cancel` to remove an unresponsive module.
+  This may be useful if the module is not able to respond to the module
+  shutdown request because it has not returned control to its reactor loop.
+  However, broker module threads are created with *deferred* cancellability,
+  so this is only effective if the module thread calls one of the functions
+  listed as a cancellation point in :linux:man7:`pthreads`.
+
 list
 ----
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -971,3 +971,6 @@ orchestrator
 fsck
 mincrit
 DCB
+cancellability
+pthreads
+pthread

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -493,7 +493,7 @@ void module_destroy (module_t *p)
 
     if (p->t) {
         if ((e = pthread_join (p->t, &res)) != 0)
-            log_errn_exit (e, "pthread_cancel");
+            log_errn_exit (e, "pthread_join");
         if (p->status != FLUX_MODSTATE_EXITED) {
             /* Calls broker.c module_status_cb() => service_remove_byuuid()
              * and releases a reference on 'p'.  Without this, disconnect

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -66,6 +66,10 @@ static struct optparse_option remove_opts[] =  {
     { .name = "force", .key = 'f', .has_arg = 0,
       .usage = "Ignore nonexistent modules",
     },
+    { .name = "cancel", .has_arg = 0,
+      .usage = "Forcibly stop an unresponsive module thread when it"
+               " reaches the next pthread(7) cancellation point",
+    },
     OPTPARSE_TABLE_END,
 };
 
@@ -75,6 +79,10 @@ static struct optparse_option reload_opts[] =  {
     },
     { .name = "name", .has_arg = 1, .arginfo = "NAME",
       .usage = "Override default module name",
+    },
+    { .name = "cancel", .has_arg = 0,
+      .usage = "Forcibly stop an unresponsive module thread when it"
+               " reaches the next pthread(7) cancellation point",
     },
     OPTPARSE_TABLE_END,
 };
@@ -372,8 +380,9 @@ static void module_remove (flux_t *h, optparse_t *p, const char *path)
                              "module.remove",
                              FLUX_NODEID_ANY,
                              0,
-                             "{s:s}",
-                             "name", fullpath ? fullpath : path))
+                             "{s:s s:b}",
+                             "name", fullpath ? fullpath : path,
+                             "cancel", optparse_hasopt (p, "cancel") ? 1 : 0))
         || flux_rpc_get (f, NULL) < 0) {
         if (!(optparse_hasopt (p, "force") && errno == ENOENT))
             log_msg_exit ("remove %s: %s", path, future_strerror (f, errno));

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -490,6 +490,7 @@ check_LTLIBRARIES = \
 	module/testmod.la \
 	module/running.la \
 	module/legacy.la \
+	module/hang.la \
 	request/req.la \
 	ingest/job-manager.la \
 	disconnect/watcher.la \
@@ -724,6 +725,11 @@ module_legacy_la_SOURCES = module/legacy.c
 module_legacy_la_CPPFLAGS = $(test_cppflags)
 module_legacy_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowher
 module_legacy_la_LIBADD = $(test_ldadd) $(LIBDL)
+
+module_hang_la_SOURCES = module/hang.c
+module_hang_la_CPPFLAGS = $(test_cppflags)
+module_hang_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowher
+module_hang_la_LIBADD = $(test_ldadd) $(LIBDL)
 
 barrier_tbarrier_SOURCES = barrier/tbarrier.c
 barrier_tbarrier_CPPFLAGS = $(test_cppflags)

--- a/t/module/hang.c
+++ b/t/module/hang.c
@@ -1,0 +1,25 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <flux/core.h>
+
+int mod_main (flux_t *h, int argc, char *argv[])
+{
+    if (flux_module_set_running (h) < 0)
+        return -1;
+    pause (); // pthreads(7) cancellation point
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -16,6 +16,7 @@ invalid_rank() {
 
 testmod=${FLUX_BUILD_DIR}/t/module/.libs/testmod.so
 legacy=${FLUX_BUILD_DIR}/t/module/.libs/legacy.so
+hangmod=${FLUX_BUILD_DIR}/t/module/.libs/hang.so
 
 module_status_bad_proto() {
 	flux python -c "import flux; print(flux.Flux().rpc(\"module.status\").get())"
@@ -318,6 +319,15 @@ test_expect_success 'testmod does respond to ping' '
 '
 test_expect_success 'module: remove testmod' '
         flux module remove -f testmod
+'
+test_expect_success 'module: load hanging module' '
+        flux module load $hangmod
+'
+test_expect_success 'module: hanging module cannot be removed' '
+        test_expect_code 137 run_timeout 2 flux module remove $hangmod
+'
+test_expect_success 'module: but --cancel works' '
+        flux module remove --cancel $hangmod
 '
 
 test_done


### PR DESCRIPTION
This adds an option to remove an ornery module by sending it a `pthread_cancel(3)` instead of politely requesting that it shut down.  That required the addition of a pthread cleanup callback, which triggered a bit of refactoring.