### PR TITLE
MAINTAINERS: update first name to match GitHub profile

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,22 +4,22 @@ to this project, please refer to [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Current Maintainers
 
-| Maintainer       | GitHub ID                                             | Affiliation |
-| ---------------- | ----------------------------------------------------- | ----------- |
-| Al Chu           | [chu11](https://github.com/chu11)                     | LLNL        |
-| Chris Dunlap     | [dun](https://github.com/dun)                         | LLNL        |
-| Chris Moussa     | [cmoussa1](https://github.com/cmoussa1)               | LLNL        |
-| Elsa Gonsiorowski| [gonsie](https://github.com/gonsie)                   | LLNL        |
-| James Corbett    | [jameshcorbett](https://github.com/jameshcorbett)     | LLNL        |
-| Jim Garlick      | [garlick](https://github.com/garlick)                 | LLNL        |
-| Jae-seung Yeom   | [JaeseungYeom](https://github.com/JaeseungYeom)       | LLNL        |
-| Mark Grondona    | [grondo](https://github.com/grondo)                   | LLNL        |
-| Daniel Milroy    | [milroy](https://github.com/milroy)                   | LLNL        |
-| Tapasya Patki    | [tpatki](https://github.com/tpatki)                   | LLNL        |
-| Tom Scogland     | [trws](https://github.com/trws)                       | LLNL        |
-| Vanessa Sochat   | [vsoch](https://github.com/vsoch)                     | LLNL        |
-| Becky Springmeyer| [springme](https://github.com/springme)               | LLNL        |
-| William Hobbs    | [wihobbs](https://github.com/wihobbs)                 | LLNL        |
+| Maintainer         | GitHub ID                                             | Affiliation |
+| ------------------ | ----------------------------------------------------- | ----------- |
+| Al Chu             | [chu11](https://github.com/chu11)                     | LLNL        |
+| Chris Dunlap       | [dun](https://github.com/dun)                         | LLNL        |
+| Christopher Moussa | [cmoussa1](https://github.com/cmoussa1)               | LLNL        |
+| Elsa Gonsiorowski  | [gonsie](https://github.com/gonsie)                   | LLNL        |
+| James Corbett      | [jameshcorbett](https://github.com/jameshcorbett)     | LLNL        |
+| Jim Garlick        | [garlick](https://github.com/garlick)                 | LLNL        |
+| Jae-seung Yeom     | [JaeseungYeom](https://github.com/JaeseungYeom)       | LLNL        |
+| Mark Grondona      | [grondo](https://github.com/grondo)                   | LLNL        |
+| Daniel Milroy      | [milroy](https://github.com/milroy)                   | LLNL        |
+| Tapasya Patki      | [tpatki](https://github.com/tpatki)                   | LLNL        |
+| Tom Scogland       | [trws](https://github.com/trws)                       | LLNL        |
+| Vanessa Sochat     | [vsoch](https://github.com/vsoch)                     | LLNL        |
+| Becky Springmeyer  | [springme](https://github.com/springme)               | LLNL        |
+| William Hobbs      | [wihobbs](https://github.com/wihobbs)                 | LLNL        |
 
 ## Maintainers Emeritus
 


### PR DESCRIPTION
#### Problem

My GitHub and various work profiles use "Christopher," but the maintainers list uses "Chris".

---

Just to make my online presence consistent, this PR updates the name in the **Current Maintainers** list to "Christopher" :-)