### PR TITLE
test/terminus: skip kill tests due to race

### DIFF
--- a/src/common/libterminus/test/terminus.c
+++ b/src/common/libterminus/test/terminus.c
@@ -274,6 +274,11 @@ static void test_protocol (void)
 
     /* kill session
      */
+    bool on_apple = false;
+    #ifdef __APPLE__
+    on_apple = true;
+    #endif
+    skip (on_apple, 11)
     f = flux_rpc_pack (h,
                        "terminus.kill",
                        0, FLUX_RPC_STREAMING,
@@ -357,6 +362,7 @@ static void test_protocol (void)
     ok (rc == 0,
         "terminus.kill (no wait): OK");
     flux_future_destroy (f);
+    end_skip; // __APPLE__
 
 
     /* kill-server


### PR DESCRIPTION
problem: There's what seems to be a race condition in the terminus wait setup that can occur if the spawned process dies too fast. This triggers very frequently on MacOS.

solution: skip these tests there for now.

I'm creating a new issue for the race condition because it seems very likely it's possible on Linux as well under the right conditions. See [this comment](https://github.com/flux-framework/flux-core/pull/6929#issuecomment-3137916572) for more details.