### PR TITLE
testsuite: fix t2429-shell-lost when hostname includes domain

### DIFF
--- a/t/issues/t2492-shell-lost.sh
+++ b/t/issues/t2492-shell-lost.sh
@@ -60,7 +60,7 @@ for rank in 3 1; do
 
     log "Submitted job $id. Waiting for shell rank $rank to be lost"
 
-    value="shell rank $rank (on $(hostname -s)): Killed"
+    value="shell rank $rank (on $(hostname)): Killed"
     flux job wait-event -Wt 120 -Hvp output -m message="$value" $id log \
 	|| die "failed to get shell lost message"
 


### PR DESCRIPTION
Problem: In `issues/t2429-shell-lost.sh`, `hostname -s` is used in an exact match for a log message, but this fails if the set hostname actually includes a domain, since the short name won't match.

Remove `-s` from the `hostname` invocation.

Fixes #7023