### PR TITLE
Support `--conf` option in `flux start` and `flux broker`

### DIFF
--- a/doc/man1/flux-broker.rst
+++ b/doc/man1/flux-broker.rst
@@ -56,6 +56,45 @@ OPTIONS
    configuration as JSON if the file extension is ``.json``, otherwise
    load the file as TOML.
 
+.. option:: --conf=VALUE
+
+   Update the broker configuration from VALUE after any configuration
+   file specified with :option:`--config-path` (or :envvar:`FLUX_CONF_DIR`)
+   is loaded. This option may be specified multiple times and values are
+   applied in order. The format of VALUE is determined as follows:
+
+   ``KEY=VAL``
+     If VALUE contains ``=``, set the configuration key at dotted path
+     KEY to VAL. VAL is parsed as JSON; if it is not valid JSON it is
+     treated as a string. Note: file paths containing ``=`` are
+     interpreted as KEY=VAL rather than as file names.
+
+   inline JSON object
+     If VALUE starts with ``{``, it is parsed as an inline JSON object
+     and merged into the configuration.
+
+   inline TOML string
+     If VALUE contains a newline (and does not start with ``{``), it is
+     parsed as an inline TOML string and merged into the configuration.
+     Note: shell command substitution (``$()``) strips trailing newlines,
+     so inline TOML strings should have an embedded newline, as TOML
+     naturally does.
+
+   path ending in ``.json``
+     Parse the file as JSON and merge the result into the configuration.
+
+   any other string
+     Treated as a path to a TOML file.
+
+   .. note::
+
+      When a broker is started with :option:`--conf`, that configuration is
+      in-memory only and is not written to files. If :option:`--config-path`
+      or :envvar:`FLUX_CONF_DIR` is also set, running :command:`flux config
+      reload` within that instance will overwrite any configuration applied
+      via :option:`--conf`, since reload reads from files only. (If no
+      config path is set, :command:`flux config reload` is a no-op.)
+
 .. _broker_logging:
 
 LOGGING

--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -132,6 +132,13 @@ OPTIONS
    Set the *PATH* for broker configuration. See :man1:`flux-broker` for
    option details. This is equivalent to :option:`-o,-cPATH`.
 
+.. option:: --conf=VALUE
+
+   Update the broker configuration from VALUE after loading any config file
+   specified with :option:`--config-path` or :envvar:`FLUX_CONF_DIR`.  This
+   option may be specified multiple times. See :man1:`flux-broker` for
+   VALUE format details. This is equivalent to :option:`-o,--conf=VALUE`.
+
 .. option:: -o, --broker-opts=OPTIONS
 
    Add options to the message broker daemon, separated by commas.

--- a/doc/man3/flux_conf_create.rst
+++ b/doc/man3/flux_conf_create.rst
@@ -28,6 +28,10 @@ SYNOPSIS
 
   flux_conf_t *flux_conf_parse (const char *path, flux_error_t *error);
 
+  int flux_conf_update (flux_conf_t *conf,
+                        const char *value,
+                        flux_error_t *error);
+
 Link with :command:`-lflux-core`.
 
 DESCRIPTION
@@ -53,6 +57,30 @@ and destroys it when the count reaches zero.
 :func:`flux_conf_parse` parse a TOML configuration file at :var:`path`
 and creates a config object that contains the result.
 
+:func:`flux_conf_update` updates :var:`conf` in place from :var:`value`.
+The format of :var:`value` is determined as follows:
+
+``KEY=VAL``
+  If :var:`value` contains ``=``, set the configuration key at the dotted
+  path :var:`KEY` to :var:`VAL`. :var:`VAL` is parsed as JSON; if it is
+  not valid JSON, it is treated as a plain string. Note: file paths
+  containing ``=`` are interpreted as KEY=VAL rather than as file names.
+
+inline JSON object
+  If :var:`value` starts with ``{``, it is parsed as an inline JSON object
+  and merged into :var:`conf`.
+
+inline TOML string
+  If :var:`value` contains a newline (and does not start with ``{``), it is
+  parsed as an inline TOML string and merged into :var:`conf`.
+
+path ending in ``.json``
+  Parse the file at :var:`value` as JSON and merge the result into
+  :var:`conf`.
+
+any other string
+  Treated as a path to a TOML file.
+
 ENCODING JSON PAYLOADS
 ======================
 
@@ -73,8 +101,12 @@ On error, NULL is returned, and :var:`errno` is set.
 :func:`flux_conf_unpack` returns 0 on success, or -1 on failure with
 :var:`errno` set.
 
-:func:`flux_conf_parse` returns 0 on success.  On error, it returns -1,
-:var:`errno` set, and if :var:`error` is non-NULL, it is filled with
+:func:`flux_conf_parse` returns a :type:`flux_conf_t` object on success.
+On error, NULL is returned, :var:`errno` is set, and if :var:`error` is
+non-NULL, it is filled with a human readable error message.
+
+:func:`flux_conf_update` returns 0 on success.  On error, it returns -1,
+:var:`errno` is set, and if :var:`error` is non-NULL, it is filled with
 a human readable error message.
 
 ERRORS

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -2128,6 +2128,7 @@ _flux_start()
         --wrap= \
         -s --test-size= \
         -c --config-path = \
+        --conf= \
         -S --setattr= \
     "
     _flux_split_longopt && split=true
@@ -2167,6 +2168,7 @@ _flux_broker()
         -v --verbose= \
         -S --setattr= \
         -c --config-path= \
+        --conf= \
     "
     _flux_split_longopt && split=true
     case $prev in

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -218,6 +218,42 @@ static void sighup_handler (int signum)
     signal (SIGHUP, SIG_DFL);
 }
 
+/* Parse config if specified in -c, --config-path or FLUX_CONF_DIR.
+ * Set new config in handle `ctx.h` on success.
+ * Return -1 on error with error logged at LOG_CRIT.
+ */
+static int parse_config (broker_ctx_t *ctx)
+{
+    flux_conf_t *conf = NULL;
+    flux_error_t error;
+    const char *config_path = optparse_get_str (ctx->opts, "config-path", NULL);
+
+    if (!config_path)
+        config_path = getenv ("FLUX_CONF_DIR");
+    if (config_path) {
+        if (!(conf = flux_conf_parse (config_path, &error))) {
+            flux_log (ctx->h, LOG_CRIT, "Config file error: %s", error.text);
+            return -1;
+        }
+        if (attr_set (ctx->attrs, "config.path", config_path) < 0) {
+            flux_conf_decref (conf);
+            flux_log (ctx->h,
+                      LOG_CRIT,
+                      "setattr config.path: %s",
+                      strerror (errno));
+            return -1;
+        }
+    }
+    if (conf) {
+        if (flux_set_conf_new (ctx->h, conf) < 0) {
+            flux_conf_decref (conf);
+            flux_log (ctx->h, LOG_CRIT, "Error caching config object");
+            return -1;
+        }
+    }
+    return 0;
+}
+
 int main (int argc, char *argv[])
 {
     broker_ctx_t ctx;
@@ -375,28 +411,8 @@ int main (int argc, char *argv[])
 
     /* Parse config.
      */
-    const char *config_path = optparse_get_str (ctx.opts, "config-path", NULL);
-    if (!config_path)
-        config_path = getenv ("FLUX_CONF_DIR");
-    if (config_path) {
-        flux_conf_t *conf;
-        if (!(conf = flux_conf_parse (config_path, &error))) {
-            flux_log (ctx.h, LOG_CRIT, "Config file error: %s", error.text);
-            goto cleanup;
-        }
-        if (flux_set_conf_new (ctx.h, conf) < 0) {
-            flux_conf_decref (conf);
-            flux_log (ctx.h, LOG_CRIT, "Error caching config object");
-            goto cleanup;
-        }
-        if (attr_set (ctx.attrs, "config.path", config_path) < 0) {
-            flux_log (ctx.h,
-                      LOG_CRIT,
-                      "setattr config.path: %s",
-                      strerror (errno));
-            goto cleanup;
-        }
-    }
+    if (parse_config (&ctx) < 0)
+        goto cleanup;
 
     if (increase_rlimits () < 0) {
         flux_log (ctx.h,

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -128,6 +128,8 @@ static struct optparse_option opts[] = {
       .usage = "Set broker attribute", },
     { .name = "config-path",.key = 'c', .has_arg = 1, .arginfo = "PATH",
       .usage = "Set broker config from PATH (default: none)", },
+    { .name = "conf",       .key = 0,   .has_arg = 1, .arginfo = "VALUE",
+      .usage = "Update broker config from VALUE", },
     OPTPARSE_TABLE_END,
 };
 
@@ -226,6 +228,7 @@ static int parse_config (broker_ctx_t *ctx)
 {
     flux_conf_t *conf = NULL;
     flux_error_t error;
+    const char *value;
     const char *config_path = optparse_get_str (ctx->opts, "config-path", NULL);
 
     if (!config_path)
@@ -241,6 +244,23 @@ static int parse_config (broker_ctx_t *ctx)
                       LOG_CRIT,
                       "setattr config.path: %s",
                       strerror (errno));
+            return -1;
+        }
+    }
+    /* Update config with all --conf= options, creating an empty config if
+     * necessary.
+     */
+    while ((value = optparse_getopt_next (ctx->opts, "conf"))) {
+        if (!conf && !(conf = flux_conf_create ())) {
+            flux_log (ctx->h,
+                      LOG_CRIT,
+                      "error creating config object: %s",
+                      strerror (errno));
+            return -1;
+        }
+        if (flux_conf_update (conf, value, &error) < 0) {
+            flux_conf_decref (conf);
+            flux_log (ctx->h, LOG_CRIT, "--conf: %s", error.text);
             return -1;
         }
     }

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -106,6 +106,8 @@ static struct optparse_option opts[] = {
       .usage = "Set broker attribute", },
     { .name = "config-path",.key = 'c', .has_arg = 1, .arginfo = "PATH",
       .usage = "Set broker config from PATH (default: none)", },
+    { .name = "conf",       .has_arg = 1, .arginfo = "VALUE",
+      .usage = "Update broker config from VALUE", },
     { .name = "recovery",   .key = 'r', .has_arg = 2, .arginfo = "[TARGET]",
       .flags = OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG,
       .usage = "Start instance in recovery mode with dump file or statedir", },
@@ -614,6 +616,7 @@ int add_args_common (char **argz,
     }
     if (config_path)
         add_argzf (argz, argz_len, "-c%s", config_path);
+    add_args_list (argz, argz_len, ctx.opts, "conf", "--conf=");
 
     return 0;
 }

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -28,6 +28,7 @@
 #include "src/common/libtomlc99/toml.h"
 #include "src/common/libutil/tomltk.h"
 #include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/jpath.h"
 #include "ccan/str/str.h"
 
 #include "conf_private.h"
@@ -178,6 +179,153 @@ static int conf_update (flux_conf_t *conf,
     if (streq (ext, "json"))
         return conf_update_json (conf, filename, error);
     return conf_update_toml (conf, filename, error);
+}
+
+/* Parse s as a JSON object string and merge into conf.
+ */
+static int conf_update_inline_json (flux_conf_t *conf,
+                                    const char *s,
+                                    flux_error_t *error)
+{
+    json_error_t j_error;
+    json_t *obj;
+    int rc = -1;
+
+    if (!(obj = json_loads (s, 0, &j_error))) {
+        errprintf (error, "inline JSON: %s", j_error.text);
+        errno = EINVAL;
+        return -1;
+    }
+    /* Both conf->obj (always a json_object()) and obj (from json_loads()
+     * on '{'-prefixed input) are guaranteed to be JSON objects, so this
+     * should not fail.
+     */
+    if (json_object_update_recursive (conf->obj, obj) < 0) {
+        errprintf (error, "merging inline JSON: internal error");
+        errno = EINVAL;
+        goto done;
+    }
+    rc = 0;
+done:
+    ERRNO_SAFE_WRAP (json_decref, obj);
+    return rc;
+}
+
+/* Parse inline string (must contain a newline) and merge into conf.
+ * If s starts with '{' (ignoring leading whitespace), parse as JSON;
+ * otherwise parse as TOML.
+ */
+static int conf_update_inline (flux_conf_t *conf,
+                               const char *s,
+                               flux_error_t *error)
+{
+    struct tomltk_error toml_error;
+    toml_table_t *tab = NULL;
+    json_t *obj = NULL;
+    int rc = -1;
+
+    /* If value starts with '{' (possibly after leading whitespace e.g. from
+     * a Python triple-quoted string), parse specifically as JSON.
+     */
+    if (s[strspn (s, " \t\n\r")] == '{')
+        return conf_update_inline_json (conf, s, error);
+
+    /* Fall back to TOML */
+    if (!(tab = tomltk_parse (s, strlen (s), &toml_error))) {
+        if (toml_error.lineno == -1)
+            errprintf (error, "%s", toml_error.errbuf);
+        else
+            errprintf (error,
+                       "line %d: %s",
+                       toml_error.lineno,
+                       toml_error.errbuf);
+        errno = EINVAL;
+        goto done;
+    }
+    if (!(obj = tomltk_table_to_json (tab))) {
+        errprintf (error,
+                   "converting inline TOML to JSON: %s",
+                   strerror (errno));
+        goto done;
+    }
+    /* Both conf->obj (always a json_object()) and obj (from
+     * tomltk_table_to_json() on a TOML table) are guaranteed to be
+     * JSON objects, so this should not fail.
+     */
+    if (json_object_update_recursive (conf->obj, obj) < 0) {
+        errprintf (error, "merging inline TOML: internal error");
+        errno = EINVAL;
+        goto done;
+    }
+    rc = 0;
+done:
+    ERRNO_SAFE_WRAP (json_decref, obj);
+    ERRNO_SAFE_WRAP (toml_free, tab);
+    return rc;
+}
+
+/* Parse s as KEY=VAL where KEY is a dotted path and VAL is a JSON scalar or
+ * a bare string. Apply to conf.
+ */
+static int conf_update_keyval (flux_conf_t *conf,
+                               const char *s,
+                               flux_error_t *error)
+{
+    const char *eq;
+    char *key = NULL;
+    json_t *val = NULL;
+    int rc = -1;
+
+    /* Note: `=` in `s` should already be guaranteed by caller.
+     * Error message returned to caller reflects this
+     */
+    if (!(eq = strchr (s, '=')) || eq == s) {
+        errprintf (error, "value must have a key in KEY=VAL");
+        errno = EINVAL;
+        goto done;
+    }
+    if (!(key = strndup (s, eq - s))) {
+        errprintf (error, "%s", strerror (errno));
+        goto done;
+    }
+
+    /* Try to parse value as JSON (includes true/false, numbers, strings):
+     * Otherwise, fallback to parsing as a string.
+     */
+    if (!(val = json_loads (eq + 1, JSON_DECODE_ANY, NULL))) {
+        if (!(val = json_string (eq + 1))) {
+            errprintf (error, "out of memory");
+            errno = ENOMEM;
+            goto done;
+        }
+    }
+    if (jpath_set (conf->obj, key, val) < 0) {
+        errprintf (error, "setting %s: %s", key, strerror (errno));
+        goto done;
+    }
+    rc = 0;
+done:
+    free (key);
+    json_decref (val);
+    return rc;
+}
+
+int flux_conf_update (flux_conf_t *conf,
+                      const char *value,
+                      flux_error_t *error)
+{
+    if (!conf || !value) {
+        errno = EINVAL;
+        errprintf (error, "%s", strerror (errno));
+        return -1;
+    }
+    if (strchr (value, '\n'))
+        return conf_update_inline (conf, value, error);
+    if (value[0] == '{')
+        return conf_update_inline_json (conf, value, error);
+    if (strchr (value, '='))
+        return conf_update_keyval (conf, value, error);
+    return conf_update (conf, value, error);
 }
 
 struct globerr {

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -154,6 +154,11 @@ static int conf_update_json (flux_conf_t *conf,
         errprintf (error, "%s:%d: %s", filename, err.line, err.text);
         goto error;
     }
+    if (!json_is_object (obj)) {
+        errprintf (error, "%s: JSON must be an object", filename);
+        errno = EINVAL;
+        goto error;
+    }
     if (conf_update_obj (conf, filename, obj, error) < 0)
         goto error;
     json_decref (obj);

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -31,6 +31,17 @@ void flux_conf_decref (const flux_conf_t *conf);
  */
 flux_conf_t *flux_conf_parse (const char *path, flux_error_t *error);
 
+/* Update conf in-place from 'value', which may be:
+ *   - KEY=VAL         - set dotted key path to JSON or string value
+ *   - inline string   - inline TOML or JSON object (starts with '{' or contains newline)
+ *   - <path>.json     - path to a JSON file
+ *   Otherwise, fall back to parsing as a TOML file
+ * Returns 0 on success, -1 on failure with errno and error set.
+ */
+int flux_conf_update (flux_conf_t *conf,
+                      const char *value,
+                      flux_error_t *error);
+
 /* Access config object.
  * If error is non-NULL, it is filled with error details on failure.
  */

--- a/src/common/libflux/test/conf.c
+++ b/src/common/libflux/test/conf.c
@@ -439,6 +439,235 @@ void test_globerr (void)
         "conf_globerr pat=oops rc=666 sets errno and error as expected");
 }
 
+void test_update (void)
+{
+    char toml_path[PATH_MAX + 1];
+    char json_path[PATH_MAX + 1];
+    char array_json_path[PATH_MAX + 1];
+    flux_conf_t *conf;
+    flux_error_t error;
+    int i;
+    const char *s;
+
+    if (!(conf = flux_conf_create ()))
+        BAIL_OUT ("flux_conf_create failed");
+
+    /* KEY=VAL: integer */
+    ok (flux_conf_update (conf, "foo=42", &error) == 0,
+        "flux_conf_update foo=42 works");
+    i = 0;
+    ok (flux_conf_unpack (conf, NULL, "{s:i}", "foo", &i) == 0 && i == 42,
+        "flux_conf_update foo=42 set expected value");
+
+    /* KEY=VAL: string */
+    ok (flux_conf_update (conf, "bar=hello", &error) == 0,
+        "flux_conf_update bar=hello works");
+    s = NULL;
+    ok (flux_conf_unpack (conf, NULL, "{s:s}", "bar", &s) == 0
+        && s != NULL && streq (s, "hello"),
+        "flux_conf_update bar=hello set expected value");
+
+    /* KEY=VAL: boolean */
+    ok (flux_conf_update (conf, "baz=true", &error) == 0,
+        "flux_conf_update baz=true works");
+    i = 0;
+    ok (flux_conf_unpack (conf, NULL, "{s:b}", "baz", &i) == 0 && i == 1,
+        "flux_conf_update baz=true set expected value");
+
+    /* KEY=VAL: empty value sets key to empty string */
+    ok (flux_conf_update (conf, "empty=", &error) == 0,
+        "flux_conf_update empty= works");
+    s = NULL;
+    ok (flux_conf_unpack (conf, NULL, "{s:s}", "empty", &s) == 0
+        && s != NULL && streq (s, ""),
+        "flux_conf_update empty= set expected value");
+
+    /* KEY=VAL: dotted key creates nested object */
+    ok (flux_conf_update (conf, "a.b.c=99", &error) == 0,
+        "flux_conf_update a.b.c=99 works");
+    i = 0;
+    ok (flux_conf_unpack (conf, NULL, "{s:{s:{s:i}}}", "a", "b", "c", &i) == 0
+        && i == 99,
+        "flux_conf_update a.b.c=99 set expected value");
+
+    /* KEY=VAL: update existing nested key, others preserved */
+    ok (flux_conf_update (conf, "a.b.c=100", &error) == 0,
+        "flux_conf_update a.b.c=100 works");
+    i = 0;
+    ok (flux_conf_unpack (conf, NULL, "{s:{s:{s:i}}}", "a", "b", "c", &i) == 0
+        && i == 100,
+        "flux_conf_update a.b.c=100 updated expected value");
+
+    /* Inline TOML (with newline) */
+    ok (flux_conf_update (conf,
+                          "[modules.alternatives]\nsched = \"sched-simple\"\n",
+                          &error) == 0,
+        "flux_conf_update inline TOML works");
+    s = NULL;
+    ok (flux_conf_unpack (conf,
+                          NULL,
+                          "{s:{s:{s:s}}}",
+                          "modules",
+                          "alternatives",
+                          "sched",
+                          &s) == 0
+        && s != NULL
+        && streq (s, "sched-simple"),
+        "flux_conf_update inline TOML set expected value");
+
+    /* Inline JSON (with newline) */
+    ok (flux_conf_update (conf,
+                          "{\"resource\":{\"noverify\":true}}\n",
+                          &error) == 0,
+        "flux_conf_update inline JSON with newline works");
+    i = 0;
+    ok (flux_conf_unpack (conf,
+                          NULL,
+                          "{s:{s:b}}",
+                          "resource",
+                          "noverify",
+                          &i) == 0 && i == 1,
+        "flux_conf_update inline JSON with newline set expected value");
+
+    /* Inline JSON (leading newline before '{', e.g. Python triple-quoted string) */
+    ok (flux_conf_update (conf,
+                          "\n{\n  \"resource\": {\"noverify\": false}\n}\n",
+                          &error) == 0,
+        "flux_conf_update inline JSON with leading \\n works");
+    i = 1;
+    ok (flux_conf_unpack (conf,
+                          NULL,
+                          "{s:{s:b}}",
+                          "resource",
+                          "noverify",
+                          &i) == 0 && i == 0,
+        "flux_conf_update inline JSON with leading \\n set expected value");
+
+    /* Inline JSON (multiple leading newlines) */
+    ok (flux_conf_update (conf,
+                          "\n\n{\n  \"resource\": {\"noverify\": true}\n}\n",
+                          &error) == 0,
+        "flux_conf_update inline JSON with leading \\n\\n works");
+    i = 0;
+    ok (flux_conf_unpack (conf,
+                          NULL,
+                          "{s:{s:b}}",
+                          "resource",
+                          "noverify",
+                          &i) == 0 && i == 1,
+        "flux_conf_update inline JSON with leading \\n\\n set expected value");
+
+    /* Inline JSON (leading newline + spaces, e.g. indented heredoc) */
+    ok (flux_conf_update (conf,
+                          "\n  {\n  \"resource\": {\"noverify\": false}\n}\n",
+                          &error) == 0,
+        "flux_conf_update inline JSON with leading \\n+spaces works");
+    i = 1;
+    ok (flux_conf_unpack (conf,
+                          NULL,
+                          "{s:{s:b}}",
+                          "resource",
+                          "noverify",
+                          &i) == 0 && i == 0,
+        "flux_conf_update inline JSON with leading \\n+spaces set expected value");
+
+    /* Inline JSON (no newline, starts with '{') */
+    ok (flux_conf_update (conf,
+                          "{\"resource\":{\"noverify\":false}}",
+                          &error) == 0,
+        "flux_conf_update inline JSON without newline works");
+    i = 1;
+    ok (flux_conf_unpack (conf,
+                          NULL,
+                          "{s:{s:b}}",
+                          "resource",
+                          "noverify",
+                          &i) == 0 && i == 0,
+        "flux_conf_update inline JSON without newline set expected value");
+
+    /* File: TOML */
+    create_test_file (NULL,
+                      "update_toml",
+                      "toml",
+                      toml_path,
+                      sizeof (toml_path),
+                      "[tab5]\nval = 55\n");
+    ok (flux_conf_update (conf, toml_path, &error) == 0,
+        "flux_conf_update .toml file works");
+    i = 0;
+    ok (flux_conf_unpack (conf, NULL, "{s:{s:i}}", "tab5", "val", &i) == 0
+        && i == 55,
+        "flux_conf_update .toml file set expected value");
+
+    /* File: JSON */
+    create_test_file (NULL,
+                      "update_json",
+                      "json",
+                      json_path,
+                      sizeof (json_path),
+                      "{\"tab6\":{\"val\":66}}");
+    ok (flux_conf_update (conf, json_path, &error) == 0,
+        "flux_conf_update .json file works");
+    i = 0;
+    ok (flux_conf_unpack (conf, NULL, "{s:{s:i}}", "tab6", "val", &i) == 0
+        && i == 66,
+        "flux_conf_update .json file set expected value");
+
+    /* Error: NULL args */
+    errno = 0;
+    ok (flux_conf_update (NULL, "x=1", &error) < 0 && errno == EINVAL,
+        "flux_conf_update conf=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_conf_update (conf, NULL, &error) < 0 && errno == EINVAL,
+        "flux_conf_update value=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_conf_update (conf, "notafile", &error) < 0 && errno == ENOENT,
+        "flux_conf_update value with nonexisting file fails with ENOENT");
+    diag ("%s", error.text);
+
+    /* Error: KEY=VAL with empty key */
+    errno = 0;
+    ok (flux_conf_update (conf, "=foo", &error) < 0 && errno == EINVAL,
+        "flux_conf_update =foo fails with EINVAL");
+    diag ("%s", error.text);
+
+    /* Error: bad inline TOML */
+    errno = 0;
+    ok (flux_conf_update (conf, "bad = \n", &error) < 0,
+        "flux_conf_update bad inline TOML fails");
+    diag ("%s", error.text);
+
+    /* Error: inline value with newline that is not '{'-prefixed fails as TOML */
+    errno = 0;
+    ok (flux_conf_update (conf, "[1,2,3]\n", &error) < 0 && errno == EINVAL,
+        "flux_conf_update inline non-'{' value with newline fails as TOML");
+    diag ("%s", error.text);
+
+    /* Error: starts with '{' but invalid JSON */
+    errno = 0;
+    ok (flux_conf_update (conf, "{bad json}", &error) < 0 && errno == EINVAL,
+        "flux_conf_update invalid inline JSON fails with EINVAL");
+    diag ("%s", error.text);
+
+    /* Error: JSON file that is not an object */
+    create_test_file (NULL,
+                      "update_array",
+                      "json",
+                      array_json_path,
+                      sizeof (array_json_path),
+                      "[1,2,3]");
+    errno = 0;
+    ok (flux_conf_update (conf, array_json_path, &error) < 0 && errno == EINVAL,
+        "flux_conf_update .json file containing array fails with EINVAL");
+    diag ("%s", error.text);
+
+    unlink (toml_path);
+    unlink (json_path);
+    unlink (array_json_path);
+    flux_conf_decref (conf);
+}
+
 void test_pack (void)
 {
     flux_conf_t *conf;
@@ -467,7 +696,8 @@ int main (int argc, char *argv[])
     test_basic (); // flux_conf_parse(), flux_conf_decref(), flux_conf_unpack()
     test_in_handle ();
     test_globerr ();
-    test_pack();
+    test_pack ();
+    test_update ();
 
     done_testing ();
 }

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -505,7 +505,6 @@ error:
     resource_config_deinit (&config);
     resource_ctx_destroy (ctx);
     ERRNO_SAFE_WRAP (json_decref, eventlog);
-    ERRNO_SAFE_WRAP (json_decref, config.R);
     return -1;
 }
 

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -696,4 +696,110 @@ test_expect_success CONNTO 'tbon.connect_timeout attr can be set to 0' '
 	test_cmp connto_0.exp connto_attr_0.out
 '
 
