### PR TITLE
modprobe: move package provided files out of `/etc`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -510,6 +510,11 @@ AC_DEFINE_UNQUOTED([FLUXLIBEXECDIR], ["$fluxlibexecdir"],
   [The expansion of "$libexecdir/flux"])
 AC_SUBST(fluxlibexecdir)
 
+adl_RECURSIVE_EVAL(["$datadir/flux"], [fluxdatadir])
+AC_DEFINE_UNQUOTED([FLUXDATADIR], ["$fluxdatadir"],
+  [The expansion of "$datadir/flux"])
+AC_SUBST(fluxdatadir)
+
 adl_RECURSIVE_EVAL(["$libexecdir/flux/cmd"], [fluxcmddir])
 AC_DEFINE_UNQUOTED([FLUXCMDDIR], ["$fluxcmddir"],
   [The expansion of "$libexecdir/flux/cmd"])

--- a/doc/man1/flux-modprobe.rst
+++ b/doc/man1/flux-modprobe.rst
@@ -9,9 +9,9 @@ SYNOPSIS
 | **flux** **modprobe** **load** [*--dry-run*] *MODULE* [*MODULE* ...]
 | **flux** **modprobe** **remove** [*--dry-run*] *MODULE* [*MODULE* ...]
 | **flux** **modprobe** **list-dependencies** [*-f*] *MODULE*
-| **flux** **modprobe** **run** [*-v*] [*--show-deps*] [*--dry-run*] [*--confdir=DIR*] *FILE*
-| **flux** **modprobe** **rc1** [*-v*] [*--timing*] [*--show-deps*] [*--dry-run*] [*--confdir=DIR*] *FILE*
-| **flux** **modprobe** **rc3** [*-v*] [*--show-deps*] [*--dry-run*] [*--confdir=DIR*] *FILE*
+| **flux** **modprobe** **run** [*-v*] [*--show-deps*] [*--dry-run*] *FILE*
+| **flux** **modprobe** **rc1** [*-v*] [*--timing*] [*--show-deps*] [*--dry-run*] *FILE*
+| **flux** **modprobe** **rc3** [*-v*] [*--show-deps*] [*--dry-run*] *FILE*
 
 
 DESCRIPTION
@@ -92,10 +92,6 @@ run
 :program:`flux modprobe run` takes the path to a modprobe rc file on
 the command line and runs it. This is mainly useful for testing.
 
-.. option:: --confdir=DIR
-
-  Use DIR for the modprobe configuration directory instead of the default.
-
 .. option:: --dry-run
 
   Do not actually run anything, but print the tasks that would be run.
