### PR TITLE
flux-update: add `--wait` option and use it as necessary in testsuite

### DIFF
--- a/doc/man1/flux-update.rst
+++ b/doc/man1/flux-update.rst
@@ -68,6 +68,10 @@ OPTIONS
 
   Print updated keys on success.
 
+.. option:: --wait
+
+  Wait until associated updates are posted to the target job's eventlog.
+
 SPECIAL KEYS
 ============
 

--- a/src/cmd/flux-update.py
+++ b/src/cmd/flux-update.py
@@ -13,10 +13,12 @@ import json
 import logging
 import math
 import sys
+import time
 
 import flux
 import flux.job
 import flux.util
+from flux.job import event_watch
 
 LOGGER = logging.getLogger("flux-update")
 
@@ -42,6 +44,7 @@ class JobspecUpdates:
         self.jobid = jobid
         self.updates = None
         self.jobspec = None
+        self.t0 = time.time()
 
     @property
     def flux_handle(self):
@@ -148,6 +151,21 @@ class JobspecUpdates:
         payload = {"id": self.jobid, "updates": self.updates}
         return self.flux_handle.rpc("job-manager.update", payload)
 
+    def wait(self):
+        """
+        Wait for expected jobspec-update event to be posted to the job
+        eventlog. To avoid matching a prior duplicate, only consider
+        events that were posted after this invocation of flux-update(1)
+        started.
+        """
+        for event in event_watch(self.flux_handle, self.jobid):
+            if (
+                event.name == "jobspec-update"
+                and event.timestamp > self.t0
+                and self.items() <= event.context.items()
+            ):
+                return
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -165,6 +183,11 @@ def parse_args():
         action="store_true",
         default=0,
         help="Be more verbose. Log updated items after success.",
+    )
+    parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="Wait for updates to appear in job eventlog before exiting",
     )
     parser.add_argument(
         "jobid",
@@ -204,6 +227,8 @@ def main():
         sys.exit(0)
 
     updates.send_rpc().get()
+    if args.wait:
+        updates.wait()
     if args.verbose:
         for key, value in updates.items():
             LOGGER.info(f"updated {key} to {value}")

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -91,7 +91,7 @@ test_expect_success 'flux job info applies jobspec updates' '
 	jobid=$(flux submit --urgency=hold true) &&
 	echo $jobid > updated_jobspec.id &&
 	flux job info $jobid jobspec | jq -e ".attributes.system.duration == 0" &&
-	flux update $jobid duration=100s &&
+	flux update --wait $jobid duration=100s &&
 	flux job info $jobid jobspec | jq -e ".attributes.system.duration == 100.0" &&
 	flux cancel $jobid
 '
@@ -111,7 +111,7 @@ test_expect_success 'flux job info applies resource updates' '
 	jobid=$(flux submit --wait-event=start sleep 300) &&
 	echo $jobid > updated_R.id &&
 	flux job info $jobid R | jq -e ".execution.expiration == 0.0" &&
-	flux update $jobid duration=300 &&
+	flux update --wait $jobid duration=300 &&
 	flux job info $jobid R | jq -e ".execution.expiration > 0.0" &&
 	flux job info $jobid eventlog &&
 	flux cancel $jobid

--- a/t/t2290-job-update.t
+++ b/t/t2290-job-update.t
@@ -70,9 +70,10 @@ test_expect_success 'update request with invalid duration type fails' '
 	    | ${FLUX_BUILD_DIR}/t/request/rpc job-manager.update 71 # EPROTO
 '
 test_expect_success 'update of duration of pending job works' '
-	flux update $jobid duration=1m &&
-	flux job wait-event -vHt 30 \
-	    -m attributes.system.duration=60.0 $jobid jobspec-update
+	flux update --wait $jobid duration=1m &&
+	flux job eventlog $jobid \
+		| grep jobspec-update \
+		| grep duration=60
 '
 test_expect_success 'update of duration accepts relative values' '
 	flux update --dry-run $jobid duration=+1m \
@@ -108,8 +109,10 @@ test_expect_success 'instance owner can adjust duration past limits' '
 '
 test_expect_success FLUX_SECURITY 'guest update of their own job works' '
 	guest_jobid=$(submit_held_job_as_guest 1m) &&
-	runas_guest flux update -v $guest_jobid duration=1m  &&
-	flux job wait-event -Ht 30 -m duration=60 $jobid jobspec-update
+	runas_guest flux update --wait -v $guest_jobid duration=1m  &&
+	flux job eventlog $guest_jobid \
+		| grep jobspec-update \
+		| grep duration=60
 '
 test_expect_success FLUX_SECURITY 'guest cannot update job duration past limit' '
 	test_expect_code 1 runas_guest flux update -v $guest_jobid duration=1h
@@ -125,13 +128,13 @@ test_expect_success FLUX_SECURITY 'instance owner can adjust guest job duration 
 '
 test_expect_success FLUX_SECURITY 'guest job is now immutable' '
 	test_expect_code 1 runas_guest \
-		flux update -v $guest_jobid duration=1m \
+		flux update --wait -v $guest_jobid duration=1m \
 			2>immutable.err &&
 	test_debug "cat immutable.err" &&
 	grep immutable immutable.err
 '
 test_expect_success 'adjust duration so future tests pass validation' '
-	flux update $jobid duration=1m
+	flux update --wait $jobid duration=1m
 '
 test_expect_success 'reload update-duration plugin with owner-allow-any=0' '
 	flux jobtap remove .update-duration &&

--- a/t/t2291-job-update-queue.t
+++ b/t/t2291-job-update-queue.t
@@ -63,7 +63,7 @@ test_expect_success 'update to same queue fails' '
 	test_must_fail flux update $jobid queue=debug
 '
 test_expect_success 'update to batch queue works' '
-	flux update $jobid queue=batch &&
+	flux update --wait $jobid queue=batch &&
 	test_debug "flux job eventlog $jobid" &&
 	flux job eventlog $jobid \
 	  | grep jobspec-update \
@@ -81,7 +81,7 @@ test_expect_success 'update to queue with lower duration limit fails' '
 	grep "duration.*exceeds policy limit" queue.err
 '
 test_expect_success 'update of duration allows queue update' '
-	flux update $jobid queue=debug duration=1m  &&
+	flux update --wait $jobid queue=debug duration=1m  &&
 	test_debug "flux job eventlog $jobid" &&
 	flux job eventlog $jobid \
 	  | grep jobspec-update \
@@ -113,7 +113,7 @@ test_expect_success 'update of queue for job with other constraints fails' '
 '
 test_expect_success 'update from queue with no constraints works' '
 	jobid=$(flux submit -t 1m --urgency=hold -q other hostname) &&
-	flux update $jobid queue=debug &&
+	flux update --wait $jobid queue=debug &&
 	test_debug "flux job eventlog $jobid" &&
 	flux job eventlog $jobid \
 	  | grep jobspec-update \
@@ -123,7 +123,7 @@ test_expect_success 'update from queue with no constraints works' '
 '
 test_expect_success 'update to queue with no constraints works' '
 	jobid=$(flux submit --urgency=hold -q debug hostname) &&
-	flux update $jobid queue=other &&
+	flux update --wait $jobid queue=other &&
 	test_debug "flux job eventlog $jobid" &&
 	flux job eventlog $jobid \
 	  | grep jobspec-update \


### PR DESCRIPTION
This PR adds a new `--wait` option to `flux update` as proposed in #7442 and uses it in the testsuite where necessary where the job eventlog is checked immediately after the update.