### PR TITLE
libflux: fix flux_pollfd() file descriptor leak

### DIFF
--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -993,3 +993,4 @@ fluxlibexecdir
 sysmon
 datadir
 rcX
+epoll

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -177,11 +177,11 @@ int flux_pollevents (flux_t *h);
 /* Obtain a file descriptor that can be used to integrate a flux_t handle
  * into an external event loop.  When one of FLUX_POLLIN, FLUX_POLLOUT, or
  * FLUX_POLLERR is raised in flux_pollevents(), this file descriptor will
- * become readable in an edge triggered fashion.  The external event loop
- * should then call flux_pollevents().  See src/common/libflux/ev_flux.[ch]
- * for an example of a libev "composite watcher" based on these interfaces,
- * that is used internally by the flux reactor.
- * Returns fd on success, -1 on failure with errno set.
+ * become readable in an edge triggered fashion.  An external event loop
+ * could watch this file descriptor for POLLIN, then call flux_pollevents()
+ * to determine what event bits are pending for the handle.
+ * The file descriptor is owned by the flux_t handle and becomes invalid
+ * upon flux_close().  Returns fd on success, -1 on failure with errno set.
  */
 int flux_pollfd (flux_t *h);
 

--- a/src/common/libflux/test/handle.c
+++ b/src/common/libflux/test/handle.c
@@ -380,6 +380,19 @@ void test_basic (void)
     flux_close (h);
 }
 
+void test_pollfd (void)
+{
+    flux_t *h;
+    if (!(h = flux_open ("loop://", 0)))
+        BAIL_OUT ("can't continue without loop handle");
+    flux_comms_error_set (h, comms_err, NULL);
+
+    ok (flux_pollfd (h) >= 0,
+        "flux_pollfd works");
+
+    flux_close (h);
+}
+
 int main (int argc, char *argv[])
 {
     int fd_before = fdcount ();
@@ -389,6 +402,7 @@ int main (int argc, char *argv[])
     test_handle_invalid_args ();
     test_flux_open_ex ();
     test_send_new ();
+    test_pollfd ();
 
     int fd_after = fdcount ();
     ok (fd_after == fd_before,


### PR DESCRIPTION
Problem: calling `flux_pollfd()` causes an epoll file descriptor to be created internally, but the file descriptor is not closed when the `flux_t` handle is destroyed.
    
Since each call to `flux_pollfd()` reuses the internal file descriptor, it is clearly "owned" by the handle.  Close it when the handle is destroyed.

Also:  update the man page to make it clear that the file descriptor belongs to the handle, and while in there, replace a convoluted example with a simple description.
