### PR TITLE
sched-simple: fix property and scheduling key propagation in allocations

### DIFF
--- a/src/bindings/python/flux/resource/ResourceSet.py
+++ b/src/bindings/python/flux/resource/ResourceSet.py
@@ -29,6 +29,10 @@ class ResourceSet:
 
     :param version: R specification version
 
+    :param kwargs: Additional keyword arguments are forwarded to the
+                   implementation constructor (e.g., ``keep_scheduling=True``
+                   for Rv1Set)
+
     :raises TypeError: A ResourceSet cannot be instantiated from arg
     :raises ValueError: Invalid R version, or invalid R encoding
     :raises KeyError: arg was a dict without a 'version' key
@@ -38,7 +42,7 @@ class ResourceSet:
     empty, version 1 ResourceSet object.
     """
 
-    def __init__(self, arg=None, version=1):
+    def __init__(self, arg=None, version=1, **kwargs):
         self._state = None
 
         if isinstance(arg, ResourceSetImplementation):
@@ -65,7 +69,7 @@ class ResourceSet:
         #  note: only version 1 supported for now
         if version == 1:
             self.version = 1
-            self.impl = Rv1Set(arg)
+            self.impl = Rv1Set(arg, **kwargs)
         else:
             raise ValueError(f"R version {version} not supported")
 

--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -648,12 +648,18 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
             actual_nslots = allocated_slots
 
         # Build result pool and update allocation state on self
+        selected_ranks = {rank for rank, _, _, _ in selected}
+
         result = object.__new__(Rv1Pool)
         result._expiration = 0.0
         result._starttime = 0.0
         result._has_nodelist = True
         result._nslots = actual_nslots
-        result._properties = {}
+        result._properties = {
+            prop: ranks & selected_ranks
+            for prop, ranks in self._properties.items()
+            if ranks & selected_ranks
+        }
         result._ranks = {}
         result._job_state = {}
         result.log = self.log

--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -281,8 +281,10 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
         if R is not None and not isinstance(R, (str, Mapping)):
             raise TypeError(f"Rv1Pool: expected str or Mapping, got {type(R)!r}")
 
-        # Rv1Set.__init__ parses the core resource structure.
-        super().__init__(R)
+        # Rv1Set.__init__ parses the core resource structure.  Pass
+        # keep_scheduling=True so R.scheduling is retained for propagation
+        # to allocations per RFC 20 §scheduling, without a second JSON parse.
+        super().__init__(R, keep_scheduling=True)
 
         # Add pool-specific fields to each rank entry.
         for info in self._ranks.values():
@@ -320,6 +322,7 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
             for rank in rank_set
             if rank in self._ranks
         }
+        new.scheduling = self.scheduling
         new._job_state = {}
         new.log = self.log
         return new
@@ -660,6 +663,7 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
             for prop, ranks in self._properties.items()
             if ranks & selected_ranks
         }
+        result.scheduling = self.scheduling
         result._ranks = {}
         result._job_state = {}
         result.log = self.log
@@ -704,6 +708,7 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
             new._ranks[rank] = dict(info)
             new._ranks[rank]["allocated_cores"] = set(info["allocated_cores"])
             new._ranks[rank]["allocated_gpus"] = set(info["allocated_gpus"])
+        new.scheduling = self.scheduling
         new._job_state = dict(self._job_state)
         # Do not copy self.log: copies are used for simulation (forecast /
         # shadow-time) and their alloc/free calls must not emit log lines.

--- a/src/bindings/python/flux/resource/Rv1Set.py
+++ b/src/bindings/python/flux/resource/Rv1Set.py
@@ -89,13 +89,22 @@ class Rv1Set(ResourceSetImplementation):
 
     version = 1
 
-    def __init__(self, arg=None):
-        """Construct from an R JSON string, dict, or ``None`` (empty)."""
+    def __init__(self, arg=None, keep_scheduling: bool = False):
+        """Construct from an R JSON string, dict, or ``None`` (empty).
+
+        Args:
+            arg: R as a JSON string, parsed dict, or ``None`` for empty.
+            keep_scheduling: If True, store the opaque ``R.scheduling`` key
+                so it can be propagated to allocations.  Non-scheduler
+                components should leave this False (the default) to avoid
+                retaining potentially large scheduler-private data.
+        """
         self._expiration: float = 0.0
         self._starttime: float = 0.0
         self._has_nodelist: bool = False
         self._ranks: Dict[int, dict] = {}
         self._properties: Dict[str, Set[int]] = {}
+        self._scheduling = None
 
         if arg is None:
             return
@@ -109,6 +118,9 @@ class Rv1Set(ResourceSetImplementation):
         version = arg["version"]  # KeyError if missing
         if version != 1:
             raise ValueError(f"R version {version} not supported")
+
+        if keep_scheduling:
+            self._scheduling = arg.get("scheduling")
 
         execution = arg.get("execution", {})
         self._expiration = float(execution.get("expiration") or 0.0)
@@ -404,6 +416,22 @@ class Rv1Set(ResourceSetImplementation):
         """Set the resource set start time (seconds since epoch)."""
         self._starttime = float(starttime)
 
+    @property
+    def scheduling(self):
+        """Return the opaque R.scheduling key, or None if not set.
+
+        The ``R.scheduling`` key is an optional RFC 20 field carrying
+        scheduler-private data.  Schedulers that set ``keep_scheduling=True``
+        in the constructor will preserve this field so it can be propagated
+        to allocations.
+        """
+        return getattr(self, "_scheduling", None)
+
+    @scheduling.setter
+    def scheduling(self, value):
+        """Set the opaque R.scheduling key."""
+        self._scheduling = value
+
     def copy_constraint(self, constraint) -> "Rv1Set":
         """Return a copy containing only ranks that satisfy *constraint*.
 
