### PR TITLE
doc: update flux-config-queues(5) with working examples

### DIFF
--- a/doc/man5/flux-config-queues.rst
+++ b/doc/man5/flux-config-queues.rst
@@ -36,12 +36,14 @@ EXAMPLE
 ::
 
    [[resource.config]]
-   hosts = test[0-7]
+   hosts = "test[0-7]"
    properties = ["debug"]
+   cores = "0-1"
 
    [[resource.config]]
-   hosts = test[8-127]
+   hosts = "test[8-127]"
    properties = ["batch"]
+   cores = "0-1"
 
    [queues.debug]
    policy.limits.duration = "30m"
@@ -55,7 +57,6 @@ EXAMPLE
    queue = "batch"
 
    [sched-fluxion-qmanager]
-   queues = "batch debug"
    queue-policy-per-queue="batch:easy debug:fcfs"
 
    [sched-fluxion-resource]


### PR DESCRIPTION
Problem: the example script included in flux-config-queues(5) will generate a parsing error because the hostlist is not a string. It will additionally error because no resources (cores) are assigned to the created queues. Then, when sched-fluxion-qmanager is reloaded, another error will occur because the "queues" key is unsupported.

Solution: fix the example script in the docs.