### PR TITLE
shell: fix stderr flow control bug

### DIFF
--- a/src/shell/output/client.c
+++ b/src/shell/output/client.c
@@ -115,11 +115,11 @@ static void output_client_control (struct output_client *client, bool stop)
 
             if (stop) {
                 flux_subprocess_stream_stop (p, "stdout");
-                flux_subprocess_stream_stop (p, "stdout");
+                flux_subprocess_stream_stop (p, "stderr");
             }
             else {
                 flux_subprocess_stream_start (p, "stdout");
-                flux_subprocess_stream_start (p, "stdout");
+                flux_subprocess_stream_start (p, "stderr");
             }
             task = flux_shell_task_next (client->shell);
         }


### PR DESCRIPTION
Problem: the shell output plugin implements flow control but due to a typo, only stops/starts stdout leaving stderr uncontrolled.

Fix typo.

Fixes #7307