### PR TITLE
configure: force bash completions to observe `--prefix`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -433,6 +433,7 @@ PKG_CHECK_MODULES([CURSES], [ncursesw], [], [])
 PKG_CHECK_MODULES([LIBARCHIVE], [libarchive], [], [])
 PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion], [
     bashcompdir="`$PKG_CONFIG \
+        --define-variable=prefix=${prefix} \
         --define-variable=datadir=${datadir} \
         --variable=completionsdir bash-completion`"
 ], [


### PR DESCRIPTION
Problem: on some of our rhel8 systems, the configure-generated `bashcompdir` variable references the system `datadir` and therefore the system `/etc` directories, even when an explicit prefix is specified.

Force `bashcompdir` to observe the prefix if set on the command line.

Fixes #7268