### PR TITLE
modprobe: add missing call to executor.shutdown()

### DIFF
--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -1066,6 +1066,7 @@ class Modprobe:
                 del futures[future]
 
         self.save_task_timing(started.values())
+        executor.shutdown(wait=True)
 
         return self.exitcode
 


### PR DESCRIPTION
Problem: The ThreadPoolExecutor used in modprobe is not properly shut down. This can lead to hangs at process exit.

Call `executor.shtudown(wait=True)` in `Mobdprobe.run()` after all work is complete.

Fixes #7054