### PR TITLE
ci: fix docker manifest generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,10 +267,5 @@ jobs:
         (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master')
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        docker manifest create fluxrm/flux-core:bookworm fluxrm/flux-core:bookworm-amd64 fluxrm/flux-core:bookworm-386 fluxrm/flux-core:bookworm-arm64
-        docker manifest push fluxrm/flux-core:bookworm
-        for d in el9 noble alpine ; do
-          docker manifest create fluxrm/flux-core:$d fluxrm/flux-core:$d-amd64 fluxrm/flux-core:$d-arm64
-          docker manifest push fluxrm/flux-core:$d
-        done
+        src/test/docker-manifest.py
 

--- a/src/test/docker-manifest.py
+++ b/src/test/docker-manifest.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+#
+#  Generate docker manifests when necessary based on set of docker tags
+#  provided by src/test/generate-matrix.py
+
+import json
+import subprocess
+from collections import defaultdict
+
+matrix = json.loads(
+    subprocess.run(
+        ["src/test/generate-matrix.py"], capture_output=True, text=True
+    ).stdout
+)
+
+tags = defaultdict(list)
+for entry in matrix["include"]:
+    if "DOCKER_TAG" in entry["env"]:
+        tags[entry["image"]].append(entry["env"]["DOCKER_TAG"])
+
+# Collect only those images with multiple tags:
+tags = {k: v for k, v in tags.items() if len(v) > 1}
+
+for image in tags.keys():
+    tag = f"fluxrm/flux-core:{image}"
+    print(f"docker manifest create {tag} ", *tags[image])
+    subprocess.run(["docker", "manifest", "create", tag, *tags[image]])
+    print(f"docker manifest push {tag} ")
+    subprocess.run(["docker", "manifest", "push", tag])


### PR DESCRIPTION
Problem: The set of images for which docker manifests are generated is hand edited in the workflows file and so can easily become outdated.

Add a script to run the docker manifest commands based on current output from `src/test/generate-matrix.py`, which contains the exact set of docker tags for each image which then must be combined into a manifest.