### PR TITLE
shell: do not abort early when tasks are oversubscribed to resources

### DIFF
--- a/t/t2600-job-shell-rcalc.t
+++ b/t/t2600-job-shell-rcalc.t
@@ -55,5 +55,15 @@ test_expect_success 'rcalc: distribute 5 slots of size 5 across 6 allocated' '
 	EOF
 	test_cmp 55.expected 55.out
 '
-
+test_expect_success 'rcalc: distribute can oversubscribe (e.g. for --add-brokers)' '
+	flux R encode -r 0-1 -c 0-7 | \
+	    ${rcalc} --cores-per-slot=8 3 > 83.out &&
+	cat >83.expected <<-EOF &&
+	Distributing 3 tasks across 2 nodes with 16 cores
+	Used 2 nodes
+	0: rank=0 ntasks=2 cores=0-7
+	1: rank=1 ntasks=1 cores=0-7
+	EOF
+	test_cmp 83.expected 83.out
+'
 test_done


### PR DESCRIPTION
Currently `rcalc_distribute()` fails with `ENOSPC` when there are not enough cores given the number of tasks and slot size passed in to the function. However, there are valid cases for this oversubscription, e.g. when options like `--add-brokers` are used when launching a new instance or when a custom taskmap is provided by the user.

This doesn't cause any issues now, but it does affect #6705, because `rcalc_distribute()` is called early with a correct slot size (instead of 1) in this PR. 

This PR modifies `rcalc_distribute()` so it doesn't abort if there are not enough slots available. Instead it repopulates the "alloc info" array and continues, allowing the function to always assign all tasks instead of giving up.

