### PR TITLE
testsuite: fix barrier in shell-lost issues test

### DIFF
--- a/t/issues/t2492-shell-lost.sh
+++ b/t/issues/t2492-shell-lost.sh
@@ -31,7 +31,7 @@ try:
     taskid = int(os.environ["FLUX_TASK_RANK"])
     if taskid == 0:
         print(f"waiting on barrier for {size} tasks", flush=True)
-    subprocess.run(["flux", "pmi", "barrier"])
+    subprocess.run(["flux", "pmi", "barrier"], close_fds=False)
     if taskid == 0:
         print(f"exited barrier", flush=True)
 


### PR DESCRIPTION
Problem: The `flux pmi barrier` call in t2492-shell-lost.sh is not functional because Python's `subprocess.run()` is closing the PMI_FD. This causes the barrier to exit prematurely and results in a race where the test job can get killed by SIGINT before it is handling the signal.

Add `close_fds=False` to the `subprocess.run()` call so that the PMI fd is not closed and the barrier functions properly.