### PR TITLE
flux-dmesg: add --stderr-level option

### DIFF
--- a/doc/man1/flux-dmesg.rst
+++ b/doc/man1/flux-dmesg.rst
@@ -54,6 +54,15 @@ OPTIONS
    or *always*. If *WHEN* is omitted, it defaults to *always*. The default
    value when the :option:`--color` option is not used is *auto*.
 
+.. option:: --stderr-level=LEVEL
+
+   Set the broker stderr log severity level.  Log messages with a severity
+   less than (more severe) or equal to the threshold are printed on the
+   local broker's standard error.  LEVEL should be a numerical syslog level
+   (0-7) or a negative number to disable.  The initial value is 3 (LOG_ERR)
+   unless overridden with the ``log-stderr-level`` broker attribute.
+   For a table of level values, see :man1:`flux-broker`.
+
 EXAMPLES
 ========
 

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -11,7 +11,7 @@ legacy=$(realpath ${FLUX_BUILD_DIR}/t/module/.libs/legacy.so)
 rpc_stream=${FLUX_BUILD_DIR}/t/request/rpc_stream
 waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
 
-flux setattr log-stderr-level 6
+flux dmesg --stderr-level=6
 
 test_expect_success 'flux-module-exec requires an argument' '
 	test_must_fail flux module-exec 2>nomod.err &&

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -256,5 +256,22 @@ test_expect_success 'setting log-forward-level to -1 works' '
 	    flux exec -r 1 flux logger --severity=emerg "smurfs" &&
 	test_must_fail grep "logger.emerg" forward.log
 '
-
+test_expect_success 'flux dmesg --stderr-level=0 works' '
+	echo 0 >stderr.exp &&
+	flux dmesg --stderr-level=0 &&
+	flux getattr log-stderr-level >stderr.out &&
+	test_cmp stderr.exp stderr.out
+'
+test_expect_success 'flux dmesg --stderr-level=-1 works' '
+	echo -1 >stderr2.exp &&
+	flux dmesg --stderr-level=-1 &&
+	flux getattr log-stderr-level >stderr2.out &&
+	test_cmp stderr2.exp stderr2.out
+'
+test_expect_success 'flux dmesg --stderr-level=8 fails' '
+	test_must_fail flux dmesg --stderr-level=8
+'
+test_expect_success 'restore stderr-level to 3 (LOG_ERR)' '
+	flux dmesg --stderr-level=3
+'
 test_done

--- a/t/t1107-heartbeat.t
+++ b/t/t1107-heartbeat.t
@@ -127,7 +127,7 @@ test_expect_success 'reconfig with warn_thresh=10 works' '
 	flux module stats heartbeat | jq -r -e ".warn_thresh == 10"
 '
 test_expect_success 'reload with period=0.1s timeout=infinity warn_thresh=3' '
-	flux exec flux setattr log-stderr-level 4 &&
+	flux exec flux dmesg --stderr-level=4 &&
 	flux exec -r 1 flux dmesg -C &&
 	flux config load <<-EOT &&
 	[heartbeat]

--- a/t/t2113-job-ingest-pipeline.t
+++ b/t/t2113-job-ingest-pipeline.t
@@ -96,9 +96,9 @@ test_expect_success 'stop validator 0' '
 	kill -STOP $valpid
 '
 test_expect_success 'remove job-ingest to trigger cleanup' '
-	flux setattr log-stderr-level 7 &&
+	flux dmesg --stderr-level=7 &&
 	flux module remove job-ingest &&
-	flux setattr log-stderr-level 1
+	flux dmesg --stderr-level=1
 '
 
 test_done

--- a/t/t2303-sched-hello.t
+++ b/t/t2303-sched-hello.t
@@ -26,7 +26,7 @@ test_expect_success 'exclude the job node from configuration' '
 	EOT
 '
 test_expect_success 'increase broker stderr log level' '
-	flux setattr log-stderr-level 6
+	flux dmesg --stderr-level=6
 '
 test_expect_success 'load scheduler' '
 	flux module load resource &&
@@ -92,7 +92,7 @@ test_expect_success 'run another job that uses the same resources' '
 	flux run -vv -N1 true
 '
 test_expect_success 'decrease broker stderr log level' '
-	flux setattr log-stderr-level 5
+	flux dmesg --stderr-level=5
 '
 
 test_done

--- a/t/t2410-sdexec-memlimit.t
+++ b/t/t2410-sdexec-memlimit.t
@@ -63,7 +63,7 @@ fi
 
 test_under_flux 1 full --config-path=$(pwd)/config
 
-flux setattr log-stderr-level 6
+flux dmesg --stderr-level=6
 
 sdexec="flux exec --service sdexec"
 getcg=$(pwd)/getcg.sh
@@ -211,6 +211,6 @@ test_expect_success 'memory.max configuration changed' '
 	test_cmp inf.exp maxupdate.out
 '
 
-flux setattr log-stderr-level 3
+flux dmesg --stderr-level=3
 
 test_done

--- a/t/t2411-sdexec-job.t
+++ b/t/t2411-sdexec-job.t
@@ -32,7 +32,7 @@ EOT
 
 test_under_flux 2 full --config-path=$(pwd)/config
 
-flux exec flux setattr log-stderr-level 7
+flux exec flux dmesg --stderr-level=7
 
 sdexec="flux exec --service sdexec"
 lptest="flux lptest"
@@ -111,6 +111,6 @@ test_expect_success 'cannot load job-exec module' '
 	test_must_fail flux module load job-exec
 '
 
-flux exec flux setattr log-stderr-level 1
+flux exec flux dmesg --stderr-level=1
 
 test_done


### PR DESCRIPTION
Problem: #7370 proposes to deprecate the current method for changing the stderr log severity level at runtime, but some flux-core tests are still adjusting the level up and down for specific test segments.

Add a new option `flux-dmesg --stderr-level=N` and corresponding `log.setattr` RPC in the log subsystem.

p.s. this only adds the new way.  A future PR can deprecate the old way.