### PR TITLE
etc: update bash completions and add testing

### DIFF
--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -99,7 +99,13 @@ __get_flux_subcommands() {
         for op in $dir/flux-*; do
             if [[ -x $op  ]]; then
                 op="${op##*flux-}"
-                subcommands+="${op%.*} "
+                # skip .in template files; strip .py but preserve version
+                # suffixes like the .minor in flux-pythonX.Y
+                case "$op" in
+                    *.in) continue ;;
+                    *.py) op="${op%.py}" ;;
+                esac
+                subcommands+="$op "
             fi
         done
     done
@@ -197,6 +203,7 @@ _flux_update()
     local cmd=$1
     OPTS="\
         -v --verbose \
+        --wait \
         -n --dry-run \
     "
     if [[ $cur != -* ]]; then
@@ -395,6 +402,7 @@ _flux_submit_commands()
         -l --label-io \
         --flags= \
         --dry-run \
+        --quiet \
         -h --help \
         --cwd= \
         --signal= \
@@ -420,6 +428,7 @@ _flux_submit_commands()
         -N --nodes= \
         --dump= \
         --conf= \
+        --broker-opts= \
         -x --exclusive \
     "
     local SUBMITBULK_OPTIONS="\
@@ -876,6 +885,8 @@ _flux_queue()
         -h --help \
         -q --queue= \
         -a --all \
+        --quiet \
+        -v --verbose \
     "
     local disable_OPTS="\
         -h --help \
@@ -884,18 +895,22 @@ _flux_queue()
         --quiet \
         -v --verbose \
         --nocheckpoint \
+        -m --message= \
     "
     local start_OPTS="\
         -h --help \
         -q --queue= \
+        -a --all \
         -v --verbose \
         --quiet \
     "
     local stop_OPTS="\
         -h --help \
         -q --queue= \
+        -a --all \
         -v --verbose \
         --quiet \
+        -m --message= \
     "
     local status_OPTS="\
         -h --help \
@@ -905,6 +920,11 @@ _flux_queue()
     local drain_OPTS="\
         -h --help \
         -t --timeout= \
+    "
+    local idle_OPTS="\
+        -h --help \
+        -t --timeout= \
+        --quiet \
     "
     local list_OPTS="\
         -q --queue= \
@@ -923,6 +943,9 @@ _flux_queue()
             return
             ;;
         --timeout | -!(-*)t)
+            return
+            ;;
+        --message | -!(-*)m)
             return
             ;;
     esac
@@ -1199,7 +1222,11 @@ _flux_overlay()
     "
     _flux_split_longopt && split=true
     case $prev in
-        -!(-*)[rtwH])
+        --wait | -!(-*)w)
+            COMPREPLY=( $(compgen -W 'full partial offline degraded lost' -- "$cur") )
+            return
+            ;;
+        -!(-*)[rtH])
             return
             ;;
     esac
@@ -1456,6 +1483,11 @@ _flux_jobs()
             _flux_complete_format_name flux jobs
             return
             ;;
+        --user | -!(-*)u)
+            active_users=$(flux jobs -Ano {username} | uniq)
+            COMPREPLY=( $(compgen -W "$active_users" -- "$cur") )
+            return
+            ;;
         --sort | -!(-*)[Lcf])
             return
             ;;
@@ -1532,6 +1564,7 @@ _flux_pkill()
         -f --filter= \
         -u --user= \
         -q --queue= \
+        --wait \
     "
     _flux_split_longopt && split=true
     case $prev in
@@ -1595,6 +1628,11 @@ _flux_pstree()
     esac
     $split && return
 
+    if [[ $cur != -* ]]; then
+        active_jobs=$(flux jobs -no $(_flux_id_fmt $cur))
+        COMPREPLY=( $(compgen -W "${active_jobs}" -- "$cur") )
+        return 0
+    fi
     COMPREPLY=( $(compgen -W "${OPTS} -h --help" -- "$cur") )
     if [[ "${COMPREPLY[@]}" == *= ]]; then
         # Add space if there is not a '=' in suggestions
