### PR TITLE
flux-resource: add queue display filtering and hidden-queues config to simplify output of `flux resource list`

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -497,7 +497,8 @@ The following field names can be specified for the **list** subcommand:
    Properties associated with resources.
 
 **propertiesx**
-   Properties associated with resources, but with queue names removed.
+   Properties associated with resources, but with all configured queue names
+   removed, regardless of any ``-q, --queue`` filter in effect.
 
 **nnodes**
    number of nodes

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -98,7 +98,9 @@ all
 .. option:: -q, --queue=QUEUE,...
 
   Filter results to only include resources in the specified *QUEUE*. Multiple
-  queues may be separated by a comma.
+  queues may be separated by a comma. When this option is used, the
+  ``{queue}`` output field reflects only the specified queues, even if
+  resources belong to additional queues.
 
 .. option:: -i, --include=TARGETS
 
@@ -488,7 +490,8 @@ The following field names can be specified for the **list** subcommand:
    State of node(s): "up", "down", "allocated", "free", "all"
 
 **queue**
-   queue(s) associated with resources.
+   Queue(s) associated with resources. When ``-q, --queue`` is used,
+   only the specified queues are shown.
 
 **properties**
    Properties associated with resources.

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -524,7 +524,8 @@ CONFIGURATION
 Similar to :man1:`flux-jobs`, the :program:`flux resource` command supports
 loading a set of config files for customizing utility output formats. Currently
 this can be used to register named format strings for the ``status``,
-``list``, and ``drain`` subcommands.
+``list``, and ``drain`` subcommands, or to suppress certain queues from the
+default output of :program:`flux resource list`.
 
 Configuration for each :program:`flux resource` subcommand is defined in a
 separate table, so to add a new format ``myformat`` for ``flux resource list``,
@@ -534,6 +535,17 @@ the following config file could be used::
   [list.formats.myformat]
   description = "My flux resource list format"
   format = "{state} {nodelist}"
+
+The ``[list]`` table also supports a ``hidden-queues`` option, which is a
+list of queue names to suppress from the ``{queue}`` output field in
+``flux resource list`` by default. Queues listed in ``hidden-queues`` are
+still shown when explicitly requested via ``-q, --queue``. This is useful
+for hiding catch-all queues (e.g. a queue that contains all nodes) that
+would otherwise clutter the default output::
+
+  # /etc/xdg/flux/flux-resource.toml
+  [list]
+  hidden-queues = ["all", "pall"]
 
 See :man1:`flux-jobs` :ref:`flux_jobs_configuration` section for more
 information about the order of precedence for loading these config files.

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -506,7 +506,7 @@ def drain_list(args):
 
 
 class ResourceSetExtra(ResourceSet):
