### PR TITLE
cmd/flux: remove duplicate command suggestions 

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -422,7 +422,6 @@ void exec_subcommand_dir (bool vopt,
 struct similar_cmds {
     int min;
     zlist_t *cmds;
-    int cmdsstrlen;
     const char *argv0;
 };
 
@@ -432,14 +431,11 @@ static void similar_check (struct similar_cmds *similar,
     int distance = levenshtein_distance (cmd, similar->argv0);
     if (distance > 0 && distance <= similar->min) {
         char *cpy = xstrdup (cmd);
-        if (distance < similar->min) {
+        if (distance < similar->min)
             zlist_purge (similar->cmds);
-            similar->cmdsstrlen = 0;
-        }
         similar->min = distance;
         zlist_append (similar->cmds, cpy);
         zlist_freefn (similar->cmds, cpy, free, true);
-        similar->cmdsstrlen += strlen (cpy);
     }
 }
 
@@ -474,7 +470,7 @@ static void find_similar_command (const char *searchpath, const char *argv0)
 {
     extern struct builtin_cmd builtin_cmds[];
     struct builtin_cmd *builtin_cmd = &builtin_cmds[0];
-    struct similar_cmds similar = {INT_MAX, NULL, 0, argv0};
+    struct similar_cmds similar = {INT_MAX, NULL, argv0};
     char *searchpathcpy;
     char *dir, *saveptr = NULL, *a1;
 

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -425,17 +425,33 @@ struct similar_cmds {
     const char *argv0;
 };
 
+/* return true if no dups */
+static bool similar_dupcheck (struct similar_cmds *similar,
+                              const char *cmd)
+{
+    char *str = zlist_first (similar->cmds);
+    while (str) {
+        if (streq (str, cmd))
+            return false;
+        str = zlist_next (similar->cmds);
+    }
+    return true;
+}
+
 static void similar_check (struct similar_cmds *similar,
                            const char *cmd)
 {
     int distance = levenshtein_distance (cmd, similar->argv0);
     if (distance > 0 && distance <= similar->min) {
-        char *cpy = xstrdup (cmd);
-        if (distance < similar->min)
+        if (distance < similar->min) {
             zlist_purge (similar->cmds);
-        similar->min = distance;
-        zlist_append (similar->cmds, cpy);
-        zlist_freefn (similar->cmds, cpy, free, true);
+            similar->min = distance;
+        }
+        if (similar_dupcheck (similar, cmd)) {
+            char *cpy = xstrdup (cmd);
+            zlist_append (similar->cmds, cpy);
+            zlist_freefn (similar->cmds, cpy, free, true);
+        }
     }
 }
 

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -861,6 +861,18 @@ test_expect_success 'multiple equally similar commands are output' '
 	grep "top" invalid4.out
 '
 
+test_expect_success 'duplicate commands are not output' '
+	TEMPDIR1=$(mktemp -d) &&
+	TEMPDIR2=$(mktemp -d) &&
+	touch $TEMPDIR1/flux-beef &&
+	chmod +x $TEMPDIR1/flux-beef &&
+	touch $TEMPDIR2/flux-beef &&
+	chmod +x $TEMPDIR2/flux-beef &&
+	test_must_fail sh -c "FLUX_EXEC_PATH=$TEMPDIR1:$TEMPDIR2 flux peef > invalid5.out 2>&1" &&
+	count=$(grep -o beef invalid5.out | wc -l) &&
+	test $count -eq 1
+'
+
 test_expect_success 'at most 3 suggested similar commands are output' '
 	TEMPDIR=$(mktemp -d) &&
 	touch $TEMPDIR/flux-mama &&


### PR DESCRIPTION
Problem: There is a builtin "python" subcommand a "flux-python" command.  When outputting command suggestions, sometimes both are output.  There also the possibility of duplicates when scanning user command directories.

When outputting command suggestions, remove duplicates.

Fixes #7448