### PR TITLE
t: cleanup waiting functions

### DIFF
--- a/t/kvs/kvs-helper.sh
+++ b/t/kvs/kvs-helper.sh
@@ -12,7 +12,7 @@ loophandlereturn() {
     index=$1
     if [ "$index" -eq "${KVS_WAIT_ITERS}" ]
     then
-        return 1
+	return 1
     fi
     return 0
 }
@@ -36,14 +36,14 @@ test_kvs_key_namespace() {
 
 # arg1 - namespace
 wait_watcherscount_nonzero() {
-        ns=$1
-        i=0
-        while (! flux module stats --parse namespaces.${ns}.watchers kvs-watch > /dev/null 2>&1 \
-               || [ "$(flux module stats --parse namespaces.${ns}.watchers kvs-watch 2> /dev/null)" = "0" ]) \
-              && [ $i -lt ${KVS_WAIT_ITERS} ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        return $(loophandlereturn $i)
+	ns=$1
+	i=0
+	while (! flux module stats --parse namespaces.${ns}.watchers kvs-watch > /dev/null 2>&1 \
+	       || [ "$(flux module stats --parse namespaces.${ns}.watchers kvs-watch 2> /dev/null)" = "0" ]) \
+	      && [ $i -lt ${KVS_WAIT_ITERS} ]
+	do
+		sleep 0.1
+		i=$((i + 1))
+	done
+	return $(loophandlereturn $i)
 }

--- a/t/kvs/kvs-helper.sh
+++ b/t/kvs/kvs-helper.sh
@@ -3,20 +3,6 @@
 
 # KVS helper functions
 
-# Loop on KVS_WAIT_ITERS is just to make sure we don't spin forever on
-# error.
-
-KVS_WAIT_ITERS=50
-
-loophandlereturn() {
-    index=$1
-    if [ "$index" -eq "${KVS_WAIT_ITERS}" ]
-    then
-	return 1
-    fi
-    return 0
-}
-
 # arg1 - key to retrieve
 # arg2 - expected value
 test_kvs_key() {
@@ -37,13 +23,6 @@ test_kvs_key_namespace() {
 # arg1 - namespace
 wait_watcherscount_nonzero() {
 	ns=$1
-	i=0
-	while (! flux module stats --parse namespaces.${ns}.watchers kvs-watch > /dev/null 2>&1 \
-	       || [ "$(flux module stats --parse namespaces.${ns}.watchers kvs-watch 2> /dev/null)" = "0" ]) \
-	      && [ $i -lt ${KVS_WAIT_ITERS} ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	return $(loophandlereturn $i)
+	test_wait_until "flux module stats --parse namespaces.${ns}.watchers kvs-watch \
+		&& [ \$(flux module stats --parse namespaces.${ns}.watchers kvs-watch 2> /dev/null) -ne 0 ]"
 }

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -339,6 +339,93 @@ test_flux_security_version() {
     test $major -ge $req_major -a $minor -ge $req_minor -a $patch -ge $req_patch
 }
 
+# Default number of iterations for test_wait_until() (can be
+# overridden)
+TEST_WAIT_UNTIL_DEFAULT_ITERS=50
+
+# Default sleep time in seconds between iterations for
+# test_wait_until() (can be overridden)
+TEST_WAIT_UNTIL_DEFAULT_SLEEP=0.1
+
+# Default verbosity for test_wait_until() (can be overridden)
+TEST_WAIT_UNTIL_DEFAULT_VERBOSE=0
+
+#
+# Common utility function to wait for a condition to be met
+# The condition is provided as a command to execute
+#
+# Usage: test_wait_until [OPTIONS] "COMMAND [ARGS...]"
+#
+# Options:
+#   -i, --iterations N   Maximum iterations to wait (default: $TEST_WAIT_UNTIL_DEFAULT_ITERS)
+#   -s, --sleep S        Sleep time between iterations (default: $TEST_WAIT_UNTIL_DEFAULT_SLEEP)
+#   -v, --verbose        Print diagnostic messages during waiting
+#
+# Example usage:
+#   test_wait_until "flux kvs get mykey" # Wait until command succeeds
+#   test_wait_until "test -f myfile"     # Wait until file exists
+#   test_wait_until "grep pattern file"  # Wait until pattern appears in file
+#   test_wait_until -i 100 -s 0.5 "custom_check_command arg1 arg2"
+#
+test_wait_until() {
+    local iterations=$TEST_WAIT_UNTIL_DEFAULT_ITERS
+    local sleep_time=$TEST_WAIT_UNTIL_DEFAULT_SLEEP
+    local verbose=$TEST_WAIT_UNTIL_DEFAULT_VERBOSE
+
+    # Process options
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -i|--iterations)
+                iterations=$2
+                shift 2
+                ;;
+            -s|--sleep)
+                sleep_time=$2
+                shift 2
+                ;;
+            -v|--verbose)
+                verbose=1
+                shift
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    # Ensure we have a command to run
+    if [ $# -eq 0 ]; then
+        echo "Error: test_wait_until requires a command to execute" >&2
+        return 1
+    fi
+
+    # The remaining arguments form the command to execute
+    local cmd="$1"
+    [ $verbose -eq 1 ] && echo "test_wait_until: running $cmd"
+
+    local i=0
+    while [ $i -lt $iterations ]
+    do
+        if [ $verbose -eq 1 ]; then
+            if eval "$cmd"; then
+                echo "test_wait_until: condition met after $i iterations"
+                return 0
+            fi
+        else
+            if eval "$cmd" >/dev/null 2>&1; then
+                return 0
+            fi
+        fi
+
+        [ $verbose -eq 1 ] && echo "test_wait_until: waiting... ($i/$iterations)"
+        sleep $sleep_time
+        i=$((i + 1))
+    done
+
+    [ $verbose -eq 1 ] && echo "test_wait_until: timeout after $iterations iterations"
+    return 1
+}
+
 #  Export a shorter name for this test
 TEST_NAME=$SHARNESS_TEST_NAME
 export TEST_NAME

--- a/t/system/0007-fsck.t
+++ b/t/system/0007-fsck.t
@@ -12,18 +12,7 @@ test_expect_success 'restart flux' '
 '
 
 wait_flux_back_up() {
-	i=0
-	while ! flux resource list > /dev/null 2>&1 \
-	      && [ $i -lt 100 ]
-	do
-		sleep 1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "100" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until -i 100 -s 1 "flux resource list"
 }
 
 test_expect_success 'wait for flux to finish starting up' '
@@ -73,18 +62,8 @@ test_expect_success 'kill flux broker' '
 '
 
 wait_fsck_fail() {
-	i=0
-	while ! sudo journalctl --since "$(cat fscktime.out)" | grep "missing blobref" > /dev/null 2>&1 \
-	      && [ $i -lt 100 ]
-	do
-		sleep 1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "100" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until -i 100 -s 1 "sudo journalctl --since \"$(cat fscktime.out)\" \
+		| grep \"missing blobref\""
 }
 
 # system instance for flux will auto restart in about 30 seconds
@@ -93,18 +72,7 @@ test_expect_success 'wait for flux to restart and fail fsck' '
 '
 
 wait_flux_stopped() {
-	i=0
-	while sudo systemctl status flux > /dev/null 2>&1 \
-	      && [ $i -lt 100 ]
-	do
-		sleep 1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "100" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until -i 100 -s 1 "! sudo systemctl status flux"
 }
 
 test_expect_success 'flux system instance is not running' '

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -486,12 +486,12 @@ test_expect_success 'kvs: 0 pending requests at end of tests before module remov
 #
 
 test_expect_success 'kvs: module stats returns reasonable transaction stats' '
-        commitdata=$(flux module stats -p transaction-opcount.commit kvs) &&
-        echo $commitdata | jq -e ".count > 0" &&
-        echo $commitdata | jq -e ".min > 0" &&
-        echo $commitdata | jq -e ".max > 0" &&
-        echo $commitdata | jq -e ".mean > 0.0" &&
-        echo $commitdata | jq -e ".stddev >= 0.0"
+	commitdata=$(flux module stats -p transaction-opcount.commit kvs) &&
+	echo $commitdata | jq -e ".count > 0" &&
+	echo $commitdata | jq -e ".min > 0" &&
+	echo $commitdata | jq -e ".max > 0" &&
+	echo $commitdata | jq -e ".mean > 0.0" &&
+	echo $commitdata | jq -e ".stddev >= 0.0"
 '
 
 #
@@ -504,8 +504,8 @@ test_expect_success 'kvs: test empty kvs txn works' '
 '
 
 test_expect_success 'kvs: module commit stats min is updated' '
-        commitdata=$(flux module stats -p transaction-opcount.commit kvs) &&
-        echo $commitdata | jq -e ".min == 0"
+	commitdata=$(flux module stats -p transaction-opcount.commit kvs) &&
+	echo $commitdata | jq -e ".min == 0"
 '
 
 #

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -516,14 +516,7 @@ test_expect_success 'kvs: module commit stats min is updated' '
 
 wait_versionwaiters() {
 	num=$1
-	i=0
-	while [ "$(flux module stats --parse namespace.primary.#versionwaiters kvs 2> /dev/null)" != "${num}" ] \
-	      && [ $i -lt ${KVS_WAIT_ITERS} ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	return $(loophandlereturn $i)
+	test_wait_until "[ \$(flux module stats --parse namespace.primary.#versionwaiters kvs 2> /dev/null) -eq ${num} ]"
 }
 
 # In order to test, wait for a version that will not happen

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -30,47 +30,47 @@ NAMESPACEORDER=namespaceorder
 NAMESPACEROOTREF=namespacerootref
 
 namespace_create_loop() {
-        i=0
-        while ! flux kvs namespace create $1 && [ $i -lt ${KVS_WAIT_ITERS} ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        return $(loophandlereturn $i)
+	i=0
+	while ! flux kvs namespace create $1 && [ $i -lt ${KVS_WAIT_ITERS} ]
+	do
+		sleep 0.1
+		i=$((i + 1))
+	done
+	return $(loophandlereturn $i)
 }
 
 get_kvs_namespace_all_ranks_loop() {
-        i=0
-        while ! flux exec -n sh -c "flux kvs get --namespace=$1 $2" \
-              && [ $i -lt ${KVS_WAIT_ITERS} ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        return $(loophandlereturn $i)
+	i=0
+	while ! flux exec -n sh -c "flux kvs get --namespace=$1 $2" \
+	      && [ $i -lt ${KVS_WAIT_ITERS} ]
+	do
+		sleep 0.1
+		i=$((i + 1))
+	done
+	return $(loophandlereturn $i)
 }
 
 get_kvs_namespace_fails_all_ranks_loop() {
-        i=0
-        while ! flux exec -n sh -c "! flux kvs get --namespace=$1 $2" \
-              && [ $i -lt ${KVS_WAIT_ITERS} ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        return $(loophandlereturn $i)
+	i=0
+	while ! flux exec -n sh -c "! flux kvs get --namespace=$1 $2" \
+	      && [ $i -lt ${KVS_WAIT_ITERS} ]
+	do
+		sleep 0.1
+		i=$((i + 1))
+	done
+	return $(loophandlereturn $i)
 }
 
 wait_versionwaiters_nonzero() {
-        i=0
-        while (! flux module stats --parse namespace.$1.#versionwaiters kvs > /dev/null 2>&1 \
-               || [ "$(flux module stats --parse namespace.$1.#versionwaiters kvs 2> /dev/null)" = "0" ]) \
-              && [ $i -lt ${KVS_WAIT_ITERS} ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        return $(loophandlereturn $i)
+	i=0
+	while (! flux module stats --parse namespace.$1.#versionwaiters kvs > /dev/null 2>&1 \
+	       || [ "$(flux module stats --parse namespace.$1.#versionwaiters kvs 2> /dev/null)" = "0" ]) \
+	      && [ $i -lt ${KVS_WAIT_ITERS} ]
+	do
+		sleep 0.1
+		i=$((i + 1))
+	done
+	return $(loophandlereturn $i)
 }
 
 #
@@ -78,7 +78,7 @@ wait_versionwaiters_nonzero() {
 #
 
 test_expect_success 'kvs: primary namespace exists/is listed' '
-        flux kvs namespace list | grep primary
+	flux kvs namespace list | grep primary
 '
 
 test_expect_success 'kvs: create primary namespace fails' '
@@ -90,50 +90,50 @@ test_expect_success 'kvs: remove primary namespace fails' '
 '
 
 test_expect_success 'kvs: get with primary namespace works' '
-        flux kvs put $DIR.test=1 &&
-        test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 1
+	flux kvs put $DIR.test=1 &&
+	test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 1
 '
 
 test_expect_success 'kvs: put with primary namespace works' '
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.test=2 &&
-        test_kvs_key $DIR.test 2
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.test=2 &&
+	test_kvs_key $DIR.test 2
 '
 
 test_expect_success 'kvs: put/get with primary namespace works' '
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.test=3 &&
-        test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 3
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.test=3 &&
+	test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 3
 '
 
 test_expect_success 'kvs: unlink with primary namespace works' '
-        flux kvs unlink --namespace=$PRIMARYNAMESPACE $DIR.test &&
-        test_must_fail flux kvs get $DIR.test
+	flux kvs unlink --namespace=$PRIMARYNAMESPACE $DIR.test &&
+	test_must_fail flux kvs get $DIR.test
 '
 
 test_expect_success 'kvs: dir with primary namespace works' '
-        flux kvs put $DIR.a=1 &&
-        flux kvs put $DIR.b=2 &&
-        flux kvs put $DIR.c=3 &&
-        flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR | sort > output &&
-        cat >expected <<EOF &&
+	flux kvs put $DIR.a=1 &&
+	flux kvs put $DIR.b=2 &&
+	flux kvs put $DIR.c=3 &&
+	flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR | sort > output &&
+	cat >expected <<EOF &&
 $DIR.a = 1
 $DIR.b = 2
 $DIR.c = 3
 EOF
-        test_cmp expected output
+	test_cmp expected output
 '
 
 test_expect_success 'kvs: unlink dir primary namespace works' '
-        flux kvs unlink --namespace=$PRIMARYNAMESPACE -Rf $DIR &&
-        ! flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR
+	flux kvs unlink --namespace=$PRIMARYNAMESPACE -Rf $DIR &&
+	! flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR
 '
 
 test_expect_success NO_CHAIN_LINT 'kvs: wait on primary namespace works' '
-        VERS=$(flux kvs version)
-        VERS=$((VERS + 1))
-        flux kvs wait --namespace=$PRIMARYNAMESPACE $VERS &
-        kvswaitpid=$!
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.xxx=99
-        test_expect_code 0 wait $kvswaitpid
+	VERS=$(flux kvs version)
+	VERS=$((VERS + 1))
+	flux kvs wait --namespace=$PRIMARYNAMESPACE $VERS &
+	kvswaitpid=$!
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.xxx=99
+	test_expect_code 0 wait $kvswaitpid
 '
 
 #
@@ -145,7 +145,7 @@ test_expect_success 'kvs: namespace create on rank 0 works' '
 '
 
 test_expect_success 'kvs: new namespace exists/is listed' '
-        flux kvs namespace list | grep $NAMESPACETEST
+	flux kvs namespace list | grep $NAMESPACETEST
 '
 
 test_expect_success 'kvs: namespace create on rank 1 works' '
@@ -153,44 +153,44 @@ test_expect_success 'kvs: namespace create on rank 1 works' '
 '
 
 test_expect_success 'kvs: new namespace exists/is listed' '
-        flux kvs namespace list | grep $NAMESPACERANK1
+	flux kvs namespace list | grep $NAMESPACERANK1
 '
 
 test_expect_success 'kvs: put/get value in new namespace works' '
-        flux kvs put --namespace=$NAMESPACETEST $DIR.test=1 &&
-        test_kvs_key_namespace $NAMESPACETEST $DIR.test 1
+	flux kvs put --namespace=$NAMESPACETEST $DIR.test=1 &&
+	test_kvs_key_namespace $NAMESPACETEST $DIR.test 1
 '
 
 test_expect_success 'kvs: unlink in new namespace works' '
-        flux kvs unlink --namespace=$NAMESPACETEST $DIR.test &&
-        ! flux kvs get --namespace=$NAMESPACETEST $DIR.test
+	flux kvs unlink --namespace=$NAMESPACETEST $DIR.test &&
+	! flux kvs get --namespace=$NAMESPACETEST $DIR.test
 '
 
 test_expect_success 'kvs: dir in new namespace works' '
-        flux kvs put --namespace=$NAMESPACETEST $DIR.a=4 &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.b=5 &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.c=6 &&
-        flux kvs dir --namespace=$NAMESPACETEST $DIR | sort > output &&
-        cat >expected <<EOF &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.a=4 &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.b=5 &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.c=6 &&
+	flux kvs dir --namespace=$NAMESPACETEST $DIR | sort > output &&
+	cat >expected <<EOF &&
 $DIR.a = 4
 $DIR.b = 5
 $DIR.c = 6
 EOF
-        test_cmp expected output
+	test_cmp expected output
 '
 
 test_expect_success 'kvs: unlink dir in new namespace works' '
-        flux kvs unlink --namespace=$NAMESPACETEST -Rf $DIR &&
-        ! flux kvs dir --namespace=$NAMESPACETEST $DIR
+	flux kvs unlink --namespace=$NAMESPACETEST -Rf $DIR &&
+	! flux kvs dir --namespace=$NAMESPACETEST $DIR
 '
 
 test_expect_success NO_CHAIN_LINT 'kvs: wait in new namespace works' '
-        VERS=`flux kvs version --namespace=$NAMESPACETEST` &&
-        VERS=$((VERS + 1))
-        flux kvs wait --namespace=$NAMESPACETEST $VERS &
-        kvswaitpid=$!
-        flux kvs put --namespace=$NAMESPACETEST $DIR.xxx=99
-        test_expect_code 0 wait $kvswaitpid
+	VERS=`flux kvs version --namespace=$NAMESPACETEST` &&
+	VERS=$((VERS + 1))
+	flux kvs wait --namespace=$NAMESPACETEST $VERS &
+	kvswaitpid=$!
+	flux kvs put --namespace=$NAMESPACETEST $DIR.xxx=99
+	test_expect_code 0 wait $kvswaitpid
 '
 
 test_expect_success 'kvs: namespace remove non existing namespace silently passes' '
@@ -199,10 +199,10 @@ test_expect_success 'kvs: namespace remove non existing namespace silently passe
 
 test_expect_success 'kvs: namespace remove works' '
 	flux kvs namespace create $NAMESPACETMP-BASIC &&
-        flux kvs put --namespace=$NAMESPACETMP-BASIC $DIR.tmp=1 &&
-        test_kvs_key_namespace $NAMESPACETMP-BASIC $DIR.tmp 1 &&
+	flux kvs put --namespace=$NAMESPACETMP-BASIC $DIR.tmp=1 &&
+	test_kvs_key_namespace $NAMESPACETMP-BASIC $DIR.tmp 1 &&
 	flux kvs namespace remove $NAMESPACETMP-BASIC &&
-        ! flux kvs get --namespace=$NAMESPACETMP-BASIC $DIR.tmp
+	! flux kvs get --namespace=$NAMESPACETMP-BASIC $DIR.tmp
 '
 
 # A namespace create races against the namespace remove above, as we
@@ -210,15 +210,15 @@ test_expect_success 'kvs: namespace remove works' '
 # yet.  So we use namespace_create_loop() to iterate and try
 # namespace create many times until it succeeds.
 test_expect_success 'kvs: namespace can be re-created after remove' '
-        namespace_create_loop $NAMESPACETMP-BASIC &&
-        flux kvs put --namespace=$NAMESPACETMP-BASIC $DIR.recreate=1 &&
-        test_kvs_key_namespace $NAMESPACETMP-BASIC $DIR.recreate 1 &&
+	namespace_create_loop $NAMESPACETMP-BASIC &&
+	flux kvs put --namespace=$NAMESPACETMP-BASIC $DIR.recreate=1 &&
+	test_kvs_key_namespace $NAMESPACETMP-BASIC $DIR.recreate 1 &&
 	flux kvs namespace remove $NAMESPACETMP-BASIC &&
-        ! flux kvs get --namespace=$NAMESPACETMP-BASIC $DIR.recreate
+	! flux kvs get --namespace=$NAMESPACETMP-BASIC $DIR.recreate
 '
 
 test_expect_success 'kvs: removed namespace not listed' '
-        ! flux kvs namespace list | grep $NAMESPACETMP-BASIC
+	! flux kvs namespace list | grep $NAMESPACETMP-BASIC
 '
 
 #
@@ -226,30 +226,30 @@ test_expect_success 'kvs: removed namespace not listed' '
 #
 
 test_expect_success 'kvs: put value in new namespace, available on other ranks' '
-        flux kvs unlink --namespace=$NAMESPACETEST -Rf $DIR &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.all=1 &&
-        VERS=`flux kvs version --namespace=$NAMESPACETEST` &&
-        flux exec -n sh -c "flux kvs wait --namespace=$NAMESPACETEST ${VERS} && \
-                         flux kvs get --namespace=$NAMESPACETEST $DIR.all"
+	flux kvs unlink --namespace=$NAMESPACETEST -Rf $DIR &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.all=1 &&
+	VERS=`flux kvs version --namespace=$NAMESPACETEST` &&
+	flux exec -n sh -c "flux kvs wait --namespace=$NAMESPACETEST ${VERS} && \
+			 flux kvs get --namespace=$NAMESPACETEST $DIR.all"
 '
 
 test_expect_success 'kvs: unlink value in new namespace, does not exist all ranks' '
-        flux kvs unlink --namespace=$NAMESPACETEST $DIR.all &&
-        VERS=`flux kvs version --namespace=$NAMESPACETEST` &&
-        flux exec -n sh -c "flux kvs wait --namespace=$NAMESPACETEST ${VERS} && \
-                         ! flux kvs get --namespace=$NAMESPACETEST $DIR.all"
+	flux kvs unlink --namespace=$NAMESPACETEST $DIR.all &&
+	VERS=`flux kvs version --namespace=$NAMESPACETEST` &&
+	flux exec -n sh -c "flux kvs wait --namespace=$NAMESPACETEST ${VERS} && \
+			 ! flux kvs get --namespace=$NAMESPACETEST $DIR.all"
 '
 
 # namespace remove on other ranks can take time, so we loop via
 # get_kvs_namespace_fails_all_ranks_loop()
 test_expect_success 'kvs: namespace remove works, recognized on other ranks' '
 	flux kvs namespace create $NAMESPACETMP-ALL &&
-        flux kvs put --namespace=$NAMESPACETMP-ALL $DIR.all=1 &&
-        VERS=`flux kvs version --namespace=$NAMESPACETMP-ALL` &&
-        flux exec -n sh -c "flux kvs wait --namespace=$NAMESPACETMP-ALL ${VERS} && \
-                         flux kvs get --namespace=$NAMESPACETMP-ALL $DIR.all" &&
+	flux kvs put --namespace=$NAMESPACETMP-ALL $DIR.all=1 &&
+	VERS=`flux kvs version --namespace=$NAMESPACETMP-ALL` &&
+	flux exec -n sh -c "flux kvs wait --namespace=$NAMESPACETMP-ALL ${VERS} && \
+			 flux kvs get --namespace=$NAMESPACETMP-ALL $DIR.all" &&
 	flux kvs namespace remove $NAMESPACETMP-ALL &&
-        get_kvs_namespace_fails_all_ranks_loop $NAMESPACETMP-ALL $DIR.all
+	get_kvs_namespace_fails_all_ranks_loop $NAMESPACETMP-ALL $DIR.all
 '
 
 # A namespace create races against the namespace remove above, as we
@@ -262,9 +262,9 @@ test_expect_success 'kvs: namespace remove works, recognized on other ranks' '
 # namespace is recognized everywhere.  Note that we cannot use flux
 # kvs wait, b/c the version may work against an old namespace.
 test_expect_success 'kvs: namespace can be re-created after remove, recognized on other ranks' '
-        namespace_create_loop $NAMESPACETMP-ALL &&
-        flux kvs put --namespace=$NAMESPACETMP-ALL $DIR.recreate=1 &&
-        get_kvs_namespace_all_ranks_loop $NAMESPACETMP-ALL $DIR.recreate &&
+	namespace_create_loop $NAMESPACETMP-ALL &&
+	flux kvs put --namespace=$NAMESPACETMP-ALL $DIR.recreate=1 &&
+	get_kvs_namespace_all_ranks_loop $NAMESPACETMP-ALL $DIR.recreate &&
 	flux kvs namespace remove $NAMESPACETMP-ALL
 '
 
@@ -275,57 +275,57 @@ test_expect_success 'kvs: namespace can be re-created after remove, recognized o
 test_expect_success 'kvs: namespace order setup' '
 	flux kvs namespace create $NAMESPACEORDER-1 &&
 	flux kvs namespace create $NAMESPACEORDER-2 &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.ordertest=1 &&
-        flux kvs put --namespace=$NAMESPACEORDER-1 $DIR.ordertest=2 &&
-        flux kvs put --namespace=$NAMESPACEORDER-2 $DIR.ordertest=3 &&
-        test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.ordertest 1 &&
-        test_kvs_key_namespace $NAMESPACEORDER-1 $DIR.ordertest 2 &&
-        test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.ordertest 3
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.ordertest=1 &&
+	flux kvs put --namespace=$NAMESPACEORDER-1 $DIR.ordertest=2 &&
+	flux kvs put --namespace=$NAMESPACEORDER-2 $DIR.ordertest=3 &&
+	test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.ordertest 1 &&
+	test_kvs_key_namespace $NAMESPACEORDER-1 $DIR.ordertest 2 &&
+	test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.ordertest 3
 '
 
 test_expect_success 'kvs: no namespace specified, lookup defaults to primary namespace' '
-        test_kvs_key $DIR.ordertest 1
+	test_kvs_key $DIR.ordertest 1
 '
 
 test_expect_success 'kvs: lookup - namespace specified in environment variable works' '
-        export FLUX_KVS_NAMESPACE=$NAMESPACEORDER-1 &&
-        test_kvs_key $DIR.ordertest 2 &&
-        unset FLUX_KVS_NAMESPACE &&
-        export FLUX_KVS_NAMESPACE=$NAMESPACEORDER-2 &&
-        test_kvs_key $DIR.ordertest 3 &&
-        unset FLUX_KVS_NAMESPACE
+	export FLUX_KVS_NAMESPACE=$NAMESPACEORDER-1 &&
+	test_kvs_key $DIR.ordertest 2 &&
+	unset FLUX_KVS_NAMESPACE &&
+	export FLUX_KVS_NAMESPACE=$NAMESPACEORDER-2 &&
+	test_kvs_key $DIR.ordertest 3 &&
+	unset FLUX_KVS_NAMESPACE
 '
 
 test_expect_success 'kvs: lookup - namespace specified in command line overrides environment variable' '
-        export FLUX_KVS_NAMESPACE=$NAMESPACETMP-BAD &&
-        test_kvs_key_namespace $NAMESPACEORDER-1 $DIR.ordertest 2 &&
-        test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.ordertest 3 &&
-        unset FLUX_KVS_NAMESPACE
+	export FLUX_KVS_NAMESPACE=$NAMESPACETMP-BAD &&
+	test_kvs_key_namespace $NAMESPACEORDER-1 $DIR.ordertest 2 &&
+	test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.ordertest 3 &&
+	unset FLUX_KVS_NAMESPACE
 '
 
 test_expect_success 'kvs: no namespace specified, put defaults to primary namespace' '
-        flux kvs put $DIR.puttest=1 &&
-        test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.puttest 1
+	flux kvs put $DIR.puttest=1 &&
+	test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.puttest 1
 '
 
 test_expect_success 'kvs: put - namespace specified in environment variable works' '
-        export FLUX_KVS_NAMESPACE=$NAMESPACEORDER-1 &&
-        flux kvs put $DIR.puttest=2 &&
-        unset FLUX_KVS_NAMESPACE &&
-        test_kvs_key_namespace $NAMESPACEORDER-1 $DIR.puttest 2 &&
-        export FLUX_KVS_NAMESPACE=$NAMESPACEORDER-2 &&
-        flux kvs put $DIR.puttest=3 &&
-        unset FLUX_KVS_NAMESPACE &&
-        test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.puttest 3
+	export FLUX_KVS_NAMESPACE=$NAMESPACEORDER-1 &&
+	flux kvs put $DIR.puttest=2 &&
+	unset FLUX_KVS_NAMESPACE &&
+	test_kvs_key_namespace $NAMESPACEORDER-1 $DIR.puttest 2 &&
+	export FLUX_KVS_NAMESPACE=$NAMESPACEORDER-2 &&
+	flux kvs put $DIR.puttest=3 &&
+	unset FLUX_KVS_NAMESPACE &&
+	test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.puttest 3
 '
 
 test_expect_success 'kvs: put - namespace specified in command line overrides environment variable' '
-        export FLUX_KVS_NAMESPACE=$NAMESPACETMP-BAD &&
-        flux kvs put --namespace=$NAMESPACEORDER-1 $DIR.puttest=4 &&
-        flux kvs put --namespace=$NAMESPACEORDER-2 $DIR.puttest=5 &&
-        unset FLUX_KVS_NAMESPACE &&
-        test_kvs_key_namespace $NAMESPACEORDER-1 $DIR.puttest 4 &&
-        test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.puttest 5
+	export FLUX_KVS_NAMESPACE=$NAMESPACETMP-BAD &&
+	flux kvs put --namespace=$NAMESPACEORDER-1 $DIR.puttest=4 &&
+	flux kvs put --namespace=$NAMESPACEORDER-2 $DIR.puttest=5 &&
+	unset FLUX_KVS_NAMESPACE &&
+	test_kvs_key_namespace $NAMESPACEORDER-1 $DIR.puttest 4 &&
+	test_kvs_key_namespace $NAMESPACEORDER-2 $DIR.puttest 5
 '
 
 #
@@ -334,31 +334,31 @@ test_expect_success 'kvs: put - namespace specified in command line overrides en
 
 test_expect_success 'kvs: namespace rootref setup' '
 	flux kvs namespace create $NAMESPACEROOTREF-1 &&
-        flux kvs put --namespace=$NAMESPACEROOTREF-1 $DIR.rootreftest=foobar &&
-        test_kvs_key_namespace $NAMESPACEROOTREF-1 $DIR.rootreftest foobar &&
-        flux kvs getroot --blobref --namespace=$NAMESPACEROOTREF-1 > rootref1
+	flux kvs put --namespace=$NAMESPACEROOTREF-1 $DIR.rootreftest=foobar &&
+	test_kvs_key_namespace $NAMESPACEROOTREF-1 $DIR.rootreftest foobar &&
+	flux kvs getroot --blobref --namespace=$NAMESPACEROOTREF-1 > rootref1
 '
 
 test_expect_success 'kvs: namespace create with init rootref' '
 	flux kvs namespace create --rootref=$(cat rootref1) $NAMESPACEROOTREF-2 &&
-        test_kvs_key_namespace $NAMESPACEROOTREF-1 $DIR.rootreftest foobar
+	test_kvs_key_namespace $NAMESPACEROOTREF-1 $DIR.rootreftest foobar
 '
 
 test_expect_success 'kvs: namespaces dont clobber each other' '
-        flux kvs put --namespace=$NAMESPACEROOTREF-1 $DIR.val=42 &&
-        flux kvs put --namespace=$NAMESPACEROOTREF-2 $DIR.val=43 &&
-        test_kvs_key_namespace $NAMESPACEROOTREF-1 $DIR.val 42 &&
-        test_kvs_key_namespace $NAMESPACEROOTREF-2 $DIR.val 43
+	flux kvs put --namespace=$NAMESPACEROOTREF-1 $DIR.val=42 &&
+	flux kvs put --namespace=$NAMESPACEROOTREF-2 $DIR.val=43 &&
+	test_kvs_key_namespace $NAMESPACEROOTREF-1 $DIR.val 42 &&
+	test_kvs_key_namespace $NAMESPACEROOTREF-2 $DIR.val 43
 '
 
 BADROOTREF="sha1-0123456789abcdef0123456789abcdef01234567"
 test_expect_success 'kvs: namespace create can take bad blobref' '
 	flux kvs namespace create --rootref=$BADROOTREF $NAMESPACEROOTREF-3 &&
-        flux kvs get --namespace=$NAMESPACEROOTREF-3 --treeobj .
+	flux kvs get --namespace=$NAMESPACEROOTREF-3 --treeobj .
 '
 
 test_expect_success 'kvs: namespace with bad rootref fails otherwise' '
-        test_must_fail flux kvs ls --namespace=$NAMESPACEROOTREF-3 .
+	test_must_fail flux kvs ls --namespace=$NAMESPACEROOTREF-3 .
 '
 
 #
@@ -376,7 +376,7 @@ test_expect_success 'kvs: namespace create on existing namespace fails on rank 1
 '
 
 test_expect_success 'kvs: get fails on invalid namespace' '
-        ! flux kvs get --namespace=$NAMESPACEBAD $DIR.test
+	! flux kvs get --namespace=$NAMESPACEBAD $DIR.test
 '
 
 test_expect_success 'kvs: get fails on invalid namespace on rank 1' '
@@ -388,7 +388,7 @@ test_expect_success 'kvs: put fails on invalid namespace' '
 '
 
 test_expect_success 'kvs: put fails on invalid namespace on rank 1' '
-        ! flux exec -n -r 1 sh -c "flux kvs put --namespace=$NAMESPACEBAD $DIR.test=1"
+	! flux exec -n -r 1 sh -c "flux kvs put --namespace=$NAMESPACEBAD $DIR.test=1"
 '
 
 test_expect_success 'kvs: version fails on invalid namespace' '
@@ -404,19 +404,19 @@ test_expect_success NO_CHAIN_LINT 'kvs: wait fails on invalid namespace' '
 '
 
 test_expect_success 'kvs: wait fails on invalid namespace on rank 1' '
-        ! flux exec -n -r 1 sh -c "flux kvs wait --namespace=$NAMESPACEBAD 1"
+	! flux exec -n -r 1 sh -c "flux kvs wait --namespace=$NAMESPACEBAD 1"
 '
 
 test_expect_success NO_CHAIN_LINT 'kvs: wait recognizes removed namespace' '
-        flux kvs namespace create $NAMESPACETMP-REMOVE-WAIT &&
-        VERS=$(flux kvs version --namespace=$NAMESPACETMP-REMOVE-WAIT) &&
-        VERS=$((VERS + 1))
-        flux kvs wait --namespace=$NAMESPACETMP-REMOVE-WAIT $VERS > wait_out 2>&1 &
-        waitpid=$! &&
-        wait_versionwaiters_nonzero $NAMESPACETMP-REMOVE-WAIT &&
-        flux kvs namespace remove $NAMESPACETMP-REMOVE-WAIT &&
-        ! wait $waitpid &&
-        grep "flux_kvs_wait_version: $(strerror_symbol ENOTSUP)" wait_out
+	flux kvs namespace create $NAMESPACETMP-REMOVE-WAIT &&
+	VERS=$(flux kvs version --namespace=$NAMESPACETMP-REMOVE-WAIT) &&
+	VERS=$((VERS + 1))
+	flux kvs wait --namespace=$NAMESPACETMP-REMOVE-WAIT $VERS > wait_out 2>&1 &
+	waitpid=$! &&
+	wait_versionwaiters_nonzero $NAMESPACETMP-REMOVE-WAIT &&
+	flux kvs namespace remove $NAMESPACETMP-REMOVE-WAIT &&
+	! wait $waitpid &&
+	grep "flux_kvs_wait_version: $(strerror_symbol ENOTSUP)" wait_out
 '
 
 #
@@ -424,83 +424,83 @@ test_expect_success NO_CHAIN_LINT 'kvs: wait recognizes removed namespace' '
 #
 
 test_expect_success 'kvs: put/get in different namespaces works' '
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.test=1 &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.test=2 &&
-        test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 1 &&
-        test_kvs_key_namespace $NAMESPACETEST $DIR.test 2
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.test=1 &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.test=2 &&
+	test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 1 &&
+	test_kvs_key_namespace $NAMESPACETEST $DIR.test 2
 '
 
 test_expect_success 'kvs: unlink in different namespaces works' '
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.testA=1 &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.testB=1 &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.testA=2 &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.testB=2 &&
-        flux kvs unlink --namespace=$PRIMARYNAMESPACE $DIR.testA &&
-        flux kvs unlink --namespace=$NAMESPACETEST $DIR.testB &&
-        test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.testB 1 &&
-        test_kvs_key_namespace $NAMESPACETEST $DIR.testA 2 &&
-        ! flux kvs get --namespace=$PRIMARYNAMESPACE $DIR.testA &&
-        ! flux kvs get --namespace=$NAMESPACETEST $DIR.testB
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.testA=1 &&
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.testB=1 &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.testA=2 &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.testB=2 &&
+	flux kvs unlink --namespace=$PRIMARYNAMESPACE $DIR.testA &&
+	flux kvs unlink --namespace=$NAMESPACETEST $DIR.testB &&
+	test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.testB 1 &&
+	test_kvs_key_namespace $NAMESPACETEST $DIR.testA 2 &&
+	! flux kvs get --namespace=$PRIMARYNAMESPACE $DIR.testA &&
+	! flux kvs get --namespace=$NAMESPACETEST $DIR.testB
 '
 
 test_expect_success 'kvs: dir in different namespace works' '
-        flux kvs unlink --namespace=$PRIMARYNAMESPACE -Rf $DIR &&
-        flux kvs unlink --namespace=$NAMESPACETEST -Rf $DIR &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.a=10 &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.b=11 &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.c=12 &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.a=13 &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.b=14 &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.c=15 &&
-        flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR | sort > primaryoutput &&
-        flux kvs dir --namespace=$NAMESPACETEST $DIR | sort > testoutput &&
-        cat >primaryexpected <<EOF &&
+	flux kvs unlink --namespace=$PRIMARYNAMESPACE -Rf $DIR &&
+	flux kvs unlink --namespace=$NAMESPACETEST -Rf $DIR &&
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.a=10 &&
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.b=11 &&
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.c=12 &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.a=13 &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.b=14 &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.c=15 &&
+	flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR | sort > primaryoutput &&
+	flux kvs dir --namespace=$NAMESPACETEST $DIR | sort > testoutput &&
+	cat >primaryexpected <<EOF &&
 $DIR.a = 10
 $DIR.b = 11
 $DIR.c = 12
 EOF
-        cat >testexpected <<EOF &&
+	cat >testexpected <<EOF &&
 $DIR.a = 13
 $DIR.b = 14
 $DIR.c = 15
 EOF
-        test_cmp primaryexpected primaryoutput &&
-        test_cmp testexpected testoutput
+	test_cmp primaryexpected primaryoutput &&
+	test_cmp testexpected testoutput
 '
 
 test_expect_success 'kvs: unlink dir in different namespaces works' '
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirA.A=A &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirA.B=B &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirB.A=A &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirB.A=B &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.subdirA.A=A &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.subdirA.B=B &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.subdirB.A=A &&
-        flux kvs put --namespace=$NAMESPACETEST $DIR.subdirB.A=B &&
-        flux kvs unlink --namespace=$PRIMARYNAMESPACE -Rf $DIR.subdirA &&
-        flux kvs unlink --namespace=$NAMESPACETEST -Rf $DIR.subdirB &&
-        ! flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR.subdirA &&
-        flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR.subdirB &&
-        flux kvs dir --namespace=$NAMESPACETEST $DIR.subdirA &&
-        ! flux kvs dir --namespace=$NAMESPACETEST $DIR.subdirB
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirA.A=A &&
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirA.B=B &&
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirB.A=A &&
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirB.A=B &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.subdirA.A=A &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.subdirA.B=B &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.subdirB.A=A &&
+	flux kvs put --namespace=$NAMESPACETEST $DIR.subdirB.A=B &&
+	flux kvs unlink --namespace=$PRIMARYNAMESPACE -Rf $DIR.subdirA &&
+	flux kvs unlink --namespace=$NAMESPACETEST -Rf $DIR.subdirB &&
+	! flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR.subdirA &&
+	flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR.subdirB &&
+	flux kvs dir --namespace=$NAMESPACETEST $DIR.subdirA &&
+	! flux kvs dir --namespace=$NAMESPACETEST $DIR.subdirB
 '
 
 test_expect_success NO_CHAIN_LINT 'kvs: wait in different namespaces works' '
-        PRIMARYVERS=$(flux kvs version --namespace=$PRIMARYNAMESPACE)
-        PRIMARYVERS=$((PRIMARYVERS + 1))
-        flux kvs wait --namespace=$PRIMARYNAMESPACE $PRIMARYVERS &
-        primarykvswaitpid=$!
+	PRIMARYVERS=$(flux kvs version --namespace=$PRIMARYNAMESPACE)
+	PRIMARYVERS=$((PRIMARYVERS + 1))
+	flux kvs wait --namespace=$PRIMARYNAMESPACE $PRIMARYVERS &
+	primarykvswaitpid=$!
 
-        TESTVERS=$(flux kvs version --namespace=$NAMESPACETEST)
-        TESTVERS=$((TESTVERS + 1))
-        flux kvs wait --namespace=$NAMESPACETEST $TESTVERS &
-        testkvswaitpid=$!
+	TESTVERS=$(flux kvs version --namespace=$NAMESPACETEST)
+	TESTVERS=$((TESTVERS + 1))
+	flux kvs wait --namespace=$NAMESPACETEST $TESTVERS &
+	testkvswaitpid=$!
 
-        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.xxx=X
-        flux kvs put --namespace=$NAMESPACETEST $DIR.xxx=X
+	flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.xxx=X
+	flux kvs put --namespace=$NAMESPACETEST $DIR.xxx=X
 
-        test_expect_code 0 wait $primarykvswaitpid
-        test_expect_code 0 wait $testkvswaitpid
+	test_expect_code 0 wait $primarykvswaitpid
+	test_expect_code 0 wait $testkvswaitpid
 '
 
 #

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -30,47 +30,20 @@ NAMESPACEORDER=namespaceorder
 NAMESPACEROOTREF=namespacerootref
 
 namespace_create_loop() {
-	i=0
-	while ! flux kvs namespace create $1 && [ $i -lt ${KVS_WAIT_ITERS} ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	return $(loophandlereturn $i)
+	test_wait_until "flux kvs namespace create $1"
 }
 
 get_kvs_namespace_all_ranks_loop() {
-	i=0
-	while ! flux exec -n sh -c "flux kvs get --namespace=$1 $2" \
-	      && [ $i -lt ${KVS_WAIT_ITERS} ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	return $(loophandlereturn $i)
+	test_wait_until "flux exec -n sh -c \"flux kvs get --namespace=$1 $2\""
 }
 
 get_kvs_namespace_fails_all_ranks_loop() {
-	i=0
-	while ! flux exec -n sh -c "! flux kvs get --namespace=$1 $2" \
-	      && [ $i -lt ${KVS_WAIT_ITERS} ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	return $(loophandlereturn $i)
+	test_wait_until "flux exec -n sh -c \"! flux kvs get --namespace=$1 $2\""
 }
 
 wait_versionwaiters_nonzero() {
-	i=0
-	while (! flux module stats --parse namespace.$1.#versionwaiters kvs > /dev/null 2>&1 \
-	       || [ "$(flux module stats --parse namespace.$1.#versionwaiters kvs 2> /dev/null)" = "0" ]) \
-	      && [ $i -lt ${KVS_WAIT_ITERS} ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	return $(loophandlereturn $i)
+	test_wait_until "flux module stats --parse namespace.$1.#versionwaiters kvs \
+		&& [ \$(flux module stats --parse namespace.$1.#versionwaiters kvs 2> /dev/null) -ne 0 ]"
 }
 
 #

--- a/t/t1007-kvs-lookup-watch.t
+++ b/t/t1007-kvs-lookup-watch.t
@@ -50,13 +50,13 @@ test_expect_success NO_CHAIN_LINT 'kvs-watch stats reports active watcher' '
 # Check that stdin contains an integer on each line that
 # is one more than the integer on the previous line.
 test_monotonicity() {
-        local item
-        local prev=0
-        while read item; do
-                test $prev -gt 0 && test $item -ne $(($prev+1)) && return 1
-                prev=$item
-        done
-        return 0
+	local item
+	local prev=0
+	while read item; do
+		test $prev -gt 0 && test $item -ne $(($prev+1)) && return 1
+		prev=$item
+	done
+	return 0
 }
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch returns commit order' '
@@ -82,7 +82,7 @@ test_expect_success 'flux kvs get --watch fails on nonexistent key' '
 '
 
 test_expect_success 'flux kvs get --watch fails on nonexistent namespace' '
-	test_must_fail flux kvs  \
+	test_must_fail flux kvs	 \
 		get --namespace=noexist --watch --count=1 test.noexist
 '
 
@@ -156,87 +156,87 @@ test_expect_success 'flux kvs get --waitcreate works on existing key' '
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --waitcreate works on non-existent key' '
-        ! flux kvs get test.waitcreate2
-        flux kvs get --waitcreate test.waitcreate2 > waitcreate2.out &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.waitcreate2=2 &&
+	! flux kvs get test.waitcreate2
+	flux kvs get --waitcreate test.waitcreate2 > waitcreate2.out &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.waitcreate2=2 &&
 	$waitfile --count=1 --timeout=10 \
 		  --pattern="2" waitcreate2.out >/dev/null &&
-        wait $pid
+	wait $pid
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --waitcreate works on non-existent namespace' '
-        ! flux kvs get --namespace=ns_waitcreate test.waitcreate3
-        flux kvs get --namespace=ns_waitcreate --waitcreate \
-                     test.waitcreate3 > waitcreate3.out &
-        pid=$! &&
-        wait_watcherscount_nonzero ns_waitcreate &&
-        flux kvs namespace create ns_waitcreate &&
-        flux kvs put --namespace=ns_waitcreate test.waitcreate3=3 &&
+	! flux kvs get --namespace=ns_waitcreate test.waitcreate3
+	flux kvs get --namespace=ns_waitcreate --waitcreate \
+		     test.waitcreate3 > waitcreate3.out &
+	pid=$! &&
+	wait_watcherscount_nonzero ns_waitcreate &&
+	flux kvs namespace create ns_waitcreate &&
+	flux kvs put --namespace=ns_waitcreate test.waitcreate3=3 &&
 	$waitfile --count=1 --timeout=10 \
 		  --pattern="3" waitcreate3.out >/dev/null &&
-        wait $pid
+	wait $pid
 '
 
 test_expect_success 'flux_kvs_lookup with waitcreate can be canceled' '
-        $FLUX_BUILD_DIR/t/kvs/waitcreate_cancel test.not_a_key
+	$FLUX_BUILD_DIR/t/kvs/waitcreate_cancel test.not_a_key
 '
 
 # in --watch & --waitcreate tests, call wait_watcherscount_nonzero to
 # ensure background watcher has started, otherwise test can be racy
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get, basic --watch & --waitcreate works' '
-        ! flux kvs get --watch test.create_later
-        flux kvs get --watch --waitcreate --count=1 \
-                     test.create_later > waitcreate.out &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.create_later=0 &&
+	! flux kvs get --watch test.create_later
+	flux kvs get --watch --waitcreate --count=1 \
+		     test.create_later > waitcreate.out &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.create_later=0 &&
 	$waitfile --count=1 --timeout=10 \
 		  --pattern="0" waitcreate.out >/dev/null &&
-        wait $pid
+	wait $pid
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate & remove key works' '
-        ! flux kvs get --watch test.create_and_remove
-        flux kvs get --watch --waitcreate --count=2 \
-                     test.create_and_remove > waitcreate2.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.create_and_remove=0 &&
+	! flux kvs get --watch test.create_and_remove
+	flux kvs get --watch --waitcreate --count=2 \
+		     test.create_and_remove > waitcreate2.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.create_and_remove=0 &&
 	$waitfile --count=1 --timeout=10 \
 		  --pattern="0" waitcreate2.out >/dev/null &&
-        flux kvs unlink test.create_and_remove &&
-        ! wait $pid &&
-        grep "No such file or directory" waitcreate2.out
+	flux kvs unlink test.create_and_remove &&
+	! wait $pid &&
+	grep "No such file or directory" waitcreate2.out
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, create & remove namespace works' '
-        ! flux kvs get --namespace=ns_create_and_remove --watch test.ns_create_and_remove
-        flux kvs get --namespace=ns_create_and_remove --watch --waitcreate --count=2 \
-                     test.ns_create_and_remove > waitcreate4.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero ns_create_and_remove &&
-        flux kvs namespace create ns_create_and_remove &&
-        flux kvs put --namespace=ns_create_and_remove test.ns_create_and_remove=0 &&
-        $waitfile --count=1 --timeout=10 \
-                  --pattern="0" waitcreate4.out >/dev/null &&
-        flux kvs namespace remove ns_create_and_remove &&
-        ! wait $pid &&
-        grep "$(strerror_symbol ENOTSUP)" waitcreate4.out
+	! flux kvs get --namespace=ns_create_and_remove --watch test.ns_create_and_remove
+	flux kvs get --namespace=ns_create_and_remove --watch --waitcreate --count=2 \
+		     test.ns_create_and_remove > waitcreate4.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero ns_create_and_remove &&
+	flux kvs namespace create ns_create_and_remove &&
+	flux kvs put --namespace=ns_create_and_remove test.ns_create_and_remove=0 &&
+	$waitfile --count=1 --timeout=10 \
+		  --pattern="0" waitcreate4.out >/dev/null &&
+	flux kvs namespace remove ns_create_and_remove &&
+	! wait $pid &&
+	grep "$(strerror_symbol ENOTSUP)" waitcreate4.out
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, doesnt work on removed namespace' '
-        flux kvs namespace create ns_remove &&
-        ! flux kvs get --namespace=ns_remove --watch test.ns_remove
-        flux kvs get --namespace=ns_remove --watch --waitcreate --count=1 \
-                     test.ns_remove > waitcreate5.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero ns_remove &&
-        flux kvs namespace remove ns_remove &&
-        ! wait $pid &&
-        grep "$(strerror_symbol ENOTSUP)" waitcreate5.out
+	flux kvs namespace create ns_remove &&
+	! flux kvs get --namespace=ns_remove --watch test.ns_remove
+	flux kvs get --namespace=ns_remove --watch --waitcreate --count=1 \
+		     test.ns_remove > waitcreate5.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero ns_remove &&
+	flux kvs namespace remove ns_remove &&
+	! wait $pid &&
+	grep "$(strerror_symbol ENOTSUP)" waitcreate5.out
 '
 
 #
@@ -244,23 +244,23 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get, --watch & --waitcreate, doesnt 
 #
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: basic --watch & --append works' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc"
-        flux kvs get --watch --append --count=4 \
-                     test.append.test > append1.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put --append test.append.test="d" &&
-        flux kvs put --append test.append.test="e" &&
-        flux kvs put --append test.append.test="f" &&
-        wait $pid &&
+	flux kvs unlink -Rf test &&
+	flux kvs put test.append.test="abc"
+	flux kvs get --watch --append --count=4 \
+		     test.append.test > append1.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put --append test.append.test="d" &&
+	flux kvs put --append test.append.test="e" &&
+	flux kvs put --append test.append.test="f" &&
+	wait $pid &&
 	cat >expected <<-EOF &&
 abc
 d
 e
 f
 	EOF
-        test_cmp expected append1.out
+	test_cmp expected append1.out
 '
 
 # N.B. When the data is small `flux kvs put foo=...` create a "val" treeobj.
@@ -268,76 +268,76 @@ f
 largeval="abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: basic --watch & --append works (initial valref)' '
-        flux kvs unlink -Rf test &&
-        echo -n ${largeval} | flux kvs put --raw test.append.test=- &&
-        flux kvs get --treeobj test.append.test | grep valref
-        flux kvs get --watch --append --count=4 \
-                     test.append.test > append1.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put --append test.append.test="1" &&
-        flux kvs put --append test.append.test="2" &&
-        flux kvs put --append test.append.test="3" &&
-        wait $pid &&
+	flux kvs unlink -Rf test &&
+	echo -n ${largeval} | flux kvs put --raw test.append.test=- &&
+	flux kvs get --treeobj test.append.test | grep valref
+	flux kvs get --watch --append --count=4 \
+		     test.append.test > append1.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put --append test.append.test="1" &&
+	flux kvs put --append test.append.test="2" &&
+	flux kvs put --append test.append.test="3" &&
+	wait $pid &&
 	cat >expected <<-EOF &&
 abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
 1
 2
 3
 	EOF
-        test_cmp expected append1.out
+	test_cmp expected append1.out
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append works with empty string' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc"
-        flux kvs get --watch --append --count=4 \
-                     test.append.test > append2.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put --append test.append.test="d" &&
-        flux kvs put --append test.append.test="e" &&
-        flux kvs put --append test.append.test= &&
-        wait $pid &&
+	flux kvs unlink -Rf test &&
+	flux kvs put test.append.test="abc"
+	flux kvs get --watch --append --count=4 \
+		     test.append.test > append2.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put --append test.append.test="d" &&
+	flux kvs put --append test.append.test="e" &&
+	flux kvs put --append test.append.test= &&
+	wait $pid &&
 	cat >expected <<-EOF &&
 abc
 d
 e
 	EOF
-        test_cmp expected append2.out
+	test_cmp expected append2.out
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append works with --waitcreate' '
-        flux kvs unlink -Rf test
-        flux kvs get --watch --waitcreate --append --count=4 \
-                     test.append.test > append3.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.append.test="abc" &&
-        flux kvs put --append test.append.test="d" &&
-        flux kvs put --append test.append.test="e" &&
-        flux kvs put --append test.append.test="f" &&
-        wait $pid &&
+	flux kvs unlink -Rf test
+	flux kvs get --watch --waitcreate --append --count=4 \
+		     test.append.test > append3.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.append.test="abc" &&
+	flux kvs put --append test.append.test="d" &&
+	flux kvs put --append test.append.test="e" &&
+	flux kvs put --append test.append.test="f" &&
+	wait $pid &&
 	cat >expected <<-EOF &&
 abc
 d
 e
 f
 	EOF
-        test_cmp expected append3.out
+	test_cmp expected append3.out
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append works with multiple appends in a transaction' '
-        flux kvs unlink -Rf test
-        flux kvs get --watch --waitcreate --append --count=7 \
-                     test.append.test > append4.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.append.test="abc" &&
-        flux kvs put --append test.append.test="d" test.append.test="e" &&
-        flux kvs put --append test.append.test="f" test.append.test="g" &&
-        flux kvs put --append test.append.test="h" test.append.test="i" &&
-        wait $pid &&
+	flux kvs unlink -Rf test
+	flux kvs get --watch --waitcreate --append --count=7 \
+		     test.append.test > append4.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.append.test="abc" &&
+	flux kvs put --append test.append.test="d" test.append.test="e" &&
+	flux kvs put --append test.append.test="f" test.append.test="g" &&
+	flux kvs put --append test.append.test="h" test.append.test="i" &&
+	wait $pid &&
 	cat >expected <<-EOF &&
 abc
 d
@@ -347,92 +347,92 @@ g
 h
 i
 	EOF
-        test_cmp expected append4.out
+	test_cmp expected append4.out
 '
 
 test_expect_success 'flux kvs get: --append fails on non-value' '
-        flux kvs unlink -Rf test &&
-        flux kvs mkdir test.append &&
-        ! flux kvs get --watch --append --count=1 test.append
+	flux kvs unlink -Rf test &&
+	flux kvs mkdir test.append &&
+	! flux kvs get --watch --append --count=1 test.append
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append & --waitcreate fails on non-value' '
-        flux kvs unlink -Rf test
-        flux kvs get --watch --waitcreate --append --count=1 test.append &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs mkdir test.append &&
-        ! wait $pid
+	flux kvs unlink -Rf test
+	flux kvs get --watch --waitcreate --append --count=1 test.append &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs mkdir test.append &&
+	! wait $pid
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append fails on removed key' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc"
-        flux kvs get --watch --append --count=4 \
-                     test.append.test > append5.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put --append test.append.test="d" &&
-        flux kvs put --append test.append.test="e" &&
-        flux kvs unlink test.append.test &&
-        ! wait $pid &&
+	flux kvs unlink -Rf test &&
+	flux kvs put test.append.test="abc"
+	flux kvs get --watch --append --count=4 \
+		     test.append.test > append5.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put --append test.append.test="d" &&
+	flux kvs put --append test.append.test="e" &&
+	flux kvs unlink test.append.test &&
+	! wait $pid &&
 	cat >expected <<-EOF &&
 abc
 d
 e
 flux-kvs: test.append.test: No such file or directory
 	EOF
-        test_cmp expected append5.out
+	test_cmp expected append5.out
 '
 
 # N.B. valref treeobj expected, but treeobj is now a dirref
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append fails on change to non-value' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc"
-        flux kvs get --watch --append --count=4 \
-                     test.append.test > append6.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put --append test.append.test="d" &&
-        flux kvs put --append test.append.test="e" &&
-        flux kvs mkdir test.append.test &&
-        ! wait $pid &&
+	flux kvs unlink -Rf test &&
+	flux kvs put test.append.test="abc"
+	flux kvs get --watch --append --count=4 \
+		     test.append.test > append6.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put --append test.append.test="d" &&
+	flux kvs put --append test.append.test="e" &&
+	flux kvs mkdir test.append.test &&
+	! wait $pid &&
 	cat >expected <<-EOF &&
 abc
 d
 e
 flux-kvs: test.append.test: Invalid argument
 	EOF
-        test_cmp expected append6.out
+	test_cmp expected append6.out
 '
 
 # N.B. valref treeobj expected, but treeobj is now a val
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append fails on fake append' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc"
-        flux kvs get --watch --append --count=4 \
-                     test.append.test > append7.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put --append test.append.test="d" &&
-        flux kvs put --append test.append.test="e" &&
-        flux kvs put test.append.test="abcdef" &&
-        test_must_fail wait $pid
+	flux kvs unlink -Rf test &&
+	flux kvs put test.append.test="abc"
+	flux kvs get --watch --append --count=4 \
+		     test.append.test > append7.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put --append test.append.test="d" &&
+	flux kvs put --append test.append.test="e" &&
+	flux kvs put test.append.test="abcdef" &&
+	test_must_fail wait $pid
 '
 
 # N.B. valref treeobj now has fewer entries
 test_expect_success NO_CHAIN_LINT 'flux kvs get: --append fails on fake append (valref)' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.append.test="abc"
-        flux kvs get --watch --append --count=4 \
-                     test.append.test > append7.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put --append test.append.test="d" &&
-        flux kvs put --append test.append.test="e" &&
-        echo -n ${largeval} | flux kvs put --raw test.append.test=- &&
-        flux kvs get --treeobj test.append.test | grep valref &&
-        test_must_fail wait $pid
+	flux kvs unlink -Rf test &&
+	flux kvs put test.append.test="abc"
+	flux kvs get --watch --append --count=4 \
+		     test.append.test > append7.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put --append test.append.test="d" &&
+	flux kvs put --append test.append.test="e" &&
+	echo -n ${largeval} | flux kvs put --raw test.append.test=- &&
+	flux kvs get --treeobj test.append.test | grep valref &&
+	test_must_fail wait $pid
 '
 
 # full checks
@@ -445,102 +445,102 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get: --append fails on fake append (
 # --watch.  Note that we can't use waitfile or flux kvs get here, b/c
 # we are specifically testing against --watch.
 wait_kvs_value() {
-        key=$1
-        value=$2
-        i=0
-        while [ "$(flux kvs get --watch --count=1 $key 2> /dev/null)" != "$value" ] \
-              && [ $i -lt ${KVS_WAIT_ITERS} ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        return $(loophandlereturn $i)
+	key=$1
+	value=$2
+	i=0
+	while [ "$(flux kvs get --watch --count=1 $key 2> /dev/null)" != "$value" ] \
+	      && [ $i -lt ${KVS_WAIT_ITERS} ]
+	do
+		sleep 0.1
+		i=$((i + 1))
+	done
+	return $(loophandlereturn $i)
 }
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/o --full doesnt detect change' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.dir_orig.a="abc"
-        flux kvs get --watch --count=2 test.dir_orig.a > full1.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.dir_new.a="xyz" &&
-        DIRREF=$(flux kvs get --treeobj test.dir_new) &&
-        flux kvs put --treeobj test.dir_orig="${DIRREF}" &&
-        wait_kvs_value test.dir_orig.a xyz &&
-        flux kvs put test.dir_orig.a="def" &&
-        $waitfile --count=1 --timeout=10 \
-                  --pattern="def" full1.out >/dev/null &&
-        wait $pid
+	flux kvs unlink -Rf test &&
+	flux kvs put test.dir_orig.a="abc"
+	flux kvs get --watch --count=2 test.dir_orig.a > full1.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.dir_new.a="xyz" &&
+	DIRREF=$(flux kvs get --treeobj test.dir_new) &&
+	flux kvs put --treeobj test.dir_orig="${DIRREF}" &&
+	wait_kvs_value test.dir_orig.a xyz &&
+	flux kvs put test.dir_orig.a="def" &&
+	$waitfile --count=1 --timeout=10 \
+		  --pattern="def" full1.out >/dev/null &&
+	wait $pid
 '
 
 # to handle racy issues, wait until ENOENT has been seen by a get
 # --watch.  Note that we can't use waitfile or flux kvs get here, b/c
 # we are specifically testing against --watch
 wait_kvs_enoent() {
-        key=$1
-        i=0
-        while flux kvs get --watch --count=1 $key 2> /dev/null \
-              && [ $i -lt ${KVS_WAIT_ITERS} ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        return $(loophandlereturn $i)
+	key=$1
+	i=0
+	while flux kvs get --watch --count=1 $key 2> /dev/null \
+	      && [ $i -lt ${KVS_WAIT_ITERS} ]
+	do
+		sleep 0.1
+		i=$((i + 1))
+	done
+	return $(loophandlereturn $i)
 }
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/o --full doesnt detect ENOENT' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.dir_orig.a="abc"
-        flux kvs get --watch --count=2 test.dir_orig.a > full2.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.dir_new.b="xyz" &&
-        DIRREF=$(flux kvs get --treeobj test.dir_new) &&
-        flux kvs put --treeobj test.dir_orig="${DIRREF}" &&
-        wait_kvs_enoent test.dir_orig.a &&
-        flux kvs put test.dir_orig.a="def" &&
-        $waitfile --count=1 --timeout=10 \
-                  --pattern="def" full2.out >/dev/null &&
-        wait $pid
+	flux kvs unlink -Rf test &&
+	flux kvs put test.dir_orig.a="abc"
+	flux kvs get --watch --count=2 test.dir_orig.a > full2.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.dir_new.b="xyz" &&
+	DIRREF=$(flux kvs get --treeobj test.dir_new) &&
+	flux kvs put --treeobj test.dir_orig="${DIRREF}" &&
+	wait_kvs_enoent test.dir_orig.a &&
+	flux kvs put test.dir_orig.a="def" &&
+	$waitfile --count=1 --timeout=10 \
+		  --pattern="def" full2.out >/dev/null &&
+	wait $pid
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full detects change' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.dir_orig.a="abc"
-        flux kvs get --watch --full --count=2 test.dir_orig.a > full3.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.dir_new.a="xyz" &&
-        DIRREF=$(flux kvs get --treeobj test.dir_new) &&
-        flux kvs put --treeobj test.dir_orig="${DIRREF}" &&
-        $waitfile --count=1 --timeout=10 \
-                  --pattern="xyz" full3.out >/dev/null &&
-        wait $pid
+	flux kvs unlink -Rf test &&
+	flux kvs put test.dir_orig.a="abc"
+	flux kvs get --watch --full --count=2 test.dir_orig.a > full3.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.dir_new.a="xyz" &&
+	DIRREF=$(flux kvs get --treeobj test.dir_new) &&
+	flux kvs put --treeobj test.dir_orig="${DIRREF}" &&
+	$waitfile --count=1 --timeout=10 \
+		  --pattern="xyz" full3.out >/dev/null &&
+	wait $pid
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full detects ENOENT' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.dir_orig.a="abc"
-        flux kvs get --watch --full --count=2 test.dir_orig.a > full4.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.dir_new.b="xyz" &&
-        DIRREF=$(flux kvs get --treeobj test.dir_new) &&
-        flux kvs put --treeobj test.dir_orig="${DIRREF}" &&
-        ! wait $pid
+	flux kvs unlink -Rf test &&
+	flux kvs put test.dir_orig.a="abc"
+	flux kvs get --watch --full --count=2 test.dir_orig.a > full4.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.dir_new.b="xyz" &&
+	DIRREF=$(flux kvs get --treeobj test.dir_new) &&
+	flux kvs put --treeobj test.dir_orig="${DIRREF}" &&
+	! wait $pid
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full works with changing data sizes' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.dir.a="abc"
-        flux kvs get --watch --full --count=5 test.dir.a > full5.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.dir.a="abcdefghijklmnopqrstuvwxyz" &&
-        flux kvs put test.dir.a="xyz" &&
-        flux kvs put test.dir.a="abcdefghijklmnopqrstuvwxyz" &&
-        flux kvs put test.dir.a="abc" &&
-        wait $pid &&
+	flux kvs unlink -Rf test &&
+	flux kvs put test.dir.a="abc"
+	flux kvs get --watch --full --count=5 test.dir.a > full5.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.dir.a="abcdefghijklmnopqrstuvwxyz" &&
+	flux kvs put test.dir.a="xyz" &&
+	flux kvs put test.dir.a="abcdefghijklmnopqrstuvwxyz" &&
+	flux kvs put test.dir.a="abc" &&
+	wait $pid &&
 	cat >expected <<-EOF &&
 abc
 abcdefghijklmnopqrstuvwxyz
@@ -552,16 +552,16 @@ abc
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full doesnt work with non-changing data' '
-        flux kvs unlink -Rf test &&
-        flux kvs put test.dir.a="abc"
-        flux kvs get --watch --full --count=3 test.dir.a > full6.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.dir.a="abc" &&
-        flux kvs put test.dir.a="abcdefghijklmnopqrstuvwxyz" &&
-        flux kvs put test.dir.a="abcdefghijklmnopqrstuvwxyz" &&
-        flux kvs put test.dir.a="xyz" &&
-        wait $pid &&
+	flux kvs unlink -Rf test &&
+	flux kvs put test.dir.a="abc"
+	flux kvs get --watch --full --count=3 test.dir.a > full6.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.dir.a="abc" &&
+	flux kvs put test.dir.a="abcdefghijklmnopqrstuvwxyz" &&
+	flux kvs put test.dir.a="abcdefghijklmnopqrstuvwxyz" &&
+	flux kvs put test.dir.a="xyz" &&
+	wait $pid &&
 	cat >expected <<-EOF &&
 abc
 abcdefghijklmnopqrstuvwxyz
@@ -571,14 +571,14 @@ xyz
 '
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/ --full & --waitcreate works' '
-        flux kvs unlink -Rf test
-        flux kvs get --watch --full --waitcreate --count=3 test.dir.a > full7.out 2>&1 &
-        pid=$! &&
-        wait_watcherscount_nonzero primary &&
-        flux kvs put test.dir.a="abc" &&
-        flux kvs put test.dir.a="def" &&
-        flux kvs put test.dir.a="xyz" &&
-        wait $pid &&
+	flux kvs unlink -Rf test
+	flux kvs get --watch --full --waitcreate --count=3 test.dir.a > full7.out 2>&1 &
+	pid=$! &&
+	wait_watcherscount_nonzero primary &&
+	flux kvs put test.dir.a="abc" &&
+	flux kvs put test.dir.a="def" &&
+	flux kvs put test.dir.a="xyz" &&
+	wait $pid &&
 	cat >expected <<-EOF &&
 abc
 def
@@ -591,15 +591,15 @@ xyz
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch, normalized key matching works ' '
 	flux kvs namespace create testnorm1 &&
-        flux kvs put --namespace=testnorm1 testnormkey1.a=1
-        flux kvs get --namespace=testnorm1 --watch --count=2 \
-                     testnormkey1...a > norm1.out &
-        pid=$! &&
-        wait_watcherscount_nonzero testnorm1 &&
-        flux kvs put --namespace=testnorm1 testnormkey1.....a=2 &&
+	flux kvs put --namespace=testnorm1 testnormkey1.a=1
+	flux kvs get --namespace=testnorm1 --watch --count=2 \
+		     testnormkey1...a > norm1.out &
+	pid=$! &&
+	wait_watcherscount_nonzero testnorm1 &&
+	flux kvs put --namespace=testnorm1 testnormkey1.....a=2 &&
 	$waitfile --count=2 --timeout=10 \
 		  --pattern="[1-2]" norm1.out >/dev/null &&
-        wait $pid
+	wait $pid
 '
 
 #
@@ -679,7 +679,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --stream and --waitcreate works 
 	flux kvs put --namespace=ns_stream test.stream.c=44 &&
 	$waitfile --count=1 --timeout=10 \
 		  --pattern="44" stream8.out >/dev/null &&
-        wait $pid
+	wait $pid
 '
 
 test_expect_success 'flux kvs eventlog get --stream works' '
@@ -728,7 +728,7 @@ test_expect_success NO_CHAIN_LINT 'watch-initial-sentinel works' '
 	$waitfile --count=1 --timeout=10 \
 		  --pattern="43" sentinel1.out >/dev/null &&
 	kill -s USR1 $pid &&
-        wait $pid &&
+	wait $pid &&
 	test_debug "cat sentinel1.out" &&
 	echo 1 > sentinel1.exp &&
 	echo 2 >> sentinel1.exp &&
@@ -753,7 +753,7 @@ test_expect_success NO_CHAIN_LINT 'watch-initial-sentinel works w/ WAITCREATE' '
 	$waitfile --count=1 --timeout=10 \
 		  --pattern="42" sentinel2.out >/dev/null &&
 	kill -s USR1 $pid &&
-        wait $pid &&
+	wait $pid &&
 	test_debug "cat sentinel2.out" &&
 	echo sentinel > sentinel2.exp &&
 	echo 1 >> sentinel2.exp &&
@@ -771,7 +771,7 @@ test_expect_success NO_CHAIN_LINT 'watch-initial-sentinel basic works (get_raw)'
 	$waitfile --count=1 --timeout=10 \
 		  --pattern="42" sentinel3.out >/dev/null &&
 	kill -s USR1 $pid &&
-        wait $pid &&
+	wait $pid &&
 	test_debug "cat sentinel3.out" &&
 	echo 1 > sentinel3.exp &&
 	echo sentinel >> sentinel3.exp &&

--- a/t/t1007-kvs-lookup-watch.t
+++ b/t/t1007-kvs-lookup-watch.t
@@ -447,14 +447,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get: --append fails on fake append (
 wait_kvs_value() {
 	key=$1
 	value=$2
-	i=0
-	while [ "$(flux kvs get --watch --count=1 $key 2> /dev/null)" != "$value" ] \
-	      && [ $i -lt ${KVS_WAIT_ITERS} ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	return $(loophandlereturn $i)
+	test_wait_until "[ \"\$(flux kvs get --watch --count=1 $key 2> /dev/null)\" = \"$value\" ]"
 }
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/o --full doesnt detect change' '
@@ -478,14 +471,7 @@ test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/o --full doesnt detect
 # we are specifically testing against --watch
 wait_kvs_enoent() {
 	key=$1
-	i=0
-	while flux kvs get --watch --count=1 $key 2> /dev/null \
-	      && [ $i -lt ${KVS_WAIT_ITERS} ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	return $(loophandlereturn $i)
+	test_wait_until "! flux kvs get --watch --count=1 $key"
 }
 
 test_expect_success NO_CHAIN_LINT 'flux kvs get --watch w/o --full doesnt detect ENOENT' '

--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -501,8 +501,8 @@ test_expect_success NO_CHAIN_LINT 'eventlog-watch-initial-sentinel works w/ WAIT
 	wait_watchers_nonzero "guest_watchers" &&
 	guestns=$(flux job namespace $jobid) &&
 	wait_watcherscount_nonzero $guestns &&
-        flux kvs eventlog append --namespace=${guestns} foobar hello &&
-        flux kvs eventlog append --namespace=${guestns} foobar goodbye &&
+	flux kvs eventlog append --namespace=${guestns} foobar hello &&
+	flux kvs eventlog append --namespace=${guestns} foobar goodbye &&
 	$waitfile --count=1 --timeout=10 \
 		  --pattern="goodbye" sentinel5.out >/dev/null &&
 	test_debug "cat sentinel5.out" &&

--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -45,19 +45,8 @@ submit_job_wait() {
 
 wait_watchers_nonzero() {
 	local str=$1
-	local i=0
-	while (! flux module stats --parse $str job-info > /dev/null 2>&1 \
-		|| [ "$(flux module stats --parse $str job-info 2> /dev/null)" = "0" ]) \
-		&& [ $i -lt 50 ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "50" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until "flux module stats --parse $str job-info \
+		&& [ \$(flux module stats --parse $str job-info 2> /dev/null) -ne 0 ]"
 }
 
 get_timestamp_field() {

--- a/t/t2233-job-info-update.t
+++ b/t/t2233-job-info-update.t
@@ -23,20 +23,9 @@ get_update_watchers() {
 
 wait_update_watchers() {
 	local count=$1
-	local i=0
 	echo "waiting for $count watchers"
-	while (! flux module stats --parse "update_watchers" job-info \
-		|| [ "$(flux module stats --parse "update_watchers" job-info 2> /dev/null)" != "${count}" ]) \
-		&& [ $i -lt 50 ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "50" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until "flux module stats --parse update_watchers job-info \
+		&& [ \$(flux module stats --parse update_watchers job-info 2> /dev/null) -eq ${count} ]"
 }
 
 # Usage: expiration_add JOBID N
@@ -58,18 +47,8 @@ expiration_add() {
 check_expiration() {
 	local jobid=$1
 	local value=$2
-	local i=0
-	while (! ${INFO_LOOKUP} -c ${jobid} R | jq -e ".execution.expiration == ${value}" \
-		&& [ $i -lt 200 ] )
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "200" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until -i 200 "${INFO_LOOKUP} -c ${jobid} R \
+		| jq -e \".execution.expiration == ${value}\""
 }
 
 # Usage: check_expiration_legacy jobid VALUE
@@ -78,18 +57,8 @@ check_expiration() {
 check_expiration_legacy() {
 	local jobid=$1
 	local value=$2
-	local i=0
-	while (! ${UPDATE_LOOKUP} ${jobid} R | jq -e ".execution.expiration == ${value}" \
-		&& [ $i -lt 200 ] )
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "200" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until -i 200 "${UPDATE_LOOKUP} ${jobid} R \
+		| jq -e \".execution.expiration == ${value}\""
 }
 
 test_expect_success 'job-info: lookup current with no update events works (job active)' '
@@ -319,18 +288,8 @@ test_expect_success NO_CHAIN_LINT 'job-info: lookup current returns cached R fro
 check_duration() {
        local jobid=$1
        local value=$2
-       local i=0
-       while (! ${INFO_LOOKUP} -c ${jobid} jobspec | jq -e ".attributes.system.duration == ${value}" \
-	       && [ $i -lt 200 ] )
-       do
-	       sleep 0.1
-	       i=$((i + 1))
-       done
-       if [ "$i" -eq "200" ]
-       then
-	       return 1
-       fi
-       return 0
+       test_wait_until -i 200 "${INFO_LOOKUP} -c ${jobid} jobspec \
+		| jq -e \".attributes.system.duration == ${value}\""
 }
 
 test_expect_success 'job-info: lookup current works with jobspec' '

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -458,18 +458,7 @@ test_expect_success 'jobs may be submitted to either queue' '
 wait_state() {
 	local jobid=$1
 	local state=$2
-	local i=0
-	while [ "$(flux jobs -no {state} ${jobid})" != "${state}" ] \
-		  && [ $i -lt 50 ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "50" ]
-	then
-	    return 1
-	fi
-	return 0
+	test_wait_until "[ \"\$(flux jobs -no {state} ${jobid})\" = \"${state}\" ]"
 }
 
 test_expect_success 'submitted jobs are not running' '

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -861,7 +861,7 @@ test_expect_success 'job stats lists jobs in correct state (mix)' '
 # Note: these wait-state tests must be before all jobs are canceled below
 test_expect_success 'flux job list-ids works with --wait-state' '
 	id=`head -n 1 pending.ids` &&
-	flux job list-ids --wait-state=sched $id | jq -e ".state == 8"  &&
+	flux job list-ids --wait-state=sched $id | jq -e ".state == 8"	&&
 	id=`head -n 1 running.ids` &&
 	flux job list-ids --wait-state=sched $id > /dev/null &&
 	flux job list-ids --wait-state=run $id | jq -e ".state == 16" &&
@@ -2411,7 +2411,7 @@ wait_id_inactive() {
 }
 
 test_expect_success 'load jobspec-update test plugin' '
-        flux jobtap load --remove=all ${PLUGINPATH}/jobspec-update-job-list.so
+	flux jobtap load --remove=all ${PLUGINPATH}/jobspec-update-job-list.so
 '
 
 test_expect_success 'run job in the default queue' '
@@ -2575,7 +2575,7 @@ test_expect_success 'job-list returns expected resource changes after reload' '
 '
 
 test_expect_success 'remove jobtap plugins' '
-        flux jobtap remove all
+	flux jobtap remove all
 '
 
 #

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -891,18 +891,7 @@ test_expect_success 'cleanup job listing jobs ' '
 '
 
 wait_inactive() {
-	local i=0
-	while [ "$(flux job list --states=inactive | wc -l)" != "$(job_list_state_count all)" ] \
-		   && [ $i -lt 50 ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "50" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until "[ \$(flux job list --states=inactive | wc -l) -eq \$(job_list_state_count all) ]"
 }
 
 # Note: annotations are not part of the following comparison
@@ -1059,19 +1048,8 @@ test_expect_success 'flux job list-ids fails with one bad ID out of several' '
 
 wait_idsync() {
 	local num=$1
-	local i=0
-	while (! flux module stats --parse idsync.waits job-list > /dev/null 2>&1 \
-		   || [ "$(flux module stats --parse idsync.waits job-list 2> /dev/null)" != "$num" ]) \
-		  && [ $i -lt 50 ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "50" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until "flux module stats --parse idsync.waits job-list \
+		&& [ \$(flux module stats --parse idsync.waits job-list 2> /dev/null) -eq $num ]"
 }
 
 test_expect_success NO_CHAIN_LINT 'flux job list-ids waits for job ids (one id)' '
@@ -1266,17 +1244,7 @@ test_expect_success 'flux job list job state timing outputs valid (job running)'
 # service been setup yet).  This checks to make sure `job-list` is
 # really up and ready.
 wait_job_list_ready() {
-	local i=0
-	while ( ! flux job list > /dev/null && [ $i -lt 50 ] )
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "50" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until "flux job list"
 }
 
 #
@@ -2347,18 +2315,7 @@ test_expect_success 'flux job list works' '
 
 wait_jobid() {
 	local jobid="$1"
-	local i=0
-	while ! flux job list --states=sched | grep $jobid > /dev/null \
-		   && [ $i -lt 50 ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "50" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until "flux job list --states=sched | grep $jobid"
 }
 
 # to ensure jobs are still in PENDING state, stop queue before
@@ -2396,18 +2353,7 @@ test_expect_success 'configure update queues' '
 
 wait_id_inactive() {
 	id=$1
-	local i=0
-	while ! flux job list --states=inactive | grep ${id} > /dev/null \
-		   && [ $i -lt 50 ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "50" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until "flux job list --states=inactive | grep ${id}"
 }
 
 test_expect_success 'load jobspec-update test plugin' '
@@ -2656,18 +2602,7 @@ test_expect_success 'list-attrs works' '
 #
 
 wait_jobs_finish() {
-	local i=0
-	while ([ "$(flux job list | wc -l)" != "0" ]) \
-		  && [ $i -lt 1000 ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "1000" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until -i 1000 "[ \$(flux job list | wc -l) -eq 0 ]"
 }
 
 test_expect_success LONGTEST 'stress job-list.list-id' '
@@ -2776,18 +2711,7 @@ test_expect_success 'job stats in each queue correct after reload' '
 
 wait_total() {
 	total=$1
-	local i=0
-	while ! flux job stats | jq -e ".job_states.total == ${total}" \
-		   && [ $i -lt 50 ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "50" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until "flux job stats | jq -e \".job_states.total == ${total}\""
 }
 
 # purge all jobs except two, the remaining two should be the failed

--- a/t/t2261-job-list-update.t
+++ b/t/t2261-job-list-update.t
@@ -30,62 +30,62 @@ fj_wait_event() {
 # - alternate userid job listing
 
 test_expect_success 'submit jobs for job list testing' '
-        #  Create `hostname` and `sleep` jobspec
-        #  N.B. Used w/ `flux job submit` for serial job submission
-        #  for efficiency (vs serial `flux submit`.
-        #
-        flux submit --dry-run hostname >hostname.json &&
-        flux submit --dry-run --time-limit=5m sleep 600 > sleeplong.json &&
-        #
-        # submit jobs that will complete
-        #
-        for i in $(seq 0 3); do
-                flux job submit hostname.json >> inactiveids
-                fj_wait_event `tail -n 1 inactiveids` clean
-        done &&
-        #
-        #  Currently all inactive ids are "completed"
-        #
-        tac inactiveids | flux job id > completed.ids &&
-        #
-        #  Submit 8 sleep jobs to fill up resources
-        #
-        for i in $(seq 0 7); do
-                flux job submit sleeplong.json >> runningids
-        done &&
-        tac runningids | flux job id > running.ids &&
-        #
-        #  Submit a set of jobs with misc urgencies
-        #
-        id1=$(flux job submit -u20 hostname.json) &&
-        id2=$(flux job submit      hostname.json) &&
-        id3=$(flux job submit -u31 hostname.json) &&
-        id4=$(flux job submit -u0  hostname.json) &&
-        id5=$(flux job submit -u20 hostname.json) &&
-        id6=$(flux job submit      hostname.json) &&
-        id7=$(flux job submit -u31 hostname.json) &&
-        id8=$(flux job submit -u0  hostname.json) &&
-        flux job id $id3 > pending.ids &&
-        flux job id $id7 >> pending.ids &&
-        flux job id $id1 >> pending.ids &&
-        flux job id $id5 >> pending.ids &&
-        flux job id $id2 >> pending.ids &&
-        flux job id $id6 >> pending.ids &&
-        flux job id $id4 >> pending.ids &&
-        flux job id $id8 >> pending.ids &&
-        cat pending.ids > active.ids &&
-        cat running.ids >> active.ids &&
-        tac inactiveids | flux job id > inactive.ids &&
-        cat active.ids > all.ids &&
-        cat inactive.ids >> all.ids &&
-        #
-        #  The job-list module has eventual consistency with the jobs stored in
-        #  the job-manager queue.  To ensure no raciness in tests, ensure
-        #  jobs above have reached expected states in job-list before continuing.
-        #
-        flux job list-ids --wait-state=sched $(job_list_state_ids pending) > /dev/null &&
-        flux job list-ids --wait-state=run $(job_list_state_ids running) > /dev/null &&
-        flux job list-ids --wait-state=inactive $(job_list_state_ids inactive) > /dev/null
+	#  Create `hostname` and `sleep` jobspec
+	#  N.B. Used w/ `flux job submit` for serial job submission
+	#  for efficiency (vs serial `flux submit`.
+	#
+	flux submit --dry-run hostname >hostname.json &&
+	flux submit --dry-run --time-limit=5m sleep 600 > sleeplong.json &&
+	#
+	# submit jobs that will complete
+	#
+	for i in $(seq 0 3); do
+		flux job submit hostname.json >> inactiveids
+		fj_wait_event `tail -n 1 inactiveids` clean
+	done &&
+	#
+	#  Currently all inactive ids are "completed"
+	#
+	tac inactiveids | flux job id > completed.ids &&
+	#
+	#  Submit 8 sleep jobs to fill up resources
+	#
+	for i in $(seq 0 7); do
+		flux job submit sleeplong.json >> runningids
+	done &&
+	tac runningids | flux job id > running.ids &&
+	#
+	#  Submit a set of jobs with misc urgencies
+	#
+	id1=$(flux job submit -u20 hostname.json) &&
+	id2=$(flux job submit	   hostname.json) &&
+	id3=$(flux job submit -u31 hostname.json) &&
+	id4=$(flux job submit -u0  hostname.json) &&
+	id5=$(flux job submit -u20 hostname.json) &&
+	id6=$(flux job submit	   hostname.json) &&
+	id7=$(flux job submit -u31 hostname.json) &&
+	id8=$(flux job submit -u0  hostname.json) &&
+	flux job id $id3 > pending.ids &&
+	flux job id $id7 >> pending.ids &&
+	flux job id $id1 >> pending.ids &&
+	flux job id $id5 >> pending.ids &&
+	flux job id $id2 >> pending.ids &&
+	flux job id $id6 >> pending.ids &&
+	flux job id $id4 >> pending.ids &&
+	flux job id $id8 >> pending.ids &&
+	cat pending.ids > active.ids &&
+	cat running.ids >> active.ids &&
+	tac inactiveids | flux job id > inactive.ids &&
+	cat active.ids > all.ids &&
+	cat inactive.ids >> all.ids &&
+	#
+	#  The job-list module has eventual consistency with the jobs stored in
+	#  the job-manager queue.  To ensure no raciness in tests, ensure
+	#  jobs above have reached expected states in job-list before continuing.
+	#
+	flux job list-ids --wait-state=sched $(job_list_state_ids pending) > /dev/null &&
+	flux job list-ids --wait-state=run $(job_list_state_ids running) > /dev/null &&
+	flux job list-ids --wait-state=inactive $(job_list_state_ids inactive) > /dev/null
 '
 
 # Note: "running" = "run" | "cleanup", we also test just "run" state
@@ -93,13 +93,13 @@ test_expect_success 'submit jobs for job list testing' '
 # checks above
 
 test_expect_success 'flux job list running jobs in started order' '
-        flux job list -s running | jq .id > list_started.out &&
-        test_cmp list_started.out running.ids
+	flux job list -s running | jq .id > list_started.out &&
+	test_cmp list_started.out running.ids
 '
 
 test_expect_success 'flux job list inactive jobs in completed order' '
-        flux job list -s inactive | jq .id > list_inactive.out &&
-        test_cmp list_inactive.out inactive.ids
+	flux job list -s inactive | jq .id > list_inactive.out &&
+	test_cmp list_inactive.out inactive.ids
 '
 
 # Note: "pending" = "depend" | "sched", we also test just "sched"
@@ -107,12 +107,12 @@ test_expect_success 'flux job list inactive jobs in completed order' '
 # state given checks above
 
 test_expect_success 'flux job list pending jobs in priority order' '
-        flux job list -s pending | jq .id > list_pending.out &&
-        test_cmp list_pending.out pending.ids
+	flux job list -s pending | jq .id > list_pending.out &&
+	test_cmp list_pending.out pending.ids
 '
 
 test_expect_success 'flux job list pending jobs with correct urgency' '
-        cat >list_urgency.exp <<-EOT &&
+	cat >list_urgency.exp <<-EOT &&
 31
 31
 20
@@ -122,12 +122,12 @@ test_expect_success 'flux job list pending jobs with correct urgency' '
 0
 0
 EOT
-        flux job list -s pending | jq .urgency > list_urgency.out &&
-        test_cmp list_urgency.out list_urgency.exp
+	flux job list -s pending | jq .urgency > list_urgency.out &&
+	test_cmp list_urgency.out list_urgency.exp
 '
 
 test_expect_success 'flux job list pending jobs with correct priority' '
-        cat >list_priority.exp <<-EOT &&
+	cat >list_priority.exp <<-EOT &&
 4294967295
 4294967295
 20
@@ -137,35 +137,35 @@ test_expect_success 'flux job list pending jobs with correct priority' '
 0
 0
 EOT
-        flux job list -s pending | jq .priority > list_priority.out &&
-        test_cmp list_priority.out list_priority.exp
+	flux job list -s pending | jq .priority > list_priority.out &&
+	test_cmp list_priority.out list_priority.exp
 '
 
 test_expect_success 'change a job urgency' '
-        jobid=`head -n 3 pending.ids | tail -n 1` &&
-        flux job urgency ${jobid} 1
+	jobid=`head -n 3 pending.ids | tail -n 1` &&
+	flux job urgency ${jobid} 1
 '
 
 test_expect_success 'wait for job-list to see job urgency change' '
-        jobidhead=`head -n 2 pending.ids > pending_after.ids` &&
-        jobidhead=`head -n 6 pending.ids | tail -n 3 >> pending_after.ids` &&
-        jobidchange=`head -n 3 pending.ids | tail -n 1 >> pending_after.ids` &&
-        jobidend=`tail -n2 pending.ids >> pending_after.ids` &&
-        i=0 &&
-        while flux job list -s pending | jq .id > list_pending_after.out && \
-              ! test_cmp list_pending_after.out pending_after.ids && \
-              [ $i -lt 5 ]
-        do
-                sleep 1
-                i=$((i + 1))
-        done &&
-        test "$i" -lt "5" &&
-        flux job list -s pending | jq .id > list_pending_after.out &&
-        test_cmp list_pending_after.out pending_after.ids
+	jobidhead=`head -n 2 pending.ids > pending_after.ids` &&
+	jobidhead=`head -n 6 pending.ids | tail -n 3 >> pending_after.ids` &&
+	jobidchange=`head -n 3 pending.ids | tail -n 1 >> pending_after.ids` &&
+	jobidend=`tail -n2 pending.ids >> pending_after.ids` &&
+	i=0 &&
+	while flux job list -s pending | jq .id > list_pending_after.out && \
+	      ! test_cmp list_pending_after.out pending_after.ids && \
+	      [ $i -lt 5 ]
+	do
+		sleep 1
+		i=$((i + 1))
+	done &&
+	test "$i" -lt "5" &&
+	flux job list -s pending | jq .id > list_pending_after.out &&
+	test_cmp list_pending_after.out pending_after.ids
 '
 
 test_expect_success 'flux job list pending jobs with correct urgency' '
-        cat >list_urgency_after.exp <<-EOT &&
+	cat >list_urgency_after.exp <<-EOT &&
 31
 31
 20
@@ -175,12 +175,12 @@ test_expect_success 'flux job list pending jobs with correct urgency' '
 0
 0
 EOT
-        flux job list -s pending | jq .urgency > list_urgency_after.out &&
-        test_cmp list_urgency_after.out list_urgency_after.exp
+	flux job list -s pending | jq .urgency > list_urgency_after.out &&
+	test_cmp list_urgency_after.out list_urgency_after.exp
 '
 
 test_expect_success 'flux job list pending jobs with correct priority' '
-        cat >list_priority_after.exp <<-EOT &&
+	cat >list_priority_after.exp <<-EOT &&
 4294967295
 4294967295
 20
@@ -190,15 +190,15 @@ test_expect_success 'flux job list pending jobs with correct priority' '
 0
 0
 EOT
-        flux job list -s pending | jq .priority > list_priority_after.out &&
-        test_cmp list_priority_after.out list_priority_after.exp
+	flux job list -s pending | jq .priority > list_priority_after.out &&
+	test_cmp list_priority_after.out list_priority_after.exp
 '
 
 test_expect_success 'cleanup job listing jobs ' '
 	flux cancel $(cat active.ids) &&
-        for jobid in `cat active.ids`; do
-            fj_wait_event $jobid clean;
-        done
+	for jobid in `cat active.ids`; do
+	    fj_wait_event $jobid clean;
+	done
 '
 
 test_done

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -447,9 +447,9 @@ test_expect_success 'flux-jobs --count works' '
 
 test_expect_success 'flux-jobs outputs message if results limit reached' '
 	count=`flux jobs --no-header -a --count=0 | wc -l` &&
-        flux jobs -a --count=${count} 2> limit1.out &&
+	flux jobs -a --count=${count} 2> limit1.out &&
 	test_must_fail grep -i "output truncated" limit1.out &&
-        flux jobs -a --count=8 2> limit2.out &&
+	flux jobs -a --count=8 2> limit2.out &&
 	grep -i "output truncated" limit2.out
 '
 

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1227,18 +1227,7 @@ test_expect_success 'update project and bank in pending jobs' '
 '
 
 wait_project_bank_synced() {
-	local i=0
-	while [ "$(flux jobs -f pending -o {project} | grep foo | wc -l)" != "$(job_list_state_count sched)" ] \
-		   && [ $i -lt 50 ]
-	do
-		sleep 0.1
-		i=$((i + 1))
-	done
-	if [ "$i" -eq "50" ]
-	then
-		return 1
-	fi
-	return 0
+	test_wait_until "[ \$(flux jobs -f pending -o {project} | grep -c foo) -eq \$(job_list_state_count sched) ]"
 }
 
 # can be racy, need to wait until `job-list` module definitely has

--- a/t/t2809-job-purge.t
+++ b/t/t2809-job-purge.t
@@ -29,15 +29,11 @@ wait_inactive_count() {
 	local how=$1
 	local target=$2
 	local tries=$3
-	local count
-	while test $tries -gt 0; do
-		count=$(inactive_count $how)
-		echo $count inactive jobs >&2
-		test $count -eq $target && return 0
-		sleep 0.25
-		tries=$(($tries-1))
-	done
-	return 1
+
+	test_wait_until -i $tries -s 0.25 "
+		count=\$(inactive_count $how)
+		test \$count -eq $target
+	"
 }
 
 #


### PR DESCRIPTION
Problem: In a number of circumstances tests need to wait for some asynchronous activity to complete before continuing tests.  Functions to wait on something are often written in this pattern:

```
wait_foo() {
	local i=0
	while ( ! flux foo && [ $i -lt 50 ] )
	do
		sleep 0.1
		i=$((i + 1))
	done
	if [ "$i" -eq "50" ]
	then
		return 1
	fi
	return 0
}
```

This can be a bit confusing, especially when "flux foo" is long, has output piped to other commands, and/or is a compound test of multiple commands.

Solution:  Refactor to the following style:

```
wait_foo() {
	local i=0
	while [ $i -lt 50 ]
	do
		flux foo && return 0
		sleep 0.1
		i=$((i + 1))
	done
	return 1
}
```

or if the test is long or a compound test:

```
wait_foo() {
	local i=0
	while [ $i -lt 50 ]
	do
		if flux foo | jq -e ".foo.bar.baz == 87"
		then
			return 0
		fi
		sleep 0.1
		i=$((i + 1))
	done
	return 1
}
```

this makes the function easier to understand and is collectively fewer lines overall.

Fixes #7396