### PR TITLE
testsuite: improve test-inception.sh script

### DIFF
--- a/t/test-inception.sh
+++ b/t/test-inception.sh
@@ -15,12 +15,12 @@ stats &
 PID=$!
 export FLUX_TESTS_LOGFILE=t
 # run sharness tests with -d -v
-flux bulksubmit -o pty --quiet \
+flux bulksubmit -o pty --quiet --job-name={./%} \
 	sh -c './{} -d -v --root=$FLUX_JOB_TMPDIR' \
 	::: t[0-9]*.t
 # python and lua tests do not support -d, -v, or --root options
-flux bulksubmit -o pty --quiet flux python {} ::: python/t*.py
-flux bulksubmit -o pty --quiet ./{} ::: lua/t*.t
+flux bulksubmit -o pty --quiet --job-name={./%} flux python {} ::: python/t*.py
+flux bulksubmit -o pty --quiet --job-name={./%} ./{} ::: lua/t*.t
 flux watch --all
 RC=$?
 kill $PID
@@ -29,11 +29,12 @@ wait
 # dump output of failed jobs to *.log
 for id in $(flux jobs -f failed -no {id}); do
     name=$(flux jobs -no {name} ${id})
-    flux job attach $id > ${name/.t}.log 2>&1
+    flux job attach $id > ${name}.output 2>&1
 done
 
 # print failed jobs listing to stdout
-flux jobs -f failed
+flux jobs -f failed \
+    -no "{id.f58:>12} {status_abbrev:>2.2} {contextual_time!F:>8h} {name}"
 
 # exit with failure if any tests failed
 exit $RC


### PR DESCRIPTION
Problem: The inception test runner displays a list of job failures at the end of the script, but most of the tests have the name `sh`, which is unhelpful.

Add job names to all submitted jobs that are the name of the test script.  Use a custom `flux jobs` output format so the whole name of the test script will be be displayed.

Create .output files instead of .log files, since this matches the suffix of files created by `make check FLUX_TEST_LOGFILES=t`.