### PR TITLE
fix lsf resolver for >1 broker per node

### DIFF
--- a/src/bindings/python/flux/uri/resolvers/lsf.py
+++ b/src/bindings/python/flux/uri/resolvers/lsf.py
@@ -67,7 +67,7 @@ def lsf_job_pid(jobid):
         check=True,
     )
     for line in sp.stdout.decode("utf-8").split("\n"):
-        if "flux-broker" in line:
+        if "flux-broker-0" in line:
             pid = line.split()[0]
             if check_lsf_jobid(pid, jobid):
                 return pid

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -204,10 +204,9 @@ test_expect_success 'setup fake csm_allocation_query for mock lsf testing' '
 	export FLUX_SSH=${SHARNESS_TEST_SRCDIR}/scripts/tssh
 '
 test_expect_success 'flux-uri mock testing of lsf resolver works' '
-	result=$(SHELL=/bin/sh flux uri --local lsf:$LSB_JOBID) &&
-	FLUX_URI_1=$(flux exec -r 1 flux getattr local-uri) &&
-	test_debug "echo checking if $result is $FLUX_URI or $FLUX_URI_1" &&
-	test "$result" = "$FLUX_URI" -o "$result" = "$FLUX_URI_1"
+	echo $FLUX_URI >lsf.exp &&
+	sh -c "flux uri --local lsf:$LSB_JOBID" >lsf.out &&
+	test_cmp lsf.exp lsf.out
 '
 test_expect_success 'cleanup jobs' '
 	flux cancel --all &&


### PR DESCRIPTION
Problem: the lsf resolver test intermittently fails in CI.

The lsf resolver searches for LSB_JOBID in the environment of any
flux-broker process it finds on the target node, then calls the
pid resolver.  But if there are multiple brokers per node, as there
are in the test, the lsf resolver might find a rank other than the
first one, which is not guaranteed to have children, and the pid
resolver fails with e.g.
```
flux-uri: ERROR: PID 262732 is a flux-broker and no child found
```
Restrict the search to processes named flux-broker-0.
Simplify the test logic, given this new constraint.

Also, improve the sharness test so it works if multiple copies are run simultaneously.

Fixes #6247