### PR TITLE
fix slurm-expiration-sync rc1 task for multi-node Slurm jobs

### DIFF
--- a/etc/modprobe/rc1.py
+++ b/etc/modprobe/rc1.py
@@ -17,7 +17,6 @@ from subprocess import Popen
 import flux.kvs
 import flux.subprocess as sp
 from flux.modprobe import run_all_rc_scripts, task
-from flux.resource import ResourceJournalConsumer
 
 
 def setup(context):
@@ -208,11 +207,7 @@ def push_cleanup(context):
 
 
 @task(
-    "slurm-expiration-sync",
-    ranks="0",
-    needs_env=["SLURM_JOB_ID"],
-    before=["sched"],
-    after=["resource"],
+    "slurm-expiration-sync", ranks="0", needs_env=["SLURM_JOB_ID"], after=["resource"]
 )
 def slurm_expiration_sync(context):
     # Check for valid SLURM_JOB_ID before proceeding:
@@ -225,24 +220,12 @@ def slurm_expiration_sync(context):
     # Force libyogrt backend to flux
     context.setenv("YOGRT_BACKEND", "flux")
 
-    consumer = ResourceJournalConsumer(context.handle).start()
-    while True:
-        event = consumer.poll(timeout=5.0)
-        if event.name == "resource-define":
-            # Once resources are defined launch Slurm time limit sync helper:
-            sp.rexec_bg(
-                context.handle,
-                ["flux", "slurm-expiration-sync", f"--jobid={jobid}"],
-                label="slurm-expiration-sync",
-            )
-        elif event.name == "resource-update":
-            # The resource-update event is posted by the resource module after
-            # flux-slurm-expiration-sync updates the expiration in R. Breaking
-            # here ensures the scheduler does not start until the expiration is
-            # up to date. Note: This task could exit early if there is another
-            # mechanism for updating the resource set in play. This case is not
-            # handled at this time.
-            break
+    # Launch helper
+    sp.rexec_bg(
+        context.handle,
+        ["flux", "slurm-expiration-sync", f"--jobid={jobid}"],
+        label="slurm-sync",
+    )
 
 
 @task("run-all-rc1", after=["*"])

--- a/src/cmd/flux-slurm-expiration-sync.py
+++ b/src/cmd/flux-slurm-expiration-sync.py
@@ -25,6 +25,7 @@ import time
 
 import flux
 import flux.slurm as slurm
+from flux.resource import ResourceJournalConsumer
 from flux.util import fsd
 
 POLL_INTERVAL_DEFAULT = 60  # seconds
@@ -53,22 +54,31 @@ def make_poll_cb(jobid, fh):
 
     def poll_and_update(fh, watcher, revents, _args):
         timeleft = slurm.slurm_timeleft(jobid)
-        if timeleft is None:
-            return
-
-        expiration = time.time() + timeleft
+        expiration = 0.0 if timeleft is None else time.time() + timeleft
         last = last_expiration[0]
 
         if last is None or abs(expiration - last) > CHANGE_THRESHOLD:
             LOGGER.debug(
                 "Slurm timeleft changed: %s remaining, expiration=%.3f",
-                fsd(timeleft),
+                "unlimited" if timeleft is None else fsd(timeleft),
                 expiration,
             )
             send_expiration_update(fh, expiration)
             last_expiration[0] = expiration
 
     return poll_and_update
+
+
+def wait_for_resource_define(fh):
+    consumer = ResourceJournalConsumer(fh).start()
+    while True:
+        try:
+            event = consumer.poll(timeout=5.0)
+            if event.name == "resource-define":
+                return
+        except OSError:
+            LOGGER.error("Timed out waiting for resource-define event")
+            sys.exit(1)
 
 
 @flux.util.CLIMain(LOGGER)
@@ -100,17 +110,9 @@ def main():
 
     fh = flux.Flux()
 
-    # Probe once at startup to confirm squeue is reachable and we have a
-    # valid time limit before entering the poll loop.
-    timeleft = slurm.slurm_timeleft(jobid)
-    if timeleft is None:
-        LOGGER.info("No Slurm time limit detected (unlimited or error), exiting")
-        # Update expiration to 0 (unlimited) so that the resource module will
-        # post a resource-update event allowing rc1 task to exit.
-        send_expiration_update(fh, 0.0)
-        sys.exit(0)
-
-    LOGGER.debug("Slurm job %d detected, %s remaining at startup", jobid, fsd(timeleft))
+    # Wait for resource-define event so resource module is ready to receive
+    # expiration updates:
+    wait_for_resource_define(fh)
 
     poll_cb = make_poll_cb(jobid, fh)
 

