### PR TITLE
add `FLUX_HWLOC_XMLFILE_NOT_THISSYSTEM`, fix cpu-affinity=dry-run with non-local topology

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -391,9 +391,28 @@ components or writing tests.
    parallel testing.  Flux may be directed to read topology from an XML file
    instead by setting :envvar:`FLUX_HWLOC_XMLFILE` to the file path.
 
+   .. note::
+      When using this option, Flux assumes the topology in the XML file is
+      from the current system. If this is not the case, for example when
+      loading a topology from another system for testing purposes, set
+      :envvar:`FLUX_HWLOC_XMLFILE_NOT_THISSYSTEM` to any non-empty value
+      to avoid unexpected behavior.
+
    :program:`flux resource reload` offers a related mechanism for loading a
    set of HWLOC xml files directly into the instance resource inventory
    for test scenarios.
+
+.. envvar:: FLUX_HWLOC_XMLFILE_NOT_THISSYSTEM
+
+   When used with :envvar:`FLUX_HWLOC_XMLFILE`, declares that the XML
+   does not come from this system (assumed by default). When set, Flux
+   omits the ``HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM`` flag and skips the
+   ``hwloc_topology_restrict()`` call that would otherwise restrict the
+   loaded topology to the currently available cpuset. Without this
+   variable, using an XML file from another system may cause unexpected
+   behavior such as missing resources. This variable may be set to any
+   non-empty value and is ignored if :envvar:`FLUX_HWLOC_XMLFILE` is
+   not set.
 
 .. envvar:: FLUX_URI_RESOLVE_LOCAL
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1088,3 +1088,5 @@ myscript
 prepending
 prepends
 pythonX
+THISSYSTEM
+topologies

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -216,6 +216,7 @@ TESTSCRIPTS = \
 	t2602-job-shell.t \
 	t2603-job-shell-initrc.t \
 	t2604-job-shell-affinity.t \
+	t2604-job-shell-affinity-xmlfile.t \
 	t2606-job-shell-output-redirection.t \
 	t2606-job-shell-output-flow.t \
 	t2607-job-shell-input.t \

--- a/t/t2604-job-shell-affinity-xmlfile.t
+++ b/t/t2604-job-shell-affinity-xmlfile.t
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+test_description='Test FLUX_HWLOC_XMLFILE with cpu-affinity=dry-run'
+
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile --debug
+
+. `dirname $0`/sharness.sh
+
+XMLFILE=${SHARNESS_TEST_SRCDIR}/hwloc-data/sierra.xml
+
+# sierra.xml: 44 cores, 4 PUs per core
+SIERRA_CORES=44
+
+test_expect_success 'hwloc XML file exists' '
+	test -f ${XMLFILE}
+'
+
+test_expect_success 'FLUX_HWLOC_XMLFILE_NOT_THISSYSTEM allows non-local topology to load' '
+	FLUX_HWLOC_XMLFILE=${XMLFILE} \
+	FLUX_HWLOC_XMLFILE_NOT_THISSYSTEM=1 \
+	flux start flux resource list -no {ncores} >cores.out &&
+	test_debug "cat cores.out" &&
+	test $(cat cores.out) -eq ${SIERRA_CORES}
+'
+test_expect_success 'FLUX_HWLOC_XMLFILE_NOT_THISSYSTEM is ignored without FLUX_HWLOC_XMLFILE' '
+	flux start flux resource list -no {ncores} > local-cores.exp &&
+	FLUX_HWLOC_XMLFILE_NOT_THISSYSTEM=1 \
+	flux start flux resource list -no {ncores} >local-cores.out &&
+	test_debug "cat local-cores.out" &&
+	test_cmp local-cores.exp local-cores.out
+'
+test_expect_success 'cpu-affinity works with FLUX_HWLOC_XMLFILE' '
+	FLUX_HWLOC_XMLFILE=${XMLFILE} \
+	FLUX_HWLOC_XMLFILE_NOT_THISSYSTEM=1 \
+	flux start flux run -n1 -c1 -o cpu-affinity=dry-run true \
+		> dry-run1.out 2>&1 &&
+	test_debug "cat dry-run1.out" &&
+	grep "cpus: 0-3" dry-run1.out
+'
+test_expect_success 'cpu-affinity=per-task works with FLUX_HWLOC_XMLFILE' '
+	FLUX_HWLOC_XMLFILE=${XMLFILE} \
+	FLUX_HWLOC_XMLFILE_NOT_THISSYSTEM=1 \
+	flux start flux run -n2 -c1 -o cpu-affinity=dry-run,per-task true \
+		> dry-run2.out 2>&1 &&
+	test_debug "cat dry-run2.out" &&
+	grep "task 0: cpus: 0-3" dry-run2.out &&
+	grep "task 1: cpus: 4-7" dry-run2.out
+'
+test_done
+


### PR DESCRIPTION
When loading an hwloc XML file from a different system via `FLUX_HWLOC_XMLFILE`, Flux always applies `HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM`, which can cause unexpected behavior such as missing resources. This makes it difficult to use external XML topology files for end-to-end testing, particularly with the shell `cpu-affinity=dry-run` option. See flux-framework/flux-sched#1408.

While `resource.norestrict=true` happens to work around the issue for initial resource discovery, this solution is neither obvious nor convenient. It also doesn't fix the shell affinity plugin.

To make the solution obvious and simple, a new environment variable `FLUX_HWLOC_XMLFILE_NOT_THISSYSTEM` is added that disables `HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM` and skips `hwloc_topology_restrict()`, allowing topology files from other systems to be used for testing. The shell cpu-affinity plugin is also updated to omit this flag when `cpu-affinity=dry-run` is set.

A new test `t2604-job-shell-affinity-xmlfile.t` validates end-to-end use of a non-local XML topology with the affinity plugin in dry-run mode.