### PR TITLE
testsuite: tidy up broker logging configuration

### DIFF
--- a/t/t0015-cron.t
+++ b/t/t0015-cron.t
@@ -10,9 +10,7 @@ RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 # Size the session to one more than the number of cores, minimum of 4
 SIZE=4
-test_under_flux ${SIZE} minimal
-
-flux setattr log-stderr-level 1
+test_under_flux ${SIZE} minimal -Slog-stderr-level=1
 
 cron_entry_check() {
     local id=$1

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -32,9 +32,7 @@ export FLUX_TEST_DISABLE_TIMEOUT=t
 export LD_PRELOAD=libfaketimeMT.so.1
 export FAKETIME_NO_CACHE=1
 export FAKETIME_TIMESTAMP_FILE=$(pwd)/faketimerc
-test_under_flux ${SIZE} minimal
-
-flux setattr log-stderr-level 1
+test_under_flux ${SIZE} minimal -Slog-stderr-level=1
 
 cron_entry_check() {
     local id=$1

--- a/t/t0040-flux-sproc.t
+++ b/t/t0040-flux-sproc.t
@@ -4,9 +4,7 @@ test_description='Test flux-sproc command'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 2
-
-flux setattr log-stderr-level 1
+test_under_flux 2 full -Slog-stderr-level=1
 
 # Usage: wait_for_state RANK STATE COUNT
 #

--- a/t/t2100-job-ingest.t
+++ b/t/t2100-job-ingest.t
@@ -9,9 +9,7 @@ if ${FLUX_BUILD_DIR}/t/ingest/submitbench --help 2>&1 | grep -q sign-type; then
     SUBMITBENCH_OPT_R="--reuse-signature"
 fi
 
-test_under_flux 4 kvs
-
-flux setattr log-stderr-level 1
+test_under_flux 4 kvs -Slog-stderr-level=1
 
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
 Y2J="flux python ${JOBSPEC}/y2j.py"

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -3,9 +3,7 @@ test_description='Test job validator'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
 Y2J="flux python ${JOBSPEC}/y2j.py"

--- a/t/t2111-job-ingest-config.t
+++ b/t/t2111-job-ingest-config.t
@@ -13,9 +13,7 @@ cat <<EOF >conf.d/ingest.toml
 disable = true
 EOF
 
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 SUBMITBENCH="${FLUX_BUILD_DIR}/t/ingest/submitbench"
 dmesg_grep=${SHARNESS_TEST_SRCDIR}/scripts/dmesg-grep.py

--- a/t/t2112-job-ingest-frobnicator.t
+++ b/t/t2112-job-ingest-frobnicator.t
@@ -10,9 +10,7 @@ cat <<EOF >conf.d/conf.toml
 [policy.jobspec.defaults.system]
 duration = "30m"
 EOF
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 JOBSPEC=${SHARNESS_TEST_SRCDIR}/jobspec
 Y2J="flux python ${JOBSPEC}/y2j.py"

--- a/t/t2113-job-ingest-pipeline.t
+++ b/t/t2113-job-ingest-pipeline.t
@@ -3,9 +3,7 @@ test_description='Test job ingest pipeline'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 1 full
-
-flux setattr log-stderr-level 1
+test_under_flux 1 full -Slog-stderr-level=1
 
 test_expect_success 'no workers are running at the start' '
 	flux module stats job-ingest >stats.out &&

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -24,9 +24,7 @@ MINJOBID_WORDS="academy-academy-academy--academy-academy-academy"
 MINJOBID_F58="f1"
 MINJOBIDS_LIST="$MINJOBID_DEC $MINJOBID_HEX $MINJOBID_KVS $MINJOBID_DOTHEX $MINJOBID_WORDS $MINJOBID_F58"
 
-test_under_flux 2 job
-
-flux setattr log-stderr-level 1
+test_under_flux 2 job -Slog-stderr-level=1
 
 # Other tests may refer to $(cat inactivejob) for inactive job id
 test_expect_success 'create one inactive job' '

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -6,9 +6,7 @@ test_description='Test flux job manager service'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 4 kvs
-
-flux setattr log-stderr-level 1
+test_under_flux 4 kvs -Slog-stderr-level=1
 
 DRAIN_CANCEL="flux python ${FLUX_SOURCE_DIR}/t/job-manager/drain-cancel.py"
 RPC=${FLUX_BUILD_DIR}/t/request/rpc

--- a/t/t2203-job-manager-single.t
+++ b/t/t2203-job-manager-single.t
@@ -7,9 +7,7 @@ test_description='Test flux job manager service with sched-simple (single)'
 . $(dirname $0)/sharness.sh
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
-test_under_flux 2 job
-
-flux setattr log-stderr-level 1
+test_under_flux 2 job -Slog-stderr-level=1
 
 # N.B. we will fake with different resources later on in this file, thus
 # the need to set resources manually instead of through test_under_flux()

--- a/t/t2204-job-manager-limited.t
+++ b/t/t2204-job-manager-limited.t
@@ -8,9 +8,7 @@ test_description='Test flux job manager service with sched-simple (limited)'
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=2"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'job-manager: submit 5 jobs' '
         flux submit --log=job{cc}.id --cc="1-5" --flags=debug -n1 \

--- a/t/t2205-job-manager-unlimited.t
+++ b/t/t2205-job-manager-unlimited.t
@@ -8,9 +8,7 @@ test_description='Test flux job manager service with sched-simple (unlimited)'
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="unlimited"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'job-manager: submit 5 jobs' '
         flux submit --log=job{cc}.id --cc="1-5" --flags=debug -n1 \

--- a/t/t2206-job-manager-annotate.t
+++ b/t/t2206-job-manager-annotate.t
@@ -7,9 +7,7 @@ test_description='Test flux job manager annotate service'
 . $(dirname $0)/sharness.sh
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'job-manager: initially run without scheduler' '
         flux module unload sched-simple

--- a/t/t2208-job-manager-wait.t
+++ b/t/t2208-job-manager-wait.t
@@ -4,7 +4,8 @@ test_description='Test flux job manager wait handling'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 1
+test_under_flux 1 full -Slog-stderr-level=1
+
 
 list_jobs=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
 SUBMIT_WAIT="flux python ${FLUX_SOURCE_DIR}/t/job-manager/submit-wait.py"
@@ -13,8 +14,6 @@ SUBMIT_SW="flux python ${FLUX_SOURCE_DIR}/t/job-manager/submit-sliding-window.py
 SUBMIT_INTER="flux python ${FLUX_SOURCE_DIR}/t/job-manager/wait-interrupted.py"
 JOB_CONV="flux python ${FLUX_SOURCE_DIR}/t/job-manager/job-conv.py"
 PRINT_CONSTANTS="${FLUX_BUILD_DIR}/t/job-manager/print-constants"
-
-flux setattr log-stderr-level 1
 
 test_job_count() {
     test $(${list_jobs} | wc -l) -eq $1

--- a/t/t2209-job-manager-bugs.t
+++ b/t/t2209-job-manager-bugs.t
@@ -5,9 +5,7 @@ test_description='Regression tests for job-manager bugs'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 1
-
-flux setattr log-stderr-level 1
+test_under_flux 1 full -Slog-stderr-level=1
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 

--- a/t/t2210-job-manager-events-journal.t
+++ b/t/t2210-job-manager-events-journal.t
@@ -6,12 +6,10 @@ test_description='Test flux job manager journal service'
 
 export FLUX_CONF_DIR=$(pwd)
 
-test_under_flux 4
+test_under_flux 4 full -Slog-stderr-level=1
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 EVENTS_JOURNAL_STREAM=${FLUX_BUILD_DIR}/t/job-manager/events_journal_stream
-
-flux setattr log-stderr-level 1
 
 test_expect_success 'flux-job: generate jobspec for simple test job' '
 	flux run --dry-run -n1 hostname >basic.json

--- a/t/t2211-job-manager-jobspec.t
+++ b/t/t2211-job-manager-jobspec.t
@@ -3,7 +3,8 @@ test_description='Checkout job manager redacted jobspec'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 1
+test_under_flux 1 full -Slog-stderr-level=1
+
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
@@ -11,8 +12,6 @@ RPC=${FLUX_BUILD_DIR}/t/request/rpc
 job_manager_getattr() {
 	echo '{"id":'$1',"attrs":["'$2'"]}' | ${RPC} job-manager.getattr
 }
-
-flux setattr log-stderr-level 1
 
 test_expect_success 'stop the queue for this test' '
 	flux queue stop

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -8,9 +8,7 @@ test_description='Test job manager jobtap plugin interface'
 
 mkdir -p config
 
-test_under_flux 4 job --config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job --config-path=$(pwd)/config -Slog-stderr-level=1
 
 PLUGINPATH=${FLUX_BUILD_DIR}/t/job-manager/plugins/.libs
 

--- a/t/t2213-job-manager-hold-single.t
+++ b/t/t2213-job-manager-hold-single.t
@@ -9,9 +9,7 @@ test_description='Test flux job manager job hold (single mode)'
 export TEST_UNDER_FLUX_CORES_PER_RANK=1
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 # N.B. resources = 1 rank, 1 core/rank
 test_expect_success 'job-manager: submit 5 jobs (job 2 held)' '

--- a/t/t2214-job-manager-hold-limited.t
+++ b/t/t2214-job-manager-hold-limited.t
@@ -8,9 +8,7 @@ test_description='Test flux job manager job hold (limited)'
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=2"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 # N.B. resources = 1 rank, 2 cores/rank
 test_expect_success 'job-manager: submit 5 jobs (job 3,4,5 held)' '

--- a/t/t2215-job-manager-hold-unlimited.t
+++ b/t/t2215-job-manager-hold-unlimited.t
@@ -8,9 +8,7 @@ test_description='Test flux job manager job hold (unlimited mode)'
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="unlimited"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 # N.B. resources = 1 rank, 2 cores/rank
 test_expect_success 'job-manager: submit 5 jobs (job 4 held)' '

--- a/t/t2216-job-manager-priority-order-single.t
+++ b/t/t2216-job-manager-priority-order-single.t
@@ -8,9 +8,7 @@ test_description='Test flux job manager urgency change to job (mode=single)'
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=1"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 # N.B. resources = 1 rank, 2 cores/rank
 test_expect_success 'job-manager: submit 4 jobs' '

--- a/t/t2217-job-manager-priority-order-limited.t
+++ b/t/t2217-job-manager-priority-order-limited.t
@@ -8,9 +8,7 @@ test_description='Test flux job manager scheduler priority ordering (limited)'
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=2"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 # N.B. resources = 1 rank, 2 cores/rank
 # flux queue stop/start to ensure no scheduling until after all jobs submitted

--- a/t/t2218-job-manager-priority-order-unlimited.t
+++ b/t/t2218-job-manager-priority-order-unlimited.t
@@ -8,9 +8,7 @@ test_description='Test flux job manager scheduler priority ordering (unlimited)'
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="unlimited"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 # N.B. resources = 1 rank, 2 cores/rank
 # flux queue stop/start to ensure no scheduling until after all jobs submitted

--- a/t/t2220-job-manager-R.t
+++ b/t/t2220-job-manager-R.t
@@ -3,7 +3,7 @@ test_description='Test job manager internal copy of R'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 1
+test_under_flux 1 full -Slog-stderr-level=1
 
 # Usage: job_manager_getattr ID ATTR
 job_manager_getattr() {
@@ -17,8 +17,6 @@ json_diff() {
 	jq --sort-keys . $2 >difftmp2 &&
 	diff difftmp1 difftmp2
 }
-
-flux setattr log-stderr-level 1
 
 test_expect_success 'submit job' '
 	flux submit -t 10s --wait-event=clean true | flux job id >jobid

--- a/t/t2221-job-manager-limit-duration.t
+++ b/t/t2221-job-manager-limit-duration.t
@@ -4,9 +4,7 @@ test_description='Test flux job manager limit-duration plugin'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 2 full
-
-flux setattr log-stderr-level 1
+test_under_flux 2 full -Slog-stderr-level=1
 
 test_expect_success 'configuring an invalid duration limit fails' '
 	test_must_fail flux config load <<-EOT

--- a/t/t2222-job-manager-limit-job-size.t
+++ b/t/t2222-job-manager-limit-job-size.t
@@ -4,9 +4,7 @@ test_description='Test flux job manager limit-job-size plugin'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 2 full
-
-flux setattr log-stderr-level 1
+test_under_flux 2 full -Slog-stderr-level=1
 
 test_expect_success 'configure an invalid job-size limit' '
 	test_must_fail flux config load <<-EOT

--- a/t/t2223-job-manager-queue-priority-order-limited.t
+++ b/t/t2223-job-manager-queue-priority-order-limited.t
@@ -8,9 +8,8 @@ test_description='Test flux job manager scheduler queue priority ordering (limit
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="limited=2"
-test_under_flux 1 job
+test_under_flux 1 job -Slog-stderr-level=1
 
-flux setattr log-stderr-level 1
 
 # N.B. resources = 1 rank, 2 cores/rank
 # flux queue stop/start to ensure no scheduling until after all jobs submitted

--- a/t/t2224-job-manager-queue-priority-order-unlimited.t
+++ b/t/t2224-job-manager-queue-priority-order-unlimited.t
@@ -8,9 +8,7 @@ test_description='Test flux job manager scheduler queue priority ordering (unlim
 
 export TEST_UNDER_FLUX_NO_JOB_EXEC=y
 export TEST_UNDER_FLUX_SCHED_SIMPLE_MODE="unlimited"
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 # N.B. resources = 1 rank, 2 cores/rank
 # flux queue stop/start to ensure no scheduling until after all jobs submitted

--- a/t/t2226-housekeeping.t
+++ b/t/t2226-housekeeping.t
@@ -3,9 +3,7 @@ test_description='Test job manager housekeeping'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 4
-
-flux setattr log-stderr-level 1
+test_under_flux 4 full -Slog-stderr-level=1
 
 # Usage: list_jobs
 list_jobs () {

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -3,9 +3,7 @@ test_description='Test flux queue command'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 1 full
-
-flux setattr log-stderr-level 1
+test_under_flux 1 full -Slog-stderr-level=1
 
 LIST_JOBS=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
 

--- a/t/t2245-policy-config.t
+++ b/t/t2245-policy-config.t
@@ -10,9 +10,7 @@ specified in RFC 33 for [policy] and [queue.<name>.policy].
 
 mkdir -p config
 
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'unknown policy key fails' '
 	test_must_fail flux config load <<-EOT

--- a/t/t2270-job-dependencies.t
+++ b/t/t2270-job-dependencies.t
@@ -9,9 +9,7 @@ test_description='Test job dependencies'
 export FLUX_CONF_DIR=$(pwd)/conf.d
 mkdir -p conf.d
 
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 PLUGINPATH=${FLUX_BUILD_DIR}/t/job-manager/plugins/.libs
 

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -6,9 +6,7 @@ test_description='Test job dependency after* support'
 
 flux version | grep -q libflux-security && test_set_prereq FLUX_SECURITY
 
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 submit_as_alternate_user()
 {

--- a/t/t2272-job-begin-time.t
+++ b/t/t2272-job-begin-time.t
@@ -4,9 +4,7 @@ test_description='Test job begin-time dependencies'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'begin-time: submit a job with begin-time +1h' '
 	DELAYED=$(flux submit --begin-time=+1h hostname) &&

--- a/t/t2273-job-alloc-bypass.t
+++ b/t/t2273-job-alloc-bypass.t
@@ -4,11 +4,10 @@ test_description='Test alloc-bypass job manager plugin'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 2 job
+test_under_flux 2 job -Slog-stderr-level=1
+
 
 flux version | grep -q libflux-security && test_set_prereq FLUX_SECURITY
-
-flux setattr log-stderr-level 1
 
 submit_as_alternate_user()
 {

--- a/t/t2274-manager-perilog-per-rank.t
+++ b/t/t2274-manager-perilog-per-rank.t
@@ -4,12 +4,10 @@ test_description='Test perilog jobtap plugin with per-rank=true'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 4 full \
+test_under_flux 4 full -Slog-stderr-level=1 \
 	--test-exit-mode=leader
 
 OFFLINE_PLUGIN=${FLUX_BUILD_DIR}/t/job-manager/plugins/.libs/offline.so
-
-flux setattr log-stderr-level 1
 
 # In case the testsuite is running as a Flux job
 unset FLUX_JOB_ID

--- a/t/t2275-job-duration-validator.t
+++ b/t/t2275-job-duration-validator.t
@@ -4,9 +4,7 @@ test_description='Test job duration validator plugin in job-manager'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 test_expect_success 'duration: no validation when there is no expiration' '
 	flux submit -t 100d true

--- a/t/t2276-job-requires.t
+++ b/t/t2276-job-requires.t
@@ -4,9 +4,7 @@ test_description='Test job constraints'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 test_expect_success 'flux run: --requires option works' '
 	flux run --dry-run \

--- a/t/t2277-dependency-singleton.t
+++ b/t/t2277-dependency-singleton.t
@@ -7,9 +7,7 @@ test_description='Test job dependency singleton support'
 
 flux version | grep -q libflux-security && test_set_prereq FLUX_SECURITY
 
-test_under_flux 2 job
-
-flux setattr log-stderr-level 1
+test_under_flux 2 job -Slog-stderr-level=1
 
 submit_as_alternate_user()
 {

--- a/t/t2280-job-memo.t
+++ b/t/t2280-job-memo.t
@@ -8,10 +8,7 @@ if flux job submit --help 2>&1 | grep -q sign-type; then
 	test_set_prereq HAVE_FLUX_SECURITY
 fi
 
-test_under_flux 1 job
-
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 runas() {
         userid=$1 && shift

--- a/t/t2290-job-update.t
+++ b/t/t2290-job-update.t
@@ -7,9 +7,7 @@ if flux job submit --help 2>&1 | grep -q sign-type; then
 	test_set_prereq HAVE_FLUX_SECURITY
 fi
 
-test_under_flux 1 job
-
-flux setattr log-stderr-level 1
+test_under_flux 1 job -Slog-stderr-level=1
 
 runas_guest() {
 	local userid=$(($(id -u)+1))

--- a/t/t2291-job-update-queue.t
+++ b/t/t2291-job-update-queue.t
@@ -7,9 +7,7 @@ if flux job submit --help 2>&1 | grep -q sign-type; then
 	test_set_prereq HAVE_FLUX_SECURITY
 fi
 
-test_under_flux 4 full
-
-flux setattr log-stderr-level 1
+test_under_flux 4 full -Slog-stderr-level=1
 
 test_expect_success 'config queues and resources' '
 	flux R encode -r 0-3 -p batch:0-2 -p debug:3 \

--- a/t/t2292-job-update-running.t
+++ b/t/t2292-job-update-running.t
@@ -7,9 +7,8 @@ if flux job submit --help 2>&1 | grep -q sign-type; then
 	test_set_prereq HAVE_FLUX_SECURITY
 fi
 
-test_under_flux 4 job
+test_under_flux 4 job -Slog-stderr-level=1
 
-flux setattr log-stderr-level 1
 export FLUX_URI_RESOLVE_LOCAL=t
 runas_guest() {
 	local userid=$(($(id -u)+1))

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -4,11 +4,9 @@ test_description='Test flux job execution service in simulated mode'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 1 job
+test_under_flux 1 job -Slog-stderr-level=1
 
 flux version | grep -q libflux-security && test_set_prereq FLUX_SECURITY
-
-flux setattr log-stderr-level 1
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 

--- a/t/t2401-job-exec-hello.t
+++ b/t/t2401-job-exec-hello.t
@@ -4,9 +4,8 @@ test_description='Test flux job exec hello protocol with multiple providers'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 1 job
+test_under_flux 1 job -Slog-stderr-level=1
 
-flux setattr log-stderr-level 1
 execservice=${SHARNESS_TEST_SRCDIR}/job-manager/exec-service.lua
 
 lastevent() { flux job eventlog $1 | awk 'END{print $2}'; }

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -13,9 +13,7 @@ if ! test -f dummy.toml; then
 fi
 
 export FLUX_CONF_DIR=$(pwd)
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 job_kvsdir()    { flux job id --to=kvs $1; }
 exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; }

--- a/t/t2407-sdbus.t
+++ b/t/t2407-sdbus.t
@@ -20,8 +20,6 @@ fi
 
 test_under_flux 2 minimal
 
-flux setattr log-stderr-level 3
-
 #
 # N.B. ListUnitsByPatterns response payload is a 'params' array whose first
 # and only item (".params[0]") is an array of units.  The jq(1) expression

--- a/t/t2408-sdbus-recovery.t
+++ b/t/t2408-sdbus-recovery.t
@@ -24,9 +24,7 @@ cat >config/config.toml <<EOF
 sdbus-debug = true
 EOF
 
-test_under_flux 1 minimal --config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 1 minimal --config-path=$(pwd)/config -Slog-stderr-level=1
 
 # Usage: bus_get_manager_prop property
 bus_get_manager_prop() {

--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -25,9 +25,7 @@ if systemctl --user show dbus | grep -q OOMPolicy=; then
 	test_set_prereq OOMPOLICY
 fi
 
-test_under_flux 2 minimal
-
-flux setattr log-stderr-level 1
+test_under_flux 2 minimal -Slog-stderr-level=1
 
 sdexec="flux exec --service sdexec"
 lptest="flux lptest"

--- a/t/t2412-sdmon.t
+++ b/t/t2412-sdmon.t
@@ -22,9 +22,7 @@ if ! busctl status >/dev/null; then
 	test_done
 fi
 
-test_under_flux 1 minimal
-
-flux setattr log-stderr-level 1
+test_under_flux 1 minimal -Slog-stderr-level=1
 
 testname="t2412-$$"
 

--- a/t/t2413-sdmon-resource.t
+++ b/t/t2413-sdmon-resource.t
@@ -30,9 +30,7 @@ enable = true
 service = "sdexec"
 EOT
 
-test_under_flux 1 full --config-path=$(pwd)/config
-
-flux setattr log-stderr-level 1
+test_under_flux 1 full --config-path=$(pwd)/config -Slog-stderr-level=1
 
 testname="t2412-$$"
 

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -4,9 +4,7 @@ test_description='Test flux job attach'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 4
-
-flux setattr log-stderr-level 1
+test_under_flux 4 full -Slog-stderr-level=1
 
 runpty=$SHARNESS_TEST_SRCDIR/scripts/runpty.py
 waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -4,9 +4,7 @@ test_description='Test flux-shell'
 
 . `dirname $0`/sharness.sh
 
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 PMI_INFO=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi_info
 KVSTEST=${FLUX_BUILD_DIR}/src/common/libpmi/test_kvstest

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -4,9 +4,7 @@ test_description='Test flux-shell'
 
 . `dirname $0`/sharness.sh
 
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 TEST_SUBPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsubprocess
 

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -4,9 +4,7 @@ test_description='Test flux-shell'
 
 . `dirname $0`/sharness.sh
 
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 TEST_SUBPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsubprocess
 LPTEST="flux lptest"

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -4,15 +4,13 @@ test_description='Test flux submit command'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 4
+test_under_flux 4 full -Slog-stderr-level=1
 
 NCORES=$(flux resource list -no {ncores})
 test ${NCORES} -gt 4 && test_set_prereq MULTICORE
 
 # Set CLIMain log level to logging.DEBUG (10), to enable stack traces
 export FLUX_PYCLI_LOGLEVEL=10
-
-flux setattr log-stderr-level 1
 
 test_expect_success 'flux submit --dry-run works without Flux instance' '
 	FLUX_URI=/no/such/path \

--- a/t/t2711-python-cli-run.t
+++ b/t/t2711-python-cli-run.t
@@ -4,12 +4,10 @@ test_description='Test flux run command'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 4
+test_under_flux 4 full -Slog-stderr-level=1
 
 # Set CLIMain log level to logging.DEBUG (10), to enable stack traces
 export FLUX_PYCLI_LOGLEVEL=10
-
-flux setattr log-stderr-level 1
 
 waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
 

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -8,9 +8,7 @@ test_description='flux alloc specific tests'
 export TEST_UNDER_FLUX_CORES_PER_RANK=4
 # Set local URI resolution for use of flux-proxy below:
 export FLUX_URI_RESOLVE_LOCAL=t
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast"
 

--- a/t/t2713-python-cli-bulksubmit.t
+++ b/t/t2713-python-cli-bulksubmit.t
@@ -7,9 +7,7 @@ test_description='flux bulksubmit specific tests'
 
 # Start an instance with 16 cores across 4 ranks
 export TEST_UNDER_FLUX_CORES_PER_RANK=4
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast --line-buffer"
 

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -7,9 +7,7 @@ test_description='flux batch specific tests'
 
 # Start an instance with 16 cores across 4 ranks
 export TEST_UNDER_FLUX_CORES_PER_RANK=4
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 NCORES=$(flux kvs get resource.R | flux R decode --count=core)
 test ${NCORES} -gt 4 && test_set_prereq MULTICORE

--- a/t/t2715-python-cli-cancel.t
+++ b/t/t2715-python-cli-cancel.t
@@ -4,12 +4,10 @@ test_description='Test flux cancel command'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 4
+test_under_flux 4 full -Slog-stderr-level=1
 
 # Set CLIMain log level to logging.DEBUG (10), to enable stack traces
 export FLUX_PYCLI_LOGLEVEL=10
-
-flux setattr log-stderr-level 1
 
 runas() {
 	userid=$1 && shift

--- a/t/t2716-python-cli-batch-conf.t
+++ b/t/t2716-python-cli-batch-conf.t
@@ -7,9 +7,7 @@ test_description='flux batch --conf tests'
 
 # Start an instance with 16 cores across 4 ranks
 export TEST_UNDER_FLUX_CORES_PER_RANK=4
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 NCORES=$(flux kvs get resource.R | flux R decode --count=core)
 test ${NCORES} -gt 4 && test_set_prereq MULTICORE

--- a/t/t2720-python-cli-multi-prog.t
+++ b/t/t2720-python-cli-multi-prog.t
@@ -6,9 +6,7 @@ test_description='flux multi-prog'
 
 
 # Start an instance with 16 cores across 4 ranks
-test_under_flux 4 job
-
-flux setattr log-stderr-level 1
+test_under_flux 4 job -Slog-stderr-level=1
 
 test_expect_success 'flux-multi-prog prints usage with no args' '
 	test_expect_code 2 flux multi-prog 2>no-args.err &&

--- a/t/t2800-jobs-cmd-multiuser.t
+++ b/t/t2800-jobs-cmd-multiuser.t
@@ -4,14 +4,13 @@ test_description='Test flux jobs command with multiple user jobs'
 
 . $(dirname $0)/sharness.sh
 
-test_under_flux 4 job
+test_under_flux 4 job -Slog-stderr-level=1
+
 
 if ! flux version | grep -q libflux-security; then
     skip_all='libflux-security not built, skipping'
     test_done
 fi
-
-flux setattr log-stderr-level 1
 
 submit_job_altuser()
 {

--- a/t/t3305-system-rpctrack-up.t
+++ b/t/t3305-system-rpctrack-up.t
@@ -15,13 +15,10 @@ commands/RPCs through their paces.
 
 export TEST_UNDER_FLUX_TOPO=kary:2
 
-test_under_flux 15 system
+test_under_flux 15 system -Slog-stderr-mode=local
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 
-test_expect_success 'tell each broker to log to stderr' '
-	flux exec flux setattr log-stderr-mode local
-'
 test_expect_success 'flux overlay parentof fails with missing RANK' '
 	test_must_fail flux overlay parentof
 '

--- a/t/t3306-system-routercrash.t
+++ b/t/t3306-system-routercrash.t
@@ -20,7 +20,7 @@ export TEST_UNDER_FLUX_TOPO=kary:1
 # before calling test_under_flux():
 ulimit -c 0
 
-test_under_flux 3 system
+test_under_flux 3 system -Slog-stderr-mode=local
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 groups="flux python ${SHARNESS_TEST_SRCDIR}/scripts/groups.py"
@@ -43,10 +43,6 @@ test_expect_success 'resource status shows no offline nodes' '
         echo 0 >offline0.exp &&
         flux resource status -s offline -no {nnodes} >offline0.out &&
         test_cmp offline0.exp offline0.out
-'
-
-test_expect_success 'tell each broker to log to stderr' '
-	flux exec flux setattr log-stderr-mode local
 '
 
 test_expect_success 'construct FLUX_URI for rank 2 (child of 1)' '

--- a/t/t3307-system-leafcrash.t
+++ b/t/t3307-system-leafcrash.t
@@ -23,13 +23,10 @@ if ! test_have_prereq NO_CHAIN_LINT; then
 	test_done
 fi
 
-test_under_flux 2 system
+test_under_flux 2 system -Slog-stderr-mode=local
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 
-test_expect_success 'tell brokers to log to stderr' '
-	flux exec flux setattr log-stderr-mode local
-'
 
 # Degraded at parent means child was lost
 test_expect_success 'start overlay status wait in the background' '

--- a/t/t3308-system-torpid.t
+++ b/t/t3308-system-torpid.t
@@ -6,14 +6,11 @@ test_description='Check torpid broker detection
 
 . `dirname $0`/sharness.sh
 
-test_under_flux 2 system
+test_under_flux 2 system -Slog-stderr-mode=local
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 groups="flux python ${SHARNESS_TEST_SRCDIR}/scripts/groups.py"
 
-test_expect_success 'tell brokers to log to stderr' '
-	flux exec flux setattr log-stderr-mode local
-'
 test_expect_success 'load heartbeat module with fast rate for testing' '
         flux module reload heartbeat period=0.5s
 '

--- a/t/t3309-system-reconnect.t
+++ b/t/t3309-system-reconnect.t
@@ -7,7 +7,7 @@ test_description='test handle reconnection
 
 . `dirname $0`/sharness.sh
 
-test_under_flux 2 system
+test_under_flux 2 system -Slog-stderr-mode=local
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 
@@ -16,10 +16,6 @@ geturi () {
 	local rank=$1
 	echo $FLUX_URI | sed -e "s/local-0/local-$rank/"
 }
-
-test_expect_success 'tell brokers to log to stderr' '
-	flux exec flux setattr log-stderr-mode local
-'
 
 test_expect_success 'flux-proxy works on rank 1 broker' '
 	flux proxy $(geturi 1) flux getattr instance-level

--- a/t/t3310-system-heartbeat.t
+++ b/t/t3310-system-heartbeat.t
@@ -7,15 +7,12 @@ test_description='Deprive a leaf node of heartbeats and make it sad'
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 
-test_under_flux 2 system
+test_under_flux 2 system -Slog-stderr-mode=local
 
 test_expect_success 'ensure child is online' '
 	flux overlay status --timeout=0 --wait full
 '
 
-test_expect_success 'tell brokers to log to stderr' '
-	flux exec flux setattr log-stderr-mode local
-'
 test_expect_success 'configure heartbeat' '
 	flux config load <<-EOT
 	[heartbeat]


### PR DESCRIPTION
Problem: many sharness tests change `log-stderr-level` or `log-stderr-mode` via `flux-setattr(1)` (sometimes executing it on all ranks with `flux-exec`), when it would be more efficient to just set those attributes on the broker command line.

Change tests to set these logging attributes on the broker command line, via `test_under_flux`.

This also will make it a bit easier to change the way dynamic updates are performed on the log subsystem later on.