### PR TITLE
libflux: reduce spurious pollfd wake-ups

### DIFF
--- a/doc/man3/flux_pollevents.rst
+++ b/doc/man3/flux_pollevents.rst
@@ -31,9 +31,10 @@ that POLLIN is raised when the handle becomes ready for reading or writing,
 but is not re-raised if those conditions are still true when :func:`poll`
 is re-entered.  The file descriptor is created on the first call to
 :func:`flux_pollfd` or :func:`flux_pollevents`.  It is used for signaling
-purposes only, not for I/O.
+purposes only, must not be read, written, or closed.
 
-:func:`flux_pollevents` returns a bitmask of poll flags for handle :var:`h`
+:func:`flux_pollevents` is normally called after a POLLIN event on
+:func:`flux_pollfd`.  It returns a bitmask of poll flags for handle :var:`h`
 and clears the pending :func:`flux_pollfd` POLLIN event, if any.
 
 Valid poll flags are:
@@ -56,6 +57,12 @@ the Flux reactor by combining prep, check, and idle watchers into a
 composite watcher for the edge triggered source.  Other event loops such
 as libev and libuv have similar concepts.  For a Flux example, refer to the
 source code for :man3:`flux_handle_watcher_create`.
+
+It is possible for the :func:`flux_pollfd` to raise POLLIN and then for
+:func:`flux_pollevents` to return zero.  Spurious wake-ups are to be expected
+from time to time with edge-triggered event sources and should not be treated
+as errors.
+
 
 RETURN VALUE
 ============

--- a/src/common/libflux/connector_interthread.c
+++ b/src/common/libflux/connector_interthread.c
@@ -276,6 +276,12 @@ static int op_getopt (void *impl, const char *option, void *val, size_t size)
             goto error;
         memcpy (val, &count, size);
     }
+    else if (streq (option, FLUX_OPT_POLLFD_EVENTS)) {
+        int events = POLLIN;
+        if (size != sizeof (events) || !val)
+            goto error;
+        memcpy (val, &events, size);
+    }
     else
         goto error;
     return 0;

--- a/src/common/libflux/connector_loop.c
+++ b/src/common/libflux/connector_loop.c
@@ -105,6 +105,12 @@ static int op_getopt (void *impl, const char *option, void *val, size_t size)
             goto error;
         memcpy (val, &limit, size);
     }
+    else if (streq (option, FLUX_OPT_POLLFD_EVENTS)) {
+        int events = POLLIN;
+        if (size != sizeof (events) || !val)
+            goto error;
+        memcpy (val, &events, size);
+    }
     else
         goto error;
     return 0;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -1165,9 +1165,9 @@ int flux_pollevents (flux_t *h)
             return -1;
         if ((e & POLLIN))
             events |= FLUX_POLLIN;
