### PR TITLE
flux-fsck: prefix output when not attached to a tty

### DIFF
--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -709,9 +709,7 @@ static int cmd_fsck (optparse_t *p, int ac, char *av[])
             struct tm tm;
             if (!timestamp_from_double (timestamp, &tm, NULL))
                 strftime (buf, sizeof (buf), "%Y-%m-%dT%T", &tm);
-            fprintf (stderr,
-                     "Checking integrity of checkpoint from %s\n",
-                     buf);
+            printf ("Checking integrity of checkpoint from %s\n", buf);
         }
 
         ctx.sequence = sequence;

--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -42,6 +42,7 @@ struct fsck_ctx {
     bool verbose;
     bool quiet;
     bool repair;
+    bool isatty;
     int errorcount;
 };
 
@@ -64,11 +65,16 @@ static void fsck_treeobj (struct fsck_ctx *ctx,
 
 static void valref_validate (struct fsck_valref_data *fvd);
 
-static void verrmsg (const char *fmt, va_list ap)
+static void verrmsg (struct fsck_ctx *ctx, const char *fmt, va_list ap)
 {
     char buf[128];
     vsnprintf (buf, sizeof (buf), fmt, ap);
-    fprintf (stderr, "%s\n", buf);
+    /* no need for log_err() prefix and formatting if user is running
+     * on command line */
+    if (ctx->isatty)
+        fprintf (stderr, "%s\n", buf);
+    else
+        log_msg ("%s", buf);
 }
 
 static __attribute__ ((format (printf, 2, 3)))
@@ -78,7 +84,7 @@ void errmsg (struct fsck_ctx *ctx, const char *fmt, ...)
     if (ctx->quiet)
         return;
     va_start (ap, fmt);
-    verrmsg (fmt, ap);
+    verrmsg (ctx, fmt, ap);
     va_end (ap);
 }
 
@@ -680,6 +686,7 @@ static int cmd_fsck (optparse_t *p, int ac, char *av[])
         ctx.repair = true;
 
     ctx.h = builtin_get_flux_handle (p);
+    ctx.isatty = isatty (STDERR_FILENO);
 
     if (kvs_is_running (&ctx))
         log_msg_exit ("please unload kvs module before using flux-fsck");

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -8,6 +8,8 @@ test_description='Test flux fsck command'
 
 test_under_flux 1 minimal
 
+runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py --line-buffer"
+
 test_expect_success 'load content and content-sqlite module' '
 	flux module load content &&
 	flux module load content-sqlite
@@ -121,6 +123,13 @@ test_expect_success 'flux-fsck --verbose outputs details (testdir.b)' '
 	test_debug "cat fsckerrors1V.err" &&
 	grep "testdir\.b" fsckerrors1V.err | grep "missing blobref" | grep "index=1" &&
 	grep "Total errors: 1" fsckerrors1V.err
+'
+test_expect_success 'flux-fsck does not prefix error messages on non-tty runs' '
+	grep "flux-fsck" fsckerrors1.err
+'
+test_expect_success 'flux-fsck prefixes error messages on tty runs' '
+	test_must_fail $runpty flux fsck > fsckerrors1PTY.out &&
+	test_must_fail grep "flux-fsck" fsckerrors1PTY.err
 '
 test_expect_success 'flux-fsck no output with --quiet (testdir.b)' '
 	test_must_fail flux fsck --quiet > fsckerrors2.out 2> fsckerrors2.err &&

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -55,7 +55,7 @@ test_expect_success 'unload kvs' '
 '
 test_expect_success 'flux-fsck works (simple)' '
 	flux fsck > simple.out 2> simple.err &&
-	grep "Checking integrity" simple.err &&
+	grep "Checking integrity" simple.out &&
 	grep "Total errors: 0" simple.err
 '
 test_expect_success 'flux-fsck verbose works (simple)' '
@@ -108,12 +108,11 @@ test_expect_success 'call sync to ensure we have checkpointed' '
 test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
-# line count includes extra diagnostic messages
 test_expect_success 'flux-fsck detects errors (testdir.b)' '
 	test_must_fail flux fsck > fsckerrors1.out 2> fsckerrors1.err &&
 	test_debug "cat fsckerrors1.err" &&
 	count=$(cat fsckerrors1.err | wc -l) &&
-	test $count -eq 3 &&
+	test $count -eq 2 &&
 	grep "testdir\.b" fsckerrors1.err | grep "missing blobref(s)" &&
 	grep "Total errors: 1" fsckerrors1.err
 '
@@ -144,12 +143,11 @@ test_expect_success 'call sync to ensure we have checkpointed' '
 test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
-# line count includes extra diagnostic messages
 test_expect_success 'flux-fsck detects errors (testdir.b & c)' '
 	test_must_fail flux fsck > fsckerrors3.out 2> fsckerrors3.err &&
 	test_debug "cat fsckerrors3.err" &&
 	count=$(cat fsckerrors3.err | wc -l) &&
-	test $count -eq 4 &&
+	test $count -eq 3 &&
 	grep "testdir\.b" fsckerrors3.err | grep "missing blobref(s)" &&
 	grep "testdir\.c" fsckerrors3.err | grep "missing blobref(s)" &&
 	grep "Total errors: 2" fsckerrors3.err
@@ -183,12 +181,11 @@ test_expect_success 'call sync to ensure we have checkpointed' '
 test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
-# line count includes extra diagnostic messages
 test_expect_success 'flux-fsck detects errors (testdir.b & c & d)' '
 	test_must_fail flux fsck > fsckerrors5.out 2> fsckerrors5.err &&
 	test_debug "cat fsckerrors5.err" &&
 	count=$(cat fsckerrors5.err | wc -l) &&
-	test $count -eq 5 &&
+	test $count -eq 4 &&
 	grep "testdir\.b" fsckerrors5.err | grep "missing blobref(s)" &&
 	grep "testdir\.c" fsckerrors5.err | grep "missing blobref(s)" &&
 	grep "testdir\.d" fsckerrors5.err | grep "missing blobref(s)" &&
@@ -237,12 +234,11 @@ test_expect_success 'call sync to ensure we have checkpointed' '
 test_expect_success 'unload kvs' '
 	flux module remove kvs
 '
-# line count includes extra diagnostic messages
 test_expect_success 'flux-fsck detects errors (testdir.b & c & d & bdir)' '
 	test_must_fail flux fsck > fsckerrors7.out 2> fsckerrors7.err &&
 	test_debug "cat fsckerrors7.err" &&
 	count=$(cat fsckerrors7.err | wc -l) &&
-	test $count -eq 6 &&
+	test $count -eq 5 &&
 	grep "testdir\.b" fsckerrors7.err | grep "missing blobref(s)" &&
 	grep "testdir\.c" fsckerrors7.err | grep "missing blobref(s)" &&
 	grep "testdir\.d" fsckerrors7.err | grep "missing blobref(s)" &&


### PR DESCRIPTION
Per discussion in #7082, minor tweaks for flux-fsck to predominantly support the fact many times fsck will be run out of rc1