### PR TITLE
libjob: fix `flux_job_timeleft()` under foreign resource managers

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -380,9 +380,13 @@ left in the current or specified job time limit. If the job has expired or is
 complete, then this command reports ``0``. If the job does not have a time
 limit, then a large number (``UINT_MAX``) is reported.
 
-If :program:`flux job timeleft` is called outside the context of a Flux job, or
-an invalid or pending job is targeted, then this command will exit with
-an error and diagnostic message.
+If :program:`flux job timeleft` is called outside the context of a Flux job,
+the remaining time is determined from the expiration of the enclosing Flux
+instance, if any. If the instance has no expiration, a large number
+(``UINT_MAX`` or ``infinity`` with :option:`-H`) is reported.
+
+If an invalid or pending job is targeted, or another error occurs, then this
+command will exit with an error and diagnostic message.
 
 Options:
 

--- a/doc/man3/flux_job_timeleft.rst
+++ b/doc/man3/flux_job_timeleft.rst
@@ -20,23 +20,25 @@ Link with :command:`-lflux-core`.
 DESCRIPTION
 ===========
 
-The :func:`flux_job_timeleft` function determines if the calling process
-is executing within the context of a Flux job (either a parallel job or
-a Flux instance running as a job), then handles querying the appropriate
-service for the remaining time in the job.
+The :func:`flux_job_timeleft` function returns the remaining time available
+to the calling process.  If the ``FLUX_JOB_ID`` environment variable is set,
+the process is assumed to be part of a Flux job and the remaining time is
+determined by querying the job's expiration from the job-list service.
+Otherwise, the expiration is determined from the instance's resource set (R)
+via the ``resource.status`` RPC, which works for any enclosing Flux instance
+with a valid expiration regardless of how it was launched.
 
 RETURN VALUE
 ============
 
 :func:`flux_job_timeleft` returns 0 on success with the remaining time in
-floating point seconds stored in :var:`timeleft`. If the job does not have
-an established time limit, then :var:`timeleft` is set to ``inf``. If the job
-time limit has expired or the job is no longer running, then :var:`timeleft`
-is set to ``0``.
+floating point seconds stored in :var:`timeleft`.  If the enclosing job or
+instance does not have an established time limit, then :var:`timeleft` is set
+to ``inf``.  If the time limit has expired or the job is no longer running,
+then :var:`timeleft` is set to ``0``.
 
-If the current process is not part of an active job or instance, or another
-error occurs, then this function returns ``-1`` with an error string set in
-``error->text``.
+If an error occurs, then this function returns ``-1`` with an error string
+set in ``error->text``.
 
 RESOURCES
 =========

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -634,10 +634,6 @@ test_expect_success 'flux job: kill can operate on multiple jobs' '
 		grep status=$((15+128<<8)) killmulti.out
 	done
 '
-test_expect_success 'flux job: timeleft reports error outside of a job' '
-	test_expect_code 1 flux job timeleft
-'
-
 test_expect_success 'flux job: timeleft reports large int with no time limit' '
 	flux run flux job timeleft > timeleft1 &&
 	test $(cat timeleft1) -gt 9999999


### PR DESCRIPTION
Currently, `flux_job_timeleft()` only works for determining the remaining time of the enclosing instance when that instance was launched as a Flux job. This PR queries the expiration for instances from R in the `resource.status RPC` instead of querying the job-list service in the parent, allowing the function to return the correct time remaining for any instance with an expiration set.

Users of `flux_job_timeleft()`, including `flux job timeleft` and libyogrt, will now report time left correctly in instances started under Slurm (with slurm-expiration-sync) or any other foreign resource manager that sets an expiration.

This is based on #7410 since the new `flux resource eventlog` options are used in testing.

Example:

```console
$ squeue -j $SLURM_JOB_ID -o %L
TIME_LEFT
27:23
$ srun -N1 src/cmd/flux start flux job timeleft -H
27.296m
```