### PR TITLE
testsuite: add elcap node hwloc data

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -542,6 +542,7 @@ check_LTLIBRARIES = \
 dist_check_DATA = \
 	hwloc-data/sierra.xml \
 	hwloc-data/corona.xml \
+	hwloc-data/elcap.xml \
 	valgrind/valgrind.supp
 
 test_ldadd = \

--- a/t/hwloc-data/elcap.xml
+++ b/t/hwloc-data/elcap.xml
@@ -1,0 +1,1548 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f" gp_index="1">
+    <info name="DMIProductName" value="HPE_CRAY_EX255a"/>
+    <info name="DMIProductVersion" value="1.7.1"/>
+    <info name="DMIBoardVendor" value="HPE"/>
+    <info name="DMIBoardName" value="HPE CRAY EX255a"/>
+    <info name="DMIBoardVersion" value="ParryPeak"/>
+    <info name="DMIBoardAssetTag" value="UNKNOWN"/>
+    <info name="DMIChassisVendor" value="HPE"/>
+    <info name="DMIChassisType" value="17"/>
+    <info name="DMIChassisVersion" value="HPE Cray EX Supercomputers"/>
+    <info name="DMIChassisAssetTag" value="UNKNOWN"/>
+    <info name="DMIBIOSVendor" value="HPE"/>
+    <info name="DMIBIOSVersion" value="1.7.1"/>
+    <info name="DMIBIOSDate" value="07/15/2025"/>
+    <info name="DMISysVendor" value="HPE"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/user.slice"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.18.0-553.69.1.1toss.t4.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Mon Aug 11 16:36:31 PDT 2025"/>
+    <info name="HostName" value="tuolumne1001"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="2.12.1"/>
+    <info name="ProcessName" value="lt-flux-R"/>
+    <object type="Package" os_index="0" cpuset="0x00ffffff" complete_cpuset="0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="3">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff" complete_cpuset="0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="502" local_memory="134127484928">
+        <page_type size="4096" count="32745968"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+              <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="5"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="12" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10">
+              <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15">
+              <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="24" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20">
+              <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25">
+              <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="30">
+              <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35">
+              <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="36"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="42" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40">
+              <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="50" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="49" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="47" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45">
+              <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="55" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="53" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="51">
+              <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="52"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="60" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="58" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="56">
+              <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="57"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="65" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="63" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="61">
+              <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="62"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="70" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="68" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="66">
+              <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="67"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="75" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="73" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="71">
+              <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="72"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="80" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="78" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="76">
+              <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="77"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="85" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="83" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="81">
+              <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="82"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="2" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="91" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="90" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="88" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="86">
+              <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="87"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="96" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="94" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="92">
+              <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="93"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="101" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="99" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="97">
+              <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="98"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="106" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="104" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="102">
+              <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="103"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="111" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="109" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="107">
+              <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="108"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="116" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="114" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="112">
+              <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="113"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="121" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="119" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="117">
+              <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="118"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="126" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="124" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="122">
+              <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="123"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="673" bridge_type="0-1" depth="0" bridge_pci="0000:[00-02]">
+        <object type="Bridge" gp_index="615" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="561" pci_busid="0000:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="723" name="hsi0" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:20:f3"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="643" bridge_type="1-1" depth="1" bridge_pci="0000:[02-02]" pci_busid="0000:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="534" pci_busid="0000:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="727" name="rsmi0" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="6a09124ba8f4a903"/>
+              <info name="XGMIHiveID" value="8a3421fb3609bef8"/>
+              <info name="RSMIVRAMSize" value="98691600"/>
+              <info name="RSMIVisibleVRAMSize" value="0"/>
+              <info name="RSMIGTTSize" value="394766404"/>
+              <info name="XGMIPeers" value="rsmi1 rsmi2 rsmi3 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="675" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
+        <object type="Bridge" gp_index="546" bridge_type="1-1" depth="1" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.1" pci_type="0604 [1022:14fd] [1022:1234] 00" pci_link_speed="0.250000">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="599" pci_busid="0000:81:00.0" pci_type="0200 [8086:1537] [ffff:0000] 03" pci_link_speed="0.250000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I210 Gigabit Backplane Connection"/>
+            <object type="OSDev" gp_index="724" name="enp129s0" osdev_type="2">
+              <info name="Address" value="00:40:a6:89:19:99"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0x0000ffff,0xff000000" complete_cpuset="0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="128">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="1" cpuset="0x0000ffff,0xff000000" complete_cpuset="0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="503" local_memory="134972620800">
+        <page_type size="4096" count="32952300"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="4" cpuset="0xff000000" complete_cpuset="0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="134" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="32" cpuset="0x01000000" complete_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="133" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="32" cpuset="0x01000000" complete_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="131" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="0" cpuset="0x01000000" complete_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="127">
+              <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="130"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="33" cpuset="0x02000000" complete_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="139" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="33" cpuset="0x02000000" complete_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="137" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="1" cpuset="0x02000000" complete_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="135">
+              <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="136"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="34" cpuset="0x04000000" complete_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="144" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="34" cpuset="0x04000000" complete_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="142" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="2" cpuset="0x04000000" complete_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="140">
+              <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="141"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="35" cpuset="0x08000000" complete_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="149" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="35" cpuset="0x08000000" complete_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="147" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="3" cpuset="0x08000000" complete_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="145">
+              <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="146"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="36" cpuset="0x10000000" complete_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="154" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="36" cpuset="0x10000000" complete_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="152" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="4" cpuset="0x10000000" complete_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="150">
+              <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="151"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="37" cpuset="0x20000000" complete_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="159" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="37" cpuset="0x20000000" complete_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="157" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="5" cpuset="0x20000000" complete_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="155">
+              <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="156"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="38" cpuset="0x40000000" complete_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="164" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="38" cpuset="0x40000000" complete_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="162" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="6" cpuset="0x40000000" complete_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="160">
+              <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="161"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="39" cpuset="0x80000000" complete_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="169" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="39" cpuset="0x80000000" complete_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="167" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="7" cpuset="0x80000000" complete_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="165">
+              <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="166"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="5" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="175" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="40" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="174" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="40" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="172" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="8" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="170">
+              <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="171"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="41" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="180" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="41" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="178" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="9" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="176">
+              <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="177"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="42" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="185" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="42" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="183" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="10" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="181">
+              <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="182"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="43" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="190" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="43" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="188" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="11" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="186">
+              <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="187"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="44" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="195" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="44" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="193" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="12" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="191">
+              <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="192"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="45" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="200" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="45" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="198" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="13" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="196">
+              <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="197"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="46" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="205" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="46" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="203" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="14" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="201">
+              <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="202"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="47" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="210" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="47" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="208" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="15" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="206">
+              <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="207"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="6" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="216" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="48" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="215" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="48" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="213" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="16" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="211">
+              <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="212"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="49" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="221" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="49" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="219" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="17" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="217">
+              <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="218"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="50" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="226" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="50" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="224" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="18" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="222">
+              <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="223"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="51" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="231" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="51" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="229" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="19" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="227">
+              <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="228"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="52" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="236" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="52" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="234" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="20" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="232">
+              <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="233"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="53" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="241" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="53" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="239" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="21" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="237">
+              <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="238"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="54" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="246" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="54" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="244" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="22" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="242">
+              <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="243"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="55" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="251" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="55" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="249" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="23" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="247">
+              <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="248"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="677" bridge_type="0-1" depth="0" bridge_pci="0001:[00-02]">
+        <object type="Bridge" gp_index="540" bridge_type="1-1" depth="1" bridge_pci="0001:[01-01]" pci_busid="0001:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="658" pci_busid="0001:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="726" name="hsi1" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:20:f2"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="571" bridge_type="1-1" depth="1" bridge_pci="0001:[02-02]" pci_busid="0001:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="631" pci_busid="0001:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="728" name="rsmi1" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="ec2e09777487b6ac"/>
+              <info name="XGMIHiveID" value="8a3421fb3609bef8"/>
+              <info name="RSMIVRAMSize" value="98691600"/>
+              <info name="RSMIVisibleVRAMSize" value="0"/>
+              <info name="RSMIGTTSize" value="394766404"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi2 rsmi3 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="679" bridge_type="0-1" depth="0" bridge_pci="0001:[80-94]">
+        <object type="Bridge" gp_index="641" bridge_type="1-1" depth="1" bridge_pci="0001:[81-94]" pci_busid="0001:80:03.1" pci_type="0604 [1022:14fd] [1022:1234] 00" pci_link_speed="7.876923">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="Bridge" gp_index="522" bridge_type="1-1" depth="2" bridge_pci="0001:[82-94]" pci_busid="0001:81:00.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+            <info name="PCIVendor" value="PMC-Sierra Inc."/>
+            <object type="Bridge" gp_index="666" bridge_type="1-1" depth="3" bridge_pci="0001:[83-83]" pci_busid="0001:82:00.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="640" pci_busid="0001:83:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="1"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="691" name="nvme0n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:4"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A07V0U61"/>
+                </object>
+                <object type="OSDev" gp_index="705" name="nvme0n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:25"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A07V0U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="618" bridge_type="1-1" depth="3" bridge_pci="0001:[84-84]" pci_busid="0001:82:01.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="616" pci_busid="0001:84:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="2"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="695" name="nvme1n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:22"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A07X0U61"/>
+                </object>
+                <object type="OSDev" gp_index="713" name="nvme1n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:6"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A07X0U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="566" bridge_type="1-1" depth="3" bridge_pci="0001:[85-85]" pci_busid="0001:82:02.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="587" pci_busid="0001:85:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="3"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="703" name="nvme2n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:0"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A02M0U61"/>
+                </object>
+                <object type="OSDev" gp_index="718" name="nvme2n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:26"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A02M0U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="511" bridge_type="1-1" depth="3" bridge_pci="0001:[86-86]" pci_busid="0001:82:03.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="563" pci_busid="0001:86:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="4"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="694" name="nvme3n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:2"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A08T0U61"/>
+                </object>
+                <object type="OSDev" gp_index="708" name="nvme3n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:16"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A08T0U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="632" bridge_type="1-1" depth="3" bridge_pci="0001:[87-87]" pci_busid="0001:82:04.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="535" pci_busid="0001:87:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="5"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="698" name="nvme4n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:24"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4DB0A02A0U61"/>
+                </object>
+                <object type="OSDev" gp_index="717" name="nvme4n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:1"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4DB0A02A0U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="579" bridge_type="1-1" depth="3" bridge_pci="0001:[88-88]" pci_busid="0001:82:05.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="507" pci_busid="0001:88:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="6"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="706" name="nvme5n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:3"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A07Z0U61"/>
+                </object>
+                <object type="OSDev" gp_index="721" name="nvme5n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:21"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A07Z0U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="525" bridge_type="1-1" depth="3" bridge_pci="0001:[89-89]" pci_busid="0001:82:06.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="650" pci_busid="0001:89:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="7"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="696" name="nvme6n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:5"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A0810U61"/>
+                </object>
+                <object type="OSDev" gp_index="711" name="nvme6n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:17"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A0810U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="596" bridge_type="1-1" depth="3" bridge_pci="0001:[8b-8b]" pci_busid="0001:82:08.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="668" pci_busid="0001:8b:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="9"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="701" name="nvme7n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:18"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4DB0A01E0U61"/>
+                </object>
+                <object type="OSDev" gp_index="719" name="nvme7n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:7"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4DB0A01E0U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="542" bridge_type="1-1" depth="3" bridge_pci="0001:[8c-8c]" pci_busid="0001:82:09.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="645" pci_busid="0001:8c:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="10"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="692" name="nvme8n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:19"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A08U0U61"/>
+                </object>
+                <object type="OSDev" gp_index="709" name="nvme8n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:9"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A08U0U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="583" bridge_type="1-1" depth="3" bridge_pci="0001:[8d-8d]" pci_busid="0001:82:0a.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="619" pci_busid="0001:8d:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="11"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="699" name="nvme9n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:8"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A02Q0U61"/>
+                </object>
+                <object type="OSDev" gp_index="715" name="nvme9n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:23"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A02Q0U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="530" bridge_type="1-1" depth="3" bridge_pci="0001:[8e-8e]" pci_busid="0001:82:0b.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="592" pci_busid="0001:8e:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="12"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="689" name="nvme10n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:27"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A07W0U61"/>
+                </object>
+                <object type="OSDev" gp_index="707" name="nvme10n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:10"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A07W0U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="648" bridge_type="1-1" depth="3" bridge_pci="0001:[8f-8f]" pci_busid="0001:82:0c.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="565" pci_busid="0001:8f:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="13"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="697" name="nvme11n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:15"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A0840U61"/>
+                </object>
+                <object type="OSDev" gp_index="712" name="nvme11n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:28"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A0840U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="545" bridge_type="1-1" depth="3" bridge_pci="0001:[91-91]" pci_busid="0001:82:0e.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="573" pci_busid="0001:91:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="15"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="702" name="nvme12n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:29"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A08N0U61"/>
+                </object>
+                <object type="OSDev" gp_index="720" name="nvme12n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:13"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A08N0U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="664" bridge_type="1-1" depth="3" bridge_pci="0001:[92-92]" pci_busid="0001:82:0f.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="544" pci_busid="0001:92:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="16"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="693" name="nvme13n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:20"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A0800U61"/>
+                </object>
+                <object type="OSDev" gp_index="710" name="nvme13n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:11"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A0800U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="612" bridge_type="1-1" depth="3" bridge_pci="0001:[93-93]" pci_busid="0001:82:10.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="518" pci_busid="0001:93:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="17"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="700" name="nvme14n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:14"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4DB0A0240U61"/>
+                </object>
+                <object type="OSDev" gp_index="716" name="nvme14n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:31"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4DB0A0240U61"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="558" bridge_type="1-1" depth="3" bridge_pci="0001:[94-94]" pci_busid="0001:82:11.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="660" pci_busid="0001:94:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="18"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="690" name="nvme15n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:12"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A02J0U61"/>
+                </object>
+                <object type="OSDev" gp_index="704" name="nvme15n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:30"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="4D40A02J0U61"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="2" cpuset="0x000000ff,0xffff0000,0x0" complete_cpuset="0x000000ff,0xffff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="253">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="2" cpuset="0x000000ff,0xffff0000,0x0" complete_cpuset="0x000000ff,0xffff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="504" local_memory="134926786560">
+        <page_type size="4096" count="32941110"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="8" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="259" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="64" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="258" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="64" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="256" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="0" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="252">
+              <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="255"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="65" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="264" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="65" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="262" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="1" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="260">
+              <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="261"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="66" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="269" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="66" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="267" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="2" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="265">
+              <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="266"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="67" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="274" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="67" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="272" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="3" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="270">
+              <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="271"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="68" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="279" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="68" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="277" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="4" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="275">
+              <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="276"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="69" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="284" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="69" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="282" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="5" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="280">
+              <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="281"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="70" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="289" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="70" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="287" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="6" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="285">
+              <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="286"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="71" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="294" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="71" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="292" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="7" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="290">
+              <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="291"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="9" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="300" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="72" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="299" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="72" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="297" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="8" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="295">
+              <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="296"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="73" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="305" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="73" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="303" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="9" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="301">
+              <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="302"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="74" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="310" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="74" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="308" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="10" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="306">
+              <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="307"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="75" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="315" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="75" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="313" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="11" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="311">
+              <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="312"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="76" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="320" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="76" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="318" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="12" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="316">
+              <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="317"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="77" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="325" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="77" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="323" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="13" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="321">
+              <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="322"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="78" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="330" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="78" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="328" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="14" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="326">
+              <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="327"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="79" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="335" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="79" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="333" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="15" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="331">
+              <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="332"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="10" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="341" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="80" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="340" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="80" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="338" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="16" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="336">
+              <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="337"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="81" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="346" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="81" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="344" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="17" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="342">
+              <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="343"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="82" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="351" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="82" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="349" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="18" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="347">
+              <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="348"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="83" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="356" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="83" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="354" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="19" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="352">
+              <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="353"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="84" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="361" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="84" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="359" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="20" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="357">
+              <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="358"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="85" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="366" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="85" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="364" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="21" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="362">
+              <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="363"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="86" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="371" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="86" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="369" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="22" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="367">
+              <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="368"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="87" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="376" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="87" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="374" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="23" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="372">
+              <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="373"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="681" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+        <object type="Bridge" gp_index="635" bridge_type="1-1" depth="1" bridge_pci="0002:[01-01]" pci_busid="0002:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="584" pci_busid="0002:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="722" name="hsi2" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:20:33"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="665" bridge_type="1-1" depth="1" bridge_pci="0002:[02-02]" pci_busid="0002:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="556" pci_busid="0002:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="729" name="rsmi2" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="8d9feacde44e5183"/>
+              <info name="XGMIHiveID" value="8a3421fb3609bef8"/>
+              <info name="RSMIVRAMSize" value="98691600"/>
+              <info name="RSMIVisibleVRAMSize" value="0"/>
+              <info name="RSMIGTTSize" value="394766404"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi3 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="3" cpuset="0xffffff00,,0x0" complete_cpuset="0xffffff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="378">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="3" cpuset="0xffffff00,,0x0" complete_cpuset="0xffffff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="505" local_memory="134960840704">
+        <page_type size="4096" count="32949424"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="12" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="384" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="96" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="383" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="96" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="381" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="0" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="377">
+              <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="380"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="97" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="389" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="97" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="387" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="1" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="385">
+              <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="386"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="98" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="394" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="98" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="392" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="2" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="390">
+              <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="391"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="99" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="399" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="99" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="397" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="3" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="395">
+              <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="396"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="100" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="404" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="100" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="402" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="4" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="400">
+              <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="401"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="101" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="409" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="101" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="407" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="5" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="405">
+              <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="406"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="102" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="414" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="102" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="412" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="6" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="410">
+              <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="411"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="103" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="419" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="103" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="417" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="7" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="415">
+              <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="416"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="13" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="425" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="104" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="424" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="104" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="422" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="8" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="420">
+              <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="421"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="105" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="430" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="105" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="428" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="9" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="426">
+              <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="427"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="106" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="435" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="106" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="433" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="10" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="431">
+              <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="432"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="107" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="440" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="107" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="438" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="11" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="436">
+              <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="437"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="108" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="445" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="108" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="443" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="12" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="441">
+              <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="442"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="109" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="450" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="109" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="448" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="13" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="446">
+              <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="447"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="110" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="455" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="110" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="453" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="14" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="451">
+              <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="452"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="111" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="460" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="111" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="458" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="15" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="456">
+              <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="457"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="14" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="466" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="112" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="465" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="112" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="463" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="16" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="461">
+              <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="462"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="113" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="471" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="113" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="469" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="17" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="467">
+              <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="468"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="114" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="476" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="114" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="474" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="18" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="472">
+              <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="473"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="115" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="481" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="115" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="479" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="19" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="477">
+              <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="478"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="116" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="486" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="116" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="484" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="20" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="482">
+              <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="483"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="117" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="491" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="117" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="489" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="21" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="487">
+              <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="488"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="118" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="496" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="118" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="494" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="22" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="492">
+              <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="493"/>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="119" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="501" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="119" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="499" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="23" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="497">
+              <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="498"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="685" bridge_type="0-1" depth="0" bridge_pci="0003:[00-02]">
+        <object type="Bridge" gp_index="562" bridge_type="1-1" depth="1" bridge_pci="0003:[01-01]" pci_busid="0003:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="509" pci_busid="0003:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="725" name="hsi3" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:20:32"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="594" bridge_type="1-1" depth="1" bridge_pci="0003:[02-02]" pci_busid="0003:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="652" pci_busid="0003:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="730" name="rsmi3" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="eada8d30abfaa6a3"/>
+              <info name="XGMIHiveID" value="8a3421fb3609bef8"/>
+              <info name="RSMIVRAMSize" value="98691600"/>
+              <info name="RSMIVisibleVRAMSize" value="0"/>
+              <info name="RSMIGTTSize" value="394766404"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="OSDev" gp_index="714" name="sda" subtype="Disk" osdev_type="0">
+      <info name="Size" value="62914560"/>
+      <info name="SectorSize" value="512"/>
+      <info name="LinuxDeviceID" value="8:0"/>
+      <info name="Vendor" value="LIO-ORG"/>
+      <info name="Model" value="FILEIO"/>
+      <info name="Revision" value="4.0"/>
+      <info name="SerialNumber" value="6001405c4bda446cffe58e040c064898"/>
+    </object>
+  </object>
+  <distances2 type="NUMANode" nbobjs="4" kind="5" name="NUMALatency" indexing="os">
+    <indexes length="8">0 1 2 3 </indexes>
+    <u64values length="30">10 32 32 32 32 10 32 32 32 32 </u64values>
+    <u64values length="18">10 32 32 32 32 10 </u64values>
+  </distances2>
+  <distances2 type="OSDev" nbobjs="4" kind="9" name="XGMIBandwidth" indexing="gp">
+    <indexes length="16">727 728 729 730 </indexes>
+    <u64values length="72">1000000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="44">1000000 100000 100000 100000 100000 1000000 </u64values>
+  </distances2>
+  <distances2 type="OSDev" nbobjs="4" kind="5" name="XGMIHops" indexing="gp">
+    <indexes length="16">727 728 729 730 </indexes>
+    <u64values length="20">0 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="12">0 1 1 1 1 0 </u64values>
+  </distances2>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.numa_memory"/>
+  <support name="discovery.disallowed_pu"/>
+  <support name="discovery.disallowed_numa"/>
+  <support name="discovery.cpukind_efficiency"/>
+  <support name="cpubind.set_thisproc_cpubind"/>
+  <support name="cpubind.get_thisproc_cpubind"/>
+  <support name="cpubind.set_proc_cpubind"/>
+  <support name="cpubind.get_proc_cpubind"/>
+  <support name="cpubind.set_thisthread_cpubind"/>
+  <support name="cpubind.get_thisthread_cpubind"/>
+  <support name="cpubind.set_thread_cpubind"/>
+  <support name="cpubind.get_thread_cpubind"/>
+  <support name="cpubind.get_thisproc_last_cpu_location"/>
+  <support name="cpubind.get_proc_last_cpu_location"/>
+  <support name="cpubind.get_thisthread_last_cpu_location"/>
+  <support name="membind.set_thisthread_membind"/>
+  <support name="membind.get_thisthread_membind"/>
+  <support name="membind.set_area_membind"/>
+  <support name="membind.get_area_membind"/>
+  <support name="membind.alloc_membind"/>
+  <support name="membind.firsttouch_membind"/>
+  <support name="membind.bind_membind"/>
+  <support name="membind.interleave_membind"/>
+  <support name="membind.migrate_membind"/>
+  <support name="membind.get_area_memlocation"/>
+  <support name="custom.exported_support"/>
+  <memattr name="Latency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="502" value="139" initiator_cpuset="0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="503" value="139" initiator_cpuset="0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="504" value="139" initiator_cpuset="0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="505" value="139" initiator_cpuset="0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="ReadBandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="502" value="5451776" initiator_cpuset="0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="503" value="5451776" initiator_cpuset="0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="504" value="5451776" initiator_cpuset="0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="505" value="5451776" initiator_cpuset="0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="ReadLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="502" value="182" initiator_cpuset="0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="503" value="182" initiator_cpuset="0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="504" value="182" initiator_cpuset="0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="505" value="182" initiator_cpuset="0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="WriteLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="502" value="96" initiator_cpuset="0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="503" value="96" initiator_cpuset="0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="504" value="96" initiator_cpuset="0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="505" value="96" initiator_cpuset="0xffffff00,,0x0"/>
+  </memattr>
+  <cpukind cpuset="0xffffffff,0xffffffff,0xffffffff">
+    <info name="FrequencyMaxMHz" value="3700"/>
+  </cpukind>
+</topology>

