### PR TITLE
add CLIPlugin to accept arbitrary R shapes/JSON on the command-line 

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -89,6 +89,9 @@ nobase_fluxpy_PYTHON = \
 	constraint/parser.py \
 	constraint/parsetab.py \
 	constraint/__init__.py \
+	shape/parser.py \
+	shape/parsetab.py \
+	shape/__init__.py \
 	abc/journal.py \
 	abc/__init__.py \
 	utils/parsedatetime/__init__.py \
@@ -130,10 +133,12 @@ endif
 
 
 BUILT_SOURCES = \
-	constraint/parsetab.py
+	constraint/parsetab.py \
+	shape/parsetab.py
 
 CLEANFILES = \
 	constraint/parser.out \
+	shape/parser.out \
 	$(BUILT_SOURCES)
 
 STDERR_DEVNULL = $(stderr_devnull_$(V))
@@ -151,8 +156,14 @@ constraint/parsetab.py: constraint/parser.py
 	  $(PYTHON) $< --outputdir $(builddir)/constraint $(STDERR_DEVNULL) && \
 	  touch $@
 
+shape/parsetab.py: shape/parser.py
+	$(AM_V_GEN)$(MKDIR_P) shape && \
+	  $(PYTHON) $< --outputdir $(builddir)/shape $(STDERR_DEVNULL) && \
+	  touch $@
+
 clean-local:
 	-rmdir constraint 2>/dev/null || :
+	-rmdir shape 2>/dev/null || :
 	-rm -f *.pyc */*.pyc *.pyo */*.pyo
 	-rm -rf __pycache__ */__pycache__
 

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -26,6 +26,7 @@ nobase_fluxpy_PYTHON = \
 	cli/fortune.py \
 	cli/plugin.py \
 	cli/plugins/__init__.py \
+	cli/plugins/shape.py \
 	core/__init__.py \
 	core/watchers.py \
 	core/inner.py \

--- a/src/bindings/python/flux/cli/plugin.py
+++ b/src/bindings/python/flux/cli/plugin.py
@@ -193,7 +193,7 @@ class CLIPlugin(ABC):  # pragma no cover
 class CLIPluginRegistry:
     """Flux CLI plugin registry helper class"""
 
-    default_plugins = []
+    default_plugins = ["shape"]
     plugin_namespace = "flux.cli.plugins"
 
     def __init__(self, prog):

--- a/src/bindings/python/flux/cli/plugins/shape.py
+++ b/src/bindings/python/flux/cli/plugins/shape.py
@@ -1,0 +1,60 @@
+##############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import json
+
+from flux.cli.plugin import CLIPlugin
+from flux.shape.parser import ShapeParser
+
+
+class ShapePlugin(CLIPlugin):
+    """Wrap the functionality provided by the command-line job shape
+    parser into a command-line plugin users can optionally prepend to
+    their `FLUX_CLI_PLUGINPATH`. As a convenience for users, also
+    provide options for specifying json files on the command-line
+    that will get absorbed into the submitted jobspec.
+    """
+
+    def __init__(self, prog, prefix="resources"):
+        super().__init__(prog, prefix=prefix)
+        self.add_option(
+            "--shape",
+            metavar="SHAPE",
+            help="Provide an RFC 46 jobspec shape on the command line. Any other resource arguments will be ignored.",
+        )
+        self.add_option(
+            "--json",
+            metavar="FILE",
+            help="Provide a JSON file specifying the `resources` section of a jobspec.",
+        )
+
+    def preinit(self, args):
+        try:
+            if args.json or args.shape:
+                args.nodes = 1  # set a number of slots, will be subsequently ignored
+        except AttributeError:
+            pass  # without args.json or args.shape set, do nothing
+
+    def modify_jobspec(self, args, jobspec):
+        if not (getattr(args, "shape", None) or getattr(args, "json", None)):
+            return
+        if getattr(args, "shape", None) and getattr(args, "json", None):
+            raise ValueError(
+                "`--resources-shape` and `--resources-json` are mutually exclusive arguments. Use only one."
+            )
+        if getattr(args, "shape", None):
+            jobspec.jobspec["resources"] = ShapeParser().parse(args.shape)
+        elif getattr(args, "json", None):
+            with open(args.json, "r") as json_file:
+                data = json.load(json_file)
+                try:
+                    jobspec.jobspec["resources"] = data["resources"]
+                except TypeError:
+                    jobspec.jobspec["resources"] = data

