### PR TITLE
broker: refactor broker module loader and add builtin modules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -616,6 +616,7 @@ AC_CONFIG_FILES( \
   src/shell/Makefile \
   src/connectors/Makefile \
   src/modules/Makefile \
+  src/modules/connector-local/Makefile \
   src/modules/kvs/Makefile \
   src/modules/content-files/Makefile \
   src/modules/job-ingest/Makefile \

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -28,6 +28,8 @@ flux_broker_SOURCES = \
 libbroker_la_SOURCES = \
 	brokercfg.c \
 	brokercfg.h \
+	module_dso.c \
+	module_dso.h \
 	module.c \
 	module.h \
 	modhash.c \

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -32,6 +32,7 @@ libbroker_la_SOURCES = \
 	module_dso.h \
 	module.c \
 	module.h \
+	module_thread.c \
 	modhash.c \
 	modhash.h \
 	modservice.c \

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -72,6 +72,7 @@ libbroker_la_SOURCES = \
 
 flux_broker_LDADD = \
 	$(builddir)/libbroker.la \
+	$(top_builddir)/src/modules/connector-local/libconnector-local.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libzmqutil/libzmqutil.la \
 	$(top_builddir)/src/common/libflux/libflux.la \

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -495,20 +495,13 @@ int main (int argc, char *argv[])
         goto cleanup;
     }
 
-    /* Load the local connector module.
+    /* Load the builtin modules, including the local connector module.
      * Other modules will be loaded in rc1 using flux module,
      * which uses the local connector.
-     * The shutdown protocol unloads it.
+     * The shutdown protocol unloads the builtin modules.
      */
-    if (ctx.verbose > 1)
-        log_msg ("loading connector-local");
-    if (modhash_load (ctx.modhash,
-                      NULL,
-                      "connector-local",
-                      NULL,
-                      NULL,
-                      &error) < 0) {
-        log_err ("load_module connector-local: %s", error.text);
+    if (modhash_load_builtins (ctx.modhash, &error) < 0) {
+        log_err ("error loading builtins: %s", error.text);
         goto cleanup;
     }
 

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -736,30 +736,16 @@ module_t *modhash_lookup (modhash_t *mh, const char *uuid)
 
 module_t *modhash_lookup_byname (modhash_t *mh, const char *name)
 {
-    zlist_t *uuids;
-    char *uuid;
-    module_t *result = NULL;
-
-    if (!name)
-        return NULL;
-    if (!(uuids = zhash_keys (mh->zh_byuuid))) {
-        errno = ENOMEM;
-        return NULL;
-    }
-    uuid = zlist_first (uuids);
-    while (uuid) {
-        module_t *p = zhash_lookup (mh->zh_byuuid, uuid);
-        if (p) {
+    if (name) {
+        module_t *p = zhash_first (mh->zh_byuuid);
+        while (p) {
             if (streq (module_get_name (p), name)
-                || streq (module_get_path (p), name)) {
-                result = p;
-                break;
-            }
+                || streq (module_get_path (p), name))
+                return p;
+            p = zhash_next (mh->zh_byuuid);
         }
-        uuid = zlist_next (uuids);
     }
-    zlist_destroy (&uuids);
-    return result;
+    return NULL;
 }
 
 int modhash_event_mcast (modhash_t *mh, const flux_msg_t *msg)

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -309,7 +309,6 @@ int modhash_load (modhash_t *mh,
                              overlay_get_uuid (mh->ctx->overlay),
                              name,
                              path,
-                             mh->ctx->rank,
                              args,
                              error)))
         goto error;

--- a/src/broker/modhash.h
+++ b/src/broker/modhash.h
@@ -52,12 +52,15 @@ module_t *modhash_lookup_byname (modhash_t *mh, const char *name);
 module_t *modhash_first (modhash_t *mh);
 module_t *modhash_next (modhash_t *mh);
 
-int modhash_load (modhash_t *mh,
-                  const char *name,
-                  const char *path,
-                  json_t *args,
-                  const flux_msg_t *request,
-                  flux_error_t *error);
+/* Initiate load of all builtin modules.
+ * Plumbing works immedediately upon success, but startup is asynchronous.
+ */
+int modhash_load_builtins (modhash_t *mh, flux_error_t *error);
+
+/* Initiate unload of all builtin modules.  Fulfill the returned future
+ * upon completion. The future is owned by modhash and should not be destroyed.
+ */
+flux_future_t *modhash_unload_builtins (modhash_t *mh);
 
 /* Add/remove an auxiliary service name that will be routed
  * to the module with the specified uuid.

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -51,21 +51,28 @@ static modservice_ctx_t *getctx (flux_t *h, module_t *p)
     return ctx;
 }
 
-static void shutdown_cb (flux_t *h, flux_msg_handler_t *mh,
-                         const flux_msg_t *msg, void *arg)
+static void shutdown_cb (flux_t *h,
+                         flux_msg_handler_t *mh,
+                         const flux_msg_t *msg,
+                         void *arg)
 {
     flux_reactor_stop (flux_get_reactor (h));
 }
 
-static void debug_cb (flux_t *h, flux_msg_handler_t *mh,
-                      const flux_msg_t *msg, void *arg)
+static void debug_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
 {
     int flags;
     int *debug_flags;
     const char *op;
 
-    if (flux_request_unpack (msg, NULL, "{s:s s:i}", "op", &op,
-                                                     "flags", &flags) < 0)
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s:i}",
+                             "op", &op,
+                             "flags", &flags) < 0)
         goto error;
     if (!(debug_flags = flux_aux_get (h, "flux::debug_flags"))) {
         if (!(debug_flags = calloc (1, sizeof (*debug_flags)))) {
@@ -97,8 +104,10 @@ error:
 /* Reactor loop is about to block.
  * Notify broker that module is running, then disable the prepare watcher.
  */