--- a/t/t4100-slurm-expiration-sync.t
+++ b/t/t4100-slurm-expiration-sync.t
@@ -107,7 +107,7 @@ test_expect_success 'flux start with 1 hour Slurm time limit' '
 	test_debug "cat $EXPIRATION_FILE" &&
 	SLURM_JOB_ID=1234 \
 	  FLUX_SLURM_MOCK_EXPIRATION_FILE=$EXPIRATION_FILE \
-	  flux start flux resource R > R-1h.json &&
+	  flux start -s2 flux resource R > R-1h.json &&
 	test_debug "cat R-1h.json" &&
 	check_expiration R-1h.json
 '
@@ -115,14 +115,14 @@ test_expect_success 'flux start with 2 hour Slurm time limit' '
 	future_time 7200 > $EXPIRATION_FILE &&
 	SLURM_JOB_ID=1234 \
 	  FLUX_SLURM_MOCK_EXPIRATION_FILE=$EXPIRATION_FILE \
-	  flux start flux resource R > R-2h.json &&
+	  flux start -s2 flux resource R > R-2h.json &&
 	check_expiration R-2h.json
 '
 test_expect_success 'Slurm time limit is propagated to jobs' '
 	future_time 3600 > $EXPIRATION_FILE &&
 	SLURM_JOB_ID=1234 \
 	  FLUX_SLURM_MOCK_EXPIRATION_FILE=$EXPIRATION_FILE \
-	  flux start flux run flux job timeleft > timeleft.out &&
+	  flux start -s2 flux run flux job timeleft > timeleft.out &&
 	timeleft=$(cat timeleft.out) &&
 	test "$timeleft" -gt 3500 &&
 	test "$timeleft" -le 3600
@@ -151,6 +151,18 @@ test_expect_success 'initial expiration is ~1 hour' '
 '
 test_expect_success 'update expiration file to ~2 hours and wait for poll' '
 	future_time 7200 > $EXPIRATION_FILE &&
+	flux python wait-expiration.py $(cat $EXPIRATION_FILE) &&
+	flux resource R > R-poll-updated.json &&
+	check_expiration R-poll-updated.json
+'
+test_expect_success 'update expiration file to unlimited and wait for poll' '
+	echo 0 > $EXPIRATION_FILE &&
+	flux python wait-expiration.py $(cat $EXPIRATION_FILE) &&
+	flux resource R > R-poll-updated.json &&
+	check_expiration R-poll-updated.json
+'
+test_expect_success 'update expiration to ~1 hour again and wait for poll' '
+	future_time 3600 > $EXPIRATION_FILE &&
 	flux python wait-expiration.py $(cat $EXPIRATION_FILE) &&
 	flux resource R > R-poll-updated.json &&
 	check_expiration R-poll-updated.json

--- a/t/t4100-slurm-expiration-sync.t
+++ b/t/t4100-slurm-expiration-sync.t
@@ -82,13 +82,6 @@ test_expect_success 'flux slurm-expiration-sync fails if squeue fails' '
 	test_must_fail flux slurm-expiration-sync --jobid=4 2>squeue-fail.err &&
 	grep "squeue failed" squeue-fail.err
 '
-test_expect_success 'flux slurm-expiration-sync works with unlimited' '
-	echo -1 > $EXPIRATION_FILE &&
-	FLUX_SLURM_MOCK_EXPIRATION_FILE=$EXPIRATION_FILE \
-	    flux slurm-expiration-sync --jobid=1234 2>unlimited.err &&
-	test_debug "cat unlimited.err" &&
-	grep -i "exiting" unlimited.err
-'
 #
 # Full flux start tests with SLURM_JOB_ID set and mock squeue
 #


### PR DESCRIPTION
As @wihobbs discovered in #7426, the slurm-expiration-sync task introduced in v0.83.0 is broken for multi-node jobs. This is a critical error that causes all multi-node Flux jobs under Slurm to fail :-(

This PR greatly simplifies the affected rc1 task by removing the attempted synchronization. The helper script is now launched after the resource module has started, and it waits for the resource-define event, which will arrive after rc1 in any Flux instance with multiple brokers.

The tests are updated to run with `flux start -s2` so the multiple broker case is at least validated.

This is the minimum viable fix for now, there is still room for further improvements in the future to further reduce the likelihood the first timeleft check comes before the expiration update (see e.g. @garlick's idea in  #7426), In practice, I was unable to reproduce the race.