### PR TITLE
flux-module: expand module name column in list output

### DIFF
--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -493,12 +493,12 @@ void lsmod_print_header (FILE *f, bool longopt)
 {
     if (longopt) {
         fprintf (f,
-                 "%-24.24s %4s  %c %s %s %-8s %s\n",
+                 "%-25.25s %4s  %c %s %s %-8s %s\n",
                  "Module", "Idle", 'S', "Sendq", "Recvq", "Service", "Path");
     }
     else {
         fprintf (f,
-                 "%-24s %4s  %c %s %s %s\n",
+                 "%-25s %4s  %c %s %s %s\n",
                  "Module", "Idle", 'S', "Sendq", "Recvq", "Service");
     }
 }


### PR DESCRIPTION
Noticed that `sched-fluxion-feasibility` is being truncated in `flux module list` output. Not a big deal except that bash completions use this output to get module names to complete, so I kept getting `sched-fluxion-feasibilit`.

In the hopes that this is the longest module name ever, this PR adds 1 character to the `flux module list` 1st column.