### PR TITLE
ci: update python version for use with coverage tool

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,6 +186,14 @@ jobs:
         git fetch -f origin ${{ github.ref }}:${{ github.ref }} ;
         echo git describe now reports $(git describe --always)
 
+    - name: setup python
+      env: ${{matrix.env}}
+      if: matrix.coverage
+      uses: actions/setup-python@v5
+      with:
+        # Use python3.12 to ensure compatbility with coverage tool:
+        python-version: '3.12'
+
     - name: coverage setup
       env: ${{matrix.env}}
       if: matrix.coverage


### PR DESCRIPTION
Problem: In github ci, the coverage report is failing with the error:
```
  Traceback (most recent call last):
   File "/home/runner/.local/bin/coverage", line 5, in <module>
     sys.argv[0] = sys.argv[0].removesuffix('.exe')
   AttributeError: 'str' object has no attribute 'removesuffix'
```
which indicates that the coverage tool requires Python >= 3.9, but this is not available in the runner.

Install Python3.12 in the github runner when coverage is enabled to avoid the error.

This will need to be manually merged.