### PR TITLE
WIP libflux: add fd:// connector

### DIFF
--- a/doc/man3/flux_pollevents.rst
+++ b/doc/man3/flux_pollevents.rst
@@ -11,21 +11,30 @@ SYNOPSIS
 
   #include <flux/core.h>
 
+  int flux_pollfd (flux_t *h);
+
   int flux_pollevents (flux_t *h);
 
-  int flux_pollfd (flux_t *h);
 
 Link with :command:`-lflux-core`.
 
 DESCRIPTION
 ===========
 
-:func:`flux_pollevents` returns a bitmask of poll flags for handle :var:`h`.
+:func:`flux_pollfd` and :func:`flux_pollevents` are used together to
+integrate a :type:`flux_t` handle into an event loop.
 
 :func:`flux_pollfd` obtains a file descriptor that becomes readable when
-:func:`flux_pollevents` has poll flags raised.  On Linux, it is an
-:linux:man7:`epoll` edge-triggered file descriptor.  The file descriptor
-is the property of :var:`h` and becomes invalid upon :man3:`flux_close`.
+handle :var:`h` needs attention.  It is suitable for monitoring using
+:linux:man2:`poll` or equivalent.  The signaling is edge-triggered, meaning
+that POLLIN is raised when the handle becomes ready for reading or writing,
+but is not re-raised if those conditions are still true when :func:`poll`
+is re-entered.  The file descriptor is created on the first call to
+:func:`flux_pollfd` or :func:`flux_pollevents`.  It is used for signaling
+purposes only, not for I/O.
+
+:func:`flux_pollevents` returns a bitmask of poll flags for handle :var:`h`
+and clears the pending :func:`flux_pollfd` POLLIN event, if any.
 
 Valid poll flags are:
 
@@ -38,20 +47,15 @@ FLUX_POLLOUT
 FLUX_POLLERR
    Handle has experienced an error.
 
-These functions can be used to integrate a :type:`flux_t` handle into any
-event loop.  The event loop would watch the :func:`flux_pollfd` for POLLIN
-events, then when one is raised, check :func:`flux_pollevents` for pending
-events.
-
-Due to edge triggering, the event loop must process all events on the handle
-before returning to sleep.
-
-When processing an edge-triggered event source, it is a best practice to
-maintain fairness by allowing other event sources to receive attention while
-working through pending I/O on the edge-triggered source.  This can be
-accomplished in the Flux reactor by combining prep, check, and idle watchers
-into a composite watcher for the edge triggered source.  This is how
-:man3:`flux_handle_watcher_create` is implemented internally.
+As indicated above, the event loop must process all events on the handle
+before returning to sleep, due to edge triggering.  When processing an
+edge-triggered event source, it is a best practice to maintain fairness by
+allowing other event sources to receive attention while working through
+pending I/O on the edge-triggered source.  This can be accomplished in
+the Flux reactor by combining prep, check, and idle watchers into a
+composite watcher for the edge triggered source.  Other event loops such
+as libev and libuv have similar concepts.  For a Flux example, refer to the
+source code for :man3:`flux_handle_watcher_create`.
 
 RETURN VALUE
 ============

--- a/doc/man3/flux_pollevents.rst
+++ b/doc/man3/flux_pollevents.rst
@@ -31,9 +31,10 @@ that POLLIN is raised when the handle becomes ready for reading or writing,
 but is not re-raised if those conditions are still true when :func:`poll`
 is re-entered.  The file descriptor is created on the first call to
 :func:`flux_pollfd` or :func:`flux_pollevents`.  It is used for signaling
-purposes only, not for I/O.
+purposes only, must not be read, written, or closed.
 
-:func:`flux_pollevents` returns a bitmask of poll flags for handle :var:`h`
+:func:`flux_pollevents` is normally called after a POLLIN event on
+:func:`flux_pollfd`.  It returns a bitmask of poll flags for handle :var:`h`
 and clears the pending :func:`flux_pollfd` POLLIN event, if any.
 
 Valid poll flags are:
