### PR TITLE
testsuite: simplify test to avoid hang

### DIFF
--- a/t/t3203-instance-recovery.t
+++ b/t/t3203-instance-recovery.t
@@ -41,13 +41,14 @@ test_expect_success 'banner message is printed in interactive recovery mode' '
 	grep "Entering Flux recovery mode" banner.out
 '
 test_expect_success '--recovery is not ignored if --test-size is specified' '
-	run_timeout --env=SHELL=/bin/sh 120 \
-	    $runpty -i none flux start \
-	        -Sbroker.rc1_path= \
-	        -Sbroker.rc3_path= \
-	    	--test-size=1 \
-	        --recovery=$(pwd)/test1 >banner.out &&
-	grep "Entering Flux recovery mode" banner.out
+	echo 1 >recovery-mode.exp &&
+	flux start \
+	    -Sbroker.rc1_path= \
+	    -Sbroker.rc3_path= \
+	    --test-size=1 \
+	    --recovery=$(pwd)/test1 \
+	    flux getattr broker.recovery-mode >recovery-mode.out &&
+	test_cmp recovery-mode.exp recovery-mode.out
 '
 test_expect_success 'rc1 failure is ignored in recovery mode' '
 	flux start --recovery=$(pwd)/test1 \


### PR DESCRIPTION
Problem: a test in t3203-instance-recovery.t hangs in CI.

I'm not sure what's going on but the test is just a cut and paste of the one above when it could be simplified to avoid the need for the runpty wrapper, which might be creating the environment needed for the hang.

Simplify the test.

Not a fix to #7091 but maybe a workaround for now.