-        if ((e & POLLERR))
-            events |= FLUX_POLLERR;
-        /* POLLOUT is purposefully ignored */
+        /* POLLOUT is purposefully ignored.
+         * Other bits are not possible with msg_deque.
+         */
     }
     return events;
 }

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -1110,7 +1110,7 @@ int flux_pollfd (flux_t *h)
             goto error;
         /* add re-queue pollfd (if defined) */
         if (!(h->flags & FLUX_O_NOREQUEUE)) {
-            ev.events = EPOLLET | EPOLLIN | EPOLLOUT;
+            ev.events = EPOLLET | EPOLLIN;
             ev.data.fd = msg_deque_pollfd (h->queue);
             if (ev.data.fd < 0)
                 goto error;

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -67,6 +67,7 @@ enum {
 #define FLUX_OPT_ROUTER_NAME        "flux::router_name"
 #define FLUX_OPT_SEND_QUEUE_COUNT   "flux::send_queue_count"
 #define FLUX_OPT_RECV_QUEUE_COUNT   "flux::recv_queue_count"
+#define FLUX_OPT_POLLFD_EVENTS      "flux::pollfd_events"
 
 /* Create/destroy a broker handle.
  * The 'uri' scheme name selects a connector to dynamically load.

--- a/src/common/libflux/msg_deque.c
+++ b/src/common/libflux/msg_deque.c
@@ -272,7 +272,7 @@ int msg_deque_pollfd (struct msg_deque *q)
     msg_deque_lock (q);
     if (q->pollfd < 0) {
         q->event = q->pollevents ? 1 : 0;
-        q->pollfd = eventfd (q->pollevents, EFD_NONBLOCK);
+        q->pollfd = eventfd (q->event, EFD_NONBLOCK);
     }
     rc = q->pollfd;
     msg_deque_unlock (q);

--- a/src/common/libflux/msg_deque.c
+++ b/src/common/libflux/msg_deque.c
@@ -272,7 +272,7 @@ int msg_deque_pollfd (struct msg_deque *q)
     msg_deque_lock (q);
     if (q->pollfd < 0) {
         q->event = q->pollevents ? 1 : 0;
-        q->pollfd = eventfd (q->event, EFD_NONBLOCK);
+        q->pollfd = eventfd (q->event, EFD_NONBLOCK | EFD_CLOEXEC);
     }
     rc = q->pollfd;
     msg_deque_unlock (q);

--- a/src/common/libflux/msg_deque.h
+++ b/src/common/libflux/msg_deque.h
@@ -40,6 +40,11 @@ int msg_deque_push_back (struct msg_deque *q, flux_msg_t *msg);
 int msg_deque_push_front (struct msg_deque *q, flux_msg_t *msg);
 flux_msg_t *msg_deque_pop_front (struct msg_deque *q);
 
+/* pollfd raises POLLIN when an event bit is set in pollevents.
+ * An unfortunate side effect of using eventfd() internally is that
+ * POLLOUT is raised when pollevents clears the pollfd.
+ * Users should watch POLLIN only.
+ */
 int msg_deque_pollfd (struct msg_deque *q);
 int msg_deque_pollevents (struct msg_deque *q);
 

--- a/src/common/libflux/test/interthread.c
+++ b/src/common/libflux/test/interthread.c
@@ -367,27 +367,18 @@ void test_poll (void)
         "flux_pollevents h2 initially returns POLLOUT");
     recv_count_is (h2, 0, "RECV_QUEUE_COUNT h2 = 0");
 
-    /* POLLIN must not be pending for the test that follows.
-     * The flux_pollevents() call above should clear it, if set initially.
-     * However, due to flux-framework/flux-core#7067, one try may not be
-     * sufficient (seems like 3 is the magic number but let's do 10).
-     */
-    for (int i = 0; i < 10; i++) {
-        pfd.fd = flux_pollfd (h2);
-        pfd.events = POLLIN;
-        pfd.revents = 0;
-        rc = poll (&pfd, 1, 0);
-        if (rc < 0)
-            diag ("poll: %s", strerror (errno));
-        if (rc == 1) {
-            int revents = flux_pollevents (h2);
-            diag ("pollfd is ready, pollevents = 0x%x", revents);
-        }
-        if (rc == 0)
-            break;
+    pfd.fd = flux_pollfd (h2);
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    rc = poll (&pfd, 1, 0);
+    if (rc < 0)
+        diag ("poll: %s", strerror (errno));
+    if (rc == 1) {
+        int revents = flux_pollevents (h2);
+        diag ("pollfd is ready, pollevents = 0x%x", revents);
     }
     ok (rc == 0,
-        "pollfd is not ready");
+        "pollfd is not ready, as required by the next test");
 
     if (!(msg = flux_request_encode ("foo", NULL)))
         BAIL_OUT ("flux_request_encode failed");


### PR DESCRIPTION
Problem: there are extra `flux_pollfd()` wakeups for every real event.

This is explained in more detail in commit messages, but to quickly summarize: the  `msg_deque` class that underlies the `interthread://` and `loop://` connector implementations, and is used to implement `flux_requeue()`, has a quirk where it asserts POLLOUT when its `pollevents` method is called with POLLIN pending.  Unfortunately, the handle pollfd implementation wraps those in an epoll fd that watches POLLIN | POLLOUT, so it gets an extra wakeup per msg_deque on every call to `flux_pollevents()` when it is responding to POLLIN.  The fix is to not watch POLLOUT on the re-queue deque or the connector when we know we don't need it, which is the case with the msg_deques which were designed to use POLLIN signaling.

This is built on top of
-  #7068 