### PR TITLE
libidset: define and enforce IDSET_MAX_UNIVERSE

### DIFF
--- a/doc/man3/idset_add.rst
+++ b/doc/man3/idset_add.rst
@@ -83,6 +83,9 @@ EINVAL
 ENOMEM
    Out of memory.
 
+ERANGE
+   Set would exceed IDSET_MAX_UNIVERSE.
+
 
 RESOURCES
 =========

--- a/doc/man3/idset_alloc.rst
+++ b/doc/man3/idset_alloc.rst
@@ -65,6 +65,9 @@ EINVAL
 ENOMEM
    Out of memory.
 
+ERANGE
+   Set would exceed IDSET_MAX_UNIVERSE.
+
 EEXIST
    :func:`idset_free_check` was called on an id that is already in the
    idset.

--- a/doc/man3/idset_create.rst
+++ b/doc/man3/idset_create.rst
@@ -62,6 +62,7 @@ universe size); and performs *first* and *last* operations in constant time.
 :func:`idset_create` creates an idset. :var:`size` specifies the universe
 size, which is the maximum *id* it can hold, plus one. The universe size is
 fixed unless :var:`flags` specify otherwise (see FLAGS below).
+The universe size must not exceed IDSET_MAX_UNIVERSE.
 
 :func:`idset_destroy` destroys an idset.
 
@@ -143,6 +144,9 @@ EINVAL
 
 ENOMEM
    Out of memory.
+
+ERANGE
+   Set would exceed IDSET_MAX_UNIVERSE.
 
 
 RESOURCES

--- a/doc/man3/idset_decode.rst
+++ b/doc/man3/idset_decode.rst
@@ -129,6 +129,9 @@ EINVAL
 ENOMEM
    Out of memory.
 
+ERANGE
+   Set would exceed MAX_UNIVERSE_SIZE.
+
 
 RESOURCES
 =========

--- a/src/common/libidset/idset.c
+++ b/src/common/libidset/idset.c
@@ -43,6 +43,10 @@ struct idset *idset_create (size_t size, int flags)
         return NULL;
     if (size == 0)
         size = IDSET_DEFAULT_SIZE;
+    if (size > IDSET_MAX_UNIVERSE) {
+        errno = ERANGE;
+        return NULL;
+    }
     if (!(idset = malloc (sizeof (*idset))))
         return NULL;
     if ((flags & IDSET_FLAG_INITFULL))
@@ -132,9 +136,17 @@ static int idset_grow (struct idset *idset, size_t size)
     Veb T;
     unsigned int id;
 
