### PR TITLE
add flux module load --exec option

### DIFF
--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -6,8 +6,8 @@ flux-module(1)
 SYNOPSIS
 ========
 
-| **flux** **module** **load** [*--name*] *module* [*args...*]
-| **flux** **module** **reload** [*--name*] [*--force*] *module* [*args...*]
+| **flux** **module** **load** [*--name*] [*--exec*] *module* [*args...*]
+| **flux** **module** **reload** [*--name*] [*--exec*] [*--force*] *module* [*args...*]
 | **flux** **module** **remove** [*--force*] *name*
 | **flux** **module** **list** [*-l*]
 | **flux** **module** **stats** [*-R*] [*--clear*] *name*
@@ -44,6 +44,10 @@ entered the running state (see LIST OUTPUT below).
   Override the default module name.  A single shared object file may be
   loaded multiple times under different names.
 
+.. option:: --exec
+
+  Load the module in a separate process, e.g. for isolation or debugging.
+
 reload
 ------
 
@@ -59,6 +63,10 @@ Reload module *name*. This is equivalent to running
 .. option:: -n, --name=NAME
 
   Override the default module name.
+
+.. option:: --exec
+
+  Load the module in a separate process, e.g. for isolation or debugging.
 
 remove
 ------

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -1302,12 +1302,14 @@ _flux_module()
 
     local load_OPTS="\
         --name= \
+        --exec \
     "
     local remove_OPTS="\
         -f --force \
     "
     local reload_OPTS="\
         ${remove_OPTS} \
+        ${load_OPTS} \
     "
     local stats_OPTS="\
         -p --parse= \

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -344,7 +344,15 @@ static int modhash_load_finalize (struct modhash *mh,
     }
     modhash_add (mh, p);
 
-    flux_log (mh->ctx->h, LOG_DEBUG, "insmod %s", module_get_name (p));
+    if (module_is_exec (p)) {
+        flux_log (mh->ctx->h,
+                  LOG_DEBUG,
+                  "insmod %s exec pid=%d",
+                  module_get_name (p),
+                  (int)module_get_pid (p));
+    }
+    else
+        flux_log (mh->ctx->h, LOG_DEBUG, "insmod %s", module_get_name (p));
     return 0;
 }
 

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -61,6 +61,11 @@ static module_t *modhash_load_builtin (modhash_t *mh,
                                       const char *name,
                                       json_t *args,
                                       flux_error_t *error);