@@ -56,6 +57,12 @@ the Flux reactor by combining prep, check, and idle watchers into a
 composite watcher for the edge triggered source.  Other event loops such
 as libev and libuv have similar concepts.  For a Flux example, refer to the
 source code for :man3:`flux_handle_watcher_create`.
+
+It is possible for the :func:`flux_pollfd` to raise POLLIN and then for
+:func:`flux_pollevents` to return zero.  Spurious wake-ups are to be expected
+from time to time with edge-triggered event sources and should not be treated
+as errors.
+
 
 RETURN VALUE
 ============

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -994,3 +994,4 @@ sysmon
 datadir
 rcX
 epoll
+libuv

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -130,7 +130,8 @@ TESTS = test_message.t \
 	test_sync.t \
 	test_disconnect.t \
 	test_msg_deque.t \
-	test_rpcscale.t
+	test_rpcscale.t \
+	test_fdconnector.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libtestutil/libtestutil.la \
@@ -251,6 +252,10 @@ test_disconnect_t_LDADD = $(test_ldadd)
 test_interthread_t_SOURCES = test/interthread.c
 test_interthread_t_CPPFLAGS = $(test_cppflags)
 test_interthread_t_LDADD = $(test_ldadd)
+
+test_fdconnector_t_SOURCES = test/fdconnector.c
+test_fdconnector_t_CPPFLAGS = $(test_cppflags)
+test_fdconnector_t_LDADD = $(test_ldadd)
 
 test_msg_deque_t_SOURCES = test/msg_deque.c
 test_msg_deque_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -64,6 +64,7 @@ libflux_la_SOURCES = \
 	connector_loop.c \
 	connector_interthread.c \
 	connector_local.c \
+	connector_fd.c \
 	reactor.c \
 	reactor_private.h \
 	watcher.c \

--- a/src/common/libflux/connector_fd.c
+++ b/src/common/libflux/connector_fd.c
@@ -1,0 +1,120 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* fd connector - use pre-connected file descriptor fd://N
+ *
+ * The file descriptor is closed on flux_close(), even though the
+ * connector didn't open it.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <poll.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/errprintf.h"
+#include "src/common/librouter/usock.h"
+#include "ccan/str/str.h"
+
+struct fd_ctx {
+    int fd;
+    struct usock_client *uclient;
+    flux_t *h;
+};
+
+static const struct flux_handle_ops handle_ops;
+
+static int op_pollevents (void *impl)
+{
+    struct fd_ctx *ctx = impl;
+
+    return ctx->uclient ? usock_client_pollevents (ctx->uclient) : 0;
+}
+
+static int op_pollfd (void *impl)
+{
+    struct fd_ctx *ctx = impl;
+
+    return ctx->uclient ? usock_client_pollfd (ctx->uclient) : -1;
+}
+
+static int op_send (void *impl, const flux_msg_t *msg, int flags)
+{
+    struct fd_ctx *ctx = impl;
+
+    return usock_client_send (ctx->uclient, msg, flags);
+}
+
+static flux_msg_t *op_recv (void *impl, int flags)
+{
+    struct fd_ctx *ctx = impl;
+
+    return usock_client_recv (ctx->uclient, flags);
+}
+
+static void op_fini (void *impl)
+{
+    struct fd_ctx *ctx = impl;
+
+    if (ctx) {
+        int saved_errno = errno;
+        usock_client_destroy (ctx->uclient);
+        if (ctx->fd >= 0)
+            (void)close (ctx->fd);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+flux_t *connector_fd_init (const char *path, int flags, flux_error_t *errp)
+{
+    struct fd_ctx *ctx;
+    char *endptr;
+    int fd;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    ctx->fd = -1;
+    if (!path) {
+        errprintf (errp, "URI path is not set");
+        goto inval;
+    }
+    errno = 0;
+    fd = strtol (path, &endptr, 10);
+    if (errno != 0 || *endptr != '\0' || fd < 0) {
+        errprintf (errp, "error parsing file descriptor");
+        goto inval;
+    }
+    if (!(ctx->uclient = usock_client_create (fd)))
+        goto error;
+    if (!(ctx->h = flux_handle_create (ctx, &handle_ops, flags)))
+        goto error;
+    ctx->fd = fd;
+    return ctx->h;
+inval:
+    errno = EINVAL;
+error:
+    op_fini (ctx);
+    return NULL;
+}
+
+static const struct flux_handle_ops handle_ops = {
+    .pollfd = op_pollfd,
+    .pollevents = op_pollevents,
+    .send = op_send,
+    .recv = op_recv,
+    .impl_destroy = op_fini,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/connector_interthread.c
+++ b/src/common/libflux/connector_interthread.c
@@ -276,6 +276,12 @@ static int op_getopt (void *impl, const char *option, void *val, size_t size)
             goto error;
         memcpy (val, &count, size);
     }
+    else if (streq (option, FLUX_OPT_POLLFD_EVENTS)) {
+        int events = POLLIN;
+        if (size != sizeof (events) || !val)
+            goto error;
+        memcpy (val, &events, size);
+    }
     else
         goto error;
     return 0;

--- a/src/common/libflux/connector_loop.c
+++ b/src/common/libflux/connector_loop.c
@@ -105,6 +105,12 @@ static int op_getopt (void *impl, const char *option, void *val, size_t size)
             goto error;
         memcpy (val, &limit, size);
     }
+    else if (streq (option, FLUX_OPT_POLLFD_EVENTS)) {
+        int events = POLLIN;
+        if (size != sizeof (events) || !val)
+            goto error;
+        memcpy (val, &events, size);
+    }
     else
         goto error;
     return 0;

--- a/src/common/libflux/connector_loop.c
+++ b/src/common/libflux/connector_loop.c
@@ -97,6 +97,14 @@ static int op_getopt (void *impl, const char *option, void *val, size_t size)
             goto error;
         memcpy (val, &ctx->cred.rolemask, size);
     }
