### PR TITLE
flux-fsck: support --scan option

### DIFF
--- a/doc/man1/common/job-other-batch.rst
+++ b/doc/man1/common/job-other-batch.rst
@@ -1,6 +1,6 @@
 .. option:: --conf=FILE|KEY=VAL|STRING|NAME
 
-   The :option:`--conf`` option allows configuration for a Flux instance
+   The :option:`--conf` option allows configuration for a Flux instance
    started via ``flux-batch(1)`` or ``flux-alloc(1)`` to be iteratively built
    on the command line. On first use, a ``conf.json`` entry is added to the
    internal jobspec file archive, and ``-c{{tmpdir}}/conf.json`` is added

--- a/doc/man1/flux-fsck.rst
+++ b/doc/man1/flux-fsck.rst
@@ -49,6 +49,13 @@ OPTIONS
    contain any errors, checkpoint that root reference to the be new
    checkpointed root reference.
 
+.. option:: -S, --scan
+
+   Iterate through all checkpoints to find the most recent checkpoint that
+   passes fsck integrity checks.  The index and root reference of the
+   checkpoint will be output at the end.  If used in conjunction with
+   :option:`--checkpoint`, the discovered checkpoint will be updated.
+
 
 EXIT STATUS
 ===========

--- a/doc/man1/flux-fsck.rst
+++ b/doc/man1/flux-fsck.rst
@@ -40,6 +40,12 @@ OPTIONS
    checkpoint.  This option directs flux-fsck to start at an arbitrary
    point.  BLOBREF must refer to an RFC 11 tree object of type "dir".
 
+.. option:: -c, --checkpoint
+
+   If a root reference specified by :option:`--rootref` does not
+   contain any errors, checkpoint that root reference to the be new
+   checkpointed root reference.
+
 
 EXIT STATUS
 ===========

--- a/doc/man1/flux-fsck.rst
+++ b/doc/man1/flux-fsck.rst
@@ -34,11 +34,14 @@ OPTIONS
 
    Don't output diagnostic messages and discovered errors.
 
-.. option:: -r, --rootref=BLOBREF
+.. option:: -r, --rootref=<BLOBREF|index>
 
    Normally the check starts with the blobref in the most recent KVS
-   checkpoint.  This option directs flux-fsck to start at an arbitrary
-   point.  BLOBREF must refer to an RFC 11 tree object of type "dir".
+   checkpoint.  This option can direct flux-fsck to start at an
+   arbitrary point by specifying a BLOBREF that points to an RFC 11
+   tree object of type "dir".  An numerical index can be direct
+   flux-fsck to start at an older checkpoint (i.e. 0 = use current checkpoint,
+   1 = checkpoint before current checkpoint, ...).
 
 .. option:: -c, --checkpoint
 

--- a/t/content/content-helper.sh
+++ b/t/content/content-helper.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 #
 
+CONTENT_RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
 # content module test helper functions
 
 # Get RPC message contents for checkpoint put
@@ -14,7 +16,7 @@ checkpoint_put_msg() {
 # Usage: checkpoint_put rootref
 checkpoint_put() {
 	o=$(checkpoint_put_msg $1)
-	jq -j -c -n ${o} | $RPC content.checkpoint-put
+	jq -j -c -n ${o} | ${CONTENT_RPC} content.checkpoint-put
 }
 
 # Get RPC message contents for checkpoint get
@@ -28,19 +30,19 @@ checkpoint_get_msg() {
 # Usage: checkpoint_get
 checkpoint_get() {
 	o=$(checkpoint_get_msg)
-	jq -j -c -n ${o} | $RPC content.checkpoint-get
+	jq -j -c -n ${o} | ${CONTENT_RPC} content.checkpoint-get
 }
 
 # Identical to checkpoint_put(), but go directly to backing store
 # Usage: checkpoint_put rootref
 checkpoint_backing_put() {
 	o=$(checkpoint_put_msg $1)
-	jq -j -c -n ${o} | $RPC content-backing.checkpoint-put
+	jq -j -c -n ${o} | ${CONTENT_RPC} content-backing.checkpoint-put
 }
 
 # Identical to checkpoint_get(), but go directly to backing store
 # Usage: checkpoint_get
 checkpoint_backing_get() {
 	o=$(checkpoint_get_msg)
-	jq -j -c -n ${o} | $RPC content-backing.checkpoint-get
+	jq -j -c -n ${o} | ${CONTENT_RPC} content-backing.checkpoint-get
 }

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -32,15 +32,11 @@ test_expect_success 'create some kvs content' '
 	flux kvs namespace create testns &&
 	flux kvs put --namespace=testns dir.a=testns
 '
-# N.B. startlog commands in rc scripts normally ensures a checkpoint
-# exists but we do this just to be extra sure
-test_expect_success 'call sync to ensure we have checkpointed' '
-	flux kvs sync
-'
 test_expect_success 'save some treeobjs for later' '
 	flux kvs get --treeobj dir.b > dirb.out &&
 	flux kvs get --treeobj dir.c > dirc.out
 '
+# N.B. kvs is checkpointed on unload of kvs
 test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
@@ -65,9 +61,7 @@ test_expect_success LONGTEST 'load kvs and create some kvs content' '
 	done &&
 	flux kvs get bigval > bigval.exp
 '
-test_expect_success LONGTEST 'call sync to ensure we have checkpointed' '
-	flux kvs sync
-'
+# N.B. kvs is checkpointed on unload of kvs
 test_expect_success LONGTEST 'unload kvs' '
 	flux module remove kvs
 '
@@ -87,9 +81,7 @@ test_expect_success 'make a reference invalid (dir.b)' '
 	flux kvs put --treeobj dir.b="$(cat dirbbad.out)" &&
 	flux kvs getroot -b > bbad.rootref
 '
-test_expect_success 'call sync to ensure we have checkpointed' '
-	flux kvs sync
-'
+# N.B. kvs is checkpointed on unload of kvs
 test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
@@ -123,9 +115,7 @@ test_expect_success 'make a reference invalid (dir.c)' '
 	flux kvs put --treeobj dir.c="$(cat dircbad2.out)" &&
 	flux kvs getroot -b > cbad.rootref
 '
-test_expect_success 'call sync to ensure we have checkpointed' '
-	flux kvs sync
-'
+# N.B. kvs is checkpointed on unload of kvs
 test_expect_success 'unload kvs' '
 	flux module remove kvs
 '

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -192,8 +192,20 @@ test_expect_success 'flux-fsck --rootref fails on non-existent ref' '
 	test_must_fail flux fsck --rootref=sha1-1234567890123456789012345678901234567890 2> rootref6.out &&
 	grep "Total errors: 1" rootref6.out
 '
+test_expect_success 'flux-fsck --rootref fails on bad checkpoints (c bad and b bad checkpoints)' '
+	test_must_fail flux fsck --verbose --rootref=0 &&
+	test_must_fail flux fsck --verbose --rootref=1 &&
+	test_must_fail flux fsck --verbose --rootref=-1
+'
+test_expect_success 'flux-fsck --rootref succeeds on good checkpoint' '
+	flux fsck --verbose --rootref=2 &&
+	flux fsck --verbose --rootref=-2
+'
 test_expect_success 'flux-fsck --rootref fails on invalid ref' '
 	test_must_fail flux fsck --rootref=lalalal
+'
+test_expect_success 'flux-fsck --rootref fails on invalid checkpoint index' '
+	test_must_fail flux fsck --rootref=999
 '
 #
 # --checkpoint tests


### PR DESCRIPTION
Built on top of #6395

Problem: Flux-fsck only allows you to fsck one root reference or checkpoint at a time.  It would be useful for fsck to find the most recent checkpoint that is valid.

Support a new --scan option that will iterate through all available checkpoints and find the most recent one that passes.

----

Notes:

- along w/ `--checkpoint` this'll update the checkpoint to the most recent good checkpoint it finds.

- I went back and forth on what to call this.  I considered "rollback", as well, but that implied `--checkpoint` vs specifying it on the command line.  Dunno if folks feel it should go the other way.