### PR TITLE
flux-resource: eventlog: add --match-context and --timeout options

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -403,6 +403,19 @@ Watch the resource journal, which is described in RFC 44.
   The current set of valid events events is *restart*, *resource-define*,
   *online*, *offline*, *drain*, *undrain*, *torpid*, and *lively*.
 
+.. option:: -m, --match-context=KEY=VAL
+
+  When used with :option:`--wait`, skip events whose context does not
+  contain a matching KEY=VAL pair. This option may be repeated to
+  require multiple pairs to match. Floating point values are compared
+  within an absolute tolerance of 1e-5 rather than exactly.
+
+.. option:: -t, --timeout=FSD
+
+  When used with :option:`--wait`, exit with an error if the expected
+  event is not received within the specified duration in RFC 23 Flux
+  Standard Duration form (e.g. ``1.5``, ``5s``, ``1.5m``).
+
 .. option:: -i, --include=TARGETS
 
   Filter events to only include those that apply to  *TARGETS*, which is

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -833,6 +833,8 @@ def eventlog(args):
         args.time_format = "human"
     if args.color is None:
         args.color = "auto"
+    if args.wait:
+        args.follow = True
 
     h = flux.Flux()
     targets = Targets(h, args.include)

--- a/t/t2318-resource-verify.t
+++ b/t/t2318-resource-verify.t
@@ -46,12 +46,12 @@ drain_reason_matches() {
 }
 
 test_expect_success 'load test R with unlikely core, GPU count' '
-	flux R encode -r 0 -c 0-1048 -g 0-7 >R.test &&
+	flux R encode -r 0 -c 0-1047 -g 0-127 >R.test &&
 	flux kvs put resource.R="$(cat R.test)"
 '
 
 # Test default behavior with implicit config
-# Expected R has 1048 cores, 8 GPUs - actual system (likely!) has fewer
+# Expected R has 1048 cores, 128 GPUs - actual system (likely!) has fewer
 # With default config (allow-extra cores, strict hostname, ignore GPUs),
 # missing cores will drain since allow-extra only allows EXTRA, not missing
 test_expect_success 'default config drains on missing cores' '


### PR DESCRIPTION
This PR adds a couple convenience options to `flux resource eventlog` that will be useful in testing:
- `-m --match-context=KEY=VAL` allows matching one more more context keys to expected values, which is useful for waiting for expected events with `--wait=EVENT` that may occur more than once.
- `-t, --timeout=FSD` is useful for aborting a `--wait` after a timeout
