### PR TITLE
broker: support module loaders other than the built-in DSO one

### DIFF
--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -22,7 +22,43 @@ DESCRIPTION
 .. program:: flux module
 
 :program:`flux module` manages dynamically loadable :man1:`flux-broker` modules.
+Modules are automatically loaded at Flux instance start up (rc1) and unloaded
+at Flux instance shutdown (rc3) using :man1:`flux-modprobe`, which is
+configured to be aware of module dependencies.  :program:`flux module` is
+more often used in test or debugging situations.
 
+Broker modules are loaded under a *name* that is automatically registered
+as a service endpoint. The name may be derived from the module file name
+or overridden on the command line.  The same module may be loaded multiple
+times under different names, although not all modules support this.  Once
+loaded, the name is used as a handle for the loaded module instance by the
+other sub-commands.
+
+Broker modules communicate with other Flux components solely with messages
+and utilize reactive (event loop) programming for concurrency, which presents
+challenges for traditional debugging techniques.  Therefore
+:program:`flux module` provides sub-commands for introspection and message
+tracing.
+
+Broker modules are often implemented as dynamic shared objects loaded
+into broker threads, but they may also be loaded into separate processes.
+This may be necessary for isolation, or to support incompatible programming
+runtime environments.  A *module loader* process assists with loading modules
+as separate processes, establishing communication with the broker, loading
+and executing the module, and communicating with the broker's module
+management framework.  The loader may be inferred from the module file name
+suffix, or specified on the command line.  The following module loaders are
+provided by flux-core:
+
+module-exec (.so*)
+  An alternate way to load traditional dynamic shared objects, with more
+  isolation than direct broker loading.
+
+A small number of modules that are integral to the broker are automatically
+loaded early in broker start-up.  Although hard-wired to a particular name
+and compiled into the broker executable, these modules otherwise behave
+like regular broker modules and may be reloaded, traced, and introspected as
+usual.
 
 COMMANDS
 ========
@@ -41,12 +77,16 @@ entered the running state (see LIST OUTPUT below).
 
 .. option:: -n, --name=NAME
 
-  Override the default module name.  A single shared object file may be
-  loaded multiple times under different names.
+  Override the default module name.
 
 .. option:: --exec
 
-  Load the module in a separate process, e.g. for isolation or debugging.
+  Force the module to be loaded as a separate process.
+
+.. option:: --loader=PATH
+
+  Specify a module loader path.  This option implies
+  :option:`--exec` and only works when *module* is a path.
 
 reload
 ------
@@ -66,7 +106,13 @@ Reload module *name*. This is equivalent to running
 
 .. option:: --exec
 
-  Load the module in a separate process, e.g. for isolation or debugging.
+  Load the module in a separate process.
+
+.. option:: --loader=PATH
+
+  Specify a module loader path.  This option implies
+  :option:`--exec` and only works when *module* is a path.
+
 
 remove
 ------
@@ -81,12 +127,15 @@ Remove module *name*.
 
 .. option:: --cancel
 
