### PR TITLE
t: rename test dirs for fsck tests

### DIFF
--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -93,7 +93,8 @@ test_expect_success 'load kvs' '
 	flux module load kvs
 '
 # unfortunately we don't have a `flux content remove` command, so we'll corrupt
-# a valref by overwriting a treeobj with a bad reference
+# a treeobj of type "valref" by overwriting one of the references within it with
+# a bad reference
 test_expect_success 'make a reference invalid (dir.b)' '
 	cat dirb.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > dirbbad.out &&
 	flux kvs put --treeobj dir.b="$(cat dirbbad.out)" &&
@@ -210,6 +211,14 @@ test_expect_success 'flux-fsck no output with --quiet (dir.b & c & d)' '
 test_expect_success 'load kvs' '
 	flux module load kvs
 '
+# N.B. this can be a bit confusing how to corrupt a dirref
+# 1) get treeobj of `dir`, this treeobj should be of type "dirref"
+# 2) get the dirref reference from the `dir` treeobj.
+# 3) get the content of this reference from content store, it should be a treeobj of type "dir"
+# 4) within this treeobj is the key "bdir", it is a treeobj of type "dirref"
+# 5) corrupt the "dirref" for "bdir"
+# 6) write this corrupted treeobj back to the content store, saving this new reference
+# 7) update the original treeobj of `dir` (it's a "dirref") to point to the bad "dir" treeobj
 test_expect_success 'make a dirref reference invalid (dir.bdir)' '
 	flux kvs get --treeobj dir > dir.out &&
 	cat dir.out | jq -r .data[0] > dir.ref &&

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -17,26 +17,26 @@ test_expect_success 'flux-fsck fails if kvs loaded' '
 	test_must_fail flux fsck
 '
 test_expect_success 'create some kvs content' '
-	flux kvs put dir.a=test &&
+	flux kvs put testdir.a=test &&
 	flux kvs getroot -b > a.rootref &&
-	flux kvs put dir.b=test1 &&
-	flux kvs put --append dir.b=test2 &&
-	flux kvs put --append dir.b=test3 &&
-	flux kvs put --append dir.b=test4 &&
+	flux kvs put testdir.b=test1 &&
+	flux kvs put --append testdir.b=test2 &&
+	flux kvs put --append testdir.b=test3 &&
+	flux kvs put --append testdir.b=test4 &&
 	flux kvs getroot -b > b.rootref &&
-	flux kvs put dir.c=testA &&
-	flux kvs put --append dir.c=testB &&
-	flux kvs put --append dir.c=testC &&
-	flux kvs put --append dir.c=testD &&
+	flux kvs put testdir.c=testA &&
+	flux kvs put --append testdir.c=testB &&
+	flux kvs put --append testdir.c=testC &&
+	flux kvs put --append testdir.c=testD &&
 	flux kvs getroot -b > c.rootref &&
-	flux kvs put dir.d=testE &&
-	flux kvs put --append dir.d=testF &&
+	flux kvs put testdir.d=testE &&
+	flux kvs put --append testdir.d=testF &&
 	flux kvs getroot -b > d.rootref &&
-	flux kvs mkdir dir.adir &&
-	flux kvs mkdir dir.bdir &&
-	flux kvs link dir alink &&
+	flux kvs mkdir testdir.adir &&
+	flux kvs mkdir testdir.bdir &&
+	flux kvs link testdir alink &&
 	flux kvs namespace create testns &&
-	flux kvs put --namespace=testns dir.a=testns
+	flux kvs put --namespace=testns testdir.a=testns
 '
 # N.B. startlog commands in rc scripts normally ensures a checkpoint
 # exists but we do this just to be extra sure
@@ -44,9 +44,9 @@ test_expect_success 'call sync to ensure we have checkpointed' '
 	flux kvs sync
 '
 test_expect_success 'save some treeobjs for later' '
-	flux kvs get --treeobj dir.b > dirb.out &&
-	flux kvs get --treeobj dir.c > dirc.out &&
-	flux kvs get --treeobj dir.d > dird.out
+	flux kvs get --treeobj testdir.b > testdirb.out &&
+	flux kvs get --treeobj testdir.c > testdirc.out &&
+	flux kvs get --treeobj testdir.d > testdird.out
 '
 test_expect_success 'unload kvs' '
 	flux module remove kvs
