### PR TITLE
flux-fsck: add --repair option

### DIFF
--- a/doc/man1/flux-fsck.rst
+++ b/doc/man1/flux-fsck.rst
@@ -40,6 +40,20 @@ OPTIONS
    checkpoint.  This option directs flux-fsck to start at an arbitrary
    point.  BLOBREF must refer to an RFC 11 tree object of type "dir".
 
+.. option:: -r, --repair
+
+   Remove any dangling references found in KVS metadata. If a KVS
+   value changes as a result of this repair, the key is moved to the
+   lost+found directory.  The original key is unlinked.  If a key
+   points to a KVS directory that is no longer valid, it is
+   unlinked. All damaged keys and their disposition are listed on
+   stderr. This process creates a new root reference for these
+   changes, and commits it as the current KVS checkpoint at the end of
+   the scan. The KVS is required to be unloaded during repair.
+
+   This option should be considered :ref:`EXPERIMENTAL <fsck_experimental>`
+   at this time.
+
 
 EXIT STATUS
 ===========
@@ -63,6 +77,13 @@ FLUX RFC
 :doc:`rfc:spec_10`
 
 :doc:`rfc:spec_11`
+
+
+.. _fsck_experimental:
+EXPERIMENTAL
+============
+
+.. include:: common/experimental.rst
 
 
 SEE ALSO

--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -34,8 +34,13 @@
 struct fsck_ctx {
     flux_t *h;
     json_t *root;
+    int sequence;
+    int repair_count;
+    zlist_t *repair_treeobjs;
+    char *hash_name;
     bool verbose;
     bool quiet;
+    bool repair;
     int errorcount;
 };
 
@@ -117,7 +122,7 @@ static void valref_validate_continuation (flux_future_t *f, void *arg)
         }
         fvd->errorcount++;
         fvd->errnum = errno;     /* we'll report the last errno */
-        if (errno == ENOENT)
+        if (fvd->ctx->repair && errno == ENOENT)
             save_missing_ref_index (fvd, *index);
     }
     fvd->in_flight--;
@@ -161,6 +166,161 @@ static void valref_validate (struct fsck_valref_data *fvd,
         log_err_exit ("could not save index value");
 }
 
