### PR TITLE
protect job `--progress`  bar from terminal escape codes with `--watch`

### DIFF
--- a/src/bindings/python/flux/job/watcher.py
+++ b/src/bindings/python/flux/job/watcher.py
@@ -9,6 +9,7 @@
 ##############################################################
 
 import os
+import re
 import sys
 import time
 from collections import Counter
@@ -16,6 +17,24 @@ from collections import Counter
 import flux
 from flux.job import output_watch_async
 from flux.progress import ProgressBar
+
+# Strip VT100/ANSI sequences that manipulate cursor position, the scroll
+# region, alternate screen, or screen contents from job output when a progress
+# bar is active.  Replaying these codes through the terminal corrupts the
+# Bottombar/ProgressBar scroll region setup.  SGR sequences (colors/styles,
+# ending in 'm') are deliberately left intact.
+_TERMINAL_ESCAPE_RE = re.compile(
+    r"\033\[[\d;]*r"  # set/reset scroll region: ESC [ ... r
+    r"|\033\[[\d;]*[HJf]"  # cursor position / erase in display / move
+    r"|\033\[[\d;]*[ABCD]"  # cursor movement: up/down/forward/backward
+    r"|\033\[[\d;]*t"  # window manipulation: ESC [ ... t
+    r"|\033\[\?[\d;]*[hl]"  # DEC private mode set/reset (incl. alt screen)
+    r"|\0337"  # save cursor: ESC 7
+    r"|\0338"  # restore cursor: ESC 8
+    r"|\033D"  # index (scroll down): ESC D
+    r"|\033M"  # reverse index (scroll up): ESC M
+    r"|\033c"  # full terminal reset: ESC c
+)
 
 
 class JobStatus:
@@ -582,6 +601,8 @@ class JobWatcher:
         stream, data = future.get_output()
         if stream is not None:
             output_stream = getattr(job, stream)
+            if self.show_progress:
+                data = _TERMINAL_ESCAPE_RE.sub("", data)
             if self.labelio:
                 for line in data.splitlines(keepends=True):
                     output_stream.write(f"{job.id}: {line}")

--- a/t/scripts/runpty.py
+++ b/t/scripts/runpty.py
@@ -385,7 +385,7 @@ def main():
         ofile = formatter(args.output, width=width, height=height)
         buf = TTYBuffer(fd, linebuffer=args.line_buffer)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
 
         if args.input and args.input == "none":
 

--- a/t/t2292-job-update-running.t
+++ b/t/t2292-job-update-running.t
@@ -188,7 +188,7 @@ fi
 # 8. Ensure new expiration is 300s greater than old expiration
 #
 test_expect_success "${label}expiration update is detected by subinstance" '
-	id=$(flux alloc --bg -t5m -n4 $conf_arg) &&
+	id=$(flux alloc --bg -t5m -N4 $conf_arg) &&
 	exp1=$(subinstance_get_expiration $id) &&
 	test_debug "echo instance expiration is $exp1" &&
 	subinstance_check_R $id &&


### PR DESCRIPTION
When using `--watch --progress` with `flux watch`, `flux submit`, or `flux bulksubmit`, job output that happens to emit VT100 escape codes can corrupt the progress bar display. Since escape codes that modify terminal layout aren't likely to be useful when watching output from multiple jobs anyway, just suppress the display of sequences in the Python `JobWatcher` class when a progress bar is active.

This fixes the one use case I have which is to run the entire testsuite under `flux bulksubmit` with a progress indicator:
```
$ flux bulksubmit -o pty --watch --progress -n1 ./{} -d -v ::: t*.t
```
