### PR TITLE
configure: use system bash completions directory by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -431,18 +431,13 @@ PKG_CHECK_MODULES([SQLITE], [sqlite3], [], [])
 PKG_CHECK_MODULES([LIBUUID], [uuid], [], [])
 PKG_CHECK_MODULES([CURSES], [ncursesw], [], [])
 PKG_CHECK_MODULES([LIBARCHIVE], [libarchive], [], [])
-
-AC_ARG_WITH([system-bash-completion-dir],
-    AS_HELP_STRING([--with-system-bash-completion-dir],
-                   [Build with system bash-completion dir]))
-AS_IF([test "x$with_system_bash_completion_dir" = "xyes"], [
-    PKG_CHECK_EXISTS([bash-completion],
-      [bashcompdir=`$PKG_CONFIG --variable=completionsdir bash-completion`],
-      [bashcompdir="${sysconfdir}/bash_completion.d"])
-  ], [
-    bashcompdir="${sysconfdir}/bash_completion.d"
-  ]
-)
+PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion], [
+    bashcompdir="`$PKG_CONFIG \
+        --define-variable=datadir=${datadir} \
+        --variable=completionsdir bash-completion`"
+], [
+    bashcompdir="${datadir}/bash-completion/completions"
+])
 AC_SUBST(bashcompdir)
 
 LX_FIND_MPI


### PR DESCRIPTION
Problem: Commit 24b2589e made bash completions install to the system directory only when `--with-system-bash-completion-dir` was specified, to work around pkg-config's `completionsdir` not respecting alternate prefixes. Since this option is likely never used, completions are always installed to `$sysconfdir` (/etc/bash_completion.d) instead.

Drop the `--with-system-bash-completion-dir` option. Use pkg-config's `completionsdir` with `--define-variable=datadir=${datadir}` set on the command line to handle alternate prefixes correctly. This allows the completions file to be installed in the system path as expected in most cases.