@@ -466,7 +494,10 @@ class Rv1Set(ResourceSetImplementation):
                 if ranks
             }
 
-        return {"version": 1, "execution": execution}
+        result = {"version": 1, "execution": execution}
+        if self.scheduling:
+            result["scheduling"] = self.scheduling
+        return result
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/t/python/t0022-resource-set.py
+++ b/t/python/t0022-resource-set.py
@@ -762,6 +762,57 @@ class TestConstraints(unittest.TestCase):
             self.rset.copy_constraint({"not": []})
 
 
+class TestScheduling(unittest.TestCase):
+    """Test R.scheduling key handling in Rv1Set base class."""
+
+    R_with_sched = {
+        "version": 1,
+        "execution": {
+            "R_lite": [{"rank": "0-1", "children": {"core": "0-3"}}],
+            "starttime": 0,
+            "expiration": 0,
+        },
+        "scheduling": {"graph": {"nodes": [], "edges": []}},
+    }
+
+    def test_scheduling_dropped_by_default(self):
+        """By default, R.scheduling is not stored (keep_scheduling=False)."""
+        rset = ResourceSet(self.R_with_sched)
+        self.assertIsNone(rset.impl.scheduling)
+        self.assertNotIn("scheduling", json.loads(rset.encode()))
+
+    def test_scheduling_preserved_with_keep_scheduling(self):
+        """With keep_scheduling=True, R.scheduling is preserved."""
+        rset = ResourceSet(self.R_with_sched, keep_scheduling=True)
+        self.assertEqual(rset.impl.scheduling, {"graph": {"nodes": [], "edges": []}})
+        encoded = json.loads(rset.encode())
+        self.assertIn("scheduling", encoded)
+        self.assertEqual(encoded["scheduling"], {"graph": {"nodes": [], "edges": []}})
+
+    def test_scheduling_property_setter(self):
+        """scheduling property setter works and propagates to encode()."""
+        rset = ResourceSet()
+        rset.impl.scheduling = {"test": "data"}
+        self.assertEqual(rset.impl.scheduling, {"test": "data"})
+        encoded = json.loads(rset.encode())
+        self.assertIn("scheduling", encoded)
+        self.assertEqual(encoded["scheduling"], {"test": "data"})
+
+    def test_scheduling_property_getter_none_when_unset(self):
+        """scheduling property returns None when not set."""
+        rset = ResourceSet()
+        self.assertIsNone(rset.impl.scheduling)
+
+    def test_scheduling_roundtrip(self):
+        """R.scheduling round-trips through encode/decode with keep_scheduling."""
+        sched = {"foo": "bar", "baz": [1, 2, 3]}
+        R = dict(self.R_with_sched, scheduling=sched)
+        rset1 = ResourceSet(R, keep_scheduling=True)
+        encoded = rset1.encode()
+        rset2 = ResourceSet(encoded, keep_scheduling=True)
+        self.assertEqual(rset2.impl.scheduling, sched)
+
+
 if __name__ == "__main__":
     unittest.main(testRunner=TAPTestRunner())
 

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -146,6 +146,28 @@ class TestRv1PoolConstruct(unittest.TestCase):
         p = Rv1Pool(R)
         self.assertAlmostEqual(p.expiration, 1234.5)
 
