### PR TITLE
shell: send EOF to write service immediately after tasks finish

### DIFF
--- a/src/shell/output/client.c
+++ b/src/shell/output/client.c
@@ -49,10 +49,10 @@ struct output_client {
 
 static void client_send_eof (struct output_client *client)
 {
-    /* Note: client should not be instantiated on rank 0, but check here
-     * just in case.
+    /* Note: client should not be instantiated on rank 0, and may be NULL
+     * if already destroyed. Check both conditions before sending EOF.
      */
-    if (client->shell_rank != 0) {
+    if (client && client->shell_rank != 0) {
         flux_future_t *f;
         /* Nonzero shell rank: send EOF to leader shell to notify
          *  that no more messages will be sent to shell.write

--- a/src/shell/output/client.c
+++ b/src/shell/output/client.c
@@ -12,13 +12,15 @@
  *
  * When output is to the KVS or a single output file, non-leader
  * shell ranks send output and log data to the rank 0 shell via
- * RPCs.
+ * RPCs using FLUX_RPC_NORESPONSE.
  *
- * Notes:
- *  - Errors from write requests to leader shell are logged.
- *  - Outstanding RPCs at shell exit are waited for synchronously.
- *  - Number of in-flight write RPCs is limited by client->hwm
- *    to avoid matchtag exhaustion.
+ * A credit-based flow control protocol limits the number of
+ * in-flight write requests: each shell starts with credits equal
+ * to client->hwm, and requests more credits from the leader when
+ * credits drop to client->lwm. If credits reach zero, the shell
+ * output plugin stops reading output from local tasks until more
+ * credits are received from the leader.
+ *
  */
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/shell/output/output.c
+++ b/src/shell/output/output.c
@@ -338,12 +338,33 @@ static int shell_output_reconnect (flux_plugin_t *p,
     return 0;
 }
 
+static int shell_output_finish (flux_plugin_t *p,
+                                const char *topic,
+                                flux_plugin_arg_t *args,
+                                void *data)
+{
+    struct shell_output *out = flux_plugin_aux_get (p, "builtin.output");
+
+    /* After all tasks finish, destroy client and send EOF to leader shell
+     * to indicate no more output will be sent from this shell.
+     *
+     * Note: All output has been read and sent to the leader before this
+     * point since tasks complete only after EOF on both stdout and stderr.
+     */
+    if (out->client) {
+        output_client_destroy (out->client);
+        out->client = NULL;
+    }
+    return 0;
+}
+
 struct shell_builtin builtin_output = {
     .name = FLUX_SHELL_PLUGIN_NAME,
     .reconnect = shell_output_reconnect,
     .init = shell_output_init,
     .task_init = shell_output_task_init,
     .task_exit = shell_output_task_exit,
+    .finish = shell_output_finish,
 };
 
 /*

--- a/src/shell/output/output.c
+++ b/src/shell/output/output.c
@@ -333,7 +333,7 @@ static int shell_output_reconnect (flux_plugin_t *p,
                                    flux_plugin_arg_t *args,
                                    void *data)
 {
-    struct shell_output *out = data;
+    struct shell_output *out = flux_plugin_aux_get (p, "builtin.output");
     kvs_output_reconnect (out->kvs);
     return 0;
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -519,6 +519,7 @@ check_LTLIBRARIES = \
 	shell/plugins/jobspec-info.la \
 	shell/plugins/taskmap-reverse.la \
 	shell/plugins/fork.la \
+	shell/plugins/finish.la \
 	job-manager/plugins/priority-wait.la \
 	job-manager/plugins/priority-invert.la \
 	job-manager/plugins/args.la \
@@ -928,6 +929,14 @@ shell_plugins_fork_la_LDFLAGS = \
 	$(fluxplugin_ldflags) -module -rpath /nowhere
 shell_plugins_fork_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
+
+shell_plugins_finish_la_SOURCES = shell/plugins/finish.c
+shell_plugins_finish_la_CPPFLAGS = $(test_cppflags)
+shell_plugins_finish_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+shell_plugins_finish_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
 
 job_manager_plugins_priority_wait_la_SOURCES = \
 	job-manager/plugins/priority-wait.c

--- a/t/shell/plugins/finish.c
+++ b/t/shell/plugins/finish.c
@@ -1,0 +1,134 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#define FLUX_SHELL_PLUGIN_NAME "finish"
+
+/* Test that delay in shell exit handler in follower shells
+ * does not prevent leader shell from calling shell.exit handler
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <flux/shell.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+static void get_shell_info (flux_shell_t *shell, int *rank, int *size)
+{
+    if (flux_shell_info_unpack (shell,
+                                "{s:i s:i}",
+                                "rank", rank,
+                                "size", size))
+        shell_die_errno (1, "flux_shell_info_unpack");
+}
+
+static int exit_cb (flux_plugin_t *p,
+                    const char *topic,
+                    flux_plugin_arg_t *args,
+                    void *data)
+{
+    flux_future_t *f;
+    flux_shell_t *shell = data;
+    int shell_rank;
+    int size;
+
+    get_shell_info (shell, &shell_rank, &size);
+
+    if (shell_rank == 0) {
+        // On rank 0, ensure all 'test-finish' requests have arrived and
+        // respond to them to release other ranks from shell.exit callback:
+        zlistx_t *requests = flux_plugin_aux_get (p, "requests");
+        flux_t *h = flux_shell_get_flux (shell);
+
+        // Run reactor until all expected requests have arrived
+        while (zlistx_size (requests) < size - 1)
+            flux_reactor_run (flux_get_reactor (h), FLUX_REACTOR_ONCE);
+
+        // Reply to all requests
+        shell_log ("responding to %d requests", (int) zlistx_size (requests));
+        const flux_msg_t *msg = zlistx_first (requests);
+        while (msg) {
+            flux_respond (h, msg, NULL);
+            msg = zlistx_next (requests);
+        }
+        return 0;
+    }
+
+    // On follower shells, simply send a request to rank 0 and wait
+    // for a response. If follower shell.exit callbacks prevent rank 0
+    // job shell from exiting the reactor due to output plugin, then
+    // this will hang the job since the leader shell only replies to
+    // these write requests from its own shell.exit handler.
+    shell_log ("sending test-finish request to rank 0");
+    if (!(f = flux_shell_rpc_pack (shell, "test-finish", 0, 0, "{}"))
+        || flux_future_get (f, NULL) < 0)
+        return shell_log_errno ("failed to wait for test-finish response");
+    return 0;
+}
+
+static void finish_service_cb (flux_t *h,
+                               flux_msg_handler_t *mh,
+                               const flux_msg_t *msg,
+                               void *arg)
+{
+    zlistx_t *requests = arg;
+    shell_log ("got request %d", (int) zlistx_size (requests) + 1);
+    zlistx_add_end (requests, flux_msg_copy (msg, false));
+}
+
+static void requests_destroy (void *arg)
+{
+    zlistx_t *l = arg;
+    flux_msg_t *msg;
+
+    if (l) {
+        msg = zlistx_first (l);
+        while (msg) {
+            flux_msg_decref (msg);
+            msg = zlistx_next (l);
+        }
+        zlistx_destroy (&l);
+    }
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    int shell_rank;
+    int size;
+
+     get_shell_info (shell, &shell_rank, &size);
+
+    flux_plugin_set_name (p, FLUX_SHELL_PLUGIN_NAME);
+
+    if (flux_plugin_add_handler (p, "shell.exit", exit_cb, shell) < 0)
+        return -1;
+
+    if (shell_rank == 0) {
+        zlistx_t *requests;
+        if (!(requests = zlistx_new ())
+            || flux_shell_service_register (shell,
+                                            "test-finish",
+                                            finish_service_cb,
+                                            requests) < 0
+            || flux_plugin_aux_set (p,
+                                    "requests",
+                                    requests,
+                                    requests_destroy) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -430,4 +430,11 @@ test_expect_success 'job-shell: open of invalid output files fails' '
 	test_must_fail flux run -N4 -n8 \
 		--output=/nosuchdir/output.{{task.id}} hostname
 '
+test_expect_success 'job-shell: slow shell.exit does not prevent rank 0 from exiting reactor' '
+	cat <<-EOF >test-finish.lua &&
+	plugin.searchpath = "${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs"
+	plugin.load { file = "finish.so" }
+	EOF
+	flux run -N4 -t 3m -o userrc=test-finish.lua true
+'
 test_done


### PR DESCRIPTION
Job shell write service clients send EOF to the leader only during plugin destruction at shell exit. If a follower shell's `shell.exit` callback delays (e.g. performing cleanup), the leader must wait for all followers to complete before it can exit the reactor and invoke its own `shell.exit` callbacks. This can cause strange cascading timeout behavior as seen in #7345.

This PR destroys the output client from the `shell.finish` callback instead of at shell process exit. This sends the client EOF immediately after tasks exit, allowing the leader to proceed without waiting for follower shells' exit callbacks.

This should resolve issue #7345 on its own, however a follow on PR will also shut down the subprocess server in the `shell.finish` callback as well for good measure.

This is based on top of #7362