### PR TITLE
flux-fsck: Support --checkpoint option

### DIFF
--- a/doc/man1/common/job-other-batch.rst
+++ b/doc/man1/common/job-other-batch.rst
@@ -1,6 +1,6 @@
 .. option:: --conf=FILE|KEY=VAL|STRING|NAME
 
-   The :option:`--conf`` option allows configuration for a Flux instance
+   The :option:`--conf` option allows configuration for a Flux instance
    started via ``flux-batch(1)`` or ``flux-alloc(1)`` to be iteratively built
    on the command line. On first use, a ``conf.json`` entry is added to the
    internal jobspec file archive, and ``-c{{tmpdir}}/conf.json`` is added

--- a/doc/man1/flux-fsck.rst
+++ b/doc/man1/flux-fsck.rst
@@ -38,6 +38,12 @@ OPTIONS
 
    Use a specific root reference as the starting root version.
 
+.. option:: -c, --checkpoint
+
+   If a root reference specified by :option:`--rootref` does not
+   contain any errors, checkpoint that root reference to the be new
+   checkpointed root reference.
+
 
 EXIT STATUS
 ===========

--- a/doc/man1/flux-fsck.rst
+++ b/doc/man1/flux-fsck.rst
@@ -15,8 +15,8 @@ DESCRIPTION
 .. program flux fsck
 
 The :program:`flux fsck` checks the integrity of the KVS backing
-store, starting with the most recent checkpoint (root version) written
-to the backing store.
+store.  By default, it start with the most recent checkpoint (root version)
+written to the backing store.
 
 
 OPTIONS
@@ -33,6 +33,10 @@ OPTIONS
 .. option:: -q, --quiet
 
    Don't output diagnostic messages and discovered errors.
+
+.. option:: -r, --rootref
+
+   Use a specific root reference as the starting root version.
 
 
 EXIT STATUS

--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -315,7 +315,7 @@ static void fsck_blobref (flux_t *h, const char *blobref)
 
 static int cmd_fsck (optparse_t *p, int ac, char *av[])
 {
-    int optindex =  optparse_option_index (p);
+    int optindex = optparse_option_index (p);
     flux_future_t *f;
     const json_t *checkpoints;
     json_t *checkpt;

--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -316,11 +316,8 @@ static void fsck_blobref (flux_t *h, const char *blobref)
 static int cmd_fsck (optparse_t *p, int ac, char *av[])
 {
     int optindex = optparse_option_index (p);
-    flux_future_t *f;
-    const json_t *checkpoints;
-    json_t *checkpt;
+    flux_future_t *f = NULL;
     const char *blobref;
-    double timestamp;
     flux_t *h;
 
     log_init ("flux-fsck");
@@ -337,23 +334,33 @@ static int cmd_fsck (optparse_t *p, int ac, char *av[])
 
     h = builtin_get_flux_handle (p);
 
-    /* index 0 is most recent checkpoint */
-    if (!(f = kvs_checkpoint_lookup (h, KVS_CHECKPOINT_FLAG_CACHE_BYPASS))
-        || kvs_checkpoint_lookup_get (f, &checkpoints) < 0
-        || !(checkpt = json_array_get (checkpoints, 0))
-        || kvs_checkpoint_parse_rootref (checkpt, &blobref) < 0
-        || kvs_checkpoint_parse_timestamp (checkpt, &timestamp) < 0)
-        log_msg_exit ("error fetching checkpoints: %s",
-                      future_strerror (f, errno));
+    if ((blobref = optparse_get_str (p, "rootref", NULL))) {
+        if (blobref_validate (blobref) < 0)
+            log_msg_exit ("invalid blobref specified");
+    }
+    else {
+        const json_t *checkpoints;
+        json_t *checkpt;
+        double timestamp;
 
-    if (!quiet) {
-        char buf[64] = "";
-        struct tm tm;
-        if (!timestamp_from_double (timestamp, &tm, NULL))
-            strftime (buf, sizeof (buf), "%Y-%m-%dT%T", &tm);
-        fprintf (stderr,
-                 "Checking integrity of checkpoint from %s\n",
-                 buf);
+        /* index 0 is most recent checkpoint */
+        if (!(f = kvs_checkpoint_lookup (h, KVS_CHECKPOINT_FLAG_CACHE_BYPASS))
+            || kvs_checkpoint_lookup_get (f, &checkpoints) < 0
+            || !(checkpt = json_array_get (checkpoints, 0))
+            || kvs_checkpoint_parse_rootref (checkpt, &blobref) < 0
+            || kvs_checkpoint_parse_timestamp (checkpt, &timestamp) < 0)
+            log_msg_exit ("error fetching checkpoints: %s",
+                          future_strerror (f, errno));
+
+        if (!quiet) {
+            char buf[64] = "";
+            struct tm tm;
+            if (!timestamp_from_double (timestamp, &tm, NULL))
+                strftime (buf, sizeof (buf), "%Y-%m-%dT%T", &tm);
+            fprintf (stderr,
+                     "Checking integrity of checkpoint from %s\n",
+                     buf);
+        }
     }
 
     fsck_blobref (h, blobref);
@@ -373,6 +380,9 @@ static struct optparse_option fsck_opts[] = {
     },
     { .name = "quiet", .key = 'q', .has_arg = 0,
       .usage = "Don't output diagnostic messages and discovered errors",
+    },
+    { .name = "rootref", .key = 'r', .has_arg = 1,
+      .usage = "check integrity based on a specific root reference",
     },
     OPTPARSE_TABLE_END
 };

--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -367,10 +367,25 @@ static int cmd_fsck (optparse_t *p, int ac, char *av[])
 
     flux_future_destroy (f);
 
-    flux_close (h);
-
     if (!quiet)
         fprintf (stderr, "Total errors: %d\n", errorcount);
+
+    if (optparse_hasopt (p, "checkpoint")
+        && optparse_hasopt (p, "rootref")
+        && errorcount == 0) {
+        if (!(f = kvs_checkpoint_commit (h,
+                                         blobref,
+                                         0, /* restart sequence at 0 */
+                                         (double)time (NULL),
+                                         KVS_CHECKPOINT_FLAG_CACHE_BYPASS))
+            || flux_rpc_get (f, NULL) < 0)
+            log_err_exit ("error updating checkpoint: %s",
+                          future_strerror (f, errno));
+        flux_future_destroy (f);
+    }
+
+    flux_close (h);
+
     return (errorcount ? -1 : 0);
 }
 
@@ -383,6 +398,9 @@ static struct optparse_option fsck_opts[] = {
     },
     { .name = "rootref", .key = 'r', .has_arg = 1,
       .usage = "check integrity based on a specific root reference",
+    },
+    { .name = "checkpoint", .key = 'c', .has_arg = 0,
+      .usage = "checkpoint rootref if there are no errors",
     },
     OPTPARSE_TABLE_END
 };

--- a/t/content/content-helper.sh
+++ b/t/content/content-helper.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 #
 
+CONTENT_RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 # content module test helper functions
 
 # Get RPC message contents for checkpoint put
@@ -14,7 +16,7 @@ checkpoint_put_msg() {
 # Usage: checkpoint_put rootref
 checkpoint_put() {
 	o=$(checkpoint_put_msg $1)
-	jq -j -c -n ${o} | $RPC content.checkpoint-put
+	jq -j -c -n ${o} | ${CONTENT_RPC} content.checkpoint-put
 }
 
 # Get RPC message contents for checkpoint get
@@ -28,19 +30,19 @@ checkpoint_get_msg() {
 # Usage: checkpoint_get
 checkpoint_get() {
 	o=$(checkpoint_get_msg)
-	jq -j -c -n ${o} | $RPC content.checkpoint-get
+	jq -j -c -n ${o} | ${CONTENT_RPC} content.checkpoint-get
 }
 
 # Identical to checkpoint_put(), but go directly to backing store
 # Usage: checkpoint_put rootref
 checkpoint_backing_put() {
 	o=$(checkpoint_put_msg $1)
-	jq -j -c -n ${o} | $RPC content-backing.checkpoint-put
+	jq -j -c -n ${o} | ${CONTENT_RPC} content-backing.checkpoint-put
 }
 
 # Identical to checkpoint_get(), but go directly to backing store
 # Usage: checkpoint_get
 checkpoint_backing_get() {
 	o=$(checkpoint_get_msg)
-	jq -j -c -n ${o} | $RPC content-backing.checkpoint-get
+	jq -j -c -n ${o} | ${CONTENT_RPC} content-backing.checkpoint-get
 }

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -54,17 +54,17 @@ test_expect_success 'flux-fsck verbose works (simple)' '
 # N.B. from 1000 to 3000 instead of 0 to 2000, easier to debug errors
 # using fold(1) (i.e. all numbers same width)
 test_expect_success LONGTEST 'load kvs and create some kvs content' '
-       flux module load kvs &&
-       for i in `seq 1000 3000`; do
+	flux module load kvs &&
+	for i in `seq 1000 3000`; do
 	   flux kvs put --append bigval=${i}
-       done &&
-       flux kvs get bigval > bigval.exp
+	done &&
+	flux kvs get bigval > bigval.exp
 '
 test_expect_success LONGTEST 'call sync to ensure we have checkpointed' '
 	flux kvs sync
 '
 test_expect_success LONGTEST 'unload kvs' '
-       flux module remove kvs
+	flux module remove kvs
 '
 test_expect_success LONGTEST 'flux-fsck works (big)' '
 	flux fsck --verbose 2> bigval.out &&


### PR DESCRIPTION
Built on top of #6905

Problem: It would be convenient if flux-fsck could checkpoint a rootref if the rootref passes fsck-ing.

Support a new --checkpoint option that will update the KVS checkpoint to the one specified by --rootref.