@@ -1617,7 +1655,7 @@ _flux_watch()
         --since= \
         --progress \
         --jps \
-        --verbose
+        -v --verbose
     "
     if [[ $cur != -* ]]; then
         #  Attempt to substitute an active jobid
@@ -1707,6 +1745,72 @@ _flux_top()
     COMPREPLY=( $(compgen -W "${OPTS} $jobs" -- "$cur") )
     if [[ "${COMPREPLY[@]}" == *= ]]; then
         # Add space if there is not a '=' in suggestions
+        compopt -o nospace
+    fi
+    return 0
+}
+
+# flux-logger(1) completions
+_flux_logger()
+{
+    local severity_levels="emerg alert crit err warning notice info debug"
+    OPTS="\
+        -s --severity= \
+        -n --appname= \
+    "
+    case "$prev" in
+        --severity|-s)
+            COMPREPLY=( $(compgen -W "$severity_levels" -- "$cur") )
+            return
+            ;;
+    esac
+    if [[ $cur == --severity=* ]]; then
+        COMPREPLY=( $(compgen -W "$severity_levels" -- "${cur#--severity=}") )
+        COMPREPLY=( "${COMPREPLY[@]/#/--severity=}" )
+        return
+    fi
+    if [[ $cur == --*= ]]; then
+        COMPREPLY=()
+        return
+    fi
+    COMPREPLY=( $(compgen -W "${OPTS} -h --help" -- "$cur") )
+    if [[ "${COMPREPLY[@]}" == *= ]]; then
+        compopt -o nospace
+    fi
+    return 0
+}
+
+# flux-post-job-event(1) completions
+_flux_post_job_event()
+{
+    # Count non-option words after 'post-job-event' to determine position
+    local npos=0 i
+    for ((i = 1; i < COMP_CWORD; ++i)); do
+        [[ ${COMP_WORDS[i]} != -* ]] && ((npos++))
+    done
+    # npos==1: completing jobid, npos>=2: name or context (no completions)
+    if ((npos == 1)); then
+        active_jobs=$(flux jobs -no $(_flux_id_fmt $cur))
+        COMPREPLY=( $(compgen -W "${active_jobs}" -- "$cur") )
+        return 0
+    fi
+    return 0
+}
+
+# flux-keygen(1) completions
+_flux_keygen()
+{
+    OPTS="\
+        -n --name= \
+        --meta= \
+    "
+    if [[ $cur == --*= ]]; then
+        compopt -o default
+        COMPREPLY=()
+        return
+    fi
+    COMPREPLY=( $(compgen -W "${OPTS} -h --help" -- "$cur") )
+    if [[ "${COMPREPLY[@]}" == *= ]]; then
         compopt -o nospace
     fi
     return 0
@@ -1854,6 +1958,7 @@ _flux_R()
         -c --cores= \
         -g --gpus= \
         -H --hosts= \
+        -p --property= \
         -l --local \
         -f --xml \
     "
@@ -1875,7 +1980,7 @@ _flux_R()
 
         _flux_split_longopt && split=true
         case $prev in
-            -!(-*)[ixcgH])
+            -!(-*)[ixcgHp])
                 return
                 ;;
         esac
@@ -1937,10 +2042,17 @@ _flux_exec()
         --label= \
         --bg \
         --waitable \
+        --with-imp \
+        -j --jobid= \
     "
 
     _flux_split_longopt && split=true
     case $prev in
+        --jobid | -!(-*)j)
+            active_jobs=$(flux jobs -no $(_flux_id_fmt $cur))
+            COMPREPLY=( $(compgen -W "${active_jobs}" -- "$cur") )
+            return
+            ;;
         --dir | -!(-*)d)
             compopt -o filenames
             COMPREPLY=( $(compgen -d -- "$cur") )
@@ -1971,7 +2083,7 @@ _flux_attr()
         -v --values \
     "
     if [[ $cmd != "flux" ]]; then
