### PR TITLE
testsuite: fix t2622-job-shell-sysmon.t skip_all behavior

### DIFF
--- a/t/t2622-job-shell-sysmon.t
+++ b/t/t2622-job-shell-sysmon.t
@@ -2,7 +2,9 @@
 #
 test_description='Test flux-shell sysmon plugin'
 
-cgdir=/sys/fs/cgroup/$(cat /proc/$$/cgroup | cut -d: -f3)
+. `dirname $0`/sharness.sh
+
+cgdir=/sys/fs/cgroup/$(cat /proc/$$/cgroup | grep ^0: | cut -d: -f3)
 if test $? -ne 0; then
         skip_all="cgroups is unavailable"
         test_done
@@ -16,7 +18,6 @@ if ! test -e $cgdir/cpu.stat; then
 	test_done
 fi
 
-. `dirname $0`/sharness.sh
 
 test_under_flux 1
 


### PR DESCRIPTION
Problem: `t2622-job-shell-sysmon.t` fails with the following errors on a system without the unified cgroup hieararchy:
```
 ./t2622-job-shell-sysmon.t: 10: test: /sys/fs/cgroup//: unexpected operator
 ./t2622-job-shell-sysmon.t: 12: test_done: not found
 ./t2622-job-shell-sysmon.t: 14: test: /sys/fs/cgroup//: unexpected operator
 ./t2622-job-shell-sysmon.t: 16: test_done: not found
```
This is because `/proc/$$/cgroup` may contain multiple lines on these systems. The `test_done: not found` errors are because this function is used before sourcing `sharness.sh` which provides the shell function.

Fix the `/proc/$$/cgroup` parsing issue by picking only the line in the file prefixed with `0:`.

Move the source of `sharness.sh` up to the top of the file to address the errors using `test_done`.