### PR TITLE
journal: fix spelling mistake in function docstring

### DIFF
--- a/src/bindings/python/flux/abc/journal.py
+++ b/src/bindings/python/flux/abc/journal.py
@@ -233,7 +233,7 @@ class JournalConsumerBase(ABC):
 
     @property
     def request_payload(self):
-        """Approprioate request payload for this journal RPC"""
+        """Appropriate request payload for this journal RPC"""
         return {}
 
     def start(self):


### PR DESCRIPTION
#### Problem

The word "appropriate" is misspelled in the docstring for `request_payload()` in the `JournalConsumerBase` class.

---

This PR just corrects the spelling mistake.