@@ -58,13 +58,13 @@ test_expect_success 'flux-fsck works (simple)' '
 '
 test_expect_success 'flux-fsck verbose works (simple)' '
 	flux fsck --verbose 2> verbose.out &&
-	grep "dir$" verbose.out &&
-	grep "dir\.a" verbose.out &&
-	grep "dir\.b" verbose.out &&
-	grep "dir\.c" verbose.out &&
-	grep "dir\.d" verbose.out &&
-	grep "dir\.adir" verbose.out &&
-	grep "dir\.bdir" verbose.out &&
+	grep "testdir$" verbose.out &&
+	grep "testdir\.a" verbose.out &&
+	grep "testdir\.b" verbose.out &&
+	grep "testdir\.c" verbose.out &&
+	grep "testdir\.d" verbose.out &&
+	grep "testdir\.adir" verbose.out &&
+	grep "testdir\.bdir" verbose.out &&
 	grep "alink" verbose.out
 '
 # Cover value with a very large number of appends
@@ -95,9 +95,9 @@ test_expect_success 'load kvs' '
 # unfortunately we don't have a `flux content remove` command, so we'll corrupt
 # a treeobj of type "valref" by overwriting one of the references within it with
 # a bad reference
-test_expect_success 'make a reference invalid (dir.b)' '
-	cat dirb.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > dirbbad.out &&
-	flux kvs put --treeobj dir.b="$(cat dirbbad.out)" &&
+test_expect_success 'make a reference invalid (testdir.b)' '
+	cat testdirb.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > testdirbbad.out &&
+	flux kvs put --treeobj testdir.b="$(cat testdirbbad.out)" &&
 	flux kvs getroot -b > bbad.rootref
 '
 test_expect_success 'call sync to ensure we have checkpointed' '
@@ -107,21 +107,21 @@ test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
 # line count includes extra diagnostic messages
-test_expect_success 'flux-fsck detects errors (dir.b)' '
+test_expect_success 'flux-fsck detects errors (testdir.b)' '
 	test_must_fail flux fsck 2> fsckerrors1.out &&
 	test_debug "cat fsckerrors1.out" &&
 	count=$(cat fsckerrors1.out | wc -l) &&
 	test $count -eq 3 &&
-	grep "dir\.b" fsckerrors1.out | grep "missing blobref(s)" &&
+	grep "testdir\.b" fsckerrors1.out | grep "missing blobref(s)" &&
 	grep "Total errors: 1" fsckerrors1.out
 '
-test_expect_success 'flux-fsck --verbose outputs details (dir.b)' '
+test_expect_success 'flux-fsck --verbose outputs details (testdir.b)' '
 	test_must_fail flux fsck --verbose 2> fsckerrors1V.out &&
 	test_debug "cat fsckerrors1V.out" &&
-	grep "dir\.b" fsckerrors1V.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.b" fsckerrors1V.out | grep "missing blobref" | grep "index=1" &&
 	grep "Total errors: 1" fsckerrors1V.out
 '
-test_expect_success 'flux-fsck no output with --quiet (dir.b)' '
+test_expect_success 'flux-fsck no output with --quiet (testdir.b)' '
 	test_must_fail flux fsck --quiet 2> fsckerrors2.out &&
 	test_debug "cat fsckerrors2.out" &&
 	count=$(cat fsckerrors2.out | wc -l) &&
@@ -130,10 +130,10 @@ test_expect_success 'flux-fsck no output with --quiet (dir.b)' '
 test_expect_success 'load kvs' '
 	flux module load kvs
 '
-test_expect_success 'make a reference invalid (dir.c)' '
-	cat dirc.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > dircbad1.out &&
-	cat dircbad1.out | jq -c .data[2]=\"sha1-1234567890123456789012345678901234567890\" > dircbad2.out &&
-	flux kvs put --treeobj dir.c="$(cat dircbad2.out)" &&
+test_expect_success 'make a reference invalid (testdir.c)' '
+	cat testdirc.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > testdircbad1.out &&
+	cat testdircbad1.out | jq -c .data[2]=\"sha1-1234567890123456789012345678901234567890\" > testdircbad2.out &&
+	flux kvs put --treeobj testdir.c="$(cat testdircbad2.out)" &&
 	flux kvs getroot -b > cbad.rootref
 '
 test_expect_success 'call sync to ensure we have checkpointed' '
