### PR TITLE
modprobe: propagate alternatives selection to all module `provides`

### DIFF
--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -460,7 +460,7 @@ class TaskDB:
             self.tasks[name].pop(to_remove)
             self.add(task, index=entry.index)
 
-    def set_alternative(self, service, name):
+    def set_alternative(self, service, name, propagate=True):
         """Select a specific alternative 'name' for service"""
         lst = self.tasks[service]
         try:
@@ -476,6 +476,11 @@ class TaskDB:
         entry = lst.pop(index)
         priority = lst[-1].priority
         lst.append(self.TaskEntry(priority + 1, entry.index, entry.task))
+
+        # now do the same for any other provides in this module
+        if propagate:
+            for provides in set(entry.task.provides) - {service}:
+                self.set_alternative(provides, name, propagate=False)
 
     def disable(self, service):
         """disable task/module/service with name 'service'"""

--- a/t/t0100-modprobe.t
+++ b/t/t0100-modprobe.t
@@ -1358,6 +1358,32 @@ test_expect_success 'modprobe: set_alternative() detects invalid module' '
 	test_debug "cat badalt.out" &&
 	grep "no module foo provides sched" badalt.out
 '
+test_expect_success 'modprobe: set_alternative() propagates to other provides' '
+	FLUX_MODPROBE_PATH=$(pwd) \
+	    flux modprobe show --set-alternative=sched=basic-scheduler \
+	        feasibility > feas.prop.json &&
+	test_debug "cat feas.prop.json" &&
+	cat feas.prop.json | jq -e ".name == \"basic-scheduler\""
+'
+test_expect_success 'modprobe: set_alternative() propagation is symmetric' '
+	FLUX_MODPROBE_PATH=$(pwd) \
+	    flux modprobe show --set-alternative=feasibility=basic-scheduler \
+	        sched > sched.sym.json &&
+	test_debug "cat sched.sym.json" &&
+	cat sched.sym.json | jq -e ".name == \"basic-scheduler\""
+'
+test_expect_success 'modprobe: alternatives config propagates to other provides' '
+	cat <<-EOF | flux config load &&
+	[modules.alternatives]
+	sched = "basic-scheduler"
+	EOF
+	flux config get | jq &&
+	test_when_finished "echo {} | flux config load" &&
+	FLUX_MODPROBE_PATH=$(pwd) \
+	    flux modprobe show feasibility > feas.conf.prop.json &&
+	test_debug "cat feas.conf.prop.json" &&
+	cat feas.conf.prop.json | jq -e ".name == \"basic-scheduler\""
+'
 test_expect_success 'remove temporary configuration' '
 	rm -rf modprobe.d
 '


### PR DESCRIPTION
Problem: When selecting an alternative, e.g. `modules.alternatives.sched=sched-fifo`, modprobe does not propagate the selected module to other services  in the module `provides`. This can lead to an attempt to load a conflicting module and unexpected failure in modprobe and rc1.

This PR propagates the selected alternative to all other services in `provides` to fix the issue.