### PR TITLE
t: increase test timeouts

### DIFF
--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -191,7 +191,7 @@ test_expect_success 'flux alloc: resource.norestrict works in subinstance' '
 '
 test_expect_success 'flux alloc: flux alloc vi works' '
 	cat <<-'EOF' >input.json &&
-	[{"expect":"test text file", "send":":q!\n", "timeout":30}]
+	[{"expect":"test text file", "send":":q!\n", "timeout":60}]
 	EOF
 	cat <<-EOF >test.txt &&
 	test text file
@@ -201,7 +201,7 @@ test_expect_success 'flux alloc: flux alloc vi works' '
 test_expect_success 'flux alloc: flux alloc flux alloc works' '
 	cat <<-'EOF' >input2.json &&
 	[{"expect":"prompt>", "send":"flux resource info\n", "timeout":120},
-	 {"expect":"prompt>", "send":"exit\n", "timeout":30}
+	 {"expect":"prompt>", "send":"exit\n", "timeout":60}
 	]
 	EOF
 	PROMPT_COMMAND="PS1=\"prompt>\"" \

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -127,12 +127,12 @@ test_expect_success 'flux uri works with relative paths' '
 '
 test_expect_success 'flux uri --wait can resolve URI for pending job' '
 	uri=$(flux uri --wait $(flux batch -n1 --wrap hostname)) &&
-	flux job wait-event -vt 30 $(flux job last) clean  &&
+	flux job wait-event -vt 60 $(flux job last) clean  &&
 	test "$uri" = "$(flux jobs -no {uri} $(flux job last))"
 '
 test_expect_success 'terminate batch job cleanly' '
 	flux proxy $(flux uri --local ${jobid}) flux cancel --all &&
-	flux job wait-event -vt 30 ${jobid} clean
+	flux job wait-event -vt 60 ${jobid} clean
 '
 test_expect_success 'flux uri jobid returns error for non-instance job' '
 	id=$(flux submit sleep 600) &&


### PR DESCRIPTION
Problem: Several tests were regularly timing out when doing larger parallel runs of the sharness tests.

Update several timeouts in t2712-python-cli-alloc.t and t2802-uri-cmd.t.