### PR TITLE
broker: add syslog capability

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -299,14 +299,13 @@ log-ring-size [Updates: C, R]
    Default: ``1024``.
 
 log-forward-level [Updates: C, R]
-   Log entries at :linux:man3:`syslog` level at or below this value
-   are forwarded to rank zero for permanent capture.  Default ``7``
-   (LOG_DEBUG).
+   Log entries of numerical severity level less than or equal to this value
+   are forwarded to rank zero for permanent capture.  Default: ``7``.
 
 log-critical-level [Updates: C, R]
-   Log entries at :linux:man3:`syslog` level at or below this value
+   Log entries of numerical severity level less than or equal to this value
    are copied to stderr on the logging rank, for capture by the
-   enclosing instance.  Default ``2`` (LOG_CRIT).
+   enclosing instance.  Default: ``2``.
 
 log-filename [Updates: C, R]
    (rank zero only) If set, session log entries, as filtered by
@@ -320,13 +319,41 @@ log-stderr-mode [Updates: C, R]
    Default: ``leader``.
 
 log-stderr-level (Updates: C, R)
-   Log entries at :linux:man3:`syslog` level at or below this value to
-   stderr, subject to log-stderr-mode.  Default: ``3`` (LOG_ERR).
+   Log entries of numerical severity level less than or equal to this value to
+   stderr, subject to log-stderr-mode.  Default: ``3``.
 
 log-level (Updates: C, R)
-   Log entries at :linux:man3:`syslog` level at or below this value
-   are stored in the ring buffer.  Default: ``7`` (LOG_DEBUG).
+   Log entries of numerical severity level less than or equal to this value
+   are stored in the ring buffer.  Default: ``7``.
 
+The numerical severity levels are defined as per :linux:man3:`syslog`:
+
+.. list-table::
+   :header-rows: 1
+
+   * - 0
+     - :const:`LOG_EMERG`
+
+   * - 1
+     - :const:`LOG_ALERT`
+
+   * - 2
+     - :const:`LOG_CRIT`
+
+   * - 3
+     - :const:`LOG_ERR`
+
+   * - 4
+     - :const:`LOG_WARNING`
+
+   * - 5
+     - :const:`LOG_NOTICE`
+
+   * - 6
+     - :const:`LOG_INFO`
+
+   * - 7
+     - :const:`LOG_DEBUG`
 
 CONTENT
 =======

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -311,6 +311,13 @@ log-filename [Updates: C, R]
    (rank zero only) If set, session log entries, as filtered by
    ``log-forward-level``, are directed to this file.  Default: none.
 
+log-syslog-enable [Updates: C, R]
+   If set to 1, each broker emits logs to syslog.  Default: none.
+
+log-syslog-level [Updates: C, R]
+   Log entries of numerical severity level less than or equal to this value
+   are emitted to syslog.  Default: ``2``.
+
 log-stderr-mode [Updates: C, R]
    If set to "leader" (default), broker rank 0 emits forwarded logs from
    other ranks to stderr, subject to the constraints of log-forward-level

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -146,8 +146,7 @@ int attr_get (attr_t *attrs, const char *name, const char **val, int *flags)
             const char *tmp;
             if (e->get (name, &tmp, e->arg) < 0)
                 goto done;
-            if (e->val)
-                free (e->val);
+            free (e->val);
             if (tmp) {
                 if (!(e->val = strdup (tmp)))
                     goto done;
@@ -182,8 +181,7 @@ int attr_set (attr_t *attrs, const char *name, const char *val)
         if (e->set (name, val, e->arg) < 0)
             goto done;
     }
-    if (e->val)
-        free (e->val);
+    free (e->val);
     if (val) {
         if (!(e->val = strdup (val)))
             goto done;

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -98,8 +98,12 @@ int attr_add (attr_t *attrs, const char *name, const char *val, int flags)
     return 0;
 }
 
-int attr_add_active (attr_t *attrs, const char *name, int flags,
-                        attr_get_f get, attr_set_f set, void *arg)
+int attr_add_active (attr_t *attrs,
+                     const char *name,
+                     int flags,
+                     attr_get_f get,
+                     attr_set_f set,
+                     void *arg)
 {
     struct entry *e;
     int rc = -1;
@@ -299,7 +303,9 @@ int attr_add_uint32 (attr_t *attrs, const char *name, uint32_t val, int flags)
     return attr_add (attrs, name, val_string, flags);
 }
 
