### PR TITLE
libeventlog: set reactor when creating future

### DIFF
--- a/src/common/libeventlog/eventlogger.c
+++ b/src/common/libeventlog/eventlogger.c
@@ -163,8 +163,10 @@ static flux_future_t *eventlogger_commit_batch (struct eventlogger *ev,
          *   failure occurred. Likely other parts of the system are
          *   in big trouble anyway...
          */
-        if ((f = flux_future_create (NULL, NULL)))
+        if ((f = flux_future_create (NULL, NULL))) {
+            flux_future_set_reactor (f, flux_get_reactor (ev->h));
             flux_future_fulfill (f, NULL, NULL);
+        }
     }
     else {
         /*  Otherwise, stop any pending timer watcher and start a


### PR DESCRIPTION
Problem: In the rare case when a eventlogger batch is committed but there is nothing to commit, an "empty" fulfilled future is returned.  However, the reactor is not set in this future.  This can lead to errors if callers then try to pass this future to functions like flux_future_then().

Set the reactor after creating the fulfilled future.

Fixes #7028