### PR TITLE
flux-pmi: add --timeout option

### DIFF
--- a/doc/man1/flux-pmi.rst
+++ b/doc/man1/flux-pmi.rst
@@ -37,6 +37,13 @@ OPTIONS
    Trace PMI operations.  This is equivalent to setting
    :envvar:`FLUX_PMI_DEBUG` in the broker environment.
 
+.. option:: -t, --timeout=FSD
+
+   Specify a timeout for the requested PMI operation(s) in RFC 23 Flux
+   Standard Duration format, e.g. "0.1s" or "32m".
+   If the timeout expires, the command exits with an error code.
+   Default: no timeout.
+
 .. option:: --method=URI
 
    Specify the PMI method to use, where the scheme portion of the URI specifies

--- a/doc/man1/flux-pmi.rst
+++ b/doc/man1/flux-pmi.rst
@@ -78,15 +78,18 @@ barrier
 
 .. program:: flux pmi barrier
 
-:program:`flux pmi barrier` does the following:
+:program:`flux pmi barrier` executes a PMI barrier and prints a message
+on rank 0 upon completion.
 
-  #. Execute PMI barrier
-  #. Execute PMI barrier
-  #. Print elapsed time of (2)
+.. option:: --test-timing
+
+  First execute a preliminary barrier to ensure all ranks enter the test
+  barrier at the same time, then execute a test barrier and print the elapsed
+  time for the test barrier on rank 0 stdout.
 
 .. option:: --test-count=N
 
-  Execute N barrier (step 2) operations (default 1).
+  Execute N barrier operations (default 1).
 
 .. option:: --test-abort=RANK
 

--- a/doc/man1/flux-pmi.rst
+++ b/doc/man1/flux-pmi.rst
@@ -84,14 +84,14 @@ barrier
   #. Execute PMI barrier
   #. Print elapsed time of (2)
 
-.. option:: --count=N
+.. option:: --test-count=N
 
   Execute N barrier (step 2) operations (default 1).
 
-.. option:: --abort=RANK
+.. option:: --test-abort=RANK
 
   Instead of entering the barrier, arrange for RANK to call the PMI
-  abort function.
+  abort function.  This option is intended for testing only.
 
 exchange
 --------

