### PR TITLE
docker: create manifest for non-multi-arch images on tag

### DIFF
--- a/src/test/docker-manifest.py
+++ b/src/test/docker-manifest.py
@@ -18,8 +18,13 @@ for entry in matrix["include"]:
     if "DOCKER_TAG" in entry["env"]:
         tags[entry["image"]].append(entry["env"]["DOCKER_TAG"])
 
-# Collect only those images with multiple tags:
-tags = {k: v for k, v in tags.items() if len(v) > 1}
+# Collect only those images with multiple tags or where image name does
+# not equal tag name. This latter check ensures that non-multi-arch docker
+# images for tags, e.g. fluxrm/flux-core:el8-v0.81.0, have a corresponding
+# image without the version tag, e.g. fluxrm/flux-core:el8. This allows
+# CI from other projects to immediately pick up the new version when pulling
+# latest docker images after a tag. (See flux-core#7225).
+tags = {k: v for k, v in tags.items() if len(v) > 1 or v[0] != k}
 
 for image in tags.keys():
     tag = f"fluxrm/flux-core:{image}"


### PR DESCRIPTION
Problem: When docker images are pushed as part of CI after a flux-core tag, no fluxrm/flux-core:IMAGE docker tags are created for non-multi-arch images. Instead there is only a fluxrm/flux-core:IMAGE-TAG. For multi-arch images, a manifest is created at fluxrm/flux-core:IMAGE combining all the multi-arch images, but for non-multi-arch images the manifest step is skipped.

Do not skip creation of the manifest if the manifest tag differs from the image tag. This will create a manifest at the expected name for images created from a tag.

Fixes #7225