### PR TITLE
scheduler: support RFC 14 range counts

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -65,6 +65,7 @@ nobase_fluxpy_PYTHON = \
 	resource/ResourcePool.py \
 	resource/ResourcePoolImplementation.py \
 	resource/Rv1Pool.py \
+	resource/ResourceCount.py \
 	resource/list.py \
 	resource/status.py \
 	resource/journal.py \

--- a/src/bindings/python/flux/resource/ResourceCount.py
+++ b/src/bindings/python/flux/resource/ResourceCount.py
@@ -1,0 +1,268 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""ResourceCount: parsed RFC 14/22 resource count with iteration support.
+
+A :class:`ResourceCount` wraps one of three count forms that may appear in a
+jobspec resource vertex:
+
+- a simple integer (fixed count)
+- an RFC 14 range dict ``{"min": N, "max": M, "operator": OP, "operand": K}``
+- an RFC 45 string (``"2-8:2:*"``, ``"2+"``, IDset ``"1,7-9"``, …)
+
+The design of the parsing interface mirrors ``libjob/count.h``::
+
+    count_create(json_t *)   →  ResourceCount.from_count_spec(int | dict | str)
+    count_first / count_next →  ResourceCount.valid_counts(available)
+"""
+
+from flux.idset import IDset
+
+
+def _expand_sequence(mn, mx, operator, operand):
+    """Expand a stepped RFC 14 arithmetic sequence into an IDset.
+
+    Args:
+        mn, mx (int): Inclusive bounds of the sequence.
+        operator (str): ``"+"`` (additive), ``"*"`` (multiplicative),
+            or ``"^"`` (exponential).
+        operand (int): Step value.
+
+    Returns:
+        IDset: All values in the sequence from *mn* to *mx*.
+
+    Raises:
+        ValueError: For unsupported operators, invalid operand/min combinations,
+            or sequences that would be empty or excessively large.
+    """
+    if operator not in ("+", "*", "^"):
+        raise ValueError(f"RFC 14 count: operator {operator!r} is not supported")
+    if operator in ("*", "^") and operand <= 1:
+        raise ValueError(
+            f"RFC 14 count: operator {operator!r} requires operand > 1, "
+            f"got {operand}"
+        )
+    if operator == "^" and mn < 2:
+        raise ValueError(f"RFC 14 count: operator '^' requires min >= 2, got {mn}")
+    if operator == "+" and operand <= 0:
+        raise ValueError(
+            f"RFC 14 count: additive operator requires operand > 0, got {operand}"
+        )
+    values = []
+    v = mn
+    while v <= mx:
+        values.append(v)
+        if operator == "+":
+            v = v + operand
+        elif operator == "*":
+            v = v * operand
+        else:  # "^"
+            v = v**operand
+        if len(values) > 65536:
+            raise ValueError("RFC 14 count: sequence too large to expand")
+    if not values:
+        raise ValueError(f"RFC 14 count: empty sequence (min={mn}, max={mx})")
+    return IDset(",".join(str(x) for x in values))
+
+
+class ResourceCount:
+    """Parsed RFC 14/22 resource count with full iteration support.
+
+    Wraps the three count forms that appear in a jobspec resource vertex
+    (integer, RFC 14 range dict, RFC 45 / IDset string) into a uniform object
+    that schedulers can iterate over candidate values.
+
+    Attributes:
+        min (int): Minimum (or fixed) count value.
+        max (int | None): Maximum count value.  ``None`` means unbounded.
+        _values (IDset | None): Explicit ordered set of valid values for
+            stepped arithmetic and IDset count forms.  ``None`` for simple
+            contiguous integer ranges and unbounded ranges.
+
+    See Also:
+        :meth:`from_count_spec` — construct from a parsed-jobspec count field.
+    """
+
+    __slots__ = ("min", "max", "_values")
+
+    def __init__(self, mn, mx, values=None):
+        self.min = mn
+        self.max = mx
+        self._values = values
+
+    @classmethod
+    def from_count_spec(cls, v, default=1):
+        """Parse an RFC 14/22 count spec and return a :class:`ResourceCount`.
+
+        Modeled after ``count_create()`` / ``count_decode()`` in
+        ``libjob/count.h``: accepts the same three representations that
+        appear in a JSON-parsed jobspec resource vertex.
+
+        Supported forms:
+
+        - **Integer**: ``4`` → ``ResourceCount(4, 4)``
+        - **Range dict**: ``{"min": 2, "max": 8}`` → ``ResourceCount(2, 8)``
+        - **Unbounded dict**: ``{"min": 2}`` → ``ResourceCount(2, None)``
+        - **Stepped dict**:
+          ``{"min": 2, "max": 8, "operator": "*", "operand": 2}``
+          → ``ResourceCount(2, 8, IDset("2,4,8"))``
+        - **RFC 45 range string**: ``"2-5"`` → ``ResourceCount(2, 5)``;
+          ``"2+"`` → ``ResourceCount(2, None)``
+        - **Stepped RFC 45 string**: ``"2-8:2:*"``
+          → ``ResourceCount(2, 8, IDset("2,4,8"))``
+        - **IDset string**: ``"1,7-9"``
+          → ``ResourceCount(1, 9, IDset("1,7-9"))``
+
+        Strings may optionally be surrounded by square brackets per RFC 45.
+
+        ``_values`` is ``None`` for simple contiguous ranges and unbounded
+        ranges; set to an :class:`~flux.idset.IDset` for stepped and
+        non-contiguous IDset forms.
+
+        Args:
+            v: Count spec — an ``int``, ``dict``, or ``str`` as it appears in
+                a JSON-decoded jobspec.  Any other type is treated as a fixed
+                count equal to *default*.
+            default (int): Fallback fixed count when *v* is not a recognised
+                type.  Defaults to ``1``.
+
+        Raises:
+            ValueError: For unbounded ranges with a non-unit step (cannot be
+                expanded to a finite set), unsupported operators, or
+                counts less than 1.
+        """
+        if isinstance(v, int):
+            if v < 1:
+                raise ValueError(f"RFC 14 count: integer count must be >= 1, got {v}")
+            return cls(v, v)
+        if isinstance(v, dict):
+            operator = v.get("operator", "+")
+            operand = int(v.get("operand", 1))
+            mn = int(v.get("min", default))
+            if mn < 1:
+                raise ValueError(f"RFC 14 count: min must be >= 1, got {mn}")
+            mx = v.get("max")
+            if mx is None:
+                if operator != "+" or operand != 1:
+                    raise ValueError(
+                        f"RFC 14 unbounded count with operator={operator!r} "
+                        f"operand={operand} cannot be expanded to a finite set"
+                    )
+                return cls(mn, None)
+            mx = int(mx)
+            if mx < mn:
+                raise ValueError(
+                    f"RFC 14 count: max must be >= min, got max={mx} min={mn}"
+                )
+            if operator == "+" and operand == 1:
+                return cls(mn, mx)
+            return cls(mn, mx, _expand_sequence(mn, mx, operator, operand))
+        if isinstance(v, str):
+            s = v.strip()
+            if s.startswith("[") and s.endswith("]"):
+                s = s[1:-1]
+            parts = s.split(":")
+            # Unbounded RFC 45 range: "min+" or "min+:operand:operator"
+            # Detected by the pre-colon segment ending with "+".
+            if parts[0].endswith("+"):
+                mn = int(parts[0][:-1])
+                if mn < 1:
+                    raise ValueError(f"RFC 14 count: min must be >= 1, got {mn}")
+                operand = int(parts[1]) if len(parts) > 1 else 1
+                operator = parts[2] if len(parts) > 2 else "+"
+                if operator != "+" or operand != 1:
+                    raise ValueError(
+                        f"RFC 45 unbounded count with operator={operator!r} "
+                        f"operand={operand} cannot be expanded to a finite set"
+                    )
+                return cls(mn, None)
+            # Bounded RFC 45 range with explicit operand: "min-max:operand[:operator]"
+            if len(parts) > 1:
+                lo_str, hi_str = parts[0].split("-")
+                mn, mx = int(lo_str), int(hi_str)
+                if mn < 1:
+                    raise ValueError(f"RFC 14 count: min must be >= 1, got {mn}")
+                if mx < mn:
+                    raise ValueError(
+                        f"RFC 14 count: max must be >= min, got max={mx} min={mn}"
+                    )
+                operand = int(parts[1])
+                operator = parts[2] if len(parts) > 2 else "+"
+                if operator == "+" and operand == 1:
+                    return cls(mn, mx)
+                return cls(mn, mx, _expand_sequence(mn, mx, operator, operand))
+            # IDset with commas (non-contiguous values): "1,7-9"
+            if "," in s:
+                ids = IDset(s)
+                mn = ids.first()
+                if mn < 1:
+                    raise ValueError(f"RFC 14 count: min must be >= 1, got {mn}")
+                return cls(mn, ids.last(), ids)
+            # Simple "min-max" range or plain integer
+            if "-" in s:
+                lo_str, hi_str = s.split("-", 1)
+                mn = int(lo_str)
+                if mn < 1:
+                    raise ValueError(f"RFC 14 count: min must be >= 1, got {mn}")
+                mx = int(hi_str)
+                if mx < mn:
+                    raise ValueError(
+                        f"RFC 14 count: max must be >= min, got max={mx} min={mn}"
+                    )
+                return cls(mn, mx)
+            mn = int(s)
+            if mn < 1:
+                raise ValueError(f"RFC 14 count: min must be >= 1, got {mn}")
+            return cls(mn, mn)
+        return cls(default, default)
+
+    def scaled(self, factor):
+        """Return a new ResourceCount with all values multiplied by *factor*.
+
+        Returns *self* unchanged when *factor* is 1 (avoids an allocation).
+        """
+        if factor == 1:
+            return self
+        mx = self.max * factor if self.max is not None else None
+        if self._values is not None:
+            new_ids = IDset(",".join(str(v * factor) for v in self._values))
+            return ResourceCount(self.min * factor, mx, new_ids)
+        return ResourceCount(self.min * factor, mx)
+
+    def valid_counts(self, available):
+        """Yield valid count values <= *available*, largest first.
+
+        Mirrors ``count_first()`` / ``count_next()`` from ``libjob/count.h``
+        but presents the sequence in descending order so callers can greedily
+        try the largest feasible allocation first.
+
+        Args:
+            available (int): Upper bound (e.g. number of available resources).
+
+        Yields:
+            int: Valid count values in descending order, from
+                ``min(available, max)`` (or just *available* if unbounded)
+                down to ``min``.  Nothing is yielded when
+                ``available < min``.
+        """
+        cap = min(available, self.max) if self.max is not None else available
+        if cap < self.min:
+            return
+        if self._values is not None:
+            for v in sorted(self._values, reverse=True):
+                if self.min <= v <= cap:
+                    yield v
+        else:
+            yield from range(cap, self.min - 1, -1)
+
+    def __repr__(self):
+        if self._values is not None:
+            return f"ResourceCount({self.min}, {self.max}, values={self._values!r})"
+        return f"ResourceCount({self.min}, {self.max})"

--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -45,6 +45,7 @@ from typing import Dict, List, Tuple
 
 from flux.idset import IDset
 from flux.job import JobID
+from flux.resource.ResourceCount import ResourceCount
 from flux.resource.ResourcePoolImplementation import (
     InfeasibleRequest,
     InsufficientResources,
@@ -62,18 +63,29 @@ class ResourceRequest:
     re-parse jobspec on every scheduling pass.
 
     Attributes:
-        nnodes (int): Minimum node count; 0 means any layout.
-        nslots (int): Total slot count.
+        node_count (ResourceCount | None): RFC 14 node count (scaled by
+            nodefactor), or ``None`` for slot-only layouts.  For exclusive
+            slot-only jobspecs this holds the slot count reinterpreted as
+            node count.
+        slot_count (ResourceCount): RFC 14 slot count.  For node-based layouts
+            this is the per-node slot count; for slot-only layouts it is the
+            total slot count; for exclusive slot-only layouts it is
+            ``ResourceCount(1, 1)``.
         slot_size (int): Cores per slot.
         gpu_per_slot (int): GPUs per slot.
         duration (float): Walltime in seconds; 0.0 means unlimited.
         constraint: RFC 31 constraint expression (dict) or None.
         exclusive (bool): Whole-node exclusive allocation.
+        nnodes (int): Minimum node count; derived from *node_count*.
+        nnodes_max (int | None): Maximum node count; ``None`` for unbounded.
+        nslots (int): Minimum total slot count; derived from *slot_count* and
+            *node_count*.
+        nslots_max (int | None): Maximum total slot count.
     """
 
     __slots__ = (
-        "nnodes",
-        "nslots",
+        "node_count",
+        "slot_count",
         "slot_size",
         "gpu_per_slot",
         "duration",
@@ -82,24 +94,61 @@ class ResourceRequest:
     )
 
     def __init__(
-        self, nnodes, nslots, slot_size, gpu_per_slot, duration, constraint, exclusive
+        self,
+        node_count,
+        slot_count,
+        slot_size,
+        gpu_per_slot,
+        duration,
+        constraint,
+        exclusive,
     ):
