### PR TITLE
doc: add missing paren in modprobe doc

### DIFF
--- a/doc/man1/flux-modprobe.rst
+++ b/doc/man1/flux-modprobe.rst
@@ -436,7 +436,7 @@ broker configuration and attributes, and even run shell commands.
 **context.get(key, default=None)**
    Get arbitrary data set by other tasks with optional default value
 
-**context.attr_get(attr, default=None**
+**context.attr_get(attr, default=None)**
    Get broker attribute. If attribute is not set, return ``default``.
 
 **context.conf_get(key, default=None)**


### PR DESCRIPTION
Problem: a closing parenthesis is missing in `flux-modprobe.rst`.

Add it.