### PR TITLE
shell: fix output flow control bug

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -363,6 +363,21 @@ plugins include:
   Set the mode in which output files are opened to either truncate or
   append. The default is to truncate.
 
+.. option:: output.client.{lwm,hwm}=N
+
+  Set the high and low watermark values used for output flow control
+  when output is being aggregated on the leader shell.  Output is aggregated
+  by default, unless it is redirected to per-rank local files.
+
+  Flow control limits the growth of message backlogs on the leader shell.
+  The option values represent a count of unacknowledged messages sent to the
+  leader shell by the local shell.  When the high watermark is reached,
+  task output handling is stopped, potentially stalling tasks once their
+  local output buffers are exhausted.  When the number of messages drops
+  to the low watermark, task output handling resumes.
+
+  The default values of 100 and 1000 should be adequate in most cases.
+
 .. option:: input.stdin.type=TYPE
 
   Set job input for **stdin** to *TYPE*. *TYPE* may be either ``service``

--- a/src/shell/output/client.c
+++ b/src/shell/output/client.c
@@ -17,7 +17,7 @@
  * Notes:
  *  - Errors from write requests to leader shell are logged.
  *  - Outstanding RPCs at shell exit are waited for synchronously.
- *  - Number of in-flight write RPCs is limited by shell_output_hwm
+ *  - Number of in-flight write RPCs is limited by client->hwm
  *    to avoid matchtag exhaustion.
  */
 #if HAVE_CONFIG_H
@@ -35,14 +35,13 @@
 #include "info.h"
 #include "output/client.h"
 
-static const int shell_output_lwm = 100;
-static const int shell_output_hwm = 1000;
-
 struct output_client {
     flux_shell_t *shell;
     int shell_rank;
     bool stopped;
     zlist_t *pending_writes;
+    int lwm;
+    int hwm;
 };
 
 static void client_send_eof (struct output_client *client)
@@ -89,7 +88,9 @@ void output_client_destroy (struct output_client *client)
     }
 }
 
-struct output_client *output_client_create (flux_shell_t *shell)
+struct output_client *output_client_create (flux_shell_t *shell,
+                                            int client_lwm,
+                                            int client_hwm)
 {
     struct output_client *client;
     if (!(client = calloc (1, sizeof (*client)))
@@ -97,6 +98,8 @@ struct output_client *output_client_create (flux_shell_t *shell)
         goto out;
     client->shell = shell;
     client->shell_rank = shell->info->shell_rank;
+    client->lwm = client_lwm;
+    client->hwm = client_hwm;
     return client;
 out:
     output_client_destroy (client);
@@ -124,6 +127,7 @@ static void output_client_control (struct output_client *client, bool stop)
             task = flux_shell_task_next (client->shell);
         }
         client->stopped = stop;
+        shell_debug ("flow control %s", stop ? "stop" : "start");
     }
 }
 
@@ -135,7 +139,7 @@ static void output_send_cb (flux_future_t *f, void *arg)
     zlist_remove (client->pending_writes, f);
     flux_future_destroy (f);
 
-    if (zlist_size (client->pending_writes) <= shell_output_lwm)
+    if (zlist_size (client->pending_writes) <= client->lwm)
         output_client_control (client, false);
 }
 
@@ -157,7 +161,7 @@ int output_client_send (struct output_client *client,
         goto error;
     if (zlist_append (client->pending_writes, f) < 0)
         shell_log_error ("failed to append pending write");
-    if (zlist_size (client->pending_writes) >= shell_output_hwm)
+    if (zlist_size (client->pending_writes) >= client->hwm)
         output_client_control (client, true);
     return 0;
 error:

--- a/src/shell/output/client.c
+++ b/src/shell/output/client.c
@@ -123,6 +123,7 @@ static void output_client_control (struct output_client *client, bool stop)
             }
             task = flux_shell_task_next (client->shell);
         }
+        client->stopped = stop;
     }
 }
 

--- a/src/shell/output/client.h
+++ b/src/shell/output/client.h
@@ -18,7 +18,9 @@
 #include <flux/core.h>
 #include <flux/shell.h>
 
-struct output_client *output_client_create (flux_shell_t *shell);
+struct output_client *output_client_create (flux_shell_t *shell,
+                                            int client_lwm,
+                                            int client_hwm);
 
 void output_client_destroy (struct output_client *client);
 

