### PR TITLE
cmd/flux: output similar commands on invalid input

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -15,6 +15,7 @@ extend-exclude = [
   "src/common/libutil/sha1.c",
   "src/common/libutil/test/sha1.c",
   "src/common/libutil/test/blobref.c",
+  "src/common/libutil/test/levenshtein.c",
   "src/common/libmissing/*.[ch]",
   "t/hwloc-data/*",
   "doc/test/spell.en.pws",

--- a/src/cmd/cmdhelp.c
+++ b/src/cmd/cmdhelp.c
@@ -42,15 +42,14 @@ static json_t *command_list_file_read (const char *path)
     return (o);
 }
 
-static int command_list_print (FILE *fp, const char *path)
+static void command_list_print (FILE *fp, const char *path)
 {
-    int rc = 0;
     size_t index;
     json_t *o = NULL;
     json_t *entry;
 
     if (!(o = command_list_file_read (path)))
-        goto out;
+        return;
 
     json_array_foreach (o, index, entry) {
         size_t i;
@@ -80,12 +79,8 @@ static int command_list_print (FILE *fp, const char *path)
             fprintf (fp, "   %-18s %s\n", name, desc);
         }
     }
-    rc = 0;
-
 out:
     json_decref (o);
-    return (rc);
-
 }
 
 static void emit_command_help_from_pattern (FILE *fp, const char *pattern)
@@ -109,8 +104,7 @@ static void emit_command_help_from_pattern (FILE *fp, const char *pattern)
 
     for (i = 0; i < gl.gl_pathc; i++) {
         const char *file = gl.gl_pathv[i];
-        if (command_list_print (fp, file) < 0)
-            log_err_exit ("%s: failed to read content\n", file);
+        command_list_print (fp, file);
     }
     globfree (&gl);
 }

--- a/src/cmd/cmdhelp.c
+++ b/src/cmd/cmdhelp.c
@@ -58,7 +58,9 @@ static void command_list_print (FILE *fp, const char *path)
         json_t *cmd;
         json_error_t error;
 
