### PR TITLE
add `flux_rexec_bg(3)` and `flux exec --bg`

### DIFF
--- a/doc/man1/flux-exec.rst
+++ b/doc/man1/flux-exec.rst
@@ -97,6 +97,15 @@ OPTIONS
    is mostly meant for testing or as a convenience to execute a configured
    ``prolog`` or ``epilog`` command under the IMP.
 
+.. option:: --bg
+
+   Run processes in background. The rank and PID of each successfully
+   started process are written to stdout. The program exits once all
+   requested processes have started or failed, but processes continue
+   running as children of the server until they exit or the server shuts
+   down. Process output is logged to the server's stdout and stderr. The
+   :option:`--label-io` and :option:`--no-input` options are ignored.
+
 CAVEATS
 =======
 

--- a/src/common/libsubprocess/client.h
+++ b/src/common/libsubprocess/client.h
@@ -32,6 +32,12 @@ flux_future_t *subprocess_rexec (flux_t *h,
                                  int flags,
                                  int lflags);
 
+flux_future_t *subprocess_rexec_bg (flux_t *h,
+                                    const char *service_name,
+                                    uint32_t rank,
+                                    const flux_cmd_t *cmd,
+                                    int local_flags);
+
 int subprocess_rexec_get (flux_future_t *f);
 bool subprocess_rexec_is_started (flux_future_t *f, pid_t *pid);
 bool subprocess_rexec_is_stopped (flux_future_t *f);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -561,6 +561,24 @@ flux_subprocess_t * flux_local_exec (flux_reactor_t *r,
     return flux_local_exec_ex (r, flags, cmd, ops, NULL, NULL, NULL);
 }
 
+flux_future_t *flux_rexec_bg (flux_t *h,
+                              const char *service_name,
+                              int rank,
+                              int flags,
+                              const flux_cmd_t *cmd)
+{
+    if (!h
+        || (rank < 0
+            && rank != FLUX_NODEID_ANY
+            && rank != FLUX_NODEID_UPSTREAM)
+        || !cmd
+        || !flux_cmd_argc (cmd)) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return subprocess_rexec_bg (h, service_name, rank, cmd, flags);
+}
+
 flux_subprocess_t *flux_rexec_ex (flux_t *h,
                                   const char *service_name,
                                   int rank,

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -184,6 +184,19 @@ flux_subprocess_t *flux_rexec_ex (flux_t *h,
                                   subprocess_log_f log_fn,
                                   void *log_data);
 
+/* Like flux_rexec(3), but run process in background.
+ *
+ * If service_name is NULL, then default to `rexec`.
+ *
+ * Once the process has been started, the returned future will be fulfilled
+ * with the payload ``{"rank":i, "pid":i}``, or an error response if there
+ * is an error.
+ */
+flux_future_t *flux_rexec_bg (flux_t *h,
+                              const char *service_name,
+                              int rank,
+                              int flags,
+                              const flux_cmd_t *cmd);
 
 /* Start / stop a read stream temporarily on local processes.  This
  * may be useful for flow control.

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -112,6 +112,7 @@ struct flux_subprocess {
     char *service_name;
     flux_future_t *f;           /* primary future reactor */
     bool remote_completed;      /* if remote has completed */
+    bool bg;                    /* if flags & SUBPROCESS_REXEC_BACKGROUND */
     int failed_errno;           /* Holds errno if FAILED state reached */
     flux_error_t failed_error;  /* Holds detailed message for failed_errno */
     int signal_pending;         /* signal sent while starting */

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -95,8 +95,22 @@ void test_corner_cases (flux_reactor_t *r)
         && errno == EINVAL,
         "flux_rexec fails with invalid flag");
 
+    ok (flux_rexec_bg (NULL, NULL, 0, 0, NULL) == NULL && errno == EINVAL,
+        "flux_rexec_bg fails with EINVAL with NULL inputs");
+    ok (flux_rexec_bg (h, NULL, 0, 0, NULL) == NULL && errno == EINVAL,
+        "flux_rexec_bg fails with EINVAL with NULL cmd");
+
     ok ((cmd = flux_cmd_create (0, avbad, NULL)) != NULL,
         "flux_cmd_create with 0 args works");
+
+    ok (flux_rexec_bg (h,
+                       NULL,
+                       0,
+                       FLUX_SUBPROCESS_FLAGS_LOCAL_UNBUF,
+                       cmd) == NULL
+        && errno == EINVAL,
+        "flux_rexec_bg fails if FLUX_SUBPROCESS_LOCAL_UNBUF flag is set");
+
     ok (flux_local_exec (r, 0, cmd, NULL) == NULL
         && errno == EINVAL,
         "flux_local_exec fails with cmd with zero args");


### PR DESCRIPTION
This PR adds support for the `SUBPROCESS_REXEC_BACKGROUND` flag proposed in https://github.com/flux-framework/rfc/pull/470. The flag is activated via a new `flux_rexec_bg(3)` API call, which simply returns a `flux_future_t *` instead of a `flux_subprocess_t *`. Once the future is fulfilled, the subprocess has either been launched in the background, or if fulfilled with error, has failed to executed. Note that the RPC is still streaming, so a successful response is always followed by an `ENODATA` response.

Using this new interface, a `--bg` flag is added to `flux exec`. With this flag, `flux exec` exits after all requested processes have started while the processes continue to run as child of the subprocess server until they exit or the server is stopped.

This is a WIP because I'm not sure if addition of a new API call is the best approach. The first attempt added a new flag to `flux_rexec(3)`. This allowed reuse of more code, especially in `flux-rexec`, but added yet another special "rexec only" flag which has to be cleared from `local_flags`, plus slightly awkward handling of `flux_subprocess_t *` which will never call some of the ops callbacks.
