### PR TITLE
broker:  strengthen support for runtime attribute updates

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -414,7 +414,8 @@ log-stderr-level :ref:`[runtime] <attr_runtime>`
    Copy matching log messages to stderr.  Default: 3 (LOG_ERR).
 
 log-level
-   Allow matching messages to enter the logging system.  Default: 7 (LOG_DEBUG).
+   Allow matching messages to enter the local broker's circular buffer.
+   Default: 7 (LOG_DEBUG).
 
 CONTENT
 =======

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -369,34 +369,34 @@ matches log messages of equal and lesser (more severe) value.  There is
 a table of severity names vs numbers in the aforementioned description.
 Negative severity values can be used to indicate "match nothing".
 
-log-ring-size :ref:`[runtime] <attr_runtime>`
+log-ring-size
    The maximum number of log messages that can be stored in the local
    ring buffer.  Default: 1024.
 
-log-forward-level :ref:`[runtime] <attr_runtime>`
+log-forward-level
    Forward matching messages to the leader broker.  This is only helpful when
    :option:`log-stderr-mode` is set to "leader", or :option:`log-filename` is
    defined.  Default: 3 (LOG_ERR).
 
-log-critical-level :ref:`[runtime] <attr_runtime>`
+log-critical-level
    Copy matching log messages to local stderr.  This is intended to ensure
    that important messages are not lost in situations so dire that
    normal logging may be unreliable.  Default: 2 (LOG_CRIT).
 
-log-filename :ref:`[runtime] <attr_runtime>`
+log-filename
    Copy log messages to a file on the leader broker.
    Messages from follower brokers are also captured if they match
    :option:`log-forward-level`.  Default: none.
 
-log-syslog-enable :ref:`[runtime] <attr_runtime>`
+log-syslog-enable
    Copy log messages to syslog if they match :option:`log-syslog-level`.
    Default: 0.
 
-log-syslog-level :ref:`[runtime] <attr_runtime>`
+log-syslog-level
    Sets the severity threshold for syslog, if :option:`log-syslog-enable`
    is set.  Default: 2 (LOG_CRIT).
 
-log-stderr-mode :ref:`[runtime] <attr_runtime>`
+log-stderr-mode
    Set the stderr mode to one of:
 
    leader
@@ -413,7 +413,7 @@ log-stderr-mode :ref:`[runtime] <attr_runtime>`
 log-stderr-level :ref:`[runtime] <attr_runtime>`
    Copy matching log messages to stderr.  Default: 3 (LOG_ERR).
 
-log-level :ref:`[runtime] <attr_runtime>`
+log-level
    Allow matching messages to enter the logging system.  Default: 7 (LOG_DEBUG).
 
 CONTENT

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -386,10 +386,10 @@ int attr_cache_immutables (attr_t *attrs, flux_t *h)
  ** Service
  **/
 
-void getattr_request_cb (flux_t *h,
-                         flux_msg_handler_t *mh,
-                         const flux_msg_t *msg,
-                         void *arg)
+static void getattr_request_cb (flux_t *h,
+                                flux_msg_handler_t *mh,
+                                const flux_msg_t *msg,
+                                void *arg)
 {
     attr_t *attrs = arg;
     const char *name;
@@ -415,10 +415,10 @@ error:
         FLUX_LOG_ERROR (h);
 }
 
-void setattr_request_cb (flux_t *h,
-                         flux_msg_handler_t *mh,
-                         const flux_msg_t *msg,
-                         void *arg)
+static void setattr_request_cb (flux_t *h,
+                                flux_msg_handler_t *mh,
+                                const flux_msg_t *msg,
+                                void *arg)
 {
     attr_t *attrs = arg;
     const char *name;
@@ -459,10 +459,10 @@ error:
         FLUX_LOG_ERROR (h);
 }
 
-void rmattr_request_cb (flux_t *h,
-                        flux_msg_handler_t *mh,
-                        const flux_msg_t *msg,
-                        void *arg)
+static void rmattr_request_cb (flux_t *h,
+                               flux_msg_handler_t *mh,
+                               const flux_msg_t *msg,
+                               void *arg)
 {
     attr_t *attrs = arg;
     const char *name;
@@ -479,10 +479,10 @@ error:
         FLUX_LOG_ERROR (h);
 }
 