-    while (newsize < size)
+    while (newsize < size) {
+        if (newsize > (IDSET_MAX_UNIVERSE >> 1)) { // avoid 32 bit overflow!
+            newsize = IDSET_MAX_UNIVERSE;
+            break;
+        }
         newsize <<= 1;
-
+    }
+    if (newsize < size) {
+        errno = ERANGE;
+        return -1;
+    }
     if (newsize > idset->T.M) {
         if (!(idset->flags & IDSET_FLAG_AUTOGROW)) {
             errno = EINVAL;

--- a/src/common/libidset/idset.h
+++ b/src/common/libidset/idset.h
@@ -38,6 +38,7 @@ typedef struct {
 } idset_error_t;
 
 #define IDSET_INVALID_ID    (UINT_MAX - 1)
+#define IDSET_MAX_UNIVERSE  ((size_t)(INT_MAX) + 1)
 
 /* Create/destroy an idset.
  * Set the initial universe size to 'size' (0 means implementation uses a

--- a/src/common/libidset/idset_decode.c
+++ b/src/common/libidset/idset_decode.c
@@ -48,6 +48,13 @@ static int errprintf (idset_error_t *errp, const char *fmt, ...)
     return -1;
 }
 
+static const char *errdecode (int errnum)
+{
+    if (errnum == ERANGE)
+        return "set universe size would exceed maximum";
+    return strerror (errnum);
+}
+
 /* strtoul() with result parameter, assumed base=10.
  * Fail if no digits, leading non-digits, or leading zero.
  * Returns 0 on success, -1 on failure.
@@ -122,7 +129,7 @@ static int append_element (struct idset *idset,
         goto inval;
     }
     if (idset && idset_range_set (idset, lo, hi) < 0) {
-        errprintf (error, "error appending '%s': %s", s, strerror (errno));
+        errprintf (error, "error appending '%s': %s", s, errdecode (errno));
         goto error;
     }
     *count += hi - lo + 1;
@@ -153,7 +160,7 @@ static int remove_element (struct idset *idset,
         goto inval;
     }
     if (idset && idset_range_clear (idset, lo, hi) < 0) {
-        errprintf (error, "error clearing '%s': %s", s, strerror (errno));
+        errprintf (error, "error clearing '%s': %s", s, errdecode (errno));
         goto error;
     }
     *maxid = hi;
@@ -230,6 +237,11 @@ static int decode_and_set_with_info (struct idset *idset,
         a1 = NULL;
     }
     free (cpy);
+    if (maxid != IDSET_INVALID_ID && maxid >= IDSET_MAX_UNIVERSE) {
+        errno = ERANGE;
+        errprintf (error, "%s", errdecode (errno));
+        return -1;
+    }
     if (countp)
         *countp = count;
     if (maxidp)
@@ -265,7 +277,7 @@ struct idset *idset_decode_ex (const char *str,
         }
     }
     if (!(idset = idset_create (size, flags))) {
-        errprintf (error, "error creating idset object: %s", strerror (errno));
+        errprintf (error, "error creating idset object: %s", errdecode (errno));
         return NULL;
     }
     if (decode_and_set_with_info (idset, str, len, NULL, NULL, error) < 0) {

--- a/src/common/libidset/test/idset.c
+++ b/src/common/libidset/test/idset.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -86,6 +87,14 @@ struct inout test_inputs[] = {
 
     { NULL, 0, NULL },
 };
+
+bool is_bigmem (void)
+{
+    const char *s = getenv ("TEST_BIGMEM");
+    if (s && streq (s, "t"))
+        return true;
+    return false;
+}
 
 void test_basic (void)
 {
@@ -1219,6 +1228,94 @@ void test_decode_addsub (void)
     idset_destroy (idset);
 }
 
+/* Idset must avoid internal veb assert failure by enforcing IDSET_MAX_UNIVERSE.
+ * Note: when run with TEST_BIGMEM=t, valgrind may complain
+ * "Warning: set address range perms: large range".
+ */
+void test_issue7494 (void)
+{
+    struct idset *idset;
+    int rc;
+    int saved_errno;
+    idset_error_t error;
+    char s[64];
+
+    /* static size too big
+     */
+    idset = idset_create (IDSET_MAX_UNIVERSE + 1, 0);
+    saved_errno = errno;
+    ok (idset == NULL && saved_errno == ERANGE,
+        "idset_create failed with size=IDSET_MAX_UNIVERSE + 1");
+    if (!idset)
+        diag ("%s", strerror (saved_errno));
+    idset_destroy (idset);
+
+    /* grown size too big
+     */
+    if (!(idset = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        BAIL_OUT ("idset_create failed");
+    errno = 0;
+    rc = idset_set (idset, IDSET_MAX_UNIVERSE);
+    saved_errno = errno;
+    ok (rc < 0 && saved_errno == ERANGE,
+        "idset_set id=IDSET_MAX_UNIVERSE failed");
+    if (rc < 0)
+        diag ("%s", strerror (saved_errno));
+    idset_destroy (idset);
+
+    /* The following two sets of tests require a large memory allocation
+     * which might not work in CI, so skip them unless TEST_BIGMEM=t.
+     */
+    skip (is_bigmem () == false, 7, "TEST_BIGMEM=t is not set");
+
+    /* static size = max works
+     */
+    ok ((idset = idset_create (IDSET_MAX_UNIVERSE, 0)) != NULL,
+        "created max static size idset");
+    ok ((idset_destroy (idset), true),
+        "idset destroyed");
+
+    /* growth doesn't blindly request headroom that exceeds maximum size.
+     */
+    size_t maxsize = IDSET_MAX_UNIVERSE;
+    size_t univsize;
+    ok ((idset = idset_create (maxsize/2 + 1, IDSET_FLAG_AUTOGROW)) != NULL,
+        "created autogrow idset that, when doubled, would exceed max size");
+    ok ((univsize = idset_universe_size (idset)) * 2 > maxsize,
+        "got universe size that is in bounds for the test");
+    ok (idset_set (idset, univsize) == 0,
+        "idset_set id=universe_size works");
+    ok (idset_universe_size (idset) > univsize,
+        "and set did grow");
+    ok ((idset_destroy (idset), true),
+        "idset destroyed");
+
+    end_skip;
+
+    /* decode fails on too big id (size=-1, flags=0)
+     */
+    (void)snprintf (s, sizeof (s), "%zu", IDSET_MAX_UNIVERSE);
+    errno = 0;
+    idset = idset_decode_ex (s, -1, -1, 0, &error);
+    ok (idset == NULL && errno == ERANGE,
+        "idset_decode_ex size=-1 flags=0 fails on id=IDSET_MAX_UNIVERSE");
+    if (!idset)
+        diag ("%s", error.text);
+    idset_destroy (idset);
+
+    /* decode fails on too big id (size=0, flags=AUTOGROW)
+     */
+    (void)snprintf (s, sizeof (s), "%zu", IDSET_MAX_UNIVERSE);
+    errno = 0;
+    idset = idset_decode_ex (s, -1, 0, IDSET_FLAG_AUTOGROW, &error);
+    ok (idset == NULL && errno == ERANGE,
+        "idset_decode_ex with size=0 flags=AUTOGROW"
+        " fails on id=IDSET_MAX_UNIVERSE");
+    if (!idset)
+        diag ("%s", error.text);
+    idset_destroy (idset);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -1252,6 +1349,7 @@ int main (int argc, char *argv[])
     test_decode_empty ();
     test_decode_info ();
     test_decode_addsub ();
+    test_issue7494 ();
 
     done_testing ();
 }


### PR DESCRIPTION
Problem: `idset_set(ids, -586)` triggers a veb.c assertion failure on an autogrow set:
```
veb.c:88: encode: Assertion `8*(b-1) < WORD' failed.
```
When converted to an unsigned integer, -586 is a large, positive number that exceeds veb's internal expectation that ids are <= INT_MAX.  This limitation is not documented or checked in the idset wrapper.
    
Define IDSET_MAX_UNIVERSE in idset.h, and fail with ERANGE if a larger universe size is specified for a static sized idset, or implied by setting  a large id on an autogrow idset.
 
Add unit tests and update man page.