### PR TITLE
broker: restrict runtime updates on some attributes

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -207,6 +207,7 @@ MAN3_FILES_SECONDARY = \
 	man3/flux_msg_set_noresponse.3 \
 	man3/flux_get_size.3 \
 	man3/flux_attr_set.3 \
+	man3/flux_attr_set_ex.3 \
 	man3/flux_module_debug_test.3 \
 	man3/flux_module_config_request_decode.3 \
 	man3/flux_set_reactor.3 \

--- a/doc/man1/flux-getattr.rst
+++ b/doc/man1/flux-getattr.rst
@@ -7,7 +7,7 @@ SYNOPSIS
 ========
 
 | **flux** **getattr** *name*
-| **flux** **setattr** *name* *value*
+| **flux** **setattr** [*--force*] *name* *value*
 | **flux** **lsattr** [*--values*]
 
 
@@ -42,6 +42,12 @@ setattr
 
 :program:`flux setattr` assigns a value to an attribute.  If the attribute
 does not exist, it is created.
+
+.. option:: -f, --force
+
+  Force an attribute to be set, even if it is not documented to respond
+  to runtime updates.
+
 
 lsattr
 ------

--- a/doc/man3/flux_attr_get.rst
+++ b/doc/man3/flux_attr_get.rst
@@ -15,6 +15,12 @@ SYNOPSIS
 
    int flux_attr_set (flux_t *h, const char *name, const char *val);
 
+   int flux_attr_set_ex (flux_t *h,
+                         const char *name,
+                         const char *val,
+                         bool force,
+                         flux_error_t *error);
+
 Link with :command:`-lflux-core`.
 
 DESCRIPTION
@@ -35,6 +41,11 @@ access and thereafter does not require an RPC to the broker to access.
 If :var:`name` is not currently a valid attribute, it is created.
 If :var:`val` is NULL, the attribute is unset.
 
+:func:`flux_attr_set_ex` is the same as above with extra arguments.  If
+:var:`force` is set, protections against runtime updates of the attribute
+are bypassed.  If :var:`error` is non-NULL, it is filled with a human
+readable error message on failure.
+
 
 RETURN VALUE
 ============
@@ -42,8 +53,8 @@ RETURN VALUE
 :func:`flux_attr_get` returns the requested value on success. On error, NULL
 is returned and :var:`errno` is set appropriately.
 
