### PR TITLE
Fix for Ubuntu Noble Docker Image to Prevent PMIx+MPICH Issues

### DIFF
--- a/scripts/fetch-and-build-mpich.sh
+++ b/scripts/fetch-and-build-mpich.sh
@@ -6,7 +6,7 @@ pushd catch2
 wget -O - https://www.mpich.org/static/downloads/4.2.2/mpich-4.2.2.tar.gz | tar xvz --strip-components 1
 mkdir -p build
 pushd build
-../configure --prefix=/usr --without-pmix
+../configure --prefix=/usr --without-pmix --disable-fortran
 make -j 4 install
 popd
 popd

--- a/src/test/docker/noble/Dockerfile
+++ b/src/test/docker/noble/Dockerfile
@@ -45,11 +45,9 @@ RUN apt-get update \
 # default version
         gcc-13 \
         g++-13 \
-        gfortran-13 \
 # newest
         gcc-14 \
         g++-14 \
-        gfortran-14 \
 # Python
         libffi-dev \
 ## python 3.12

--- a/src/test/docker/noble/Dockerfile
+++ b/src/test/docker/noble/Dockerfile
@@ -39,14 +39,17 @@ RUN apt-get update \
         make \
         cmake \
         ninja-build \
+        gfortran \
         clang-18 \
         clang-tools-18 \
 # default version
         gcc-13 \
         g++-13 \
+        gfortran-13 \
 # newest
         gcc-14 \
         g++-14 \
+        gfortran-14 \
 # Python
         libffi-dev \
 ## python 3.12
@@ -65,7 +68,6 @@ RUN apt-get update \
         libsqlite3-dev \
         uuid-dev \
         libhwloc-dev \
-        libmpich-dev \
         libevent-dev \
         libarchive-dev \
         libpam-dev \


### PR DESCRIPTION
In testing some stuff for our upcoming [performance tools and benchmarking tutorial](https://github.com/llnl/benchpark-tutorial) for [HPDC](https://hpdc.sci.utah.edu/2025/workshops.html), I discovered that there are still issues with the Ubuntu Noble Docker image regarding MPICH. The majority of the issue is covered in this [Launchpad bug report](https://bugs.launchpad.net/ubuntu/+source/mpich/+bug/2072338). Long story short, the apt-installed MPICH builds with PMIx support, but still uses the Hydra process manager. This causes issues when trying to run MPI code because Hydra does not provide a PMIx interface.

The Docker image for Ubuntu Noble already tried to work around this by building MPICH from source. However, the image is still installing `libmpich-dev`. This, combined with loader search paths, is causing MPI applications to link against the apt-installed `libmpich.so`, which causes the same issue as when installing all of MPICH from apt.

To fix this issue, this PR simply removes `libmpich-dev` from the Ubuntu Noble Docker image. It also adds installs of `gfortran` because, during local testing, the script to build MPICH from source was failing due to not being able to find a Fortran compiler.