### PR TITLE
modprobe: fix handling of `modprobe.Context.bash()` errors and expand testing

### DIFF
--- a/doc/man1/flux-modprobe.rst
+++ b/doc/man1/flux-modprobe.rst
@@ -58,6 +58,11 @@ service name instead of module name e.g.::
 
 loads the currently configured scheduler module.
 
+This command will only load modules that are not already loaded, so it
+may be used to ensure a given set of modules are loaded. If all target
+modules and their dependencies are loaded, then an informational message
+is printed that there was nothing to do and the program exits with success.
+
 
 remove
 ------

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -941,8 +941,24 @@ class Modprobe:
             self._active_tasks.append(module)
 
     def load(self, modules):
-        """Load modules and their dependencies"""
-        self.run(self.get_deps(self.solve(modules)))
+        """
+        Load modules and their dependencies (if not already loaded)
+
+        Args:
+            modules (list): List of modules to load.
+
+        Raises:
+            FileExistsError: Target modules (and all their dependencies)
+                are already loaded, so there is nothing to do.
+        """
+        mlist = ModuleList(self.handle)
+        needed_modules = [x for x in self.solve(modules) if x not in mlist]
+        if needed_modules:
+            self.run(self.get_deps(needed_modules))
+        else:
+            raise FileExistsError(
+                "All modules and their dependencies are already loaded."
+            )
 
     def _solve_modules_remove(self, modules=None):
         """Solve for a set of currently loaded modules to remove"""

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -13,13 +13,13 @@ import concurrent
 import copy
 import glob
 import os
+import subprocess
 import sys
 import threading
 import time
 from collections import defaultdict, namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from subprocess import Popen
 
 import flux
 import flux.importer
@@ -535,7 +535,14 @@ class Context:
 
     def bash(self, command):
         """Execute command under ``bash -c``"""
-        Popen(["bash", "-c", command]).wait()
+        process = subprocess.run(["bash", "-c", command])
+        if process.returncode != 0:
+            if process.returncode > 0:
+                raise RuntimeError(
+                    f"bash: exited with exit status {process.returncode}"
+                )
+            else:
+                raise RuntimeError(f"bash: died by signal {process.returncode}")
 
     def load_modules(self, modules):
         """Set a list of modules to load by name"""

--- a/src/cmd/flux-modprobe.py
+++ b/src/cmd/flux-modprobe.py
@@ -84,7 +84,11 @@ def rc3(args):
 
 def load(args):
     M = Modprobe().configure_modules()
-    M.load(args.modules)
+    try:
+        M.load(args.modules)
+    except FileExistsError:
+        LOGGER.info("All modules and dependencies are already loaded")
+
     sys.exit(M.exitcode)
 
 

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -982,7 +982,7 @@ static int process_args (flux_t *h, struct simple_sched *ss,
             ss->schedutil_flags &= ~SCHEDUTIL_HELLO_PARTIAL_OK;
         }
         else {
-            flux_log_error (h, "Unknown module option: '%s'", argv[i]);
+            flux_log (h, LOG_ERR, "Unknown module option: '%s'", argv[i]);
             errno = EINVAL;
             return -1;
         }


### PR DESCRIPTION
This PR fixes the `modprobe.Context.bash()` helper, which currently is ignoring non-zero exit status from the invoked command(s).

Additionally, a few more tests are added to the modprobe testsuite to check that the `bash()` helper is working properly, and that module load failures (and other `@task` failures) cause `flux modprobe` to fail.