### PR TITLE
ci: pin macos lua version to 5.4

### DIFF
--- a/scripts/install-deps-macos.sh
+++ b/scripts/install-deps-macos.sh
@@ -23,12 +23,19 @@ brew install \
   libarchive \
   hwloc \
   sqlite \
-  lua \
+  lua@5.4 \
   luarocks \
   python3 \
   cffi \
   libyaml \
   jq
+
+# Make lua@5.4 the default lua, otherwise it will be 5.5:
+brew link --force lua@5.4
+
+# Point luarocks at the 5.4 installation
+luarocks config lua_dir $(brew --prefix lua@5.4)
+luarocks config lua_version 5.4
 
 python3 -m venv macos-venv
 source macos-venv/bin/activate
@@ -36,7 +43,6 @@ source macos-venv/bin/activate
 pip3 install setuptools
 pip3 install -r scripts/requirements-dev.txt
 
-# luaposix now required for configure:
-luarocks install luaposix
+luarocks --lua-version 5.4 install luaposix --tree /opt/homebrew
 
 echo "Now run scripts/configure-macos.sh"


### PR DESCRIPTION
Problem: The latest Lua version installed by brew in the macos ci builder is 5.5, but this version is not supported by flux-core or the luaposix module.

Pin Lua to v5.4 for now in macos. This unfortunately requires several steps to get right because brew pulls in 5.5 anyway.