--- a/src/bindings/python/flux/shape/parser.py
+++ b/src/bindings/python/flux/shape/parser.py
@@ -1,0 +1,679 @@
+##############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import argparse
+import json
+
+import ply.lex as lex
+import ply.yacc as yacc
+import yaml
+
+
+class ShapeSyntaxError(Exception):
+    """
+    Specialized SyntaxError exception to allow ShapeParser to throw
+    a SyntaxError without PLY trying to force recovery.
+
+    """
+
+    pass
+
+
+class ShapeLexer(object):
+    """
+    Simple job shape jobspec resources syntax lexical analyzer based on RFC 46.
+    Used mainly as the lexer for BaseShapeParser
+    """
+
+    #  Different quoting states for single vs double quotes:
+    states = (
+        ("squoting", "exclusive"),
+        ("dquoting", "exclusive"),
+        ("count", "exclusive"),
+        ("dictkey", "exclusive"),
+        ("dictvalue", "exclusive"),
+    )
+
+    tokens = (
+        "TYPE",
+        "SLOT",
+        "OPERATOR",
+        "IDSET",
+        "INTEGER",
+        "KEY",
+        "FALSE",
+        "NULL",
+        "TRUE",
+        "NUMBER",
+        "STRING",
+        "QSTRING",
+        "ARRAY",
+        "LBRACKET",
+        "RBRACKET",
+        "LBRACE",
+        "RBRACE",
+    )
+
+    literals = ",;:/+-"
+
+    # Ignore whitespace in default state
+    t_ignore = " \t\r\n\f\v"
+
+    # Tokens in 'quoting' state
+    t_squoting_ignore = ""
+    t_dquoting_ignore = ""
+    t_count_ignore = t_ignore
+    t_dictkey_ignore = t_dictvalue_ignore = t_ignore
+
+    def __init__(self, **kw_args):
+        super().__init__()
+        self.lexer = lex.lex(module=self, **kw_args)
+        self.bracket_level = 0
+        self.last_lbracket = 0
+        self.last_rbracket = 0
+        self.brace_level = 0
+        self.last_lbrace = 0
+        self.last_rbrace = 0
+        self.slot_count = 0
+        self.quote_type = None
+        self.quote_start = None
+        self.quote_empty = True
+        self.array_start = None
+
+    def input(self, data):
+        self.lexer.push_state("INITIAL")
+        self.bracket_level = 0
+        self.last_lbracket = 0
+        self.last_rbracket = 0
+        self.brace_level = 0
+        self.last_lbrace = 0
+        self.last_rbrace = 0
+        self.slot_count = 0
+        self.quote_type = None
+        self.quote_start = None
+        self.quote_empty = True
+        self.array_start = None
+        self.lexer.input(data)
+
+    def __getattr__(self, attr):
+        return getattr(self.lexer, attr)
+
+    def t_ANY_error(self, t):
+        raise ShapeSyntaxError(
+            f"Illegal character '{t.value[0]}' at position {t.lexer.lexpos}"
+        )
+
+    # Order of functions is important. Define special tokens earlier to have
+    # them take precedence.
+    # c.f. http://www.dabeaz.com/ply/ply.html#ply_nn6
+
+    def t_squoting_dquoting_eof(self, t):
+        raise ShapeSyntaxError(
+            f"Unclosed quote {self.quote_type} at position {self.quote_start}"
+        )
+
+    def t_squoting_QSTRING(self, t):
+        r"[^']+"
+        self.quote_empty = False
+        return t
+
+    def t_dquoting_QSTRING(self, t):
+        r'[^"]+'
+        self.quote_empty = False
+        return t
+
+    def t_squoting_QUOTE(self, t):
+        r"'"
+        return self.end_quote_helper(t)
+
+    def t_dquoting_QUOTE(self, t):
+        r'"'
+        return self.end_quote_helper(t)
+
+    def end_quote_helper(self, t):
+        t.lexer.pop_state()
+        if self.quote_empty:
+            t.value = ""
+            t.type = "QSTRING"
+        # If not empty, QSTRING token(s) were already returned,
+        # don't return the closing quote
+        else:
+            t = None
+        return t
+
+    # This must come after quoting states, so it only lexes starting quote
+    def t_ANY_QUOTE(self, t):
+        r"\"|'"
+        self.quote_start = t.lexer.lexpos
+        self.quote_empty = True
+        self.quote_type = t.value
+        if t.value == "'":
+            t.lexer.push_state("squoting")
+        else:
+            t.lexer.push_state("dquoting")
+
+    def t_TYPE(self, t):
+        r"[^={}[\]/;\s\"\']+"
+        if t.value.lower() == "slot":
+            t.value = "slot"
+            t.type = "SLOT"
+            self.slot_count += 1
+        return t
+
+    def t_EQUALS(self, t):
+        r"="
+        t.lexer.push_state("count")
+
+    def t_count_OPERATOR(self, t):
+        r":[+*^]"
+        return t
+
+    def t_count_IDSET(self, t):
+        r"[1-9]\d*((?=,)|-[1-9]\d*(?=,))(,[1-9]\d*(-[1-9]\d*)?)*"
+        return t
+
+    def t_count_INTEGER(self, t):
+        r"[1-9]\d*"
+        t.value = int(t.value)
+        return t
+
+    def t_count_end(self, t):
+        r"(?=[{/;])"
+        t.lexer.pop_state()
+
+    def t_dictkey_KEY(self, t):
+        r"(?![+-])[^:,{}]+"
+        if t.value == "x":
+            t.value = "exclusive"
+        return t
+
+    def t_dictkey_COLON(self, t):
+        r":"
+        t.lexer.push_state("dictvalue")
+        t.type = ":"
+        return t
+
+    def t_dictvalue_ARRAY(self, t):
+        r"\[.*]"
+        t.lexer.pop_state()
+        t.value = json.loads(t.value.replace("'", '"'))
+        return t
+
+    def t_dictvalue_NUMBER(self, t):
+        r"-?(0|[1-9]\d*)(\.\d*)?((e|E)(-|\+)?\d+)?(?=[},])"
+        try:
+            t.value = int(t.value)
+        except Exception:
+            t.value = float(t.value)
+        return t
+
+    def t_dictvalue_STRING(self, t):
+        r"[^,{}[\]]+"
+        if t.value.lower() == "false":
+            t.value = False
+            t.type = "FALSE"
+        elif t.value.lower() == "null":
+            t.value = None
+            t.type = "NULL"
+        elif t.value.lower() == "true":
+            t.value = True
+            t.type = "TRUE"
+        return t
+
+    def t_dictvalue_COMMA(self, t):
+        r","
+        t.lexer.pop_state()
+        t.type = ","
+        return t
+
+    def t_dictvalue_RBRACE(self, t):
+        r"}"
+        t.lexer.pop_state()
+        return self.t_ANY_RBRACE(t)
+
+    def t_ANY_LBRACE(self, t):
+        r"{"
+        self.brace_level += 1
+        self.last_lbrace = t.lexer.lexpos - 1
+        t.lexer.push_state("dictkey")
+        return t
+
+    def t_ANY_RBRACE(self, t):
+        r"}"
+        self.brace_level -= 1
+        self.last_rbrace = t.lexer.lexpos - 1
+        t.lexer.pop_state()
+        return t
+
+    def t_ANY_LBRACKET(self, t):
+        r"\["
+        self.bracket_level += 1
+        self.last_lbracket = t.lexer.lexpos - 1
+        return t
+
+    def t_ANY_RBRACKET(self, t):
+        r"]"
+        self.bracket_level -= 1
+        self.last_rbracket = t.lexer.lexpos - 1
+        return t
+
+
+class ShapeParser:
+    r"""
+    Base RFC 46 job shape resources syntax parser class.
+
+    This class implements an RFC 46 compliant Jobspec resources syntax
+    parser with the following simplified grammar:
+    ::
+
+       resources   : list
+
+       list        : '[' vertex (';' vertex)* ']'
+                   | vertex
+
+       vertex      : 'slot' ('=' count)? ('{' label (',' item)* '}')? '/' list
+                   | type ('=' count)? dict? ('/' list)?
+
+       type        : STRING
+
+       label       : STRING
+
+       count       : '[' count-value ']'
+                   | count-value
+
+       count-value : RANGE
+                   | IDSET
+                   | INTEGER
+
+       dict        : '{' (item (',' item)*)? '}'
+
+       item        : key ':' VALUE
+                   | (+|-)? key
+
+       key         : 'x'
+                   | STRING
+
+
+    The result of parsing is an RFC 14 resources list returned as a Python list.
+
+    """
+
+    def __init__(
+        self, lexer=None, optimize=True, debug=False, write_tables=False, **kw_args
+    ):
+        super().__init__()
+        self.lexer = ShapeLexer() if lexer is None else lexer
+        self.tokens = self.lexer.tokens
+        self.query = None
+        self.parser = yacc.yacc(
+            module=self,
+            optimize=optimize,
+            debug=debug,
+            write_tables=write_tables,
+            **kw_args,
+        )
+        self.default_slot_label = "task"
+        self.range_as_dict = False
+
+    def parse(self, query, **kw_args):
+        self.query = query
+        return self.parser.parse(query, lexer=self.lexer, debug=0, **kw_args)
+
+    def p_error(self, p):
+        if p is None:
+            if self.lexer.bracket_level > 0:
+                pos = self.lexer.last_lbracket
+                raise ShapeSyntaxError(f"Unclosed bracket in position {pos}")
+            if self.lexer.brace_level > 0:
+                pos = self.lexer.last_lbrace
+                raise ShapeSyntaxError(f"Unclosed brace in position {pos}")
+            raise ShapeSyntaxError(f"Unexpected end of input in '{self.query}'")
+        if self.lexer.bracket_level < 0:
+            raise ShapeSyntaxError(
+                f"Mismatched brackets starting at position {self.lexer.last_rbracket}."
+            )
+        if self.lexer.brace_level < 0:
+            raise ShapeSyntaxError(
+                f"Mismatched braces starting at position {self.lexer.last_rbrace}."
+            )
+        raise ShapeSyntaxError(f"Invalid token '{p.value}' at position {p.lexpos}")
+
+    def p_resources(self, p):
+        """
+        resources : list
+        """
+        p[0] = p[1]
+
+    def p_list_brackets(self, p):
+        """
+        list : LBRACKET vertices RBRACKET
+        """
+        p[0] = p[2]
+
+    def p_list_single(self, p):
+        """
+        list : vertex
+        """
+        p[0] = [p[1]]
+
+    def p_vertices_multi(self, p):
+        """
+        vertices : vertex ';' vertices
+        """
+        p[0] = [p[1]] + p[3]
+
+    def p_vertices_single(self, p):
+        """
+        vertices : vertex
+        """
+        p[0] = [p[1]]
+
+    def p_vertex_with(self, p):
+        """
+        vertex : non_slot '/' list
+               | slot '/' list
+        """
+        p[0] = p[1]
+        p[0].update({"with": p[3]})
+
+    def p_vertex(self, p):
+        """
+        vertex : non_slot
+        """
+        p[0] = p[1]
+
+    def p_non_slot_count_dict(self, p):
+        """
+        non_slot : TYPE count dict
+                 | QSTRING count dict
+        """
+        p[0] = {"type": p[1], "count": p[2]}
+        p[0].update(p[3])
+
+    def p_non_slot_dict(self, p):
+        """
+        non_slot : TYPE dict
+                 | QSTRING dict
+        """
+        p[0] = {"type": p[1], "count": 1}
+        p[0].update(p[2])
+
+    def p_non_slot_count(self, p):
+        """
+        non_slot : TYPE count
+                 | QSTRING count
+        """
+        p[0] = {"type": p[1], "count": p[2]}
+
+    def p_non_slot(self, p):
+        """
+        non_slot : TYPE
+                 | QSTRING
+        """
+        p[0] = {"type": p[1], "count": 1}
+
+    def p_slot_label_dict(self, p):
+        """
+        slot : slot_tc LBRACE key ',' items RBRACE
+        """
+        p[0] = p[1]
+        p[0].update({"label": p[3]})
+        p[0].update(p[5])
+
+    def p_slot_label(self, p):
+        """
+        slot : slot_tc LBRACE key RBRACE
+        """
+        p[0] = p[1]
+        p[0].update({"label": p[3]})
+
+    def p_slot(self, p):
+        """
+        slot : slot_tc
+        """
+        if self.lexer.slot_count > 1:
+            raise ShapeSyntaxError("Multiple slots require labels")
+        p[0] = p[1]
+        p[1].update({"label": self.default_slot_label})
+
+    def p_slot_tc_count(self, p):
+        """
+        slot_tc : SLOT count
+        """
+        p[0] = {"type": p[1], "count": p[2]}
+
+    def p_slot_tc(self, p):
+        """
+        slot_tc : SLOT
+        """
+        p[0] = {"type": p[1], "count": 1}
+
+    def p_count_brackets(self, p):
+        """
+        count : LBRACKET count_value RBRACKET
+        """
+        p[0] = p[2]
+
+    def p_count(self, p):
+        """
+        count : count_value
+        """
+        p[0] = p[1]
+
+    def p_count_value_range(self, p):
+        """
+        count_value : INTEGER '-' INTEGER
+                    | INTEGER '-' INTEGER ':' INTEGER
+                    | INTEGER '-' INTEGER ':' INTEGER OPERATOR
+        """
+        if self.range_as_dict:
+            p[0] = {"min": p[1], "max": p[3], "operand": 1, "operator": "+"}
+            if len(p) > 4:
+                p[0]["operand"] = p[5]
+            if len(p) > 6:
+                p[0]["operator"] = p[6][1]
+        else:
+            p[0] = "".join([str(token) for token in p[1:]])
+
+    def p_count_value_range_nomax(self, p):
+        """
+        count_value : INTEGER '+'
+                    | INTEGER '+' ':' INTEGER
+                    | INTEGER '+' ':' INTEGER OPERATOR
+        """
+        if self.range_as_dict:
+            p[0] = {"min": p[1]}
+            if len(p) > 3:
+                p[0].update(
+                    {
+                        "max": float("inf"),
+                        "operand": p[4],
+                        "operator": "+",
+                    }
+                )
+            if len(p) > 5:
+                p[0]["operator"] = p[5][1]
+        else:
+            p[0] = "".join([str(token) for token in p[1:]])
+
+    def p_count_value(self, p):
+        """
+        count_value : IDSET
+                    | INTEGER
+        """
+        p[0] = p[1]
+
+    def p_dict(self, p):
+        """
+        dict : LBRACE items RBRACE
+        """
+        p[0] = p[2]
+
+    def p_dict_empty(self, p):
+        """
+        dict : LBRACE RBRACE
+        """
+        p[0] = {}
+
+    def p_items_multi(self, p):
+        """
+        items : item ',' items
+        """
+        p[0] = p[1]
+        p[0].update(p[3])
+
+    def p_items_single(self, p):
+        """
+        items : item
+        """
+        p[0] = p[1]
+
+    def p_item_key_value(self, p):
+        """
+        item : key ':' value
+        """
+        p[0] = {p[1]: p[3]}
+
+    def p_item_minus(self, p):
+        """
+        item : '-' key
+        """
+        p[0] = {p[2]: False}
+
+    def p_item_plus(self, p):
+        """
+        item : '+' key
+        """
+        p[0] = {p[2]: True}
+
+    def p_item_key(self, p):
+        """
+        item : key
+        """
+        p[0] = {p[1]: True}
+
+    def p_key(self, p):
+        """
+        key : KEY
+            | QSTRING
+        """
+        p[0] = p[1]
+
+    def p_value(self, p):
+        """
+        value : FALSE
+              | NULL
+              | TRUE
+              | dict
+              | ARRAY
+              | NUMBER
+              | STRING
+              | QSTRING
+        """
+        p[0] = p[1]
+
+
+if __name__ == "__main__":
+    """
+    Test command which can be run as flux python -m flux.shape.parser
+    Also used to generate ply's parsetab.py in defined outputdir.
+    """
+
+    argparser = argparse.ArgumentParser(prog="shape.parser")
+    argparser.add_argument(
+        "--outputdir",
+        "-o",
+        metavar="DIR",
+        type=str,
+        help="Set outputdir for parsetab.py generation",
+    )
+    argparser.add_argument(
+        "--debug",
+        "-d",
+        action="store_true",
+        help="Emit lexer debug information before parsing expression",
+    )
+    argparser.add_argument(
+        "--yaml",
+        "-y",
+        action="store_true",
+        help="Output as YAML instead of JSON",
+    )
+    argparser.add_argument(
+        "--rangedict",
+        "-r",
+        action="store_true",
+        help="Store ranges as dicts instead of RFC 45 strings",
+    )
+    argparser.add_argument(
+        "--wrapresources",
+        "-w",
+        action="store_true",
+        help="Wrap result in outer 'resources' key",
+    )
+    argparser.add_argument(
+        "--label",
+        "-l",
+        action="store",
+        default="task",
+        help="Label used for single slot if not specified",
+    )
+    argparser.add_argument(
+        "expression",
+        metavar="EXPRESSION",
+        type=str,
+        nargs="*",
+        help="Expression to parse",
+    )
+    args = argparser.parse_args()
+
+    if args.outputdir:
+        print(f"Generating shape parsetab.py in {args.outputdir}")
+
+    parser = ShapeParser(
+        optimize=False,
+        debug=True,
+        write_tables=True,
+        outputdir=args.outputdir,
+    )
+    parser.default_slot_label = args.label
+    parser.range_as_dict = args.rangedict
+
+    if args.expression:
+
+        s = " ".join(args.expression)
+        if args.debug:
+            print(f"parsing expression `{s}'")
+            lexer = ShapeLexer()
+            lexer.input(s)
+            while True:
+                tok = lexer.token()
+                if not tok:
+                    break
+                print(tok)
+
+        result = parser.parse(s)
+        if args.wrapresources:
+            result = {"resources": result}
+
+        if args.yaml:
+            # workaround for ancient version of pyyaml on el8
+            # borrowed from https://stackoverflow.com/questions/16782112/
+            yaml.add_representer(
+                dict,
+                lambda self, data: yaml.representer.SafeRepresenter.represent_dict(
+                    self, data.items()
+                ),
+            )
+            print(yaml.dump(result, default_flow_style=False))
+        else:
+            print(json.dumps(result))
+
+# vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -89,6 +89,7 @@ TESTSCRIPTS = \
 	t0036-broker-rundir.t \
 	t0037-content-files-checkpoint.t \
 	t0038-rreq-reader.t \
