### PR TITLE
flux-start: print message when --test-exit-timeout expires

### DIFF
--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -57,6 +57,7 @@ static struct {
     const char *start_mode;
     flux_reactor_t *reactor;
     flux_watcher_t *timer;
+    bool shutdown;
     zlist_t *clients;
     optparse_t *opts;
     int verbose;
@@ -324,10 +325,11 @@ void update_timer (void)
         if (count > 0 && leader_exit)
             shutdown = true;
     }
-    if (shutdown)
+    if (shutdown && !ctx.shutdown)
         flux_watcher_start (ctx.timer);
-    else
+    else if (!shutdown && ctx.shutdown)
         flux_watcher_stop (ctx.timer);
+    ctx.shutdown = shutdown;
 }
 
 static void completion_cb (flux_subprocess_t *p)


### PR DESCRIPTION
Problem: in CI, broker death by SIGKILL could be due to the test exit timeout or something else like the kernel OOM killer - it's hard to tell sometimes.

Log  "Exit timeout: killed rank RANKS" to stderr when the test exit timeout expires.  Example:
```
$ ./flux start -s16
ƒ(s=16,d=0,builddir) $ pgrep flux-broker | tail - 1
3948062
ƒ(s=16,d=0,builddir) $ kill -15 3948062
ƒ(s=16,d=0,builddir) $
Oct 13 14:34:33.285216 PDT 2025 broker.err[0]: dead to Flux: system76-pc (rank 15)
[wait patiently for 20s]
flux-start: Exit timeout: killed rank 0-14
flux-start: 13 (pid 3948042) Killed
flux-start: 11 (pid 3948010) Killed
flux-start: 10 (pid 3948006) Killed
flux-start: 9 (pid 3948002) Killed
flux-start: 8 (pid 3947996) Killed
flux-start: 7 (pid 3947992) Killed
flux-start: 0 (pid 3947979) Killed
flux-start: 6 (pid 3947988) Killed
flux-start: 5 (pid 3947985) Killed
flux-start: 4 (pid 3947983) Killed
flux-start: 3 (pid 3947982) Killed
flux-start: 2 (pid 3947981) Killed
flux-start: 14 (pid 3948052) Killed
flux-start: 12 (pid 3948014) Killed
flux-start: 1 (pid 3947980) Killed
$
```

Also fix a logic error that caused extra SIGKILLS to be sent.