### PR TITLE
support drop-in scripts in `$libexecdir/flux/{prolog,epilog,housekeeping}.d`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -648,6 +648,7 @@ AC_CONFIG_FILES( \
   etc/flux-taskmap.pc \
   etc/flux.service \
   etc/flux-housekeeping@.service \
+  etc/flux-run-system-scripts \
   src/cmd/flux-run-housekeeping \
   etc/flux-prolog@.service \
   etc/flux-epilog@.service \

--- a/doc/man1/flux-config.rst
+++ b/doc/man1/flux-config.rst
@@ -149,6 +149,12 @@ The following configuration keys may be printed with
 **rundir**
    The configured ``${runstatedir}/flux`` directory.
 
+**confdir**
+  The configured ``${sysconfdir}/flux`` directory.
+
+**libexecdir**
+   The configured ``${libexecdir}/flux`` directory.
+
 **lua_cpath_add**
    Consulted by :man1:`flux` when setting the :envvar:`LUA_CPATH` environment
    variable.

--- a/doc/man5/flux-config-job-manager.rst
+++ b/doc/man5/flux-config-job-manager.rst
@@ -98,6 +98,13 @@ release-after
   have completed housekeeping when the timer fires are released. Following
   that, resources are released as each execution target completes.
 
+exit-on-first-error
+  (optional, bool) Controls error handling behavior when housekeeping
+  is managed by the ``flux-housekeeping@JOBID`` systemd service. If ``false``
+  (default), all discovered scripts are executed and housekeeping exits with
+  the highest recorded exit code. If ``true``, housekeeping exits immediately
+  on encountering the first error.
+
 .. _plugin_specific_keys:
 
 PLUGIN SPECIFIC KEYS
@@ -146,6 +153,12 @@ prolog
       (optional, bool) A boolean indicating if the prolog should be terminated
       when a fatal job exception is raised while the prolog is active. The
       default is true.
+   exit-on-first-error
+      (optional, bool) Controls error handling behavior when prolog execution
+      is managed by the ``flux-prolog@JOBID`` systemd service. If ``false``
+      (default), all discovered scripts are executed and the prolog exits with
+      the highest recorded exit code. If ``true``, the prolog exits immediately
+      on encountering the first error.
 
 epilog
    (optional) Table of configuration for a job-manager epilog. If
@@ -181,6 +194,12 @@ epilog
       default is false. (``cancel-on-exception`` should only be used with
       the epilog for testing purposes, since users can generate exceptions
       on their jobs)
+   exit-on-first-error
+      (optional, bool) Controls error handling behavior when epilog execution
+      is managed by the ``flux-epilog@JOBID`` systemd service. If ``false``
+      (default), all discovered scripts are executed and the epilog exits with
+      the highest recorded exit code. If ``true``, the epilog exits immediately
+      on encountering the first error.
 
 perilog
   (optional) Common prolog/epilog configuration keys:

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -988,3 +988,4 @@ kwargs
 subdirectory
 py
 nopanic
+fluxlibexecdir

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -28,17 +28,24 @@ fluxlibexec_SCRIPTS = \
 	flux-run-system-scripts
 
 # Install empty modprobe/*.d directories after rc1.py and rc3.py are installed
+# Install empty fluxlibexecdir/{prolog,epilog,housekeeping}.d directories
 install-data-hook:
 	$(MKDIR_P) $(DESTDIR)$(fluxconfdir)/modprobe/modprobe.d
 	$(MKDIR_P) $(DESTDIR)$(fluxconfdir)/modprobe/rc1.d
 	$(MKDIR_P) $(DESTDIR)$(fluxconfdir)/modprobe/rc3.d
+	for dir in prolog.d epilog.d housekeeping.d; do \
+	  $(MKDIR_P) $(DESTDIR)$(fluxlibexecdir)/$$dir; \
+	done
 
-# Remove empty modprobe directories on uninstall
+# Remove empty modprobe/{prolog,epilog,housekeeping}.d directories on uninstall
 uninstall-hook:
 	rmdir $(DESTDIR)$(fluxconfdir)/modprobe/modprobe.d 2>/dev/null || :
 	rmdir $(DESTDIR)$(fluxconfdir)/modprobe/rc1.d 2>/dev/null || :
 	rmdir $(DESTDIR)$(fluxconfdir)/modprobe/rc3.d 2>/dev/null || :
 	rmdir $(DESTDIR)$(fluxconfdir)/modprobe 2>/dev/null || :
+	for dir in prolog.d epilog.d housekeeping.d; do \
+	  rmdir $(DESTDIR)$(fluxlibexecdir)/$$dir 2>/dev/null || :; \
+	done
 
 fluxhelpdir = $(datadir)/flux/help.d
 fluxhelp_DATA = flux/help.d/core.json

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -24,6 +24,9 @@ nobase_dist_fluxconf_SCRIPTS = \
 nobase_dist_fluxconf_DATA = \
 	modprobe/modprobe.toml
 
+fluxlibexec_SCRIPTS = \
+	flux-run-system-scripts
+
 # Install empty modprobe/*.d directories after rc1.py and rc3.py are installed
 install-data-hook:
 	$(MKDIR_P) $(DESTDIR)$(fluxconfdir)/modprobe/modprobe.d

--- a/etc/flux-core.pc.in
+++ b/etc/flux-core.pc.in
@@ -7,6 +7,7 @@ mandir=@mandir@
 fluxconfdir=@fluxconfdir@
 fluxcmddir=@fluxcmddir@
 fluxlibdir=@fluxlibdir@
+fluxlibexecdir=@fluxlibexecdir@
 fluxmoddir=@fluxmoddir@
 fluxcmdhelpdir=@datadir@/flux/help.d
 fluxshellrcdir=@fluxconfdir@/shell

--- a/etc/flux-epilog@.service.in
+++ b/etc/flux-epilog@.service.in
@@ -5,5 +5,5 @@ CollectMode=inactive-or-failed
 [Service]
 Type=oneshot
 EnvironmentFile=-@X_RUNSTATEDIR@/flux-epilog@%I.env
-ExecStart=@X_SYSCONFDIR@/flux/system/epilog
+ExecStart=@X_LIBEXECDIR@/flux/flux-run-system-scripts epilog
 ExecStopPost=-rm -f @X_RUNSTATEDIR@/flux-epilog@%I.env

--- a/etc/flux-housekeeping@.service.in
+++ b/etc/flux-housekeeping@.service.in
@@ -5,7 +5,7 @@ CollectMode=inactive-or-failed
 [Service]
 Type=oneshot
 EnvironmentFile=-@X_RUNSTATEDIR@/flux-housekeeping@%I.env
-ExecStart=@X_SYSCONFDIR@/flux/system/housekeeping
+ExecStart=@X_LIBEXECDIR@/flux/flux-run-system-scripts housekeeping
 ExecStopPost=-rm -f @X_RUNSTATEDIR@/flux-housekeeping@%I.env
 ExecStopPost=-sh -c '\
     if test "$SERVICE_RESULT" != "success"; then \

--- a/etc/flux-prolog@.service.in
+++ b/etc/flux-prolog@.service.in
@@ -5,5 +5,5 @@ CollectMode=inactive-or-failed
 [Service]
 Type=oneshot
 EnvironmentFile=-@X_RUNSTATEDIR@/flux-prolog@%I.env
-ExecStart=@X_SYSCONFDIR@/flux/system/prolog
+ExecStart=@X_LIBEXECDIR@/flux/flux-run-system-scripts prolog
 ExecStopPost=-rm -f @X_RUNSTATEDIR@/flux-prolog@%I.env

--- a/etc/flux-run-system-scripts.in
+++ b/etc/flux-run-system-scripts.in
@@ -1,0 +1,77 @@
+#!/bin/sh
+###############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+#
+# Run a set of package and system installed administrative scripts,
+# e.g. prolog, epilog, or housekeeping.
+#
+# Intended to be executed by the flux-* oneshot systemd units.
+#
+# Exits with the largest exit code of all scripts unless
+#
+#   job-manager.[prolog|epilog|housekeeping].exit-on-first-error=true
+#
+# in which case the script exits on the first encountered error.
+#
+
+log() { echo "$@" >&2; }
+die() { echo "${prog:-$0}: $@" >&2; exit 1; }
+
+prog=$1
+test -n "$prog" || die "required prolog|epilog|housekeeping argument missing"
+
+exit_on_first_error=$(flux config get -q --type=boolean --default=false \
+                      job-manager.${prog}.exit-on-first-error)
+system_path="@X_LIBEXECDIR@/flux/${prog}.d"
+flux_sysconfdir="@X_SYSCONFDIR@/flux/system"
+legacy_path="${flux_sysconfdir}/${prog}"
+sysconf_path="${flux_sysconfdir}/${prog}.d"
+
+test $FLUX_JOB_USERID && user=$(id -n -u $FLUX_JOB_USERID 2>/dev/null)
+
+log "Running ${prog} for ${FLUX_JOB_ID:-unknown}/${user:-unknown}"
+
+run_all() {
+    log "Running all in ${1}"
+    for file in "${1}"/*; do
+        test -f "$file" -a -x "$file" || continue
+        name=$(basename "$file")
+        log "running $name"
+        $file
+        rc=$?
+        if test $rc -ne 0; then
+            log "$name: exit $rc"
+            if test "$exit_on_first_error" = "true"; then
+                exit $rc
+            fi
+            test $rc -gt $exit_rc && exit_rc=$rc
+        fi
+    done
+}
+
+exit_rc=0
+
+# Run all files in system install path. These scripts are provided by
+# system packages:
+run_all "${system_path}"
+
+# Backwards compat: If ${sysconfdir}/flux/system/${prog} exists, then run it.
+# Otherwise, just run all files in sysconf_path
+#
+if test -f "${legacy_path}" -a -x "${legacy_path}"; then
+    log "Running ${prog} found at ${legacy_path} (skipping ${sysconf_path})"
+    if ! exec "${legacy_path}"; then
+        die "Failed to execute ${legacy_path}"
+    fi
+else
+    run_all "${sysconf_path}"
+fi
+
+exit $exit_rc

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -53,6 +53,11 @@ static struct builtin builtin_tab[] = {
         .val_intree = ABS_TOP_SRCDIR "/etc",
     },
     {
+        .key = "libexecdir",
+        .val_installed = FLUXLIBEXECDIR,
+        .val_intree = ABS_TOP_SRCDIR "/etc",
+    },
+    {
         .key = "lua_cpath_add",
         .val_installed = LUAEXECDIR "/?.so",
         .val_intree = ABS_TOP_BUILDDIR "/src/bindings/lua/?.so",

--- a/src/modules/job-manager/housekeeping.c
+++ b/src/modules/job-manager/housekeeping.c
@@ -21,6 +21,7 @@
  *   [job-manager.housekeeping]
  *   #command = ["command", "arg1", "arg2", ...]
  *   release-after = "FSD"
+ *   exit-on-first-error = [true|false] # For flux-run-system-scripts
  *
  * Partial release:
  *   The 'release-after' config key enables partial release of resources.
@@ -775,6 +776,7 @@ static int housekeeping_parse_config (const flux_conf_t *conf,
     const char *imp_path = NULL;
     char *imp_path_cpy = NULL;
     int use_systemd_unit = 0;
+    int exit_on_first_error = -1; /* Note: only for flux-run-system-scripts */
 
     if (flux_conf_unpack (conf,
                           &e,
@@ -790,10 +792,11 @@ static int housekeeping_parse_config (const flux_conf_t *conf,
     if (json_unpack_ex (housekeeping,
                         &jerror,
                         0,
-                        "{s?o s?s s?b !}",
+                        "{s?o s?s s?b s?b !}",
                         "command", &cmdline,
                         "release-after", &release_after_fsd,
-                        "use-systemd-unit", &use_systemd_unit) < 0)
+                        "use-systemd-unit", &use_systemd_unit,
+                        "exit-on-first-error", &exit_on_first_error) < 0)
         return errprintf (error, "job-manager.housekeeping: %s", jerror.text);
 
     if (use_systemd_unit) {

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -180,6 +180,7 @@ static struct perilog_procdesc *perilog_procdesc_create (json_t *o,
     struct perilog_procdesc *pd = NULL;
     int per_rank = 0;
     int cancel_on_exception = -1;
+    int exit_on_first_error = -1; /* Note: only for flux-run-system-scripts */
     const char *timeout;
     double kill_timeout = -1.;
     flux_cmd_t *cmd = NULL;
@@ -195,12 +196,13 @@ static struct perilog_procdesc *perilog_procdesc_create (json_t *o,
     if (json_unpack_ex (o,
                         &error,
                         0,
-                        "{s?o s?s s?F s?b s?b !}",
+                        "{s?o s?s s?F s?b s?b s?b !}",
                         "command", &command,
                         "timeout", &timeout,
                         "kill-timeout", &kill_timeout,
                         "per-rank", &per_rank,
-                        "cancel-on-exception", &cancel_on_exception) < 0) {
+                        "cancel-on-exception", &cancel_on_exception,
+                        "exit-on-first-error", &exit_on_first_error) < 0) {
         errprintf (errp, "%s", error.text);
         return NULL;
     }

--- a/src/test/docker/docker-run-systest.sh
+++ b/src/test/docker/docker-run-systest.sh
@@ -85,8 +85,12 @@ fi
 #  Saving to a file (avoiding a colon in the name) seems to work around
 #  these issues.
 #
+# N.B: docker save -o option doesn't seem to work and we can't use redirection
+# under checks_group() below. Therefore, use docker_save() shell function here:
+docker_save() { docker save $1> $2; }
+
 checks_group "Moving $IMAGE from docker to podman" \
-  docker save -o /tmp/systest-$$.tar $IMAGE \
+  docker_save $IMAGE /tmp/systest-$$.tar \
   && ls -lh /tmp/systest-$$.tar \
   && (podman load -i /tmp/systest-$$.tar || die "podman load failed") \
   && rm -f /tmp/systest-$$.tar

--- a/t/system/0006-perilog.t
+++ b/t/system/0006-perilog.t
@@ -1,0 +1,96 @@
+#
+#  Check prolog run via IMP
+#
+IMP=$(flux config get exec.imp)
+test -n "$IMP" && test_set_prereq HAVE_IMP
+
+fluxcmddir=$(pkg-config --variable=fluxcmddir flux-core)
+libexecdir=$(pkg-config --variable=fluxlibexecdir flux-core)
+confdir="/etc/flux/imp/conf.d"
+
+test_expect_success HAVE_IMP 'configure a system prolog' '
+	cleanup "sudo rm -f $confdir/imp-prolog.toml" &&
+	cat <<-EOF >imp-prolog.toml &&
+	[run.prolog]
+	allowed-users = ["flux"]
+	allowed-environment = ["FLUX_*"]
+	path = "$fluxcmddir/flux-run-prolog"
+	EOF
+	sudo cp imp-prolog.toml $confdir &&
+	sudo chmod 644 $confdir/imp-prolog.toml &&
+	ls -l $confdir/imp-prolog.toml &&
+	cat <<-EOF >site-prolog &&
+	env
+	EOF
+	sudo mkdir -p /etc/flux/system/prolog.d &&
+	cleanup "sudo rm -rf /etc/flux/system/prolog.d" &&
+	sudo cp site-prolog /etc/flux/system/prolog.d &&
+	sudo chmod 755 /etc/flux/system/prolog.d/site-prolog &&
+	cat <<-EOF >pkg-prolog &&
+	sleep 0
+	EOF
+	sudo cp pkg-prolog $libexecdir/prolog.d &&
+	cleanup "sudo rm -f $libexecdir/prolog.d/pkg-prolog" &&
+	sudo chmod 755 $libexecdir/prolog.d/pkg-prolog
+'
+test_expect_success HAVE_IMP 'configure the perilog plugin to run prolog' '
+	cleanup "sudo flux config reload" &&
+	flux config get |
+	    jq ".\"job-manager\".prolog.\"per-rank\"=true" |
+	    sudo flux config load &&
+	flux config get | jq
+'
+test_expect_success HAVE_IMP 'load jobtap perilog.so plugin' '
+	sudo flux jobtap load perilog.so || : &&
+	cleanup "sudo flux jobtap remove perilog.so"
+'
+test_expect_success HAVE_IMP 'run a job' '
+	flux run -vvv hostname
+'
+test_expect_success HAVE_IMP 'get prolog output' '
+	id=$(flux job last | flux job id --to=f58plain) &&
+	sudo journalctl -u flux-prolog@${id} >prolog.log
+'
+test_expect_success HAVE_IMP 'prolog ran site prolog' '
+	grep site-prolog prolog.log
+'
+test_expect_success HAVE_IMP 'prolog ran package prolog' '
+	grep pkg-prolog prolog.log
+'
+test_expect_success HAVE_IMP 'failed pkg prolog script fails prolog' '
+	test_when_finished "sudo flux resource undrain 0 || :" &&
+	cat <<-EOF >00failed-prolog &&
+	exit 1
+	EOF
+	sudo cp 00failed-prolog $libexecdir/prolog.d &&
+	sudo chmod 755 $libexecdir/prolog.d/00failed-prolog &&
+	test_must_fail flux run hostname &&
+	id=$(flux job last | flux job id --to=f58plain) &&
+	sudo journalctl -u flux-prolog@${id} >prolog-failed.log
+'
+test_expect_success HAVE_IMP 'failed prolog ran other prolog scripts' '
+	grep site-prolog prolog-failed.log
+'
+test_expect_success HAVE_IMP 'prolog ran package prolog' '
+	grep pkg-prolog prolog-failed.log
+'
+# Note: set exit-on-first-error for prolog,epilog,housekeeping to test that
+# the value is accepted, even though it is only used for the prolog here.
+test_expect_success HAVE_IMP 'set job-manager.*.exit-on-first-error=true' '
+	flux config get |
+	    jq ".\"job-manager\".prolog.\"exit-on-first-error\"=true" |
+	    jq ".\"job-manager\".epilog.\"exit-on-first-error\"=true" |
+	    jq ".\"job-manager\".housekeeping.\"exit-on-first-error\"=true" |
+	    sudo flux config load
+'
+test_expect_success HAVE_IMP 'failed prolog skips other prolog scripts' '
+	test_when_finished "sudo flux resource undrain 0 || :" &&
+	test_must_fail flux run -vvv hostname &&
+	id=$(flux job last | flux job id --to=f58plain) &&
+	sudo journalctl -u flux-prolog@${id} >prolog-failed-exit-on-error.log &&
+	test_must_fail grep site-prolog prolog-failed-exit-on-error.log &&
+	test_must_fail grep pkg-prolog prolog-failed-exit-on-error.log
+'
+test_expect_success HAVE_IMP 'remove failing prolog script (for future tests)' '
+	sudo rm -f $libexecdir/prolog.d/00failed-prolog
+'

--- a/t/t9000-system.t
+++ b/t/t9000-system.t
@@ -68,6 +68,9 @@ alias test_expect_success='expect_success_wrap'
 for testscript in ${FLUX_SOURCE_DIR}/t/system/${T9000_SYSTEM_GLOB}; do
 	TEST_LABEL="$(basename $testscript)"
 	. $testscript
+        # Do final_cleanup between tests
+	test_eval_ "$final_cleanup"
+	final_cleanup=
 done
 
 test_done


### PR DESCRIPTION
This PR adds a wrapper script for handling the execution of prolog,epilog,housekeeping instead of executing `/etc/flux/system/{prolog,epilog,housekeeping}` directly from the `flux-{prolog,epilog,housekeeping}@JOBID` systemd units. The wrapper script (installed at `$libexecdir/flux-run-system-scripts`) executes scripts in the following order for `name` in `prolog`, `epilog`, `housekeeping`:

 1. All package provided scripts at `$libexecdir/flux/{name}.d`
 2. If `/etc/flux/system/{name}` exists, then this script is executed directly for backwards compatibiliy, and step 3. is skipped.
 3. All system provided scripts at `/etc/flux/system/{name}.d`

This preserves behavior on existing systems while still allowing packages to install drop-in scripts into the system that will be executed as part of system instance prolog, epilog, or houskeeping. Documentation in the admin guide has been updated to reflect the changes.

By default, `flux-run-system-scripts` exits with the largest exit code of all scripts after executing everything. This behavior may be modified via the `job-manager.{name}.exit-on-first-error` key (set to `true` to exit on the first encountered error)

A trivial amount of testing is added to the system test workload. In order to get the tests to work reliably, a couple minor changes to the system test scripts was required.

This is WIP to get some feedback before adding a few more tests.


Fixes #6699