### PR TITLE
drain nodes with "terminated before first barrier" exception (multiuser jobs only)

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -460,6 +460,23 @@ static void exit_cb (struct bulk_exec *exec,
                               hosts ? hosts : "(unknown)",
                               idset_count (ranks) ? "s" : "",
                               ids ? ids : "(unknown)");
+
+        /* If this job was run under the IMP, drain the affected ranks since
+         * this could indicate an unrecoverable node issue (like missing
+         * or incorrect MUNGE key)
+         */
+        if (job->multiuser
+            && jobinfo_drain_ranks (job,
+                                    ids,
+                                    "%s terminated before first barrier",
+                                    idf58 (job->id)) < 0)
+            flux_log_error (job->h,
+                            "failed to drain %s (rank%s %s) for job %s",
+                            hosts ? hosts : "(unknown)",
+                            idset_count (ranks) ? "s" : "",
+                            ids ? ids : "(unknown)",
+                            idf58 (job->id));
+
         free (ids);
         free (hosts);
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -54,6 +54,7 @@ LONGTESTSCRIPTS = \
 	t3202-instance-restart-testexec.t \
 	t3203-instance-recovery.t \
 	t4000-issues-test-driver.t \
+	t2800-jobs-cmd.t \
 	t2801-top-cmd.t \
 	t2808-shutdown-cmd.t \
 	t2712-python-cli-alloc.t \
@@ -242,7 +243,6 @@ TESTSCRIPTS = \
 	t2716-python-cli-batch-conf.t \
 	t2717-python-cli-plugins.t \
 	t2720-python-cli-multi-prog.t \
-	t2800-jobs-cmd.t \
 	t2800-jobs-cmd-multiuser.t \
 	t2800-jobs-recursive.t \
 	t2800-jobs-instance-info.t \

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -113,6 +113,16 @@ test_expect_success 'job-exec: IMP failure on one rank terminates job' '
 	flux job wait-event -vt 20 ${id}  clean &&
 	test_must_fail_or_be_terminated flux job attach -vEX ${id}
 '
-
+test_expect_success 'job-exec: failed rank is drained' '
+	flux resource drain -no "{ranks} {reason}" >drain.out &&
+	test_debug "cat drain.out" &&
+	cat <<-EOF >drain.expected &&
+	0-1 $id terminated before first barrier
+	EOF
+	test_cmp drain.expected drain.out
+'
+test_expect_success 'undrain ranks' '
+	flux resource undrain 0-1
+'
 
 test_done


### PR DESCRIPTION
This PR drains ranks that exit before the first barrier if the job was a multiuser job.

This preserves existing behavior for single user instances (job exception only), but adds the requested behavior in #7383 for multi user system instances, where it more likely a node issue has caused the early failure of the IMP or job shell.

Fixes #7383