-        self.nnodes = nnodes
-        self.nslots = nslots
+        self.node_count = node_count
+        self.slot_count = slot_count
         self.slot_size = slot_size
         self.gpu_per_slot = gpu_per_slot
         self.duration = duration
         self.constraint = constraint
         self.exclusive = exclusive
 
+    @property
+    def nnodes(self):
+        """Minimum node count; 0 for slot-only layouts."""
+        return self.node_count.min if self.node_count is not None else 0
+
+    @property
+    def nnodes_max(self):
+        """Maximum node count; 0 for slot-only; None for unbounded."""
+        return self.node_count.max if self.node_count is not None else 0
+
+    @property
+    def nslots(self):
+        """Minimum total slot count."""
+        if self.node_count is None:
+            return self.slot_count.min
+        return self.slot_count.min * self.node_count.min
+
+    @property
+    def nslots_max(self):
+        """Maximum total slot count; None for unbounded."""
+        if self.node_count is None:
+            return self.slot_count.max
+        if self.node_count.max is None or self.slot_count.max is None:
+            return None
+        return self.slot_count.max * self.node_count.max
+
     @classmethod
     def from_jobspec(cls, jobspec):
-        """Parse a V1 jobspec dict and return a :class:`ResourceRequest`.
+        """Parse a jobspec dict and return a :class:`ResourceRequest`.
 
