### PR TITLE
ci: add tmate action which can be enabled via debug flag when re-running jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,6 +130,9 @@ jobs:
       run: make check -j4 TESTS=
     - name: check what works so far
       run: scripts/check-macos.sh
+    - name: tmate debug
+      if: ${{ !cancelled() && runner.debug }}
+      uses: mxschmitt/action-tmate@v3
 
   generate-matrix:
     # https://stackoverflow.com/questions/59977364
@@ -209,6 +212,10 @@ jobs:
       timeout-minutes: ${{matrix.timeout_minutes}}
       env: ${{matrix.env}}
       run: ${{matrix.command}}
+
+    - name: tmate debug
+      if: ${{ !cancelled() && runner.debug }}
+      uses: mxschmitt/action-tmate@v3
 
     - name: annotate errors
       if: failure() || cancelled()

--- a/doc/guide/debug.rst
+++ b/doc/guide/debug.rst
@@ -68,7 +68,11 @@ CI failures
 Failures that occur only in a github CI workflow can be directly examined
 with `tmate access <https://mxschmitt.github.io/action-tmate/>`_.
 
-Example: temporarily patch a failing macos workflow:
+In flux-core, the tmate action can be enabled by restarting the workflow
+and selecting the "Enable debug logging" checkbox.
+
+For other framework projects, the tmate action can be temporarily patched
+into the workflows config as in the diff below for the macos workflow:
 
 .. code-block::
 


### PR DESCRIPTION
This PR permanently adds the tmate action to the github workflow. During normal runs, the tmate action is disabled. However, it can easily be enabled by selecting the "Enable debug" flag when re-running jobs.