### PR TITLE
libflux: rename/deprecate public functions based on aux_delete()

### DIFF
--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -271,7 +271,7 @@ void *flux_plugin_aux_get (flux_plugin_t *p, const char *key)
 
 void flux_plugin_aux_delete (flux_plugin_t *p, const void *val)
 {
-    return aux_delete (&p->aux, val);
+    return aux_delete_value (&p->aux, val);
 }
 
 const char *flux_plugin_strerror (flux_plugin_t *p)

--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -269,9 +269,15 @@ void *flux_plugin_aux_get (flux_plugin_t *p, const char *key)
     return aux_get (p->aux, key);
 }
 
-void flux_plugin_aux_delete (flux_plugin_t *p, const void *val)
+void flux_plugin_aux_delete_value (flux_plugin_t *p, const void *val)
 {
     return aux_delete_value (&p->aux, val);
+}
+
+// deprecated
+void flux_plugin_aux_delete (flux_plugin_t *p, const void *val)
+{
+    return flux_plugin_aux_delete_value (p, val);
 }
 
 const char *flux_plugin_strerror (flux_plugin_t *p)

--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -113,7 +113,10 @@ void * flux_plugin_aux_get (flux_plugin_t *p, const char *key);
 
 /*  Delete auxiliary data by value.
  */
-void flux_plugin_aux_delete (flux_plugin_t *p, const void *val);
+void flux_plugin_aux_delete_value (flux_plugin_t *p, const void *val);
+
+FLUX_DEPRECATED(void flux_plugin_aux_delete (flux_plugin_t *p,
+                                             const void *val));
 
 /*  Set optional JSON string as load-time config for plugin 'p'.
  */

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -122,8 +122,8 @@ void test_invalid_args ()
         "flux_plugin_aux_get (p, NULL) returns EINVAL");
     ok (flux_plugin_aux_get (p, "foo") == NULL && errno == ENOENT,
         "flux_plugin_aux_get (p, 'foo') returns ENOENT");
-    lives_ok ({flux_plugin_aux_delete (p, NULL);},
-        "flux_plugin_aux_delete (p, NULL) doesn't crash");
+    lives_ok ({flux_plugin_aux_delete_value (p, NULL);},
+        "flux_plugin_aux_delete_value (p, NULL) doesn't crash");
 
     ok (flux_plugin_add_handler (NULL, "foo.*", foo, NULL) < 0 && errno == EINVAL,
         "flux_plugin_add_handler (NULL, ...) returns EINVAL");

--- a/src/common/libutil/aux.c
+++ b/src/common/libutil/aux.c
@@ -168,7 +168,7 @@ int aux_set (struct aux_item **head,
     return 0;
 }
 
-void aux_delete (struct aux_item **head, const void *val)
+void aux_delete_value (struct aux_item **head, const void *val)
 {
     struct aux_item *item;
 

--- a/src/common/libutil/aux.h
+++ b/src/common/libutil/aux.h
@@ -36,7 +36,7 @@ struct aux_item;
 int aux_set (struct aux_item **aux, const char *key,
              void *val, aux_free_f free_fn);
 
-void aux_delete (struct aux_item **aux, const void *val);
+void aux_delete_value (struct aux_item **aux, const void *val);
 
 void *aux_get (struct aux_item *aux, const char *key);
 

--- a/src/common/libutil/test/aux.c
+++ b/src/common/libutil/test/aux.c
@@ -190,25 +190,25 @@ void test_delete (void)
             BAIL_OUT ("aux_set failed on item %d", i);
 
     myfree_count = 0;
-    aux_delete (NULL, "foo");
+    aux_delete_value (NULL, "foo");
     ok (myfree_count == 0,
-        "aux_delete aux=NULL does nothing");
+        "aux_delete_value aux=NULL does nothing");
 
     myfree_count = 0;
-    aux_delete (&aux, NULL);
+    aux_delete_value (&aux, NULL);
     ok (myfree_count == 0,
-        "aux_delete val=NULL does nothing");
+        "aux_delete_value val=NULL does nothing");
 
     myfree_count = 0;
