### PR TITLE
testsuite: make faketime timestamp file updates atomic

### DIFF
--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -60,8 +60,10 @@ flux_cron() {
 cat >make-faketime.sh <<EOF
 #!/bin/sh
 d="\$@"
-date +"@%Y-%m-%d %H:%M:%S" --date="\${d}" > ${FAKETIME_TIMESTAMP_FILE}
+date +"@%Y-%m-%d %H:%M:%S" --date="\${d}" > ${FAKETIME_TIMESTAMP_FILE}.tmp
 sync
+# Use mv so timestamp file update is atomic
+mv ${FAKETIME_TIMESTAMP_FILE}.tmp ${FAKETIME_TIMESTAMP_FILE}
 echo timestamp file: \$(cat $FAKETIME_TIMESTAMP_FILE): date is now \$(date) >&2
 # Poke flux cron so libev wakes up and reifies time:
 flux cron list >/dev/null 2>&1 || :


### PR DESCRIPTION
Problem: When `make-faketime.sh` writes to the libfaketime timestamp file in t0016-cron-faketime.t, it may be possible that some Flux or other process calls gettimeofday() or other time call in the middle of the write. This could cause unexpected failures in the test.

Write faketime timestamp to a temporary file first, then atomically rename it to the target file to avoid a partial read or other similar race condition.

This _might_ address #7377, but I'm not too hopeful. We can merge this since it won't hurt anything and see if we still get similar failures in the faketime tests going forward.