### PR TITLE
scheduler: support Rv1Pool subclasses

### DIFF
--- a/doc/python/scheduler.rst
+++ b/doc/python/scheduler.rst
@@ -655,10 +655,91 @@ hello/reload protocol.
 Customizing the resource pool
 -----------------------------
 
-By default the scheduler uses the built-in
-:class:`~flux.resource.ResourcePool.ResourcePool` version dispatch to
-construct its resource pool.  A custom pool class can be injected without
-modifying the scheduler itself using the pool class hook described below.
+The built-in :class:`~flux.resource.Rv1Pool` pool implementation exposes
+two override points that let a scheduler enforce topology-aware allocation
+policies without replacing the entire pool.  To substitute a different pool
+class entirely, see `Pool class hook (pool_class)`_ below.
+
+The underscore-prefixed methods below follow the Python *protected override*
+convention: subclasses of :class:`~flux.resource.Rv1Pool` may override them,
+but scheduler policy code should not call them directly.
+
+Pool-level selection hook
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Override :meth:`~flux.resource.Rv1Pool.Rv1Pool._select_resources` to control
+which candidates are chosen during each allocation.  The base class calls
+this method with a worst-fit-sorted list of
+``(rank, info, free_cores, free_gpus)`` tuples that already pass
+availability and constraint filters:
+
+.. code-block:: python
+
+   from flux.resource import InsufficientResources
+   from flux.resource.Rv1Pool import Rv1Pool
+
+   class _RackPoolV1(Rv1Pool):
+
+       def _select_resources(self, candidates, request):
+           # Group candidates by rack, then try the fullest rack first.
+           racks = {}
+           for entry in candidates:
+               rack_id = self._rack_map.get(entry[0])
+               if rack_id is not None:
+                   racks.setdefault(rack_id, []).append(entry)
+           for _count, rack_candidates in sorted(
+               ((len(v), v) for v in racks.values()), reverse=True
+           ):
+               try:
+                   return super()._select_resources(rack_candidates, request)
+               except InsufficientResources:
+                   continue
+           raise InsufficientResources("no single rack has sufficient resources")
+
+The method must return ``(selected, actual_nslots)`` on success, or raise
+:exc:`~flux.resource.InsufficientResources` if the candidates cannot satisfy
+the request.  Calling ``super()._select_resources(candidates, request)``
+delegates to the base greedy loop for the candidate subset.
+
+Pool-level feasibility hook
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Override :meth:`~flux.resource.Rv1Pool.Rv1Pool._check_feasibility` to add
+topology-aware permanent-denial logic.  The base class call must come first
+so that basic structural checks (node count, cores, GPUs, constraints) are
+enforced before the topology check:
+
+.. code-block:: python
+
+   from flux.resource import InfeasibleRequest
+   from flux.resource.Rv1Pool import Rv1Pool
+
+   class _RackPoolV1(Rv1Pool):
+
+       def _check_feasibility(self, request):
+           super()._check_feasibility(request)   # base structural checks first
+
+           if not self._rack_map or request.nnodes == 0:
+               return
+           max_rack_nodes = max(
+               sum(1 for r in self._ranks if self._rack_map.get(r) == rid)
+               for rid in set(self._rack_map.values())
+           )
+           if max_rack_nodes < request.nnodes:
+               raise InfeasibleRequest(
+                   f"rack-local request for {request.nnodes} node(s) cannot be "
+                   f"satisfied: largest rack has {max_rack_nodes} node(s)"
+               )
+
+Raising :exc:`~flux.resource.InfeasibleRequest` causes the scheduler to
+permanently deny the job via :meth:`~AllocRequest.deny`.  Returning
+normally indicates the request is structurally satisfiable; the scheduler
+will keep it pending and retry allocation when resources become available.
+
+Both hooks receive the full :class:`~flux.resource.Rv1Pool.ResourceRequest`
+object — the same object stored as ``job.resource_request`` on the
+:class:`PendingJob`.  This includes ``request.jobspec`` for reading
+site-specific ``attributes.system`` hints beyond the standard parsed fields.
 
 Pool class hook (pool_class)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -710,16 +791,28 @@ to map version integers to version-specific implementation classes in an
                raise ValueError(f"R version {version} not supported by RackPool")
            super().__init__(impl_class(R, log=log))
 
+The complete worked example of all three hooks — selection, feasibility, and
+pool class — is
+`t/scheduler/RackPool.py <https://github.com/flux-framework/flux-core/blob/master/t/scheduler/RackPool.py>`__
+in the source tree.
+`t/scheduler/sched-rack-subclass.py <https://github.com/flux-framework/flux-core/blob/master/t/scheduler/sched-rack-subclass.py>`__
+shows the class-attribute binding pattern.
+
+
 
 The R.scheduling key
 --------------------
 
 R may carry a ``scheduling`` key in its top-level JSON object containing
 scheduler-specific topology metadata.  Schedulers use this key to encode
-information not captured in the standard R execution section — for example,
-rack or chassis membership, network topology, or fabric locality.
+information that is not captured in the standard R execution section — for
+example, rack or chassis membership, network topology, or fabric locality.
+
 :class:`~flux.resource.Rv1Pool` propagates the ``scheduling`` key to every
-allocated R by default.
+allocated R by default, making it available to downstream consumers.
+Schedulers that store rank-indexed data in the key should override
+:meth:`~flux.resource.Rv1Pool.Rv1Pool.alloc` to filter it down to the
+allocated ranks before returning.
 
 Writer identification
 ~~~~~~~~~~~~~~~~~~~~~
@@ -734,6 +827,73 @@ and :meth:`~Scheduler._make_pool` instantiates it automatically.  This enables
 a sub-instance scheduler to load the same pool class as the parent without any
 explicit configuration — the parent bakes the URI into every allocated R, and
 the sub-instance picks it up on startup.
