### PR TITLE
Support `NO_COLOR` environment variable in Flux utilities with `--color` option

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -430,6 +430,7 @@ $(RST_FILES): \
 	man1/common/job-other-run.rst \
 	man1/common/job-shell-options.rst \
 	man1/common/job-mustache-templates.rst \
+	man1/common/color.rst \
 	man3/common/resources.rst \
 	man3/common/experimental.rst \
 	man3/common/json_pack.rst \
@@ -534,6 +535,7 @@ EXTRA_DIST = \
 	man1/common/job-other-run.rst \
 	man1/common/job-shell-options.rst \
 	man1/common/job-mustache-templates.rst \
+	man1/common/color.rst \
 	man3/common/resources.rst \
 	man3/common/experimental.rst \
 	man3/index.rst \

--- a/doc/man1/common/color.rst
+++ b/doc/man1/common/color.rst
@@ -1,0 +1,4 @@
+Colorize output. The optional argument *WHEN* can be "always", "never",
+or "auto". If *WHEN* is omitted, "always" is used. When the option is
+not used, the default is "auto", or "never" if :envvar:`NO_COLOR` is set
+to a non-empty value in the environment.

--- a/doc/man1/flux-dmesg.rst
+++ b/doc/man1/flux-dmesg.rst
@@ -50,9 +50,7 @@ OPTIONS
 
 .. option:: -L, --color[=WHEN]
 
-   Colorize output. The optional argument *WHEN* can be *auto*, *never*,
-   or *always*. If *WHEN* is omitted, it defaults to *always*. The default
-   value when the :option:`--color` option is not used is *auto*.
+   .. include:: common/color.rst
 
 EXAMPLES
 ========

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -138,9 +138,7 @@ OPTIONS
 
 .. option:: --color[=WHEN]
 
-   Control output coloring.  The optional argument *WHEN* can be
-   *auto*, *never*, or *always*.  If *WHEN* is omitted, it defaults to
-   *always*.  Otherwise the default is *auto*.
+  .. include:: common/color.rst
 
 .. option:: --stats
 

--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -507,9 +507,7 @@ Display the contents of an RFC 18 KVS eventlog referred to by *key*.
 
 .. option:: -L, --color[=WHEN]
 
-  Control output colorization. The optional argument *WHEN* can be one of
-  'auto', 'never', or 'always'. The default value of *WHEN* if omitted is
-  'always'. The default is 'auto' if the option is unused.
+  .. include:: common/color.rst
 
 .. option:: -S, --stream
 
@@ -566,10 +564,7 @@ referred to by *key*.
 
 .. option:: -L, --color[=WHEN]
 
-  Control output colorization. The optional argument *WHEN* can be one of
-  'auto', 'never', or 'always'. The default value of *WHEN* if omitted is
-  'always'. The default is 'auto' if the option is unused.
-
+  .. include:: common/color.rst
 
 
 RESOURCES

--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -189,10 +189,9 @@ named modules, or all modules if none are named.
    Filter output by message type, a comma-separated list.  Valid types are
    ``request``, ``response``, ``event``, or ``control``.
 
-.. option:: -L, --color=WHEN
+.. option:: -L, --color[=WHEN]
 
-   Colorize output when supported; WHEN can be ``always`` (default if omitted),
-   ``never``, or ``auto`` (default).
+  .. include:: common/color.rst
 
 .. option:: -H, --human
 

--- a/doc/man1/flux-overlay.rst
+++ b/doc/man1/flux-overlay.rst
@@ -67,10 +67,9 @@ below.
    Do not fill in presumed state of nodes that are inaccessible behind
    offline/lost overlay parents.
 
-.. option:: -L, --color=WHEN
+.. option:: -L, --color[=WHEN]
 
-   Colorize output when supported; WHEN can be 'always' (default if omitted),
-   'never', or 'auto' (default).
+  .. include:: common/color.rst
 
 .. option:: -H, --highlight=TARGET
 
@@ -145,10 +144,7 @@ argument.
    Filter output by message type, a comma-separated list.  Valid types are
    ``request``, ``response``, ``event``, or ``control``.
 
-.. option:: -L, --color=WHEN
-
-   Colorize output when supported; WHEN can be ``always`` (default if omitted),
-   ``never``, or ``auto`` (default).
+.. include:: common/color.rst
 
 .. option:: -H, --human
 

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -388,9 +388,7 @@ Watch the resource journal, which is described in RFC 44.
 
 .. option:: -L, --color[=WHEN]
 
