### PR TITLE
broker: assign event seqs in the broker not overlay

### DIFF
--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -227,7 +227,7 @@ static void module_cb (module_t *p, void *arg)
             broker_request_sendmsg_new (ctx, &msg);
             break;
         case FLUX_MSGTYPE_EVENT:
-            if (flux_send_new (ctx->h_overlay, &msg, 0) < 0) {
+            if (flux_send_new (ctx->h, &msg, 0) < 0) {
                 flux_log_error (ctx->h,
                                 "%s(%s): send to overlay: %s",
                                 __FUNCTION__,

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -282,7 +282,7 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
             return NULL;
         }
         if (!(f = flux_rpc_pack (h,
-                                 "overlay.publish",
+                                 "event.publish",
                                  0,
                                  0,
                                  "{s:s s:i s:s}",
@@ -298,7 +298,7 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
     }
     else {
         if (!(f = flux_rpc_pack (h,
-                                 "overlay.publish",
+                                 "event.publish",
                                  0,
                                  0,
                                  "{s:s s:i}",

--- a/t/lua/t0003-events.t
+++ b/t/lua/t0003-events.t
@@ -55,36 +55,36 @@ type_ok (msg, 'table', "recv_event: got msg as a table")
 is_deeply (msg, {}, "recv_event: got empty payload as expected")
 
 
--- poke at overlay.publish service
+-- poke at event.publish service
 -- good request, no payload
 local request = { topic = "foo", flags = 0 }
-local response, err = f:rpc ("overlay.publish", request);
-is (err, nil, "overlay.publish: works without payload")
+local response, err = f:rpc ("event.publish", request);
+is (err, nil, "event.publish: works without payload")
 
 -- good request, with raw payload
 local request = { topic = "foo", flags = 0, payload = "aGVsbG8gd29ybGQ=" }
-local response, err = f:rpc ("overlay.publish", request);
-is (err, nil, "overlay.publish: works with payload")
+local response, err = f:rpc ("event.publish", request);
+is (err, nil, "event.publish: works with payload")
 
 -- good request, with JSON "{}\0"
 local request = { topic = "foo", flags = 0, payload = "e30A" }
-local response, err = f:rpc ("overlay.publish", request);
-is (err, nil, "overlay.publish: works with json payload")
+local response, err = f:rpc ("event.publish", request);
+is (err, nil, "event.publish: works with json payload")
 
 -- flags missing from request
 local request = { topic = "foo" }
-local response, err = f:rpc ("overlay.publish", request);
-is (err, "Protocol error", "overlay.publish: no flags, fails with EPROTO")
+local response, err = f:rpc ("event.publish", request);
+is (err, "Protocol error", "event.publish: no flags, fails with EPROTO")
 
 -- mangled base64 payload
 local request = { topic = "foo", flags = 0, payload = "aGVsbG8gd29ybGQ%" }
-local response, err = f:rpc ("overlay.publish", request);
-is (err, "Protocol error", "overlay.publish: bad base64, fails with EPROTO")
+local response, err = f:rpc ("event.publish", request);
+is (err, "Protocol error", "event.publish: bad base64, fails with EPROTO")
 
 -- good request, mangled JSON payload "{\0"
 local request = { topic = "foo", flags = 4, payload = "ewA=" }
-local response, err = f:rpc ("overlay.publish", request);
-is (err, "Protocol error", "overlay.publish: bad json payload, fails with EPROTO")
+local response, err = f:rpc ("event.publish", request);
+is (err, "Protocol error", "event.publish: bad json payload, fails with EPROTO")
 
 done_testing ()
 

--- a/t/t0004-event.t
+++ b/t/t0004-event.t
@@ -87,8 +87,8 @@ test_expect_success 'publish private event with no payload (synchronous,loopback
 	run_timeout 5 flux event pub -p -s -l foo.bar
 '
 
-test_expect_success 'overlay.publish request with empty payload fails with EPROTO(71)' '
-	${RPC} overlay.publish 71 </dev/null
+test_expect_success 'event.publish request with empty payload fails with EPROTO(71)' '
+	${RPC} event.publish 71 </dev/null
 '
 
 


### PR DESCRIPTION
Problem: flux-framework/flux-core#7109 moved all event publishing from the broker to the overlay subsystem so that the peer multicast portion could eventually run in separate thread.  Unfortunately, moving all event publication machinery to overlay creates an unnecessary requirement that overlay be running on a size=1 instance, and will complicate `flux module reload overlay`, should that be useful.

Leave the resource intensive event mcast code in overlay but move the rest of it back into the broker.

TL;DR

Recall there are two ways that event messages are routed per RFC 3:

1) A bare event message is forwarded upstream on the TBON and published when it arrives on rank 0.

2) An event message is base64 encoded and encapsulated in a request message that is sent to rank 0, where it is published.

Publication occurs only on rank 0 and consists of assigning a monotonically increasing sequence number, distributing the message to local broker and module subscribers, and sending the event message to the overlay via the interthread message channel for further distribution.

The overlay now routes events as follows:

- If received from the local broker on the interthread channel: On rank 0, messages are mcast to all children. On rank > 0, messages are forwarded to the parent for publication.

- If received from an overlay child: On rank 0, messages are forwarded to the local broker for publication. On rank > 0, message are forwarded to the parent for publication

- If received from the overlay parent (rank > 0), messages are mcast to all children AND sent to the local broker on the interthread channel for distribution to local broker and module subscribers.

Update the overlay unit test that were exercising full event publication. Update some event sharness tests that used the other RPC name.