### PR TITLE
Show full usernames by default in flux-jobs(1) and flux-pgrep(1) 

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -233,7 +233,7 @@ following is the format used for the default format:
 
 ::
 
-   {id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} \
+   {id.f58:>12} ?:{queue:<8.8} +:{username:<8.8} {name:<10.10+} \
    {status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} \
    {contextual_time!F:>8h} {contextual_info}
 

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -40,7 +40,7 @@ class FluxJobsConfig(UtilConfig):
         "default": {
             "description": "Default flux-jobs format string",
             "format": (
-                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{id.f58:>12} ?:{queue:<8.8} +:{username:<8.8} {name:<10.10+} "
                 "{status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} "
                 "{contextual_time!F:>8h} {contextual_info}"
             ),
@@ -48,7 +48,7 @@ class FluxJobsConfig(UtilConfig):
         "cute": {
             "description": "Cute flux-jobs format string (default with emojis)",
             "format": (
-                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{id.f58:>12} ?:{queue:<8.8} +:{username:<8.8} {name:<10.10+} "
                 "{status_emoji:>5.5} {ntasks:>6} {nnodes:>6h} "
                 "{contextual_time!F:>8h} {contextual_info}"
             ),
@@ -56,7 +56,7 @@ class FluxJobsConfig(UtilConfig):
         "long": {
             "description": "Extended flux-jobs format string",
             "format": (
-                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{id.f58:>12} ?:{queue:<8.8} +:{username:<8.8} {name:<10.10+} "
                 "{status:>9.9} {ntasks:>6} {nnodes:>6h} "
                 "{t_submit!d:%b%d %R::>12} {t_remaining!F:>12h} "
                 "{contextual_time!F:>8h} {contextual_info}"
@@ -72,7 +72,7 @@ class FluxJobsConfig(UtilConfig):
         "endreason": {
             "description": "Show why each job ended",
             "format": (
-                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{id.f58:>12} ?:{queue:<8.8} +:{username:<8.8} {name:<10.10+} "
                 "{status_abbrev:>2.2} {t_inactive!d:%b%d %R::>12h} {inactive_reason}"
             ),
         },

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -35,7 +35,7 @@ class FluxPgrepConfig(UtilConfig):
         "full": {
             "description": "full flux-pgrep format string",
             "format": (
-                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{id.f58:>12} ?:{queue:<8.8} +:{username:<8.8} {name:<10.10+} "
                 "{status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} "
                 "{contextual_time!F:>8h} {contextual_info}"
             ),
@@ -43,7 +43,7 @@ class FluxPgrepConfig(UtilConfig):
         "long": {
             "description": "Extended flux-pgrep format string",
             "format": (
-                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{id.f58:>12} ?:{queue:<8.8} +:{username:<8.8} {name:<10.10+} "
                 "{status:>9.9} {ntasks:>6} {nnodes:>6h} "
                 "{t_submit!d:%b%d %R::>12} {t_remaining!F:>12h} "
                 "{contextual_time!F:>8h} {contextual_info}"


### PR DESCRIPTION
Last week, on the WSC rounds, a frequent complaint of users was that the default output of `flux jobs` cut off full usernames, and it felt like something they had to constantly work around. With the IdM upgrade last year, now a lot of usernames are longer than 8 characters, and I assume this is something we'd see at other centers as well.

I don't think showing a `+` at the end of the username to indicate the length exceeded 8 characters would really address the usability, since that would still require our users to constantly override the default format. 

This seems like a very reasonable request. I think we should change the default format.