+
+The URI is resolved the same way as ``pool-class=URI``: a plain module name
+(e.g. ``"RackPool"``) imports the Python module and reads its ``pool_class``
+attribute; ``module:ClassName`` (e.g. ``"RackPool:RackPool"``) loads a named
+class directly.  The module must be importable via ``PYTHONPATH`` at startup
+time in both the parent and any sub-instance brokers.
+
+For the auto-discovery to work end-to-end, the pool's
+:meth:`~flux.resource.Rv1Pool.Rv1Pool.alloc` override must preserve the
+``writer`` key in the possibly trimmed ``scheduling`` it attaches to
+allocated R.
+
+Sub-instance resource pools
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In Flux, the R allocated to a job becomes the resource inventory of any
+sub-instance that starts inside that job.  A scheduler loaded in the
+sub-instance therefore initialises its pool from the allocated R.
+
+The sub-instance's resource module re-ranks the allocated nodes from zero:
+if the parent allocated original ranks ``{2, 3}``, the sub-instance sees
+them as ranks ``{0, 1}``.  The ``execution.R_lite`` section is updated
+automatically, but the ``scheduling`` key is not — its rank references still
+use the parent's numbering.  Two invariants must hold for the pool to be
+consistent:
+
+1. **Only allocated ranks appear in** ``scheduling``.  Override
+   :meth:`~flux.resource.Rv1Pool.Rv1Pool.alloc` to trim the key before the
+   result is returned, so each nesting level sees only its own topology:
+
+   .. code-block:: python
+
+      def alloc(self, jobid, request):
+          result = super().alloc(jobid, request)
+          if result.scheduling:
+              result.scheduling = dict(result.scheduling)
+              result.scheduling["racks"] = _filter_racks(
+                  result.scheduling.get("racks", []), set(result._ranks)
+              )
+          return result
+
+2. **Ranks in** ``scheduling`` **are re-mapped to match the pool.**
+   The sub-instance resource module always re-ranks allocated nodes from zero,
+   so pool ranks are always 0..N-1.  After trimming, the n-th rank in
+   ``scheduling`` (sorted ascending) corresponds to pool rank ``n``.  Apply
+   the sorted-zip unconditionally; when ranks already match it is a no-op:
+
+   .. code-block:: python
+
+      sorted_orig = sorted(rack_map)               # e.g. [2, 3]
+      rank_remap = dict(zip(sorted_orig, range(len(self._ranks))))
+      rack_map = {rank_remap[o]: rid for o, rid in rack_map.items()}
+      scheduling["racks"] = _rerank_racks(scheduling.get("racks", []), rank_remap)
+
+.. note::
+
+   The sorted-zip re-ranking assumes that the n-th node in the parent's
+   allocated R (ascending rank order) becomes broker rank ``n`` in the
+   sub-instance.  This holds for the typical case of one broker per physical
+   node with the default block taskmap.  It can break when a non-default
+   taskmap reorders task assignment across nodes (the broker's PMI rank —
+   which becomes its broker rank — equals its task rank).  Using hostnames
+   to correlate ``scheduling`` entries with pool entries is more robust in
+   principle, but does not work when multiple brokers share a node (as in
+   test instances), where each host appears more than once.
+
+`t/scheduler/RackPool.py <https://github.com/flux-framework/flux-core/blob/master/t/scheduler/RackPool.py>`__ demonstrates both steps.
 
 
 API reference

--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -549,8 +549,6 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                 "slot count specifies discrete valid values that this scheduler "
                 "does not support; use a simple min-max range instead"
             )
-        nnodes = request.nnodes
-        nslots = request.nslots
         slot_size = request.slot_size
         gpu_per_slot = request.gpu_per_slot
         exclusive = request.exclusive
@@ -587,66 +585,7 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
             reverse=True,
         )
 
-        # Greedy selection — each entry is (rank, info, alloc_cores, alloc_gpus)
-        selected: List[Tuple[int, dict, frozenset, frozenset]] = []
-
-        if nnodes > 0:
-            nnodes_min = nnodes
-            # nnodes_max: same as min → fixed; larger → bounded range; None → unbounded
-            nnodes_target = request.nnodes_max
-            slots_per_node = nslots // nnodes_min
-            for rank, info, free_cores, free_gpus in candidates:
-                if nnodes_target is not None and len(selected) >= nnodes_target:
-                    break
-                if exclusive:
-                    if len(free_cores) < len(info["cores"]):
-                        continue
-                    alloc_cores = frozenset(free_cores)
-                    alloc_gpus = frozenset(free_gpus)
-                else:
-                    need_cores = slots_per_node * slot_size
-                    need_gpus = slots_per_node * gpu_per_slot
-                    if len(free_cores) < need_cores or len(free_gpus) < need_gpus:
-                        continue
-                    alloc_cores = frozenset(sorted(free_cores)[:need_cores])
-                    alloc_gpus = frozenset(sorted(free_gpus)[:need_gpus])
-                selected.append((rank, info, alloc_cores, alloc_gpus))
-            if len(selected) < nnodes_min:
-                self._check_feasibility(request)
-                raise InsufficientResources("insufficient resources")
-        else:
-            nslots_min = nslots
-            nslots_target = request.nslots_max  # None → unbounded
-            allocated_slots = 0
-            for rank, info, free_cores, free_gpus in candidates:
-                if nslots_target is not None and allocated_slots >= nslots_target:
-                    break
-                free_core_slots = len(free_cores) // slot_size
-                if gpu_per_slot > 0:
-                    free_gpu_slots = len(free_gpus) // gpu_per_slot
-                    free_slots = min(free_core_slots, free_gpu_slots)
-                else:
-                    free_slots = free_core_slots
-                if nslots_target is not None:
-                    take = min(free_slots, nslots_target - allocated_slots)
-                else:
-                    take = free_slots  # unbounded: take all available on this node
-                if take > 0:
-                    ncores_take = take * slot_size
-                    ngpus_take = take * gpu_per_slot
-                    alloc_cores = frozenset(sorted(free_cores)[:ncores_take])
-                    alloc_gpus = frozenset(sorted(free_gpus)[:ngpus_take])
-                    selected.append((rank, info, alloc_cores, alloc_gpus))
-                    allocated_slots += take
-            if allocated_slots < nslots_min:
-                self._check_feasibility(request)
-                raise InsufficientResources("insufficient resources")
-
-        # Compute actual allocated slot count for storage in R.
-        if nnodes > 0:
-            actual_nslots = slots_per_node * len(selected)
-        else:
-            actual_nslots = allocated_slots
+        selected, actual_nslots = self._select_resources(candidates, request)
 
         # Build result pool and update allocation state on self
         selected_ranks = {rank for rank, _, _, _ in selected}
