### PR TITLE
flux-module trace: capture early messages

### DIFF
--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -12,7 +12,7 @@ SYNOPSIS
 | **flux** **module** **list** [*-l*]
 | **flux** **module** **stats** [*-R*] [*--clear*] *name*
 | **flux** **module** **debug** [*--setbit=VAL*] [*--clearbit=VAL*] [*--set=MASK*] [*--clear=MASK*] *name*
-| **flux** **module** **trace** [-f] [*-t TYPE,...*] [-T *topic-glob*] *name...*
+| **flux** **module** **trace** [-f] [*-t TYPE,...*] [-T *topic-glob*] [*name...*]
 
 
 
@@ -159,7 +159,13 @@ trace
 .. program:: flux module trace
 
 Display message summaries for messages transmitted and received by the
-named modules.
+named modules, or all modules if none are named.
+
+.. note::
+
+   Trace requests are accepted for modules before they are loaded.
+   As a consequence, a trace request for a misspelled module name may be
+   accepted, but produce no output.
 
 .. option:: -f, --full
 

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -25,6 +25,7 @@
 
 #include "module.h"
 #include "broker.h"
+#include "trace.h"
 #include "modhash.h"
 #include "overlay.h"
 
@@ -32,6 +33,7 @@ struct modhash {
     zhash_t *zh_byuuid;
     flux_msg_handler_t **handlers;
     struct broker *ctx;
+    struct flux_msglist *trace_requests;
 };
 
 static json_t *modhash_get_modlist (modhash_t *mh,
@@ -53,6 +55,11 @@ int modhash_response_sendmsg_new (modhash_t *mh, flux_msg_t **msg)
         errno = ENOSYS;
         return -1;
     }
+    trace_module_msg (mh->ctx->h,
+                      "rx",
+                      module_get_name (p),
+                      mh->trace_requests,
+                      *msg);
     return module_sendmsg_new (p, msg);
 }
 
@@ -149,6 +156,11 @@ static void module_cb (module_t *p, void *arg)
 
     if (!msg)
         goto done;
