### PR TITLE
testsuite: fix several flaky tests

### DIFF
--- a/t/python/t0032-resource-journal.py
+++ b/t/python/t0032-resource-journal.py
@@ -31,12 +31,15 @@ class TestResourceJournalConsumer(unittest.TestCase):
 
         events = []
         while True:
-            # Read events until we see resource-define
             event = consumer.poll(timeout=5.0)
             events.append(event)
-            if event.name == "resource-define":
+            # The following `since=` test assumes at least 3 events in
+            # the events array. Ensure we've got that and exit this loop:
+            if len(events) == 3:
                 break
         consumer.stop()
+
+        self.assertTrue(len(events) >= 3)
 
         # events are ordered
         self.assertTrue(

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -201,8 +201,17 @@ test_expect_success 'I/O -- long lines' '
 	test_cmp output expected
 '
 
+# The version of stdbuf(1) in older versions of uutils/coreutils does
+# not exec() its argument but instead remains the parent and collects
+# exit status. This version does not forward signals to children, so
+# it breaks the test below. Detect versions of stdbuf that don't exec
+# their arguments and skip the test if found.
+if test $(stdbuf --output=L sh -c 'ps -q $PPID -o comm=') != "stdbuf"; then
+    test_set_prereq WORKING_STDBUF
+fi
+
 waitfile=$SHARNESS_TEST_SRCDIR/scripts/waitfile.lua
-test_expect_success 'signal forwarding works' '
+test_expect_success WORKING_STDBUF 'signal forwarding works' '
 	cat >test_signal.sh <<-EOF &&
 	#!/bin/bash
 	sig=\${1-INT}

--- a/t/t0100-modprobe.t
+++ b/t/t0100-modprobe.t
@@ -1013,13 +1013,14 @@ test_expect_success 'modprobe load/remove loads/removes same set of modules' '
 	test_must_fail grep heartbeat load-remove.out
 '
 # Note in the test below: resource, heartbeat may be removed in any order
-# so only the last 4 lines of output are compared, which should include
+# so those two modules are removed from output, leaving only:
 # kvs-watch, kvs, content-sqlite, and content
 test_expect_success 'modprobe load/remove loads/removes same set of modules' '
 	flux start -Sbroker.rc1_path= -Sbroker.rc3_path= \
 	    sh -c "flux modprobe load resource && flux modprobe remove --dry-run resource && flux modprobe remove all" >remove-dry-run.out 2>&1 &&
 	test_debug "cat remove-dry-run.out" &&
-	cat remove-dry-run.out | tail -4 > remove-dry-run-truncated.out &&
+	cat remove-dry-run.out | grep -Ev "heartbeat|resource" \
+	    > remove-dry-run-truncated.out &&
 	cat <<-EOF >remove-dry-run.expected &&
 	remove kvs-watch
 	remove kvs


### PR DESCRIPTION
Fix four flaky tests observed in a particular VM environment:

- `t0032-resource-journal.py`: handle resource-define event arriving
  before online event
- `t2814-hostlist-cmd.t`: add retry loop to cover race between overlay
  and resource module marking a node down
- `t0100-modprobe.t`: filter unordered modules before comparing removal
  order
- `t0005-exec.t`: skip signal forwarding test when `stdbuf` is
  non-conformant (older `uutils/coreutils` versions of coreutils)