### PR TITLE
broker: support python broker modules

### DIFF
--- a/doc/man1/flux-modprobe.rst
+++ b/doc/man1/flux-modprobe.rst
@@ -221,7 +221,9 @@ Each entry in the ``modules`` array supports the following keys:
    then the last entry loaded will be used.
 
 **module**
-   (optional, string) The module to load if different from *name*
+   (optional, string) The module to load if different from *name*. May be a
+   path to a shared object (``.so``) or Python (``.py``) file, or a bare
+   module name resolved via :envvar:`FLUX_MODULE_PATH`.
 
 **provides**
    (optional, array of string) List of service names this module provides,

--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -21,7 +21,7 @@ DESCRIPTION
 
 .. program:: flux module
 
-:program:`flux module` manages dynamically loadable :man1:`flux-broker` modules.
+:program:`flux module` manages :man1:`flux-broker` modules.
 Modules are automatically loaded at Flux instance start up (rc1) and unloaded
 at Flux instance shutdown (rc3) using :man1:`flux-modprobe`, which is
 configured to be aware of module dependencies.  :program:`flux module` is
@@ -42,17 +42,24 @@ tracing.
 
 Broker modules are often implemented as dynamic shared objects loaded
 into broker threads, but they may also be loaded into separate processes.
-This may be necessary for isolation, or to support incompatible programming
-runtime environments.  A *module loader* process assists with loading modules
-as separate processes, establishing communication with the broker, loading
-and executing the module, and communicating with the broker's module
-management framework.  The loader may be inferred from the module file name
-suffix, or specified on the command line.  The following module loaders are
-provided by flux-core:
+This may be necessary for isolation, or to support modules written in
+languages with their own runtime, such as Python.  A *module loader*
+process assists with loading such modules, establishing communication with
+the broker, executing the module, and reporting completion back to the
+broker's module management framework.  The loader is inferred from the
+module file name suffix, or may be specified on the command line.  The
+following module loaders are provided by flux-core:
 
 module-exec (.so*)
-  An alternate way to load traditional dynamic shared objects, with more
-  isolation than direct broker loading.
+  Loads a dynamic shared object as a separate process, providing more
+  isolation than direct broker thread loading.
+
+module-python-exec (.py)
+  Loads Python broker modules.  The Python file must define either a
+  :func:`mod_main` function or a single
+  :class:`~flux.brokermod.BrokerModule` subclass (see `MODULE ENTRY POINT`_).
+  The :class:`~flux.brokermod.BrokerModule` base class simplifies writing
+  Python broker modules with decorator-based handler registration.
 
 A small number of modules that are integral to the broker are automatically
 loaded early in broker start-up.  Although hard-wired to a particular name
@@ -68,9 +75,10 @@ load
 
 .. program:: flux module load
 
-Load *module*, which may be either the path to a shared object file, including
-the ``.so`` suffix, or the basename of a shared object file on the
-:envvar:`FLUX_MODULE_PATH`, without the suffix.
+Load *module*, which may be the path to a shared object file (including the
+``.so`` suffix), the path to a Python file (including the ``.py`` suffix),
+or the basename of either on the :envvar:`FLUX_MODULE_PATH`, without the
+suffix.
 
 When :program:`flux module load` completes successfully, the new module has
 entered the running state (see LIST OUTPUT below).
@@ -288,7 +296,7 @@ The *list* command displays one line for each unique (as determined by
 SHA1 hash) loaded module.
 
 **Module**
-   The value of the **mod_name** symbol for this module.
+   The module name.
 
 **Idle**
    Idle times are defined as the number of seconds since the module last sent
@@ -305,20 +313,30 @@ SHA1 hash) loaded module.
    displayed in a comma-separated list.
 
 **Path**