+static module_t *modhash_load_exec (modhash_t *mh,
+                                    const char *name,
+                                    char *path,
+                                    json_t *args,
+                                    flux_error_t *error);
 
 int modhash_response_sendmsg_new (modhash_t *mh, flux_msg_t **msg)
 {
@@ -316,7 +321,7 @@ static int mod_svc_cb (flux_msg_t **msg, void *arg)
 /* Perform the final steps of loading a broker module:
  * - set status and message callbacks
  * - register a service under the module name
- * - start the module thread
+ * - start the module thread/process
  * * insert the module object into the modhash
  */
 static int modhash_load_finalize (struct modhash *mh,
@@ -343,19 +348,14 @@ static int modhash_load_finalize (struct modhash *mh,
     return 0;
 }
 
-static module_t *modhash_load_dso (modhash_t *mh,
-                                   const char *name_or_null,
-                                   const char *path_or_name,
-                                   json_t *args,
-                                   flux_error_t *error)
+static int modhash_resolve_dso (const char *name_or_null,
+                                const char *path_or_name,
+                                char **namep,
+                                char **pathp,
+                                flux_error_t *error)
 {
-    broker_ctx_t *ctx = mh->ctx;
-    const char *broker_uuid = overlay_get_uuid (ctx->overlay);
     char *path = NULL;
     char *name = NULL;
-    void *dso;
-    mod_main_f mod_main;
-    module_t *p;
 
     /* Handle 'flux module load /path/to/foo.dso' or 'flux module load foo'.
      * In the latter case, search FLUX_MODULE_PATH for foo.dso.
@@ -363,7 +363,7 @@ static module_t *modhash_load_dso (modhash_t *mh,
     if (strchr (path_or_name, '/')) {
         if (!(path = strdup (path_or_name))) {
             errprintf (error, "error duplicating module path");
-            return NULL;
+            return -1;
         }
     }
     else {
@@ -371,10 +371,10 @@ static module_t *modhash_load_dso (modhash_t *mh,
         if (!searchpath) {
             errprintf (error, "FLUX_MODULE_PATH is not set in the environment");
             errno = EINVAL;
-            return NULL;
+            return -1;
         }
         if (!(path = module_dso_search (path_or_name, searchpath, error)))
-            return NULL;
+            return -1;
     }
     /* If the name is not specified, derive it from the module path.
      * E.g. the path '/path/to/foo.dso' suggests a module name of 'foo'.
@@ -389,44 +389,54 @@ static module_t *modhash_load_dso (modhash_t *mh,
                    "error duplicating module name: %s",
                    strerror (errno));
         ERRNO_SAFE_WRAP (free, path);
-        goto error;
+        return -1;
     }
+    *namep = name;
+    *pathp = path;
+    return 0;
+}
+
+static module_t *modhash_load_dso (modhash_t *mh,
+                                   const char *name,
+                                   char *path, // stolen
+                                   json_t *args,
+                                   flux_error_t *error)
+{
+    broker_ctx_t *ctx = mh->ctx;
+    const char *broker_uuid = overlay_get_uuid (ctx->overlay);
+    void *dso;
+    mod_main_f mod_main;
+    module_t *p;
+
     /* Now open the DSO and obtain the mod_main() function pointer
      * that will be called from a new module thread in module_start().
      * The name is only passed to this function so the deprecated mod_name
      * symbol can be sanity checked, if defined.
      */
-    if (!(dso = module_dso_open (path, name, &mod_main, error))) {
-        ERRNO_SAFE_WRAP (free, path);
-        goto error;
-    }
+    if (!(dso = module_dso_open (path, name, &mod_main, error)))
+        return NULL;
+
     /* Create the module object.
      */
-    if (!(p = module_create (ctx->h,
-                             broker_uuid,
-                             name,
-                             mod_main,
-                             args,
-                             error))
+    if (!(p = module_create_thread (ctx->h,
+                                    broker_uuid,
+                                    name,
+                                    mod_main,
+                                    args,
+                                    error))
         || module_aux_set (p, NULL, dso, module_dso_close) < 0) {
         module_dso_close (dso);
-        ERRNO_SAFE_WRAP (free, path);
-        goto error_module;
+        goto error;
     }
     if (module_aux_set (p, "path", path, (flux_free_f)free) < 0) {
-        ERRNO_SAFE_WRAP (free, path);
-        goto error_module;
+        errprintf (error,
+                   "error stashing module path in aux container: %s",
+                   strerror (errno));
+        goto error;
     }
-    /*  Register service, start module thread, and insert into modhash.
-     */
-    if (modhash_load_finalize (ctx->modhash, p, error) < 0)
-        goto error_module;
-    free (name);
     return p;
-error_module:
-    module_destroy (p);
 error:
-    ERRNO_SAFE_WRAP (free, name);
+    module_destroy (p);
     return NULL;
 }
 
@@ -448,8 +458,9 @@ static void load_cb (flux_t *h,
                      void *arg)
 {
     broker_ctx_t *ctx = arg;
-    const char *name = NULL;
-    const char *path;
+    const char *name_or_null = NULL;
+    const char *path_or_name;
+    int exec = 0;
     json_t *args;
     flux_error_t error;
     const char *errmsg = NULL;
@@ -458,24 +469,57 @@ static void load_cb (flux_t *h,
 
     if (flux_request_unpack (msg,
                              NULL,
-                             "{s?s s:s s:o}",
-                             "name", &name,
-                             "path", &path,
-                             "args", &args) < 0)
+                             "{s?s s:s s:o s?b}",
+                             "name", &name_or_null,
+                             "path", &path_or_name,
+                             "args", &args,
+                             "exec", &exec) < 0)
         goto error;
-    if ((builtin = builtins_find (ctx->modhash, path))) {
-        p = modhash_load_builtin (ctx->modhash, builtin, name, args, &error);
+
+    if ((builtin = builtins_find (ctx->modhash, path_or_name))) {
+        if (exec) {
+            errno = EINVAL;
+            errmsg = "built-in modules cannot execute in a separate process";
+            goto error;
+        }
+        p = modhash_load_builtin (ctx->modhash,
+                                  builtin,
+                                  name_or_null,
+                                  args,
+                                  &error);
         if (!p) {
             errmsg = error.text;
             goto error;
         }
     }
     else {
-        if (!(p = modhash_load_dso (ctx->modhash, name, path, args, &error))) {
+        char *name = NULL;
+        char *path = NULL;
+        if (modhash_resolve_dso (name_or_null,
+                                 path_or_name,
+                                 &name,
+                                 &path,
+                                 &error) < 0) {
             errmsg = error.text;
             goto error;
         }
+        if (exec)
+            p = modhash_load_exec (ctx->modhash, name, path, args, &error);
+        else
+            p = modhash_load_dso (ctx->modhash, name, path, args, &error);
+        if (!p) {
+            ERRNO_SAFE_WRAP (free, name);
+            ERRNO_SAFE_WRAP (free, path);
+            errmsg = error.text;
+            goto error;
+        }
+        free (name);
+        // N.B. path is stolen by modhash_load_*() on success
     }
+    /* Register service, start module thread, and insert into modhash.
+     */
+    if (modhash_load_finalize (ctx->modhash, p, &error) < 0)
+        goto error_module;
     /* Push the insmod request onto the module.  A response will be generated
      * from the module status callback, after the module is active.
      */
@@ -974,12 +1018,12 @@ static module_t *modhash_load_builtin (modhash_t *mh,
     module_t *p;
     char *cpy;
 
-    if (!(p = module_create (mh->ctx->h,
-                             broker_uuid,
-                             name ? name : bb->name,
-                             bb->main,
-                             args,
-                             error)))
+    if (!(p = module_create_thread (mh->ctx->h,
+                                    broker_uuid,
+                                    name ? name : bb->name,
+                                    bb->main,
+                                    args,
+                                    error)))
         return NULL;
     if (!(cpy = strdup ("builtin"))
         || module_aux_set (p, "path", cpy, (flux_free_f)free) < 0) {
@@ -989,8 +1033,6 @@ static module_t *modhash_load_builtin (modhash_t *mh,
         ERRNO_SAFE_WRAP (free, cpy);
         goto error;
     }
-    if (modhash_load_finalize (mh, p, error) < 0)
-        goto error;
     return p;
 error:
     module_destroy (p);
@@ -1052,10 +1094,14 @@ flux_future_t *modhash_load_builtins (modhash_t *mh, flux_error_t *error)
         mh->f_builtins_load = f;
     }
     for (int i = 0; i < ARRAY_SIZE (builtins); i++) {
+        module_t *p;
         if (mh->ctx->verbose > 1)
             log_msg ("loading %s", builtins[i]->name);
-        if (!modhash_load_builtin (mh, builtins[i], NULL, NULL, error))
+        if (!(p = modhash_load_builtin (mh, builtins[i], NULL, NULL, error))
+            || modhash_load_finalize (mh, p, error) < 0) {
+            module_destroy (p);
             return NULL;
+        }
     }
     modhash_load_builtins_cond_fulfill (mh, mh->f_builtins_load);
     return mh->f_builtins_load;
@@ -1100,6 +1146,36 @@ flux_future_t *modhash_unload_builtins (modhash_t *mh)
     }
     modhash_unload_builtins_cond_fulfill (mh, mh->f_builtins_unload);
     return mh->f_builtins_unload;
+}
+
+static module_t *modhash_load_exec (modhash_t *mh,
+                                    const char *name,
+                                    char *path, // stolen
+                                    json_t *args,
+                                    flux_error_t *error)
+{
+    broker_ctx_t *ctx = mh->ctx;
+    const char *broker_uuid = overlay_get_uuid (ctx->overlay);
+    module_t *p;
+
+    if (!(p = module_create_exec (ctx->h,
+                                  broker_uuid,
+                                  name,
+                                  path,
+                                  args,
+                                  error)))
+        goto error;
+    if (module_aux_set (p, "path", path, (flux_free_f)free) < 0) {
+        ERRNO_SAFE_WRAP (free, path);
+        errprintf (error,
+                   "error stashing module path in aux container: %s",
+                   strerror (errno));
+        goto error;
+    }
+    return p;
+error:
+    module_destroy (p);
+    return NULL;
 }
 
 /*

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -677,6 +677,21 @@ ssize_t module_get_recv_queue_count (module_t *p)
     return count;
 }
 
+
+bool module_is_exec (module_t *p)
+{
+    if (!p || !p->is_exec)
+        return false;
+    return true;
+}
+
+pid_t module_get_pid (module_t *p)
+{
+    if (!p || !p->is_exec)
+        return -1;
+    return flux_subprocess_pid (p->exec.p);
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -30,10 +30,24 @@
 #include "src/common/libutil/aux.h"
 #include "src/common/libutil/basename.h"
 #include "src/common/librouter/subhash.h"
+#include "src/common/librouter/rpc_track.h"
 #include "ccan/str/str.h"
 
 #include "module.h"
 #include "modservice.h"
+
+struct broker_module_thread {
+    struct module_args args;/* passed to module thread via (void *) param */
+    pthread_t t;            /* module thread */
+};
+
+struct broker_module_exec {
+    flux_cmd_t *cmd;
+    flux_subprocess_t *p;
+    struct rpc_track *tracker;
+};
+
+extern char **environ;
 
 struct broker_module {
     flux_t *h;              /* ref to broker's internal flux_t handle */
@@ -44,12 +58,15 @@ struct broker_module {
 
     flux_t *h_broker_end;   /* broker end of interthread channel */
 
-    struct module_args args;/* passed to module thread via (void *) param */
+    bool is_exec;
+    union {
+        struct broker_module_thread thread;
+        struct broker_module_exec exec;
+    };
 
     uuid_t uuid;            /* uuid for unique request sender identity */
     char uuid_str[UUID_STR_LEN];
     char uri[128];
-    pthread_t t;            /* module thread */
     char *name;
     int status;
     int errnum;
@@ -147,12 +164,11 @@ error:
     return NULL;
 }
 
-module_t *module_create (flux_t *h,
-                         const char *parent_uuid,
-                         const char *name,
-                         mod_main_f mod_main,
-                         json_t *mod_args,
-                         flux_error_t *error)
+static module_t *module_create (flux_t *h,
+                                const char *parent_uuid,
+                                const char *name,
+                                json_t *mod_args,
+                                flux_error_t *error)
 {
     flux_reactor_t *r = flux_get_reactor (h);
     module_t *p;
@@ -198,11 +214,6 @@ module_t *module_create (flux_t *h,
         flux_msg_decref (msg);
         goto cleanup;
     }
-    /* Prepare (void *) argument to module thread.
-     * Take care not to change these while the thread is executing.
-     */
-    p->args.uri = p->uri;
-    p->args.main = mod_main;
     return p;
 nomem:
     errprintf (error, "out of memory");
@@ -210,6 +221,55 @@ nomem:
 cleanup:
     module_destroy (p);
     return NULL;
+}
+
+module_t *module_create_exec (flux_t *h,
+                              const char *parent_uuid,
+                              const char *name,
+                              const char *path,
+                              json_t *mod_args,
+                              flux_error_t *error)
+{
+    module_t *p;
+    if (!(p = module_create (h, parent_uuid, name, mod_args, error)))
+        return NULL;
+    p->is_exec = true;
+
+    const char *av[] = { "flux", "module-exec", path, NULL };
+    int ac = 3;
+    if (!(p->exec.cmd = flux_cmd_create (ac, (char **)av, environ))
+        || flux_cmd_add_message_channel (p->exec.cmd,
+                                         "FLUX_MODULE_URI",
+                                         p->uri) < 0) {
+        errprintf (error, "error creating %s command object", p->name);
+        module_destroy (p);
+        return NULL;
+    }
+    if (!(p->exec.tracker = rpc_track_create (MSG_HASH_TYPE_UUID_MATCHTAG))) {
+        errprintf (error, "error creating %s rpc tracker", p->name);
+        module_destroy (p);
+        return NULL;
+    }
+    return p;
+}
+
+module_t *module_create_thread (flux_t *h,
+                                const char *parent_uuid,
+                                const char *name,
+                                mod_main_f mod_main,
+                                json_t *mod_args,
+                                flux_error_t *error)
+{
+    module_t *p;
+    if (!(p = module_create (h, parent_uuid, name, mod_args, error)))
+        return NULL;
+
+    /* Prepare (void *) argument to module thread.
+     * Take care not to change these while the thread is executing.
+     */
+    p->thread.args.uri = p->uri;
+    p->thread.args.main = mod_main;
+    return p;
 }
 
 const char *module_get_name (module_t *p)
@@ -257,6 +317,14 @@ flux_msg_t *module_recvmsg (module_t *p)
 {
     flux_msg_t *msg;
     msg = flux_recv (p->h_broker_end, FLUX_MATCH_ANY, FLUX_O_NONBLOCK);
+    if (msg && p->is_exec) {
+        int saved_errno = errno;
+        int type;
+        if (flux_msg_get_type (msg, &type) == 0
+            && type == FLUX_MSGTYPE_RESPONSE)
+            rpc_track_update (p->exec.tracker, msg);
+        errno = saved_errno;
+    }
     return msg;
 }
 
@@ -286,6 +354,13 @@ int module_sendmsg_new (module_t *p, flux_msg_t **msg)
         *msg = NULL;
         return 0;
     }
+    if (p->is_exec && type == FLUX_MSGTYPE_REQUEST) {
+        flux_msg_t *cpy;
+        if ((cpy = flux_msg_copy (*msg, false))) {
+            rpc_track_update (p->exec.tracker, cpy);
+            flux_msg_decref (cpy);
+        }
+    }
     return flux_send_new (p->h_broker_end, msg, 0);
 }
 
@@ -303,6 +378,25 @@ int module_disconnect_arm (module_t *p,
     return 0;
 }
 
+static void log_tracker_error (flux_t *h, const flux_msg_t *msg, int errnum)
+{
+    if (errnum != ENOSYS) {
+        const char *topic = "unknown";
+        (void)flux_msg_get_topic (msg, &topic);
+        flux_log_error (h,
+                        "tracker: error sending %s EHOSTUNREACH response",
+                        topic);
+    }
+}
+
+static void fail_module_rpcs (const flux_msg_t *msg, void *arg)
+{
+    module_t *p = arg;
+
+    if (flux_respond_error (p->h, msg, EHOSTUNREACH, "module disconnect") < 0)
+        log_tracker_error (p->h, msg, errno);
+}
+
 void module_destroy (module_t *p)
 {
     int e;
@@ -312,20 +406,28 @@ void module_destroy (module_t *p)
     if (!p)
         return;
 
-    if (p->t) {
-        if ((e = pthread_join (p->t, &res)) != 0)
-            log_errn_exit (e, "pthread_join");
-        if (p->status != FLUX_MODSTATE_EXITED) {
-            /* Calls broker.c module_status_cb() => service_remove_byuuid()
-             * and releases a reference on 'p'.  Without this, disconnect
-             * requests sent when other modules are destroyed can still find
-             * this service name and trigger a use-after-free segfault.
-             * See also: flux-framework/flux-core#4564.
-             */
-            module_set_status (p, FLUX_MODSTATE_EXITED);
+    if (p->is_exec) {
+        flux_subprocess_destroy (p->exec.p);
+        flux_cmd_destroy (p->exec.cmd);
+        rpc_track_purge (p->exec.tracker, fail_module_rpcs, p);
+        rpc_track_destroy (p->exec.tracker);
+    }
+    else {
+        if (p->thread.t) {
+            if ((e = pthread_join (p->thread.t, &res)) != 0)
+                log_errn_exit (e, "pthread_join");
+            if (res == PTHREAD_CANCELED)
+                flux_log (p->h, LOG_DEBUG, "%s thread was canceled", p->name);
         }
-        if (res == PTHREAD_CANCELED)
-            flux_log (p->h, LOG_DEBUG, "%s thread was canceled", p->name);
+    }
+    if (p->status != FLUX_MODSTATE_EXITED) {
+        /* Calls broker.c module_status_cb() => service_remove_byuuid()
+         * and releases a reference on 'p'.  Without this, disconnect
+         * requests sent when other modules are destroyed can still find
+         * this service name and trigger a use-after-free segfault.
+         * See also: flux-framework/flux-core#4564.
+         */
+        module_set_status (p, FLUX_MODSTATE_EXITED);
     }
 
     /* Send disconnect messages to services used by this module.
@@ -393,15 +495,85 @@ int module_set_defer (module_t *p, bool flag)
     return 0;
 }
 
+/* Log something and notify the broker (via its module status callback)
+ * if a module running as a sub-process terminates.  N.B. this isn't called
+ * if the sub-process enters the FAILED state - see similar code in the
+ * state callback below.
+ */
+static void exec_completion_cb (flux_subprocess_t *proc)
+{
+    module_t *p = flux_subprocess_aux_get (proc, "module");
+    int rc;
+    bool failed = true;
+    if ((rc = flux_subprocess_exit_code (proc)) >= 0) {
+        if (rc == 0)
+            failed = false;
+        else
+            flux_log (p->h, LOG_ERR, "%s: exited with rc=%d", p->name, rc);
+    }
+    else if ((rc = flux_subprocess_signaled (proc)) >= 0)
+        flux_log (p->h, LOG_ERR, "%s: killed by %s", p->name, strsignal (rc));
+    else
+        flux_log (p->h, LOG_ERR, "%s: completed (not signal or exit)", p->name);
+    if (p->status != FLUX_MODSTATE_EXITED) {
+        if (failed)
+            module_set_errnum (p, ECHILD);
+        module_set_status (p, FLUX_MODSTATE_EXITED);
+    }
+}
+
+static void exec_state_cb (flux_subprocess_t *proc,
+                           flux_subprocess_state_t state)
+{
+    module_t *p = flux_subprocess_aux_get (proc, "module");
+    switch (state) {
+        case FLUX_SUBPROCESS_RUNNING:
+            break;
+        case FLUX_SUBPROCESS_FAILED:
+            flux_log (p->h,
+                      LOG_ERR,
+                      "%s: %s failed: %s",
+                      p->name,
+                      flux_subprocess_state_string (state),
+                      strerror (flux_subprocess_fail_errno (proc)));
+            if (p->status != FLUX_MODSTATE_EXITED) {
+                module_set_errnum (p, ECHILD);
+                module_set_status (p, FLUX_MODSTATE_EXITED);
+            }
+            break;
+        case FLUX_SUBPROCESS_EXITED:
+        case FLUX_SUBPROCESS_INIT:
+        case FLUX_SUBPROCESS_STOPPED:
+            break; // ignore
+    }
+
+}
+
 int module_start (module_t *p)
 {
     int errnum;
     int rc = -1;
 
     flux_watcher_start (p->broker_w);
-    if ((errnum = pthread_create (&p->t, NULL, module_thread, &p->args))) {
-        errno = errnum;
-        goto done;
+    if (p->is_exec) {
+        flux_reactor_t *r = flux_get_reactor (p->h);
+        flux_subprocess_ops_t ops = {
+            .on_completion = exec_completion_cb,
+            .on_state_change = exec_state_cb,
+        };
+        int flags = FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH;
+        if (!(p->exec.p = flux_local_exec (r, flags, p->exec.cmd, &ops))
+            || flux_subprocess_aux_set (p->exec.p, "module", p, NULL) < 0)
+            goto done;
+    }
+    else {
+        if ((errnum = pthread_create (&p->thread.t,
+                                      NULL,
+                                      module_thread,
+                                      &p->thread.args))) {
+            errno = errnum;
+            goto done;
+        }
     }
     rc = 0;
 done:
@@ -410,14 +582,24 @@ done:
 
 int module_cancel (module_t *p, flux_error_t *error)
 {
-    if (p->t) {
-        int e;
-        if ((e = pthread_cancel (p->t)) != 0 && e != ESRCH) {
-            errprintf (error, "pthread_cancel: %s", strerror (e));
+    if (p->is_exec) {
+        flux_future_t *f;
+        if (!(f = flux_subprocess_kill (p->exec.p, SIGKILL))) {
+            errprintf (error, "flux_subprocess_kill: %s", strerror (errno));
             return -1;
         }
-        p->module_unload_requested = true;
+        flux_future_destroy (f);
     }
+    else {
+        if (p->thread.t) {
+            int e;
+            if ((e = pthread_cancel (p->thread.t)) != 0 && e != ESRCH) {
+                errprintf (error, "pthread_cancel: %s", strerror (e));
+                return -1;
+            }
+        }
+    }
+    p->module_unload_requested = true;
     return 0;
 }
 

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -130,6 +130,9 @@ bool module_is_subscribed (module_t *p, const char *topic);
 ssize_t module_get_send_queue_count (module_t *p);
 ssize_t module_get_recv_queue_count (module_t *p);
 
+bool module_is_exec (module_t *p);
+pid_t module_get_pid (module_t *p);
+
 #endif /* !_BROKER_MODULE_H */
 
 /*

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -40,12 +40,18 @@ struct module_builtin {
     mod_main_f main;
 };
 
-module_t *module_create (flux_t *h,
-                         const char *parent_uuid,
-                         const char *name,
-                         mod_main_f mod_main,
-                         json_t *args,
-                         flux_error_t *error);
+module_t *module_create_thread (flux_t *h,
+                                const char *parent_uuid,
+                                const char *name,
+                                mod_main_f mod_main,
+                                json_t *args,
+                                flux_error_t *error);
+module_t *module_create_exec (flux_t *h,
+                              const char *parent_uuid,
+                              const char *name,
+                              const char *path,
+                              json_t *args,
+                              flux_error_t *error);
 void module_destroy (module_t *p);
 
 /* accessors

--- a/src/broker/module_exec.c
+++ b/src/broker/module_exec.c
@@ -26,6 +26,9 @@
 #include "config.h"
 #endif
 #include <stdlib.h>
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h>
+#endif
 #ifdef HAVE_ARGZ_ADD
 #include <argz.h>
 #else
@@ -332,6 +335,9 @@ int main (int argc, char *argv[])
     else {
         broker_mode_init (&me);
         flux_log_set_appname (me.h, me.name);
+#ifdef PR_SET_NAME
+        (void)prctl (PR_SET_NAME, me.name, 0, 0, 0);
+#endif
     }
 
     /* Set flux::uuid and flux::name per RFC 5

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -330,8 +330,8 @@ static void module_load (flux_t *h,
         log_err_exit ("could not canonicalize module path '%s'", path);
     if (!(args = args_create (argc, argv))
         || !(payload = json_pack ("{s:s s:O}",
-                               "path", fullpath ? fullpath : path,
-                               "args", args))
+                                  "path", fullpath ? fullpath : path,
+                                  "args", args))
         || (name && set_string (payload, "name", name) < 0))
         log_msg_exit ("failed to create module.load payload");
     if (!(f = flux_rpc_pack (h,
@@ -494,12 +494,23 @@ void lsmod_print_header (FILE *f, bool longopt)
     if (longopt) {
         fprintf (f,
                  "%-25.25s %4s  %c %s %s %-8s %s\n",
-                 "Module", "Idle", 'S', "Sendq", "Recvq", "Service", "Path");
+                 "Module",
+                 "Idle",
+                 'S',
+                 "Sendq",
+                 "Recvq",
+                 "Service",
+                 "Path");
     }
     else {
         fprintf (f,
                  "%-25s %4s  %c %s %s %s\n",
-                 "Module", "Idle", 'S', "Sendq", "Recvq", "Service");
+                 "Module",
+                 "Idle",
+                 'S',
+                 "Sendq",
+                 "Recvq",
+                 "Service");
     }
 }
 
@@ -520,7 +531,8 @@ void lsmod_print_entry (FILE *f,
 
     if (longopt) {
         char *s = lsmod_services_string (services, name, 8);
-        fprintf (f, "%-25.25s %4s  %c %5d %5d %-8s %s\n",
+        fprintf (f,
+                 "%-25.25s %4s  %c %5d %5d %-8s %s\n",
                  name,
                  idle_s,
                  state,
@@ -532,7 +544,8 @@ void lsmod_print_entry (FILE *f,
     }
     else {
         char *s = lsmod_services_string (services, name, 0);
-        fprintf (f, "%-25.25s %4s  %c %5d %5d %s\n",
+        fprintf (f,
+                 "%-25.25s %4s  %c %5d %5d %s\n",
                  name,
                  idle_s,
                  state,
@@ -558,7 +571,8 @@ void lsmod_print_list (FILE *f, json_t *o, bool longopt)
     json_array_foreach (o, index, value) {
         recvqueue = 0;
         sendqueue = 0;
-        if (json_unpack (value, "{s:s s:s s:i s:i s:o s?i s?i}",
+        if (json_unpack (value,
+                         "{s:s s:s s:i s:i s:o s?i s?i}",
                          "name", &name,
                          "path", &path,
                          "idle", &idle,

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -85,12 +85,18 @@ static struct optparse_option reload_opts[] =  {
       .usage = "Forcibly stop an unresponsive module thread when it"
                " reaches the next pthread(7) cancellation point",
     },
+    { .name = "exec", .has_arg = 0,
+      .usage = "Load module as a separate process",
+    },
     OPTPARSE_TABLE_END,
 };
 
 static struct optparse_option load_opts[] =  {
     { .name = "name", .has_arg = 1, .arginfo = "NAME",
       .usage = "Override default module name",
+    },
+    { .name = "exec", .has_arg = 0,
+      .usage = "Load module as a separate process",
     },
     OPTPARSE_TABLE_END,
 };
@@ -329,9 +335,10 @@ static void module_load (flux_t *h,
     if (canonicalize_if_path (path, &fullpath) < 0)
         log_err_exit ("could not canonicalize module path '%s'", path);
     if (!(args = args_create (argc, argv))
-        || !(payload = json_pack ("{s:s s:O}",
+        || !(payload = json_pack ("{s:s s:O s:b}",
                                   "path", fullpath ? fullpath : path,
-                                  "args", args))
+                                  "args", args,
+                                  "exec", optparse_hasopt (p, "exec") ? 1 : 0))
         || (name && set_string (payload, "name", name) < 0))
         log_msg_exit ("failed to create module.load payload");
     if (!(f = flux_rpc_pack (h,

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -7,6 +7,9 @@ test_description='Test flux-module-exec'
 test_under_flux 1 minimal
 
 testmod=$(realpath ${FLUX_BUILD_DIR}/t/module/.libs/testmod.so)
+legacy=$(realpath ${FLUX_BUILD_DIR}/t/module/.libs/legacy.so)
+rpc_stream=${FLUX_BUILD_DIR}/t/request/rpc_stream
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
 
 flux setattr log-stderr-level 6
 
@@ -18,6 +21,21 @@ test_expect_success 'flux-module-exec fails on --badopt' '
 	test_must_fail flux module-exec --badopt $testmod 2>badopt.err &&
 	grep "unrecognized option" badopt.err
 '
+test_expect_success 'FLUX_MODULE_URI and --name fail when used together' '
+	test_must_fail sh -c "FLUX_MODULE_URI=foo://bar flux module-exec \
+	    --name=foo $testmod" 2>urimod.err &&
+	grep "are incompatible" urimod.err
+'
+test_expect_success 'FLUX_MODULE_URI and free args fail when used together' '
+	test_must_fail sh -c "FLUX_MODULE_URI=foo://bar flux module-exec \
+	    $testmod arg" 2>uriarg.err &&
+	grep "are incompatible" uriarg.err
+'
+
+##
+# test mode
+##
+
 test_expect_success 'flux-module-exec fails on unknown module' '
 	test_must_fail flux module-exec badmod 2>badmod.err &&
 	grep "module not found in search path" badmod.err
@@ -85,6 +103,80 @@ test_expect_success NO_CHAIN_LINT 'send heartbeat.shutdown' '
 test_expect_success NO_CHAIN_LINT 'heartbeat unloads without error' '
 	pid=$(cat <heartbeat.pid) &&
 	wait $pid
+'
+
+##
+# broker mode
+##
+
+test_expect_success 'flux module load --exec heartbeat works' '
+	flux module load --exec heartbeat
+'
+test_expect_success 'flux ping heartbeat works' '
+	flux ping -c 1 heartbeat
+'
+test_expect_success 'flux module stats heartbeat works' '
+	flux module stats heartbeat
+'
+test_expect_success 'flux module remove heartbeat works' '
+	flux module remove heartbeat
+'
+test_expect_success 'flux module load --exec fails on unknown module' '
+	test_must_fail flux module load --exec badmod 2>badexecmod.err &&
+	grep "module not found in search path" badexecmod.err
+'
+test_expect_success 'flux module load --exec fails on module init failure' '
+	test_must_fail flux module load --exec \
+	    $testmod --init-failure 2>modexecfail.err &&
+	grep "error" modexecfail.err
+'
+test_expect_success 'flux module load testmod' '
+	flux module load $testmod
+'
+test_expect_success 'flux module reload --exec testmod works' '
+	flux module reload --exec $testmod
+'
+test_expect_success 'flux ping testmod works' '
+	flux ping -c 1 testmod
+'
+test_expect_success 'simulated module panic cause module to exit' '
+	flux setattr broker.module-nopanic 1 &&
+	flux dmesg -C &&
+	flux event pub testmod.panic &&
+	sh -c "while flux module stats testmod; do true; done" &&
+	flux dmesg | grep "module runtime failure"
+'
+test_expect_success 'flux module load testmod' '
+	flux module load --exec $testmod
+'
+test_expect_success NO_CHAIN_LINT 'start background streaming RPC' '
+	$rpc_stream testmod.info </dev/null >stream.out 2>stream.err &
+	echo $! >stream.pid
+'
+test_expect_success NO_CHAIN_LINT 'wait for first response to RPC' '
+	$waitfile -t 15 stream.out
+'
+test_expect_success 'simulated module segfault causes module to exit' '
+	flux dmesg -C &&
+	flux event pub testmod.segfault &&
+	sh -c "while flux module stats testmod; do true; done" &&
+	flux dmesg >segfault.out
+'
+test_expect_success 'segfault is reported' '
+	grep "testmod: killed by Segmentation fault" segfault.out
+'
+test_expect_success 'broker treats this the same as spurious module exit' '
+	grep "module runtime failure" segfault.out
+'
+test_expect_success NO_CHAIN_LINT 'streaming RPC was terminated' '
+	pid=$(cat stream.pid) &&
+	test_must_fail wait $pid
+'
+test_expect_success NO_CHAIN_LINT 'broker responded with module disconnect' '
+	grep "module disconnect" stream.err
+'
+test_expect_success 'legacy module cannot be loaded under new name' '
+        test_must_fail flux module load --exec --name=newname $legacy
 '
 
 test_done


### PR DESCRIPTION
Problem: although Flux broker extension modules are only allowed to interact with each other using messages, this isolation is not  enforced and a badly behaved module can crash the broker.

Add support for `flux module [re]load --exec`.   The broker runs `flux module-exec MODULE` as a sub-process instead of a thread, communicating with it over a dedicated sub-process message channel.

This is the final PR of the stack and is built on top of
- #7073
- #7072 
- #7071
- #7068