### PR TITLE
doc: add section on running tests as Flux jobs to debug guide

### DIFF
--- a/doc/guide/debug.rst
+++ b/doc/guide/debug.rst
@@ -97,3 +97,65 @@ into the workflows config as in the diff below for the macos workflow:
 
 Push that temporary change to a personal fork, then find the ssh address by
 examining the action output.
+
+*****************************
+running tests as Flux jobs
+*****************************
+
+Tests in the testsuite can be run as Flux jobs to help with debugging and
+testing under different conditions. This approach is particularly useful
+for ensuring tests are isolated from the enclosing Flux environment, running
+tests in parallel across multiple nodes, or detecting race conditions.
+
+Example: run a single test as a Flux job
+
+.. code-block::
+
+  $ flux run -o pty -n1 ./t1234-test.t -d -v
+
+This ensures the test is properly isolated from the enclosing environment,
+which can be helpful for debugging environment-related issues or verifying
+that a test doesn't depend on external state. The :option:`-o pty` option
+allocates a pty for the job to enable colorized output from the sharness
+tests.
+
+Example: run all sharness tests in parallel as Flux jobs
+
+.. code-block::
+
+  $ flux bulksubmit -n1 -o pty --watch --progress --job-name={./%} ./{} -d -v ::: t*.t
+
+This is useful for running the entire test suite (or a subset depending on
+what the glob after ``:::`` matches) quickly when you have access to multiple
+nodes or cores. Each test runs as a separate job using one core (cores per
+test can be adjusted with :option:`-c, --cores-per-task=N`), allowing
+you to leverage available resources efficiently. The :option:`--watch`
+option displays live output from jobs as they execute, :option:`--progress`
+shows progress and pass/fail counts, and :option:`--job-name={./%}` sets
+each job name to the test file basename with the ``.t`` extension removed.
+
+.. note::
+  After running tests with ``bulksubmit``, you can list any failures with
+  ``flux jobs -f failed`` and then examine the output of a specific failed
+  test using ``flux job attach JOBID``.
+
+Example: run a single test multiple times to detect race conditions
+
+.. code-block::
+
+  $ flux submit --cc=1-16 -o pty --watch --progress -n1 ./t1234-test.t -d -v --root={{tmpdir}}
+
+This runs the same test 16 times simultaneously, each with one core and a
+unique temporary directory. This is particularly effective for finding
+race conditions or intermittent failures that only appear under concurrent
+execution. Adjust the ``--cc`` range as needed for your testing requirements.
+Test concurrency can be further increased by running this example under
+:command:`flux start -N`, where N is greater than 1.
+
+.. note::
+  Similar to ``bulksubmit``, failures can be identified with
+  ``flux jobs -f failed`` and examined with ``flux job attach JOBID``.
+
+.. note::
+  The ``-d -v`` flags enable debug mode and verbose output respectively,
+  which provide more detailed information when tests fail.

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1005,3 +1005,5 @@ bourne
 histchars
 cpusets
 sproc
+testsuite
+sharness


### PR DESCRIPTION
This adds some hints on running sharness tests as jobs to the debugging guide as suggested by @garlick awhile ago.