### PR TITLE
job-list: honor job updates in all job states

### DIFF
--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -799,16 +799,11 @@ static int journal_jobspec_update_event (struct job_state_ctx *jsctx,
         errno = EPROTO;
         return -1;
     }
-    /* Generally speaking, after a job is running, jobspec-update
-     * events should have no effect.  Note that in some cases,
-     * such as job duration, jobspec-updates can alter a job's
-     * behavior, but it is via an update to R.  In this case, we
-     * elect to not update the job duration seen by the user in
-     * the jobspec.  The effect will be seen changes in R (in this
-     * example, via the job expiration time in R).
+    /* Discounting testing scenarios, jobspec-update events usually go
+     * through job-manager and passed feasibility checks.  Honor the
+     * jobspec-update events, regardless of job state.
      */
-    if (job->state < FLUX_JOB_STATE_RUN)
-        update_jobspec (jsctx, job, context, true);
+    update_jobspec (jsctx, job, context, true);
     return 0;
 }
 
@@ -823,10 +818,11 @@ static int journal_resource_update_event (struct job_state_ctx *jsctx,
         errno = EPROTO;
         return -1;
     }
-    /* Generally speaking, resource-update events only have an effect
-     * when a job is running. */
-    if (job->state == FLUX_JOB_STATE_RUN)
-        update_resource (jsctx, job, context);
+    /* Discounting testing scenarios, resource-update events usually go
+     * through job-manager and passed feasibility checks.  Honor the
+     * resource-update events, regardless of job state.
+     */
+    update_resource (jsctx, job, context);
     return 0;
 }
 

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -105,8 +105,6 @@ test_expect_success 'flux job info jobspec fails on bad id' '
 	test_must_fail flux job info 12345 jobspec
 '
 
-# N.B. In future may wish to update expiration via `flux update` tool
-# when feature is available
 test_expect_success 'flux job info applies resource updates' '
 	jobid=$(flux submit --wait-event=start sleep 300) &&
 	echo $jobid > updated_R.id &&

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -2524,6 +2524,40 @@ test_expect_success 'remove jobtap plugins' '
 '
 
 #
+# jobspec-update and resource-update update on a running job (issue 7487)
+#
+
+test_expect_success 'run a job' '
+	flux submit --time-limit=10m --wait-event=start sleep 600 | flux job id > runupdate.id
+'
+
+# expiration should be 10m out, just make sure it is > 2m out
+test_expect_success 'duration and expiration expected values' '
+	flux job list -s active | grep $(cat runupdate.id) | jq -e ".duration == 600.0" &&
+	current=$(date +%s) &&
+	testexp=`expr $current + 2 \* 60` &&
+	echo $testexp > test_expiration2.out &&
+	flux job list -s active | grep $(cat runupdate.id) | jq -e ".expiration > $(cat test_expiration2.out)"
+'
+
+test_expect_success 'update job duration' '
+	flux update --wait $(cat runupdate.id) duration=+100m
+'
+
+test_expect_success 'cancel job' '
+	flux cancel $(cat runupdate.id)
+'
+
+# expiration should be 110m out, just make sure it is > 100m out
+test_expect_success 'duration and expiration updated as expected' '
+	flux job list -s inactive | grep $(cat runupdate.id) | jq -e ".duration == 6600.0" &&
+	current=$(date +%s) &&
+	testexp=`expr $current + 100 \* 60` &&
+	echo $testexp > test_expiration3.out &&
+	flux job list -s inactive | grep $(cat runupdate.id) | jq -e ".expiration > $(cat test_expiration3.out)"
+'
+
+#
 # job list special cases
 #
 

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -1373,7 +1373,6 @@ test_expect_success 'flux job list outputs no project and bank by default' '
 	flux job list -s inactive | grep $jobid | jq -e ".project == null" &&
 	flux job list -s inactive | grep $jobid | jq -e ".bank == null"
 '
-# initially put job on hold, jobspec-updates don't matter after the job is running
 test_expect_success 'flux job list outputs project and bank if one set' '
 	jobid=`flux submit --urgency=hold true | flux job id` &&
 	echo $jobid > jobprojectbank2.id &&


### PR DESCRIPTION
Problem: The job-list module does not honor jobspec or R updates in all job states.  In some cases, this may make sense.
For example, a queue change in a jobspec update does not matter if a job is already running.

However, there are circumstances they may make sense.  For example, the duration for a job via a jobspec update does not affect the launch of the job once it is already running, but can affect its expiration.  The output from job-list should reflect those changes.

In addition, the initial implementation of jobspec-update and resource-update event handling was done before the "flux update" tool existed.  So the job-list module tried to handle the logic of whether jobspec or R updates made sense.  Now that the "flux update" tool exists and job-manager update feasibility checks are done, we can more safely assume that the events that are posted have been already vetted.

Solution: Honor changes to jobspec or R via jobspec-update or resource-update events regardless of job state.