-  Use :linux:man3:`pthread_cancel` to remove an unresponsive module.
-  This may be useful if the module is not able to respond to the module
-  shutdown request because it has not returned control to its reactor loop.
-  However, broker module threads are created with *deferred* cancellability,
-  so this is only effective if the module thread calls one of the functions
-  listed as a cancellation point in :linux:man7:`pthreads`.
+  Call :linux:man3:`pthread_cancel` on a thread or send :const:`SIGKILL`
+  to a process as appropriate to force a module to terminate.  This may be
+  useful if the module is not able to respond to the module shutdown request
+  because it has not returned control to its reactor loop.
+
+  Note that broker modules running as threads are created with *deferred*
+  cancellability.  This means that cancellation is only effective if the
+  module thread calls one of the functions listed as a cancellation point
+  in :linux:man7:`pthreads`.
 
 list
 ----

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -61,7 +61,7 @@ man_pages = [
     ('man1/flux-batch', 'flux-batch', 'submit a batch script to Flux', [author], 1),
     ('man1/flux-multi-prog', 'flux-multi-prog', 'run a parallel program with a different executable and arguments for each task', [author], 1),
     ('man1/flux-job', 'flux-job', 'Job Housekeeping Tool', [author], 1),
-    ('man1/flux-module', 'flux-module', 'manage Flux extension modules', [author], 1),
+    ('man1/flux-module', 'flux-module', 'manage Flux broker modules', [author], 1),
     ('man1/flux-overlay', 'flux-overlay', 'Show flux overlay network status', [author], 1),
     ('man1/flux-uptime', 'flux-uptime', 'Tell how long Flux has been up and running', [author], 1),
     ('man1/flux-ping', 'flux-ping', 'measure round-trip latency to Flux services', [author], 1),

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -395,10 +395,10 @@ static int modhash_resolve_dso (const char *name_or_null,
     if (name_or_null)
         name = strdup (name_or_null);
     else
-        name = module_dso_name (path);
+        name = module_name_frompath (path);
     if (!name) {
         errprintf (error,
-                   "error duplicating module name: %s",
+                   "error determining/duplicating module name: %s",
                    strerror (errno));
         ERRNO_SAFE_WRAP (free, path);
         return -1;

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -1186,6 +1186,7 @@ static module_t *modhash_load_exec (modhash_t *mh,
         return NULL;
     if (!(p = module_create_exec (ctx->h,
                                   broker_uuid,
+                                  "module-exec",
                                   name,
                                   path,
                                   args,

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -15,6 +15,7 @@
 #include <jansson.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/dirwalk.h"
 #include "src/common/libutil/iterators.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/errno_safe.h"
@@ -360,6 +361,40 @@ static int modhash_load_finalize (struct modhash *mh,
     return 0;
 }
 
+static char *modhash_dso_search (const char *name,
+                                 const char *searchpath,
+                                 flux_error_t *error)
+{
+    char *pattern;
+    zlist_t *files = NULL;
+    char *path;
+
+    if (asprintf (&pattern, "%s.so*", name) < 0) {
+        errprintf (error, "out of memory");
+        return NULL;
+    }
+    if (!(files = dirwalk_find (searchpath,
+                                DIRWALK_REALPATH | DIRWALK_NORECURSE,
+                                pattern,
+                                1,
+                                NULL,
+                                NULL))
+        || zlist_size (files) == 0) {
+        errprintf (error, "module not found in search path");
+        errno = ENOENT;
+        goto error;
+    }
+    if (!(path = strdup (zlist_first (files))))
+        goto error;
+    zlist_destroy (&files);
+    free (pattern);
+    return path;
+error:
+    ERRNO_SAFE_WRAP (zlist_destroy, &files);
+    ERRNO_SAFE_WRAP (free, pattern);
+    return NULL;
+};
+
 static int modhash_resolve_dso (const char *name_or_null,
                                 const char *path_or_name,
                                 char **namep,
@@ -385,7 +420,7 @@ static int modhash_resolve_dso (const char *name_or_null,
             errno = EINVAL;
             return -1;
         }
-        if (!(path = module_dso_search (path_or_name, searchpath, error)))
+        if (!(path = modhash_dso_search (path_or_name, searchpath, error)))
             return -1;
     }
     /* If the name is not specified, derive it from the module path.

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -13,6 +13,7 @@
 #endif
 #include <flux/core.h>
 #include <jansson.h>
+#include <fnmatch.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/dirwalk.h"
@@ -37,6 +38,21 @@ struct modhash {
     flux_future_t *f_builtins_unload;
 };
 
+struct modloader {
+    const char *glob;
+    const char *cmd;
+};
+
+/* The info needed to load a module.  This struct is filled by
+ * modhash_resolve_byname() and modhash_resolve_bypath().
+ * Its dynamically allocated members are released by modinfo_release().
+ */
+struct modinfo {
+    char *path;
+    char *name;
+    char *loader;
+};
+
 extern struct module_builtin builtin_config;
 extern struct module_builtin builtin_connector_local;
 extern struct module_builtin builtin_groups;
@@ -54,6 +70,13 @@ static struct module_builtin *builtins[] = {
     &builtin_overlay,
 };
 
+/* New broker module types can be supported by adding a module
+ * loader command and mapping it to a file extension in this table.
+ */
+static const struct modloader loaders[] = {
+    { .glob = ".so*", .cmd = "module-exec" },
+};
+
 static json_t *modhash_get_modlist (modhash_t *mh,
                                     double now,
                                     struct service_switch *sw);
@@ -67,10 +90,81 @@ static module_t *modhash_load_builtin (modhash_t *mh,
                                       json_t *args,
                                       flux_error_t *error);
 static module_t *modhash_load_exec (modhash_t *mh,
-                                    const char *name,
-                                    char *path,
+                                    const struct modinfo *info,
                                     json_t *args,
                                     flux_error_t *error);
+
+static void modinfo_release (struct modinfo *info)
+{
+    if (info) {
+        int saved_errno = errno;
+        free (info->name);
+        free (info->path);
+        free (info->loader);
+        memset (info, 0, sizeof (*info));
+        errno = saved_errno;
+    }
+}
+
+/* Find a module loader whose suffix glob matches the suffix of 'path'.
+ */
+static const struct modloader *modloader_find_bysuffix (const char *path)
+{
+    const struct modloader *ld = NULL;
+
+    for (int i = 0; ld == NULL && i < ARRAY_SIZE (loaders); i++) {
+        char *pattern;
+
+        if (asprintf (&pattern, "*%s", loaders[i].glob) < 0)
+            return NULL;
+        if (fnmatch (pattern, path, 0) == 0)
+            ld = &loaders[i];
+        free (pattern);
+    }
+    if (!ld)
+        errno = ENOENT;
+    return ld;
+}
+
+/* Given a module name, look for a file on the search path whose suffix
+ * matches a module loader.  Return the module loader and the file path
+ * (caller must free the latter).
+ */
+static const struct modloader *modloader_find_byname (const char *name,
+                                                      const char *searchpath,
+                                                      char **pathp)
+{
+    const struct modloader *ld = NULL;
+    char *path = NULL;
+
+    for (int i = 0; ld == NULL && i < ARRAY_SIZE (loaders); i++) {
+        char *pattern;
+        zlist_t *files;
+
+        if (asprintf (&pattern, "%s%s", name, loaders[i].glob) < 0)
+            return NULL;
+        if ((files = dirwalk_find (searchpath,
+                                   DIRWALK_REALPATH | DIRWALK_NORECURSE,
+                                   pattern,
+                                   1,
+                                   NULL,
+                                   NULL))
+            && zlist_size (files) > 0) {
+            ld = &loaders[i];
+            path = strdup (zlist_first (files));
+        }
+        ERRNO_SAFE_WRAP (zlist_destroy, &files);
+        ERRNO_SAFE_WRAP (free, pattern);
+    }
+    if (!ld) {
+        errno = ENOENT;
+        return NULL;
+    }
+    if (!path)
+        return NULL;
+    *pathp = path;
+    return ld;
+}
 
 int modhash_response_sendmsg_new (modhash_t *mh, flux_msg_t **msg)
 {
@@ -361,91 +455,87 @@ static int modhash_load_finalize (struct modhash *mh,
     return 0;
 }
 
-static char *modhash_dso_search (const char *name,
-                                 const char *searchpath,
-                                 flux_error_t *error)
+/* Find a module that matches the specified target, which is a module name
+ * (file basename minus extension).  Search FLUX_MODULE_PATH for the
+ * module with known extensions.
+ * On success, fill 'infop' (caller must call modinfo_release()) and return 0.
+ * On failure, fill errp and return -1.
+ */
+static int modhash_resolve_byname (const char *target,
+                                   const char *name_override, // may be NULL
+                                   struct modinfo *infop,
+                                   flux_error_t *errp)
 {
-    char *pattern;
-    zlist_t *files = NULL;
-    char *path;
+    const char *searchpath = getenv ("FLUX_MODULE_PATH");
+    struct modinfo info = { 0 };
+    const struct modloader *ld;
 
-    if (asprintf (&pattern, "%s.so*", name) < 0) {
-        errprintf (error, "out of memory");
-        return NULL;
+    if (!searchpath) {
+        errno = EINVAL;
+        return errprintf (errp,
+                          "FLUX_MODULE_PATH is not set in the environment");
     }
-    if (!(files = dirwalk_find (searchpath,
-                                DIRWALK_REALPATH | DIRWALK_NORECURSE,
-                                pattern,
-                                1,
-                                NULL,
-                                NULL))
-        || zlist_size (files) == 0) {
-        errprintf (error, "module not found in search path");
-        errno = ENOENT;
-        goto error;
+    if (!(ld = modloader_find_byname (target, searchpath, &info.path))) {
+        return errprintf (errp,
+                          "module not found in search path%s%s",
+                          errno == ENOENT ? "" : ": ",
+                          errno == ENOENT ? "" : strerror (errno));
     }
-    if (!(path = strdup (zlist_first (files))))
-        goto error;
-    zlist_destroy (&files);
-    free (pattern);
-    return path;
-error:
-    ERRNO_SAFE_WRAP (zlist_destroy, &files);
-    ERRNO_SAFE_WRAP (free, pattern);
-    return NULL;
+    if (!(info.name = strdup (name_override ? name_override : target))
+        || !(info.loader = strdup (ld->cmd))) {
+        modinfo_release (&info);
+        return errprintf (errp, "failed to duplicate module info");
+    }
+    *infop = info;
+    return 0;
 };
 
-static int modhash_resolve_dso (const char *name_or_null,
-                                const char *path_or_name,
-                                char **namep,
-                                char **pathp,
-                                flux_error_t *error)
+/* Assume that target is a (possibly relative) file path.
+ * On success, fill 'infop' (caller must call modinfo_release()) and return 0.
+ * On failure, fill errp and return -1.
+ * N.B. The loader is responsible to make sure the file exists and conforms
+ * to RFC 5, not this function.
+ */
+static int modhash_resolve_bypath (const char *target,
+                                   const char *name_override, // may be NULL
+                                   const char *loader_override, // may be NULL
+                                   struct modinfo *infop,
+                                   flux_error_t *errp)
 {
-    char *path = NULL;
-    char *name = NULL;
+    struct modinfo info = { 0 };
 
-    /* Handle 'flux module load /path/to/foo.dso' or 'flux module load foo'.
-     * In the latter case, search FLUX_MODULE_PATH for foo.dso.
-     */
-    if (strchr (path_or_name, '/')) {
-        if (!(path = strdup (path_or_name))) {
-            errprintf (error, "error duplicating module path");
-            return -1;
-        }
-    }
-    else {
-        const char *searchpath = getenv ("FLUX_MODULE_PATH");
-        if (!searchpath) {
-            errprintf (error, "FLUX_MODULE_PATH is not set in the environment");
-            errno = EINVAL;
-            return -1;
-        }
-        if (!(path = modhash_dso_search (path_or_name, searchpath, error)))
-            return -1;
-    }
-    /* If the name is not specified, derive it from the module path.
-     * E.g. the path '/path/to/foo.dso' suggests a module name of 'foo'.
-     * This doesn't have to be true if the name is specified.
-     */
-    if (name_or_null)
-        name = strdup (name_or_null);
+    if (name_override)
+        info.name = strdup (name_override);
     else
-        name = module_name_frompath (path);
-    if (!name) {
-        errprintf (error,
-                   "error determining/duplicating module name: %s",
-                   strerror (errno));
-        ERRNO_SAFE_WRAP (free, path);
-        return -1;
+        info.name = module_name_frompath (target);
+    if (!info.name)
+        return errprintf (errp, "error determining/duplicating module name");
+    if (!(info.path = strdup (target))) {
+        modinfo_release (&info);
+        return errprintf (errp, "could not duplicate module path");
     }
-    *namep = name;
-    *pathp = path;
+    if (loader_override)
+        info.loader = strdup (loader_override);
+    else {
+        const struct modloader *ld;
+
+        if (!(ld = modloader_find_bysuffix (target))) {
+            modinfo_release (&info);
+            return errprintf (errp,
+                   "could not determine loader from path suffix");
+        }
+        info.loader = strdup (ld->cmd);
+    }
+    if (!info.loader) {
+        modinfo_release (&info);
+        return errprintf (errp, "could not duplicate loader command");
+    }
+    *infop = info;
     return 0;
 }
 
 static module_t *modhash_load_dso (modhash_t *mh,
-                                   const char *name,
-                                   char *path, // stolen
+                                   const struct modinfo *info,
                                    json_t *args,
                                    flux_error_t *error)
 {
@@ -454,6 +544,7 @@ static module_t *modhash_load_dso (modhash_t *mh,
     void *dso;
     mod_main_f mod_main;
     module_t *p;
+    char *cpy;
 
     if (attr_get (ctx->attrs, "broker.uuid", &broker_uuid) < 0)
         return NULL;
@@ -463,14 +554,14 @@ static module_t *modhash_load_dso (modhash_t *mh,
      * The name is only passed to this function so the deprecated mod_name
      * symbol can be sanity checked, if defined.
      */
-    if (!(dso = module_dso_open (path, name, &mod_main, error)))
+    if (!(dso = module_dso_open (info->path, info->name, &mod_main, error)))
         return NULL;
 
     /* Create the module object.
      */
     if (!(p = module_create_thread (ctx->h,
                                     broker_uuid,
-                                    name,
+                                    info->name,
                                     mod_main,
                                     args,
                                     error))
@@ -478,7 +569,9 @@ static module_t *modhash_load_dso (modhash_t *mh,
         module_dso_close (dso);
         goto error;
     }
-    if (module_aux_set (p, "path", path, (flux_free_f)free) < 0) {
+    if (!(cpy = strdup (info->path))
+        || module_aux_set (p, "path", cpy, (flux_free_f)free) < 0) {
+        ERRNO_SAFE_WRAP (free, cpy);
         errprintf (error,
                    "error stashing module path in aux container: %s",
                    strerror (errno));
@@ -508,8 +601,9 @@ static void load_cb (flux_t *h,
                      void *arg)
 {
     broker_ctx_t *ctx = arg;
-    const char *name_or_null = NULL;
-    const char *path_or_name;
+    const char *name_override = NULL;
+    const char *loader_override = NULL;
+    const char *target;
     int exec = 0;
     json_t *args;
     flux_error_t error;
@@ -519,52 +613,81 @@ static void load_cb (flux_t *h,
 
     if (flux_request_unpack (msg,
                              NULL,
-                             "{s?s s:s s:o s?b}",
-                             "name", &name_or_null,
-                             "path", &path_or_name,
+                             "{s:s s?s s?s s:o s?b}",
+                             "path", &target,
+                             "name", &name_override,
+                             "loader", &loader_override,
                              "args", &args,
                              "exec", &exec) < 0)
         goto error;
 
-    if ((builtin = builtins_find (ctx->modhash, path_or_name))) {
-        if (exec) {
+    /* Modules that are built-in are compiled with the broker and are
+     * looked up in a table.  The "target" should be the canonical module name
+     * (which can be overridden at load time with name_override).
+     */
+    if ((builtin = builtins_find (ctx->modhash, target))) {
+        if (exec || loader_override) {
             errno = EINVAL;
             errmsg = "built-in modules cannot execute in a separate process";
             goto error;
         }
-        p = modhash_load_builtin (ctx->modhash,
-                                  builtin,
-                                  name_or_null,
-                                  args,
-                                  &error);
-        if (!p) {
+        if (!(p = modhash_load_builtin (ctx->modhash,
+                                        builtin,
+                                        name_override,
+                                        args,
+                                        &error))) {
             errmsg = error.text;
             goto error;
         }
     }
-    else {
-        char *name = NULL;
-        char *path = NULL;
-        if (modhash_resolve_dso (name_or_null,
-                                 path_or_name,
-                                 &name,
-                                 &path,
-                                 &error) < 0) {
-            errmsg = error.text;
-            goto error;
+    /* Other modules may be loaded directly into the broker address space
+     * or indirectly wired up to the broker via an external loader process.
+     * Below, "resolving" the module means filling a modinfo struct with
+     * the info needed to load it, namely a filename, a module name (either
+     * the canonical one or an override), and a loader command.
+     */
+    else { // target looks like a usable filename e.g. "./kvs.so"
+        struct modinfo info = { 0 };
+
+        if (strchr (target, '/')) {
+            if (modhash_resolve_bypath (target,
+                                        name_override,
+                                        loader_override,
+                                        &info,
+                                        &error) < 0) {
+                errmsg = error.text;
+                goto error;
+            }
         }
-        if (exec)
-            p = modhash_load_exec (ctx->modhash, name, path, args, &error);
+        else { // target is a module name like "kvs"
+            if (loader_override) {
+                errno = EINVAL;
+                errmsg = "module loader may only be specified with module path";
+                goto error;
+            }
+            if (modhash_resolve_byname (target,
+                                        name_override,
+                                        &info,
+                                        &error) < 0) {
+                errmsg = error.text;
+                goto error;
+            }
+        }
+        /* By default, modules ending in .so* are loaded directly into the
+         * broker address space, unless the exec flag is set, then via a
+         * module loader.  All other modules types are expected to need us
+         * to exec a loader on their behalf.
+         */
+        if (fnmatch ("*.so*", info.path, 0) == 0 && !exec && !loader_override)
+            p = modhash_load_dso (ctx->modhash, &info, args, &error);
         else
-            p = modhash_load_dso (ctx->modhash, name, path, args, &error);
+            p = modhash_load_exec (ctx->modhash, &info, args, &error);
         if (!p) {
-            ERRNO_SAFE_WRAP (free, name);
-            ERRNO_SAFE_WRAP (free, path);
+            modinfo_release (&info);
             errmsg = error.text;
             goto error;
         }
-        free (name);
-        // N.B. path is stolen by modhash_load_*() on success
+        modinfo_release (&info);
     }
     /* Register service, start module thread, and insert into modhash.
      */
@@ -1208,27 +1331,28 @@ flux_future_t *modhash_unload_builtins (modhash_t *mh)
 }
 
 static module_t *modhash_load_exec (modhash_t *mh,
-                                    const char *name,
-                                    char *path, // stolen
+                                    const struct modinfo *info,
                                     json_t *args,
                                     flux_error_t *error)
 {
     broker_ctx_t *ctx = mh->ctx;
     const char *broker_uuid;
     module_t *p;
+    char *cpy;
 
     if (attr_get (ctx->attrs, "broker.uuid", &broker_uuid) < 0)
         return NULL;
     if (!(p = module_create_exec (ctx->h,
                                   broker_uuid,
-                                  "module-exec",
-                                  name,
-                                  path,
+                                  info->loader,
+                                  info->name,
+                                  info->path,
                                   args,
                                   error)))
         goto error;
-    if (module_aux_set (p, "path", path, (flux_free_f)free) < 0) {
-        ERRNO_SAFE_WRAP (free, path);
+    if (!(cpy = strdup (info->path))
+        || module_aux_set (p, "path", cpy, (flux_free_f)free) < 0) {
+        ERRNO_SAFE_WRAP (free, cpy);
         errprintf (error,
                    "error stashing module path in aux container: %s",
                    strerror (errno));

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -223,7 +223,7 @@ static int module_insmod_respond (flux_t *h, module_t *p)
     if (errnum == 0)
         rc = flux_respond (h, msg, NULL);
     else
-        rc = flux_respond_error (h, msg, errnum, NULL);
+        rc = flux_respond_error (h, msg, errnum, module_strerror (p));
 
     module_aux_set (p, "insmod", NULL, NULL);
     return rc;
@@ -372,6 +372,8 @@ static void module_status_cb (module_t *p, int prev_status, void *arg)
      */
     if (status == FLUX_MODSTATE_EXITED) {
         flux_log (ctx->h, LOG_DEBUG, "module %s exited", name);
+        if (module_get_errnum (p) != 0)
+            flux_log (ctx->h, LOG_ERR, "%s: %s", name, module_strerror (p));
         service_remove_byuuid (ctx->services, module_get_uuid (p));
 
         if (!module_unload_requested (p)

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -505,50 +505,73 @@ int module_set_defer (module_t *p, bool flag)
 static void exec_completion_cb (flux_subprocess_t *proc)
 {
     module_t *p = flux_subprocess_aux_get (proc, "module");
+    const char *loader;
     int rc;
-    bool failed = true;
+
+    if (!(loader = flux_cmd_arg (p->exec.cmd, 1)))
+        loader = "unknown";
+
     if ((rc = flux_subprocess_exit_code (proc)) >= 0) {
-        if (rc == 0)
-            failed = false;
-        else
-            flux_log (p->h, LOG_ERR, "%s: exited with rc=%d", p->name, rc);
+        if (rc == 0 && p->status != FLUX_MODSTATE_EXITED) {
+            module_errprintf (p,
+                              "loader (%s) exited with exit code 0"
+                              " but did not report module status",
+                              loader);
+            module_set_errnum (p, EINVAL);
+        }
+        else if (rc != 0) {
+            module_errprintf (p,
+                              "loader (%s) exited with exit code %d",
+                              loader,
+                              rc);
+            module_set_errnum (p, EINVAL);
+        }
     }
-    else if ((rc = flux_subprocess_signaled (proc)) >= 0)
-        flux_log (p->h, LOG_ERR, "%s: killed by %s", p->name, strsignal (rc));
-    else
-        flux_log (p->h, LOG_ERR, "%s: completed (not signal or exit)", p->name);
-    if (p->status != FLUX_MODSTATE_EXITED) {
-        if (failed)
-            module_set_errnum (p, ECHILD);
+    else if ((rc = flux_subprocess_signaled (proc)) >= 0) {
+        module_errprintf (p,
+                          "loader (%s) killed by %s",
+                          loader,
+                          strsignal (rc));
+        module_set_errnum (p, EINVAL);
+    }
+    else {
+        module_errprintf (p,
+                          "loader (%s) completed with unknown status",
+                          loader);
+        module_set_errnum (p, EINVAL);
+    }
+
+    if (p->status != FLUX_MODSTATE_EXITED)
         module_set_status (p, FLUX_MODSTATE_EXITED);
-    }
 }
 
 static void exec_state_cb (flux_subprocess_t *proc,
                            flux_subprocess_state_t state)
 {
     module_t *p = flux_subprocess_aux_get (proc, "module");
+    const char *loader;
+
+    if (!(loader = flux_cmd_arg (p->exec.cmd, 1)))
+        loader = "unknown";
+
     switch (state) {
         case FLUX_SUBPROCESS_RUNNING:
             break;
         case FLUX_SUBPROCESS_FAILED:
-            flux_log (p->h,
-                      LOG_ERR,
-                      "%s: %s failed: %s",
-                      p->name,
-                      flux_subprocess_state_string (state),
-                      strerror (flux_subprocess_fail_errno (proc)));
-            if (p->status != FLUX_MODSTATE_EXITED) {
-                module_set_errnum (p, ECHILD);
+            module_errprintf (p,
+                              "loader (%s) %s failed: %s",
+                              loader,
+                              flux_subprocess_state_string (state),
+                              flux_subprocess_fail_error (proc));
+            module_set_errnum (p, flux_subprocess_fail_errno (proc));
+            if (p->status != FLUX_MODSTATE_EXITED)
                 module_set_status (p, FLUX_MODSTATE_EXITED);
-            }
             break;
         case FLUX_SUBPROCESS_EXITED:
         case FLUX_SUBPROCESS_INIT:
         case FLUX_SUBPROCESS_STOPPED:
             break; // ignore
     }
-
 }
 
 int module_start (module_t *p)

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -711,6 +711,17 @@ pid_t module_get_pid (module_t *p)
     return flux_subprocess_pid (p->exec.p);
 }
 
+char *module_name_frompath (const char *path)
+{
+    const char *name;
+    const char *cp;
+
+    name = basename_simple (path);
+    if (!(cp = strchr (name, '.')))
+        return strdup (name);
+    return strndup (name, cp - name);
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -69,6 +69,7 @@ struct broker_module {
     char *name;
     int status;
     int errnum;
+    flux_error_t error;
     bool muted;             /* module is under directive 42, no new messages */
     bool module_unload_requested;
     struct aux_item *aux;
@@ -657,6 +658,28 @@ void module_set_errnum (module_t *p, int errnum)
 int module_get_errnum (module_t *p)
 {
     return p->errnum;
+}
+
+int module_errprintf (module_t *p, const char *fmt, ...)
+{
+    va_list ap;
+    int rc = 0;
+
+    va_start (ap, fmt);
+    if (p)
+        rc = verrprintf (&p->error, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
+const char *module_strerror (module_t *p)
+{
+    if (p) {
+        if (p->errnum != 0 && strlen (p->error.text) > 0)
+            return p->error.text;
+        return strerror (p->errnum);
+    }
+    return "Unknown";
 }
 
 int module_subscribe (module_t *p, const char *topic)

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -224,6 +224,7 @@ cleanup:
 
 module_t *module_create_exec (flux_t *h,
                               const char *parent_uuid,
+                              const char *module_loader,
                               const char *name,
                               const char *path,
                               json_t *mod_args,
@@ -234,7 +235,7 @@ module_t *module_create_exec (flux_t *h,
         return NULL;
     p->is_exec = true;
 
-    const char *av[] = { "flux", "module-exec", path, NULL };
+    const char *av[] = { "flux", module_loader, path, NULL };
     int ac = 3;
     if (!(p->exec.cmd = flux_cmd_create (ac, (char **)av, environ))
         || flux_cmd_add_message_channel (p->exec.cmd,

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -134,6 +134,11 @@ ssize_t module_get_recv_queue_count (module_t *p);
 bool module_is_exec (module_t *p);
 pid_t module_get_pid (module_t *p);
 
+/* Guess the broker module's name based on its path.
+ * Caller must free the returned string.
+ */
+char *module_name_frompath (const char *path);
+
 #endif /* !BROKER_MODULE_H */
 
 /*

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -97,6 +97,10 @@ void module_set_status_cb (module_t *p, module_status_cb_f cb, void *arg);
 int module_get_errnum (module_t *p);
 void module_set_errnum (module_t *p, int errnum);
 
+int module_errprintf (module_t *p, const char *fmt, ...)
+     __attribute__ ((format (printf, 2, 3)));
+const char *module_strerror (module_t *p);
+
 /* Start module thread.
  */
 int module_start (module_t *p);

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -48,6 +48,7 @@ module_t *module_create_thread (flux_t *h,
                                 flux_error_t *error);
 module_t *module_create_exec (flux_t *h,
                               const char *parent_uuid,
+                              const char *module_loader,
                               const char *name,
                               const char *path,
                               json_t *args,

--- a/src/broker/module_dso.c
+++ b/src/broker/module_dso.c
@@ -110,16 +110,4 @@ error:
     return NULL;
 }
 
-char *module_dso_name (const char *path)
-{
-    const char *name;
-    const char *cp;
-
-    name = basename_simple (path);
-    // if path ends in .so or .so.VERSION, strip it off
-    if ((cp = strstr (name, ".so")))
-        return strndup (name, cp - name);
-    return strdup (name);
-}
-
 // vi:ts=4 sw=4 expandtab

--- a/src/broker/module_dso.c
+++ b/src/broker/module_dso.c
@@ -19,47 +19,12 @@
 #include <dlfcn.h>
 
 #include "src/common/libflux/plugin_private.h" // for plugin_deepbind()
-#include "src/common/libutil/dirwalk.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/basename.h"
 #include "ccan/str/str.h"
 
 #include "module_dso.h"
-
-char *module_dso_search (const char *name,
-                         const char *searchpath,
-                         flux_error_t *error)
-{
-    char *pattern;
-    zlist_t *files = NULL;
-    char *path;
-
-    if (asprintf (&pattern, "%s.so*", name) < 0) {
-        errprintf (error, "out of memory");
-        return NULL;
-    }
-    if (!(files = dirwalk_find (searchpath,
-                                DIRWALK_REALPATH | DIRWALK_NORECURSE,
-                                pattern,
-                                1,
-                                NULL,
-                                NULL))
-        || zlist_size (files) == 0) {
-        errprintf (error, "module not found in search path");
-        errno = ENOENT;
-        goto error;
-    }
-    if (!(path = strdup (zlist_first (files))))
-        goto error;
-    zlist_destroy (&files);
-    free (pattern);
-    return path;
-error:
-    ERRNO_SAFE_WRAP (zlist_destroy, &files);
-    ERRNO_SAFE_WRAP (free, pattern);
-    return NULL;
-};
 
 void module_dso_close (void *dso)
 {

--- a/src/broker/module_dso.h
+++ b/src/broker/module_dso.h
@@ -38,11 +38,6 @@ void *module_dso_open (const char *path,
  */
 void module_dso_close (void *dso);
 
-/* Guess the broker module's name based on its path.
- * Caller must free the returned string.
- */
-char *module_dso_name (const char *path);
-
 #endif /* !BROKER_MODULE_DSO_H */
 
 // vi:ts=4 sw=4 expandtab

--- a/src/broker/module_dso.h
+++ b/src/broker/module_dso.h
@@ -15,14 +15,6 @@
 
 #include "module.h"
 
-/* Search 'searchpath', a colon-separated list of directories, for a file
- * whose path matches the pattern "name.so*".  Return its full path (caller
- * must free).
- */
-char *module_dso_search (const char *name,
-                         const char *searchpath,
-                         flux_error_t *error);
-
 /* dlopen(3) the DSO at path and fetch a pointer to a symbol named 'mod_main'.
  * Optional:  if name is set and 'mod_name' is defined in the dso, fail if
  * they do not match.  This is a sanity check that modules still using the

--- a/src/broker/module_exec.c
+++ b/src/broker/module_exec.c
@@ -191,7 +191,7 @@ static void test_mode_init (struct modexec *me,
             log_err_exit ("error duplicating module name");
     }
     else  {
-        if (!(name = module_dso_name (path)))
+        if (!(name = module_name_frompath (path)))
             log_err_exit ("error determining module name");
     }
     if (flux_aux_set (me->h, "flux::name", name, (flux_free_f)free) < 0)

--- a/src/broker/module_exec.c
+++ b/src/broker/module_exec.c
@@ -13,12 +13,12 @@
  * There are two modes:
  *
  * broker mode
- * Usage: flux module-exec MODULE
+ * Usage: flux module-exec PATH
  * This mode is used when 'flux module load --exec MODULE' is run.
  * FLUX_MODULE_URI will be set to the module's handle.
  *
  * test mode
- * Usage: flux module-exec [--name=NAME] MODULE [args...]
+ * Usage: flux module-exec [--name=NAME] PATH [args...]
  * This mode can be used to manually set up broker modules for debugging.
  */
 
@@ -62,7 +62,7 @@ struct modexec {
 };
 
 static const char *cmdname = "flux-module-exec";
-static const char *cmdusage = "[OPTIONS] MODULE ARGS...";
+static const char *cmdusage = "[OPTIONS] PATH ARGS...";
 
 static struct optparse_option cmdopts[] = {
     {
@@ -178,7 +178,7 @@ static int fake_the_uuid (flux_t *h)
 }
 
 static void test_mode_init (struct modexec *me,
-                            const char *module,
+                            const char *path,
                             int argc,
                             char **argv)
 {
@@ -191,7 +191,7 @@ static void test_mode_init (struct modexec *me,
             log_err_exit ("error duplicating module name");
     }
     else  {
-        if (!(name = module_dso_name (module)))
+        if (!(name = module_dso_name (path)))
             log_err_exit ("error determining module name");
     }
     if (flux_aux_set (me->h, "flux::name", name, (flux_free_f)free) < 0)
@@ -214,24 +214,14 @@ static void test_mode_init (struct modexec *me,
     flux_future_destroy (f);
 }
 
-static void modexec_load (struct modexec *me, const char *module)
+static void modexec_load (struct modexec *me, const char *path)
 {
+    const char *name = flux_aux_get (me->h, "flux::name");
     flux_error_t error;
 
-    if (strchr (module, '/')) {
-        if (!(me->path = strdup (module)))
-            log_err_exit ("error duplicating path");
-    }
-    else {
-        const char *searchpath = getenv ("FLUX_MODULE_PATH");
-        if (!searchpath)
-            log_msg_exit ("FLUX_MODULE_PATH is not set in the environment");
-        if (!(me->path = module_dso_search (module, searchpath, &error)))
-            log_msg_exit ("%s: %s", module, error.text);
-    }
-    const char *name = flux_aux_get (me->h, "flux::name");
-    me->dso = module_dso_open (me->path, name, &me->mod_main, &error);
-    if (!me->dso)
+    if (!(me->path = strdup (path)))
+        log_err_exit ("error duplicating path");
+    if (!(me->dso = module_dso_open (me->path, name, &me->mod_main, &error)))
         log_err_exit ("%s", error.text);
 }
 
@@ -239,7 +229,7 @@ int main (int argc, char *argv[])
 {
     struct modexec me = { 0 };
     int optindex;
-    const char *module;
+    const char *path;
     const char *uri;
     bool test_mode = true;
     int mod_main_errno = 0;
@@ -257,7 +247,7 @@ int main (int argc, char *argv[])
         optparse_print_usage (me.opts);
         exit (1);
     }
-    module = argv[optindex++];
+    path = argv[optindex++];
 
     /* If the broker is starting this program as a sub-process, it will
      * set FLUX_MODULE_URI in the environment  Otherwise, assume "test mode"
@@ -277,7 +267,7 @@ int main (int argc, char *argv[])
         log_msg_exit ("flux_open: %s", error.text);
     if (test_mode) {
         log_msg ("loading module in test mode");
-        test_mode_init (&me, module, argc - optindex, argv + optindex);
+        test_mode_init (&me, path, argc - optindex, argv + optindex);
     }
     else {
         char *modargs;
@@ -302,7 +292,7 @@ int main (int argc, char *argv[])
 
     /* Load the DSO and set me->path
      */
-    modexec_load (&me, module);
+    modexec_load (&me, path);
 
     /* Run the DSO mod_main()
      */

--- a/src/broker/module_exec.c
+++ b/src/broker/module_exec.c
@@ -271,16 +271,15 @@ int main (int argc, char *argv[])
     }
     else {
         char *modargs;
-        const char *name;
         if (flux_module_initialize (me.h, &modargs, &error) < 0)
             log_msg_exit ("initialize error: %s", error.text);
         if (parse_modargs (&me, modargs) < 0)
             log_err_exit ("error parsing module arguments");
         free (modargs);
 
-        name = flux_aux_get (me.h, "flux::name");
-        flux_log_set_appname (me.h, name);
 #ifdef PR_SET_NAME
+        const char *name;
+        name = flux_aux_get (me.h, "flux::name");
         (void)prctl (PR_SET_NAME, name, 0, 0, 0);
 #endif
     }

--- a/src/broker/module_thread.c
+++ b/src/broker/module_thread.c
@@ -110,7 +110,6 @@ void *module_thread (void *arg)
     }
 
     const char *name = flux_aux_get (ctx.h, "flux::name");
-    flux_log_set_appname (ctx.h, name);
     setup_module_profiling (name);
 
     if (parse_modargs (&ctx, ctx.modargs) < 0) {

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -88,6 +88,9 @@ static struct optparse_option reload_opts[] =  {
     { .name = "exec", .has_arg = 0,
       .usage = "Load module as a separate process",
     },
+    { .name = "loader", .has_arg = 1, .arginfo = "PATH",
+      .usage = "Use the specified loader program",
+    },
     OPTPARSE_TABLE_END,
 };
 
@@ -97,6 +100,9 @@ static struct optparse_option load_opts[] =  {
     },
     { .name = "exec", .has_arg = 0,
       .usage = "Load module as a separate process",
+    },
+    { .name = "loader", .has_arg = 1, .arginfo = "PATH",
+      .usage = "Use the specified loader program",
     },
     OPTPARSE_TABLE_END,
 };
@@ -327,6 +333,7 @@ static void module_load (flux_t *h,
                          char **argv)
 {
     const char *name = optparse_get_str (p, "name", NULL);
+    const char *loader = optparse_get_str (p, "loader", NULL);
     char *fullpath = NULL;
     flux_future_t *f;
     json_t *args;
@@ -339,7 +346,8 @@ static void module_load (flux_t *h,
                                   "path", fullpath ? fullpath : path,
                                   "args", args,
                                   "exec", optparse_hasopt (p, "exec") ? 1 : 0))
-        || (name && set_string (payload, "name", name) < 0))
+        || (name && set_string (payload, "name", name) < 0)
+        || (loader && set_string (payload, "loader", loader) < 0))
         log_msg_exit ("failed to create module.load payload");
     if (!(f = flux_rpc_pack (h,
                              "module.load",

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -218,6 +218,7 @@ int flux_module_initialize (flux_t *h, char **ap, flux_error_t *error)
         errprintf (error, "welcome decode failure: %s", strerror (errno));
         goto done;
     }
+    flux_log_set_appname (h, name);
     if (cache_config (h, conf, error) < 0
         || cache_attributes (h, attrs, error) < 0
         || set_aux_strdup (h, "flux::name", name, error) < 0

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -490,7 +490,8 @@ check_PROGRAMS = \
 	shell/mpir \
 	debug/stall \
 	util/jobspec1-validate \
-	util/marshall
+	util/marshall \
+	module/testloader
 
 if HAVE_MPI
 check_PROGRAMS += \
@@ -1176,6 +1177,11 @@ util_marshall_SOURCES = util/marshall.c
 util_marshall_CPPFLAGS = $(test_cppflags)
 util_marshall_LDADD = $(test_ldadd)
 util_marshall_LDFLAGS = $(test_ldflags)
+
+module_testloader_SOURCES = module/testloader.c
+module_testloader_CPPFLAGS = $(test_cppflags)
+module_testloader_LDADD = $(test_ldadd)
+module_testloader_LDFLAGS = $(test_ldflags)
 
 stats_stats_basic_la_SOURCES = stats/stats-basic.c
 stats_stats_basic_la_CPPFLAGS = $(test_cppflags)

--- a/t/module/testloader.c
+++ b/t/module/testloader.c
@@ -1,0 +1,63 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* testloader.c - no-op module loader for testing */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+int die (const char *msg)
+{
+    fprintf (stderr, "%s\n", msg);
+    exit (1);
+}
+int die_error (const char *msg, flux_error_t *error)
+{
+    fprintf (stderr, "%s: %s\n", msg, error->text);
+    exit (1);
+}
+
+int main (int argc, char **argv)
+{
+    const char *uri;
+    char *modargs;
+    flux_error_t error;
+    flux_t *h;
+    int errnum = 0;
+
+    if (!(uri = getenv ("FLUX_MODULE_URI")))
+        die ("FLUX_MODULE_URI is not set");
+    if (argc != 2)
+        die ("loader requires a path argument");
+    if (!(h = flux_open_ex (uri, 0, &error)))
+        die_error ("flux_open", &error);
+    if (flux_module_initialize (h, &modargs, &error) < 0)
+        die_error ("flux_module_initialize", &error);
+    if (flux_module_register_handlers (h, &error) < 0)
+        die_error ("flux_module_register_handlers", &error);
+
+    /* Replace flux_reactor_run with call into module's mod_main().
+     * Use path, modargs.
+     */
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        errnum = errno;
+
+    if (flux_module_finalize (h, errnum, &error) < 0)
+        die_error ("flux_module_finalize", &error);
+
+    free (modargs);
+    flux_close (h);
+
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -164,7 +164,7 @@ test_expect_success 'simulated module segfault causes module to exit' '
 	flux dmesg >segfault.out
 '
 test_expect_success 'segfault is reported' '
-	grep "testmod: killed by Segmentation fault" segfault.out
+	grep "killed by Segmentation fault" segfault.out
 '
 test_expect_success 'broker treats this the same as spurious module exit' '
 	grep "module runtime failure" segfault.out

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -7,6 +7,7 @@ test_description='Test flux-module-exec'
 test_under_flux 1 minimal
 
 testmod=$(realpath ${FLUX_BUILD_DIR}/t/module/.libs/testmod.so)
+heartbeatmod=$(realpath ${FLUX_BUILD_DIR}/src/modules/.libs/heartbeat.so)
 legacy=$(realpath ${FLUX_BUILD_DIR}/t/module/.libs/legacy.so)
 rpc_stream=${FLUX_BUILD_DIR}/t/request/rpc_stream
 waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
@@ -37,9 +38,9 @@ test_expect_success 'FLUX_MODULE_URI and free args fail when used together' '
 ##
 
 test_expect_success 'flux-module-exec fails on unknown module' '
-	test_must_fail flux module-exec badmod 2>badmod.err &&
-	grep "module not found in search path" badmod.err
+	test_must_fail flux module-exec /badmod.so
 '
+
 test_expect_success 'simulated module failure causes command failure' '
 	test_must_fail flux module-exec \
 	    $testmod --init-failure 2>modfail.err &&
@@ -91,7 +92,7 @@ shutdown_mod() {
 }
 
 test_expect_success NO_CHAIN_LINT 'start heartbeat in the background' '
-	flux module-exec heartbeat &
+	flux module-exec $heartbeatmod &
 	echo $! >heartbeat.pid
 '
 test_expect_success NO_CHAIN_LINT 'ping heartbeat works' '

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -11,6 +11,7 @@ heartbeatmod=$(realpath ${FLUX_BUILD_DIR}/src/modules/.libs/heartbeat.so)
 legacy=$(realpath ${FLUX_BUILD_DIR}/t/module/.libs/legacy.so)
 rpc_stream=${FLUX_BUILD_DIR}/t/request/rpc_stream
 waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+testloader="${FLUX_BUILD_DIR}/t/module/testloader"
 
 flux setattr log-stderr-level 6
 
@@ -178,6 +179,31 @@ test_expect_success NO_CHAIN_LINT 'broker responded with module disconnect' '
 '
 test_expect_success 'legacy module cannot be loaded under new name' '
         test_must_fail flux module load --exec --name=newname $legacy
+'
+
+##
+# special loaders
+##
+
+test_expect_success 'module loader can be explicitly set' '
+	flux module load --loader=module-exec $heartbeatmod &&
+	flux module unload heartbeat
+'
+test_expect_success 'faux module loader works' '
+	flux module load --loader=$testloader $heartbeatmod args &&
+	flux module unload heartbeat
+'
+test_expect_success 'module loader cannot be specified with non-path module' '
+	test_must_fail flux module load --loader=module-exec heartbeat
+'
+test_expect_success 'the false command fails gracefully as a module loader' '
+	test_must_fail flux module load --loader=$(which false) $heartbeatmod
+'
+test_expect_success 'the true command fails gracefully as a module loader' '
+	test_must_fail flux module load --loader=$(which true) $heartbeatmod
+'
+test_expect_success 'a nonexistent module loader fails gracefully' '
+	test_must_fail flux module load --loader=/noexist $heartbeatmod
 '
 
 test_done


### PR DESCRIPTION
Problem: only regular dso modules can be loaded as separate processes, but in the future it may be useful to support modules written in other programming environments such as python, as noted in
- #7400

This refactors the broker module loading code to support multiple module loaders.  There are two ways to use a new loader
1) specify both the loader and the module by path e.g.
```
flux module load --loader=my_python_loader.py ./testmod.py
```
2) add a new loader and file suffix glob to the loader table in the broker.  For example add
```c
{ .cmd = "module-python-exec", .glob = ".py" }
```
then either of the following would work
```
flux module load ./testmod.py
flux module load testmod         # <--- if testmod.py is found in FLUX_MODULE_PATH
```
This is built on top of
- #7417 