### PR TITLE
python: improve broker module error propagation and test integration

### DIFF
--- a/src/bindings/python/flux/brokermod.py
+++ b/src/bindings/python/flux/brokermod.py
@@ -115,6 +115,15 @@ class BrokerModule:
         if lib.flux_module_set_running(self._h.handle) < 0:
             raise OSError("flux_module_set_running failed")
 
+    def debug_test(self, flag, clear=False):
+        """Test a module debug bit, optionally clearing it.
+
+        Returns True if the bit identified by *flag* is set.  If *clear* is
+        True the bit is atomically cleared after being read.  Bits are set
+        externally via ``flux module debug --setbit N <module-name>``.
+        """
+        return lib.flux_module_debug_test(self._h.handle, flag, clear)
+
     def stop(self):
         """Stop the reactor and exit :meth:`run` normally."""
         self._h.reactor_stop()

--- a/src/broker/flux-module-python-exec.py
+++ b/src/broker/flux-module-python-exec.py
@@ -95,6 +95,11 @@ def main():
         # User-facing argument errors: print message only, no traceback
         print(f"{os.path.basename(path)}: {exc}", file=sys.stderr)
         errnum = errno_mod.EINVAL
+    except OSError as exc:
+        # Module exited with error already logged via the broker log.
+        # Propagate the original errno if available so the caller sees a
+        # meaningful error code (e.g. EEXIST for service already registered).
+        errnum = exc.errno if exc.errno else errno_mod.ECONNRESET
     except Exception:  # pylint: disable=broad-except
         traceback.print_exc()
         errnum = errno_mod.ECONNRESET

--- a/t/module/testmod.py
+++ b/t/module/testmod.py
@@ -19,6 +19,13 @@ class TestMod(BrokerModule):
     def hello(self, msg):
         self.handle.respond(msg, {"name": self.name})
 
+    @request_handler("debug_check")
+    def debug_check(self, msg):
+        """Return whether the debug bit *flag* is set, optionally clearing it."""
+        flag = msg.payload.get("flag", 0)
+        clear = msg.payload.get("clear", False)
+        self.handle.respond(msg, {"set": self.debug_test(flag, clear=clear)})
+
     @request_handler("die")
     def die(self, msg):
         raise RuntimeError("die handler raised per test request")

--- a/t/module/testmod.py
+++ b/t/module/testmod.py
@@ -10,6 +10,8 @@
 
 # testmod.py - minimal Python broker module for testing flux-module-python-exec
 
+import errno
+
 from flux.brokermod import BrokerModule, event_handler, request_handler
 
 
@@ -39,6 +41,8 @@ def mod_main(h, *args):
     for arg in args:
         if arg == "--init-failure":
             raise RuntimeError("init failure per test request")
+        if arg == "--oserror-failure":
+            raise OSError(errno.EEXIST, "service already registered")
     TestMod(h, *args).run()
 
 

--- a/t/t0028-module-python-exec.t
+++ b/t/t0028-module-python-exec.t
@@ -114,6 +114,10 @@ test_expect_success 'debug_test: remove testmod' '
 	flux module remove testmod
 '
 
+test_expect_success 'OSError errno is propagated on module init failure' '
+	test_must_fail flux module load $testmod --oserror-failure 2>oserr.err &&
+	grep -i "File exists" oserr.err
+'
 test_expect_success 'flux module load testmod.py under alternate name works' '
 	flux module load --name altmod $testmod &&
 	flux ping -c 1 altmod &&

--- a/t/t0028-module-python-exec.t
+++ b/t/t0028-module-python-exec.t
@@ -20,6 +20,19 @@ if result.get('name') != '$1':
 "
 }
 
+# check_debug NAME FLAG [clear] - return true if debug bit FLAG is set in NAME
+# Passes clear=True if a third argument is given.
+check_debug() {
+	local name="$1" flag="$2"
+	local clear="False"; [ $# -ge 3 ] && clear="True"
+	flux python -c "
+import flux, sys
+h = flux.Flux()
+result = h.rpc('$name.debug_check', {'flag': $flag, 'clear': $clear}).get()
+sys.exit(0 if result.get('set') else 1)
+"
+}
+
 # trigger_die NAME - send a die RPC to NAME.die (no response expected)
 trigger_die() {
 	flux python -c "
@@ -78,6 +91,29 @@ test_expect_success 'flux module load testmod.py with args works' '
 test_expect_success 'flux module load testmod.py --init-failure fails' '
 	test_must_fail flux module load $testmod --init-failure
 '
+
+##
+# BrokerModule.debug_test()
+##
+
+test_expect_success 'debug_test: load testmod' '
+	flux module load $testmod
+'
+test_expect_success 'debug_test: bit is clear before setbit' '
+	test_must_fail check_debug testmod 1
+'
+test_expect_success 'debug_test: bit is set after flux module debug --setbit' '
+	flux module debug --setbit 1 testmod &&
+	check_debug testmod 1
+'
+test_expect_success 'debug_test: clear=True reads and clears the bit atomically' '
+	check_debug testmod 1 true &&
+	test_must_fail check_debug testmod 1
+'
+test_expect_success 'debug_test: remove testmod' '
+	flux module remove testmod
+'
+
 test_expect_success 'flux module load testmod.py under alternate name works' '
 	flux module load --name altmod $testmod &&
 	flux ping -c 1 altmod &&


### PR DESCRIPTION
This adds a couple of missing things from the python broker module infrastructure: support for the `flux module debug` stuff, and better propagation of OSError exceptions.