### PR TITLE
broker: minor cleanup of attribute usage

### DIFF
--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -13,7 +13,6 @@
 #endif
 #include <limits.h>
 #include <jansson.h>
-#include <inttypes.h>
 #include <fnmatch.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -348,124 +347,6 @@ int attr_set_flags (attr_t *attrs, const char *name, int flags)
     rc = 0;
 done:
     return rc;
-}
-
-static int get_int (const char *name, const char **val, void *arg)
-{
-    int *i = arg;
-    static char s[32];
-
-    if (snprintf (s, sizeof (s), "%d", *i) >= sizeof (s)) {
-        errno = EOVERFLOW;
-        return -1;
-    }
-    *val = s;
-    return 0;
-}
-
-static int set_int (const char *name, const char *val, void *arg)
-{
-    int *i = arg;
-    char *endptr;
-    long n;
-
-    if (!val) {
-        errno = EINVAL;
-        return -1;
-    }
-    errno = 0;
-    n = strtol (val, &endptr, 0);
-    if (errno != 0 || *endptr != '\0') {
-        errno = EINVAL;
-        return -1;
-    }
-    if (n <= INT_MIN || n >= INT_MAX) {
-        errno = ERANGE;
-        return -1;
-    }
-    *i = (int)n;
-    return 0;
-}
-
-int attr_add_int (attr_t *attrs, const char *name, int val, int flags)
-{
-    char s[32];
-
-    if (snprintf (s, sizeof (s), "%d", val) >= sizeof (s)) {
-        errno = EOVERFLOW;
-        return -1;
-    }
-    return attr_add (attrs, name, s, flags);
-}
-
-int attr_add_active_int (attr_t *attrs, const char *name, int *val, int flags)
-{
-    return attr_add_active (attrs, name, flags, get_int, set_int, val);
-}
-
-static int get_uint32 (const char *name, const char **val, void *arg)
-{
-    uint32_t *i = arg;
-    static char s[32];
-
-    if (snprintf (s, sizeof (s), "%" PRIu32, *i) >= sizeof (s)) {
-        errno = EOVERFLOW;
-        return -1;
-    }
-    *val = s;
-    return 0;
-}
-
-static int set_uint32 (const char *name, const char *val, void *arg)
-{
-    uint32_t *i = arg;
-    char *endptr;
-    unsigned long n;
-
-    errno = 0;
-    n = strtoul (val, &endptr, 0);
-    if (errno != 0 || *endptr != '\0') {
-        errno = EINVAL;
-        return -1;
-    }
-    *i = n;
-    return 0;
-}
-
-int attr_add_uint32 (attr_t *attrs, const char *name, uint32_t val, int flags)
-{
-    char val_string[32];
-
-    snprintf (val_string, sizeof (val_string), "%"PRIu32, val);
-
-    return attr_add (attrs, name, val_string, flags);
-}
-
-int attr_add_active_uint32 (attr_t *attrs,
-                            const char *name,
-                            uint32_t *val,
-                            int flags)
-{
-    return attr_add_active (attrs, name, flags, get_uint32, set_uint32, val);
-}
-
-int attr_get_uint32 (attr_t *attrs, const char *name, uint32_t *value)
-{
-    const char *s;
-    uint32_t i;
-    char *endptr;
-
-    if (attr_get (attrs, name, &s, NULL) < 0)
-        return -1;
-
-    errno = 0;
-    i = strtoul (s, &endptr, 10);
-    if (errno != 0 || *endptr != '\0') {
-        errno = EINVAL;
-        return -1;
-    }
-    *value = i;
-    return 0;
 }
 
 const char *attr_first (attr_t *attrs)

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -11,7 +11,6 @@
 #ifndef BROKER_ATTR_H
 #define BROKER_ATTR_H
 
