### PR TITLE
broker: rename event.publish to overlay.publish

### DIFF
--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -2714,7 +2714,7 @@ void overlay_destroy (struct overlay *ov)
 static const struct flux_msg_handler_spec htab[] = {
     {
         FLUX_MSGTYPE_REQUEST,
-        "event.publish",
+        "overlay.publish",
         overlay_publish_cb,
         FLUX_ROLE_USER,
     },

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -282,7 +282,7 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
             return NULL;
         }
         if (!(f = flux_rpc_pack (h,
-                                 "event.publish",
+                                 "overlay.publish",
                                  0,
                                  0,
                                  "{s:s s:i s:s}",
@@ -298,7 +298,7 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
     }
     else {
         if (!(f = flux_rpc_pack (h,
-                                 "event.publish",
+                                 "overlay.publish",
                                  0,
                                  0,
                                  "{s:s s:i}",

--- a/t/lua/t0003-events.t
+++ b/t/lua/t0003-events.t
@@ -55,36 +55,36 @@ type_ok (msg, 'table', "recv_event: got msg as a table")
 is_deeply (msg, {}, "recv_event: got empty payload as expected")
 
 
--- poke at event.publish service
+-- poke at overlay.publish service
 -- good request, no payload
 local request = { topic = "foo", flags = 0 }
-local response, err = f:rpc ("event.publish", request);
-is (err, nil, "event.publish: works without payload")
+local response, err = f:rpc ("overlay.publish", request);
+is (err, nil, "overlay.publish: works without payload")
 
 -- good request, with raw payload
 local request = { topic = "foo", flags = 0, payload = "aGVsbG8gd29ybGQ=" }
-local response, err = f:rpc ("event.publish", request);
-is (err, nil, "event.publish: works with payload")
+local response, err = f:rpc ("overlay.publish", request);
+is (err, nil, "overlay.publish: works with payload")
 
 -- good request, with JSON "{}\0"
 local request = { topic = "foo", flags = 0, payload = "e30A" }
-local response, err = f:rpc ("event.publish", request);
-is (err, nil, "event.publish: works with json payload")
+local response, err = f:rpc ("overlay.publish", request);
+is (err, nil, "overlay.publish: works with json payload")
 
 -- flags missing from request
 local request = { topic = "foo" }
-local response, err = f:rpc ("event.publish", request);
-is (err, "Protocol error", "event.publish: no flags, fails with EPROTO")
+local response, err = f:rpc ("overlay.publish", request);
+is (err, "Protocol error", "overlay.publish: no flags, fails with EPROTO")
 
 -- mangled base64 payload
 local request = { topic = "foo", flags = 0, payload = "aGVsbG8gd29ybGQ%" }
-local response, err = f:rpc ("event.publish", request);
-is (err, "Protocol error", "event.publish: bad base64, fails with EPROTO")
+local response, err = f:rpc ("overlay.publish", request);
+is (err, "Protocol error", "overlay.publish: bad base64, fails with EPROTO")
 
 -- good request, mangled JSON payload "{\0"
 local request = { topic = "foo", flags = 4, payload = "ewA=" }
-local response, err = f:rpc ("event.publish", request);
-is (err, "Protocol error", "event.publish: bad json payload, fails with EPROTO")
+local response, err = f:rpc ("overlay.publish", request);
+is (err, "Protocol error", "overlay.publish: bad json payload, fails with EPROTO")
 
 done_testing ()
 

--- a/t/t0004-event.t
+++ b/t/t0004-event.t
@@ -87,8 +87,8 @@ test_expect_success 'publish private event with no payload (synchronous,loopback
 	run_timeout 5 flux event pub -p -s -l foo.bar
 '
 
-test_expect_success 'event.publish request with empty payload fails with EPROTO(71)' '
-	${RPC} event.publish 71 </dev/null
+test_expect_success 'overlay.publish request with empty payload fails with EPROTO(71)' '
+	${RPC} overlay.publish 71 </dev/null
 '
 
 


### PR DESCRIPTION
Problem: `event.subscribe` and `event.unsubscribe` are handled by the broker, but `event.publish` is handled by the overlay code, which might move to a built-in broker module at some point.

Change the RPC target from `event.publish` to `overlay.publish` so the publish method can move outside of the broker with the overlay code.

Update tests.

This follows on and probably should have been submitted with
- #7100

The idea of moving the overlay code to a built-in module was brought up in
- #6967