### PR TITLE
avoid potential `flux job attach` hangs with MPIR tools and add graceful job shell rexec server shutdown

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -513,6 +513,13 @@ plugins include:
   two seconds).  The polling period may be changed to a different value
   in RFC 23 Flux Standard Duration format.
 
+.. option:: rexec-shutdown-timeout=FSD
+
+  When all tasks exit, processes launched via the rexec server receive
+  SIGTERM, then SIGKILL after this timeout (RFC 23 Flux Standard Duration).
+  Default: 60s.
+
+
 .. _flux_shell_initrc:
 
 SHELL INITRC

--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -1338,6 +1338,12 @@ void attach_event_continuation (flux_future_t *f, void *arg)
             ctx->exit_code = flux_job_waitstatus_to_exitcode (status, &error);
             if (ctx->exit_code != 0)
                 log_msg ("%s", error.text);
+
+            /* All shells have exited, so no more MPIR data is expected.
+             * Clean up MPIR state now to ensure flux-job attach exits
+             * properly when the job completes.
+             */
+            mpir_shutdown (ctx->h);
         }
     }
 

--- a/src/cmd/job/mpir.h
+++ b/src/cmd/job/mpir.h
@@ -18,4 +18,6 @@ void mpir_setup_interface (flux_t *h,
                            int leader_rank,
                            const char *shell_service);
 
+void mpir_shutdown (flux_t *h);
+
 #endif /* !FLUX_JOB_MPIR_H */

--- a/src/common/libsubprocess/server.h
+++ b/src/common/libsubprocess/server.h
@@ -49,6 +49,12 @@ void subprocess_server_destroy (subprocess_server_t *s);
  * there are some, the orig. reactor must be allowed to run in order for the
  * shutdown to make progress.  Therefore this future should be tracked with
  * flux_future_then(), not flux_future_get() which would deadlock.
+ *
+ * This function may be called more than once, e.g. to allow SIGKILL to be
+ * sent after a timeout of the initial call. In this case the previous
+ * future will no longer be fulfilled and should be destroyed.
+ *
+ * The caller owns the returned future and should eventually destroy it.
  */
 flux_future_t *subprocess_server_shutdown (subprocess_server_t *s, int signum);
 

--- a/src/shell/rexec.c
+++ b/src/shell/rexec.c
@@ -25,17 +25,21 @@
 
 #include "src/common/libsubprocess/server.h"
 #include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/fsd.h"
 
 #include "builtins.h"
 #include "internal.h"
 #include "svc.h"
 #include "log.h"
 
+static double default_shutdown_timeout = 60.;
+
 struct shell_rexec {
     flux_shell_t *shell;
     subprocess_server_t *server;
     char *name;
     bool parent_is_trusted;
+    double shutdown_timeout;
 };
 
 static void rexec_destroy (struct shell_rexec *rexec)