+    else if (streq (option, "flux::message_count_limit")) {
+        int limit;
+        if ((limit = msg_deque_get_limit (ctx->queue)) < 0)
+            return -1;
+        if (size != sizeof (limit) || !val)
+            goto error;
+        memcpy (val, &limit, size);
+    }
     else
         goto error;
     return 0;
@@ -124,6 +132,15 @@ static int op_setopt (void *impl,
         if (size != val_size || !val)
             goto error;
         memcpy (&ctx->cred.rolemask, val, val_size);
+    }
+    else if (streq (option, "flux::message_count_limit")) {
+        int limit;
+        val_size = sizeof (limit);
+        if (size != val_size || !val)
+            goto error;
+        memcpy (&limit, val, val_size);
+        if (msg_deque_set_limit (ctx->queue, limit) < 0)
+            return -1;
     }
     else
         goto error;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -1141,6 +1141,10 @@ int flux_pollevents (flux_t *h)
     h = lookup_clone_ancestor (h);
     int e, events = 0;
 
+    /* create pollfd if needed */
+    if (flux_pollfd (h) < 0)
+        return -1;
+
     /* wait for handle event */
     if (h->pollfd >= 0) {
         struct epoll_event ev;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -1161,10 +1161,9 @@ int flux_pollevents (flux_t *h)
             return -1;
         if ((e & POLLIN))
             events |= FLUX_POLLIN;
-        if ((e & POLLOUT))
-            events |= FLUX_POLLOUT;
         if ((e & POLLERR))
             events |= FLUX_POLLERR;
+        /* POLLOUT is purposefully ignored */
     }
     return events;
 }

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -1165,9 +1165,9 @@ int flux_pollevents (flux_t *h)
             return -1;
         if ((e & POLLIN))
             events |= FLUX_POLLIN;
