### PR TITLE
content-sqlite/files: support validate target

### DIFF
--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -195,6 +195,44 @@ error:
         flux_log_error (h, "error responding to store request");
 }
 
+/* Handle a content-backing.validate request from the rank 0 broker's
+ * content-cache service.  The raw request payload is a hash digest.
+ * The raw response payload is the blob content.
+ * These payloads are specified in RFC 10.
+ */
+static void validate_cb (flux_t *h,
+                         flux_msg_handler_t *mh,
+                         const flux_msg_t *msg,
+                         void *arg)
+{
+    struct content_files *ctx = arg;
+    const void *hash;
+    size_t hash_size;
+    char blobref[BLOBREF_MAX_STRING_SIZE];
+    const char *errstr = NULL;
+
+    if (flux_request_decode_raw (msg, NULL, &hash, &hash_size) < 0)
+        goto error;
+    if (hash_size != ctx->hash_size) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (blobref_hashtostr (ctx->hashfun,
+                           hash,
+                           hash_size,
+                           blobref,
+                           sizeof (blobref)) < 0)
+        goto error;
+    if (filedb_validate (ctx->dbpath, blobref, &errstr) < 0)
+        goto error;
+    if (flux_respond_raw (h, msg, NULL, 0) < 0)
+        flux_log_error (h, "error responding to validate request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to validate request");
+}
+
 /* Handle a content-backing.checkpoint-get request from the rank 0 kvs module.
  * The KVS stores its last root reference here for restart purposes.
  *
@@ -308,6 +346,12 @@ static const struct flux_msg_handler_spec htab[] = {
         FLUX_MSGTYPE_REQUEST,
         "content-backing.store",
         store_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-backing.validate",
+        validate_cb,
         0
     },
     {

--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -298,12 +298,36 @@ static void content_files_destroy (struct content_files *ctx)
  * The topic strings in the table consist of <service name>.<method>.
  */
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST, "content-backing.load",    load_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content-backing.store",   store_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content-backing.checkpoint-get", checkpoint_get_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content-backing.checkpoint-put", checkpoint_put_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content-files.stats-get",
-      stats_get_cb, FLUX_ROLE_USER },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-backing.load",
+        load_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-backing.store",
+        store_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-backing.checkpoint-get",
+        checkpoint_get_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-backing.checkpoint-put",
+        checkpoint_put_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-files.stats-get",
+        stats_get_cb,
+        FLUX_ROLE_USER
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/content-files/filedb.c
+++ b/src/modules/content-files/filedb.c
@@ -99,6 +99,31 @@ int filedb_put (const char *dbpath,
     return 0;
 }
 
+int filedb_validate (const char *dbpath,
+                     const char *key,
+                     const char **errstr)
+{
+    char path[1024];
+    struct stat statbuf;
+
+    if (strlen (key) == 0 || strchr (key, '/') || streq (key, "..")
+                          || streq (key, ".")) {
+        errno = EINVAL;
+        if (errstr)
+            *errstr = "invalid key name";
+        return -1;
+    }
+    if (snprintf (path, sizeof (path), "%s/%s", dbpath, key) >= sizeof (path)) {
+        errno = EOVERFLOW;
+        if (errstr)
+            *errstr = "key name too long for internal buffer";
+        return -1;
+    }
+    if (stat (path, &statbuf) < 0)
+        return -1;
+    return 0;
+}
+
 /*
  * vi:ts=4 sw=4 expandtab
  */

--- a/src/modules/content-files/filedb.h
+++ b/src/modules/content-files/filedb.h
@@ -15,7 +15,7 @@
  * On success, 'datap' and 'sizep' are assigned the contents and size
  * and 0 is returned (*datap must be freed).
  * On failure, -1 is returned with errno set.
