### PR TITLE
t: fix non-bourne shell test failure

### DIFF
--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -212,7 +212,7 @@ test_expect_success 'flux-start fails with non-executable rc2' '
 	cat <<-EOF >no-shebang.sh &&
 	true
 	EOF
-	test_expect_code 126 run_timeout 30 flux start $ARGS ./no-shebang.sh
+	test_expect_code 126 run_timeout --env=SHELL=/bin/sh 30 flux start $ARGS ./no-shebang.sh
 '
 test_expect_success 'flux-start fails with invalid shebang in rc2' '
 	chmod +x no-shebang.sh &&


### PR DESCRIPTION
Problem: Test in t0001-basic failed in a non-bourne shell.

Solution: Set SHELL to /bin/sh in test.

Fixes #7357