-        if ((e & POLLERR))
-            events |= FLUX_POLLERR;
-        /* POLLOUT is purposefully ignored */
+        /* POLLOUT is purposefully ignored.
+         * Other bits are not possible with msg_deque.
+         */
     }
     return events;
 }

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -1110,7 +1110,7 @@ int flux_pollfd (flux_t *h)
             goto error;
         /* add re-queue pollfd (if defined) */
         if (!(h->flags & FLUX_O_NOREQUEUE)) {
-            ev.events = EPOLLET | EPOLLIN | EPOLLOUT;
+            ev.events = EPOLLET | EPOLLIN;
             ev.data.fd = msg_deque_pollfd (h->queue);
             if (ev.data.fd < 0)
                 goto error;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -70,11 +70,13 @@ flux_t *connector_interthread_init (const char *uri,
                                     int flags,
                                     flux_error_t *errp);
 flux_t *connector_local_init (const char *uri, int flags, flux_error_t *errp);
+flux_t *connector_fd_init (const char *uri, int flags, flux_error_t *errp);
 
 static struct builtin_connector builtin_connectors[] = {
     { "loop", &connector_loop_init },
     { "interthread", &connector_interthread_init },
     { "local", &connector_local_init },
+    { "fd", &connector_fd_init },
 };
 
 static void handle_trace (flux_t *h, const char *fmt, ...)

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -67,6 +67,7 @@ enum {
 #define FLUX_OPT_ROUTER_NAME        "flux::router_name"
 #define FLUX_OPT_SEND_QUEUE_COUNT   "flux::send_queue_count"
 #define FLUX_OPT_RECV_QUEUE_COUNT   "flux::recv_queue_count"
+#define FLUX_OPT_POLLFD_EVENTS      "flux::pollfd_events"
 
 /* Create/destroy a broker handle.
  * The 'uri' scheme name selects a connector to dynamically load.

--- a/src/common/libflux/msg_deque.c
+++ b/src/common/libflux/msg_deque.c
@@ -272,7 +272,7 @@ int msg_deque_pollfd (struct msg_deque *q)
     msg_deque_lock (q);
     if (q->pollfd < 0) {
         q->event = q->pollevents ? 1 : 0;
-        q->pollfd = eventfd (q->pollevents, EFD_NONBLOCK);
+        q->pollfd = eventfd (q->event, EFD_NONBLOCK);
     }
     rc = q->pollfd;
     msg_deque_unlock (q);

--- a/src/common/libflux/msg_deque.c
+++ b/src/common/libflux/msg_deque.c
@@ -10,33 +10,6 @@
 
 /* msg_dequeue.c - reactive, thread-safe, output-restricted message deque */
 
-/* The pollfd/pollevents pattern was borrowed from zeromq's ZMQ_EVENTS/ZMQ_FD,
- * described in zmq_getsockopt(3).  It is an edge-triggered notification system
- * in which the pollfd, a special file descriptor created with eventfd(2),
- * can be watched reactively for a POLLIN event, then the actual event on the
- * queue is determined by sampling pollevents.  The valid pollevents bits are:
- *
- * POLLIN   messages are available to pop
- * POLLOUT  messages may be pushed (always asserted currently)
- *
- * The pollevents should not be confused with pollfd events.  In pollfd, only
- * POLLIN is expected, signaling that one of the bits is newly set in
- * pollevents, and used to wake up a reactor loop to service those bits.
- *
- * "edge-triggered" means that pollfd does not reassert if the reactor handler
- * returns with the condition that caused the event still true.  In the case
- * of msg_deque POLLIN events, a handler must pop all messages before
- * returning, or if fairness is a concern (one message queue starving out other
- * reactor handlers), a specialized watcher in the pattern of ev_flux.c or
- * ev_zmq.c is needed.  ev_zmq.c contains further explanation about that
- * technique. When msg_deque is used within a connector, the reactive signaling
- * is encapsulated in the flux_t handle, so flux_handle_watcher_create(3),
- * based on ev_flux.c, already implements a fair handler.
- *
- * In the current implementation, msg_deque size is unlimited, so POLLOUT is
- * always asserted in pollevents.
- */
-
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/common/libflux/msg_deque.c
+++ b/src/common/libflux/msg_deque.c
@@ -272,7 +272,7 @@ int msg_deque_pollfd (struct msg_deque *q)
     msg_deque_lock (q);
     if (q->pollfd < 0) {
         q->event = q->pollevents ? 1 : 0;
-        q->pollfd = eventfd (q->event, EFD_NONBLOCK);
+        q->pollfd = eventfd (q->event, EFD_NONBLOCK | EFD_CLOEXEC);
     }
     rc = q->pollfd;
     msg_deque_unlock (q);

--- a/src/common/libflux/msg_deque.c
+++ b/src/common/libflux/msg_deque.c
@@ -33,6 +33,7 @@ struct msg_deque {
     uint64_t event;
     pthread_mutex_t lock;
     int flags;
+    int count;
 };
 
 void msg_deque_destroy (struct msg_deque *q)
@@ -142,6 +143,7 @@ int msg_deque_push_back (struct msg_deque *q, flux_msg_t *msg)
         }
     }
     list_add (&q->messages, &msg->list);
