### PR TITLE
broker: add connector-local introspection

### DIFF
--- a/src/common/librouter/Makefile.am
+++ b/src/common/librouter/Makefile.am
@@ -11,6 +11,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
 	-I$(top_srcdir)/src/common/libccan \
+	$(JANSSON_CFLAGS) \
 	$(LIBUUID_CFLAGS)
 
 noinst_LTLIBRARIES = \
@@ -72,7 +73,9 @@ test_ldadd = \
         $(top_builddir)/src/common/libtestutil/libtestutil.la \
         $(top_builddir)/src/common/libflux-core.la \
         $(top_builddir)/src/common/libflux-internal.la \
-        $(top_builddir)/src/common/libtap/libtap.la
+        $(top_builddir)/src/common/libtap/libtap.la \
+        $(JANSSON_LIBS) \
+        $(LIBUUID_LIBS)
 
 test_cppflags = \
         $(AM_CPPFLAGS) \

--- a/src/common/librouter/test/usock.c
+++ b/src/common/librouter/test/usock.c
@@ -108,6 +108,10 @@ void server_invalid (void)
     ok (usock_server_create (r, NULL, 0666) == NULL && errno == EINVAL,
         "usock_server_create sockpath=NULL fails with EINVAL");
 
+    errno = 0;
+    ok (usock_server_stats_get (NULL) == NULL && errno == EINVAL,
+        "usock_server_stats_get server=NULL fails with EINVAL");
+
     flux_reactor_destroy (r);
 }
 

--- a/src/common/librouter/usock.h
+++ b/src/common/librouter/usock.h
@@ -13,6 +13,7 @@
 
 #include <sys/types.h>
 #include <flux/core.h>
+#include <jansson.h>
 
 #include "auth.h"
 
@@ -58,6 +59,8 @@ void usock_server_destroy (struct usock_server *server);
 void usock_server_set_acceptor (struct usock_server *server,
                                 usock_acceptor_f cb,
                                 void *arg);
+
+json_t *usock_server_stats_get (struct usock_server *server);
 
 // accessor for start/stop/ref/unref
 flux_watcher_t *usock_server_listen_watcher (struct usock_server *server);

--- a/src/connectors/Makefile.am
+++ b/src/connectors/Makefile.am
@@ -10,7 +10,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	-I$(top_srcdir)/src/common/libccan
+	-I$(top_srcdir)/src/common/libccan \
+	$(JANSSON_CFLAGS)
 
 fluxconnector_LTLIBRARIES = \
 	ssh.la
@@ -24,5 +25,6 @@ ssh_la_SOURCES = \
 	ssh/ssh.c
 ssh_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la
+	$(top_builddir)/src/common/libflux-core.la \
+	$(JANSSON_LIBS)
 ssh_la_LDFLAGS = $(connector_ldflags)

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -275,8 +275,18 @@ error:
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST,  "connector-local.config-reload", reload_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST,  "connector-local.config-sync", reload_cb, 0 },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "connector-local.config-reload",
+        reload_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "connector-local.config-sync",
+        reload_cb,
+        0
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 


### PR DESCRIPTION
Problem: in #7379 it was noted that the `connector-local` doesn't provide any info on who is connected to it, which might be useful in debug situations.

Override the default stats-get handler in `connector-local`.

Example output of `flux module stats connector-local`

```json
{
 "server": {
  "clients": [
   {
    "uuid": "154a546f-fc33-48ef-97f3-779a94ad3714",
    "userid": 5588,
    "pid": 223329,
    "txcount": 18,
    "rxcount": 31,
    "rxbacklog": 0
   },
   {
    "uuid": "031dbc03-6b38-43cd-aa5f-6621b9a16e22",
    "userid": 5588,
    "pid": 223550,
    "txcount": 1,
    "rxcount": 0,
    "rxbacklog": 0
   }
  ],
  "connects": 18
 },
 "allow_guest_user": false,
 "allow_root_owner": false
}
```