-        if [[ $cur != -* && $cmd == "getattr" ]]; then
+        if [[ $cur != -* && ( $cmd == "getattr" || $cmd == "setattr" ) ]]; then
             COMPREPLY=( $(compgen -W "$(flux lsattr)" -- "$cur") )
             return 0
         fi
@@ -2251,6 +2363,115 @@ _flux_sproc()
     return 0
 }
 
+# flux-fsck(1) completions
+_flux_fsck()
+{
+    local cmd=$1
+    local split=false
+    local OPTS="\
+        -v --verbose \
+        -q --quiet \
+        -r --rootref= \
+        -R --repair \
+        -j --job-aware \
+    "
+    _flux_split_longopt && split=true
+    case $prev in
+        --rootref | -!(-*)r)
+            return
+            ;;
+    esac
+    $split && return
+
+    COMPREPLY=( $(compgen -W "${OPTS} -h --help" -- "$cur") )
+    if [[ "${COMPREPLY[@]}" == *= ]]; then
+        compopt -o nospace
+    fi
+    return 0
+}
+
+# flux-startlog(1) completions
+_flux_startlog()
+{
+    local cmd=$1
+    local OPTS="\
+        --check \
+        --quiet \
+        -v --show-version \
+    "
+    COMPREPLY=( $(compgen -W "${OPTS} -h --help" -- "$cur") )
+    return 0
+}
+
+# flux-pmi(1) completions
+_flux_pmi()
+{
+    local cmd=$1
+    local subcmds="barrier get exchange"
+    local split=false
+
+    local general_OPTS="\
+        --method= \
+        --libpmi-noflux \
+        --libpmi2-cray \
+        -v --verbose= \
+        -t --timeout= \
+    "
+    local barrier_OPTS="\
+        --test-count= \
+        --test-abort= \
+        --test-timing \
+    "
+    local get_OPTS="\
+        --ranks= \
+    "
+    local exchange_OPTS="\
+        --count= \
+    "
+
+    _flux_split_longopt && split=true
+    case $prev in
+        --method | --timeout | --test-count | --test-abort | --count | \
+            --ranks | -!(-*)[vt])
+            return
+            ;;
+    esac
+    $split && return
+
+    if [[ $cur == --*= ]]; then
+        COMPREPLY=()
+        return 0
+    fi
+    if [[ $cmd != "pmi" ]]; then
+        var="${cmd//-/_}_OPTS"
+        COMPREPLY=( $(compgen -W "${!var} -h --help" -- "$cur") )
+    else
+        COMPREPLY=( $(compgen -W "${general_OPTS} ${subcmds} -h --help" -- "$cur") )
+    fi
+    if [[ "${COMPREPLY[@]}" == *= ]]; then
+        compopt -o nospace
+    fi
+    return 0
+}
+
+# flux-pythonX.Y(1) and flux-python-version(1) completions
+# Both are versioned python wrappers that accept --get-path
+_flux_python3()
+{
+    local split=false
+    _flux_split_longopt && split=true
+    case $prev in
+        --get-path) return ;;
+    esac
+    $split && return
+    if [[ $cur != -* ]]; then
+        compopt -o default -o bashdefault
+        return 0
+    fi
+    COMPREPLY=( $(compgen -W "--get-path -h --help" -- "$cur") )
+    return 0
+}
+
 _flux_core()
 {
     FLUX_OPTS="-v --verbose -V --version -p --parent -r --root"
@@ -2330,6 +2551,24 @@ _flux_core()
     dmesg)
         _flux_dmesg $subcmd
         ;;
+    keygen)
+        _flux_keygen $subcmd
+        ;;
+    logger)
+        _flux_logger $subcmd
+        ;;
+    post-job-event)
+        _flux_post_job_event
+        ;;
+    fsck)
+        _flux_fsck $subcmd
+        ;;
+    startlog)
+        _flux_startlog $subcmd
+        ;;
+    pmi)
+        _flux_pmi $subcmd
+        ;;
     ping)
         _flux_ping $subcmd
         ;;
@@ -2373,6 +2612,9 @@ _flux_core()
         # reset to defaults and let readline take over
         compopt -o default
         COMPREPLY=()
