### PR TITLE
avoid masking the exit status of the task that triggered a `exit-timeout` or `exit-on-error` job exception

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -181,6 +181,7 @@ MAN3_FILES_SECONDARY = \
 	man3/flux_shell_err.3 \
 	man3/flux_shell_fatal.3 \
 	man3/flux_shell_raise.3 \
+	man3/flux_shell_raise_exit_status.3 \
 	man3/flux_shell_log_setlevel.3 \
 	man3/flux_shell_task_info_unpack.3 \
 	man3/flux_shell_task_cmd.3 \

--- a/doc/man3/flux_shell_log.rst
+++ b/doc/man3/flux_shell_log.rst
@@ -39,6 +39,10 @@ SYNOPSIS
                           const char *fmt,
                           ...);
 
+   void flux_shell_raise_exit_status (int wait_status,
+                                      const char *fmt,
+                                      ...);
+
    int flux_shell_log_setlevel (int level, const char *dest);
 
 Link with :command:`-lflux-core`.
@@ -109,6 +113,19 @@ note that the choices of :var:`errnum` are either 0 or :var:`errno`.
 :func:`flux_shell_raise` explicitly raises an exception for the current
 job of the given :var:`type` and :var:`severity`. Exceptions of severity 0
 will result in termination of the job by the execution system.
