### PR TITLE
libsubprocess/test: add test instrumentation

### DIFF
--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -803,7 +803,7 @@ void bg_test (flux_t *h,
         "%s: flux_rpc_get_unpack returned successfully",
         label);
     ok (status == expected_status,
-        "%s: got expected status (got 0x%04x, expected 0x%04x",
+        "%s: got expected status (got 0x%04x, expected 0x%04x)",
         label,
         status,
         expected_status);

--- a/src/common/libsubprocess/test/stdio.c
+++ b/src/common/libsubprocess/test/stdio.c
@@ -1444,10 +1444,11 @@ void credit_output_cb (flux_subprocess_t *p, const char *stream)
 
         sprintf (cmpbuf, "abcdefghijklmnopqrstuvwxyz0123456789\n");
         ok (streq (outputbuf, cmpbuf),
-            "flux_subprocess_read returned correct data");
+            "flux_subprocess_read returned correct data: %s", outputbuf);
         /* 26 (ABCs) + 10 (1-10) + 1 for `\n' */
         ok (outputbuf_len == (26 + 10 + 1),
-            "flux_subprocess_read returned correct amount of data");
+            "flux_subprocess_read returned correct amount of data: %d",
+            outputbuf_len);
     }
     stdout_output_cb_count++;
 }


### PR DESCRIPTION
Problem: A credit test in test/stdio.c is failing occasionally in CI, but there is little clue why.

Add a little extra debug output to help try and solve the problem.