@@ -788,6 +727,83 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
             if rank in self._ranks:
                 self._ranks[rank]["allocated_cores"] |= oinfo["cores"]
                 self._ranks[rank]["allocated_gpus"] |= oinfo["gpus"]
+
+    def _select_resources(self, candidates: list, request) -> tuple:
+        """Select resources from *candidates* to satisfy *request*.
+
+        *candidates* is a list of ``(rank, info, free_cores, free_gpus)``
+        tuples, already filtered for availability and sorted worst-fit by the
+        caller.  Returns ``(selected, actual_nslots)`` where *selected* is a
+        list of ``(rank, info, alloc_cores, alloc_gpus)`` tuples.
+
+        Subclasses may override this method to implement topology-aware
+        selection policies (e.g. locality or exclusivity within a chassis or
+        rack).  The override receives the full candidate list with constraint
+        filtering already applied; it must raise
+        :exc:`~flux.resource.ResourcePoolImplementation.InsufficientResources`
+        if the request cannot be satisfied from the candidates provided.
+        """
+        nnodes = request.nnodes
+        nslots = request.nslots
+        slot_size = request.slot_size
+        gpu_per_slot = request.gpu_per_slot
+        exclusive = request.exclusive
+        selected: List[Tuple[int, dict, frozenset, frozenset]] = []
+
+        if nnodes > 0:
+            nnodes_min = nnodes
+            nnodes_target = request.nnodes_max
+            slots_per_node = nslots // nnodes_min
+            for rank, info, free_cores, free_gpus in candidates:
+                if nnodes_target is not None and len(selected) >= nnodes_target:
+                    break
+                if exclusive:
+                    if len(free_cores) < len(info["cores"]):
+                        continue
+                    alloc_cores = frozenset(free_cores)
+                    alloc_gpus = frozenset(free_gpus)
+                else:
+                    need_cores = slots_per_node * slot_size
+                    need_gpus = slots_per_node * gpu_per_slot
+                    if len(free_cores) < need_cores or len(free_gpus) < need_gpus:
+                        continue
+                    alloc_cores = frozenset(sorted(free_cores)[:need_cores])
+                    alloc_gpus = frozenset(sorted(free_gpus)[:need_gpus])
+                selected.append((rank, info, alloc_cores, alloc_gpus))
+            if len(selected) < nnodes_min:
+                self._check_feasibility(request)
+                raise InsufficientResources("insufficient resources")
+            actual_nslots = slots_per_node * len(selected)
+        else:
+            nslots_min = nslots
+            nslots_target = request.nslots_max
+            allocated_slots = 0
+            for rank, info, free_cores, free_gpus in candidates:
+                if nslots_target is not None and allocated_slots >= nslots_target:
+                    break
+                free_core_slots = len(free_cores) // slot_size
+                if gpu_per_slot > 0:
+                    free_gpu_slots = len(free_gpus) // gpu_per_slot
+                    free_slots = min(free_core_slots, free_gpu_slots)
+                else:
+                    free_slots = free_core_slots
+                if nslots_target is not None:
+                    take = min(free_slots, nslots_target - allocated_slots)
+                else:
+                    take = free_slots
+                if take > 0:
+                    ncores_take = take * slot_size
+                    ngpus_take = take * gpu_per_slot
+                    alloc_cores = frozenset(sorted(free_cores)[:ncores_take])
+                    alloc_gpus = frozenset(sorted(free_gpus)[:ngpus_take])
+                    selected.append((rank, info, alloc_cores, alloc_gpus))
+                    allocated_slots += take
+            if allocated_slots < nslots_min:
+                self._check_feasibility(request)
+                raise InsufficientResources("insufficient resources")
+            actual_nslots = allocated_slots
+
+        return selected, actual_nslots
 
     def _check_feasibility(self, request) -> None:
         """Raise :exc:`InfeasibleRequest` if *request* can structurally never

--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -522,14 +522,7 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                 "slot count specifies discrete valid values that this scheduler "
                 "does not support; use a simple min-max range instead"
             )
-        self._check_feasibility(
-            request.nnodes,
-            request.nslots,
-            request.slot_size,
-            request.exclusive,
-            request.constraint,
-            request.gpu_per_slot,
-        )
+        self._check_feasibility(request)
 
     def alloc(self, jobid: int, request) -> "Rv1Pool":
         """Allocate resources for *jobid* matching *request*.
@@ -619,9 +612,7 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                     alloc_gpus = frozenset(sorted(free_gpus)[:need_gpus])
                 selected.append((rank, info, alloc_cores, alloc_gpus))
             if len(selected) < nnodes_min:
