### PR TITLE
modprobe: ensure required modules of activated alternatives are also active

### DIFF
--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -1006,6 +1006,9 @@ class Modprobe:
             if not isinstance(task, Module):
                 raise ValueError(f"{module} is not a module")
             self._active_tasks.append(module)
+            # append any requires from this module
+            for other in task.requires:
+                self._active_tasks.append(other)
 
     def load(self, modules):
         """


### PR DESCRIPTION
This bug was uncovered while doing some other modprobe work:

Modules that are selected as the current alternative for some service, e.g. `sched`, do not automatically have their `requires` list activated. If the module also has a `needs` on a module it `requires`, this can end up _deactivating_ the selected alternative since its `needs` is not met.

Automatically activate modules in the required list of an activated module. Also, add a couple new tests to check the expected behavior.