+static json_t *repair_valref (struct fsck_ctx *ctx,
+                              json_t *treeobj,
+                              struct fsck_valref_data *fvd)
+{
+    json_t *repaired;
+    int *missing;
+    int i;
+    int count = treeobj_get_count (treeobj);
+
+    if (!(repaired = treeobj_create_valref (NULL)))
+        log_err_exit ("cannot create treeobj valref");
+
+    missing = zlist_pop (fvd->missing_indexes);
+    for (i = 0; i < count; i++) {
+        const char *blobref = treeobj_get_blobref (treeobj, i);
+        if (!missing || i != (*missing)) {
+            if (treeobj_append_blobref (repaired, blobref) < 0)
+                log_err_exit ("cannot append blobref to valref");
+        }
+        else {
+            free (missing);
+            missing = zlist_pop (fvd->missing_indexes);
+        }
+    }
+
+    /* if no blobrefs in valref, all blobs were bad, gotta convert to
+     * empty val treeobj
+     */
+    if (treeobj_get_count (repaired) == 0) {
+        json_decref (repaired);
+        if (!(repaired = treeobj_create_val (NULL, 0)))
+            log_err_exit ("cannot create treeobj val");
+    }
+
+    return repaired;
+}
+
+/* add dir if it is missing, otherwise return it.  convert dirref to
+ * dir if necessary
+ */
+static json_t *get_dir (struct fsck_ctx *ctx,
+                        json_t *treeobj_dir,
+                        const char *dir_name)
+{
+    json_t *o;
+
+    if (!(o = treeobj_get_entry (treeobj_dir, dir_name))) {
+        if (!(o = treeobj_create_dir ()))
+            log_err_exit ("cannot create treeobj dir");
+        if (treeobj_insert_entry (treeobj_dir, dir_name, o) < 0)
+            log_err_exit ("cannot add dir to treeobj");
+    }
+    else {
+        if (treeobj_is_dirref (o)) {
+            flux_future_t *f;
+            const char *ref;
+            int refcount;
+            json_t *subdir, *subdirtmp;
+            const void *data;
+            size_t size;
+
+            if ((refcount = treeobj_get_count (o)) < 0
+                || refcount != 1
+                || !(ref = treeobj_get_blobref (o, 0)))
+                log_err_exit ("cannot get dirref blobref");
+
+            if (!(f = content_load_byblobref (ctx->h,
+                                              ref,
+                                              CONTENT_FLAG_CACHE_BYPASS))
+                || content_load_get (f, &data, &size) < 0)
+                log_err_exit ("failed to load treeobj dir");
+
+            /* deep copy b/c we may be modifying it */
+            if (!(subdirtmp = treeobj_decodeb (data, size))
+                || !(subdir = treeobj_deep_copy (subdirtmp))
+                || treeobj_insert_entry (treeobj_dir, dir_name, subdir) < 0)
+                log_err_exit ("failed to update entry from dirref to dir");
+
+            json_decref (subdirtmp);
+            o = subdir;
+        }
+        else if (!treeobj_is_dir (o)) {
+            /* if it is not a dir or dirref, we overwrite it with a dir */
+            if (!(o = treeobj_create_dir ()))
+                log_err_exit ("cannot create treeobj dir");
+            if (treeobj_insert_entry (treeobj_dir, dir_name, o) < 0)
+                log_err_exit ("cannot add dir to treeobj");
+        }
+    }
+    return o;
+}
+
+static void put_valref_lost_and_found (struct fsck_ctx *ctx,
+                                       const char *path,
+                                       json_t *repaired)
+{
+    json_t *dir = ctx->root;
+    char *cpy;
+    char *next, *name;
+
+    if (asprintf (&cpy, "lost+found.%s", path) < 0)
+        log_err_exit ("cannot allocate lost+found path");
+    name = cpy;
+
+    while ((next = strchr (name, '.'))) {
+        json_t *subdir;
+
+        *next++ = '\0';
+
+        if (!treeobj_is_dir (dir))
+            log_err_exit ("treeobj dir is type %s", treeobj_type_name (dir));
+
+        subdir = get_dir (ctx, dir, name);
+        name = next;
+        dir = subdir;
+    }
+
+    if (treeobj_insert_entry (dir, name, repaired) < 0)
+        log_err_exit ("cannot insert repaired valref");
+
+    free (cpy);
+
+    ctx->repair_count++;
+}
+
+static void unlink_path (struct fsck_ctx *ctx,
+                         const char *path)
+{
+    json_t *dir = ctx->root;
+    char *cpy;
+    char *next, *name;
+
+    if (!(cpy = strdup (path)))
+        log_err_exit ("cannot allocate path copy");
+    name = cpy;
+
+    while ((next = strchr (name, '.'))) {
+        json_t *subdir;
+
+        *next++ = '\0';
+
+        if (!treeobj_is_dir (dir))
+            log_err_exit ("treeobj dir is type %s", treeobj_type_name (dir));
+
+        subdir = get_dir (ctx, dir, name);
+        name = next;
+        dir = subdir;
+    }
+
+    if (treeobj_delete_entry (dir, name) < 0)
+        log_err_exit ("cannot unlink repaired entry");
+
+    free (cpy);
+}
+
 static void fsck_valref (struct fsck_ctx *ctx,
                          const char *path,
                          json_t *treeobj)
@@ -194,6 +354,21 @@ static void fsck_valref (struct fsck_ctx *ctx,
                             strerror (fvd.errnum));
         }
         ctx->errorcount++;
+
+        /* can only recover if errors were all bad references */
+        if (ctx->repair
+            && fvd.errorcount == zlist_size (fvd.missing_indexes)) {
+            json_t *repaired = repair_valref (ctx, treeobj, &fvd);
+
+            put_valref_lost_and_found (ctx, path, repaired);
+
+            unlink_path (ctx, path);
+
+            if (!ctx->quiet)
+                fprintf (stderr, "%s repaired and moved to lost+found\n", path);
+
+            json_decref (repaired);
+        }
     }
 
     zlist_destroy (&fvd.missing_indexes);
@@ -262,6 +437,11 @@ static void fsck_dirref (struct fsck_ctx *ctx,
                         path,
                         future_strerror (f, errno));
         ctx->errorcount++;
+        if (ctx->repair && errno == ENOENT) {
+            unlink_path (ctx, path);
+            if (!ctx->quiet)
+                fprintf (stderr, "%s unlinked due to missing blobref\n", path);
+        }
         flux_future_destroy (f);
         return;
     }
@@ -350,6 +530,115 @@ static bool kvs_is_running (struct fsck_ctx *ctx)
 	return running;
 }
 
