### PR TITLE
broker: interpret sticky bit in -Sstatedir=DIR

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -62,6 +62,12 @@ statedir-cleanup [Updates: C]
    If set to ``1`` the directory is removed on broker exit.
    If set to ``0`` the directory is not removed.
 
+.. note::
+   If ``statedir`` or ``rundir`` is set on the command line, and the
+   specified directory has the sticky bit set, it is assumed to be a ``/tmp``
+   like directory, and the broker creates a unique temporary directory within
+   that directory.
+
 security.owner
    The numeric userid of the owner of this Flux instance.
 

--- a/t/t0036-broker-rundir.t
+++ b/t/t0036-broker-rundir.t
@@ -112,6 +112,20 @@ for attr in rundir statedir; do
 	test_must_fail flux start ${ARGS_NORC} flux setattr $attr x &&
 	test_must_fail flux start ${ARGS_NORC} flux setattr $attr-cleanup x
     '
+    test_expect_success "-S$attr=DIR interprets DIR sticky bit" '
+	dirname=`mktemp -d` &&
+	chmod 1777 $dirname &&
+	flux start ${ARGS_NORC} -S$attr=$dirname \
+		./checkattrs.sh >$attr-sticky.out
+    '
+    test_expect_success "$attr/DIR was used" '
+	grep "^$attr=$dirname/" $attr-sticky.out
+    '
+    test_expect_success "$attr/DIR was cleaned up but not $attr" '
+	subdirname=$(kv_lookup $attr $attr-sticky.out) &&
+	test -d $(dirname $subdirname) &&
+	test ! -e $subdirname
+    '
 
 done # for loop
 


### PR DESCRIPTION
Problem: as discussed in #6990, it's somewhat inconvenient to make the user specify a unique path when they submit a job that should use an alternate location for `statedir`.

If  `-Sstatedir=DIR` refers to a `/tmp` like directory (a directory with the sticky bit set), then a unique directory is created with in it.

So on CORAL-2 systems where rabbits are mounted on `/l/ssd`, one could specify `--broker-opts=-Sstatedir=/l/ssd` to ensure the content-sqlite db doesn't eat up memory in the tmpfs ramdisk on rank 0.