### PR TITLE
etc/modprobe: use flux dump --maxreqs in rc3

### DIFF
--- a/etc/modprobe/rc3.py
+++ b/etc/modprobe/rc3.py
@@ -47,7 +47,7 @@ def content_dump(context):
 
     print(f"dumping content to {dumpfile}")
     context.bash(
-        "flux dump --sd-notify --quiet --ignore-failed-read "
+        "flux dump --sd-notify --quiet --ignore-failed-read --maxreqs=128 "
         + f"--checkpoint {dumpfile}"
     )
     if dumplink:


### PR DESCRIPTION
Problem: flux-dump recently added the --maxreqs option to improve performance.  rc3 is a perfect place to use it since the broker is shutting down and no jobs are running.

Use --maxreqs=128 with flux-dump in rc3.

Fixes #7195