### PR TITLE
flux-fsck: fix duplicate option character

### DIFF
--- a/doc/man1/flux-fsck.rst
+++ b/doc/man1/flux-fsck.rst
@@ -41,7 +41,7 @@ OPTIONS
    checkpoint.  This option directs flux-fsck to start at an arbitrary
    point.  BLOBREF must refer to an RFC 11 tree object of type "dir".
 
-.. option:: -r, --repair
+.. option:: -R, --repair
 
    Remove any dangling references found in KVS metadata. If a KVS
    value changes as a result of this repair, the key is moved to the

--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -786,7 +786,7 @@ static struct optparse_option fsck_opts[] = {
     { .name = "rootref", .key = 'r', .has_arg = 1, .arginfo = "BLOBREF",
       .usage = "Check integrity starting with BLOBREF",
     },
-    { .name = "repair", .key = 'r', .has_arg = 0,
+    { .name = "repair", .key = 'R', .has_arg = 0,
       .usage = "Repair recoverable keys and place in lost+found",
     },
     OPTPARSE_TABLE_END


### PR DESCRIPTION
Problem: In flux-fsck both the --rootref and --repair options use the same short option character 'r'.

Use the character 'R' for --repair instead of 'r'.  Update documentation accordingly.

---

Ooops!!!

