### PR TITLE
broker: skip `$SHELL -c` wrapper for executable files

### DIFF
--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -546,6 +546,7 @@ test_expect_success 'rexec: server shutdown works with zombie processes' '
 	#!/bin/bash
 	# Start instance with subprocess server
 	cat <<-EOF2 >shutdown-test.sh &&
+		#!/bin/bash
 		# Create zombie processes
 		flux exec -r 0 --bg --waitable --label=z1 sleep 0
 		flux exec -r 0 --bg --waitable --label=z2 sleep 0

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -657,6 +657,7 @@ test_expect_success 'flux job: timeleft -H works with time limit' '
 '
 test_expect_success 'flux job: timeleft works under alloc (and job)' '
 	cat <<-EOF >test.sh &&
+	#!/bin/sh
 	flux job timeleft > timeleft3
 	flux run flux job timeleft > timeleft4
 	EOF

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -533,10 +533,12 @@ test_expect_success 'flux-queue: stop with named queues and --nocheckpoint works
 	[queues.batch]
 	EOT
 	cat >stopqueues.sh <<-EOT &&
+	#!/bin/sh
 	flux queue start --all
 	flux queue stop --all
 	EOT
 	cat >stopqueuesnocheckpoint.sh <<-EOT &&
+	#!/bin/sh
 	flux queue start --all
 	flux queue stop --all --nocheckpoint
 	EOT


### PR DESCRIPTION
This PR implements a small optimization in the broker runat logic to skip the `$SHELL -c` wrapper if the provided command line:
 - contains no whitespace
 - points to a regular file
 - the file is executable

In this case interpreting the "command line" by the shell is unnecessary so skip it.

This works around the issue reported in #7330 since there won't be an extra `tcsh` parent for batch scripts.

As noted in #7330, this will make it an error to point rc2 at an executable script that doesn't have a shebang, whereas that works now. I don't think this will be an issue, but it did require fixing a few autogenerated scripts in the testsuite.