### PR TITLE
enhance `flux-python` for multi-version support, add `flux-pythonX.Y` convenience scripts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -529,6 +529,8 @@ adl_RECURSIVE_EVAL(["$fluxlibdir/python$PYTHON_VERSION"], [fluxpylinkdir])
 AC_DEFINE_UNQUOTED([FLUXPYLINKDIR], ["$fluxpylinkdir"],
   [The expansion of "$fluxlibdir/python$PYTHON_VERSION"])
 AC_SUBST(fluxpylinkdir)
+adl_RECURSIVE_EVAL(["$fluxpylinkdir"], [X_FLUXPYLINKDIR])
+AC_SUBST([X_FLUXPYLINKDIR])
 
 adl_RECURSIVE_EVAL(["$libdir/flux/modules"], [fluxmoddir])
 AC_DEFINE_UNQUOTED([FLUXMODDIR], ["$fluxmoddir"],
@@ -658,6 +660,7 @@ AC_CONFIG_FILES( \
   etc/flux-epilog@.service \
   src/cmd/flux-run-prolog \
   src/cmd/flux-run-epilog \
+  src/cmd/flux-python${PYTHON_VERSION}:src/cmd/flux-python-version.in \
   doc/Makefile \
   doc/test/Makefile \
   t/Makefile \
@@ -669,6 +672,12 @@ AC_CONFIG_FILES( \
 AC_CONFIG_LINKS([ \
   t/fluxometer.lua:t/fluxometer.lua \
 ])
+
+AC_CONFIG_COMMANDS(
+  [chmod],
+  [chmod +x src/cmd/flux-python${PYTHON_VERSION}],
+  [PYTHON_VERSION=$PYTHON_VERSION]
+)
 
 AC_OUTPUT
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -60,7 +60,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-hostlist.1 \
 	man1/flux-housekeeping.1 \
 	man1/flux-modprobe.1 \
-	man1/flux-sproc.1
+	man1/flux-sproc.1 \
+	man1/flux-python.1
 
 # These files are generated as clones of a primary page.
 # Sphinx handles this automatically if declared in the conf.py

--- a/doc/man1/flux-python.rst
+++ b/doc/man1/flux-python.rst
@@ -1,0 +1,159 @@
+===============
+flux-python(1)
+===============
+
+
+SYNOPSIS
+========
+
+**flux** **python** [*--get-path*] [*--list-versions*] [*ARGS...*]
+
+**flux** **pythonX.Y** [*--get-path*] [*ARGS...*]
+
+
+DESCRIPTION
+===========
+
+.. program:: flux python
+
+:program:`flux python` provides convenient access to the Python interpreter
+configured for the current Flux installation, with the Flux Python
+bindings automatically available for import.
+
+When invoked without options, :program:`flux python` prepends the Flux Python
+bindings installation path to :envvar:`PYTHONPATH` and executes the configured
+Python interpreter with all remaining arguments. This allows running Python
+scripts or interactive sessions with immediate access to the correct **flux**
+module for the current Flux installation without manual :envvar:`PYTHONPATH`
+manipulation.
+
+The command also supports special options to get the path to the bindings
+as well as support discovery of available Python versions when bindings
+for multiple Python version may be installed.
+
+By default, Flux installs Python bindings to a standard Python installation
+path (e.g., ``site-packages``). However, prepending this entire directory
+to :envvar:`PYTHONPATH` would place all modules in that location ahead of
+the user's existing Python path, potentially overriding other installed
+packages. To avoid this issue, Flux creates per-version symbolic links
+to only the Flux Python bindings in an isolated directory under the Flux
+library path. This isolated path is what :program:`flux python` adds to
+:envvar:`PYTHONPATH` and what :option:`--get-path` reports, ensuring users
+can access Flux bindings without inadvertently affecting the import order
+of other Python modules.
+
+
+OPTIONS
+=======
+
+.. option:: --get-path
+
+   Print the installation path of the Flux Python bindings for this Python
+   version and exit. This reports the isolated path containing only Flux
+   bindings, not the full Python site-packages directory, allowing the
+   bindings to be added to :envvar:`PYTHONPATH` without affecting the import
+   order of other Python modules.
+
+.. option:: --list-versions
+
+   List available python bindings versions by looking for
+   :program:`flux-pythonX.Y` wrapper scripts in :envvar:`FLUX_EXEC_PATH`.
+   Each line of output shows a version-specific command (e.g., ``python3.10``,
+   ``python3.11``) that can be invoked via :program:`flux pythonX.Y**`. This
+   option helps discover which Python versions have Flux bindings installed
+   in multi-version environments.
+
+
+VERSION-SPECIFIC COMMANDS
+==========================
+
+When multiple Flux installations are built against different Python versions,
+each installs a :program:`flux pythonX.Y` command (e.g., :program:`flux
+python3.10`, :program:`flux python3.11`) corresponding to its target Python
+version. These commands provide explicit access to Flux bindings for specific
+Python versions.
+
+The :program:`flux pythonX.Y` commands accept the same :option:`--get-path`
+option as :program:`flux python`, allowing users to query the bindings path
+for any installed Python version:
+
+.. code-block:: console
+
+   $ flux python3.10 --get-path
+   /usr/lib/flux/python3.10
+
+
+To discover which version-specific commands are available, use:
+
+.. code-block:: console
+
+   $ flux python --list-versions
+   python3.10
+   python3.11
+   python3.12
+
+
+EXAMPLES
+========
+
+Run a Python script with Flux bindings available:
+
+.. code-block:: console
+
+   $ flux python myscript.py
+
+Start an interactive Python session:
+
+.. code-block:: console
+
+   $ flux python
+   >>> import flux
+   >>> h = flux.Flux()
+
+Get the path to default Flux Python bindings:
+
+.. code-block:: console
+
+   $ flux python --get-path
+   /usr/lib/flux/python3.11
+
+Use a specific Python version:
+
+.. code-block:: console
+
+   $ flux python3.10 -c "import sys; print(sys.version)"
+   3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
+
+Manually set :envvar:`PYTHONPATH` for external tools:
+
+.. code-block:: console
+
+   $ export PYTHONPATH=$(flux python --get-path):$PYTHONPATH
+   $ python3 -c 'import flux; print(flux.Flux().attr_get("rank"))'
+   0
+
+ENVIRONMENT
+===========
+
+.. envvar:: PYTHONPATH
+
+   The :program:`flux python` command prepends the Flux bindings installation
+   path to this environment variable before executing Python. Any
+   existing :envvar:`PYTHONPATH` entries are preserved.
+
+.. envvar:: FLUX_EXEC_PATH
+
+   Used by :option:`--list-versions` to discover installed
+   :program:`flux-pythonX.Y` commands across all directories in the Flux
+   command search path.
+
+
+RESOURCES
+=========
+
+.. include:: common/resources.rst
+
+SEE ALSO
+========
+
+:man1:`flux`, :linux:man1:`python`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -75,6 +75,7 @@ man_pages = [
     ('man1/flux-housekeeping', 'flux-housekeeping', 'list and terminate housekeeping tasks', [author], 1),
     ('man1/flux-modprobe', 'flux-modprobe', 'efficient and extensible task and module manager', [author], 1),
     ('man1/flux-sproc', 'flux-sproc', 'manage flux subprocesses', [author], 1),
+    ('man1/flux-python', 'flux-python', 'invoke Python interpreter with Flux bindings available', [author], 1),
     ('man3/flux_attr_get', 'flux_attr_set', 'get/set Flux broker attributes', [author], 3),
     ('man3/flux_attr_get', 'flux_attr_set_ex', 'get/set Flux broker attributes', [author], 3),
     ('man3/flux_attr_get', 'flux_attr_get', 'get/set Flux broker attributes', [author], 3),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1084,3 +1084,7 @@ getppid
 ppid
 JobID
 fprintf
+myscript
+prepending
+prepends
+pythonX

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -132,7 +132,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-run-prolog \
 	flux-run-epilog \
 	flux-modprobe.py \
-	flux-sproc.py
+	flux-sproc.py \
+	flux-python$(PYTHON_VERSION)
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/builtin/python.c
+++ b/src/cmd/builtin/python.c
@@ -14,7 +14,10 @@
 #include <unistd.h>
 
 #include "builtin.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/environment.h"
+#include "src/common/libutil/basename.h"
+#include "src/common/libutil/dirwalk.h"
 #include "ccan/str/str.h"
 
 static void prepare_environment (void)
@@ -28,6 +31,33 @@ static void prepare_environment (void)
     environment_destroy (env);
 }
 
+static int filter_exe (dirwalk_t *d, void *arg)
+{
+    return (access (dirwalk_path (d), X_OK) == 0);
+}
+
+static void list_versions (void)
+{
+    const char *name;
+    zlist_t *l;
+    if (!(l = dirwalk_find (getenv ("FLUX_EXEC_PATH"),
+                            DIRWALK_NORECURSE,
+                            "flux-python[0-9]*",
+                            -1,
+                            filter_exe,
+                            NULL)))
+        log_err_exit ("Unable to find all flux-python versions");
+
+    name = zlist_first (l);
+    while (name) {
+        /* Print name with flux- prefix removed:
+         */
+        printf ("%s\n", basename_simple (name) + strlen ("flux-"));
+        name = zlist_next (l);
+    }
+    zlist_destroy (&l);
+}
+
 static int cmd_python (optparse_t *p, int ac, char *av[])
 {
     /*  Support `--get-path` as first argument (other args are ignored.
@@ -36,6 +66,13 @@ static int cmd_python (optparse_t *p, int ac, char *av[])
     if (ac > 1 && streq (av[1], "--get-path")) {
         printf ("%s\n",
                 flux_conf_builtin_get ("python_path", FLUX_CONF_INSTALLED));
+        exit (0);
+    }
+    /*  Support `--list-versions` as first argument (other args are ignored.
+     *  Print installed python path and exit if found.
+     */
+    if (ac > 1 && streq (av[1], "--list-versions")) {
+        list_versions ();
         exit (0);
     }
 

--- a/src/cmd/builtin/python.c
+++ b/src/cmd/builtin/python.c
@@ -15,6 +15,7 @@
 
 #include "builtin.h"
 #include "src/common/libutil/environment.h"
+#include "ccan/str/str.h"
 
 static void prepare_environment (void)
 {
@@ -29,6 +30,15 @@ static void prepare_environment (void)
 
 static int cmd_python (optparse_t *p, int ac, char *av[])
 {
+    /*  Support `--get-path` as first argument (other args are ignored.
+     *  Print installed python path and exit if found.
+     */
+    if (ac > 1 && streq (av[1], "--get-path")) {
+        printf ("%s\n",
+                flux_conf_builtin_get ("python_path", FLUX_CONF_INSTALLED));
+        exit (0);
+    }
+
     /*
      *  Ensure av[0] matches the full path of the interpreter we're executing.
      *  Other than just being good practice, this ensures that sys.executable

--- a/src/cmd/flux-python-version.in
+++ b/src/cmd/flux-python-version.in
@@ -1,0 +1,25 @@
+#!/bin/sh
+##############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+# `flux pythonX.Y` wrapper script:
+#
+# Print path to Flux Python bindings for this Python version if
+# exactly `--get-path` is the first argument. Otherwise, invoke
+# the Python interpreter representing this version.
+#
+
+if test "$1" = "--get-path"; then
+    echo "@X_FLUXPYLINKDIR@"
+    exit 0
+fi
+
+export PYTHONPATH="@X_FLUXPYLINKDIR@:$PYTHONPATH"
+exec @PYTHON@ "$@"

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -119,7 +119,22 @@ test_expect_success 'flux-keygen fails with unknown arg' '
 test_expect_success 'flux-python command runs a python that finds flux' '
 	flux python -c "import flux"
 '
-
+test_expect_success 'flux-python --get-path reports installed path' '
+	flux python --get-path >get-path.out &&
+	flux config builtin --installed python_path >get-path.expected &&
+	test_cmp get-path.expected get-path.out
+'
+test_expect_success 'flux-python3.x command exists and works' '
+	pycmd=$(basename $(flux python --get-path)) &&
+	test_debug "echo checking flux $pycmd" &&
+	flux $pycmd --version  >pyversion.out &&
+	flux python --version >pyversion.expected &&
+	test_cmp pyversion.expected pyversion.out
+'
+test_expect_success 'flux-python3.x command --get-path works' '
+	flux python --get-path >get-pathX.out &&
+	test_cmp get-path.expected get-pathX.out
+'
 test_expect_success 'flux-python command runs the configured python' '
 	define_line=$(grep "^#define PYTHON_INTERPRETER" ${FLUX_BUILD_DIR}/config/config.h) &&
 	pypath=$(echo ${define_line} | sed -E '\''s~.*define PYTHON_INTERPRETER "(.*)"~\1~'\'') &&

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -124,6 +124,22 @@ test_expect_success 'flux-python --get-path reports installed path' '
 	flux config builtin --installed python_path >get-path.expected &&
 	test_cmp get-path.expected get-path.out
 '
+test_expect_success 'flux-python --list-versions works' '
+	mkdir pyvertest &&
+	touch pyvertest/flux-python0.0 &&
+	chmod +x pyvertest/flux-python0.0 &&
+	FLUX_EXEC_PATH_PREPEND=./pyvertest \
+	  flux python --list-versions >pyvertest.out &&
+	test_debug "cat pyvertest.out" &&
+	grep python0.0 pyvertest.out
+'
+test_expect_success 'flux-python --list-versions skips non-executables' '
+	touch pyvertest/flux-python0.1 &&
+	FLUX_EXEC_PATH_PREPEND=./pyvertest \
+	  flux python --list-versions >pyvertest2.out &&
+	test_debug "cat pyvertest2.out" &&
+	test_must_fail grep python0.1 pyvertest2.out
+'
 test_expect_success 'flux-python3.x command exists and works' '
 	pycmd=$(basename $(flux python --get-path)) &&
 	test_debug "echo checking flux $pycmd" &&


### PR DESCRIPTION
This is a propsal to address issue #7340.

This PR adds `flux-pythonX.Y` wrapper scripts (e.g., `flux-python3.10`) that are installed alongside each Flux build targeting a specific Python version. These scripts support a `--get-path` option to print the isolated installation path of the Flux Python bindings.

This PR also adds `--get-path` and `--list-versions` options to the `flux python` builtin command. The `--get-path` option prints the path to Flux Python bindings for current Flux. The `--list-versions` option discovers and lists all supported `pythonX.Y` versions by virtue of  `flux-pythonX.Y` commands in `FLUX_EXEC_PATH`.

Note that `--get-path` in these utilities prints the configured install path, never an in-tree path.

The `flux-pythonX.Y` wrapper scripts can be packaged in the `flux-core-pythonX.Y` RPM subpackages, and along with `flux python --list-version` would give users and easy way to discover available Flux Python bindings and get the isolated path to them.

For example:
```console
$ flux python --get-path
/usr/lib64/flux/python3.11

$ flux python --list-versions
python3.10
python3.11
python3.12

$ flux python3.10 --get-path
/usr/lib/flux/python3.10

$ flux python3.10 --version
Python 3.10.12
```

Fixes #7340