### PR TITLE
ci: fix podman build failure in docker-run-systest.sh

### DIFF
--- a/src/test/docker/docker-run-systest.sh
+++ b/src/test/docker/docker-run-systest.sh
@@ -95,10 +95,6 @@ checks_group "Moving $IMAGE from docker to podman" \
   && (podman load -i /tmp/systest-$$.tar || die "podman load failed") \
   && rm -f /tmp/systest-$$.tar
 
-#  Note: There's a bug in podman < 4 which saves an image loaded from
-#  docker save as the wrong name, so we use the image digest instead:
-IMAGE=$(docker images --format {{.ID}} $IMAGE)
-
 checks_group "Building system image for user $USER $(id -u) group=$(id -g)" \
   podman build \
     ${NOCACHE} \


### PR DESCRIPTION
Problem: After loading an image from docker into podman, the `docker-run-systest.sh` script converts `IMAGE` to a bare image ID before passing it to `podman build`. When podman receives a bare hash like "205df43e8915" in the FROM directive, it seems to interpret it as an image name to pull from a registry rather than a reference to a local image, causing the build to fail with registry access errors.

Remove the line that converts IMAGE to an image ID. This line was originally added as a workaround for a bug in podman < 4 where images loaded from `docker save` were saved with incorrect names. The workaround is no longer needed with current podman versions.