@@ -80,6 +84,7 @@ static int rexec_auth_cb (const flux_msg_t *msg,
 static struct shell_rexec *rexec_create (flux_shell_t *shell)
 {
     struct shell_rexec *rexec;
+    const char *timeout = NULL;
 
     if (!(rexec = calloc (1, sizeof (*rexec))))
         return NULL;
@@ -92,6 +97,22 @@ static struct shell_rexec *rexec_create (flux_shell_t *shell)
     pid_t ppid = getppid (); // 0 =  parent is in a different pid namespace
     if (ppid > 0 && kill (getppid (), 0) == 0)
         rexec->parent_is_trusted = true;
+
+    rexec->shutdown_timeout = default_shutdown_timeout;
+
+    if (flux_shell_getopt_unpack (shell,
+                                  "rexec-shutdown-timeout",
+                                  "s",
+                                  &timeout) < 0) {
+        shell_log_errno ("invalid rexec-shutdown-timeout");
+        goto error;
+    }
+
+    if (timeout
+        && fsd_parse_duration (timeout, &rexec->shutdown_timeout) < 0) {
+        shell_log_errno ("failed to parse rexec-shutdown-timeout");
+        goto error;
+    }
 
     /* N.B. subprocess_server_create() registers the methods: exec, write,
      * kill, list, and disconnect.  Give the server its own namespace.  The
@@ -137,6 +158,35 @@ static int rexec_init (flux_plugin_t *p,
 
 static void shutdown_cb (flux_future_t *f, void *arg)
 {
+    struct shell_rexec *rexec = arg;
+
+    /* On timeout, if shell_rexec was passed as arg, escalate to SIGKILL
+     * and wait for shutdown_timeout again. Pass NULL as arg this time so
+     * the callback stops the reactor on the second timeout instead of
+     * retrying indefinitely.
+     *
+     * This approach allows clients to receive completion messages for
+     * subprocesses terminated with SIGKILL. If we destroyed the subprocess
+     * server instead, SIGKILL would be sent but final RPCs to clients
+     * would never be sent.
+     */
+    if (flux_future_get (f, NULL) < 0
+        && errno == ETIMEDOUT
+        && rexec != NULL) {
+        flux_future_destroy (f);
+        if ((f = subprocess_server_shutdown (rexec->server, SIGKILL))
+            && flux_future_then (f,
+                                 rexec->shutdown_timeout,
+                                 shutdown_cb,
+                                 NULL) == 0)
+            return;
+
+        /* On failure, fall through to stopping the reactor. The subprocess
+         * server will be destroyed by the shell and SIGKILL sent again, but
+         * clients may not receive termination messages.
+         */
+        shell_warn ("failed to shutdown rexec server cleanly with SIGKILL");
+    }
     flux_reactor_stop (flux_future_get_reactor (f));
     flux_future_destroy (f);
 }
@@ -153,14 +203,20 @@ static int rexec_exit (flux_plugin_t *p,
 
         /* Send SIGTERM to any subprocesses running in the server and
          * tell the server to shutdown. Future will be fulfilled when
-         * all processes have exited (immediatebly if there are none).
+         * all processes have exited (immediately if there are none),
+         * Wait for shutdown_timeout before giving up and handing control
+         * back to the shell. The subprocess server will then be destroyed
+         * at which point processes will be sent SIGKILL.
          *
          * The reactor needs to be run for the future to be fulfilled,
          * but the shell has exited flux_reactor_run() at this point,
          * so call it explicitly here.
          */
         if (!(f = subprocess_server_shutdown (rexec->server, SIGTERM))
-            || flux_future_then (f, -1., shutdown_cb, NULL) < 0) {
+            || flux_future_then (f,
+                                 rexec->shutdown_timeout,
+                                 shutdown_cb,
+                                 rexec) < 0) {
             shell_log_errno ("subprocess_server_shutdown");
             flux_future_destroy (f);
             return -1;

--- a/t/shell/mpir.c
+++ b/t/shell/mpir.c
@@ -106,6 +106,7 @@ int main (int ac, char **av)
 
     flux_reactor_run (flux_get_reactor (h), 0);
 
+    mpir_shutdown (h);
     proctable_destroy (proctable);
     flux_close (h);
     optparse_destroy (p);

--- a/t/shell/mpir.c
+++ b/t/shell/mpir.c
@@ -14,6 +14,8 @@
 #include "config.h"
 #endif
 
+#include <signal.h>
+
 #include <flux/core.h>
 #include <flux/optparse.h>
 
@@ -46,6 +48,12 @@ static struct optparse_option opts[] = {
       .has_arg = 0,
       .usage = "test tool launch via MPIR_executable_path",
     },
+    { .name = "send-sigcont",
+      .key = 'S',
+      .has_arg = 1,
+      .arginfo = "ID",
+      .usage = "send SIGCONT to job ID after tool launch",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -63,6 +71,7 @@ int main (int ac, char **av)
     int rank;
     flux_t *h = NULL;
     const char *service;
+    const char *jobid;
     optparse_t *p;
     int optindex;
 
@@ -103,6 +112,18 @@ int main (int ac, char **av)
 
     mpir_setup_interface (h, 0, false, false, rank, service);
     print_proctable ();
+
+    if ((jobid = optparse_get_str (p, "send-sigcont", NULL))) {
+        flux_jobid_t id;
+        flux_future_t *f;
+
+        if (flux_job_id_parse (jobid, &id) < 0)
+            log_msg_exit ("failed to parse jobid '%s'", jobid);
+        if (!(f = flux_job_kill (h, id, SIGCONT))
+            || flux_future_get (f, NULL) < 0)
+            log_err_exit ("flux_job_kill");
+        flux_future_destroy (f);
+    }
 
     flux_reactor_run (flux_get_reactor (h), 0);
 

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -383,4 +383,8 @@ test_expect_success 'job-shell: shell inherits FLUX_F58_FORCE_ASCII from job' '
 		id=$(flux submit --wait --output={{id}}.out hostname) &&
 	test -f ${id}.out
 '
+test_expect_success 'job-shell: rexec-shutdown-timeout catches bad values' '
+	test_must_fail flux run -o rexec-shutdown-timeout=1 true &&
+	test_must_fail flux run -o rexec-shutdown-timeout=1.1f true
+'
 test_done


### PR DESCRIPTION
This PR fixes a couple issues identified in #7269 related to `MPIR_executable_path` support:

1. When MPIR  tools are launched via `MPIR_executable_path`, they hold references on the `flux job attach` reactor, which may cause it to hang indefinitely waiting for the tools to exit even after the job finishes if the job shell is killed before it can complete the libsubprocess protocol.
2. The shell's rexec server destroys all subprocesses with SIGKILL on exit,  preventing tools from exiting cleanly and the rexec server from sending completions messages to the client.

Solution:
- In the job shell rexec server, implement graceful shutdown for subprocesses with SIGTERM, followed  by SIGKILL escalation after a configurable timeout (default 60s). This gives tools processes a chance to exit cleanly and notify `flux job attach`.
- Track MPIR tool processes in `flux job attach` and clean them up when the job `finish` event  is received, ensuring `flux job attach` exits promptly even if the job shell is killed before it fully exits or on node failure, etc.

Closes #7269