+    trace_module_msg (ctx->h,
+                      "tx",
+                      module_get_name (p),
+                      ctx->modhash->trace_requests,
+                      msg);
     if (flux_msg_get_type (msg, &type) < 0)
         goto done;
     switch (type) {
@@ -242,6 +254,15 @@ static void module_status_cb (module_t *p, int prev_status, void *arg)
 static int mod_svc_cb (flux_msg_t **msg, void *arg)
 {
     module_t *p = arg;
+    modhash_t *mh = module_aux_get (p, "modhash");
+
+    if (mh) {
+        trace_module_msg (mh->ctx->h,
+                          "rx",
+                          module_get_name (p),
+                          mh->trace_requests,
+                          *msg);
+    }
     return module_sendmsg_new (p, msg);
 }
 
@@ -479,13 +500,7 @@ static void trace_cb (flux_t *h,
 {
     broker_ctx_t *ctx = arg;
     struct flux_match match = FLUX_MATCH_ANY;
-    json_t *names = NULL;
-    size_t index;
-    json_t *entry;
-    const char *errmsg = NULL;
-    flux_error_t error;
-    zlist_t *l = NULL;
-    module_t *p;
+    json_t *names;
 
     if (flux_request_unpack (msg,
                              NULL,
@@ -498,34 +513,12 @@ static void trace_cb (flux_t *h,
         errno = EPROTO;
         goto error;
     }
-    /* Put modules in a list as the names are checked,
-     */
-    if (!(l = zlist_new ()))
-        goto nomem;
-    json_array_foreach (names, index, entry) {
-        const char *name = json_string_value (entry);
-        if (!(p = modhash_lookup_byname (ctx->modhash, (name)))) {
-            errprintf (&error, "%s module is not loaded", name);
-            errmsg = error.text;
-            errno = ENOENT;
-            goto error;
-        }
-        if (zlist_append (l, p) < 0)
-            goto nomem;
-    }
-    p = zlist_first (l);
-    while (p) {
-        (void)module_trace (p, msg);
-        p = zlist_next (l);
-    }
-    zlist_destroy (&l);
+    if (flux_msglist_append (ctx->modhash->trace_requests, msg) < 0)
+        goto error;
     return;
-nomem:
-    errno = ENOMEM;
 error:
-    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "error responding to module.trace");
-    zlist_destroy (&l);
 }
 
 static void status_cb (flux_t *h,
@@ -584,13 +577,8 @@ static void disconnect_cb (flux_t *h,
                            void *arg)
 {
     broker_ctx_t *ctx = arg;
-    module_t *p;
 
-    p = zhash_first (ctx->modhash->zh_byuuid);
-    while (p) {
-        module_trace_disconnect (p, msg);
-        p = zhash_next (ctx->modhash->zh_byuuid);
-    }
+    (void)flux_msglist_disconnect (ctx->modhash->trace_requests, msg);
 }
 
 static const struct flux_msg_handler_spec htab[] = {
@@ -645,7 +633,8 @@ modhash_t *modhash_create (struct broker *ctx)
     if (!mh)
         return NULL;
     mh->ctx = ctx;
-    if (flux_msg_handler_addvec (ctx->h, htab, ctx, &mh->handlers) < 0)
+    if (flux_msg_handler_addvec (ctx->h, htab, ctx, &mh->handlers) < 0
+        || !(mh->trace_requests = flux_msglist_create ()))
         goto error;
     if (!(mh->zh_byuuid = zhash_new ())) {
         errno = ENOMEM;
@@ -677,6 +666,7 @@ int modhash_destroy (modhash_t *mh)
             zhash_destroy (&mh->zh_byuuid);
         }
         flux_msg_handler_delvec (mh->handlers);
+        flux_msglist_destroy (mh->trace_requests);
         free (mh);
     }
     errno = saved_errno;
@@ -778,6 +768,11 @@ int modhash_event_mcast (modhash_t *mh, const flux_msg_t *msg)
 
     p = zhash_first (mh->zh_byuuid);
     while (p) {
+        trace_module_msg (mh->ctx->h,
+                          "rx",
+                          module_get_name (p),
+                          mh->trace_requests,
+                          msg);
         if (module_event_cast (p, msg) < 0)
             return -1;
         p = zhash_next (mh->zh_byuuid);

--- a/src/broker/modhash.h
+++ b/src/broker/modhash.h
@@ -59,6 +59,19 @@ int modhash_load (modhash_t *mh,
                   const flux_msg_t *request,
                   flux_error_t *error);
 
+/* Add/remove an auxiliary service name that will be routed
+ * to the module with the specified uuid.
+ */
+int modhash_service_add (modhash_t *mh,
+                         const char *uuid,
+                         const char *service,
+                         flux_error_t *error);
+
+int modhash_service_remove (modhash_t *mh,
+                            const char *uuid,
+                            const char *service,
+                            flux_error_t *error);
+
 #endif /* !_BROKER_MODHASH_H */
 
 /*

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -107,9 +107,6 @@ int module_event_cast (module_t *p, const flux_msg_t *msg);
 ssize_t module_get_send_queue_count (module_t *p);
 ssize_t module_get_recv_queue_count (module_t *p);
 
-int module_trace (module_t *p, const flux_msg_t *msg);
-void module_trace_disconnect (module_t *p, const flux_msg_t *msg);
-
 #endif /* !_BROKER_MODULE_H */
 
 /*

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -36,6 +36,14 @@ const char *module_get_path (module_t *p);
 const char *module_get_uuid (module_t *p);
 double module_get_lastseen (module_t *p);
 
+/* Associate aux data with a module.
+ */
+void *module_aux_get (module_t *p, const char *name);
+int module_aux_set (module_t *p,
+                    const char *name,
+                    void *val,
+                    flux_free_f destroy);
+
 /* The poller callback is called when module socket is ready for
  * reading with module_recvmsg().
  */

--- a/src/broker/trace.c
+++ b/src/broker/trace.c
@@ -37,9 +37,24 @@ static const char *fake_control_topic (char *buf,
     return buf;
 }
 
+static bool match_module (const char *module_name, json_t *names)
+{
+    size_t index;
+    json_t *entry;
+
+    if (json_array_size (names) == 0)
+        return true;
+    json_array_foreach (names, index, entry) {
+        const char *name = json_string_value (entry);
+        if (name && streq (name, module_name))
+            return true;
+    }
+    return false;
+}
+
 static bool match_nodeid (uint32_t overlay_peer, int nodeid)
 {
-    if (nodeid == -1 || overlay_peer == FLUX_NODEID_ANY)
+    if (overlay_peer == FLUX_NODEID_ANY)
         return true;
     return nodeid == overlay_peer;
 }
@@ -94,15 +109,18 @@ static void trace_msg (flux_t *h,
     while (req) {
         struct flux_match match = FLUX_MATCH_ANY;
         int nodeid = -1;
+        json_t *names = NULL;
         int full = 0;
         if (flux_request_unpack (req,
                                  NULL,
-                                 "{s:i s:s s?i s?b}",
+                                 "{s:i s:s s?i s?o s?b}",
                                  "typemask", &match.typemask,
                                  "topic_glob", &match.topic_glob,
                                  "nodeid", &nodeid,
+                                 "names", &names,
                                  "full", &full) < 0
-            || !match_nodeid (overlay_peer, nodeid)
+            || (nodeid != -1 && !match_nodeid (overlay_peer, nodeid))
+            || (names != NULL && !match_module (module_name, names))
             || !flux_msg_cmp (msg, match))
             goto next;
 

--- a/src/broker/trace.c
+++ b/src/broker/trace.c
@@ -16,6 +16,8 @@
 #include "overlay.h"
 #include "trace.h"
 
+#include "ccan/str/str.h"
+
 static const char *fake_control_topic (char *buf,
                                        size_t size,
                                        const flux_msg_t *msg)
@@ -85,6 +87,8 @@ static void trace_msg (flux_t *h,
                 flux_msg_get_payload (msg, NULL, &payload_size);
             break;
     }
+    if (topic && streq (topic, "module.trace")) // avoid getting in a loop!
+        return;
 
     req = flux_msglist_first (trace_requests);
     while (req) {

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -205,7 +205,7 @@ static struct optparse_subcommand subcommands[] = {
       debug_opts,
     },
     { "trace",
-      "[OPTIONS] module [module...]",
+      "[OPTIONS] [module module...]",
       "Trace module messages",
       cmd_trace,
       0,
@@ -978,10 +978,6 @@ static void trace_ctx_init (struct trace_ctx *ctx,
 
     memset (ctx, 0, sizeof (*ctx));
 
-    if (n == ac) {
-        optparse_print_usage (p);
-        exit (1);
-    }
     ctx->max_name_len = parse_name_list (&ctx->names, ac - n, av + n);
     if (ctx->max_name_len < 0)
         log_err_exit ("could not parse module name list");

--- a/t/t3401-module-trace.t
+++ b/t/t3401-module-trace.t
@@ -8,9 +8,6 @@ test_under_flux 1
 
 waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
 
-test_expect_success 'flux module trace fails with missing module name' '
-	test_must_fail flux module trace
-'
 test_expect_success 'flux module trace fails with unknown argument' '
 	test_must_fail flux module trace --not-an-arg
 '
@@ -28,11 +25,18 @@ test_expect_success NO_CHAIN_LINT 'start second background trace with --full' '
 	flux module trace --full kvs job-manager >trace1a.out &
 	echo $! >trace1a.pid
 '
+test_expect_success NO_CHAIN_LINT 'start third background trace with no module name' '
+	flux module trace --full >trace1b.out &
+	echo $! >trace1b.pid
+'
 test_expect_success NO_CHAIN_LINT 'heartbeat.pulse event was captured' '
 	$waitfile -t 60 -p heartbeat.pulse trace.out
 '
 test_expect_success NO_CHAIN_LINT 'heartbeat.pulse event was captured with --full' '
 	$waitfile -t 60 -p heartbeat.pulse trace1a.out
+'
+test_expect_success NO_CHAIN_LINT 'heartbeat.pulse event was captured with no module name' '
+	$waitfile -t 60 -p heartbeat.pulse trace1b.out
 '
 test_expect_success NO_CHAIN_LINT 'send one kvs.ping' '
 	flux ping -c 1 kvs
@@ -42,6 +46,9 @@ test_expect_success NO_CHAIN_LINT 'kvs.ping request/response was captured' '
 '
 test_expect_success NO_CHAIN_LINT 'kvs.ping request/response was captured with --full' '
 	$waitfile -t 60 -c 2 -p kvs.ping trace1a.out
+'
+test_expect_success NO_CHAIN_LINT 'kvs.ping request/response was captured with no module name' '
+	$waitfile -t 60 -c 2 -p kvs.ping trace1b.out
 '
 # This RPC happens to return a human readable error on failure
 test_expect_success NO_CHAIN_LINT 'send one job-manager.kill (failing)' '
@@ -53,6 +60,9 @@ test_expect_success NO_CHAIN_LINT 'job-manager.kill request/response was capture
 test_expect_success NO_CHAIN_LINT 'job-manager.kill request/response was captured with --full' '
 	$waitfile -t 60 -c 2 -p "job%-manager.kill" trace1a.out
 '
+test_expect_success NO_CHAIN_LINT 'job-manager.kill request/response was captured with no module name' '
+	$waitfile -t 60 -c 2 -p "job%-manager.kill" trace1b.out
+'
 
 test_expect_success NO_CHAIN_LINT 'stop background trace' '
 	pid=$(cat trace.pid) &&
@@ -61,6 +71,11 @@ test_expect_success NO_CHAIN_LINT 'stop background trace' '
 '
 test_expect_success NO_CHAIN_LINT 'stop second background trace' '
 	pid=$(cat trace1a.pid) &&
+	kill -15 $pid &&
+	wait $pid || true
+'
+test_expect_success NO_CHAIN_LINT 'stop third background trace' '
+	pid=$(cat trace1b.pid) &&
 	kill -15 $pid &&
 	wait $pid || true
 '

--- a/t/t3401-module-trace.t
+++ b/t/t3401-module-trace.t
@@ -96,4 +96,18 @@ test_expect_success NO_CHAIN_LINT 'barrier.ping request/response was captured' '
 test_expect_success NO_CHAIN_LINT 'stop background trace' '
 	kill -15 $(cat trace2.pid); wait || true
 '
+
+test_expect_success NO_CHAIN_LINT 'start background trace on resource module' '
+	flux module trace --human --color=never --delta --type=request resource >trace3.out &
+	echo $! >trace3.pid
+'
+test_expect_success NO_CHAIN_LINT 'reload resource module' '
+	flux module reload resource
+'
+test_expect_success NO_CHAIN_LINT 'kvs.lookup request was captured' '
+	$waitfile -t 60 -p kvs.lookup trace3.out
+'
+test_expect_success NO_CHAIN_LINT 'stop background trace' '
+	kill -15 $(cat trace3.pid); wait || true
+'
 test_done


### PR DESCRIPTION
Problem: a module has to be loaded before you can initiate  a trace on it, so early message are missed.

If a module trace request is received with no module name,  trace messages communicated over the broker end of the module  sockets.

This was a bit hasty so I'll mark it WIP until I've had a chance to review it more thoroughly.

