### PR TITLE
shell: add `shell.finish` callback

### DIFF
--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -112,6 +112,7 @@ static int shell_load_builtin (flux_shell_t *shell,
                                     sb->post_init,
                                     NULL) < 0
         || flux_plugin_add_handler (p, "shell.exit", sb->exit, NULL) < 0
+        || flux_plugin_add_handler (p, "shell.finish", sb->finish, NULL) < 0
         || flux_plugin_add_handler (p, "shell.start",sb->start, NULL) < 0
         || flux_plugin_add_handler (p, "task.init",  sb->task_init, NULL) < 0
         || flux_plugin_add_handler (p, "task.fork",  sb->task_fork, NULL) < 0

--- a/src/shell/builtins.h
+++ b/src/shell/builtins.h
@@ -27,6 +27,7 @@ struct shell_builtin {
     flux_plugin_f task_fork;
     flux_plugin_f start;
     flux_plugin_f task_exit;
+    flux_plugin_f finish;
     flux_plugin_f exit;
 };
 

--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -38,6 +38,7 @@ struct flux_shell {
     struct shell_svc *svc;
     zlist_t *tasks;
     flux_shell_task_t *current_task;
+    int tasks_exited;
     struct mustache_renderer *mr;
 
     struct plugstack *plugstack;

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -89,6 +89,12 @@ static void task_completion_cb (struct shell_task *task, void *arg)
     if (flux_shell_remove_completion_ref (shell, "task%d", task->rank) < 0)
         shell_log_errno ("failed to remove task%d completion reference",
                          task->rank);
+
+    /* Once the last task has exited, call shell.finish callbacks
+     */
+    if (++shell->tasks_exited == zlist_size (shell->tasks)
+         && plugstack_call (shell->plugstack, "shell.finish", NULL) < 0)
+        shell_log_errno ("shell.finish");
 }
 
 int flux_shell_setopt (flux_shell_t *shell,


### PR DESCRIPTION
This PR adds a new `shell.finish` callback to the job shell, invoked after all local tasks complete but before the reactor exits.

This enables plugins to perform cleanup or initiate asynchronous work while the reactor is still active, without waiting for `shell.exit` which runs after reactor shutdown.

No plugins make use of this callback yet, that will come in a couple follow-on PRs.