-        Handles the two common V1 layouts:
+        Walks the resource graph recursively, like libjjc, to support both
+        RFC 25 V1 jobspecs and jobspecs with non-V1 resource hierarchies.
+        Unknown resource types are skipped but their ``with`` children are
+        still traversed.  The version key value is not checked (see #6682).
 
-        - ``node → slot → core[+gpu]``  (``flux submit -N<n> ...``)
-        - ``slot → core[+gpu]``          (``flux submit -n<n> ...``)
+        RFC 14 range counts in all forms (integer, dict, RFC 45 string, idset
+        string) on the node or slot resource are fully supported: the scheduler
+        allocates as many resources as available up to the maximum.
 
         Raises:
             ValueError: If the jobspec cannot be parsed.
@@ -108,49 +157,87 @@ class ResourceRequest:
         resources = jobspec.get("resources", [])
         if not resources:
             raise ValueError("jobspec has no resources")
-        top = resources[0]
-        rtype = top.get("type")
-        if rtype == "node":
-            nnodes = top.get("count", 1)
-            slot = top["with"][0]
-            nslots_per_node = slot.get("count", 1)
-            nslots = nslots_per_node * nnodes
-            slot_children = slot["with"]
-        elif rtype == "slot":
-            nnodes = 0
-            nslots = top.get("count", 1)
-            slot_children = top["with"]
-        else:
-            raise ValueError(f"unsupported top-level resource type: {rtype!r}")
 
-        slot_size = 1
-        gpu_per_slot = 0
-        for child in slot_children:
-            if child.get("type") == "core":
-                slot_size = child.get("count", 1)
-            elif child.get("type") == "gpu":
-                gpu_per_slot = child.get("count", 1)
+        # State accumulated during the recursive walk (last-write-wins,
+        # matching libjjc behavior).
+        state = {
+            "nnodes": None,  # ResourceCount or None if no node vertex found
+            "nslots": None,  # ResourceCount or None if no slot vertex found
+            "slot_size": None,  # None until a core vertex is found
+            "gpu_per_slot": 0,
+            "exclusive": False,
+            "nodefactor": 1,  # product of non-node counts above node level
+        }
 
-        exclusive = bool(top.get("exclusive", False))
-        # Exclusive allocation is per-node; if nnodes was not specified
-        # (slot-only jobspec), each slot occupies one exclusive node.
-        if exclusive and nnodes == 0:
-            nnodes = nslots
+        def walk(res_list, nodefactor):
+            for vertex in res_list:
+                rtype = vertex.get("type", "")
+                count = ResourceCount.from_count_spec(vertex.get("count", 1))
+                children = vertex.get("with", [])
+                if rtype == "node":
+                    state["nnodes"] = count
+                    state["nodefactor"] = nodefactor
+                    if vertex.get("exclusive", False):
+                        state["exclusive"] = True
+                    if children:
+                        walk(children, nodefactor)
+                else:
+                    # Non-node: accumulate nodefactor (use min for ranges),
+                    # then record known types and recurse.
+                    new_nf = nodefactor * count.min
+                    if rtype == "slot":
+                        state["nslots"] = count
+                        if vertex.get("exclusive", False):
+                            state["exclusive"] = True
+                    elif rtype == "core":
+                        state["slot_size"] = count.min
+                    elif rtype == "gpu":
+                        state["gpu_per_slot"] = count.min
+                    # else: unknown type — ignore, continue recursing
+                    if children:
+                        walk(children, new_nf)
+
+        walk(resources, 1)
+
         # RFC 25: in jobspec V1, attributes.system and duration are required.
+        # Check this before validating the resource structure so that the error
+        # message matches what the C jj/jjc parsers produce for V1 jobspecs.
         system = jobspec.get("attributes", {}).get("system")
         if jobspec.get("version") == 1:
             if system is None:
                 raise ValueError("getting duration: Object item not found: system")
             if system.get("duration") is None:
                 raise ValueError("getting duration: Object item not found: duration")
+
+        if state["nslots"] is None:
+            raise ValueError("Unable to determine slot count")
+        if state["slot_size"] is None:
+            raise ValueError("Unable to determine slot size")
+
+        nf = state["nodefactor"]
+        sc = state["nslots"]  # ResourceCount for the slot vertex
+
+        if state["nnodes"] is not None:
+            node_count = state["nnodes"].scaled(nf)
+            slot_count = sc  # per-node slot ResourceCount
+        else:
+            node_count = None
+            slot_count = sc
+
+        exclusive = state["exclusive"]
+        # Exclusive allocation is per-node; if no node vertex was specified
+        # (slot-only jobspec), each slot occupies one exclusive node.
+        if exclusive and node_count is None:
+            node_count = slot_count  # slot count reinterpreted as node count
+            slot_count = ResourceCount(1, 1)  # 1 slot per exclusive node
         attrs = system or {}
         duration = attrs.get("duration") or 0.0
         constraint = attrs.get("constraints") or None
         return cls(
-            nnodes,
-            nslots,
-            slot_size,
-            gpu_per_slot,
+            node_count,
+            slot_count,
+            state["slot_size"],
+            state["gpu_per_slot"],
             float(duration),
             constraint,
             exclusive,
@@ -409,6 +496,20 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
             InfeasibleRequest: If the request can never be satisfied by
                 this pool's total capacity.
         """
+        # Reject stepped/IDset counts that this scheduler cannot honor.
+        # The stepped count form encodes constraints (e.g. power-of-two node
+        # counts) that the simple range allocator ignores; reject immediately
+        # rather than silently violating the constraint.
+        if request.node_count is not None and request.node_count._values is not None:
+            raise InfeasibleRequest(
+                "node count specifies discrete valid values that this scheduler "
+                "does not support; use a simple min-max range instead"
+            )
+        if request.slot_count is not None and request.slot_count._values is not None:
+            raise InfeasibleRequest(
+                "slot count specifies discrete valid values that this scheduler "
+                "does not support; use a simple min-max range instead"
+            )
         self._check_feasibility(
             request.nnodes,
             request.nslots,
@@ -433,6 +534,16 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
             InsufficientResources: Resources temporarily insufficient.
             InfeasibleRequest: Request structurally infeasible.
         """
+        if request.node_count is not None and request.node_count._values is not None:
+            raise InfeasibleRequest(
+                "node count specifies discrete valid values that this scheduler "
+                "does not support; use a simple min-max range instead"
+            )
+        if request.slot_count is not None and request.slot_count._values is not None:
+            raise InfeasibleRequest(
+                "slot count specifies discrete valid values that this scheduler "
+                "does not support; use a simple min-max range instead"
+            )
         nnodes = request.nnodes
         nslots = request.nslots
         slot_size = request.slot_size
@@ -475,9 +586,12 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
         selected: List[Tuple[int, dict, frozenset, frozenset]] = []
 
         if nnodes > 0:
-            slots_per_node = nslots // nnodes
+            nnodes_min = nnodes
+            # nnodes_max: same as min → fixed; larger → bounded range; None → unbounded
+            nnodes_target = request.nnodes_max
+            slots_per_node = nslots // nnodes_min
             for rank, info, free_cores, free_gpus in candidates:
-                if len(selected) >= nnodes:
+                if nnodes_target is not None and len(selected) >= nnodes_target:
                     break
                 if exclusive:
                     if len(free_cores) < len(info["cores"]):
@@ -492,15 +606,17 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                     alloc_cores = frozenset(sorted(free_cores)[:need_cores])
                     alloc_gpus = frozenset(sorted(free_gpus)[:need_gpus])
                 selected.append((rank, info, alloc_cores, alloc_gpus))
-            if len(selected) < nnodes:
+            if len(selected) < nnodes_min:
                 self._check_feasibility(
                     nnodes, nslots, slot_size, exclusive, constraint, gpu_per_slot
                 )
                 raise InsufficientResources("insufficient resources")
         else:
-            remaining_slots = nslots
+            nslots_min = nslots
+            nslots_target = request.nslots_max  # None → unbounded
+            allocated_slots = 0
             for rank, info, free_cores, free_gpus in candidates:
-                if remaining_slots <= 0:
+                if nslots_target is not None and allocated_slots >= nslots_target:
                     break
                 free_core_slots = len(free_cores) // slot_size
                 if gpu_per_slot > 0:
@@ -508,15 +624,18 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                     free_slots = min(free_core_slots, free_gpu_slots)
                 else:
                     free_slots = free_core_slots
-                take = min(free_slots, remaining_slots)
+                if nslots_target is not None:
+                    take = min(free_slots, nslots_target - allocated_slots)
+                else:
+                    take = free_slots  # unbounded: take all available on this node
                 if take > 0:
                     ncores_take = take * slot_size
                     ngpus_take = take * gpu_per_slot
                     alloc_cores = frozenset(sorted(free_cores)[:ncores_take])
                     alloc_gpus = frozenset(sorted(free_gpus)[:ngpus_take])
                     selected.append((rank, info, alloc_cores, alloc_gpus))
-                    remaining_slots -= take
-            if remaining_slots > 0:
+                    allocated_slots += take
+            if allocated_slots < nslots_min:
                 self._check_feasibility(
                     nnodes, nslots, slot_size, exclusive, constraint, gpu_per_slot
                 )

--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -522,11 +522,18 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                 )
                 raise InsufficientResources("insufficient resources")
 
+        # Compute actual allocated slot count for storage in R.
+        if nnodes > 0:
+            actual_nslots = slots_per_node * len(selected)
+        else:
+            actual_nslots = allocated_slots
+
         # Build result pool and update allocation state on self
         result = object.__new__(Rv1Pool)
         result._expiration = 0.0
         result._starttime = 0.0
         result._has_nodelist = True
+        result._nslots = actual_nslots
         result._properties = {}
         result._ranks = {}
         result._job_state = {}

--- a/src/bindings/python/flux/resource/Rv1Set.py
+++ b/src/bindings/python/flux/resource/Rv1Set.py
@@ -113,6 +113,7 @@ class Rv1Set(ResourceSetImplementation):
         execution = arg.get("execution", {})
         self._expiration = float(execution.get("expiration") or 0.0)
         self._starttime = float(execution.get("starttime") or 0.0)
+        self._nslots: int = int(execution.get("nslots") or 0)
 
         # Track whether the input included a nodelist so _build_dict can
         # round-trip it faithfully (nodelist is a Flux extension, not in RFC 20).
@@ -451,6 +452,8 @@ class Rv1Set(ResourceSetImplementation):
             "starttime": self._starttime,
             "expiration": self._expiration,
         }
+        if getattr(self, "_nslots", 0) > 0:
+            execution["nslots"] = self._nslots
 
         if getattr(self, "_has_nodelist", False):
             hostnames = [info["hostname"] for _, info in sorted(self._ranks.items())]

--- a/src/bindings/python/flux/resource/__init__.py
+++ b/src/bindings/python/flux/resource/__init__.py
@@ -10,6 +10,7 @@
 
 from flux.resource.Rv1Set import Rv1Set
 from flux.resource.ResourceSet import ResourceSet
+from flux.resource.ResourceCount import ResourceCount
 from flux.resource.list import resource_list, SchedResourceList
 from flux.resource.status import resource_status, ResourceStatus
 from flux.resource.journal import ResourceJournalConsumer

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -88,6 +88,7 @@ TESTSCRIPTS = \
 	t0035-content-sqlite-checkpoint.t \
 	t0036-broker-rundir.t \
 	t0037-content-files-checkpoint.t \
+	t0038-rreq-reader.t \
 	t0025-broker-state-machine.t \
 	t0027-broker-groups.t \
 	t0040-flux-sproc.t \
@@ -429,6 +430,7 @@ dist_check_SCRIPTS = \
 	scripts/sqlite-query.py \
 	scripts/sqlite-write.py \
 	scripts/pipe.py \
+	scripts/rreq-reader.py \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
 	valgrind/workload.d/job-info \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -328,6 +328,7 @@ TESTSCRIPTS = \
 	python/t0038-brokermod.py \
 	python/t0039-rv1pool.py \
 	python/t0040-proctitle.py \
