### PR TITLE
make broker groups easier to look at when debugging

### DIFF
--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -707,7 +707,7 @@ int cmd_stats (optparse_t *p, int argc, char **argv)
         if (!(f = flux_rpc (h, topic, NULL, nodeid, 0)))
             log_err_exit ("%s", topic);
         if (flux_rpc_get (f, &json_str) < 0)
-            log_err_exit ("%s", topic);
+            log_msg_exit ("%s: %s", topic, future_strerror (f, errno));
         if (!json_str)
             log_errn_exit (EPROTO, "%s", topic);
         parse_json (p, json_str);

--- a/t/t0027-broker-groups.t
+++ b/t/t0027-broker-groups.t
@@ -17,6 +17,11 @@ test_expect_success 'broker.online contains full instance' '
 	test_cmp broker.online.exp broker.online.out
 '
 
+test_expect_success 'flux module stats groups agrees' '
+	flux module stats groups >stats.out &&
+	jq -e -r .subtree.\"broker.online\" <stats.out >broker.online.stats &&
+	test_cmp broker.online.exp broker.online.stats
+'
 test_expect_success 'groups.get of nonexistent group returns empty set' '
 	cat >newgroup.exp <<-EOT &&
 
@@ -28,6 +33,9 @@ test_expect_success 'groups.get of nonexistent group returns empty set' '
 test_expect_success 'groups.get on rank > 0 fails with reasonable error' '
 	test_must_fail ${GROUPSCMD} get --rank 1 broker.online 2>test0.err &&
 	grep "only available on rank 0" test0.err
+'
+test_expect_success 'but flux module stats groups does work' '
+	flux exec -r 1 flux module stats groups
 '
 
 test_expect_success 'nonlocal groups.join fails with appropriate error' '


### PR DESCRIPTION
Problem: while debugging #6909, it might have been handy to be able to look directly at the broker groups memberships, but there is no tool for that.

Just add a `stats-get` handler so `flux module stats groups` can show the group names and membership at the current broker's subtree.  Seeing that a group named `sdmon.online` was missing some ranks may have prompted earlier checking on the state of the  `sdmon` module on the offline nodes.