### PR TITLE
t: fix incorrectly running job list sort tests

### DIFF
--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1256,6 +1256,34 @@ test_expect_success 'remove jobtap plugins' '
 	flux jobtap remove all
 '
 
+# sort tests
+
+test_expect_success 'flux-jobs allows sorting order in format' '
+	flux jobs -ano "{ncores}	{t_submit}	{id.f58}" \
+		| sort -k1,1n -k2,2n \
+		| cut -f 3 >sort1.expected &&
+	flux jobs -ano "sort:ncores,t_submit {id.f58}" >sort1.out &&
+	test_cmp sort1.expected sort1.out
+'
+test_expect_success 'flux-jobs allows sorting order via --sort' '
+	flux jobs -ano "{ntasks}	{t_submit}	{id.f58}" \
+		| sort -k1,1n -k2,2rn \
+		| cut -f 3 >sort2.expected &&
+	flux jobs -an --sort=ntasks,-t_submit -o "{id.f58}" >sort2.out &&
+	test_cmp sort2.expected sort2.out
+'
+test_expect_success 'flux-jobs --sort overrides sort: in format' '
+	flux jobs -ano "{ntasks}	{t_submit}	{id.f58}" \
+		| sort -k1,1n -k2,2rn \
+		| cut -f 3 >sort3.expected &&
+	flux jobs -an --sort=ntasks,-t_submit -o "sort:t_submit {id.f58}" \
+		>sort3.out &&
+	test_cmp sort3.expected sort3.out
+'
+test_expect_success 'flux-jobs invalid sort key throws exception' '
+	test_must_fail flux jobs -a --sort=foo 2>sort.error &&
+	grep "Invalid sort key: foo" sort.error
+'
 
 #
 # format header tests.
@@ -1636,31 +1664,5 @@ test_expect_success 'flux-jobs --stats works after jobs purged (defaultqueue)' '
 	EOF
 	head -1 statspurgeqdefault.output > statspurgeqdefault.actual &&
 	test_cmp statspurgeqdefault.expected statspurgeqdefault.actual
-'
-test_expect_success 'flux-jobs allows sorting order in format' '
-	flux jobs -ano "{ncores}	{t_submit}	{id.f58}" \
-		| sort -k1,2n \
-		| cut -f 3 >sort1.expected &&
-	flux jobs -ano "sort:ncores,t_submit {id.f58}" >sort1.out &&
-	test_cmp sort1.expected sort1.out
-'
-test_expect_success 'flux-jobs allows sorting order via --sort' '
-	flux jobs -ano "{ntasks}	{t_submit}	{id.f58}" \
-		| sort -k1n,2rn \
-		| cut -f 3 >sort2.expected &&
-	flux jobs -an --sort=ntasks,-t_submit -o "{id.f58}" >sort2.out &&
-	test_cmp sort2.expected sort2.out
-'
-test_expect_success 'flux-jobs --sort overrides sort: in format' '
-	flux jobs -ano "{ntasks}	{t_submit}	{id.f58}" \
-		| sort -k1n,2rn \
-		| cut -f 3 >sort3.expected &&
-	flux jobs -an --sort=ntasks,-t_submit -o "sort:t_submit {id.f58}" \
-		>sort3.out &&
-	test_cmp sort3.expected sort3.out
-'
-test_expect_success 'flux-jobs invalid sort key throws exception' '
-	test_must_fail flux jobs -a --sort=foo 2>sort.error &&
-	grep "Invalid sort key: foo" sort.error
 '
 test_done


### PR DESCRIPTION
Problem: A set of job sorting tests in t2800-jobs-cmd.t are run after all jobs are purged.  This results in the tests not testing anything because there are no jobs to sort.  In addition, there was a sorting error in the tests.

Move the tests higher up in the file so they run against actual listed jobs.  Correct the sorting error so the tests now work.

Fixes #7368