@@ -159,10 +155,6 @@ located at ``/etc/flux/modprobe/rc1.py`` plus any extra Python rc files
 found in ``/etc/flux/modprobe/rc1.d/*.py``. This command is typically called
 from Flux's rc1 script.
 
-.. option:: --confdir=DIR
-
-Override the default modprobe config directory.
-
 .. option:: --timing
 
 Dump task timing information to the KVS.
@@ -189,10 +181,6 @@ rc3
 :program:`flux modprobe rc3` unloads all broker modules and executes
 defined shutdown tasks from ``/etc/flux/modprobe/rc3.py`` and
 ``etc/flux/modprobe/rc3.d/*.py``.
-
-.. option:: --confdir=DIR
-
-Override the default modprobe config directory.
 
 .. option:: -v, --verbose
 

--- a/doc/man1/flux-modprobe.rst
+++ b/doc/man1/flux-modprobe.rst
@@ -112,10 +112,6 @@ show
 :program:`flux modprobe show` dumps the configuration information for a
 module or service.
 
-.. option:: --path=PATH
-
-Set the path to the module configuration TOML file.
-
 .. option:: -S, --set-alternative=NAME=MODULE
 
 Set the alternative for service NAME to module MODULE.

--- a/doc/man1/flux-modprobe.rst
+++ b/doc/man1/flux-modprobe.rst
@@ -195,9 +195,23 @@ MODULE CONFIG
 =============
 
 :program:`flux modprobe` loads information about Flux modules from the
-``modules`` array in ``modprobe.toml``. Module configuration may be
-extended by dropping new TOML files into ``modprobe.d`` in the modprobe
-configuration directory, typically ``/etc/flux/modprobe``.
+``modules`` array in ``modprobe.toml``.
+
+Module configuration may be extended by dropping new TOML files into a
+``modprobe.d`` directory in the modprobe search path. The default search
+path is::
+
+  $datadir/flux/modprobe:$sysconfdir/flux/modprobe
+
+which is typically::
+
+  /usr/share/flux/modprobe:/etc/flux/modprobe
+
+Packages should install files under ``/usr/libexec/flux/modprobe`` while
+site updates and modifications go under ``/etc/flux/modprobe``.
+
+The default search path can be overridden using :envvar:`FLUX_MODPROBE_PATH`
+or extended using :envvar:`FLUX_MODPROBE_PATH_APPEND`
 
 Each entry in the ``modules`` array supports the following keys:
 
@@ -287,6 +301,23 @@ using the *task* decorator imported from :py:func:`flux.modprobe.task`, e.g.:
   @task("test")
   def test_task(context):
     print("running test task")
+
+Similar to module configuration, tasks and setup may be added to the default
+:command:`rc1` and :command:`rc3` by dropping new Python files into a
+``rcX.d`` directory in the modprobe rc search path. The default search
+path is::
+
+  $libexecdir/flux/modprobe:$sysconfdir/flux/modprobe
+
+which, e.g. for ``rc1`` would typically be:
+
+  /usr/libexec/flux/modprobe/rc1.d:/etc/flux/modprobe/rc1.d
+
+Packages should install files under ``/usr/libexec/flux/modprobe`` while
+site updates and modifications go under ``/etc/flux/modprobe``.
+
+The default search path can be overridden using :envvar:`FLUX_MODPROBE_PATH`
+or extended using :envvar:`FLUX_MODPROBE_PATH_APPEND`
 
 The *task* decorator requires a task *name*, and in addition supports the
 following optional arguments:

--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -486,9 +486,25 @@ MISCELLANEOUS
 
 .. envvar:: FLUX_MODPROBE_PATH
 
-   If set to a colon-separated list of directories, :man1:`flux-modprobe` will
-   append these directories to the default search path for ``modprobe.toml``,
-   ``modprobe.d/*.toml``, ``rc1.d/*.py``, and ``rc3.d/*.py``.
+   Override the default search path in :man1:`flux-modprobe`. Normally,
+   after loading the built-in default ``modprobe.toml`` and ``rcX.py``,
+   :command:`flux modprobe` loads all extra module configuration from
+   ``modprobe.d/*.toml`` using the search path::
+
+     $datadir/flux/modprobe:$sysconfdir/flux/modprobe
+
+   and all rc Python files from ``rcX.d/*.py`` using the search path::
+
+     $libexecdir/flux/modprobe:$sysconfdir/flux/modprobe
+
+   :envvar:`FLUX_MODPROBE_PATH` overrides these internal paths. If set to
+   an empty string, then the internal default search paths are disabled.
+
+.. envvar:: FLUX_MODPROBE_PATH_APPEND
+
+   If set to a colon-separated list of directories, :man1:`flux-modprobe`
+   will append these directories to its default search path instead of
+   overriding as with :envvar:`FLUX_MODPROBE_PATH`.
 
 .. envvar:: FLUX_RC_EXTRA
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -991,3 +991,5 @@ py
 nopanic
 fluxlibexecdir
 sysmon
+datadir
+rcX

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -17,11 +17,13 @@ dist_cron_DATA = \
 
 nobase_dist_fluxconf_SCRIPTS = \
 	rc1.old \
-	rc3.old \
+	rc3.old
+
+nobase_dist_fluxlibexec_SCRIPTS = \
 	modprobe/rc1.py \
 	modprobe/rc3.py
 
-nobase_dist_fluxconf_DATA = \
+nobase_dist_fluxdata_DATA = \
 	modprobe/modprobe.toml
 
 fluxlibexec_SCRIPTS = \
@@ -30,19 +32,29 @@ fluxlibexec_SCRIPTS = \
 # Install empty modprobe/*.d directories after rc1.py and rc3.py are installed
 # Install empty fluxlibexecdir/{prolog,epilog,housekeeping}.d directories
 install-data-hook:
-	$(MKDIR_P) $(DESTDIR)$(fluxconfdir)/modprobe/modprobe.d
-	$(MKDIR_P) $(DESTDIR)$(fluxconfdir)/modprobe/rc1.d
-	$(MKDIR_P) $(DESTDIR)$(fluxconfdir)/modprobe/rc3.d
+	for dir in $(fluxconfdir) $(fluxdatadir); do \
+	  $(MKDIR_P) $(DESTDIR)$$dir/modprobe/modprobe.d; \
+	done
+	for dir in $(fluxconfdir) $(fluxlibexecdir); do \
+	  $(MKDIR_P) $(DESTDIR)$$dir/modprobe/rc1.d; \
+	  $(MKDIR_P) $(DESTDIR)$$dir/modprobe/rc3.d; \
+	done
 	for dir in prolog.d epilog.d housekeeping.d; do \
 	  $(MKDIR_P) $(DESTDIR)$(fluxlibexecdir)/$$dir; \
 	done
 
 # Remove empty modprobe/{prolog,epilog,housekeeping}.d directories on uninstall
 uninstall-hook:
-	rmdir $(DESTDIR)$(fluxconfdir)/modprobe/modprobe.d 2>/dev/null || :
-	rmdir $(DESTDIR)$(fluxconfdir)/modprobe/rc1.d 2>/dev/null || :
-	rmdir $(DESTDIR)$(fluxconfdir)/modprobe/rc3.d 2>/dev/null || :
-	rmdir $(DESTDIR)$(fluxconfdir)/modprobe 2>/dev/null || :
+	for dir in $(fluxconfdir) $(fluxdatadir); do \
+	  rmdir $(DESTDIR)$$dir/modprobe/modprobe.d 2>/dev/null || :; \
+	done
+	for dir in $(fluxconfdir) $(fluxlibexecdir); do \
+	  rmdir $(DESTDIR)$$dir/modprobe/rc1.d 2>/dev/null || :; \
+	  rmdir $(DESTDIR)$$dir/modprobe/rc3.d 2>/dev/null || :; \
+	done
+	for dir in $(fluxconfdir) $(fluxlibexecdir) $(fluxdatadir); do \
+	  rmdir $(DESTDIR)$$dir/modprobe 2>/dev/null || :; \
+	done
 	for dir in prolog.d epilog.d housekeeping.d; do \
 	  rmdir $(DESTDIR)$(fluxlibexecdir)/$$dir 2>/dev/null || :; \
 	done

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -2179,7 +2179,6 @@ _flux_modprobe()
         -f, --full \
     "
     show_OPTS="\
-        --path= \
         -S, --set-alternative= \
         -D, --disable= \
     "

--- a/etc/flux-core.pc.in
+++ b/etc/flux-core.pc.in
@@ -8,6 +8,7 @@ fluxconfdir=@fluxconfdir@
 fluxcmddir=@fluxcmddir@
 fluxlibdir=@fluxlibdir@
 fluxlibexecdir=@fluxlibexecdir@
+fluxdatadir=@fluxdatadir@
 fluxmoddir=@fluxmoddir@
 fluxcmdhelpdir=@datadir@/flux/help.d
 fluxshellrcdir=@fluxconfdir@/shell

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import threading
 import time
-from collections import defaultdict, namedtuple
+from collections import OrderedDict, defaultdict, namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -671,7 +671,10 @@ class Modprobe:
         self.handle = self.context.handle
         self.rank = self.handle.get_rank()
 
-        self.confdir = default_flux_confdir() / "modprobe"
+        self.searchpath = {
+            "toml": self._get_searchpath(),
+            "py": self._get_searchpath(builtindir="libexecdir"),
+        }
 
         # Active tasks are those added via the @task decorator, and
         # which will be active by default when running "all" tasks:
@@ -772,24 +775,64 @@ class Modprobe:
                 # Allow <module>.key to update an existing configured module:
                 self.update_module(name, entry)
 
-    def _modprobe_path_expand(self, path=None, name="modprobe", ext="toml"):
-        if path is None:
-            etc = Path(self.confdir)
-            path = etc / f"{name}.{ext}"
-        else:
-            etc = Path(path).parent
-
-        files = [path]
-        dirs = [etc]
-        dirs.extend(
-            filter(
+    def _get_searchpath(self, builtindir="datadir"):
+        """
+        Return list of dirs in ``FLUX_MODPROBE_PATH`` if set, o/w returns the
+        default modprobe search path.
+        Args:
+            builtindir (str): base path for builtin/package path. Should
+                be either "datadir" or "libexecdir".
+        """
+        if "FLUX_MODPROBE_PATH" in os.environ:
+            searchpath = filter(
                 lambda s: s and not s.isspace(),
-                os.environ.get("FLUX_MODPROBE_PATH", "").split(":"),
+                os.environ["FLUX_MODPROBE_PATH"].split(":"),
             )
-        )
-        for directory in dirs:
+            # return searchpath without duplicates
+            return list(OrderedDict.fromkeys(searchpath))
+
+        pkgdir = conf_builtin_get(builtindir)
+        confdir = conf_builtin_get("confdir")
+        return [f"{pkgdir}/modprobe", f"{confdir}/modprobe"]
+
+    def _searchpath_expand(self, name="modprobe", ext="toml"):
+        """
+        Expand searchpath for extension ``ext`` based on configured paths.
+        """
+        files = []
+        for directory in self.searchpath[ext]:
             if Path(directory).exists():
                 files.extend(sorted(glob.glob(f"{directory}/{name}.d/*.{ext}")))
+        return files
+
+    def _get_toml_files(self):
+        """
+        Return all modprobe config toml files found in the following order
+         - Always read ``{fluxdatadir}/modprobe/modprobe.toml``
+         - for dir in self.searchpath: read ``{dir}/modprobe.d/*.toml``
+        """
+        files = []
+        builtin_toml_config = (
+            Path(conf_builtin_get("datadir")) / "modprobe" / "modprobe.toml"
+        )
+        if builtin_toml_config.exists():
+            files.append(str(builtin_toml_config))
+        files.extend(self._searchpath_expand())
+        return files
+
+    def _get_rc_files(self, name="rc1"):
+        """
+        Return all modprobe rc *.py files found in the following order
+         - Always read ``{fluxdatadir}/modprobe/{name}.py`` (e.g. ``rc1.py``)
+         - for dir in self.searchpath: read ``{dir}/{name}.d/*.py``
+        """
+        files = []
+        builtin_rc_file = (
+            Path(conf_builtin_get("libexecdir")) / "modprobe" / f"{name}.py"
+        )
+        if builtin_rc_file.exists():
+            files.append(str(builtin_rc_file))
+        files.extend(self._searchpath_expand(name=name, ext="py"))
         return files
 
     def _update_modules_from_config(self):
@@ -810,15 +853,10 @@ class Modprobe:
                 self.update_module(key, entry)
 
     def configure_modules(self):
-        """Load all configured modules in searchpath
-
-        Loads all modules TOML files in the following order:
-            1. From ``path`` if provided.
-               default path=``{sysconfdir}/modprobe/modprobe.toml``
-            2. From ``dirname(path)/modprobe.d/*.toml``
-            3. for dir in FLUX_MODPROBE_PATH: ``{dir}/modprobe.d/*.toml``
         """
-        for file in self._modprobe_path_expand():
+        Load module configuration from TOML config.
+        """
+        for file in self._get_toml_files():
             self.add_modules(file)
 
         self._update_modules_from_config()
@@ -1030,9 +1068,8 @@ class Modprobe:
             self._load_file(name)
             return
 
-        # O/w, add tasks from "named" file in confdir, plus all tasks
-        # in {confdir}/{name}.d/*.py and FLUX_MODPROBE_PAtH
-        for file in self._modprobe_path_expand(name=name, ext="py"):
+        # O/w, load all rc files in configured search path:
+        for file in self._get_rc_files(name):
             self._load_file(file)
 
     def activate_modules(self, modules):

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -783,17 +783,27 @@ class Modprobe:
             builtindir (str): base path for builtin/package path. Should
                 be either "datadir" or "libexecdir".
         """
+        searchpath = []
         if "FLUX_MODPROBE_PATH" in os.environ:
             searchpath = filter(
                 lambda s: s and not s.isspace(),
                 os.environ["FLUX_MODPROBE_PATH"].split(":"),
             )
-            # return searchpath without duplicates
-            return list(OrderedDict.fromkeys(searchpath))
+        else:
+            pkgdir = conf_builtin_get(builtindir)
+            confdir = conf_builtin_get("confdir")
+            searchpath = [f"{pkgdir}/modprobe", f"{confdir}/modprobe"]
 
-        pkgdir = conf_builtin_get(builtindir)
-        confdir = conf_builtin_get("confdir")
-        return [f"{pkgdir}/modprobe", f"{confdir}/modprobe"]
+        if "FLUX_MODPROBE_PATH_APPEND" in os.environ:
+            searchpath.extend(
+                filter(
+                    lambda s: s and not s.isspace(),
+                    os.environ["FLUX_MODPROBE_PATH_APPEND"].split(":"),
+                )
+            )
+
+        # return searchpath without duplicates
+        return list(OrderedDict.fromkeys(searchpath))
 
     def _searchpath_expand(self, name="modprobe", ext="toml"):
         """

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -809,7 +809,7 @@ class Modprobe:
             else:
                 self.update_module(key, entry)
 
-    def configure_modules(self, path=None):
+    def configure_modules(self):
         """Load all configured modules in searchpath
 
         Loads all modules TOML files in the following order:
@@ -818,7 +818,7 @@ class Modprobe:
             2. From ``dirname(path)/modprobe.d/*.toml``
             3. for dir in FLUX_MODPROBE_PATH: ``{dir}/modprobe.d/*.toml``
         """
-        for file in self._modprobe_path_expand(path):
+        for file in self._modprobe_path_expand():
             self.add_modules(file)
 
         self._update_modules_from_config()

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -660,7 +660,7 @@ class Modprobe:
     The modprobe main class. Intended for use by flux-modprobe(1).
     """
 
-    def __init__(self, confdir=None, timing=False, verbose=False, dry_run=False):
+    def __init__(self, timing=False, verbose=False, dry_run=False):
         self.exitcode = 0
         self.timing = None
         self.t0 = None
@@ -671,10 +671,7 @@ class Modprobe:
         self.handle = self.context.handle
         self.rank = self.handle.get_rank()
 
-        if confdir is None:
-            self.confdir = default_flux_confdir() / "modprobe"
-        else:
-            self.confdir = Path(confdir)
+        self.confdir = default_flux_confdir() / "modprobe"
 
         # Active tasks are those added via the @task decorator, and
         # which will be active by default when running "all" tasks:

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -702,6 +702,10 @@ class Modprobe:
             )
         )
 
+    def print(self, *args):
+        """Wrapper for context.print()"""
+        self.context.print(*args)
+
     def add_timing(self, name, starttime, end=None):
         if self.timing is None:
             return
@@ -811,6 +815,7 @@ class Modprobe:
         """
         files = []
         for directory in self.searchpath[ext]:
+            self.print(f"checking {directory}/{name}.d/*.{ext}")
             if Path(directory).exists():
                 files.extend(sorted(glob.glob(f"{directory}/{name}.d/*.{ext}")))
         return files
@@ -825,6 +830,7 @@ class Modprobe:
         builtin_toml_config = (
             Path(conf_builtin_get("datadir")) / "modprobe" / "modprobe.toml"
         )
+        self.print(f"checking {builtin_toml_config}")
         if builtin_toml_config.exists():
             files.append(str(builtin_toml_config))
         files.extend(self._searchpath_expand())
@@ -840,6 +846,7 @@ class Modprobe:
         builtin_rc_file = (
             Path(conf_builtin_get("libexecdir")) / "modprobe" / f"{name}.py"
         )
+        self.print(f"checking {builtin_rc_file}")
         if builtin_rc_file.exists():
             files.append(str(builtin_rc_file))
         files.extend(self._searchpath_expand(name=name, ext="py"))
@@ -867,6 +874,7 @@ class Modprobe:
         Load module configuration from TOML config.
         """
         for file in self._get_toml_files():
+            self.print(f"loading {file}")
             self.add_modules(file)
 
         self._update_modules_from_config()
@@ -1075,11 +1083,13 @@ class Modprobe:
     def read_rcfile(self, name):
         # For absolute file path, just add tasks from single file:
         if name.endswith(".py"):
+            self.print(f"loading {name}")
             self._load_file(name)
             return
 
         # O/w, load all rc files in configured search path:
         for file in self._get_rc_files(name):
+            self.print(f"loading {file}")
             self._load_file(file)
 
     def activate_modules(self, modules):

--- a/src/cmd/flux-modprobe.py
+++ b/src/cmd/flux-modprobe.py
@@ -45,9 +45,7 @@ def set_alternatives(M, alternatives):
 
 
 def runtasks(args, rcfile, timing=False):
-    M = Modprobe(
-        confdir=args.confdir, timing=timing, verbose=args.verbose, dry_run=args.dry_run
-    )
+    M = Modprobe(timing=timing, verbose=args.verbose, dry_run=args.dry_run)
     t0 = M.timestamp
     M.configure_modules()
     M.read_rcfile(rcfile)
@@ -85,7 +83,7 @@ def rc3(args):
         os.execv(f"{confdir}/rc3.old", ["rc3"])
         sys.exit(1)
 
-    M = Modprobe(confdir=args.confdir, verbose=args.verbose, dry_run=args.dry_run)
+    M = Modprobe(verbose=args.verbose, dry_run=args.dry_run)
     M.configure_modules()
     # rc3 always removes all modules
     M.set_remove()
@@ -206,23 +204,11 @@ def parse_args():
         help="Don't do anything. Print what would be run",
     )
     run_parser.add_argument(
-        "--confdir",
-        metavar="DIR",
-        default=None,
-        help="Set default config directory",
-    )
-    run_parser.add_argument(
         "file", metavar="FILE", help="Run commands defined in Python rc file FILE"
     )
     run_parser.set_defaults(func=run)
 
     rc1_parser = subparsers.add_parser("rc1", formatter_class=help_formatter())
-    rc1_parser.add_argument(
-        "--confdir",
-        metavar="DIR",
-        default=None,
-        help="Set default config directory",
-    )
     rc1_parser.add_argument(
         "--timing",
         action="store_true",
@@ -244,12 +230,6 @@ def parse_args():
     rc1_parser.set_defaults(func=rc1)
 
     rc3_parser = subparsers.add_parser("rc3", formatter_class=help_formatter())
-    rc3_parser.add_argument(
-        "--confdir",
-        metavar="DIR",
-        default=None,
-        help="Set default config directory",
-    )
     rc3_parser.add_argument(
         "-v", "--verbose", action="store_true", help="Print tasks as they are executed"
     )

--- a/src/cmd/flux-modprobe.py
+++ b/src/cmd/flux-modprobe.py
@@ -104,7 +104,7 @@ def load(args):
 
 
 def show(args):
-    M = Modprobe().configure_modules(args.path)
+    M = Modprobe().configure_modules()
     set_alternatives(M, args.set_alternative)
     disable_modules(M, args.disable)
     print(json.dumps(M.get_task(args.module).to_dict(), default=str))
@@ -274,12 +274,6 @@ def parse_args():
     list_deps_parser.set_defaults(func=list_dependencies)
 
     show_parser = subparsers.add_parser("show", formatter_class=help_formatter())
-    show_parser.add_argument(
-        "--path",
-        metavar="PATH",
-        type=str,
-        help="Set path to module configuration TOML file",
-    )
     show_parser.add_argument(
         "-S",
         "--set-alternative",

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -58,6 +58,11 @@ static struct builtin builtin_tab[] = {
         .val_intree = ABS_TOP_SRCDIR "/etc",
     },
     {
+        .key = "datadir",
+        .val_installed = FLUXDATADIR,
+        .val_intree = ABS_TOP_SRCDIR "/etc",
+    },
+    {
         .key = "lua_cpath_add",
         .val_installed = LUAEXECDIR "/?.so",
         .val_intree = ABS_TOP_BUILDDIR "/src/bindings/lua/?.so",

--- a/t/t0100-modprobe.t
+++ b/t/t0100-modprobe.t
@@ -544,6 +544,23 @@ test_expect_success 'modprobe fails if task raises exception' '
 	test_debug "cat output${seq}" &&
 	grep "next:.*test exception" output${seq}
 '
+test_expect_success 'modprobe: FLUX_MODPROBE_PATH works' '
+	FLUX_MODPROBE_PATH=$(pwd) \
+	  flux modprobe rc1 --dry-run --verbose >path.out 2>&1 &&
+	grep "checking $(pwd)" path.out &&
+	test_must_fail \
+	  grep $(flux config builtin libexecdir)/modprobe/modprobe.d path.out &&
+	test_must_fail \
+	  grep $(flux config builtin libexecdir)/modprobe/rc1.d path.out
+'
+test_expect_success 'modprobe: FLUX_MODPROBE_PATH_APPEND works' '
+	FLUX_MODPROBE_PATH_APPEND=$(pwd) \
+	  flux modprobe rc1 --dry-run --verbose >path-append.out 2>&1 &&
+	test_debug "cat path-append.out" &&
+	grep "checking $(pwd)" path-append.out &&
+	grep $(flux config builtin libexecdir)/modprobe/modprobe.d path-append.out &&
+	grep $(flux config builtin libexecdir)/modprobe/rc1.d path-append.out
+'
 test_expect_success 'modprobe: detects missing required modprobe.toml keys' '
 	mkdir modprobe.d &&
 	test_when_finished "rm -rf modprobe.d" &&

--- a/t/t0100-modprobe.t
+++ b/t/t0100-modprobe.t
@@ -553,8 +553,9 @@ test_expect_success 'modprobe: detects missing required modprobe.toml keys' '
 	[[modules]]
 	ranks = "0"
 	EOF
-	FLUX_MODPROBE_PATH=$(pwd) \
-	  test_must_fail flux modprobe show a 2>missing.err &&
+	( export FLUX_MODPROBE_PATH=$(pwd) &&
+	  test_must_fail flux modprobe show a 2>missing.err
+	) &&
 	test_debug "cat missing.err" &&
 	grep -i "missing required config key" missing.err
 '
@@ -566,8 +567,9 @@ test_expect_success 'modprobe: detects invalid modprobe.toml entries' '
 	name = "a"
 	badkey = ""
 	EOF
-	FLUX_MODPROBE_PATH=$(pwd) \
-	  test_must_fail flux modprobe show a 2>invalid.err &&
+	( export FLUX_MODPROBE_PATH=$(pwd) &&
+	  test_must_fail flux modprobe show a 2>invalid.err
+	) &&
 	test_debug "cat invalid.err" &&
 	grep -i "invalid config key" invalid.err
 '
@@ -748,8 +750,9 @@ test_expect_success 'modprobe module priority works' '
 	cat feas1.json | jq -e ".name == \"advanced-scheduler\""
 '
 test_expect_success 'modprobe: disable detects invalid module' '
-	FLUX_MODPROBE_PATH=$(pwd) \
-		test_must_fail flux modprobe show --disable=foo sched
+	( export FLUX_MODPROBE_PATH=$(pwd) &&
+	  test_must_fail flux modprobe show --disable=foo sched
+	)
 '
 test_expect_success 'modprobe: disabling module results in other alternative' '
 	FLUX_MODPROBE_PATH=$(pwd) \
@@ -803,9 +806,9 @@ test_expect_success 'modprobe: explicit load can load non-default module' '
 	test_cmp basic-load.expected basic-load.out
 '
 test_expect_success 'modprobe: --set-alternative detects bad input' '
-	FLUX_MODPROBE_PATH=$(pwd) \
-		test_must_fail \
-			flux modprobe show --set-alternative=sched sched
+	( export FLUX_MODPROBE_PATH=$(pwd) &&
+	  test_must_fail flux modprobe show --set-alternative=sched sched
+	)
 '
 test_expect_success 'modprobe: set_alternative() works' '
 	FLUX_MODPROBE_PATH=$(pwd) \
@@ -843,10 +846,11 @@ test_expect_success 'modprobe: priority can be updated via TOML file' '
 	cat sched4.json | jq -e ".name == \"basic-scheduler\""
 '
 test_expect_success 'modprobe: set_alternative() detects invalid module' '
-	FLUX_MODPROBE_PATH=$(pwd) \
-	    test_must_fail \
+	( export FLUX_MODPROBE_PATH=$(pwd) &&
+	  test_must_fail \
 	        flux modprobe show --set-alternative=sched=foo sched \
-		    > badalt.out 2>&1 &&
+		    > badalt.out 2>&1
+	) &&
 	test_debug "cat badalt.out" &&
 	grep "no module foo provides sched" badalt.out
 '

--- a/t/t0100-modprobe.t
+++ b/t/t0100-modprobe.t
@@ -544,23 +544,29 @@ test_expect_success 'modprobe fails if task raises exception' '
 	test_debug "cat output${seq}"
 '
 test_expect_success 'modprobe: detects missing required modprobe.toml keys' '
-	cat <<-EOF >missing.toml &&
+	mkdir modprobe.d &&
+	test_when_finished "rm -rf modprobe.d" &&
+	cat <<-EOF >modprobe.d/missing.toml &&
 	[[modules]]
 	name = "a"
 	[[modules]]
 	ranks = "0"
 	EOF
-	test_must_fail flux modprobe show --path=missing.toml a 2>missing.err &&
+	FLUX_MODPROBE_PATH=$(pwd) \
+	  test_must_fail flux modprobe show a 2>missing.err &&
 	test_debug "cat missing.err" &&
 	grep -i "missing required config key" missing.err
 '
 test_expect_success 'modprobe: detects invalid modprobe.toml entries' '
-	cat <<-EOF >invalid.toml &&
+	mkdir modprobe.d &&
+	test_when_finished "rm -rf modprobe.d" &&
+	cat <<-EOF >modprobe.d/invalid.toml &&
 	[[modules]]
 	name = "a"
 	badkey = ""
 	EOF
-	test_must_fail flux modprobe show --path=invalid.toml a 2>invalid.err &&
+	FLUX_MODPROBE_PATH=$(pwd) \
+	  test_must_fail flux modprobe show a 2>invalid.err &&
 	test_debug "cat invalid.err" &&
 	grep -i "invalid config key" invalid.err
 '

--- a/t/t0100-modprobe.t
+++ b/t/t0100-modprobe.t
@@ -538,10 +538,11 @@ test_expect_success 'modprobe fails if task raises exception' '
 
 	@task("next")
 	def needed(context):
-	   raise RuntimeException("test exception")
+	   raise RuntimeError("test exception")
 	EOF
-	test_must_fail flux modprobe run test${seq}.py >output${seq} &&
-	test_debug "cat output${seq}"
+	test_must_fail flux modprobe run test${seq}.py >output${seq} 2>&1 &&
+	test_debug "cat output${seq}" &&
+	grep "next:.*test exception" output${seq}
 '
 test_expect_success 'modprobe: detects missing required modprobe.toml keys' '
 	mkdir modprobe.d &&


### PR DESCRIPTION
This PR moves internal config and rc files for modprobe out of `/etc/flux/modprobe` and into `/usr/share/flux/modprobe` (datadir) and `/usr/libexec/flux/modprobe` (libexecdir). The two paths are used because `/usr/share` is more appropriate for TOML config files, while `/usr/libexec` is standard for code like the Python `rcX.py` files. (It is an open question whether to just put the two types of configuration for modprobe under the same paths. This is why the PR is currently WIP)

The modprobe default search path now works like this:
 - the default `modprobe.toml` or `rcX.py` is read first from `/usr/share/flux/modprobe/modprobe.toml` or `/usr/lbexec/flux/modprobe/rcX.py`
 - If `FLUX_MODPROBE_PATH` is set, then it is a colon separated PATH from which `$dir/modprobe.d/*.toml` or `$dir/rcX.d/*.py` are read.
 - Otherwise, the default search path is `/usr/share/flux/modprobe:/etc/flux/modprobe` for TOML config and `/usr/libexec/flux/modprobe:/etc/flux/modprobe` for rcX python files.
 
 This preserves backwards compatibility (files from other projects can stay in `/etc/flux/modprobe` until it is convenient  to move them to the package directories) and also allows `FLUX_MODPROBE_PATH` to be set to an empty value to disable reading of package and system modprobe files (better isolation).

Arguably the split between `datadir` and `libexecdir` for these files is most correct. However, it could be confusing that package modprobe files are read from two different paths. It also makes it tricky to append to the default search path, and therefore support for a `FLUX_MODPROBE_PATH_APPEND` is added here.

It may be worth it to evaluate if the TOML and Python files should just both go in `/usr/libexec` or `/usr/share` or wherever. Thus this PR is WIP for now (didn't want to write documentation and tests before we settled on the correct approach)