--- a/src/shell/output/conf.h
+++ b/src/shell/output/conf.h
@@ -25,6 +25,8 @@ struct output_stream {
     const char *buffer_type;
     const char *template;
     const char *mode;
+    int client_lwm;
+    int client_hwm;
     bool label;
     bool per_shell;
 };

--- a/src/shell/output/output.c
+++ b/src/shell/output/output.c
@@ -244,9 +244,14 @@ struct shell_output *shell_output_create (flux_plugin_t *p,
          */
         kvs_output_flush (out->kvs);
     }
-    else if (!(out->client = output_client_create (shell))) {
-        shell_log_errno ("failed to create output service client");
-        goto error;
+    else {
+        int lwm = out->conf->out.client_lwm;
+        int hwm = out->conf->out.client_hwm;
+
+        if (!(out->client = output_client_create (shell, lwm, hwm))) {
+            shell_log_errno ("failed to create output service client");
+            goto error;
+        }
     }
     return out;
 error:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -216,6 +216,7 @@ TESTSCRIPTS = \
 	t2603-job-shell-initrc.t \
 	t2604-job-shell-affinity.t \
 	t2606-job-shell-output-redirection.t \
+	t2606-job-shell-output-flow.t \
 	t2607-job-shell-input.t \
 	t2608-job-shell-log.t \
 	t2609-job-shell-events.t \

--- a/t/t2606-job-shell-output-flow.t
+++ b/t/t2606-job-shell-output-flow.t
@@ -1,0 +1,66 @@
+#!/bin/sh
+#
+test_description='Test flux-shell output flow control'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 4 job
+
+test_expect_success 'negative output.client.lwm fails' '
+	test_must_fail flux run -o output.client.lwm=-1 true
+'
+test_expect_success 'negative output.client.hwm fails' '
+	test_must_fail flux run -o output.client.hwm=-1 true
+'
+test_expect_success 'output.client.hwm = output.client.lwm fails' '
+	test_must_fail flux run \
+	    -o output.client.lwm=1 -o output.client.hwm=1 true
+'
+test_expect_success 'output.client.hwm < output.client.lwm fails' '
+	test_must_fail flux run \
+	    -o output.client.lwm=2 -o output.client.hwm=1 true
+'
+test_expect_success 'run a job that generates stdout on all ranks' '
+	flux run -N4 -l -o verbose \
+	    flux lptest >simple.out 2>simple.err
+'
+test_expect_success 'now do stdout with a tiny output.client.hwm/lwm' '
+	flux run -N4 -l -o verbose -o \
+	    output.client.lwm=1 -o output.client.hwm=10 \
+	    flux lptest >simple_flow.out 2>simple_flow.err
+'
+test_expect_success 'flow control stop and start occurred' '
+	test_debug "grep output simple_flow.err" &&
+	grep -q "flow control stop" simple_flow.err &&
+	grep -q "flow control start" simple_flow.err
+'
+test_expect_success 'no output was lost' '
+	test_debug "ls -l simple.out simple_flow.out" &&
+	sort <simple.out >simple.out.sorted &&
+	sort <simple_flow.out >simple_flow.out.sorted &&
+	test_cmp simple.out.sorted simple_flow.out.sorted
+'
+test_expect_success 'stderr has flow control as well' '
+	flux run -N4 -l -o verbose -o \
+	    output.client.lwm=1 -o output.client.hwm=10 \
+	    sh -c "flux lptest >&2" 2>err_flow.err &&
+	grep -q "flow control stop" err_flow.err &&
+	grep -q "flow control start" err_flow.err
+'
+test_expect_success 'run a job with output.client.lwm=0' '
+	flux run -N4 -l -o verbose -o \
+	    output.client.lwm=0 -o output.client.hwm=10 \
+	    flux lptest >zero.out 2>zero.err
+'
+test_expect_success 'flow control stop and start occurred' '
+	test_debug "grep output zero.err" &&
+	grep -q "flow control stop" zero.err &&
+	grep -q "flow control start" zero.err
+'
+test_expect_success 'no output was lost' '
+	test_debug "ls -l simple.out zero.out" &&
+	sort <zero.out >zero.out.sorted &&
+	test_cmp simple.out.sorted zero.out.sorted
+'
+
+test_done


### PR DESCRIPTION
Problem: shell output never resumes once flow control stops it.

A flag variable in `output_client_control()` is not being set to record the the stop, so a start is treated as a no-op.

Set the flag when the state changes.

Fixes #7319