+    def test_scheduling_stored(self):
+        """R.scheduling is stored and round-trips through to_dict."""
+        sched = {"graph": {"nodes": [], "edges": []}}
+        R = dict(R_4x4, scheduling=sched)
+        p = Rv1Pool(R)
+        self.assertEqual(p._scheduling, sched)
+        self.assertEqual(p.to_dict()["scheduling"], sched)
+
+    def test_scheduling_propagates_to_alloc(self):
+        """R.scheduling rides along into the allocation R per RFC 20."""
+        sched = {"graph": {"nodes": [], "edges": []}}
+        R = dict(R_4x4, scheduling=sched)
+        pool = Rv1Pool(R)
+        result = pool.alloc(1, rr(nslots=1, slot_size=1))
+        self.assertEqual(result._scheduling, sched)
+        self.assertEqual(result.to_dict()["scheduling"], sched)
+
+    def test_no_scheduling_absent_from_to_dict(self):
+        """to_dict omits scheduling key when R.scheduling is not set."""
+        p = Rv1Pool(R_4x4)
+        self.assertNotIn("scheduling", p.to_dict())
+
 
 class TestRv1PoolUpDown(unittest.TestCase):
     def setUp(self):

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -303,6 +303,21 @@ class TestRv1PoolAlloc(unittest.TestCase):
         self.assertIn("nodelist", d["execution"])
         self.assertTrue(d["execution"]["nodelist"])
 
+    def test_alloc_propagates_properties(self):
+        # Properties on allocated ranks should appear in the allocated R so
+        # that consumers (e.g. schedulers on reconnect) can read them back.
+        pool = Rv1Pool(R_props)  # ranks 0-1: "fast", ranks 2-3: "slow"
+        a = pool.alloc(1, rr(0, 1, 1, constraint={"properties": ["fast"]}))
+        self.assertIn("fast", a._properties)
+        self.assertNotIn("slow", a._properties)
+
+    def test_alloc_excludes_unmatched_properties(self):
+        # Properties that belong to ranks not in the allocation must not appear.
+        pool = Rv1Pool(R_props)
+        a = pool.alloc(1, rr(0, 1, 1, constraint={"properties": ["slow"]}))
+        self.assertIn("slow", a._properties)
+        self.assertNotIn("fast", a._properties)
+
 
 class TestRv1PoolWorstFit(unittest.TestCase):
     """Verify worst-fit picks the node with the most free cores."""

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -24,6 +24,23 @@ list_R() {
 	done
 }
 
+test_expect_success 'sched-simple: reload resource with properties and R.scheduling' '
+	flux module unload sched-simple &&
+	flux kvs put resource.R="$(flux kvs get resource.R |
+		flux R set-property xx:0-1 |
+		jq ".+{scheduling:{test:\"data\"}}")" &&
+	flux module reload resource noverify &&
+	flux module load sched-simple
+'
+test_expect_success 'sched-simple: allocated R contains execution.properties' '
+	flux run -n1 --requires=xx hostname &&
+	flux job info $(flux job last) R | jq -e ".execution.properties.xx"
+'
+test_expect_success 'sched-simple: allocated R contains R.scheduling' '
+	flux run -n1 hostname &&
+	flux job info $(flux job last) R | jq -e ".scheduling.test == \"data\""
+'
+
 test_expect_success 'unload job-exec module to prevent job execution' '
 	flux module remove job-exec
 '


### PR DESCRIPTION
Problem: `sched-simple` no longer propagates properties or the scheduling key to sub-instances.

Fix these regressions in Rv1Pool and add unit tests.

We probably should have had integration tests that caught this, so add a couple to the sched-simple sharness test.