-#include <stdint.h>
 #include <flux/core.h>
 
 enum {
@@ -46,15 +45,6 @@ int attr_delete (attr_t *attrs, const char *name, bool force);
  */
 int attr_add (attr_t *attrs, const char *name, const char *val, int flags);
 
-/* Helper functions to add a non-string attribute.  It performs the conversion
- *  to a string on the caller's behalf.
- */
-int attr_add_int (attr_t *attrs, const char *name, int val, int flags);
-int attr_add_uint32 (attr_t *attrs,
-                     const char *name,
-                     uint32_t val,
-                     int flags);
-
 /* Get/set an attribute.
  */
 int attr_get (attr_t *attrs, const char *name, const char **val, int *flags);
@@ -78,21 +68,6 @@ int attr_add_active (attr_t *attrs,
                      attr_get_f get,
                      attr_set_f set,
                      void *arg);
-
-/* Add an attribute that tracks an integer value
- */
-int attr_add_active_int (attr_t *attrs,
-                         const char *name,
-                         int *val,
-                         int flags);
-int attr_add_active_uint32 (attr_t *attrs,
-                            const char *name,
-                            uint32_t *val,
-                            int flags);
-
-/* Get an attribute and parse it as an integer value.
- */
-int attr_get_uint32 (attr_t *attrs, const char *name, uint32_t *value);
 
 /* Iterate over attribute names with internal cursor.
  */

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -132,6 +132,16 @@ static struct optparse_option opts[] = {
     OPTPARSE_TABLE_END,
 };
 
+static int addattr_int (attr_t *attrs, const char *name, int val, int flags)
+{
+    char s[32];
+    if (snprintf (s, sizeof (s), "%d", val) >= sizeof (s)) {
+        errno = EOVERFLOW;
+        return -1;
+    }
+    return attr_add (attrs, name, s, flags);
+}
+
 static char *parse_nameval (const char *nameval, const char **valp)
 {
     char *cpy;
@@ -325,7 +335,7 @@ int main (int argc, char *argv[])
             level = LOG_INFO;
         else
             level = LOG_ERR;
-        (void)attr_add_int (ctx.attrs, "log-stderr-level", level, 0);
+        (void)addattr_int (ctx.attrs, "log-stderr-level", level, 0);
     }
 
     /* Set the broker.uuid attribute, used for request/response routing.
@@ -443,14 +453,8 @@ int main (int argc, char *argv[])
         goto cleanup;
     }
 
-    if (attr_add_int (ctx.attrs,
-                      "rank",
-                      ctx.info.rank,
-                      ATTR_IMMUTABLE) < 0
-        || attr_add_int (ctx.attrs,
-                         "size",
-                         ctx.info.size,
-                         ATTR_IMMUTABLE) < 0) {
+    if (addattr_int (ctx.attrs, "rank", ctx.info.rank, ATTR_IMMUTABLE) < 0
+        || addattr_int (ctx.attrs, "size", ctx.info.size, ATTR_IMMUTABLE) < 0) {
         flux_log (ctx.h, LOG_CRIT, "setattr rank/size: %s", strerror (errno));
         goto cleanup;
     }

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -568,14 +568,15 @@ void log_early (const char *buf, int len, void *arg)
     attr_t *attrs = arg;
     const char *val;
     int flags = 0;
-    uint32_t level;
+    int level;
     struct stdlog_header hdr;
 
     if (attr_get (attrs, "log-stderr-mode", &val, NULL) == 0
         && streq (val, "local")) {
         flags = LOG_FOR_SYSTEMD;
     }
-    if (attr_get_uint32 (attrs, "log-stderr-level", &level) == 0
+    if (attr_get (attrs, "log-stderr-level", &val, NULL) == 0
+        && set_level (&level, val) == 0
         && stdlog_decode (buf, len, &hdr, NULL, NULL, NULL, NULL) == 0
         && STDLOG_SEVERITY (hdr.pri) > level)
         return;

--- a/src/broker/rundir.c
+++ b/src/broker/rundir.c
@@ -230,7 +230,7 @@ int rundir_create (attr_t *attrs,
     if (attr_get (attrs, key, &val, NULL) == 0 && val)
         do_cleanup = streq (val, "0") ? false : true;
     (void)attr_delete (attrs, key, true);
-    if (attr_add_int (attrs, key, do_cleanup ? 1 : 0, ATTR_IMMUTABLE) < 0)
+    if (attr_add (attrs, key, do_cleanup ? "1" : "0", ATTR_IMMUTABLE) < 0)
         goto error_setattr;
 
     rc = 0;

--- a/src/cmd/builtin/shutdown.c
+++ b/src/cmd/builtin/shutdown.c
@@ -108,6 +108,22 @@ static void process_updates (flux_future_t *f)
         log_msg_exit ("%s", future_strerror (f, errno));
 }
 
+static int rmattr (flux_t *h, const char *name)
+{
+    flux_future_t *f;
+    int rc = 0;
+    if (!(f = flux_rpc_pack (h,
+                             "attr.rm",
+                             FLUX_NODEID_ANY,
+                             0,
+                             "{s:s}",
+                             "name", name))
+        || flux_rpc_get (f, NULL) < 0)
+        rc = -1;
+    flux_future_destroy (f);
+    return rc;
+}
+
 static int subcmd (optparse_t *p, int ac, char *av[])
 {
     flux_t *h;
@@ -146,7 +162,7 @@ static int subcmd (optparse_t *p, int ac, char *av[])
         flags &= ~FLUX_RPC_STREAMING;
 
     if (optparse_hasopt (p, "skip-gc")) {
-        if (flux_attr_set (h, "content.dump", "") < 0)
+        if (rmattr (h, "content.dump") < 0)
             log_err_exit ("error clearing content.dump attribute");
     }
 

--- a/src/modules/content/cache.c
+++ b/src/modules/content/cache.c
@@ -1042,15 +1042,16 @@ static int get_hash_name (struct content_cache *cache)
 {
     const char *s;
 
-    if (!(s = flux_attr_get (cache->h, "content.hash")))
+    if (!(s = flux_attr_get (cache->h, "content.hash"))) {
+        if (flux_attr_set (cache->h, "content.hash", default_hash) < 0) {
+            flux_log_error (cache->h, "setattr content.hash");
+            return -1;
+        }
         s = default_hash;
+    }
     if ((content_hash_size = blobref_validate_hashtype (s)) < 0
         || !(cache->hash_name = strdup (s))) {
         flux_log_error (cache->h, "%s: unknown hash type", s);
-        return -1;
-    }
-    if (flux_attr_set (cache->h, "content.hash", cache->hash_name) < 0) {
-        flux_log_error (cache->h, "setattr content.hash");
         return -1;
     }
     return 0;


### PR DESCRIPTION
Problem: there is some dead and ought-to-be-dead code in the broker attribute subsystem.

Get rid of the useless bits.

Clean up a couple of places where attributes are used in a silly way.