### PR TITLE
python: add userid, rolemask getters for Flux messages and testing

### DIFF
--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -109,6 +109,26 @@ class Message(WrapperPimpl):
     def type_str(self):
         return msg_typestr(self.type)
 
+    @property
+    def userid(self):
+        userid = ffi.new("uint32_t [1]")
+        self.pimpl.get_userid(userid)
+        return userid[0]
+
+    @userid.setter
+    def userid(self, userid):
+        self.pimpl.set_userid(userid)
+
+    @property
+    def rolemask(self):
+        rolemask = ffi.new("uint32_t [1]")
+        self.pimpl.get_rolemask(rolemask)
+        return rolemask[0]
+
+    @rolemask.setter
+    def rolemask(self, rolemask):
+        self.pimpl.set_rolemask(rolemask)
+
     def decode(self):
         """Decode a message
 

--- a/t/python/t0008-message.py
+++ b/t/python/t0008-message.py
@@ -11,6 +11,7 @@
 ###############################################################
 
 import json
+import os
 import unittest
 
 import flux
@@ -68,6 +69,10 @@ class TestMessage(unittest.TestCase):
         m.type = flux.constants.FLUX_MSGTYPE_RESPONSE
         self.assertEqual(m.type, flux.constants.FLUX_MSGTYPE_RESPONSE)
 
+        # proto block getters work
+        self.assertEqual(m.userid, flux.constants.FLUX_USERID_UNKNOWN)
+        self.assertEqual(m.rolemask, 0)
+
     def test_basic_response(self):
         m = Message(flux.constants.FLUX_MSGTYPE_RESPONSE)
         self.assertIsNotNone(m)
@@ -82,8 +87,11 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(topic, "test")
         self.assertIsNone(payload_str)
 
-    def test_baseic_event(self):
+    def test_basic_event(self):
         m = Message(flux.constants.FLUX_MSGTYPE_EVENT)
+        m.rolemask = flux.constants.FLUX_ROLE_USER
+        m.userid = os.getuid()
+
         self.assertIsNotNone(m)
         self.assertEqual(m.type, flux.constants.FLUX_MSGTYPE_EVENT)
         self.assertEqual(m.type_str, "event")
@@ -96,6 +104,9 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(topic, "event.test")
         self.assertIsNone(payload_str)
 
+        self.assertEqual(m.userid, os.getuid())
+        self.assertEqual(m.rolemask, flux.constants.FLUX_ROLE_USER)
+
     def test_send(self):
         payload = {"test": "foo"}
         cb_called = [False]
@@ -106,6 +117,11 @@ class TestMessage(unittest.TestCase):
             self.assertEqual(msgtype, flux.constants.FLUX_MSGTYPE_RESPONSE)
             self.assertEqual(topic, "test.foo")
             self.assertIsNone(payload)
+            self.assertEqual(msg.userid, os.getuid())
+            self.assertEqual(
+                msg.rolemask,
+                flux.constants.FLUX_ROLE_OWNER | flux.constants.FLUX_ROLE_LOCAL,
+            )
             handle.reactor_stop()
 
         watcher = self.f.msg_watcher_create(


### PR DESCRIPTION
Problem: currently from the Python bindings there is no way to retrieve the userid of the user sending a message or the message's rolemask.

Add a wrapper for this. Add some unit tests as well.