-static void prepare_cb (flux_reactor_t *r, flux_watcher_t *w,
-                        int revents, void *arg)
+static void prepare_cb (flux_reactor_t *r,
+                        flux_watcher_t *w,
+                        int revents,
+                        void *arg)
 {
     modservice_ctx_t *ctx = arg;
 

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -40,10 +40,8 @@ static modservice_ctx_t *getctx (flux_t *h, module_t *p)
     modservice_ctx_t *ctx = flux_aux_get (h, "flux::modservice");
 
     if (!ctx) {
-        if (!(ctx = calloc (1, sizeof (*ctx)))) {
-            errno = ENOMEM;
+        if (!(ctx = calloc (1, sizeof (*ctx))))
             return NULL;
-        }
         ctx->h = h;
         ctx->p = p;
         flux_aux_set (h, "flux::modservice", ctx, freectx);
@@ -75,10 +73,8 @@ static void debug_cb (flux_t *h,
                              "flags", &flags) < 0)
         goto error;
     if (!(debug_flags = flux_aux_get (h, "flux::debug_flags"))) {
-        if (!(debug_flags = calloc (1, sizeof (*debug_flags)))) {
-            errno = ENOMEM;
+        if (!(debug_flags = calloc (1, sizeof (*debug_flags))))
             goto error;
-        }
         flux_aux_set (h, "flux::debug_flags", debug_flags, free);
     }
     if (streq (op, "setbit"))

--- a/src/broker/modservice.h
+++ b/src/broker/modservice.h
@@ -13,7 +13,7 @@
 
 #include "module.h"
 
-int modservice_register (flux_t *h, module_t *p);
+int modservice_register (flux_t *h);
 
 #endif /* !_BROKER_MODSERVICE_H */
 

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -53,7 +53,6 @@ struct broker_module {
 
     uuid_t uuid;            /* uuid for unique request sender identity */
     char uuid_str[UUID_STR_LEN];
-    char *parent_uuid_str;
     int rank;
     json_t *attr_cache;     /* attrs to be cached in module flux_t */
     flux_conf_t *conf;
@@ -346,9 +345,6 @@ module_t *module_create (flux_t *h,
     p->h = h;
     if (!(p->conf = flux_conf_copy (flux_get_conf (h))))
         goto cleanup;
-    if (!(p->parent_uuid_str = strdup (parent_uuid)))
-        goto nomem;
-    strncpy (p->uuid_str, parent_uuid, sizeof (p->uuid_str) - 1);
     if (args) {
         size_t index;
         json_t *entry;
@@ -564,7 +560,6 @@ void module_destroy (module_t *p)
     free (p->argz);
     free (p->name);
     free (p->path);
-    free (p->parent_uuid_str);
     flux_conf_decref (p->conf);
     json_decref (p->attr_cache);
     flux_msglist_destroy (p->rmmod_requests);

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -60,7 +60,6 @@ struct broker_module {
     bool mod_main_failed;
     int mod_main_errno;
     char *name;
-    char *path;             /* retain the full path as a key for lookup */
     void *dso;              /* reference on dlopened module */
     int argc;
     char **argv;
@@ -356,8 +355,7 @@ module_t *module_create (flux_t *h,
     if (!(p->argv = calloc (1, sizeof (p->argv[0]) * (p->argc + 1))))
         goto nomem;
     argz_extract (p->argz, p->argz_len, p->argv);
-    if (!(p->path = strdup (path))
-        || !(p->rmmod_requests = flux_msglist_create ())
+    if (!(p->rmmod_requests = flux_msglist_create ())
         || !(p->insmod_requests = flux_msglist_create ()))
         goto nomem;
     if (name) {
@@ -419,11 +417,6 @@ nomem:
 cleanup:
     module_destroy (p);
     return NULL;
-}
-
-const char *module_get_path (module_t *p)
-{
-    return p && p->path ? p->path : "unknown";
 }
 
 const char *module_get_name (module_t *p)
@@ -556,7 +549,6 @@ void module_destroy (module_t *p)
     free (p->argv);
     free (p->argz);
     free (p->name);
-    free (p->path);
     flux_conf_decref (p->conf);
     json_decref (p->attr_cache);
     flux_msglist_destroy (p->rmmod_requests);

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -56,7 +56,7 @@ struct broker_module {
     json_t *attr_cache;     /* attrs to be cached in module flux_t */
     flux_conf_t *conf;
     pthread_t t;            /* module thread */
-    mod_main_f *main;       /* dlopened mod_main() */
+    mod_main_f main;        /* dlopened mod_main() */
     bool mod_main_failed;
     int mod_main_errno;
     char *name;
@@ -318,7 +318,7 @@ module_t *module_create (flux_t *h,
     module_t *p;
     void *dso;
     const char **mod_namep;
-    mod_main_f *mod_main;
+    mod_main_f mod_main;
 
     dlerror ();
     if (!(dso = dlopen (path, RTLD_NOW | RTLD_GLOBAL | plugin_deepbind ()))) {

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -184,6 +184,13 @@ static void *module_thread (void *arg)
         log_err ("flux_open %s", uri);
         goto done;
     }
+    /* Set flux::uuid and flux::name per RFC 5
+     */
+    if (flux_aux_set (ctx.h, "flux::uuid", p->uuid_str, NULL) < 0
+        || flux_aux_set (ctx.h, "flux::name", p->name, NULL) < 0) {
+        log_err ("%s: error setting flux:: attributes", p->name);
+        goto done;
+    }
     if (attr_cache_from_json (ctx.h, p->attr_cache) < 0) {
         log_err ("%s: error priming broker attribute cache", p->name);
         goto done;
@@ -194,7 +201,7 @@ static void *module_thread (void *arg)
         goto done;
     }
     p->conf = NULL; // flux_set_conf() transfers ownership to p->h_module_end
-    if (modservice_register (ctx.h, p) < 0) {
+    if (modservice_register (ctx.h) < 0) {
         log_err ("%s: modservice_register", p->name);
         goto done;
     }

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -53,7 +53,6 @@ struct broker_module {
 
     uuid_t uuid;            /* uuid for unique request sender identity */
     char uuid_str[UUID_STR_LEN];
-    int rank;
     json_t *attr_cache;     /* attrs to be cached in module flux_t */
     flux_conf_t *conf;
     pthread_t t;            /* module thread */
@@ -315,7 +314,6 @@ module_t *module_create (flux_t *h,
                          const char *parent_uuid,
                          const char *name, // may be NULL
                          const char *path,
-                         int rank,
                          json_t *args,
                          flux_error_t *error)
 {
@@ -341,7 +339,6 @@ module_t *module_create (flux_t *h,
         goto nomem;
     p->main = mod_main;
     p->dso = dso;
-    p->rank = rank;
     p->h = h;
     if (!(p->conf = flux_conf_copy (flux_get_conf (h))))
         goto cleanup;

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -61,11 +61,6 @@ int module_disconnect_arm (module_t *p,
                            disconnect_send_f cb,
                            void *arg);
 
-int module_push_rmmod (module_t *p, const flux_msg_t *msg);
-const flux_msg_t *module_pop_rmmod (module_t *p);
-int module_push_insmod (module_t *p, const flux_msg_t *msg);
-const flux_msg_t *module_pop_insmod (module_t *p);
-
 /* Get/set module status.
  */
 void module_set_status (module_t *p, int status);

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -32,8 +32,8 @@ typedef int (*mod_main_f)(flux_t *h, int argc, char *argv[]);
 
 module_t *module_create (flux_t *h,
                          const char *parent_uuid,
-                         const char *name, // may be NULL
-                         const char *path,
+                         const char *name,
+                         mod_main_f mod_main,
                          json_t *args,
                          flux_error_t *error);
 void module_destroy (module_t *p);

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -28,7 +28,7 @@ enum {
 typedef struct broker_module module_t;
 typedef void (*modpoller_cb_f)(module_t *p, void *arg);
 typedef void (*module_status_cb_f)(module_t *p, int prev_status, void *arg);
-typedef int (mod_main_f)(flux_t *h, int argc, char *argv[]);
+typedef int (*mod_main_f)(flux_t *h, int argc, char *argv[]);
 
 module_t *module_create (flux_t *h,
                          const char *parent_uuid,

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -16,9 +16,19 @@
 
 #include "src/common/librouter/disconnect.h"
 
+/* Module states, for embedding in keepalive messages (rfc 5)
+ */
+enum {
+    FLUX_MODSTATE_INIT           = 0,
+    FLUX_MODSTATE_RUNNING        = 1,
+    FLUX_MODSTATE_FINALIZING     = 2,
+    FLUX_MODSTATE_EXITED         = 3,
+};
+
 typedef struct broker_module module_t;
 typedef void (*modpoller_cb_f)(module_t *p, void *arg);
 typedef void (*module_status_cb_f)(module_t *p, int prev_status, void *arg);
+typedef int (mod_main_f)(flux_t *h, int argc, char *argv[]);
 
 module_t *module_create (flux_t *h,
                          const char *parent_uuid,

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -24,7 +24,6 @@ module_t *module_create (flux_t *h,
                          const char *parent_uuid,
                          const char *name, // may be NULL
                          const char *path,
-                         int rank,
                          json_t *args,
                          flux_error_t *error);
 void module_destroy (module_t *p);

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -31,7 +31,6 @@ void module_destroy (module_t *p);
 /* accessors
  */
 const char *module_get_name (module_t *p);
-const char *module_get_path (module_t *p);
 const char *module_get_uuid (module_t *p);
 double module_get_lastseen (module_t *p);
 

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -36,6 +36,11 @@ struct module_args {
     mod_main_f main;
 };
 
+struct module_builtin {
+    const char *name;
+    mod_main_f main;
+};
+
 module_t *module_create (flux_t *h,
                          const char *parent_uuid,
                          const char *name,

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -30,6 +30,12 @@ typedef void (*modpoller_cb_f)(module_t *p, void *arg);
 typedef void (*module_status_cb_f)(module_t *p, int prev_status, void *arg);
 typedef int (*mod_main_f)(flux_t *h, int argc, char *argv[]);
 
+struct module_args {
+    char *uuid;
+    char *name;
+    mod_main_f main;
+};
+
 module_t *module_create (flux_t *h,
                          const char *parent_uuid,
                          const char *name,

--- a/src/broker/module_dso.c
+++ b/src/broker/module_dso.c
@@ -1,0 +1,125 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* module_dso.c - find/open/close a broker module dso */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <flux/core.h>
+#include <dlfcn.h>
+
+#include "src/common/libflux/plugin_private.h" // for plugin_deepbind()
+#include "src/common/libutil/dirwalk.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/basename.h"
+#include "ccan/str/str.h"
+
+#include "module_dso.h"
+
+char *module_dso_search (const char *name,
+                         const char *searchpath,
+                         flux_error_t *error)
+{
+    char *pattern;
+    zlist_t *files = NULL;
+    char *path;
+
+    if (asprintf (&pattern, "%s.so*", name) < 0) {
+        errprintf (error, "out of memory");
+        return NULL;
+    }
+    if (!(files = dirwalk_find (searchpath,
+                                DIRWALK_REALPATH | DIRWALK_NORECURSE,
+                                pattern,
+                                1,
+                                NULL,
+                                NULL))
+        || zlist_size (files) == 0) {
+        errprintf (error, "module not found in search path");
+        errno = ENOENT;
+        goto error;
+    }
+    if (!(path = strdup (zlist_first (files))))
+        goto error;
+    zlist_destroy (&files);
+    free (pattern);
+    return path;
+error:
+    ERRNO_SAFE_WRAP (zlist_destroy, &files);
+    ERRNO_SAFE_WRAP (free, pattern);
+    return NULL;
+};
+
+void module_dso_close (void *dso)
+{
+    int saved_errno = errno;
+#ifndef __SANITIZE_ADDRESS__
+    dlclose (dso);
+#endif
+    errno = saved_errno;
+}
+
+/* Open DSO and set mod_mainp to the module's mod_main() function.
+ * If the module defines the legacy mod_name symbol, make sure it's
+ * the same as 'name'.
+ * The caller must dlclose() the returned DSO pointer once mod_main()
+ * is no longer needed.
+ */
+void *module_dso_open (const char *path,
+                       const char *name, // check only
+                       mod_main_f *mod_mainp,
+                       flux_error_t *error)
+{
+    void *dso;
+    mod_main_f mod_main;
+    const char **mod_name;
+
+    dlerror ();
+    if (!(dso = dlopen (path, RTLD_NOW | RTLD_GLOBAL | plugin_deepbind ()))) {
+        errprintf (error, "%s", dlerror ());
+        errno = ENOENT;
+        return NULL;
+    }
+    if (!(mod_main = dlsym (dso, "mod_main"))) {
+        errprintf (error, "module does not define mod_main()");
+        errno = EINVAL;
+        goto error;
+    }
+    if (name && (mod_name = dlsym (dso, "mod_name")) && *mod_name != NULL) {
+        if (!streq (*mod_name, name)) {
+            errprintf (error, "mod_name %s != name %s", *mod_name, name);
+            errno = EINVAL;
+            goto error;
+        }
+    }
+    *mod_mainp = mod_main;
+    return dso;
+error:
+    ERRNO_SAFE_WRAP (dlclose, dso);
+    return NULL;
+}
+
+char *module_dso_name (const char *path)
+{
+    char *name;
+    char *cp;
+
+    name = basename_simple (path);
+    // if path ends in .so or .so.VERSION, strip it off
+    if ((cp = strstr (name, ".so")))
+        return strndup (name, cp - name);
+    return strdup (name);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/broker/module_dso.h
+++ b/src/broker/module_dso.h
@@ -1,0 +1,48 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _BROKER_MODULE_DSO_H
+#define _BROKER_MODULE_DSO_H
+
+#include <flux/core.h>
+
+#include "module.h"
+
+/* Search 'searchpath', a colon-separated list of directories, for a file
+ * whose path matches the pattern "name.so*".  Return its full path (caller
+ * must free).
+ */
+char *module_dso_search (const char *name,
+                         const char *searchpath,
+                         flux_error_t *error);
+
+/* dlopen(3) the DSO at path and fetch a pointer to a symbol named 'mod_main'.
+ * Optional:  if name is set and 'mod_name' is defined in the dso, fail if
+ * they do not match.  This is a sanity check that modules still using the
+ * deprecated mod_name symbol are at least setting it to the expected value.
+ * The open DSO is returned.  Call module_dso_close() when done with it.
+ */
+void *module_dso_open (const char *path,
+                       const char *name,
+                       mod_main_f *mod_mainp,
+                       flux_error_t *error);
+
+/* Call dlclose(3) if not using the address sanitizer.  Preserve errno.
+ */
+void module_dso_close (void *dso);
+
+/* Guess the broker module's name based on its path.
+ * Caller must free the returned string.
+ */
+char *module_dso_name (const char *path);
+
+#endif /* !_BROKER_MODULE_DSO_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/broker/module_thread.c
+++ b/src/broker/module_thread.c
@@ -1,0 +1,286 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#ifdef HAVE_ARGZ_ADD
+#include <argz.h>
+#else
+#include "src/common/libmissing/argz.h"
+#endif
+#include <signal.h>
+#include <pthread.h>
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/aux.h"
+#include "ccan/str/str.h"
+
+#include "module.h"
+#include "modservice.h"
+
+struct module_ctx {
+    flux_t *h;
+    bool mod_main_failed;
+    int mod_main_errno;
+    int argc;
+    char **argv;
+    size_t argz_len;
+    char *argz;
+};
+
+static void module_thread_cleanup (void *arg);
+
+static int setup_module_profiling (const char *name)
+{
+    size_t len = strlen (name);
+    // one character longer than target to pass -Wstringop-truncation
+    char local_name[17] = {0};
+    const char *name_ptr = name;
+    // pthread name is limited to 16 bytes including \0 on linux
+    if (len > 15) {
+        strncpy (local_name, name, 16);
+        local_name[15] = 0;
+        name_ptr = local_name;
+    }
+    // Set the name of each thread to its module name
+#if HAVE_PTHREAD_SETNAME_NP_WITH_TID
+    (void) pthread_setname_np (pthread_self (), name_ptr);
+#else // e.g. macos
+    (void) pthread_setname_np (name_ptr);
+#endif
+    return (0);
+}
+
+static int attr_cache_from_json (flux_t *h, json_t *cache)
+{
+    const char *name;
+    json_t *o;
+
+    json_object_foreach (cache, name, o) {
+        const char *val = json_string_value (o);
+        if (flux_attr_set_cacheonly (h, name, val) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+/* Decode welcome message and
+ * - set ctx->argc, ctx->argv
+ * - populate the broker attr cache in ctx->h
+ * This is called from the module thread.
+ */
+static int welcome_decode_new (struct module_ctx *ctx, flux_msg_t **msg)
+{
+    json_t *args;
+    json_t *attrs;
+    json_t *conf;
+
+    if (flux_request_unpack (*msg,
+                             NULL,
+                             "{s:o s:o s:o}",
+                             "args", &args,
+                             "attrs", &attrs,
+                             "conf", &conf) < 0)
+        return -1;
+
+    if (attr_cache_from_json (ctx->h, attrs) < 0)
+        goto error;
+
+    flux_conf_t *cf;
+    if (!(cf = flux_conf_pack ("O", conf))
+        || flux_set_conf (ctx->h, cf) < 0) {
+        flux_conf_decref (cf);
+        goto error;
+    }
+
+    if (!json_is_null (args)) {
+        size_t index;
+        json_t *entry;
+
+        json_array_foreach (args, index, entry) {
+            const char *s = json_string_value (entry);
+            if (s && (argz_add (&ctx->argz, &ctx->argz_len, s) != 0)) {
+                errno = ENOMEM;
+                goto error;
+            }
+        }
+    }
+    ctx->argc = argz_count (ctx->argz, ctx->argz_len);
+    if (!(ctx->argv = calloc (1, sizeof (ctx->argv[0]) * (ctx->argc + 1))))
+        goto error;
+    argz_extract (ctx->argz, ctx->argz_len, ctx->argv);
+
+    flux_msg_decref (*msg);
+    *msg = NULL;
+    return 0;
+error:
+    return -1;
+}
+
+/*  Synchronize the FINALIZING state with the broker, so the broker
+ *   can stop messages to this module until we're fully shutdown.
+ */
+static int module_finalizing (flux_t *h, double timeout)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_rpc_pack (h,
+                             "module.status",
+                             FLUX_NODEID_ANY,
+                             0,
+                             "{s:i}",
+                             "status", FLUX_MODSTATE_FINALIZING))
+        || flux_future_wait_for (f, timeout) < 0
+        || flux_rpc_get (f, NULL)) {
+        flux_log_error (h, "module.status FINALIZING error");
+        flux_future_destroy (f);
+        return -1;
+    }
+    flux_future_destroy (f);
+    return 0;
+}
+
+void *module_thread (void *arg)
+{
+    struct module_args *args = arg;
+    sigset_t signal_set;
+    int errnum;
+    struct module_ctx ctx;
+    struct flux_match match = {
+        .typemask = FLUX_MSGTYPE_REQUEST,
+        .matchtag = FLUX_MATCHTAG_NONE,
+        .topic_glob = "welcome",
+    };
+
+    memset (&ctx, 0, sizeof (ctx));
+    pthread_cleanup_push (module_thread_cleanup, &ctx);
+
+    setup_module_profiling (args->name);
+
+    /* Connect to broker socket, enable logging, register built-in services
+     */
+    char uri[128];
+    (void)snprintf (uri, sizeof (uri), "interthread://%s", args->uuid);
+    if (!(ctx.h = flux_open (uri, 0))) {
+        log_err ("%s: flux_open %s", args->name, uri);
+        goto done;
+    }
+    flux_log_set_appname (ctx.h, args->name);
+
+    /* Set flux::uuid and flux::name per RFC 5
+     */
+    if (flux_aux_set (ctx.h, "flux::uuid", (char *)args->uuid, NULL) < 0
+        || flux_aux_set (ctx.h, "flux::name", args->name, NULL) < 0) {
+        log_err ("%s: error setting flux:: attributes", args->name);
+        goto done;
+    }
+    /* Receive welcome message
+     */
+    flux_msg_t *msg;
+    if (!(msg = flux_recv (ctx.h, match, 0))
+        || welcome_decode_new (&ctx, (flux_msg_t **)&msg) < 0) {
+        flux_msg_decref (msg);
+        log_err ("%s: welcome failure", args->name);
+        goto done;
+    }
+    /* Register services
+     */
+    if (modservice_register (ctx.h) < 0) {
+        log_err ("%s: modservice_register", args->name);
+        goto done;
+    }
+
+    /* Block all signals
+     */
+    if (sigfillset (&signal_set) < 0) {
+        log_err ("%s: sigfillset", args->name);
+        goto done;
+    }
+    if ((errnum = pthread_sigmask (SIG_BLOCK, &signal_set, NULL)) != 0) {
+        log_errn (errnum, "pthread_sigmask");
+        goto done;
+    }
+
+
+    /* Run the module's main().
+     */
+    if (args->main (ctx.h, ctx.argc, ctx.argv) < 0) {
+        ctx.mod_main_failed = true;
+        ctx.mod_main_errno = errno;
+    }
+done:
+    pthread_cleanup_pop (1);
+
+    return NULL;
+}
+
+/* This function is invoked in the module thread context in one of two ways:
+ * - module_thread() calls pthread_cleanup_pop(3) upon return of mod_main()
+ * - pthread_cancel(3) terminates the module thread at a cancellation point
+ * pthread_cancel(3) can be called in two situations:
+ * - flux module remove --cancel
+ * - when modhash_destroy() is called with lingering modules
+ * Since modhash_destroy() is called after exiting the broker reactor loop,
+ * the broker won't be responsive to any RPCs from this module thread.
+ */
+static void module_thread_cleanup (void *arg)
+{
+    struct module_ctx *ctx = arg;
+    flux_msg_t *msg;
+    flux_future_t *f;
+
+    if (ctx->mod_main_failed) {
+        if (ctx->mod_main_errno == 0)
+            ctx->mod_main_errno = ECONNRESET;
+        flux_log (ctx->h, LOG_CRIT, "module exiting abnormally");
+    }
+
+    /* Before processing unhandled requests, ensure that this module
+     * is "muted" in the broker. This ensures the broker won't try to
+     * feed a message to this module after we've closed the handle,
+     * which could cause the broker to block.
+     */
+    if (module_finalizing (ctx->h, 1.0) < 0)
+        flux_log_error (ctx->h, "failed to set module state to finalizing");
+
+    /* If any unhandled requests were received during shutdown,
+     * respond to them now with ENOSYS.
+     */
+    while ((msg = flux_recv (ctx->h, FLUX_MATCH_REQUEST, FLUX_O_NONBLOCK))) {
+        const char *topic = "unknown";
+        (void)flux_msg_get_topic (msg, &topic);
+        flux_log (ctx->h, LOG_DEBUG, "responding to post-shutdown %s", topic);
+        if (flux_respond_error (ctx->h, msg, ENOSYS, NULL) < 0)
+            flux_log_error (ctx->h, "responding to post-shutdown %s", topic);
+        flux_msg_destroy (msg);
+    }
+    if (!(f = flux_rpc_pack (ctx->h,
+                             "module.status",
+                             FLUX_NODEID_ANY,
+                             FLUX_RPC_NORESPONSE,
+                             "{s:i s:i}",
+                             "status", FLUX_MODSTATE_EXITED,
+                             "errnum", ctx->mod_main_errno))) {
+        flux_log_error (ctx->h, "module.status EXITED error");
+        goto done;
+    }
+    flux_future_destroy (f);
+done:
+    flux_close (ctx->h);
+    free (ctx->argz);
+    free (ctx->argv);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -37,6 +37,7 @@
 
 #include <assert.h>
 
+#include "src/broker/module.h"
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/oom.h"

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -483,6 +483,42 @@ int flux_conf_unpack (const flux_conf_t *conf,
     return rc;
 }
 
+flux_conf_t *flux_conf_vpack (const char *fmt, va_list ap)
+{
+    flux_conf_t *conf;
+
+    if (!fmt) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(conf = flux_conf_create ()))
+        return NULL;
+    json_decref (conf->obj);
+    if (!(conf->obj = json_vpack_ex (NULL, 0, fmt, ap))) {
+        flux_conf_decref (conf);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    return conf;
+}
+
+flux_conf_t *flux_conf_pack (const char *fmt, ...)
+{
+    va_list ap;
+    flux_conf_t *conf;
+
+    if (!fmt) {
+        errno = EINVAL;
+        return NULL;
+    }
+    va_start (ap, fmt);
+    conf = flux_conf_vpack (fmt, ap);
+    va_end (ap);
+
+    return conf;
+}
+
 int flux_conf_reload_decode (const flux_msg_t *msg, const flux_conf_t **confp)
 {
     const char *auxkey = "flux::conf";

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -71,6 +71,9 @@ int flux_conf_unpack (const flux_conf_t *conf,
                       const char *fmt,
                       ...);
 
+flux_conf_t *flux_conf_vpack (const char *fmt, va_list ap);
+flux_conf_t *flux_conf_pack (const char *fmt, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -19,6 +19,7 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/dirwalk.h"
+#include "src/broker/module.h"
 
 bool flux_module_debug_test (flux_t *h, int flag, bool clear)
 {

--- a/src/common/libflux/module.h
+++ b/src/common/libflux/module.h
@@ -18,19 +18,7 @@
 extern "C" {
 #endif
 
-/* Module states, for embedding in keepalive messages (rfc 5)
- */
-enum {
-    FLUX_MODSTATE_INIT           = 0,
-    FLUX_MODSTATE_RUNNING        = 1,
-    FLUX_MODSTATE_FINALIZING     = 2,
-    FLUX_MODSTATE_EXITED         = 3,
-};
-
-/* Mandatory symbols for modules
- */
 #define MOD_NAME(x) const char *mod_name = x
-typedef int (mod_main_f)(flux_t *h, int argc, char *argv[]);
 
 /* Test and optionally clear module debug bit from within a module, as
  * described in RFC 5.  Return true if 'flag' bit is set.  If clear=true,

--- a/src/common/libflux/module.h
+++ b/src/common/libflux/module.h
@@ -18,6 +18,9 @@
 extern "C" {
 #endif
 
+/* The mod_name symbol in broker modules is deprecated.
+ * This is not for use in new code.
+ */
 #define MOD_NAME(x) const char *mod_name = x
 
 /* Test and optionally clear module debug bit from within a module, as

--- a/src/common/libflux/test/conf.c
+++ b/src/common/libflux/test/conf.c
@@ -437,6 +437,24 @@ void test_globerr (void)
         "conf_globerr pat=oops rc=666 sets errno and error as expected");
 }
 
+void test_pack (void)
+{
+    flux_conf_t *conf;
+
+    errno = 0;
+    ok (flux_conf_pack (NULL) == NULL && errno == EINVAL,
+        "flux_conf_pack fmt=NULL fails with EINVAL");
+
+    conf = flux_conf_pack ("{s:i}", "foo", 42);
+    ok (conf != NULL,
+        "flux_conf_pack works");
+    int i;
+    ok (flux_conf_unpack (conf, NULL, "{s:i}", "foo", &i) == 0 && i == 42,
+        "flux_conf_unpack has expected result");
+
+    flux_conf_decref (conf);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -447,6 +465,7 @@ int main (int argc, char *argv[])
     test_basic (); // flux_conf_parse(), flux_conf_decref(), flux_conf_unpack()
     test_in_handle ();
     test_globerr ();
+    test_pack();
 
     done_testing ();
 }

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -14,6 +14,7 @@ AM_CPPFLAGS = \
 	$(JANSSON_CFLAGS)
 
 SUBDIRS = \
+	connector-local \
 	kvs \
 	content-files \
 	job-ingest \
@@ -25,7 +26,6 @@ SUBDIRS = \
 
 fluxmod_LTLIBRARIES = \
 	barrier.la \
-	connector-local.la \
 	content.la \
 	content-files.la \
 	content-sqlite.la \
@@ -54,13 +54,6 @@ barrier_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la
 barrier_la_LDFLAGS = $(fluxmod_ldflags) -module
-
-connector_local_la_SOURCES = \
-	connector-local/local.c
-connector_local_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la
-connector_local_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 content_la_SOURCES = \
 	content/main.c \

--- a/src/modules/connector-local/Makefile.am
+++ b/src/modules/connector-local/Makefile.am
@@ -1,0 +1,19 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	$(CODE_COVERAGE_CPPFLAGS) \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/librouter \
+	-I$(top_builddir)/src/common/libflux \
+	$(JANSSON_CFLAGS)
+
+noinst_LTLIBRARIES = libconnector-local.la
+
+libconnector_local_la_SOURCES = \
+	local.c

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -33,6 +33,7 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/librouter/usock.h"
 #include "src/common/librouter/router.h"
+#include "src/broker/module.h"
 
 enum {
     DEBUG_AUTHFAIL_ONESHOT = 1, /* force auth to fail one time */
@@ -208,9 +209,9 @@ error:
  * Missing [access] keys are interpreted as false.
  * [access] keys other than the above are not allowed.
  */
-int parse_config (struct connector_local *ctx,
-                  const flux_conf_t *conf,
-                  flux_error_t *errp)
+static int parse_config (struct connector_local *ctx,
+                         const flux_conf_t *conf,
+                         flux_error_t *errp)
 {
     flux_error_t error;
     int allow_guest_user = 0;
@@ -275,7 +276,7 @@ static const struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
-int mod_main (flux_t *h, int argc, char **argv)
+static int mod_main (flux_t *h, int argc, char **argv)
 {
     struct connector_local ctx;
     const char *local_uri = NULL;
@@ -342,6 +343,11 @@ done:
     router_destroy (ctx.router);
     return rc;
 }
+
+struct module_builtin builtin_connector_local = {
+    .name = "connector-local",
+    .main = mod_main,
+};
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/content/main.c
+++ b/src/modules/content/main.c
@@ -37,6 +37,4 @@ done:
     return rc;
 }
 
-MOD_NAME ("content");
-
 // vi:ts=4 sw=4 expandtab

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -1387,6 +1387,4 @@ error:
     return rc;
 }
 
-MOD_NAME (MODULE_NAME);
-
 // vi:ts=4 sw=4 expandtab

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -14,7 +14,7 @@ invalid_rank() {
 	echo $((${SIZE} + 1))
 }
 
-testmod=${FLUX_BUILD_DIR}/t/module/.libs/testmod.so
+testmod=$(realpath ${FLUX_BUILD_DIR}/t/module/.libs/testmod.so)
 legacy=${FLUX_BUILD_DIR}/t/module/.libs/legacy.so
 hangmod=${FLUX_BUILD_DIR}/t/module/.libs/hang.so
 

--- a/t/t1102-cmddriver.t
+++ b/t/t1102-cmddriver.t
@@ -126,17 +126,19 @@ test_expect_success 'cmddriver adds its own path to PATH' '
 	true
 	EOF
 	chmod +x bin/flux &&
-	fluxcmd=$(command -v flux) &&
-	result=$(PATH=$(pwd)/bin:/bin:/usr/bin \
+	fluxcmd=$(realpath $(command -v flux)) &&
+	testbin=$(realpath ./bin) &&
+	result=$(PATH=$testbin:/bin:/usr/bin \
 	         $fluxcmd env sh -c "command -v flux") &&
 	test_debug "echo result=$result" &&
 	test "$result" = "$fluxcmd"
 '
+
 # Use bogus flux in PATH and ensure flux cmddriver inserts its own path
 # just before this path, not at front of PATH.
 test_expect_success 'cmddriver inserts its path at end of PATH' '
 	fluxdir=$(dirname $fluxcmd) &&
-	result=$(PATH=/foo:$(pwd)/bin:/bin:/usr/bin \
+	result=$(PATH=/foo:$testbin:/bin:/usr/bin \
 	         $fluxcmd env printenv PATH) &&
 	test_debug "echo result=$result" &&
 	test "$result" = "/foo:$fluxdir:$(pwd)/bin:/bin:/usr/bin"


### PR DESCRIPTION
Last week, I set out to make some headway on adding an option to load broker modules in a separate process address space, but all I ended up accomplishing was some refactoring to disentangle the existing module code.

Regardless of the approach we eventually take for the original goal, I think this refactoring work is probably worth doing.  It was some really old code.

As a bonus, "builtin modules" are implemented, similar to the shell's, and `connector-local` is now compiled in.