@@ -143,24 +143,24 @@ test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
 # line count includes extra diagnostic messages
-test_expect_success 'flux-fsck detects errors (dir.b & c)' '
+test_expect_success 'flux-fsck detects errors (testdir.b & c)' '
 	test_must_fail flux fsck 2> fsckerrors3.out &&
 	test_debug "cat fsckerrors3.out" &&
 	count=$(cat fsckerrors3.out | wc -l) &&
 	test $count -eq 4 &&
-	grep "dir\.b" fsckerrors3.out | grep "missing blobref(s)" &&
-	grep "dir\.c" fsckerrors3.out | grep "missing blobref(s)" &&
+	grep "testdir\.b" fsckerrors3.out | grep "missing blobref(s)" &&
+	grep "testdir\.c" fsckerrors3.out | grep "missing blobref(s)" &&
 	grep "Total errors: 2" fsckerrors3.out
 '
-test_expect_success 'flux-fsck --verbose outputs details (dir.b & c)' '
+test_expect_success 'flux-fsck --verbose outputs details (testdir.b & c)' '
 	test_must_fail flux fsck --verbose 2> fsckerrors3V.out &&
 	test_debug "cat fsckerrors3V.out" &&
-	grep "dir\.b" fsckerrors3V.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" fsckerrors3V.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" fsckerrors3V.out | grep "missing blobref" | grep "index=2" &&
+	grep "testdir\.b" fsckerrors3V.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" fsckerrors3V.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" fsckerrors3V.out | grep "missing blobref" | grep "index=2" &&
 	grep "Total errors: 2" fsckerrors3V.out
 '
-test_expect_success 'flux-fsck no output with --quiet (dir.b & c)' '
+test_expect_success 'flux-fsck no output with --quiet (testdir.b & c)' '
 	test_must_fail flux fsck --quiet 2> fsckerrors4.out &&
 	test_debug "cat fsckerrors4.out" &&
 	count=$(cat fsckerrors4.out | wc -l) &&
@@ -169,10 +169,10 @@ test_expect_success 'flux-fsck no output with --quiet (dir.b & c)' '
 test_expect_success 'load kvs' '
 	flux module load kvs
 '
-test_expect_success 'make a reference invalid (dir.d)' '
-	cat dird.out | jq -c .data[0]=\"sha1-1234567890123456789012345678901234567890\" > dirdbad1.out &&
-	cat dirdbad1.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > dirdbad2.out &&
-	flux kvs put --treeobj dir.d="$(cat dirdbad2.out)" &&
+test_expect_success 'make a reference invalid (testdir.d)' '
+	cat testdird.out | jq -c .data[0]=\"sha1-1234567890123456789012345678901234567890\" > testdirdbad1.out &&
+	cat testdirdbad1.out | jq -c .data[1]=\"sha1-1234567890123456789012345678901234567890\" > testdirdbad2.out &&
+	flux kvs put --treeobj testdir.d="$(cat testdirdbad2.out)" &&
 	flux kvs getroot -b > dbad.rootref
 '
 test_expect_success 'call sync to ensure we have checkpointed' '
@@ -182,27 +182,27 @@ test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
 # line count includes extra diagnostic messages
-test_expect_success 'flux-fsck detects errors (dir.b & c & d)' '
+test_expect_success 'flux-fsck detects errors (testdir.b & c & d)' '
 	test_must_fail flux fsck 2> fsckerrors5.out &&
 	test_debug "cat fsckerrors5.out" &&
 	count=$(cat fsckerrors5.out | wc -l) &&
 	test $count -eq 5 &&
-	grep "dir\.b" fsckerrors5.out | grep "missing blobref(s)" &&
-	grep "dir\.c" fsckerrors5.out | grep "missing blobref(s)" &&
-	grep "dir\.d" fsckerrors5.out | grep "missing blobref(s)" &&
+	grep "testdir\.b" fsckerrors5.out | grep "missing blobref(s)" &&
+	grep "testdir\.c" fsckerrors5.out | grep "missing blobref(s)" &&
+	grep "testdir\.d" fsckerrors5.out | grep "missing blobref(s)" &&
 	grep "Total errors: 3" fsckerrors5.out
 '