+static void save_treeobj (struct fsck_ctx *ctx, json_t *treeobj)
+{
+    if (zlist_append (ctx->repair_treeobjs, json_incref (treeobj)) < 0)
+        log_err_exit ("failed to save treeobj");
+    zlist_freefn (ctx->repair_treeobjs,
+                  treeobj,
+                  (zlist_free_fn *) json_decref,
+                  true);
+}
+
+static void get_treeobjs (struct fsck_ctx *ctx, json_t *dir)
+{
+    json_t *dir_data;
+    void *iter;
+
+    if (!(dir_data = treeobj_get_data (dir)))
+        log_err_exit ("cannot get dir data");
+
+    iter = json_object_iter (dir_data);
+    while (iter) {
+        json_t *dir_entry = json_object_iter_value (iter);
+        if (treeobj_is_dir (dir_entry)) {
+            char *data;
+            ssize_t datalen;
+            char ref[BLOBREF_MAX_STRING_SIZE];
+            json_t *dirref;
+
+            /* depth first, so that all sub-dirs are converted to
+             * dirrefs before we save off the treeobj for later
+             * writing to the content store */
+            get_treeobjs (ctx, dir_entry);
+
+            save_treeobj (ctx, dir_entry);
+
+            if (!(data = treeobj_encode (dir_entry)))
+                log_err_exit ("cannot encode treeobj");
+            datalen = strlen (data);
+            if (blobref_hash (ctx->hash_name,
+                              data,
+                              datalen,
+                              ref,
+                              sizeof (ref)) < 0)
+                log_err_exit ("cannot calculate blobref");
+
+            if (!(dirref = treeobj_create_dirref (ref)))
+                log_err_exit ("cannot create treeobj dirref");
+            if (json_object_iter_set_new (dir, iter, dirref) < 0)
+                log_err_exit ("cannot update dir entry to dirref");
+
+            free (data);
+        }
+        iter = json_object_iter_next (dir_data, iter);
+    }
+}
+
+static void store_treeobjs (struct fsck_ctx *ctx)
+{
+    json_t *obj;
+
+    /* N.B. future work, parallelize this */
+    while ((obj = zlist_pop (ctx->repair_treeobjs))) {
+        char *data;
+        ssize_t datalen;
+        flux_future_t *f;
+        if (!(data = treeobj_encode (obj)))
+            log_err_exit ("cannot encode treeobj");
+        datalen = strlen (data);
+        if (!(f = content_store (ctx->h,
+                                 data,
+                                 datalen,
+                                 CONTENT_FLAG_CACHE_BYPASS))
+            || flux_rpc_get (f, NULL) < 0)
+            log_err_exit ("failed to store blob to content store");
+        free (data);
+    }
+}
+
+static void sync_checkpoint (struct fsck_ctx *ctx)
+{
+    char *data;
+    ssize_t datalen;
+    char ref[BLOBREF_MAX_STRING_SIZE];
+    flux_future_t *f;
+
+    if (!(data = treeobj_encode (ctx->root)))
+        log_err_exit ("cannot encode treeobj");
+    datalen = strlen (data);
+
+    if (blobref_hash (ctx->hash_name,
+                      data,
+                      datalen,
+                      ref,
+                      sizeof (ref)) < 0)
+        log_err_exit ("cannot calculate blobref");
+
+    if (!(f = kvs_checkpoint_commit (ctx->h,
+                                     ref,
+                                     ctx->sequence + 1,
+                                     0.,
+                                     KVS_CHECKPOINT_FLAG_CACHE_BYPASS))
+        || flux_rpc_get (f, NULL) < 0)
+        log_err_exit ("failed to checkpoint updated root");
+
+    flux_future_destroy (f);
+
+    if (!ctx->quiet)
+        fprintf (stderr, "Updated primary checkpoint to include lost+found\n");
+}
+
 static int cmd_fsck (optparse_t *p, int ac, char *av[])
 {
     struct fsck_ctx ctx = {0};
@@ -368,6 +657,8 @@ static int cmd_fsck (optparse_t *p, int ac, char *av[])
         ctx.verbose = true;
     if (optparse_hasopt (p, "quiet"))
         ctx.quiet = true;
+    if (optparse_hasopt (p, "repair"))
+        ctx.repair = true;
 
     ctx.h = builtin_get_flux_handle (p);
 
@@ -382,12 +673,14 @@ static int cmd_fsck (optparse_t *p, int ac, char *av[])
         const json_t *checkpoints;
         json_t *checkpt;
         double timestamp;
+        int sequence;
 
         /* index 0 is most recent checkpoint */
         if (!(f = kvs_checkpoint_lookup (ctx.h, KVS_CHECKPOINT_FLAG_CACHE_BYPASS))
             || kvs_checkpoint_lookup_get (f, &checkpoints) < 0
             || !(checkpt = json_array_get (checkpoints, 0))
             || kvs_checkpoint_parse_rootref (checkpt, &blobref) < 0
+            || kvs_checkpoint_parse_sequence (checkpt, &sequence) < 0
             || kvs_checkpoint_parse_timestamp (checkpt, &timestamp) < 0)
             log_msg_exit ("error fetching checkpoints: %s",
                           future_strerror (f, errno));
@@ -401,6 +694,8 @@ static int cmd_fsck (optparse_t *p, int ac, char *av[])
                      "Checking integrity of checkpoint from %s\n",
                      buf);
         }