-    aux_delete (&aux, &i);
+    aux_delete_value (&aux, &i);
     ok (myfree_count == 0,
-        "aux_delete val=unknown does nothing");
+        "aux_delete_value val=unknown does nothing");
 
     myfree_count = 0;
     for (i = 0; i < 8; i++)
-        aux_delete (&aux, &items[i]);
+        aux_delete_value (&aux, &items[i]);
     ok (myfree_count == 8,
-        "aux_delete works with valid pointer");
+        "aux_delete_value works with valid pointer");
 }
 
 int main (int argc, char *argv[])

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -166,7 +166,7 @@ void *job_aux_get (struct job *job, const char *name)
 
 void job_aux_delete (struct job *job, const void *val)
 {
-    aux_delete (&job->aux, val);
+    aux_delete_value (&job->aux, val);
 }
 
 void job_aux_destroy (struct job *job)

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -164,7 +164,7 @@ void *job_aux_get (struct job *job, const char *name)
     return aux_get (job->aux, name);
 }
 
-void job_aux_delete (struct job *job, const void *val)
+void job_aux_delete_value (struct job *job, const void *val)
 {
     aux_delete_value (&job->aux, val);
 }

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -84,7 +84,7 @@ int job_aux_set (struct job *job,
                  void *val,
                  flux_free_f destroy);
 void *job_aux_get (struct job *job, const char *name);
-void job_aux_delete (struct job *job, const void *val);
+void job_aux_delete_value (struct job *job, const void *val);
 void job_aux_destroy (struct job *job);
 
 /* Helpers for maintaining czmq containers of 'struct job'.

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -474,7 +474,7 @@ static void jobtap_finalize (struct jobtap *jobtap, flux_plugin_t *p)
             struct aux_wrap *wrap;
 
             if ((wrap = aux_wrap_get (p, job, false)))
-                job_aux_delete (job, wrap);
+                job_aux_delete_value (job, wrap);
 
             job = zlistx_next (jobs);
         }

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -2159,7 +2159,7 @@ int flux_jobtap_job_aux_delete (flux_plugin_t *p,
     if (!(job = jobtap_lookup_jobid (p, id)))
         return -1;
     if ((wrap = aux_wrap_get (p, job, false)))
-        aux_delete (&wrap->aux, val);
+        aux_delete_value (&wrap->aux, val);
     return 0;
 }
 

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -2149,9 +2149,9 @@ void * flux_jobtap_job_aux_get (flux_plugin_t *p,
     return aux_get (wrap->aux, name);
 }
 
-int flux_jobtap_job_aux_delete (flux_plugin_t *p,
-                                flux_jobid_t id,
-                                void *val)
+int flux_jobtap_job_aux_delete_value (flux_plugin_t *p,
+                                      flux_jobid_t id,
+                                      void *val)
 {
     struct job *job;
     struct aux_wrap *wrap;
@@ -2161,6 +2161,14 @@ int flux_jobtap_job_aux_delete (flux_plugin_t *p,
     if ((wrap = aux_wrap_get (p, job, false)))
         aux_delete_value (&wrap->aux, val);
     return 0;
+}
+
+// deprecated
+int flux_jobtap_job_aux_delete (flux_plugin_t *p,
+                                flux_jobid_t id,
+                                void *val)
+{
+    return flux_jobtap_job_aux_delete_value (p, id, val);
 }
 
 int flux_jobtap_job_set_flag (flux_plugin_t *p,

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -156,9 +156,13 @@ void * flux_jobtap_job_aux_get (flux_plugin_t *p,
  *
  *  If `id` is FLUX_JOBTAP_CURRENT_JOB then the current job will be used.
  */
-int flux_jobtap_job_aux_delete (flux_plugin_t *p,
-                                flux_jobid_t id,
-                                void *val);
+FLUX_DEPRECATED(int flux_jobtap_job_aux_delete (flux_plugin_t *p,
+                                                flux_jobid_t id,
+                                                void *val));
+
+int flux_jobtap_job_aux_delete_value (flux_plugin_t *p,
+                                      flux_jobid_t id,
+                                      void *val);
 
 /*  Set a named flag on job `id`.
  */