+	python/t0041-resource-count.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -780,6 +780,24 @@ class TestRv1PoolEncode(unittest.TestCase):
         self.assertAlmostEqual(d["execution"]["starttime"], 100.0)
         self.assertAlmostEqual(d["execution"]["expiration"], 200.0)
 
+    def test_nslots_in_alloc_R(self):
+        """nslots is stored in R execution dict after alloc (regression of #6632)."""
+        p = Rv1Pool(R_4x4)
+        a = p.alloc(1, rr(0, 4, 1))
+        self.assertEqual(a.to_dict()["execution"]["nslots"], 4)
+
+    def test_nslots_absent_without_alloc(self):
+        """Pool not produced by alloc() has no nslots in R."""
+        p = Rv1Pool(R_4x4)
+        self.assertNotIn("nslots", p.to_dict()["execution"])
+
+    def test_nslots_round_trip(self):
+        """nslots survives to_dict() → Rv1Pool() round-trip."""
+        p = Rv1Pool(R_4x4)
+        a = p.alloc(1, rr(0, 4, 1))
+        p2 = Rv1Pool(a.to_dict())
+        self.assertEqual(p2.to_dict()["execution"]["nslots"], 4)
+
 
 class TestRv1PoolDumps(unittest.TestCase):
     def test_single_rank(self):
@@ -909,6 +927,193 @@ class TestFromJobspec(unittest.TestCase):
             with self.subTest(pool=type(pool).__name__):
                 rr = pool.parse_resource_request(jobspec)
                 self.assertIsNone(rr.constraint)
+
+
+class TestParseCount(unittest.TestCase):
+    """Tests for ResourceRequest._parse_count."""
+
+    def test_integer(self):
+        self.assertEqual(ResourceRequest._parse_count(4), (4, 4))
+
+    def test_dict_bounded(self):
+        self.assertEqual(ResourceRequest._parse_count({"min": 2, "max": 8}), (2, 8))
+
+    def test_dict_unbounded(self):
+        self.assertEqual(ResourceRequest._parse_count({"min": 2}), (2, None))
+
+    def test_dict_explicit_default_operator_accepted(self):
+        """Explicit operator='+' operand=1 is the implied default — accepted."""
+        self.assertEqual(
+            ResourceRequest._parse_count(
+                {"min": 2, "max": 8, "operator": "+", "operand": 1}
+            ),
+            (2, 8),
+        )
+
+    def test_dict_unsupported_operator_raises(self):
+        """operator='*' is not yet supported — raises ValueError."""
+        with self.assertRaises(ValueError):
+            ResourceRequest._parse_count(
+                {"min": 2, "max": 8, "operator": "*", "operand": 2}
+            )
+
+    def test_dict_nonunit_operand_raises(self):
+        """operator='+' with operand≠1 is not yet supported — raises ValueError."""
+        with self.assertRaises(ValueError):
+            ResourceRequest._parse_count(
+                {"min": 2, "max": 8, "operator": "+", "operand": 4}
+            )
+
+
+class TestRangeAlloc(unittest.TestCase):
+    """Tests for RFC 14 range count support in alloc()."""
+
+    def test_nnodes_bounded_range_takes_max(self):
+        """Request 2-4 nodes on 4-node pool → allocates all 4."""
+        pool = Rv1Pool(R_4x4)
+        result = pool.alloc(1, rr(nnodes=2, nslots=2, nnodes_max=4))
+        self.assertEqual(len(result._ranks), 4)
+
+    def test_nslots_stored_in_R(self):
+        """Actual allocated slot count is stored in R execution dict."""
+        pool = Rv1Pool(R_4x4)
+        result = pool.alloc(1, rr(nnodes=2, nslots=2, nnodes_max=4))
+        self.assertEqual(result.to_dict()["execution"]["nslots"], 4)
+
+    def test_nnodes_bounded_range_capped_at_max(self):
+        """Request 2-3 nodes on 4-node pool → allocates exactly 3."""
+        pool = Rv1Pool(R_4x4)
+        result = pool.alloc(1, rr(nnodes=2, nslots=2, nnodes_max=3))
+        self.assertEqual(len(result._ranks), 3)
+
+    def test_nnodes_bounded_range_min_satisfied(self):
+        """Request 2-4 nodes, only 2 up → allocates 2 (minimum)."""
+        pool = Rv1Pool(R_4x4)
+        pool.mark_down("2-3")
+        result = pool.alloc(1, rr(nnodes=2, nslots=2, nnodes_max=4))
+        self.assertEqual(len(result._ranks), 2)
+
+    def test_nnodes_bounded_range_below_min_raises(self):
+        """Request 3-4 nodes, only 2 up → InsufficientResources."""
+        pool = Rv1Pool(R_4x4)
+        pool.mark_down("2-3")
+        with self.assertRaises(InsufficientResources):
+            pool.alloc(1, rr(nnodes=3, nslots=3, nnodes_max=4))
+
+    def test_nnodes_range_max_exceeds_pool_is_feasible(self):
+        """Range min=2 max=8 on 4-node pool → allocates 4 (max capped at pool size)."""
+        pool = Rv1Pool(R_4x4)
+        result = pool.alloc(1, rr(nnodes=2, nslots=2, nnodes_max=8))
+        self.assertEqual(len(result._ranks), 4)
+
+    def test_nnodes_unbounded_takes_all(self):
+        """Unbounded nnodes_max (None) → allocates all available nodes."""
+        pool = Rv1Pool(R_4x4)
+        pool.mark_down("3")
+        result = pool.alloc(1, rr(nnodes=1, nslots=1, nnodes_max=None))
+        self.assertEqual(len(result._ranks), 3)
+
+    def test_nslots_bounded_range_takes_max(self):
+        """Request 2-8 slots on pool with 4 nodes × 4 cores → gets 16 slots."""
+        pool = Rv1Pool(R_4x4)
+        result = pool.alloc(1, rr(nnodes=0, nslots=2, nslots_max=16))
+        total = sum(len(r["cores"]) for r in result._ranks.values())
+        self.assertEqual(total, 16)
+
+    def test_nslots_bounded_range_capped_at_max(self):
+        """Request 2-6 slots on 16-slot pool → gets exactly 6."""
+        pool = Rv1Pool(R_4x4)
+        result = pool.alloc(1, rr(nnodes=0, nslots=2, nslots_max=6))
+        total = sum(len(r["cores"]) for r in result._ranks.values())
+        self.assertEqual(total, 6)
+
+    def test_nslots_unbounded_takes_all(self):
+        """Unbounded nslots_max (None) → drains all free slots."""
+        pool = Rv1Pool(R_4x4)
+        result = pool.alloc(1, rr(nnodes=0, nslots=1, nslots_max=None))
+        total = sum(len(r["cores"]) for r in result._ranks.values())
+        self.assertEqual(total, 16)  # 4 nodes × 4 cores
+
+    def test_from_jobspec_range_dict(self):
+        """from_jobspec with range dict sets nnodes/nnodes_max correctly."""
+        jobspec = {
+            "version": 1,
+            "resources": [
+                {
+                    "type": "node",
+                    "count": {"min": 2, "max": 4},
+                    "with": [
+                        {
+                            "type": "slot",
+                            "count": 1,
+                            "with": [{"type": "core", "count": 2}],
+                        }
+                    ],
+                }
+            ],
+            "tasks": [],
+            "attributes": {"system": {"duration": 60.0}},
+        }
+        pool = Rv1Pool(R_4x4)
+        req = pool.parse_resource_request(jobspec)
+        self.assertEqual(req.nnodes, 2)
+        self.assertEqual(req.nnodes_max, 4)
+        self.assertEqual(req.nslots, 2)  # 1 slot/node × 2 min nodes
+        self.assertEqual(req.nslots_max, 4)  # 1 slot/node × 4 max nodes
+
+    def test_from_jobspec_unbounded_range(self):
+        """from_jobspec with min-only count → nnodes_max is None (unbounded)."""
+        jobspec = {
+            "version": 1,
+            "resources": [
+                {
+                    "type": "node",
+                    "count": {"min": 1},
+                    "with": [
+                        {
+                            "type": "slot",
+                            "count": 1,
+                            "with": [{"type": "core", "count": 1}],
+                        }
+                    ],
+                }
+            ],
+            "tasks": [],
+            "attributes": {"system": {"duration": 60.0}},
+        }
+        pool = Rv1Pool(R_4x4)
+        req = pool.parse_resource_request(jobspec)
+        self.assertEqual(req.nnodes, 1)
+        self.assertIsNone(req.nnodes_max)
+        result = pool.alloc(1, req)
+        self.assertEqual(len(result._ranks), 4)
+
+    def test_fixed_count_nnodes_max_equals_nnodes(self):
+        """Fixed integer count → nnodes_max == nnodes (no range)."""
+        pool = Rv1Pool(R_4x4)
+        req = pool.parse_resource_request(
+            {
+                "version": 1,
+                "resources": [
+                    {
+                        "type": "node",
+                        "count": 2,
+                        "with": [
+                            {
+                                "type": "slot",
+                                "count": 1,
+                                "with": [{"type": "core", "count": 1}],
+                            }
+                        ],
+                    }
+                ],
+                "tasks": [],
+                "attributes": {"system": {"duration": 60.0}},
+            }
+        )
+        self.assertEqual(req.nnodes, 2)
+        self.assertEqual(req.nnodes_max, 2)
+
 
 
 if __name__ == "__main__":

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -15,8 +15,12 @@ import unittest
 
 import subflux  # noqa: F401 - for PYTHONPATH
 from flux.resource import InfeasibleRequest, InsufficientResources