- * Pass '*errstr' in pre-set to NULL and if a human readable error message
+ * Pass '*errstr' (pre-set to NULL) and if a human readable error message
  * is appropriate, it is assigned on error (do not free).
  */
 int filedb_get (const char *dbpath,
@@ -28,7 +28,7 @@ int filedb_get (const char *dbpath,
 /* Put file named 'key' with content 'data' and length 'size' to the
  * dbpath directory.  On success, 0 is returned.
  * On failure, -1 is returned with errno set.
- * Pass '*errstr' in pre-set to NULL and if a human readable error message
+ * Pass '*errstr' (pre-set to NULL) and if a human readable error message
  * is appropriate, it is assigned on error (do not free).
  */
 int filedb_put (const char *dbpath,

--- a/src/modules/content-files/filedb.h
+++ b/src/modules/content-files/filedb.h
@@ -37,6 +37,16 @@ int filedb_put (const char *dbpath,
                 size_t size,
                 const char **errstr);
 
+/* Validate file named 'key' from the dbpath directory exists.
+ * Return 0 if file exists.
+ * On failure, -1 is returned with errno set.
+ * Pass '*errstr' (pre-set to NULL) and if a human readable error message
+ * is appropriate, it is assigned on error (do not free).
+ */
+int filedb_validate (const char *dbpath,
+                     const char *key,
+                     const char **errstr);
+
 #endif /* !_CONTENT_FILES_FILEDB_H */
 
 /*

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -237,6 +237,8 @@ static int content_sqlite_load (struct content_sqlite *ctx,
     }
     *datap = data;
     *sizep = size;
+    /* call sqlite3_reset() on ctx->load_stmt in caller, after it has
+     * used returned data pointer */
     return 0;
 error:
     ERRNO_SAFE_WRAP (sqlite3_reset, ctx->load_stmt);

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -45,6 +45,8 @@ const char *sql_load = "SELECT object,size FROM objects"
                        "  WHERE hash = ?1 LIMIT 1";
 const char *sql_store = "INSERT INTO objects (hash,size,object) "
                         "  values (?1, ?2, ?3)";
+const char *sql_validate = "SELECT EXISTS("
+                           "  SELECT 1 FROM objects WHERE hash = ?1)";
 const char *sql_objects_count = "SELECT count(1) FROM objects";
 
 const char *sql_checkpt_get_v1 = "SELECT value FROM checkpt"
@@ -84,6 +86,7 @@ struct content_sqlite {
     sqlite3 *db;
     sqlite3_stmt *load_stmt;
     sqlite3_stmt *store_stmt;
+    sqlite3_stmt *validate_stmt;
     sqlite3_stmt *checkpt_get_stmt;
     sqlite3_stmt *checkpt_put_stmt;
     sqlite3_stmt *checkpt_prune_stmt;
@@ -321,6 +324,43 @@ error:
     return -1;
 }
 
+/* Validate blob in objects table.
+ * Returns 0 if valid, -1 on error (ENOENT if  not found)
+ */
+static int content_sqlite_validate (struct content_sqlite *ctx,
+                                    const void *hash,
+                                    int hash_size)
+{
+    if (sqlite3_bind_text (ctx->validate_stmt,
+                           1,
+                           (char *)hash,
+                           hash_size,
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "validate: binding key");
+        set_errno_from_sqlite_error (ctx);
+        goto error;
+    }
+    if (sqlite3_step (ctx->validate_stmt) != SQLITE_ROW) {
+        //log_sqlite_error (ctx, "validate: executing stmt");
+        errno = ENOENT;
+        goto error;
+    }
+    if (sqlite3_column_type (ctx->validate_stmt, 0) != SQLITE_INTEGER) {
+        flux_log (ctx->h, LOG_ERR, "validate: result is not an integer");
+        errno = EINVAL;
+        goto error;
+    }
+    if (!sqlite3_column_int (ctx->validate_stmt, 0)) {
+        errno = ENOENT;
+        goto error;
+    }
+    (void )sqlite3_reset (ctx->validate_stmt);
+    return 0;
+error:
+    ERRNO_SAFE_WRAP (sqlite3_reset, ctx->validate_stmt);
+    return -1;
+}
+
 static void load_cb (flux_t *h,
                      flux_msg_handler_t *mh,
                      const flux_msg_t *msg,
@@ -385,6 +425,34 @@ void store_cb (flux_t *h,
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "store: flux_respond_error");
+}
+
+static void validate_cb (flux_t *h,
+                         flux_msg_handler_t *mh,
+                         const flux_msg_t *msg,
+                         void *arg)
+{
+    struct content_sqlite *ctx = arg;
+    const void *hash;
+    size_t hash_size;
+
+    if (flux_request_decode_raw (msg,
+                                 NULL,
+                                 &hash,
+                                 &hash_size) < 0)
+        goto error;
+    if (hash_size != ctx->hash_size) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (content_sqlite_validate (ctx, hash, hash_size) < 0)
+        goto error;
+    if (flux_respond_raw (h, msg, NULL, 0) < 0)
+        flux_log_error (h, "validate: flux_respond_raw");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "validate: flux_respond_error");
 }
 
 void checkpoint_get_cb (flux_t *h,
@@ -536,6 +604,10 @@ static void content_sqlite_closedb (struct content_sqlite *ctx)
 {
     if (ctx) {
         int saved_errno = errno;
+        if (ctx->validate_stmt) {
+            if (sqlite3_finalize (ctx->validate_stmt) != SQLITE_OK)
+                log_sqlite_error (ctx, "sqlite_finalize validate_stmt");
+        }
         if (ctx->store_stmt) {
             if (sqlite3_finalize (ctx->store_stmt) != SQLITE_OK)
                 log_sqlite_error (ctx, "sqlite_finalize store_stmt");
@@ -755,6 +827,14 @@ static int content_sqlite_opendb (struct content_sqlite *ctx, bool truncate)
         goto error;
     }
     if (sqlite3_prepare_v2 (ctx->db,
+                            sql_validate,
+                            -1,
+                            &ctx->validate_stmt,
+                            NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "preparing validate stmt");
+        goto error;
+    }
+    if (sqlite3_prepare_v2 (ctx->db,
                             sql_checkpt_get_v2,
                             -1,
                             &ctx->checkpt_get_stmt,
@@ -950,6 +1030,12 @@ static const struct flux_msg_handler_spec htab[] = {
         FLUX_MSGTYPE_REQUEST,
         "content-backing.store",
         store_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-backing.validate",
+        validate_cb,
         0
     },
     {

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -938,14 +938,36 @@ static void content_sqlite_destroy (struct content_sqlite *ctx)
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST, "content-backing.load",    load_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content-backing.store",   store_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content-backing.checkpoint-get",
-                            checkpoint_get_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content-backing.checkpoint-put",
-                            checkpoint_put_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content-sqlite.stats-get",
-                            stats_get_cb, FLUX_ROLE_USER },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-backing.load",
+        load_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-backing.store",
+        store_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-backing.checkpoint-get",
+        checkpoint_get_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-backing.checkpoint-put",
+        checkpoint_put_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-sqlite.stats-get",
+        stats_get_cb,
+        FLUX_ROLE_USER
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -432,6 +432,7 @@ dist_check_SCRIPTS = \
 	ingest/bad-validate.py
 
 check_PROGRAMS = \
+	content/content_validate \
 	loop/logstderr \
 	loop/issue2337 \
 	loop/issue2711 \
@@ -558,6 +559,11 @@ test_ldflags = \
 test_cppflags = \
 	-I$(top_srcdir)/src/common/libtap \
 	$(AM_CPPFLAGS)
+
+content_content_validate_SOURCES = content/content_validate.c
+content_content_validate_CPPFLAGS = $(test_cppflags)
+content_content_validate_LDADD = $(test_ldadd)
+content_content_validate_LDFLAGS = $(test_ldflags)
 
 loop_logstderr_SOURCES = loop/logstderr.c
 loop_logstderr_CPPFLAGS = $(test_cppflags)

--- a/t/content/content_validate.c
+++ b/t/content/content_validate.c
@@ -1,0 +1,52 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libutil/blobref.h"
+#include "src/common/libutil/log.h"
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    uint32_t hash[BLOBREF_MAX_DIGEST_SIZE];
+    ssize_t hash_size;
+    const char *ref;
+    flux_future_t *f;
+
+    if (argc != 2) {
+        fprintf (stderr, "Usage: content_validate <ref>\n");
+        return (1);
+    }
+    ref = argv[1];
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if ((hash_size = blobref_strtohash (ref, hash, sizeof (hash))) < 0)
+        log_err_exit ("blobref_strtohash");
+
+    if (!(f = flux_rpc_raw (h,
+                            "content-backing.validate",
+                            hash,
+                            hash_size,
+                            0,
+                            0)))
+        log_err_exit ("flux_rpc_raw");
+
+    if (flux_rpc_get (f, NULL) < 0)
+        log_err_exit ("flux_rpc_get");
+    printf ("valid\n");
+    flux_close (h);
+    return (0);
+}

--- a/t/kvs/lookup_invalid.c
+++ b/t/kvs/lookup_invalid.c
@@ -46,7 +46,10 @@ int main (int argc, char *argv[])
     }
 
     /* invalid lookup - do not specify namespace or root ref */
-    if (!(f = flux_rpc_pack (h, "kvs.lookup", FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (h,
+                             "kvs.lookup",
+                             FLUX_NODEID_ANY,
+                             0,
                              "{s:s s:i}",
                              "key", key,
                              "flags", 0)))

--- a/t/kvs/setrootevents.c
+++ b/t/kvs/setrootevents.c
@@ -70,7 +70,10 @@ int main (int argc, char *argv[])
     else
         topic = "kvs.setroot-unpause";
 
-    if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (h,
+                             topic,
+                             FLUX_NODEID_ANY,
+                             0,
                              "{ s:s }",
                              "namespace", ns)))
         log_err_exit ("flux_rpc_pack");

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -20,6 +20,7 @@ RPC=${FLUX_BUILD_DIR}/t/request/rpc
 SPAMUTIL="${FLUX_BUILD_DIR}/t/kvs/content-spam"
 rc1_kvs=$SHARNESS_TEST_SRCDIR/rc/rc1-kvs
 rc3_kvs=$SHARNESS_TEST_SRCDIR/rc/rc3-kvs
+VALIDATE=${FLUX_BUILD_DIR}/t/content/content_validate
 
 test_expect_success 'load content module with lower purge/age thresholds' '
 	flux exec flux module load content \
@@ -84,6 +85,20 @@ test_expect_success 'load 1m blob bypassing cache' '
 	HASHSTR=`cat 1m.0.hash` &&
 	flux content load --bypass-cache ${HASHSTR} >1m.0.load &&
 	test_cmp 1m.0.store 1m.0.load
+'
+
+# validate
+
+test_expect_success 'content validate works on valid hash' '
+	HASHSTR=`cat 4k.0.hash` &&
+	${VALIDATE} ${HASHSTR} > validate1.out &&
+	grep "valid" validate1.out
+'
+
+test_expect_success 'content validate works on invalid hash' '
+	HASHSTR="sha1-abcdef01234567890abcdef01234567890abcdef" &&
+	test_must_fail ${VALIDATE} ${HASHSTR} 2> validate2.err &&
+	grep "No such file" validate2.err
 '
 
 # Verify same blobs on all ranks


### PR DESCRIPTION
Support a "validate" RPC service in the content backing modules, simply to validate that an blobref hash is valid.  Without it, a "load" has to be used instead, which requires sending over the content data itself.  So it's pretty costly.

Multiple ways to do this of course, but I went with "return empty payload" for validated / success, and ENOENT for "not valid" / "not found".

I elected not to add API functions to `libcontent` and a "forwarder" in the `content` module, as this is only used by `fsck` at the moment.  IMO forwarding through the `content` cache module could suggest that verification within the `content` cache is ok, but that isn't ok.  We only want to validate in the backing module. 

Note, see associated RFC PR: https://github.com/flux-framework/rfc/pull/455
