### PR TITLE
rc1: do not run fsck in recovery mode

### DIFF
--- a/etc/modprobe/rc1.py
+++ b/etc/modprobe/rc1.py
@@ -141,6 +141,8 @@ def check_clean_shutdown(context):
 #
 # If a dump was restored, we can assume the prior instance was shutdown
 # cleanly.
+#
+# Special case: no fsck in recovery mode
 @task(
     "fsck",
     ranks="0",
@@ -148,6 +150,7 @@ def check_clean_shutdown(context):
     after=["content-backing", "restore"],
     requires=["content-backing"],
     needs=["content-backing"],
+    needs_attrs=["!broker.recovery-mode"],
 )
 def fsck(context):
     try:

--- a/t/system/0007-fsck.t
+++ b/t/system/0007-fsck.t
@@ -138,3 +138,23 @@ test_expect_success 'restart flux' '
 test_expect_success 'wait for flux to finish starting back up' '
 	wait_flux_back_up
 '
+
+test_expect_success 'stop flux cleanly' '
+	sudo systemctl stop flux
+'
+
+test_expect_success 'start flux in recovery mode' '
+	sudo -u flux flux start --recovery "flux dmesg" | grep rc1 > log4.out
+'
+
+test_expect_success 'flux in recovery mode does not run fsck' '
+	test_must_fail grep "Checking integrity" log4.out
+'
+
+test_expect_success 'start flux' '
+	sudo systemctl start flux
+'
+
+test_expect_success 'wait for flux to finish starting back up' '
+	wait_flux_back_up
+'


### PR DESCRIPTION
Problem: It was discovered that fsck is run when flux is started in recovery mode.  Since we are in recovery mode, the fsck really
shouldn't be run.  It would be up to an administrator to run it manually if desired.

Disable fsck when flux starts in recovery mode.

Fixes #7353