### PR TITLE
doc: fix formatting typo in flux-modprobe(1)

### DIFF
--- a/doc/man1/flux-modprobe.rst
+++ b/doc/man1/flux-modprobe.rst
@@ -352,7 +352,7 @@ following optional arguments:
    (optional, list) A list of task or module names this task requires. This is
    used to ensure required tasks are active when activating another task.
    It does not indicate that this task will necessarily be run before or after
-   the tasks it requires. (See ``before`` or ``after` for those features)
+   the tasks it requires. (See ``before`` or ``after`` for those features)
 
 **needs**
    (optional, list) A list of tasks or modules this task needs. Disables this


### PR DESCRIPTION
Problem: A keyword is not consistently quoted, leading to formatting errors.

Fix the backtick quotations.