### PR TITLE
ensure starttime and expiration appear in resource set returned from `flux resource R`

### DIFF
--- a/src/bindings/python/flux/resource/ResourceSet.py
+++ b/src/bindings/python/flux/resource/ResourceSet.py
@@ -274,3 +274,19 @@ class ResourceSet:
     @property
     def properties(self):
         return ",".join(json.loads(self.get_properties()).keys())
+
+    @property
+    def expiration(self):
+        return self.impl.get_expiration()
+
+    @expiration.setter
+    def expiration(self, expiration):
+        return self.impl.set_expiration(expiration)
+
+    @property
+    def starttime(self):
+        return self.impl.get_starttime()
+
+    @starttime.setter
+    def starttime(self, starttime):
+        return self.impl.set_starttime(starttime)

--- a/src/bindings/python/flux/resource/ResourceSetImplementation.py
+++ b/src/bindings/python/flux/resource/ResourceSetImplementation.py
@@ -90,3 +90,23 @@ class ResourceSetImplementation(ABC):  # pragma: no cover
     def remove_ranks(self, ranks):
         """Remove an IDset of ranks from a resource set"""
         raise NotImplementedError
+
+    @abstractmethod
+    def get_expiration(self):
+        """Get the expiration time from a resource set"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_expiration(self, expiration):
+        """Set the expiration time from a resource set"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_starttime(self):
+        """Get the starttime time from a resource set"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_starttime(self, starttime):
+        """Set the starttime time from a resource set"""
+        raise NotImplementedError

--- a/src/bindings/python/flux/resource/Rlist.py
+++ b/src/bindings/python/flux/resource/Rlist.py
@@ -143,3 +143,15 @@ class Rlist(WrapperPimpl):
                 "copy_constraint: " + ffi.string(error.text).decode("utf-8")
             ) from exc
         return Rlist(handle=handle)
+
+    def set_expiration(self, expiration):
+        self.pimpl.handle.expiration = expiration
+
+    def get_expiration(self):
+        return self.pimpl.handle.expiration
+
+    def set_starttime(self, starttime):
+        self.pimpl.handle.starttime = starttime
+
+    def get_starttime(self):
+        return self.pimpl.handle.starttime

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -723,6 +723,8 @@ def emit_R(args):
     resources, config = get_resource_list(args)
 
     rset = ResourceSet()
+    rset.starttime = resources["all"].starttime
+    rset.expiration = resources["all"].expiration
     for state in args.states:
         try:
             rset.add(resources[state])

--- a/src/modules/resource/status.c
+++ b/src/modules/resource/status.c
@@ -471,7 +471,7 @@ error:
  * resource-define
  *   could be called in test from 'flux resource reload'
  * resource-update
- *   expiration only at this time - ignore
+ *   expiration has updated, invalidate cache
  * online, offline, drain, undrain
  *   invalidate R_down only
  */
@@ -493,6 +493,8 @@ static void reslog_cb (struct reslog *reslog,
     }
     else if (status->shrink_down_ranks
         && streq (name, "offline"))
+        invalidate_cache (&status->cache, true);
+    else if (streq (name, "resource-update"))
         invalidate_cache (&status->cache, true);
     else if (streq (name, "online")
         || streq (name, "offline")


### PR DESCRIPTION
This PR fixes a minor issue where the current starttime and expiration are not present in the output of `flux resource R`.

The problem exists in 2 places:
- the status cache is not invalidated on a `resource-update` event, so a stale expiration could be present in the resource set returned by the `resource.sched-status` RPC.
- The `flux resource R` implementation creates an empty resource set object and doesn't update the expiration and starttime before adding the requested resources to the set.

This PR fixes those two issues. The Python `ResourceSet` class unit tests are also expanded since there was some missing coverage.