### PR TITLE
t: add test with empty kvs txn

### DIFF
--- a/src/common/libsubprocess/test/stdio.c
+++ b/src/common/libsubprocess/test/stdio.c
@@ -1445,7 +1445,7 @@ void credit_output_cb (flux_subprocess_t *p, const char *stream)
         sprintf (cmpbuf, "abcdefghijklmnopqrstuvwxyz0123456789");
         ok (streq (outputbuf, cmpbuf),
             "flux_subprocess_read returned correct data: %s", outputbuf);
-        /* 26 (ABCs) + 10 (1-10) */
+        /* 26 (ABCs) + 10 (0-9) */
         ok (outputbuf_len == (26 + 10),
             "flux_subprocess_read returned correct amount of data: %d",
             outputbuf_len);

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -495,6 +495,20 @@ test_expect_success 'kvs: module stats returns reasonable transaction stats' '
 '
 
 #
+# test empty kvs txn works
+#
+
+# "flux kvs sync" implements sync via an empty KVS txn
+test_expect_success 'kvs: test empty kvs txn works' '
+	flux kvs sync
+'
+
+test_expect_success 'kvs: module commit stats min is updated' '
+        commitdata=$(flux module stats -p transaction-opcount.commit kvs) &&
+        echo $commitdata | jq -e ".min == 0"
+'
+
+#
 # test ENOSYS on unfinished requests when unloading the KVS module
 #
 # N.B. do this last as we are unloading the kvs module


### PR DESCRIPTION
Problem: There is no coverage for ensuring an empty KVS txn works.

Add tests to t1001-kvs-internals.t.

Also a misc cleanup fix that I had laying around without a PR to stick it in :-)