### PR TITLE
doc: fix flux-jobs(1) docs on contextual_time

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -534,7 +534,7 @@ the state of the job or other context:
    returned (if supported by the scheduler). In other states, the assigned
    nodelist is returned (if resources were assigned).
 
-**contextual_info**
+**contextual_time**
    Returns the job runtime for jobs in RUN state or later, otherwise the
    job duration (if set) is returned.
 


### PR DESCRIPTION
Problem: flux-jobs(1) has a typo, where contextual_info appears twice, and contextual_time appears undocumented.

The second contextual_info should actually be contextual_time. Fix it.