-   The full path to the broker module shared object file (only shown with
+   The full path to the broker module file (only shown with
    the **-l, --long** option).
 
 
-MODULE SYMBOLS
-==============
+MODULE ENTRY POINT
+==================
 
-All Flux modules define the following global symbols:
-
-**const char \*mod_name;**
-   A null-terminated string defining the module name.
+C broker modules define the following entry point:
 
 **int mod_main (void \*context, int argc, char \**argv);**
    An entry function.
+
+Python broker modules may define one of the following entry points:
+
+**mod_main (h, \*args)**
+   An entry function called with a :class:`flux.Flux` handle and any
+   module arguments.
+
+**class MyModule(BrokerModule)**
+   As a shortcut, a Python module that defines a single
+   :class:`~flux.brokermod.BrokerModule` subclass and no :func:`mod_main`
+   has its entry point synthesized automatically as
+   ``MyModule(h, *args).run()``.  If multiple subclasses are present,
+   :func:`mod_main` must be defined explicitly to resolve the ambiguity.
 
 
 RESOURCES

--- a/doc/python/broker_modules.rst
+++ b/doc/python/broker_modules.rst
@@ -1,0 +1,149 @@
+.. _python_broker_modules:
+
+Python Broker Modules
+=====================
+
+Flux broker modules extend the broker with new services.  Traditionally
+modules are written in C as dynamic shared objects, but Flux also supports
+modules written in Python.  A Python broker module is a :file:`.py` file that
+defines either a :func:`mod_main` entry function or a single
+:class:`~flux.brokermod.BrokerModule` subclass.
+
+
+Loading a Python module
+-----------------------
+
+Python modules are loaded and removed with the same :man1:`flux-module`
+commands used for C modules:
+
+.. code-block:: console
+
+   $ flux module load /path/to/mymod.py
+   $ flux ping mymod
+   $ flux module remove mymod
+
+The module name defaults to the file's basename without the ``.py`` suffix
+and may be overridden with ``--name``:
+
+.. code-block:: console
+
+   $ flux module load --name myservice /path/to/mymod.py
+
+
+The mod_main entry point
+------------------------
+
+A Python broker module may define a top-level function named :func:`mod_main`:
+
+.. code-block:: python
+
+   def mod_main(h, *args):
+       ...
+
+``h`` is a :class:`flux.Flux` handle connected to the broker.  ``args``
+is a (possibly empty) tuple of strings passed after the module path on the
+:program:`flux module load` command line.  The function must run the reactor
+(directly or via :class:`~flux.brokermod.BrokerModule`) and return only after
+the reactor exits.
+
+Defining :func:`mod_main` explicitly is optional when using
+:class:`~flux.brokermod.BrokerModule` — see `Using BrokerModule`_ below.
+
+
+Using BrokerModule
+------------------
+
+:class:`~flux.brokermod.BrokerModule` is a base class that handles the
+boilerplate of registering message handlers, managing the reactor, and
+looking up the module name.  Subclass it and use the
+:func:`~flux.brokermod.request_handler` and
+:func:`~flux.brokermod.event_handler` decorators to declare handlers:
+
+.. code-block:: python
+
+   from flux.brokermod import BrokerModule, event_handler, request_handler
+
+
+   class MyModule(BrokerModule):
+
+       @request_handler("info")
+       def info(self, msg):
+           self.handle.respond(msg, {"name": self.name})
+
+       @event_handler("shutdown", prefix=False)
+       def on_shutdown(self, msg):
+           self.stop()
+
+When a module file contains exactly one :class:`~flux.brokermod.BrokerModule`
+subclass and no :func:`mod_main`, the loader synthesizes the entry point
+automatically as ``MyModule(h, *args).run()``, so no explicit
+:func:`mod_main` is required.  If multiple subclasses are present,
+:func:`mod_main` must be defined to resolve the ambiguity:
+
+.. code-block:: python
+
+   def mod_main(h, *args):
+       MyModule(h, *args).run()
+
+Handler methods receive a :class:`~flux.message.Message` object.  For request
+handlers, call :meth:`flux.Flux.respond` on the handle to send a response.
+
+By default each handler's topic is prefixed with the module name, so
+``@request_handler("info")`` registers ``mymod.info``.  Pass
+``prefix=False`` to use the topic string as-is.
+
+By default, only requests from the instance owner are delivered to a handler.
+Pass ``allow_guest=True`` to also accept requests from non-owner users:
+
+.. code-block:: python
+
+   @request_handler("status", allow_guest=True)
+   def status(self, msg):
+       self.handle.respond(msg, {"running": True})
+
+The :attr:`~flux.brokermod.BrokerModule.handle` property returns the
+:class:`flux.Flux` handle, giving full access to the Flux Python API for
+RPCs, KVS operations, timers, and other watchers.
+
+
+Error handling
+--------------
+
+If :meth:`~flux.brokermod.BrokerModule.run` raises :exc:`OSError`, or if
+:func:`mod_main` raises any exception, the broker treats the module as
+having exited with an error and logs a ``module runtime failure`` message.
+Use :meth:`~flux.brokermod.BrokerModule.stop_error` to signal an error from
+within a handler.
+
+
+Module arguments
+----------------
+
+Arguments passed after the module path at load time are available as
+``args`` in :func:`mod_main` and as
+:attr:`~flux.brokermod.BrokerModule.args` on a :class:`~flux.brokermod.BrokerModule`
+instance:
+
+.. code-block:: console
+
+   $ flux module load /path/to/mymod.py --verbose --count=4
+
+.. code-block:: python
+
+   def mod_main(h, *args):
+       # args == ('--verbose', '--count=4')
+       MyModule(h, *args).run()
+
+Arguments are split on whitespace; quoting is not supported.
+
+
+API reference
+-------------
+
+.. autoclass:: flux.brokermod.BrokerModule
+   :members:
+   :undoc-members:
+
+.. autofunction:: flux.brokermod.request_handler
+
+.. autofunction:: flux.brokermod.event_handler

--- a/doc/python/index.rst
+++ b/doc/python/index.rst
@@ -12,6 +12,7 @@ command line are possible in Python as well via the ``flux`` package.
 
    basics
    job_submission
+   broker_modules
    complete_api
    developer
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1093,3 +1093,6 @@ topologies
 blocklist
 OSError
 ValueError
+BrokerModule
+MyModule
+subclasses

--- a/etc/modprobe/modprobe.toml
+++ b/etc/modprobe/modprobe.toml
@@ -9,6 +9,8 @@
 #            then the last one loaded will be used.
 #
 #   module   (optional) The module to load if different from name.
+#            May be a path to a shared object (.so) or Python (.py) file,
+#            or a bare module name resolved via FLUX_MODULE_PATH.
 #
 #   provides (optional) List of services this module provides, e.g. "sched".
 #             If multiple modules provide the same service name, the last one

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -13,6 +13,7 @@ nobase_fluxpy_PYTHON = \
 	importer.py \
 	eventlog.py \
 	conf_builtin.py \
+	brokermod.py \
 	cli/__init__.py \
 	cli/base.py \
 	cli/alloc.py \

--- a/src/bindings/python/flux/brokermod.py
+++ b/src/bindings/python/flux/brokermod.py
@@ -1,0 +1,197 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from _flux._core import ffi, lib
+from flux.constants import FLUX_MSGTYPE_EVENT, FLUX_MSGTYPE_REQUEST
+
+
+def request_handler(topic, prefix=True, allow_guest=False):
+    """Decorator to register a method as a request handler.
+
+    The handler is invoked with (self, msg) when a request matching
+    ``<module_name>.<topic>`` is received.  If ``prefix=False``, the topic
+    is used as-is without prepending the module name.  If ``allow_guest=True``,
+    requests from non-owner users (``FLUX_ROLE_USER``) are also accepted.
+    """
+
+    def decorator(func):
+        func._flux_handler = {
+            "msgtype": FLUX_MSGTYPE_REQUEST,
+            "topic": topic,
+            "prefix": prefix,
+            "allow_guest": allow_guest,
+        }
+        return func
+
+    return decorator
+
+
+def event_handler(topic, prefix=True):
+    """Decorator to register a method as an event handler.
+
+    The handler is invoked with (self, msg) when an event matching
+    ``<module_name>.<topic>`` is received.  If ``prefix=False``, the topic
+    is used as-is without prepending the module name.
+    """
+
+    def decorator(func):
+        func._flux_handler = {
+            "msgtype": FLUX_MSGTYPE_EVENT,
+            "topic": topic,
+            "prefix": prefix,
+        }
+        return func
+
+    return decorator
+
+
+class BrokerModule:
+    """Base class for Python broker modules.
+
+    Subclass this and use the :func:`request_handler` and
+    :func:`event_handler` decorators to register message handlers, then
+    call :meth:`run` to start the reactor.  Handler topics are automatically
+    prefixed with the module name unless ``prefix=False`` is passed to the
+    decorator.
+
+    Example::
+
+        from flux.brokermod import BrokerModule, event_handler, request_handler
+
+        class MyModule(BrokerModule):
+
+            @request_handler("info")
+            def info(self, msg):
+                self.handle.respond(msg, self.name)
+
+            @event_handler("panic")
+            def panic(self, msg):
+                self.stop_error()
+
+    When this is the only :class:`BrokerModule` subclass in the file and no
+    :func:`mod_main` is defined, the loader synthesizes the entry point
+    automatically.  An explicit :func:`mod_main` is only needed to resolve
+    ambiguity when multiple subclasses are present.
+    """
+
+    def __init__(self, h, *args):
+        self._h = h
+        self._args = args
+        name_p = ffi.cast("char *", lib.flux_aux_get(h.handle, b"flux::name"))
+        self._name = ffi.string(name_p).decode() if name_p != ffi.NULL else "unknown"
+        self._watchers = []
+        self._stopped_with_error = False
+        self._register_handlers()
+
+    @property
+    def handle(self):
+        """The underlying :class:`flux.Flux` handle."""
+        return self._h
+
+    @property
+    def name(self):
+        """The module name as assigned by the broker."""
+        return self._name
+
+    @property
+    def args(self):
+        """Tuple of module arguments passed at load time."""
+        return self._args
+
+    def set_running(self):
+        """Signal to the broker that the module is now running.
+
+        Call this before performing synchronous initialization in
+        :meth:`run` to allow ``flux module load`` to return instead of
+        waiting for the reactor to start.  See :man3:`flux_module_set_running`.
+        """
+        if lib.flux_module_set_running(self._h.handle) < 0:
+            raise OSError("flux_module_set_running failed")
+
+    def stop(self):
+        """Stop the reactor and exit :meth:`run` normally."""
+        self._h.reactor_stop()
+
+    def stop_error(self):
+        """Stop the reactor and cause :meth:`run` to raise :exc:`OSError`."""
+        self._stopped_with_error = True
+        self._h.reactor_stop_error()
+
+    def run(self):
+        """Run the reactor until stopped.
+
+        Raises :exc:`OSError` if the reactor was stopped with an error
+        (e.g. via :meth:`stop_error`) or if a Python exception was set
+        on the handle during a callback.
+        """
+        if self._h.reactor_run() < 0 or self._stopped_with_error:
+            raise OSError("reactor exited with error")
+
+    def _register_handlers(self):
+        for cls in type(self).__mro__:
+            for attr_name, func in cls.__dict__.items():
+                spec = getattr(func, "_flux_handler", None)
+                if spec is None:
+                    continue
+                method = getattr(self, attr_name)
+                msgtype = spec["msgtype"]
+                topic = (
+                    f"{self._name}.{spec['topic']}" if spec["prefix"] else spec["topic"]
+                )
+                rolemask = None
+                if spec.get("allow_guest"):
+                    rolemask = lib.FLUX_ROLE_OWNER | lib.FLUX_ROLE_USER
+                if msgtype == FLUX_MSGTYPE_EVENT:
+                    self._h.event_subscribe(topic)
+
+                def _make_cb(m):
+                    def cb(handle, mtype, msg, arg):
+                        m(msg)
+
+                    return cb
+
+                w = self._h.msg_watcher_create(
+                    _make_cb(method), msgtype, topic, rolemask=rolemask
+                )
+                w.start()
+                self._watchers.append(w)
+
+
+def resolve_entry_point(mod):
+    """Resolve the entry point callable from a Python broker module object.
+
+    If the module defines :func:`mod_main` it is returned as-is.  Otherwise,
+    a single :class:`BrokerModule` subclass is searched for in the module's
+    namespace and its entry point synthesized as ``cls(h, *args).run()``.
+
+    :raises ValueError: if no entry point can be determined, or if multiple
+        :class:`BrokerModule` subclasses are found without an explicit
+        :func:`mod_main`.
+    """
+    mod_main = getattr(mod, "mod_main", None)
+    if mod_main is not None:
+        return mod_main
+    subclasses = [
+        v
+        for v in vars(mod).values()
+        if isinstance(v, type) and issubclass(v, BrokerModule) and v is not BrokerModule
+    ]
+    if len(subclasses) == 1:
+        cls = subclasses[0]
+        return lambda h, *args: cls(h, *args).run()
+    if len(subclasses) > 1:
+        names = ", ".join(c.__name__ for c in subclasses)
+        raise ValueError(
+            f"multiple BrokerModule subclasses found ({names}); define mod_main()"
+        )
+    raise ValueError("no mod_main() or BrokerModule subclass found")
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -15,7 +15,14 @@ from contextlib import contextmanager
 from _flux._core import ffi, lib
 from flux.constants import FLUX_POLLERR, FLUX_POLLIN, FLUX_POLLOUT
 from flux.core.inner import raw
-from flux.core.watchers import FDWatcher, SignalWatcher, TimerWatcher
+from flux.core.watchers import (
+    CheckWatcher,
+    FDWatcher,
+    IdleWatcher,
+    PrepareWatcher,
+    SignalWatcher,
+    TimerWatcher,
+)
 from flux.future import Future
 from flux.message import Message, MessageWatcher
 from flux.rpc import RPC
@@ -265,6 +272,15 @@ class Flux(Wrapper):
 
     def timer_watcher_create(self, after, callback, repeat=0.0, args=None):
         return TimerWatcher(self, after, callback, repeat=repeat, args=args)
+
+    def prepare_watcher_create(self, callback, args=None):
+        return PrepareWatcher(self, callback, args=args)
+
+    def check_watcher_create(self, callback, args=None):
+        return CheckWatcher(self, callback, args=args)
+
+    def idle_watcher_create(self, callback=None, args=None):
+        return IdleWatcher(self, callback, args=args)
 
     def signal_watcher_create(self, signum, callback, args=None):
         return SignalWatcher(self, signum, callback, args)

--- a/src/bindings/python/flux/core/watchers.py
+++ b/src/bindings/python/flux/core/watchers.py
@@ -14,7 +14,7 @@ import signal
 
 from flux.core.inner import ffi, lib, raw
 
-__all__ = ["TimerWatcher", "FDWatcher", "SignalWatcher"]
+__all__ = ["TimerWatcher", "FDWatcher", "SignalWatcher", "CheckWatcher", "IdleWatcher"]
 
 
 class Watcher(object):
@@ -99,6 +99,19 @@ class TimerWatcher(Watcher):
             ),
         )
 
