### PR TITLE
broker: fix potential zmq_unbind() race

### DIFF
--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1685,19 +1685,9 @@ int overlay_bind (struct overlay *ov, const char *uri, const char *uri2)
 
 /* Don't allow downstream peers to reconnect while we are shutting down.
  */
-void overlay_shutdown (struct overlay *overlay, bool unbind)
+void overlay_shutdown (struct overlay *overlay)
 {
     overlay->shutdown_in_progress = true;
-
-    if (unbind && overlay->bind_zsock) {
-        const char *uri;
-        uri = bizcard_uri_first (overlay->bizcard);
-        while (uri) {
-            if (zmq_unbind (overlay->bind_zsock, uri) < 0)
-                flux_log (overlay->h, LOG_ERR, "zmq_unbind %s failed", uri);
-            uri = bizcard_uri_next (overlay->bizcard);
-        }
-    }
 }
 
 /* Call after overlay bootstrap (bind/connect),

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -164,11 +164,8 @@ int overlay_set_monitor_cb (struct overlay *ov,
 int overlay_register_attrs (struct overlay *overlay);
 
 /* Stop allowing new connections from downstream peers.
- * If unbind is false, stop all communication on the socket.
- * Otherwise arrange to send a disconnect control message in response
- * to all messages.
  */
-void overlay_shutdown (struct overlay *overlay, bool unbind);
+void overlay_shutdown (struct overlay *overlay);
 
 /* Say goodbye to parent.
  * After this, sends to parent are dropped.

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -515,7 +515,7 @@ static void action_cleanup (struct state_machine *s)
      * let existing ones continue to communicate so they can
      * shut down and disconnect.
      */
-    overlay_shutdown (s->ctx->overlay, false);
+    overlay_shutdown (s->ctx->overlay);
 
     if (runat_is_defined (s->ctx->runat, "cleanup")) {
         if (runat_start (s->ctx->runat, "cleanup", runat_completion_cb, s) < 0) {
@@ -538,10 +538,6 @@ static void action_cleanup (struct state_machine *s)
 static void action_finalize (struct state_machine *s)
 {
     sd_timeout_reset (s);
-    /* Now that all clients have disconnected, finalize all
-     * downstream communication.
-     */
-    overlay_shutdown (s->ctx->overlay, true);
 
     if (runat_is_defined (s->ctx->runat, "rc3")) {
         if (runat_start (s->ctx->runat, "rc3", runat_completion_cb, s) < 0) {
@@ -582,6 +578,8 @@ static void shutdown_warn_timer_cb (flux_reactor_t *r,
 static void action_shutdown (struct state_machine *s)
 {
     sd_timeout_reset (s);
+
+    overlay_shutdown (s->ctx->overlay);
 
     if (overlay_get_child_peer_count (s->ctx->overlay) == 0) {
         state_machine_post (s, "children-none");


### PR DESCRIPTION
Problem: sharness tests occasionally hang during shutdown and are killed by the flux-start exit timeout.

Failures were chiefly observed during development of flux-framework/flux-core#7112, a PR which refactors the overlay code and likely changes some timing.  A particular sharness test, `t0035-content-sqlite-checkpoint.t`, which uses "minimal" personality (size=2) and thus progresses rapidly through the final states on broker 0, began to fail a lot.  However, I think we have seen this failure mode in CI intermittently on a variety of different tests, so this change is proposed as a general fix.

When the hang occurs, it is observed that the final handshake with broker rank 1 is not completed:
- broker 1 sends a goodbye request upon entring GOODBYE state
- broker 0 receives the goodbye request
- broker 0 sends a goodbye response
- broker 1 never receives the response
- broker 1 remains in GOODBYE state
- broker 1 is killed by flux-start's exit timeout

Since broker 0 rapidly finalizes after handing the response over to zeromq, most likely the zeromq teardown is somehow aborting the in-flight message.  However, there is protection for this in the ZMQ_LINGER socket option, which we set to 5 on the downstream socket. This option causes `zmq_close()` to block for up to the specified number of milliseconds to allow in-flight messages to be delivered.  The time is a little short, but increasing it to a large value such as 2000 experimentally did not impact the test failure rate.

There is also a call to `zmq_unbind()` that occurs immediately after the response is sent, in the state machine action callback for FINALIZE (rc3) state.  I did not think this call was disruptive to in-flight messages, but removing it or adding a brief sleep() call right before it resolved the issue.  Note: the failures were easily recreated on Ubuntu 22.04 LTS with libzmq3-dev-4.3.4-2.

The `zmq_unbind()` call was added in 2022 by flux-framework/flux-core#4277 in an attempt to prevent follower brokers from reconnecting to the leader broker of a system instance in FINALIZE (rc3) state.  The primary issue was log noise.  However, in 2024 during El Capitan integration, it was found that clients reconnecting during CLEANUP state were also a nuisance and and a shutdown flag was added in flux-framework/flux-core#5883 that causes overlay.hello requests to be quietly rejected in CLEANUP state and beyond.

The more recent measure, along with other measures added during El Capitan integration, such as a reduced follower respawn rate, should be sufficient to address the log noise issue without `zmq_unbind()`.

Therefore, drop the `zmq_unbind()` call and avoid the race.