--- a/t/t0026-flux-R.t
+++ b/t/t0026-flux-R.t
@@ -82,6 +82,13 @@ test_expect_success 'flux R encode --xml works with AMD RSMI gpus' '
 	test_debug "echo encode XML = $result" &&
 	test "$result" = "rank0/core[0-47],gpu[0-7]"
 '
+test_expect_success 'flux R encode --xml works with El Capitan node' '
+	flux R encode --xml=$SHARNESS_TEST_SRCDIR/hwloc-data/elcap.xml \
+	    > R.elcap &&
+	result=$(flux R decode --short < R.elcap) &&
+	test_debug "echo encode XML = $result" &&
+	test "$result" = "rank0/core[0-95],gpu[0-3]"
+'
 test_expect_success 'flux R decode --include works' '
 	result=$(flux R encode -r 0-1023 | flux R decode --include 5-7 --short) &&
 	test_debug "echo $result" &&


### PR DESCRIPTION
Problem: LLNL's El Capitan system employs a node type that may be interesting to include in future tests of Flux's resource representation, particularly as it evolves beyond Rv1.

Add a representative hwloc XML dump from
- HPE/Cray EX255A login node on tuolomne
- hwloc-2.12.1-4.t4
- rhwloc_local_topology_xml() from flux-core-0.77.0

Add a simple Rv1 encode test.