-  Control color output. The optional argument *WHEN* can be one of *auto*,
-  *never*, or *always*. If *WHEN* is omitted, it defaults to *always*.
-  Otherwise the default is *auto*.
+  .. include:: common/color.rst
 
 .. option:: -F, --follow
 

--- a/doc/man1/flux-top.rst
+++ b/doc/man1/flux-top.rst
@@ -35,9 +35,7 @@ OPTIONS
 
 .. option:: --color[=WHEN]
 
-   Colorize output.  The optional argument *WHEN* can be *auto*, *never*,
-   or *always*.  If *WHEN* is omitted, it defaults to *always*. The default
-   value when the :option:`--color` option is not used is *auto*.
+  .. include:: common/color.rst
 
 .. option:: -q, --queue=NAME
 

--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -560,6 +560,12 @@ MISCELLANEOUS
    configured to launch jobs with systemd, as described in
    :man5:`flux-config-exec`.
 
+.. envvar:: NO_COLOR
+
+   If set to a non-empty value, Flux utilities that support the
+   :option:`--color` option default to "never" instead of "auto", disabling
+   color output unless :option:`--color` is explicitly passed on the command
+   line.  See `no-color.org <https://no-color.org>`_ for details.
 
 .. _sub_command_environment:
 

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -233,27 +233,11 @@ void dmesg_print (struct dmesg_ctx *ctx,
     fflush (stdout);
 }
 
