### PR TITLE
modprobe: allow rc1 tasks to manipulate environment of rc2 and rc3

### DIFF
--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1090,3 +1090,6 @@ prepends
 pythonX
 THISSYSTEM
 topologies
+blocklist
+OSError
+ValueError

--- a/src/common/libsubprocess/command.c
+++ b/src/common/libsubprocess/command.c
@@ -1012,7 +1012,7 @@ char **cmd_argv_expand (flux_cmd_t *cmd)
     return expand_argz (cmd->argz, cmd->argz_len);
 }
 
-int cmd_set_env (flux_cmd_t *cmd, char **env)
+int flux_cmd_env_replace (flux_cmd_t *cmd, char **env)
 {
     size_t new_envz_len = 0;
     char *new_envz = NULL;

--- a/src/common/libsubprocess/command.h
+++ b/src/common/libsubprocess/command.h
@@ -102,6 +102,12 @@ void flux_cmd_unsetenv (flux_cmd_t *cmd, const char *name);
 const char *flux_cmd_getenv (const flux_cmd_t *cmd, const char *name);
 
 /*
+ *  Replace environment for `cmd` with `env`, discarding any previous
+ *   environment.
+ */
+int flux_cmd_env_replace (flux_cmd_t *cmd, char **env);
+
+/*
  *  Set/get the working directory for the command `cmd`.
  */
 int flux_cmd_setcwd (flux_cmd_t *cmd, const char *cwd);

--- a/src/common/libsubprocess/command_private.h
+++ b/src/common/libsubprocess/command_private.h
@@ -50,11 +50,6 @@ char **cmd_env_expand (flux_cmd_t *cmd);
 char **cmd_argv_expand (flux_cmd_t *cmd);
 
 /*
- *  Set an entirely new environment, discarding internal one.
- */
-int cmd_set_env (flux_cmd_t *cmd, char **env);
-
-/*
  *  Return list of channels.  Should not be destroyed by caller.
  */
 zlist_t *cmd_channel_list (flux_cmd_t *cmd);

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -607,7 +607,7 @@ static void server_exec_cb (flux_t *h,
      * environment.
      */
     if (env[0] == NULL) {
-        if (cmd_set_env (cmd, environ) < 0) {
+        if (flux_cmd_env_replace (cmd, environ) < 0) {
             errmsg = "error setting up command environment";
             goto error;
         }

--- a/src/common/libsubprocess/test/command.c
+++ b/src/common/libsubprocess/test/command.c
@@ -111,7 +111,7 @@ void set_cmd_attributes2 (flux_cmd_t *cmd)
 {
     char *env[] = { "PATH=/bin:/usr/bin", NULL };
 
-    ok (cmd_set_env (cmd, env) == 0,
+    ok (flux_cmd_env_replace (cmd, env) == 0,
         "cmd_set_env");
 }
 

--- a/t/t0034-broker-getenv.t
+++ b/t/t0034-broker-getenv.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_description='Test broker.getenv rpc'
+test_description='Test broker.getenv and broker.setenv RPCs'
 
 . `dirname $0`/sharness.sh
 
@@ -12,11 +12,20 @@ test_under_flux 1
 umask 022
 
 broker_getenv() {
-    flux python -c "import flux; print(flux.Flux().rpc(\"broker.getenv\",{\"names\":[\"$1\"]}).get_str())"
+    names=$(printf '"%s",' "$@" | sed 's/,$//') &&
+    flux python -c "import flux; print(flux.Flux().rpc(\"broker.getenv\",{\"names\":[$names]}).get_str())"
 }
 
 broker_getenv_eproto() {
     flux python -c "import flux; print(flux.Flux().rpc(\"broker.getenv\",{}).get_str())"
+}
+
+broker_setenv() {
+    flux python -c "import flux, json; flux.Flux().rpc(\"broker.setenv\",{\"env\":json.loads('$1')}).get()"
+}
+
+broker_setenv_eproto() {
+    flux python -c "import flux; flux.Flux().rpc(\"broker.setenv\",{}).get()"
 }
 
 test_expect_success 'getenv is able to fetch test variable' '
@@ -26,6 +35,12 @@ test_expect_success 'getenv is able to fetch test variable' '
 	broker_getenv BROKER_ENV_TEST >getenv.out &&
 	jq -r -e env.BROKER_ENV_TEST <getenv.out >value.out &&
 	test_cmp value.exp value.out
+'
+
+test_expect_success 'getenv is able to fetch multiple variables' '
+	broker_getenv BROKER_ENV_TEST PATH >getenv-multi.out &&
+	jq < getenv-multi.out &&
+	jq -e ".env | length == 2" < getenv-multi.out
 '
 
 test_expect_success 'getenv returns an empty object when variable is not set' '
@@ -44,7 +59,85 @@ test_expect_success 'getenv fails for simulated guest' '
 	  test_must_fail broker_getenv BROKER_ENV_TEST \
 	) 2>eperm.err &&
 	grep "Request requires owner credentials" eperm.err
+'
 
+test_expect_success 'setenv can set a new variable' '
+	broker_setenv "{\"BROKER_ENV_TEST2\": \"efgh\"}" &&
+	broker_getenv BROKER_ENV_TEST2 >setenv1.out &&
+	test $(jq -r -e .env.BROKER_ENV_TEST2 <setenv1.out) = "efgh"
+'
+
+test_expect_success 'setenv can overwrite an existing variable' '
+	broker_setenv "{\"BROKER_ENV_TEST\": \"wxyz\"}" &&
+	broker_getenv BROKER_ENV_TEST >setenv2.out &&
+	test $(jq -r -e .env.BROKER_ENV_TEST <setenv2.out) = "wxyz"
+'
+
+test_expect_success 'setenv can set multiple variables at once' '
+	broker_setenv "{\"BROKER_ENV_MULTI1\": \"foo\", \
+	                \"BROKER_ENV_MULTI2\": \"bar\"}" &&
+	broker_getenv BROKER_ENV_MULTI1 BROKER_ENV_MULTI2 >setenv_multi.out &&
+	test $(jq -r -e .env.BROKER_ENV_MULTI1 <setenv_multi.out) = "foo" &&
+	test $(jq -r -e .env.BROKER_ENV_MULTI2 <setenv_multi.out) = "bar"
+'
+
+test_expect_success 'setenv with null value unsets the variable' '
+	broker_setenv "{\"BROKER_ENV_TEST2\": null}" &&
+	broker_getenv BROKER_ENV_TEST2 >setenv_unset.out &&
+	test $(jq -e ".env | length" <setenv_unset.out) -eq 0
+'
+
+test_expect_success 'setenv with null value is a no-op for unset variable' '
+	broker_setenv "{\"BROKER_ENV_NOTSET\": null}" &&
+	broker_getenv BROKER_ENV_NOTSET >setenv_unset2.out &&
+	test $(jq -e ".env | length" <setenv_unset2.out) -eq 0
+'
+
+test_expect_success 'setenv can mix set and unset in one call' '
+	broker_setenv "{\"BROKER_ENV_MULTI1\": null, \"BROKER_ENV_MULTI3\": \"baz\"}" &&
+	broker_getenv BROKER_ENV_MULTI1 >setenv_mix1.out &&
+	broker_getenv BROKER_ENV_MULTI3 >setenv_mix2.out &&
+	test $(jq -e ".env | length" <setenv_mix1.out) -eq 0 &&
+	test $(jq -r -e .env.BROKER_ENV_MULTI3 <setenv_mix2.out) = "baz"
+'
+
+test_expect_success 'malformed setenv request fails with EPROTO' '
+	test_must_fail broker_setenv_eproto 2>setenv_eproto.err &&
+	grep "Protocol error" setenv_eproto.err
+'
+
+test_expect_success 'setenv fails when env value is not a string or null' '
+	test_must_fail broker_setenv "{\"BROKER_ENV_BAD\": 42}" 2>setenv_bad.err &&
+	grep "Protocol error" setenv_bad.err
+'
+
+test_expect_success 'setenv fails when variable name contains =' '
+	test_must_fail broker_setenv "{\"BAD=NAME\": \"val\"}" 2>setenv_badname.err &&
+	grep "Protocol error" setenv_badname.err
+'
+
+test_expect_success 'setenv fails for empty variable name' '
+	test_must_fail broker_setenv "{\"\": \"val\"}" 2>setenv_emptyname.err &&
+	grep "Protocol error" setenv_emptyname.err
+'
+
+test_expect_success 'setenv validation failure leaves no variables set' '
+	test_must_fail broker_setenv \
+	    "{\"SETENV_ATOMIC\": \"ok\", \
+	      \"BAD=NAME\": \"val\", \
+	      \"SETENV_ATOMIC2\": \"ok\"}" \
+	    2>setenv_atomic.err &&
+	grep "Protocol error" setenv_atomic.err &&
+	broker_getenv SETENV_ATOMIC SETENV_ATOMIC2 >atomic.json &&
+	test $(jq -e ".env | length" <atomic.json) -eq 0
+'
+
+test_expect_success 'setenv fails for simulated guest' '
+	( export FLUX_HANDLE_ROLEMASK=0x2; \
+	  export FLUX_HANDLE_USERID=$(($(id -u)+1)); \
+	  test_must_fail broker_setenv "{\"BROKER_ENV_TEST\": \"val\"}" \
+	) 2>setenv_eperm.err &&
+	grep "Request requires owner credentials" setenv_eperm.err
 '
 
 test_done


### PR DESCRIPTION
This PR solves the issue described in #7407, namely that rc1 can't modify the environment that will be seen by rc2 (or rc3), since it runs as s separate process from the broker.

This PR:
- adds a `broker.setenv` RPC that allows an instance owner to set or unset environment variables in the broker's address space
- moves the initialization of the environment for runat tasks to just before they are launched, so that any changes made by rc1 are reflected in rc2 and rc3
- moves the modprobe `context.getenv()` and `needs_env` implementation from #7405 to this PR
- adds `context.setenv()` to modprobe which modprobe tasks can use to set environment variables that should be exported locally as well as to rc2 and rc3

Fixes #7407