### PR TITLE
libflux: drop msglist polling methods

### DIFF
--- a/src/common/libflux/msglist.h
+++ b/src/common/libflux/msglist.h
@@ -33,16 +33,6 @@ const flux_msg_t *flux_msglist_last (struct flux_msglist *l);
 
 int flux_msglist_count (struct flux_msglist *l);
 
-/* These functions are for integration of flux_msglist into an event loop.
- * The pollfd file descriptor becomes readable when a poll event has been
- * raised (edge triggered).  This indicates that the pollevents mask has been
- * updated.  The mask cnosists of POLLIN | POLLOUT | POLLERR.  N.B. POLLOUT
- * is always ready in the current implementation.
- * Both functions return -1 on error with errno set.
- */
-int flux_msglist_pollevents (struct flux_msglist *l);
-int flux_msglist_pollfd (struct flux_msglist *l);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/test/msglist.c
+++ b/src/common/libflux/test/msglist.c
@@ -8,9 +8,6 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-/* msglist.c - test pollevents/pollfd aspect of flux_msglist
- */
-
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -75,80 +72,11 @@ void check_msglist (void)
     flux_msglist_destroy (l);
 }
 
-
-void check_poll (void)
-{
-    struct flux_msglist *ml;
-    int e;
-    flux_msg_t *msg;
-    const flux_msg_t *tmp;
-    struct pollfd pfd;
-
-    if (!(msg = flux_request_encode ("foo", NULL)))
-        BAIL_OUT ("flux_request_encode failed");
-
-    ok ((ml = flux_msglist_create ()) != NULL,
-        "flux_msglist_create works");
-    ok ((e = flux_msglist_pollevents (ml)) >= 0 && e == POLLOUT,
-        "flux_msglist_pollevents on empty msglist returns POLLOUT");
-    ok (flux_msglist_push (ml, msg) == 0,
-        "flux_msglist_push works");
-    ok ((e = flux_msglist_pollevents (ml)) >= 0 && e == (POLLOUT | POLLIN),
-        "flux_msglist_pollevents on non-empty msglist returns POLLOUT|POLLIN");
-    ok (flux_msglist_push (ml, msg) == 0,
-        "flux_msglist_push works");
-    ok ((e = flux_msglist_pollevents (ml)) >= 0 && e == (POLLOUT | POLLIN),
-        "flux_msglist_pollevents still returns POLLOUT|POLLIN");
-    ok ((tmp = flux_msglist_pop (ml)) != NULL,
-        "flux_msglist_pop returns a message");
-    ok ((e = flux_msglist_pollevents (ml)) >= 0 && e == (POLLOUT | POLLIN),
-        "flux_msglist_pollevents still returns POLLOUT|POLLIN");
-    flux_msg_decref (tmp);
-
-    ok ((tmp = flux_msglist_pop (ml)) != NULL,
-        "flux_msglist_pop returns a message");
-    ok ((e = flux_msglist_pollevents (ml)) >= 0 && e == POLLOUT,
-        "flux_msglist_pollevents on empty msglist returns POLLOUT");
-    flux_msg_decref (tmp);
-
-    ok ((pfd.fd = flux_msglist_pollfd (ml)) >= 0,
-        "flux_msglist_pollfd works");
-    pfd.events = POLLIN,
-    pfd.revents = 0,
-    ok (poll (&pfd, 1, 0) == 1 && pfd.revents == POLLIN,
-        "flux_msglist_pollfd suggests we read pollevents");
-    ok ((e = flux_msglist_pollevents (ml)) >= 0 && e == POLLOUT,
-        "flux_msglist_pollevents on empty msglist returns POLLOUT");
-    pfd.events = POLLIN,
-    pfd.revents = 0,
-    ok (poll (&pfd, 1, 0) == 0,
-        "pollfd is no longer ready");
-    ok (flux_msglist_push (ml, msg) == 0,
-        "flux_msglist_push works");
-    pfd.events = POLLIN,
-    pfd.revents = 0,
-    ok (poll (&pfd, 1, 0) == 1 && pfd.revents == POLLIN,
-        "pollfd suggests we read pollevents");
-    ok ((e = flux_msglist_pollevents (ml)) >= 0 && e == (POLLOUT | POLLIN),
-        "flux_msglist_pollevents on non-empty msglist returns POLLOUT|POLLIN");
-    pfd.events = POLLIN,
-    pfd.revents = 0,
-    ok (poll (&pfd, 1, 0) == 0,
-        "pollfd is no longer ready");
-    ok ((e = flux_msglist_pollevents (ml)) >= 0 && e == (POLLOUT | POLLIN),
-        "msglist_pollevents still returns POLLOUT|POLLIN");
-
-    flux_msg_decref (msg);
-    flux_msglist_destroy (ml);
-
-}
-
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
 
     check_msglist ();
-    check_poll ();
 
     done_testing ();
     return (0);


### PR DESCRIPTION
Problem: `flux_msglist_pollfd(`) and `flux_msglist_pollevents()` are no longer used.

Get rid of them.

TL;DR This  mechanism moved to the internal-only `msg_deque` class.  flux-pmix did use these interfaces to implement its reactive interthread message channel, but that has been replaced by back-to-back `flux_t` handles using the `interthread://` connector.  I prepared this commit last year but I guess was probably waiting for there to be a flux-pmix tag and forgot about it.