### PR TITLE
testsuite: prevent lstopo window pop-up

### DIFF
--- a/t/t2318-resource-verify.t
+++ b/t/t2318-resource-verify.t
@@ -11,7 +11,7 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 # with "extra" GPUs. Since we're not testing GPU detection here, just
 # disable the rsmi component of HWLOC when used to avoid the issue.
 # (This needs to be done before test_under_flux is called)
-if hwloc-ls | grep rsmi >/dev/null 2>&1; then
+if hwloc-ls --of console | grep rsmi >/dev/null 2>&1; then
     export HWLOC_COMPONENTS=-rsmi
 fi
 


### PR DESCRIPTION
Problem: the `hwloc-ls` call recently added to `t2318-resource-verify.t` triggers an lstopo window pop-up on some systems.

This was observed on a system derived from Ubuntu 22.04. It does not happen on RHEL 8 based systems.

Add `--of console` to force console (stdout) mode.