### PR TITLE
broker: reduce the number of mallocs in logging path

### DIFF
--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -64,11 +64,7 @@ void logbuf_destroy (logbuf_t *logbuf);
 
 static void logbuf_entry_destroy (struct logbuf_entry *e)
 {
-    if (e) {
-        if (e->buf)
-            free (e->buf);
-        free (e);
-    }
+    free (e);
 }
 
 /* Create a logbuf entry from RFC 5424 formatted buf.
@@ -77,15 +73,12 @@ static void logbuf_entry_destroy (struct logbuf_entry *e)
  */
 static struct logbuf_entry *logbuf_entry_create (const char *buf, int len)
 {
-    struct logbuf_entry *e = calloc (1, sizeof (*e));
-    if (!e)
+    struct logbuf_entry *e;
+
+    if (!(e = calloc (1, sizeof (*e) + len + 1)))
         return NULL;
-    if (!(e->buf = malloc (len + 1))) {
-        free (e);
-        return NULL;
-    }
+    e->buf = (char *)(e + 1);
     memcpy (e->buf, buf, len);
-    e->buf[len] = '\0';
     return e;
 }
 


### PR DESCRIPTION
Problem: the broker ring buffer implementation is malloc-heavy.

This converts the logging ring buffer from `zlist_t` to a CCAN list so that a list node doesn't need to be allocated each time an entry is appended to the ring.  It also combines two mallocs used to allocate a list entry into one.

This is probably not significant since our log volume is not too crazy, but it was an easy change, so there.