### PR TITLE
job-info: fix resource leaks

### DIFF
--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -647,6 +647,7 @@ void update_lookup_cb (flux_t *h,
         errmsg = error.text;
         goto error;
     }
+    json_decref (keys);
     return;
 
 error:

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -426,7 +426,7 @@ static int watch (struct info_ctx *ctx,
         if ((ret = eventlog_allow_lru (w->ctx,
                                        w->msg,
                                        w->id)) < 0)
-            return -1;
+            goto error;
 
         if (ret)
             w->allow = true;


### PR DESCRIPTION
While reproducing an issue running sharness tests under `FLUX_TEST_VALGRIND=t`, valgrind reported some memory leaks in the job-info module.

This PR fixes the two leaks discovered, and also fixes a race in one test that was reproducible when the test was run under valgrind.