-int attr_add_active_uint32 (attr_t *attrs, const char *name, uint32_t *val,
+int attr_add_active_uint32 (attr_t *attrs,
+                            const char *name,
+                            uint32_t *val,
                             int flags)
 {
     return attr_add_active (attrs, name, flags, get_uint32, set_uint32, val);
@@ -355,8 +361,10 @@ int attr_cache_immutables (attr_t *attrs, flux_t *h)
  ** Service
  **/
 
-void getattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                         const flux_msg_t *msg, void *arg)
+void getattr_request_cb (flux_t *h,
+                         flux_msg_handler_t *mh,
+                         const flux_msg_t *msg,
+                         void *arg)
 {
     attr_t *attrs = arg;
     const char *name;
@@ -371,9 +379,11 @@ void getattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = ENOENT;
         goto error;
     }
-    if (flux_respond_pack (h, msg, "{s:s s:i}",
-                                   "value", val,
-                                   "flags", flags) < 0)
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:s s:i}",
+                           "value", val,
+                           "flags", flags) < 0)
         FLUX_LOG_ERROR (h);
     return;
 error:
@@ -381,15 +391,20 @@ error:
         FLUX_LOG_ERROR (h);
 }
 
-void setattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                         const flux_msg_t *msg, void *arg)
+void setattr_request_cb (flux_t *h,
+                         flux_msg_handler_t *mh,
+                         const flux_msg_t *msg,
+                         void *arg)
 {
     attr_t *attrs = arg;
     const char *name;
     const char *val;
 
-    if (flux_request_unpack (msg, NULL, "{s:s s:s}", "name", &name,
-                                                     "value", &val) < 0)
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s:s}",
+                             "name", &name,
+                             "value", &val) < 0)
         goto error;
     if (attr_set (attrs, name, val) < 0) {
         if (errno != ENOENT)
@@ -405,8 +420,10 @@ error:
         FLUX_LOG_ERROR (h);
 }
 