+#
+# test --conf option
+#
+test_expect_success '--conf KEY=VAL integer sets broker config' '
+	cat <<-EOF >conf_keyval.exp &&
+	1
+	EOF
+	flux broker ${ARGS} \
+		--conf=tbon.zmqdebug=1 \
+		flux getattr tbon.zmqdebug >conf_keyval.out &&
+	test_cmp conf_keyval.exp conf_keyval.out
+'
+test_expect_success '--conf inline TOML sets broker config' '
+	cat <<-EOF >conf_toml.exp &&
+	1
+	EOF
+	flux broker ${ARGS} \
+		--conf="$(printf "[tbon]\nzmqdebug = 1\n")" \
+		flux getattr tbon.zmqdebug >conf_toml.out &&
+	test_cmp conf_toml.exp conf_toml.out
+'
+test_expect_success '--conf may be specified multiple times' '
+	cat <<-EOF >conf_multi.exp &&
+	1
+	EOF
+	flux broker ${ARGS} \
+		--conf=tbon.zmqdebug=1 \
+		--conf=tbon.zmq_io_threads=1 \
+		flux getattr tbon.zmqdebug >conf_multi.out &&
+	test_cmp conf_multi.exp conf_multi.out
+'
+test_expect_success '--conf overrides --config-path value' '
+	mkdir conf_override &&
+	cat <<-EOF >conf_override/tbon.toml &&
+	[tbon]
+	zmqdebug = 0
+	EOF
+	cat <<-EOF >conf_override.exp &&
+	1
+	EOF
+	flux broker ${ARGS} \
+		-c conf_override \
+		--conf=tbon.zmqdebug=1 \
+		flux getattr tbon.zmqdebug >conf_override.out &&
+	test_cmp conf_override.exp conf_override.out
+'
+test_expect_success '--conf inline JSON sets broker config' '
+	cat <<-EOF >conf_json.exp &&
+	1
+	EOF
+	flux broker ${ARGS} \
+		--conf="{\"tbon\":{\"zmqdebug\":1}}" \
+		flux getattr tbon.zmqdebug >conf_json.out &&
+	test_cmp conf_json.exp conf_json.out
+'
+test_expect_success '--conf TOML file sets broker config' '
+	cat <<-EOF >conf_file.toml &&
+	[tbon]
+	zmqdebug = 1
+	EOF
+	cat <<-EOF >conf_file.exp &&
+	1
+	EOF
+	flux broker ${ARGS} \
+		--conf=conf_file.toml \
+		flux getattr tbon.zmqdebug >conf_file.out &&
+	test_cmp conf_file.exp conf_file.out
+'
+test_expect_success '--conf JSON file sets broker config' '
+	cat <<-EOF >conf_file.json &&
+	{"tbon":{"zmqdebug":1}}
+	EOF
+	cat <<-EOF >conf_json_file.exp &&
+	1
+	EOF
+	flux broker ${ARGS} \
+		--conf=conf_file.json \
+		flux getattr tbon.zmqdebug >conf_json_file.out &&
+	test_cmp conf_json_file.exp conf_json_file.out
+'
+test_expect_success '--conf with invalid value fails' '
+	test_must_fail flux broker ${ARGS} --conf=notafile true
+'
+
+#
+# test flux start passes --conf option through to broker
+#
+test_expect_success 'flux start --conf passes single option to broker' '
+	cat <<-EOF >start_conf.exp &&
+	1
+	EOF
+	flux start ${ARGS} --conf=tbon.zmqdebug=1 \
+		flux getattr tbon.zmqdebug >start_conf.out &&
+	test_cmp start_conf.exp start_conf.out
+'
+test_expect_success 'flux start --conf passes multiple options to broker' '
+	cat <<-EOF >start_conf_multi.exp &&
+	1
+	1
+	EOF
+	flux start ${ARGS} --conf=tbon.zmqdebug=1 --conf=tbon.zmq_io_threads=1 \
+		sh -c "flux getattr tbon.zmqdebug; \
+		       flux getattr tbon.zmq_io_threads" >start_conf_multi.out &&
+	test_cmp start_conf_multi.exp start_conf_multi.out
+'
+
 test_done


### PR DESCRIPTION
This PR adds a new `--conf` option to the Flux broker. The option improves upon the existing `-c, --config-path` option by allowing multiple use as well as dotted `KEY=VAL` syntax such as `tbon.tcp_user_timeout=5m` when an `=` appears in the option value, otherwise it falls through to parsing as inline JSON if a `{` appears at the beginning of the option argument, otherwise TOML if a newline appears, and finally loads as a config file (JSON if the filename extension is `.json`, TOML otherwise)

This somewhat mirrors what's supported in `flux batch` and `flux alloc`, except for "named configuration" support in those utilities.

`flux start` also gets a `--conf` option, but this is just passed along to the broker.

This option made a lot more sense to add to the broker, since the conf updates can be applied in memory after loading any file specified by `-c, --config-path` or `FLUX_CONF_DIR`, no temporary files required.