### PR TITLE
doc: update flux-broker-attributes(7) defaults

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -184,11 +184,11 @@ broker.sd-stop-timeout
 
 conf.shell_initrc [Updates: C, R]
    The path to the :man1:`flux-shell` initrc script.  Default:
-   ``${prefix}/etc/flux/shell/initrc.lua``.
+   ``${sysconfdir}/flux/shell/initrc.lua``.
 
 conf.shell_pluginpath [Updates: C, R]
    The list of colon-separated directories to be searched by :man1:`flux-shell`
-   for shell plugins.  Default: ``${prefix}/lib/flux/shell/plugins``.
+   for shell plugins.  Default: ``${libdir}/flux/shell/plugins``.
 
 config.path [Updates: see below]
    A config file or directory (containing ``*.toml`` config files) for

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -997,3 +997,4 @@ epoll
 libuv
 PYCLI
 backtraces
+libdir


### PR DESCRIPTION
Problem: The documentation for conf.shell_initrc and conf.shell_pluginpath use "${prefix}/flux" to describe the defaults. While this is commonly correct, it isn't technically correct.

Update conf.shell_initrc's default with "${sysconfdir}" and conf.shell_pluginpath's default with "${libdir}".

Fixes #7101

---

Per comment in #7101, there was discussion of adding `flux config builtin ....`, but I ended up electing not to.