### PR TITLE
python: add toy scheduler framework

### DIFF
--- a/doc/python/index.rst
+++ b/doc/python/index.rst
@@ -13,6 +13,7 @@ command line are possible in Python as well via the ``flux`` package.
    basics
    job_submission
    broker_modules
+   scheduler
    complete_api
    developer
 

--- a/doc/python/scheduler.rst
+++ b/doc/python/scheduler.rst
@@ -1,0 +1,598 @@
+.. _python_scheduler:
+
+.. currentmodule:: flux.scheduler
+
+Writing a Python Scheduler
+==========================
+
+Flux supports scheduler broker modules written in Python.  The
+:class:`Scheduler` base class handles all of the RFC 27
+protocol scaffolding — service registration, resource acquisition, the
+hello/ready handshake with job-manager — so that a Python scheduler only
+needs to implement scheduling policy.
+
+This guide walks through writing a working scheduler from scratch,
+explains each override point, and covers more advanced topics such as
+job annotations and start-time forecasting.
+
+
+Minimal example
+---------------
+
+The base class maintains a :class:`PendingJob` heap queue
+(:attr:`~Scheduler._queue`) and provides default
+implementations of :meth:`~Scheduler.alloc`,
+:meth:`~Scheduler.free`,
+:meth:`~Scheduler.cancel`, and
+:meth:`~Scheduler.prioritize`.  A minimal scheduler only
+needs to override :meth:`~Scheduler.schedule`:
+
+.. code-block:: python
+
+   import heapq
+   from flux.resource import InsufficientResources, InfeasibleRequest
+   from flux.scheduler import Scheduler
+
+   class SimpleScheduler(Scheduler):
+
+       def schedule(self):
+           while self._queue:
+               job = self._queue[0]
+               try:
+                   alloc = self.resources.alloc(job.jobid, job.resource_request)
+               except InsufficientResources:
+                   break   # not enough resources — wait for free
+               except InfeasibleRequest as exc:
+                   job.request.deny(str(exc))
+               else:
+                   job.request.success(alloc)
+               heapq.heappop(self._queue)
+
+   def mod_main(h, *args):
+       SimpleScheduler(h, *args).run()
+
+Save this as :file:`my-sched.py` and load it:
+
+.. code-block:: console
+
+   $ flux module unload sched-simple
+   $ flux module load my-sched.py
+
+The :func:`mod_main` entry point is the same convention used by all Python
+broker modules (see :ref:`python_broker_modules`).
+
+
+The resource pool
+-----------------
+
+:attr:`~Scheduler.resources` is an instance of
+:class:`~flux.resource.Rv1Pool` that represents the entire managed resource
+set.  It tracks which resources are up, down, and currently allocated.
+The pool implementation is selected automatically based on the R version
+field in the resource data (currently only version 1 is supported).
+
+The resource request
+~~~~~~~~~~~~~~~~~~~~
+
+Each :class:`PendingJob` carries a pool-specific resource request object in
+``job.resource_request``, parsed once from the jobspec when the alloc request
+arrives by :meth:`~flux.resource.ResourcePool.parse_resource_request`.  The
+type and fields of this object are defined by the pool; scheduler policy code
+treats it as opaque and passes it directly to
+:meth:`~flux.resource.ResourcePool.alloc`.
+
+If you need the raw jobspec dict — for instance, to inspect job attributes in
+an :meth:`~Scheduler.alloc` override — it is passed as the *jobspec* parameter
+to :meth:`~Scheduler.alloc`:
+
+.. code-block:: python
+
+   def alloc(self, request, jobid, priority, userid, t_submit, jobspec):
+       # jobspec is the parsed dict; inspect it before calling super()
+       super().alloc(request, jobid, priority, userid, t_submit, jobspec)
+
+Allocating resources
+~~~~~~~~~~~~~~~~~~~~
+
+Pass the jobid and resource request to :meth:`~flux.resource.ResourcePool.alloc`:
+
+.. code-block:: python
+
+   try:
+       alloc = self.resources.alloc(job.jobid, job.resource_request)
+   except InsufficientResources:
+       # Not enough resources now — queue the request and retry later
+       ...
+   except OSError as exc:
+       # Request can never be satisfied (InfeasibleRequest or other error)
+       request.deny(str(exc))
+       return
+
+RFC 31 constraint expressions (``constraint`` field on the resource request)
+are carried through automatically; the resource pool evaluates them when
+selecting candidate nodes.
+
+On success, :meth:`~flux.resource.ResourcePool.alloc` returns a resource
+pool object containing only the allocated resources.  Pass it directly to
+:meth:`~AllocRequest.success`, which converts it automatically:
+
+.. code-block:: python
+
+   request.success(alloc)
+
+The pool also records the job's expected expiration (derived from ``request.duration``)
+internally; :meth:`~flux.resource.ResourcePool.free` and start-time
+simulation (via :meth:`~flux.resource.ResourcePool.copy` and
+:meth:`~flux.resource.ResourcePool.job_end_times`) use this state.
+
+Releasing resources
+~~~~~~~~~~~~~~~~~~~
+
+The base class :meth:`~Scheduler.free` calls
+:meth:`~flux.resource.ResourcePool.free` automatically — no override is
+needed unless the scheduler has additional per-job cleanup to do.
+
+A job's resources may be released in multiple calls when housekeeping is
+configured: housekeeping returns resources in batches of one or more ranks as
+they become ready, with *final* set to ``False`` until the last batch.
+Schedulers that override :meth:`~Scheduler.free` must handle this: *R*
+contains only the subset being freed on each call, and per-job state should
+not be discarded until *final* is ``True``.
+
+Resource state changes
+~~~~~~~~~~~~~~~~~~~~~~
+
+Node drain/undrain and other resource state changes arrive automatically
+via the ``resource.acquire`` streaming RPC.  After each update, the base
+class calls :meth:`~Scheduler.resource_update`, giving the
+scheduler a chance to retry pending allocations:
+
+.. code-block:: python
+
+   def resource_update(self):
+       self._retry_pending()
+
+
+Alloc requests
+--------------
+
+When job-manager asks the scheduler to allocate resources for a job, two
+distinct objects are created and stored together on the
+:class:`PendingJob`:
+
+- ``job.resource_request`` — a pool-specific object describing *what the job
+  needs*.  Created once from jobspec by
+  :meth:`~flux.resource.ResourcePool.parse_resource_request` when the alloc
+  arrives.  For the built-in pools this carries fields for node count, slot count,
+  cores and GPUs per slot, duration, constraints, and exclusivity.
+  Used by the scheduler during each :meth:`~Scheduler.schedule`
+  pass to decide whether resources can be satisfied.  Persists for the
+  lifetime of the pending job.
+
+- :class:`AllocRequest` (``job.request``) — represents the
+  *open RFC 27 protocol transaction* with job-manager.  Wraps the message
+  handle and provides the response methods that finalize the exchange.  Must
+  be finalized exactly once; consumed when the scheduler responds.
+
+The scheduler reads :attr:`~PendingJob.resource_request` to
+make scheduling decisions, then calls a method on
+:attr:`~PendingJob.request` to report the outcome.
+
+:class:`AllocRequest` must be finalized exactly once by
+calling one of:
+
+:meth:`request.success(R, annotations=None) <AllocRequest.success>`
+    Allocation succeeded.  *R* is the pool object returned by
+    :meth:`~flux.resource.ResourcePool.alloc`; it is converted to a dict
+    automatically.  The base class commits R to the KVS asynchronously
+    before sending the response to job-manager, ensuring R is safely
+    stored before the job can run.
+
+:meth:`request.deny(note=None) <AllocRequest.deny>`
+    Permanent denial — the job will never run.  *note* is a human-readable
+    reason that appears in :man1:`flux-job` eventlog.  Use this for
+    structurally unsatisfiable requests (too many cores, unsupported resource
+    type, etc.).
+
+:meth:`request.cancel() <AllocRequest.cancel>`
+    The alloc request is being withdrawn.  Call this from
+    :meth:`~Scheduler.cancel`.
+
+    .. note::
+
+       Cancelling an alloc request is **not** the same as cancelling the job.
+       Job-manager may withdraw an alloc request — for example, to shrink the
+       outstanding request count back within the configured ``queue-depth`` —
+       while leaving the job itself in the pending queue.  The job will receive
+       a fresh alloc request when a slot opens up.
+
+:meth:`request.annotate(annotations) <AllocRequest.annotate>`
+    Send an intermediate annotation update while the job is pending.  May be
+    called any number of times before finalizing.  Annotations are visible
+    in :man1:`flux-jobs` output.
+
+    RFC 27 defines two standard ``sched`` annotation keys:
+
+    resource_summary
+        Free-form string describing the allocated resources
+        (e.g., ``"rank[0-1]/core[0-3]"``).  Set this on a successful
+        allocation.
+
+    t_estimate
+        Estimated start time as a Unix epoch float, or ``null`` to clear.
+        Set this on pending jobs that have a shadow reservation; clear it
+        on allocation.
+
+    Example (planning scheduler posting a reservation estimate):
+
+    .. code-block:: python
+
+       # RFC 27 sched annotation: t_estimate is wall clock seconds since epoch
+       request.annotate({"sched": {"t_estimate": shadow_time}})
+
+    When a pending job is cancelled the base class automatically clears any
+    annotations that were previously sent for that job — no explicit null
+    annotation is needed in :meth:`~Scheduler.cancel` overrides.
+
+    .. note::
+
+       Scheduler annotations are **not** recorded in the job eventlog.
+       :man1:`flux-job` ``wait-event annotations`` cannot be used to wait for
+       them in tests; instead poll :man1:`flux-jobs`
+       ``-no {annotations.sched.field}``.
+
+
+Override points
+---------------
+
+Subclass :class:`Scheduler` and override any of the
+following methods:
+
+:meth:`hello(self, jobid, priority, userid, t_submit, R) <Scheduler.hello>`
+    Called once per running job during startup, before the reactor starts.
+    The default marks *R* as allocated in the resource pool.  Override to
+    also record per-job state needed by the scheduler subclass.
+
+:meth:`alloc(self, request, jobid, priority, userid, t_submit, jobspec) <Scheduler.alloc>`
+    Called when job-manager requests an allocation.  The default calls
+    :meth:`~flux.resource.ResourcePool.parse_resource_request` on the pool
+    to parse *jobspec* and pushes a :class:`PendingJob` onto
+    :attr:`_queue`.  Override to reject jobs before they enter the queue.
+
+:meth:`free(self, jobid, R, final=False) <Scheduler.free>`
+    Called when resources are released for a completed or cancelled job.
+    *final* is ``True`` on the last (or only) call for the job.  When
+    housekeeping is configured, resources may arrive in multiple partial
+    batches before *final* is set; see `Releasing resources`_ for details.
+    The default calls :meth:`~flux.resource.ResourcePool.free` on the pool.
+    Override (calling :meth:`~Scheduler.free` via ``super()``) to also
+    remove per-job state or log the event, taking care not to discard
+    per-job state until *final* is ``True``.
+
+:meth:`cancel(self, jobid) <Scheduler.cancel>`
+    Called when a pending alloc is cancelled by the user.  The default
+    removes *jobid* from :attr:`~Scheduler._queue` and calls
+    :meth:`~AllocRequest.cancel`.
+
+:meth:`prioritize(self, jobs) <Scheduler.prioritize>`
+    Called with a list of ``[jobid, priority]`` pairs when job priorities
+    change.  The default updates the priority of each job in
+    :attr:`~Scheduler._queue` and re-heapifies.
+
+:meth:`schedule(self) <Scheduler.schedule>`
+    Called to run the scheduling loop after one or more scheduling events
+    (alloc, free, cancel, prioritize, expiration, or resource state change).
+    Events are coalesced by an adaptive timer so that
+    :meth:`~Scheduler.schedule` is not called more often than
+    necessary; see `Scheduling deferral`_ for details.
+    The default implementation is a no-op.
+
+    Example::
+
+        def schedule(self):
+            while self._queue:
+                job = self._queue[0]
+                try:
+                    alloc = self.resources.alloc(job.jobid, job.resource_request)
+                except InsufficientResources:
+                    break   # head blocked; stop (FIFO)
+                except OSError as exc:
+                    job.request.deny(str(exc))
+                else:
+                    job.request.success(alloc)
+                heapq.heappop(self._queue)
+
+:meth:`resource_update(self) <Scheduler.resource_update>`
+    Called after each resource state update.  For queue-based schedulers
+    that rely on :meth:`~Scheduler.schedule`, this override
+    is usually not needed because the base class calls
+    :meth:`~Scheduler._request_schedule` automatically after
+    every resource update.  Override only if you need to react to the updated
+    :attr:`~Scheduler.resources` value before the scheduling
+    pass.
+
+:meth:`feasibility_check(self, msg, jobspec) <Scheduler.feasibility_check>`
+    Called for ``feasibility.check`` RPCs from job-ingest.  The default
+    calls :meth:`~flux.resource.ResourcePool.parse_resource_request` and
+    :meth:`~flux.resource.ResourcePool.check_feasibility` on the pool,
+    responding with ``EINVAL`` if the job can never fit the total resource
+    set.  Override only if custom feasibility logic is needed.
+
+:meth:`forecast(self) <Scheduler.forecast>`
+    Called after each :meth:`~Scheduler.schedule` pass to annotate pending
+    jobs with forward-looking estimates such as ``sched.t_estimate``.  The
+    base class implementation is a no-op.  Override to post start-time
+    estimates (or other planning metadata) without impacting scheduling
+    throughput — :meth:`~Scheduler.forecast` is rate-limited to at most
+    once per :attr:`~Scheduler.FORECAST_PERIOD` seconds so that annotation
+    work is kept off the critical scheduling path during bursts.
+
+    Example (annotating the head-of-queue job with its estimated start time):
+
+    .. code-block:: python
+
+       def forecast(self):
+           if not self._queue:
+               return
+           head = sorted(self._queue)[0]
+           t = self._shadow_time(head)   # simulate pool forward to find earliest start
+           if head._last_annotation != t:
+               head._last_annotation = t
+               head.request.annotate({"sched": {"t_estimate": t}})
+
+
+Queue depth
+-----------
+
+The ``queue-depth=`` module argument controls how many alloc requests
+job-manager sends concurrently:
+
+- ``queue-depth=unlimited`` (the default) — all pending jobs get an alloc
+  request at once.  The scheduler sees the full queue on startup.
+
+- ``queue-depth=N`` (a positive integer) — job-manager sends at most N
+  outstanding requests.  Use this to bound the scheduler queue and annotation
+  overhead.  :class:`FIFOScheduler` defaults to ``queue-depth=8`` to match
+  the behaviour of the built-in ``sched-simple``.
+
+Set the class attribute :attr:`~Scheduler.queue_depth` on the
+subclass to choose a default; use a plain integer or the string
+``"unlimited"``:
+
+.. code-block:: python
+
+   class MyScheduler(Scheduler):
+       queue_depth = 8   # or "unlimited"
+
+The base class translates the value to the wire format for the hello
+protocol automatically.  Users can override the default at load time:
+
+.. code-block:: console
+
+   $ flux module load my-sched.py queue-depth=unlimited
+
+
+Scheduling deferral
+-------------------
+
+Every scheduling event (alloc, free, cancel, prioritize, expiration, resource
+update) calls :meth:`~Scheduler._request_schedule` rather than
+calling :meth:`~Scheduler.schedule` directly.  The base class
+defers the actual call via a one-shot timer, coalescing multiple events into a
+single :meth:`~Scheduler.schedule` invocation.
+
+The timer uses an adaptive delay tuned automatically at runtime:
+
+- The delay **starts at zero**, so the first event after an idle period is
+  processed on the very next reactor iteration — no added latency.
+- After each :meth:`~Scheduler.schedule` call, the base class
+  compares two exponential moving averages (EWMAs) [#ewma]_:
+
+  - :attr:`~Scheduler._sched_interval_ewma` — average time
+    between :meth:`~Scheduler._request_schedule` calls
+    (measures how fast events are arriving).
+  - :attr:`~Scheduler._sched_duration_ewma` — average time
+    :meth:`~Scheduler.schedule` takes to run (measures
+    scheduling cost).
+
+- If events arrive **faster than** :meth:`~Scheduler.schedule`
+  can process them (``interval < duration``), the timer delay is raised to
+  approximately ``duration``, coalescing the burst into roughly one scheduling
+  pass per cycle.  A ``DEBUG`` log message is emitted when the delay changes.
+- Once events slow down again the delay resets to zero immediately.
+
+Two class attributes control the behaviour and can be overridden on the
+subclass:
+
+.. code-block:: python
+
+   class MyScheduler(Scheduler):
+       SCHED_DELAY_MAX  = 1.0   # seconds; cap on adaptive delay (default 1s)
+       SCHED_EWMA_ALPHA = 0.25  # EWMA smoothing factor (default 0.25 ≈ 4 samples)
+
+:attr:`~Scheduler.SCHED_DELAY_MAX` bounds worst-case scheduling
+latency during a sustained burst.
+:attr:`~Scheduler.SCHED_EWMA_ALPHA` controls how quickly the
+timer reacts: higher values respond faster but are noisier; lower values are
+smoother but adapt more slowly.
+
+For schedulers with a small ``queue-depth=`` (e.g. ``sched-fifo``'s default
+of 8), events arrive at most 8-at-a-time so the interval rarely falls below
+the schedule duration and the delay stays near zero.  Schedulers using
+``queue-depth=unlimited`` benefit most from the adaptive timer during large
+submission bursts.
+
+.. rubric:: Footnotes
+
+.. [#ewma] An *exponential moving average* (EMA, or EWMA with weights) is a
+   low-pass filter that gives exponentially decreasing weight to older
+   samples: ``new = α × sample + (1 − α) × old``.  With ``α = 0.25`` the
+   influence of a sample halves roughly every three updates.  See
+   https://en.wikipedia.org/wiki/Exponential_smoothing for background.
+
+
+Forecast deferral
+-----------------
+
+:meth:`~Scheduler.forecast` is triggered after every
+:meth:`~Scheduler.schedule` call, but rate-limited by a separate one-shot
+timer so that annotation work does not accumulate on the critical path during
+scheduling bursts.
+
+The mechanism is simpler than the adaptive scheduling timer: after each
+:meth:`~Scheduler.schedule` call the base class calls
+:meth:`~Scheduler._request_forecast`.  If the forecast timer is not already
+armed it is set to fire after :attr:`~Scheduler.FORECAST_PERIOD` seconds
+(default ``1.0``).  Subsequent :meth:`~Scheduler._request_forecast` calls
+while the timer is armed are no-ops, so a burst of N scheduling events
+results in exactly one :meth:`~Scheduler.forecast` call roughly one second
+after the burst begins.
+
+The period can be tuned per-instance at load time::
+
+    flux module load sched-fifo forecast-period=0.5
+
+or overridden on the subclass:
+
+.. code-block:: python
+
+   class MyScheduler(Scheduler):
+       FORECAST_PERIOD = 2.0   # run forecast() at most once every 2 seconds
+
+Because :meth:`~Scheduler.forecast` runs asynchronously after
+:meth:`~Scheduler.schedule`, the data it reads from ``self._queue`` and
+``self.resources`` reflects the state at the time the timer fires, not the
+time the triggering scheduling event occurred.  This is correct: annotations
+should reflect the *current* queue state, not a stale snapshot from a burst
+that has since been partially resolved.
+
+
+Module arguments
+----------------
+
+Arguments passed after the module path at load time arrive as ``*args``
+in :func:`mod_main` and are forwarded to ``__init__``:
+
+.. code-block:: console
+
+   $ flux module load my-sched.py queue-depth=8 log-level=debug forecast-period=2.0
+
+The base class automatically handles three built-in arguments:
+
+queue-depth=N|unlimited
+    Maximum number of concurrent outstanding alloc requests (default 8, or
+    ``"unlimited"`` if :attr:`~Scheduler.queue_depth` is set to that string
+    on the subclass).
+
+log-level=LEVEL
+    Minimum log severity to emit.  *LEVEL* is one of ``emerg``, ``alert``,
+    ``crit``, ``err``, ``warning``, ``notice``, ``info``, or ``debug``
+    (default ``info``).
+
+forecast-period=SECONDS
+    Sets :attr:`~Scheduler.FORECAST_PERIOD` on the instance (default 1.0).
+
+Any argument not consumed by the subclass or the base class is rejected with
+an error at load time, so a typo like ``log_level=debug`` (underscore instead
+of hyphen) is caught immediately.  Subclasses parse their own arguments before
+calling ``super().__init__``, which consumes the built-in ones and then rejects
+whatever remains:
+
+.. code-block:: python
+
+   def __init__(self, h, *args):
+       # Parse custom arguments first; leave the rest for the base class.
+       remaining = []
+       for arg in args:
+           if arg.startswith("my-option="):
+               self._my_option = arg[10:]
+           else:
+               remaining.append(arg)
+       super().__init__(h, *remaining)   # handles queue-depth=, log-level=, forecast-period=
+
+
+
+Logging
+-------
+
+Both the scheduler and pool implementations log via ``self.log(level, msg)``,
+where *level* is a :mod:`syslog` priority constant.  The base class filters
+messages against :attr:`~Scheduler.log_level` before forwarding to
+``handle.log``, so only messages at or above the configured severity are
+emitted:
+
+.. code-block:: python
+
+   import syslog
+   self.log(syslog.LOG_DEBUG, f"alloc: {jobid}: {alloc.dumps()}")
+   self.log(syslog.LOG_ERR,   f"unexpected error: {exc}")
+
+The default :attr:`~Scheduler.log_level` is ``LOG_INFO``.  Set it at load
+time to enable more verbose output:
+
+.. code-block:: console
+
+   $ flux module load my-sched.py log-level=debug
+
+Valid level names are ``emerg``, ``alert``, ``crit``, ``err``, ``warning``,
+``notice``, ``info``, and ``debug``.
+
+Pool implementations receive the same ``self.log`` method and should call it
+unconditionally — no ``None`` check is needed.
+
+Log messages appear in :man1:`flux-dmesg` and the broker's stderr.
+
+
+Testing
+-------
+
+Use :man1:`flux-module` to load and remove the scheduler during a running
+instance:
+
+.. code-block:: console
+
+   $ flux module unload sched-simple
+   $ flux module load ./my-sched.py
+   $ flux run -n2 hostname
+   $ flux module reload my-sched.py          # reload without restarting instance
+   $ flux module remove my-sched.py
+   $ flux module load sched-simple
+
+Write sharness shell tests using ``test_under_flux`` with the ``job``
+personality (which loads a mock resource set and disables job execution),
+replacing the default scheduler with your own:
+
+.. code-block:: sh
+
+   test_under_flux 4 job
+
+   test_expect_success 'load my scheduler' '
+       flux module unload sched-simple &&
+       flux module load ./my-sched.py
+   '
+   test_expect_success 'job runs' '
+       jobid=$(flux submit hostname) &&
+       flux job wait-event --timeout=5 $jobid alloc
+   '
+
+See :file:`t/t2306-sched-fifo.t` in the source tree for a comprehensive
+example covering annotations, priority, cancel, drain/undrain, and the
+hello/reload protocol.
+
+
+API reference
+-------------
+
+.. autoclass:: flux.scheduler.Scheduler
+   :members:
+   :undoc-members:
+
+
+.. autoclass:: flux.scheduler.AllocRequest
+   :members:
+
+.. autoclass:: flux.scheduler.PendingJob
+   :members:
+
+.. autoclass:: flux.resource.ResourcePool.ResourcePool
+   :members:

--- a/etc/modprobe/modprobe.toml
+++ b/etc/modprobe/modprobe.toml
@@ -167,3 +167,11 @@ after = ["job-manager", "resource"]
 requires = ["job-manager", "resource"]
 ranks = "0"
 priority = 40
+
+[[modules]]
+name = "sched-backfill"
+provides = ["sched", "feasibility"]
+after = ["job-manager", "resource"]
+requires = ["job-manager", "resource"]
+ranks = "0"
+priority = 40

--- a/etc/modprobe/modprobe.toml
+++ b/etc/modprobe/modprobe.toml
@@ -159,3 +159,11 @@ after = ["job-manager", "resource"]
 requires = ["job-manager", "resource"]
 ranks = "0"
 priority = 50
+
+[[modules]]
+name = "sched-fifo"
+provides = ["sched", "feasibility"]
+after = ["job-manager", "resource"]
+requires = ["job-manager", "resource"]
+ranks = "0"
+priority = 40

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -60,6 +60,8 @@ nobase_fluxpy_PYTHON = \
 	resource/ResourceSetImplementation.py \
 	resource/Rv1Set.py \
 	resource/ResourceSet.py \
+	resource/ResourcePool.py \
+	resource/ResourcePoolImplementation.py \
 	resource/list.py \
 	resource/status.py \
 	resource/journal.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -3,6 +3,7 @@ nobase_fluxpy_PYTHON = \
 	kvs.py \
 	wrapper.py \
 	rpc.py \
+	scheduler.py \
 	message.py \
 	constants.py \
 	util.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -62,6 +62,7 @@ nobase_fluxpy_PYTHON = \
 	resource/ResourceSet.py \
 	resource/ResourcePool.py \
 	resource/ResourcePoolImplementation.py \
+	resource/Rv1Pool.py \
 	resource/list.py \
 	resource/status.py \
 	resource/journal.py \

--- a/src/bindings/python/flux/job/__init__.py
+++ b/src/bindings/python/flux/job/__init__.py
@@ -11,7 +11,14 @@
 from flux.job.Jobspec import Jobspec, JobspecV1, validate_jobspec
 from flux.job.JobID import id_parse, id_encode, JobID
 from flux.job.kvs import job_kvs, job_kvs_guest
-from flux.job.kill import kill_async, kill, cancel_async, cancel
+from flux.job.kill import (
+    kill_async,
+    kill,
+    cancel_async,
+    cancel,
+    job_raise_async,
+    job_raise,
+)
 from flux.job.submit import submit_async, submit, submit_get_id
 from flux.job.info import JobInfo, JobInfoFormat, job_fields_to_attrs
 from flux.job.list import job_list, job_list_inactive, job_list_id, JobList, get_job

--- a/src/bindings/python/flux/job/kill.py
+++ b/src/bindings/python/flux/job/kill.py
@@ -10,7 +10,7 @@
 import signal
 from typing import Optional, Union
 
-from _flux._core import ffi
+from _flux._core import ffi, lib
 from flux.core.handle import Flux  # for typing
 from flux.future import Future
 from flux.job._wrapper import _RAW as RAW
@@ -22,12 +22,13 @@ def kill_async(
 ):
     """Send a signal to a running job asynchronously
 
-    :param flux_handle: handle for Flux broker from flux.Flux()
-    :type flux_handle: Flux
-    :param jobid: the job ID of the job to kill
-    :param signum: signal to send (default SIGTERM)
-    :returns: a Future
-    :rtype: Future
+    Args:
+        flux_handle: handle for Flux broker from flux.Flux()
+        jobid: the job ID of the job to kill
+        signum: signal to send (default SIGTERM)
+
+    Returns:
+        Future: a future fulfilled when the signal is delivered
     """
     if not signum:
         signum = signal.SIGTERM
@@ -37,10 +38,10 @@ def kill_async(
 def kill(flux_handle: Flux, jobid: Union[JobID, int], signum: Optional[int] = None):
     """Send a signal to a running job.
 
-    :param flux_handle: handle for Flux broker from flux.Flux()
-    :type flux_handle: Flux
-    :param jobid: the job ID of the job to kill
-    :param signum: signal to send (default SIGTERM)
+    Args:
+        flux_handle: handle for Flux broker from flux.Flux()
+        jobid: the job ID of the job to kill
+        signum: signal to send (default SIGTERM)
     """
     return kill_async(flux_handle, jobid, signum).get()
 
@@ -72,3 +73,49 @@ def cancel(flux_handle: Flux, jobid: Union[JobID, int], reason: Optional[str] = 
         reason: the textual reason associated with the cancelation
     """
     return cancel_async(flux_handle, jobid, reason).get()
+
+
+def job_raise_async(
+    flux_handle: Flux,
+    jobid: Union[JobID, int],
+    exc_type: str,
+    severity: int = 0,
+    note: Optional[str] = None,
+):
+    """Raise a job exception asynchronously.
+
+    Args:
+        flux_handle: handle for Flux broker from flux.Flux()
+        jobid: the job ID of the job
+        exc_type: exception type string (e.g. ``"scheduler-restart"``)
+        severity: severity level; 0 causes the job to abort
+        note: optional human-readable message
+
+    Returns:
+        Future: a future fulfilled when the exception is raised
+    """
+    note_enc = note.encode() if note else ffi.NULL
+    return Future(
+        lib.flux_job_raise(
+            flux_handle.handle, int(jobid), exc_type.encode(), severity, note_enc
+        )
+    )
+
+
+def job_raise(
+    flux_handle: Flux,
+    jobid: Union[JobID, int],
+    exc_type: str,
+    severity: int = 0,
+    note: Optional[str] = None,
+):
+    """Raise a job exception.
+
+    Args:
+        flux_handle: handle for Flux broker from flux.Flux()
+        jobid: the job ID of the job
+        exc_type: exception type string (e.g. ``"scheduler-restart"``)
+        severity: severity level; 0 causes the job to abort
+        note: optional human-readable message
+    """
+    return job_raise_async(flux_handle, jobid, exc_type, severity, note).get()

--- a/src/bindings/python/flux/resource/ResourcePool.py
+++ b/src/bindings/python/flux/resource/ResourcePool.py
@@ -1,0 +1,189 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Public wrapper for Flux scheduler resource pool implementations.
+
+:class:`ResourcePool` is a plain delegating wrapper around a
+:class:`~flux.resource.ResourcePoolImplementation.ResourcePoolImplementation`,
+following the same pattern as :class:`~flux.resource.ResourceSet.ResourceSet`
+wraps a :class:`~flux.resource.ResourceSetImplementation.ResourceSetImplementation`.
+
+Calling ``ResourcePool(R)`` dispatches to the appropriate concrete
+implementation based on the ``version`` field in the R JSON:
+
+- Version 1 → :class:`~flux.resource.Rv1Pool.Rv1Pool` (pure-Python)
+"""
+
+import json
+from collections.abc import Mapping
+
+from flux.resource.ResourcePoolImplementation import (
+    InfeasibleRequest,
+    InsufficientResources,
+    ResourcePoolImplementation,
+)
+
+
+class ResourcePool:
+    """Public wrapper for a resource pool implementation.
+
+    Accepts the same argument forms as
+    :class:`~flux.resource.ResourceSet.ResourceSet`:
+
+    - An R JSON string or parsed dict → dispatches to the correct
+      :class:`ResourcePoolImplementation` subclass by version.
+    - A :class:`ResourcePoolImplementation` instance → wraps it directly.
+    """
+
+    # Expose the module-level exception classes as class attributes so that
+    # callers can use either ResourcePool.InsufficientResources or the
+    # canonical flux.resource.InsufficientResources import path.
+    InsufficientResources = InsufficientResources
+    InfeasibleRequest = InfeasibleRequest
+
+    def __init__(self, arg=None, version=1, log=None, **kwargs):
+        if isinstance(arg, ResourcePoolImplementation):
+            self.impl = arg
+            self.version = getattr(arg, "version", version)
+            return
+
+        if isinstance(arg, str):
+            arg = json.loads(arg)
+
+        if isinstance(arg, Mapping):
+            version = arg.get("version", version)
+        elif arg is not None:
+            raise TypeError(f"ResourcePool cannot be instantiated from {type(arg)}")
+
+        if version == 1:
+            from flux.resource.Rv1Pool import Rv1Pool
+
+            self.impl = Rv1Pool(arg, log=log, **kwargs)
+            self.version = 1
+        else:
+            raise ValueError(f"R version {version} not supported by ResourcePool")
+
+    # ------------------------------------------------------------------
+    # Generation counter (pool mutation tracking)
+    # ------------------------------------------------------------------
+
+    @property
+    def generation(self) -> int:
+        """Monotonically increasing mutation counter."""
+        return self.impl.generation
+
+    # ------------------------------------------------------------------
+    # Availability management
+    # ------------------------------------------------------------------
+
+    def mark_up(self, ids: str) -> None:
+        """Mark resources identified by idset string (or ``"all"``) as up."""
+        self.impl.mark_up(ids)
+
+    def mark_down(self, ids: str) -> None:
+        """Mark resources identified by idset string (or ``"all"``) as down."""
+        self.impl.mark_down(ids)
+
+    def remove_ranks(self, ranks) -> None:
+        """Remove ranks from the pool (called on shrink events)."""
+        self.impl.remove_ranks(ranks)
+
+    @property
+    def expiration(self) -> float:
+        """Resource expiration timestamp (seconds since epoch, 0 = none)."""
+        return self.impl.get_expiration()
+
+    @expiration.setter
+    def expiration(self, value: float) -> None:
+        self.impl.set_expiration(value)
+
+    # ------------------------------------------------------------------
+    # Job lifecycle
+    # ------------------------------------------------------------------
+
+    def register_alloc(self, jobid: int, R: "ResourcePool") -> None:
+        """Register an existing allocation during scheduler reconnect."""
+        impl_R = R.impl if isinstance(R, ResourcePool) else R
+        self.impl.register_alloc(jobid, impl_R)
+
+    def free(self, jobid: int, R=None, final: bool = False) -> None:
+        """Return a job's allocated resources to the pool."""
+        r_impl = R.impl if isinstance(R, ResourcePool) else R
+        self.impl.free(jobid, r_impl, final)
+
+    def update_expiration(self, jobid: int, expiration: float) -> None:
+        """Update the tracked end time for a running job."""
+        self.impl.update_expiration(jobid, expiration)
+
+    def job_end_times(self):
+        """Return a list of ``(jobid, end_time)`` pairs for all tracked jobs."""
+        return self.impl.job_end_times()
+
+    # ------------------------------------------------------------------
+    # Scheduling operations
+    # ------------------------------------------------------------------
+
+    def parse_resource_request(self, jobspec: dict):
+        """Parse a jobspec dict and return a pool-specific resource request."""
+        return self.impl.parse_resource_request(jobspec)
+
+    def alloc(self, jobid: int, request) -> "ResourcePool":
+        """Allocate resources for *jobid* and return the allocated pool."""
+        return ResourcePool(self.impl.alloc(jobid, request))
+
+    def check_feasibility(self, request) -> None:
+        """Check whether *request* is structurally satisfiable."""
+        self.impl.check_feasibility(request)
+
+    # ------------------------------------------------------------------
+    # Structural copies
+    # ------------------------------------------------------------------
+
+    def copy(self) -> "ResourcePool":
+        """Return a full independent copy preserving allocation state."""
+        return ResourcePool(self.impl.copy())
+
+    def to_resource_set(self):
+        """Return a topology+availability snapshot as a ResourceSet."""
+        from flux.resource.ResourceSet import ResourceSet
+
+        return ResourceSet(self.impl.to_set())
+
+    def copy_allocated(self):
+        """Return a ResourceSet containing only the allocated resources."""
+        from flux.resource.ResourceSet import ResourceSet
+
+        return ResourceSet(self.impl.copy_allocated())
+
+    def copy_down(self):
+        """Return a ResourceSet containing only the down resources."""
+        from flux.resource.ResourceSet import ResourceSet
+
+        return ResourceSet(self.impl.copy_down())
+
+    # ------------------------------------------------------------------
+    # Serialization and display
+    # ------------------------------------------------------------------
+
+    def dumps(self) -> str:
+        """Return a compact human-readable summary of the resource set."""
+        return self.impl.dumps()
+
+    def to_dict(self) -> dict:
+        """Return the resource set as a parsed R JSON dict."""
+        return self.impl.to_dict()
+
+    def set_starttime(self, starttime: float) -> None:
+        """Set the resource set starttime (seconds since epoch)."""
+        self.impl.set_starttime(starttime)
+
+    def set_expiration(self, expiration: float) -> None:
+        """Set the resource set expiration (seconds since epoch, 0 = none)."""
+        self.impl.set_expiration(expiration)

--- a/src/bindings/python/flux/resource/ResourcePoolImplementation.py
+++ b/src/bindings/python/flux/resource/ResourcePoolImplementation.py
@@ -1,0 +1,149 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Abstract base class for resource pool implementations.
+
+:class:`ResourcePoolImplementation` extends
+:class:`~flux.resource.ResourceSetImplementation.ResourceSetImplementation`
+with the scheduler-layer protocol: availability tracking (up/down),
+allocation, and per-job state management.
+"""
+
+from abc import abstractmethod
+
+from flux.resource.ResourceSetImplementation import ResourceSetImplementation
+
+
+class InsufficientResources(OSError):
+    """Not enough resources available right now — retry after a free event."""
+
+
+class InfeasibleRequest(OSError):
+    """Request can never be satisfied by this pool."""
+
+
+class ResourcePoolImplementation(ResourceSetImplementation):  # pragma: no cover
+    """ABC for resource pool implementations.
+
+    Extends :class:`ResourceSetImplementation` with availability tracking
+    and allocation management required by the scheduler layer.
+
+    The :attr:`generation` counter is incremented by :meth:`_bump` after
+    every mutation (alloc, free, mark_up/down, update_expiration, etc.).
+    Callers can snapshot ``pool.generation`` before a :meth:`copy` and
+    compare later to detect whether the copy has gone stale.
+    """
+
+    #: Monotonically increasing counter; incremented by every mutation.
+    #: Class-level default shadowed by an instance attribute on first bump.
+    generation: int = 0
+
+    def log(self, level: int, msg: str) -> None:
+        """Log a message at *level* (a :mod:`syslog` priority constant).
+
+        Set at construction time to the scheduler's filtered ``log`` method so
+        that pool implementations can call ``self.log(syslog.LOG_WARNING, ...)``
+        unconditionally.  This no-op default is used when no logger is supplied
+        (e.g. in unit tests).
+        """
+
+    def _bump(self) -> None:
+        """Increment :attr:`generation` to signal that pool state has changed."""
+        self.generation += 1
+
+    @property
+    def expiration(self) -> float:
+        """Resource expiration timestamp (seconds since epoch, 0 = none)."""
+        return self.get_expiration()
+
+    @expiration.setter
+    def expiration(self, value: float) -> None:
+        self.set_expiration(value)
+
+    # ------------------------------------------------------------------
+    # Availability management
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def mark_up(self, ids: str) -> None:
+        """Mark resources identified by idset string (or ``"all"``) as up."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def mark_down(self, ids: str) -> None:
+        """Mark resources identified by idset string (or ``"all"``) as down."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def copy_down(self):
+        """Return a resource set containing only the down (not schedulable) resources."""
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Job lifecycle
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def register_alloc(self, jobid: int, R) -> None:
+        """Register an existing allocation during scheduler reconnect."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def free(self, jobid: int, R=None, final: bool = False) -> None:
+        """Return a job's allocated resources to the pool."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_expiration(self, jobid: int, expiration: float) -> None:
+        """Update the tracked end time for a running job."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def job_end_times(self):
+        """Return a list of ``(jobid, end_time)`` pairs for all tracked jobs."""
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Scheduling operations
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def parse_resource_request(self, jobspec: dict):
+        """Parse a jobspec dict and return a pool-specific resource request."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def alloc(self, jobid: int, request):
+        """Allocate resources for *jobid* matching *request*."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def check_feasibility(self, request) -> None:
+        """Check whether *request* is structurally satisfiable."""
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Structural copies
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def copy(self):
+        """Return a full independent copy preserving allocation state."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def copy_allocated(self):
+        """Return a resource set containing only the allocated resources."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def to_set(self):
+        """Return a topology+availability snapshot as a resource set."""
+        raise NotImplementedError

--- a/src/bindings/python/flux/resource/ResourceSet.py
+++ b/src/bindings/python/flux/resource/ResourceSet.py
@@ -275,6 +275,10 @@ class ResourceSet:
     def properties(self):
         return ",".join(json.loads(self.get_properties()).keys())
 
+    def to_dict(self):
+        """Return the resource set as a parsed R JSON dict."""
+        return self.impl.to_dict()
+
     @property
     def expiration(self):
         return self.impl.get_expiration()

--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -1,0 +1,724 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Rv1 resource pool: combined resource-set and scheduler-layer implementation.
+
+:class:`Rv1Pool` inherits from both :class:`~flux.resource.Rv1Set.Rv1Set`
+(resource-set tracking) and
+:class:`~flux.resource.ResourcePoolImplementation.ResourcePoolImplementation`
+(scheduler-layer protocol).  It adds per-rank availability and allocation
+tracking to the base Rv1Set representation.
+
+The internal ``_ranks`` dict is extended with three extra keys beyond what
+``Rv1Set`` uses::
+
+    {"hostname": str, "cores": frozenset, "gpus": frozenset,
+     "up": bool, "allocated_cores": set, "allocated_gpus": set}
+
+``Rv1Pool`` supports GPU scheduling and worst-fit allocation.  Constraints (properties, hostlist, ranks,
+boolean operators) are supported via the inherited
+:meth:`~flux.resource.Rv1Set.Rv1Set._matches_constraint` method.
+
+To obtain an ``Rv1Pool`` from an R JSON string or dict, call::
+
+    from flux.resource import ResourcePool
+    pool = ResourcePool(R)          # factory dispatch → Rv1Pool
+
+or directly::
+
+    from flux.resource.Rv1Pool import Rv1Pool
+    pool = Rv1Pool(R)
+"""
+
+import json
+import syslog
+import time
+from collections.abc import Mapping
+from typing import Dict, List, Tuple
+
+from flux.idset import IDset
+from flux.job import JobID
+from flux.resource.ResourcePoolImplementation import (
+    InfeasibleRequest,
+    InsufficientResources,
+    ResourcePoolImplementation,
+)
+from flux.resource.Rv1Set import Rv1Set
+
+
+class ResourceRequest:
+    """Parsed resource request extracted from a V1 jobspec.
+
+    Returned by :meth:`Rv1Pool.parse_resource_request` and stored on
+    :class:`~flux.scheduler.PendingJob`.  Passed to
+    :meth:`Rv1Pool.alloc` so that the pool does not need to
+    re-parse jobspec on every scheduling pass.
+
+    Attributes:
+        nnodes (int): Minimum node count; 0 means any layout.
+        nslots (int): Total slot count.
+        slot_size (int): Cores per slot.
+        gpu_per_slot (int): GPUs per slot.
+        duration (float): Walltime in seconds; 0.0 means unlimited.
+        constraint: RFC 31 constraint expression (dict) or None.
+        exclusive (bool): Whole-node exclusive allocation.
+    """
+
+    __slots__ = (
+        "nnodes",
+        "nslots",
+        "slot_size",
+        "gpu_per_slot",
+        "duration",
+        "constraint",
+        "exclusive",
+    )
+
+    def __init__(
+        self, nnodes, nslots, slot_size, gpu_per_slot, duration, constraint, exclusive
+    ):
+        self.nnodes = nnodes
+        self.nslots = nslots
+        self.slot_size = slot_size
+        self.gpu_per_slot = gpu_per_slot
+        self.duration = duration
+        self.constraint = constraint
+        self.exclusive = exclusive
+
+    @classmethod
+    def from_jobspec(cls, jobspec):
+        """Parse a V1 jobspec dict and return a :class:`ResourceRequest`.
+
+        Handles the two common V1 layouts:
+
+        - ``node → slot → core[+gpu]``  (``flux submit -N<n> ...``)
+        - ``slot → core[+gpu]``          (``flux submit -n<n> ...``)
+
+        Raises:
+            ValueError: If the jobspec cannot be parsed.
+            KeyError: If required fields are missing.
+        """
+        resources = jobspec.get("resources", [])
+        if not resources:
+            raise ValueError("jobspec has no resources")
+        top = resources[0]
+        rtype = top.get("type")
+        if rtype == "node":
+            nnodes = top.get("count", 1)
+            slot = top["with"][0]
+            nslots_per_node = slot.get("count", 1)
+            nslots = nslots_per_node * nnodes
+            slot_children = slot["with"]
+        elif rtype == "slot":
+            nnodes = 0
+            nslots = top.get("count", 1)
+            slot_children = top["with"]
+        else:
+            raise ValueError(f"unsupported top-level resource type: {rtype!r}")
+
+        slot_size = 1
+        gpu_per_slot = 0
+        for child in slot_children:
+            if child.get("type") == "core":
+                slot_size = child.get("count", 1)
+            elif child.get("type") == "gpu":
+                gpu_per_slot = child.get("count", 1)
+
+        exclusive = bool(top.get("exclusive", False))
+        # RFC 25: in jobspec V1, attributes.system and duration are required.
+        system = jobspec.get("attributes", {}).get("system")
+        if jobspec.get("version") == 1:
+            if system is None:
+                raise ValueError("getting duration: Object item not found: system")
+            if system.get("duration") is None:
+                raise ValueError("getting duration: Object item not found: duration")
+        attrs = system or {}
+        duration = attrs.get("duration") or 0.0
+        constraint = attrs.get("constraints") or None
+        return cls(
+            nnodes,
+            nslots,
+            slot_size,
+            gpu_per_slot,
+            float(duration),
+            constraint,
+            exclusive,
+        )
+
+    @property
+    def ncores(self):
+        """Total cores requested (nslots × slot_size)."""
+        return self.nslots * self.slot_size
+
+    @property
+    def ngpus(self):
+        """Total GPUs requested (nslots × gpu_per_slot)."""
+        return self.nslots * self.gpu_per_slot
+
+
+class Rv1Pool(Rv1Set, ResourcePoolImplementation):
+    """Pure-Python Rv1 resource pool combining resource-set and scheduler layers.
+
+    MRO: ``Rv1Pool → Rv1Set → ResourceSetImplementation →
+    ResourcePoolImplementation → ABC → object``
+
+    The ``_ranks`` dict carries three extra pool-specific keys beyond the
+    base :class:`~flux.resource.Rv1Set.Rv1Set` representation::
+
+        up              – True if rank is schedulable
+        allocated_cores – set of core IDs currently allocated on this rank
+        allocated_gpus  – set of GPU IDs currently allocated on this rank
+    """
+
+    version = 1
+
+    #: Pool options recognised by this implementation.  The scheduler logs
+    #: a warning for any key in ``pool_kwargs`` not listed here.
+    known_options: frozenset = frozenset()
+
+    def __init__(self, R, log=None, **kwargs) -> None:
+        """Construct from an R JSON string, dict, or ``None`` (empty)."""
+        if log is not None:
+            self.log = log
+        if R is not None and not isinstance(R, (str, Mapping)):
+            raise TypeError(f"Rv1Pool: expected str or Mapping, got {type(R)!r}")
+
+        # Rv1Set.__init__ parses the core resource structure.
+        super().__init__(R)
+
+        # Add pool-specific fields to each rank entry.
+        for info in self._ranks.values():
+            info["up"] = True
+            info["allocated_cores"] = set()
+            info["allocated_gpus"] = set()
+
+        # _job_state: jobid -> (end_time, alloc) for all tracked jobs.
+        self._job_state: Dict[int, Tuple[float, "Rv1Pool"]] = {}
+
+    # ------------------------------------------------------------------
+    # Rv1Set override: _copy_from_ranks must add pool-specific fields
+    # ------------------------------------------------------------------
+
+    def _copy_from_ranks(self, rank_set: set) -> "Rv1Pool":
+        """Return a new Rv1Pool containing only the given ranks (alloc cleared)."""
+        new = object.__new__(Rv1Pool)
+        new._expiration = self._expiration
+        new._starttime = self._starttime
+        new._has_nodelist = getattr(self, "_has_nodelist", False)
+        new._properties = {
+            prop: ranks & rank_set
+            for prop, ranks in self._properties.items()
+            if ranks & rank_set
+        }
+        new._ranks = {
+            rank: {
+                "hostname": self._ranks[rank]["hostname"],
+                "cores": self._ranks[rank]["cores"],
+                "gpus": self._ranks[rank]["gpus"],
+                "up": self._ranks[rank]["up"],
+                "allocated_cores": set(),
+                "allocated_gpus": set(),
+            }
+            for rank in rank_set
+            if rank in self._ranks
+        }
+        new._job_state = {}
+        new.log = self.log
+        return new
+
+    # ------------------------------------------------------------------
+    # ResourcePoolImplementation — availability management
+    # ------------------------------------------------------------------
+
+    def mark_up(self, ids: str) -> None:
+        """Mark ranks as schedulable."""
+        if ids == "all":
+            for info in self._ranks.values():
+                info["up"] = True
+        else:
+            for rank in IDset(ids):
+                if rank in self._ranks:
+                    self._ranks[rank]["up"] = True
+        self._bump()
+
+    def mark_down(self, ids: str) -> None:
+        """Mark ranks as not schedulable."""
+        if ids == "all":
+            for info in self._ranks.values():
+                info["up"] = False
+        else:
+            for rank in IDset(ids):
+                if rank in self._ranks:
+                    self._ranks[rank]["up"] = False
+        self._bump()
+
+    def remove_ranks(self, ranks) -> None:
+        """Remove ranks from the pool (shrink event)."""
+        if not isinstance(ranks, IDset):
+            ranks = IDset(ranks)
+        for rank in ranks:
+            self._ranks.pop(rank, None)
+            for prop_ranks in self._properties.values():
+                prop_ranks.discard(rank)
+        self._bump()
+
+    # ------------------------------------------------------------------
+    # ResourcePoolImplementation — job lifecycle
+    # ------------------------------------------------------------------
+
+    def register_alloc(self, jobid: int, R: "Rv1Pool") -> None:
+        """Register an existing allocation during scheduler reconnect.
+
+        Raises:
+            ValueError: If R contains ranks absent from this pool, which
+                indicates the job's resources are no longer available (e.g.
+                the rank was excluded from configuration before the scheduler
+                was reloaded).  The caller should raise a fatal exception on
+                the job.
+        """
+        missing = set(R._ranks.keys()) - set(self._ranks.keys())
+        if missing:
+            raise ValueError(
+                f"allocation contains ranks not in resource pool: " f"{sorted(missing)}"
+            )
+        self._set_allocated(R)
+        self._job_state[jobid] = (R.get_expiration(), R)
+        self._bump()
+        self.log(syslog.LOG_INFO, f"hello: {JobID(jobid).f58}: {R.dumps()}")
+
+    def free(self, jobid: int, R=None, final: bool = False) -> None:
+        """Return a job's allocated resources to this pool.
+
+        The scheduler allocation protocol may partially release a job's
+        resources by rank; each partial free updates both the pool and the
+        job's tracked allocation in :attr:`_job_state`.
+
+        Args:
+            jobid: ID of the job whose resources are being freed.
+            R: Resource set to free.  For a partial free this contains only
+                the subset being freed; when ``final`` is True and ``R`` is
+                provided it must exactly match the tracked allocation.
+                If ``None``, all tracked resources for the job are freed.
+            final: If True, all resources remaining in the tracked allocation
+                are freed and the job state is removed.  For a partial free,
+                ``R`` must be a subset of the tracked allocation.  These
+                checks catch job manager accounting errors.
+
+        Raises:
+            ValueError: If ``R`` contains ranks not in the job's tracked
+                allocation, or if ``final`` is True and ``R`` does not match
+                the tracked allocation exactly.
+        """
+        if R is not None and jobid in self._job_state:
+            _, alloc = self._job_state[jobid]
+            extra = set(R._ranks.keys()) - set(alloc._ranks.keys())
+            if extra:
+                raise ValueError(
+                    f"free: {JobID(jobid).f58}: R contains ranks not in "
+                    f"job allocation: {extra}"
+                )
+            if final:
+                missing = set(alloc._ranks.keys()) - set(R._ranks.keys())
+                mismatched = {
+                    rank
+                    for rank in R._ranks
+                    if R._ranks[rank]["cores"] != alloc._ranks[rank]["cores"]
+                    or R._ranks[rank]["gpus"] != alloc._ranks[rank]["gpus"]
+                }
+                if missing or mismatched:
+                    raise ValueError(
+                        f"free: {JobID(jobid).f58}: final R mismatch: "
+                        f"got {R.dumps()}, expected {alloc.dumps()}"
+                    )
+        if final:
+            _, alloc = self._job_state.pop(jobid, (0.0, None))
+            if alloc is None:
+                return
+            for rank, ainfo in alloc._ranks.items():
+                if rank in self._ranks:
+                    self._ranks[rank]["allocated_cores"] -= ainfo["cores"]
+                    self._ranks[rank]["allocated_gpus"] -= ainfo["gpus"]
+            freed_dumps = alloc.dumps()
+        elif R is not None:
+            for rank, ainfo in R._ranks.items():
+                if rank in self._ranks:
+                    self._ranks[rank]["allocated_cores"] -= ainfo["cores"]
+                    self._ranks[rank]["allocated_gpus"] -= ainfo["gpus"]
+            freed_dumps = R.dumps()
+            if jobid in self._job_state:
+                end_time, alloc = self._job_state[jobid]
+                remaining = set(alloc._ranks.keys()) - set(R._ranks.keys())
+                self._job_state[jobid] = (end_time, alloc._copy_from_ranks(remaining))
+        else:
+            _, alloc = self._job_state.pop(jobid, (0.0, None))
+            if alloc is None:
+                return
+            for rank, ainfo in alloc._ranks.items():
+                if rank in self._ranks:
+                    self._ranks[rank]["allocated_cores"] -= ainfo["cores"]
+                    self._ranks[rank]["allocated_gpus"] -= ainfo["gpus"]
+            freed_dumps = alloc.dumps()
+        self.log(
+            syslog.LOG_DEBUG,
+            f"free: {JobID(jobid).f58}: {freed_dumps}" + (" (final)" if final else ""),
+        )
+        self._bump()
+
+    def update_expiration(self, jobid: int, expiration: float) -> None:
+        """Update the end time for a tracked job."""
+        if jobid in self._job_state:
+            _, alloc = self._job_state[jobid]
+            self._job_state[jobid] = (expiration, alloc)
+            self._bump()
+
+    def job_end_times(self) -> List[Tuple[int, float]]:
+        """Return a list of ``(jobid, end_time)`` pairs for all tracked jobs."""
+        return [(jid, end_time) for jid, (end_time, _) in self._job_state.items()]
+
+    # ------------------------------------------------------------------
+    # ResourcePoolImplementation — scheduling operations
+    # ------------------------------------------------------------------
+
+    def parse_resource_request(self, jobspec: dict) -> ResourceRequest:
+        """Parse a V1 jobspec and return a :class:`ResourceRequest`."""
+        return ResourceRequest.from_jobspec(jobspec)
+
+    def check_feasibility(self, request) -> None:
+        """Check whether a request is structurally satisfiable.
+
+        Tests against total pool capacity (ignoring current allocations
+        and availability) so that transient conditions don't affect the
+        result.
+
+        Args:
+            request: A :class:`ResourceRequest` from
+                :meth:`parse_resource_request`.
+
+        Raises:
+            InfeasibleRequest: If the request can never be satisfied by
+                this pool's total capacity.
+        """
+        self._check_feasibility(
+            request.nnodes,
+            request.nslots,
+            request.slot_size,
+            request.exclusive,
+            request.constraint,
+            request.gpu_per_slot,
+        )
+
+    def alloc(self, jobid: int, request) -> "Rv1Pool":
+        """Allocate resources for *jobid* matching *request*.
+
+        Args:
+            jobid (int): The job ID; stored in :attr:`_job_state`.
+            request: A :class:`ResourceRequest` from
+                :meth:`parse_resource_request`.
+
+        Returns:
+            A new :class:`Rv1Pool` containing the allocated resources.
+
+        Raises:
+            InsufficientResources: Resources temporarily insufficient.
+            InfeasibleRequest: Request structurally infeasible.
+        """
+        nnodes = request.nnodes
+        nslots = request.nslots
+        slot_size = request.slot_size
+        gpu_per_slot = request.gpu_per_slot
+        exclusive = request.exclusive
+        constraint = request.constraint
+
+        if constraint is not None and isinstance(constraint, str):
+            constraint = json.loads(constraint)
+
+        # Build candidate list: up ranks with enough free cores (and GPUs).
+        # Each entry is (rank, info, free_cores, free_gpus).
+        candidates = []
+        for rank, info in self._ranks.items():
+            if not info["up"]:
+                continue
+            free_cores = info["cores"] - info["allocated_cores"]
+            free_gpus = info["gpus"] - info["allocated_gpus"]
+            needed_cores = len(info["cores"]) if exclusive else slot_size
+            if len(free_cores) < needed_cores:
+                continue
+            if gpu_per_slot > 0 and len(free_gpus) < gpu_per_slot:
+                continue
+            candidates.append((rank, info, free_cores, free_gpus))
+
+        if constraint is not None:
+            candidates = [
+                (r, i, fc, fg)
+                for r, i, fc, fg in candidates
+                if self._matches_constraint(r, i, constraint)
+            ]
+
+        # Worst-fit: descending free cores (break ties by free GPUs)
+        candidates.sort(
+            key=lambda x: (len(x[2]), len(x[3])),
+            reverse=True,
+        )
+
+        # Raise EOVERFLOW for structurally infeasible requests
+        self._check_feasibility(
+            nnodes, nslots, slot_size, exclusive, constraint, gpu_per_slot
+        )
+
+        # Greedy selection — each entry is (rank, info, alloc_cores, alloc_gpus)
+        selected: List[Tuple[int, dict, frozenset, frozenset]] = []
+
+        if nnodes > 0:
+            slots_per_node = nslots // nnodes
+            for rank, info, free_cores, free_gpus in candidates:
+                if len(selected) >= nnodes:
+                    break
+                if exclusive:
+                    if len(free_cores) < len(info["cores"]):
+                        continue
+                    alloc_cores = frozenset(free_cores)
+                    alloc_gpus = frozenset(free_gpus)
+                else:
+                    need_cores = slots_per_node * slot_size
+                    need_gpus = slots_per_node * gpu_per_slot
+                    if len(free_cores) < need_cores or len(free_gpus) < need_gpus:
+                        continue
+                    alloc_cores = frozenset(sorted(free_cores)[:need_cores])
+                    alloc_gpus = frozenset(sorted(free_gpus)[:need_gpus])
+                selected.append((rank, info, alloc_cores, alloc_gpus))
+            if len(selected) < nnodes:
+                raise InsufficientResources("insufficient resources")
+        else:
+            remaining_slots = nslots
+            for rank, info, free_cores, free_gpus in candidates:
+                if remaining_slots <= 0:
+                    break
+                free_core_slots = len(free_cores) // slot_size
+                if gpu_per_slot > 0:
+                    free_gpu_slots = len(free_gpus) // gpu_per_slot
+                    free_slots = min(free_core_slots, free_gpu_slots)
+                else:
+                    free_slots = free_core_slots
+                take = min(free_slots, remaining_slots)
+                if take > 0:
+                    ncores_take = take * slot_size
+                    ngpus_take = take * gpu_per_slot
+                    alloc_cores = frozenset(sorted(free_cores)[:ncores_take])
+                    alloc_gpus = frozenset(sorted(free_gpus)[:ngpus_take])
+                    selected.append((rank, info, alloc_cores, alloc_gpus))
+                    remaining_slots -= take
+            if remaining_slots > 0:
+                raise InsufficientResources("insufficient resources")
+
+        # Build result pool and update allocation state on self
+        result = object.__new__(Rv1Pool)
+        result._expiration = 0.0
+        result._starttime = 0.0
+        result._has_nodelist = True
+        result._properties = {}
+        result._ranks = {}
+        result._job_state = {}
+        result.log = self.log
+
+        for rank, info, alloc_cores, alloc_gpus in selected:
+            result._ranks[rank] = {
+                "hostname": info["hostname"],
+                "cores": alloc_cores,
+                "gpus": alloc_gpus,
+                "allocated_cores": set(alloc_cores),
+                "allocated_gpus": set(alloc_gpus),
+                "up": True,
+            }
+            info["allocated_cores"] |= alloc_cores
+            info["allocated_gpus"] |= alloc_gpus
+
+        if request.duration > 0.0:
+            end_time = time.time() + request.duration
+        elif self._expiration > 0.0:
+            end_time = self._expiration
+        else:
+            end_time = 0.0
+        self._job_state[jobid] = (end_time, result)
+        self._bump()
+        self.log(syslog.LOG_DEBUG, f"alloc: {JobID(jobid).f58}: {result.dumps()}")
+        return result
+
+    # ------------------------------------------------------------------
+    # ResourcePoolImplementation — structural copies
+    # ------------------------------------------------------------------
+
+    def copy(self) -> "Rv1Pool":
+        """Return a full independent copy preserving allocation state."""
+        new = object.__new__(Rv1Pool)
+        new.generation = self.generation
+        new._expiration = self._expiration
+        new._starttime = self._starttime
+        new._has_nodelist = getattr(self, "_has_nodelist", False)
+        new._properties = {p: set(s) for p, s in self._properties.items()}
+        new._ranks = {}
+        for rank, info in self._ranks.items():
+            new._ranks[rank] = dict(info)
+            new._ranks[rank]["allocated_cores"] = set(info["allocated_cores"])
+            new._ranks[rank]["allocated_gpus"] = set(info["allocated_gpus"])
+        new._job_state = dict(self._job_state)
+        # Do not copy self.log: copies are used for simulation (forecast /
+        # shadow-time) and their alloc/free calls must not emit log lines.
+        return new
+
+    def copy_allocated(self) -> Rv1Set:
+        """Return an Rv1Set containing only the allocated resources.
+
+        Properties are intersected with the allocated ranks so that
+        queue/property information is preserved (e.g. for sched.resource-status).
+        """
+        new = object.__new__(Rv1Set)
+        new._expiration = self._expiration
+        new._starttime = self._starttime
+        new._has_nodelist = False
+        new._ranks = {
+            rank: {
+                "hostname": info["hostname"],
+                "cores": frozenset(info["allocated_cores"]),
+                "gpus": frozenset(info["allocated_gpus"]),
+            }
+            for rank, info in self._ranks.items()
+            if info["allocated_cores"] or info["allocated_gpus"]
+        }
+        allocated_set = set(new._ranks)
+        new._properties = {
+            prop: ranks & allocated_set
+            for prop, ranks in self._properties.items()
+            if ranks & allocated_set
+        }
+        return new
+
+    def copy_down(self) -> Rv1Set:
+        """Return an Rv1Set containing only the down ranks."""
+        new = object.__new__(Rv1Set)
+        new._expiration = self._expiration
+        new._starttime = self._starttime
+        new._has_nodelist = False
+        new._properties = {}
+        new._ranks = {
+            rank: {
+                "hostname": info["hostname"],
+                "cores": info["cores"],
+                "gpus": info["gpus"],
+            }
+            for rank, info in self._ranks.items()
+            if not info["up"]
+        }
+        return new
+
+    def to_set(self) -> Rv1Set:
+        """Return a topology+availability snapshot as an Rv1Set.
+
+        The returned set contains all ranks with their topology (cores,
+        gpus) and current up/down state, but no allocation information.
+        """
+        new = object.__new__(Rv1Set)
+        new._expiration = self._expiration
+        new._starttime = self._starttime
+        new._has_nodelist = getattr(self, "_has_nodelist", False)
+        new._properties = {p: set(s) for p, s in self._properties.items()}
+        new._ranks = {
+            rank: {
+                "hostname": info["hostname"],
+                "cores": info["cores"],
+                "gpus": info["gpus"],
+            }
+            for rank, info in self._ranks.items()
+        }
+        return new
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _set_allocated(self, other: "Rv1Pool") -> None:
+        """Mark resources in *other* as allocated in this pool."""
+        for rank, oinfo in other._ranks.items():
+            if rank in self._ranks:
+                self._ranks[rank]["allocated_cores"] |= oinfo["cores"]
+                self._ranks[rank]["allocated_gpus"] |= oinfo["gpus"]
+
+    def _check_feasibility(
+        self,
+        nnodes: int,
+        nslots: int,
+        slot_size: int,
+        exclusive: bool,
+        constraint,
+        gpu_per_slot: int,
+    ) -> None:
+        """Raise EOVERFLOW if the request can structurally never be satisfied."""
+        all_candidates = list(self._ranks.items())
+        if constraint is not None:
+            all_candidates = [
+                (r, i)
+                for r, i in all_candidates
+                if self._matches_constraint(r, i, constraint)
+            ]
+
+        if exclusive:
+            need_nodes = max(nnodes, 1)
+            eligible = [
+                (r, i)
+                for r, i in all_candidates
+                if len(i["cores"]) >= slot_size
+                and (gpu_per_slot == 0 or len(i["gpus"]) >= gpu_per_slot)
+            ]
+            if len(eligible) < need_nodes:
+                raise InfeasibleRequest(
+                    f"unsatisfiable request: need {need_nodes} exclusive node(s), "
+                    f"only {len(eligible)} eligible",
+                )
+            return
+
+        if nnodes > 0:
+            slots_per_node = nslots // nnodes
+            cores_per_node = slots_per_node * slot_size
+            gpus_per_node = slots_per_node * gpu_per_slot
+            eligible = [
+                (r, i)
+                for r, i in all_candidates
+                if len(i["cores"]) >= cores_per_node and len(i["gpus"]) >= gpus_per_node
+            ]
+            if len(eligible) < nnodes:
+                raise InfeasibleRequest(
+                    f"unsatisfiable request: need {nnodes} node(s) with "
+                    f"{cores_per_node} cores"
+                    + (f" and {gpus_per_node} GPUs" if gpus_per_node else "")
+                    + f" each, only {len(eligible)} eligible",
+                )
+            return
+
+        # A slot must fit within a single rank, so check per-rank slot
+        # capacity rather than total cores across all ranks.
+        total_slots_avail = sum(len(i["cores"]) // slot_size for _, i in all_candidates)
+        if total_slots_avail < nslots:
+            total_cores = sum(len(i["cores"]) for _, i in all_candidates)
+            raise InfeasibleRequest(
+                f"unsatisfiable request: need {nslots} slot(s) of "
+                f"{slot_size} core(s), only {total_slots_avail} such "
+                f"slot(s) available (total cores: {total_cores})",
+            )
+        if gpu_per_slot > 0:
+            total_gpu_slots = sum(
+                min(len(i["cores"]) // slot_size, len(i["gpus"]) // gpu_per_slot)
+                for _, i in all_candidates
+            )
+            if total_gpu_slots < nslots:
+                total_gpus = sum(len(i["gpus"]) for _, i in all_candidates)
+                raise InfeasibleRequest(
+                    f"unsatisfiable request: need {nslots} slot(s) with "
+                    f"{gpu_per_slot} GPU(s) each, only {total_gpu_slots} "
+                    f"available (total GPUs: {total_gpus})",
+                )

--- a/src/bindings/python/flux/resource/Rv1Set.py
+++ b/src/bindings/python/flux/resource/Rv1Set.py
@@ -525,16 +525,25 @@ class Rv1Set(ResourceSetImplementation):
             return rank in IDset(constraint["ranks"])
 
         if "and" in constraint:
-            return all(
-                self._matches_constraint(rank, info, c) for c in constraint["and"]
-            )
+            ops = constraint["and"]
+            if not isinstance(ops, list):
+                raise ValueError(
+                    f"'and' operand must be a list, got {type(ops).__name__}"
+                )
+            return all(self._matches_constraint(rank, info, c) for c in ops)
 
         if "or" in constraint:
-            return any(
-                self._matches_constraint(rank, info, c) for c in constraint["or"]
-            )
+            ops = constraint["or"]
+            if not isinstance(ops, list):
+                raise ValueError(
+                    f"'or' operand must be a list, got {type(ops).__name__}"
+                )
+            return any(self._matches_constraint(rank, info, c) for c in ops)
 
         if "not" in constraint:
-            return not self._matches_constraint(rank, info, constraint["not"][0])
+            ops = constraint["not"]
+            if not isinstance(ops, list) or len(ops) < 1:
+                raise ValueError(f"'not' operand must be a non-empty list, got {ops!r}")
+            return not self._matches_constraint(rank, info, ops[0])
 
         return True  # unreachable given the known-ops check above

--- a/src/bindings/python/flux/resource/__init__.py
+++ b/src/bindings/python/flux/resource/__init__.py
@@ -13,6 +13,7 @@ from flux.resource.ResourceSet import ResourceSet
 from flux.resource.list import resource_list, SchedResourceList
 from flux.resource.status import resource_status, ResourceStatus
 from flux.resource.journal import ResourceJournalConsumer
+from flux.resource.Rv1Pool import Rv1Pool
 from flux.resource.ResourcePool import ResourcePool
 
 InsufficientResources = ResourcePool.InsufficientResources

--- a/src/bindings/python/flux/resource/__init__.py
+++ b/src/bindings/python/flux/resource/__init__.py
@@ -13,3 +13,7 @@ from flux.resource.ResourceSet import ResourceSet
 from flux.resource.list import resource_list, SchedResourceList
 from flux.resource.status import resource_status, ResourceStatus
 from flux.resource.journal import ResourceJournalConsumer
+from flux.resource.ResourcePool import ResourcePool
+
+InsufficientResources = ResourcePool.InsufficientResources
+InfeasibleRequest = ResourcePool.InfeasibleRequest

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -1,0 +1,1085 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Base class for Python Flux scheduler broker modules.
+
+Provides the RFC 27 scheduler protocol scaffolding so that subclasses
+only need to implement scheduling policy:
+
+- Registers the ``sched`` and ``feasibility`` dynamic services
+- Manages the ``resource.acquire`` streaming RPC for resource state
+- Performs the hello/ready handshake with job-manager on startup
+- Dispatches alloc, free, cancel, prioritize, expiration, and
+  resource-status messages to overridable methods
+
+The base class maintains a :class:`PendingJob` heap queue (:attr:`_queue`)
+and provides default implementations of :meth:`alloc`, :meth:`free`,
+:meth:`cancel`, and :meth:`prioritize`.  A minimal scheduler only needs
+to override :meth:`schedule`::
+
+    import heapq
+    from flux.resource import InsufficientResources, InfeasibleRequest
+    from flux.scheduler import Scheduler
+
+    class MyScheduler(Scheduler):
+
+        def schedule(self):
+            while self._queue:
+                job = self._queue[0]
+                try:
+                    alloc = self.resources.alloc(job.jobid, job.resource_request)
+                except InsufficientResources:
+                    break   # not enough resources — wait for free
+                except InfeasibleRequest as exc:
+                    job.request.deny(str(exc))
+                else:
+                    job.request.success(alloc)
+                heapq.heappop(self._queue)
+
+    def mod_main(h, *args):
+        MyScheduler(h, *args).run()
+"""
+
+import errno
+import functools
+import heapq
+import syslog
+import time
+
+from _flux._core import ffi, lib
+from flux.brokermod import BrokerModule, request_handler
+from flux.constants import FLUX_RPC_STREAMING
+from flux.job import JobID, job_raise_async
+from flux.kvs import KVSTxn
+from flux.kvs import commit_async as kvs_commit_async
+from flux.kvs import get_key_direct as kvs_get
+from flux.resource import InfeasibleRequest
+from flux.resource.ResourcePool import ResourcePool
+
+
+@functools.total_ordering
+class PendingJob:
+    """Pending allocation request held in the scheduler queue.
+
+    Created by the default :meth:`Scheduler.alloc` implementation and stored
+    in :attr:`Scheduler._queue`.  Subclasses may access the queue directly
+    (it is a ``heapq`` min-heap ordered by :meth:`__lt__`).
+
+    Attributes:
+        jobid (int): The job ID.
+        priority (int): Job priority (higher is more urgent).
+        t_submit (float): Submission time (seconds since epoch).
+        request (:class:`AllocRequest`): The open RFC 27 allocation request.
+        resource_request: Pool-specific parsed resource request returned by
+            :meth:`~ResourcePool.parse_resource_request`; passed to
+            :meth:`~ResourcePool.alloc` when scheduling.
+    """
+
+    __slots__ = (
+        "jobid",
+        "priority",
+        "t_submit",
+        "request",
+        "resource_request",
+        "_last_annotation",
+    )
+
+    def __init__(self, jobid, priority, t_submit, request, resource_request):
+        self.jobid = jobid
+        self.priority = priority
+        self.t_submit = t_submit
+        self.request = request
+        self.resource_request = resource_request
+        self._last_annotation = None
+
+    def __eq__(self, other):
+        if not isinstance(other, PendingJob):
+            return NotImplemented
+        return self.priority == other.priority and self.jobid == other.jobid
+
+    def __lt__(self, other):
+        # Higher priority first; tie-break by lower jobid (FIFO)
+        if self.priority != other.priority:
+            return self.priority > other.priority
+        return self.jobid < other.jobid
+
+
+# ResourcePool is defined in flux.resource.pool to avoid circular imports.
+# Re-exported here so existing code can import it from either location.
+__all__ = ["ResourcePool", "PendingJob", "AllocRequest", "Scheduler"]
+
+
+# RFC 27 alloc response type codes
+_ALLOC_SUCCESS = 0
+_ALLOC_ANNOTATE = 1
+_ALLOC_DENY = 2
+_ALLOC_CANCEL = 3
+
+
+class AllocRequest:
+    """Represents a pending allocation request from the job-manager.
+
+    Passed to :meth:`Scheduler.alloc` and typically stored in the
+    scheduler's pending queue until resources become available.  Call
+    :meth:`success`, :meth:`deny`, or :meth:`cancel` to finalize the
+    request; call :meth:`annotate` to update job annotations while it
+    is pending.
+
+    Attributes:
+        jobid (int): The job ID for this allocation request.
+    """
+
+    __slots__ = ("_scheduler", "_msg", "jobid", "_annotated_sched_keys")
+
+    def __init__(self, scheduler, msg):
+        self._scheduler = scheduler
+        self._msg = msg
+        self.jobid = msg.payload["id"]
+        self._annotated_sched_keys = set()
+
+    def success(self, R, annotations=None, clear=True):
+        """Finalize the request with a successful allocation.
+
+        Args:
+            R: The allocated resources, either as a resource pool object
+                (anything with a ``to_dict()`` method) or a pre-converted
+                dict.  Pool objects are converted automatically.
+            annotations (dict, optional): Scheduler annotations to attach.
+            clear (bool): If True (the default), any ``sched`` annotation keys
+                set via :meth:`annotate` while the job was pending are
+                automatically nulled in the success response, unless overridden
+                by *annotations*.  This ensures pending-state annotations
+                (e.g. ``reason_pending``, ``t_estimate``) are cleaned up
+                without each scheduler needing to track and clear them manually.
+        """
+        if not isinstance(R, dict):
+            R = R.to_dict()
+        if clear and self._annotated_sched_keys:
+            # Start with nulls for all previously-annotated keys, then overlay
+            # the caller's annotations so explicitly-set keys take precedence.
+            sched = {k: None for k in self._annotated_sched_keys}
+            sched.update((annotations or {}).get("sched", {}))
+            annotations = {**(annotations or {}), "sched": sched}
+        self._scheduler.alloc_success(self._msg, R, annotations)
+
+    def deny(self, note=None):
+        """Finalize the request with a permanent denial.
+
+        Args:
+            note (str, optional): Human-readable reason for the denial.
+        """
+        self._scheduler.alloc_deny(self._msg, note)
+
+    def cancel(self):
+        """Finalize the request indicating it was cancelled."""
+        self._scheduler.alloc_cancel(self._msg)
+
+    def annotate(self, annotations):
+        """Send an annotation update for this pending request.
+
+        May be called any number of times before the request is finalized.
+        Keys set here are tracked so that :meth:`success` can automatically
+        clear them.
+
+        Args:
+            annotations (dict): Annotation dict to attach to the job.
+        """
+        self._annotated_sched_keys.update((annotations or {}).get("sched", {}).keys())
+        self._scheduler.alloc_annotate(self._msg, annotations)
+
+
+class Scheduler(BrokerModule):
+    """Base class for Python scheduler broker modules.
+
+    Handles the RFC 27 protocol scaffolding so that subclasses only need
+    to implement scheduling policy.
+
+    The base class maintains a pending-job queue (:attr:`_queue`, a
+    ``heapq`` of :class:`PendingJob` ordered by priority then jobid) and
+    provides default implementations of :meth:`alloc` (parse jobspec and
+    enqueue), :meth:`free` (release resources), :meth:`cancel` (dequeue
+    and cancel), and :meth:`prioritize` (re-sort the queue).  Subclasses
+    must override :meth:`schedule` to implement their allocation policy,
+    and may override any of the defaults.
+
+    Subclasses may also override:
+
+    - :meth:`hello` — called once per running job during startup (optional;
+      default marks resources allocated)
+    - :meth:`resource_update` — called after resource state changes
+    - :meth:`feasibility_check` — called for ``feasibility.check`` RPCs
+    - :meth:`forecast` — called after :meth:`schedule` to annotate pending
+      jobs with forward-looking estimates such as ``sched.t_estimate``
+
+    Subclasses may set the class attributes:
+
+    - ``queue_depth`` — maximum pending alloc requests: a positive integer
+      (e.g. ``8``) for limited mode, or the string ``"unlimited"`` (default).
+      The base class translates this to the wire format automatically.
+      End users may override at load time with ``queue-depth=N|unlimited``.
+    - ``FORECAST_PERIOD`` — minimum seconds between :meth:`forecast` calls
+      (default 1.0); end users may override at load time with
+      ``forecast-period=N``.
+
+    Alloc requests are represented by :class:`AllocRequest` objects passed
+    to :meth:`alloc`.  Call ``request.success(R)``, ``request.deny(note)``,
+    ``request.cancel()``, or ``request.annotate(d)`` to respond.
+
+    The current resource pool is available as :attr:`resources`.  Resource
+    state is updated automatically from ``resource.acquire`` and
+    :meth:`resource_update` is called after each update.
+    """
+
+    #: Maximum number of pending alloc requests the job-manager will queue
+    #: for this scheduler.  Set to a positive integer (e.g. ``8``) for
+    #: ``limited`` mode or to the string ``"unlimited"`` for unlimited mode.
+    #: The :class:`Scheduler` base class translates this to the wire format
+    #: sent in ``job-manager.sched-ready``; subclasses and end users should
+    #: never need to know about the internal ``"limited=N"`` representation.
+    #: End users may override at load time with ``queue-depth=N|unlimited``.
+    queue_depth = "unlimited"
+
+    #: Maximum scheduling delay used when coalescing bursts of alloc requests.
+    #: The adaptive timer will not exceed this value regardless of how long
+    #: ``schedule()`` takes.  1 second is a reasonable upper bound for most
+    #: HPC schedulers; lower it if worst-case latency matters more than
+    #: throughput during large submission bursts.
+    SCHED_DELAY_MAX = 1.0
+
+    #: Exponential weighted moving average (EWMA) smoothing factor for the
+    #: adaptive scheduling timer.  Higher values react faster to changes in
+    #: burst rate and scheduling cost; lower values are more stable.
+    #: 0.25 converges in roughly 4 samples.
+    SCHED_EWMA_ALPHA = 0.25
+
+    #: Minimum interval in seconds between :meth:`forecast` calls.  During
+    #: scheduling bursts :meth:`forecast` is deferred and coalesced so that
+    #: annotation work runs at most once per ``FORECAST_PERIOD`` seconds,
+    #: keeping it off the critical path of job dispatch.  End users may
+    #: override at load time with ``forecast-period=N``.
+    FORECAST_PERIOD = 1.0
+
+    #: If True (the default), send ``partial-ok: True`` in the hello RPC so
+    #: that job-manager may report partially-freed ranks for running jobs.
+    #: Set to False (or pass ``test-hello-nopartial`` at load time on
+    #: subclasses that support it) to disable partial-ok behaviour.
+    hello_partial_ok = True
+
+    #: Extra keyword arguments forwarded to :class:`~flux.resource.ResourcePool`
+    #: (and on to the pool implementation) at construction time.  Subclasses
+    #: that accept pool-specific load-time options should parse them in
+    #: ``__init__`` and store the result here, e.g.
+    #: ``self.pool_kwargs = {"opt": value}``.
+    pool_kwargs: dict = {}
+
+    #: Minimum syslog priority level emitted by :meth:`log`.  Messages with a
+    #: numerically higher level (lower priority) are silently dropped.
+    #: Defaults to ``LOG_ERR``; set ``log-level=debug`` at load time for
+    #: verbose pool and scheduler diagnostics.
+    log_level: int = syslog.LOG_INFO
+
+    #: Map of level name strings to syslog priority constants, used when
+    #: parsing the ``log-level=`` module argument.
+    _LOG_LEVEL_NAMES: dict = {
+        "emerg": syslog.LOG_EMERG,
+        "alert": syslog.LOG_ALERT,
+        "crit": syslog.LOG_CRIT,
+        "err": syslog.LOG_ERR,
+        "warning": syslog.LOG_WARNING,
+        "notice": syslog.LOG_NOTICE,
+        "info": syslog.LOG_INFO,
+        "debug": syslog.LOG_DEBUG,
+    }
+
+    def __init_subclass__(cls, **kwargs):
+        # Automatically call _reject_unknown_args() after each subclass
+        # __init__ returns, so that unrecognised module arguments are caught
+        # and reported at load time (before set_running(), where errors
+        # propagate back to the flux module load command line).
+        #
+        # Only classes that explicitly define __init__ are wrapped; classes
+        # that inherit __init__ from a parent already have the check baked in
+        # via the parent's wrapper.
+        #
+        # The type(self) is _cls guard ensures the check only fires in the
+        # wrapper belonging to the actual instantiated class.  This means
+        # that when a subclass calls super().__init__(), the parent's wrapper
+        # skips the check (leaving self._pending_args intact for the subclass
+        # to process), and only the leaf wrapper triggers the final check.
+        # Multi-level scheduler inheritance (e.g. a test scheduler subclassing
+        # FIFOScheduler) therefore works correctly at any depth.
+        super().__init_subclass__(**kwargs)
+        if "__init__" in cls.__dict__:
+            original = cls.__init__
+
+            def wrapped(self, h, *args, _orig=original, _cls=cls):
+                _orig(self, h, *args)
+                if type(self) is _cls:
+                    self._reject_unknown_args()
+
+            cls.__init__ = wrapped
+
+    def __init__(self, h, *args):
+        super().__init__(h, *args)
+        self._resources = None
+        self._acquire_rpc = None
+        self._queue = []  # heapq of PendingJob, ordered by PendingJob.__lt__
+        # Adaptive scheduling timer: defers schedule() calls to coalesce bursts.
+        # _sched_pending: True while the timer is armed (prevents re-arming).
+        # _sched_delay: current one-shot delay in seconds (0 = next iteration).
+        # _sched_duration_ewma: exponential moving average of schedule() execution time.
+        # _sched_interval_ewma: exponential moving average of time between _request_schedule() calls.
+        # _sched_last_request: monotonic timestamp of last _request_schedule().
+        self._sched_pending = False
+        self._sched_delay = 0.0
+        self._sched_duration_ewma = 0.0
+        self._sched_interval_ewma = 0.0
+        self._sched_last_request = None
+        self._sched_timer = h.timer_watcher_create(0.0, self._on_sched_timer)
+        # Forecast timer: defers forecast() calls to keep annotation work off
+        # the critical scheduling path.  _forecast_pending is True while the
+        # one-shot timer is armed; subsequent _request_forecast() calls while
+        # it is armed are no-ops, coalescing the burst into a single call.
+        self._forecast_pending = False
+        self._forecast_timer = h.timer_watcher_create(0.0, self._on_forecast_timer)
+        self._pending_args = []
+        for arg in args:
+            if arg.startswith("queue-depth="):
+                val = arg[12:]
+                if val == "unlimited":
+                    self.queue_depth = "unlimited"
+                else:
+                    try:
+                        n = int(val)
+                        if n < 1:
+                            raise ValueError
+                        self.queue_depth = n
+                    except ValueError:
+                        raise ValueError(
+                            f"queue-depth={val!r} is invalid: "
+                            f"expected a positive integer or 'unlimited'"
+                        )
+            elif arg == "mode=unlimited":
+                self.queue_depth = "unlimited"
+            elif arg.startswith("mode=limited="):
+                val = arg[13:]
+                try:
+                    n = int(val)
+                    if n < 1:
+                        raise ValueError
+                    self.queue_depth = n
+                except ValueError:
+                    raise ValueError(
+                        f"mode=limited= requires a positive integer, got {val!r}"
+                    )
+            elif arg.startswith("log-level="):
+                name = arg[10:].lower()
+                if name not in self._LOG_LEVEL_NAMES:
+                    raise ValueError(
+                        f"log-level={name!r} is invalid: "
+                        f"expected one of {', '.join(self._LOG_LEVEL_NAMES)}"
+                    )
+                self.log_level = self._LOG_LEVEL_NAMES[name]
+            elif arg.startswith("forecast-period="):
+                val = arg[16:]
+                try:
+                    v = float(val)
+                    if v <= 0:
+                        raise ValueError
+                    self.FORECAST_PERIOD = v
+                except ValueError:
+                    raise ValueError(
+                        f"forecast-period must be a positive number, got {val!r}"
+                    )
+            else:
+                self._pending_args.append(arg)
+
+    def _reject_unknown_args(self):
+        """Raise ValueError if any unrecognized module arguments remain.
+
+        Call this at the end of a subclass ``__init__`` after processing
+        any subclass-specific arguments from :attr:`_pending_args`.
+        """
+        if self._pending_args:
+            raise ValueError(
+                f"unknown argument {self._pending_args[0]!r}: "
+                f"built-in options are queue-depth, log-level, forecast-period"
+            )
+
+    # ------------------------------------------------------------------
+    # Logging
+    # ------------------------------------------------------------------
+
+    def log(self, level: int, msg: str) -> None:
+        """Emit *msg* via ``handle.log`` if *level* is at or above :attr:`log_level`.
+
+        Pool implementations receive this method as their ``log`` callable so
+        that both scheduler and pool diagnostics share the same threshold.
+        """
+        if level <= self.log_level:
+            self.handle.log(level, msg)
+
+    # ------------------------------------------------------------------
+    # Public interface: resource state
+    # ------------------------------------------------------------------
+
+    @property
+    def resources(self):
+        """The current resource pool."""
+        return self._resources
+
+    # ------------------------------------------------------------------
+    # Adaptive scheduling timer
+    # ------------------------------------------------------------------
+
+    def _request_schedule(self):
+        """Request a scheduling pass, coalescing bursts via an adaptive timer.
+
+        Records the time of the request and updates the inter-request interval
+        exponential moving average.  Arms the one-shot scheduling timer if it
+        is not already pending; subsequent calls while the timer is armed are
+        recorded for moving-average purposes but do not re-arm the timer,
+        coalescing all requests in the window into a single :meth:`schedule`
+        call.
+
+        The timer delay starts at zero (fires on the next reactor iteration,
+        same as the previous prepare/check/idle behaviour) and adjusts
+        automatically: when alloc requests arrive faster than :meth:`schedule`
+        can process them, the delay grows toward the measured schedule
+        duration (capped at :attr:`SCHED_DELAY_MAX`) to coalesce the burst.
+        When requests become infrequent again the delay resets to zero,
+        preserving low latency for normal operation.
+        """
+        now = time.monotonic()
+        if self._sched_last_request is not None:
+            interval = now - self._sched_last_request
+            a = self.SCHED_EWMA_ALPHA
+            self._sched_interval_ewma = (
+                a * interval + (1 - a) * self._sched_interval_ewma
+            )
+        self._sched_last_request = now
+        if not self._sched_pending:
+            self._sched_pending = True
+            self._sched_timer.reset(after=self._sched_delay)
+
+    def _on_sched_timer(self, *_):
+        """Timer callback: run schedule() and update the adaptive delay."""
+        self._sched_pending = False
+        t0 = time.monotonic()
+        self.schedule()
+        duration = time.monotonic() - t0
+
+        a = self.SCHED_EWMA_ALPHA
+        self._sched_duration_ewma = a * duration + (1 - a) * self._sched_duration_ewma
+
+        # Burst detection: requests arrive faster than schedule() runs.
+        # Add a coalescing delay proportional to the schedule duration so
+        # that the scheduler runs at most once per scheduling cycle.
+        # When the burst ends (interval ≥ duration) reset to zero.
+        old_delay = self._sched_delay
+        if (
+            self._sched_interval_ewma > 0
+            and self._sched_interval_ewma < self._sched_duration_ewma
+        ):
+            self._sched_delay = min(self._sched_duration_ewma, self.SCHED_DELAY_MAX)
+        else:
+            self._sched_delay = 0.0
+
+        if self._sched_delay != old_delay:
+            if self._sched_delay > 0:
+                self.log(
+                    syslog.LOG_DEBUG,
+                    f"sched: burst detected, coalescing delay="
+                    f"{self._sched_delay * 1000:.1f}ms",
+                )
+            else:
+                self.log(syslog.LOG_DEBUG, "sched: burst ended, delay=0")
+
+        self._request_forecast()
+
+    # ------------------------------------------------------------------
+    # Forecast timer
+    # ------------------------------------------------------------------
+
+    def _request_forecast(self):
+        """Request a forecast pass, rate-limited to :attr:`FORECAST_PERIOD`.
+
+        Arms the one-shot forecast timer if it is not already pending.
+        Subsequent calls while the timer is armed are no-ops, so a burst of
+        :meth:`schedule` calls results in a single :meth:`forecast` call
+        :attr:`FORECAST_PERIOD` seconds after the first request in the burst.
+        """
+        if not self._forecast_pending:
+            self._forecast_pending = True
+            self._forecast_timer.reset(after=self.FORECAST_PERIOD)
+
+    def _on_forecast_timer(self, *_):
+        """Timer callback: run forecast()."""
+        self._forecast_pending = False
+        self.forecast()
+
+    # ------------------------------------------------------------------
+    # Alloc response implementation (called via AllocRequest)
+    # ------------------------------------------------------------------
+
+    def alloc_success(self, msg, R, annotations=None):
+        """Commit R to KVS and send an alloc success response.
+
+        Typically called via :meth:`AllocRequest.success`.  *R* must be a
+        dict (parsed R JSON object).  The alloc response to job-manager is
+        sent only after R is safely stored in KVS.
+
+        Args:
+            msg: The alloc request :class:`~flux.message.Message`.
+            R (dict): The allocated resource set as a parsed JSON object.
+            annotations (dict, optional): Scheduler annotations to include.
+        """
+        jobid = msg.payload["id"]
+
+        # Compute KVS key: job.<f58id>.R
+        buf = ffi.new("char[128]")
+        if lib.flux_job_kvs_key(buf, 128, jobid, b"R") < 0:
+            raise OSError("flux_job_kvs_key failed")
+        key = ffi.string(buf).decode()
+
+        txn = KVSTxn(self.handle)
+        txn.put(key, R)
+        f = kvs_commit_async(self.handle, _kvstxn=txn)
+        f.then(self._alloc_commit_continuation, (msg, R, annotations))
+
+    def _alloc_commit_continuation(self, future, args):
+        """Send the alloc response after the KVS commit completes."""
+        msg, R_dict, annotations = args
+        try:
+            future.get()
+        except OSError as exc:
+            self.log(syslog.LOG_ERR, f"alloc: KVS commit failed: {exc}")
+            self.stop_error()
+            return
+        resp = {"id": msg.payload["id"], "type": _ALLOC_SUCCESS, "R": R_dict}
+        if annotations is not None:
+            resp["annotations"] = annotations
+        self.handle.respond(msg, resp)
+
+    def alloc_deny(self, msg, note=None):
+        """Send an alloc denial response.  Typically called via :meth:`AllocRequest.deny`.
+
+        Args:
+            msg: The alloc request :class:`~flux.message.Message`.
+            note (str, optional): Human-readable reason for the denial.
+        """
+        resp = {"id": msg.payload["id"], "type": _ALLOC_DENY}
+        if note is not None:
+            resp["note"] = note
+        self.handle.respond(msg, resp)
+
+    def alloc_cancel(self, msg):
+        """Send an alloc cancel response.  Typically called via :meth:`AllocRequest.cancel`.
+
+        Args:
+            msg: The original alloc request :class:`~flux.message.Message`.
+        """
+        self.handle.respond(msg, {"id": msg.payload["id"], "type": _ALLOC_CANCEL})
+
+    def alloc_annotate(self, msg, annotations):
+        """Send an alloc annotation update.  Typically called via :meth:`AllocRequest.annotate`.
+
+        Args:
+            msg: The alloc request :class:`~flux.message.Message`.
+            annotations (dict): Annotation dict to attach to the job.
+        """
+        self.handle.respond(
+            msg,
+            {
+                "id": msg.payload["id"],
+                "type": _ALLOC_ANNOTATE,
+                "annotations": annotations,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Override points
+    # ------------------------------------------------------------------
+
+    def schedule(self):
+        """Called to run the scheduling loop.
+
+        Override this in subclasses to implement allocation policy.  Triggered
+        automatically after every :meth:`alloc`, :meth:`free`,
+        :meth:`cancel`, :meth:`prioritize`, :meth:`expiration`, and
+        :meth:`resource_update` event via an adaptive one-shot timer.  When
+        events arrive in rapid bursts the timer delay grows to coalesce them
+        into fewer :meth:`schedule` calls; when events are infrequent the
+        delay returns to zero so that each event is processed promptly.
+        """
+
+    def hello(self, jobid, priority, userid, t_submit, R):
+        """Called for each running job during the hello protocol.
+
+        Invoked synchronously during :meth:`run` before the reactor starts.
+        The default implementation marks *R* as allocated in the resource pool,
+        which is sufficient for most schedulers.  Override to additionally
+        track per-job state (e.g., store the job's expiration time).
+
+        Args:
+            jobid (int): The job ID.
+            priority (int): Job priority.
+            userid (int): Submitting user ID.
+            t_submit (float): Job submission time.
+            R: The job's current allocation.
+        """
+        self.resources.register_alloc(jobid, R)
+
+    def alloc(self, request, jobid, priority, userid, t_submit, jobspec):
+        """Queue an allocation request for the next :meth:`schedule` pass.
+
+        Parses *jobspec* and pushes a :class:`PendingJob` onto
+        :attr:`_queue`.  Override to change how jobs are parsed or queued.
+
+        Args:
+            request (:class:`AllocRequest`): The allocation request to respond to.
+            jobid (int): The job ID (also available as ``request.jobid``).
+            priority (int): Job priority.
+            userid (int): Submitting user ID.
+            t_submit (float): Job submission time.
+            jobspec (dict): The raw jobspec dict.
+        """
+        try:
+            rr = self.resources.parse_resource_request(jobspec)
+        except (KeyError, IndexError, ValueError) as exc:
+            request.deny(f"cannot parse jobspec: {exc}")
+            return
+        heapq.heappush(
+            self._queue,
+            PendingJob(jobid, priority, t_submit, request, rr),
+        )
+
+    def free(self, jobid, R, final=False):
+        """Return released resources to the pool.
+
+        Calls :meth:`~ResourcePool.free` on the resource pool.  Override
+        (calling ``super().free()``) to perform additional bookkeeping such
+        as removing per-job state.
+
+        Args:
+            jobid (int): The job ID.
+            R: The released resources.
+            final (bool): True if this is the final free for the job.
+        """
+        self.resources.free(jobid, R, final)
+
+    def cancel(self, jobid):
+        """Remove a pending job from the queue and respond with cancel.
+
+        Args:
+            jobid (int): The job ID to cancel.
+        """
+        for i, job in enumerate(self._queue):
+            if job.jobid == jobid:
+                self._queue.pop(i)
+                heapq.heapify(self._queue)
+                job.request.cancel()
+                return
+
+    def prioritize(self, jobs):
+        """Apply priority updates to queued jobs and re-sort the queue.
+
+        Args:
+            jobs (list): List of ``[jobid, priority]`` pairs.
+        """
+        priority_map = {jobid: priority for jobid, priority in jobs}
+        for job in self._queue:
+            if job.jobid in priority_map:
+                job.priority = priority_map[job.jobid]
+        heapq.heapify(self._queue)
+
+    def resource_update(self):
+        """Called after resource state changes from resource.acquire.
+
+        The updated state is available via :attr:`resources`.
+        """
+
+    def forecast(self):
+        """Called after :meth:`schedule` to annotate pending jobs with
+        forward-looking estimates.
+
+        Override in subclasses to populate ``sched.t_estimate`` (and other
+        forward-looking annotations) on pending jobs.  The base class
+        implementation is a no-op.
+
+        Triggered automatically after each :meth:`schedule` call, but
+        rate-limited to at most once per :attr:`FORECAST_PERIOD` seconds so
+        that annotation work is kept off the critical scheduling path during
+        bursts.  End users may tune the rate with ``forecast-period=N`` at
+        module load time.
+        """
+
+    def expiration(self, msg, jobid, expiration):
+        """Called when job-manager requests a job expiration update.
+
+        The default implementation accepts all updates by responding success.
+        Planning schedulers that track per-job expiration should override this
+        to update their internal records before calling
+        ``self.handle.respond(msg, None)``.
+
+        Args:
+            msg: The request :class:`~flux.message.Message`.
+            jobid (int): The job ID whose expiration is being updated.
+            expiration (float): New expiration timestamp (seconds since epoch).
+        """
+        self.handle.respond(msg, None)
+
+    def feasibility_check(self, msg, jobspec):
+        """Called for ``feasibility.check`` RPC.
+
+        Default implementation responds success if the job could ever fit
+        within the total resource set (ignoring current availability).
+        Subclasses may override for custom feasibility logic.
+
+        Args:
+            msg: The request :class:`~flux.message.Message`.
+            jobspec (dict): The raw jobspec dict.
+        """
+        try:
+            rr = self.resources.parse_resource_request(jobspec)
+            self.resources.check_feasibility(rr)
+        except (KeyError, IndexError, ValueError) as exc:
+            self.handle.respond_error(msg, errno.EINVAL, str(exc))
+            return
+        except InfeasibleRequest as exc:
+            self.handle.respond_error(msg, errno.EOVERFLOW, str(exc))
+            return
+        except OSError as exc:
+            self.handle.respond_error(msg, exc.errno, str(exc))
+            return
+        self.handle.respond(msg, None)
+
+    # ------------------------------------------------------------------
+    # run() — initialization then reactor
+    # ------------------------------------------------------------------
+
+    def run(self):
+        """Initialize the scheduler and start the reactor.
+
+        Performs the RFC 27 initialization sequence:
+
+        1. Register the ``sched`` dynamic service
+        2. Register the ``feasibility`` dynamic service
+        3. ``flux_module_set_running()`` — allow ``flux module load`` to return
+        4. ``resource.acquire`` — sync first response, async continuation
+        5. ``job-manager.sched-hello`` — sync hello protocol
+        6. ``job-manager.sched-ready`` — announce readiness
+        7. Start the reactor
+
+        Raises:
+            OSError: If any initialization step fails.
+        """
+        self._service_register("sched")
+        self._service_register("feasibility")
+        try:
+            self.set_running()
+            self._acquire_resources()
+            self._sched_hello()
+            self._sched_ready()
+        except OSError as exc:
+            self.log(syslog.LOG_ERR, f"initialization failed: {exc}")
+            return
+        super().run()
+
+    # ------------------------------------------------------------------
+    # RFC 27 sched message handlers (registered by BrokerModule)
+    # ------------------------------------------------------------------
+
+    @request_handler("sched.alloc", prefix=False)
+    def _handle_alloc(self, msg):
+        try:
+            p = msg.payload
+            request = AllocRequest(self, msg)
+            self.alloc(
+                request,
+                p["id"],
+                p["priority"],
+                p["userid"],
+                p["t_submit"],
+                p["jobspec"],
+            )
+            self._request_schedule()
+        except Exception as exc:
+            self.log(syslog.LOG_ERR, f"alloc callback raised: {exc}")
+            self.stop_error()
+
+    @request_handler("sched.free", prefix=False)
+    def _handle_free(self, msg):
+        try:
+            p = msg.payload
+            R = ResourcePool(p["R"])
+            self.free(p["id"], R, final=p.get("final", False))
+            self._request_schedule()
+        except Exception as exc:
+            self.log(syslog.LOG_ERR, f"free callback raised: {exc}")
+            self.stop_error()
+
+    @request_handler("sched.cancel", prefix=False)
+    def _handle_cancel(self, msg):
+        try:
+            self.cancel(msg.payload["id"])
+            self._request_schedule()
+        except Exception as exc:
+            self.log(syslog.LOG_ERR, f"cancel callback raised: {exc}")
+            self.stop_error()
+
+    @request_handler("sched.prioritize", prefix=False)
+    def _handle_prioritize(self, msg):
+        try:
+            self.prioritize(msg.payload.get("jobs", []))
+            self._request_schedule()
+        except Exception as exc:
+            self.log(syslog.LOG_ERR, f"prioritize callback raised: {exc}")
+            self.stop_error()
+
+    @request_handler("sched.resource-status", prefix=False)
+    def _handle_resource_status(self, msg):
+        try:
+            pool = self._resources
+            resp = {
+                "all": pool.to_dict(),
+                "allocated": pool.copy_allocated().to_dict(),
+                "down": pool.copy_down().to_dict(),
+            }
+            self.handle.respond(msg, resp)
+        except Exception as exc:
+            self.log(syslog.LOG_ERR, f"resource-status failed: {exc}")
+            lib.flux_respond_error(
+                self.handle.handle, msg.handle, errno.EINVAL, str(exc).encode()
+            )
+
+    @request_handler("sched.expiration", prefix=False)
+    def _handle_expiration(self, msg):
+        try:
+            p = msg.payload
+            jobid = p["id"]
+            exp = p["expiration"]
+            if exp < 0:
+                raise ValueError(f"invalid expiration {exp}")
+            self.expiration(msg, jobid, exp)
+            self._request_schedule()
+        except Exception as exc:
+            self.log(syslog.LOG_ERR, f"expiration callback raised: {exc}")
+            lib.flux_respond_error(
+                self.handle.handle, msg.handle, errno.EINVAL, str(exc).encode()
+            )
+
+    @request_handler("feasibility.check", prefix=False)
+    def _handle_feasibility(self, msg):
+        try:
+            self.feasibility_check(msg, msg.payload.get("jobspec", {}))
+        except Exception as exc:
+            self.log(syslog.LOG_ERR, f"feasibility callback raised: {exc}")
+            errmsg = str(exc).encode()
+            if (
+                lib.flux_respond_error(
+                    self.handle.handle, msg.handle, errno.EINVAL, errmsg
+                )
+                < 0
+            ):
+                self.stop_error()
+
+    # ------------------------------------------------------------------
+    # Internal: RFC 27 initialization helpers
+    # ------------------------------------------------------------------
+
+    def _service_register(self, name):
+        """Register a dynamic service by name (synchronous)."""
+        self.handle.service_register(name).get()
+
+    def _acquire_resources(self):
+        """Issue resource.acquire, process first response synchronously."""
+        f = self.handle.rpc("resource.acquire", flags=FLUX_RPC_STREAMING)
+        try:
+            data = f.get()
+        except OSError as exc:
+            raise OSError(f"resource.acquire failed: {exc}") from exc
+
+        # Build initial resource pool from the "resources" R object
+        R = data.get("resources")
+        if R is None:
+            raise OSError("resource.acquire: missing 'resources' field")
+        self._resources = ResourcePool(R, log=self.log, **self.pool_kwargs)
+
+        # Warn once about any pool_kwargs not recognised by this pool
+        # implementation, then prune them so subsequent pool constructions
+        # (e.g. during the hello loop) don't repeat the warning.
+        known = getattr(self._resources.impl, "known_options", frozenset())
+        for key in [k for k in self.pool_kwargs if k not in known]:
+            self.log(syslog.LOG_WARNING, f"pool: ignoring unknown option {key!r}")
+            del self.pool_kwargs[key]
+
+        # All resources start down; first update brings some up
+        self._resources.mark_down("all")
+        self._apply_resource_update(data)
+
+        # Reset past the first response (mirrors flux_future_reset in
+        # ss_resource_update), then install async continuation for subsequent
+        # resource state changes (up/down/shrink/expiration).
+        f.reset()
+        self._acquire_rpc = f
+        f.then(self._acquire_continuation)
+
+    def _acquire_continuation(self, future):
+        """Async continuation for streaming resource.acquire responses."""
+        try:
+            data = future.get()
+        except OSError as exc:
+            self.log(syslog.LOG_ERR, f"exiting due to resource update failure: {exc}")
+            self.stop()
+            return
+        self._apply_resource_update(data)
+        future.reset()
+
+    def _apply_resource_update(self, data):
+        """Update resource state from a resource.acquire response dict."""
+        if "up" in data:
+            self._resources.mark_up(data["up"])
+        if "down" in data:
+            self._resources.mark_down(data["down"])
+        if "expiration" in data and data["expiration"] >= 0:
+            self._resources.expiration = data["expiration"]
+            self.log(
+                syslog.LOG_INFO,
+                f"resource expiration updated to " f"{data['expiration']:.2f}",
+            )
+        if "shrink" in data:
+            from flux.idset import IDset
+
+            self._resources.remove_ranks(IDset(data["shrink"]))
+        self.resource_update()
+        self._request_schedule()
+
+    def _job_raise_continuation(self, future, jobid):
+        """Log an error if a job_raise RPC fails."""
+        try:
+            future.get()
+        except OSError as exc:
+            self.log(
+                syslog.LOG_ERR,
+                f"error raising fatal exception on {jobid.f58}: {exc}",
+            )
+
+    def _sched_hello(self):
+        """Synchronous hello protocol with job-manager (RFC 27).
+
+        Sends ``job-manager.sched-hello`` and for each running job looks up
+        R from the KVS and calls :meth:`hello`.
+        """
+        f = self.handle.rpc(
+            "job-manager.sched-hello",
+            {"partial-ok": self.hello_partial_ok},
+            flags=FLUX_RPC_STREAMING,
+        )
+        while True:
+            try:
+                data = f.get()
+            except OSError as exc:
+                if exc.errno == errno.ENODATA:
+                    break
+                raise OSError(f"sched-hello failed: {exc}") from exc
+
+            jobid = data["id"]
+            free_ranks = data.get("free")
+
+            # Look up R from KVS
+            buf = ffi.new("char[128]")
+            if lib.flux_job_kvs_key(buf, 128, jobid, b"R") < 0:
+                raise OSError("flux_job_kvs_key failed")
+            key = ffi.string(buf).decode()
+
+            try:
+                R_dict = kvs_get(self.handle, key)
+            except OSError:
+                self.log(
+                    syslog.LOG_ERR,
+                    f"hello: failed to look up R for job {JobID(jobid).f58}",
+                )
+                f.reset()
+                continue
+
+            # If partial-ok and some ranks are free, strip them from R
+            if free_ranks:
+                from flux.idset import IDset
+
+                rset = ResourcePool(R_dict, log=self.log, **self.pool_kwargs)
+                rset.remove_ranks(IDset(free_ranks))
+                R_dict = rset.to_dict()
+
+            try:
+                R = ResourcePool(R_dict, log=self.log, **self.pool_kwargs)
+                self.hello(
+                    jobid,
+                    data["priority"],
+                    data["userid"],
+                    data["t_submit"],
+                    R,
+                )
+            except Exception as exc:
+                self.log(
+                    syslog.LOG_ERR,
+                    f"hello callback failed for job {JobID(jobid).f58}: {exc}",
+                )
+                self.log(
+                    syslog.LOG_ERR,
+                    f"raising fatal exception on running job id={JobID(jobid).f58}",
+                )
+                f_raise = job_raise_async(
+                    self.handle,
+                    jobid,
+                    "scheduler-restart",
+                    0,
+                    "failed to reallocate R for running job",
+                )
+                f_raise.then(self._job_raise_continuation, JobID(jobid))
+
+            f.reset()
+
+    def _sched_ready(self):
+        """Send job-manager.sched-ready and announce scheduler mode."""
+        depth = self.queue_depth
+        if depth == "unlimited":
+            payload = {"mode": "unlimited"}
+        else:
+            try:
+                n = int(depth)
+                if n < 1:
+                    raise ValueError
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"queue_depth must be a positive integer or 'unlimited', "
+                    f"got {depth!r}"
+                )
+            payload = {"mode": "limited", "limit": n}
+
+        f = self.handle.rpc("job-manager.sched-ready", payload)
+        try:
+            f.get()
+        except OSError as exc:
+            raise OSError(f"sched-ready failed: {exc}") from exc
+
+        level_name = {v: k for k, v in self._LOG_LEVEL_NAMES.items()}.get(
+            self.log_level, str(self.log_level)
+        )
+        self.log(
+            syslog.LOG_INFO,
+            f"ready: queue-depth={depth}"
+            f" log-level={level_name}"
+            f" Rv{self.resources.version}"
+            f" {self.resources.dumps()}",
+        )
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -35,6 +35,9 @@ libmodule_builtins_la_LIBADD = \
 	$(builddir)/overlay/liboverlay.la
 libmodule_builtins_la_LDFLAGS = $(san_ld_zdef_flag)
 
+dist_fluxmod_SCRIPTS = \
+	sched-fifo.py
+
 fluxmod_LTLIBRARIES = \
 	content.la \
 	content-files.la \

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -36,7 +36,8 @@ libmodule_builtins_la_LIBADD = \
 libmodule_builtins_la_LDFLAGS = $(san_ld_zdef_flag)
 
 dist_fluxmod_SCRIPTS = \
-	sched-fifo.py
+	sched-fifo.py \
+	sched-backfill.py
 
 fluxmod_LTLIBRARIES = \
 	content.la \

--- a/src/modules/sched-backfill.py
+++ b/src/modules/sched-backfill.py
@@ -1,0 +1,279 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""EASY backfill scheduler broker module.
+
+Implements the EASY backfill algorithm.  The highest-priority pending job
+(the "head" job) receives a resource reservation: it is guaranteed to start
+no later than the earliest time that enough running jobs will have finished
+to satisfy its request (the "shadow time").  Lower-priority jobs may run
+immediately (backfill) provided they meet both of the EASY constraints:
+
+1. Fit within the currently free resources.
+2. Have a known duration short enough that they will finish before the
+   head job's shadow time, so the reservation is not violated.
+
+Jobs submitted without a duration (``--time-limit=0``) cannot be backfilled
+because their finish time is unknown.
+
+The shadow time is computed by running the allocator against a temporary
+copy of the resource pool and advancing through expiration events until the
+head job fits.  This gives an accurate shadow time that respects topology
+and property constraints — it tightens the backfill window compared to
+count-based heuristics without over-constraining candidates.
+
+Load with::
+
+    flux module load sched-backfill [queue-depth=N|unlimited] [log-level=LEVEL]
+
+``queue-depth`` bounds the number of pending alloc requests kept in the
+scheduler queue (default 8).  Set to ``unlimited`` to expose the full queue.
+
+``log-level`` sets the minimum syslog level for scheduler and pool log
+messages (default ``err``; use ``debug`` for verbose output).
+
+Reference:
+    Ahuva W. Mu'alem and Dror G. Feitelson, "Utilization, Predictability,
+    Workloads, and User Runtime Estimates in Scheduling the IBM SP2 with
+    Backfilling," IEEE Transactions on Parallel and Distributed Systems,
+    12(6):529-543, June 2001.
+"""
+
+import heapq
+import syslog
+import time
+
+from _flux._core import lib
+from flux.job import JobID
+from flux.resource import InfeasibleRequest, InsufficientResources
+from flux.scheduler import Scheduler
+
+
+class BackfillScheduler(Scheduler):
+    """EASY backfill scheduler.
+
+    Overrides:
+      - :meth:`expiration` — update the pool's end-time tracking for the job
+      - :meth:`cancel`     — clear annotations before removing from queue
+      - :meth:`schedule`   — head-first with backfill for lower-priority jobs
+
+    Helper methods (not base-class overrides):
+      - :meth:`_try_alloc`        — attempt a real allocation, handling exceptions
+      - :meth:`_shadow_time`      — compute head job's reservation time via simulation
+      - :meth:`_annotate_pending` — send ``t_estimate`` annotation to the head job
+    """
+
+    def __init__(self, h, *args):
+        super().__init__(h, *args)
+        # Cache for _shadow_time(): keyed on (pool.generation, head.jobid).
+        # pool.generation is bumped on every pool mutation (job start/complete,
+        # node up/down), so the cache is automatically invalidated whenever
+        # the shadow time could have changed.  Canceling a non-head pending
+        # job does not mutate the pool and therefore does not invalidate it.
+        self._shadow_cache_key = None
+        self._shadow_cache_value = None
+
+    # ------------------------------------------------------------------
+    # Scheduler overrides
+    # ------------------------------------------------------------------
+
+    def expiration(self, msg, jobid, expiration):
+        """Update the running job's end time in the resource pool.
+
+        Called when a job's time limit is extended or reduced.  Keeping the
+        pool's end-time tracking current is essential for accurate shadow-time
+        computation: a stale end time would cause the simulation to free the
+        job's resources at the wrong moment.
+        """
+        self.resources.update_expiration(jobid, expiration)
+        self.handle.respond(msg, None)
+
+    def cancel(self, jobid):
+        """Remove a pending job from the queue, clearing its annotations first."""
+        for job in self._queue:
+            if job.jobid == jobid:
+                job.request.annotate(
+                    {"sched": {"resource_summary": None, "t_estimate": None}}
+                )
+                break
+        super().cancel(jobid)
+
+    # ------------------------------------------------------------------
+    # Scheduling logic
+    # ------------------------------------------------------------------
+
+    def _try_alloc(self, job, backfill=None):
+        """Attempt to allocate resources for a job.
+
+        Args:
+            job: A :class:`~flux.scheduler.PendingJob` to allocate.
+            backfill: If not ``None``, the jobid of the head job whose
+                reservation this job is backfilling around; the annotation
+                records this relationship.
+
+        Returns:
+            True if the job was handled (alloc succeeded or request was
+            permanently denied); False if resources are temporarily
+            insufficient (:exc:`~flux.resource.InsufficientResources`).
+        """
+        rr = job.resource_request
+        try:
+            alloc = self.resources.alloc(job.jobid, rr)
+        except InsufficientResources:
+            return False  # not enough resources now — retry after next free
+        except InfeasibleRequest as exc:
+            job.request.deny(str(exc) or "unsatisfiable request")
+            return True
+
+        # Stamp the alloc R object with wall-clock start/expiration times
+        # before handing it back to job-manager via RFC 27 success response.
+        reactor = lib.flux_get_reactor(self.handle.handle)
+        now = lib.flux_reactor_now(reactor)
+        alloc.set_starttime(now)
+        if rr.duration > 0.0:
+            alloc.set_expiration(now + rr.duration)
+        elif self.resources.expiration > 0.0:
+            alloc.set_expiration(self.resources.expiration)
+
+        summary = alloc.dumps()
+        annotations = {"sched": {"resource_summary": summary}}
+        if backfill is not None:
+            annotations["sched"]["backfill"] = JobID(backfill).f58
+        job.request.success(alloc, annotations)
+        return True
+
+    def _annotate_pending(self, shadow):
+        """Post ``t_estimate`` annotation on the head-of-queue job.
+
+        Only sends the annotation when the value has changed since the last
+        send, to avoid redundant RPC overhead.
+
+        Args:
+            shadow: Shadow time in seconds since the Unix epoch, or ``None``
+                if the shadow time is unknown.
+        """
+        if not self._queue:
+            return
+        head = sorted(self._queue)[0]
+        if head._last_annotation != shadow:
+            head._last_annotation = shadow
+            head.request.annotate({"sched": {"t_estimate": shadow}})
+
+    def _shadow_time(self, head):
+        """Compute the EASY reservation time for the head job via direct simulation.
+
+        Creates a temporary deep copy of the resource pool and advances it
+        through expiration events until the head job's request fits.  Using
+        the allocator directly (rather than count-based heuristics) gives an
+        accurate shadow time that respects topology and property constraints,
+        tightening the backfill window without over-constraining candidates.
+
+        The result is cached by ``(pool.generation, head.jobid)``.
+        ``pool.generation`` is bumped on every pool mutation (job start/complete,
+        node up/down), so the cache is automatically invalidated when the shadow
+        time may have changed.  Canceling a lower-priority pending job leaves the
+        pool unchanged and does not invalidate the cache.
+
+        Args:
+            head: The highest-priority :class:`~flux.scheduler.PendingJob`
+                for which the reservation is being computed.
+
+        Returns:
+            The earliest wall-clock time (seconds since the Unix epoch) at
+            which the head job is guaranteed to fit, or ``None`` if the
+            request is permanently infeasible or no future expirations remain.
+        """
+        key = (self.resources.generation, head.jobid)
+        if self._shadow_cache_key == key:
+            return self._shadow_cache_value
+
+        sim = self.resources.copy()
+        rr = head.resource_request
+        t = 0.0
+        shadow = None
+        while True:
+            try:
+                sim.alloc(head.jobid, rr)
+                shadow = max(t, time.time())  # map sim time to wall clock
+                break
+            except InfeasibleRequest:
+                break  # permanently infeasible — shadow stays None
+            except InsufficientResources:
+                # Not enough resources now; advance to the next expiration.
+                nxt = min(
+                    (e for _, e in sim.job_end_times() if e > t),
+                    default=None,
+                )
+                if nxt is None:
+                    break  # no future expirations — shadow stays None
+                t = nxt
+                for jid, end_time in list(sim.job_end_times()):
+                    if 0 < end_time <= t:
+                        sim.free(jid)
+
+        self._shadow_cache_key = key
+        self._shadow_cache_value = shadow
+        return shadow
+
+    def schedule(self):
+        """Schedule the head job; backfill lower-priority jobs around its reservation.
+
+        If the head job allocates immediately, recurse to handle the new head
+        (which may also be immediately schedulable).  If it is blocked, compute
+        its shadow time and attempt to backfill each lower-priority job that:
+
+        1. Has a known duration, and
+        2. Will finish (``now + duration``) before the shadow time — the EASY
+           constraint that guarantees the head job's reservation is not violated.
+        """
+        if not self._queue:
+            return
+
+        head = self._queue[0]
+
+        # Only the head job carries a t_estimate annotation.  Clear any stale
+        # annotation on non-head jobs (e.g. a job displaced by a higher-priority
+        # arrival since the last schedule() call).
+        for job in self._queue[1:]:
+            if job._last_annotation is not None:
+                job._last_annotation = None
+                job.request.annotate({"sched": {"t_estimate": None}})
+
+        if self._try_alloc(head):
+            heapq.heappop(self._queue)
+            self.schedule()  # new head may also be immediately schedulable
+            return
+
+        # Head is blocked — compute its shadow time (EASY reservation).
+        shadow = self._shadow_time(head)
+        now = time.time()
+
+        kept = [head]
+        for job in sorted(self._queue[1:]):  # priority order among non-head jobs
+            duration = job.resource_request.duration
+            # EASY constraint: backfill only if the job finishes before shadow.
+            can_backfill = (
+                shadow is not None and duration > 0.0 and now + duration <= shadow
+            )
+            if can_backfill and self._try_alloc(job, backfill=head.jobid):
+                self.log(
+                    syslog.LOG_DEBUG,
+                    f"backfill: {JobID(job.jobid).f58} (shadow={shadow:.0f})",
+                )
+            else:
+                kept.append(job)
+
+        self._queue = kept
+        heapq.heapify(self._queue)
+        self._annotate_pending(shadow)
+
+
+def mod_main(h, *args):
+    BackfillScheduler(h, *args).run()

--- a/src/modules/sched-fifo.py
+++ b/src/modules/sched-fifo.py
@@ -1,0 +1,233 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Simple priority-FIFO scheduler broker module.
+
+Jobs are ordered by descending priority then ascending jobid (FIFO within
+a priority level), matching the behaviour of sched-simple.  The head of
+the queue is attempted first; if it cannot be allocated the pass stops,
+preserving strict FIFO ordering.
+
+An optional ``forecast()`` implementation annotates each queued job with
+a ``t_estimate`` by simulating allocations forward in time.
+
+Load with::
+
+    flux module load sched-fifo [queue-depth=N|unlimited] [log-level=LEVEL]
+
+``queue-depth`` bounds the number of pending alloc requests kept in the
+scheduler queue (default 8, matching sched-simple).  Set to ``unlimited``
+if the full pending queue must be visible for policy or annotation purposes.
+
+``log-level`` sets the minimum syslog level for scheduler and pool log
+messages (default ``err``; use ``debug`` for verbose output).
+"""
+
+import heapq
+import time as _time
+
+from _flux._core import lib
+from flux.resource import InfeasibleRequest, InsufficientResources
+from flux.scheduler import Scheduler
+
+
+class FIFOScheduler(Scheduler):
+    """Priority-FIFO scheduler.
+
+    Overrides:
+      - :meth:`schedule` — drain the queue head-first, stopping on the first
+                           blocked job to preserve FIFO ordering
+      - :meth:`forecast` — annotate queued jobs with ``t_estimate`` via
+                           forward simulation (optional planning hook)
+
+    Helper methods (not base-class overrides):
+      - :meth:`_sim_alloc`  — allocate one job in a simulation, advancing time
+      - :meth:`_try_alloc`  — attempt a real allocation, handling exceptions
+    """
+
+    #: Default to 8 to match sched-simple behaviour: job-manager queues at
+    #: most 8 pending alloc requests, bounding scheduler queue size and
+    #: annotation overhead.  Override at load time with ``queue-depth=unlimited``
+    #: if the full pending queue must be visible (e.g. for policy decisions).
+    queue_depth = 8
+
+    def __init__(self, h, *args):
+        super().__init__(h, *args)
+
+    # ------------------------------------------------------------------
+    # Scheduler overrides
+    # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Scheduling loop
+    # ------------------------------------------------------------------
+
+    def schedule(self):
+        """Drain the head of the queue as long as allocations succeed.
+
+        Stops at the first job that cannot be allocated, preserving strict
+        FIFO ordering: a lower-priority job must never start before the job
+        ahead of it in the queue.
+        """
+        while self._queue:
+            job = self._queue[0]
+            if not self._try_alloc(job):
+                break  # head blocked — stop to preserve FIFO ordering
+            heapq.heappop(self._queue)
+
+    def _sim_alloc(self, sim, jobid, rr, t_floor):
+        """Allocate a resource request in a simulation pool.
+
+        Starts from ``t_floor`` and repeatedly calls ``sim.alloc()``.  On
+        :exc:`~flux.resource.InsufficientResources` it advances to the next
+        expiration event, frees those resources, and retries, simulating the
+        passage of time.
+
+        Args:
+            sim: A deep-copy resource pool used for simulation.
+            jobid: ID of the job being simulated.
+            rr: :class:`~flux.resource.Rv1Pool.ResourceRequest` for the job.
+            t_floor: FIFO ordering floor — the estimated start time of the
+                preceding job in the queue; this job cannot start earlier.
+
+        Returns:
+            The sim time at which the allocation succeeded (may equal
+            ``t_floor`` if resources were immediately available), or ``None``
+            if no future expirations remain to free enough resources.
+
+        Raises:
+            InfeasibleRequest: Propagated from ``sim.alloc()`` so the caller
+                can skip the job, as :meth:`schedule` would.
+        """
+        t = t_floor
+        while True:
+            try:
+                sim.alloc(jobid, rr)
+                return t
+            except InfeasibleRequest:
+                raise  # propagate so caller can skip the job, as schedule() would
+            except InsufficientResources:
+                # Not enough resources now; advance to the next expiration.
+                nxt = min(
+                    (e for _, e in sim.job_end_times() if e > t),
+                    default=None,
+                )
+                if nxt is None:
+                    return None  # no future expirations — cannot estimate
+                t = nxt
+                for jid, end_time in list(sim.job_end_times()):
+                    if 0 < end_time <= t:
+                        sim.free(jid)
+
+    def forecast(self):
+        """Annotate queued jobs with ``t_estimate`` via forward simulation.
+
+        Makes a deep copy of the resource pool and walks the queue in priority
+        order, calling :meth:`_sim_alloc` for each job.  The FIFO ordering
+        constraint is enforced via *t_floor*: job *k* cannot be estimated to
+        start earlier than job *k-1*.  Estimation stops at the first job with
+        no known duration (``--time-limit=0``) or whose request is permanently
+        infeasible; remaining jobs receive ``None`` to clear stale estimates.
+
+        Permanently infeasible jobs (those that would be denied in the real
+        scheduling loop) are skipped: their annotation is cleared and
+        estimation continues for the remaining jobs, without advancing the
+        FIFO floor.  Estimation stops only at the first job with no known
+        duration or with no future expirations to free enough resources.
+
+        Complexity is O(N × M) where N is the number of queued jobs (bounded
+        by ``queue_depth``, default 8) and M is the number of running jobs
+        with known end times.  Each running job is freed from the simulation
+        at most once across the entire walk.
+
+        Annotations are suppressed when the value is unchanged since the last
+        send, so overhead in steady state is minimal.
+        """
+        if not self._queue:
+            return
+        sim = self.resources.copy()
+
+        t_prev = 0.0
+        can_estimate = True
+        for job in sorted(self._queue):
+            rr = job.resource_request
+
+            if can_estimate:
+                try:
+                    t = self._sim_alloc(sim, job.jobid, rr, t_prev)
+                except InfeasibleRequest:
+                    # Permanently infeasible: the real schedule() loop would deny
+                    # and remove this job, then continue to the next one.  Do the
+                    # same here — clear the annotation and keep estimating.
+                    t_est = None
+                    if job._last_annotation != t_est:
+                        job._last_annotation = t_est
+                        job.request.annotate({"sched": {"t_estimate": t_est}})
+                    continue
+                # Map sim time 0 (no advancement needed) to current wall clock.
+                t_est = max(t, _time.time()) if t is not None else None
+            else:
+                # Cannot estimate jobs beyond an unknown-duration job in the chain.
+                t_est = None
+
+            if job._last_annotation != t_est:
+                job._last_annotation = t_est
+                job.request.annotate({"sched": {"t_estimate": t_est}})
+
+            if not can_estimate or t is None:
+                can_estimate = False
+                continue
+
+            # Advance the FIFO floor: the next job cannot start before this one.
+            duration = rr.duration
+            if duration > 0.0:
+                sim.update_expiration(job.jobid, t + duration)
+                t_prev = t
+            else:
+                can_estimate = False  # unknown end time — cannot chain further
+
+    def _try_alloc(self, job):
+        """Attempt to allocate resources for a job.
+
+        Args:
+            job: A :class:`~flux.scheduler.PendingJob` at the head of the
+                queue.
+
+        Returns:
+            True if the job was handled (alloc succeeded or request was
+            permanently denied); False if resources are temporarily
+            insufficient (:exc:`~flux.resource.InsufficientResources`).
+        """
+        rr = job.resource_request
+        try:
+            alloc = self.resources.alloc(job.jobid, rr)
+        except InsufficientResources:
+            return False  # not enough resources now — retry after next free
+        except InfeasibleRequest as exc:
+            job.request.deny(str(exc) or "unsatisfiable request")
+            return True
+
+        # Stamp the alloc R object with wall-clock start/expiration times
+        # before handing it back to job-manager via RFC 27 success response.
+        reactor = lib.flux_get_reactor(self.handle.handle)
+        now = lib.flux_reactor_now(reactor)
+        alloc.set_starttime(now)
+        if rr.duration > 0.0:
+            alloc.set_expiration(now + rr.duration)
+        elif self.resources.expiration > 0.0:
+            alloc.set_expiration(self.resources.expiration)
+
+        summary = alloc.dumps()
+        job.request.success(alloc, {"sched": {"resource_summary": summary}})
+        return True
+
+
+def mod_main(h, *args):
+    FIFOScheduler(h, *args).run()

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -324,6 +324,7 @@ TESTSCRIPTS = \
 	python/t0036-subprocess.py \
 	python/t0037-slurm.py \
 	python/t0038-brokermod.py \
+	python/t0039-rv1pool.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -184,6 +184,7 @@ TESTSCRIPTS = \
 	t2303-sched-hello.t \
 	t2304-sched-simple-alloc-check.t \
 	t2305-sched-slow.t \
+	t2306-sched-fifo.t \
 	t2310-resource-module.t \
 	t2311-resource-drain.t \
 	t2312-resource-exclude.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -185,6 +185,7 @@ TESTSCRIPTS = \
 	t2304-sched-simple-alloc-check.t \
 	t2305-sched-slow.t \
 	t2306-sched-fifo.t \
+	t2307-sched-backfill.t \
 	t2310-resource-module.t \
 	t2311-resource-drain.t \
 	t2312-resource-exclude.t \

--- a/t/python/t0022-resource-set.py
+++ b/t/python/t0022-resource-set.py
@@ -663,6 +663,105 @@ class TestRSet(unittest.TestCase):
         self.assertIn("R_lite", d["execution"])
 
 
+class TestConstraints(unittest.TestCase):
+    """Tests for RFC 31 constraint matching via copy_constraint().
+
+    Fixture: R_with_props has 2 ranks.
+      rank 0 (node0): property "foo"
+      rank 1 (node1): properties "foo" and "bar"
+    """
+
+    def setUp(self):
+        self.rset = ResourceSet(TestRSet.R_with_props)
+
+    # ------------------------------------------------------------------
+    # Valid constraints
+    # ------------------------------------------------------------------
+
+    def test_properties_match(self):
+        # Both ranks have "foo"; result should contain both.
+        r = self.rset.copy_constraint({"properties": ["foo"]})
+        self.assertEqual(r.nnodes, 2)
+
+    def test_properties_subset(self):
+        # Only rank 1 has "bar".
+        r = self.rset.copy_constraint({"properties": ["bar"]})
+        self.assertEqual(r.nnodes, 1)
+
+    def test_properties_negation(self):
+        # "^bar" means NOT bar — only rank 0 qualifies.
+        r = self.rset.copy_constraint({"properties": ["^bar"]})
+        self.assertEqual(r.nnodes, 1)
+
+    def test_properties_unknown_returns_empty(self):
+        # No rank has property "zzz"; result is empty.
+        r = self.rset.copy_constraint({"properties": ["zzz"]})
+        self.assertEqual(r.nnodes, 0)
+
+    def test_and_constraint(self):
+        # Both "foo" AND "bar" — only rank 1 qualifies.
+        r = self.rset.copy_constraint(
+            {"and": [{"properties": ["foo"]}, {"properties": ["bar"]}]}
+        )
+        self.assertEqual(r.nnodes, 1)
+
+    def test_or_constraint(self):
+        # "foo" OR "bar" — both ranks qualify (rank 0 via foo, rank 1 via both).
+        r = self.rset.copy_constraint(
+            {"or": [{"properties": ["foo"]}, {"properties": ["bar"]}]}
+        )
+        self.assertEqual(r.nnodes, 2)
+
+    def test_not_constraint(self):
+        # NOT "bar" — only rank 0 qualifies.
+        r = self.rset.copy_constraint({"not": [{"properties": ["bar"]}]})
+        self.assertEqual(r.nnodes, 1)
+
+    def test_hostlist_constraint(self):
+        r = self.rset.copy_constraint({"hostlist": "node0"})
+        self.assertEqual(r.nnodes, 1)
+
+    def test_ranks_constraint(self):
+        r = self.rset.copy_constraint({"ranks": "1"})
+        self.assertEqual(r.nnodes, 1)
+
+    def test_constraint_as_json_string(self):
+        # copy_constraint() accepts a JSON string as well as a dict.
+        r = self.rset.copy_constraint('{"properties": ["bar"]}')
+        self.assertEqual(r.nnodes, 1)
+
+    # ------------------------------------------------------------------
+    # Invalid constraint operators
+    # ------------------------------------------------------------------
+
+    def test_unknown_operator_raises(self):
+        # "foo" is not a recognised RFC 31 operator.
+        with self.assertRaises(ValueError):
+            self.rset.copy_constraint({"foo": []})
+
+    # ------------------------------------------------------------------
+    # Invalid operand types for logical operators
+    # ------------------------------------------------------------------
+
+    def test_and_non_list_raises(self):
+        # "and" must be a list; passing a dict must raise ValueError so the
+        # feasibility check rejects the job rather than silently matching all.
+        with self.assertRaises(ValueError):
+            self.rset.copy_constraint({"and": {}})
+
+    def test_or_non_list_raises(self):
+        with self.assertRaises(ValueError):
+            self.rset.copy_constraint({"or": {}})
+
+    def test_not_non_list_raises(self):
+        with self.assertRaises(ValueError):
+            self.rset.copy_constraint({"not": {}})
+
+    def test_not_empty_list_raises(self):
+        with self.assertRaises(ValueError):
+            self.rset.copy_constraint({"not": []})
+
+
 if __name__ == "__main__":
     unittest.main(testRunner=TAPTestRunner())
 

--- a/t/python/t0022-resource-set.py
+++ b/t/python/t0022-resource-set.py
@@ -626,6 +626,42 @@ class TestRSet(unittest.TestCase):
         self.assertEqual(result.ngpus, 1)
         self.assertEqual(str(result), "rank0/core[0-3],gpu0")
 
+    def test_to_dict_matches_encode(self):
+        """to_dict() must produce the same result as json.loads(encode())."""
+        rset = ResourceSet(self.R_input)
+        self.assertEqual(rset.to_dict(), json.loads(rset.encode()))
+
+    def test_to_dict_round_trips(self):
+        """ResourceSet constructed from to_dict() must equal the original."""
+        rset = ResourceSet(self.R_input)
+        rset2 = ResourceSet(rset.to_dict())
+        self.assertEqual(str(rset), str(rset2))
+
+    def test_to_dict_round_trips_properties(self):
+        """Properties must survive to_dict() → ResourceSet() round-trip."""
+        rset = ResourceSet(self.R_with_props)
+        rset2 = ResourceSet(rset.to_dict())
+        props = json.loads(rset2.get_properties())
+        self.assertIn("foo", props)
+        self.assertIn("bar", props)
+        self.assertEqual(props["foo"], "0-1")
+        self.assertEqual(props["bar"], "1")
+
+    def test_to_dict_round_trips_nodelist(self):
+        """Nodelist must survive to_dict() → ResourceSet() round-trip."""
+        rset = ResourceSet(self.R_with_props)
+        rset2 = ResourceSet(rset.to_dict())
+        self.assertEqual(str(rset2.nodelist), "node[0-1]")
+
+    def test_to_dict_returns_dict(self):
+        """to_dict() must return a plain Python dict."""
+        rset = ResourceSet(self.R_input)
+        d = rset.to_dict()
+        self.assertIsInstance(d, dict)
+        self.assertEqual(d["version"], 1)
+        self.assertIn("execution", d)
+        self.assertIn("R_lite", d["execution"])
+
 
 if __name__ == "__main__":
     unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -1,0 +1,894 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import json
+import time
+import unittest
+
+import subflux  # noqa: F401 - for PYTHONPATH
+from flux.resource import InfeasibleRequest, InsufficientResources
+from flux.resource.Rv1Pool import ResourceRequest, Rv1Pool
+from pycotap import TAPTestRunner
+
+
+def rr(
+    nnodes=0,
+    nslots=1,
+    slot_size=1,
+    gpu_per_slot=0,
+    duration=0.0,
+    constraint=None,
+    exclusive=False,
+):
+    """Convenience wrapper to build a ResourceRequest for tests."""
+    return ResourceRequest(
+        nnodes, nslots, slot_size, gpu_per_slot, duration, constraint, exclusive
+    )
+
+
+# 4 nodes, 4 cores each (no GPUs)
+R_4x4 = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0-3", "children": {"core": "0-3"}}],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": ["node0", "node1", "node2", "node3"],
+    },
+}
+
+# 2 nodes, 2 cores each — total cores (4) >= slot_size=3, but no single
+# node has 3 cores; used to test per-node slot-capacity checks.
+R_2x2 = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0-1", "children": {"core": "0-1"}}],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": ["node0", "node1"],
+    },
+}
+
+# 2 nodes: rank0 has 4 cores + 2 GPUs, rank1 has 4 cores + 2 GPUs
+R_gpu = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0-1", "children": {"core": "0-3", "gpu": "0-1"}}],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": ["gpu0", "gpu1"],
+    },
+}
+
+# 2 nodes, 4 cores + 1 GPU each — total GPUs (2) >= gpu_per_slot=2, but
+# no single node has 2 GPUs; used to test per-node GPU-slot-capacity checks.
+R_1gpu_per_node = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0-1", "children": {"core": "0-3", "gpu": "0"}}],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": ["gpu0", "gpu1"],
+    },
+}
+
+# 4 nodes with properties: rank0,1 have "fast"; rank2,3 have "slow"
+R_props = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0-3", "children": {"core": "0-1"}}],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": ["node0", "node1", "node2", "node3"],
+        "properties": {"fast": "0-1", "slow": "2-3"},
+    },
+}
+
+
+class TestRv1PoolConstruct(unittest.TestCase):
+    def test_from_dict(self):
+        p = Rv1Pool(R_4x4)
+        self.assertEqual(p.count("core"), 16)
+
+    def test_from_string(self):
+        p = Rv1Pool(json.dumps(R_4x4))
+        self.assertEqual(p.count("core"), 16)
+
+    def test_bad_type_raises(self):
+        with self.assertRaises(TypeError):
+            Rv1Pool(42)
+
+    def test_gpu_parsed(self):
+        p = Rv1Pool(R_gpu)
+        self.assertEqual(p.count("core"), 8)
+        self.assertEqual(p.count("gpu"), 4)
+
+    def test_unknown_resource_count_zero(self):
+        p = Rv1Pool(R_4x4)
+        self.assertEqual(p.count("banana"), 0)
+
+    def test_expiration(self):
+        R = dict(R_4x4)
+        R["execution"] = dict(R_4x4["execution"], expiration=1234.5)
+        p = Rv1Pool(R)
+        self.assertAlmostEqual(p.expiration, 1234.5)
+
+
+class TestRv1PoolUpDown(unittest.TestCase):
+    def setUp(self):
+        self.pool = Rv1Pool(R_4x4)
+        self.pool.mark_down("all")
+
+    def test_all_down_count_still_total(self):
+        # count() totals all ranks regardless of up/down
+        self.assertEqual(self.pool.count("core"), 16)
+
+    def test_mark_up_single(self):
+        self.pool.mark_up("0")
+        alloc = self.pool.alloc(1, rr(0, 1, 1))
+        self.assertEqual(alloc.count("core"), 1)
+
+    def test_mark_up_all(self):
+        self.pool.mark_up("all")
+        alloc = self.pool.alloc(1, rr(0, 4, 1))
+        self.assertEqual(alloc.count("core"), 4)
+
+    def test_all_down_enospc(self):
+        with self.assertRaises(InsufficientResources):
+            self.pool.alloc(1, rr(0, 1, 1))
+
+    def test_copy_down(self):
+        down = self.pool.copy_down()
+        self.assertEqual(down.count("core"), 16)
+
+    def test_copy_down_after_partial_up(self):
+        self.pool.mark_up("0-1")
+        down = self.pool.copy_down()
+        self.assertEqual(down.count("core"), 8)  # ranks 2 and 3
+
+
+class TestRv1PoolExpiration(unittest.TestCase):
+    def test_set_get(self):
+        p = Rv1Pool(R_4x4)
+        p.expiration = 9999.0
+        self.assertAlmostEqual(p.expiration, 9999.0)
+
+    def test_set_expiration_method(self):
+        p = Rv1Pool(R_4x4)
+        p.set_expiration(5000.0)
+        self.assertAlmostEqual(p.expiration, 5000.0)
+
+    def test_set_starttime_method(self):
+        p = Rv1Pool(R_4x4)
+        p.set_starttime(1000.0)
+        d = p.to_dict()
+        self.assertAlmostEqual(d["execution"]["starttime"], 1000.0)
+
+
+class TestRv1PoolAlloc(unittest.TestCase):
+    def setUp(self):
+        self.pool = Rv1Pool(R_4x4)
+
+    def test_alloc_one_slot(self):
+        a = self.pool.alloc(1, rr(0, 1, 1))
+        self.assertEqual(a.count("core"), 1)
+
+    def test_alloc_reduces_free(self):
+        self.pool.alloc(1, rr(0, 4, 1))
+        # 4 cores gone; 12 remain
+        a2 = self.pool.alloc(2, rr(0, 4, 1))
+        self.assertEqual(a2.count("core"), 4)
+        with self.assertRaises(InsufficientResources):
+            self.pool.alloc(3, rr(0, 9, 1))
+
+    def test_alloc_multi_slot(self):
+        a = self.pool.alloc(1, rr(0, 4, 2))  # 8 cores total
+        self.assertEqual(a.count("core"), 8)
+
+    def test_enospc_when_exhausted(self):
+        self.pool.alloc(1, rr(0, 16, 1))  # fill all
+        with self.assertRaises(InsufficientResources):
+            self.pool.alloc(2, rr(0, 1, 1))
+
+    def test_eoverflow_too_many_cores(self):
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.alloc(1, rr(0, 1, 100))
+
+    def test_slot_size_fits_total_but_not_per_node(self):
+        # slot_size=3 on a 2-node × 2-core cluster: total cores=4 >= 3, but
+        # no single node has 3 cores, so the slot can never be filled.
+        # Must raise InfeasibleRequest, not InsufficientResources (which
+        # would leave the job stuck in the queue forever).
+        p = Rv1Pool(R_2x2)
+        with self.assertRaises(InfeasibleRequest):
+            p.alloc(1, rr(0, 1, 3))
+
+    def test_slot_size_exactly_fills_node(self):
+        # slot_size equal to the per-node core count should succeed.
+        p = Rv1Pool(R_2x2)
+        a = p.alloc(1, rr(0, 1, 2))
+        self.assertEqual(a.count("core"), 2)
+        self.assertEqual(len(a._ranks), 1)
+
+    def test_nslots_exceeds_per_node_slot_capacity(self):
+        # 5 single-core slots requested, but 2-node × 2-core cluster
+        # only provides 4 slots total.  InfeasibleRequest, not ENOSPC.
+        p = Rv1Pool(R_2x2)
+        with self.assertRaises(InfeasibleRequest):
+            p.alloc(1, rr(0, 5, 1))
+
+    def test_nnodes(self):
+        # 2 nodes, 2 slots each, 1 core per slot
+        a = self.pool.alloc(1, rr(2, 4, 1))
+        self.assertEqual(a.count("core"), 4)
+        # result must span exactly 2 ranks
+        self.assertEqual(len(a._ranks), 2)
+
+    def test_nnodes_enospc(self):
+        # Fill 3 of 4 nodes; requesting all 4 should then be ENOSPC
+        self.pool.alloc(1, rr(3, 12, 1))
+        with self.assertRaises(InsufficientResources):
+            self.pool.alloc(2, rr(4, 4, 1))
+
+    def test_nnodes_more_than_pool_eoverflow(self):
+        # Asking for more nodes than exist is permanently infeasible
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.alloc(1, rr(5, 5, 1))
+
+    def test_nnodes_eoverflow(self):
+        # need 2 nodes with 8 cores each, but nodes only have 4
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.alloc(1, rr(2, 16, 4))
+
+    def test_jobid_tracked_in_job_state(self):
+        self.pool.alloc(42, rr(0, 1, 1))
+        self.assertIn(42, self.pool._job_state)
+
+    def test_alloc_with_duration_records_end_time(self):
+        before = time.time()
+        self.pool.alloc(1, rr(0, 1, 1, duration=3600.0))
+        end_time, _ = self.pool._job_state[1]
+        self.assertGreater(end_time, before + 3600.0 - 1)
+        self.assertLess(end_time, before + 3600.0 + 10)
+
+    def test_alloc_no_duration_end_time_zero(self):
+        # No duration, no pool expiration → end_time is 0.0
+        self.pool.alloc(1, rr(0, 1, 1, duration=0.0))
+        end_time, _ = self.pool._job_state[1]
+        self.assertEqual(end_time, 0.0)
+
+    def test_alloc_no_duration_uses_pool_expiration(self):
+        self.pool.set_expiration(9999.0)
+        self.pool.alloc(1, rr(0, 1, 1, duration=0.0))
+        end_time, _ = self.pool._job_state[1]
+        self.assertAlmostEqual(end_time, 9999.0)
+
+    def test_alloc_result_has_nodelist(self):
+        # The shell requires execution.nodelist in the R returned for each job.
+        a = self.pool.alloc(1, rr(0, 1, 1))
+        d = a.to_dict()
+        self.assertIn("nodelist", d["execution"])
+        self.assertTrue(d["execution"]["nodelist"])
+
+
+class TestRv1PoolWorstFit(unittest.TestCase):
+    """Verify worst-fit picks the node with the most free cores."""
+
+    def _make_uneven_pool(self):
+        """2-node pool: rank0 has 4 cores, rank1 has 2 cores."""
+        R = {
+            "version": 1,
+            "execution": {
+                "R_lite": [
+                    {"rank": "0", "children": {"core": "0-3"}},
+                    {"rank": "1", "children": {"core": "0-1"}},
+                ],
+                "starttime": 0,
+                "expiration": 0,
+                "nodelist": ["big", "small"],
+            },
+        }
+        return Rv1Pool(R)
+
+    def test_picks_larger_node_first(self):
+        p = self._make_uneven_pool()
+        # Allocate 1 core; worst-fit should pick rank0 (4 free > 2 free)
+        a = p.alloc(1, rr(0, 1, 1))
+        self.assertIn(0, a._ranks)
+        self.assertNotIn(1, a._ranks)
+
+
+class TestRv1PoolExclusive(unittest.TestCase):
+    def setUp(self):
+        self.pool = Rv1Pool(R_4x4)
+
+    def test_exclusive_reserves_whole_node(self):
+        # Request 1 slot exclusively — should reserve all 4 cores of that node
+        a = self.pool.alloc(1, rr(1, 1, 1, exclusive=True))
+        self.assertEqual(a.count("core"), 4)
+        self.assertEqual(len(a._ranks), 1)
+
+    def test_exclusive_blocks_second_alloc_on_same_node(self):
+        a = self.pool.alloc(1, rr(1, 1, 1, exclusive=True))
+        rank = next(iter(a._ranks))
+        info = self.pool._ranks[rank]
+        # That node should now show all 4 cores allocated
+        self.assertEqual(len(info["allocated_cores"]), 4)
+
+
+class TestRv1PoolGPU(unittest.TestCase):
+    def setUp(self):
+        self.pool = Rv1Pool(R_gpu)
+
+    def test_alloc_with_gpu(self):
+        a = self.pool.alloc(1, rr(0, 2, 1, gpu_per_slot=1))
+        self.assertEqual(a.count("core"), 2)
+        self.assertEqual(a.count("gpu"), 2)
+
+    def test_gpu_enospc(self):
+        # Use up all GPUs first
+        self.pool.alloc(1, rr(0, 4, 1, gpu_per_slot=1))
+        with self.assertRaises(InsufficientResources):
+            self.pool.alloc(2, rr(0, 1, 1, gpu_per_slot=1))
+
+    def test_gpu_eoverflow(self):
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.alloc(1, rr(0, 1, 1, gpu_per_slot=10))
+
+    def test_no_gpu_requested_ignores_gpu_nodes(self):
+        # CPU-only request should succeed on GPU nodes
+        a = self.pool.alloc(1, rr(0, 2, 1))
+        self.assertEqual(a.count("core"), 2)
+
+    def test_gpu_eoverflow_no_gpu_nodes(self):
+        # CPU-only pool, GPU requested → InfeasibleRequest
+        p = Rv1Pool(R_4x4)
+        with self.assertRaises(InfeasibleRequest):
+            p.alloc(1, rr(0, 1, 1, gpu_per_slot=1))
+
+    def test_gpu_per_slot_fits_total_but_not_per_node(self):
+        # gpu_per_slot=2, but each node has only 1 GPU.  Total GPUs (2)
+        # satisfies the naive total check (2 >= 1*2=2), but no single node
+        # can supply a 2-GPU slot.  Must raise InfeasibleRequest.
+        p = Rv1Pool(R_1gpu_per_node)
+        with self.assertRaises(InfeasibleRequest):
+            p.alloc(1, rr(0, 1, 1, gpu_per_slot=2))
+
+    def test_gpu_per_slot_exactly_fills_node(self):
+        # gpu_per_slot equal to the per-node GPU count should succeed.
+        p = Rv1Pool(R_1gpu_per_node)
+        a = p.alloc(1, rr(0, 1, 1, gpu_per_slot=1))
+        self.assertEqual(a.count("gpu"), 1)
+
+
+class TestRv1PoolFree(unittest.TestCase):
+    def setUp(self):
+        self.pool = Rv1Pool(R_4x4)
+
+    def test_free_restores_resources(self):
+        self.pool.alloc(1, rr(0, 16, 1))
+        self.pool.free(1)
+        a2 = self.pool.alloc(2, rr(0, 16, 1))
+        self.assertEqual(a2.count("core"), 16)
+
+    def test_free_removes_from_job_state(self):
+        self.pool.alloc(1, rr(0, 1, 1))
+        self.assertIn(1, self.pool._job_state)
+        self.pool.free(1)
+        self.assertNotIn(1, self.pool._job_state)
+
+    def test_free_tolerant(self):
+        # free() should not raise even when jobid is unknown
+        self.pool.alloc(1, rr(0, 1, 1))
+        self.pool.free(1)
+        self.pool.free(1)  # second free — should not raise
+
+
+class TestRv1PoolRegisterAlloc(unittest.TestCase):
+    def test_register_alloc_marks_busy(self):
+        p1 = Rv1Pool(R_4x4)
+        a = p1.alloc(1, rr(0, 4, 1))  # allocate 4 cores
+
+        # Build a fresh pool and replay the allocation via register_alloc
+        p2 = Rv1Pool(R_4x4)
+        p2.register_alloc(2, a)
+
+        # p2 should now have 4 cores allocated; only 12 left
+        alloc2 = p2.alloc(3, rr(0, 12, 1))
+        self.assertEqual(alloc2.count("core"), 12)
+        with self.assertRaises(InsufficientResources):
+            p2.alloc(4, rr(0, 1, 1))
+
+    def test_register_alloc_populates_job_state(self):
+        p1 = Rv1Pool(R_4x4)
+        a = p1.alloc(1, rr(0, 4, 1))
+
+        p2 = Rv1Pool(R_4x4)
+        p2.register_alloc(99, a)
+        self.assertIn(99, p2._job_state)
+
+    def test_register_alloc_missing_rank_raises(self):
+        # Simulates scheduler reload after a rank is excluded from config:
+        # the job's R has rank 0, but the new pool has no rank 0.
+        p1 = Rv1Pool(R_4x4)
+        a = p1.alloc(1, rr(0, 4, 1))  # allocate one node (rank 0)
+
+        # Build a pool with rank 0 removed (as if excluded in config)
+        from flux.idset import IDset
+
+        p2 = Rv1Pool(R_4x4)
+        p2.remove_ranks(IDset("0"))
+        with self.assertRaises(ValueError):
+            p2.register_alloc(1, a)
+
+    def test_register_alloc_succeeds_when_rank_is_down(self):
+        # During system instance bringup, compute nodes may be slow to come
+        # online so the scheduler starts with all ranks present but marked
+        # down.  register_alloc() must still succeed: down ranks are tracked
+        # in _ranks (just with up=False) and are not considered missing.
+        p1 = Rv1Pool(R_4x4)
+        a = p1.alloc(1, rr(0, 4, 1))  # allocate one node
+
+        p2 = Rv1Pool(R_4x4)
+        p2.mark_down("all")  # all nodes down at hello time
+        p2.register_alloc(1, a)  # must not raise
+        self.assertIn(1, p2._job_state)
+
+    def test_register_alloc_uses_r_expiration(self):
+        p1 = Rv1Pool(R_4x4)
+        a = p1.alloc(1, rr(0, 4, 1))
+        a.set_expiration(5000.0)
+
+        p2 = Rv1Pool(R_4x4)
+        p2.register_alloc(10, a)
+        end_time, _ = p2._job_state[10]
+        self.assertAlmostEqual(end_time, 5000.0)
+
+
+class TestRv1PoolUpdateExpiration(unittest.TestCase):
+    def test_update_expiration_changes_end_time(self):
+        p = Rv1Pool(R_4x4)
+        p.alloc(1, rr(0, 1, 1, duration=3600.0))
+        p.update_expiration(1, 9999.0)
+        end_time, _ = p._job_state[1]
+        self.assertAlmostEqual(end_time, 9999.0)
+
+    def test_update_expiration_unknown_jobid_is_noop(self):
+        p = Rv1Pool(R_4x4)
+        # Should not raise for unknown jobid
+        p.update_expiration(999, 5000.0)
+
+
+class TestRv1PoolCheckFeasibility(unittest.TestCase):
+    def setUp(self):
+        self.pool = Rv1Pool(R_4x4)
+
+    def test_feasible_request_succeeds(self):
+        # 8 cores fits in 4-node × 4-core pool
+        self.pool.check_feasibility(rr(0, 8, 1))
+
+    def test_infeasible_too_many_cores_eoverflow(self):
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.check_feasibility(rr(0, 100, 1))
+
+    def test_slot_size_fits_total_but_not_per_node(self):
+        # slot_size=5 exceeds per-node capacity (4 cores each on R_4x4)
+        # but fits the total (16).  Per-node check must still reject it.
+        # Mirrors the C librlist test "too large of slot returns EOVERFLOW".
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.check_feasibility(rr(0, 1, 5))
+
+    def test_infeasible_too_many_nodes_eoverflow(self):
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.check_feasibility(rr(5, 5, 1))
+
+    def test_feasible_even_when_pool_exhausted(self):
+        # Fully allocate the pool; feasibility checks a clean copy, so it
+        # should still succeed for a satisfiable request.
+        self.pool.alloc(1, rr(0, 16, 1))
+        self.pool.check_feasibility(rr(0, 8, 1))  # should not raise
+
+    def test_infeasible_with_property_constraint(self):
+        pool = Rv1Pool(R_props)
+        # "fast" nodes have only 4 cores total; requesting 10 is infeasible
+        with self.assertRaises(InfeasibleRequest):
+            pool.check_feasibility(rr(0, 10, 1, constraint={"properties": ["fast"]}))
+
+    def test_feasible_with_property_constraint(self):
+        pool = Rv1Pool(R_props)
+        # "fast" nodes have 4 cores total; requesting 2 is fine
+        pool.check_feasibility(rr(0, 2, 1, constraint={"properties": ["fast"]}))
+
+    def test_does_not_modify_pool(self):
+        # check_feasibility must not alter the pool's allocation state
+        self.pool.alloc(1, rr(0, 8, 1))
+        self.pool.check_feasibility(rr(0, 8, 1))
+        # Still 8 cores allocated; only 8 remain
+        with self.assertRaises(InsufficientResources):
+            self.pool.alloc(2, rr(0, 9, 1))
+
+
+class TestRv1PoolCopy(unittest.TestCase):
+    def setUp(self):
+        self.pool = Rv1Pool(R_4x4)
+        self.pool.alloc(1, rr(0, 4, 1))
+
+    def test_copy_preserves_allocation(self):
+        # copy() preserves alloc state so it can be used for simulation
+        fresh = self.pool.copy()
+        # 4 cores were already allocated in setUp; only 12 remain free
+        with self.assertRaises(InsufficientResources):
+            fresh.alloc(1, rr(0, 16, 1))
+        a = fresh.alloc(2, rr(0, 12, 1))
+        self.assertEqual(a.count("core"), 12)
+
+    def test_copy_is_independent(self):
+        # Mutations to the copy must not affect the original
+        fresh = self.pool.copy()
+        fresh.free(1)
+        # original still has job 1 allocated
+        self.assertEqual(self.pool.copy_allocated().count("core"), 4)
+
+    def test_copy_preserves_up_down(self):
+        self.pool.mark_down("3")
+        fresh = self.pool.copy()
+        down = fresh.copy_down()
+        self.assertIn(3, down._ranks)
+
+    def test_copy_allocated(self):
+        ca = self.pool.copy_allocated()
+        self.assertEqual(ca.count("core"), 4)
+
+    def test_copy_allocated_empty_when_none(self):
+        p = Rv1Pool(R_4x4)
+        ca = p.copy_allocated()
+        self.assertEqual(ca.count("core"), 0)
+
+    def test_copy_allocated_preserves_properties(self):
+        # Allocate on a rank with a property, then verify copy_allocated
+        # carries the matching property (needed for sched.resource-status queue).
+        pool = Rv1Pool(R_props)  # ranks 0-1 have "fast", 2-3 have "slow"
+        pool.alloc(1, rr(1, 2, 1, constraint={"properties": ["fast"]}))
+        ca = pool.copy_allocated()
+        self.assertIn("fast", ca._properties)
+        self.assertNotIn("slow", ca._properties)
+
+
+class TestRv1PoolConstraints(unittest.TestCase):
+    def setUp(self):
+        self.pool = Rv1Pool(R_props)
+
+    def test_property_constraint(self):
+        a = self.pool.alloc(1, rr(0, 2, 1, constraint={"properties": ["fast"]}))
+        # Both allocated slots must be on ranks 0 or 1
+        for rank in a._ranks:
+            self.assertIn(rank, {0, 1})
+
+    def test_property_constraint_eoverflow(self):
+        # "fast" nodes have only 4 cores total (2 ranks × 2 cores)
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.alloc(1, rr(0, 10, 1, constraint={"properties": ["fast"]}))
+
+    def test_hostlist_constraint(self):
+        a = self.pool.alloc(1, rr(0, 1, 1, constraint={"hostlist": "node0"}))
+        self.assertIn(0, a._ranks)
+
+    def test_ranks_constraint(self):
+        a = self.pool.alloc(1, rr(0, 1, 1, constraint={"ranks": "2-3"}))
+        for rank in a._ranks:
+            self.assertIn(rank, {2, 3})
+
+    def test_not_constraint(self):
+        a = self.pool.alloc(
+            1,
+            rr(
+                0,
+                1,
+                1,
+                constraint={"not": [{"properties": ["slow"]}]},
+            ),
+        )
+        for rank in a._ranks:
+            self.assertIn(rank, {0, 1})
+
+    def test_constraint_as_json_string(self):
+        a = self.pool.alloc(
+            1,
+            rr(
+                0,
+                1,
+                1,
+                constraint=json.dumps({"properties": ["slow"]}),
+            ),
+        )
+        for rank in a._ranks:
+            self.assertIn(rank, {2, 3})
+
+
+class TestRv1PoolRemoveRanks(unittest.TestCase):
+    def test_remove_reduces_count(self):
+        from flux.idset import IDset
+
+        p = Rv1Pool(R_4x4)
+        p.remove_ranks(IDset("2-3"))
+        self.assertEqual(p.count("core"), 8)
+
+    def test_remove_prevents_alloc_on_removed(self):
+        from flux.idset import IDset
+
+        p = Rv1Pool(R_4x4)
+        p.remove_ranks(IDset("0-2"))
+        a = p.alloc(1, rr(0, 4, 1))
+        # Only rank3 remains; can only get 4 cores
+        self.assertEqual(a.count("core"), 4)
+        self.assertEqual(list(a._ranks.keys()), [3])
+
+
+class TestRv1PoolPartialFree(unittest.TestCase):
+    """Tests for partial-free (housekeeping) protocol.
+
+    The scheduler allocation protocol may return a job's resources one or more
+    ranks at a time before the final free.  Each partial free must:
+      - release those ranks' cores/GPUs for immediate reuse
+      - update _job_state to remove freed ranks (preventing double-free)
+      - not remove the job from _job_state until final=True
+    """
+
+    def setUp(self):
+        # 4-node pool, 4 cores each.  Allocate job 1 across all 4 ranks.
+        self.pool = Rv1Pool(R_4x4)
+        self.alloc = self.pool.alloc(1, rr(0, 16, 1))
+
+    def _partial_R(self, ranks):
+        """Return an Rv1Pool containing only *ranks* from the full allocation."""
+        return self.alloc._copy_from_ranks(set(ranks))
+
+    def test_partial_free_releases_resources(self):
+        # Free ranks 0 and 1; their 8 cores should become available.
+        partial = self._partial_R([0, 1])
+        self.pool.free(1, partial, final=False)
+        a2 = self.pool.alloc(2, rr(0, 8, 1))
+        self.assertEqual(a2.count("core"), 8)
+
+    def test_partial_free_updates_job_state(self):
+        # After freeing ranks 0-1, _job_state should only track ranks 2-3.
+        partial = self._partial_R([0, 1])
+        self.pool.free(1, partial, final=False)
+        _, remaining = self.pool._job_state[1]
+        self.assertNotIn(0, remaining._ranks)
+        self.assertNotIn(1, remaining._ranks)
+        self.assertIn(2, remaining._ranks)
+        self.assertIn(3, remaining._ranks)
+
+    def test_partial_free_keeps_job_in_state(self):
+        partial = self._partial_R([0, 1])
+        self.pool.free(1, partial, final=False)
+        self.assertIn(1, self.pool._job_state)
+
+    def test_no_double_free_after_realloc(self):
+        # Free ranks 0-1, reallocate them to job 2, then final-free job 1.
+        # Job 2 must still hold ranks 0-1 after job 1's final free.
+        partial = self._partial_R([0, 1])
+        self.pool.free(1, partial, final=False)
+
+        job2_alloc = self.pool.alloc(2, rr(0, 8, 1))
+        self.assertEqual(job2_alloc.count("core"), 8)
+
+        # Final free job 1 (ranks 2-3 remaining in _job_state)
+        final_partial = self._partial_R([2, 3])
+        self.pool.free(1, final_partial, final=True)
+
+        # Job 2's cores (ranks 0-1) must still be allocated
+        for rank in job2_alloc._ranks:
+            info = self.pool._ranks[rank]
+            self.assertTrue(
+                len(info["allocated_cores"]) > 0,
+                f"rank {rank} was double-freed",
+            )
+
+    def test_final_free_releases_remaining(self):
+        # Partial free ranks 0-1, then final free should release ranks 2-3.
+        partial = self._partial_R([0, 1])
+        self.pool.free(1, partial, final=False)
+        final_partial = self._partial_R([2, 3])
+        self.pool.free(1, final_partial, final=True)
+        self.assertNotIn(1, self.pool._job_state)
+        # All cores should now be free
+        a = self.pool.alloc(2, rr(0, 16, 1))
+        self.assertEqual(a.count("core"), 16)
+
+    def test_final_free_r_mismatch_raises(self):
+        # Final free with wrong R (rank 0 only, but ranks 0-3 still tracked)
+        # should raise ValueError.
+        wrong_R = self._partial_R([0])
+        with self.assertRaises(ValueError):
+            self.pool.free(1, wrong_R, final=True)
+
+    def test_partial_free_extra_rank_raises(self):
+        # Freeing a rank not in the job's allocation must raise ValueError.
+        partial = self._partial_R([0])
+        self.pool.free(1, partial, final=False)
+        # Now rank 0 is no longer in _job_state[1]; freeing it again is extra.
+        with self.assertRaises(ValueError):
+            self.pool.free(1, partial, final=False)
+
+    def test_simulation_free_without_r_after_partial_free(self):
+        # After a partial free, the simulation (R=None) must only free
+        # the remaining tracked ranks, not the already-freed ones.
+        partial = self._partial_R([0, 1])
+        self.pool.free(1, partial, final=False)
+
+        # Reallocate freed ranks to job 2
+        job2_alloc = self.pool.alloc(2, rr(0, 8, 1))
+
+        # Simulate what backfill does: free job 1 via R=None on a copy
+        sim = self.pool.copy()
+        sim.free(1)
+
+        # In the simulation, ranks 2-3 (job 1 remainder) should now be free
+        for rank in [2, 3]:
+            self.assertEqual(len(sim._ranks[rank]["allocated_cores"]), 0)
+        # Ranks 0-1 belong to job 2 in sim and must still be allocated
+        for rank in job2_alloc._ranks:
+            self.assertGreater(len(sim._ranks[rank]["allocated_cores"]), 0)
+
+
+class TestRv1PoolEncode(unittest.TestCase):
+    def test_encode_is_valid_json(self):
+        p = Rv1Pool(R_4x4)
+        s = p.encode()
+        d = json.loads(s)
+        self.assertEqual(d["version"], 1)
+        self.assertIn("R_lite", d["execution"])
+
+    def test_to_dict_matches_encode(self):
+        p = Rv1Pool(R_4x4)
+        self.assertEqual(p.to_dict(), json.loads(p.encode()))
+
+    def test_round_trip(self):
+        p1 = Rv1Pool(R_4x4)
+        a = p1.alloc(1, rr(0, 4, 1))
+        p2 = Rv1Pool(a.to_dict())
+        self.assertEqual(p2.count("core"), 4)
+
+    def test_encode_includes_gpu(self):
+        p = Rv1Pool(R_gpu)
+        a = p.alloc(1, rr(0, 1, 1, gpu_per_slot=1))
+        d = a.to_dict()
+        children = d["execution"]["R_lite"][0]["children"]
+        self.assertIn("gpu", children)
+
+    def test_encode_includes_properties(self):
+        p = Rv1Pool(R_props)
+        d = p.to_dict()
+        self.assertIn("properties", d["execution"])
+        self.assertIn("fast", d["execution"]["properties"])
+
+    def test_encode_expiration_starttime(self):
+        p = Rv1Pool(R_4x4)
+        p.set_starttime(100.0)
+        p.set_expiration(200.0)
+        d = p.to_dict()
+        self.assertAlmostEqual(d["execution"]["starttime"], 100.0)
+        self.assertAlmostEqual(d["execution"]["expiration"], 200.0)
+
+
+class TestRv1PoolDumps(unittest.TestCase):
+    def test_single_rank(self):
+        p = Rv1Pool(R_4x4)
+        a = p.alloc(1, rr(1, 1, 1, exclusive=True))
+        s = a.dumps()
+        # Should look like "rank<N>/core[0-3]"
+        self.assertRegex(s, r"^rank\d+/core")
+
+    def test_multi_rank(self):
+        p = Rv1Pool(R_4x4)
+        a = p.alloc(1, rr(0, 8, 1))
+        s = a.dumps()
+        self.assertIn("rank", s)
+        self.assertIn("core", s)
+
+    def test_gpu_in_dumps(self):
+        p = Rv1Pool(R_gpu)
+        a = p.alloc(1, rr(0, 1, 1, gpu_per_slot=1))
+        s = a.dumps()
+        self.assertIn("gpu", s)
+
+
+class TestFromJobspec(unittest.TestCase):
+    """Test from_jobspec / parse_resource_request for both pool classes."""
+
+    # Minimal valid V1 jobspec: slot -> core, attributes.system.duration present
+    VALID_V1 = {
+        "version": 1,
+        "resources": [
+            {"type": "slot", "count": 2, "with": [{"type": "core", "count": 1}]}
+        ],
+        "tasks": [],
+        "attributes": {"system": {"duration": 60.0}},
+    }
+    # V1 jobspec missing attributes.system entirely
+    NO_SYSTEM = {
+        "version": 1,
+        "resources": [
+            {"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}]}
+        ],
+        "tasks": [],
+        "attributes": {},
+    }
+    # V1 jobspec with attributes.system but missing duration
+    NO_DURATION = {
+        "version": 1,
+        "resources": [
+            {"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}]}
+        ],
+        "tasks": [],
+        "attributes": {"system": {}},
+    }
+    # Non-V1 jobspec with no attributes.system (should be accepted)
+    NON_V1_NO_SYSTEM = {
+        "version": 9999,
+        "resources": [
+            {"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}]}
+        ],
+        "tasks": [],
+        "attributes": {},
+    }
+
+    def _pools(self):
+        """Return one instance of each pool class for parametrised tests."""
+        return [Rv1Pool(R_4x4)]
+
+    def test_valid_v1_parses(self):
+        for pool in self._pools():
+            with self.subTest(pool=type(pool).__name__):
+                rr = pool.parse_resource_request(self.VALID_V1)
+                self.assertEqual(rr.nslots, 2)
+                self.assertAlmostEqual(rr.duration, 60.0)
+
+    def test_v1_missing_system_raises(self):
+        for pool in self._pools():
+            with self.subTest(pool=type(pool).__name__):
+                with self.assertRaises(ValueError) as ctx:
+                    pool.parse_resource_request(self.NO_SYSTEM)
+                self.assertIn("system", str(ctx.exception))
+
+    def test_v1_missing_duration_raises(self):
+        for pool in self._pools():
+            with self.subTest(pool=type(pool).__name__):
+                with self.assertRaises(ValueError) as ctx:
+                    pool.parse_resource_request(self.NO_DURATION)
+                self.assertIn("duration", str(ctx.exception))
+
+    def test_non_v1_missing_system_accepted(self):
+        for pool in self._pools():
+            with self.subTest(pool=type(pool).__name__):
+                rr = pool.parse_resource_request(self.NON_V1_NO_SYSTEM)
+                self.assertAlmostEqual(rr.duration, 0.0)
+
+    def test_empty_constraints_dict_treated_as_none(self):
+        """Empty constraints dict {} (sent by queue-update plugin) → constraint=None."""
+        jobspec = {
+            "version": 1,
+            "resources": [
+                {"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}]}
+            ],
+            "tasks": [],
+            "attributes": {"system": {"duration": 60.0, "constraints": {}}},
+        }
+        for pool in self._pools():
+            with self.subTest(pool=type(pool).__name__):
+                rr = pool.parse_resource_request(jobspec)
+                self.assertIsNone(rr.constraint)
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/rc/rc1-job.py
+++ b/t/rc/rc1-job.py
@@ -65,17 +65,15 @@ def sched_simple_setdebug(context):
 def set_fake_resources(context):
 
     cores = int(os.environ.get("TEST_UNDER_FLUX_CORES_PER_RANK", 2))
+    gpus = int(os.environ.get("TEST_UNDER_FLUX_GPUS_PER_RANK", 0))
     size = int(context.attr_get("size"))
     core_idset = IDset().set(0, cores - 1)
     rank_idset = IDset().set(0, size - 1)
-    R = (
-        subprocess.run(
-            ["flux", "R", "encode", f"-r{rank_idset}", f"-c{core_idset}"],
-            stdout=subprocess.PIPE,
-        )
-        .stdout.decode("utf-8")
-        .rstrip()
-    )
+    cmd = ["flux", "R", "encode", f"-r{rank_idset}", f"-c{core_idset}"]
+    if gpus > 0:
+        gpu_idset = IDset().set(0, gpus - 1)
+        cmd += [f"-g{gpu_idset}"]
+    R = subprocess.run(cmd, stdout=subprocess.PIPE).stdout.decode("utf-8").rstrip()
     flux.kvs.put(context.handle, "resource.R", json.loads(R))
     print(f"setting fake resources {R}")
     flux.kvs.commit(context.handle)

--- a/t/t2306-sched-fifo.t
+++ b/t/t2306-sched-fifo.t
@@ -1,0 +1,294 @@
+#!/bin/sh
+
+test_description='sched-fifo Python scheduler tests'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+# Custom resource set: 2 nodes, 2 cores each (4 single-core slots total)
+flux R encode -r0-1 -c0-1 >R.test
+
+# GPU resource set: 2 nodes, 2 cores + 1 GPU each
+flux R encode -r0-1 -c0-1 -g0 >R.test.gpu
+
+query_free="flux resource list --state=free -no {rlist}"
+
+alloc_summary() { flux jobs -no {annotations.sched.resource_summary} "$1"; }
+
+# Poll until annotation field matches expected value (scheduler annotations
+# do not generate eventlog entries, so wait-event cannot be used)
+wait_annotation() {
+	local id="$1" field="$2" value="$3"
+	test_wait_until -i 100 \
+	    "flux jobs -no {annotations.sched.$field} $id | grep -q '$value'"
+}
+
+# Poll until annotation field is empty/cleared
+wait_no_annotation() {
+	local id="$1" field="$2"
+	test_wait_until -i 100 "test \"\$(flux jobs -no {annotations.sched.$field} $id)\" = \"\""
+}
+
+
+test_expect_success 'unload job-exec to prevent job execution' '
+	flux module remove job-exec
+'
+test_expect_success 'reload job-ingest without validator' '
+	flux module reload -f job-ingest disable-validator
+'
+test_expect_success 'generate single-core jobspec' '
+	flux run --dry-run hostname >basic.json
+'
+test_expect_success 'load sched-fifo with custom resource set' '
+	flux module unload sched-simple &&
+	flux resource reload R.test &&
+	flux module load sched-fifo &&
+	test_debug "echo result=\"$($query_free)\"" &&
+	test "$($query_free)" = "rank[0-1]/core[0-1]"
+'
+
+#
+# Argument validation
+#
+test_expect_success 'sched-fifo: invalid queue-depth is rejected' '
+	flux module unload sched-fifo &&
+	test_must_fail flux module load sched-fifo queue-depth=bogus &&
+	flux module load sched-fifo
+'
+test_expect_success 'sched-fifo: invalid log-level is rejected' '
+	flux module unload sched-fifo &&
+	test_must_fail flux module load sched-fifo log-level=bogus &&
+	flux module load sched-fifo
+'
+test_expect_success 'sched-fifo: unknown argument is rejected' '
+	flux module unload sched-fifo &&
+	test_must_fail flux module load sched-fifo log_level=debug &&
+	flux module load sched-fifo
+'
+test_expect_success 'sched-fifo: valid log-level is accepted' '
+	flux module reload sched-fifo log-level=debug &&
+	flux module reload sched-fifo
+'
+#
+# Basic FIFO allocation (worst-fit is default)
+#
+test_expect_success 'sched-fifo: submit 5 single-core jobs (4 slots available)' '
+	flux job submit basic.json >j1.id &&
+	flux job submit basic.json >j2.id &&
+	flux job submit basic.json >j3.id &&
+	flux job submit basic.json >j4.id &&
+	flux job submit basic.json >j5.id &&
+	flux job wait-event --timeout=5 $(cat j4.id) alloc &&
+	flux job wait-event --timeout=5 $(cat j5.id) submit
+'
+test_expect_success 'sched-fifo: worst-fit spreads across nodes' '
+	alloc_summary $(cat j1.id) >summaries.out &&
+	alloc_summary $(cat j2.id) >>summaries.out &&
+	alloc_summary $(cat j3.id) >>summaries.out &&
+	alloc_summary $(cat j4.id) >>summaries.out &&
+	test $(grep -c "^rank0/" summaries.out) = 2 &&
+	test $(grep -c "^rank1/" summaries.out) = 2
+'
+
+test_expect_success 'sched-fifo: submit second pending job' '
+	flux job submit basic.json >j6.id
+'
+
+#
+# Priority: boosting urgency of j6 should move it ahead of j5
+#
+test_expect_success 'sched-fifo: boost j6 urgency above j5' '
+	flux job urgency $(cat j6.id) 20 &&
+	flux job wait-event --timeout=5 $(cat j6.id) urgency
+'
+test_expect_success 'sched-fifo: higher-priority job runs when slot opens' '
+	flux cancel $(cat j1.id) &&
+	flux job wait-event --timeout=5 $(cat j1.id) free &&
+	flux job wait-event --timeout=5 $(cat j6.id) alloc
+'
+test_expect_success 'sched-fifo: lower-priority job remains pending' '
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat j5.id) alloc
+'
+
+#
+# Cancel a pending job
+#
+test_expect_success 'sched-fifo: cancel pending job gets exception' '
+	flux cancel $(cat j5.id) &&
+	flux job wait-event --timeout=5 $(cat j5.id) exception
+'
+test_expect_success 'sched-fifo: cancel remaining running jobs' '
+	flux cancel $(cat j2.id) $(cat j3.id) $(cat j4.id) $(cat j6.id) &&
+	flux job wait-event --timeout=5 $(cat j6.id) free &&
+	test "$($query_free)" = "rank[0-1]/core[0-1]"
+'
+
+#
+# GPU job denial: with no GPU resources in the custom R.test resource set,
+# GPU jobs fail with an infeasibility error.
+#
+test_expect_success 'sched-fifo: GPU job is denied when no GPUs available' '
+	jobid=$(flux run -n1 -g1 --dry-run hostname | flux job submit) &&
+	flux job wait-event --timeout=5 $jobid exception &&
+	flux job eventlog $jobid | grep -i "gpu"
+'
+
+#
+# Infeasibility: request that can never be satisfied
+#
+test_expect_success 'sched-fifo: infeasible job is denied immediately' '
+	jobid=$(flux submit -n1 -c100 hostname) &&
+	flux job wait-event --timeout=5 $jobid exception
+'
+
+#
+# GPU scheduling: GPU jobs are allocated when GPU resources are present.
+#
+test_expect_success 'sched-fifo: reload with GPU resource set' '
+	flux module remove sched-fifo &&
+	flux resource reload R.test.gpu &&
+	flux module load sched-fifo
+'
+test_expect_success 'sched-fifo: generate single-GPU jobspec' '
+	flux run -n1 -g1 --dry-run hostname >gpu.json
+'
+test_expect_success 'sched-fifo: GPU job is scheduled by Rv1Pool' '
+	flux job submit gpu.json >jg1.id &&
+	flux job wait-event --timeout=5 $(cat jg1.id) alloc &&
+	alloc_summary $(cat jg1.id) | grep -q "gpu" &&
+	flux job info $(cat jg1.id) R | \
+	    jq -e "[.execution.R_lite[].children | has(\"gpu\")] | any"
+'
+test_expect_success 'sched-fifo: cancel GPU job' '
+	flux cancel $(cat jg1.id) &&
+	flux job wait-event --timeout=5 $(cat jg1.id) free
+'
+test_expect_success 'sched-fifo: restore non-GPU resource set' '
+	flux module remove sched-fifo &&
+	flux resource reload R.test &&
+	flux module load sched-fifo
+'
+
+#
+# resource_update: drain/undrain triggers rescheduling
+#
+test_expect_success 'sched-fifo: restore symmetric resource set' '
+	flux module remove sched-fifo &&
+	flux resource reload R.test &&
+	flux module load sched-fifo
+'
+
+#
+# forecast: t_estimate annotations via forward simulation
+#
+# R.test has 4 single-core slots (2 nodes × 2 cores).  jf_run fills all 4
+# slots with a 3600s walltime.  Both pending jobs carry a time limit so that
+# the simulation can chain: jf_head gets t_estimate ≈ now+3600 (when jf_run
+# frees), and jf_second gets t_estimate ≈ now+7200 (after jf_head runs its
+# 3600s).  Long time limits are used so that the simulation times are well in
+# the future and never flattened to now by max(t, time.time()), which would
+# make the two estimates equal on slow CI runners.
+#
+test_expect_success 'sched-fifo: forecast-period: invalid value is rejected' '
+	flux module unload sched-fifo &&
+	test_must_fail flux module load sched-fifo forecast-period=bogus &&
+	test_must_fail flux module load sched-fifo forecast-period=0 &&
+	test_must_fail flux module load sched-fifo forecast-period=-1 &&
+	flux module load sched-fifo
+'
+test_expect_success 'sched-fifo: forecast: submit job filling all 4 slots' '
+	flux submit -n4 --time-limit=3600s hostname >jf_run.id &&
+	flux job wait-event --timeout=5 $(cat jf_run.id) alloc
+'
+test_expect_success 'sched-fifo: forecast: submit two blocked pending jobs' '
+	flux submit -n4 --time-limit=3600s hostname >jf_head.id &&
+	flux submit -n4 --time-limit=3600s hostname >jf_second.id &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jf_head.id) alloc
+'
+test_expect_success 'sched-fifo: forecast: head job gets t_estimate annotation' '
+	wait_annotation $(cat jf_head.id) t_estimate "[0-9]"
+'
+test_expect_success 'sched-fifo: forecast: second job estimate is after head job estimate' '
+	test_wait_until -i 100 "
+		t_head=\$(flux jobs -no {annotations.sched.t_estimate} $(cat jf_head.id)) &&
+		t_second=\$(flux jobs -no {annotations.sched.t_estimate} $(cat jf_second.id)) &&
+		test -n \"\$t_head\" && test -n \"\$t_second\" &&
+		test \"\${t_second%%.*}\" -gt \"\${t_head%%.*}\"
+	"
+'
+test_expect_success 'sched-fifo: forecast: t_estimate cleared when head job runs' '
+	flux cancel $(cat jf_run.id) &&
+	flux job wait-event --timeout=5 $(cat jf_head.id) alloc &&
+	test "$(flux jobs -no {annotations.sched.t_estimate} $(cat jf_head.id))" = ""
+'
+test_expect_success 'sched-fifo: forecast: cancel forecast test jobs' '
+	flux cancel $(cat jf_head.id) $(cat jf_second.id) &&
+	flux job wait-event --timeout=5 $(cat jf_head.id) free
+'
+
+#
+# forecast: stale t_estimate cleared when a no-duration job becomes head
+#
+# jf_run2 fills all 4 slots.  jf_est gets a t_estimate via forecast().
+# A higher-priority job with no time limit (jf_inf) is then submitted and
+# boosted to head of queue.  Since jf_inf has unknown duration, forecast()
+# cannot chain past it; jf_est's stale t_estimate must be cleared.
+#
+test_expect_success 'sched-fifo: forecast stale: fill all 4 slots' '
+	flux submit -n4 --time-limit=300s hostname >jf_run2.id &&
+	flux job wait-event --timeout=5 $(cat jf_run2.id) alloc
+'
+test_expect_success 'sched-fifo: forecast stale: submit pending job with time limit' '
+	flux submit -n4 --time-limit=300s hostname >jf_est.id &&
+	wait_annotation $(cat jf_est.id) t_estimate "[0-9]"
+'
+test_expect_success 'sched-fifo: forecast stale: submit higher-priority job with no time limit' '
+	flux submit -n4 hostname >jf_inf.id &&
+	flux job urgency $(cat jf_inf.id) 20 &&
+	flux job wait-event --timeout=5 $(cat jf_inf.id) urgency
+'
+test_expect_success 'sched-fifo: forecast stale: stale t_estimate on jf_est is cleared' '
+	wait_no_annotation $(cat jf_est.id) t_estimate
+'
+test_expect_success 'sched-fifo: forecast stale: cancel stale-annotation test jobs' '
+	flux cancel $(cat jf_run2.id) $(cat jf_est.id) $(cat jf_inf.id) &&
+	flux job wait-event --timeout=5 $(cat jf_run2.id) free
+'
+
+test_expect_success 'sched-fifo: drain rank 0' '
+	flux resource drain 0
+'
+test_expect_success 'sched-fifo: fill rank 1 (2 cores)' '
+	flux job submit basic.json >jd1.id &&
+	flux job submit basic.json >jd2.id &&
+	flux job wait-event --timeout=5 $(cat jd2.id) alloc &&
+	alloc_summary $(cat jd1.id) | grep -q "^rank1/" &&
+	alloc_summary $(cat jd2.id) | grep -q "^rank1/"
+'
+test_expect_success 'sched-fifo: job blocks when drained node is only option' '
+	flux job submit basic.json >jd3.id &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jd3.id) alloc
+'
+test_expect_success 'sched-fifo: undrain rank 0 unblocks pending job' '
+	flux resource undrain 0 &&
+	flux job wait-event --timeout=5 $(cat jd3.id) alloc &&
+	alloc_summary $(cat jd3.id) | grep -q "^rank0/"
+'
+test_expect_success 'sched-fifo: cancel drain test jobs' '
+	flux cancel $(cat jd1.id) $(cat jd2.id) $(cat jd3.id) &&
+	flux job wait-event --timeout=5 $(cat jd3.id) free
+'
+
+test_expect_success 'sched-fifo: drain cleanup and queue drain' '
+	flux module reload sched-fifo &&
+	run_timeout 30 flux queue drain
+'
+test_expect_success 'reload sched-simple' '
+	flux module remove sched-fifo &&
+	flux module load sched-simple
+'
+
+test_done

--- a/t/t2307-sched-backfill.t
+++ b/t/t2307-sched-backfill.t
@@ -1,0 +1,426 @@
+#!/bin/sh
+
+test_description='sched-backfill EASY backfill scheduler tests'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+# Custom resource set: 2 nodes, 2 cores each (4 single-core slots total)
+flux R encode -r0-1 -c0-1 >R.test
+
+# GPU resource set: 2 nodes, 2 cores + 1 GPU each
+flux R encode -r0-1 -c0-1 -g0 >R.test.gpu
+
+query_free="flux resource list --state=free -no {rlist}"
+
+alloc_summary() { flux jobs -no {annotations.sched.resource_summary} "$1"; }
+t_estimate()    { flux jobs -no {annotations.sched.t_estimate} "$1"; }
+
+# Poll until annotation field matches expected value (scheduler annotations
+# do not generate eventlog entries, so wait-event cannot be used)
+wait_annotation() {
+	local id="$1" field="$2" value="$3"
+	test_wait_until -i 100 \
+	    "flux jobs -no {annotations.sched.$field} $id | grep -q '$value'"
+}
+
+# Poll until annotation field is empty/cleared
+wait_no_annotation() {
+	local id="$1" field="$2"
+	test_wait_until -i 100 "test \"\$(flux jobs -no {annotations.sched.$field} $id)\" = \"\""
+}
+
+
+# Poll until all resources are free
+wait_free() {
+	test_wait_until -i 300 \
+	    "flux resource list --state=free -no {rlist} | grep -qx 'rank\[0-1\]/core\[0-1\]'"
+}
+
+test_expect_success 'unload job-exec to prevent job execution' '
+	flux module remove job-exec
+'
+test_expect_success 'reload job-ingest without validator' '
+	flux module reload -f job-ingest disable-validator
+'
+test_expect_success 'generate single-core jobspec' '
+	flux run --dry-run hostname >basic.json
+'
+test_expect_success 'load sched-backfill with custom resource set' '
+	flux module unload sched-simple &&
+	flux resource reload R.test &&
+	flux module load sched-backfill &&
+	test_debug "echo result=\"$($query_free)\"" &&
+	test "$($query_free)" = "rank[0-1]/core[0-1]"
+'
+
+#
+# Argument validation
+#
+test_expect_success 'sched-backfill: invalid queue-depth is rejected' '
+	flux module unload sched-backfill &&
+	test_must_fail flux module load sched-backfill queue-depth=bogus &&
+	flux module load sched-backfill
+'
+#
+# Basic FIFO allocation (worst-fit is default; no backfill opportunity
+# since all jobs have the same resource requirements)
+#
+test_expect_success 'sched-backfill: submit 5 single-core jobs (4 slots available)' '
+	flux job submit basic.json >j1.id &&
+	flux job submit basic.json >j2.id &&
+	flux job submit basic.json >j3.id &&
+	flux job submit basic.json >j4.id &&
+	flux job submit basic.json >j5.id &&
+	flux job wait-event --timeout=5 $(cat j4.id) alloc &&
+	flux job wait-event --timeout=5 $(cat j5.id) submit
+'
+test_expect_success 'sched-backfill: cancel basic FIFO jobs' '
+	flux cancel $(cat j1.id) $(cat j2.id) $(cat j3.id) $(cat j4.id) \
+	            $(cat j5.id) &&
+	flux job wait-event --timeout=5 $(cat j4.id) free &&
+	wait_free
+'
+
+#
+# EASY backfill
+#
+# Resource layout: jlong holds 2 of 4 cores with a 3600s walltime, leaving
+# 2 cores free.  jhead needs all 4 cores and is blocked; its estimated
+# reservation time is approximately jlong_submit_time + 3600s.
+# Long walltimes are used so the shadow time stays well in the future even
+# on slow CI runners where test setup may take many seconds.
+#
+# Three backfill candidates are submitted while jhead waits:
+#   jnodur   - 1 core, no duration:  cannot backfill (finish time unknown)
+#   jshort   - 1 core, 60s:          can backfill (fits; 60 < 3600s shadow)
+#   jtoolong - 1 core, 4000s:        cannot backfill (would end after shadow)
+#
+test_expect_success 'sched-backfill: submit 2-core job with 3600s walltime' '
+	flux submit -n2 --time-limit=3600s hostname >jlong.id &&
+	flux job wait-event --timeout=5 $(cat jlong.id) alloc
+'
+test_expect_success 'sched-backfill: head job needing all 4 cores is blocked' '
+	flux submit -n4 hostname >jhead.id &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jhead.id) alloc
+'
+test_expect_success 'sched-backfill: head job gets t_estimate annotation' '
+	wait_annotation $(cat jhead.id) t_estimate "[0-9]"
+'
+test_expect_success 'sched-backfill: job without duration does not backfill' '
+	flux job submit basic.json >jnodur.id &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jnodur.id) alloc
+'
+test_expect_success 'sched-backfill: job with short duration backfills' '
+	flux submit -n1 --time-limit=60s hostname >jshort.id &&
+	flux job wait-event --timeout=5 $(cat jshort.id) alloc
+'
+test_expect_success 'sched-backfill: backfilled job has backfill annotation set to head jobid' '
+	jhead=$(flux job id --to=f58 $(cat jhead.id)) &&
+	wait_annotation $(cat jshort.id) backfill "$jhead"
+'
+test_expect_success 'sched-backfill: head job is still pending after backfill' '
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jhead.id) alloc
+'
+test_expect_success 'sched-backfill: job with duration exceeding shadow does not backfill' '
+	flux submit -n1 --time-limit=4000s hostname >jtoolong.id &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jtoolong.id) alloc
+'
+test_expect_success 'sched-backfill: cancel backfill test jobs' '
+	flux cancel $(cat jlong.id) $(cat jshort.id) \
+	            $(cat jhead.id) $(cat jnodur.id) $(cat jtoolong.id) &&
+	flux job wait-event --timeout=5 $(cat jlong.id) free &&
+	wait_free
+'
+
+#
+# Exclusive allocation: an exclusive job reserves the whole node even if
+# it only requests 1 slot.  _shadow_time must account for the full node
+# core count (alloc.count("core")), not just nslots*slot_size, or it will
+# undercount freed cores and return None, preventing any backfill.
+#
+# Setup: jexcl runs exclusively on node 0 (reserves both cores) with a 3600s
+# walltime, leaving node 1's 2 cores free.  jexcl_head needs all 4 cores
+# and is blocked.  jexcl_short (1 core, 60s) should backfill on node 1.
+#
+test_expect_success 'sched-backfill: exclusive: submit exclusive 1-node job' '
+	flux submit -N1 -n1 --exclusive --time-limit=3600s hostname >jexcl.id &&
+	flux job wait-event --timeout=5 $(cat jexcl.id) alloc &&
+	alloc_summary $(cat jexcl.id) | grep -q "^rank0/"
+'
+test_expect_success 'sched-backfill: exclusive: head job needing all 4 cores is blocked' '
+	flux submit -n4 hostname >jexcl_head.id &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jexcl_head.id) alloc
+'
+test_expect_success 'sched-backfill: exclusive: short job backfills on the free node' '
+	flux submit -n1 --time-limit=60s hostname >jexcl_short.id &&
+	flux job wait-event --timeout=5 $(cat jexcl_short.id) alloc &&
+	alloc_summary $(cat jexcl_short.id) | grep -q "^rank1/"
+'
+test_expect_success 'sched-backfill: exclusive: cancel exclusive test jobs' '
+	flux cancel $(cat jexcl.id) $(cat jexcl_head.id) $(cat jexcl_short.id) &&
+	flux job wait-event --timeout=5 $(cat jexcl.id) free &&
+	wait_free
+'
+
+#
+# Node-based backfill: the shadow-time estimate for a node-based head job
+# (nnodes > 0) must count free *nodes*, not aggregate cores.
+#
+# With R.test (2 nodes × 2 cores each), jnb_long runs exclusively on node 0,
+# consuming both of its cores.  jnb_head needs both nodes (-N2) and is blocked.
+# At this point the 2 free cores on node 1 equal jnb_head's slot requirement
+# (2 slots × 1 core), so the old aggregate-core path returned shadow=now and
+# backfill was impossible.  The node-based path returns shadow=jnb_long's
+# end time (~3600s out), allowing jnb_short (1 node, 60s) to backfill.
+#
+test_expect_success 'sched-backfill: node-based: exclusive job occupies rank 0' '
+	flux submit -N1 -n1 --exclusive --time-limit=3600s hostname >jnb_long.id &&
+	flux job wait-event --timeout=5 $(cat jnb_long.id) alloc &&
+	alloc_summary $(cat jnb_long.id) | grep -q "^rank0/"
+'
+test_expect_success 'sched-backfill: node-based: head job needing both nodes is blocked' '
+	flux submit -N2 -n2 hostname >jnb_head.id &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jnb_head.id) alloc
+'
+test_expect_success 'sched-backfill: node-based: head job gets t_estimate annotation' '
+	wait_annotation $(cat jnb_head.id) t_estimate "[0-9]"
+'
+test_expect_success 'sched-backfill: node-based: short 1-node job backfills on rank 1' '
+	flux submit -N1 -n1 --time-limit=60s hostname >jnb_short.id &&
+	flux job wait-event --timeout=5 $(cat jnb_short.id) alloc &&
+	alloc_summary $(cat jnb_short.id) | grep -q "^rank1/"
+'
+test_expect_success 'sched-backfill: node-based: head job still pending after backfill' '
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jnb_head.id) alloc
+'
+test_expect_success 'sched-backfill: node-based: cancel node-based backfill test jobs' '
+	flux cancel $(cat jnb_long.id) $(cat jnb_head.id) $(cat jnb_short.id) &&
+	flux job wait-event --timeout=5 $(cat jnb_long.id) free &&
+	wait_free
+'
+
+#
+# Priority: boosting urgency of a lower-priority pending job moves it to
+# head of queue, so it gets the reservation and runs first
+#
+test_expect_success 'sched-backfill: submit 2-core holder job' '
+	flux submit -n2 hostname >jp_hold.id &&
+	flux job wait-event --timeout=5 $(cat jp_hold.id) alloc
+'
+test_expect_success 'sched-backfill: submit two 4-core pending jobs' '
+	flux submit -n4 hostname >jp1.id &&
+	flux submit -n4 hostname >jp2.id &&
+	flux job wait-event --timeout=5 $(cat jp1.id) submit &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jp1.id) alloc
+'
+test_expect_success 'sched-backfill: boost jp2 urgency above jp1' '
+	flux job urgency $(cat jp2.id) 20 &&
+	flux job wait-event --timeout=5 $(cat jp2.id) urgency
+'
+test_expect_success 'sched-backfill: higher-priority job runs when slot opens' '
+	flux cancel $(cat jp_hold.id) &&
+	flux job wait-event --timeout=5 $(cat jp_hold.id) free &&
+	flux job wait-event --timeout=5 $(cat jp2.id) alloc
+'
+test_expect_success 'sched-backfill: lower-priority job remains pending' '
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jp1.id) alloc
+'
+test_expect_success 'sched-backfill: cancel priority test jobs' '
+	flux cancel $(cat jp1.id) $(cat jp2.id) &&
+	flux job wait-event --timeout=5 $(cat jp2.id) free &&
+	wait_free
+'
+
+#
+# Stale t_estimate: when a higher-priority job displaces the head, the old
+# head's t_estimate annotation must be cleared.
+#
+# jst_hold occupies 2 of 4 cores.  jst_head needs all 4 and is blocked,
+# receiving a t_estimate reservation.  A new higher-priority job (jst_new)
+# is then submitted and boosted to head; schedule() must clear the stale
+# t_estimate on jst_head.
+#
+test_expect_success 'sched-backfill: stale t_estimate: hold 2 cores' '
+	flux submit -n2 --time-limit=3600s hostname >jst_hold.id &&
+	flux job wait-event --timeout=5 $(cat jst_hold.id) alloc
+'
+test_expect_success 'sched-backfill: stale t_estimate: head job blocked and annotated' '
+	flux submit -n4 hostname >jst_head.id &&
+	wait_annotation $(cat jst_head.id) t_estimate "[0-9]"
+'
+test_expect_success 'sched-backfill: stale t_estimate: higher-priority job displaces head' '
+	flux submit -n4 hostname >jst_new.id &&
+	flux job urgency $(cat jst_new.id) 20 &&
+	flux job wait-event --timeout=5 $(cat jst_new.id) urgency
+'
+test_expect_success 'sched-backfill: stale t_estimate: old head t_estimate is cleared' '
+	wait_no_annotation $(cat jst_head.id) t_estimate
+'
+test_expect_success 'sched-backfill: stale t_estimate: cancel stale-annotation test jobs' '
+	flux cancel $(cat jst_hold.id) $(cat jst_head.id) $(cat jst_new.id) &&
+	flux job wait-event --timeout=5 $(cat jst_hold.id) free &&
+	wait_free
+'
+
+#
+# Cancel a pending job
+#
+test_expect_success 'sched-backfill: cancel pending job gets exception' '
+	flux submit -n4 hostname >jc_run.id &&
+	flux submit -n4 hostname >jc_pend.id &&
+	flux job wait-event --timeout=5 $(cat jc_run.id) alloc &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jc_pend.id) alloc &&
+	flux cancel $(cat jc_pend.id) &&
+	flux job wait-event --timeout=5 $(cat jc_pend.id) exception &&
+	flux cancel $(cat jc_run.id) &&
+	flux job wait-event --timeout=5 $(cat jc_run.id) free
+'
+
+#
+# GPU job with no GPUs in resource set: structurally infeasible, denied
+# immediately with an error mentioning GPUs.
+#
+test_expect_success 'sched-backfill: GPU job is denied when no GPUs available' '
+	jobid=$(flux run -n1 -g1 --dry-run hostname | flux job submit) &&
+	flux job wait-event --timeout=5 $jobid exception &&
+	flux job eventlog $jobid | grep -i "gpu"
+'
+
+#
+# Infeasibility: request that can never be satisfied
+#
+test_expect_success 'sched-backfill: infeasible job is denied immediately' '
+	jobid=$(flux submit -n1 -c100 hostname) &&
+	flux job wait-event --timeout=5 $jobid exception
+'
+
+#
+# GPU scheduling: with GPU resources present, GPU jobs are scheduled and the
+# allocated R contains GPU children.
+#
+test_expect_success 'sched-backfill: reload with GPU resource set' '
+	flux module remove sched-backfill &&
+	flux resource reload R.test.gpu &&
+	flux module load sched-backfill
+'
+test_expect_success 'sched-backfill: generate single-GPU jobspec' '
+	flux run -n1 -g1 --dry-run hostname >gpu.json
+'
+test_expect_success 'sched-backfill: GPU job is scheduled by Rv1Pool' '
+	flux job submit gpu.json >jg1.id &&
+	flux job wait-event --timeout=5 $(cat jg1.id) alloc &&
+	alloc_summary $(cat jg1.id) | grep -q "gpu" &&
+	flux job info $(cat jg1.id) R | \
+	    jq -e "[.execution.R_lite[].children | has(\"gpu\")] | any"
+'
+test_expect_success 'sched-backfill: cancel basic GPU job' '
+	flux cancel $(cat jg1.id) &&
+	flux job wait-event --timeout=5 $(cat jg1.id) free
+'
+
+#
+# GPU backfill: shadow-time computation uses aggregate GPU counts (slot-based
+# path) for requests with nnodes==0.
+#
+# With R.test.gpu (2 nodes × 2 cores + 1 GPU each), jgpu_long holds 1 GPU on
+# one node with a 3600s walltime, leaving 1 GPU free on the other node.
+# jgpu_head needs 2 GPUs (both nodes) and is blocked; shadow ~ now+3600s.
+# jgpu_short (1 GPU, 60s) can backfill — it fits and 60 < 3600.
+# jgpu_nodur (1 GPU, no duration) cannot backfill — finish time unknown.
+#
+test_expect_success 'sched-backfill: GPU backfill: submit 1-GPU job with 3600s walltime' '
+	flux submit -n1 -g1 --time-limit=3600s hostname >jgpu_long.id &&
+	flux job wait-event --timeout=5 $(cat jgpu_long.id) alloc &&
+	alloc_summary $(cat jgpu_long.id) | grep -q "gpu"
+'
+test_expect_success 'sched-backfill: GPU backfill: head job needing 2 GPUs is blocked' '
+	flux submit -n2 -g1 hostname >jgpu_head.id &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jgpu_head.id) alloc
+'
+test_expect_success 'sched-backfill: GPU backfill: head job gets t_estimate annotation' '
+	wait_annotation $(cat jgpu_head.id) t_estimate "[0-9]"
+'
+test_expect_success 'sched-backfill: GPU backfill: job without duration cannot backfill' '
+	flux submit -n1 -g1 hostname >jgpu_nodur.id &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jgpu_nodur.id) alloc
+'
+test_expect_success 'sched-backfill: GPU backfill: short GPU job backfills' '
+	flux submit -n1 -g1 --time-limit=60s hostname >jgpu_short.id &&
+	flux job wait-event --timeout=5 $(cat jgpu_short.id) alloc &&
+	alloc_summary $(cat jgpu_short.id) | grep -q "gpu"
+'
+test_expect_success 'sched-backfill: GPU backfill: head job still pending after backfill' '
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jgpu_head.id) alloc
+'
+test_expect_success 'sched-backfill: GPU backfill: cancel GPU backfill test jobs' '
+	flux cancel $(cat jgpu_long.id) $(cat jgpu_head.id) \
+	            $(cat jgpu_short.id) $(cat jgpu_nodur.id) &&
+	flux job wait-event --timeout=5 $(cat jgpu_long.id) free
+'
+
+test_expect_success 'sched-backfill: restore non-GPU resource set' '
+	flux module remove sched-backfill &&
+	flux resource reload R.test &&
+	flux module load sched-backfill
+'
+
+#
+# Hello protocol: reload with running jobs
+#
+test_expect_success 'sched-backfill: reload with outstanding allocations' '
+	flux job submit basic.json >jh1.id &&
+	flux job submit basic.json >jh2.id &&
+	flux job submit basic.json >jh3.id &&
+	flux job submit basic.json >jh4.id &&
+	flux job wait-event --timeout=5 $(cat jh4.id) alloc &&
+	flux module reload sched-backfill &&
+	test_debug "echo result=\"$($query_free)\"" &&
+	test "$($query_free)" = ""
+'
+test_expect_success 'sched-backfill: cancel hello test jobs' '
+	flux cancel $(cat jh1.id) $(cat jh2.id) $(cat jh3.id) $(cat jh4.id) &&
+	flux job wait-event --timeout=5 $(cat jh4.id) free &&
+	wait_free
+'
+
+#
+# resource_update: drain/undrain triggers rescheduling
+#
+test_expect_success 'sched-backfill: drain rank 0' '
+	flux resource drain 0
+'
+test_expect_success 'sched-backfill: fill rank 1 (2 cores)' '
+	flux job submit basic.json >jd1.id &&
+	flux job submit basic.json >jd2.id &&
+	flux job wait-event --timeout=5 $(cat jd2.id) alloc &&
+	alloc_summary $(cat jd1.id) | grep -q "^rank1/" &&
+	alloc_summary $(cat jd2.id) | grep -q "^rank1/"
+'
+test_expect_success 'sched-backfill: job blocks when drained node is only option' '
+	flux job submit basic.json >jd3.id &&
+	test_expect_code 1 flux job wait-event --timeout=0.5 $(cat jd3.id) alloc
+'
+test_expect_success 'sched-backfill: undrain rank 0 unblocks pending job' '
+	flux resource undrain 0 &&
+	flux job wait-event --timeout=5 $(cat jd3.id) alloc &&
+	alloc_summary $(cat jd3.id) | grep -q "^rank0/"
+'
+test_expect_success 'sched-backfill: cancel drain test jobs' '
+	flux cancel $(cat jd1.id) $(cat jd2.id) $(cat jd3.id) &&
+	flux job wait-event --timeout=5 $(cat jd3.id) free
+'
+
+test_expect_success 'sched-backfill: drain cleanup and queue drain' '
+	flux module reload sched-backfill &&
+	run_timeout 30 flux queue drain
+'
+test_expect_success 'reload sched-simple' '
+	flux module remove sched-backfill &&
+	flux module load sched-simple
+'
+
+test_done