+    q->count++;
     msg_deque_unlock (q);
     return 0;
 }
@@ -161,6 +163,7 @@ int msg_deque_push_front (struct msg_deque *q, flux_msg_t *msg)
         }
     }
     list_add_tail (&q->messages, &msg->list);
+    q->count++;
     msg_deque_unlock (q);
     return 0;
 }
@@ -175,6 +178,7 @@ flux_msg_t *msg_deque_pop_front (struct msg_deque *q)
         list_del_init (&msg->list);
         if ((q->pollevents & POLLIN) && list_empty (&q->messages))
             q->pollevents &= ~POLLIN;
+        q->count--;
     }
     msg_deque_unlock (q);
     return msg;
@@ -185,9 +189,9 @@ bool msg_deque_empty (struct msg_deque *q)
     if (!q)
         return true;
     msg_deque_lock (q);
-    bool res = list_empty (&q->messages);
+    size_t count = q->count;
     msg_deque_unlock (q);
-    return res;
+    return count > 0 ? false : true;
 }
 
 size_t msg_deque_count (struct msg_deque *q)
@@ -195,10 +199,7 @@ size_t msg_deque_count (struct msg_deque *q)
     if (!q)
         return 0;
     msg_deque_lock (q);
-    size_t count = 0;
-    flux_msg_t *msg = NULL;
-    list_for_each (&q->messages, msg, list)
-        count++;
+    size_t count = q->count;
     msg_deque_unlock (q);
     return count;
 }

