### PR TITLE
libsubprocess: rename lflags to local_flags

### DIFF
--- a/src/common/libsubprocess/client.c
+++ b/src/common/libsubprocess/client.c
@@ -108,7 +108,7 @@ flux_future_t *subprocess_rexec (flux_t *h,
                                  uint32_t rank,
                                  flux_cmd_t *cmd,
                                  int flags,
-                                 int lflags)
+                                 int local_flags)
 {
     flux_future_t *f = NULL;
     struct rexec_ctx *ctx;
@@ -129,7 +129,7 @@ flux_future_t *subprocess_rexec (flux_t *h,
                              "{s:O s:i s:i}",
                              "cmd", ctx->cmd,
                              "flags", ctx->flags,
-                             "lflags", lflags))
+                             "local_flags", local_flags))
         || flux_future_aux_set (f,
                                 "flux::rexec",
                                 ctx,

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -580,7 +580,7 @@ int remote_exec (flux_subprocess_t *p)
 {
     flux_future_t *f;
     int flags = 0;
-    int lflags = p->flags;
+    int local_flags = p->flags;
 
     if (zlist_size (cmd_channel_list (p->cmd)) > 0)
         flags |= SUBPROCESS_REXEC_CHANNEL;
@@ -593,14 +593,14 @@ int remote_exec (flux_subprocess_t *p)
 
     /* Clear LOCAL_UNBUF for the remote subprocess object.
      */
-    lflags &= ~FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF;
+    local_flags &= ~FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF;
 
     if (!(f = subprocess_rexec (p->h,
                                 p->service_name,
                                 p->rank,
                                 p->cmd,
                                 flags,
-                                lflags))
+                                local_flags))
         || flux_future_then (f, -1., rexec_continuation, p) < 0) {
         llog_debug (p,
                     "error sending rexec.exec request: %s",

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -351,14 +351,14 @@ static void server_exec_cb (flux_t *h,
     const char *errmsg = NULL;
     flux_error_t error;
     int flags;
-    int lflags = 0;
+    int local_flags = 0;
 
     if (flux_request_unpack (msg,
                              NULL,
                              "{s:o s:i s?i}",
                              "cmd", &cmd_obj,
                              "flags", &flags,
-                             "lflags", &lflags) < 0)
+                             "local_flags", &local_flags) < 0)
         goto error;
     if (s->shutdown) {
         errmsg = "subprocess server is shutting down";
@@ -416,7 +416,7 @@ static void server_exec_cb (flux_t *h,
     flux_cmd_unsetenv (cmd, "NOTIFY_SOCKET"); // see sd_notify(3)
 
     if (!(p = flux_local_exec_ex (flux_get_reactor (s->h),
-                                  lflags,
+                                  local_flags,
                                   cmd,
                                   &ops,
                                   NULL,


### PR DESCRIPTION
Problem: the 'lflags' key in the subprocess exec request is poorly named.

Rename to 'local_flags'.