### PR TITLE
doc: add note about `--signal=SIG@TIME` behavior in batch jobs

### DIFF
--- a/doc/man1/common/job-other-options.rst
+++ b/doc/man1/common/job-other-options.rst
@@ -105,6 +105,13 @@
    greater than the remaining time of a job as it starts, the job will
    be signaled immediately.
 
+   .. note::
+      A signal sent to a batch job is delivered to both the batch script and
+      any running jobs. If the script does not handle the signal it may exit
+      first, terminating the batch job early. It is recommended to use a
+      ``trap`` in the script to allow running jobs to handle the signal and
+      exit cleanly.
+
    The default behavior is to not send any warning signal to jobs.
 
 .. option:: --dry-run


### PR DESCRIPTION
Problem: A signal sent to a batch job is delivered both to all the running jobs and the batch script. The latter may be surprising or catch users off guard if they expect only the jobs to be signaled.

Add a note to the submission commands documentation for `--signal` describing signal behavior for batch jobs, and suggesting batch scripts use a `trap` to capture `SIG` to avoid early exit.

Fixes #6964

@ryanday36, does this seem sufficient to close #6964?