### PR TITLE
track job time time limit when Flux is run as a Slurm job

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -68,6 +68,7 @@ nobase_fluxpy_PYTHON = \
 	queue.py \
 	modprobe.py \
 	subprocess.py \
+	slurm.py \
 	uri/uri.py \
 	uri/__init__.py \
 	uri/resolvers/jobid.py \

--- a/src/bindings/python/flux/slurm.py
+++ b/src/bindings/python/flux/slurm.py
@@ -1,0 +1,57 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import subprocess
+
+SLURM_TIME_UNLIMITED = {"UNLIMITED", "NOT_SET", "INVALID"}
+
+
+def _parse_slurm_time(timestr):
+    """Parse Slurm time string (D-HH:MM:SS, HH:MM:SS, MM:SS) to seconds.
+    Returns None if the time limit is unlimited or unparsable.
+    """
+    timestr = timestr.strip()
+    if timestr in SLURM_TIME_UNLIMITED:
+        return None
+    days = 0
+    if "-" in timestr:
+        d, timestr = timestr.split("-", 1)
+        days = int(d)
+    parts = timestr.split(":")
+    try:
+        if len(parts) == 3:
+            h, m, s = int(parts[0]), int(parts[1]), int(parts[2])
+        elif len(parts) == 2:
+            h, m, s = 0, int(parts[0]), int(parts[1])
+        else:
+            return None
+    except ValueError:
+        return None
+    return days * 86400 + h * 3600 + m * 60 + s
+
+
+def slurm_timeleft(jobid):
+    """Return remaining time in seconds for jobid, or None if no time limit"""
+    try:
+        result = subprocess.run(
+            ["squeue", "--noheader", f"--job={jobid}", "-o", "%L"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            msg = result.stderr.decode("utf-8")
+            raise RuntimeError(f"squeue failed: {msg}")
+        return _parse_slurm_time(result.stdout.decode("utf-8"))
+    except FileNotFoundError:
+        raise RuntimeError("squeue not found in PATH")
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -133,6 +133,7 @@ dist_fluxcmd_SCRIPTS = \
 	flux-run-epilog \
 	flux-modprobe.py \
 	flux-sproc.py \
+	flux-slurm-expiration-sync.py \
 	flux-python$(PYTHON_VERSION)
 
 fluxcmd_PROGRAMS = \

--- a/src/cmd/flux-slurm-expiration-sync.py
+++ b/src/cmd/flux-slurm-expiration-sync.py
@@ -1,0 +1,138 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""
+slurm-expiration-sync
+
+Poll squeue for remaining time of the enclosing Slurm job and notify
+the resource module via RPC when the expiration changes, so that
+flux_job_timeleft(3) reflects the Slurm job's expiration.
+
+"""
+
+import argparse
+import logging
+import signal
+import sys
+import time
+
+import flux
+import flux.slurm as slurm
+from flux.util import fsd
+
+POLL_INTERVAL_DEFAULT = 60  # seconds
+CHANGE_THRESHOLD = 5.0  # seconds -- ignore jitter smaller than this
+
+LOGGER = logging.getLogger("slurm-expiration-sync")
+
+
+def send_expiration_update(fh, expiration):
+    """Send updated expiration timestamp to the resource module."""
+    try:
+        f = fh.rpc(
+            "resource.expiration-update",
+            {"expiration": expiration},
+            0,
+            0,
+        )
+        f.get()
+        LOGGER.debug("expiration updated to %.3f", expiration)
+    except Exception as e:
+        LOGGER.warning("resource.expiration-update failed: %s", e)
+
+
+def make_poll_cb(jobid, fh):
+    last_expiration = [None]
+
+    def poll_and_update(fh, watcher, revents, _args):
+        timeleft = slurm.slurm_timeleft(jobid)
+        if timeleft is None:
+            return
+
+        expiration = time.time() + timeleft
+        last = last_expiration[0]
+
+        if last is None or abs(expiration - last) > CHANGE_THRESHOLD:
+            LOGGER.debug(
+                "Slurm timeleft changed: %s remaining, expiration=%.3f",
+                fsd(timeleft),
+                expiration,
+            )
+            send_expiration_update(fh, expiration)
+            last_expiration[0] = expiration
+
+    return poll_and_update
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=POLL_INTERVAL_DEFAULT,
+        metavar="SECONDS",
+        help="squeue polling interval in seconds (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--jobid", "-j", metavar="JOBID", help="Operate on Slurm job JOBID"
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Enable debug logging"
+    )
+    args = parser.parse_args()
+
+    LOGGER.setLevel(args.verbose and logging.DEBUG or logging.INFO)
+
+    try:
+        jobid = int(args.jobid)
+    except (ValueError, TypeError):
+        LOGGER.error("Invalid or missing --jobid")
+        sys.exit(1)
+
+    fh = flux.Flux()
+
+    # Probe once at startup to confirm squeue is reachable and we have a
+    # valid time limit before entering the poll loop.
+    timeleft = slurm.slurm_timeleft(jobid)
+    if timeleft is None:
+        LOGGER.info("No Slurm time limit detected (unlimited or error), exiting")
+        # Update expiration to 0 (unlimited) so that the resource module will
+        # post a resource-update event allowing rc1 task to exit.
+        send_expiration_update(fh, 0.0)
+        sys.exit(0)
+
+    LOGGER.debug("Slurm job %d detected, %s remaining at startup", jobid, fsd(timeleft))
+
+    poll_cb = make_poll_cb(jobid, fh)
+
+    # Fire immediately to push the initial expiration, then on each interval
+    timer = fh.timer_watcher_create(
+        0,
+        poll_cb,
+        repeat=args.poll_interval,
+    )
+    timer.start()
+
+    sigwatcher = fh.signal_watcher_create(
+        signal.SIGTERM, lambda handle, x, y, watcher: handle.reactor_stop()
+    )
+    sigwatcher.start()
+
+    try:
+        fh.reactor_run()
+    except KeyboardInterrupt:
+        # exit normally on ctrl-c
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -493,11 +493,13 @@ static void proc_output_cb (flux_subprocess_t *p, const char *stream)
     else if (len) {
         /* background process: log output (ignore EOF) */
 
-        const char *command = basename_simple (flux_cmd_arg (p->cmd, 0));
+        const char *label = flux_cmd_get_label (p->cmd);
+        if (!label)
+            label = basename_simple (flux_cmd_arg (p->cmd, 0));
         if (streq (stream, "stderr"))
-            llog_error (s, "%s[%d]: %s", command, (int)p->pid, buf);
+            llog_error (s, "%s[%d]: %s", label, (int)p->pid, buf);
         else
-            llog_info (s, "%s[%d]: %s", command, (int)p->pid, buf);
+            llog_info (s, "%s[%d]: %s", label, (int)p->pid, buf);
     }
     return;
 

--- a/src/modules/resource/inventory.c
+++ b/src/modules/resource/inventory.c
@@ -915,8 +915,18 @@ error:
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST, "resource.reload",  resource_reload, 0 },
-    { FLUX_MSGTYPE_REQUEST, "resource.get",  resource_get, 0 },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "resource.reload",
+        resource_reload,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "resource.get",
+        resource_get,
+        0
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -319,6 +319,7 @@ TESTSCRIPTS = \
 	python/t0034-queuelist.py \
 	python/t0035-kvs-no-checkpoint.py \
 	python/t0036-subprocess.py \
+	python/t0037-slurm.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY
@@ -349,6 +350,7 @@ EXTRA_DIST= \
 	scripts/run_timeout.py \
 	scripts/startctl.py \
 	scripts/groups.py \
+	scripts/squeue \
 	jobspec \
 	resource \
 	marshall \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -281,6 +281,7 @@ TESTSCRIPTS = \
 	t3310-system-heartbeat.t \
 	t3400-overlay-trace.t \
 	t3401-module-trace.t \
+	t4100-slurm-expiration-sync.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \

--- a/t/python/t0037-slurm.py
+++ b/t/python/t0037-slurm.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+#
+# flux.slurm module tests
+#
+
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import flux.slurm as slurm
+import subflux  # noqa: F401 - To set up PYTHONPATH
+from pycotap import TAPTestRunner
+
+
+class TestSlurm(unittest.TestCase):
+    """Tests for slurm._parse_slurm_time function"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.orig_path = os.environ["PATH"]
+        cls.t_path = str(Path(__file__).resolve().parent.parent / "scripts")
+        os.environ["PATH"] = cls.t_path + ":" + os.environ["PATH"]
+
+    def reset_path(self):
+        os.environ["PATH"] = self.orig_path
+
+    def test_parse_slurm_time(self):
+        """Test squeue %L time parser"""
+        tests = [
+            {"input": "1:00:00", "result": 3600},
+            {"input": "0:59", "result": 59},
+            {"input": "10:00:00", "result": 36000},
+            {"input": "1-00:00:00", "result": 86400},
+            {"input": "1:01:04", "result": 3664},
+            {"input": "11:00:00", "result": 39600},
+            {"input": "11:23:59", "result": 41039},
+            {"input": "12:00:00", "result": 43200},
+            {"input": "1:21:32", "result": 4892},
+            {"input": "16:00:00", "result": 57600},
+            {"input": "2:00", "result": 120},
+            {"input": "20:00", "result": 1200},
+            {"input": "2-00:00:00", "result": 172800},
+            {"input": "2-00:24:19", "result": 174259},
+            {"input": "2-13:01:51", "result": 219711},
+            {"input": "23:43:40", "result": 85420},
+            {"input": "3-12:45:11", "result": 305111},
+            {"input": "4-22:11:00", "result": 425460},
+            {"input": "5:00", "result": 300},
+            {"input": "59:13", "result": 3553},
+            {"input": "7-00:00:00", "result": 604800},
+            {"input": "0:00", "result": 0},
+            {"input": "UNLIMITED", "result": None},
+            {"input": "NOT_SET", "result": None},
+            {"input": "a:bc", "result": None},
+            {"input": "1:2:3:4:5", "result": None},
+        ]
+        for entry in tests:
+            result = slurm._parse_slurm_time(entry["input"])
+            self.assertEqual(result, entry["result"])
+
+    def test_mock_remaining_time(self):
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=True) as fp:
+            os.environ["FLUX_SLURM_MOCK_EXPIRATION_FILE"] = fp.name
+            fp.write(str(int(time.time() + 3600)))
+            fp.flush()
+            self.assertAlmostEqual(slurm.slurm_timeleft(1234), 3600, delta=15)
+
+            # Update expiration, timeleft should change
+            fp.seek(0)
+            fp.write(str(int(time.time() + 300)))
+            fp.flush()
+            self.assertAlmostEqual(slurm.slurm_timeleft(1234), 300, delta=15)
+
+            # Update to unlimited
+            fp.seek(0)
+            fp.write(str(-1))
+            fp.flush()
+            self.assertIsNone(slurm.slurm_timeleft(1234))
+
+            del os.environ["FLUX_SLURM_MOCK_EXPIRATION_FILE"]
+
+    def test_squeue_missing(self):
+        os.environ["PATH"] = "."
+        try:
+            with self.assertRaises(RuntimeError) as cm:
+                slurm.slurm_timeleft(1234)
+        finally:
+            self.reset_path()
+        self.assertRegex(str(cm.exception), "squeue not found")
+
+    def test_squeue_failure(self):
+        # FLUX_SLURM_MOCK_EXPIRATION_FILE not set, command will error
+        with self.assertRaises(RuntimeError) as cm:
+            slurm.slurm_timeleft(1234)
+        self.assertRegex(str(cm.exception), "squeue failed")
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner(), buffer=False)

