### PR TITLE
docs: readme mention of contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ exits, Flux exits.
 For more information on starting Flux in various environments and using it,
 please refer to our [docs](https://flux-framework.readthedocs.io) pages.
 
+#### Contributing
+
+We are an open-source community and welcome contributions and feedback. For Governance, Contributing, contacts, and Code of Conduct guides, see [RFC 1.](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_1.html). 
+
 #### Release
 
 SPDX-License-Identifier: LGPL-3.0


### PR DESCRIPTION
Problem: the Code of Conduct (TBA), Governance, contacts, and how to contribute (Contributing guide) need to be easy to find at the root of the repository.
Solution: add an expected Contributing section that references RFC 1. There is currently not CoC content there, but we will add soon. If/when this template is good for flux-core we will extend to other flux-framework projects (I will open similar PRs if that sounds good)!

ping @grondo @garlick 