### PR TITLE
`flux-jobs`: add space before parentheses for `-c/--count` option, add "+" for `-u/--user` help message

### DIFF
--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -279,7 +279,7 @@ def parse_args():
         metavar="[USERNAME|UID]",
         default=str(os.getuid()),
         help="Limit output to specific username or userid "
-        '(Specify "all" for all users)',
+        + '(Specify "all" for all users)',
     )
     parser.add_argument(
         "--name",


### PR DESCRIPTION
#### Problem

There is no space before the parentheses in the help message for the `-c/--count` optional argument like the other options that have parentheses in their help messages.

The help message for the `-u/--user` optional argument also does not use a "+" sign to attach the second line like the other multi-line help messages in `flux-jobs.py`.

---

This PR just adds a space to the help message before the parentheses for the `-c/--count` optional argument and adds a "+" sign before the second line of the help message for the `-u/--user` optional argument to make it consistent with the other multi-line help messages.