### PR TITLE
broker: drop FLUX_FAKE_HOSTNAME environment variable

### DIFF
--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -166,10 +166,10 @@ OPTIONS
 
 .. option:: --test-hosts=HOSTLIST
 
-   Set :envvar:`FLUX_FAKE_HOSTNAME` in the environment of each broker so that
-   the broker can bootstrap from a config file instead of PMI.  HOSTLIST is
-   assumed to be in rank order.  The broker will use the fake hostname to
-   find its entry in the configured bootstrap host array.
+   Set the hostname attribute of each broker so that it can bootstrap from
+   a config file instead of PMI.  HOSTLIST is assumed to be in rank order.
+   The broker will use this hostname to find its entry in the configured
+   bootstrap host array.
 
 .. option:: --test-exit-timeout=FSD
 

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -104,6 +104,11 @@ hostlist :ref:`[readonly] <attr_readonly>`
    An RFC 29 hostlist in broker rank order.  This value may be used to
    translate between broker ranks and hostnames.
 
+hostname
+   The system hostname.  This attribute is set on the broker command line by
+   :option:`flux start --test-hosts`, which is useful in certain test
+   scenarios.
+
 broker.mapping :ref:`[readonly] <attr_readonly>`
    A string representing the process mapping of broker ranks in the Flux
    Task Map format described in RFC 34.  For example, ``[[0,16,1,1]]`` means

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -100,7 +100,7 @@ parent-kvs-namespace :ref:`[readonly] <attr_readonly>`
    This is the KVS namespace assigned to this Flux instance by its enclosing
    instance, if it was launched by Flux as a job.
 
-hostlist :ref:`[readonly] <attr_readonly>`
+hostlist
    An RFC 29 hostlist in broker rank order.  This value may be used to
    translate between broker ranks and hostnames.
 

--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -383,17 +383,6 @@ components or writing tests.
    code that authorizes actions based on the possession of particular roles.
    This is restricted to the instance owner.
 
-.. envvar:: FLUX_FAKE_HOSTNAME
-
-   When Flux bootstraps from a configuration file as described in
-   :man5:`flux-config-bootstrap`, a :man1:`flux-broker` determines its rank
-   by looking up its own hostname in a ``hosts`` array and using the array
-   index as its rank.  To allow this to be tested on a single node,
-   :envvar:`FLUX_FAKE_HOSTNAME` may be set in the broker's environment to use
-   the specified name instead of the result of :linux:man3:`gethostname`.  Use
-   of this capability in test is simplified by the
-   :option:`flux start --test-hosts` option.
-
 .. envvar:: FLUX_HWLOC_XMLFILE
 
    Flux discovers available resources dynamically using `HWLOC

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1041,3 +1041,4 @@ builtins
 ignorefail
 noop
 readonly
+gethostbyname

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -132,7 +132,7 @@ static struct optparse_option opts[] = {
       .usage = "Start a test instance by launching N brokers locally", },
     { .group = 2,
       .name = "test-hosts", .has_arg = 1, .arginfo = "HOSTLIST",
-      .usage = "Set FLUX_FAKE_HOSTNAME in environment of each broker", },
+      .usage = "Set fake hostnames for brokers", },
     { .group = 2,
       .name = "test-exit-timeout", .has_arg = 1, .arginfo = "FSD",
       .usage = "After a broker exits, kill other brokers after timeout", },
@@ -677,6 +677,8 @@ struct client *client_create (const char *broker_path,
         goto fail;
 
     add_argzf (&argz, &argz_len, "--setattr=rundir=%s", rundir);
+    if (hostname)
+        add_argzf (&argz, &argz_len, "--setattr=hostname=%s", hostname);
 
     if (rank == 0 && cmd_argz) /* must be last arg */
         argz_append (&argz, &argz_len, cmd_argz, cmd_argz_len);
@@ -699,13 +701,8 @@ struct client *client_create (const char *broker_path,
                              1,
                              "FLUX_START_URI",
                              "local://%s/start",
-                             rundir) < 0
-        || (hostname && flux_cmd_setenvf (cli->cmd,
-                                          1,
-                                          "FLUX_FAKE_HOSTNAME",
-                                          "%s",
-                                          hostname) < 0))
-            log_err_exit ("error setting up environment for rank %d", rank);
+                             rundir) < 0)
+        log_err_exit ("error setting up environment for rank %d", rank);
     return cli;
 fail:
     ERRNO_SAFE_WRAP (free, argz);

--- a/t/issues/t4182-resource-rerank.sh
+++ b/t/issues/t4182-resource-rerank.sh
@@ -10,8 +10,8 @@ cat <<EOF2 >t4182-broker-wrapper.sh
 # Usage: t4182-broker-wrapper.sh hostlist ARGS ...
 
 hostlist=\$1; shift
-FLUX_FAKE_HOSTNAME=\$(flux hostlist --nth=\$FLUX_TASK_RANK "\$hostlist")
-flux broker -Shostlist="\$hostlist" "\$@"
+fake_hostname=\$(flux hostlist --nth=\$FLUX_TASK_RANK "\$hostlist")
+flux broker -Shostlist="\$hostlist" -Shostname="\$fake_hostname" "\$@"
 EOF2
 chmod +x t4182-broker-wrapper.sh
 
@@ -35,7 +35,7 @@ flux dmesg | grep 'sched-simple.*ready'  | tail -1
 flux resource list
 
 #  Disable rlist/hwloc resource verification
-#    --test-hosts set FLUX_FAKE_HOSTNAME but hwloc doesn't know about that
+#    --test-hosts set -Shostname but hwloc doesn't know about that
 echo "resource.noverify = true" >t4182-resource.toml
 
 #  ensure R rerank failure is ignored (i.e. job completes successfully)

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -284,8 +284,8 @@ test_expect_success NO_CHAIN_LINT 'a warning is printed when upstream URI has un
 	[[bootstrap.hosts]]
 	host = "fake1"
 	EOT
-	FLUX_FAKE_HOSTNAME=fake1 \
-		flux broker -vv -Sbroker.rc1_path= -Sbroker.rc3_path= \
+	flux broker -vv -Sbroker.rc1_path= -Sbroker.rc3_path= \
+		-Shostname=fake1 \
 		--config-path=conf8b 2>warn.err &
 	echo $! >warn.pid &&
 	waitgrep "unable to resolve upstream peer" warn.err 30

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -210,7 +210,7 @@ test_expect_success 'create initial program for testing' '
 
 test_expect_success 'start size=2 instance with ipc://' '
 	BINDDIR=$(mktemp -d) &&
-	test_when_finished "rm -rf $BINDIR" &&
+	test_when_finished "rm -rf $BINDDIR" &&
 	mkdir conf8 &&
 	cat <<-EOT >conf8/bootstrap.toml &&
 	[bootstrap]
@@ -232,7 +232,6 @@ test_expect_success 'start size=2 instance with ipc://' '
 	EXP
 	test_cmp ipc.exp ipc.out
 '
-
 test_expect_success 'start size=3 instance with ipc:// and custom topology' '
 	BINDDIR=$(mktemp -d) &&
 	test_when_finished "rm -rf $BINDIR" &&


### PR DESCRIPTION
Problem: the FLUX_FAKE_HOSTNAME environment variable is used to implement `flux start --test-hosts=HOSTLIST`, but since that was implemented, a broker attribute named `hostname` was added.

It probably makes sense at this point to just allow `hostname` to be set on the broker command line and drop the environment variable.

Do that and update users.

If this is used in other projects at all, it is most likely via the `flux start --test-hosts` interface.