+
+        ctx.sequence = sequence;
     }
 
     fsck_blobref (&ctx, blobref);
@@ -410,6 +705,26 @@ static int cmd_fsck (optparse_t *p, int ac, char *av[])
     if (!ctx.quiet)
         fprintf (stderr, "Total errors: %d\n", ctx.errorcount);
 
+    if (ctx.repair && ctx.repair_count) {
+        const char *tmp;
+        if (!(tmp = flux_attr_get (ctx.h, "content.hash"))
+            || !(ctx.hash_name = strdup (tmp)))
+            log_err_exit ("could not get content hash name");
+
+        if (!(ctx.repair_treeobjs = zlist_new ()))
+            log_err_exit ("cannot create list for treeobjs");
+
+        get_treeobjs (&ctx, ctx.root);
+
+        /* and gotta save root at end too */
+        save_treeobj (&ctx, ctx.root);
+
+        store_treeobjs (&ctx);
+
+        sync_checkpoint (&ctx);
+    }
+
+    zlist_destroy (&ctx.repair_treeobjs);
     json_decref (ctx.root);
     flux_close (ctx.h);
 
@@ -425,6 +740,9 @@ static struct optparse_option fsck_opts[] = {
     },
     { .name = "rootref", .key = 'r', .has_arg = 1, .arginfo = "BLOBREF",
       .usage = "Check integrity starting with BLOBREF",
+    },
+    { .name = "repair", .key = 'r', .has_arg = 0,
+      .usage = "Repair recoverable keys and place in lost+found",
     },
     OPTPARSE_TABLE_END
 };

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -134,14 +134,14 @@ done:
 }
 
 /* A job could not be reloaded due to some problem like a truncated eventlog.
- * Move job data to lost+found for manual cleanup.
+ * Move job data to job-lost+found for manual cleanup.
  */
 static void move_to_lost_found (flux_t *h, const char *key, flux_jobid_t id)
 {
     char nkey[128];
     flux_future_t *f;
 
-    snprintf (nkey, sizeof (nkey), "lost+found.job.%s", idf58 (id));
+    snprintf (nkey, sizeof (nkey), "job-lost+found.job.%s", idf58 (id));
     if (!(f = flux_kvs_move (h, NULL, key, NULL, nkey, 0))
         || flux_future_get (f, NULL) < 0) {
         flux_log (h,

--- a/t/t2219-job-manager-restart.t
+++ b/t/t2219-job-manager-restart.t
@@ -223,10 +223,10 @@ test_expect_success 'new queue configured on restart uses defaults' '
 	grep "^newqueue: Scheduling is stopped" dump_queue_ignored.out
 '
 
-test_expect_success 'bad job directory is moved to lost+found' '
+test_expect_success 'bad job directory is moved to job-lost+found' '
 	flux start \
 	    -Scontent.restore=${DUMPS}/warn/dump-shorteventlog.tar.bz2 \
-	    flux kvs dir -R lost+found
+	    flux kvs dir -R job-lost+found
 '
 
 for dump in ${DUMPS}/valid/*.tar.bz2; do


### PR DESCRIPTION
Problem: flux-fsck can identify corrupted KVS entries, but does not presently do anything to help users recover data.

Support a --lost-and-found option.  Corrupted KVS entries will be recovered as best as possible and placed into a "lost+found"
directory for users to consider using.

----

notes:

- I struggled with some documentation / verbiage here.  "recover" doesn't seem to be the right word sometimes, as that suggests full recovery.  Perhaps there's a better word I'm not thinking of.

- there is no handling of corrupted treeobjs, like hypothetically a treeobj that is outright bad (fails `treeobj_validate()`).  We could stick "empty values" in `lost+found` for those?

- I chose the directory "lost+found", which is actually what is used by the `job-manager` for its lost and found.  Should change?  Should `job-manager` path change?