+
+:func:`flux_shell_raise_exit_status` raises a fatal exec exception
+(type ``exec``, severity 0) for the current job, and additionally
+records :var:`wait_status` as the job's exit status when it is >= 0.
+The :var:`wait_status` should be the raw POSIX wait status (as returned
+by :linux:man2:`waitpid`) of the failing task, so that the job exit
+status reflects the actual task failure rather than the status of tasks
+subsequently killed during job termination. If :var:`wait_status` is < 0,
+the function behaves like :func:`flux_shell_raise` with type ``exec``
+and severity 0.  In either case, once an exception has been successfully
+raised, the function sets an internal flag to prevent a duplicate
+exception from being raised by a subsequent call to :func:`flux_shell_fatal`
+or :func:`flux_shell_raise`.
 
 :func:`flux_shell_log_setlevel` sets default severity of logging
 destination :var:`dest` to :var:`level`. If :var:`dest` is NULL then the

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -283,6 +283,7 @@ man_pages = [
     ('man3/flux_shell_log', 'flux_shell_err', 'Log shell plugin messages to registered shell loggers', [author], 3),
     ('man3/flux_shell_log', 'flux_shell_fatal', 'Log shell plugin messages to registered shell loggers', [author], 3),
     ('man3/flux_shell_log', 'flux_shell_raise', 'Log shell plugin messages to registered shell loggers', [author], 3),
+    ('man3/flux_shell_log', 'flux_shell_raise_exit_status', 'Log shell plugin messages to registered shell loggers', [author], 3),
     ('man3/flux_shell_log', 'flux_shell_log_setlevel', 'Log shell plugin messages to registered shell loggers', [author], 3),
     ('man3/flux_shell_log', 'flux_shell_log', 'Log shell plugin messages to registered shell loggers', [author], 3),
     ('man3/flux_shell_plugstack_call', 'flux_shell_plugstack_call', 'Calls the function referenced by topic.', [author], 3),

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -90,6 +90,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <signal.h>
+#include <sys/wait.h>
 #include <flux/core.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -198,6 +199,7 @@ static struct jobinfo * jobinfo_new (void)
 {
     struct jobinfo *job = calloc (1, sizeof (*job));
     job->refcount = 1;
+    job->exception_wait_status = -1;
     return job;
 }
 
@@ -391,8 +393,12 @@ static void jobinfo_complete (struct jobinfo *job, const struct idset *ranks)
     flux_t *h = job->ctx->h;
     job->running = 0;
 
-    if (job->exception_in_progress && job->wait_status == 0)
-        job->wait_status = 1<<8;
+    if (job->exception_in_progress) {
+        if (job->exception_wait_status >= 0)
+            job->wait_status = job->exception_wait_status;
+        else if (job->wait_status == 0)
+            job->wait_status = 1<<8;
+    }
 
     if (h && job->req) {
         jobinfo_emit_event_pack_nowait (job, "complete",
@@ -1411,15 +1417,17 @@ static void exception_cb (flux_t *h,
     struct job_exec_ctx *ctx = arg;
     flux_jobid_t id;
     int severity = 0;
+    int wait_status = -1;
     const char *type = NULL;
     struct jobinfo *job = NULL;
 
     if (flux_event_unpack (msg,
                            NULL,
-                           "{s:I s:s s:i}",
+                           "{s:I s:s s:i s?i}",
                            "id", &id,
                            "type", &type,
-                           "severity", &severity) < 0) {
+                           "severity", &severity,
+                           "wait_status", &wait_status) < 0) {
         flux_log_error (h, "job-exception event");
         return;
     }
@@ -1437,6 +1445,17 @@ static void exception_cb (flux_t *h,
          *   doesn't dump a duplicate exception into the eventlog.
          */
         job->exception_in_progress = 1;
+        /*  If the exception includes a task wait_status, convert it to
+         *  shell exit status form and record it for use in jobinfo_complete().
+         */
+        if (wait_status >= 0) {
+            int exit_code;
+            if (WIFSIGNALED (wait_status))
+                exit_code = 128 + WTERMSIG (wait_status);
+            else
+                exit_code = WEXITSTATUS (wait_status);
+            job->exception_wait_status = exit_code << 8;
+        }
         flux_log (h, LOG_DEBUG, "exec aborted: id=%s", idf58 (id));
         jobinfo_fatal_error (job, 0, "aborted due to exception type=%s", type);
     }

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -92,6 +92,7 @@ struct jobinfo {
 
     int                   reattach;      /* job-manager reattach attempt */
     int                   wait_status;
+    int                   exception_wait_status; /* from exception event, or -1 */
 
     struct eventlogger *  ev;           /* event batcher */
 

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -65,16 +65,18 @@ int raise_check_severity (int severity)
     return 0;
 }
 
-int raise_job_exception (struct job_manager *ctx,
-                         struct job *job,
-                         const char *type,
-                         int severity,
-                         uint32_t userid,
-                         const char *note)
+static int raise_job_exception_ex (struct job_manager *ctx,
+                                    struct job *job,
+                                    const char *type,
+                                    int severity,
+                                    uint32_t userid,
+                                    const char *note,
+                                    int wait_status)
 {
     flux_jobid_t id = job->id;
     flux_future_t *f;
     json_t *evctx;
+    json_t *pub;
 
     // if no note specified, set to empty string per RFC21
     if (!note)
@@ -94,18 +96,42 @@ int raise_job_exception (struct job_manager *ctx,
             goto nomem;
         }
     }
+    // add optional wait_status key
+    if (wait_status >= 0) {
+        json_t *val;
+        if (!(val = json_integer (wait_status))
+            || json_object_set_new (evctx, "wait_status", val) < 0) {
+            json_decref (val);
+            goto nomem;
+        }
+    }
     // post exception to job eventlog
     if (event_job_post_pack (ctx->event, job, "exception", 0, "O", evctx) < 0)
         goto error;
     // publish job-exception event
+    if (!(pub = json_pack ("{s:I s:s s:i}",
+                           "id", id,
+                           "type", type,
+                           "severity", severity)))
+        goto nomem;
+    if (wait_status >= 0) {
+        json_t *val;
+        if (!(val = json_integer (wait_status))
+            || json_object_set_new (pub, "wait_status", val) < 0) {
+            json_decref (val);
+            json_decref (pub);
+            goto nomem;
+        }
+    }
     if (!(f = flux_event_publish_pack (ctx->h,
                                        "job-exception",
                                        FLUX_MSGFLAG_PRIVATE,
-                                       "{s:I s:s s:i}",
-                                       "id", id,
-                                       "type", type,
-                                       "severity", severity)))
+                                       "O",
+                                       pub))) {
+        json_decref (pub);
         goto error;
+    }
+    json_decref (pub);
     flux_future_destroy (f);
     json_decref (evctx);
     return 0;
@@ -114,6 +140,16 @@ nomem:
 error:
     ERRNO_SAFE_WRAP (json_decref, evctx);
     return -1;
