### PR TITLE
testsuite: avoid potential hang in t0014-runlevel.t

### DIFF
--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -50,6 +50,7 @@ test_expect_success 'rc2 failure if stdin not a tty' '
 
 test_expect_success 'rc3 failure causes instance failure' '
 	test_expect_code 1 flux start \
+		-Sbroker.rc1_path= \
 		-Sbroker.rc3_path=false \
 		-Slog-stderr-level=6 \
 		true 2>rc3_failure.log


### PR DESCRIPTION
Problem: The test "rc3 failure causes instance failure" in t0014-runlevel.t often hangs during CI.

Though the root cause of the hang has not been determined, experimental results indicate the hang could be due to module cleanup, since the test runs a normal rc1, but bypasses a normal shutdown by setting rc3 to `false`. Avoid the potential hang due to module cleanup by skipping rc1. The test is supposed to be checking if a failed rc3 causes instance failure, not the module cleanup path when rc3 isn't run.

I've run this branch a few times in CI and haven't reproduced the hang, though that's no guarantee 🤷 