-void lsattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                        const flux_msg_t *msg, void *arg)
+void lsattr_request_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
 {
     attr_t *attrs = arg;
     const char *name;

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -47,7 +47,9 @@ int attr_add (attr_t *attrs, const char *name, const char *val, int flags);
  *  to a string on the caller's behalf.
  */
 int attr_add_int (attr_t *attrs, const char *name, int val, int flags);
-int attr_add_uint32 (attr_t *attrs, const char *name, uint32_t val,
+int attr_add_uint32 (attr_t *attrs,
+                     const char *name,
+                     uint32_t val,
                      int flags);
 
 /* Get/set an attribute.
@@ -62,14 +64,22 @@ int attr_set_flags (attr_t *attrs, const char *name, int flags);
 
 /* Add an attribute with callbacks for get/set.
  */
-int attr_add_active (attr_t *attrs, const char *name, int flags,
-                     attr_get_f get, attr_set_f set, void *arg);
+int attr_add_active (attr_t *attrs,
+                     const char *name,
+                     int flags,
+                     attr_get_f get,
+                     attr_set_f set,
+                     void *arg);
 
 /* Add an attribute that tracks an integer value
  */
-int attr_add_active_int (attr_t *attrs, const char *name, int *val,
+int attr_add_active_int (attr_t *attrs,
+                         const char *name,
+                         int *val,
                          int flags);
-int attr_add_active_uint32 (attr_t *attrs, const char *name, uint32_t *val,
+int attr_add_active_uint32 (attr_t *attrs,
+                            const char *name,
+                            uint32_t *val,
                             int flags);
 
 /* Get an attribute and parse it as an integer value.

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -401,7 +401,8 @@ int main (int argc, char *argv[])
     /* Initialize logging.
      * OK to call flux_log*() after this.
      */
-    logbuf_initialize (ctx.h, ctx.rank, ctx.attrs);
+    if (logbuf_initialize (ctx.h, ctx.rank, ctx.attrs) < 0)
+        goto cleanup;
 
     /* Allow flux_get_rank(), flux_get_size(), flux_get_hostybyrank(), etc.
      * to work in the broker without causing a synchronous RPC to self that

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -150,8 +150,7 @@ void logbuf_destroy (logbuf_t *logbuf)
         flux_msglist_destroy (logbuf->followers);
         if (logbuf->f)
             (void)fclose (logbuf->f);
-        if (logbuf->filename)
-            free (logbuf->filename);
+        free (logbuf->filename);
         free (logbuf);
     }
 }
@@ -224,8 +223,7 @@ static int logbuf_set_filename (logbuf_t *logbuf, const char *destination)
         fclose (f);
         return -1;
     }
-    if (logbuf->filename)
-        free (logbuf->filename);
+    free (logbuf->filename);
     if (logbuf->f)
         fclose (logbuf->f);
     logbuf->f = f;

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -173,11 +173,12 @@ void logbuf_destroy (logbuf_t *logbuf)
 static int set_level (int *value, const char *val)
 {
     int level;
+    char *endptr;
     if (!val)
         goto error;
     errno = 0;
-    level = strtol (val, NULL, 10);
-    if (errno != 0)
+    level = strtol (val, &endptr, 10);
+    if (errno != 0 || *endptr != '\0')
         goto error;
     if (level < LOG_EMERG || level > LOG_DEBUG) {
         errno = EINVAL;
@@ -193,11 +194,12 @@ error:
 static int logbuf_set_ring_size (logbuf_t *logbuf, const char *val)
 {
     int size;
-    if (!val)
+    char *endptr;
+    if (!val || strlen (val) == 0)
         goto error;
     errno = 0;
-    size = strtol (val, NULL, 10);
-    if (errno != 0 || size < 0)
+    size = strtol (val, &endptr, 10);
+    if (errno != 0 || *endptr != '\0' || size < 0)
         goto error;
     logbuf_trim (logbuf, size);
     logbuf->ring_size = size;
@@ -215,7 +217,7 @@ static int logbuf_set_filename (logbuf_t *logbuf, const char *destination)
 {
     char *filename;
     FILE *f;
-    if (!destination) {
+    if (!destination || strlen (destination) == 0) {
         errno = EINVAL;
         return -1;
     }

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -178,4 +178,65 @@ test_expect_success 'dmesg: long lines are not truncated' '
 	test $result -eq 3001
 '
 
+test_expect_success 'setting log-stderr-mode to empty value fails' '
+	test_must_fail flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-stderr-mode= true
+'
+test_expect_success 'setting log-stderr-mode=wrong fails' '
+	test_must_fail flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-stderr-mode=wrong \
+	    true
+'
+test_expect_success 'setting log-ring-size to empty value fails' '
+	test_must_fail flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-ring-size= true
+'
+test_expect_success 'setting log-ring-size to negative value fails' '
+	test_must_fail flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-ring-size=-1 true
+'
+test_expect_success 'setting log-ring-size to value with extra text fails' '
+	test_must_fail flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-ring-size=4xx true
+'
+test_expect_success 'setting log-filename to empty value fails' '
+	test_must_fail flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-filename= true
+'
+test_expect_success 'setting log-syslog-enable=1 works' '
+	test $(flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-syslog-enable=1 \
+	    flux getattr log-syslog-enable) -eq 1
+'
+test_expect_success 'setting log-syslog-enable=0 works' '
+	test $(flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-syslog-enable=0 \
+	    flux getattr log-syslog-enable) -eq 0
+'
+test_expect_success 'setting log-syslog-enable=foo is true' '
+	test $(flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-syslog-enable=foo \
+	    flux getattr log-syslog-enable) -eq 1
+'
+test_expect_success 'setting log-syslog-level=7 works' '
+	test $(flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-syslog-level=7 \
+	    flux getattr log-syslog-level) -eq 7
+'
+test_expect_success 'setting log-syslog-level=0 works' '
+	test $(flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-syslog-level=0 \
+	    flux getattr log-syslog-level) -eq 0
+'
+test_expect_success 'setting log-syslog-level=8 fails' '
+	test_must_fail flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-syslog-level=8 \
+	    true
+'
+test_expect_success 'setting log-syslog-level to value with extra text fails' '
+	test_must_fail flux start \
+	    -o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Slog-syslog-level=5xx \
+	    true
+'
+
 test_done

--- a/t/t3401-module-trace.t
+++ b/t/t3401-module-trace.t
@@ -98,8 +98,11 @@ test_expect_success NO_CHAIN_LINT 'stop background trace' '
 '
 
 test_expect_success NO_CHAIN_LINT 'start background trace on resource module' '
-	flux module trace --human --color=never --delta --type=request resource >trace3.out &
+	flux module trace --human --color=never --delta --type=request,response,event resource >trace3.out &
 	echo $! >trace3.pid
+'
+test_expect_success NO_CHAIN_LINT 'heartbeat.pulse event was captured' '
+	$waitfile -t 60 -p heartbeat.pulse trace3.out
 '
 test_expect_success NO_CHAIN_LINT 'reload resource module' '
 	flux module reload resource


### PR DESCRIPTION
Problem: sys admins may want to capture logs from batch  or alloc subinstances.

This adds basic support for copying broker logs to syslog.  For now, this is only configurable with broker attributes.  Two attributes are added:
 ```
log-syslog-enable=1
log-syslog-level=2
```
The log entries are prefixed with "username@job-path".  Here are a couple of example logs from a test instance and a batch job run within that test instance:
```
Jul 17 17:25:30 system76-pc flux[983068]: garlick@/ job-manager.debug[0]: scheduler: hello +partial-ok
Jul 17 17:25:44 system76-pc flux[983757]: garlick@/ƒ3pBZx4P broker.debug[0]: rmmod barrier
```
Syslog is disabled by default of course.  I was thinking maybe we could add a toml config option that would tell the system instance to enable it for batch/alloc instances (only).  Then we could perhaps start logging summary info about jobs run within the instance as a simple alternative to
- #5952

This was a quick hack with no tests yet.  I wasn't sure if it was going to be all that useful, so I thought I'd pause here and ask for feedback on the approach.