### PR TITLE
libflux: ensure flux_pollfd() is edge triggered

### DIFF
--- a/t/issues/t3503-nofiles-limit.sh
+++ b/t/issues/t3503-nofiles-limit.sh
@@ -9,8 +9,8 @@
 #   definitely cause the broker to run over the artificially lowered
 #   fd limit.
 #
-ulimit -n 117
-ulimit -Hn 117
+ulimit -n 147
+ulimit -Hn 147
 flux start \
     sh -c '
 flux submit --cc=1-12 hostname &&


### PR DESCRIPTION
Problem: when `flux_open()` is used with the FLUX_O_NOREQUEUE flag, the connector implementation's pollfd method is returned directly by `flux_pollfd()`, but not all connectors supply an edge-triggered fd, as required by `flux_pollfd()`.

For example, the local connector's pollfd method returns the level-triggered communications socket.

FLUX_O_NOREQUEUE was added to reduce the number of file descriptors used by interthread sockets from 3 (deque, requeue, and epoll wrapper) to 1 (deque).  Since back-to-back interthread pairs are used for each broker module, this allowed more co-located test brokers to be run for a given file descriptor limit.

Compromise: let FLUX_O_NOREQUEUE suppress creation of the requeue deque, saving 1 file descriptor, but unconditionally create the epoll wrapper, for the greater good of consistent `flux_pollfd()` semantics.

Interthread connectors opened with FLUX_O_NOREQUEUE thus now use 2 file descriptors.