--- a/src/modules/job-manager/plugins/begin-time.c
+++ b/src/modules/job-manager/plugins/begin-time.c
@@ -66,8 +66,8 @@ static void begin_time_cb (flux_reactor_t *r,
     flux_t *h = flux_jobtap_get_flux (b->p);
     if (flux_jobtap_dependency_remove (b->p, b->id, b->desc) < 0)
         flux_log_error (h, "begin-time: flux_jobtap_dependency_remove");
-    if (flux_jobtap_job_aux_delete (b->p, b->id, b) < 0)
-        flux_log_error (h, "begin-time: flux_jobtap_job_aux_delete");
+    if (flux_jobtap_job_aux_delete_value (b->p, b->id, b) < 0)
+        flux_log_error (h, "begin-time: flux_jobtap_job_aux_delete_value");
 }
 
 

--- a/src/modules/job-manager/plugins/dependency-after.c
+++ b/src/modules/job-manager/plugins/dependency-after.c
@@ -579,8 +579,10 @@ static void release_dependency_references (flux_plugin_t *p)
 
     /*  Destroy this job's dependency reference list.
      */
-    if (flux_jobtap_job_aux_delete (p, FLUX_JOBTAP_CURRENT_JOB, l) < 0)
-        flux_log_error (h, "release_references: flux_jobtap_job_aux_delete");
+    if (flux_jobtap_job_aux_delete_value (p, FLUX_JOBTAP_CURRENT_JOB, l) < 0) {
+        flux_log_error (h,
+                        "release_references: flux_jobtap_job_aux_delete_value");
+    }
 }
 
 static int release_dependent_jobs (flux_plugin_t *p,
@@ -646,9 +648,12 @@ static int priority_cb (flux_plugin_t *p,
          *  be used, and we don't need to attempt deref of dependencies
          *  (see bottom of inactive_cb()).
          */
-        if (flux_jobtap_job_aux_delete (p, FLUX_JOBTAP_CURRENT_JOB, l) < 0) {
+        if (flux_jobtap_job_aux_delete_value (p,
+                                              FLUX_JOBTAP_CURRENT_JOB,
+                                              l) < 0) {
             flux_log_error (flux_jobtap_get_flux (p),
-                            "dependency-after: flux_jobtap_job_aux_delete");
+                            "dependency-after:"
+                            " flux_jobtap_job_aux_delete_value");
         }
     }
     return 0;

--- a/t/job-manager/plugins/job_aux.c
+++ b/t/job-manager/plugins/job_aux.c
@@ -47,11 +47,12 @@ static int depend_cb (flux_plugin_t *p,
                                             "flux_jobtap_aux_get failed: %s",
                                             strerror (errno));
 
-    rc = flux_jobtap_job_aux_delete (p, id, val);
+    rc = flux_jobtap_job_aux_delete_value (p, id, val);
     if (rc < 0)
         return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
                                             "test", 0,
-                                            "flux_jobtap_aux_delete failed: %s",
+                                            "flux_jobtap_aux_delete_value"
+                                            " failed: %s",
                                             strerror (errno));
 
     if (flux_jobtap_job_aux_get (p, id, "foo"))
@@ -114,10 +115,11 @@ static int validate_cb (flux_plugin_t *p,
                                        "flux_jobtap_aux_get() failed: %s",
                                        strerror (errno));
 
-    rc = flux_jobtap_job_aux_delete (p, FLUX_JOBTAP_CURRENT_JOB, val);
+    rc = flux_jobtap_job_aux_delete_value (p, FLUX_JOBTAP_CURRENT_JOB, val);
     if (rc < 0)
         return flux_jobtap_reject_job (p, args,
-                                       "flux_jobtap_aux_delete() failed: %s",
+                                       "flux_jobtap_aux_delete_value() failed:"
+                                       " %s",
                                        strerror (errno));
 
     if (flux_jobtap_job_aux_get (p, FLUX_JOBTAP_CURRENT_JOB, "foo"))


### PR DESCRIPTION
Problem: aux_delete() takes a value not a key, but the name doesn't hint at this, making it an accident waiting to happen.

Rename these public functions (leaving the old names deprecated):
```
flux_plugin_aux_delete() => flux_plugin_aux_delete_value()
flux_jobtap_job_aux_delete() => flux_jobtap_job_aux_delete_value()
```

Rename the internal functions too.

Fixes #7394