### PR TITLE
bug: python validation multiplies string

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -297,6 +297,7 @@ TESTSCRIPTS = \
 	python/t0013-job-list.py \
 	python/t0014-job-kvslookup.py \
 	python/t0015-job-output.py \
+	python/t0016-job-validate.py \
 	python/t0020-hostlist.py \
 	python/t0021-idset.py \
 	python/t0022-resource-set.py \

--- a/t/python/t0016-job-validate.py
+++ b/t/python/t0016-job-validate.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2014 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import json
+import locale
+import os
+import subprocess
+import unittest
+
+import flux
+import yaml
+from flux import job
+
+
+def __flux_size():
+    return 1
+
+
+def read_yaml(path):
+    with open(path, "r") as fd:
+        basic_yaml = fd.read()
+    return yaml_to_json(basic_yaml)
+
+
+def yaml_to_json(s):
+    obj = yaml.safe_load(s)
+    return json.dumps(obj, separators=(",", ":"))
+
+
+def determine_ascii():
+    use_ascii = False
+    build_opts = subprocess.check_output(["flux", "version"]).decode()
+    if locale.getlocale()[1] != "UTF-8" or "ascii-only" in build_opts:
+        use_ascii = True
+    return use_ascii
+
+
+class TestJobValidate(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        os.unsetenv("FLUX_F58_FORCE_ASCII")
+        self.fh = flux.Flux()
+        self.use_ascii = determine_ascii()
+        self.jobspec_dir = os.path.abspath(
+            os.path.join(os.environ["FLUX_SOURCE_DIR"], "t", "jobspec")
+        )
+        jobspec_path = os.path.join(self.jobspec_dir, "valid", "basic_v1.yaml")
+        self.basic_jobspec = read_yaml(jobspec_path)
+
+    def test_00_valid_submit(self):
+        job.submit(self.fh, self.basic_jobspec)
+
+    def test_01_non_integer_submit(self):
+        js = json.loads(self.basic_jobspec)
+
+        # Change to string
+        js["resources"][0]["count"] = "1"
+
+        # resource count must be an integer for type 'slot' (got 'str')
+        with self.assertRaises(EnvironmentError):
+            job.submit(self.fh, json.dumps(js))
+
+        # Negative
+        js["resources"][0]["count"] = -1
+
+        # node, slot, or core count must be > 0
+        with self.assertRaises(EnvironmentError):
+            job.submit(self.fh, json.dumps(js))
+
+        # 0 is (still) not OK
+        js["resources"][0]["count"] = 0
+        with self.assertRaises(EnvironmentError):
+            job.submit(self.fh, json.dumps(js))
+
+        # float values not OK
+        js["resources"][0]["count"] = 1.0
+        with self.assertRaises(EnvironmentError):
+            job.submit(self.fh, json.dumps(js))
+
+
+if __name__ == "__main__":
+    from subflux import rerun_under_flux
+
+    if rerun_under_flux(size=__flux_size(), personality="job"):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner())
+
+
+# vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
This was a bug discovered by @milroy in `resource_walk` discussed [here](https://github.com/compspec/fractale/pull/21#pullrequestreview-3532968709). When counting resources for a jobspec, we saw an output that was obviously a multiplied string (e.g., `222222` instead of the multiplied value (12). The fix should be fairly straight forward - parse the count and resource count as integers. They can never be a non integer.

Problem: When we use the walk helper, the resource count assumes the inputs to be integers. If they are strings, we get multiplied string output.
Solution: parse the count and resource count as int.