### PR TITLE
testsuite: drop maxrss > 0 test

### DIFF
--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -203,8 +203,7 @@ test_expect_success 'flux module stats --rusage=badopt fails' '
 '
 
 test_expect_success 'flux module stats --rusage --parse maxrss works' '
-	RSS=$(flux module stats --rusage --parse maxrss $REALMOD) &&
-	test "$RSS" -gt 0
+	RSS=$(flux module stats --rusage --parse maxrss $REALMOD)
 '
 
 test_expect_success 'flux module stats with no args is an error' '


### PR DESCRIPTION
Problem: a test that `flux module stats --rusage` returns maxrss > 0 is failing mysteriously on a particular platform.

Drop the check for maxrss > 0 as this value is passed directly through from getrusage(2) and is only used for debugging.

Fixes #7162