### PR TITLE
Revert "broker: short circuit groups when quorum.size == 1"

### DIFF
--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -418,7 +418,7 @@ static void action_quorum (struct state_machine *s)
     }
     if (s->ctx->rank > 0)
         quorum_check_parent (s);
-    else if (s->quorum.size > 1) {
+    else {
         if (!(s->quorum.f = flux_rpc_pack (s->ctx->h,
                                            "groups.get",
                                            FLUX_NODEID_ANY,
@@ -436,8 +436,6 @@ static void action_quorum (struct state_machine *s)
             flux_watcher_start (s->quorum.warn_timer);
         }
     }
-    else
-        state_machine_post (s, "quorum-full");
 }
 
 static void action_run (struct state_machine *s)


### PR DESCRIPTION
Problem: sometimes the broker enters RUN state without rank 0 membership in the broker.online group.

A recent attempt to skip unnecessary work during startup of size=1 instances unintentionally introduced a race in tests that expect the resources of rank 0 to be online immediately.

This was reported in #7000

This reverts commit d4f40e8e64654f16d671be8f8c5a2c152bf0565b.