### PR TITLE
broker: wait for built-in plugins to be RUNNING before loading other modules

### DIFF
--- a/etc/rc1.old
+++ b/etc/rc1.old
@@ -1,7 +1,6 @@
 #!/bin/sh -e
 
-# Allow connector-local more time to start listening on socket
-RANK=$(FLUX_LOCAL_CONNECTOR_RETRY_COUNT=30 flux getattr rank)
+RANK=$(flux getattr rank)
 
 # Usage: modload {all|<rank>} modname [args ...]
 modload() {

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -205,7 +205,6 @@ int main (int argc, char *argv[])
     flux_msg_handler_t **handlers = NULL;
     const flux_conf_t *conf;
     const char *method;
-    flux_error_t error;
 
     setlocale (LC_ALL, "");
 
@@ -487,22 +486,12 @@ int main (int argc, char *argv[])
     if (create_runat_phases (&ctx) < 0)
         goto cleanup;
 
-    state_machine_post (ctx.state_machine, "start");
+    state_machine_kickoff (ctx.state_machine);
 
     /* Create shutdown mechanism
      */
     if (!(ctx.shutdown = shutdown_create (&ctx))) {
         log_err ("error creating shutdown mechanism");
-        goto cleanup;
-    }
-
-    /* Load the builtin modules, including the local connector module.
-     * Other modules will be loaded in rc1 using flux module,
-     * which uses the local connector.
-     * The shutdown protocol unloads the builtin modules.
-     */
-    if (modhash_load_builtins (ctx.modhash, &error) < 0) {
-        log_err ("error loading builtins: %s", error.text);
         goto cleanup;
     }
 

--- a/src/broker/modhash.h
+++ b/src/broker/modhash.h
@@ -52,13 +52,14 @@ module_t *modhash_lookup_byname (modhash_t *mh, const char *name);
 module_t *modhash_first (modhash_t *mh);
 module_t *modhash_next (modhash_t *mh);
 
-/* Initiate load of all builtin modules.
+/* Initiate load of builtin modules that have autoload=true.
  * Plumbing works immedediately upon success, but startup is asynchronous.
+ * Fulfill the returned future upon completion of startup (do not destroy).
  */
-int modhash_load_builtins (modhash_t *mh, flux_error_t *error);
+flux_future_t *modhash_load_builtins (modhash_t *mh, flux_error_t *error);
 
-/* Initiate unload of all builtin modules.  Fulfill the returned future
- * upon completion. The future is owned by modhash and should not be destroyed.
+/* Initiate unload of all builtin modules that have autoload=true.
+ * Fulfill the returned future upon completion (do not destroy).
  */
 flux_future_t *modhash_unload_builtins (modhash_t *mh);
 

--- a/src/broker/state_machine.h
+++ b/src/broker/state_machine.h
@@ -30,6 +30,8 @@ typedef enum {
 struct state_machine *state_machine_create (struct broker *ctx);
 void state_machine_destroy (struct state_machine *s);
 
+void state_machine_kickoff (struct state_machine *s);
+
 void state_machine_post (struct state_machine *s, const char *event);
 
 void state_machine_kill (struct state_machine *s, int signum);

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -152,7 +152,7 @@ test_expect_success 'capture state transitions from size=1 instance' '
 '
 
 test_expect_success 'all expected events and state transitions occurred' '
-	grep "start: none->join"			states.log &&
+	grep "builtins-success: none->join"		states.log &&
 	grep "parent-none: join->init"			states.log &&
 	grep "rc1-none: init->quorum"			states.log &&
 	grep "quorum-full: quorum->run"			states.log &&
@@ -170,7 +170,7 @@ test_expect_success 'capture state transitions from size=2 instance' '
 '
 
 test_expect_success 'all expected events and state transitions occurred on rank 0' '
-	grep "\[0\]: start: none->join"				states2.log &&
+	grep "\[0\]: builtins-success: none->join"		states2.log &&
 	grep "\[0\]: parent-none: join->init"			states2.log &&
 	grep "\[0\]: rc1-none: init->quorum"			states2.log &&
 	grep "\[0\]: quorum-full: quorum->run"			states2.log &&
@@ -182,7 +182,7 @@ test_expect_success 'all expected events and state transitions occurred on rank 
 '
 
 test_expect_success 'all expected events and state transitions occurred on rank 1' '
-	grep "\[1\]: start: none->join"				states2.log &&
+	grep "\[1\]: builtins-success: none->join"		states2.log &&
 	grep "\[1\]: parent-ready: join->init"			states2.log &&
 	grep "\[1\]: rc1-none: init->quorum"			states2.log &&
 	grep "\[1\]: quorum-full: quorum->run"			states2.log &&
@@ -202,7 +202,7 @@ test_expect_success 'capture state transitions from instance with rc1 failure' '
 '
 
 test_expect_success 'all expected events and state transitions occurred' '
-	grep "start: none->join"			states_rc1.log &&
+	grep "builtins-success: none->join"		states_rc1.log &&
 	grep "parent-none: join->init"			states_rc1.log &&
 	grep "rc1-fail: init->shutdown"			states_rc1.log &&
 	grep "children-none: shutdown->finalize"	states_rc1.log &&
@@ -218,7 +218,7 @@ test_expect_success 'capture state transitions from instance with rc2 failure' '
 '
 
 test_expect_success 'all expected events and state transitions occurred' '
-	grep "start: none->join"			states_rc2.log &&
+	grep "builtins-success: none->join"		states_rc2.log &&
 	grep "parent-none: join->init"			states_rc2.log &&
 	grep "rc1-none: init->quorum"			states_rc2.log &&
 	grep "quorum-full: quorum->run"			states_rc2.log &&
@@ -238,7 +238,7 @@ test_expect_success 'capture state transitions from instance with rc3 failure' '
 '
 
 test_expect_success 'all expected events and state transitions occurred' '
-	grep "start: none->join"			states_rc3.log &&
+	grep "builtins-success: none->join"		states_rc3.log &&
 	grep "parent-none: join->init"			states_rc3.log &&
 	grep "rc1-none: init->quorum"			states_rc3.log &&
 	grep "quorum-full: quorum->run"			states_rc3.log &&

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -55,6 +55,17 @@ test_expect_success 'broker.quorum can be 0-1 (size=2) for compatibility' '
 	flux start -s2 ${ARGS} -Sbroker.quorum=0-1 true 2>compat2.err &&
 	grep assuming compat2.err
 '
+test_expect_success 'simulate builtins-fail with a bad connector-local config' '
+	cat >badconfig.toml <<-EOT &&
+	[access]
+	allow_root-owner = 42
+	EOT
+	test_must_fail flux start \
+		--config-path=badconfig.toml \
+		-Slog-stderr-level=6 \
+		true 2>builtins.err &&
+	grep "builtins-fail: none->exit" builtins.err
+'
 test_expect_success 'create rc1 that blocks on FIFO for rank != 0' '
 	cat <<-EOT >rc1_block &&
 	#!/bin/bash


### PR DESCRIPTION
Problem: since the early days, there has a been a race between loading the `connector-local` module and loading other modules, which requires that the local connector be usable.  We have addressed this in CI by increasing connect retries in rc1, but that still can fail on occasion.

This integrates builtin module loading into the broker state machine such that the state does not advance to from NONE to JOIN until after the built-in (`autoload=true`) modules are in RUNNING state.  Since `connector-local` does not enter RUNNING state until it is listening on the socket, this effectively closes the race.

This appears to address the failures that are occurring in CI in #6959, where the broker groups subsystem is converted to an `autoload=true` module.