### PR TITLE
broker: don't trust /etc/shells completely to determine if rc2 is interactive shell

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -718,7 +718,12 @@ static bool is_interactive_shell (const char *argz, size_t argz_len)
         char *shell;
         char *cmd = argz_next (argz, argz_len, NULL);
         while ((shell = getusershell ())) {
-            if (streq (cmd, shell) || streq (cmd, basename_simple (shell))) {
+            const char *basename = basename_simple (shell);
+            if (streq (basename, "true"))
+                continue;
+            if (streq (basename, "false"))
+                continue;
+            if (streq (cmd, shell) || streq (cmd, basename)) {
                 result = true;
                 break;
             }


### PR DESCRIPTION
problem: some distributions, like OpenSUSE apparently, include /bin/true and /bin/false in their /etc/shells file.  Presumably so there are valid options for giving users non-shells to kinda-sorta prevent interactive logins badly.

solution: blacklist true and false, because they are not shells