-                self._check_feasibility(
-                    nnodes, nslots, slot_size, exclusive, constraint, gpu_per_slot
-                )
+                self._check_feasibility(request)
                 raise InsufficientResources("insufficient resources")
         else:
             nslots_min = nslots
@@ -648,9 +639,7 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                     selected.append((rank, info, alloc_cores, alloc_gpus))
                     allocated_slots += take
             if allocated_slots < nslots_min:
-                self._check_feasibility(
-                    nnodes, nslots, slot_size, exclusive, constraint, gpu_per_slot
-                )
+                self._check_feasibility(request)
                 raise InsufficientResources("insufficient resources")
 
         # Compute actual allocated slot count for storage in R.
@@ -800,16 +789,23 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                 self._ranks[rank]["allocated_cores"] |= oinfo["cores"]
                 self._ranks[rank]["allocated_gpus"] |= oinfo["gpus"]
 
-    def _check_feasibility(
-        self,
-        nnodes: int,
-        nslots: int,
-        slot_size: int,
-        exclusive: bool,
-        constraint,
-        gpu_per_slot: int,
-    ) -> None:
-        """Raise EOVERFLOW if the request can structurally never be satisfied."""
+    def _check_feasibility(self, request) -> None:
+        """Raise :exc:`InfeasibleRequest` if *request* can structurally never
+        be satisfied by this pool.
+
+        Subclasses may override to add topology-aware feasibility checks on
+        top of the base size and constraint checks.  Call
+        ``super()._check_feasibility(request)`` first to run the base checks,
+        then add subclass-specific checks.
+        """
+        nnodes = request.nnodes
+        nslots = request.nslots
+        slot_size = request.slot_size
+        exclusive = request.exclusive
+        gpu_per_slot = request.gpu_per_slot
+        constraint = request.constraint
+        if constraint is not None and isinstance(constraint, str):
+            constraint = json.loads(constraint)
         all_candidates = list(self._ranks.items())
         if constraint is not None:
             all_candidates = [

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -188,6 +188,7 @@ TESTSCRIPTS = \
 	t2306-sched-fifo.t \
 	t2307-sched-backfill.t \
 	t2308-sched-generator.t \
+	t2309-sched-rack.t \
 	t2310-resource-module.t \
 	t2311-resource-drain.t \
 	t2312-resource-exclude.t \
@@ -463,6 +464,8 @@ dist_check_SCRIPTS = \
 	job-manager/wait-interrupted.py \
 	job-manager/sched-helper.sh \
 	job-manager/job-conv.py \
+	scheduler/RackPool.py \
+	scheduler/sched-rack-subclass.py \
 	job-attach/outputsleep.sh \
 	job-exec/dummy.sh \
 	job-exec/imp.sh \

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -435,6 +435,57 @@ class TestRv1PoolWorstFit(unittest.TestCase):
         self.assertNotIn(1, a._ranks)
 
 
+class TestRv1PoolSelectResourcesOverride(unittest.TestCase):
+    """_select_resources is an overridable hook."""
+
+    R_uneven = {
+        "version": 1,
+        "execution": {
+            "R_lite": [
+                {"rank": "0", "children": {"core": "0-3"}},
+                {"rank": "1", "children": {"core": "0-1"}},
+            ],
+            "starttime": 0,
+            "expiration": 0,
+            "nodelist": ["big", "small"],
+        },
+    }
+
+    def test_override_controls_resource_selection(self):
+        """Subclass can reverse candidate order to implement best-fit."""
+
+        class BestFitPool(Rv1Pool):
+            def _select_resources(self, candidates, request):
+                return super()._select_resources(list(reversed(candidates)), request)
+
+        pool = BestFitPool(self.R_uneven)
+        # Default (worst-fit) picks rank0; best-fit should pick rank1 (smaller)
+        a = pool.alloc(1, rr(0, 1, 1))
+        self.assertIn(1, a._ranks)
+        self.assertNotIn(0, a._ranks)
+
+    def test_override_can_raise_insufficient(self):
+        """Override may raise InsufficientResources to block an allocation."""
+
+        class NoSmallPool(Rv1Pool):
+            def _select_resources(self, candidates, request):
+                # Reject any candidate with fewer than 4 cores
+                filtered = [
+                    (r, i, fc, fg)
+                    for r, i, fc, fg in candidates
+                    if len(i["cores"]) >= 4
+                ]
+                return super()._select_resources(filtered, request)
+
+        pool = NoSmallPool(self.R_uneven)
+        # rank1 has only 2 cores and is filtered out; rank0 satisfies the request
+        a = pool.alloc(1, rr(0, 1, 1))
+        self.assertIn(0, a._ranks)
+        # Requesting 2 nodes fails — only one has enough cores
+        with self.assertRaises(InsufficientResources):
+            pool.alloc(2, rr(2, 2, 1))
+
+
 class TestRv1PoolExclusive(unittest.TestCase):
     def setUp(self):
         self.pool = Rv1Pool(R_4x4)

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -678,6 +678,39 @@ class TestRv1PoolCheckFeasibility(unittest.TestCase):
         with self.assertRaises(InfeasibleRequest):
             self.pool.check_feasibility(req)
 
+    def test_constraint_as_json_string(self):
+        """Constraint passed as a JSON string is parsed correctly."""
+        import json
+
+        pool = Rv1Pool(R_props)
+        # "fast" nodes have 4 cores total; 10 is infeasible.
+        # Pass the constraint as a JSON string rather than a dict to exercise
+        # the json.loads() path in _check_feasibility.
+        req = ResourceRequest(
+            None,
+            ResourceCount(10, 10),
+            1,
+            0,
+            60.0,
+            json.dumps({"properties": ["fast"]}),
+            False,
+        )
+        with self.assertRaises(InfeasibleRequest):
+            pool.check_feasibility(req)
+
+    def test_subclass_can_extend_check_feasibility(self):
+        """Subclass can add checks via super()._check_feasibility(request)."""
+
+        class StrictPool(Rv1Pool):
+            def _check_feasibility(self, request):
+                super()._check_feasibility(request)
+                if request.nnodes > 2:
+                    raise InfeasibleRequest("at most 2 nodes allowed")
+
+        StrictPool(R_4x4).check_feasibility(rr(2, 2, 1))  # should pass
+        with self.assertRaises(InfeasibleRequest):
+            StrictPool(R_4x4).check_feasibility(rr(3, 3, 1))  # subclass rejects
+
 
 class TestRv1PoolCopy(unittest.TestCase):
     def setUp(self):

--- a/t/scheduler/RackPool.py
+++ b/t/scheduler/RackPool.py
@@ -1,0 +1,249 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""RackPool: Rv1Pool extension demonstrating rack-local allocation hooks.
+
+Rack topology is read from the ``scheduling.racks`` key of R.  The pool
+is selected automatically when the system R carries a ``writer`` key
+matching a module URI, or explicitly via sched-simple's ``pool-class=``
+argument.  In both cases the directory containing this file must be on
+``PYTHONPATH``::
+
+    PYTHONPATH=/path/to/dir flux module load sched-simple pool-class=RackPool
+
+The ``R.scheduling`` key format expected by this pool::
+
+    {
+      "scheduling": {
+        "writer": "RackPool",
+        "racks": [
+          {"id": 0, "ranks": "0-3"},
+          {"id": 1, "ranks": "4-7"}
+        ]
+      }
+    }
+
+Allocated R objects carry a trimmed ``scheduling`` key containing only the
+ranks that were allocated, so that a nested sub-instance scheduler sees only
+its own portion of the rack topology.  On sub-instance startup the resource
+module re-ranks the pool from 0 but treats the ``scheduling`` key as opaque,
+so :class:`_RackPoolV1` re-maps the ``scheduling`` ranks to match by zipping
+the two sorted rank sequences.
+
+This module demonstrates three :class:`~flux.resource.Rv1Pool.Rv1Pool`
+extension hooks:
+
+- :meth:`~flux.resource.Rv1Pool.Rv1Pool._select_resources` — rack-local
+  candidate selection.
+- :meth:`~flux.resource.Rv1Pool.Rv1Pool._check_feasibility` — permanent
+  denial when the request cannot fit in any single rack.
+- :meth:`~flux.resource.ResourcePool.ResourcePool` wrapping pattern —
+  version-dispatching outer class compatible with
+  :attr:`~flux.scheduler.Scheduler.pool_class`.
+"""
+
+import json
+from collections.abc import Mapping
+
+from flux.idset import IDset
+from flux.resource import InfeasibleRequest, InsufficientResources
+from flux.resource.ResourcePool import ResourcePool
+from flux.resource.Rv1Pool import Rv1Pool
+
+
+def _build_rack_map(scheduling):
+    """Return a dict mapping rank -> rack_id from R.scheduling.racks."""
+    rack_map = {}
+    for rack in (scheduling or {}).get("racks", []):
+        rack_id = rack["id"]
+        for rank in IDset(rack["ranks"]):
+            rack_map[rank] = rack_id
+    return rack_map
+
+
+def _ranks_to_idset_str(ranks):
+    """Convert a sorted list of rank integers to a compact IDset string."""
+    return str(IDset(",".join(str(r) for r in ranks)))
+
+
+def _filter_racks(racks, rank_set):
+    """Return racks with entries restricted to ranks in rank_set."""
+    result = []
+    for rack in racks:
+        kept = sorted(r for r in IDset(rack["ranks"]) if r in rank_set)
+        if kept:
+            result.append({"id": rack["id"], "ranks": _ranks_to_idset_str(kept)})
+    return result
+
+
+def _rerank_racks(racks, rank_remap):
+    """Return racks with rank numbers translated through rank_remap."""
+    result = []
+    for rack in racks:
+        new_ranks = sorted(
+            rank_remap[r] for r in IDset(rack["ranks"]) if r in rank_remap
+        )
+        if new_ranks:
+            result.append({"id": rack["id"], "ranks": _ranks_to_idset_str(new_ranks)})
+    return result
+
+
+class _RackPoolV1(Rv1Pool):
+    """Rv1Pool subclass that constrains allocation to a single rack."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.scheduling is None:
+            raise ValueError("RackPool requires R.scheduling")
+        scheduling = dict(self.scheduling)
+        rack_map = _build_rack_map(scheduling)
+        if not rack_map:
+            raise ValueError("RackPool requires R.scheduling with rack topology")
+
+        # Re-map scheduling ranks to pool ranks.  The sub-instance resource
+        # module always re-ranks allocated nodes from 0, so the n-th rank in
+        # scheduling (sorted ascending) corresponds to the n-th pool rank.
+        # Apply the sorted-zip unconditionally; when ranks already match it
+        # produces the identity mapping and is a no-op.
+        if rack_map:
+            sorted_orig = sorted(rack_map)
+            if len(sorted_orig) != len(self._ranks):
+                raise ValueError(
+                    f"sched-rack: rank count mismatch: "
+                    f"{len(sorted_orig)} in scheduling vs {len(self._ranks)} in pool"
+                )
+            rank_remap = dict(zip(sorted_orig, range(len(self._ranks))))
+            rack_map = {rank_remap[o]: rid for o, rid in rack_map.items()}
+            scheduling["racks"] = _rerank_racks(scheduling.get("racks", []), rank_remap)
+
+        self.scheduling = scheduling
+        self._rack_map = rack_map
+
+    def alloc(self, jobid, request):
+        result = super().alloc(jobid, request)
+        # Trim scheduling.racks to only the allocated ranks so that a
+        # sub-instance scheduler inherits only its portion of the topology.
+        if result.scheduling:
+            result.scheduling = dict(result.scheduling)
+            result.scheduling["racks"] = _filter_racks(
+                result.scheduling.get("racks", []), set(result._ranks)
+            )
+        return result
+
+    def _select_resources(self, candidates, request):
+        """Select candidates from a single rack.
+
+        If ``attributes.system.rack_exclusive`` is true in the jobspec, the
+        entire rack is allocated — all available nodes in the chosen rack are
+        reserved for the job even if fewer were requested.  Otherwise, tries
+        each rack in order of most available candidates and delegates to the
+        base greedy loop.  Falls back to base behaviour if no rack topology
+        is present.
+        """
+        if not self._rack_map:
+            return super()._select_resources(candidates, request)
+
+        rack_exclusive = (
+            request.jobspec.get("attributes", {})
+            .get("system", {})
+            .get("rack_exclusive", False)
+        )
+
+        racks = {}
+        for entry in candidates:
+            rack_id = self._rack_map.get(entry[0])
+            if rack_id is not None:
+                racks.setdefault(rack_id, []).append(entry)
+
+        if rack_exclusive:
+            # Whole-rack exclusive: allocate every available node in the
+            # chosen rack.  Requires at least request.nnodes candidates so
+            # the base request is satisfiable within the rack.
+            nnodes = request.nnodes if request.nnodes > 0 else 1
+            for _count, rack_candidates in sorted(
+                ((len(v), v) for v in racks.values()), reverse=True
+            ):
+                if len(rack_candidates) < nnodes:
+                    continue
+                selected = [
+                    (rank, info, frozenset(fc), frozenset(fg))
+                    for rank, info, fc, fg in rack_candidates
+                ]
+                actual_nslots = sum(
+                    len(ac) // request.slot_size for _, _, ac, _ in selected
+                )
+                return selected, actual_nslots
+            raise InsufficientResources(
+                "rack_exclusive: no rack has sufficient available nodes"
+            )
+
+        # Normal rack-local: try racks in descending order of available candidates
+        for _count, rack_candidates in sorted(
+            ((len(v), v) for v in racks.values()), reverse=True
+        ):
+            try:
+                return super()._select_resources(rack_candidates, request)
+            except InsufficientResources:
+                continue
+
+        raise InsufficientResources("no single rack has sufficient resources")
+
+    def _check_feasibility(self, request):
+        """Extend base feasibility check with rack-size constraint."""
+        super()._check_feasibility(request)
+
+        if not self._rack_map or request.nnodes == 0:
+            return
+
+        rack_node_counts = {}
+        for rank in self._ranks:
+            rack_id = self._rack_map.get(rank)
+            if rack_id is not None:
+                rack_node_counts[rack_id] = rack_node_counts.get(rack_id, 0) + 1
+
+        if not rack_node_counts:
+            return
+        max_rack_nodes = max(rack_node_counts.values())
+        if max_rack_nodes < request.nnodes:
+            raise InfeasibleRequest(
+                f"rack-local request for {request.nnodes} node(s) cannot be "
+                f"satisfied: largest rack has {max_rack_nodes} node(s)"
+            )
+
+
+class RackPool(ResourcePool):
+    """Version-dispatching rack pool.
+
+    Wraps a version-specific rack implementation — currently :class:`_RackPoolV1`
+    for Rv1 resources.  Inheriting from
+    :class:`~flux.resource.ResourcePool.ResourcePool` means that
+    :attr:`~flux.scheduler.Scheduler.pool_class` can be set to this class
+    directly: :meth:`~flux.scheduler.Scheduler._make_pool` gets a
+    :class:`~flux.resource.ResourcePool.ResourcePool`-compatible object back
+    without any extra wrapping, and the built-in version dispatch is preserved
+    here rather than in the scheduler base class.
+
+    To support a future R version, add a version-specific implementation
+    class and extend ``_impl_map``.
+    """
+
+    _impl_map = {1: _RackPoolV1}
+
+    def __init__(self, R, log=None, **kwargs):
+        if isinstance(R, str):
+            R = json.loads(R)
+        version = R.get("version", 1) if isinstance(R, Mapping) else 1
+        impl_class = self._impl_map.get(version)
+        if impl_class is None:
+            raise ValueError(f"R version {version} not supported by RackPool")
+        super().__init__(impl_class(R, log=log))
+
+
+pool_class = RackPool

--- a/t/scheduler/sched-rack-subclass.py
+++ b/t/scheduler/sched-rack-subclass.py
@@ -1,0 +1,47 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Minimal scheduler subclass using pool_class to bind RackPool.
+
+Tests the ``if self.pool_class is not None`` path in
+:meth:`~flux.scheduler.Scheduler._make_pool`.
+"""
+
+import heapq
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from RackPool import RackPool  # noqa: E402
+
+from flux.resource import InfeasibleRequest, InsufficientResources
+from flux.scheduler import Scheduler
+
+
+class RackSubclassScheduler(Scheduler):
+    pool_class = RackPool
+
+    def schedule(self):
+        while self._queue:
+            job = self._queue[0]
+            try:
+                alloc = self.resources.alloc(job.jobid, job.resource_request)
+            except InsufficientResources:
+                break
+            except InfeasibleRequest as exc:
+                job.request.deny(str(exc))
+            else:
+                job.request.success(alloc)
+            heapq.heappop(self._queue)
+            yield
+
+
+def mod_main(h, *args):
+    RackSubclassScheduler(h, *args).run()

--- a/t/t2309-sched-rack.t
+++ b/t/t2309-sched-rack.t
@@ -1,0 +1,199 @@
+#!/bin/sh
+
+test_description='sched-simple pool-class: rack-local allocation using RackPool'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+# RackPool.py lives in t/scheduler/; make it importable as 'rackpool'.
+export PYTHONPATH="${SHARNESS_TEST_SRCDIR}/scheduler${PYTHONPATH:+:${PYTHONPATH}}"
+
+# 4-node instance: ranks 0-1 in rack 0, ranks 2-3 in rack 1
+test_under_flux 4 job
+
+# Module URI used as the scheduling.writer value for auto-discovery.
+RACK_POOL_MOD="RackPool"
+
+# Build R with rack topology injected into scheduling key
+build_rack_R() {
+	flux R encode -r0-3 -c0-1 | \
+	    jq --arg writer "${RACK_POOL_MOD}" '.scheduling = {
+	        "writer": $writer,
+	        "racks": [
+	            {"id": 0, "ranks": "0-1"},
+	            {"id": 1, "ranks": "2-3"}
+	        ]
+	    }'
+}
+
+test_expect_success 'load sched-simple with rack topology R' '
+	flux module unload sched-simple &&
+	build_rack_R >R.rack &&
+	flux resource reload R.rack &&
+	flux module load sched-simple
+'
+test_expect_success 'RackPool raises ValueError when scheduling key is absent' '
+	cat >test_no_sched.py <<-EOF &&
+	import sys
+	sys.path.insert(0, "${SHARNESS_TEST_SRCDIR}/scheduler")
+	from RackPool import RackPool
+	import json, subprocess
+	R = json.loads(subprocess.check_output(["flux", "R", "encode", "-r0-3", "-c0-1"]))
+	RackPool(R, log=lambda lvl, msg: None)
+	EOF
+	test_must_fail flux python test_no_sched.py
+'
+
+test_expect_success 'RackPool raises ValueError when scheduling key has no rack topology' '
+	cat >test_no_racks.py <<-EOF &&
+	import sys
+	sys.path.insert(0, "${SHARNESS_TEST_SRCDIR}/scheduler")
+	from RackPool import RackPool
+	import json, subprocess
+	R = json.loads(subprocess.check_output(["flux", "R", "encode", "-r0-3", "-c0-1"]))
+	R["scheduling"] = {"writer": "${RACK_POOL_MOD}"}
+	RackPool(R, log=lambda lvl, msg: None)
+	EOF
+	test_must_fail flux python test_no_racks.py
+'
+
+test_expect_success 'sub-instance on rack-local allocation inherits topology' '
+	cat >batch-subinst.sh <<-EOF &&
+	#!/bin/sh
+	jobid=\$(flux submit --nodes=1 --exclusive hostname) &&
+	flux job wait-event --timeout=10 \${jobid} alloc &&
+	flux job info \${jobid} R | jq -e ".scheduling.racks | length == 1" &&
+	flux job info \${jobid} R | jq -e ".scheduling.racks[0].ranks | tonumber < 2" &&
+	flux job wait-event --timeout=10 \${jobid} clean &&
+	flux run --nodes=2 --exclusive hostname
+	EOF
+	chmod +x batch-subinst.sh &&
+	batchjob=$(flux batch --nodes=2 --exclusive batch-subinst.sh) &&
+	flux job wait-event --timeout=30 ${batchjob} alloc &&
+	flux job info ${batchjob} R | jq -e ".scheduling.writer == \"${RACK_POOL_MOD}\"" &&
+	flux job attach ${batchjob}
+'
+test_expect_success 'explicit pool-class= overrides writer-based discovery' '
+	flux module unload sched-simple &&
+	flux module load sched-simple pool-class=${RACK_POOL_MOD} &&
+	jobid=$(flux submit --nodes=1 --exclusive hostname) &&
+	flux job wait-event --timeout=10 ${jobid} alloc &&
+	flux job info ${jobid} R | jq -e ".scheduling.racks | length == 1" &&
+	flux job wait-event --timeout=10 ${jobid} clean &&
+	flux module unload sched-simple &&
+	flux module load sched-simple
+'
+
+test_expect_success 'disable job-exec and validator' '
+	flux module remove job-exec &&
+	flux module reload -f job-ingest disable-validator
+'
+test_expect_success 'single-node job allocates successfully' '
+	jobid=$(flux submit --nodes=1 --exclusive hostname) &&
+	flux job wait-event --timeout=10 ${jobid} alloc
+'
+test_expect_success 'allocated R carries scheduling key with writer' '
+	flux job info ${jobid} R | jq -e ".scheduling.racks" &&
+	flux job info ${jobid} R | jq -e ".scheduling.writer == \"${RACK_POOL_MOD}\""
+'
+test_expect_success 'cleanup single-node job' '
+	flux cancel ${jobid} &&
+	flux job wait-event --timeout=10 ${jobid} clean
+'
+test_expect_success 'two-node job allocates within one rack' '
+	jobid=$(flux submit --nodes=2 --exclusive hostname) &&
+	flux job wait-event --timeout=10 ${jobid} alloc &&
+	R=$(flux job info ${jobid} R) &&
+	ranks=$(echo ${R} | jq -r ".execution.R_lite[0].rank") &&
+	test_debug "echo allocated ranks: ${ranks}" &&
+	{ test "${ranks}" = "0-1" || test "${ranks}" = "2-3"; }
+'
+test_expect_success 'cleanup two-node job' '
+	flux cancel ${jobid} &&
+	flux job wait-event --timeout=10 ${jobid} clean
+'
+test_expect_success 'three-node job is denied: cannot fit in one rack' '
+	jobid=$(flux submit --nodes=3 --exclusive hostname) &&
+	flux job wait-event --timeout=10 ${jobid} exception &&
+	flux job info ${jobid} eventlog | grep "rack-local"
+'
+test_expect_success 'jobs can backfill into different racks independently' '
+	job0=$(flux submit --nodes=2 --exclusive hostname) &&
+	flux job wait-event --timeout=10 ${job0} alloc &&
+	job1=$(flux submit --nodes=2 --exclusive hostname) &&
+	flux job wait-event --timeout=10 ${job1} alloc &&
+	flux cancel ${job0} ${job1} &&
+	flux job wait-event --timeout=10 ${job1} clean
+'
+test_expect_success 'two single-node jobs share a rack when the other is full' '
+	job0=$(flux submit --nodes=2 --exclusive hostname) &&
+	flux job wait-event --timeout=10 ${job0} alloc &&
+	job0_rack_id=$(flux job info ${job0} R | jq -r ".scheduling.racks[0].id") &&
+	job1=$(flux submit --nodes=1 --exclusive hostname) &&
+	job2=$(flux submit --nodes=1 --exclusive hostname) &&
+	flux job wait-event --timeout=10 ${job1} alloc &&
+	flux job wait-event --timeout=10 ${job2} alloc &&
+	job1_rack_id=$(flux job info ${job1} R | jq -r ".scheduling.racks[0].id") &&
+	job2_rack_id=$(flux job info ${job2} R | jq -r ".scheduling.racks[0].id") &&
+	test_debug "echo job0_rack_id: ${job0_rack_id}, job1_rack_id: ${job1_rack_id}, job2_rack_id: ${job2_rack_id}" &&
+	test "${job1_rack_id}" = "${job2_rack_id}" &&
+	test "${job1_rack_id}" != "${job0_rack_id}" &&
+	flux cancel ${job0} ${job1} ${job2} &&
+	flux job wait-event --timeout=10 ${job2} clean
+'
+test_expect_success 'rack_exclusive job allocates entire rack' '
+	jobid=$(flux submit --nodes=1 --exclusive \
+	    --setattr=system.rack_exclusive=true hostname) &&
+	flux job wait-event --timeout=10 ${jobid} alloc &&
+	flux job info ${jobid} R >rack_excl.R &&
+	jq -e ".scheduling.racks | length == 1" rack_excl.R &&
+	rack_ranks=$(jq -r ".scheduling.racks[0].ranks" rack_excl.R) &&
+	test_debug "echo rack_exclusive allocated ranks: ${rack_ranks}" &&
+	{ test "${rack_ranks}" = "0-1" || test "${rack_ranks}" = "2-3"; }
+'
+test_expect_success 'regular job runs on remaining rack while rack_exclusive job is running' '
+	job1=$(flux submit --nodes=1 --exclusive hostname) &&
+	flux job wait-event --timeout=10 ${job1} alloc &&
+	job1_ranks=$(flux job info ${job1} R | jq -r ".execution.R_lite[0].rank") &&
+	test_debug "echo regular job allocated ranks: ${job1_ranks}" &&
+	test "${job1_ranks}" != "${rack_ranks}"
+'
+test_expect_success 'cleanup rack_exclusive and regular jobs' '
+	flux cancel ${jobid} ${job1} &&
+	flux job wait-event --timeout=10 ${jobid} clean &&
+	flux job wait-event --timeout=10 ${job1} clean
+'
+test_expect_success 'unload sched-simple' '
+	flux module remove sched-simple
+'
+
+# Test the pool_class class-attribute path in Scheduler._make_pool.
+# sched-rack-subclass.py is a Scheduler subclass with pool_class = RackPool
+# set as a class attribute, so no pool-class= argument or scheduling.writer
+# is required.
+RACK_SUBCLASS="${SHARNESS_TEST_SRCDIR}/scheduler/sched-rack-subclass.py"
+
+test_expect_success 'load sched-rack-subclass (pool_class class attribute)' '
+	flux module load ${RACK_SUBCLASS}
+'
+test_expect_success 'pool_class attr: single-node job allocates successfully' '
+	jobid=$(flux submit --nodes=1 --exclusive hostname) &&
+	flux job wait-event --timeout=10 ${jobid} alloc &&
+	flux job info ${jobid} R | jq -e ".scheduling.racks | length == 1" &&
+	flux cancel ${jobid} &&
+	flux job wait-event --timeout=10 ${jobid} clean
+'
+test_expect_success 'pool_class attr: two-node job allocates within one rack' '
+	jobid=$(flux submit --nodes=2 --exclusive hostname) &&
+	flux job wait-event --timeout=10 ${jobid} alloc &&
+	ranks=$(flux job info ${jobid} R | jq -r ".execution.R_lite[0].rank") &&
+	{ test "${ranks}" = "0-1" || test "${ranks}" = "2-3"; } &&
+	flux cancel ${jobid} &&
+	flux job wait-event --timeout=10 ${jobid} clean
+'
+test_expect_success 'unload sched-rack-subclass' '
+	flux module remove sched-rack-subclass
+'
+
+test_done


### PR DESCRIPTION
Problem: if we were to replace fluxion qmanager with a python front end as discussed in #7496, the `ResourcePool` class would presumably be replaced with fluxion-resource, either through RPCs to its broker module, or direct access through python bindings to `reapi`.  Additional override points would make this easier. 

This is an attempt to add override points.  Marking WIP for now since qmanager integration may need deeper investigation, but wanted to publish the effort and link it back to the qmanager issue.

A test-only scheduler is added here that demonstrates override points.  It uses the `scheduling` key to implement hardwired, topology-aware pool selection for a rack/node hierarchy.

Note: new overrides and use of `R.scheduling` key documented [here](https://flux-framework--7500.org.readthedocs.build/projects/flux-core/en/7500/python/scheduler.html#customizing-the-resource-pool)