### PR TITLE
flux-fsck: use content.load on older versions

### DIFF
--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -357,6 +357,7 @@ static void fsck_valref (struct fsck_ctx *ctx,
 
         /* can only recover if errors were all bad references */
         if (ctx->repair
+            && fvd.missing_indexes
             && fvd.errorcount == zlist_size (fvd.missing_indexes)) {
             json_t *repaired = repair_valref (ctx, treeobj, &fvd);
 


### PR DESCRIPTION
Problem: In older versions of flux, content.validate isn't available, thus flux-fsck cannot work against older versions of flux.

Divert to content.load if content.validate is not available.

---

just like #7044, hand tested on docker w/ v0.76.0. I don't think we have infrastructure to do a "current master" vs "random older versions", that's perhaps something to consider for another day?