-test_expect_success 'flux-fsck --verbose outputs details (dir.b & c & d)' '
+test_expect_success 'flux-fsck --verbose outputs details (testdir.b & c & d)' '
 	test_must_fail flux fsck --verbose 2> fsckerrors5V.out &&
 	test_debug "cat fsckerrors5V.out" &&
-	grep "dir\.b" fsckerrors5V.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" fsckerrors5V.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" fsckerrors5V.out | grep "missing blobref" | grep "index=2" &&
-	grep "dir\.d" fsckerrors5V.out | grep "missing blobref" | grep "index=0" &&
-	grep "dir\.d" fsckerrors5V.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.b" fsckerrors5V.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" fsckerrors5V.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" fsckerrors5V.out | grep "missing blobref" | grep "index=2" &&
+	grep "testdir\.d" fsckerrors5V.out | grep "missing blobref" | grep "index=0" &&
+	grep "testdir\.d" fsckerrors5V.out | grep "missing blobref" | grep "index=1" &&
 	grep "Total errors: 3" fsckerrors5V.out
 '
-test_expect_success 'flux-fsck no output with --quiet (dir.b & c & d)' '
+test_expect_success 'flux-fsck no output with --quiet (testdir.b & c & d)' '
 	test_must_fail flux fsck --quiet 2> fsckerrors6.out &&
 	test_debug "cat fsckerrors6.out" &&
 	count=$(cat fsckerrors6.out | wc -l) &&
@@ -212,21 +212,21 @@ test_expect_success 'load kvs' '
 	flux module load kvs
 '
 # N.B. this can be a bit confusing how to corrupt a dirref
-# 1) get treeobj of `dir`, this treeobj should be of type "dirref"
-# 2) get the dirref reference from the `dir` treeobj.
+# 1) get treeobj of `testdir`, this treeobj should be of type "dirref"
+# 2) get the dirref reference from the `testdir` treeobj.
 # 3) get the content of this reference from content store, it should be a treeobj of type "dir"
 # 4) within this treeobj is the key "bdir", it is a treeobj of type "dirref"
 # 5) corrupt the "dirref" for "bdir"
 # 6) write this corrupted treeobj back to the content store, saving this new reference
-# 7) update the original treeobj of `dir` (it's a "dirref") to point to the bad "dir" treeobj
-test_expect_success 'make a dirref reference invalid (dir.bdir)' '
-	flux kvs get --treeobj dir > dir.out &&
-	cat dir.out | jq -r .data[0] > dir.ref &&
-	flux content load $(cat dir.ref) > dir.treeobj &&
-	cat dir.treeobj | jq -c .data.bdir.data[0]=\"sha1-1234567890123456789012345678901234567890\" > bdirbad.out &&
+# 7) update the original treeobj of `testdir` (it's a "dirref") to point to the bad "dir" treeobj
+test_expect_success 'make a dirref reference invalid (testdir.bdir)' '
+	flux kvs get --treeobj testdir > testdir.out &&
+	cat testdir.out | jq -r .data[0] > testdir.ref &&
+	flux content load $(cat testdir.ref) > testdir.treeobj &&
+	cat testdir.treeobj | jq -c .data.bdir.data[0]=\"sha1-1234567890123456789012345678901234567890\" > bdirbad.out &&
 	cat bdirbad.out | flux content store > bdirbad.ref &&
-	cat dir.out | jq -c .data[0]=\"$(cat bdirbad.ref)\" > dirupdate.out &&
-	flux kvs put --treeobj dir="$(cat dirupdate.out)" &&
+	cat testdir.out | jq -c .data[0]=\"$(cat bdirbad.ref)\" > testdirupdate.out &&
+	flux kvs put --treeobj testdir="$(cat testdirupdate.out)" &&
 	flux kvs getroot -b > bdirbad.rootref
 '
 test_expect_success 'call sync to ensure we have checkpointed' '
@@ -236,29 +236,29 @@ test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
 # line count includes extra diagnostic messages
