### PR TITLE
libsubprocess: allow all flags to work remotely

### DIFF
--- a/src/common/libsubprocess/client.c
+++ b/src/common/libsubprocess/client.c
@@ -107,7 +107,8 @@ flux_future_t *subprocess_rexec (flux_t *h,
                                  const char *service_name,
                                  uint32_t rank,
                                  flux_cmd_t *cmd,
-                                 int flags)
+                                 int flags,
+                                 int lflags)
 {
     flux_future_t *f = NULL;
     struct rexec_ctx *ctx;
@@ -125,9 +126,10 @@ flux_future_t *subprocess_rexec (flux_t *h,
                              topic,
                              rank,
                              FLUX_RPC_STREAMING,
-                             "{s:O s:i}",
+                             "{s:O s:i s:i}",
                              "cmd", ctx->cmd,
-                             "flags", ctx->flags))
+                             "flags", ctx->flags,
+                             "lflags", lflags))
         || flux_future_aux_set (f,
                                 "flux::rexec",
                                 ctx,

--- a/src/common/libsubprocess/client.h
+++ b/src/common/libsubprocess/client.h
@@ -29,7 +29,8 @@ flux_future_t *subprocess_rexec (flux_t *h,
                                  const char *service_name,
                                  uint32_t rank,
                                  flux_cmd_t *cmd,
-                                 int flags);
+                                 int flags,
+                                 int lflags);
 
 int subprocess_rexec_get (flux_future_t *f);
 bool subprocess_rexec_is_started (flux_future_t *f, pid_t *pid);

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -51,18 +51,18 @@ typedef enum {
  * Subprocess flags
  */
 enum {
-    /* flux_local_exec(): let parent stdin, stdout, stderr, carry to
+    /* let parent stdin, stdout, stderr, carry to
      * child.  Do not create "stdin", "stdout", or "stderr" channels.
      * Subsequently, flux_subprocess_write()/close()/read()/read_line()
      * will fail on streams of "stdin", "stdout", or "stderr".
      */
     FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH = 1,
-    /* flux_local_exec(): do not call setpgrp() before exec(2) */
+    /* do not call setpgrp() before exec(2) */
     FLUX_SUBPROCESS_FLAGS_NO_SETPGRP = 2,
-    /* flux_local_exec(): use fork(2)/exec(2) even if posix_spawn(3)
+    /* use fork(2)/exec(2) even if posix_spawn(3)
      * available */
     FLUX_SUBPROCESS_FLAGS_FORK_EXEC = 4,
-    /* flux_rexec(): In order to improve performance, do not locally
+    /* flux_rexec() only: In order to improve performance, do not locally
      * copy and buffer output from the remote subprocess.  Immediately
      * call output callbacks.  Users should call
      * flux_subprocess_read() to retrieve the data.  If

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -56,35 +56,6 @@ struct simple_ctx {
 
 extern char **environ;
 
-void corner_case_test (flux_t *h)
-{
-    char *true_av[] = { "true", NULL };
-    flux_subprocess_t *p;
-    flux_cmd_t *cmd;
-
-    cmd = flux_cmd_create (1, true_av, environ);
-    if (!cmd)
-        BAIL_OUT ("flux_cmd_create failed");
-
-    /* N.B. Issue #5968: flags are not passed from `flux_rexec` to
-     * remote subprocesses.  As of this test addition, errors may
-     * occur on other flags, but the only actual flag that should not
-     * be allowed on remote subprocesses is
-     * FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH, which makes no sense
-     * for non-local subprocesses.
-     *
-     * Although other flags would elicit failures, we do not test them.
-     */
-    p = flux_rexec (h,
-                    FLUX_NODEID_ANY,
-                    FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH,
-                    cmd,
-                    NULL);
-    ok (p == NULL && errno == EINVAL,
-        "flux_rexec failed for unsupported flag");
-    flux_cmd_destroy (cmd);
-}
-
 static void simple_output_cb (flux_subprocess_t *p, const char *stream)
 {
     struct simple_ctx *ctx = flux_subprocess_aux_get (p, "ctx");
@@ -753,8 +724,6 @@ int main (int argc, char *argv[])
 
     h = rcmdsrv_create (SERVER_NAME);
 
-    diag ("corner_case_test");
-    corner_case_test (h);
     diag ("simple_test");
     simple_test (h);
     diag ("simple_pre_running_write_close");

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -293,7 +293,7 @@ test_expect_success 'rexec from rank 1 to rank 0 works' '
 
 test_expect_success NO_CHAIN_LINT 'kill fails with ESRCH when pid is unknown' '
 	test_must_fail $rexec_script kill 15 12345678 2>kill.err &&
-	grep "No such process" kill.err
+	grep "does not belong to any subprocess" kill.err
 '
 
 test_done


### PR DESCRIPTION
Problem: `flux_rexec()` doesn't allow some flags to be set that were thought to only be useful for local subprocesses, but this is unnecessarily limiting.

For example, since SIGCHLD can only be handled in one thread of a multi-threaded process, local subprocesses must be launched from one thread.  In that context, another thread might need to use the remote subprocess interface to launch "local" processes.

Allow all flags to pass the validity check in `flux_rexec()`. Pass them to the server via a new `lflags` key (RFC 42 update required).

Call `flux_subprocess_kill()` from the server kill handler instead of hardwiring `killpg(2)` for remote subprocesses.
Return better human-readable errors when remote kill fails.

Update unit tests.

N.B. issue #5968 was probably closed prematurely, when the SETPGRP flag was inverted.  This completes the fix to the described problem.

Fixes #5968