### PR TITLE
broker: fail with a useful message when attribute names are misspelled on the command line

### DIFF
--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -209,6 +209,31 @@ int attr_add (attr_t *attrs, const char *name, const char *val, int flags)
     return 0;
 }
 
+int attr_set_cmdline (attr_t *attrs,
+                      const char *name,
+                      const char *val,
+                      flux_error_t *errp)
+{
+    struct registered_attr *reg;
+
+
+    if (!attrs || !name) {
+        errno = EINVAL;
+        return errprintf (errp, "invalid argument");
+    }
+    if (!(reg = attrtab_lookup (name)))
+        return errprintf (errp, "unknown attribute");
+    if ((reg->flags & ATTR_READONLY)) {
+        errno = EINVAL;
+        return errprintf (errp, "attribute may not be set on the command line");
+    }
+    if (attr_add (attrs, name, val, 0) < 0) {
+        if (errno != EEXIST || attr_set (attrs, name, val) < 0)
+            return errprintf (errp, "%s", strerror (errno));
+    }
+    return 0;
+}
+
 int attr_add_active (attr_t *attrs,
                      const char *name,
                      int flags,

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -19,6 +19,11 @@
 
 #include "attr.h"
 
+struct registered_attr {
+    const char *name;
+    int flags;
+};
+
 struct broker_attr {
     zhash_t *hash;
     flux_msg_handler_t **handlers;
@@ -31,6 +36,96 @@ struct entry {
     attr_set_f set;
     attr_get_f get;
     void *arg;
+};
+
+struct registered_attr attrtab[] = {
+
+    // general
+    { "rank", ATTR_READONLY },
+    { "size", ATTR_READONLY },
+    { "version", ATTR_READONLY },
+    { "rundir", 0 },
+    { "rundir-cleanup", 0 },
+    { "statedir", 0 },
+    { "statedir-cleanup", 0 },
+    { "security.owner", ATTR_READONLY },
+    { "local-uri", 0 },
+    { "parent-uri", ATTR_READONLY },
+    { "instance-level", ATTR_READONLY },
+    { "jobid", ATTR_READONLY },
+    { "jobid-path", ATTR_READONLY },
+    { "parent-kvs-namespace", ATTR_READONLY },
+    { "hostlist", 0 },
+    { "hostname", 0 },
+    { "broker.mapping", ATTR_READONLY },
+    { "broker.critical-ranks", 0 },
+    { "broker.boot-method", 0 },
+    { "broker.pid", ATTR_READONLY },
+    { "broker.quorum", 0 },
+    { "broker.quorum-warn", 0 },
+    { "broker.shutdown-warn", 0 },
+    { "broker.shutdown-timeout", 0 },
+    { "broker.cleanup-timeout", 0 },
+    { "broker.rc1_path", 0 },
+    { "broker.rc3_path", 0 },
+    { "broker.rc2_none", 0 },
+    { "broker.rc2_pgrp", 0 },
+    { "broker.exit-restart", ATTR_RUNTIME },
+    { "broker.module-nopanic", ATTR_RUNTIME },
+    { "broker.starttime", ATTR_READONLY },
+    { "broker.sd-notify", 0 },
+    { "broker.sd-stop-timeout", 0 },
+    { "broker.exit-norestart", 0 },
+    { "broker.recovery-mode", 0 },
+    { "broker.uuid", ATTR_READONLY },
+    { "conf.shell_initrc", ATTR_RUNTIME },
+    { "conf.shell_pluginpath", ATTR_RUNTIME },
+    { "config.path", 0 },
+
+    // tree based overlay network
+    { "tbon.topo", ATTR_CONFIG },
+    { "tbon.descendants", ATTR_READONLY },
+    { "tbon.level", ATTR_READONLY },
+    { "tbon.maxlevel", ATTR_READONLY },
+    { "tbon.endpoint", ATTR_READONLY },
+    { "tbon.parent-endpoint", ATTR_READONLY },
+    { "tbon.zmqdebug", ATTR_CONFIG },
+    { "tbon.zmq_io_threads", ATTR_CONFIG },
+    { "tbon.child_rcvhwm", ATTR_CONFIG },
+    { "tbon.prefertcp", 0 },
+    { "tbon.interface-hint", ATTR_RUNTIME | ATTR_CONFIG },
+    { "tbon.torpid_min", ATTR_CONFIG },
+    { "tbon.torpid_max", ATTR_CONFIG },
+    { "tbon.tcp_user_timeout", ATTR_CONFIG },
+    { "tbon.connect_timeout", ATTR_CONFIG },
+
+    // logging
+    { "log-ring-size", ATTR_RUNTIME },
+    { "log-forward-level", ATTR_RUNTIME },
+    { "log-critical-level", ATTR_RUNTIME },
+    { "log-filename", ATTR_RUNTIME },
+    { "log-syslog-enable", ATTR_RUNTIME },
+    { "log-syslog-level", ATTR_RUNTIME },
+    { "log-stderr-mode", ATTR_RUNTIME },
+    { "log-stderr-level", ATTR_RUNTIME },
+    { "log-level", ATTR_RUNTIME },
+
+    // content
+    { "content.backing-module", 0 },
+    { "content.hash", 0 },
+    { "content.dump", 0 },
+    { "content.restore", 0 },
+
+    // cron
+    { "cron.directory", 0 },
+
+    // for testing
+    { "test.*", ATTR_RUNTIME },
+    { "test-ro.*", ATTR_READONLY },
+
+    // misc undocumented
+    { "vendor.*", ATTR_RUNTIME}, // flux-framework/flux-pmix#109
+    { "tbon.fanout", 0 }, // legacy, replaced by tbon.topo
 };
 
 static void entry_destroy (void *arg)

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -15,7 +15,10 @@
 #include <flux/core.h>
 
 enum {
-    ATTR_IMMUTABLE = 1,    /* attribute is cacheable */
+    ATTR_IMMUTABLE      = 0x01, // value never changes once set
+    ATTR_READONLY       = 0x02, // value is not to be set on cmdline by users
+    ATTR_RUNTIME        = 0x04, // value may be updated by users [unused]
+    ATTR_CONFIG         = 0x08, // value overrides TOML config [unused]
 };
 
 /* Callbacks for active values.  Return 0 on success, -1 on error with

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -61,6 +61,11 @@ int attr_get (attr_t *attrs, const char *name, const char **val, int *flags);
 
 int attr_set (attr_t *attrs, const char *name, const char *val);
 
+int attr_set_cmdline (attr_t *attrs,
+                      const char *name,
+                      const char *val,
+                      flux_error_t *errp);
+
 /* Set an attribute's flags.
  */
 int attr_set_flags (attr_t *attrs, const char *name, int flags);

--- a/src/broker/test/attr.c
+++ b/src/broker/test/attr.c
@@ -31,86 +31,86 @@ void basic (void)
     /* attr_get, attr_set on unknown fails
      */
     errno = 0;
-    ok (attr_get (attrs, "foo", NULL, NULL) < 0 && errno == ENOENT,
+    ok (attr_get (attrs, "test.foo", NULL, NULL) < 0 && errno == ENOENT,
         "attr_get on unknown attr fails with errno == ENOENT");
     errno = 0;
-    ok (attr_set (attrs, "foo", "bar") < 0 && errno == ENOENT,
+    ok (attr_set (attrs, "test.foo", "bar") < 0 && errno == ENOENT,
         "attr_set on unknown attr fails with errno == ENOENT");
 
     /* attr_add, attr_get works
      */
-    ok ((attr_add (attrs, "foo", "bar", 0) == 0),
+    ok ((attr_add (attrs, "test.foo", "bar", 0) == 0),
         "attr_add works");
     errno = 0;
-    ok ((attr_add (attrs, "foo", "bar", 0) < 0 && errno == EEXIST),
+    ok ((attr_add (attrs, "test.foo", "bar", 0) < 0 && errno == EEXIST),
         "attr_add on existing attr fails with EEXIST");
-    ok (attr_get (attrs, "foo", NULL, NULL) == 0,
+    ok (attr_get (attrs, "test.foo", NULL, NULL) == 0,
         "attr_get on new attr works with NULL args");
     val = NULL;
     flags = 0;
-    ok (attr_get (attrs, "foo", &val, &flags) == 0 && streq (val, "bar")
+    ok (attr_get (attrs, "test.foo", &val, &flags) == 0 && streq (val, "bar")
         && flags == 0,
         "attr_get on new attr works returns correct val,flags");
 
     /* attr_delete works
      */
-    ok (attr_delete (attrs, "foo", false) == 0,
+    ok (attr_delete (attrs, "test.foo", false) == 0,
         "attr_delete works");
     errno = 0;
-    ok (attr_get (attrs, "foo", NULL, NULL) < 0 && errno == ENOENT,
+    ok (attr_get (attrs, "test.foo", NULL, NULL) < 0 && errno == ENOENT,
         "attr_get on deleted attr fails with errno == ENOENT");
 
     /* ATTR_IMMUTABLE protects against update/delete from user;
      * update/delete can NOT be forced on broker.
      */
-    ok (attr_add (attrs, "foo", "baz", ATTR_IMMUTABLE) == 0,
+    ok (attr_add (attrs, "test.foo", "baz", ATTR_IMMUTABLE) == 0,
         "attr_add ATTR_IMMUTABLE works");
     flags = 0;
     val = NULL;
-    ok (attr_get (attrs, "foo", &val, &flags) == 0 && streq (val, "baz")
+    ok (attr_get (attrs, "test.foo", &val, &flags) == 0 && streq (val, "baz")
         && flags == ATTR_IMMUTABLE,
         "attr_get returns correct value and flags");
     errno = 0;
-    ok (attr_set (attrs, "foo", "bar") < 0 && errno == EPERM,
+    ok (attr_set (attrs, "test.foo", "bar") < 0 && errno == EPERM,
         "attr_set on immutable attr fails with EPERM");
     errno = 0;
-    ok (attr_set (attrs, "foo", "baz")  < 0 && errno == EPERM,
+    ok (attr_set (attrs, "test.foo", "baz")  < 0 && errno == EPERM,
         "attr_set (force) on immutable fails with EPERM");
     errno = 0;
-    ok (attr_delete (attrs, "foo", false) < 0 && errno == EPERM,
+    ok (attr_delete (attrs, "test.foo", false) < 0 && errno == EPERM,
         "attr_delete on immutable attr fails with EPERM");
     errno = 0;
-    ok (attr_delete (attrs, "foo", true) < 0 && errno == EPERM,
+    ok (attr_delete (attrs, "test.foo", true) < 0 && errno == EPERM,
         "attr_delete (force) on immutable fails with EPERM");
 
     /* Add couple more attributes and exercise iterator.
      * initial hash contents: foo=bar
      */
     val = attr_first (attrs);
-    ok (val && streq (val, "foo"),
-        "attr_first returned foo");
+    ok (val && streq (val, "test.foo"),
+        "attr_first returned test.foo");
     ok (attr_next (attrs) == NULL,
         "attr_next returned NULL");
-    ok (attr_add (attrs, "foo1", "42", 0) == 0
-        && attr_add (attrs, "foo2", "43", 0) == 0
-        && attr_add (attrs, "foo3", "44", 0) == 0
-        && attr_add (attrs, "foo4", "44", 0) == 0,
-        "attr_add foo1, foo2, foo3, foo4 works");
+    ok (attr_add (attrs, "test.foo1", "42", 0) == 0
+        && attr_add (attrs, "test.foo2", "43", 0) == 0
+        && attr_add (attrs, "test.foo3", "44", 0) == 0
+        && attr_add (attrs, "test.foo4", "44", 0) == 0,
+        "attr_add test.foo[1-4] works");
     val = attr_first (attrs);
-    ok (val && strstarts (val, "foo"),
-        "attr_first returned foo-prefixed attr");
+    ok (val && strstarts (val, "test"),
+        "attr_first returned test-prefixed attr");
     val = attr_next (attrs);
-    ok (val && strstarts (val, "foo"),
-        "attr_next returned foo-prefixed attr");
+    ok (val && strstarts (val, "test"),
+        "attr_next returned test-prefixed attr");
     val = attr_next (attrs);
-    ok (val && strstarts (val, "foo"),
-        "attr_next returned foo-prefixed attr");
+    ok (val && strstarts (val, "test"),
+        "attr_next returned test-prefixed attr");
     val = attr_next (attrs);
-    ok (val && strstarts (val, "foo"),
-        "attr_next returned foo-prefixed attr");
+    ok (val && strstarts (val, "test"),
+        "attr_next returned test-prefixed attr");
     val = attr_next (attrs);
-    ok (val && strstarts (val, "foo"),
-        "attr_next returned foo-prefixed attr");
+    ok (val && strstarts (val, "test"),
+        "attr_next returned test-prefixed attr");
     ok (attr_next (attrs) == NULL,
         "attr_next returned NULL");
 
@@ -129,69 +129,69 @@ void active (void)
 
     /* attr_add_active (int helper)
      */
-    ok (attr_add_active_int (attrs, "a", &a, 0) == 0,
+    ok (attr_add_active_int (attrs, "test.a", &a, 0) == 0,
         "attr_add_active_int works");
     a = 0;
-    ok (attr_get (attrs, "a", &val, NULL) == 0 && val && streq (val, "0"),
+    ok (attr_get (attrs, "test.a", &val, NULL) == 0 && val && streq (val, "0"),
         "attr_get on active int tracks val=0");
     a = 1;
-    ok (attr_get (attrs, "a", &val, NULL) == 0 && streq (val, "1"),
+    ok (attr_get (attrs, "test.a", &val, NULL) == 0 && streq (val, "1"),
         "attr_get on active int tracks val=1");
     a = -1;
-    ok (attr_get (attrs, "a", &val, NULL) == 0 && streq (val, "-1"),
+    ok (attr_get (attrs, "test.a", &val, NULL) == 0 && streq (val, "-1"),
         "attr_get on active int tracks val=-1");
     a = INT_MAX - 1;
-    ok (attr_get (attrs, "a", &val, NULL) == 0
+    ok (attr_get (attrs, "test.a", &val, NULL) == 0
         && strtol (val, NULL, 10) == INT_MAX - 1,
         "attr_get on active int tracks val=INT_MAX-1");
     a = INT_MIN + 1;
-    ok (attr_get (attrs, "a", &val, NULL) == 0
+    ok (attr_get (attrs, "test.a", &val, NULL) == 0
         && strtol (val, NULL, 10) == INT_MIN + 1,
         "attr_get on active int tracks val=INT_MIN+1");
 
-    ok (attr_set (attrs, "a", "0") == 0 && a == 0,
+    ok (attr_set (attrs, "test.a", "0") == 0 && a == 0,
         "attr_set on active int sets val=0");
-    ok (attr_set (attrs, "a", "1") == 0 && a == 1,
+    ok (attr_set (attrs, "test.a", "1") == 0 && a == 1,
         "attr_set on active int sets val=1");
-    ok (attr_set (attrs, "a", "-1") == 0 && a == -1,
+    ok (attr_set (attrs, "test.a", "-1") == 0 && a == -1,
         "attr_set on active int sets val=-1");
-    ok (attr_delete (attrs, "a", true) == 0,
+    ok (attr_delete (attrs, "test.a", true) == 0,
         "attr_delete (force) works on active attr");
 
     /* attr_add_active (uint32_t helper)
      */
-    ok (attr_add_active_uint32 (attrs, "b", &b, 0) == 0,
+    ok (attr_add_active_uint32 (attrs, "test.b", &b, 0) == 0,
         "attr_add_active_uint32 works");
     b = 0;
-    ok (attr_get (attrs, "b", &val, NULL) == 0 && val && streq (val, "0"),
+    ok (attr_get (attrs, "test.b", &val, NULL) == 0 && val && streq (val, "0"),
         "attr_get on active uin32_t tracks val=0");
     b = 1;
-    ok (attr_get (attrs, "b", &val, NULL) == 0 && streq (val, "1"),
+    ok (attr_get (attrs, "test.b", &val, NULL) == 0 && streq (val, "1"),
         "attr_get on active uint32_t tracks val=1");
     b = UINT_MAX - 1;
-    ok (attr_get (attrs, "b", &val, NULL) == 0
+    ok (attr_get (attrs, "test.b", &val, NULL) == 0
         && strtoul (val, NULL, 10) == UINT_MAX - 1,
         "attr_get on active uint32_t tracks val=UINT_MAX-1");
 
-    ok (attr_set (attrs, "b", "0") == 0 && b == 0,
+    ok (attr_set (attrs, "test.b", "0") == 0 && b == 0,
         "attr_set on active uint32_t sets val=0");
-    ok (attr_set (attrs, "b", "1") == 0 && b == 1,
+    ok (attr_set (attrs, "test.b", "1") == 0 && b == 1,
         "attr_set on active uint32_t sets val=1");
-    ok (attr_delete (attrs, "b", true) == 0,
+    ok (attr_delete (attrs, "test.b", true) == 0,
         "attr_delete (force) works on active attr");
 
     /* immutable active int works as expected
      */
-    ok (attr_add_active_int (attrs, "c", &c, ATTR_IMMUTABLE) == 0,
+    ok (attr_add_active_int (attrs, "test.c", &c, ATTR_IMMUTABLE) == 0,
         "attr_add_active_int ATTR_IMMUTABLE works");
     c = 42;
-    ok (attr_get (attrs, "c", &val, NULL) == 0 && val && streq (val, "42"),
+    ok (attr_get (attrs, "test.c", &val, NULL) == 0 && val && streq (val, "42"),
         "attr_get returns initial val=42");
     c = 43;
-    ok (attr_get (attrs, "c", &val, NULL) == 0 && val && streq (val, "42"),
+    ok (attr_get (attrs, "test.c", &val, NULL) == 0 && val && streq (val, "42"),
         "attr_get ignores value changes");
     errno = 0;
-    ok (attr_delete (attrs, "c", true) < 0 && errno == EPERM,
+    ok (attr_delete (attrs, "test.c", true) < 0 && errno == EPERM,
         "attr_delete (force) fails with EPERM");
 
     attr_destroy (attrs);

--- a/t/batch/jobspec/v0.47.json
+++ b/t/batch/jobspec/v0.47.json
@@ -3,9 +3,9 @@
     "system": {
       "batch": {
         "broker-opts": [
-          "-Stestattr=foo"
+          "-Stest.attr=foo"
         ],
-        "script": "#!/bin/sh\ntest $(flux getattr testattr) = \"foo\"\n"
+        "script": "#!/bin/sh\ntest $(flux getattr test.attr) = \"foo\"\n"
       },
       "cwd": "/tmp",
       "duration": 0,

--- a/t/python/t0001-handle.py
+++ b/t/python/t0001-handle.py
@@ -70,7 +70,7 @@ class TestHandle(unittest.TestCase):
     def test_rpc_null_payload(self):
         """Sending a request that receives a NULL response"""
         resp = self.f.rpc(
-            "attr.set", {"name": "attr-that-doesnt-exist", "value": "foo"}
+            "attr.set", {"name": "test.attr-that-doesnt-exist", "value": "foo"}
         ).get()
         self.assertIsNone(resp)
 
@@ -89,30 +89,30 @@ class TestHandle(unittest.TestCase):
         self.assertEqual(attr_rank, rank)
 
     def test_attr_set(self):
-        self.f.attr_set("foo", "bar")
-        self.assertEqual(self.f.attr_get("foo"), "bar")
+        self.f.attr_set("test.foo", "bar")
+        self.assertEqual(self.f.attr_get("test.foo"), "bar")
 
-        self.f.attr_set("baz", str(1))
-        self.assertEqual(self.f.attr_get("baz"), "1")
+        self.f.attr_set("test.baz", str(1))
+        self.assertEqual(self.f.attr_get("test.baz"), "1")
 
-        self.f.attr_set("utf8-test", "ƒ Φ Ψ Ω Ö")
-        self.assertEqual(self.f.attr_get("utf8-test"), "ƒ Φ Ψ Ω Ö")
+        self.f.attr_set("test.utf8-test", "ƒ Φ Ψ Ω Ö")
+        self.assertEqual(self.f.attr_get("test.utf8-test"), "ƒ Φ Ψ Ω Ö")
 
         with self.assertRaises(OSError):
             self.f.attr_set("local-uri", "foo")
         with self.assertRaises(ValueError):
-            self.f.attr_set("foo", 1)
+            self.f.attr_set("test.foo", 1)
         with self.assertRaises(ValueError):
             self.f.attr_set(42, "foo")
 
     def test_attr_remove(self):
-        self.f.attr_set("testrm", "rm")
-        self.assertEqual(self.f.attr_get("testrm"), "rm")
+        self.f.attr_set("test.rm", "rm")
+        self.assertEqual(self.f.attr_get("test.rm"), "rm")
 
-        self.f.attr_remove("testrm")
+        self.f.attr_remove("test.rm")
 
         with self.assertRaises(OSError):
-            self.f.attr_get("testrm")
+            self.f.attr_get("test.rm")
 
         with self.assertRaises(OSError):
             self.f.attr_remove("local-uri")

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -468,11 +468,11 @@ test_expect_success NO_ASAN 'test_under_flux fails if loaded modules are not unl
 '
 
 test_expect_success 'flux-start -o,--setattr ATTR=VAL can set broker attributes' '
-	ATTR_VAL=`flux start ${ARGS} -o,--setattr=foo-test=42 flux getattr foo-test` &&
+	ATTR_VAL=`flux start ${ARGS} -o,--setattr=test.foo=42 flux getattr test.foo` &&
 	test $ATTR_VAL -eq 42
 '
 test_expect_success 'flux-start --setattr ATTR=VAL can set broker attributes' '
-	ATTR_VAL=`flux start ${ARGS} --setattr=foo-test=42 flux getattr foo-test` &&
+	ATTR_VAL=`flux start ${ARGS} --setattr=test.foo=42 flux getattr test.foo` &&
 	test $ATTR_VAL -eq 42
 '
 test_expect_success 'hostlist attr is set on size 1 instance' '

--- a/t/t0008-attr.t
+++ b/t/t0008-attr.t
@@ -34,6 +34,18 @@ test_expect_success 'flux lsattr -v works' '
 	ATTR_VAL=$(flux lsattr -v | awk "/^rank / { print \$2 }") &&
 	test "${ATTR_VAL}" -eq 0
 '
+test_expect_success 'broker --setattr fails on unknown attribute' '
+	test_must_fail flux start -Sunknownattr=abc true
+'
+test_expect_success 'broker --setattr fails on read-only attribute' '
+	test_must_fail flux start -Stest-ro.foo=bac true
+'
+test_expect_success 'flux setattr fails on unknown attribute' '
+	test_must_fail flux setattr unknown-foo bar
+'
+test_expect_success 'flux getattr fails on unknown attribute' '
+	test_must_fail flux getattr unknown-bar
+'
 test_expect_success 'flux lsattr with extra argument fails' '
 	test_must_fail flux lsattr badarg
 '

--- a/t/t0008-attr.t
+++ b/t/t0008-attr.t
@@ -17,18 +17,18 @@ test_expect_success 'flux getattr rank works' '
 test_expect_success 'flux setattr rank fails (immutable)' '
 	test_must_fail flux setattr rank 42
 '
-test_expect_success 'flux getattr attrtest.nonexist fails' '
-	test_must_fail flux getattr nonexist
+test_expect_success 'flux getattr test.nonexist fails' '
+	test_must_fail flux getattr test.nonexist
 '
 test_expect_success 'flux setattr works' '
-	flux setattr attrtest.foo bar &&
-	ATTR_VAL=`flux getattr attrtest.foo` &&
+	flux setattr test.foo bar &&
+	ATTR_VAL=`flux getattr test.foo` &&
 	test "${ATTR_VAL}" = "bar"
 '
 test_expect_success 'flux lsattr works' '
 	flux lsattr >lsattr_out &&
 	grep -q rank lsattr_out &&
-	grep -q attrtest.foo lsattr_out
+	grep -q test.foo lsattr_out
 '
 test_expect_success 'flux lsattr -v works' '
 	ATTR_VAL=$(flux lsattr -v | awk "/^rank / { print \$2 }") &&

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -121,13 +121,13 @@ test_expect_success 'flux getattr allowed for non-owner' '
 '
 
 test_expect_success 'flux setattr allowed for owner' '
-	flux setattr log-stderr-level 7 &&
-	test $(flux getattr log-stderr-level) -eq 7
+	flux setattr test.foo 7 &&
+	test $(flux getattr test.foo) -eq 7
 '
 
 test_expect_success 'flux setattr NOT allowed for non-owner' '
-	! FLUX_HANDLE_ROLEMASK=0x2 flux setattr log-stderr-level 6 &&
-	test $(flux getattr log-stderr-level) -eq 7
+	! FLUX_HANDLE_ROLEMASK=0x2 flux setattr test.foo 6 &&
+	test $(flux getattr test.foo) -eq 7
 '
 
 test_expect_success 'flux logger not allowed for non-owner' '

--- a/t/t0100-modprobe.t
+++ b/t/t0100-modprobe.t
@@ -396,11 +396,11 @@ test_expect_success 'modprobe needs_attrs works with attr set to zero' '
 	def first(context):
 	    print("first")
 
-	@task("last", needs_attrs=["zero"], after=["*"])
+	@task("last", needs_attrs=["test.zero"], after=["*"])
 	def last(context):
 	    print("last")
 	EOF
-	flux setattr zero 0 &&
+	flux setattr test.zero 0 &&
 	flux modprobe run test${seq}.py >output${seq} &&
 	test_debug "cat output${seq}" &&
 	cat <<-EOF >test${seq}.expected &&
@@ -418,11 +418,11 @@ test_expect_success 'modprobe needs_attrs works' '
 	def first(context):
 	    print("first")
 
-	@task("last", needs_attrs=["needed"])
+	@task("last", needs_attrs=["test.needed"])
 	def last(context):
 	    print("last")
 	EOF
-	flux setattr needed 1 &&
+	flux setattr test.needed 1 &&
 	flux modprobe run test${seq}.py >output${seq} &&
 	test_debug "cat output${seq}" &&
 	cat <<-EOF >test${seq}.expected &&
@@ -439,7 +439,7 @@ test_expect_success 'modprobe `!` with another attr also prevents task' '
 	def first(context):
 	    print("first")
 
-	@task("last", needs_attrs=["!size", "needed"])
+	@task("last", needs_attrs=["!size", "test.needed"])
 	def last(context):
 	    print("last")
 	EOF


### PR DESCRIPTION
Problem: when an attribute name is misspelled on the broker command line, there is no error.

During an early period of flux development, broker attributes were a handy way for components to be configured or to provide visibility into internal settings.  Since then, we've developed better mechanisms for those things, but broker attributes are still managed very loosely.

This adds a table of known attributes and
- prohibits setting attributes that are not matched in the table
- prohibits setting some known attributes on the command line, as documented in flux-broker-attributes(7)
- prints a useful error message when an attribute is misspelled or is on the command line when it shouldn't be

This change is proposed to partially remedy
- #7324

No mechanism is added for registering new namespaces, as discussed in that issue, but that could be added if need be.  (I wasn't too sure it was really required).