--- a/src/common/libflux/msg_deque.h
+++ b/src/common/libflux/msg_deque.h
@@ -23,6 +23,14 @@ enum {
 struct msg_deque *msg_deque_create (int flags);
 void msg_deque_destroy (struct msg_deque *q);
 
+/* By default, there are no limts on msg_deques.
+ * If one is added, then upon reaching full, push fails with EWOULDBLOCK
+ * and upon reaching non-full, POLLOUT is raised.
+ * A limit of zero means unlimited.
+ */
+int msg_deque_set_limit (struct msg_deque *q, int limit);
+int msg_deque_get_limit (struct msg_deque *q);
+
 /* msg_deque_push_back() and msg_deque_push_front() steal a reference on
  * 'msg' on success.  If MSG_DEQUE_SINGLE_THREAD was not specified, then
  * that is expected to be the *only* reference and further access to the

--- a/src/common/libflux/msg_deque.h
+++ b/src/common/libflux/msg_deque.h
@@ -40,6 +40,11 @@ int msg_deque_push_back (struct msg_deque *q, flux_msg_t *msg);
 int msg_deque_push_front (struct msg_deque *q, flux_msg_t *msg);
 flux_msg_t *msg_deque_pop_front (struct msg_deque *q);
 
+/* pollfd raises POLLIN when an event bit is set in pollevents.
+ * An unfortunate side effect of using eventfd() internally is that
+ * POLLOUT is raised when pollevents clears the pollfd.
+ * Users should watch POLLIN only.
+ */
 int msg_deque_pollfd (struct msg_deque *q);
 int msg_deque_pollevents (struct msg_deque *q);
 

--- a/src/common/libflux/msg_deque.h
+++ b/src/common/libflux/msg_deque.h
@@ -23,7 +23,7 @@ enum {
 struct msg_deque *msg_deque_create (int flags);
 void msg_deque_destroy (struct msg_deque *q);
 
-/* By default, there are no limts on msg_deques.
+/* By default, there are no limits on msg_deques.
  * If one is added, then upon reaching full, push fails with EWOULDBLOCK
  * and upon reaching non-full, POLLOUT is raised.
  * A limit of zero means unlimited.

--- a/src/common/libflux/test/fdconnector.c
+++ b/src/common/libflux/test/fdconnector.c
@@ -1,0 +1,190 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "ccan/str/str.h"
+#include "ccan/array_size/array_size.h"
+
+static int fdcount (void)
+{
+    int fd, fdlimit = sysconf (_SC_OPEN_MAX);
+    int count = 0;
+    for (fd = 0; fd < fdlimit; fd++) {
+        if (fcntl (fd, F_GETFD) != -1) {
+            count++;
+        }
+    }
+    return count;
+}
+
+void test_basic (void)
+{
+    int sock[2];
+    char uri[2][32];
+    flux_t *h[2];
+    flux_msg_t *msg;
+    flux_msg_t *req;
+    flux_msg_t *rep;
+    const char *topic;
+    const char *payload;
+
+    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, sock) < 0)
+        BAIL_OUT ("could not create socketpair");
+
+    /* send auth byte in both directions to prevent flux_open() hang */
+    char c = 0;
+    if (write (sock[0], &c, 1) < 0 || write (sock[1], &c, 1) < 0)
+        BAIL_OUT ("could not write auth bytes");
+
+    /* create pair to use in test */
+    for (int i = 0; i < 2; i++) {
+        snprintf (uri[i], sizeof (uri[0]), "fd://%d", sock[i]);
+        h[i] = flux_open (uri[i], 0);
+        ok (h[i] != NULL,
+            "basic: flux_open %s works", uri[i]);
+    }
+
+    /* send request h[0] -> h[1] */
+    if (!(req = flux_request_encode ("foo.bar", "baz")))
+        BAIL_OUT ("basic: could not create request");
+    ok (flux_send (h[0], req, 0) == 0,
+       "basic: flux_send on first handle works");
+    msg = flux_recv (h[1], FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "basic: flux_recv on second handle works");
+    ok (flux_msg_route_count (msg) == 0,
+        "basic: request has no route stack");
+    ok (flux_request_decode (msg, &topic, &payload) == 0
+        && streq (topic, "foo.bar")
+        && streq (payload, "baz"),
+        "basic: request has expected topic and payload");
+    if (!(rep = flux_response_derive (msg, 0)))
+        BAIL_OUT ("basic: could not create response");
+    flux_msg_destroy (msg);
+
+    /* send response h[1] -> h[0] */
+    ok (flux_send (h[1], rep, 0) == 0,
+       "basic: flux_send on second handle works");
+    msg = flux_recv (h[0], FLUX_MATCH_ANY, 0);
+    ok (msg != NULL,
+        "basic: flux_recv on first handle works");
+    ok (flux_msg_route_count (msg) == 0,
+        "basic: response has no route stack");
+    ok (flux_response_decode (msg, &topic, &payload) == 0
+        && streq (topic, "foo.bar")
+        && payload == NULL,
+        "basic: response has expected topic and payload");
+    flux_msg_destroy (msg);
+    flux_msg_destroy (req);
+    flux_msg_destroy (rep);
+
+    flux_close (h[1]);
+    flux_close (h[0]);
+}
+
+void test_poll (void)
+{
+    int sock[2];
+    char uri[2][32];
+    flux_t *h[2];
+    flux_msg_t *msg;
+    flux_msg_t *msg2;
+    struct pollfd pfd;
+    int rc;
+
+    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, sock) < 0)
+        BAIL_OUT ("could not create socketpair");
+
+    /* send auth byte in both directions to prevent flux_open() hang */
+    char c = 0;
+    if (write (sock[0], &c, 1) < 0 || write (sock[1], &c, 1) < 0)
+        BAIL_OUT ("could not write auth bytes");
+
+    /* create pair to use in test */
+    for (int i = 0; i < 2; i++) {
+        snprintf (uri[i], sizeof (uri[0]), "fd://%d", sock[i]);
+        h[i] = flux_open (uri[i], 0);
+        ok (h[i] != NULL,
+            "basic: flux_open %s works", uri[i]);
+    }
+
+    ok ((flux_pollfd (h[1])) >= 0,
+        "flux_pollfd works");
+    ok (flux_pollevents (h[1]) == FLUX_POLLOUT,
+        "flux_pollevents initially returns POLLOUT");
+
+    pfd.fd = flux_pollfd (h[1]);
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    rc = poll (&pfd, 1, 0);
+    if (rc < 0)
+        diag ("poll: %s", strerror (errno));
+    if (rc == 1) {
+        int revents = flux_pollevents (h[1]);
+        diag ("pollfd is ready, pollevents = 0x%x", revents);
+    }
+    ok (rc == 0,
+        "pollfd is not ready, as required by the next test");
+
+    if (!(msg = flux_request_encode ("foo", NULL)))
+        BAIL_OUT ("flux_request_encode failed");
+    ok (flux_send (h[0], msg, 0) == 0,
+        "flux_send  works");
+
+    pfd.fd = flux_pollfd (h[1]);
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    rc = poll (&pfd, 1, 1000); // timeout is in units of ms
+    ok (rc == 1,
+        "pollfd became ready");
+    ok (flux_pollevents (h[1]) == (FLUX_POLLOUT | FLUX_POLLIN),
+        "flux_pollevents returns POLLOUT|POLLIN");
+    ok ((msg2 = flux_recv (h[1], FLUX_MATCH_ANY, 0)) != NULL,
+        "flux_recv works");
+    flux_msg_decref (msg2);
+
+    // N.B. we don't own the pollfd so no close here
+    flux_msg_destroy (msg);
+    flux_close (h[0]);
+    flux_close (h[1]);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    int start_fdcount = fdcount ();
+
+    test_basic ();
+    test_poll ();
+
+    int end_fdcount = fdcount ();
+
+    ok (start_fdcount == end_fdcount,
+        "no file descriptors leaked");
+    if (start_fdcount != end_fdcount)
+        diag ("test leaked %d file descriptors", end_fdcount - start_fdcount);
+
+    done_testing ();
+    return 0;
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libflux/test/interthread.c
+++ b/src/common/libflux/test/interthread.c
@@ -367,27 +367,18 @@ void test_poll (void)
         "flux_pollevents h2 initially returns POLLOUT");
     recv_count_is (h2, 0, "RECV_QUEUE_COUNT h2 = 0");
 