+        ;;
+    python[0-9]*.[0-9]*|python-version)
+        _flux_python3 $subcmd
         ;;
     housekeeping)
         _flux_housekeeping $subcmd

--- a/src/test/docker/poison-libflux.sh.in
+++ b/src/test/docker/poison-libflux.sh.in
@@ -94,9 +94,15 @@ done
 printf " Installing poison flux commands...\n"
 mkdir -p -m 0755 $CMDDIR
 for cmd in \
-	terminus ping keygen logger event module kvs start job queue exec \
-	cron mini jobs resource admin jobtap job-validator \
-	job-exec-override uri pstree; do
+      admin job-frobnicator queue alloc jobs archive jobtap R batch \
+      job-validator relay broker keygen resource bulksubmit kvs restore \
+      cancel logger cgroup lptest run config lsattr setattr content modprobe \
+      shutdown cron module slurm-expiration-sync dmesg module-exec sproc \
+      dump module-python-exec start env multi-prog startlog event overlay \
+      submit exec terminus fortune top fsck pgrep update getattr ping uptime \
+      heaptrace pkill uri help pmi hostlist post-job-event housekeeping \
+      proxy imp-exec-helper pstree job python version job-exec-override watch
+    do
 	cat <<-EOF >${CMDDIR}/flux-${cmd}
 	#!/bin/sh
 	printf "Error: running poison command $0\n"

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -106,6 +106,7 @@ TESTSCRIPTS = \
 	t0026-flux-R.t \
 	t0090-content-enospc.t \
 	t0100-modprobe.t \
+	t0800-completion.t \
 	t1000-kvs.t \
 	t1001-kvs-internals.t \
 	t1003-kvs-stress.t \

