### PR TITLE
t: fix racy flux-top test

### DIFF
--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -178,7 +178,7 @@ test_expect_success 'flux-top JOBID fails when JOBID is not a flux instance' '
 test_expect_success NO_CHAIN_LINT 'flux-top quits on q keypress' '
 	$runpty --quit-char=q --format=asciicast -o keys.log flux top &
 	pid=$! &&
-	sleep 1 &&
+	$waitfile --timeout=30 --pattern="JOBID" keys.log &&
 	kill -USR1 $pid &&
 	wait $pid
 '


### PR DESCRIPTION
Problem: A test in t2801-top-cmd.t is potentially racy due to the backgrounding of a process.

Ensure the backgrounded process has started by waiting for some flux-top output in the output file.  After that, initiate the actual test.

Fixes #7351