### PR TITLE
modprobe/rc1: call flux restore with --sd-notify

### DIFF
--- a/etc/modprobe/rc1.py
+++ b/etc/modprobe/rc1.py
@@ -103,7 +103,7 @@ def restore(context):
         return
     print(f"restoring content from {dumpfile}")
     if dumpfile.exists():
-        cmd = f"flux restore --quiet --checkpoint --size-limit=100M {dumpfile}"
+        cmd = f"flux restore --sd-notify --quiet --checkpoint --size-limit=100M {dumpfile}"
         context.bash(cmd)
     if dumplink and dumplink.exists():
         dumplink.unlink()


### PR DESCRIPTION
Problem: Under the "restore" task, "flux restore" is not called with the --sd-notify option like in "rc1.old".  --sd-notify was added after rc1.py was created, so it was likely just not copied over.

Add the missing --sd-notify option.