-:func:`flux_attr_set` returns zero on success. On error, -1 is returned
-and errno is set appropriately.
+:func:`flux_attr_set` and :func:`flux_attr_set_ex` return zero on success.
+On error, -1 is returned and errno is set appropriately.
 
 
 ERRORS

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -76,6 +76,7 @@ man_pages = [
     ('man1/flux-modprobe', 'flux-modprobe', 'efficient and extensible task and module manager', [author], 1),
     ('man1/flux-sproc', 'flux-sproc', 'manage flux subprocesses', [author], 1),
     ('man3/flux_attr_get', 'flux_attr_set', 'get/set Flux broker attributes', [author], 3),
+    ('man3/flux_attr_get', 'flux_attr_set_ex', 'get/set Flux broker attributes', [author], 3),
     ('man3/flux_attr_get', 'flux_attr_get', 'get/set Flux broker attributes', [author], 3),
     ('man3/flux_aux_set', 'flux_aux_get', 'get/set auxiliary handle data', [author], 3),
     ('man3/flux_aux_set', 'flux_aux_set', 'get/set auxiliary handle data', [author], 3),

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -125,6 +125,7 @@ static struct registered_attr attrtab[] = {
     // for testing
     { "test.*", ATTR_RUNTIME },
     { "test-ro.*", ATTR_READONLY },
+    { "test-nr.*", 0 },
 
     // misc undocumented
     { "vendor.*", ATTR_RUNTIME}, // flux-framework/flux-pmix#109

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -16,7 +16,7 @@
 enum {
     ATTR_IMMUTABLE      = 0x01, // value never changes once set
     ATTR_READONLY       = 0x02, // value is not to be set on cmdline by users
-    ATTR_RUNTIME        = 0x04, // value may be updated by users [unused]
+    ATTR_RUNTIME        = 0x04, // value may be updated by users
     ATTR_CONFIG         = 0x08, // value overrides TOML config [unused]
 };
 

--- a/src/cmd/builtin/attr.c
+++ b/src/cmd/builtin/attr.c
@@ -23,6 +23,7 @@ static int cmd_setattr (optparse_t *p, int ac, char *av[])
     flux_t *h = builtin_get_flux_handle (p);
     const char *name;
     const char *val;
+    flux_error_t error;
 
     log_init ("flux-setattr");
 
@@ -32,8 +33,9 @@ static int cmd_setattr (optparse_t *p, int ac, char *av[])
     }
     name = av[n];
     val = av[n + 1];
-    if (flux_attr_set (h, name, val) < 0)
-        log_err_exit ("flux_attr_set");
+
+    if (flux_attr_set_ex (h, name, val, false, &error) < 0)
+        log_msg_exit ("%s: %s", name, error.text);
 
     flux_close (h);
     return (0);

--- a/src/cmd/builtin/attr.c
+++ b/src/cmd/builtin/attr.c
@@ -20,6 +20,7 @@
 static int cmd_setattr (optparse_t *p, int ac, char *av[])
 {
     int n = optparse_option_index (p);
+    int force = optparse_hasopt (p, "force") ? 1 : 0;
     flux_t *h = builtin_get_flux_handle (p);
     const char *name;
     const char *val;
@@ -34,12 +35,19 @@ static int cmd_setattr (optparse_t *p, int ac, char *av[])
     name = av[n];
     val = av[n + 1];
 
-    if (flux_attr_set_ex (h, name, val, false, &error) < 0)
+    if (flux_attr_set_ex (h, name, val, force, &error) < 0)
         log_msg_exit ("%s: %s", name, error.text);
 
     flux_close (h);
     return (0);
 }
+
+static struct optparse_option setattr_opts[] = {
+    { .name = "force", .key = 'f', .has_arg = 0,
+      .usage = "force update of attribute that doesn't support runtime changes",
+    },
+    OPTPARSE_TABLE_END
+};
 
 static struct optparse_option lsattr_opts[] = {
     { .name = "values", .key = 'v', .has_arg = 0,
@@ -149,7 +157,7 @@ int subcommand_attr_register (optparse_t *p)
         "name value",
         "Set broker attribute",
         0,
-        NULL);
+        setattr_opts);
     if (e != OPTPARSE_SUCCESS)
         return (-1);
 

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -44,6 +44,16 @@ const char *flux_attr_get (flux_t *h, const char *name);
  */
 int flux_attr_set (flux_t *h, const char *name, const char *val);
 
+/* Same as above but with option to force updates on attributes that
+ * are not documented to support runtime update, and to return detailed
+ * error messages.
+ */
+int flux_attr_set_ex (flux_t *h,
+                      const char *name,
+                      const char *val,
+                      bool force,
+                      flux_error_t *errp);
+
 /* hotwire flux_attr_get()'s cache for testing */
 int flux_attr_set_cacheonly (flux_t *h, const char *name, const char *val);
 

--- a/src/modules/overlay/overlay.c
+++ b/src/modules/overlay/overlay.c
@@ -2411,7 +2411,7 @@ static int overlay_configure_torpid (struct overlay *ov,
                               "tbon.torpid_max must be greater than torpid_min");
         if (fsd_format_duration (fsd, sizeof (fsd), tmax_val) < 0
             || flux_attr_set_ex (ov->h, "tbon.torpid_max", fsd, true, NULL) < 0)
-            return errprintf (errp, "error updating tbon.torpid_min attribute");
+            return errprintf (errp, "error updating tbon.torpid_max attribute");
         ov->torpid_max = tmax_val;
     }
     return 0;

