### PR TITLE
testsuite: fix racy tests in `t4100-slurm-expiration-sync.t`

### DIFF
--- a/t/scripts/squeue
+++ b/t/scripts/squeue
@@ -51,11 +51,18 @@ def main():
     if mock_file is None:
         print("mock squeue: FLUX_SLURM_MOCK_EXPIRATION_FILE not set", file=sys.stderr)
         sys.exit(1)
-    try:
-        with open(mock_file) as f:
-            expiration = float(f.read().strip())
-    except (OSError, ValueError) as e:
-        print(f"mock squeue: {mock_file}: {e}", file=sys.stderr)
+    for _ in range(5):
+        try:
+            with open(mock_file) as f:
+                expiration = float(f.read().strip())
+            break
+        except OSError as e:
+            print(f"mock squeue: {mock_file}: {e}", file=sys.stderr)
+            sys.exit(1)
+        except ValueError:
+            time.sleep(0.05)
+    else:
+        print(f"mock squeue: {mock_file}: could not parse expiration", file=sys.stderr)
         sys.exit(1)
 
     timeleft = expiration - time.time()

--- a/t/t4100-slurm-expiration-sync.t
+++ b/t/t4100-slurm-expiration-sync.t
@@ -161,8 +161,8 @@ test_expect_success 'update expiration file to unlimited and wait for poll' '
 	flux resource R > R-poll-updated.json &&
 	check_expiration R-poll-updated.json
 '
-test_expect_success 'update expiration to ~1 hour again and wait for poll' '
-	future_time 3600 > $EXPIRATION_FILE &&
+test_expect_success 'update expiration to ~40 min and wait for poll' '
+	future_time 2400 > $EXPIRATION_FILE &&
 	flux python wait-expiration.py $(cat $EXPIRATION_FILE) &&
 	flux resource R > R-poll-updated.json &&
 	check_expiration R-poll-updated.json


### PR DESCRIPTION
This PR fixes a couple possible race conditions in `t4100-slurm-expiration-sync.t`.

Fixes #7432