### PR TITLE
sysmon: handle hybrid cgroup hierarchy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -217,6 +217,8 @@ AC_CHECK_HEADERS( \
   link.h \
   [sys/ucred.h] \
   [sys/prctl.h] \
+  [sys/vfs.h] \
+  [linux/magic.h] \
 )
 
 ##

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -107,7 +107,9 @@ libutil_la_SOURCES = \
 	parse_size.c \
 	basename.h \
 	basename.c \
-	ansi_color.h
+	ansi_color.h \
+	cgroup.h \
+	cgroup.c
 
 libutil_la_LDFLAGS = \
         $(AM_LDFLAGS) \

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -148,7 +148,8 @@ TESTS = test_sha1.t \
 	test_environment.t \
 	test_basemoji.t \
 	test_sigutil.t \
-	test_parse_size.t
+	test_parse_size.t \
+	test_cgroup.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -312,3 +313,7 @@ test_sigutil_t_LDADD = $(test_ldadd)
 test_parse_size_t_SOURCES = test/parse_size.c
 test_parse_size_t_CPPFLAGS = $(test_cppflags)
 test_parse_size_t_LDADD = $(test_ldadd)
+
+test_cgroup_t_SOURCES = test/cgroup.c
+test_cgroup_t_CPPFLAGS = $(test_cppflags)
+test_cgroup_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/cgroup.c
+++ b/src/common/libutil/cgroup.c
@@ -1,0 +1,192 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#ifndef HAVE_STRLCPY
+#include "src/common/libmissing/strlcpy.h"
+#endif
+#include <errno.h>
+#include <dirent.h>
+#include <ctype.h>
+#include <stdbool.h>
+#include <limits.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#ifdef HAVE_SYS_VFS_H
+#include <sys/vfs.h>
+#endif
+#ifdef HAVE_LINUX_MAGIC_H
+#include <linux/magic.h>
+#endif
+#ifndef TMPFS_MAGIC
+#define TMPFS_MAGIC 0x01021994 /* from linux/magic.h */
+#endif
+#ifndef CGROUP_SUPER_MAGIC
+#define CGROUP_SUPER_MAGIC 0x27e0eb
+#endif
+#ifndef CGROUP2_SUPER_MAGIC
+#define CGROUP2_SUPER_MAGIC 0x63677270
+#endif
+#include <signal.h>
+
+#include "basename.h"
+
+#include "cgroup.h"
+
+static char *remove_leading_dotdot (char *relpath)
+{
+    while (strncmp (relpath, "/..", 3) == 0)
+        relpath += 3;
+    return relpath;
+}
+
+/*
+ *  Look up the current cgroup relative path from /proc/self/cgroup.
+ *
+ *  If cgroup->unified is true, then look for the first entry where
+ *   'subsys' is an empty string.
+ *
+ *  Otherwise, use the `name=systemd` line.
+ *
+ *  See NOTES: /proc/[pid]/cgroup in cgroups(7).
+ */
+static int cgroup_init_path (struct cgroup_info *cgroup)
+{
+    int rc = -1;
+    int n;
+    FILE *fp;
+    size_t size = 0;
+    char *line = NULL;
+    int saved_errno;
+
+    if (!(fp = fopen ("/proc/self/cgroup", "r")))
+        return -1;
+
+    while ((n = getline (&line, &size, fp)) >= 0) {
+        char *nl;
+        char *relpath = NULL;
+        char *subsys = strchr (line, ':');
+        if ((nl = strchr (line, '\n')))
+            *nl = '\0';
+        if (subsys == NULL
+            || *(++subsys) == '\0'
+            || !(relpath = strchr (subsys, ':')))
+            continue;
+
+        /* Nullify subsys, relpath is already nul-terminated at newline */
+        *(relpath++) = '\0';
+
+        /* Remove leading /.. in relpath. This could be due to cgroup
+         * mounted in a container.
+         */
+        relpath = remove_leading_dotdot (relpath);
+
+        /*  If unified cgroups are being used, then stop when we find
+         *   subsys="". Otherwise stop at subsys="name=systemd":
+         */
+        if ((cgroup->unified && subsys[0] == '\0')
+            || (!cgroup->unified && strcmp (subsys, "name=systemd") == 0)) {
+            int len = sizeof (cgroup->path);
+            if (snprintf (cgroup->path,
+                          len,
+                          "%s%s",
+                          cgroup->mount_dir,
+                          relpath) < len)
+                rc = 0;
+            break;
+        }
+    }
+    if (rc < 0)
+        errno = ENOENT;
+
+    saved_errno = errno;
+    free (line);
+    fclose (fp);
+    errno = saved_errno;
+    return rc;
+}
+
+/*  Determine if this system is using the unified (v2) or legacy (v1)
+ *   cgroups hierarchy (See https://systemd.io/CGROUP_DELEGATION/)
+ *   and mount point for systemd managed cgroups.
+ */
+static int cgroup_init_mount_dir_and_type (struct cgroup_info *cg)
+{
+#ifndef __APPLE__
+    struct statfs fs;
+
+    /*  Assume unified unless we discover otherwise
+     */
+    cg->unified = true;
+
+    /*  Check if either /sys/fs/cgroup or /sys/fs/cgroup/unified
+     *   are mounted as type cgroup2. If so, use this as the mount dir
+     *   (Note: these paths are guaranteed to fit in cg->mount_dir, so
+     *    no need to check for truncation)
+     */
+    (void) strlcpy (cg->mount_dir, "/sys/fs/cgroup", sizeof (cg->mount_dir));
+    if (statfs (cg->mount_dir, &fs) < 0)
+        return -1;
+
+    /* if cgroup2 fs mounted: unified hierarchy for all users of cgroupfs
+     */
+    if (fs.f_type == CGROUP2_SUPER_MAGIC)
+        return 0;
+
+    /*  O/w, check if cgroup2 unified hierarchy mounted at
+     *   /sys/fs/cgroup/unified
+     */
+    (void) strlcpy (cg->mount_dir,
+                    "/sys/fs/cgroup/unified",
+                    sizeof (cg->mount_dir));
+    if (statfs (cg->mount_dir, &fs) < 0)
+        return -1;
+
+    if (fs.f_type == CGROUP2_SUPER_MAGIC)
+        return 0;
+
+    /*  O/w, if /sys/fs/cgroup is mounted as tmpfs, we need to check
+     *   for /sys/fs/cgroup/systemd mounted as cgroupfs (legacy).
+     */
+    if (fs.f_type == TMPFS_MAGIC) {
+
+        (void) strlcpy (cg->mount_dir,
+                        "/sys/fs/cgroup/systemd",
+                        sizeof (cg->mount_dir));
+        if (statfs (cg->mount_dir, &fs) == 0
+            && fs.f_type == CGROUP_SUPER_MAGIC) {
+            cg->unified = false;
+            return 0;
+        }
+    }
+
+#endif
+    /*  Unable to determine cgroup mount point and/or unified vs legacy */
+    return -1;
+}
+
+int cgroup_info_init (struct cgroup_info *cgroup)
+{
+    if (cgroup_init_mount_dir_and_type (cgroup) < 0
+        || cgroup_init_path (cgroup) < 0)
+        return -1;
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libutil/cgroup.h
+++ b/src/common/libutil/cgroup.h
@@ -1,0 +1,22 @@
+/************************************************************\
+ * Copyright 2024 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef UTIL_CGROUP_H
+#define UTIL_CGROUP_H 1
+
+struct cgroup_info {
+    char mount_dir[PATH_MAX + 1];
+    char path[PATH_MAX + 1];
+    bool unified;
+};
+
+int cgroup_info_init (struct cgroup_info *cgroup);
+
+#endif /* !UTIL_CGROUP_H */

--- a/src/common/libutil/cgroup.h
+++ b/src/common/libutil/cgroup.h
@@ -11,6 +11,10 @@
 #ifndef UTIL_CGROUP_H
 #define UTIL_CGROUP_H 1
 
+#include <sys/param.h>
+#include <stdbool.h>
+#include <stdarg.h>
+
 struct cgroup_info {
     char mount_dir[PATH_MAX + 1];
     char path[PATH_MAX + 1];
@@ -18,5 +22,23 @@ struct cgroup_info {
 };
 
 int cgroup_info_init (struct cgroup_info *cgroup);
+
+int cgroup_access (struct cgroup_info *cgroup, const char *name, int mode);
+
+/* Parse value from cgroup file
+ */
+int cgroup_scanf (struct cgroup_info *cgroup,
+                  const char *name,
+                  const char *fmt,
+                  ...);
+
+/* Parse one value from a flat-keyed cgroup file
+ */
+int cgroup_key_scanf (struct cgroup_info *cgroup,
+                      const char *name,
+                      const char *key,
+                      const char *fmt,
+                      ...);
+
 
 #endif /* !UTIL_CGROUP_H */

--- a/src/common/libutil/test/cgroup.c
+++ b/src/common/libutil/test/cgroup.c
@@ -1,0 +1,76 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "src/common/libtap/tap.h"
+#include "ccan/array_size/array_size.h"
+
+#include "cgroup.h"
+
+void test_cpu (struct cgroup_info *cgroup)
+{
+    const char *keys[] = {"usage_usec", "user_usec", "system_usec"};
+
+    skip (cgroup_access (cgroup, "cpu.stat", R_OK) < 0,
+          ARRAY_SIZE (keys),
+          "cpu.stat (unavailable)");
+
+    for (int i = 0; i < ARRAY_SIZE (keys); i++) {
+        int rc;
+        unsigned long long u64 = 0;
+
+        rc = cgroup_key_scanf (cgroup, "cpu.stat", keys[i], "%llu", &u64);
+        ok (rc == 1, "cgroup_scanf scanned cpu.stat:%s", keys[i]);
+        diag ("cpu.stat:%s=%llu", keys[i], u64);
+    }
+
+    end_skip;
+}
+
+void test_memory (struct cgroup_info *cgroup)
+{
+    const char *names[] = {"memory.current", "memory.peak"};
+
+    for (int i = 0; i < ARRAY_SIZE (names); i++) {
+        int rc;
+        unsigned long long u64 = 0;
+
+        skip (cgroup_access (cgroup, names[i], R_OK) < 0,
+              1,
+              "%s (unavailable)",
+              names[i]);
+
+        rc = cgroup_scanf (cgroup, names[i], "%llu", &u64);
+        ok (rc == 1, "cgroup_scanf scanned %s", names[i]);
+        diag ("%s=%llu", names[i], u64);
+
+        end_skip;
+    }
+}
+
+int main(int argc, char** argv)
+{
+    struct cgroup_info cgroup;
+
+    if (cgroup_info_init (&cgroup) < 0) {
+        diag ("incompatible cgroup configuration");
+        plan (SKIP_ALL);
+    }
+    else {
+        plan (NO_PLAN);
+        test_cpu (&cgroup);
+        test_memory (&cgroup);
+    }
+    done_testing();
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t2622-job-shell-sysmon.t
+++ b/t/t2622-job-shell-sysmon.t
@@ -6,18 +6,15 @@ test_description='Test flux-shell sysmon plugin'
 
 cgdir=/sys/fs/cgroup/$(cat /proc/$$/cgroup | grep ^0: | cut -d: -f3)
 if test $? -ne 0; then
-        skip_all="cgroups is unavailable"
+        skip_all="incompatible cgroup configuration"
         test_done
 fi
-if ! test -e $cgdir/memory.current || ! test -e $cgdir/memory.peak; then
-	skip_all="memory.current and/or memory.peak are unavailable"
-	test_done
+if test -e $cgdir/memory.current && test -e $cgdir/memory.peak; then
+	test_set_prereq MEMORY
 fi
-if ! test -e $cgdir/cpu.stat; then
-	skip_all="cpu.stat is unavailable"
-	test_done
+if test -e $cgdir/cpu.stat; then
+	test_set_prereq CPU
 fi
-
 
 test_under_flux 1
 
@@ -26,22 +23,34 @@ test_expect_success 'sysmon plugin is not loaded by default' '
 	test_must_fail grep sysmon disable.out
 '
 test_expect_success 'sysmon logs usage summary' '
-	flux run -o sysmon true 2>enable.err &&
-	grep "sysmon: memory.peak=" enable.err &&
+	flux run -o sysmon true 2>enable.err
+'
+test_expect_success MEMORY 'sysmon logs memory.peak' '
+	grep "sysmon: memory.peak=" enable.err
+'
+test_expect_success CPU 'sysmon logs loadavg' '
 	grep "sysmon: loadavg-overall=" enable.err
 '
 test_expect_success 'reload rank 0 heartbeat with fast period' '
 	flux module reload heartbeat period=0.1s
 '
 test_expect_success 'sysmon trace logs current usage - heartbeat sync' '
-	flux run -o verbose=2 -o sysmon sleep 1 2>tracehb.err &&
-	grep "sysmon: memory.current=" tracehb.err &&
+	flux run -o verbose=2 -o sysmon sleep 1 2>tracehb.err
+'
+test_expect_success CPU 'sysmon logs loadavg' '
 	grep "sysmon: loadavg=" tracehb.err
 '
+test_expect_success MEMORY 'sysmon logs memory.current' '
+	grep "sysmon: memory.current=" tracehb.err
+'
 test_expect_success 'sysmon trace logs current usage - timer sync' '
-	flux run -o verbose=2 -o sysmon.period=0.1s sleep 1 2>tracetimer.err &&
-	grep "sysmon: memory.current=" tracetimer.err &&
+	flux run -o verbose=2 -o sysmon.period=0.1s sleep 1 2>tracetimer.err
+'
+test_expect_success CPU 'sysmon logs loadavg' '
 	grep "sysmon: loadavg=" tracetimer.err
+'
+test_expect_success MEMORY 'sysmon logs memory.current' '
+	grep "sysmon: memory.current=" tracetimer.err
 '
 test_expect_success '-o sysmon.period=30 is accepted as a valid FSD' '
 	flux run -o sysmon.period=30 true


### PR DESCRIPTION
Problem: sysmon assumes the unfied cgroup hierarchy, but some modern systems use the hybrid hierarchy.
    
Use  cgroup support code pulled in from flux-security, as it handles the hybrid cgroup hierarchy
In addition, use some new cgroup helpers to parse `/sys` files instead of embedding one-offs.
    
Also, treat missing memory or cpu `/sys` files as non-fatal warnings, simply disabling one or the other with a warning message.
    
Fixes #7026

As extra credit later on, the oom plugin could be similarly converted.