+from flux.resource.ResourceCount import ResourceCount
 from flux.resource.Rv1Pool import ResourceRequest, Rv1Pool
 from pycotap import TAPTestRunner
+
+# Sentinel for "not provided" — distinguishes omitted from None (unbounded).
+_UNSET = object()
 
 
 def rr(
@@ -27,10 +31,31 @@ def rr(
     duration=0.0,
     constraint=None,
     exclusive=False,
+    nnodes_max=_UNSET,
+    nslots_max=_UNSET,
 ):
-    """Convenience wrapper to build a ResourceRequest for tests."""
+    """Convenience wrapper to build a ResourceRequest for tests.
+
+    Constructs :class:`ResourceCount` objects from flat parameters.  For node-based
+    layouts the per-node slot count is derived as ``nslots // nnodes``.
+    Pass ``nnodes_max=None`` for an unbounded node range; omit it for a
+    fixed count equal to *nnodes*.  Same semantics for ``nslots_max``.
+    """
+    if nnodes_max is _UNSET:
+        nnodes_max = nnodes
+    if nslots_max is _UNSET:
+        nslots_max = nslots
+
+    if nnodes > 0:
+        spn = nslots // nnodes  # slots per node (fixed)
+        node_count = ResourceCount(nnodes, nnodes_max)
+        slot_count = ResourceCount(spn, spn)
+    else:
+        node_count = None
+        slot_count = ResourceCount(nslots, nslots_max)
+
     return ResourceRequest(
-        nnodes, nslots, slot_size, gpu_per_slot, duration, constraint, exclusive
+        node_count, slot_count, slot_size, gpu_per_slot, duration, constraint, exclusive
     )
 
 
@@ -515,6 +540,40 @@ class TestRv1PoolCheckFeasibility(unittest.TestCase):
         with self.assertRaises(InsufficientResources):
             self.pool.alloc(2, rr(0, 9, 1))
 
+    def test_stepped_node_count_raises(self):
+        """Stepped node count (e.g. powers-of-two) is rejected immediately."""
+        jobspec = {
+            "version": 1,
+            "resources": [
+                {
+                    "type": "node",
+                    "count": {"min": 1, "max": 4, "operator": "*", "operand": 2},
+                    "with": [
+                        {
+                            "type": "slot",
+                            "count": 1,
+                            "with": [{"type": "core", "count": 1}],
+                        }
+                    ],
+                }
+            ],
+            "tasks": [],
+            "attributes": {"system": {"duration": 60.0}},
+        }
+        req = self.pool.parse_resource_request(jobspec)
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.check_feasibility(req)
+
+    def test_stepped_slot_count_raises(self):
+        """Stepped slot count is rejected immediately."""
+        from flux.idset import IDset
+
+        req = ResourceRequest(
+            None, ResourceCount(2, 8, IDset("2,4,8")), 1, 0, 60.0, None, False
+        )
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.check_feasibility(req)
+
 
 class TestRv1PoolCopy(unittest.TestCase):
     def setUp(self):
@@ -929,40 +988,111 @@ class TestFromJobspec(unittest.TestCase):
                 self.assertIsNone(rr.constraint)
 
 
-class TestParseCount(unittest.TestCase):
-    """Tests for ResourceRequest._parse_count."""
+class TestFromJobspecNonV1(unittest.TestCase):
+    """Tests for from_jobspec() with non-V1 resource hierarchies (regression of #6632).
 
-    def test_integer(self):
-        self.assertEqual(ResourceRequest._parse_count(4), (4, 4))
+    Expected nnodes/nslots values are cross-checked against the jjc-reader
+    output in t/t0024-jjc-reader.t for the corresponding use_case YAML files.
+    """
 
-    def test_dict_bounded(self):
-        self.assertEqual(ResourceRequest._parse_count({"min": 2, "max": 8}), (2, 8))
+    def test_nonv1_version_accepted(self):
+        """version != 1 is accepted (no duration check); slot→core parsed correctly.
 
-    def test_dict_unbounded(self):
-        self.assertEqual(ResourceRequest._parse_count({"min": 2}), (2, None))
+        Equivalent to use_case_2.5 (version: 999, slot(10)→core(1)).
+        jjc-reader: nodefactor=0 nnodes=0 nslots=10 slot_size=1
+        """
+        jobspec = {
+            "version": 999,
+            "resources": [
+                {
+                    "type": "slot",
+                    "count": 10,
+                    "with": [{"type": "core", "count": 1}],
+                }
+            ],
+            "tasks": [],
+            "attributes": {"system": {"duration": 3600.0}},
+        }
+        req = ResourceRequest.from_jobspec(jobspec)
+        self.assertEqual(req.nnodes, 0)
+        self.assertEqual(req.nslots, 10)
+        self.assertEqual(req.slot_size, 1)
 
-    def test_dict_explicit_default_operator_accepted(self):
-        """Explicit operator='+' operand=1 is the implied default — accepted."""
-        self.assertEqual(
-            ResourceRequest._parse_count(
-                {"min": 2, "max": 8, "operator": "+", "operand": 1}
-            ),
-            (2, 8),
-        )
+    def test_unknown_toplevel_type_skipped(self):
+        """Unknown top-level resource type is skipped; node found as sibling.
 
-    def test_dict_unsupported_operator_raises(self):
-        """operator='*' is not yet supported — raises ValueError."""
-        with self.assertRaises(ValueError):
-            ResourceRequest._parse_count(
-                {"min": 2, "max": 8, "operator": "*", "operand": 2}
-            )
+        Equivalent to use_case_1.9 (version: 1, ssd + node(1)→slot(1)→core(1)).
+        jjc-reader: nodefactor=1 nnodes=1 nslots=1 slot_size=1
+        """
+        jobspec = {
+            "version": 1,
+            "resources": [
+                {"type": "ssd", "count": 100000, "exclusive": True},
+                {
+                    "type": "node",
+                    "count": 1,
+                    "exclusive": False,
+                    "with": [
+                        {
+                            "type": "slot",
+                            "count": 1,
+                            "with": [{"type": "core", "count": 1}],
+                        }
+                    ],
+                },
+            ],
+            "tasks": [],
+            "attributes": {"system": {"duration": 3600.0}},
+        }
+        req = ResourceRequest.from_jobspec(jobspec)
+        self.assertEqual(req.nnodes, 1)
+        self.assertEqual(req.nslots, 1)
+        self.assertEqual(req.slot_size, 1)
 
-    def test_dict_nonunit_operand_raises(self):
-        """operator='+' with operand≠1 is not yet supported — raises ValueError."""
-        with self.assertRaises(ValueError):
-            ResourceRequest._parse_count(
-                {"min": 2, "max": 8, "operator": "+", "operand": 4}
-            )
+    def test_complex_hierarchy_nodefactor(self):
+        """Counts from non-node types above node accumulate into nodefactor.
+
+        Equivalent to use_case_1.10 shape: rack(5)→slot(2)→node(1)→slot(1)→core(2)
+        jjc-reader: nodefactor=10 nnodes=1 nslots=1 slot_size=2 exclusive=true
+        Old sched-simple: nnodes=10, nslots=10, slot_size=2
+        """
+        jobspec = {
+            "version": 1,
+            "resources": [
+                {
+                    "type": "rack",
+                    "count": 5,
+                    "with": [
+                        {
+                            "type": "slot",
+                            "count": 2,
+                            "with": [
+                                {
+                                    "type": "node",
+                                    "count": 1,
+                                    "exclusive": True,
+                                    "with": [
+                                        {
+                                            "type": "slot",
+                                            "count": 1,
+                                            "with": [{"type": "core", "count": 2}],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "tasks": [],
+            "attributes": {"system": {"duration": 3600.0}},
+        }
+        req = ResourceRequest.from_jobspec(jobspec)
+        # nodefactor=5*2=10, nnodes=10*1=10, nslots=1*10=10, slot_size=2
+        self.assertEqual(req.nnodes, 10)
+        self.assertEqual(req.nslots, 10)
+        self.assertEqual(req.slot_size, 2)
+        self.assertTrue(req.exclusive)
 
 
 class TestRangeAlloc(unittest.TestCase):
@@ -1113,7 +1243,6 @@ class TestRangeAlloc(unittest.TestCase):
         )
         self.assertEqual(req.nnodes, 2)
         self.assertEqual(req.nnodes_max, 2)
-
 
 
 if __name__ == "__main__":

--- a/t/python/t0041-resource-count.py
+++ b/t/python/t0041-resource-count.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Unit tests for ResourceCount and ResourceCount.from_count_spec.
+
+Coverage mirrors the C test suite in src/common/libjob/test/count.c,
+adapted for the Python interface:
+
+  - test_codec    → TestFromCountSpec* (parsing + structural verification)
+  - test_iteration → TestIteration (valid_counts yields all values)
+"""
+
+import unittest
+
+import subflux  # noqa: F401 - for PYTHONPATH
+from flux.idset import IDset
+from flux.resource.ResourceCount import ResourceCount
+from pycotap import TAPTestRunner
+
+# ---------------------------------------------------------------------------
+# TestResourceCount: constructor, valid_counts, scaled
+# ---------------------------------------------------------------------------
+
+
+class TestResourceCount(unittest.TestCase):
+    """Tests for the ResourceCount constructor, valid_counts(), and scaled()."""
+
+    # -- valid_counts ---------------------------------------------------------
+
+    def test_valid_counts_contiguous(self):
+        """Simple range yields all integers from cap down to min."""
+        c = ResourceCount(2, 5)
+        self.assertEqual(list(c.valid_counts(5)), [5, 4, 3, 2])
+
+    def test_valid_counts_contiguous_capped(self):
+        """available < max caps the top of the range."""
+        c = ResourceCount(2, 8)
+        self.assertEqual(list(c.valid_counts(5)), [5, 4, 3, 2])
+
+    def test_valid_counts_contiguous_below_min(self):
+        """available < min yields nothing."""
+        c = ResourceCount(4, 8)
+        self.assertEqual(list(c.valid_counts(3)), [])
+
+    def test_valid_counts_exact_min(self):
+        """available == min yields exactly min."""
+        c = ResourceCount(4, 8)
+        self.assertEqual(list(c.valid_counts(4)), [4])
+
+    def test_valid_counts_unbounded(self):
+        """Unbounded count (max=None) treats available as the cap."""
+        c = ResourceCount(2, None)
+        self.assertEqual(list(c.valid_counts(4)), [4, 3, 2])
+
+    def test_valid_counts_stepped(self):
+        """Stepped sequence (powers of two) yields only valid values."""
+        c = ResourceCount(2, 8, IDset("2,4,8"))
+        self.assertEqual(list(c.valid_counts(8)), [8, 4, 2])
+
+    def test_valid_counts_stepped_capped(self):
+        """Values above available are skipped in a stepped sequence."""
+        c = ResourceCount(2, 8, IDset("2,4,8"))
+        self.assertEqual(list(c.valid_counts(5)), [4, 2])
+
+    def test_valid_counts_stepped_below_min(self):
+        """Stepped sequence with available < min yields nothing."""
+        c = ResourceCount(2, 8, IDset("2,4,8"))
+        self.assertEqual(list(c.valid_counts(1)), [])
+
+    def test_valid_counts_fixed(self):
+        """Fixed count (min == max) yields exactly one value."""
+        c = ResourceCount(3, 3)
+        self.assertEqual(list(c.valid_counts(10)), [3])
+
+    def test_valid_counts_fixed_below(self):
+        """Fixed count with available < min yields nothing."""
+        c = ResourceCount(3, 3)
+        self.assertEqual(list(c.valid_counts(2)), [])
+
+    def test_valid_counts_integer_one(self):
+        """Count(1, 1) yields [1] when available >= 1."""
+        c = ResourceCount(1, 1)
+        self.assertEqual(list(c.valid_counts(1)), [1])
+
+    # -- scaled ---------------------------------------------------------------
+
+    def test_scaled_simple(self):
+        c = ResourceCount(2, 8)
+        s = c.scaled(4)
+        self.assertEqual(s.min, 8)
+        self.assertEqual(s.max, 32)
+        self.assertIsNone(s._values)
+
+    def test_scaled_unbounded(self):
+        c = ResourceCount(2, None)
+        s = c.scaled(3)
+        self.assertEqual(s.min, 6)
+        self.assertIsNone(s.max)
+
+    def test_scaled_factor_one_returns_self(self):
+        """scaled(1) returns the same object (identity optimisation)."""
+        c = ResourceCount(2, 8)
+        self.assertIs(c.scaled(1), c)
+
+    def test_scaled_with_values(self):
+        c = ResourceCount(2, 8, IDset("2,4,8"))
+        s = c.scaled(2)
+        self.assertEqual(s.min, 4)
+        self.assertEqual(s.max, 16)
+        self.assertIsNotNone(s._values)
+        self.assertEqual(list(s.valid_counts(16)), [16, 8, 4])
+
+
+# ---------------------------------------------------------------------------
+# TestFromCountSpecValid: well-formed inputs — structural checks
+# (mirrors test_codec 'expected success' rows)
+# ---------------------------------------------------------------------------
+
+
+class TestFromCountSpecValid(unittest.TestCase):
+    """Data-driven tests for well-formed from_count_spec inputs."""
+
+    def _check(self, spec, exp_min, exp_max, exp_values=None):
+        c = ResourceCount.from_count_spec(spec)
+        self.assertEqual(c.min, exp_min, f"spec={spec!r}")
+        self.assertEqual(c.max, exp_max, f"spec={spec!r}")
+        if exp_values is None:
+            self.assertIsNone(c._values, f"spec={spec!r}")
+        else:
+            self.assertIsNotNone(c._values, f"spec={spec!r}")
+
+    # integers
+    def test_integer_2(self):
+        self._check(2, 2, 2)
+
+    def test_integer_large(self):
+        self._check(1048576, 1048576, 1048576)
+
+    # plain integer strings
+    def test_str_2(self):
+        self._check("2", 2, 2)
+
+    def test_str_13(self):
+        self._check("13", 13, 13)
+
+    # IDset strings (comma-separated → _values set)
+    def test_str_idset_7_9(self):
+        c = ResourceCount.from_count_spec("7-9")
+        self.assertEqual(c.min, 7)
+        self.assertEqual(c.max, 9)
+        self.assertIsNone(c._values)  # contiguous → no _values
+
+    def test_str_idset_1_7_9(self):
+        c = ResourceCount.from_count_spec("1,7-9")
+        self.assertEqual(c.min, 1)
+        self.assertEqual(c.max, 9)
+        self.assertIsNotNone(c._values)
+
+    def test_str_idset_1_7_9_16(self):
+        c = ResourceCount.from_count_spec("1,7-9,16")
+        self.assertEqual(c.min, 1)
+        self.assertEqual(c.max, 16)
+        self.assertIsNotNone(c._values)
+
+    def test_str_idset_1_3_7_9_14_16(self):
+        c = ResourceCount.from_count_spec("1-3,7-9,14,16")
+        self.assertEqual(c.min, 1)
+        self.assertEqual(c.max, 16)
+        self.assertIsNotNone(c._values)
+
+    # bracketed forms
+    def test_str_bracketed_integer(self):
+        self._check("[2]", 2, 2)
+
+    def test_str_bracketed_range(self):
+        c = ResourceCount.from_count_spec("[7-9]")
+        self.assertEqual(c.min, 7)
+        self.assertEqual(c.max, 9)
+        self.assertIsNone(c._values)
+
+    def test_str_bracketed_idset(self):
+        c = ResourceCount.from_count_spec("[2,3,4,5]")
+        self.assertIsNotNone(c._values)
+
+    # RFC 45 range strings
+    def test_str_singleton_range(self):
+        self._check("3-3", 3, 3)
+
+    def test_str_unbounded(self):
+        self._check("2+", 2, None)
+
+    def test_str_bracketed_unbounded(self):
+        self._check("[2+]", 2, None)
+
+    def test_str_range_with_operand(self):
+        c = ResourceCount.from_count_spec("2-5:3")
+        self.assertEqual(c.min, 2)
+        self.assertEqual(c.max, 5)
+        self.assertIsNotNone(c._values)
+
+    def test_str_range_explicit_default_op(self):
+        c = ResourceCount.from_count_spec("2-5:1:+")
+        self.assertEqual(c.min, 2)
+        self.assertEqual(c.max, 5)
+        self.assertIsNone(c._values)
+
+    def test_str_multiplicative(self):
+        c = ResourceCount.from_count_spec("2-8:2:*")
+        self.assertEqual(c.min, 2)
+        self.assertEqual(c.max, 8)
+        self.assertIsNotNone(c._values)
+
+    def test_str_large_additive(self):
+        c = ResourceCount.from_count_spec("25-133:17:+")
+        self.assertEqual(c.min, 25)
+        self.assertEqual(c.max, 133)
+        self.assertIsNotNone(c._values)
+
+    def test_str_unbounded_explicit_operand(self):
+        self._check("2+:1:+", 2, None)
+
+    # dict forms
+    def test_dict_bounded(self):
+        self._check({"min": 2, "max": 8}, 2, 8)
+
+    def test_dict_singleton(self):
+        self._check({"min": 3, "max": 3}, 3, 3)
+
+    def test_dict_unbounded(self):
+        self._check({"min": 2}, 2, None)
+
+    def test_dict_explicit_default_op(self):
+        c = ResourceCount.from_count_spec(
+            {"min": 2, "max": 5, "operand": 1, "operator": "+"}
+        )
+        self.assertEqual(c.min, 2)
+        self.assertEqual(c.max, 5)
+        self.assertIsNone(c._values)
+
+    def test_dict_nonunit_additive(self):
+        c = ResourceCount.from_count_spec({"min": 2, "max": 5, "operand": 3})
+        self.assertIsNotNone(c._values)
+
+    def test_dict_multiplicative(self):
+        c = ResourceCount.from_count_spec(
+            {"min": 2, "max": 8, "operand": 2, "operator": "*"}
+        )
+        self.assertIsNotNone(c._values)
+
+    def test_dict_large_additive(self):
+        c = ResourceCount.from_count_spec(
+            {"min": 25, "max": 133, "operand": 17, "operator": "+"}
+        )
+        self.assertIsNotNone(c._values)
+
+    def test_dict_exponential(self):
+        c = ResourceCount.from_count_spec(
+            {"min": 2, "max": 16, "operand": 2, "operator": "^"}
+        )
+        self.assertIsNotNone(c._values)
+
+
+# ---------------------------------------------------------------------------
+# TestFromCountSpecErrors: malformed inputs that must raise ValueError
+# (mirrors test_codec 'expected failures' rows and test_iteration failures)
+# ---------------------------------------------------------------------------
+
+
+# (label, spec) pairs that must raise ValueError
+_INVALID_STRING_CASES = [
+    ("empty string", ""),
+    ("empty brackets", "[]"),
+    ("zero integer string", "0"),
+    ("zero min range", "0-8"),
+    ("zero in brackets", "[0]"),
+    ("negative leading dash", "-5"),
+    ("negative in brackets", "[-5]"),
+    ("max lt min simple range", "3-0"),
+    ("max lt min bracketed range", "[3-0]"),
+    ("max lt min with step", "3-2:1:+"),
+    ("missing max after dash", "0-"),
+    ("missing max in brackets", "[0-]"),
+    ("operand 1 multiplicative str", "2-8:1:*"),
+    ("operand 1 exponential str", "2-8:1:^"),
+    ("unknown operator str", "2-8:1:/"),
+    ("unbounded nonunit step", "2+:2:*"),
+    ("unbounded nonunit step exp", "2+:2:^"),
+    ("caret min 1", "1-16:2:^"),
+    ("float-like", "4.2"),
+    ("non-numeric", "x"),
+    ("trailing garbage after range", "1-2x"),
+    ("mismatched open bracket", "[0"),
+    ("mismatched close bracket", "0]"),
+]
+
+_INVALID_DICT_CASES = [
+    ("zero min", {"min": 0, "max": 8}),
+    ("negative min", {"min": -2, "max": 6, "operand": 1, "operator": "+"}),
+    ("max lt min additive", {"min": 3, "max": 1, "operand": 2, "operator": "+"}),
+    ("max lt min unit step", {"min": 3, "max": 1}),
+    ("operand 0 additive", {"min": 4, "max": 6, "operand": 0, "operator": "+"}),
+    ("operand 1 multiplicative", {"min": 2, "max": 16, "operand": 1, "operator": "*"}),
+    ("operand 1 exponential", {"min": 2, "max": 16, "operand": 1, "operator": "^"}),
+    ("caret min 1", {"min": 1, "max": 16, "operand": 2, "operator": "^"}),
+    ("unknown operator", {"min": 2, "max": 16, "operand": 1, "operator": "/"}),
+    ("unbounded nonunit step", {"min": 2, "operator": "*", "operand": 2}),
+    ("unbounded nonunit step exp", {"min": 2, "operator": "^", "operand": 2}),
+]
+
+
+class TestFromCountSpecErrors(unittest.TestCase):
+    """from_count_spec must raise ValueError for all malformed inputs."""
+
+    def _assert_invalid_string(self, label, spec):
+        with self.assertRaises((ValueError, Exception), msg=label):
+            ResourceCount.from_count_spec(spec)
+
+    def _assert_invalid_dict(self, label, spec):
+        with self.assertRaises(ValueError, msg=label):
+            ResourceCount.from_count_spec(spec)
+
+
+def _make_string_error_test(label, spec):
+    def test(self):
+        with self.assertRaises((ValueError, Exception), msg=label):
+            ResourceCount.from_count_spec(spec)
+
+    test.__name__ = "test_invalid_str_" + label.replace(" ", "_")
+    test.__doc__ = f"from_count_spec({spec!r}) must raise — {label}"
+    return test
+
+
+def _make_dict_error_test(label, spec):
+    def test(self):
+        with self.assertRaises(ValueError, msg=label):
+            ResourceCount.from_count_spec(spec)
+
+    test.__name__ = "test_invalid_dict_" + label.replace(" ", "_")
+    test.__doc__ = f"from_count_spec({spec!r}) must raise — {label}"
+    return test
+
+
+for _label, _spec in _INVALID_STRING_CASES:
+    setattr(
+        TestFromCountSpecErrors,
+        _make_string_error_test(_label, _spec).__name__,
+        _make_string_error_test(_label, _spec),
+    )
+
+for _label, _spec in _INVALID_DICT_CASES:
+    setattr(
+        TestFromCountSpecErrors,
+        _make_dict_error_test(_label, _spec).__name__,
+        _make_dict_error_test(_label, _spec),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestIteration: valid_counts enumerates all values correctly
+# (mirrors test_iteration in count.c; values are compared as sorted sets
+#  since valid_counts yields descending while C iterates ascending)
+# ---------------------------------------------------------------------------
+
+
+# (spec, expected_values_ascending)
+_ITERATION_CASES = [
+    # integer and simple string forms
+    (1, [1]),
+    ("13", [13]),
+    ("5,7,13", [5, 7, 13]),
+    # contiguous dict range
+    ({"min": 4, "max": 6}, [4, 5, 6]),
+    # explicit default operator — same as above
+    ({"min": 4, "max": 6, "operand": 1, "operator": "+"}, [4, 5, 6]),
+    # additive step (operand only, no explicit operator)
+    ({"min": 1, "max": 3, "operand": 2}, [1, 3]),
+    # additive step with explicit operator
+    ({"min": 1, "max": 3, "operand": 2, "operator": "+"}, [1, 3]),
+    # multiplicative
+    ({"min": 2, "max": 16, "operand": 2, "operator": "*"}, [2, 4, 8, 16]),
+    # exponential
+    ({"min": 2, "max": 16, "operand": 2, "operator": "^"}, [2, 4, 16]),
+    # string forms
+    ("2-5:3", [2, 5]),
+    ("2-5:1:+", [2, 3, 4, 5]),
+    ("2-8:2:*", [2, 4, 8]),
+    ("25-133:17:+", [25, 42, 59, 76, 93, 110, 127]),
+    ("2-16:2:^", [2, 4, 16]),
+    # large additive dict
+    (
+        {"min": 25, "max": 133, "operand": 17, "operator": "+"},
+        [25, 42, 59, 76, 93, 110, 127],
+    ),
+]
+
+
+def _make_iteration_test(spec, expected):
+    def test(self):
+        c = ResourceCount.from_count_spec(spec)
+        # valid_counts yields descending; compare as sorted lists
+        got = sorted(c.valid_counts(c.max if c.max is not None else expected[-1]))
+        self.assertEqual(got, sorted(expected), f"spec={spec!r}")
+
+    test.__name__ = "test_iter_" + repr(spec).replace(" ", "").replace("'", "")[:60]
+    test.__doc__ = f"iteration of {spec!r} yields {expected}"
+    return test
+
+
+class TestIteration(unittest.TestCase):
+    """valid_counts enumerates every value in the count, for all count forms."""
+
+
+for _spec, _expected in _ITERATION_CASES:
+    _t = _make_iteration_test(_spec, _expected)
+    setattr(TestIteration, _t.__name__, _t)
+
+
+# ---------------------------------------------------------------------------
+# TestFromCountSpecIterationErrors: inputs that must fail even via count_create
+# path (mirrors test_iteration expected failures)
+# ---------------------------------------------------------------------------
+
+
+class TestIterationErrors(unittest.TestCase):
+    def test_negative_integer_raises(self):
+        with self.assertRaises((ValueError, Exception)):
+            ResourceCount.from_count_spec(-1)
+
+    def test_string_missing_max_raises(self):
+        """'13-' (missing max) must raise."""
+        with self.assertRaises((ValueError, Exception)):
+            ResourceCount.from_count_spec("13-")
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/scripts/rreq-reader.py
+++ b/t/scripts/rreq-reader.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+"""rreq-reader: parse a JSON jobspec from stdin, print ResourceRequest fields.
+
+Output (one line):
+  nnodes=N nslots=M slot_size=P slot_gpus=R exclusive=T/F duration=D.D
+
+Exit 1 and print error to stderr on failure.
+"""
+
+import json
+import sys
+
+from flux.resource.Rv1Pool import ResourceRequest
+
+
+def main():
+    try:
+        jobspec = json.load(sys.stdin)
+        rr = ResourceRequest.from_jobspec(jobspec)
+    except (ValueError, KeyError) as e:
+        print(f"rreq-reader: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        f"nnodes={rr.nnodes} nslots={rr.nslots} "
+        f"slot_size={rr.slot_size} slot_gpus={rr.gpu_per_slot} "
+        f"exclusive={str(rr.exclusive).lower()} "
+        f"duration={rr.duration:.1f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/t/t0038-rreq-reader.t
+++ b/t/t0038-rreq-reader.t
@@ -1,0 +1,115 @@
+#!/bin/sh
+
+test_description='Test Python ResourceRequest.from_jobspec via rreq-reader'
+
+. `dirname $0`/sharness.sh
+
+rreq="flux python ${SHARNESS_TEST_SRCDIR}/scripts/rreq-reader.py"
+y2j="flux python ${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py"
+
+# ---------------------------------------------------------------------------
+# Inline error cases
+# ---------------------------------------------------------------------------
+
+test_expect_success 'rreq-reader: V1 missing attributes.system raises error' '
+	cat >input.$test_count <<-EOF &&
+	{"version":1,"resources":[{"type":"slot","count":1,"with":[{"type":"core","count":1}]}],"tasks":[],"attributes":{}}
+	EOF
+	test_expect_code 1 $rreq <input.$test_count >out.$test_count 2>err.$test_count &&
+	grep -q "system" err.$test_count
+'
+
+test_expect_success 'rreq-reader: V1 missing duration raises error' '
+	cat >input.$test_count <<-EOF &&
+	{"version":1,"resources":[{"type":"slot","count":1,"with":[{"type":"core","count":1}]}],"tasks":[],"attributes":{"system":{}}}
+	EOF
+	test_expect_code 1 $rreq <input.$test_count >out.$test_count 2>err.$test_count &&
+	grep -q "duration" err.$test_count
+'
+
+test_expect_success 'rreq-reader: stepped node count parses successfully' '
+	cat >input.$test_count <<-EOF &&
+	{"version":1,"resources":[{"type":"node","count":{"min":2,"max":8,"operator":"*","operand":2},"with":[{"type":"slot","count":1,"with":[{"type":"core","count":1}]}]}],"tasks":[],"attributes":{"system":{"duration":60}}}
+	EOF
+	cat >expected.$test_count <<-EOF &&
+	nnodes=2 nslots=2 slot_size=1 slot_gpus=0 exclusive=false duration=60.0
+	EOF
+	$rreq <input.$test_count >out.$test_count &&
+	test_cmp expected.$test_count out.$test_count
+'
+
+test_expect_success 'rreq-reader: no resources raises error' '
+	cat >input.$test_count <<-EOF &&
+	{"version":1,"resources":[],"tasks":[],"attributes":{"system":{"duration":60}}}
+	EOF
+	test_expect_code 1 $rreq <input.$test_count >out.$test_count 2>err.$test_count
+'
+
+# ---------------------------------------------------------------------------
+# Canonical jobspec YAML files that produce errors
+#
+# <filename-without-extension> ==<expected error substring>
+# ---------------------------------------------------------------------------
+
+cat <<EOF >invalid.txt
+attributes_system        ==Unable to determine slot size
+attributes_user          ==Unable to determine slot size
+basic                    ==Unable to determine slot size
+example2                 ==Unable to determine slot size
+resource_count_string_min_only ==Unable to determine slot size
+resource_count_string_range    ==Unable to determine slot size
+use_case_1.1             ==Unable to determine slot size
+use_case_1.2             ==Unable to determine slot size
+use_case_1.8             ==Unable to determine slot size
+use_case_2.1             ==Unable to determine slot size
+use_case_2.2             ==Unable to determine slot size
+use_case_2.6             ==Unable to determine slot size
+use_case_2.7             ==Unable to determine slot size
+EOF
+
+while read line; do
+	yaml=$(echo $line | awk -F== '{print $1}' | sed 's/  *$//').yaml
+	expected=$(echo $line | awk -F== '{print $2}')
+
+	test_expect_success "rreq-reader: $yaml gets expected error" '
+		echo $expected >expected.$test_count &&
+		cat $SHARNESS_TEST_SRCDIR/jobspec/valid/$yaml | $y2j >$test_count.json &&
+		test_expect_code 1 $rreq <$test_count.json >out.$test_count 2>err.$test_count &&
+		grep -qF "$expected" err.$test_count
+	'
+done <invalid.txt
+
+# ---------------------------------------------------------------------------
+# Canonical jobspec YAML files that parse successfully
+#
+# <filename-without-extension> ==<expected output>
+# ---------------------------------------------------------------------------
+
+cat <<EOF >valid.txt
+basic_v1    ==nnodes=0 nslots=1 slot_size=1 slot_gpus=0 exclusive=false duration=0.0
+example1    ==nnodes=4 nslots=4 slot_size=2 slot_gpus=0 exclusive=false duration=3600.0
+use_case_1.3  ==nnodes=4 nslots=16 slot_size=4 slot_gpus=0 exclusive=false duration=3600.0
+use_case_1.4  ==nnodes=4 nslots=16 slot_size=4 slot_gpus=0 exclusive=false duration=3600.0
+use_case_1.5  ==nnodes=2 nslots=4 slot_size=2 slot_gpus=0 exclusive=false duration=14400.0
+use_case_1.6  ==nnodes=2 nslots=2 slot_size=30 slot_gpus=0 exclusive=false duration=3600.0
+use_case_1.7  ==nnodes=3 nslots=3 slot_size=1 slot_gpus=0 exclusive=false duration=3600.0
+use_case_1.9  ==nnodes=1 nslots=1 slot_size=1 slot_gpus=0 exclusive=false duration=3600.0
+use_case_1.10 ==nnodes=10 nslots=10 slot_size=2 slot_gpus=0 exclusive=true duration=3600.0
+use_case_1.11 ==nnodes=2 nslots=2 slot_size=5 slot_gpus=7 exclusive=true duration=3600.0
+use_case_2.3  ==nnodes=0 nslots=10 slot_size=2 slot_gpus=0 exclusive=false duration=3600.0
+use_case_2.4  ==nnodes=1 nslots=1 slot_size=6 slot_gpus=0 exclusive=false duration=3600.0
+use_case_2.5  ==nnodes=0 nslots=10 slot_size=1 slot_gpus=0 exclusive=false duration=3600.0
+EOF
+
+while read line; do
+	yaml=$(echo $line | awk -F== '{print $1}' | sed 's/  *$//').yaml
+	expected=$(echo $line | awk -F== '{print $2}')
+
+	test_expect_success "rreq-reader: $yaml returns $expected" '
+		echo $expected >expected.$test_count &&
+		cat $SHARNESS_TEST_SRCDIR/jobspec/valid/$yaml | $y2j | $rreq >out.$test_count &&
+		test_cmp expected.$test_count out.$test_count
+	'
+done <valid.txt
+
+test_done


### PR DESCRIPTION
Problem: PR #6973 added range count support to the C sched-simple so that jobs with RFC 14 min/max count dicts would not be rejected.  When the C sched-simple was replaced by the Python implementation (PR #7461) this support was regressed: from_jobspec() treated any non-integer count as an error, causing jobs with range counts to be immediately denied.

Restore range support by adding _parse_count() to ResourceRequest to handle integer and dict {"min", "max"} count forms as they arrive from a JSON-parsed jobspec (RFC 14).

Since it was not much extra work, go beyond what the C version did (which only used the minimum value): add nnodes_max and nslots_max fields to ResourceRequest and update alloc() to greedily fill up to the maximum, or to pool capacity when max is absent, while requiring only the minimum to be satisfied.  The feasibility check on failure uses the minimum, so a range request whose max exceeds pool size is still considered feasible.

Raise ValueError for any operator/operand combination that implies different semantics than our current implementation.  The implied default (operator="+", operand=1, meaning any count in [min,max]) is accepted when stated explicitly.  The ValueError propagates to a job denial with a clear "not yet supported" message.

RFC 14 also defines operator and operand fields that constrain which counts within [min, max] are acceptable (addition, multiplication, exponentiation step functions).  RFC 45 defines a compact string representation of range expressions for use in command line interfaces. Both are left for follow-on work.