+    def reset(self, after=None, repeat=None):
+        """Reset the timer and restart it.
+
+        Updates the timer values and re-arms it from scratch, even if it is
+        already running.  Parameters default to the values passed at creation.
+        """
+        if after is None:
+            after = self.after
+        if repeat is None:
+            repeat = self.repeat
+        raw.flux_timer_watcher_reset(self.handle, float(after), float(repeat))
+        self.start()
+
 
 @ffi.def_extern()
 def fd_handler_wrapper(unused1, unused2, revents, opaque_handle):
@@ -143,6 +156,80 @@ def signal_handler_wrapper(_unused1, _unused2, _unused3, opaque_handle):
     except Exception as exc:
         type(watcher.flux_handle).set_exception(exc)
         watcher.flux_handle.reactor_stop_error()
+
+
+class PrepareWatcher(Watcher):
+    """Watcher that fires once per reactor iteration, before blocking.
+
+    Fires just before the event loop calls ``backend_poll``.  Typically
+    paired with an :class:`IdleWatcher` (no callback) and a
+    :class:`CheckWatcher`: if work is pending, ``prepare_cb`` starts the
+    idle watcher to prevent blocking; ``check_cb`` does the work and stops
+    the idle watcher.
+    """
+
+    def __init__(self, flux_handle, callback, args=None):
+        self.callback = callback
+        self.args = args
+        self.handle = None
+        self.wargs = ffi.new_handle(self)
+        super(PrepareWatcher, self).__init__(
+            flux_handle,
+            raw.flux_prepare_watcher_create(
+                raw.flux_get_reactor(flux_handle),
+                lib.timeout_handler_wrapper,
+                self.wargs,
+            ),
+        )
+
+
+class CheckWatcher(Watcher):
+    """Watcher that fires once per reactor iteration, after blocking.
+
+    Fires just after the event loop returns from ``backend_poll``, before
+    I/O callbacks from the current poll are dispatched.  Typically paired
+    with a :class:`PrepareWatcher` and an :class:`IdleWatcher`; see
+    :class:`PrepareWatcher` for the pattern.
+    """
+
+    def __init__(self, flux_handle, callback, args=None):
+        self.callback = callback
+        self.args = args
+        self.handle = None
+        self.wargs = ffi.new_handle(self)
+        super(CheckWatcher, self).__init__(
+            flux_handle,
+            raw.flux_check_watcher_create(
+                raw.flux_get_reactor(flux_handle),
+                lib.timeout_handler_wrapper,
+                self.wargs,
+            ),
+        )
+
+
+class IdleWatcher(Watcher):
+    """Watcher that prevents the event loop from blocking.
+
+    When active, keeps ``backend_poll`` from sleeping so that the loop
+    spins without waiting for I/O.  Typically used without a callback (pass
+    ``callback=None``) as part of the prepare/idle/check pattern: the
+    prepare watcher starts this watcher when there is work pending, and the
+    check watcher stops it after the work is done.
+    """
+
+    def __init__(self, flux_handle, callback=None, args=None):
+        self.callback = callback
+        self.args = args
+        self.handle = None
+        self.wargs = ffi.new_handle(self) if callback is not None else ffi.NULL
+        super(IdleWatcher, self).__init__(
+            flux_handle,
+            raw.flux_idle_watcher_create(
+                raw.flux_get_reactor(flux_handle),
+                lib.timeout_handler_wrapper if callback is not None else ffi.NULL,
+                self.wargs,
+            ),
+        )
 
 
 class SignalWatcher(Watcher):

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -137,4 +137,7 @@ test_runat_t_CPPFLAGS = $(test_cppflags)
 test_runat_t_LDADD = $(test_ldadd)
 test_runat_t_LDFLAGS = $(test_ldflags)
 
