### PR TITLE
fix resource leaks and flaky tests found when running the testsuite under valgrind

### DIFF
--- a/src/common/libjob/count.c
+++ b/src/common/libjob/count.c
@@ -112,14 +112,14 @@ struct count *count_create (json_t *json_count,
     count->isrange = true;
     return count;
 error:
-    free (count);
+    count_destroy (count);
     return NULL;
 }
 
 void count_destroy (struct count *count)
 {
     if (count) {
-        free (count->idset);
+        idset_destroy (count->idset);
         free (count);
     }
 }
@@ -191,7 +191,7 @@ struct count *count_decode (const char *s)
         goto success;
     }
     // decoding as an idset failed or was invalid, so try as an RFC14 range
-    free (count->idset);
+    idset_destroy (count->idset);
     count->isrange = true;
     count->operator = '+';
     count->operand = 1;
@@ -242,7 +242,7 @@ success:
 error_inval:
     errno = EINVAL;
 error:
-    free (count);
+    count_destroy (count);
     free (cpy);
     return NULL;
 }

--- a/src/common/libjob/jjc.c
+++ b/src/common/libjob/jjc.c
@@ -68,7 +68,10 @@ static int jjc_read_vertex (json_t *o, int level, struct jjc_counts *jj, int nod
         jj->slot_size = count;
     else if (streq (type, "gpu"))
         jj->slot_gpus = count;
-    // ignore unknown resources
+    else if (!streq (type, "node")) {
+        // ignore unknown resources
+        count_destroy (count);
+    }
     if (with)
         return jjc_read_level (with, level+1, jj, nodefactor);
     return 0;

--- a/src/modules/groups/groups.c
+++ b/src/modules/groups/groups.c
@@ -653,7 +653,7 @@ static void stats_get_request_cb (flux_t *h,
         errmsg = "error building groups object";
         goto error;
     }
-    if (flux_respond_pack (h, msg, "{s:o}", "subtree", obj) < 0)
+    if (flux_respond_pack (h, msg, "{s:O}", "subtree", obj) < 0)
         flux_log_error (h, "error responding to groups.stats-get");
     json_decref (obj);
     return;

--- a/src/modules/heartbeat/heartbeat.c
+++ b/src/modules/heartbeat/heartbeat.c
@@ -169,8 +169,11 @@ static int heartbeat_timeout_adjust (struct heartbeat *hb, double timeout)
     if (hb->sync) {
         flux_future_t *f;
         if (!(f = flux_sync_create (hb->h, 0.))
-            || flux_future_then (f, timeout, sync_cb, hb) < 0)
+            || flux_future_then (f, timeout, sync_cb, hb) < 0) {
+            flux_future_destroy (f);
             return -1;
+        }
+        flux_future_destroy (hb->sync);
         hb->sync = f;
     }
     return 0;

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -168,7 +168,9 @@ static void interface_teardown (struct start *start, char *s, int errnum)
                   flux_strerror (errnum));
 
         free (start->topic);
+        free (start->update_topic);
         start->topic = NULL;