--- a/t/scripts/squeue
+++ b/t/scripts/squeue
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Mock squeue for testing flux.slurm.slurm_timeleft()
+
+Reads an expiration timestamp from FLUX_SLURM_MOCK_EXPIRATION_FILE,
+computes remaining time, and emits it in Slurm %L format.
+
+The expiration file should contain a Unix timestamp (float), e.g.:
+    echo $(date -d '+1 hour' +%s) > /tmp/expiration
+    FLUX_SLURM_MOCK_EXPIRATION_FILE=/tmp/expiration squeue ...
+
+A value < 0 is treated as the special case "UNLIMITED"
+
+The file can be overwritten at any time to simulate dynamic time limit
+changes.
+"""
+
+import os
+import sys
+import time
+
+
+def seconds_to_slurm_time(seconds):
+    """Convert integer seconds to Slurm %L time string."""
+
+    # Special case: -1 is unlimited, return UNLIMITED
+    if seconds < 0:
+        return "UNLIMITED"
+    seconds = max(0, int(seconds))
+    minutes, s = divmod(seconds, 60)
+    hours, m = divmod(minutes, 60)
+    days, h = divmod(hours, 24)
+    if days > 0:
+        return f"{days}-{h:02d}:{m:02d}:{s:02d}"
+    if h > 0:
+        return f"{h}:{m:02d}:{s:02d}"
+    return f"{m}:{s:02d}"
+
+
+def main():
+    mock_file = os.environ.get("FLUX_SLURM_MOCK_EXPIRATION_FILE")
+    if mock_file is None:
+        print("mock squeue: FLUX_SLURM_MOCK_EXPIRATION_FILE not set", file=sys.stderr)
+        sys.exit(1)
+    try:
+        with open(mock_file) as f:
+            expiration = float(f.read().strip())
+    except (OSError, ValueError) as e:
+        print(f"mock squeue: {mock_file}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    timeleft = expiration - time.time()
+    print(seconds_to_slurm_time(timeleft))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/t/t4100-slurm-expiration-sync.t
+++ b/t/t4100-slurm-expiration-sync.t
@@ -1,0 +1,170 @@
+#!/bin/sh
+
+test_description='Test Slurm expiration synchronization'
+
+. $(dirname $0)/sharness.sh
+
+# Capture original PATH before test_under_flux re-executes this script
+# with a modified PATH, and before we prepend the scripts directory.
+ORIG_PATH=$PATH
+export ORIG_PATH
+
+test_under_flux 1
+
+# Skip the "squeue not in PATH" test if a real squeue is found in the
+# original PATH, since it would be found even without the mock.
+! command -v squeue >/dev/null 2>&1 && test_set_prereq NO_SQUEUE
+
+# Put mock squeue script first on PATH
+PATH=${SHARNESS_TEST_SRCDIR}/scripts:$PATH
+export PATH
+
+# future_time N - return a Unix timestamp N seconds from now
+future_time() {
+	echo $(( $(date +%s) + $1 ))
+}
+
+# check_expiration FILE
+# Check that execution.expiration in FILE is within 1 second of
+# EXPIRATION_FILE
+check_expiration() {
+	local expected=$(cat $EXPIRATION_FILE)
+	test_debug "echo checking: $(jq .execution.expiration <$1) = $expected"
+	cat $1 | jq -e ".execution.expiration - $expected | fabs | . < 1"
+}
+
+# check_expiration_zero FILE
+# Check that execution.expiration in FILE is 0 (unlimited)
+check_expiration_zero() {
+	jq -e '.execution.expiration == 0' "$1"
+}
+
+EXPIRATION_FILE=expiration.txt
+
+cat >wait-expiration.py <<EOF
+import sys
+import flux
+from flux.resource import ResourceJournalConsumer
+from flux.eventlog import EventLogFormatter
+
+expected = float(sys.argv[1])
+fh = flux.Flux()
+
+evf = EventLogFormatter(format="text", timestamp_format="human")
+
+consumer = ResourceJournalConsumer(fh).start()
+while True:
+    event = consumer.poll(15.)
+    print(evf.format(event), file=sys.stderr)
+    if event.name == "resource-update":
+        if abs(event.context.get("expiration", 0.0) - expected) < 1.0:
+            break
+EOF
+
+#
+# flux slurm-expiration-sync failure modes
+#
+test_expect_success 'flux slurm-expiration-sync fails without --jobid' '
+	test_must_fail flux slurm-expiration-sync 2>noslurmid.err
+'
+test_expect_success 'flux slurm-expiration-sync with invalid jobid fails' '
+	test_must_fail flux slurm-expiration-sync --jobid=foo 2>invalidid.err &&
+	grep -i "invalid" invalidid.err
+'
+test_expect_success NO_SQUEUE 'flux slurm-expiration-sync fails if squeue not in PATH' '
+	test_must_fail env PATH=$ORIG_PATH \
+		flux slurm-expiration-sync --jobid=1234 2>nosqueue.err &&
+	grep "squeue not found" nosqueue.err
+'
+# Note: In following test FLUX_MOCK_SLURM_EXPIRATION_FILE not set,
+# so squeue wrapper will fail.
+test_expect_success 'flux slurm-expiration-sync fails if squeue fails' '
+	test_must_fail flux slurm-expiration-sync --jobid=4 2>squeue-fail.err &&
+	grep "squeue failed" squeue-fail.err
+'
+test_expect_success 'flux slurm-expiration-sync works with unlimited' '
+	echo -1 > $EXPIRATION_FILE &&
+	FLUX_SLURM_MOCK_EXPIRATION_FILE=$EXPIRATION_FILE \
+	    flux slurm-expiration-sync --jobid=1234 2>unlimited.err &&
+	test_debug "cat unlimited.err" &&
+	grep -i "exiting" unlimited.err
+'
+#
+# Full flux start tests with SLURM_JOB_ID set and mock squeue
+#
+test_expect_success 'flux start without SLURM_JOB_ID leaves expiration as 0' '
+	flux start flux resource R > R-noslurm.json &&
+	check_expiration_zero R-noslurm.json
+'
+test_expect_success 'flux start with invalid SLURM_JOB_ID works with warning' '
+	SLURM_JOB_ID=invalid \
+	  flux start flux resource R 2>start-invalidid.err &&
+	test_debug "cat start-invalidid.err" &&
+	grep "invalid SLURM_JOB_ID" start-invalidid.err
+'
+test_expect_success 'flux start with unlimited Slurm time limit' '
+	echo -1 > $EXPIRATION_FILE &&
+	SLURM_JOB_ID=1234 \
+	  FLUX_SLURM_MOCK_EXPIRATION_FILE=$EXPIRATION_FILE \
+	  flux start flux resource R > R-unlimited.json &&
+	check_expiration_zero R-unlimited.json
+'
+test_expect_success 'flux start with 1 hour Slurm time limit' '
+	future_time 3600 > $EXPIRATION_FILE &&
+	test_debug "cat $EXPIRATION_FILE" &&
+	SLURM_JOB_ID=1234 \
+	  FLUX_SLURM_MOCK_EXPIRATION_FILE=$EXPIRATION_FILE \
+	  flux start flux resource R > R-1h.json &&
+	test_debug "cat R-1h.json" &&
+	check_expiration R-1h.json
+'
+test_expect_success 'flux start with 2 hour Slurm time limit' '
+	future_time 7200 > $EXPIRATION_FILE &&
+	SLURM_JOB_ID=1234 \
+	  FLUX_SLURM_MOCK_EXPIRATION_FILE=$EXPIRATION_FILE \
+	  flux start flux resource R > R-2h.json &&
+	check_expiration R-2h.json
+'
+test_expect_success 'Slurm time limit is propagated to jobs' '
+	future_time 3600 > $EXPIRATION_FILE &&
+	SLURM_JOB_ID=1234 \
+	  FLUX_SLURM_MOCK_EXPIRATION_FILE=$EXPIRATION_FILE \
+	  flux start flux run flux job timeleft > timeleft.out &&
+	timeleft=$(cat timeleft.out) &&
+	test "$timeleft" -gt 3500 &&
+	test "$timeleft" -le 3600
+'
+test_expect_success 'initial program has YOGRT_BACKEND=flux' '
+	future_time 3600 > $EXPIRATION_FILE &&
+	SLURM_JOB_ID=1234 \
+	  FLUX_SLURM_MOCK_EXPIRATION_FILE=$EXPIRATION_FILE \
+	  flux start env > yogrt.env &&
+	grep YOGRT_BACKEND=flux yogrt.env
+'
+#
+# Polling test: verify that expiration is updated when Slurm time limit changes
+#
+test_expect_success 'start slurm-expiration-sync in background with short poll interval' '
+	future_time 3600 > $EXPIRATION_FILE &&
+	SLURM_JOB_ID=1234 \
+	FLUX_SLURM_MOCK_EXPIRATION_FILE=$EXPIRATION_FILE \
+	flux exec --bg --label=slurm-sync --waitable \
+		flux slurm-expiration-sync -v --jobid=1234 --poll-interval=0.1
+'
+test_expect_success 'initial expiration is ~1 hour' '
+	flux python wait-expiration.py $(cat $EXPIRATION_FILE) &&
+	flux resource R > R-poll-initial.json &&
+	check_expiration R-poll-initial.json
+'
+test_expect_success 'update expiration file to ~2 hours and wait for poll' '
+	future_time 7200 > $EXPIRATION_FILE &&
+	flux python wait-expiration.py $(cat $EXPIRATION_FILE) &&
+	flux resource R > R-poll-updated.json &&
+	check_expiration R-poll-updated.json
+'
+# send SIGINT for graceful exit of bg slurm-expiration-sync process:
+test_expect_success 'stop slurm-expiration-sync' '
+	flux sproc kill --wait 2 slurm-sync
+'
+
+test_done


### PR DESCRIPTION
This is a proposed partial solution for #7248.

It is based on top of #7404

In short, this PR adds a new helper utility,  `flux slurm-expiration-sync`, which is started from rc1 when it appears Flux is running under Slurm. The script queries Slurm for the job's time limit at startup, and if there is one it sends the expiration to the resource module which posts a `resource-update` event. This propagates the expiration to the scheduler. The script continues to poll the Slurm time limit in case it is updated while the job is active.

To get there, some other required changes included:
- addition of a `resource.expiration-update` RPC which allows the helper script to notify the `resource` module of expiration updates
- A new `needs_env` parameter for the modprobe `@task` decorator. This allows a modprobe task to be selectively scheduled based on presence (or absence) of an environment variable. Since it may be surprising that the broker environment is filtered in rc1/rc3, `needs_env` first checks the local environment and falls back to the broker environment if the variable is not found. (This allows it to be used for `SLURM_JOB_ID` in the implementation)
- A `flux.slurm` helper Python module is added, mainly to enable easy unit testing of the Slurm squeue time limit output and syntax as well as a new `flux.slurm.slurm_timeleft()` function.
- A mock `squeue` in `t/scripts` for testing purposes.

real world demo:
```console
$ salloc -t 60 -N1 -p pdebug
salloc: Pending job allocation 5100573
salloc: job 5100573 queued and waiting for resources
salloc: job 5100573 has been allocated resources
$ srun --pty src/cmd/flux start
$ flux run flux job timeleft -H
58.3895m
```

in another window adjust slurm job timelimit `scontrol update jobid=JOBID timelimit=30m`, wait ~1m (or watch resource eventlog for resource-update event)
```console
$ flux run flux job timeleft -H
25.3813m
```

This should be enough to allow libyogrt to work for _jobs_ run in the Flux instance, but querying the remaining time will still fail if queried from the initial program environment, because `flux_job_timeleft(3)` does not work when the instance is not a Flux job. (This could be fixed by querying resource.R if we want to do that, but it could be in a separate PR)

