### PR TITLE
etc: restore dropped support for `cron.directory` in rc1

### DIFF
--- a/etc/rc1.old
+++ b/etc/rc1.old
@@ -82,6 +82,25 @@ modload all job-ingest
 modload 0 job-exec
 modload all heartbeat
 
+# N.B.: copied from etc/rc1.d/02-cron
+# Load crontabs from directory if cron.directory attribute is set
+
+if test $RANK -eq 0 \
+	&& cron_dir=$(flux getattr cron.directory 2>/dev/null) \
+	&& test -d "$cron_dir"; then
+	shopt -s nullglob
+	for file in $cron_dir/*; do
+		if test -f $file; then
+			if ! flux cron tab <$file; then
+				echo "could not load crontab: $file" >&2
+				exit 1
+			fi
+		fi
+	done
+	shopt -u nullglob
+fi
+
+
 core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}
 IFS=:


### PR DESCRIPTION
I noticed this one while building RPMs for the latest release. If this gets merged I can just patch the RPM for now. Sorry :facepalm: 

Problem: Commit 87026681211cb175f2998ee00ca4b89691d56f74 moved support for loading crontabs (previously in `etc/rc1.d/02-cron`) to modprobe's rc1.py. However, commit 71efe36762587d312ccec886ef7117ee247ac209, restored the old rc1 as rc1.old without also bringing back suport for crontabs.

Copy the old contents of `02-cron` directly into rc1.old to preserve the default crontab support.