### PR TITLE
libeventlog: wait for pending commits to complete

### DIFF
--- a/src/common/libeventlog/eventlogger.c
+++ b/src/common/libeventlog/eventlogger.c
@@ -206,8 +206,10 @@ static void timer_commit_cb (flux_future_t *f, void *arg)
     flux_future_destroy (f);
 }
 
-static void
-timer_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+static void timer_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
 {
     struct eventlog_batch *batch = arg;
     double timeout = batch->ev->commit_timeout;
@@ -294,7 +296,8 @@ static int append_wait (struct eventlogger *ev,
 
     if (flux_kvs_txn_put (ev->current->txn,
                           FLUX_KVS_APPEND,
-                          path, entrystr) < 0)
+                          path,
+                          entrystr) < 0)
         return -1;
 
     return eventlogger_flush (ev);

--- a/src/common/libeventlog/eventlogger.c
+++ b/src/common/libeventlog/eventlogger.c
@@ -164,7 +164,7 @@ static flux_future_t *eventlogger_commit_batch (struct eventlogger *ev,
          *   in big trouble anyway...
          */
         if ((f = flux_future_create (NULL, NULL))) {
-            flux_future_set_reactor (f, flux_get_reactor (ev->h));
+            flux_future_set_flux (f, ev->h);
             flux_future_fulfill (f, NULL, NULL);
         }
     }


### PR DESCRIPTION
Problem: Both eventlogger_commit() and eventlogger_flush() assume all prior pending commits have completed.  This is not a problem under normal conditions, as there is always some "current" event data in the eventlogger that needs to be written out, and commit/flush can wait for that commit to be completed.

However, under some circumstances there may not be any "current" data to be written out.  This can lead to a race as code returns a fulfilled future, assuming all prior pending commits have completed.

Its worth noting there is no current use of eventlogger_commit() that could lead to a race.  Races with eventlogger_flush() are
theoretically possible in the shell.

Solution: When there are no "current" events to be written out and there are pending commits waiting to be completed, wait for the most recent pending commit to complete before fulfilling the future.  We accomplish this by creating a new "empty" batch of events and commit that empty set of events.  The future created by this "empty"  batch can be waited on.

Fixes #7257
