### PR TITLE
sdexec: fix false unit not started error

### DIFF
--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -401,6 +401,18 @@ test_expect_success 'sdexec sets FLUX_URI to local broker' '
 	$sdexec -r 1 $printenv FLUX_URI >uri.out &&
 	test_must_fail test_cmp uri.exp uri.out
 '
+test_expect_success 'sdexec handles task exit 127' '
+	test_expect_code 127 $sdexec -r 0 /bin/sh -c "exit 127"
+'
+test_expect_success 'sdexec handles task exit 199' '
+	test_expect_code 199 $sdexec -r 0 /bin/sh -c "exit 199"
+'
+test_expect_success 'sdexec handles task exit 244' '
+	test_expect_code 244 $sdexec -r 0 /bin/sh -c "exit 244"
+'
+test_expect_success 'sdexec handles task exit 255' '
+	test_expect_code 255 $sdexec -r 0 /bin/sh -c "exit 255"
+'
 test_expect_success 'sdexec reconfig fails with bad sdexec-debug value' '
 	test_must_fail flux config load <<-EOT 2>config.err &&
 	[systemd]


### PR DESCRIPTION
Problem: some task exit codes (like 255) are incorrectly interpreted as systemd errors.

The check for systemd reserved error code is too broad.  Fix that, and add tests.
