### PR TITLE
broker: add args param to topology_create()

### DIFF
--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -494,7 +494,7 @@ int boot_pmi (const char *hostname,
                    strerror (errno));
         goto error;
     }
-    if (!(topo = topology_create (topo_uri, info.size, &error))) {
+    if (!(topo = topology_create (topo_uri, info.size, NULL, &error))) {
         errprintf (errp,
                    "error creating '%s' topology: %s",
                    topo_uri,

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -130,7 +130,7 @@ struct context *ctx_create (flux_t *h,
         BAIL_OUT ("attr_create failed");
     if (!(ctx->uuid = init_broker_uuid (h, ctx->attrs)))
         BAIL_OUT ("error creating broker.uuid");
-    if (!(ctx->topo = topology_create (topo_uri, size, &error)))
+    if (!(ctx->topo = topology_create (topo_uri, size, NULL, &error)))
         BAIL_OUT ("cannot create '%s' topology: %s", topo_uri, error.text);
     if (topology_set_rank (ctx->topo, rank) < 0)
         BAIL_OUT ("cannot set topology rank");

--- a/src/broker/topology.h
+++ b/src/broker/topology.h
@@ -17,16 +17,17 @@
 #include <flux/idset.h>
 
 /* Create/destroy tree topology of size.
- * The default topology is "flat" (rank 0 is parent of all other ranks),
+ * The default topology is a flat one (rank 0 is parent of all other ranks),
  * and queries are from the perspective of rank 0.
  * If uri is non-NULL, the scheme selects a topology type, and the path
- * provides additional detail.  The following schemes are available:
- *
- * kary:K
- * Set the topology to a complete k-ary tree with fanout K.
+ * provides additional detail.
+ * If args is non-NULL it contains additional topology arguments.
+ * (The "custom" topology, looks for "hosts", which should be a hosts array
+ * from the [bootstrap] config.
  */
 struct topology *topology_create (const char *uri,
                                   int size,
+                                  json_t *args,
                                   flux_error_t *error);
 void topology_decref (struct topology *topo);
 struct topology *topology_incref (struct topology *topo);
@@ -69,7 +70,10 @@ void topology_hosts_set (json_t *hosts);
  */
 struct topology_plugin {
     const char *name;
-    int (*init)(struct topology *topo, const char *path, flux_error_t *error);
+    int (*init)(struct topology *topo,
+                const char *path,
+                json_t *args,
+                flux_error_t *error);
 };
 
 #endif /* !BROKER_TOPOLOGY_H */


### PR DESCRIPTION
Problem: the `custom` topology gets the config `hosts` array by accessing a global variable set by `topology_hosts_set()` which is inconsistent with the design of the topology class.

Add a JSON `args` argument to `topology_create()` that allows additional arguments of any sort to be provided (NULL OK).

Provide the `hosts` array through `args`.

Update broker users.
Update unit tests.