### PR TITLE
testsuite: improve cleanup in t2412-sdmon.t

### DIFF
--- a/t/t2412-sdmon.t
+++ b/t/t2412-sdmon.t
@@ -38,6 +38,10 @@ start_test_unit() {
 stop_test_unit() {
 	systemctl --user stop $1
 }
+reset_test_unit() {
+	systemctl --user reset-failed $1
+}
+
 # Usage: wait_for_none MAXSEC
 wait_for_none() {
 	local retry=$(($1*10))
@@ -75,7 +79,9 @@ test_expect_success 'load sdmon module' '
 '
 test_expect_success 'make sure residual test units are not running' '
 	stop_test_unit shell-t2412 || true &&
-	stop_test_unit imp-shell-t2412 || true
+	stop_test_unit imp-shell-t2412 || true &&
+	reset_test_unit shell-t2412 || true &&
+	reset_test_unit imp-shell-t2412 || true
 '
 test_expect_success 'wait for it to join the sdmon.online group' '
 	run_timeout 30 $groups waitfor --count=1 sdmon.online


### PR DESCRIPTION
On my test system I was getting failures in `t2412-sdmon.t` because an old `shell-t412.service` unit was in a failed state in my systemd user unit. The `systemctl --user stop` command didn't seem to clean up the unit, so subsequent tests were failing.

This PR just adds an additional `systemctl --user reset-failed <unit>` to the part of the test that tries to ensure residual units are not running. This seems to resolve the issue on my system, but we'll see if it passes in CI.