-static void dmesg_colors_init (struct dmesg_ctx *ctx)
-{
-    const char *when;
-
-    if (!(when = optparse_get_str (ctx->p, "color", "auto")))
-        when = "always";
-    if (streq (when, "always"))
-        ctx->color = 1;
-    else if (streq (when, "never"))
-        ctx->color = 0;
-    else if (streq (when, "auto"))
-        ctx->color = isatty (STDOUT_FILENO) ? 1 : 0;
-    else
-        log_msg_exit ("Invalid argument to --color: '%s'", when);
-}
-
 static void dmesg_ctx_init (struct dmesg_ctx *ctx, optparse_t *p)
 {
     memset (ctx, 0, sizeof (*ctx));
     ctx->p = p;
-    dmesg_colors_init (ctx);
+    ctx->color = optparse_get_color (ctx->p, "color");
     if (optparse_hasopt (p, "delta")) {
         if (!optparse_hasopt (p, "human"))
             log_msg_exit ("--delta can only be used with --human");

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -714,20 +714,7 @@ static bool validate_wait (const char *wait)
 // N.B. used by both status and trace subcommands
 static int status_use_color (optparse_t *p)
 {
-    const char *when;
-    int color;
-
-    if (!(when = optparse_get_str (p, "color", "auto")))
-        when = "always";
-    if (streq (when, "always"))
-        color = 1;
-    else if (streq (when, "never"))
-        color = 0;
-    else if (streq (when, "auto"))
-        color = isatty (STDOUT_FILENO) ? 1 : 0;
-    else
-        log_msg_exit ("Invalid argument to --color: '%s'", when);
-    return color;
+    return optparse_get_color (p, "color");
 }
 
 static struct idset *highlight_ranks (struct status *ctx, optparse_t *p)

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -22,6 +22,7 @@ from flux.idset import IDset
 from flux.job import JobID, JobInfo, JobInfoFormat, JobList, job_fields_to_attrs
 from flux.job.stats import JobStats
 from flux.util import (
+    ColorAction,
     FilterAction,
     FilterActionSetUpdate,
     FilterActionUser,
@@ -123,7 +124,7 @@ def fetch_jobs_flux(args, fields, flux_handle=None):
 
     attrs = job_fields_to_attrs(fields)
 
-    if args.color == "always" or args.color == "auto":
+    if args.color.enabled:
         attrs.update(job_fields_to_attrs(["result", "annotations"]))
     if args.recursive:
         attrs.update(job_fields_to_attrs(["annotations", "status", "userid"]))
@@ -336,16 +337,7 @@ def parse_args():
         action="store_true",
         help="Output jobs in JSON instead of formatted output",
     )
-    parser.add_argument(
-        "--color",
-        type=str,
-        metavar="WHEN",
-        choices=["never", "always", "auto"],
-        nargs="?",
-        const="always",
-        default="auto",
-        help="Colorize output; WHEN can be 'never', 'always', or 'auto' (default)",
-    )
+    parser.add_argument("--color", action=ColorAction)
     parser.add_argument(
         "-R",
         "--recursive",
@@ -397,7 +389,7 @@ def parse_args():
 
 
 def color_setup(args, job):
-    if args.color == "always" or (args.color == "auto" and sys.stdout.isatty()):
+    if args.color.enabled:
         if job.result:
             if job.result == "COMPLETED":
                 sys.stdout.write("\033[01;32m")

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -1960,11 +1960,12 @@ struct eventlog_wait_event_ctx {
 static struct eventlog_formatter *formatter_create (optparse_t *p)
 {
     struct eventlog_formatter *evf;
-    const char *color = optparse_get_str (p, "color", "auto");
+    int color = optparse_get_color (p, "color");
     bool human = optparse_hasopt (p, "human");
     bool unformatted = optparse_hasopt (p, "unformatted");
 
-    if (unformatted && (human || streq (color, "always"))) {
+    if (unformatted
+        && (human || streq (optparse_get_str (p, "color", ""), "always"))) {
         log_msg ("Do not specify --unformatted with --human or --color=always");
         return NULL;
     }
@@ -1980,10 +1981,7 @@ static struct eventlog_formatter *formatter_create (optparse_t *p)
         log_err ("failed to set human timestamp format");
         goto error;
     }
-    if (eventlog_formatter_colors_init (evf, color ? color : "always") < 0) {
-        log_err ("invalid value: --color=%s", color);
-        goto error;
-    }
+    (void) eventlog_formatter_set_color (evf, color);
     return evf;
 error:
     eventlog_formatter_destroy (evf);

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -947,24 +947,6 @@ static void trace_print (struct trace_ctx *ctx,
             trace_color_reset (ctx));
 }
 
-static int trace_use_color (optparse_t *p)
-{
-    const char *when;
-    int color;
-
-    if (!(when = optparse_get_str (p, "color", "auto")))
-        when = "always";
-    if (streq (when, "always"))
-        color = 1;
-    else if (streq (when, "never"))
-        color = 0;
-    else if (streq (when, "auto"))
-        color = isatty (STDOUT_FILENO) ? 1 : 0;
-    else
-        log_msg_exit ("Invalid argument to --color: '%s'", when);
-    return color;
-}
-
 static int parse_name_list (json_t **result, int ac, char **av)
 {
     json_t *a;
@@ -1010,7 +992,7 @@ static void trace_ctx_init (struct trace_ctx *ctx,
     }
     ctx->match = FLUX_MATCH_ANY;
     ctx->match.topic_glob = optparse_get_str (p, "topic", "*");
-    ctx->color = trace_use_color (p); // borrowed from status subcommand
+    ctx->color = optparse_get_color (p, "color");
     if (optparse_hasopt (p, "type")) {
         const char *arg;
 

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -33,6 +33,7 @@ from flux.resource import (
 from flux.rpc import RPC
 from flux.util import (
     AltField,
+    ColorAction,
     Deduplicator,
     FilterActionSetUpdate,
     UtilConfig,
@@ -451,7 +452,7 @@ def status(args):
     formatter = flux.util.OutputFormat(fmt, headings=headings)
 
     # Remove any `{color*}` fields if color is off
-    if args.color == "never" or (args.color == "auto" and not sys.stdout.isatty()):
+    if not args.color.enabled:
         formatter = formatter.copy(except_fields=["color_up", "color_off"])
 
     #  Skip empty lines unless --states or --skip-empty
@@ -994,13 +995,7 @@ def main():
     drain_parser.add_argument(
         "-L",
         "--color",
-        type=str,
-        metavar="WHEN",
-        choices=["never", "always", "auto"],
-        nargs="?",
-        const="always",
-        default="auto",
-        help="Use color; WHEN can be 'never', 'always', or 'auto' (default)",
+        action=ColorAction,
     )
     drain_parser.add_argument(
         "targets", nargs="?", help="List of targets to drain (IDSET or HOSTLIST)"
@@ -1069,13 +1064,7 @@ def main():
     status_parser.add_argument(
         "-L",
         "--color",
-        type=str,
-        metavar="WHEN",
-        choices=["never", "always", "auto"],
-        nargs="?",
-        const="always",
-        default="auto",
-        help="Use color; WHEN can be 'never', 'always', or 'auto' (default)",
+        action=ColorAction,
     )
     status_parser.add_argument(
         "--from-stdin", action="store_true", help=argparse.SUPPRESS
@@ -1251,13 +1240,7 @@ def main():
     eventlog_parser.add_argument(
         "-L",
         "--color",
-        type=str,
-        metavar="WHEN",
-        choices=["never", "always", "auto"],
-        nargs="?",
-        const="always",
-        default="auto",
-        help="Use color; WHEN can be 'never', 'always', or 'auto' (default)",
+        action=ColorAction,
     )
     eventlog_parser.add_argument(
         "-F",

--- a/src/cmd/job/eventlog.c
+++ b/src/cmd/job/eventlog.c
@@ -141,7 +141,7 @@ static void formatter_parse_options (optparse_t *p,
 {
     const char *format = optparse_get_str (p, "format", "text");
     const char *time_format = optparse_get_str (p, "time-format", "raw");
-    const char *when = optparse_get_str (p, "color", "auto");
+    int color = optparse_get_color (p, "color");
 
     if (optparse_hasopt (p, "human")) {
         format = "text",
@@ -152,8 +152,7 @@ static void formatter_parse_options (optparse_t *p,
         log_msg_exit ("invalid format type '%s'", format);
     if (eventlog_formatter_set_timestamp_format (evf, time_format) < 0)
         log_msg_exit ("invalid time-format type '%s'", time_format);
-    if (eventlog_formatter_colors_init (evf, when ? when : "always") < 0)
-        log_msg_exit ("invalid value: --color=%s", when);
+    (void) eventlog_formatter_set_color (evf, color);
 }
 
 static void eventlog_continuation (flux_future_t *f, void *arg)

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -311,24 +311,6 @@ fail:
     return NULL;
 }
 
-static int color_optparse (optparse_t *opts)
-{
-    const char *when;
-    int color = 0;
-
-    if (!(when = optparse_get_str (opts, "color", "auto")))
-        when = "always";
-    if (streq (when, "always"))
-        color = 1;
-    else if (streq (when, "never"))
-        color = 0;
-    else if (streq (when, "auto"))
-        color = isatty (STDOUT_FILENO) ? 1 : 0;
-    else
-        fatal (0, "Invalid argument to --color: '%s'", when);
-    return color;
-}
-
 static struct optparse_option cmdopts[] = {
     { .name = "test-exit", .has_arg = 0, .flags = OPTPARSE_OPT_HIDDEN,
       .usage = "Exit after screen initialization, for testing",
@@ -376,7 +358,7 @@ int main (int argc, char *argv[])
     }
     if (!isatty (STDIN_FILENO))
         fatal (0, "stdin is not a terminal");
-    initialize_curses (color_optparse (opts));
+    initialize_curses (optparse_get_color (opts, "color"));
 
     if (!(top = top_create (target,
                             NULL,

--- a/src/common/libeventlog/formatter.c
+++ b/src/common/libeventlog/formatter.c
@@ -105,6 +105,20 @@ struct eventlog_formatter *eventlog_formatter_create ()
     return evf;
 }
 
+int eventlog_formatter_set_color (struct eventlog_formatter *evf, int color)
+{
+    if (!evf || color < 0 || color > 1) {
+        errno = EINVAL;
+        return -1;
+    }
+    /* For now, always enable context colorization if evf->color is set:
+     * (This is a separate variable to allow for future possible disablement)
+     */
+    evf->color = color;
+    evf->context_color = color;
+    return 0;
+}
+
 int eventlog_formatter_colors_init (struct eventlog_formatter *evf,
                                     const char *when)
 {

--- a/src/common/libeventlog/formatter.c
+++ b/src/common/libeventlog/formatter.c
@@ -119,30 +119,6 @@ int eventlog_formatter_set_color (struct eventlog_formatter *evf, int color)
     return 0;
 }
 
-int eventlog_formatter_colors_init (struct eventlog_formatter *evf,
-                                    const char *when)
-{
-    if (!evf || !when) {
-        errno = EINVAL;
-        return -1;
-    }
-    if (streq (when, "always"))
-        evf->color = 1;
-    else if (streq (when, "never"))
-        evf->color = 0;
-    else if (streq (when, "auto"))
-        evf->color = isatty (STDOUT_FILENO) ? 1 : 0;
-    else {
-        errno = EINVAL;
-        return -1;
-    }
-    /* For now, always enable context colorization if evf->color is set:
-     * (This is a separate variable to allow for future possible disablement)
-     */
-    evf->context_color = evf->color;
-    return 0;
-}
-
 void eventlog_formatter_set_no_newline (struct eventlog_formatter *evf)
 {
     if (evf) {

--- a/src/common/libeventlog/formatter.h
+++ b/src/common/libeventlog/formatter.h
@@ -24,6 +24,11 @@ void eventlog_formatter_destroy (struct eventlog_formatter *evf);
 int eventlog_formatter_colors_init (struct eventlog_formatter *evf,
                                     const char *when);
 
+/*  Enable color if color=1, disable if color=0.
+ *  Returns -1 with EINVAL if color is not 0 or 1.
+ */
+int eventlog_formatter_set_color (struct eventlog_formatter *evf, int color);
+
 /*  Reset an eventlog formatter. (Clear t0 timestamp).
  *  Formatting options remain unchanged.
  */

--- a/src/common/libeventlog/formatter.h
+++ b/src/common/libeventlog/formatter.h
@@ -19,11 +19,6 @@
 struct eventlog_formatter *eventlog_formatter_create (void);
 void eventlog_formatter_destroy (struct eventlog_formatter *evf);
 
-/*  Set color: when can be "always", "never", or "auto":
- */
-int eventlog_formatter_colors_init (struct eventlog_formatter *evf,
-                                    const char *when);
-
 /*  Enable color if color=1, disable if color=0.
  *  Returns -1 with EINVAL if color is not 0 or 1.
  */

--- a/src/common/libeventlog/test/formatter.c
+++ b/src/common/libeventlog/test/formatter.c
@@ -170,8 +170,8 @@ static void test_basic ()
             BAIL_OUT ("failed to load JSON input '%s'", test->input);
 
         /* Disable color for tests */
-        ok (eventlog_formatter_colors_init (evf, "never") == 0,
-            "eventlog_formatter_colors_init (never)");
+        ok (eventlog_formatter_set_color (evf, 0) == 0,
+            "eventlog_formatter_set_color (0)");
 
         /* 1. Test unformatted, should equal input
          */
@@ -229,8 +229,8 @@ static void test_basic ()
 
         /* 5. Test "reltime"/"human" timestamp with color
          */
-        ok (eventlog_formatter_colors_init (evf, "always") == 0,
-            "eventlog_formatter_colors_init (always)");
+        ok (eventlog_formatter_set_color (evf, 1) == 0,
+            "eventlog_formatter_set_color (1)");
         ok (eventlog_formatter_set_timestamp_format (evf, "human") == 0,
             "eventlog_formatter_set_timestamp_format human works");
         ok ((result = eventlog_entry_dumps (evf, &error, entry)) != NULL,
@@ -275,13 +275,6 @@ static void test_invalid ()
         "eventlog_formatter_set_format (NULL, \"text\") returns EINVAL");
     ok (eventlog_formatter_set_format (evf, "foo") < 0 && errno == EINVAL,
         "eventlog_formatter_set_format (evf, \"foo\") returns EINVAL");
-
-    ok (eventlog_formatter_colors_init (NULL, "auto") < 0 && errno == EINVAL,
-        "eventlog_formatter_colors_init (NULL, \"auto\") returns EINVAL");
-    ok (eventlog_formatter_colors_init (evf, NULL) < 0 && errno == EINVAL,
-        "eventlog_formatter_colors_init (evf, NULL) returns EINVAL");
-    ok (eventlog_formatter_colors_init (evf, "foo") < 0 && errno == EINVAL,
-        "eventlog_formatter_colors_init (evf, \"foo\") returns EINVAL");
 
     ok (eventlog_formatter_set_color (NULL, 1) < 0 && errno == EINVAL,
         "eventlog_formatter_set_color (NULL, 1) returns EINVAL");

--- a/src/common/libeventlog/test/formatter.c
+++ b/src/common/libeventlog/test/formatter.c
@@ -283,6 +283,13 @@ static void test_invalid ()
     ok (eventlog_formatter_colors_init (evf, "foo") < 0 && errno == EINVAL,
         "eventlog_formatter_colors_init (evf, \"foo\") returns EINVAL");
 
+    ok (eventlog_formatter_set_color (NULL, 1) < 0 && errno == EINVAL,
+        "eventlog_formatter_set_color (NULL, 1) returns EINVAL");
+    ok (eventlog_formatter_set_color (evf, -1) < 0 && errno == EINVAL,
+        "eventlog_formatter_set_color (evf, -1) returns EINVAL");
+    ok (eventlog_formatter_set_color (evf, 2) < 0 && errno == EINVAL,
+        "eventlog_formatter_set_color (evf, 2) returns EINVAL");
+
     if (!(good = json_pack ("{s:f s:s s:{s:s}}",
                             "timestamp", 1699995759.0,
                             "name", "good",

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #endif
 #include <stdio.h>
+#include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -1071,6 +1072,28 @@ const char *optparse_get_str (optparse_t *p,
     if (n == 0)
         return default_value;
     return s;
+}
+
+int optparse_get_color (optparse_t *p, const char *name)
+{
+    const char *when = "auto";
+
+    /* Option used without an argument (optparse_get_str() returns NULL)
+     * implies "always":
+     */
+    when = optparse_get_str (p, name, when);
+    if (when == NULL)
+        when = "always";
+
+    if (streq (when, "always"))
+        return 1;
+    if (streq (when, "never"))
+        return 0;
+    if (streq (when, "auto"))
+        return isatty (STDOUT_FILENO) ? 1 : 0;
+
+    optparse_fatalmsg (p, 1, "Invalid argument to --%s: '%s'", name, when);
+    return -1;
 }
 
 const char *optparse_getopt_next (optparse_t *p, const char *name)

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -1077,6 +1077,13 @@ const char *optparse_get_str (optparse_t *p,
 int optparse_get_color (optparse_t *p, const char *name)
 {
     const char *when = "auto";
+    const char *no_color = getenv ("NO_COLOR");
+
+    /* If NO_COLOR set to a non-empty value, set default to 'never'
+     * (See no-color.org)
+     */
+    if (no_color && no_color[0] != '\0')
+        when = "never";
 
     /* Option used without an argument (optparse_get_str() returns NULL)
      * implies "always":

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -434,6 +434,9 @@ const char *optparse_get_str (optparse_t *p,
  *
  *  If the option is provided without an argument, "always" is assumed.
  *
+ *  If NO_COLOR is set to a non-empty value in the environment, the default
+ *  is "never" instead of "auto", but an explicit option argument overrides it.
+ *
  *  Calls the fatal error function if 'name' is unknown or if the argument
  *  is not one of the supported values above.
  */

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -424,6 +424,22 @@ const char *optparse_get_str (optparse_t *p,
                               const char *default_value);
 
 /*
+ *  Check option 'name' (typically "color") for standard color-enablement
+ *  arguments, returning 1 if color should be enabled or 0 if not.
+ *  Supported arguments are:
+ *
+ *   "auto"   enable color if stdout is connected to a tty (default)
+ *   "always" force enable color
+ *   "never"  force disable color
+ *
+ *  If the option is provided without an argument, "always" is assumed.
+ *
+ *  Calls the fatal error function if 'name' is unknown or if the argument
+ *  is not one of the supported values above.
+ */
+int optparse_get_color (optparse_t *p, const char *name);
+
+/*
  *   Return option index from previous call to optparse_parse_args ().
  *    Returns -1 if args have not yet been parsed, and thus option index is
  *    not valid.


### PR DESCRIPTION
Many Flux utilities support a `--color` option but each implements its own processing logic, and none supports the `NO_COLOR` environment variable for disabling color by default as described at [no-color.org](https://no-color.org).

This PR first replaces replicated code for processing the standard `--color[=WHEN]` option with standard interfaces for C (`optparse_get_color()`) and Python (a new `ColorAction` `argparse.Action` class). Utilities with `--color` options are then transitioned to these interfaces to reduce duplication, unify behavior, and support the `NO_COLOR` environment variable.
Finally, documentation is standardized as well and `NO_COLOR` is added to `flux-environment(7)`.
