### PR TITLE
testsuite: fix t2318-resource-verify.t on non-RSMI system

### DIFF
--- a/t/t2318-resource-verify.t
+++ b/t/t2318-resource-verify.t
@@ -11,7 +11,9 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 # with "extra" GPUs. Since we're not testing GPU detection here, just
 # disable the rsmi component of HWLOC when used to avoid the issue.
 # (This needs to be done before test_under_flux is called)
-export HWLOC_COMPONENTS=-rsmi
+if hwloc-ls | grep rsmi >/dev/null 2>&1; then
+    export HWLOC_COMPONENTS=-rsmi
+fi
 
 test_under_flux 1
 


### PR DESCRIPTION
Problem: On a Turing RK1 system (Rockchip RK3588 based) running Ubuntu 22.04.5, t2318-resource-verify.t segfaults when the workaround for extra GPUs introduced in 56dfdd779aa2dbf0c5cef823b9e7a6bbe0b9d45a is active, i.e. HWLOC_COMPONENTS=-rsmi is set in the environment.

Since the workaround is only required on RSMI systems, only set the environment variable if the string "rsmi" appears in hwloc-ls output.