### PR TITLE
fix assorted bugs in broker and job-manager

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1652,6 +1652,7 @@ static bool signal_is_deadly (int signum)
 static void killall_cb (flux_future_t *f, void *arg)
 {
     broker_ctx_t *ctx = arg;
+    int signum = (int) ptr2int (flux_future_aux_get (f, "signum"));
     int count = 0;
     if (flux_rpc_get_unpack (f, "{s:i}", "count", &count) < 0) {
         flux_log_error (ctx->h,
@@ -1663,7 +1664,7 @@ static void killall_cb (flux_future_t *f, void *arg)
         flux_log (ctx->h,
                   LOG_INFO,
                   "forwarded signal %d to %d jobs",
-                  (int) ptr2int (flux_future_aux_get (f, "signal")),
+                  signum,
                   count);
     }
 }

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -439,7 +439,7 @@ static int event_release_context_decode (json_t *context,
 {
     *final = 0;
 
-    if (json_unpack (context, "{ s:b }", "final", &final) < 0) {
+    if (json_unpack (context, "{ s:b }", "final", final) < 0) {
         errno = EPROTO;
         return -1;
     }

--- a/src/modules/job-manager/housekeeping.c
+++ b/src/modules/job-manager/housekeeping.c
@@ -166,9 +166,12 @@ static void allocation_destructor (void **item)
 static char *get_rlist_ranks (struct rlist *rl)
 {
     struct idset *ids;
+    char *ranks;
     if (!(ids = rlist_ranks (rl)))
         return NULL;
-    return idset_encode (ids, IDSET_FLAG_RANGE);
+    ranks = idset_encode (ids, IDSET_FLAG_RANGE);
+    idset_destroy (ids);
+    return ranks;
 }
 
 static int update_cmd_env (flux_cmd_t *cmd,
@@ -177,15 +180,16 @@ static int update_cmd_env (flux_cmd_t *cmd,
                            struct rlist *rl)
 {
     char *ranks;
+    int rc = 0;
 
     if (!(ranks = get_rlist_ranks (rl))
         || flux_cmd_setenvf (cmd, 1, "FLUX_JOB_ID", "%ju", (uintmax_t)id) < 0
         || flux_cmd_setenvf (cmd, 1, "FLUX_JOB_USERID", "%u", userid) < 0
         || flux_cmd_setenvf (cmd, 1, "FLUX_JOB_RANKS", "%s", ranks) < 0)
-        return -1;
+        rc = -1;
 
     free (ranks);
-    return 0;
+    return rc;
 }
 
 static struct allocation *allocation_create (struct housekeeping *hk,

--- a/src/modules/job-manager/jobtap-internal.h
+++ b/src/modules/job-manager/jobtap-internal.h
@@ -44,11 +44,11 @@ int jobtap_get_priority (struct jobtap *jobtap,
  */
 int jobtap_validate (struct jobtap *jobtap,
                      struct job *job,
-                     char **errp);
+                     flux_error_t *errp);
 
 int jobtap_call_create (struct jobtap *jobtap,
                         struct job *job,
-                        char **errp);
+                        flux_error_t *errp);
 
 /*  Jobtap call to iterate attributes.system.dependencies dictionary
  *   and call job.dependency.<schema> for each entry.
@@ -61,15 +61,14 @@ int jobtap_call_create (struct jobtap *jobtap,
 int jobtap_check_dependencies (struct jobtap *jobtap,
                                struct job *job,
                                bool raise_exception,
-                               char **errp);
+                               flux_error_t *errp);
 
 /*  Call `job.update.<key>` callback to verify that a jobspec update of
  *  'key' to 'value' is allowed. The flux_msg_cred parameter should be set
  *  to the credentials of the original requestor.
  *
- *  Returns an error with 'errp' (Caller must free) set if no plugin is
- *  registered to handle updates of 'key', or if the callback returned an
- *  error.
+ *  Returns an error with 'errp' set if no plugin is registered to handle
+ *  updates of 'key', or if the callback returned an error.
  *
  *  If the update needs further validation via `job.validate`, then
  *  needs_validation will be set nonzero. The caller should be sure to pass
@@ -88,18 +87,18 @@ int jobtap_job_update (struct jobtap *jobtap,
                        int *needs_validation,
                        int *needs_feasibility,
                        json_t **updates,
-                       char **errp);
+                       flux_error_t *errp);
 
 /*  Call the `job.validate` plugin stack, but using an updated jobspec by
  *  applying 'updates' to 'job'.
  *
  *  If validation fails, then this function will return -1 with the error
- *  set in 'errp' (Caller must free).
+ *  set in 'errp'.
  */
 int jobtap_validate_updates (struct jobtap *jobtap,
                              struct job *job,
                              json_t *updates,
-                             char **errp);
+                             flux_error_t *errp);
 
 /*  Load a new jobtap from `path`. Path may start with `builtin.` to
  *   attempt to load one of the builtin jobtap plugins.

--- a/src/modules/job-manager/plugins/dependency-after.c
+++ b/src/modules/job-manager/plugins/dependency-after.c
@@ -454,7 +454,6 @@ static int dependency_after_cb (flux_plugin_t *p,
     if (!(ref = after_ref_create (afterid, l, after))
         || !(l = after_refs_get (p, id))
         || !zlistx_add_end (l, ref)) {
-        after_info_destroy (after);
         after_ref_destroy (ref);
         return flux_jobtap_reject_job (p, args, "failed to create ref");
     }
@@ -465,8 +464,6 @@ static int dependency_after_cb (flux_plugin_t *p,
      */
     if (type == AFTER_START
         && flux_jobtap_job_subscribe (p, afterid) < 0) {
-        after_info_destroy (after);
-        after_ref_destroy (ref);
         return flux_jobtap_reject_job (p, args, "failed to subscribe to %s",
                                        idf58 (id));
     }

--- a/src/modules/job-manager/plugins/history.c
+++ b/src/modules/job-manager/plugins/history.c
@@ -152,7 +152,7 @@ static int jobtap_cb (flux_plugin_t *p,
                                 "id", &entry->id,
                                 "t_submit", &entry->t_submit,
                                 "userid", &userid) < 0)
-        return -1;
+        goto error;
     key = userid2key (userid);
     if (streq (topic, "job.inactive-remove")) {
         void *handle;
@@ -165,18 +165,17 @@ static int jobtap_cb (flux_plugin_t *p,
             job_entry_destroy (entry);
             return 0;
         }
-        if (!hola_list_insert (hist->users, key, entry, true)) {
-            job_entry_destroy (entry);
-            return -1;
-        }
+        if (!hola_list_insert (hist->users, key, entry, true))
+            goto error;
     }
     else if (streq (topic, "job.new")) {
-        if (!hola_list_insert (hist->users, key, entry, true)) {
-            job_entry_destroy (entry);
-            return -1;
-        }
+        if (!hola_list_insert (hist->users, key, entry, true))
+            goto error;
     }
     return 0;
+error:
+    job_entry_destroy (entry);
+    return -1;
 }
 
 static int append_int (json_t *a, json_int_t i)

--- a/src/modules/job-manager/plugins/history.c
+++ b/src/modules/job-manager/plugins/history.c
@@ -287,6 +287,7 @@ static void history_get_cb (flux_t *h,
     if (flux_respond_pack (h, msg, "{s:O}", "jobs", jobs) < 0)
         flux_log_error (h, "error responding to job-manager.history.get");
     json_decref (jobs);
+    return;
 error:
     if (flux_respond_error (h, msg, errno, errmsg) < 0)
         flux_log_error (h, "error responding to job-manager.history.get");

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -162,7 +162,7 @@ static flux_cmd_t *cmd_from_json (json_t *o)
 
     json_array_foreach (o, index, value) {
         const char *arg = json_string_value (value);
-        if (!value
+        if (!arg
             || flux_cmd_argv_append (cmd, arg) < 0)
             goto fail;
     }

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -820,6 +820,7 @@ static struct perilog_proc *procdesc_run (flux_t *h,
                       "%s: %s: failed to decode ranks from R",
                       idf58 (id),
                       perilog_proc_name (proc));
+            goto error;
     }
     if (flux_cmd_setenvf (pd->cmd, 1, "FLUX_JOB_ID", "%s", idf58 (id)) < 0
         || flux_cmd_setenvf (pd->cmd, 1, "FLUX_JOB_RANKS", "%s", rank_str) < 0

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -702,23 +702,24 @@ static void error_cb (struct bulk_exec *bulk_exec,
                       flux_subprocess_t *p,
                       void *arg)
 {
-    struct perilog_proc *proc = bulk_exec_aux_get (bulk_exec, "perilog_proc");
-    flux_t *h = flux_jobtap_get_flux (proc->p);
-    int rank = flux_subprocess_rank (p);
-    const char *hostname = flux_get_hostbyrank (h, rank);
-    const char *error = flux_subprocess_fail_error (p);
+    struct perilog_proc *proc;
+    int rank;
+    flux_t *h;
 
-    if (!proc)
+    if (!(proc = bulk_exec_aux_get (bulk_exec, "perilog_proc"))
+        || !(h = flux_jobtap_get_flux (proc->p)))
         return;
+
+    rank = flux_subprocess_rank (p);
 
     flux_log (h,
               LOG_ERR,
               "%s: %s: %s (rank %d): %s",
               idf58 (proc->id),
               perilog_proc_name (proc),
-              hostname,
+              flux_get_hostbyrank (h, rank),
               rank,
-              error);
+              flux_subprocess_fail_error (p));
 }
 
 static bool perilog_log_ignore (struct perilog_conf *conf, const char *s)

--- a/src/modules/job-manager/plugins/post-event.c
+++ b/src/modules/job-manager/plugins/post-event.c
@@ -43,6 +43,7 @@ static void post_event_cb (flux_t *h,
             goto error;
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "error responding to job-manager.post-event");
+    return;
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "error responding to job-manager.post-event");

--- a/src/modules/job-manager/plugins/validate-duration.c
+++ b/src/modules/job-manager/plugins/validate-duration.c
@@ -78,12 +78,12 @@ static int validate_duration (flux_plugin_t *p,
 static void kvs_lookup_cb (flux_future_t *f, void *arg)
 {
     flux_t *h = flux_future_get_flux (f);
-    double val;
+    double val = expiration;
     if (flux_kvs_lookup_get_unpack (f,
                                     "{s:{s:F}}",
                                     "execution",
                                       "expiration", &val) < 0) {
-        flux_log_error (h, "flux_kvs_lookup_unpack");
+        flux_log_error (h, "Failed to extract expiration from R update");
     }
     flux_future_reset (f);
     if (fabs (val - expiration) < 1.e-5)

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -94,6 +94,7 @@ static void queue_destroy (struct queue *q)
         json_decref (q->requires);
         free (q->name);
         free (q->disable_reason);
+        free (q->stop_reason);
         free (q);
         errno = saved_errno;
     }

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -486,7 +486,7 @@ int restart_from_kvs (struct job_manager *ctx)
     job = zhashx_first (ctx->inactive_jobs);
     while (job) {
         (void)jobtap_call (ctx->jobtap, job, "job.inactive-add", NULL);
-        job = zhashx_next (ctx->active_jobs);
+        job = zhashx_next (ctx->inactive_jobs);
     }
 
     /* Restore misc state.

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -417,16 +417,15 @@ int restart_from_kvs (struct job_manager *ctx)
     while (job) {
         if (job->state == FLUX_JOB_STATE_NEW
             || job->state == FLUX_JOB_STATE_DEPEND) {
-            char *errmsg = NULL;
+            flux_error_t errmsg;
             if (jobtap_check_dependencies (ctx->jobtap,
                                            job,
                                            true,
                                            &errmsg) < 0) {
                 flux_log (ctx->h, LOG_ERR,
                           "restart: id=%s: dependency check failed: %s",
-                          idf58 (job->id), errmsg);
+                          idf58 (job->id), errmsg.text);
             }
-            free (errmsg);
         }
         /*
          *  On restart, call 'job.create' and 'job.new' plugin callbacks

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -370,7 +370,7 @@ static void expiration_update_cb (flux_future_t *f, void *arg)
                                     note) < 0)
             flux_log_error (ctx->h, "expiration_update: raise_job_exception");
     }
-    job_aux_delete (job, "job-manager::R-update");
+    job_aux_set (job, "job-manager::R-update", NULL, NULL);
 }
 
 /* Send <exec_service>.expiration request to adjust job expiration
@@ -398,7 +398,7 @@ int start_send_expiration_update (struct start *start,
         || flux_future_then (f, -1., expiration_update_cb, job) < 0
         || flux_future_aux_set (f, "job-manager::ctx", ctx, NULL) < 0) {
         int saved_errno = errno;
-        (void) job_aux_delete (job, "job-manager::R-update");
+        (void) job_aux_set (job, "job-manager::R-update", NULL, NULL);
         flux_future_destroy (f);
         errno = saved_errno;
         return -1;

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -80,7 +80,7 @@ static int submit_job (struct job_manager *ctx,
                        json_t *errors)
 {
     flux_error_t e;
-    char *error = NULL;
+    flux_error_t error = {{0}};
 
     if (queue_submit_check (ctx->queue, job->jobspec_redacted, &e) < 0) {
         set_errorf (errors, job->id, "%s", e.text);
@@ -108,8 +108,7 @@ static int submit_job (struct job_manager *ctx,
         set_errorf (errors,
                     job->id,
                     "%s",
-                    error ? error : "rejected by plugin");
-        free (error);
+                    strlen (error.text) > 0 ? error.text : "rejected by plugin");
         goto error_post_invalid;
     }
     /* Call job.new callback now that job is accepted, so plugins


### PR DESCRIPTION
As an experiment I used Claude Code (Opus 4.6) to look for issues in `broker.c` as well as `job-manger.c` and `job-manager/plugins/*`. This set of fixes is the result of that work.

A few bugs were due to the strange way some error messages are allocated on return by some internal jobtap functions, so this PR cleans that up to use the more standard `flux_error_t` interface.