--- a/src/modules/overlay/overlay.c
+++ b/src/modules/overlay/overlay.c
@@ -2399,7 +2399,7 @@ static int overlay_configure_torpid (struct overlay *ov,
         if (tmax_check != 0 && !(tmin_val < tmax_check))
             return errprintf (errp, "tbon.torpid_min must be less than torpid_max");
         if (fsd_format_duration (fsd, sizeof (fsd), tmin_val) < 0
-            || flux_attr_set (ov->h, "tbon.torpid_min", fsd) < 0)
+            || flux_attr_set_ex (ov->h, "tbon.torpid_min", fsd, true, NULL) < 0)
             return errprintf (errp, "error updating tbon.torpid_min attribute");
         ov->torpid_min = tmin_val;
     }
@@ -2410,7 +2410,7 @@ static int overlay_configure_torpid (struct overlay *ov,
             return errprintf (errp,
                               "tbon.torpid_max must be greater than torpid_min");
         if (fsd_format_duration (fsd, sizeof (fsd), tmax_val) < 0
-            || flux_attr_set (ov->h, "tbon.torpid_max", fsd) < 0)
+            || flux_attr_set_ex (ov->h, "tbon.torpid_max", fsd, true, NULL) < 0)
             return errprintf (errp, "error updating tbon.torpid_min attribute");
         ov->torpid_max = tmax_val;
     }

--- a/t/t0008-attr.t
+++ b/t/t0008-attr.t
@@ -46,6 +46,18 @@ test_expect_success 'flux setattr fails on unknown attribute' '
 test_expect_success 'flux getattr fails on unknown attribute' '
 	test_must_fail flux getattr unknown-bar
 '
+test_expect_success 'flux setattr refuses to update !runtime attribute' '
+	flux setattr test-nr.foo bar &&
+	test_must_fail flux setattr test-nr.foo baz
+'
+test_expect_success 'but --force works' '
+	flux setattr --force test-nr.foo baz
+'
+test_expect_success 'yep, the value changed' '
+	echo baz >nr.exp &&
+	flux getattr test-nr.foo >nr.out &&
+	test_cmp nr.exp nr.out
+'
 test_expect_success 'flux lsattr with extra argument fails' '
 	test_must_fail flux lsattr badarg
 '

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -92,7 +92,7 @@ test_expect_success 'flux-proxy forwards LD_LIBRARY_PATH' '
 
 test_expect_success 'set bogus broker version' '
 	flux getattr version >realversion &&
-	flux setattr version 0.0.0
+	flux setattr -f version 0.0.0
 '
 test_expect_success 'flux-proxy fails with version mismatch' '
 	test_must_fail flux proxy $FLUX_URI true
@@ -101,7 +101,7 @@ test_expect_success 'flux-proxy --force works with version mismatch' '
 	flux proxy --force $FLUX_URI true
 '
 test_expect_success 'restore real broker version' '
-	flux setattr version $(cat realversion)
+	flux setattr -f version $(cat realversion)
 '
 
 test_expect_success 'flux-proxy works with jobid argument' '


### PR DESCRIPTION
Problem: [flux-broker-attributes(7)](https://flux-framework.readthedocs.io/projects/flux-core/en/latest/man7/flux-broker-attributes.html) notes that some attributes may be updated at run time and others not, but this is not enforced.

Use the ATTR_RUNTIME flag (previously added with the attribute table) to restrict updates via the `attr.set` RPC.  Allow the update to be forced if an optional `force` flag is set.  The force flag is need so "remote owners" of attributes such as the overlay module can make changes to non-immutable attributes despite the restriction.  The restriction therefore is advisory rather than mandatory.  The functions used inside the broker are unchanged.

A new API function `flux_attr_set_ex()` is added that includes the force flag, and also a `flux_error_t` so that human readable errors from the RPC can be retrieved by the caller.

Then a `flux setattr --force` option is added.