-test_expect_success 'flux-fsck detects errors (dir.b & c & d & bdir)' '
+test_expect_success 'flux-fsck detects errors (testdir.b & c & d & bdir)' '
 	test_must_fail flux fsck 2> fsckerrors7.out &&
 	test_debug "cat fsckerrors7.out" &&
 	count=$(cat fsckerrors7.out | wc -l) &&
 	test $count -eq 6 &&
-	grep "dir\.b" fsckerrors7.out | grep "missing blobref(s)" &&
-	grep "dir\.c" fsckerrors7.out | grep "missing blobref(s)" &&
-	grep "dir\.d" fsckerrors7.out | grep "missing blobref(s)" &&
-	grep "dir\.bdir" fsckerrors7.out | grep "missing dirref blobref" &&
+	grep "testdir\.b" fsckerrors7.out | grep "missing blobref(s)" &&
+	grep "testdir\.c" fsckerrors7.out | grep "missing blobref(s)" &&
+	grep "testdir\.d" fsckerrors7.out | grep "missing blobref(s)" &&
+	grep "testdir\.bdir" fsckerrors7.out | grep "missing dirref blobref" &&
 	grep "Total errors: 4" fsckerrors7.out
 '
-test_expect_success 'flux-fsck --verbose outputs details (dir.b & c & d & bdir)' '
+test_expect_success 'flux-fsck --verbose outputs details (testdir.b & c & d & bdir)' '
 	test_must_fail flux fsck --verbose 2> fsckerrors7V.out &&
 	test_debug "cat fsckerrors7V.out" &&
-	grep "dir\.b" fsckerrors7V.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" fsckerrors7V.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" fsckerrors7V.out | grep "missing blobref" | grep "index=2" &&
-	grep "dir\.d" fsckerrors7V.out | grep "missing blobref" | grep "index=0" &&
-	grep "dir\.d" fsckerrors7V.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.bdir" fsckerrors7V.out | grep "missing dirref blobref" &&
+	grep "testdir\.b" fsckerrors7V.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" fsckerrors7V.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" fsckerrors7V.out | grep "missing blobref" | grep "index=2" &&
+	grep "testdir\.d" fsckerrors7V.out | grep "missing blobref" | grep "index=0" &&
+	grep "testdir\.d" fsckerrors7V.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.bdir" fsckerrors7V.out | grep "missing dirref blobref" &&
 	grep "Total errors: 4" fsckerrors7V.out
 '
-test_expect_success 'flux-fsck no output with --quiet (dir.b & c & d & bdir)' '
+test_expect_success 'flux-fsck no output with --quiet (testdir.b & c & d & bdir)' '
 	test_must_fail flux fsck --quiet 2> fsckerrors8.out &&
 	test_debug "cat fsckerrors8.out" &&
 	count=$(cat fsckerrors8.out | wc -l) &&
@@ -273,7 +273,7 @@ test_expect_success 'flux-fsck works on rootref a' '
 	test_debug "cat rootref1.out" &&
 	count=$(cat rootref1.out | wc -l) &&
 	test $count -eq 3 &&
-	grep "dir\.a" rootref1.out &&
+	grep "testdir\.a" rootref1.out &&
 	grep "Total errors: 0" rootref1.out
 '
 test_expect_success 'flux-fsck works on rootref b' '
@@ -281,8 +281,8 @@ test_expect_success 'flux-fsck works on rootref b' '
 	test_debug "cat rootref2.out" &&
 	count=$(cat rootref2.out | wc -l) &&
 	test $count -eq 4 &&
-	grep "dir\.a" rootref2.out &&
-	grep "dir\.b" rootref2.out &&
+	grep "testdir\.a" rootref2.out &&
+	grep "testdir\.b" rootref2.out &&
 	grep "Total errors: 0" rootref2.out
 '
 test_expect_success 'flux-fsck works on rootref c' '
@@ -290,9 +290,9 @@ test_expect_success 'flux-fsck works on rootref c' '
 	test_debug "cat rootref3.out" &&
 	count=$(cat rootref3.out | wc -l) &&
 	test $count -eq 5 &&
-	grep "dir\.a" rootref3.out &&
-	grep "dir\.b" rootref3.out &&
-	grep "dir\.c" rootref3.out &&
+	grep "testdir\.a" rootref3.out &&
+	grep "testdir\.b" rootref3.out &&
+	grep "testdir\.c" rootref3.out &&
 	grep "Total errors: 0" rootref3.out
 '
 test_expect_success 'flux-fsck works on rootref d' '
