### PR TITLE
python: add explicit `attr_set()` method to Flux handle class

### DIFF
--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -284,6 +284,22 @@ class Flux(Wrapper):
     def attr_get(self, attr_name):
         return self.flux_attr_get(attr_name).decode("utf-8")
 
+    def attr_set(self, attr, value):
+        """
+        Set a broker attribute
+        Args:
+            attr (str): attribute to set
+            value (str): attribute value.
+        Raises:
+            ValueError: either ``attr`` or ``value`` are not strings.
+            OSError: failure in underlying ``flux_attr_set(3)`` API call.
+        """
+        if not isinstance(attr, str):
+            raise ValueError("Attribute name must be a string")
+        if not isinstance(value, str):
+            raise ValueError("Attribute value must be a string")
+        self.flux_attr_set(attr, value)
+
     def conf_get(self, key=None, default=None, update=False):
         """
         Access Flux configuration via this handle. On first use, the

--- a/t/python/t0001-handle.py
+++ b/t/python/t0001-handle.py
@@ -88,6 +88,23 @@ class TestHandle(unittest.TestCase):
         rank = self.f.get_rank()
         self.assertEqual(attr_rank, rank)
 
+    def test_attr_set(self):
+        self.f.attr_set("foo", "bar")
+        self.assertEqual(self.f.attr_get("foo"), "bar")
+
+        self.f.attr_set("baz", str(1))
+        self.assertEqual(self.f.attr_get("baz"), "1")
+
+        self.f.attr_set("utf8-test", "ƒ Φ Ψ Ω Ö")
+        self.assertEqual(self.f.attr_get("utf8-test"), "ƒ Φ Ψ Ω Ö")
+
+        with self.assertRaises(OSError):
+            self.f.attr_set("local-uri", "foo")
+        with self.assertRaises(ValueError):
+            self.f.attr_set("foo", 1)
+        with self.assertRaises(ValueError):
+            self.f.attr_set(42, "foo")
+
     def test_conf_get(self):
         # Works with empty config
         self.assertEqual(self.f.conf_get(), {})


### PR DESCRIPTION
This is a simple PR that adds an explicit `attr_set()` method to the handle class. The method detects non-string arguments and raises more sensible errors than the direct cffi call would, which looks like this:

```
$ flux python -c 'import flux; flux.Flux().attr_set("foo", 1)'
Traceback (most recent call last):
  File "/usr/lib/aarch64-linux-gnu/flux/python3.10/flux/wrapper.py", line 194, in __call__
    result = self.fun(*args)
TypeError: initializer for ctype 'char *' must be a cdata pointer, not int

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/aarch64-linux-gnu/flux/python3.10/flux/wrapper.py", line 196, in __call__
    raise InvalidArguments(
flux.wrapper.InvalidArguments: 
Invalid arguments passed to wrapped C function:
Name: attr_set
C signature: int(*)(struct flux_handle *, char *, char *)
Arguments: ('foo', 1)
```

As @chu11 suggested, this also makes the method discoverable in the docs.