### PR TITLE
set default jobspec jobspec using `os.environ` in `JobspecV1` factory functions

### DIFF
--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -441,7 +441,7 @@ class Jobspec(object):
     @property
     def environment(self):
         """
-        Environment of job. Defaults to ``None``.
+        Environment of job.
         """
         try:
             return self.jobspec["attributes"]["system"]["environment"]
@@ -843,6 +843,8 @@ class JobspecV1(Jobspec):
             self.duration = duration
         if environment is not None:
             self.environment = environment
+        else:
+            self.environment = dict(os.environ)
         if env_expand is not None:
             if not isinstance(env_expand, abc.Mapping):
                 raise ValueError("env_expand must be a mapping")
@@ -1038,8 +1040,8 @@ class JobspecV1(Jobspec):
                 setter.
             environment (Mapping): Set the environment for the job via a
                 mapping of environment variable name to value. If not
-                provided then the environment will be empty and must be
-                assigned via the :attr:`~JobspecV1.environment` setter.
+                provided then the environment will be initialized using
+                :obj:`os.environ`.
             env_expand (Mapping): A  mapping of environment variables that
                 contain mustache templates to be expanded by the job shell
                 at runtime. (See the :manpage:`flux-run(1)` MUSTACHE

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -957,6 +957,13 @@ class TestJob(unittest.TestCase):
         with self.assertRaises(ValueError):
             JobspecV1.from_command(["sleep", "0"], rlimits=True)
 
+    def test_38_environment_default(self):
+        jobspec = JobspecV1.from_command(["sleep", "0"])
+        self.assertEqual(jobspec.environment, dict(os.environ))
+
+        jobspec = JobspecV1.from_command(["sleep", "0"], environment={})
+        self.assertEqual(jobspec.environment, {})
+
 
 if __name__ == "__main__":
     from subflux import rerun_under_flux


### PR DESCRIPTION
As noted in #6890, it is unexpected that the default jobspec environment when not explicitly passing `environment` is empty.

I can't really think of a good reason for this default, and it is easy to fix so let's do that.

This shouldn't break any existing users since setting `jobspec.environment = dict` will still work.

Just in case, we should get a couple reviews of this one.