+	t0039-shape-parser.t \
 	t0025-broker-state-machine.t \
 	t0027-broker-groups.t \
 	t0040-flux-sproc.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -252,6 +252,7 @@ TESTSCRIPTS = \
 	t2715-python-cli-cancel.t \
 	t2716-python-cli-batch-conf.t \
 	t2717-python-cli-plugins.t \
+	t2718-python-cli-job-shape.t \
 	t2720-python-cli-multi-prog.t \
 	t2800-jobs-cmd-multiuser.t \
 	t2800-jobs-recursive.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -340,6 +340,7 @@ TESTSCRIPTS = \
 	python/t0042-job-manager-alloc-cache.py \
 	python/t0043-sdexec-map.py \
 	python/t0043-scheduler-pool.py \
+	python/t0045-job-shape-parser.py \
 	python/t0100-modprobe.py \
 	python/t1000-service-add-remove.py
 

--- a/t/python/t0019-cli-plugin.py
+++ b/t/python/t0019-cli-plugin.py
@@ -211,11 +211,19 @@ class TestConflictDetection(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             with open(os.path.join(d, "a.py"), "w") as f:
                 f.write(self.PLUGIN_SITE)
-            with open(os.path.join(d, "b.py"), "w") as f:
-                f.write(self.PLUGIN_SITE2)
-            os.environ["FLUX_CLI_PLUGINPATH_OVERRIDE"] = d
-            registry = CLIPluginRegistry("submit")
-            self.assertEqual(len(registry.plugins), 1)
+            with tempfile.TemporaryDirectory() as d2:
+                with open(os.path.join(d2, "b.py"), "w") as f:
+                    f.write(self.PLUGIN_SITE2)
+                os.environ["FLUX_CLI_PLUGINPATH_OVERRIDE"] = f"{d2}:{d}"
+                registry = CLIPluginRegistry("submit")
+                self.assertEqual(
+                    sum(
+                        1
+                        for p in registry.plugins
+                        if str(p.__class__) == "<class 'b.PluginSite2'>"
+                    ),
+                    1,
+                )
 
     def test_02_different_prefix_same_name_coexists(self):
         # two plugins with different prefixes get distinct dests and load cleanly

--- a/t/python/t0045-job-shape-parser.py
+++ b/t/python/t0045-job-shape-parser.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+
+import subflux  # noqa: F401 - To set up PYTHONPATH
+from flux.shape.parser import ShapeParser, ShapeSyntaxError
+from pycotap import TAPTestRunner
+
+VALID = [
+    {
+        "in": "slot=4/node",
+        "out": [
+            {
+                "type": "slot",
+                "count": 4,
+                "label": "task",
+                "with": [{"type": "node", "count": 1}],
+            }
+        ],
+    },
+    {
+        "in": "slot=3-30/node",
+        "out": [
+            {
+                "type": "slot",
+                "count": "3-30",
+                "label": "task",
+                "with": [{"type": "node", "count": 1}],
+            }
+        ],
+    },
+    {
+        "in": "slot=4{nodelevel}/node{-x}/socket=2+/core=4+",
+        "out": [
+            {
+                "type": "slot",
+                "count": 4,
+                "label": "nodelevel",
+                "with": [
+                    {
+                        "type": "node",
+                        "count": 1,
+                        "exclusive": False,
+                        "with": [
+                            {
+                                "type": "socket",
+                                "count": "2+",
+                                "with": [{"type": "core", "count": "4+"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    },
+    {
+        "in": "slot=4{nodelevel}/node/socket=2/core=4",
+        "out": [
+            {
+                "type": "slot",
+                "count": 4,
+                "label": "nodelevel",
+                "with": [
+                    {
+                        "type": "node",
+                        "count": 1,
+                        "with": [
+                            {
+                                "type": "socket",
+                                "count": 2,
+                                "with": [{"type": "core", "count": 4}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    },
+    {
+        "in": "[cluster/slot=2{ib}/node/[memory=4{unit:GB};ib10g];switch/slot=2{bicore}/node/core=2]",
+        "out": [
+            {
+                "type": "cluster",
+                "count": 1,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": 2,
+                        "label": "ib",
+                        "with": [
+                            {
+                                "type": "node",
+                                "count": 1,
+                                "with": [
+                                    {"type": "memory", "count": 4, "unit": "GB"},
+                                    {"type": "ib10g", "count": 1},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "type": "switch",
+                "count": 1,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": 2,
+                        "label": "bicore",
+                        "with": [
+                            {
+                                "type": "node",
+                                "count": 1,
+                                "with": [{"type": "core", "count": 2}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        ],
+    },
+    {
+        "in": "cluster=2/slot/node=1+{-x}/core=30",
+        "out": [
+            {
+                "type": "cluster",
+                "count": 2,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": 1,
+                        "label": "task",
+                        "with": [
+                            {
+                                "type": "node",
+                                "count": "1+",
+                                "exclusive": False,
+                                "with": [{"type": "core", "count": 30}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    },
+    {
+        "in": "slot=4,9,16,25/node",
+        "out": [
+            {
+                "type": "slot",
+                "count": "4,9,16,25",
+                "label": "task",
+                "with": [{"type": "node", "count": 1}],
+            }
+        ],
+    },
+    {
+        "in": "slot=10/core=2",
+        "out": [
+            {
+                "type": "slot",
+                "count": 10,
+                "label": "task",
+                "with": [{"type": "core", "count": 2}],
+            }
+        ],
+    },
+    {
+        "in": "node/[slot=10{read-db}/[core;memory=4{unit:GB}];slot{db}/[core=6;memory=24{unit:GB}]]",
+        "out": [
+            {
+                "type": "node",
+                "count": 1,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": 10,
+                        "label": "read-db",
+                        "with": [
+                            {"type": "core", "count": 1},
+                            {"type": "memory", "count": 4, "unit": "GB"},
+                        ],
+                    },
+                    {
+                        "type": "slot",
+                        "count": 1,
+                        "label": "db",
+                        "with": [
+                            {"type": "core", "count": 6},
+                            {"type": "memory", "count": 24, "unit": "GB"},
+                        ],
+                    },
+                ],
+            }
+        ],
+    },
+    {
+        "in": "slot=10/[memory=2+{unit:GB};core]",
+        "out": [
+            {
+                "type": "slot",
+                "count": 10,
+                "label": "task",
+                "with": [
+                    {"type": "memory", "count": "2+", "unit": "GB"},
+                    {"type": "core", "count": 1},
+                ],
+            }
+        ],
+    },
+    {
+        "in": "slot=2{4GB-node}/node/memory=4+{unit:GB}",
+        "out": [
+            {
+                "type": "slot",
+                "count": 2,
+                "label": "4GB-node",
+                "with": [
+                    {
+                        "type": "node",
+                        "count": 1,
+                        "with": [{"type": "memory", "count": "4+", "unit": "GB"}],
+                    }
+                ],
+            }
+        ],
+    },
+    {
+        "in": "slot/node",
+        "out": [
+            {
+                "type": "slot",
+                "count": 1,
+                "label": "task",
+                "with": [{"type": "node", "count": 1}],
+            }
+        ],
+    },
+]
+
+INVALID = [
+    "slot=2{blah",
+    "node/[slot=10{read-db}/[core;memory=4{unit:GB}];slot{db}/[blah",
+    "slot/",
+    "slot=2{bla}}",
+    "node/[slot=10{read-db}/[core;memory=4{unit:GB}]]]",
+]
+
+
+class TestParser(unittest.TestCase):
+    def test_parse_valid(self):
+        parser = ShapeParser()
+        for test in VALID:
+            print(f"checking `{test['in']}'")
+            result = parser.parse(test["in"])
+            self.assertEqual(test["out"], result)
+
+    def test_parse_invalid(self):
+        parser = ShapeParser()
+        for test in INVALID:
+            print(f"checking invalid input `{test}'")
+            with self.assertRaises((SyntaxError, ShapeSyntaxError)):
+                parser.parse(test)
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t0039-shape-parser.t
+++ b/t/t0039-shape-parser.t
@@ -1,0 +1,254 @@
+#!/bin/sh
+
+test_description='Test python flux.shape.parser standalone operation'
+
+. `dirname $0`/sharness.sh
+
+parser="flux python -m flux.shape.parser"
+
+test_expect_success 'flux.shape.parser works' '
+	$parser
+'
+test_expect_success 'flux.shape.parser prints usage' '
+	$parser --help >usage.out 2>&1 &&
+	grep -i usage usage.out
+'
+test_expect_success 'flux.shape.parser parses simple expression' '
+	cat >expected <<-EOF &&
+	[{"type": "slot", "count": 4, "label": "task", "with": [{"type": "node", "count": 2}]}]
+	EOF
+	$parser -- slot=4/node=[2] >output &&
+	test_cmp expected output
+'
+test_expect_success 'flux.shape.parser fails with unclosed quote' '
+	test_must_fail $parser -- slot/\"blahblahblah 2>error_a &&
+	grep "Unclosed quote" error_a
+'
+test_expect_success 'flux.shape.parser handles dicts' '
+	cat >expected_b <<-EOF &&
+	[{"type": "slot", "count": 1, "label": "task", "foo": "bar", "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser -- slot{task\,foo:bar}/node{} >output_b &&
+	test_cmp expected_b output_b
+'
+test_expect_success 'flux.shape.parser fails with invalid token' '
+	test_must_fail $parser -- slot/node=\; 2>error_c &&
+	grep "Invalid token" error_c
+'
+test_expect_success 'flux.shape.parser fails with illegal character' '
+	test_must_fail $parser -- slot/node=a 2>error_d &&
+	grep "Illegal character" error_d
+'
+test_expect_success 'flux.shape.parser handles single slot without label' '
+	cat >expected1 <<-EOF &&
+	[{"type": "slot", "count": 1, "label": "task", "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser -- slot/node >output1 &&
+	test_cmp expected1 output1
+'
+test_expect_success 'flux.shape.parser parses slot with label' '
+	cat >expected2 <<-EOF &&
+	[{"type": "slot", "count": 4, "label": "nodelevel", "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser -- "slot=4{nodelevel}/node" >output2 &&
+	test_cmp expected2 output2
+'
+test_expect_success 'flux.shape.parser parses count range' '
+	cat >expected3 <<-EOF &&
+	[{"type": "slot", "count": "3-30", "label": "task", "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser -- slot=3-30/node >output3 &&
+	test_cmp expected3 output3
+'
+test_expect_success 'flux.shape.parser parses open-ended range' '
+	cat >expected4 <<-EOF &&
+	[{"type": "slot", "count": "2+", "label": "task", "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser -- slot=2+/node >output4 &&
+	test_cmp expected4 output4
+'
+test_expect_success 'flux.shape.parser parses idset count' '
+	cat >expected5 <<-EOF &&
+	[{"type": "slot", "count": "4,9,16,25", "label": "task", "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser -- slot=4,9,16,25/node >output5 &&
+	test_cmp expected5 output5
+'
+test_expect_success 'flux.shape.parser parses attributes in dict' '
+	cat >expected6 <<-EOF &&
+	[{"type": "node", "count": 1, "exclusive": false, "with": [{"type": "core", "count": 4}]}]
+	EOF
+	$parser -- "node{-x}/core=4" >output6 &&
+	test_cmp expected6 output6
+'
+test_expect_success 'flux.shape.parser parses nested resources' '
+	cat >expected7 <<-EOF &&
+	[{"type": "node", "count": 1, "with": [{"type": "socket", "count": 2, "with": [{"type": "core", "count": 4}]}]}]
+	EOF
+	$parser -- node/socket=2/core=4 >output7 &&
+	test_cmp expected7 output7
+'
+test_expect_success 'flux.shape.parser parses resource list with brackets' '
+	cat >expected8 <<-EOF &&
+	[{"type": "slot", "count": 10, "label": "task1", "with": [{"type": "core", "count": 1}]}, {"type": "slot", "count": 2, "label": "task2", "with": [{"type": "core", "count": 2}]}]
+	EOF
+	$parser -- "[slot=10{task1}/core;slot=2{task2}/core=2]" >output8 &&
+	test_cmp expected8 output8
+'
+test_expect_success 'flux.shape.parser parses complex example from RFC 46' '
+	cat >expected9 <<-EOF &&
+	[{"type": "node", "count": 1, "with": [{"type": "slot", "count": 10, "label": "read-db", "with": [{"type": "core", "count": 1}, {"type": "memory", "count": 4, "unit": "GB"}]}, {"type": "slot", "count": 1, "label": "db", "with": [{"type": "core", "count": 6}, {"type": "memory", "count": 24, "unit": "GB"}]}]}]
+	EOF
+	$parser -- "node/[slot=10{read-db}/[core;memory=4{unit:GB}];slot{db}/[core=6;memory=24{unit:GB}]]" >output9 &&
+	test_cmp expected9 output9
+'
+test_expect_success 'flux.shape.parser --yaml produces yaml output' '
+	cat >expected10 <<-EOF &&
+	- type: slot
+	  count: 4
+	  label: task
+	  with:
+	  - type: node
+	    count: 1
+
+	EOF
+	$parser --yaml -- slot=4/node >output10 &&
+	test_cmp expected10 output10
+'
+test_expect_success 'flux.shape.parser --debug shows token information' '
+	$parser --debug -- slot=4/node >output11 2>&1 &&
+	grep "LexToken" output11
+'
+test_expect_success 'flux.shape.parser --wrapresources wraps output' '
+	cat >expected12 <<-EOF &&
+	{"resources": [{"type": "slot", "count": 4, "label": "task", "with": [{"type": "node", "count": 1}]}]}
+	EOF
+	$parser --wrapresources -- slot=4/node >output12 &&
+	test_cmp expected12 output12
+'
+test_expect_success 'flux.shape.parser --label changes default slot label' '
+	cat >expected13 <<-EOF &&
+	[{"type": "slot", "count": 1, "label": "mytask", "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser --label=mytask -- slot/node >output13 &&
+	test_cmp expected13 output13
+'
+test_expect_success 'flux.shape.parser --rangedict outputs range as dict' '
+	cat >expected14 <<-EOF &&
+	[{"type": "slot", "count": {"min": 3, "max": 30, "operand": 1, "operator": "+"}, "label": "task", "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser --rangedict -- slot=3-30/node >output14 &&
+	test_cmp expected14 output14
+'
+test_expect_success 'flux.shape.parser rejects invalid syntax' '
+	test_must_fail $parser -- "slot/" >error15.out 2>&1 &&
+	grep -i "error\|invalid" error15.out
+'
+test_expect_success 'flux.shape.parser rejects unclosed brace' '
+	test_must_fail $parser -- "slot=2{blah" >error16.out 2>&1 &&
+	grep -i "error\|unclosed" error16.out
+'
+test_expect_success 'flux.shape.parser rejects mismatched braces' '
+	test_must_fail $parser -- "slot=2{bla}}" >error17.out 2>&1 &&
+	grep -i "error\|mismatch" error17.out
+'
+test_expect_success 'flux.shape.parser rejects mismatched brackets' '
+	test_must_fail $parser -- "node/[slot=10/core]]]" >error18.out 2>&1 &&
+	grep -i "error\|mismatch" error18.out
+'
+test_expect_success 'flux.shape.parser requires label for multiple slots' '
+	test_must_fail $parser -- "[slot=2/node;slot=3/node]" >error19.out 2>&1 &&
+	grep -i "error\|label" error19.out
+'
+test_expect_success 'flux.shape.parser parses quoted strings' '
+	cat >expected20 <<-EOF &&
+	[{"type": "my type", "count": 1, "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser -- "\"my type\"/node" >output20 &&
+	test_cmp expected20 output20
+'
+test_expect_success 'flux.shape.parser parses single-quoted strings' '
+	cat >expected21 <<-EOF &&
+	[{"type": "my type", "count": 1, "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser -- "'"'my type'"'/node" >output21 &&
+	test_cmp expected21 output21
+'
+test_expect_success 'flux.shape.parser handles empty quotes' '
+	cat >expected22 <<-EOF &&
+	[{"type": "node", "count": 1, "unit": ""}]
+	EOF
+	$parser -- "node{unit:\"\"}" >output22 &&
+	test_cmp expected22 output22
+'
+test_expect_success 'flux.shape.parser parses boolean values in dict' '
+	cat >expected23 <<-EOF &&
+	[{"type": "node", "count": 1, "key": true, "flag": false}]
+	EOF
+	$parser -- "node{key:true,flag:false}" >output23 &&
+	test_cmp expected23 output23
+'
+test_expect_success 'flux.shape.parser parses null value in dict' '
+	cat >expected24 <<-EOF &&
+	[{"type": "node", "count": 1, "key": null}]
+	EOF
+	$parser -- "node{key:null}" >output24 &&
+	test_cmp expected24 output24
+'
+test_expect_success 'flux.shape.parser parses number values in dict' '
+	cat >expected25 <<-EOF &&
+	[{"type": "node", "count": 1, "int": 42, "float": 3.14, "sci": 100000.0}]
+	EOF
+	$parser -- "node{int:42,float:3.14,sci:1e5}" >output25 &&
+	test_cmp expected25 output25
+'
+test_expect_success 'flux.shape.parser parses array values in dict' '
+	cat >expected26 <<-EOF &&
+	[{"type": "node", "count": 1, "ports": [8080, 8081]}]
+	EOF
+	$parser -- "node{ports:[8080,8081]}" >output26 &&
+	test_cmp expected26 output26
+'
+test_expect_success 'flux.shape.parser shorthand x expands to exclusive' '
+	cat >expected27 <<-EOF &&
+	[{"type": "node", "count": 1, "exclusive": true}]
+	EOF
+	$parser -- "node{x}" >output27 &&
+	test_cmp expected27 output27
+'
+test_expect_success 'flux.shape.parser +key shorthand for true' '
+	cat >expected28 <<-EOF &&
+	[{"type": "node", "count": 1, "key": true}]
+	EOF
+	$parser -- "node{+key}" >output28 &&
+	test_cmp expected28 output28
+'
+test_expect_success 'flux.shape.parser -key shorthand for false' '
+	cat >expected29 <<-EOF &&
+	[{"type": "node", "count": 1, "key": false}]
+	EOF
+	$parser -- "node{-key}" >output29 &&
+	test_cmp expected29 output29
+'
+test_expect_success 'flux.shape.parser handles range with operand' '
+	cat >expected30 <<-EOF &&
+	[{"type": "slot", "count": {"min": 3, "max": 30, "operand": 2, "operator": "+"}, "label": "task", "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser --rangedict -- "slot=3-30:2/node" >output30 &&
+	test_cmp expected30 output30
+'
+test_expect_success 'flux.shape.parser handles range with operator' '
+	cat >expected31 <<-EOF &&
+	[{"type": "slot", "count": {"min": 3, "max": 30, "operand": 2, "operator": "+"}, "label": "task", "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser --rangedict -- "slot=3-30:2:+/node" >output31 &&
+	test_cmp expected31 output31
+'
+test_expect_success 'flux.shape.parser handles open range with operand' '
+	cat >expected32 <<-EOF &&
+	[{"type": "slot", "count": {"min": 3, "max": Infinity, "operand": 2, "operator": "+"}, "label": "task", "with": [{"type": "node", "count": 1}]}]
+	EOF
+	$parser --rangedict -- "slot=3+:2/node" >output32 &&
+	test_cmp expected32 output32
+'
+test_done

--- a/t/t2717-python-cli-plugins.t
+++ b/t/t2717-python-cli-plugins.t
@@ -82,9 +82,9 @@ test_expect_success 'flux-run: new plugin with the same name, diff dest/prefix i
 	grep -e "I am a valid plugin" \
 	     -e "Option for setting AMD SMI compute" help1.out
 '
-test_expect_success 'flux-batch: --list-plugins shows only plugins with no option conflicts' '
+test_expect_success 'flux-batch: --list-plugins shows plugins in the PLUGINPATH' '
 	flux batch --list-plugins >> tmp_help_real.out &&
-	grep "loaded from" tmp_help_real.out | wc -l | grep -qx 5
+	grep "MultiUserPlugin loaded from" tmp_help_real.out
 '
 test_expect_success 'flux-batch: FLUX_CLI_PLUGINPATH_OVERRIDE wins a fight against FLUX_CLI_PLUGINPATH' '
 	FLUX_CLI_PLUGINPATH_OVERRIDE= FLUX_CLI_PLUGINPATH=${SHARNESS_TEST_SRCDIR}/cli-plugins/extras/ \

--- a/t/t2718-python-cli-job-shape.t
+++ b/t/t2718-python-cli-job-shape.t
@@ -1,0 +1,143 @@
+#!/bin/sh
+
+test_description='Test command line plugin for RFC 46 job shape'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+test_expect_success 'flux-alloc: a job that does not provide a job shape can run' '
+	flux alloc -N 1 flux resource list -no {nnodes} | grep 1
+'
+test_expect_success 'flux-run: job that calls shape plugin has resources set properly' '
+	cat <<-EOF | jq -S . > exp1.json &&
+	[
+	  {
+	    "type": "slot",
+	    "count": 4,
+	    "label": "task",
+	    "with": [
+	      {
+	        "type": "node",
+	        "count": 1
+	      }
+	    ]
+	  }
+	]
+	EOF
+	flux run --resources-shape=slot=4/node --dry-run hostname | jq -S .resources > output1.json &&
+	test_cmp exp1.json output1.json
+'
+test_expect_success 'flux-alloc: job with invalid shape is rejected' '
+	test_must_fail flux alloc --resources-shape=slot/ echo hello 2> err.out &&
+	grep "flux-alloc: ERROR" err.out
+'
+test_expect_success 'flux-batch: subinstance job with shape plugin has proper resources' '
+	cat <<-EOF | jq -S . > exp2.json &&
+	[
+	  {
+	    "type": "node",
+	    "count": 1,
+	    "with": [
+	      {
+	        "type": "slot",
+	        "count": 10,
+	        "label": "read-db",
+	        "with": [
+	          {
+	            "type": "core",
+	            "count": 1
+	          },
+	          {
+	            "type": "memory",
+	            "count": 4,
+	            "unit": "GB"
+	          }
+	        ]
+	      },
+	      {
+	        "type": "slot",
+	        "count": 1,
+	        "label": "db",
+	        "with": [
+	          {
+	            "type": "core",
+	            "count": 6
+	          },
+	          {
+	            "type": "memory",
+	            "count": 24,
+	            "unit": "GB"
+	          }
+	        ]
+	      }
+	    ]
+	  }
+	]
+	EOF
+	flux batch --resources-shape=node/[slot=10{read-db}/[core\;memory=4{unit:GB}]\;slot{db}/[core=6\;memory=24{unit:GB}]] \
+	    --dry-run --wrap hostname | jq -S .resources > output2.json && 
+	test_cmp exp2.json output2.json
+'
+test_expect_success 'flux-submit: providing --resources-json gets the expected resource set' '
+	cat <<-EOF | jq -S .resources > r_set.json &&
+	{
+	  "resources": [
+	    {
+	      "type": "slot",
+	      "count": 10,
+	      "label": "task",
+	      "with": [
+	        {
+	          "type": "core",
+	          "count": 2
+	        }
+	      ]
+	    }
+	  ]
+	}	
+	EOF
+	flux submit --resources-json=r_set.json --dry-run hostname | jq -S .resources > output3.json && 
+	test_cmp r_set.json output3.json
+'
+test_expect_success 'flux-submit: providing invalid json gets rejected' '
+	cat <<-EOF  > r_set2.json &&
+	{
+	  "resources": [
+	    {
+	      "type": "slot",
+	      "count": 10,
+	      "label": "task",
+	      "with": [
+	        {
+	          "type": "core"aloskdjfioqwejio;fwqeio;,
+	          "count": 2
+	        }
+	      ]
+	    }
+	  ],
+	}	
+	EOF
+	test_must_fail flux submit --resources-json=r_set2.json hostname 2> output4.err &&
+	grep "flux-submit: ERROR: Expecting " output4.err
+'
+test_expect_success 'flux-alloc: job request with both shape and json is rejected' '
+	cat <<-EOF | jq -S . > exp4.json &&
+	[
+	  {
+	    "type": "slot",
+	    "count": 4,
+	    "label": "task",
+	    "with": [
+	      {
+	        "type": "node",
+	        "count": 1
+	      }
+	    ]
+	  }
+	]
+	EOF
+	test_must_fail flux run --resources-shape=slot=4/node --resources-json=exp4.json --dry-run hostname 2> err4.err  &&
+	grep "flux-run: ERROR" err4.err
+'
+test_done


### PR DESCRIPTION
This PR takes the excellent work done by @sam-maloney for [RFC#46](github.com/flux-framework/rfc/pull/465) and extends it into a command-line plugin that users can opt in to by setting `FLUX_CLI_PLUGINPATH`. This was [originally suggested by @grondo](https://github.com/flux-framework/rfc/pull/465#issuecomment-3201763842) as a way for us to test/get user feedback on the ergonomics of specifying shape on the command line, and make progress toward incorporating that option into our standard command line.

The plugin is relatively straightforward and the testing just references examples from the corresponding RFC. I know this is coming up right before many 🌴s, so no rush on reviews, but I wanted to get it to a stopping point before my own holiday begins :).