+}
+
+int raise_job_exception (struct job_manager *ctx,
+                         struct job *job,
+                         const char *type,
+                         int severity,
+                         uint32_t userid,
+                         const char *note)
+{
+    return raise_job_exception_ex (ctx, job, type, severity, userid, note, -1);
 }
 
 void raise_handle_request (flux_t *h,
@@ -129,14 +165,16 @@ void raise_handle_request (flux_t *h,
     const char *type;
     const char *note = NULL;
     const char *errstr = NULL;
+    int wait_status = -1;
 
     if (flux_request_unpack (msg,
                              NULL,
-                             "{s:I s:i s:s s?s}",
+                             "{s:I s:i s:s s?s s?i}",
                              "id", &id,
                              "severity", &severity,
                              "type", &type,
-                             "note", &note) < 0
+                             "note", &note,
+                             "wait_status", &wait_status) < 0
         || flux_msg_get_cred (msg, &cred) < 0)
         goto error;
     if (raise_check_severity (severity)) {
@@ -161,7 +199,7 @@ void raise_handle_request (flux_t *h,
         errstr = "guests can only raise exceptions on their own jobs";
         goto error;
     }
-    if (raise_job_exception (ctx, job, type, severity, cred.userid, note) < 0)
+    if (raise_job_exception_ex (ctx, job, type, severity, cred.userid, note, wait_status) < 0)
         goto error;
     /* NB: job object may be destroyed in event_job_post_pack().
      * Do not reference the object after this point:

--- a/src/shell/doom.c
+++ b/src/shell/doom.c
@@ -59,6 +59,7 @@ struct shell_doom {
     bool exit_on_error;
     int exit_rc;
     int exit_rank;
+    int exit_wait_status; // raw POSIX wait_status of failing task, -1 if unknown
     bool lost_shell;
 };
 
@@ -104,6 +105,21 @@ static const char *get_jobspec_command_arg0 (struct shell_doom *doom)
     return basename_simple (json_string_value (s));
 }
 
+static void doom_fatal (struct shell_doom *doom, const char *fmt, ...)
+    __attribute__ ((format (printf, 2, 3)));
+
+static void doom_fatal (struct shell_doom *doom, const char *fmt, ...)
+{
+    char note [4096];
+    va_list ap;
+
+    va_start (ap, fmt);
+    vsnprintf (note, sizeof (note), fmt, ap);
+    va_end (ap);
+    flux_shell_raise_exit_status (doom->exit_wait_status, "%s", note);
+    shell_die (doom->exit_rc, "%s", note);
+}
+
 static void doom_check (struct shell_doom *doom,
                         int rank,
                         int exitcode,
@@ -125,12 +141,12 @@ static void doom_check (struct shell_doom *doom,
     doom->hl = hostlist_copy (flux_shell_get_hostlist (doom->shell));
 
     if (doom->exit_on_error && doom->exit_rc != 0) {
-        shell_die (doom->exit_rc,
-                   "%s: %s rank %d on host %s failed and exit-on-error is set",
-                   get_jobspec_command_arg0 (doom),
-                   doom->lost_shell ? "shell" : "task",
-                   doom->exit_rank,
-                   doom_exit_host (doom));
+        doom_fatal (doom,
+                    "%s: %s rank %d on host %s failed and exit-on-error is set",
+                    get_jobspec_command_arg0 (doom),
+                    doom->lost_shell ? "shell" : "task",
+                    doom->exit_rank,
+                    doom_exit_host (doom));
     }
     else if (doom->timeout != TIMEOUT_NONE)
         flux_watcher_start (doom->timer);
@@ -158,6 +174,8 @@ static void doom_post (struct shell_doom *doom, json_t *task_info)
         || !(f = flux_kvs_commit (doom->shell->h, NULL, 0, txn)))
         shell_log_errno ("error posting task-exit eventlog entry");
 
+    if (json_unpack (task_info, "{s:i}", "wait_status", &doom->exit_wait_status) < 0)
+        doom->exit_wait_status = -1;
     doom_check (doom,
                 get_exit_rank (task_info),
                 get_exit_code (task_info),
@@ -214,13 +232,13 @@ static void doom_timeout (flux_reactor_t *r,
     char fsd[64];
 
     fsd_format_duration (fsd, sizeof (fsd), doom->timeout);
-    shell_die (doom->exit_rc,
-               "%s: %s rank %d on host %s exited and exit-timeout=%s has expired",
-               get_jobspec_command_arg0 (doom),
-               doom->lost_shell ? "shell" : "task",
-               doom->exit_rank,
-               doom_exit_host (doom),
-               fsd);
+    doom_fatal (doom,
+                "%s: %s rank %d on host %s exited and exit-timeout=%s has expired",
+                get_jobspec_command_arg0 (doom),
+                doom->lost_shell ? "shell" : "task",
+                doom->exit_rank,
+                doom_exit_host (doom),
+                fsd);
 }
 
 static int doom_task_exit (flux_plugin_t *p,
@@ -321,6 +339,7 @@ static struct shell_doom *doom_create (flux_shell_t *shell)
         return NULL;
     doom->shell = shell;
     doom->timeout = default_timeout;
+    doom->exit_wait_status = -1;
     if (parse_args (shell, &doom->timeout, &doom->exit_on_error) < 0)
         goto error;
     if (shell->info->shell_rank == 0) {

--- a/src/shell/doom.c
+++ b/src/shell/doom.c
@@ -105,6 +105,21 @@ static const char *get_jobspec_command_arg0 (struct shell_doom *doom)
     return basename_simple (json_string_value (s));
 }
 
+/* Return a parenthetical string describing how a task exited, e.g.
+ * " (Segmentation fault)" or " (Exit 2)". Returns "" when wait_status
+ * is unknown (< 0). Caller provides buf for the formatted result.
+ */
+static const char *doom_disposition (int wait_status, char *buf, size_t len)
+{
+    if (wait_status < 0)
+        return "";
+    if (WIFSIGNALED (wait_status))
+        snprintf (buf, len, " (%s)", strsignal (WTERMSIG (wait_status)));
+    else
+        snprintf (buf, len, " (Exit %d)", WEXITSTATUS (wait_status));
+    return buf;
+}
+
 static void doom_fatal (struct shell_doom *doom, const char *fmt, ...)
     __attribute__ ((format (printf, 2, 3)));
 
@@ -141,12 +156,15 @@ static void doom_check (struct shell_doom *doom,
     doom->hl = hostlist_copy (flux_shell_get_hostlist (doom->shell));
 
     if (doom->exit_on_error && doom->exit_rc != 0) {
+        char disp[64] = "";
         doom_fatal (doom,
-                    "%s: %s rank %d on host %s failed and exit-on-error is set",
+                    "%s: %s rank %d on host %s failed%s %s",
                     get_jobspec_command_arg0 (doom),
                     doom->lost_shell ? "shell" : "task",
                     doom->exit_rank,
-                    doom_exit_host (doom));
+                    doom_exit_host (doom),
+                    doom_disposition (doom->exit_wait_status, disp, sizeof (disp)),
+                    "and exit-on-error is set");
     }
     else if (doom->timeout != TIMEOUT_NONE)
         flux_watcher_start (doom->timer);
@@ -231,14 +249,17 @@ static void doom_timeout (flux_reactor_t *r,
     struct shell_doom *doom = arg;
     char fsd[64];
 
+    char disp[64] = "";
     fsd_format_duration (fsd, sizeof (fsd), doom->timeout);
     doom_fatal (doom,
-                "%s: %s rank %d on host %s exited and exit-timeout=%s has expired",
+                "%s: %s rank %d on host %s exited%s and exit-timeout=%s %s",
                 get_jobspec_command_arg0 (doom),
                 doom->lost_shell ? "shell" : "task",
                 doom->exit_rank,
                 doom_exit_host (doom),
-                fsd);
+                doom_disposition (doom->exit_wait_status, disp, sizeof (disp)),
+                fsd,
+                "has expired");
 }
 
 static int doom_task_exit (flux_plugin_t *p,

--- a/src/shell/log.c
+++ b/src/shell/log.c
@@ -240,28 +240,39 @@ int flux_shell_err (const char *component,
     return -1;
 }
 
-void flux_shell_raise (const char *type,
-                      int severity,
-                      const char *fmt, ...)
+static void shell_raise_ex (const char *type,
+                            int severity,
+                            int wait_status,
+                            const char *note)
 {
     flux_shell_t *shell = logger.shell;
     flux_future_t *f;
-    char buf [4096];
-    va_list ap;
 
     if (!shell || !shell->h || !shell->info || logger.exception_logged)
         return;
 
-    va_start (ap, fmt);
-    msgfmt (buf, sizeof (buf), 0, fmt, ap);
-    va_end (ap);
-
-    if (!(f = flux_job_raise (shell->h,
-                              shell->info->jobid,
-                              "exec",
-                              0,
-                              buf))
-       || flux_future_get (f, NULL) < 0) {
+    if (wait_status >= 0)
+        f = flux_rpc_pack (shell->h,
+                           "job-manager.raise",
+                           FLUX_NODEID_ANY,
+                           0,
+                           "{s:I s:s s:i s:s s:i}",
+                           "id", shell->info->jobid,
+                           "type", type,
+                           "severity", severity,
+                           "note", note,
+                           "wait_status", wait_status);
+    else
+        f = flux_rpc_pack (shell->h,
+                           "job-manager.raise",
+                           FLUX_NODEID_ANY,
+                           0,
+                           "{s:I s:s s:i s:s}",
+                           "id", shell->info->jobid,
+                           "type", type,
+                           "severity", severity,
+                           "note", note);
+    if (!f || flux_future_get (f, NULL) < 0) {
         fprintf (stderr,
                  "flux-shell: failed to raise job exception: %s\n",
                  flux_future_error_string (f));
@@ -269,6 +280,32 @@ void flux_shell_raise (const char *type,
     else
         shell_log_set_exception_logged ();
     flux_future_destroy (f);
+}
+
+void flux_shell_raise (const char *type,
+                      int severity,
+                      const char *fmt, ...)
+{
+    char buf [4096];
+    va_list ap;
+
+    va_start (ap, fmt);
+    msgfmt (buf, sizeof (buf), 0, fmt, ap);
+    va_end (ap);
+
+    shell_raise_ex (type, severity, -1, buf);
+}
+
+void flux_shell_raise_exit_status (int wait_status, const char *fmt, ...)
+{
+    char buf [4096];
+    va_list ap;
+
+    va_start (ap, fmt);
+    msgfmt (buf, sizeof (buf), 0, fmt, ap);
+    va_end (ap);
+
+    shell_raise_ex ("exec", 0, wait_status, buf);
 }
 
 void flux_shell_fatal (const char *component,

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -404,6 +404,14 @@ void flux_shell_fatal (const char *component,
 
 void flux_shell_raise (const char *type, int severity, const char *fmt, ...);
 
+/* Raise a fatal exec exception with severity=0, and optionally set the
+ * job wait_status to wait_status (if >= 0) so that job-exec uses the
+ * provided exit status for the job finish event rather than the largest
+ * shell exit status. Sets exception_logged to prevent a second raise.
+ */
+void flux_shell_raise_exit_status (int wait_status, const char *fmt, ...)
+    __attribute__ ((format (printf, 2, 3)));
+
 /*  Set default severity of logging destination 'dest' to level.
  *   If dest == NULL then set the internal log dispatch level --
  *   (i.e. no messages above severity level will be logged to any

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -351,6 +351,27 @@ test_expect_success 'job-manager: drain unblocks when last job is canceled' '
 	run_timeout 5 ${DRAIN_CANCEL} ${jobid}
 '
 
+test_expect_success 'job-manager: raise with wait_status includes it in exception event' '
+	jobid=$(flux job submit basic.json) &&
+	jid=$(flux job id --to=dec $jobid) &&
+	printf "{\"id\":%s,\"severity\":1,\"type\":\"ws-test\",\"wait_status\":11}" $jid |
+	    ${RPC} job-manager.raise &&
+	flux job wait-event --timeout=5.0 --match-context=type=ws-test $jobid exception &&
+	flux job eventlog $jobid | grep exception | grep wait_status=11 &&
+	flux cancel $jobid
+'
+
+test_expect_success 'job-manager: raise without wait_status omits it from exception event' '
+	jobid=$(flux job submit basic.json) &&
+	jid=$(flux job id --to=dec $jobid) &&
+	printf "{\"id\":%s,\"severity\":1,\"type\":\"no-ws-test\"}" $jid |
+	    ${RPC} job-manager.raise &&
+	flux job wait-event --timeout=5.0 --match-context=type=no-ws-test $jobid exception &&
+	flux job eventlog $jobid | grep exception | grep "no-ws-test" >no_ws.out &&
+	test_must_fail grep wait_status no_ws.out &&
+	flux cancel $jobid
+'
+
 test_expect_success 'list request with empty payload fails with EPROTO(71)' '
 	${RPC} job-manager.list 71 </dev/null
 '

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -202,4 +202,15 @@ test_expect_success FLUX_SECURITY \
 	flux job wait-event -vHt 15s $jobid clean &&
 	flux job status -vvv $jobid
 '
+test_expect_success 'job-exec: exception wait_status overrides finish status' '
+	jobid=$(flux submit \
+	    --setattr=system.exec.test.run_duration=30s hostname) &&
+	flux job wait-event -t 5 $jobid start &&
+	jid=$(flux job id --to=dec $jobid) &&
+	printf "{\"id\":%s,\"severity\":0,\"type\":\"test\",\"wait_status\":11}" $jid |
+	    ${RPC} job-manager.raise &&
+	flux job wait-event -t 5 $jobid finish | grep status=35584 &&
+	flux job wait-event -t 5 $jobid clean
+'
+
 test_done

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -24,13 +24,13 @@ test_expect_success 'flux-shell: create 30s sleep script - rank 1 exits early' '
 test_expect_success 'flux-shell: run script with 2 tasks and 1s timeout' '
 	test_must_fail run_timeout 30 flux run \
 		-n2 -o exit-timeout=1s ./testscript.sh 2>tmout.err &&
-	grep "exception.*timeout" tmout.err
+	grep "exception.*Exit 200.*timeout" tmout.err
 '
 
 test_expect_success 'flux-shell: run script with 2 nodes and 1s timeout' '
 	test_must_fail run_timeout 30 flux run \
 		-n2 -N2 -o exit-timeout=1s ./testscript.sh 2>tmout2.err &&
-	grep "exception.*timeout" tmout2.err
+	grep "exception.*Exit 200.*timeout" tmout2.err
 '
 
 test_expect_success 'flux-shell: run script with 2 tasks and exit-on-error' '
@@ -69,11 +69,13 @@ test_expect_success 'flux-shell: create script - rank 1 kills itself with SIGSEG
 '
 test_expect_success 'flux-shell: exit-on-error preserves failing task signal in finish status' '
 	jobid=$(flux submit -n2 -o exit-on-error ./sigtest.sh) &&
-	flux job wait-event -t 30 $jobid finish | grep "status=35584"
+	flux job wait-event -t 30 $jobid finish | grep "status=35584" &&
+	flux job eventlog $jobid | grep exception | grep "Segmentation fault"
 '
 test_expect_success 'flux-shell: exit-timeout preserves failing task signal in finish status' '
 	jobid=$(flux submit -n2 -o exit-timeout=1s ./sigtest.sh) &&
-	flux job wait-event -t 30 $jobid finish | grep "status=35584"
+	flux job wait-event -t 30 $jobid finish | grep "status=35584" &&
+	flux job eventlog $jobid | grep exception | grep "Segmentation fault"
 '
 test_expect_success 'flux-shell: exit-timeout=aaa is rejected' '
 	test_must_fail flux run -o exit-timeout=aaa true

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -59,6 +59,22 @@ test_expect_success 'flux-shell: exit-on-error catches lost shell' '
 	test_must_fail run_timeout 30 flux run \
 		-n2 -N2 -o exit-on-error ./test2.sh
 '
+test_expect_success 'flux-shell: create script - rank 1 kills itself with SIGSEGV' '
+	cat >sigtest.sh <<-"EOT" &&
+	#!/bin/sh
+	test $FLUX_TASK_RANK -eq 1 && kill -SEGV $$
+	sleep 30
+	EOT
+	chmod +x sigtest.sh
+'
+test_expect_success 'flux-shell: exit-on-error preserves failing task signal in finish status' '
+	jobid=$(flux submit -n2 -o exit-on-error ./sigtest.sh) &&
+	flux job wait-event -t 30 $jobid finish | grep "status=35584"
+'
+test_expect_success 'flux-shell: exit-timeout preserves failing task signal in finish status' '
+	jobid=$(flux submit -n2 -o exit-timeout=1s ./sigtest.sh) &&
+	flux job wait-event -t 30 $jobid finish | grep "status=35584"
+'
 test_expect_success 'flux-shell: exit-timeout=aaa is rejected' '
 	test_must_fail flux run -o exit-timeout=aaa true
 '


### PR DESCRIPTION
This PR implements support for the optional `wait_status` parameter to `job-manager.raise` added recently to RFC 21, then uses that field, when present, to set the job's `status` in the `finish` event.

A new `flux_shell_raise_wait_status(3)` function is added to the shell API which allows the doom plugin to set the fatal exception `wait_status` for a job to the exit status of the task which actually caused the `exit-on-error` or `exit-timeout` exception.

This fixes the specific case described in #7462 in which a single task segfaults, but the subsequent cleanup after the doom plugin raises an exception masks the segfault and the `finish` event records the exit status of the job as `Terminated` (killed by signal 15) instead of `Segmentation fault` (killed by signal 11).

To make things even more obvious, a string status of the first exited task is added to these exceptions, so we go from:
```
1.043s: job.exception ƒ93ycnLf type=exec severity=0 sh: task rank 1 on host ubuntu exited and exit-timeout=1s has expired
```
to
```
1.047s: job.exception ƒNL6AvRQs type=exec severity=0 sh: task rank 1 on host ubuntu exited (Segmentation fault) and exit-timeout=1s has expired
```