### PR TITLE
libsubprocess: fix test portability issue on macos

### DIFF
--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -815,7 +815,7 @@ void background_waitable_test (flux_t *h)
     char *cmd_noexist[] = { "/noexist", NULL };
     char *cmd_true[] = { "true", NULL };
     char *cmd_false[] = { "false", NULL };
-    char *cmd_sleep[] = { "sleep", "inf", NULL };
+    char *cmd_sleep[] = { "sleep", "30", NULL };
     bg_test (h, "noexist", 1, cmd_noexist, -ENOENT, false);
     bg_test (h, "success", 1, cmd_true, 0, false);
     bg_test (h, NULL, 1, cmd_true, 0, false);


### PR DESCRIPTION
Problem: A test in `libsubprocess/test/remote.c` uses "sleep inf" to test background process signaling, but "inf" is a GNU extension not supported by macOS sleep. The test usually passes by chance because the sleep process is typically terminated before it can parse its arguments and exit with an error. However, when the process does start in time to check its arguments, the test fails with:

 not ok 129 - sleep: got expected status (got 0x0100, expected 0x000f)

Replace "inf" with "30" seconds, which is portable across all sleep implementations.

Fixes #7301