+dist_fluxcmd_SCRIPTS = \
+	flux-module-python-exec.py
+
 EXTRA_DIST = README.md

--- a/src/broker/flux-module-python-exec.py
+++ b/src/broker/flux-module-python-exec.py
@@ -1,0 +1,110 @@
+##############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+# flux-module-python-exec - load and run a Python broker module
+#
+# This program is used as a module loader by the Flux broker when loading
+# Python broker modules (.py suffix).  It implements the broker module
+# loader protocol described in RFC 5:
+#
+#   1. Open a handle using FLUX_MODULE_URI from the environment.
+#   2. Initialize the module via flux_module_initialize().
+#   3. Register standard module handlers via flux_module_register_handlers().
+#   4. Dynamically import the Python module at PATH and call mod_main(h, *args).
+#      The Python module is responsible for running the reactor.
+#   5. Finalize the module via flux_module_finalize().
+#
+# The Python module must define either:
+#
+#   def mod_main(h, *args): ...
+#
+# or a single BrokerModule subclass, in which case mod_main is synthesized as
+# BrokerModuleSubclass(h, *args).run().  h is a flux.Flux handle and args are
+# the (possibly empty) module args split from the space-delimited string
+# returned by flux_module_initialize().
+#
+# Usage: flux module-python-exec PATH
+
+import errno as errno_mod
+import os
+import sys
+import traceback
+
+from _flux._core import ffi, lib
+from flux.brokermod import resolve_entry_point
+from flux.core.handle import Flux
+from flux.importer import import_path
+
+
+def die(msg):
+    print(f"{os.path.basename(sys.argv[0])}: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def die_error(msg, error):
+    text = ffi.string(error.text).decode("utf-8", errors="replace")
+    die(f"{msg}: {text}")
+
+
+def main():
+    if len(sys.argv) != 2:
+        die(f"Usage: {os.path.basename(sys.argv[0])} PATH")
+    path = sys.argv[1]
+    uri = os.environ.get("FLUX_MODULE_URI")
+    if not uri:
+        die("FLUX_MODULE_URI is not set")
+
+    try:
+        h = Flux(url=uri)
+    except OSError as exc:
+        die(f"flux_open: {exc}")
+
+    error = ffi.new("flux_error_t[1]")
+    args_p = ffi.new("char **")
+    if lib.flux_module_initialize(h.handle, args_p, error) < 0:
+        die_error("flux_module_initialize", error[0])
+
+    modargs = None
+    if args_p[0] != ffi.NULL:
+        modargs = ffi.string(args_p[0]).decode("utf-8")
+        lib.free(args_p[0])
+
+    if lib.flux_module_register_handlers(h.handle, error) < 0:
+        die_error("flux_module_register_handlers", error[0])
+
+    mod = import_path(path)
+
+    args = modargs.split() if modargs else []
+
+    try:
+        mod_main = resolve_entry_point(mod)
+    except ValueError as exc:
+        die(f"{path}: {exc}")
+
+    errnum = 0
+    try:
+        mod_main(h, *args)
+    except ValueError as exc:
+        # User-facing argument errors: print message only, no traceback
+        print(f"{os.path.basename(path)}: {exc}", file=sys.stderr)
+        errnum = errno_mod.EINVAL
+    except Exception:  # pylint: disable=broad-except
+        traceback.print_exc()
+        errnum = errno_mod.ECONNRESET
+
+    error = ffi.new("flux_error_t[1]")
+    if lib.flux_module_finalize(h.handle, errnum, error) < 0:
+        die_error("flux_module_finalize", error[0])
+
+
+if __name__ == "__main__":
+    main()
+
+# vi: ts=4 sw=4 expandtab

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -75,6 +75,7 @@ static struct module_builtin *builtins[] = {
  */
 static const struct modloader loaders[] = {
     { .glob = ".so*", .cmd = "module-exec" },
+    { .glob = ".py", .cmd = "module-python-exec" },
 };
 
 static json_t *modhash_get_modlist (modhash_t *mh,

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -127,9 +127,10 @@ static const struct modloader *modloader_find_bysuffix (const char *path)
     return ld;
 }
 
-/* Given a module name, look for a file on the search path whose suffix
- * matches a module loader.  Return the module loader and the file path
- * (caller must free the latter).
+/* Given a module name, search 'searchpath', a colon-separated list of
+ * directories, for a file whose filename suffix matches one of the patterns
+ * in the loaders[] array.  Return the matching loaders[] entry and the
+ * file path (caller must free the latter).
  */
 static const struct modloader *modloader_find_byname (const char *name,
                                                       const char *searchpath,

--- a/src/common/libflux/conf_builtin.c
+++ b/src/common/libflux/conf_builtin.c
@@ -73,7 +73,8 @@ static struct builtin builtin_tab[] = {
         .val_installed = FLUXCMDDIR,
         .val_intree = ABS_TOP_BUILDDIR "/src/cmd:" \
                       ABS_TOP_SRCDIR "/src/cmd:" \
-                      ABS_TOP_BUILDDIR "/src/broker",
+                      ABS_TOP_BUILDDIR "/src/broker:" \
+                      ABS_TOP_SRCDIR "/src/broker",
     },
     {
         .key = "connector_path",
@@ -83,7 +84,8 @@ static struct builtin builtin_tab[] = {
     {
         .key = "module_path",
         .val_installed = FLUXMODDIR,
-        .val_intree = ABS_TOP_BUILDDIR "/src/modules/.libs",
+        .val_intree = ABS_TOP_BUILDDIR "/src/modules/.libs:" \
+                      ABS_TOP_SRCDIR "/src/modules",
     },
     {
         .key = "rc1_path",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -322,6 +322,7 @@ TESTSCRIPTS = \
 	python/t0035-kvs-no-checkpoint.py \
 	python/t0036-subprocess.py \
 	python/t0037-slurm.py \
+	python/t0038-brokermod.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -72,6 +72,7 @@ TESTSCRIPTS = \
 	t0005-rexec.t \
 	t0005-exec-jobid.t \
 	t0006-module-exec.t \
+	t0028-module-python-exec.t \
 	t0007-ping.t \
 	t0008-attr.t \
 	t0009-dmesg.t \
@@ -357,7 +358,8 @@ EXTRA_DIST= \
 	marshall \
 	batch \
 	job-manager/dumps \
-	flux-resource
+	flux-resource \
+	module/testmod.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/module/testmod.py
+++ b/t/module/testmod.py
@@ -1,0 +1,38 @@
+##############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+# testmod.py - minimal Python broker module for testing flux-module-python-exec
+
+from flux.brokermod import BrokerModule, event_handler, request_handler
+
+
+class TestMod(BrokerModule):
+
+    @request_handler("hello")
+    def hello(self, msg):
+        self.handle.respond(msg, {"name": self.name})
+
+    @request_handler("die")
+    def die(self, msg):
+        raise RuntimeError("die handler raised per test request")
+
+    @event_handler("panic")
+    def panic(self, msg):
+        self.stop_error()
+
+
+def mod_main(h, *args):
+    for arg in args:
+        if arg == "--init-failure":
+            raise RuntimeError("init failure per test request")
+    TestMod(h, *args).run()
+
+
+# vi: ts=4 sw=4 expandtab

--- a/t/python/t0038-brokermod.py
+++ b/t/python/t0038-brokermod.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Unit tests for flux.brokermod (BrokerModule, request_handler, event_handler).
+# A broker is not required; the flux handle is mocked.
+
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import subflux  # noqa: F401 - To set up PYTHONPATH
+from flux.brokermod import (
+    BrokerModule,
+    event_handler,
+    request_handler,
+    resolve_entry_point,
+)
+from flux.constants import FLUX_MSGTYPE_EVENT, FLUX_MSGTYPE_REQUEST
+from pycotap import TAPTestRunner
+
+
+class TestDecorators(unittest.TestCase):
+    def test_request_handler_sets_metadata(self):
+        @request_handler("hello")
+        def func(self, msg):
+            pass
+
+        self.assertEqual(
+            func._flux_handler,
+            {
+                "msgtype": FLUX_MSGTYPE_REQUEST,
+                "topic": "hello",
+                "prefix": True,
+                "allow_guest": False,
+            },
+        )
+
+    def test_event_handler_sets_metadata(self):
+        @event_handler("panic")
+        def func(self, msg):
+            pass
+
+        self.assertEqual(
+            func._flux_handler,
+            {"msgtype": FLUX_MSGTYPE_EVENT, "topic": "panic", "prefix": True},
+        )
+
+    def test_request_handler_prefix_false(self):
+        @request_handler("broker.hello", prefix=False)
+        def func(self, msg):
+            pass
+
+        self.assertEqual(func._flux_handler["prefix"], False)
+        self.assertEqual(func._flux_handler["topic"], "broker.hello")
+
+    def test_event_handler_prefix_false(self):
+        @event_handler("heartbeat", prefix=False)
+        def func(self, msg):
+            pass
+
+        self.assertEqual(func._flux_handler["prefix"], False)
+        self.assertEqual(func._flux_handler["topic"], "heartbeat")
+
+
+def make_mock_handle(name=b"mymod"):
+    """Return a MagicMock Flux handle with ffi/lib mocked to return name."""
+    mock_ffi = MagicMock()
+    mock_ffi.string.return_value = name
+    mock_lib = MagicMock()
+    return MagicMock(), mock_ffi, mock_lib
+
+
+class TestBrokerModule(unittest.TestCase):
+    def _make_module(self, cls, name=b"mymod"):
+        mock_h, mock_ffi, mock_lib = make_mock_handle(name)
+        with patch("flux.brokermod.ffi", mock_ffi), patch(
+            "flux.brokermod.lib", mock_lib
+        ):
+            mod = cls(mock_h)
+        return mod, mock_h
+
+    def test_name_from_aux(self):
+        """BrokerModule.name reflects the value returned by flux_aux_get."""
+
+        class Mod(BrokerModule):
+            pass
+
+        mod, _ = self._make_module(Mod, name=b"mymod")
+        self.assertEqual(mod.name, "mymod")
+
+    def test_name_unknown_when_null(self):
+        """BrokerModule.name is 'unknown' when flux_aux_get returns NULL."""
+
+        class Mod(BrokerModule):
+            pass
+
+        mock_h = MagicMock()
+        mock_ffi = MagicMock()
+        mock_lib = MagicMock()
+        # Make cast() return the same object as NULL so the != check fails
+        sentinel = object()
+        mock_ffi.NULL = sentinel
+        mock_ffi.cast.return_value = sentinel
+        with patch("flux.brokermod.ffi", mock_ffi), patch(
+            "flux.brokermod.lib", mock_lib
+        ):
+            mod = Mod(mock_h)
+        self.assertEqual(mod.name, "unknown")
+
+    def test_request_handler_registered(self):
+        """A @request_handler method is registered via msg_watcher_create."""
+
+        class Mod(BrokerModule):
+            @request_handler("hello")
+            def hello(self, msg):
+                pass
+
+        mod, mock_h = self._make_module(Mod)
+        topics = [call[0][2] for call in mock_h.msg_watcher_create.call_args_list]
+        self.assertIn("mymod.hello", topics)
+
+    def test_event_handler_registered(self):
+        """A @event_handler method is registered via msg_watcher_create and event_subscribe."""
+
+        class Mod(BrokerModule):
+            @event_handler("panic")
+            def panic(self, msg):
+                pass
+
+        mod, mock_h = self._make_module(Mod)
+        topics = [call[0][2] for call in mock_h.msg_watcher_create.call_args_list]
+        self.assertIn("mymod.panic", topics)
+        mock_h.event_subscribe.assert_called_once_with("mymod.panic")
+
+    def test_prefix_false_skips_module_name(self):
+        """A handler with prefix=False is registered without the module name prefix."""
+
+        class Mod(BrokerModule):
+            @event_handler("heartbeat", prefix=False)
+            def hb(self, msg):
+                pass
+
+        mod, mock_h = self._make_module(Mod)
+        topics = [call[0][2] for call in mock_h.msg_watcher_create.call_args_list]
+        self.assertIn("heartbeat", topics)
+        self.assertNotIn("mymod.heartbeat", topics)
+
+    def test_multiple_handlers_all_registered(self):
+        """All decorated handlers in a class are registered."""
+
+        class Mod(BrokerModule):
+            @request_handler("hello")
+            def hello(self, msg):
+                pass
+
+            @event_handler("panic")
+            def panic(self, msg):
+                pass
+
+        mod, mock_h = self._make_module(Mod)
+        self.assertEqual(mock_h.msg_watcher_create.call_count, 2)
+
+    def test_inherited_handlers_registered(self):
+        """Handlers inherited from a base class are also registered."""
+
+        class Base(BrokerModule):
+            @request_handler("hello")
+            def hello(self, msg):
+                pass
+
+        class Derived(Base):
+            @event_handler("panic")
+            def panic(self, msg):
+                pass
+
+        mod, mock_h = self._make_module(Derived)
+        topics = [call[0][2] for call in mock_h.msg_watcher_create.call_args_list]
+        self.assertIn("mymod.hello", topics)
+        self.assertIn("mymod.panic", topics)
+
+    def test_watchers_started(self):
+        """Watchers returned by msg_watcher_create are started."""
+
+        class Mod(BrokerModule):
+            @request_handler("hello")
+            def hello(self, msg):
+                pass
+
+        mod, mock_h = self._make_module(Mod)
+        watcher = mock_h.msg_watcher_create.return_value
+        watcher.start.assert_called_once()
+
+    def test_allow_guest_sets_rolemask(self):
+        """allow_guest=True passes FLUX_ROLE_OWNER|FLUX_ROLE_USER as rolemask."""
+
+        class Mod(BrokerModule):
+            @request_handler("info", allow_guest=True)
+            def info(self, msg):
+                pass
+
+        mock_h, mock_ffi, mock_lib = make_mock_handle()
+        mock_lib.FLUX_ROLE_OWNER = 1
+        mock_lib.FLUX_ROLE_USER = 2
+        with patch("flux.brokermod.ffi", mock_ffi), patch(
+            "flux.brokermod.lib", mock_lib
+        ):
+            Mod(mock_h)
+
+        call_kwargs = mock_h.msg_watcher_create.call_args_list[0][1]
+        self.assertEqual(call_kwargs.get("rolemask"), 1 | 2)
+
+    def test_no_allow_guest_rolemask_is_none(self):
+        """Without allow_guest, rolemask is None (broker default applies)."""
+
+        class Mod(BrokerModule):
+            @request_handler("info")
+            def info(self, msg):
+                pass
+
+        _, mock_h = self._make_module(Mod)
+        call_kwargs = mock_h.msg_watcher_create.call_args_list[0][1]
+        self.assertIsNone(call_kwargs.get("rolemask"))
+
+
+def _make_mod(**attrs):
+    """Return a types.ModuleType with the given attributes set."""
+    mod = types.ModuleType("testmod")
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+class TestResolveEntryPoint(unittest.TestCase):
+    def test_mod_main_returned_directly(self):
+        """resolve_entry_point returns mod_main when it is defined."""
+
+        def mod_main(h, *args):
+            pass
+
+        mod = _make_mod(mod_main=mod_main)
+        self.assertIs(resolve_entry_point(mod), mod_main)
+
+    def test_single_subclass_synthesizes_entry_point(self):
+        """resolve_entry_point synthesizes an entry point from a single BrokerModule subclass."""
+
+        class MyMod(BrokerModule):
+            pass
+
+        mod = _make_mod(MyMod=MyMod)
+        entry = resolve_entry_point(mod)
+        self.assertTrue(callable(entry))
+
+    def test_single_subclass_calls_run(self):
+        """The synthesized entry point calls cls(h, *args).run()."""
+
+        run_called = []
+
+        class MyMod(BrokerModule):
+            def run(self):
+                run_called.append(self._args)
+
+        mod = _make_mod(MyMod=MyMod)
+        entry = resolve_entry_point(mod)
+
+        mock_h = MagicMock()
+        mock_ffi = MagicMock()
+        mock_lib = MagicMock()
+        with patch("flux.brokermod.ffi", mock_ffi), patch(
+            "flux.brokermod.lib", mock_lib
+        ):
+            entry(mock_h, "a", "b")
+
+        self.assertEqual(run_called, [("a", "b")])
+
+    def test_multiple_subclasses_raises(self):
+        """resolve_entry_point raises ValueError when multiple subclasses are present."""
+
+        class ModA(BrokerModule):
+            pass
+
+        class ModB(BrokerModule):
+            pass
+
+        mod = _make_mod(ModA=ModA, ModB=ModB)
+        with self.assertRaises(ValueError) as ctx:
+            resolve_entry_point(mod)
+        self.assertIn("multiple BrokerModule subclasses", str(ctx.exception))
+
+    def test_no_entry_point_raises(self):
+        """resolve_entry_point raises ValueError when neither mod_main nor a subclass is found."""
+        mod = _make_mod()
+        with self.assertRaises(ValueError) as ctx:
+            resolve_entry_point(mod)
+        self.assertIn("no mod_main()", str(ctx.exception))
+
+    def test_base_class_not_counted_as_subclass(self):
+        """BrokerModule itself imported into the module namespace is not treated as a subclass."""
+        mod = _make_mod(BrokerModule=BrokerModule)
+        with self.assertRaises(ValueError):
+            resolve_entry_point(mod)
+
+    def test_mod_main_takes_precedence_over_subclass(self):
+        """mod_main is preferred over a BrokerModule subclass when both are present."""
+
+        def mod_main(h, *args):
+            pass
+
+        class MyMod(BrokerModule):
+            pass
+
+        mod = _make_mod(mod_main=mod_main, MyMod=MyMod)
+        self.assertIs(resolve_entry_point(mod), mod_main)
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t0028-module-python-exec.t
+++ b/t/t0028-module-python-exec.t
@@ -1,0 +1,117 @@
+#!/bin/sh
+#
+
+test_description='Test flux-module-python-exec'
+
+. `dirname $0`/sharness.sh
+test_under_flux 1 minimal
+
+testmod=$(realpath ${SHARNESS_TEST_SRCDIR}/module/testmod.py)
+
+# check_hello NAME - send a hello RPC to NAME.hello and verify the response
+check_hello() {
+	flux python -c "
+import flux, sys
+h = flux.Flux()
+result = h.rpc('$1.hello').get()
+if result.get('name') != '$1':
+    print('unexpected name: ' + str(result), file=sys.stderr)
+    sys.exit(1)
+"
+}
+
+# trigger_die NAME - send a die RPC to NAME.die (no response expected)
+trigger_die() {
+	flux python -c "
+import flux
+h = flux.Flux()
+try:
+    h.rpc('$1.die').get()
+except Exception:
+    pass
+"
+}
+
+##
+# Error cases (direct invocation without FLUX_MODULE_URI)
+##
+
+test_expect_success 'flux-module-python-exec fails without FLUX_MODULE_URI' '
+	test_must_fail env -u FLUX_MODULE_URI \
+	    flux module-python-exec $testmod 2>nouri.err &&
+	grep "FLUX_MODULE_URI" nouri.err
+'
+test_expect_success 'flux-module-python-exec fails with no path argument' '
+	test_must_fail env -u FLUX_MODULE_URI \
+	    flux module-python-exec 2>noarg.err &&
+	grep "Usage" noarg.err
+'
+test_expect_success 'flux-module-python-exec fails with too many arguments' '
+	test_must_fail env -u FLUX_MODULE_URI \
+	    flux module-python-exec $testmod extra 2>extraarg.err &&
+	grep "Usage" extraarg.err
+'
+
+##
+# Broker mode
+##
+
+test_expect_success 'flux module load testmod.py works' '
+	flux module load $testmod
+'
+test_expect_success 'flux ping testmod works' '
+	flux ping -c 1 testmod
+'
+test_expect_success 'flux module stats testmod works' '
+	flux module stats testmod
+'
+test_expect_success 'flux module list shows testmod' '
+	flux module list | grep testmod
+'
+test_expect_success 'flux module remove testmod works' '
+	flux module remove testmod
+'
+test_expect_success 'flux module load testmod.py with args works' '
+	flux module load $testmod somearg &&
+	flux module remove testmod
+'
+test_expect_success 'flux module load testmod.py --init-failure fails' '
+	test_must_fail flux module load $testmod --init-failure
+'
+test_expect_success 'flux module load testmod.py under alternate name works' '
+	flux module load --name altmod $testmod &&
+	flux ping -c 1 altmod &&
+	check_hello altmod &&
+	flux module remove altmod
+'
+test_expect_success 'handler exception causes module exit with error' '
+	flux setattr broker.module-nopanic 1 &&
+	flux module load $testmod &&
+	flux dmesg -C &&
+	trigger_die testmod &&
+	sh -c "while flux module stats testmod 2>/dev/null; do true; done" &&
+	flux dmesg | grep "module runtime failure"
+'
+test_expect_success 'early module exit with error is reported by broker' '
+	flux setattr broker.module-nopanic 1 &&
+	flux module load $testmod &&
+	flux dmesg -C &&
+	flux event pub testmod.panic &&
+	sh -c "while flux module stats testmod 2>/dev/null; do true; done" &&
+	flux dmesg | grep "module runtime failure"
+'
+test_expect_success 'modprobe can load and remove testmod.py declared in TOML' '
+	mkdir -p modprobe.d &&
+	test_when_finished "rm -rf modprobe.d" &&
+	cat >modprobe.d/testmod.toml <<-EOF &&
+	[[modules]]
+	name = "testmod"
+	module = "$testmod"
+	EOF
+	FLUX_MODPROBE_PATH=$(pwd) flux modprobe load testmod &&
+	flux ping -c 1 testmod &&
+	check_hello testmod &&
+	FLUX_MODPROBE_PATH=$(pwd) flux modprobe remove testmod
+'
+
+test_done


### PR DESCRIPTION
Problem: there is no direct support for writing broker modules in python

This adds a python "module loader" and a convenience BrokerModule class to the python bindings.  This should make it pretty easy to write python broker modules, and lower the barrier of entry for creating tightly integrated Flux distributed services.

This provides a bit of documentation for would-be authors: https://flux-framework--7424.org.readthedocs.build/projects/flux-core/en/7424/python/broker_modules.html

For full disclosure, this PR was prepared with heavy assistance from Claude Code.

This currently is based upon
- #7422 