### PR TITLE
etc/modprobe: remove kvs requires on restore task

### DIFF
--- a/etc/modprobe/rc1.py
+++ b/etc/modprobe/rc1.py
@@ -92,7 +92,7 @@ def check_restore(context):
     ranks="0",
     before=["kvs"],
     after=["content-backing", "check-restore"],
-    requires=["check-restore", "content-backing", "kvs"],
+    requires=["check-restore", "content-backing"],
     needs=["content-backing", "check-restore"],
     needs_attrs=["content.restore"],
 )


### PR DESCRIPTION
Problem: The rc1 "restore" task lists loading the "kvs" as a "requires" dependency.  This conflicts with A) "flux restore --checkpoint" cannot be run if the kvs is loaded and B) "kvs" is listed in this task as a "before" dependency

Solution: Remove "kvs" from the list of "requires" for the "restore" task.