### PR TITLE
ci: fetch tags for flux-accounting build check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
+    - run: git fetch --tags || true
     - run: >
         src/test/docker/docker-run-checks.sh --image=el8 --install-only \
           --tag=fluxrm/flux-core:el8


### PR DESCRIPTION
Problem: flux-accounting's configure now checks the flux-core version, but the CI build doesn't fetch tags, causing flux-core to report an incorrect version.

Fetch tags before the build and install of flux-core in the flux-accounting CI check.