### PR TITLE
etc: remove shopt usage from rc1.old

### DIFF
--- a/etc/rc1.old
+++ b/etc/rc1.old
@@ -88,7 +88,6 @@ modload all heartbeat
 if test $RANK -eq 0 \
 	&& cron_dir=$(flux getattr cron.directory 2>/dev/null) \
 	&& test -d "$cron_dir"; then
-	shopt -s nullglob
 	for file in $cron_dir/*; do
 		if test -f $file; then
 			if ! flux cron tab <$file; then
@@ -97,7 +96,6 @@ if test $RANK -eq 0 \
 			fi
 		fi
 	done
-	shopt -u nullglob
 fi
 
 


### PR DESCRIPTION
Problem: Commit ee047214df897daadd228e09797c2edfc9407601 copied the contents of the old `etc/rc1.d/02-cron` directly into rc1.old, but that file was designed to be run under bash and contains `shopt` commands which only work under bash. Since `rc1` and `rc1.old` use `/bin/sh`, this shell builtin may not be available.

The for loop in `02-cron` already checked for existence of the file to load, so the `shopt` commands are likely unnecessary. Remove them so that rc1.old becomes POSIX sh compatible.

Fixes #6960