--- a/t/t0800-completion.t
+++ b/t/t0800-completion.t
@@ -1,0 +1,527 @@
+#!/bin/bash
+#
+
+test_description='Test bash completions for flux commands'
+
+# test_under_flux re-executes this script via 'sh $0'.  Re-exec as bash
+# immediately so the rest of the script can use bash-specific features.
+[ -z "$BASH_VERSION" ] && exec bash "$0" "$@"
+
+. "$(dirname $0)"/sharness.sh
+
+FLUX_COMPLETION=${SHARNESS_TEST_SRCDIR}/../etc/completions/flux.pre
+
+if ! test -f "$FLUX_COMPLETION"; then
+    skip_all='skipping bash completion tests: flux.pre not found'
+    test_done
+fi
+
+SIZE=2
+test_under_flux ${SIZE} job
+
+shopt -s extglob
+
+# compopt is only valid inside a real readline completion context.
+# Stub it out so completion functions don't error when called directly.
+compopt() { :; }
+
+#
+# Stub out 'flux' so static completion tests don't need a live instance.
+# This is overridden in the dynamic section below via 'unset -f flux'.
+#
+flux() {
+    local subcmd="$1"; shift
+    case "$subcmd" in
+    jobs)
+        echo "ƒ111111111"
+        echo "ƒ222222222"
+        ;;
+    queue)
+        # 'flux queue status' output format: "NAME: ..."
+        echo "default: enabled"
+        echo "batch: enabled"
+        ;;
+    env)
+        # __get_flux_subcommands calls 'flux env printenv FLUX_EXEC_PATH'
+        echo ""
+        ;;
+    *)
+        return 1
+        ;;
+    esac
+}
+export -f flux
+
+# shellcheck source=/dev/null
+. "$FLUX_COMPLETION"
+
+# Save the real __get_flux_subcommands before the static stub overrides it
+_orig_get_flux_subcommands=$(declare -f __get_flux_subcommands)
+
+# Override __get_flux_subcommands so top-level completion works without
+# a real FLUX_EXEC_PATH pointing to installed binaries.
+__get_flux_subcommands() {
+    echo "jobs submit run alloc batch bulksubmit cancel job resource queue \
+          overlay config module jobtap pgrep pkill pstree watch top dmesg \
+          ping exec kvs cron start broker shutdown archive housekeeping uri \
+          modprobe sproc proxy update hostlist dump restore R keygen logger \
+          post-job-event fsck startlog pmi uptime version env cgroup \
+          heaptrace lptest relay python python3.13 getattr setattr lsattr \
+          content admin help"
+}
+
+# Temp file used to capture COMPREPLY across function calls
+COMP_OUT=$(mktemp)
+test_at_end_hook_() { rm -f "$COMP_OUT"; }
+
+#
+# run_completion CMDLINE
+#
+# Sets COMP_WORDS/COMP_CWORD/cur/prev from CMDLINE (last word is $cur),
+# calls _flux_core, writes one completion per line to $COMP_OUT.
+#
+run_completion() {
+    local cmdline="$1"
+    read -ra COMP_WORDS <<< "$cmdline"
+    # If cmdline ends with a space, the current word is empty
+    if [[ "$cmdline" == *" " ]]; then
+        COMP_WORDS+=("")
+    fi
+    COMP_CWORD=$(( ${#COMP_WORDS[@]} - 1 ))
+    cur="${COMP_WORDS[$COMP_CWORD]}"
+    prev="${COMP_WORDS[$COMP_CWORD-1]}"
+    COMPREPLY=()
+    _flux_core
+    printf '%s\n' "${COMPREPLY[@]}" > "$COMP_OUT"
+}
+
+# completion_has WORD  -- succeeds if WORD appears in last completion result
+completion_has() { grep -qxF -- "$1" "$COMP_OUT"; }
+
+# completion_lacks WORD -- succeeds if WORD does NOT appear
+completion_lacks() { ! grep -qxF -- "$1" "$COMP_OUT"; }
+
+# completion_has_match PATTERN -- succeeds if any line matches ERE pattern
+completion_has_match() { grep -qE -- "$1" "$COMP_OUT"; }
+
+# completion_empty -- succeeds if COMPREPLY was empty (e.g. file completion
+# was delegated to readline via compopt -o default).
+# Note: COMPREPLY=( $(compgen ...) ) with no matches still produces a
+# one-element empty-string array, so we check for any non-empty line content
+# rather than file size.
+completion_empty() { ! grep -q . "$COMP_OUT"; }
+
+#
+# Top-level command completion
+#
+test_expect_success 'top-level: completes known subcommands' '
+    run_completion "flux " &&
+    completion_has "jobs" &&
+    completion_has "submit" &&
+    completion_has "run" &&
+    completion_has "cancel"
+'
+test_expect_success 'top-level: completes flux options' '
+    run_completion "flux -" &&
+    completion_has "--verbose" &&
+    completion_has "--version"
+'
+
+#
+# flux-pkill
+#
+test_expect_success 'pkill: completes --wait' '
+    run_completion "flux pkill --" &&
+    completion_has "--wait"
+'
+test_expect_success 'pkill: completes --queue' '
+    run_completion "flux pkill --" &&
+    completion_has "--queue="
+'
+
+#
+# flux-watch
+#
+test_expect_success 'watch: completes -v short form' '
+    run_completion "flux watch -" &&
+    completion_has "-v"
+'
+test_expect_success 'watch: completes --verbose' '
+    run_completion "flux watch --" &&
+    completion_has "--verbose"
+'
+
+#
+# flux-exec
+#
+test_expect_success 'exec: completes --with-imp' '
+    run_completion "flux exec --" &&
+    completion_has "--with-imp"
+'
+test_expect_success 'exec: completes --jobid' '
+    run_completion "flux exec --" &&
+    completion_has "--jobid="
+'
+test_expect_success 'exec: --jobid completes with active jobids' '
+    run_completion "flux exec --jobid " &&
+    completion_has "ƒ111111111"
+'
+
+#
+# flux-queue
+#
+test_expect_success 'queue enable: completes --quiet and --verbose' '
+    run_completion "flux queue enable --" &&
+    completion_has "--quiet" &&
+    completion_has "--verbose"
+'
+test_expect_success 'queue disable: completes --message' '
+    run_completion "flux queue disable --" &&
+    completion_has "--message="
+'
+test_expect_success 'queue start: completes --all' '
+    run_completion "flux queue start --" &&
+    completion_has "--all"
+'
+test_expect_success 'queue stop: completes --all and --message' '
+    run_completion "flux queue stop --" &&
+    completion_has "--all" &&
+    completion_has "--message="
+'
+test_expect_success 'queue idle: completes --timeout and --quiet' '
+    run_completion "flux queue idle --" &&
+    completion_has "--timeout=" &&
+    completion_has "--quiet"
+'
+
+#
+# flux-submit/run/alloc/batch
+#
+test_expect_success 'submit: completes --quiet' '
+    run_completion "flux submit --" &&
+    completion_has "--quiet"
+'
+test_expect_success 'run: completes --quiet' '
+    run_completion "flux run --" &&
+    completion_has "--quiet"
+'
+test_expect_success 'batch: completes --broker-opts' '
+    run_completion "flux batch --" &&
+    completion_has "--broker-opts="
+'
+test_expect_success 'alloc: completes --broker-opts' '
+    run_completion "flux alloc --" &&
+    completion_has "--broker-opts="
+'
+
+#
+# flux-R encode
+#
+test_expect_success 'R encode: completes --property' '
+    run_completion "flux R encode --" &&
+    completion_has "--property="
+'
+
+#
+# flux-dump / flux-restore: file completion for positional arg
+#
+test_expect_success 'dump: completes options' '
+    run_completion "flux dump --" &&
+    completion_has "--verbose" &&
+    completion_has "--quiet"
+'
+test_expect_success 'dump: non-option arg delegates to file completion' '
+    run_completion "flux dump somefile" &&
+    completion_empty
+'
+test_expect_success 'restore: completes options' '
+    run_completion "flux restore --" &&
+    completion_has "--verbose" &&
+    completion_has "--quiet"
+'
+test_expect_success 'restore: non-option arg delegates to file completion' '
+    run_completion "flux restore somefile" &&
+    completion_empty
+'
+
+#
+# flux-fsck
+#
+test_expect_success 'fsck: completes --verbose and --quiet' '
+    run_completion "flux fsck --" &&
+    completion_has "--verbose" &&
+    completion_has "--quiet"
+'
+test_expect_success 'fsck: completes --repair and --job-aware' '
+    run_completion "flux fsck --" &&
+    completion_has "--repair" &&
+    completion_has "--job-aware"
+'
+test_expect_success 'fsck: --rootref takes an argument (no completion)' '
+    run_completion "flux fsck --rootref " &&
+    completion_empty
+'
+
+#
+# flux-startlog
+#
+test_expect_success 'startlog: completes --check and --quiet' '
+    run_completion "flux startlog --" &&
+    completion_has "--check" &&
+    completion_has "--quiet"
+'
+test_expect_success 'startlog: completes --show-version' '
+    run_completion "flux startlog --" &&
+    completion_has "--show-version"
+'
+
+#
+# flux-pmi
+#
+test_expect_success 'pmi: completes subcommands' '
+    run_completion "flux pmi " &&
+    completion_has "barrier" &&
+    completion_has "get" &&
+    completion_has "exchange"
+'
+test_expect_success 'pmi: completes --method and --verbose' '
+    run_completion "flux pmi --" &&
+    completion_has "--method=" &&
+    completion_has "--verbose="
+'
+test_expect_success 'pmi barrier: completes --test-count and --test-timing' '
+    run_completion "flux pmi barrier --" &&
+    completion_has "--test-count=" &&
+    completion_has "--test-timing"
+'
+test_expect_success 'pmi get: completes --ranks' '
+    run_completion "flux pmi get --" &&
+    completion_has "--ranks="
+'
+test_expect_success 'pmi exchange: completes --count' '
+    run_completion "flux pmi exchange --" &&
+    completion_has "--count="
+'
+
+#
+# flux-pythonX.Y / flux-python-version: versioned python wrappers
+#
+test_expect_success 'python3: prefix completes to versioned pythonX.Y command' '
+    run_completion "flux python3" &&
+    completion_has_match "^python[0-9]+\.[0-9]" &&
+    completion_lacks "python3"
+'
+test_expect_success 'python3.13: completes --get-path' '
+    run_completion "flux python3.13 --" &&
+    completion_has "--get-path"
+'
+test_expect_success 'python3.13: non-option arg delegates to file completion' '
+    run_completion "flux python3.13 script.py" &&
+    completion_empty
+'
+test_expect_success 'python: does not complete --get-path' '
+    run_completion "flux python --" &&
+    completion_lacks "--get-path"
+'
+
+#
+# flux-batch: file completion for script arg
+#
+test_expect_success 'batch: non-option arg delegates to file completion' '
+    run_completion "flux batch myscript" &&
+    completion_empty
+'
+
+#
+# flux-module load / flux-jobtap load: file completion for plugin path
+#
+test_expect_success 'module load: non-option arg delegates to file completion' '
+    run_completion "flux module load /path/to/mod" &&
+    completion_empty
+'
+test_expect_success 'jobtap load: non-option arg delegates to file completion' '
+    run_completion "flux jobtap load /path/to/plugin" &&
+    completion_empty
+'
+
+#
+# flux-keygen (new)
+#
+test_expect_success 'keygen: completes --name and --meta' '
+    run_completion "flux keygen --" &&
+    completion_has "--name=" &&
+    completion_has "--meta="
+'
+
+#
+# flux-logger (new)
+#
+test_expect_success 'logger: completes --severity' '
+    run_completion "flux logger --" &&
+    completion_has "--severity="
+'
+test_expect_success 'logger: --severity completes log levels' '
+    run_completion "flux logger --severity " &&
+    completion_has "info" &&
+    completion_has "debug" &&
+    completion_has "err"
+'
+
+#
+# flux-cancel: spot-check existing completion still works
+#
+test_expect_success 'cancel: completes --states' '
+    run_completion "flux cancel --" &&
+    completion_has "--states="
+'
+test_expect_success 'cancel: --states completes state names' '
+    run_completion "flux cancel --states " &&
+    completion_has "running" &&
+    completion_has "pending"
+'
+
+#
+# Dynamic jobid completion (stubbed)
+#
+test_expect_success 'cancel: non-option arg completes with jobids' '
+    run_completion "flux cancel " &&
+    completion_has "ƒ111111111"
+'
+test_expect_success 'job attach: completes with jobids' '
+    run_completion "flux job attach " &&
+    completion_has "ƒ111111111"
+'
+
+#
+# Queue name completion (stubbed)
+#
+test_expect_success 'jobs: --queue completes queue names' '
+    run_completion "flux jobs --queue " &&
+    completion_has "default" &&
+    completion_has "batch"
+'
+test_expect_success 'submit: --queue completes queue names' '
+    run_completion "flux submit --queue " &&
+    completion_has "default" &&
+    completion_has "batch"
+'
+
+# -----------------------------------------------------------------------
+# Dynamic tests: use the real flux instance started by test_under_flux.
+# Remove the stub so completion functions call the real flux binary.
+# -----------------------------------------------------------------------
+unset -f flux
+
+test_expect_success 'setup: submit a regular sleep job' '
+    JOBID_REGULAR=$(flux submit --wait-event=start sleep 300) &&
+    test_debug "echo regular job: $JOBID_REGULAR"
+'
+test_expect_success 'setup: submit a batch instance' '
+    JOBID_INSTANCE=$(flux batch -n1 --wrap sleep 300) &&
+    flux uri --wait $JOBID_INSTANCE >/dev/null &&
+    test_debug "echo instance job: $JOBID_INSTANCE"
+'
+
+#
+# Jobid completion with real jobs
+#
+test_expect_success 'cancel: completes real active jobids' '
+    run_completion "flux cancel " &&
+    completion_has "$JOBID_REGULAR" &&
+    completion_has "$JOBID_INSTANCE"
+'
+test_expect_success 'job attach: completes real active jobids' '
+    run_completion "flux job attach " &&
+    completion_has "$JOBID_REGULAR" &&
+    completion_has "$JOBID_INSTANCE"
+'
+test_expect_success 'exec --jobid: completes real active jobids' '
+    run_completion "flux exec --jobid " &&
+    completion_has "$JOBID_REGULAR" &&
+    completion_has "$JOBID_INSTANCE"
+'
+test_expect_success 'update: completes real active jobids' '
+    run_completion "flux update " &&
+    completion_has "$JOBID_REGULAR" &&
+    completion_has "$JOBID_INSTANCE"
+'
+
+#
+# Instance-only completion: proxy/shutdown only show jobs with a URI
+#
+test_expect_success 'proxy: completes instance jobids only' '
+    run_completion "flux proxy " &&
+    completion_has "$JOBID_INSTANCE" &&
+    completion_lacks "$JOBID_REGULAR"
+'
+test_expect_success 'shutdown: completes instance jobids only' '
+    run_completion "flux shutdown " &&
+    completion_has "$JOBID_INSTANCE" &&
+    completion_lacks "$JOBID_REGULAR"
+'
+
+#
+# Coverage check: every flux command must have a completion function or be
+# listed in one of the two sets below.
+#
+test_expect_success 'completion coverage: all commands covered or explicitly excluded' '
+    # Restore the real __get_flux_subcommands (overridden at top for static tests)
+    eval "$_orig_get_flux_subcommands" &&
+    # Populate FLUX_BUILTINS so __get_flux_subcommands enumerates builtin commands
+    eval $(bash "${SHARNESS_TEST_SRCDIR}/../etc/completions/get_builtins.sh" \
+        "${SHARNESS_TEST_SRCDIR}/../src/cmd/builtin") &&
+
+    # Commands that have completions but are dispatched without a _flux_<cmd>
+    # function (handled inline in _flux_core or via a shared function):
+    #   submit/run/alloc/batch/bulksubmit -> _flux_submit_commands
+    #   getattr/setattr/lsattr            -> _flux_attr
+    #   help                              -> inline compgen in _flux_core
+    #   python                            -> inline compopt in _flux_core
+    special="submit run alloc batch bulksubmit getattr setattr lsattr help python" &&
+
+    # Commands intentionally without completions.  Add a brief reason for each.
+    denylist="
+        event           \
+        fortune         \
+        terminus        \
+        job-exec-override   \
+        job-frobnicator     \
+        job-validator       \
+        multi-prog          \
+        slurm-expiration-sync \
+        imp-exec-helper     \
+        run-epilog          \
+        run-prolog          \
+        run-housekeeping    \
+        cgroup              \
+        env                 \
+        heaptrace           \
+        lptest              \
+        relay               \
+        uptime              \
+        version             \
+        module-exec         \
+        module-python-exec  \
+    " &&
+
+    missing="" &&
+    for cmd in $(__get_flux_subcommands); do
+        fn="_flux_${cmd//-/_}"
+        # pythonX.Y versioned commands (e.g. python3.13) cannot map to a
+        # valid bash function name; they use _flux_python3 via the case dispatch
+        [[ $cmd =~ ^python[0-9]+\.[0-9] ]] && fn="_flux_python3"
+        if ! declare -f "$fn" >/dev/null 2>&1 &&
+           ! _flux_contains_word "$cmd" $special &&
+           ! _flux_contains_word "$cmd" $denylist; then
+            missing="$missing $cmd"
+        fi
+    done &&
+    test_debug "echo commands with missing completions:${missing:- none}" &&
+    test -z "$missing"
+'
+
+test_expect_success 'cleanup: cancel test jobs' '
+    flux cancel $JOBID_REGULAR $JOBID_INSTANCE
+'
+
+test_done


### PR DESCRIPTION
This PR updates the Flux bash completions with missing commands and options.

It then adds a framework for testing the bash completions, including a check that attempts to check for missing commands (that are not in a specific denylist).