--- a/src/cmd/builtin/pmi.c
+++ b/src/cmd/builtin/pmi.c
@@ -59,8 +59,8 @@ static int internal_cmd_get (optparse_t *p, int argc, char *argv[])
 static int internal_cmd_barrier (optparse_t *p, int argc, char *argv[])
 {
     int n = optparse_option_index (p);
-    int count = optparse_get_int (p, "count", 1);
-    int abort = optparse_get_int (p, "abort", -1);
+    int count = optparse_get_int (p, "test-count", 1);
+    int test_abort = optparse_get_int (p, "test-abort", -1);
     struct timespec t;
     const char *label;
     flux_error_t error;
@@ -80,9 +80,9 @@ static int internal_cmd_barrier (optparse_t *p, int argc, char *argv[])
     if (upmi_barrier (upmi, &error) < 0)
         log_msg_exit ("barrier: %s", error.text);
 
-    // abort one rank if --abort was specified
-    if (abort != -1) {
-        if (info.rank == abort) {
+    // abort one rank if --test-abort was specified
+    if (test_abort != -1) {
+        if (info.rank == test_abort) {
             flux_error_t e;
             errprintf (&e, "flux-pmi: rank %d is aborting", info.rank);
             if (upmi_abort (upmi, e.text, &error) < 0) {
@@ -227,10 +227,10 @@ static int cmd_pmi (optparse_t *p, int argc, char *argv[])
 }
 
 static struct optparse_option barrier_opts[] = {
-    { .name = "count",      .has_arg = 1, .arginfo = "N",
-       .usage = "Execute N barrier operations (default 1)", },
-    { .name = "abort",      .has_arg = 1, .arginfo = "RANK",
-       .usage = "RANK calls abort instead of barrier", },
+    { .name = "test-count",      .has_arg = 1, .arginfo = "N",
+       .usage = "For testing, execute N barrier operations (default 1)", },
+    { .name = "test-abort",      .has_arg = 1, .arginfo = "RANK",
+       .usage = "For testing, RANK calls abort instead of barrier", },
     OPTPARSE_TABLE_END,
 };
 static struct optparse_option get_opts[] = {

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -163,13 +163,13 @@ test_expect_success 'flux-pmi barrier works' '
 	flux run --label-io -n2 \
 	    flux pmi barrier
 '
-test_expect_success 'flux-pmi barrier --count works' '
+test_expect_success 'flux-pmi barrier --test-count works' '
 	flux run --label-io -n2 \
-	    flux pmi barrier --count=2
+	    flux pmi barrier --test-count=2
 '
-test_expect_success 'flux-pmi barrier --abort works' '
+test_expect_success 'flux-pmi barrier --test-abort works' '
 	test_expect_code 143 flux run --label-io -n2 \
-	    flux pmi barrier --abort=1 2>barrier_abort.err &&
+	    flux pmi barrier --test-abort=1 2>barrier_abort.err &&
 	grep -i abort barrier_abort.err
 '
 test_expect_success 'flux-pmi exchange works' '
@@ -237,7 +237,7 @@ test_expect_success 'flux-pmi --method=libpmi barrier works w/ flux libpmi.so' '
 '
 test_expect_success 'flux-pmi --method=libpmi barrier abort works w/ flux libpmi.so' '
 	test_expect_code 143 flux run -n2 bash -c "\
-	    flux pmi -v --method=libpmi:$(cat libpmi) barrier --abort 1"
+	    flux pmi -v --method=libpmi:$(cat libpmi) barrier --test-abort 1"
 '
 test_expect_success 'flux-pmi --method=libpmi exchange works w/ flux libpmi.so' '
 	flux run -n2 bash -c "\
@@ -272,7 +272,7 @@ test_expect_success 'flux-pmi --method=libpmi2 barrier works w/ flux pmi lib' '
 '
 test_expect_success 'flux-pmi --method=libpmi2 barrier works w/ flux pmi lib' '
 	test_expect_code 143 flux run -n2 bash -c "\
-	    flux pmi -v --method=libpmi2:$(cat libpmi2) barrier --abort 1"
+	    flux pmi -v --method=libpmi2:$(cat libpmi2) barrier --test-abort 1"
 '
 test_expect_success 'flux-pmi --method=libpmi2 exchange works w/ flux pmi lib' '
 	flux run -n2 bash -c "\

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -161,15 +161,15 @@ test_expect_success 'PMI1 can calculate clique ranks with 128 tasks per node' '
 
 test_expect_success 'flux-pmi barrier works' '
 	flux run --label-io -n2 \
-	    flux pmi barrier
+	    flux pmi barrier --test-timing
 '
 test_expect_success 'flux-pmi barrier --test-count works' '
 	flux run --label-io -n2 \
-	    flux pmi barrier --test-count=2
+	    flux pmi barrier --test-timing --test-count=2
 '
 test_expect_success 'flux-pmi barrier --test-abort works' '
 	test_expect_code 143 flux run --label-io -n2 \
-	    flux pmi barrier --test-abort=1 2>barrier_abort.err &&
+	    flux pmi barrier --test-timing --test-abort=1 2>barrier_abort.err &&
 	grep -i abort barrier_abort.err
 '
 test_expect_success 'flux-pmi exchange works' '
@@ -197,7 +197,7 @@ test_expect_success 'flux-pmi get works with multiple keys' '
 	    flux pmi get flux.instance-level PMI_process_mapping
 '
 test_expect_success 'flux-pmi works outside of job' '
-	flux pmi -v --libpmi-noflux barrier
+	flux pmi -v --libpmi-noflux barrier --test-timing
 '
 test_expect_success 'flux-pmi fails with bad subcommand' '
 	test_must_fail flux run flux pmi notacmd
@@ -217,7 +217,8 @@ test_expect_success 'flux-pmi --method=simple fails outside of job' '
 	test_must_fail flux pmi --method=simple barrier
 '
 test_expect_success 'flux-pmi -v --method=simple works within job' '
-	flux run --label-io -n2 flux pmi -v --method=simple barrier
+	flux run --label-io -n2 \
+	    flux pmi -v --method=simple barrier --test-timing
 '
 test_expect_success 'flux-pmi -opmi=off --method=simple fails' '
 	test_must_fail flux run -o pmi=off \
@@ -233,7 +234,7 @@ test_expect_success 'flux-pmi --method=libpmi:/bad/path fails' '
 '
 test_expect_success 'flux-pmi --method=libpmi barrier works w/ flux libpmi.so' '
 	flux run -n2 bash -c "\
-	    flux pmi -v --method=libpmi:$(cat libpmi) barrier"
+	    flux pmi -v --method=libpmi:$(cat libpmi) barrier --test-timing"
 '
 test_expect_success 'flux-pmi --method=libpmi barrier abort works w/ flux libpmi.so' '
 	test_expect_code 143 flux run -n2 bash -c "\


### PR DESCRIPTION
Problem: flux-pmi doesn't have a built-in timeout, but that could be handy.

Add a (general) `--timeout=FSD` option.  If the timer expires, the command fails.  This would be used like
```
flux pmi --timeout=35m barrier
```

It comes before the `barrier` subcommand because it can apply to any subcommand.

Also, since `flux pmi barrier` is  getting used outside of the test environment
- Don't do barrier timing (which has overhead) unless a new `--test-timing` option is specified
- Rename `--count` to `--test-count`
- Rename `--abort` to `--test-abort`

to make it clear that those options probably aren't useful in the real world.