### PR DESCRIPTION
Problem: it's tricky to try new R designs or experiment with scheduler-adjacent changes in flux-core, since `sched-simple` relies on C code that is laborious to re-engineer.

Acknowledging that flux-sched is the production scheduler code base, and that what's in flux-core is essentially a test vehicle, adopt a "don't worry about performance" attitude and lay groundwork for more agile development in python for this area, and at the same time remedy some long ignored deficiencies in flux-core's native scheduling capability. 
 
Implement a `Scheduler` subclass of  `BrokerMod` that implements the scaffolding for interfacing with the job manager and resource module common to all schedulers.  A scheduler implementation would be a subclass of `scheduler`.

To facilitate experiments with an Rv1 replacement, abstract the resource representation in a `ResourcePool` class that does resource selection, feasibility checking, and other operations for an abstract resource representation.  Two Rv1 implementations are provided, one based on C `librlist`, and one in pure python.  The pure python one adds GPU support.  

To demonstrate the framework, two schedulers are provided:
- `sched-fifo`, a priorty-FIFO scheduler like `sched-simple`, except it uses the pure python Rv1 class so it supports GPUs.  It also gives all jobs start time estimates (when duration is set), using a forward-simulation method with a throw-away copy of the resource pool object.
- `sched-backfill`, an EASY backfill scheduler, which is one step beyond FIFO in planning (literally - it plans _one_ job).

I invested some time experimenting with `ResourcePool` and `Scheduler` to make sure they were not completely naive: implementing the `sched-simple` scheduler in python (forthcoming in a future PR) with clean test results, testing throughput to work through first order performance issues, and playing with a backfill planning and forward-simulation for time estimates.  Those experiments brought some clarity to the design, so hopefully they are a bit more evolved than they would be otherwise.

A mundane question: I needed a way to easily select the scheduler on the `flux-start` command line when testing, so I just mimiced the `content-backing.module` broker attribute logic currently in rc1.py with a `sched.module` attribute, which lets you `flux start -Ssched.module=sched-backfill`.  Is there a better/existing way to do that?

This is currently based on
- #7447