-void lsattr_request_cb (flux_t *h,
-                        flux_msg_handler_t *mh,
-                        const flux_msg_t *msg,
-                        void *arg)
+static void lsattr_request_cb (flux_t *h,
+                               flux_msg_handler_t *mh,
+                               const flux_msg_t *msg,
+                               void *arg)
 {
     attr_t *attrs = arg;
     const char *name;

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -139,15 +139,15 @@ static struct registered_attr attrtab[] = {
     { "tbon.connect_timeout", ATTR_CONFIG },
 
     // logging
-    { "log-ring-size", ATTR_RUNTIME },
-    { "log-forward-level", ATTR_RUNTIME },
-    { "log-critical-level", ATTR_RUNTIME },
-    { "log-filename", ATTR_RUNTIME },
-    { "log-syslog-enable", ATTR_RUNTIME },
-    { "log-syslog-level", ATTR_RUNTIME },
-    { "log-stderr-mode", ATTR_RUNTIME },
+    { "log-ring-size", ATTR_IMMUTABLE },
+    { "log-forward-level", ATTR_IMMUTABLE },
+    { "log-critical-level", ATTR_IMMUTABLE },
+    { "log-filename", 0 },
+    { "log-syslog-enable", ATTR_IMMUTABLE },
+    { "log-syslog-level", ATTR_IMMUTABLE },
+    { "log-stderr-mode", ATTR_IMMUTABLE },
     { "log-stderr-level", ATTR_RUNTIME },
-    { "log-level", ATTR_RUNTIME },
+    { "log-level", ATTR_IMMUTABLE },
 
     // content
     { "content.backing-module", 0 },

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -181,6 +181,7 @@ static struct registered_attr attrtab[] = {
  */
 static struct setattr_redirect redirtab[] = {
     { "test-rd.*", "testrd.setattr" },
+    { "log-stderr-level", "log.setattr" },
 };
 
 static struct registered_attr *attrtab_lookup (const char *name)

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -13,12 +13,6 @@
 
 #include <flux/core.h>
 
-/* Callbacks for active values.  Return 0 on success, -1 on error with
- * errno set.  Errors are propagated to the return of attr_set() and attr_get().
- */
-typedef int (*attr_get_f)(const char *name, const char **val, void *arg);
-typedef int (*attr_set_f)(const char *name, const char *val, void *arg);
-
 typedef struct broker_attr attr_t;
 
 /* Create/destroy attribute cache
@@ -44,14 +38,6 @@ int attr_set_cmdline (attr_t *attrs,
                       const char *name,
                       const char *val,
                       flux_error_t *errp);
-
-/* Add an attribute with callbacks for get/set.
- */
-int attr_add_active (attr_t *attrs,
-                     const char *name,
-                     attr_get_f get,
-                     attr_set_f set,
-                     void *arg);
 
 /* Iterate over attribute names with internal cursor.
  */

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -615,8 +615,6 @@ cleanup:
         || sigaction (SIGTERM, &old_sigact_term, NULL) < 0)
         flux_log_error (ctx.h, "error restoring signal mask");
 
-    /* Unregister builtin services
-     */
     if (modhash_destroy (ctx.modhash) > 0) {
         if (ctx.exit_rc == 0)
             ctx.exit_rc = 1;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -617,12 +617,11 @@ cleanup:
 
     /* Unregister builtin services
      */
-    attr_destroy (ctx.attrs);
-
     if (modhash_destroy (ctx.modhash) > 0) {
         if (ctx.exit_rc == 0)
             ctx.exit_rc = 1;
     }
+    attr_destroy (ctx.attrs);
     zlist_destroy (&ctx.sigwatchers);
     shutdown_destroy (ctx.shutdown);
     state_machine_destroy (ctx.state_machine);

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -26,6 +26,7 @@
 #include "src/common/libutil/wallclock.h"
 #include "src/common/libutil/stdlog.h"
 #include "src/common/libutil/timestamp.h"
+#include "src/common/libutil/errprintf.h"
 #include "ccan/str/str.h"
 #include "ccan/list/list.h"
 
@@ -40,6 +41,7 @@ static const int default_forward_level = LOG_ERR;
 static const int default_critical_level = LOG_CRIT;
 static const int default_stderr_level = LOG_ERR;
 static const int default_syslog_level = LOG_ERR;
+static const bool default_syslog_enable = false;
 static const stderr_mode_t default_stderr_mode = MODE_LEADER;
 static const int default_level = LOG_DEBUG;
 
@@ -50,7 +52,7 @@ typedef struct {
     uint32_t rank;
     char *filename;
     FILE *f;
-    int syslog_enable;
+    bool syslog_enable;
     int syslog_level;
     char *jobid_path;
     char *username;
@@ -138,13 +140,6 @@ static logbuf_t *logbuf_create (void)
         errno = ENOMEM;
         goto cleanup;
     }
-    logbuf->forward_level = default_forward_level;
-    logbuf->critical_level = default_critical_level;
-    logbuf->syslog_level = default_syslog_level;
-    logbuf->stderr_level = default_stderr_level;
-    logbuf->stderr_mode = default_stderr_mode;
-    logbuf->level = default_level;
-    logbuf->ring_size = default_ring_size;
     list_head_init (&logbuf->ring);
     if (!(logbuf->followers = flux_msglist_create ()))
         goto cleanup;
@@ -172,257 +167,273 @@ void logbuf_destroy (logbuf_t *logbuf)
     }
 }
 
-static int set_level (int *value, const char *val)
+static int getattr_int (attr_t *attrs, const char *name, int *vp)
 {
-    int level;
+    const char *val;
     char *endptr;
-    if (!val)
-        goto error;
-    errno = 0;
-    level = strtol (val, &endptr, 10);
-    if (errno != 0 || *endptr != '\0')
-        goto error;
-    if (level > LOG_DEBUG) {
+    long long v;
+
+    if (attr_get (attrs, name, &val) < 0)
+        return -1;
+    if (!val) {
         errno = EINVAL;
         return -1;
+    }
+    errno = 0;
+    v = strtoll (val, &endptr, 10);
+    if (errno != 0
+        || *endptr != '\0'
+        || endptr == val
+        || v < INT_MIN
+        || v > INT_MAX) {
+        errno = EINVAL;
+        return -1;
+    }
+    *vp = v;
+    return 0;
+}
+
+static int getattr_level (attr_t *attrs, const char *name, int *vp)
+{
+    int v;
+
+    if (getattr_int (attrs, name, &v) < 0)
+        return -1;
+    if (v > LOG_DEBUG) { /* N.B. negative is ok (match nothing) */
+        errno = EINVAL;
+        return -1;
+    }
+    *vp = v;
+    return 0;
+}
+
+static int getattr_mode (attr_t *attrs, const char *name, stderr_mode_t *vp)
+{
+    const char *val;
+    stderr_mode_t mode;
+
+    if (attr_get (attrs, name, &val) < 0)
+        return -1;
+    if (!val) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (streq (val, "local"))
+        mode = MODE_LOCAL;
+    else if (streq (val, "leader"))
+        mode = MODE_LEADER;
+    else {
+        errno = EINVAL;
+        return -1;
+    }
+    *vp = mode;
+    return 0;
+}
+
+static int getattr_size (attr_t *attrs, const char *name, size_t *vp)
+{
+    const char *val;
+    char *endptr;
+    long long v;
+
+    if (attr_get (attrs, name, &val) < 0)
+        return -1;
+    if (!val) {
+        errno = EINVAL;
+        return -1;
+    }
+    errno = 0;
+    v = strtoll (val, &endptr, 10);
+    if (errno != 0
+        || *endptr != '\0'
+        || endptr == val
+        || v < 0
+        || v > SIZE_MAX) {
+        errno = EINVAL;
+        return -1;
+    }
+    *vp = v;
+    return 0;
+}
+
+static int setattr_int (attr_t *attrs, const char *name, long long v)
+{
+    char val[64];
+
+    snprintf (val, sizeof (val), "%lld", v);
+    return attr_set (attrs, name, val);
+}
+
+static int setattr_mode (attr_t *attrs, const char *name, stderr_mode_t mode)
+{
+    const char *val;
+    switch (mode) {
+        case MODE_LEADER:
+            val = "leader";
+            break;
+        case MODE_LOCAL:
+            val = "local";
+            break;
+    }
+    return attr_set (attrs, name, val);
+}
+
+static int register_attr_level (attr_t *attrs,
+                                const char *name,
+                                int *value,
+                                int default_value,
+                                flux_error_t *errp)
+{
+    int level;
+
+    if (getattr_level (attrs, name, &level) < 0) {
+        if (errno != ENOENT)
+            return errprintf (errp, "%s: %s", name, strerror (errno));
+        if (setattr_int (attrs, name, default_value) < 0)
+            return errprintf (errp, "%s: %s", name, strerror (errno));
+        level = default_value;
     }
     *value = level;
     return 0;
-error:
-    errno = EINVAL;
-    return -1;
 }
 
-static int logbuf_set_ring_size (logbuf_t *logbuf, const char *val)
+static int register_attr_size (attr_t *attrs,
+                               const char *name,
+                               size_t *value,
+                               size_t default_value,
+                               flux_error_t *errp)
 {
-    int size;
-    char *endptr;
-    if (!val || strlen (val) == 0)
-        goto error;
-    errno = 0;
-    size = strtol (val, &endptr, 10);
-    if (errno != 0 || *endptr != '\0' || size < 0)
-        goto error;
-    logbuf_trim (logbuf, size);
-    logbuf->ring_size = size;
-    return 0;
-error:
-    errno = EINVAL;
-    return -1;
-}
+    size_t size;
 
-/* Set the log filename (rank 0 only).
- * Allow other ranks to try to set this without effect
- * so that the same broker options can be used across a session.
- */
-static int logbuf_set_filename (logbuf_t *logbuf, const char *destination)
-{
-    char *filename;
-    FILE *f;
-    if (!destination || strlen (destination) == 0) {
-        errno = EINVAL;
-        return -1;
+    if (getattr_size (attrs, name, &size) < 0) {
+        if (errno != ENOENT)
+            return errprintf (errp, "%s: %s", name, strerror (errno));
+        if (setattr_int (attrs, name, default_value) < 0)
+            return errprintf (errp, "%s: %s", name, strerror (errno));
+        size = default_value;
     }
-    if (logbuf->rank > 0)
-        return 0;
-    if (!(f = fopen (destination, "a")))
-        return -1;
-    if (!(filename = strdup (destination))) {
-        fclose (f);
-        return -1;
-    }
-    free (logbuf->filename);
-    if (logbuf->f)
-        fclose (logbuf->f);
-    logbuf->f = f;
-    logbuf->filename = filename;
+    *value = size;
     return 0;
 }
 
-static void logbuf_set_syslog (logbuf_t *logbuf, const char *val)
+static int register_attr_bool (attr_t *attrs,
+                               const char *name,
+                               bool *value,
+                               bool default_value,
+                               flux_error_t *errp)
 {
-    int enable;
+    int val;
+    bool flag;
 
-    if (val && streq (val, "0"))
-        enable = 0;
-    else
-        enable = 1;
-    if (logbuf->syslog_enable && !enable) {
-        closelog ();
-        logbuf->syslog_enable = 0;
+    if (getattr_int (attrs, name, &val) < 0) {
+        if (errno != ENOENT)
+            return errprintf (errp, "getattr %s: %s", name, strerror (errno));
+        if (setattr_int (attrs, name, default_value ? 1 : 0) < 0)
+            return errprintf (errp, "setattr %s: %s", name, strerror (errno));
+        flag = default_value;
     }
-    else if (!logbuf->syslog_enable && enable) {
-        openlog ("flux", LOG_NDELAY | LOG_PID, LOG_USER);
-        logbuf->syslog_enable = 1;
-    }
-}
-
-static const char *int_to_string (int n)
-{
-    static char s[32]; // ample room to avoid overflow
-    (void)snprintf (s, sizeof (s), "%d", n);
-    return s;
-}
-
-static int attr_get_log (const char *name, const char **val, void *arg)
-{
-    logbuf_t *logbuf = arg;
-
-    if (streq (name, "log-forward-level"))
-        *val = int_to_string (logbuf->forward_level);
-    else if (streq (name, "log-critical-level"))
-        *val = int_to_string (logbuf->critical_level);
-    else if (streq (name, "log-stderr-level"))
-        *val = int_to_string (logbuf->stderr_level);
-    else if (streq (name, "log-stderr-mode"))
-        *val = logbuf->stderr_mode == MODE_LEADER ? "leader" : "local";
-    else if (streq (name, "log-ring-size"))
-        *val = int_to_string (logbuf->ring_size);
-    else if (streq (name, "log-filename"))
-        *val = logbuf->filename;
-    else if (streq (name, "log-syslog-enable"))
-        *val = int_to_string (logbuf->syslog_enable);
-    else if (streq (name, "log-syslog-level"))
-        *val = int_to_string (logbuf->syslog_level);
-    else if (streq (name, "log-level"))
-        *val = int_to_string (logbuf->level);
     else {
-        errno = ENOENT;
-        return -1;
-    }
-    return 0;
-}
-
-static int attr_set_log (const char *name, const char *val, void *arg)
-{
-    logbuf_t *logbuf = arg;
-    int rc = -1;
-
-    if (streq (name, "log-forward-level")) {
-        if (set_level (&logbuf->forward_level, val) < 0)
-            goto done;
-    }
-    else if (streq (name, "log-critical-level")) {
-        if (set_level (&logbuf->critical_level, val) < 0)
-            goto done;
-    }
-    else if (streq (name, "log-stderr-level")) {
-        if (set_level (&logbuf->stderr_level, val) < 0)
-            goto done;
-    }
-    else if (streq (name, "log-stderr-mode")) {
-        if (!val) {
-            errno = EINVAL;
-            goto done;
-        }
-        if (streq (val, "leader"))
-            logbuf->stderr_mode = MODE_LEADER;
-        else if (streq (val, "local"))
-            logbuf->stderr_mode = MODE_LOCAL;
+        if (val == 0)
+            flag = false;
+        else if (val == 1)
+            flag = true;
         else {
             errno = EINVAL;
-            goto done;
+            return errprintf (errp, "%s: value must be 0 or 1", name);
         }
     }
-    else if (streq (name, "log-ring-size")) {
-        if (logbuf_set_ring_size (logbuf, val) < 0)
-            goto done;
-    }
-    else if (streq (name, "log-filename")) {
-        if (logbuf_set_filename (logbuf, val) < 0)
-            goto done;
-    }
-    else if (streq (name, "log-syslog-enable")) {
-        logbuf_set_syslog (logbuf, val);
-    }
-    else if (streq (name, "log-syslog-level")) {
-        if (set_level (&logbuf->syslog_level, val) < 0)
-            goto done;
-    }
-    else if (streq (name, "log-level")) {
-        if (set_level (&logbuf->level, val) < 0)
-            goto done;
-    }
-    else {
-        errno = ENOENT;
-        goto done;
-    }
-    rc = 0;
-done:
-    return rc;
+    *value = flag;
+    return 0;
 }
 
-static int logbuf_register_attrs (logbuf_t *logbuf, attr_t *attrs)
+static int register_attr_mode (attr_t *attrs,
+                               const char *name,
+                               stderr_mode_t *value,
+                               stderr_mode_t default_value,
+                               flux_error_t *errp)
 {
-    int rc = -1;
+    stderr_mode_t mode;
 
+    if (getattr_mode (attrs, name, &mode) < 0) {
+        if (errno != ENOENT)
+            return errprintf (errp, "getattr %s: %s", name, strerror (errno));
+        if (setattr_mode (attrs, name, default_value) < 0)
+            return errprintf (errp, "setattr %s: %s", name, strerror (errno));
+        mode = default_value;
+    }
+    *value = mode;
+    return 0;
+}
+
+static int logbuf_register_attrs (logbuf_t *logbuf, flux_error_t *errp)
+{
     /* log-filename
      * Only allowed to be set on rank 0 (ignore initial value on rank > 0).
      */
     if (logbuf->rank == 0) {
-        if (attr_add_active (attrs,
-                             "log-filename",
-                             attr_get_log,
-                             attr_set_log,
-                             logbuf) < 0)
-            goto done;
+        const char *path;
+        if (attr_get (logbuf->attrs, "log-filename", &path) == 0) {
+            if (path && !(logbuf->filename = strdup (path)))
+                return errprintf (errp, "Error duplicating logfile name");
+        }
     }
     else {
-        (void)attr_delete (attrs, "log-filename");
-        if (attr_set (attrs, "log-filename", NULL) < 0)
-            goto done;
+        (void)attr_delete (logbuf->attrs, "log-filename");
+        if (attr_set (logbuf->attrs, "log-filename", NULL) < 0) {
+            return errprintf (errp,
+                              "setattr log-filename: %s",
+                              strerror (errno));
+        }
     }
-    if (attr_add_active (attrs,
-                         "log-stderr-level",
-                         attr_get_log,
-                         attr_set_log,
-                         logbuf) < 0)
-        goto done;
-    if (attr_add_active (attrs,
-                         "log-stderr-mode",
-                         attr_get_log,
-                         attr_set_log,
-                         logbuf) < 0)
-        goto done;
-    if (attr_add_active (attrs,
-                         "log-level",
-                         attr_get_log,
-                         attr_set_log,
-                         logbuf) < 0)
-        goto done;
-    if (attr_add_active (attrs,
-                         "log-forward-level",
-                         attr_get_log,
-                         attr_set_log,
-                         logbuf) < 0)
-        goto done;
-    if (attr_add_active (attrs,
-                         "log-critical-level",
-                         attr_get_log,
-                         attr_set_log,
-                         logbuf) < 0)
-        goto done;
-    if (attr_add_active (attrs,
-                         "log-ring-size",
-                         attr_get_log,
-                         attr_set_log,
-                         logbuf) < 0)
-        goto done;
-    if (attr_add_active (attrs,
-                         "log-syslog-enable",
-                         attr_get_log,
-                         attr_set_log,
-                         logbuf) < 0)
-        goto done;
-    if (attr_add_active (attrs,
-                         "log-syslog-level",
-                         attr_get_log,
-                         attr_set_log,
-                         logbuf) < 0)
-        goto done;
-    rc = 0;
-done:
-    return rc;
+    if (register_attr_level (logbuf->attrs,
+                             "log-level",
+                             &logbuf->level,
+                             default_level,
+                             errp) < 0)
+        return -1;
+    if (register_attr_level (logbuf->attrs,
+                             "log-stderr-level",
+                             &logbuf->stderr_level,
+                             default_stderr_level,
+                             errp) < 0)
+        return -1;
+    if (register_attr_level (logbuf->attrs,
+                             "log-forward-level",
+                             &logbuf->forward_level,
+                             default_forward_level,
+                             errp) < 0)
+        return -1;
+    if (register_attr_level (logbuf->attrs,
+                             "log-critical-level",
+                             &logbuf->critical_level,
+                             default_critical_level,
+                             errp) < 0)
+        return -1;
+    if (register_attr_level (logbuf->attrs,
+                             "log-syslog-level",
+                             &logbuf->syslog_level,
+                             default_syslog_level,
+                             errp) < 0)
+        return -1;
+    if (register_attr_size (logbuf->attrs,
+                            "log-ring-size",
+                            &logbuf->ring_size,
+                            default_ring_size,
+                            errp) < 0)
+        return -1;
+    if (register_attr_bool (logbuf->attrs,
+                            "log-syslog-enable",
+                            &logbuf->syslog_enable,
+                            default_syslog_enable,
+                            errp) < 0)
+        return -1;
+    if (register_attr_mode (logbuf->attrs,
+                            "log-stderr-mode",
+                             &logbuf->stderr_mode,
+                             default_stderr_mode,
+                             errp) < 0)
+        return -1;
+    return 0;
 }
 
 static int logbuf_forward (logbuf_t *logbuf, const char *buf, int len)
@@ -565,8 +576,7 @@ void log_early (const char *buf, int len, void *arg)
         && streq (val, "local")) {
         flags = LOG_FOR_SYSTEMD;
     }
-    if (attr_get (attrs, "log-stderr-level", &val) == 0
-        && set_level (&level, val) == 0
+    if (getattr_level (attrs, "log-stderr-level", &level) == 0
         && stdlog_decode (buf, len, &hdr, NULL, NULL, NULL, NULL) == 0
         && STDLOG_SEVERITY (hdr.pri) > level)
         return;
@@ -580,6 +590,13 @@ static int logbuf_append (logbuf_t *logbuf, const char *buf, int len)
     uint32_t rank = FLUX_NODEID_ANY;
     int severity = LOG_INFO;
     struct stdlog_header hdr;
+
+    /* Fetch this from the attribute hash again for each log entry,
+     * in case it changed.
+     */
+    (void)getattr_level (logbuf->attrs,
+                         "log-stderr-level",
+                         &logbuf->stderr_level);
 
     stdlog_init (&hdr);
     if (stdlog_decode (buf, len, &hdr, NULL, NULL, NULL, NULL) == 0) {
@@ -784,14 +801,28 @@ static void logbuf_finalize (void *arg)
 
 int logbuf_initialize (flux_t *h, uint32_t rank, attr_t *attrs)
 {
+    flux_error_t error;
     logbuf_t *logbuf = logbuf_create ();
+
     if (!logbuf)
         goto error;
     logbuf->h = h;
     logbuf->rank = rank;
     logbuf->attrs = attrs;
-    if (logbuf_register_attrs (logbuf, attrs) < 0)
+    if (logbuf_register_attrs (logbuf, &error) < 0) {
+        flux_log (h, LOG_ERR, "%s", error.text);
         goto error;
+    }
+    if (logbuf->syslog_enable)
+        openlog ("flux", LOG_NDELAY | LOG_PID, LOG_USER);
+    if (logbuf->filename) {
+        FILE *f;
+        if (!(f = fopen (logbuf->filename, "a"))) {
+            flux_log_error (h, "Error opening logfile %s", logbuf->filename);
+            return -1;
+        }
+        logbuf->f = f;
+    }
     if (flux_msg_handler_addvec (h, htab, logbuf, &logbuf->handlers) < 0)
         goto error;
     flux_log_set_redirect (h, logbuf_append_redirect, logbuf);

--- a/src/broker/test/attr.c
+++ b/src/broker/test/attr.c
@@ -108,70 +108,6 @@ void basic (void)
     attr_destroy (attrs);
 }
 
-int active_get (const char *name, const char **val, void *arg)
-{
-    const char **cpp = arg;
-    *val = *cpp;
-    return 0;
-}
-
-int active_set (const char *name, const char *val, void *arg)
-{
-    const char **cpp = arg;
-    *cpp = val;
-    return 0;
-}
-
-
-void active (void)
-{
-    attr_t *attrs;
-    const char *val;
-    const char *a;
-    const char *b;
-
-    if (!(attrs = attr_create ()))
-        BAIL_OUT ("attr_create failed");
-
-    ok (attr_add_active (attrs,
-                         "test.a",
-                         active_get,
-                         active_set,
-                         &a) == 0,
-        "attr_add_active works");
-    a = "x";
-    ok (attr_get (attrs, "test.a", &val) == 0 && val && streq (val, "x"),
-        "attr_get on active a tracks val=x");
-    a = "y";
-    ok (attr_get (attrs, "test.a", &val) == 0 && streq (val, "y"),
-        "attr_get on active a tracks val=y");
-    a = NULL;
-    ok (attr_get (attrs, "test.a", &val) == 0 && val == NULL,
-        "attr_get on active a tracks val=NULL");
-    ok (attr_delete (attrs, "test.a") == 0,
-        "attr_delete works on active attr");
-
-    /* immutable active works as expected
-     */
-    ok (attr_add_active (attrs,
-                         "test-im.b",
-                         active_get,
-                         active_set,
-                         &b) == 0,
-        "attr_add_active of immutable attr works");
-    b = "m";
-    ok (attr_get (attrs, "test-im.b", &val) == 0 && val && streq (val, "m"),
-        "attr_get returns initial val=m");
-    b = "n";
-    ok (attr_get (attrs, "test-im.b", &val) == 0 && val && streq (val, "m"),
-        "attr_get ignores value changes");
-    errno = 0;
-    ok (attr_delete (attrs, "test-im.b") < 0 && errno == EPERM,
-        "attr_delete fails with EPERM");
-
-    attr_destroy (attrs);
-}
-
 void unknown (void)
 {
     attr_t *attrs;
@@ -182,11 +118,6 @@ void unknown (void)
     errno = 0;
     ok (attr_set (attrs, "unknown", "foo") < 0 && errno == ENOENT,
         "attr_set of unknown attribute fails with ENOENT");
-
-    errno = 0;
-    ok (attr_add_active (attrs, "unknown", NULL, NULL, NULL) < 0
-        && errno == ENOENT,
-        "attr_add_active of unknown attribute fails with ENOENT");
 
     attr_destroy (attrs);
 }
@@ -239,7 +170,6 @@ int main (int argc, char **argv)
     plan (NO_PLAN);
 
     basic ();
-    active ();
     unknown ();
     cmdline ();
 

--- a/src/common/libtestutil/test_file.c
+++ b/src/common/libtestutil/test_file.c
@@ -1,3 +1,17 @@
+/************************************************************\
+ * Copyright 2025 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "test_file.h"
 
 #include <errno.h>
@@ -9,13 +23,12 @@
 #include "src/common/libtap/tap.h"
 
 
-void
-create_test_file (const char *dir,
-                  const char *prefix,
-                  const char *extension,
-                  char *path,
-                  size_t pathlen,
-                  const char *contents)
+void create_test_file (const char *dir,
+                       const char *prefix,
+                       const char *extension,
+                       char *path,
+                       size_t pathlen,
+                       const char *contents)
 {
     int fd;
     const char *ext = extension ? extension : ".txt";
@@ -35,8 +48,7 @@ create_test_file (const char *dir,
         BAIL_OUT ("close %s: %s", path, strerror (errno));
 }
 
-void
-create_test_dir (char *dir, int dirlen)
+void create_test_dir (char *dir, int dirlen)
 {
     const char *tmpdir = getenv ("TMPDIR");
     if (snprintf (dir,
@@ -50,28 +62,28 @@ create_test_dir (char *dir, int dirlen)
 
 static pthread_once_t global_test_dir_once = PTHREAD_ONCE_INIT;
 static char global_test_dir[PATH_MAX];
-static void
-init_global_test_dir ()
+static void init_global_test_dir (void)
 {
-  create_test_dir (global_test_dir, sizeof global_test_dir);
+    create_test_dir (global_test_dir, sizeof global_test_dir);
 }
 
 __attribute__ ((destructor))
-static void
-cleanup_global_test_dir ()
+static void cleanup_global_test_dir (void)
 {
-  // Skip if it was never created
-  if (global_test_dir[0] == 0)
-    return;
-  if (rmdir (global_test_dir) < 0) {
-    fprintf (stderr, "could not cleanup test dir %s: %s\n", global_test_dir, strerror (errno));
-    exit (1);
-  }
+    // Skip if it was never created
+    if (global_test_dir[0] == 0)
+        return;
+    if (rmdir (global_test_dir) < 0) {
+        fprintf (stderr,
+                 "could not cleanup test dir %s: %s\n",
+                 global_test_dir,
+                 strerror (errno));
+        exit (1);
+     }
 }
 
-const char *
-get_test_dir ()
+const char *get_test_dir (void)
 {
-  pthread_once (&global_test_dir_once, init_global_test_dir);
-  return global_test_dir;
+    pthread_once (&global_test_dir_once, init_global_test_dir);
+    return global_test_dir;
 }

--- a/src/common/libtestutil/test_file.h
+++ b/src/common/libtestutil/test_file.h
@@ -1,14 +1,23 @@
+/************************************************************\
+ * Copyright 2015 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
 #ifndef TEST_FILE_H
 #define TEST_FILE_H
 
 #include <stddef.h>
 
 
-/** 
+/**
  * @brief Get a single statically managed test directory for this process
  */
-const char *
-get_test_dir ();
+const char *get_test_dir (void);
 
 void
 create_test_file (const char *dir,
@@ -17,7 +26,6 @@ create_test_file (const char *dir,
                   char *path,
                   size_t pathlen,
                   const char *contents);
-void
-create_test_dir (char *dir, int dirlen);
+void create_test_dir (char *dir, int dirlen);
 
 #endif // TEST_FILE_H

--- a/src/common/libtestutil/util.c
+++ b/src/common/libtestutil/util.c
@@ -38,8 +38,10 @@ struct test_server {
     char uuid_str[UUID_STR_LEN];
 };
 
-void shutdown_cb (flux_t *h, flux_msg_handler_t *mh,
-                  const flux_msg_t *msg, void *arg)
+void shutdown_cb (flux_t *h,
+                  flux_msg_handler_t *mh,
+                  const flux_msg_t *msg,
+                  void *arg)
 {
     flux_reactor_stop (flux_get_reactor (h));
 }
@@ -76,8 +78,10 @@ int test_server_stop (flux_t *c)
     return rc;
 }
 
-static void diag_cb (flux_t *h, flux_msg_handler_t *mh,
-                     const flux_msg_t *msg, void *arg)
+static void diag_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
 {
     int msgtype;
     const char *topic = NULL;
@@ -88,8 +92,10 @@ static void diag_cb (flux_t *h, flux_msg_handler_t *mh,
         if (flux_msg_get_topic (msg, &topic) < 0)
             goto badmsg;
     }
-    diag ("server: < %s%s%s", flux_msg_typestr (msgtype),
-           topic ? " " : "", topic ? topic : "");
+    diag ("server: < %s%s%s",
+          flux_msg_typestr (msgtype),
+          topic ? " " : "",
+          topic ? topic : "");
     return;
 badmsg:
     diag ("server: malformed message:", flux_strerror (errno));
@@ -157,8 +163,10 @@ flux_t *test_server_create (int cflags, test_server_f cb, void *arg)
      * N.B. this has to go in before shutdown else shutdown will be masked.
      */
     if (!a->cb) {
-        if (!(a->diag_mh = flux_msg_handler_create (a->s, FLUX_MATCH_ANY,
-                                                    diag_cb, a)))
+        if (!(a->diag_mh = flux_msg_handler_create (a->s,
+                                                    FLUX_MATCH_ANY,
+                                                    diag_cb,
+                                                    a)))
             BAIL_OUT ("flux_msg_handler_create");
         flux_msg_handler_start (a->diag_mh);
         a->cb = diag_server;
@@ -168,8 +176,10 @@ flux_t *test_server_create (int cflags, test_server_f cb, void *arg)
      */
     struct flux_match match = FLUX_MATCH_REQUEST;
     match.topic_glob = "shutdown";
-    if (!(a->shutdown_mh = flux_msg_handler_create (a->s, match,
-                                                    shutdown_cb, a)))
+    if (!(a->shutdown_mh = flux_msg_handler_create (a->s,
+                                                    match,
+                                                    shutdown_cb,
+                                                    a)))
         BAIL_OUT ("flux_msg_handler_create");
     flux_msg_handler_start (a->shutdown_mh);
 
@@ -177,7 +187,9 @@ flux_t *test_server_create (int cflags, test_server_f cb, void *arg)
      */
     if ((e = pthread_create (&a->thread, NULL, thread_wrapper, a)) != 0)
         BAIL_OUT ("pthread_create");
-    if (flux_aux_set (a->c, "test_server", a,
+    if (flux_aux_set (a->c,
+                      "test_server",
+                      a,
                       (flux_free_f)test_server_destroy) < 0)
         BAIL_OUT ("flux_aux_set");
     return a->c;

--- a/src/common/libtestutil/util_rpc.c
+++ b/src/common/libtestutil/util_rpc.c
@@ -15,16 +15,20 @@
 #include "src/common/libtap/tap.h"
 #include "util_rpc.h"
 
-static void reclaim_timeout (flux_reactor_t *r, flux_watcher_t *w,
-                             int revents, void *arg)
+static void reclaim_timeout (flux_reactor_t *r,
+                             flux_watcher_t *w,
+                             int revents,
+                             void *arg)
 {
     int *flag = arg;
     *flag = 1;
     diag ("matchtag_reclaim timed out");
 }
 
-static void reclaim_fake_cb (flux_t *h, flux_msg_handler_t *mh,
-                             const flux_msg_t *msg, void *arg)
+static void reclaim_fake_cb (flux_t *h,
+                             flux_msg_handler_t *mh,
+                             const flux_msg_t *msg,
+                             void *arg)
 {
 }
 
@@ -45,8 +49,11 @@ int reclaim_matchtag (flux_t *h, int count, double timeout)
         BAIL_OUT ("flux_msg_handler_create failed");
     flux_msg_handler_start (mh);
 
-    if (!(timer = flux_timer_watcher_create (r, timeout, 0,
-                                             reclaim_timeout, &expired)))
+    if (!(timer = flux_timer_watcher_create (r,
+                                             timeout,
+                                             0,
+                                             reclaim_timeout,
+                                             &expired)))
         BAIL_OUT ("flux_timer_watcher_create failed");
     flux_watcher_start (timer);
 

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -249,5 +249,16 @@ test_expect_success 'setting log-forward-level to -1 works' '
 	    flux exec -r 1 flux logger --severity=emerg "smurfs" &&
 	test_must_fail grep "logger.emerg" forward.log
 '
+test_expect_success 'log-stderr-level can be set to 0 on the fly' '
+	flux setattr log-stderr-level 0 &&
+	test "$(flux getattr log-stderr-level)" = "0"
+'
+test_expect_success 'log-stderr-level can be set to -1 on the fly' '
+	flux setattr log-stderr-level -1 &&
+	test "$(flux getattr log-stderr-level)" = "-1"
+'
+test_expect_success 'log-stderr-level cannot be set to 8 on the fly' '
+	test_must_fail flux setattr log-stderr-level 8
+'
 
 test_done


### PR DESCRIPTION
This replaces the callback based "active attribute" interface with an RPC redirect table so that update handlers need not run in the same thread.  Then it changes the log subsystem to use the new interface.

Rather than retain the ability to dynamically update _all_ log attributes, drop runtime update support from all but `log-stderr-level` as this seems to be the only one that is usefully updated on the fly (mainly in test).  The others can be customized on the broker command line.

This PR is proposed in lieu of
- #7370 

that one doesn't solve the callback problem in an general way, but instead just adds a purpose built RPC for updating `log-stderr-level` and changes the  user interface from `flux setattr` to `flux dmesg`.