-    /* POLLIN must not be pending for the test that follows.
-     * The flux_pollevents() call above should clear it, if set initially.
-     * However, due to flux-framework/flux-core#7067, one try may not be
-     * sufficient (seems like 3 is the magic number but let's do 10).
-     */
-    for (int i = 0; i < 10; i++) {
-        pfd.fd = flux_pollfd (h2);
-        pfd.events = POLLIN;
-        pfd.revents = 0;
-        rc = poll (&pfd, 1, 0);
-        if (rc < 0)
-            diag ("poll: %s", strerror (errno));
-        if (rc == 1) {
-            int revents = flux_pollevents (h2);
-            diag ("pollfd is ready, pollevents = 0x%x", revents);
-        }
-        if (rc == 0)
-            break;
+    pfd.fd = flux_pollfd (h2);
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    rc = poll (&pfd, 1, 0);
+    if (rc < 0)
+        diag ("poll: %s", strerror (errno));
+    if (rc == 1) {
+        int revents = flux_pollevents (h2);
+        diag ("pollfd is ready, pollevents = 0x%x", revents);
     }
     ok (rc == 0,
-        "pollfd is not ready");
+        "pollfd is not ready, as required by the next test");
 
     if (!(msg = flux_request_encode ("foo", NULL)))
         BAIL_OUT ("flux_request_encode failed");


### PR DESCRIPTION
Problem: when launching broker modules or other "agents" as subprocesses, it would be handy to be able to pass messages over a pre-connected, inherited file descriptors similar to what we do for PMI.

Add a `fd://` connector that could be used for such things.

This is peeled off of some "modules as processes work" so I'll mark it WIP for now until the rest of the context is posted.

This was built on top of
- #7071
- #7068