### PR TITLE
libflux: rename internal functions for tracing

### DIFF
--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -73,7 +73,7 @@ libflux_la_SOURCES = \
 	watcher.c \
 	watcher_private.h \
 	watcher_wrap.c \
-	hwatcher.c \
+	watcher_handle.c \
 	msg_handler.c \
 	message.c \
 	message_private.h \


### PR DESCRIPTION
Problem: `hwatcher_prepare_cb()` and `hwatcher_check_cb()` appeared in a perf trace while debugging #7307, but poor function naming made the trace less intuitive than it could have been.

Rename the handle watcher internal functions, replacing `hwatcher_` with `handle_watcher`.

Rename the source file from `hwatcher.c` to `watcher_handle.c`, following the pattern of other watcher source files in libflux.