-    def __init__(
+    def __init__(  # lgtm[py/missing-call-to-init]
         self,
         arg=None,
         version=1,

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -106,6 +106,13 @@ class FluxResourceConfig(UtilConfig):
                 for key2, val2 in value.items():
                     if key2 == "formats":
                         self.validate_formats(path, val2)
+                    elif key == "list" and key2 == "hidden-queues":
+                        if not isinstance(val2, list) or not all(
+                            isinstance(q, str) for q in val2
+                        ):
+                            raise ValueError(
+                                f"{path}: list.hidden-queues must be a list of strings"
+                            )
                     else:
                         raise ValueError(f"{path}: invalid key {key}.{key2}")
             else:
@@ -500,11 +507,18 @@ def drain_list(args):
 
 class ResourceSetExtra(ResourceSet):
     def __init__(
-        self, arg=None, version=1, flux_config=None, queue=None, queue_filter=None
+        self,
+        arg=None,
+        version=1,
+        flux_config=None,
+        queue=None,
+        queue_filter=None,
+        hidden_queues=None,
     ):
         self.flux_config = flux_config
         self._queue = queue
         self._queue_filter = queue_filter
+        self._hidden_queues = hidden_queues or set()
         if isinstance(arg, ResourceSet):
             self._rset = arg
             if arg.state:
@@ -540,7 +554,10 @@ class ResourceSetExtra(ResourceSet):
                 return ""
             properties = json.loads(self.get_properties())
             for key, value in self.flux_config["queues"].items():
-                if self._queue_filter and key not in self._queue_filter:
+                if self._queue_filter:
+                    if key not in self._queue_filter:
+                        continue
+                elif key in self._hidden_queues:
                     continue
                 if "requires" not in value or set(value["requires"]).issubset(
                     set(properties)
@@ -577,11 +594,14 @@ def split_by_property_combinations(rset):
     return [rset.copy_constraint(x) for x in constraint_combinations(rset)]
 
 
-def resources_uniq_lines(resources, states, formatter, config, queues=None):
+def resources_uniq_lines(
+    resources, states, formatter, config, queues=None, hidden_queues=None
+):
     """
     Generate a set of resource sets that would produce unique lines given
     the ResourceSet formatter argument. Include only the provided states
     """
+    hidden_queues = hidden_queues or set()
     #  uniq_fields are the fields on which to combine like results
     uniq_fields = ["state", "properties", "propertiesx", "queue"]
 
@@ -606,14 +626,18 @@ def resources_uniq_lines(resources, states, formatter, config, queues=None):
     #  ResourceSetExtra.queue before expanding 'queues' to the full
     #  configured queue list below. propertiesx always strips all
     #  configured queue names regardless of the filter.
-    queue_filter = set(queues) if queues else None
+    queue_filter = queues if queues else None
 
     #  Get a list of configured queues if a specific list of queues
-    #  was not supplied by the caller. If no queues are configured then
-    #  one "anonymous" queue is simulated with [None]
+    #  was not supplied by the caller. Hidden queues are excluded from the
+    #  default list but are still visible when explicitly requested via -q.
+    #  If no queues are configured then one "anonymous" queue is simulated
+    #  with [None].
     if not queues:
         if config and "queues" in config:
-            queues = config["queues"].keys()
+            queues = [q for q in config["queues"] if q not in hidden_queues]
+            if not queues:
+                queues = [None]
         else:
             queues = [None]
 
@@ -640,7 +664,12 @@ def resources_uniq_lines(resources, states, formatter, config, queues=None):
             if not rset.ranks:
                 continue
             rset.state = state
-            rset = ResourceSetExtra(rset, flux_config=config, queue_filter=queue_filter)
+            rset = ResourceSetExtra(
+                rset,
+                flux_config=config,
+                queue_filter=queue_filter,
+                hidden_queues=hidden_queues,
+            )
             key = fmt.format(rset)
 
             if key not in lines:
@@ -716,11 +745,18 @@ def list_handler(args):
     }
     resources, config = get_resource_list(args)
 
-    fmt = FluxResourceConfig("list").load().get_format_string(args.format)
+    list_config = FluxResourceConfig("list").load()
+    fmt = list_config.get_format_string(args.format)
     formatter = flux.util.OutputFormat(fmt, headings=headings)
+    hidden_queues = set(list_config.config.get("hidden-queues", []))
 
     lines = resources_uniq_lines(
-        resources, args.states, formatter, config, queues=args.queue
+        resources,
+        args.states,
+        formatter,
+        config,
+        queues=args.queue,
+        hidden_queues=hidden_queues,
     )
     items = sort_output(args, lines.values())
     if args.skip_empty or (args.include and not args.no_skip_empty):

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -499,9 +499,12 @@ def drain_list(args):
 
 
 class ResourceSetExtra(ResourceSet):
-    def __init__(self, arg=None, version=1, flux_config=None, queue=None):
+    def __init__(
+        self, arg=None, version=1, flux_config=None, queue=None, queue_filter=None
+    ):
         self.flux_config = flux_config
         self._queue = queue
+        self._queue_filter = queue_filter
         if isinstance(arg, ResourceSet):
             self._rset = arg
             if arg.state:
@@ -515,12 +518,11 @@ class ResourceSetExtra(ResourceSet):
     @property
     def propertiesx(self):
         properties = json.loads(self.get_properties())
-        queues = self.queue
-        if self.queue:
-            queues = queues.split(",")
-            for q in queues:
-                if q in properties:
-                    properties.pop(q)
+        #  Strip all configured queue names from properties, so that
+        #  properties used only for queue membership are not displayed.
+        if self.flux_config and "queues" in self.flux_config:
+            for q in self.flux_config["queues"]:
+                properties.pop(q, None)
         return ",".join(properties.keys())
 
     @property
@@ -538,6 +540,8 @@ class ResourceSetExtra(ResourceSet):
                 return ""
             properties = json.loads(self.get_properties())
             for key, value in self.flux_config["queues"].items():
+                if self._queue_filter and key not in self._queue_filter:
+                    continue
                 if "requires" not in value or set(value["requires"]).issubset(
                     set(properties)
                 ):
@@ -598,6 +602,12 @@ def resources_uniq_lines(resources, states, formatter, config, queues=None):
 
     fmt = flux.util.OutputFormat(uniq_fmt, headings=formatter.headings)
 
+    #  If specific queues were requested, save them as a filter for
+    #  ResourceSetExtra.queue before expanding 'queues' to the full
+    #  configured queue list below. propertiesx always strips all
+    #  configured queue names regardless of the filter.
+    queue_filter = set(queues) if queues else None
+
     #  Get a list of configured queues if a specific list of queues
     #  was not supplied by the caller. If no queues are configured then
     #  one "anonymous" queue is simulated with [None]
@@ -630,7 +640,7 @@ def resources_uniq_lines(resources, states, formatter, config, queues=None):
             if not rset.ranks:
                 continue
             rset.state = state
-            rset = ResourceSetExtra(rset, flux_config=config)
+            rset = ResourceSetExtra(rset, flux_config=config, queue_filter=queue_filter)
             key = fmt.format(rset)
 
             if key not in lines:

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -553,12 +553,11 @@ test_expect_success 'flux resource lists expected queues in states (every)' '
 '
 test_expect_success 'flux resource list --queue works for a queue with no constraints' '
 	flux resource list --queue=every -o "{state} {nnodes} {queue}" >queue-every.out &&
-	test $(grep "free 1" queue-every.out | grep -c batch) -eq 1 &&
-	test $(grep "free 1" queue-every.out | grep -c debug) -eq 1 &&
-	test $(grep "free 1" queue-every.out | grep -c every) -eq 2 &&
-	test $(grep "allocated 1" queue-every.out | grep -c batch) -eq 1 &&
-	test $(grep "allocated 1" queue-every.out | grep -c debug) -eq 1 &&
-	test $(grep "allocated 1" queue-every.out | grep -c every) -eq 2
+	test_debug "cat queue-every.out" &&
+	grep "free 2 every" queue-every.out &&
+	grep "allocated 2 every" queue-every.out &&
+	test_must_fail grep batch queue-every.out &&
+	test_must_fail grep debug queue-every.out
 '
 test_expect_success 'flux resource list includes queue names for empty sets' '
 	# There are no nodes in 'down' state in this test, so use that:

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -597,6 +597,42 @@ test_expect_success 'flux resource list includes queue names for empty sets (mul
 	grep "debug down 0" queue-batch,debug-down.out &&
 	grep "batch down 0" queue-batch,debug-down.out
 '
+test_expect_success 'setup hidden-queues config' '
+	mkdir -p hidden-config/flux &&
+	cat <<-EOF >hidden-config/flux/flux-resource.toml
+	[list]
+	hidden-queues = ["every"]
+	EOF
+'
+test_expect_success 'flux resource list hidden-queues suppresses queue' '
+	XDG_CONFIG_HOME=$(pwd)/hidden-config \
+		flux resource list -o "{state} {nnodes} {queue}" \
+		>hidden-queues.out &&
+	test_debug "cat hidden-queues.out" &&
+	test_must_fail grep -w every hidden-queues.out &&
+	grep batch hidden-queues.out &&
+	grep debug hidden-queues.out
+'
+test_expect_success 'flux resource list -q shows hidden queue when explicitly requested' '
+	XDG_CONFIG_HOME=$(pwd)/hidden-config \
+		flux resource list -q every \
+		-o "{state} {nnodes} {queue}" >hidden-q-every.out &&
+	test_debug "cat hidden-q-every.out" &&
+	grep -w every hidden-q-every.out &&
+	test_must_fail grep -w batch hidden-q-every.out &&
+	test_must_fail grep -w debug hidden-q-every.out
+'
+test_expect_success 'flux resource list rejects invalid hidden-queues config' '
+	mkdir -p bad-config/flux &&
+	cat <<-EOF >bad-config/flux/flux-resource.toml &&
+	[list]
+	hidden-queues = "not-a-list"
+	EOF
+	test_must_fail env XDG_CONFIG_HOME=$(pwd)/bad-config \
+		flux resource list 2>bad-config.err &&
+	test_debug "cat bad-config.err" &&
+	grep "hidden-queues" bad-config.err
+'
 test_expect_success 'cleanup jobs' '
 	flux cancel $(cat job2A.id) $(cat job2B.id)
 '

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -486,6 +486,12 @@ test_expect_success 'flux resource list -q shows only requested queue when node 
 	grep "free 2 batch" listqueue_multi_q.out &&
 	test_must_fail grep -w "all" listqueue_multi_q.out
 '
+test_expect_success 'flux resource list -q strips all queue names from propertiesx' '
+	flux resource list -q batch -o "{state} {nnodes} {propertiesx}" \
+		>listpropx_multi_q.out &&
+	test_debug "cat listpropx_multi_q.out" &&
+	grep "free 2 $" listpropx_multi_q.out
+'
 test_expect_success 'configure queues and resource with extra property' '
 	flux R encode -r 0-3 -p batch:0-1 -p debug:2-3 -p foo:0-3\
 	   | tr -d "\n" \

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -633,6 +633,54 @@ test_expect_success 'flux resource list rejects invalid hidden-queues config' '
 	test_debug "cat bad-config.err" &&
 	grep "hidden-queues" bad-config.err
 '
+test_expect_success 'setup config with hidden-queues and custom format in same file' '
+	mkdir -p combo-config/flux &&
+	cat <<-EOF >combo-config/flux/flux-resource.toml
+	[list]
+	hidden-queues = ["every"]
+	[list.formats.myformat]
+	description = "test format"
+	format = "{state} {nnodes} {queue}"
+	EOF
+'
+test_expect_success 'list.hidden-queues and list.formats can coexist in same config file' '
+	XDG_CONFIG_HOME=$(pwd)/combo-config \
+		flux resource list -o "{state} {nnodes} {queue}" \
+		>combo-hidden.out &&
+	test_debug "cat combo-hidden.out" &&
+	test_must_fail grep -w every combo-hidden.out &&
+	XDG_CONFIG_HOME=$(pwd)/combo-config \
+		flux resource list -o myformat \
+		>combo-format.out &&
+	test_debug "cat combo-format.out" &&
+	grep batch combo-format.out
+'
+test_expect_success 'setup split config: hidden-queues in one file, format in another' '
+	mkdir -p split-hidden-config/flux split-format-config/flux &&
+	cat <<-EOF >split-hidden-config/flux/flux-resource.toml &&
+	[list]
+	hidden-queues = ["every"]
+	EOF
+	cat <<-EOF >split-format-config/flux/flux-resource.toml
+	[list.formats.myformat2]
+	description = "test format 2"
+	format = "{state} {nnodes} {queue}"
+	EOF
+'
+test_expect_success 'list.hidden-queues not overwritten when format added in separate config' '
+	XDG_CONFIG_HOME=$(pwd)/split-format-config \
+	XDG_CONFIG_DIRS=$(pwd)/split-hidden-config \
+		flux resource list -o "{state} {nnodes} {queue}" \
+		>split-hidden.out &&
+	test_debug "cat split-hidden.out" &&
+	test_must_fail grep -w every split-hidden.out &&
+	XDG_CONFIG_HOME=$(pwd)/split-format-config \
+	XDG_CONFIG_DIRS=$(pwd)/split-hidden-config \
+		flux resource list -o myformat2 \
+		>split-format.out &&
+	test_debug "cat split-format.out" &&
+	grep batch split-format.out
+'
 test_expect_success 'cleanup jobs' '
 	flux cancel $(cat job2A.id) $(cat job2B.id)
 '

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -480,6 +480,12 @@ test_expect_success 'flux resource lists no properties in propertiesx (multi)' '
 	flux resource list -o "{state} {nnodes} {propertiesx}" > listpropx_multi.out &&
 	grep "free 4" listpropx_multi.out
 '
+test_expect_success 'flux resource list -q shows only requested queue when node is in multiple queues' '
+	flux resource list -q batch -o "{state} {nnodes} {queue}" >listqueue_multi_q.out &&
+	test_debug "cat listqueue_multi_q.out" &&
+	grep "free 2 batch" listqueue_multi_q.out &&
+	test_must_fail grep -w "all" listqueue_multi_q.out
+'
 test_expect_success 'configure queues and resource with extra property' '
 	flux R encode -r 0-3 -p batch:0-1 -p debug:2-3 -p foo:0-3\
 	   | tr -d "\n" \


### PR DESCRIPTION
This PR makes a couple simple changes to `flux resource list` to make output less cluttered on systems with overlapping queues. There's a couple changes here:

1. When using `flux resource list -q, --queue=`, only display the selected queues in the QUEUE column. Properties for other queues are also stripped so that listing a single queue is much more manageable when there are overlapping queues.
2. Support a new `list.hidden-queues` option in the `flux-resource.toml` config. This contains an array of queue names that should be suppressed in output by default. This is useful for the case of an `all` or `pall` queue that overlaps with every other queue and clutters default `flux resource list` output.

Unfortunately, there's a bit of a version problem now with the `flux-resource.toml` and other utility config files. The config file loader raises a fatal error on unknown keys, so new config items can't be placed in configuration until all versions being used support the key in question. I'm not sure if the fatal error should be changed to a warning, or if there's some other, more practical fix.