### PR TITLE
testsuite: preserve `LD_LIBRARY_PATH` in some tests

### DIFF
--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -51,6 +51,7 @@ test_expect_success 'flux-shell: historical batch jobspec still work' '
 		input=$(basename $spec) &&
 		cat $spec |
 		    jq -S ".attributes.system.environment.PATH=\"$PATH\"" |
+		    jq -S ".attributes.system.environment.LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH\"" |
 		    jq -S ".attributes.system.environment.PYTHONPATH=\"$PYTHONPATH\"" |
 		    jq -S ".attributes.system.environment.HOME=\"$HOME\"" |
 		    jq -S ".attributes.system.cwd=\"$(pwd)\"" \

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -254,7 +254,7 @@ test_expect_success 'flux-pmi --libpmi-noflux fails w/ flux libpmi.so' '
 test_expect_success 'flux broker refuses the Flux libpmi.so and goes single' '
 	test_when_finished "cat debug.err" &&
 	FLUX_PMI_DEBUG=1 FLUX_PMI_CLIENT_METHODS="libpmi single" \
-	    LD_LIBRARY_PATH=$(dirname $(cat libpmi)) \
+	    LD_LIBRARY_PATH=$(dirname $(cat libpmi)):${LD_LIBRARY_PATH} \
             flux start true 2>debug.err &&
 	grep single debug.err
 '
@@ -302,7 +302,7 @@ test_expect_success 'flux-pmi --libpmi-noflux fails w/ flux libpmi2.so' '
 test_expect_success 'flux broker refuses the Flux pmi lib and goes single' '
 	test_when_finished "cat debug.err" &&
 	FLUX_PMI_DEBUG=1 FLUX_PMI_CLIENT_METHODS="libpmi2 single" \
-	    LD_LIBRARY_PATH=$(dirname $(cat libpmi2)) \
+	    LD_LIBRARY_PATH=$(dirname $(cat libpmi2)):${LD_LIBRARY_PATH} \
             flux start true 2>debug.err &&
 	grep single debug.err
 '


### PR DESCRIPTION
Problem: As reported in #6908, some tests fail when `LD_LIBRARY_PATH` is required for proper Flux operation.

In t2613-job-shell-batch.t, update `LD_LIBRARY_PATH` along with other environment variables when modifying "old" jobspec for the tests.

In t3002-pmi.t, prepend to `LD_LIBRARY_PATH` instead of overwriting it.