### PR TITLE
flux-job: fix rare hang in attach with interactive pty

### DIFF
--- a/t/scripts/runpty.py
+++ b/t/scripts/runpty.py
@@ -159,7 +159,7 @@ def parse_args():
         default="",
     )
     parser.add_argument(
-        "--line-buffer", help="Attempt to line buffer theoutput", action="store_true"
+        "--line-buffer", help="Attempt to line buffer the output", action="store_true"
     )
     parser.add_argument("COMMAND")
     parser.add_argument("ARGS", nargs=argparse.REMAINDER)

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -13,7 +13,7 @@ FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"
 
 INITRC_TESTDIR="${SHARNESS_TEST_SRCDIR}/shell/initrc"
 INITRC_PLUGINPATH="${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs"
-runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast"
+runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast -t SIGKILL@1m"
 waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
 
 shell_leader_rank() {


### PR DESCRIPTION
This PR fixes a potential hang in `flux job attach` with an interactive pty when the job shell is in the process of exiting. This was the likely cause of #7301, since in that test two invocations of `flux job attach` are run in quick succession (the 2nd was the cause of the hangs)

Additionally, some timeouts are added to `t2612-job-shell-pty.t` to turn any future hangs into errors.