@@ -300,45 +300,45 @@ test_expect_success 'flux-fsck works on rootref d' '
 	test_debug "cat rootref4.out" &&
 	count=$(cat rootref4.out | wc -l) &&
 	test $count -eq 6 &&
-	grep "dir\.a" rootref4.out &&
-	grep "dir\.b" rootref4.out &&
-	grep "dir\.c" rootref4.out &&
-	grep "dir\.d" rootref4.out &&
+	grep "testdir\.a" rootref4.out &&
+	grep "testdir\.b" rootref4.out &&
+	grep "testdir\.c" rootref4.out &&
+	grep "testdir\.d" rootref4.out &&
 	grep "Total errors: 0" rootref4.out
 '
 test_expect_success 'flux-fsck works on rootref w/ bad b' '
 	test_must_fail flux fsck --verbose --rootref=$(cat bbad.rootref) 2> rootref5.out &&
 	test_debug "cat rootref5.out" &&
-	grep "dir\.b" rootref5.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.b" rootref5.out | grep "missing blobref" | grep "index=1" &&
 	grep "Total errors: 1" rootref5.out
 '
 test_expect_success 'flux-fsck works on rootref c w/ bad b and c' '
 	test_must_fail flux fsck --verbose --rootref=$(cat cbad.rootref) 2> rootref6.out &&
 	test_debug "cat rootref6.out" &&
-	grep "dir\.b" rootref6.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" rootref6.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" rootref6.out | grep "missing blobref" | grep "index=2" &&
+	grep "testdir\.b" rootref6.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" rootref6.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" rootref6.out | grep "missing blobref" | grep "index=2" &&
 	grep "Total errors: 2" rootref6.out
 '
 test_expect_success 'flux-fsck works on rootref d w/ bad b and c and d' '
 	test_must_fail flux fsck --verbose --rootref=$(cat dbad.rootref) 2> rootref7.out &&
 	test_debug "cat rootref7.out" &&
-	grep "dir\.b" rootref7.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" rootref7.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" rootref7.out | grep "missing blobref" | grep "index=2" &&
-	grep "dir\.d" rootref7.out | grep "missing blobref" | grep "index=0" &&
-	grep "dir\.d" rootref7.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.b" rootref7.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" rootref7.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" rootref7.out | grep "missing blobref" | grep "index=2" &&
+	grep "testdir\.d" rootref7.out | grep "missing blobref" | grep "index=0" &&
+	grep "testdir\.d" rootref7.out | grep "missing blobref" | grep "index=1" &&
 	grep "Total errors: 3" rootref7.out
 '
 test_expect_success 'flux-fsck works on rootref w/ bad b and c and d and bdir' '
 	test_must_fail flux fsck --verbose --rootref=$(cat bdirbad.rootref) 2> rootref8.out &&
 	test_debug "cat rootref8.out" &&
-	grep "dir\.b" rootref8.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" rootref8.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.c" rootref8.out | grep "missing blobref" | grep "index=2" &&
-	grep "dir\.d" rootref8.out | grep "missing blobref" | grep "index=0" &&
-	grep "dir\.d" rootref8.out | grep "missing blobref" | grep "index=1" &&
-	grep "dir\.bdir" rootref8.out | grep "missing dirref blobref" &&
+	grep "testdir\.b" rootref8.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" rootref8.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.c" rootref8.out | grep "missing blobref" | grep "index=2" &&
+	grep "testdir\.d" rootref8.out | grep "missing blobref" | grep "index=0" &&
+	grep "testdir\.d" rootref8.out | grep "missing blobref" | grep "index=1" &&
+	grep "testdir\.bdir" rootref8.out | grep "missing dirref blobref" &&
 	grep "Total errors: 4" rootref8.out
 '
 test_expect_success 'flux-fsck --rootref fails on non-existent ref' '


### PR DESCRIPTION
Problem: The test directories in t2816-fsck-cmd.t are simply named "dir", but things can get confusing when comments describe
treeobjs of type "dir".

Rename all "dir" paths to "testdir".

----

splitting off from bigger PR b/c it's quite "noisy" with a lot of search and replace changes.