-        if (json_unpack_ex (entry, &error, 0,
+        if (json_unpack_ex (entry,
+                            &error,
+                            0,
                             "{s:s s:o}",
                             "description", &description,
                             "commands", &commands) < 0) {
@@ -69,7 +71,9 @@ static void command_list_print (FILE *fp, const char *path)
         json_array_foreach (commands, i, cmd) {
             const char *name = NULL;
             const char *desc = NULL;
-            if (json_unpack_ex (cmd, &error, 0,
+            if (json_unpack_ex (cmd,
+                                &error,
+                                0,
                                 "{s:s s:s}",
                                 "name", &name,
                                 "description", &desc) < 0) {

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -28,6 +28,8 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/environment.h"
 #include "src/common/libutil/intree.h"
+#include "src/common/libutil/levenshtein.h"
+#include "src/common/libutil/dirwalk.h"
 
 #include "cmdhelp.h"
 #include "builtin.h"
@@ -417,6 +419,109 @@ void exec_subcommand_dir (bool vopt,
     free (path);
 }
 
+struct similar_cmds {
+    int min;
+    zlist_t *cmds;
+    int cmdsstrlen;
+    const char *argv0;
+};
+
+static void similar_check (struct similar_cmds *similar,
+                           const char *cmd)
+{
+    int distance = levenshtein_distance (cmd, similar->argv0);
+    if (distance > 0 && distance <= similar->min) {
+        char *cpy = xstrdup (cmd);
+        if (distance < similar->min) {
+            zlist_purge (similar->cmds);
+            similar->cmdsstrlen = 0;
+        }
+        similar->min = distance;
+        zlist_append (similar->cmds, cpy);
+        zlist_freefn (similar->cmds, cpy, free, true);
+        similar->cmdsstrlen += strlen (cpy);
+    }
+}
+
+static int similar_filter (dirwalk_t *d, void *arg)
+{
+    struct similar_cmds *similar = arg;
+    const char *path = dirwalk_path (d);
+    const char *name = dirwalk_name (d);
+    char *cmdname;
+
+    if (!strstarts (name, "flux-"))
+        return 0;
+
+    if (access (path, X_OK) < 0)
+        return 0;
+
+    /* +5 to get past "flux-" */
+    cmdname = xstrdup (name + 5);
+
+    /* strip off ".py" if necessary */
+    if (strends (cmdname, ".py")) {
+        char *tmp = strrchr (cmdname, '.');
+        *tmp = '\0';
+    }
+
+    similar_check (similar, cmdname);
+    free (cmdname);
+    return 0;
+}
+
+static void find_similar_command (const char *searchpath, const char *argv0)
+{
+    extern struct builtin_cmd builtin_cmds[];
+    struct builtin_cmd *builtin_cmd = &builtin_cmds[0];
+    struct similar_cmds similar = {INT_MAX, NULL, 0, argv0};
+    char *searchpathcpy;
+    char *dir, *saveptr = NULL, *a1;
+
+    similar.min = INT_MAX;
+    if (!(similar.cmds = zlist_new ()))
+        log_err_exit ("failed to create cmds list");
+    similar.argv0 = argv0;
+
+    /* first check out builtins */
+    while (builtin_cmd->name) {
+        similar_check (&similar, builtin_cmd->name);
+        builtin_cmd++;
+    }
+
+    /* now check commands in search paths */
+    searchpathcpy = xstrdup (searchpath);
+    a1 = searchpathcpy;
+    while ((dir = strtok_r (a1, ":", &saveptr))) {
+        (void)dirwalk (dir, DIRWALK_NORECURSE, similar_filter, &similar);
+        a1 = NULL;
+    }
+    free (searchpathcpy);
+
+    /* only output if command is similar enough, we'll go with a
+     * distance of at most 3.
+     *
+     * e.g. "resourcccce" will be similar to "resource", but not
+     * "resourccccce".
+     */
+    if (similar.min <= 3) {
+        char *str;
+        int i = 3;
+
+        log_msg ("The most similar command%s",
+                 zlist_size (similar.cmds) > 1 ? "s are" : " is");
+
+        /* output at most 3 commands */
+        str = zlist_first (similar.cmds);
+        while (str && i-- > 0) {
+            log_msg ("\t%s", str);
+            str = zlist_next (similar.cmds);
+        }
+    }
+
+    zlist_destroy (&similar.cmds);
+}
+
 void exec_subcommand (const char *searchpath, bool vopt, int argc, char *argv[])
 {
     if (strchr (argv[0], '/')) {
@@ -435,8 +540,9 @@ void exec_subcommand (const char *searchpath, bool vopt, int argc, char *argv[])
             a1 = NULL;
         }
         free (cpy);
-        log_msg_exit ("`%s' is not a flux command.  See 'flux --help'",
-                      argv[0]);
+        log_msg ("`%s' is not a flux command.  See 'flux --help'", argv[0]);
+        find_similar_command (searchpath, argv[0]);
+        exit (1);
     }
 }
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -109,7 +109,9 @@ libutil_la_SOURCES = \
 	basename.c \
 	ansi_color.h \
 	cgroup.h \
-	cgroup.c
+	cgroup.c \
+	levenshtein.h \
+	levenshtein.c
 
 libutil_la_LDFLAGS = \
         $(AM_LDFLAGS) \
@@ -149,7 +151,8 @@ TESTS = test_sha1.t \
 	test_basemoji.t \
 	test_sigutil.t \
 	test_parse_size.t \
-	test_cgroup.t
+	test_cgroup.t \
+	test_levenshtein.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -317,3 +320,7 @@ test_parse_size_t_LDADD = $(test_ldadd)
 test_cgroup_t_SOURCES = test/cgroup.c
 test_cgroup_t_CPPFLAGS = $(test_cppflags)
 test_cgroup_t_LDADD = $(test_ldadd)
+
+test_levenshtein_t_SOURCES = test/levenshtein.c
+test_levenshtein_t_CPPFLAGS = $(test_cppflags)
+test_levenshtein_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/levenshtein.c
+++ b/src/common/libutil/levenshtein.c
@@ -1,0 +1,92 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "levenshtein.h"
+
+/* Return the minimum of three values */
+static inline int min3 (int a, int b, int c)
+{
+    int min = a;
+    if (b < min)
+        min = b;
+    if (c < min)
+        min = c;
+    return min;
+}
+
+int levenshtein_distance (const char *s1, const char *s2)
+{
+    int *matrix;
+    size_t s1len, s2len;
+    int i, j;
+    int result;
+
+    /* Handle NULL inputs */
+    if (!s1 || !s2) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /* Get string lengths */
+    s1len = strlen (s1);
+    s2len = strlen (s2);
+
+    /* Fast path for empty strings */
+    if (s1len == 0)
+        return s2len;
+    if (s2len == 0)
+        return s1len;
+
+    /* Allocate a single-dimensional matrix to represent a 2D array
+     * of size (s1len+1) x (s2len+1) */
+    matrix = malloc ((s1len + 1) * (s2len + 1) * sizeof (int));
+    if (!matrix) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    /* Initialize first row */
+    for (i = 0; i <= s1len; i++)
+        matrix[i * (s2len + 1)] = i;
+
+    /* Initialize first column */
+    for (j = 0; j <= s2len; j++)
+        matrix[j] = j;
+
+    /* Fill in the rest of the matrix */
+    for (i = 1; i <= s1len; i++) {
+        for (j = 1; j <= s2len; j++) {
+            int cost = (s1[i-1] == s2[j-1]) ? 0 : 1;
+
+            matrix[i * (s2len + 1) + j] = min3(
+                matrix[(i-1) * (s2len + 1) + j] + 1,     /* deletion */
+                matrix[i * (s2len + 1) + (j-1)] + 1,     /* insertion */
+                matrix[(i-1) * (s2len + 1) + (j-1)] + cost  /* substitution */
+            );
+        }
+    }
+
+    /* Get the result from the bottom-right cell */
+    result = matrix[s1len * (s2len + 1) + s2len];
+
+    free (matrix);
+    return result;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libutil/levenshtein.h
+++ b/src/common/libutil/levenshtein.h
@@ -1,0 +1,34 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_LEVENSHTEIN_H
+#define _UTIL_LEVENSHTEIN_H
+
+#include <stddef.h>
+
+/*  Calculate the Levenshtein distance between two strings.
+ *
+ *  The Levenshtein distance is the minimum number of single-character
+ *  operations (insertions, deletions, or substitutions) required to
+ *  change one string into another.
+ *
+ *  Parameters:
+ *    s1 - First string
+ *    s2 - Second string
+ *
+ *  Returns:
+ *    The Levenshtein distance between the two strings.
+ *    Returns -1 on error (e.g., memory allocation failure).
+ */
+int levenshtein_distance (const char *s1, const char *s2);
+
+#endif /* !_UTIL_LEVENSHTEIN_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/test/levenshtein.c
+++ b/src/common/libutil/test/levenshtein.c
@@ -1,0 +1,81 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/levenshtein.h"
+
+void test_corner_cases (void)
+{
+    /* Test NULL inputs */
+    ok (levenshtein_distance (NULL, "abc") == -1,
+        "distance(NULL, \"abc\") returns -1");
+    ok (levenshtein_distance ("abc", NULL) == -1,
+        "distance(\"abc\", NULL) returns -1");
+    ok (levenshtein_distance (NULL, NULL) == -1,
+        "distance(NULL, NULL) returns -1");
+}
+
+void test_basics (void)
+{
+    /* Test empty strings */
+    ok (levenshtein_distance ("", "") == 0,
+        "distance(\"\", \"\") == 0");
+    ok (levenshtein_distance ("", "a") == 1,
+        "distance(\"\", \"a\") == 1");
+    ok (levenshtein_distance ("a", "") == 1,
+        "distance(\"a\", \"\") == 1");
+
+    /* Test identical strings */
+    ok (levenshtein_distance ("a", "a") == 0,
+        "distance(\"a\", \"a\") == 0");
+    ok (levenshtein_distance ("abc", "abc") == 0,
+        "distance(\"abc\", \"abc\") == 0");
+
+    /* Test insertions */
+    ok (levenshtein_distance ("a", "ab") == 1,
+        "distance(\"a\", \"ab\") == 1");
+    ok (levenshtein_distance ("b", "ab") == 1,
+        "distance(\"b\", \"ab\") == 1");
+
+    /* Test deletions */
+    ok (levenshtein_distance ("ab", "a") == 1,
+        "distance(\"ab\", \"a\") == 1");
+    ok (levenshtein_distance ("ab", "b") == 1,
+        "distance(\"ab\", \"b\") == 1");
+
+    /* Test substitutions */
+    ok (levenshtein_distance ("a", "b") == 1,
+        "distance(\"a\", \"b\") == 1");
+    ok (levenshtein_distance ("abc", "abd") == 1,
+        "distance(\"abc\", \"abd\") == 1");
+
+    /* Test multiple operations */
+    ok (levenshtein_distance ("kitten", "sitting") == 3,
+        "distance(\"kitten\", \"sitting\") == 3");
+    ok (levenshtein_distance ("saturday", "sunday") == 3,
+        "distance(\"saturday\", \"sunday\") == 3");
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+    test_corner_cases ();
+    test_basics ();
+    done_testing ();
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -845,6 +845,39 @@ test_expect_success 'command --help works outside of flux instance' '
 	test_kvs_subcmd_help
 '
 
+# cover a builtin command, a c binary, and a python script
+test_expect_success 'typoed commands are given suggestions on correct commands' '
+	test_must_fail flux dmsg > invalid1.out 2>&1 &&
+	grep "dmesg" invalid1.out &&
+	test_must_fail flux modole > invalid2.out 2>&1 &&
+	grep "module" invalid2.out &&
+	test_must_fail flux resourcce > invalid3.out 2>&1 &&
+	grep "resource" invalid3.out
+'
+
+test_expect_success 'multiple equally similar commands are output' '
+	test_must_fail flux mom > invalid4.out 2>&1 &&
+	grep "job" invalid4.out &&
+	grep "top" invalid4.out
+'
+
+test_expect_success 'at most 3 suggested similar commands are output' '
+	TEMPDIR=$(mktemp -d) &&
+	touch $TEMPDIR/flux-mama &&
+	touch $TEMPDIR/flux-dada &&
+	touch $TEMPDIR/flux-baba &&
+	touch $TEMPDIR/flux-lala &&
+	chmod +x $TEMPDIR/flux-* &&
+	test_must_fail sh -c "FLUX_EXEC_PATH=$TEMPDIR flux fafa > invalidmax.out 2>&1" &&
+	count=$(grep -oE "mama|dada|baba|lala" invalidmax.out | wc -l) &&
+	test $count -eq 3
+'
+
+test_expect_success 'really bad typoed commands are not given suggestions' '
+	test_must_fail flux resouurrccee > invalidbad.out 2>&1 &&
+	test_must_fail grep "similar" invalidbad.out
+'
+
 # Note: flux-start auto-removes rundir
 
 test_done


### PR DESCRIPTION
Problem: When a user inputs an invalid command to the flux command (e.g. "flux kkvs") the flux command outputs an appropriate message indicating the command is invalid.  It'd be nice if the flux command could output similar commands, in case the user typoed something or isn't quite sure what the command is actually called.

Solution: Using Levenshtein distance, calculate what commands are most similar to the invalid command specified by the user.  If one is pretty similar, output a message informing the user of that command.

example:

```
>src/cmd/flux fvs
flux: `fvs' is not a flux command.  See 'flux --help'
flux: The most similar command is `kvs`
```

Notes:

This was a simple issue I wrote up awhile ago and thought it might be a good experiment to see if it could be solved with AI.

I started with the prompt "i would like the flux command to output a message suggesting a similar command when an invalid command is entered".

The result was "meh".  It had enough quirks that I ultimately ended up doing it myself, with 1 or 2 ideas brought over.  But did have AI pull in a levenshtein distance implementation (string comparison algorithm) in its own commit.  


