### PR TITLE
python: add set_proctitle() and use it in python modules, job validator and frobnicator

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -15,6 +15,7 @@ nobase_fluxpy_PYTHON = \
 	eventlog.py \
 	conf_builtin.py \
 	brokermod.py \
+	proctitle.py \
 	cli/__init__.py \
 	cli/base.py \
 	cli/alloc.py \

--- a/src/bindings/python/flux/proctitle.py
+++ b/src/bindings/python/flux/proctitle.py
@@ -1,0 +1,32 @@
+##############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import ctypes
+import ctypes.util
+import platform
+
+
+def set_proctitle(name):
+    """Set the process name shown in top, ps, and /proc/self/comm.
+
+    Uses prctl(PR_SET_NAME) on Linux, matching the mechanism used by the
+    Flux broker itself. The kernel silently truncates the name to 15
+    characters. On non-Linux platforms this is a no-op.
+    """
+    if platform.system() != "Linux":
+        return
+    try:
+        libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+        libc.prctl(15, name.encode(), 0, 0, 0)  # 15 == PR_SET_NAME
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/broker/flux-module-python-exec.py
+++ b/src/broker/flux-module-python-exec.py
@@ -41,6 +41,7 @@ from _flux._core import ffi, lib
 from flux.brokermod import resolve_entry_point
 from flux.core.handle import Flux
 from flux.importer import import_path
+from flux.proctitle import set_proctitle
 
 
 def die(msg):
@@ -75,6 +76,10 @@ def main():
     if args_p[0] != ffi.NULL:
         modargs = ffi.string(args_p[0]).decode("utf-8")
         lib.free(args_p[0])
+
+    name_p = ffi.cast("char *", lib.flux_aux_get(h.handle, b"flux::name"))
+    if name_p != ffi.NULL:
+        set_proctitle(ffi.string(name_p).decode())
 
     if lib.flux_module_register_handlers(h.handle, error) < 0:
         die_error("flux_module_register_handlers", error[0])

--- a/src/cmd/flux-job-frobnicator.py
+++ b/src/cmd/flux-job-frobnicator.py
@@ -17,6 +17,7 @@ import sys
 import flux
 from flux.job import Jobspec
 from flux.job.frobnicator import JobFrobnicator
+from flux.proctitle import set_proctitle
 
 LOGGER = logging.getLogger("flux-job-frobnicator")
 
@@ -49,6 +50,8 @@ class HelpAction(argparse.Action):
 
 @flux.util.CLIMain(LOGGER)
 def main():
+
+    set_proctitle("job-frobnicator")
 
     parser = argparse.ArgumentParser(
         prog="flux-job-frobnicator",

--- a/src/cmd/flux-job-validator.py
+++ b/src/cmd/flux-job-validator.py
@@ -16,6 +16,7 @@ import sys
 
 import flux
 from flux.job.validator import JobValidator
+from flux.proctitle import set_proctitle
 
 LOGGER = logging.getLogger("flux-job-validator")
 
@@ -48,6 +49,8 @@ class HelpAction(argparse.Action):
 
 @flux.util.CLIMain(LOGGER)
 def main():
+
+    set_proctitle("job-validator")
 
     parser = argparse.ArgumentParser(
         prog="flux-job-validator",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -327,6 +327,7 @@ TESTSCRIPTS = \
 	python/t0037-slurm.py \
 	python/t0038-brokermod.py \
 	python/t0039-rv1pool.py \
+	python/t0040-proctitle.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0040-proctitle.py
+++ b/t/python/t0040-proctitle.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Unit tests for flux.proctitle.set_proctitle().
+# No broker or real prctl() call is required; libc and platform are mocked.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import flux.proctitle as pt
+import subflux  # noqa: F401 - To set up PYTHONPATH
+from pycotap import TAPTestRunner
+
+
+class TestSetProctitle(unittest.TestCase):
+    def test_no_op_on_non_linux(self):
+        """set_proctitle() returns without calling prctl on non-Linux platforms."""
+        mock_libc = MagicMock()
+        with patch.object(pt.platform, "system", return_value="Darwin"), patch.object(
+            pt.ctypes, "CDLL", return_value=mock_libc
+        ):
+            pt.set_proctitle("test")
+        mock_libc.prctl.assert_not_called()
+
+    def test_prctl_called_on_linux(self):
+        """set_proctitle() calls prctl(PR_SET_NAME) on Linux."""
+        mock_libc = MagicMock()
+        with patch.object(pt.platform, "system", return_value="Linux"), patch.object(
+            pt.ctypes, "CDLL", return_value=mock_libc
+        ):
+            pt.set_proctitle("mymod")
+        mock_libc.prctl.assert_called_once_with(15, b"mymod", 0, 0, 0)
+
+    def test_prctl_failure_is_silently_ignored(self):
+        """set_proctitle() does not raise when prctl() raises an exception."""
+        mock_libc = MagicMock()
+        mock_libc.prctl.side_effect = RuntimeError("mocked prctl failure")
+        with patch.object(pt.platform, "system", return_value="Linux"), patch.object(
+            pt.ctypes, "CDLL", return_value=mock_libc
+        ):
+            pt.set_proctitle("test")  # must not raise
+
+    def test_cdll_failure_is_silently_ignored(self):
+        """set_proctitle() does not raise when ctypes.CDLL() itself raises."""
+        with patch.object(pt.platform, "system", return_value="Linux"), patch.object(
+            pt.ctypes, "CDLL", side_effect=OSError("mocked CDLL failure")
+        ):
+            pt.set_proctitle("test")  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t0028-module-python-exec.t
+++ b/t/t0028-module-python-exec.t
@@ -46,6 +46,37 @@ except Exception:
 }
 
 ##
+# flux.proctitle unit tests
+##
+
+test_expect_success 'set_proctitle sets /proc/self/comm on Linux' '
+	flux python -c "
+import platform, sys
+from flux.proctitle import set_proctitle
+set_proctitle(\"flux-test-proc\")
+if platform.system() == \"Linux\":
+    with open(\"/proc/self/comm\") as f:
+        comm = f.read().strip()
+    if comm != \"flux-test-proc\":
+        print(f\"expected flux-test-proc, got {comm!r}\", file=sys.stderr)
+        sys.exit(1)
+"
+'
+test_expect_success 'set_proctitle truncates long names to 15 chars' '
+	flux python -c "
+import platform, sys
+from flux.proctitle import set_proctitle
+set_proctitle(\"flux-this-name-is-too-long\")
+if platform.system() == \"Linux\":
+    with open(\"/proc/self/comm\") as f:
+        comm = f.read().strip()
+    if len(comm) > 15:
+        print(f\"expected truncation to 15 chars, got {comm!r}\", file=sys.stderr)
+        sys.exit(1)
+"
+'
+
+##
 # Error cases (direct invocation without FLUX_MODULE_URI)
 ##
 


### PR DESCRIPTION
This PR sets the proctitle for python broker modules to the module name so they don't all appear as `python3` in `ps`, `pstree` and `top` output.

e.g.:

```console
flux-broker-0(199187)─┬─bash(199687)───pstree(211512)
                      └─sched-simple(199626)
```