+        start->update_topic = NULL;
 
         job = zhashx_first (ctx->active_jobs);
         while (job) {

--- a/src/modules/overlay/overlay.c
+++ b/src/modules/overlay/overlay.c
@@ -2575,7 +2575,7 @@ static void overlay_config_reload_cb (flux_t *h,
     struct overlay *ov = arg;
     const char *topic = "unknown";
     flux_error_t error;
-    flux_conf_t *conf;
+    flux_conf_t *conf = NULL;
     bool initialize = false;
 
     if (flux_request_decode (msg, &topic, NULL) < 0
@@ -2589,14 +2589,13 @@ static void overlay_config_reload_cb (flux_t *h,
         goto error;
     if (flux_set_conf_new (h, conf) < 0) {
         errprintf (&error, "Failed to update config");
-        goto error_decref;
+        goto error;
     }
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "error responding to %s request", topic);
     return;
-error_decref:
-    flux_conf_decref (conf);
 error:
+    flux_conf_decref (conf);
     if (flux_respond_error (h, msg, errno, error.text) < 0)
         flux_log_error (h, "error responding to %s request", topic);
 }

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -82,6 +82,7 @@ static void resource_config_deinit (struct resource_config *config)
 {
     if (config) {
         int saved_errno = errno;
+        json_decref (config->R);
         rlist_verify_config_destroy (config->verify);
         config->verify = NULL;
         errno = saved_errno;
@@ -499,7 +500,6 @@ int mod_main (flux_t *h, int argc, char **argv)
     resource_config_deinit (&config);
     resource_ctx_destroy (ctx);
     json_decref (eventlog);
-    json_decref (config.R);
     return 0;
 error:
     resource_config_deinit (&config);

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -1031,7 +1031,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     }
 
     if (process_args (h, ss, argc, argv) < 0)
-        return -1;
+        goto done;
 
     ss->util_ctx = schedutil_create (h, ss->schedutil_flags, &ops, ss);
     if (ss->util_ctx == NULL) {

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -719,10 +719,12 @@ static void feasibility_cb (flux_t *h,
         goto err;
     }
     rlist_destroy (alloc);
+    jjc_destroy (&jj);
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "feasibility_cb: flux_respond_pack");
     return;
 err:
+    jjc_destroy (&jj);
     rlist_destroy (alloc);
     if (flux_respond_error (h, msg, errno, errmsg) < 0)
         flux_log_error (h, "feasibility_cb: flux_respond_error");

--- a/t/t2226-housekeeping.t
+++ b/t/t2226-housekeeping.t
@@ -212,7 +212,8 @@ test_expect_success 'run a job and ensure error was logged' '
 	wait_for_running 0 &&
 	flux run true &&
 	wait_for_running 0 &&
-	flux dmesg | grep "error launching process"
+	# Note: under valgrind error is "nonzero exit code" not "error launching..."
+	flux dmesg | grep -e "error launching process" -e "nonzero exit code"
 '
 test_expect_success 'create housekeeping script with one failing rank (3)' '
 	cat >housekeeping3.sh <<-EOT &&

--- a/t/t2290-job-update.t
+++ b/t/t2290-job-update.t
@@ -71,9 +71,8 @@ test_expect_success 'update request with invalid duration type fails' '
 '
 test_expect_success 'update of duration of pending job works' '
 	flux update $jobid duration=1m &&
-	flux job eventlog $jobid \
-		| grep jobspec-update \
-		| grep duration=60
+	flux job wait-event -vHt 30 \
+	    -m attributes.system.duration=60.0 $jobid jobspec-update
 '
 test_expect_success 'update of duration accepts relative values' '
 	flux update --dry-run $jobid duration=+1m \
@@ -104,31 +103,25 @@ test_expect_success 'add a duration limit and submit a held job' '
 '
 test_expect_success 'instance owner can adjust duration past limits' '
 	flux update $jobid duration=1h &&
-	flux job eventlog $jobid \
-		| grep jobspec-update \
-		| grep duration=3600
+	flux job wait-event -Ht 30 \
+	    -m attributes.system.duration=3600.0 $jobid jobspec-update
 '
 test_expect_success FLUX_SECURITY 'guest update of their own job works' '
 	guest_jobid=$(submit_held_job_as_guest 1m) &&
 	runas_guest flux update -v $guest_jobid duration=1m  &&
-	flux job eventlog $guest_jobid \
-		| grep jobspec-update \
-		| grep duration=60
+	flux job wait-event -Ht 30 -m duration=60 $jobid jobspec-update
 '
 test_expect_success FLUX_SECURITY 'guest cannot update job duration past limit' '
 	test_expect_code 1 runas_guest flux update -v $guest_jobid duration=1h
 '
 test_expect_success 'instance owner can adjust duration past limits' '
 	flux update $jobid duration=1h &&
-	flux job eventlog $jobid \
-		| grep jobspec-update \
-		| grep duration=3600
+	flux job wait-event -Ht 30 \
+	    -m attributes.system.duration=3600.0 $jobid jobspec-update
 '
 test_expect_success FLUX_SECURITY 'instance owner can adjust guest job duration past limits' '
 	flux update $guest_jobid duration=1h &&
-	flux job eventlog $guest_jobid \
-		| grep jobspec-update \
-		| grep duration=3600
+	flux job wait-event -Ht 30 -m duration=3600 $jobid jobspec-update
 '
 test_expect_success FLUX_SECURITY 'guest job is now immutable' '
 	test_expect_code 1 runas_guest \
@@ -164,9 +157,8 @@ test_expect_success 'load update-test jobtap plugin' '
 '
 test_expect_success 'now update of attributes.system.test works' '
 	flux update $jobid test=foo-update &&
-	flux job eventlog $jobid \
-		| grep jobspec-update \
-		| grep foo-update
+	flux job wait-event -Ht 30 \
+	    -m attributes.system.test=foo-update $jobid jobspec-update
 '
 test_expect_success 'update-test plugin can reject updates' '
 	test_expect_code 1 flux update $jobid test=fail-test 2>fail-test.err &&
@@ -175,9 +167,9 @@ test_expect_success 'update-test plugin can reject updates' '
 '
 test_expect_success 'multiple keys can be updated successfully' '
 	flux update -v $jobid test=ok test2=ok2 &&
-	flux job eventlog $jobid &&
-	flux job eventlog $jobid \
-		| grep jobspec-update \
-		| grep "test=\"ok\" attributes.system.test2=\"ok2\""
+	flux job wait-event -vHt 30 \
+	    -m attributes.system.test=ok $jobid jobspec-update &&
+	flux job wait-event -Ht 30 \
+	    -m attributes.system.test2=ok2 $jobid jobspec-update
 '
 test_done

--- a/t/t2811-flux-pgrep.t
+++ b/t/t2811-flux-pgrep.t
@@ -48,18 +48,19 @@ test_expect_success 'flux-pgrep default override w/ named format works' '
 	grep "INFO" default_override_named.out
 '
 test_expect_success 'flux-pkill works' '
-	flux pkill ^test &&
+	flux pkill --wait ^test &&
 	test_expect_code 1 flux pkill ^test &&
 	flux pkill foo
 '
 test_expect_success 'flux-pgrep works with jobid ranges' '
 	flux submit --bcc=1-6 sleep 60 >ids &&
 	flux submit --bcc=1-6 sleep 60 >ids2 &&
+	test_wait_until -v "test \$(flux jobs -no {id} | wc -l) -eq 12" &&
 	flux pgrep $(head -n 1 ids)..$(tail -n1 ids) >pgrep.ids &&
 	test $(wc -l <pgrep.ids) -eq 6 &&
 	flux pgrep $(head -n 1 ids)..$(tail -n1 ids2) >pgrep2.ids &&
 	test $(wc -l <pgrep2.ids) -eq 12 &&
-	flux pkill $(head -n1 ids)..$(tail -n1 ids) &&
+	flux pkill --wait $(head -n1 ids)..$(tail -n1 ids) &&
 	flux pgrep $(head -n 1 ids)..$(tail -n1 ids2) >pgrep3.ids &&
 	test $(wc -l <pgrep3.ids) -eq 6 &&
 	flux pgrep -a $(head -n 1 ids)..$(tail -n1 ids2) >pgrep4.ids &&

--- a/t/t2813-flux-watch.t
+++ b/t/t2813-flux-watch.t
@@ -131,7 +131,7 @@ test_expect_success 'flux-watch: --filter works' '
 	grep "Watching ${nfailed} job" failed.out
 '
 test_expect_success 'flux-watch: handles binary data' '
-	id=$(flux submit dd if=/dev/urandom count=1) &&
+	id=$(flux submit --wait-event=start dd if=/dev/urandom count=1) &&
 	test_debug "flux job eventlog -p guest.output -HL $id" &&
 	flux job attach $id >binary.expected &&
 	flux watch $id >binary.output &&

--- a/t/t3300-system-basic.t
+++ b/t/t3300-system-basic.t
@@ -80,7 +80,7 @@ test_expect_success 'ping to rank 2 fails' '
 '
 
 test_expect_success 'wait for overlay status to be degraded' '
-	run_timeout 10 flux overlay status --summary --wait degraded
+	run_timeout 10 flux overlay status --timeout=0 --summary --wait degraded
 '
 
 test_expect_success 'run broker rank=2' '
@@ -88,7 +88,7 @@ test_expect_success 'run broker rank=2' '
 '
 
 test_expect_success 'wait for subtree to be full' '
-	run_timeout 10 flux overlay status --summary --wait full
+	run_timeout 10 flux overlay status --timeout=0 --summary --wait full
 '
 
 test_expect_success 'run broker rank=2 again fails' '


### PR DESCRIPTION
I ran all sharness tests under valgrind with
```console
$ flux bulksubmit -n1 -c5 --watch --progress --env=FLUX_TEST_VALGRIND=t -o pty ./{} -d -v ::: t[0-9]*.t
```
There were about 13 or 14 test failures on the first run .

This PR is a set of fixes that include both test reliability updates and actual memory leak fixes.

There is one remaining failure described in #7443, since it was the only one that wasn't immediately obvious.
Fixes for #7442 are also left for after this PR.
