### PR TITLE
flux-module: fix list output alignment

### DIFF
--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -520,7 +520,7 @@ void lsmod_print_entry (FILE *f,
 
     if (longopt) {
         char *s = lsmod_services_string (services, name, 8);
-        fprintf (f, "%-24.24s %4s  %c %5d %5d %-8s %s\n",
+        fprintf (f, "%-25.25s %4s  %c %5d %5d %-8s %s\n",
                  name,
                  idle_s,
                  state,
@@ -532,7 +532,7 @@ void lsmod_print_entry (FILE *f,
     }
     else {
         char *s = lsmod_services_string (services, name, 0);
-        fprintf (f, "%-24.24s %4s  %c %5d %5d %s\n",
+        fprintf (f, "%-25.25s %4s  %c %5d %5d %s\n",
                  name,
                  idle_s,
                  state,


### PR DESCRIPTION
Problem: the header is not column-aligned with the data in flux-module list output.

An earlier change to make room for long module names adjusted the header position without adjusting the data field width and fill.

Adjust the data format to match the header.