### PR TITLE
flux-start: suppress module panic in recovery mode

### DIFF
--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -540,6 +540,7 @@ void process_recovery_option (char **argz,
 
     add_argzf (argz, argz_len, "-Sbroker.recovery-mode=1");
     add_argzf (argz, argz_len, "-Sbroker.quorum=1");
+    add_argzf (argz, argz_len, "-Sbroker.module-nopanic=1");
     add_argzf (argz, argz_len, "-Slog-stderr-level=5");
 
     // if --recovery has no optional argument, assume this is the system


### PR DESCRIPTION
Problem: when a recovery instance is started with `flux start --recovery`, a spurious module exit could cause the recovery instance to shut down unexpectedly.

Since we're in a degraded state, add `-Sbroker.module-nopanic=1` to the broker options that are set in recovery mode.