### PR TITLE
testsuite: fix non-bourne shell test failure

### DIFF
--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -205,7 +205,7 @@ test_expect_success 'setup fake csm_allocation_query for mock lsf testing' '
 '
 test_expect_success 'flux-uri mock testing of lsf resolver works' '
 	echo $FLUX_URI >lsf.exp &&
-	sh -c "flux uri --local lsf:$LSB_JOBID" >lsf.out &&
+	SHELL=/bin/sh flux uri --local lsf:$LSB_JOBID >lsf.out &&
 	test_cmp lsf.exp lsf.out
 '
 test_expect_success 'cleanup jobs' '


### PR DESCRIPTION
Problem: Test in t2802-uri-cmd failed in a non-bourne shell. Test was recently broken in

758622ba065b80c55fb40805adb239bc3d4d85e0

Solution: Set SHELL to /bin/sh in test.