### PR TITLE
python: add `JobspecV1.apply_options()` and `from_submit`/`alloc`/`batch()` factory methods

### DIFF
--- a/doc/python/job_submission.rst
+++ b/doc/python/job_submission.rst
@@ -17,16 +17,32 @@ Job submission
 
 Job submission is performed by creating a ``flux.job.Jobspec`` object,
 populating it with attributes, and then passing it to one of the submission
-functions, e.g. :ref:`flux.job.submit <python_flux_job_submit_func>`. Jobspec
-objects define everything
-about a job, including the job's resources, executable, working directory,
-environment, and stdio streams.
+functions, e.g. :ref:`flux.job.submit <python_flux_job_submit_func>`.
+Jobspec objects define everything about a job, including the job's
+resources, executable, working directory, environment, and stdio streams.
 
-Basic Jobspec creation is generally done with the
-``JobspecV1.from_command`` class method and its
-variants ``from_batch_command`` and ``from_nest_command``, which are helper
-methods replicating the jobspecs created by the
-job submission command-line utilities.
+``JobspecV1`` provides two layers of factory methods. The low-level
+methods — :meth:`~flux.job.JobspecV1.from_command`,
+:meth:`~flux.job.JobspecV1.from_batch_command`, and
+:meth:`~flux.job.JobspecV1.from_nest_command` — build the RFC 14 jobspec
+structure directly, accepting raw values for environment, resource limits,
+and duration. Further customization of the resulting jobspec is done via
+various setters, getters, and methods of :meth:`~flux.job.JobspecV1`, or
+further processing by :meth:`~flux.job.JobspecV1.apply_options`, which is
+a convenience method used by command-line tools to process common options
+and CLI plugin arguments.
+
+High-level methods -- :meth:`~flux.job.JobspecV1.from_submit`,
+:meth:`~flux.job.JobspecV1.from_alloc`, and :meth:`~flux.job.JobspecV1.from_batch`
+are also available which give callers full access to the same options
+available in the command-line tools :man1:`flux-submit`, :man1:`flux-alloc`,
+and :man1:`flux-batch` respectively.  These methods are equivalent to calling
+a low-level method and :meth:`~flux.job.JobspecV1.apply_options`
+with the appropriate ``prog`` in a single step. They use command-line flag
+aligned parameter names (``ntasks``, ``nodes``, ``time_limit``) and pass any
+remaining keyword arguments to :meth:`~flux.job.JobspecV1.apply_options`. The
+result is a jobspec equivalent to what ``flux submit``, ``flux alloc``, or
+``flux batch`` would produce.
 
 
 .. autoclass:: flux.job.Jobspec
@@ -36,6 +52,155 @@ job submission command-line utilities.
 	:show-inheritance:
 	:members:
 
+
+High-level factory methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:meth:`~flux.job.JobspecV1.from_submit`,
+:meth:`~flux.job.JobspecV1.from_alloc`, and
+:meth:`~flux.job.JobspecV1.from_batch` are the recommended starting
+point for most Python code. Each wraps the corresponding low-level
+method and calls :meth:`~flux.job.JobspecV1.apply_options` internally,
+so all :meth:`~flux.job.JobspecV1.apply_options` keyword arguments
+(``env``, ``rlimit``, ``time_limit``, ``dependency``, ``shell_options``,
+``attributes``, and more) can be passed directly, as can any CLI plugin
+option dests. The resulting jobspec is passed to :func:`~flux.job.submit`
+or :func:`~flux.job.submit_async` to actually run the job.
+
+Build a jobspec for a 16-task command and submit it:
+
+.. code-block:: python
+
+    import flux
+    import flux.job
+    from flux.job import JobspecV1
+
+    js = JobspecV1.from_submit(
+        ["myapp", "--input", "data.h5"],
+        ntasks=16,
+        cores_per_task=4,
+        time_limit="2h",
+        dependency=["afterok:f1234abcd"],
+        shell_options={"verbose": 1},
+        attributes={"system.queue": "gpu"},
+    )
+    jobid = flux.job.submit(flux.Flux(), js)
+
+Build a jobspec for a nested Flux instance on four nodes:
+
+.. code-block:: python
+
+    js = JobspecV1.from_alloc(
+        nodes=4,
+        time_limit="1h",
+        conf={"resource": {"noverify": True}},
+    )
+    jobid = flux.job.submit(flux.Flux(), js)
+
+Build a jobspec for a batch script from a file or inline content:
+
+.. code-block:: python
+
+    # From a file — job name defaults to the filename
+    js = JobspecV1.from_batch("/path/to/script.sh", nodes=4)
+
+    # Inline script content — use the content= keyword argument
+    js = JobspecV1.from_batch(
+        content="#!/bin/bash\nflux run -n8 myapp\n",
+        nslots=8,
+        time_limit="30m",
+        output="job-{{id}}.out",
+    )
+    jobid = flux.job.submit(flux.Flux(), js)
+
+See `Applying options to jobspecs`_ below for details on passing shell
+options, jobspec attributes, environment rules, resource limits, and CLI
+plugin options through these methods.
+
+
+Applying options to jobspecs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:meth:`~flux.job.JobspecV1.apply_options` can be called on any jobspec,
+including those created with the lower-level factory methods. It modifies
+the jobspec in-place and returns *self* so calls can be chained.
+
+**Shell options and jobspec attributes**
+
+``shell_options`` sets job-shell options; ``attributes`` sets jobspec
+attributes. Both accept plain Python dicts.
+
+.. code-block:: python
+
+    from flux.job import JobspecV1
+
+    js = JobspecV1.from_command(["hostname"]).apply_options(
+        shell_options={"verbose": 1},
+        attributes={"system.queue": "batch", ".user.comment": "my job"},
+    )
+
+Note that the above is equivalent to:
+
+.. code-block:: python
+
+    from flux.job import JobspecV1
+
+    js = JobspecV1.from_submit(
+        ["hostname"],
+        shell_options={"verbose": 1},
+        attributes={"system.queue": "batch", ".user.comment": "my job"},
+    )
+
+
+**Environment and resource limits**
+
+``env`` accepts filter rules applied to the submitter's environment.
+``rlimit`` propagates resource limits. The high-level factory methods
+(:meth:`~flux.job.JobspecV1.from_submit`,
+:meth:`~flux.job.JobspecV1.from_alloc`,
+:meth:`~flux.job.JobspecV1.from_batch`) always propagate the full environment
+and default resource limits even when neither is specified — matching CLI
+behavior. When calling :meth:`~flux.job.JobspecV1.apply_options` directly,
+``env`` and ``rlimit`` are only applied when explicitly passed; a call that
+omits both leaves any previously set environment and rlimits unchanged.
+
+.. code-block:: python
+
+    js.apply_options(
+        env=["MY_RANK={{rank}}", "-LD_PRELOAD", "IMPORTANT_VAR"],
+        rlimit=["-*", "nofile=65536"],
+    )
+
+**Using CLI plugin options**
+
+When ``prog`` is set, CLI plugins registered for that command are loaded
+and their ``modify_jobspec()`` hooks are invoked. Run ``flux <cmd> --help``
+to see what plugins are loaded — their options appear under "Options provided
+by plugins". The kwarg dest for each option is the flag name with the leading
+``--`` removed and dashes replaced by underscores (e.g. ``--amd-gpumode`` →
+``amd_gpumode``):
+
+.. code-block:: python
+
+    # --amd-gpumode is listed under "Options provided by plugins" in
+    # "flux submit --help" output; its dest is amd_gpumode
+    js = JobspecV1.from_submit(
+        ["myapp"],
+        ntasks=8,
+        amd_gpumode="TPX",
+    )
+
+    # Or apply to an existing jobspec:
+    js.apply_options(prog="submit", amd_gpumode="TPX")
+
+For programmatic discovery of available plugin option dests:
+
+.. code-block:: python
+
+    from flux.cli.plugin import CLIPluginRegistry
+
+    for opt in CLIPluginRegistry("submit").options:
+        print(f"{opt.name} -> dest: {opt.dest}")
 
 
 Job manipulation

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -31,6 +31,7 @@ nobase_fluxpy_PYTHON = \
 	core/handle.py \
 	core/trampoline.py \
 	job/__init__.py \
+	job/_utils.py \
 	job/JobID.py \
 	job/Jobspec.py \
 	job/event.py \

--- a/src/bindings/python/flux/cli/alloc.py
+++ b/src/bindings/python/flux/cli/alloc.py
@@ -16,6 +16,7 @@ import time
 import flux
 import flux.job
 from flux.cli import base
+from flux.job._utils import list_split
 from flux.uri import JobURI
 
 
@@ -56,9 +57,9 @@ class AllocCmd(base.BatchAllocCmd):
             cores_per_slot=args.cores_per_slot,
             gpus_per_slot=args.gpus_per_slot,
             num_nodes=args.nodes,
-            broker_opts=base.list_split(args.broker_opts),
+            broker_opts=list_split(args.broker_opts),
             exclusive=args.exclusive,
-            conf=args.conf.config,
+            conf=args.conf.config if args.conf else None,
             duration=args.time_limit,
             name=args.job_name,
             cwd=args.cwd if args.cwd is not None else os.getcwd(),

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -1030,34 +1030,6 @@ class MiniCmd:
         """
         raise NotImplementedError()
 
-    def handle_add_file_arg(self, jobspec, arg):
-        """Process a single argument to --add-file=ARG."""
-        perms = None
-        #  Note: Replace any newline escaped by the shell with literal '\n'
-        #  so that newline detection below works for file data passed on
-        #  on the command line:
-        name, _, data = arg.replace("\\n", "\n").partition("=")
-        if not data:
-            # No '=' implies path-only argument (no multiline allowed)
-            if "\n" in name:
-                raise ValueError("--add-file: file name missing")
-            data = name
-            name = basename(data)
-        else:
-            # Check if name specifies permissions after ':'
-            tmpname, _, permstr = name.partition(":")
-            try:
-                perms = int(permstr, base=8)
-                name = tmpname
-            except ValueError:
-                # assume ':' was part of name
-                pass
-        try:
-            jobspec.add_file(name, data, perms=perms)
-        except (TypeError, ValueError, OSError) as exc:
-            raise ValueError(f"--add-file={arg}: {exc}") from None
-
-    # pylint: disable=too-many-branches,too-many-statements
     def jobspec_create(self, args):
         """
         Create a jobspec from args and return it to caller

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -14,169 +14,19 @@
 
 import argparse
 import atexit
-import fnmatch
-import json
 import logging
 import os
-import pathlib
-import re
-import resource
-import signal
 import sys
-from collections import ChainMap
-from itertools import chain
-from os.path import basename
-from string import Template
-from urllib.parse import parse_qs, urlparse
-
-try:
-    import tomllib  # novermin
-except ModuleNotFoundError:
-    from flux.utils import tomli as tomllib
 
 import flux
 from flux import debugged, job, util
 from flux.cli.plugin import CLIPluginRegistry
-from flux.constraint.parser import ConstraintParser, ConstraintSyntaxError
 from flux.idset import IDset
 from flux.job import JobspecV1, JobWatcher
+from flux.job._utils import BatchConfig
 from flux.progress import ProgressBar
-from flux.util import dict_merge, get_treedict, set_treedict
 
 LOGGER = logging.getLogger("flux")
-
-
-def decode_signal(val):
-    """
-    Decode a signal as string or number
-    A string can be of the form 'SIGUSR1' or just 'USR1'
-    """
-    if isinstance(val, int):
-        return val
-    try:
-        return int(val)
-    except ValueError:
-        pass  # Fall back to signal name
-    try:
-        return getattr(signal, val)
-    except AttributeError:
-        pass  # Fall back SIG{name}
-    try:
-        return getattr(signal, f"SIG{val}")
-    except AttributeError:
-        pass  # Fall through to raise ValueError
-    raise ValueError(f"signal '{val}' is invalid")
-
-
-def decode_duration(val):
-    """
-    Decode a duration as a number or string in FSD
-    """
-    if isinstance(val, (float, int)):
-        return val
-    try:
-        return float(val)
-    except ValueError:
-        pass  # Fall back to fsd
-    return util.parse_fsd(val)
-
-
-def parse_signal_option(arg):
-    """
-    Parse the --signal= option argument of the form SIG@TIME, where
-    both signal and time are optional.
-
-    Returns a dict with signal and timeleft members
-    """
-    signo = signal.SIGUSR1
-    tleft = 60
-    if arg is not None:
-        sig, _, time = arg.partition("@")
-        if time:
-            tleft = time
-        if sig:
-            signo = sig
-    try:
-        signum = decode_signal(signo)
-        if signum <= 0:
-            raise ValueError("signal must be > 0")
-    except ValueError as exc:
-        raise ValueError(f"--signal={arg}: {exc}") from None
-
-    try:
-        timeleft = decode_duration(tleft)
-    except ValueError as exc:
-        raise ValueError(f"--signal={arg}: {exc}") from None
-
-    return {"signum": signum, "timeleft": timeleft}
-
-
-class MiniConstraintParser(ConstraintParser):
-    operator_map = {
-        None: "properties",
-        "host": "hostlist",
-        "hosts": "hostlist",
-        "rank": "ranks",
-    }
-    split_values = {"properties": ","}
-    combined_terms = {"properties"}
-
-
-class URIArg:
-    """Convenience class for handling dependencies
-
-    Splits a dependency URI into fields and returns an RFC 26 dependency
-    entry via the entry attribute.
-    """
-
-    def __init__(self, uri, name):
-        # append `:` if missing in uri so that a plain string is treated as
-        # a scheme with no path.
-        if ":" not in uri:
-            uri += ":"
-
-        # replace first ':' with ':FXX' to work around urlparse refusal
-        # to treat integer only path as a scheme:path.
-        self.uri = urlparse(uri.replace(":", ":FXX", 1))
-
-        if not self.uri.scheme or not self.uri.path:
-            raise ValueError(f'Invalid {name} URI "{uri}"')
-
-        self.path = self.uri.path.replace("FXX", "", 1)
-        self.scheme = self.uri.scheme
-
-    @staticmethod
-    def _try_number(value):
-        """Convert value to an int or a float if possible"""
-        for _type in (int, float):
-            try:
-                return _type(value)
-            except ValueError:
-                continue
-        return value
-
-    @property
-    def entry(self):
-        entry = {
-            "scheme": self.scheme,
-            "value": self.path,
-        }
-        if self.uri.query:
-            for key, val in parse_qs(self.uri.query).items():
-                #  val is always a list, but convert to single value
-                #   if it only contains a single item:
-                if len(val) > 1:
-                    entry[key] = [self._try_number(x) for x in val]
-                else:
-                    entry[key] = self._try_number(val[0])
-        return entry
-
-
-def dependency_array_create(uris):
-    dependencies = []
-    for uri in uris:
-        dependencies.append(URIArg(uri, "dependency").entry)
-    return dependencies
 
 
 class BeginTimeAction(argparse.Action):
@@ -192,167 +42,6 @@ class BeginTimeAction(argparse.Action):
             items = []
         items.append(uri)
         setattr(namespace, "dependency", items)
-
-
-def filter_dict(env, pattern, reverseMatch=True):
-    """
-    Filter out all keys that match "pattern" from dict 'env'
-
-    Pattern is assumed to be a shell glob(7) pattern, unless it begins
-    with '/', in which case the pattern is a regex.
-    """
-    if pattern.startswith("/"):
-        pattern = pattern[1::].rstrip("/")
-    else:
-        pattern = fnmatch.translate(pattern)
-    regex = re.compile(pattern)
-    if reverseMatch:
-        return dict(filter(lambda x: not regex.match(x[0]), env.items()))
-    return dict(filter(lambda x: regex.match(x[0]), env.items()))
-
-
-def get_rlimits(name="*"):
-    """
-    Return set of rlimits matching `name` in a dict
-    """
-    rlimits = {}
-    pattern = f"RLIMIT_{name}".upper()
-    for limit in fnmatch.filter(resource.__dict__.keys(), pattern):
-        soft, hard = resource.getrlimit(getattr(resource, limit))
-        #  Remove RLIMIT_ prefix and lowercase the result for compatibility
-        #  with rlimit shell plugin:
-        rlimits[limit[7::].lower()] = soft
-    if not rlimits:
-        raise ValueError(f'No corresponding rlimit matching "{name}"')
-    return rlimits
-
-
-def list_split(opts):
-    """
-    Return a list by splitting each member of opts on ','
-    """
-    if isinstance(opts, str):
-        return list_split([opts])
-    if opts:
-        x = chain.from_iterable([x.split(",") for x in opts])
-        return list(x)
-    return []
-
-
-def get_filtered_rlimits(user_rules=None):
-    """
-    Get a filtered set of rlimits based on user rules and defaults
-    """
-    #  We start with the entire set of available rlimits and then apply
-    #  rules to remove or override them. Therefore, the set of default
-    #  rules excludes limits *not* to propagate by default.
-    rules = [
-        "-memlock",
-        "-ofile",
-        "-msgqueue",
-        "-nice",
-        "-rtprio",
-        "-rttime",
-        "-sigpending",
-    ]
-
-    if user_rules:
-        rules.extend(list_split(user_rules))
-
-    rlimits = get_rlimits()
-    for rule in rules:
-        if rule.startswith("-"):
-            # -name removes RLIMIT_{pattern} from propagated rlimits
-            rlimits = filter_dict(rlimits, rule[1::].lower())
-        else:
-            name, *rest = rule.split("=", 1)
-            if not rest:
-                #  limit with no value pulls in current limit(s)
-                limits = get_rlimits(name.lower())
-                for key, value in limits.items():
-                    rlimits[key] = value
-            else:
-                if not hasattr(resource, f"RLIMIT_{name}".upper()):
-                    raise ValueError(f'Invalid rlimit "{name}"')
-                #  limit with value sets limit to that value
-                if rest[0] in ["unlimited", "infinity", "inf"]:
-                    value = resource.RLIM_INFINITY
-                else:
-                    try:
-                        value = int(rest[0])
-                    except ValueError:
-                        raise ValueError(f"Invalid value in {name}={rest[0]}")
-                rlimits[name.lower()] = value
-    return rlimits
-
-
-def get_filtered_environment(rules, environ=None):
-    """
-    Filter environment dictionary 'environ' given a list of rules.
-    Each rule can filter, set, or modify the existing environment.
-    """
-    env_expand = {}
-    if environ is None:
-        environ = dict(os.environ)
-    if rules is None:
-        return environ, env_expand
-    for rule in rules:
-        #
-        #  If rule starts with '-' then the rest of the rule is a pattern
-        #   which filters matching environment variables from the
-        #   generated environment.
-        #
-        if rule.startswith("-"):
-            environ = filter_dict(environ, rule[1::])
-        #
-        #  If rule starts with '^', then the result of the rule is a filename
-        #   from which to read more rules.
-        #
-        elif rule.startswith("^"):
-            filename = os.path.expanduser(rule[1::])
-            with open(filename) as envfile:
-                lines = [line.strip() for line in envfile]
-                environ, envx = get_filtered_environment(lines, environ=environ)
-                env_expand.update(envx)
-        #
-        #  Otherwise, the rule is an explicit variable assignment
-        #   VAR=VAL. If =VAL is not provided then VAL refers to the
-        #   value for VAR in the current environment of this process.
-        #
-        #  Quoted shell variables are expanded using values from the
-        #   built environment, not the process environment. So
-        #   --env=PATH=/bin --env=PATH='$PATH:/foo' results in
-        #   PATH=/bin:/foo.
-        #
-        else:
-            var, *rest = rule.split("=", 1)
-            if not rest:
-                #
-                #  VAR alone with no set value pulls in all matching
-                #   variables from current environment that are not already
-                #   in the generated environment.
-                env = filter_dict(os.environ, var, reverseMatch=False)
-                for key, value in env.items():
-                    if key not in environ:
-                        environ[key] = value
-            elif "{{" in rest[0]:
-                #
-                #  Mustache template which should be expanded by job shell.
-                #  Place result in env_expand instead of environ:
-                env_expand[var] = rest[0]
-            else:
-                #
-                #  Template lookup: use jobspec environment first, fallback
-                #   to current process environment using ChainMap:
-                lookup = ChainMap(environ, os.environ)
-                try:
-                    environ[var] = Template(rest[0]).substitute(lookup)
-                except ValueError:
-                    LOGGER.error("--env: Unable to substitute %s", rule)
-                    raise
-                except KeyError as ex:
-                    raise Exception(f"--env: Variable {ex} not found in {rule}")
-    return environ, env_expand
 
 
 class EnvFileAction(argparse.Action):
@@ -390,120 +79,6 @@ class EnvFilterAction(argparse.Action):
             items = []
         items.append("-" + values)
         setattr(namespace, "env", items)
-
-
-class BatchConfig:
-    """Convenience class for handling a --conf=[FILE|KEY=VAL] option
-
-    Iteratively build a "config" dict from successive updates.
-    """
-
-    loaders = {".toml": tomllib.load, ".json": json.load}
-
-    def __init__(self):
-        self.config = None
-
-    def update_string(self, value):
-        # Update config with JSON or TOML string
-        try:
-            conf = json.loads(value)
-        except json.decoder.JSONDecodeError:
-            # Try TOML
-            try:
-                conf = tomllib.loads(value)
-            except tomllib.TOMLDecodeError:
-                raise ValueError(
-                    "--conf: failed to parse multiline as TOML or JSON"
-                ) from None
-        self.config = dict_merge(self.config, conf)
-        return self
-
-    def update_keyval(self, keyval):
-        # dotted key (e.g. resource.noverify=true)
-        key, _, value = keyval.partition("=")
-        try:
-            value = json.loads(value)
-        except json.decoder.JSONDecodeError:
-            value = str(value)
-        try:
-            set_treedict(self.config, key, value)
-        except TypeError as e:
-            raise TypeError(f"failed to set {key} to {value}: {e}")
-        return self
-
-    def update_file(self, path, extension=".toml"):
-        # Update from file in the filesystem
-        try:
-            loader = self.loaders[extension]
-        except KeyError:
-            raise ValueError("--conf: {path} must end in .toml or .json")
-        try:
-            with open(path, "rb") as fp:
-                conf = loader(fp)
-        except OSError as exc:
-            raise ValueError(f"--conf: {exc}") from None
-        except (json.decoder.JSONDecodeError, tomllib.TOMLDecodeError) as exc:
-            raise ValueError(f"--conf: parse error: {path}: {exc}") from None
-        self.config = dict_merge(self.config, conf)
-        return self
-
-    def _find_config(self, name):
-        # Find a named config as either TOML or JSON in XDG search path
-        for path in util.xdg_searchpath(subdir="config"):
-            # Take the first matching filename preferring TOML:
-            for ext in (".toml", ".json"):
-                filename = f"{path}/{name}{ext}"
-                if os.path.exists(filename):
-                    return filename, self.loaders[ext]
-        return None, None
-
-    def update_named_config(self, name):
-        # Update from a named configuration file in a standard path or paths.
-        filename, loader = self._find_config(name)
-        if filename is not None:
-            try:
-                with open(filename, "rb") as fp:
-                    self.config = dict_merge(self.config, loader(fp))
-                    return self
-            except (
-                OSError,
-                tomllib.TOMLDecodeError,
-                json.decoder.JSONDecodeError,
-            ) as exc:
-                raise ValueError(f"--conf={name}: {filename}: {exc}") from None
-        raise ValueError(f"--conf: named config '{name}' not found")
-
-    def update(self, value):
-        """
-        Update current config with value using the following rules:
-        - If value contains one or more newlines, parse it as a JSON or
-          TOML string.
-        - Otherwise, if value contains an ``=``, then parse it as a dotted
-          key and value, e.g. ``resource.noverify=true``. The value (part
-          after the ``=``) will be parsed as JSON.
-        - Otherwise, if value ends in ``.toml`` or ``.json`` treat value as
-          a path and attempt to parse contents of file as TOML or JSON.
-        - Otherwise, read a named config from a standard config search path.
-
-        Configuration can be updated iteratively. The end result is available
-        in the ``config`` attribute.
-        """
-        if self.config is None:
-            self.config = {}
-        if "\n" in value:
-            return self.update_string(value)
-        if "=" in value:
-            return self.update_keyval(value)
-        extension = pathlib.Path(value).suffix
-        if extension in (".toml", ".json"):
-            return self.update_file(value, extension)
-        return self.update_named_config(value)
-
-    def get(self, key, default=None):
-        """
-        Get a value from the current config using dotted key form
-        """
-        return get_treedict(self.config or {}, key, default=default)
 
 
 class ConfAction(argparse.Action):
@@ -725,37 +300,13 @@ class Xcmd:
         return " ".join(result)
 
 
-def parse_jobspec_keyval(label, keyval):
-    """Parse a key[=value] option as used with --setopt and --setattr
-
-    Supports ^key=filename to load JSON object from a file
-    """
-    # Split into key, val with a default of 1 if no val given:
-    key, val = (keyval.split("=", 1) + [1])[:2]
-
-    # Support key prefix of ^ to load value from a file
-    if key.startswith("^"):
-        key = key.lstrip("^")
-        with open(val) as filep:
-            try:
-                val = json.load(filep)
-            except (json.JSONDecodeError, TypeError) as exc:
-                raise ValueError(f"{label}: {val}: {exc}") from exc
-    else:
-        try:
-            val = json.loads(val)
-        except (json.JSONDecodeError, TypeError):
-            # val was not a JSON string, keep as is
-            pass
-    return key, val
-
-
 class MiniCmd:
     """
     MiniCmd is the base class for all flux submission subcommands
     """
 
     def __init__(self, prog, usage=None, description=None, exclude_io=False):
+        self.prog = prog
         self.flux_handle = None
         self.exitcode = 0
         self.progress = None
@@ -1039,76 +590,16 @@ class MiniCmd:
 
         jobspec = self.init_jobspec(args)
 
-        jobspec.environment, env_expand = get_filtered_environment(args.env)
-        if env_expand:
-            # "expanded" environment variables are set in env-expand
-            # shell options dict and will be processed by the shell.
-            jobspec.setattr_shell_option("env-expand", env_expand)
+        # Apply job options (env, rlimits, signal, taskmap, deps,
+        # constraints, setopt, setattr, add-file, plugins).
+        # _preinit=False because preinit() was already called above.
+        jobspec.apply_options(args, prog=self.prog, _preinit=False)
 
-        rlimits = get_filtered_rlimits(args.rlimit)
-        if rlimits:
-            jobspec.setattr_shell_option("rlimit", rlimits)
-        if args.signal:
-            entry = parse_signal_option(args.signal)
-            jobspec.setattr_shell_option("signal", entry)
-
-        # --taskmap is only defined for run/submit, but we check
-        # for it in the base jobspec_create() for convenience
-        if hasattr(args, "taskmap") and args.taskmap is not None:
-            jobspec.setattr_shell_option(
-                "taskmap", URIArg(args.taskmap, "taskmap").entry
-            )
-
-        if args.dependency is not None:
-            jobspec.setattr(
-                "system.dependencies", dependency_array_create(args.dependency)
-            )
-        if args.requires is not None:
-            constraint = " ".join(args.requires)
-            try:
-                jobspec.setattr(
-                    "system.constraints", MiniConstraintParser().parse(constraint)
-                )
-            except ConstraintSyntaxError as exc:
-                raise ValueError(f"--requires='{constraint}': {exc}")
-
-        if args.setopt is not None:
-            for keyval in args.setopt:
-                key, val = parse_jobspec_keyval("--setopt", keyval)
-                jobspec.setattr_shell_option(key, val)
-
-        if args.debug_emulate:
+        # MPIR debugging support (CLI-only: sets global debugger state)
+        if getattr(args, "debug_emulate", False):
             debugged.set_mpir_being_debugged(1)
-
         if debugged.get_mpir_being_debugged() == 1:
-            # if stop-tasks-in-exec is present, overwrite
-            jobspec.setattr_shell_option("stop-tasks-in-exec", json.loads("1"))
-
-        if args.setattr is not None:
-            for keyval in args.setattr:
-                key, val = parse_jobspec_keyval("--setattr", keyval)
-
-                #  If key does not explicitly start with ".", "attributes.", "system."
-                #   or "user.", then "system." is implied. This is a
-                #   meant to be a usability enhancement since almost all
-                #   uses of --setattr will target attributes.system.
-                #
-                #  Allow users to set keys at the top level by
-                #   specifying "." before the key name, e.g. the key
-                #   ".foo" sets "attributes.foo".
-                if not key.startswith((".", "attributes.", "user.", "system.")):
-                    key = "system." + key
-                elif key.startswith("."):
-                    key = "attributes" + key
-
-                jobspec.setattr(key, val)
-
-        if args.add_file is not None:
-            for arg in args.add_file:
-                self.handle_add_file_arg(jobspec, arg)
-
-        # allow plugins to modify jobspec after its construction
-        self.plugins.modify_jobspec(args, jobspec)
+            jobspec.setattr_shell_option("stop-tasks-in-exec", 1)
 
         return jobspec
 
@@ -1686,7 +1177,7 @@ class BatchAllocCmd(MiniCmd):
         self.parser.add_argument(
             "--conf",
             metavar="CONF",
-            default=BatchConfig(),
+            default=None,
             action=ConfAction,
             help="Set configuration for a child Flux instance. CONF may be a "
             + "multiline string in JSON or TOML, a configuration key=value, a "
@@ -1746,6 +1237,13 @@ class BatchAllocCmd(MiniCmd):
             action="store_true",
             help="With -N, --nodes, allocate nodes exclusively",
         )
+
+    def jobspec_create(self, args):
+        # Ensure args.conf is a BatchConfig before preinit() so plugins can
+        # call args.conf.update() safely even when --conf was not specified.
+        if args.conf is None:
+            args.conf = BatchConfig()
+        return super().jobspec_create(args)
 
     def init_common(self, args):
         """Common initialization code for batch/alloc"""

--- a/src/bindings/python/flux/cli/batch.py
+++ b/src/bindings/python/flux/cli/batch.py
@@ -16,6 +16,7 @@ import sys
 import flux
 import flux.job
 from flux.cli import base
+from flux.job._utils import list_split
 from flux.job.directives import DirectiveParser
 
 LOGGER = logging.getLogger("flux-batch")
@@ -111,9 +112,9 @@ class BatchCmd(base.BatchAllocCmd):
             cores_per_slot=args.cores_per_slot,
             gpus_per_slot=args.gpus_per_slot,
             num_nodes=args.nodes,
-            broker_opts=base.list_split(args.broker_opts),
+            broker_opts=list_split(args.broker_opts),
             exclusive=args.exclusive,
-            conf=args.conf.config,
+            conf=args.conf.config if args.conf else None,
             duration=args.time_limit,
             cwd=args.cwd if args.cwd is not None else os.getcwd(),
             input=args.input,

--- a/src/bindings/python/flux/cli/plugin.py
+++ b/src/bindings/python/flux/cli/plugin.py
@@ -80,6 +80,10 @@ class CLIPluginOption:
             self._unprefixed_dest = None
         self.kwargs = kwargs
 
+    @property
+    def dest(self):
+        return self.kwargs["dest"]
+
 
 class CLIPlugin(ABC):  # pragma no cover
     """Base class for a CLI submission plugin
@@ -237,14 +241,14 @@ class CLIPluginRegistry:
         self.options = []
         for plugin in self.plugins:
             for option in plugin.options:
-                if option.kwargs["dest"] in option_dests:
+                if option.dest in option_dests:
                     raise ValueError(
                         f"{option.name} conflicts with another option (or its `dest`)"
                     )
                 else:
                     self.options.append(option)
                     ## keep a temporary list of "dests" to ensure no conflicts
-                    option_dests[option.kwargs["dest"]] = 1
+                    option_dests[option.dest] = 1
         return self  ## possibly unnecessary now
 
     def _make_alias(self, plugin):
@@ -254,10 +258,9 @@ class CLIPluginRegistry:
         and whose unprefixed and prefixed forms differ get an entry.
         """
         return {
-            opt._unprefixed_dest: opt.kwargs["dest"]
+            opt._unprefixed_dest: opt.dest
             for opt in plugin.options
-            if opt._unprefixed_dest is not None
-            and opt._unprefixed_dest != opt.kwargs["dest"]
+            if opt._unprefixed_dest is not None and opt._unprefixed_dest != opt.dest
         }
 
     def preinit(self, args):

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -15,6 +15,7 @@ import json
 import math
 import numbers
 import os
+import pathlib
 import threading
 from types import SimpleNamespace
 
@@ -31,6 +32,7 @@ from flux.job._utils import (
     get_filtered_environment,
     get_filtered_rlimits,
     jobspec_add_file,
+    normalize_conf,
     parse_jobspec_keyval,
     parse_signal_option,
 )
@@ -1147,6 +1149,14 @@ class JobspecV1(Jobspec):
                 practical.
             queue (str): Set the queue for the job.
             bank (str): Set the bank for the job.
+
+        Note:
+            This method is a low-level factory function which builds a
+            minimum RFC 14 jobspec directly. See :meth:`from_submit` for
+            a more full-featured alternative which wraps this method and
+            :meth:`apply_options` in a single call, and therefore supports
+            most options offered by the :man1:`flux-submit` CLI utility,
+            including options provided by configured CLI plugins.
         """
         if not isinstance(num_tasks, int) or num_tasks < 1:
             raise ValueError("task count must be a integer >= 1")
@@ -1252,6 +1262,13 @@ class JobspecV1(Jobspec):
                 broker command line.
             **kwargs: Extra named arguments as accepted in
                 :func:`~JobspecV1.from_command`
+
+        Note:
+            This is a low-level builder. For most Python code, :meth:`from_batch`
+            is preferred — it wraps this method and :meth:`apply_options`
+            in a single call and accepts a file path or inline script
+            content directly.
+
         """
         if not script.startswith("#!"):
             raise ValueError(f"{jobname} does not appear to start with '#!'")
@@ -1316,6 +1333,12 @@ class JobspecV1(Jobspec):
                 broker command line.
             **kwargs: Extra named arguments as accepted in
                 :func:`~JobspecV1.from_command`
+
+        Note:
+            This is a low-level builder. For most Python code, :meth:`from_alloc`
+            is preferred — it wraps this method and :meth:`apply_options`
+            in a single call, and therefore supports most :man1:`flux-alloc`
+            options include options provided by configured CLI plugins.
         """
         broker_opts = list(broker_opts) if broker_opts is not None else []
         if conf is not None:
@@ -1336,6 +1359,430 @@ class JobspecV1(Jobspec):
         if conf is not None:
             jobspec.add_file("conf.json", conf)
         return jobspec
+
+    @classmethod
+    def from_submit(
+        cls,
+        command,
+        *,
+        ntasks=1,
+        nodes=None,
+        cores_per_task=1,
+        gpus_per_task=None,
+        exclusive=False,
+        name=None,
+        queue=None,
+        bank=None,
+        cwd=None,
+        output=None,
+        error=None,
+        input=None,
+        label_io=False,
+        unbuffered=False,
+        **kwargs,
+    ):
+        """Create a jobspec for a command job with options applied.
+
+        Equivalent to :meth:`from_command` followed by
+        :meth:`apply_options` with ``prog="submit"``. Resource layout
+        and basic job arguments are listed below; all
+        :meth:`apply_options` keyword arguments (``env``, ``rlimit``,
+        ``time_limit``, ``dependency``, etc.) and CLI plugin option
+        dests are forwarded via ``**kwargs``.
+
+        Args:
+            command (list[str]): Command to execute.
+            ntasks (int): Number of tasks. Default ``1``.
+            nodes (int): Number of nodes to distribute tasks across.
+            cores_per_task (int): Cores per task. Default ``1``.
+            gpus_per_task (int): GPUs per task.
+            exclusive (bool): Allocate nodes exclusively.
+            name (str): Job name.
+            queue (str): Target queue.
+            bank (str): Target bank.
+            cwd (str): Working directory.
+            output (str): Path for standard output.
+            error (str): Path for standard error.
+            input (str): Path for standard input.
+            label_io (bool): Label output lines with task IDs.
+            unbuffered (bool): Disable output buffering.
+            **kwargs: Forwarded to :meth:`apply_options`.
+
+        Returns:
+            :class:`JobspecV1`
+
+        Note:
+            CLI plugin ``preinit()`` callbacks are invoked (via
+            :meth:`apply_options`) after the jobspec structure is built.
+            Mutations to resource-sizing attributes such as *ntasks* or
+            *nodes* inside ``preinit()`` are therefore ignored; use
+            ``modify_jobspec()`` for structural changes.
+
+        Example:
+
+            Build and submit a 16-task job with shell options and attributes::
+
+                import flux
+                import flux.job
+                from flux.job import JobspecV1
+
+                js = JobspecV1.from_submit(
+                    ["myapp", "--input", "data.h5"],
+                    ntasks=16,
+                    cores_per_task=4,
+                    time_limit="2h",
+                    shell_options={"verbose": 1},
+                    attributes={"system.queue": "gpu"},
+                    dependency=["afterok:f1234abcd"],
+                )
+                jobid = flux.job.submit(flux.Flux(), js)
+
+            Pass options registered by CLI plugins using their prefixed dest
+            name.  Run ``flux submit --help`` to see what plugins are loaded;
+            plugin options appear under "Options provided by plugins". The dest
+            for each option is the flag name with the leading ``--`` removed and
+            dashes replaced by underscores (e.g. ``--amd-gpumode`` →
+            ``amd_gpumode``)::
+
+                # --amd-gpumode is listed in "flux submit --help" output
+                js = JobspecV1.from_submit(["myapp"], ntasks=8, amd_gpumode="TPX")
+
+            For programmatic discovery of installed plugin option dests::
+
+                from flux.cli.plugin import CLIPluginRegistry
+
+                for opt in CLIPluginRegistry("submit").options:
+                    print(f"{opt.name} -> dest: {opt.dest}")
+
+            See :meth:`apply_options` for a full description of all accepted
+            keyword arguments.
+        """
+        js = cls.from_command(
+            command,
+            num_tasks=ntasks,
+            cores_per_task=cores_per_task,
+            gpus_per_task=gpus_per_task,
+            num_nodes=nodes,
+            exclusive=exclusive,
+            name=name,
+            queue=queue,
+            bank=bank,
+            cwd=cwd,
+            output=output,
+            error=error,
+            input=input,
+            label_io=label_io,
+            unbuffered=unbuffered,
+        )
+        # Pass env and rlimit explicitly so apply_options() propagates the
+        # caller's environment and default resource limits even when neither
+        # was specified. apply_options() only applies env/rlimit when they
+        # are passed as explicit keyword arguments (or when an args namespace
+        # is provided); without this, a bare apply_options(**kwargs) call
+        # would skip propagation when the caller omits env= and rlimit=.
+        # An empty list triggers full propagation with defaults (same as
+        # passing no rules on the CLI).
+        return js.apply_options(
+            prog="submit",
+            env=kwargs.pop("env", []),
+            rlimit=kwargs.pop("rlimit", []),
+            **kwargs,
+        )
+
+    @classmethod
+    def from_alloc(
+        cls,
+        *,
+        nslots=None,
+        nodes=None,
+        cores_per_slot=1,
+        gpus_per_slot=None,
+        exclusive=False,
+        broker_opts=None,
+        conf=None,
+        bg=False,
+        name=None,
+        queue=None,
+        bank=None,
+        cwd=None,
+        output=None,
+        error=None,
+        input=None,
+        label_io=False,
+        unbuffered=False,
+        **kwargs,
+    ):
+        """Create a jobspec for a nested Flux instance with options applied.
+
+        Equivalent to :meth:`from_nest_command` followed by
+        :meth:`apply_options` with ``prog="alloc"``. Either *nslots* or
+        *nodes* must be provided; if only *nodes* is given, *nslots*
+        defaults to *nodes* and *exclusive* is forced ``True``.
+
+        Args:
+            nslots (int): Number of resource slots.
+            nodes (int): Number of nodes. Sets *nslots* when *nslots*
+                is not given and forces *exclusive* ``True``.
+            cores_per_slot (int): Cores per slot. Default ``1``.
+            gpus_per_slot (int): GPUs per slot.
+            exclusive (bool): Allocate nodes exclusively.
+            broker_opts (list[str]): Options passed to the child broker.
+            conf: Broker configuration as a :class:`dict`,
+                :class:`~flux.job.BatchConfig`, or a string accepted by
+                :meth:`BatchConfig.update` (key=val, JSON, TOML, file path).
+            bg (bool): Start instance in the background without
+                attaching. Appends ``-Sbroker.rc2_none=1`` to
+                *broker_opts* and sets the ``pty.capture`` shell option.
+            name (str): Job name.
+            queue (str): Target queue.
+            bank (str): Target bank.
+            cwd (str): Working directory. Defaults to ``os.getcwd()``.
+            output (str): Path for standard output.
+            error (str): Path for standard error.
+            input (str): Path for standard input.
+            label_io (bool): Label output lines with task IDs.
+            unbuffered (bool): Disable output buffering.
+            **kwargs: Forwarded to :meth:`apply_options`.
+
+        Returns:
+            :class:`JobspecV1`
+
+        Note:
+            CLI plugin ``preinit()`` callbacks are invoked (via
+            :meth:`apply_options`) after the jobspec structure is built.
+            Mutations to resource-sizing attributes such as *nslots* or
+            *nodes* inside ``preinit()`` are therefore ignored; use
+            ``modify_jobspec()`` for structural changes.
+
+        Example:
+
+            Start a nested Flux instance on four nodes with a broker config::
+
+                import flux
+                import flux.job
+                from flux.job import JobspecV1
+
+                js = JobspecV1.from_alloc(
+                    nodes=4,
+                    time_limit="1h",
+                    conf={"resource": {"noverify": True}},
+                    shell_options={"verbose": 1},
+                )
+                jobid = flux.job.submit(flux.Flux(), js)
+
+            See :meth:`apply_options` for a full description of all accepted
+            keyword arguments, including CLI plugin options.
+        """
+        if nslots is None:
+            if nodes is not None:
+                nslots = nodes
+                exclusive = True
+            else:
+                raise ValueError("from_alloc() requires nslots or nodes")
+        if cwd is None:
+            cwd = os.getcwd()
+
+        if bg:
+            broker_opts = list(broker_opts or [])
+            broker_opts.append("-Sbroker.rc2_none=1")
+
+        js = cls.from_nest_command(
+            command=[],
+            num_slots=nslots,
+            cores_per_slot=cores_per_slot,
+            gpus_per_slot=gpus_per_slot,
+            num_nodes=nodes,
+            broker_opts=broker_opts,
+            exclusive=exclusive,
+            conf=normalize_conf(conf),
+            name=name,
+            queue=queue,
+            bank=bank,
+            cwd=cwd,
+            output=output,
+            error=error,
+            input=input,
+            label_io=label_io,
+            unbuffered=unbuffered,
+        )
+        if bg:
+            js.setattr_shell_option("pty.capture", 1)
+        # See from_submit() for why env= and rlimit= are passed explicitly.
+        return js.apply_options(
+            prog="alloc",
+            env=kwargs.pop("env", []),
+            rlimit=kwargs.pop("rlimit", []),
+            **kwargs,
+        )
+
+    @classmethod
+    def from_batch(
+        cls,
+        script=None,
+        *,
+        content=None,
+        nslots=None,
+        nodes=None,
+        cores_per_slot=1,
+        gpus_per_slot=None,
+        exclusive=False,
+        broker_opts=None,
+        conf=None,
+        wrap=False,
+        name=None,
+        queue=None,
+        bank=None,
+        cwd=None,
+        output=None,
+        error=None,
+        input=None,
+        label_io=False,
+        unbuffered=False,
+        **kwargs,
+    ):
+        """Create a jobspec for a batch script job with options applied.
+
+        Equivalent to :meth:`from_batch_command` followed by
+        :meth:`apply_options` with ``prog="batch"``. The script may be
+        supplied as a file path via *script* or as inline string content
+        via *content*; exactly one must be provided.
+
+        If neither *nslots* nor *nodes* is provided, *nslots* defaults
+        to ``1``. If only *nodes* is given, *nslots* defaults to *nodes*
+        and *exclusive* is forced ``True``.
+
+        Args:
+            script (str or os.PathLike): Path to the batch script file.
+                The file is read and *name* defaults to the filename.
+                Mutually exclusive with *content*.
+            content (str): Inline script content. *name* defaults to
+                ``"batch"``. Mutually exclusive with *script*.
+            nslots (int): Number of resource slots. Default ``1``.
+            nodes (int): Number of nodes. Sets *nslots* when *nslots*
+                is not given and forces *exclusive* ``True``.
+            cores_per_slot (int): Cores per slot. Default ``1``.
+            gpus_per_slot (int): GPUs per slot.
+            exclusive (bool): Allocate nodes exclusively.
+            broker_opts (list[str]): Options passed to the child broker.
+            conf: Broker configuration — see :meth:`from_alloc`.
+            wrap (bool): If ``True`` and the script has no shebang,
+                prepend ``#!/bin/sh``.
+            name (str): Job name. Defaults to the script filename when
+                *script* is given, otherwise ``"batch"``.
+            queue (str): Target queue.
+            bank (str): Target bank.
+            cwd (str): Working directory. Defaults to ``os.getcwd()``.
+            output (str): Path for standard output. Defaults to
+                ``"flux-{{id}}.out"``.
+            error (str): Path for standard error.
+            input (str): Path for standard input.
+            label_io (bool): Label output lines with task IDs.
+            unbuffered (bool): Disable output buffering.
+            **kwargs: Forwarded to :meth:`apply_options`.
+
+        Returns:
+            :class:`JobspecV1`
+
+        Raises:
+            TypeError: If both *script* and *content* are given, or
+                neither is given.
+
+        Note:
+            CLI plugin ``preinit()`` callbacks are invoked (via
+            :meth:`apply_options`) after the jobspec structure is built.
+            Mutations to resource-sizing attributes such as *nslots* or
+            *nodes* inside ``preinit()`` are therefore ignored; use
+            ``modify_jobspec()`` for structural changes.
+
+        Example:
+
+            Submit a batch script from a file::
+
+                import flux
+                import flux.job
+                from flux.job import JobspecV1
+
+                js = JobspecV1.from_batch(
+                    "/path/to/script.sh",
+                    nodes=4,
+                    time_limit="2h",
+                    attributes={"system.queue": "batch"},
+                )
+                jobid = flux.job.submit(flux.Flux(), js)
+
+            Submit an inline script::
+
+                js = JobspecV1.from_batch(
+                    content="#!/bin/bash\nflux run -n8 myapp\n",
+                    nslots=8,
+                    output="myapp-{{id}}.out",
+                    error="myapp-{{id}}.err",
+                )
+                jobid = flux.job.submit(flux.Flux(), js)
+
+            See :meth:`apply_options` for a full description of all accepted
+            keyword arguments, including how to discover and use CLI plugin
+            options.
+        """
+        if script is not None and content is not None:
+            raise TypeError("from_batch() accepts 'script' or 'content', not both")
+        if script is None and content is None:
+            raise TypeError(
+                "from_batch() requires 'script' (file path) or 'content' (inline script)"
+            )
+
+        if content is not None:
+            script = content
+        else:
+            script_path = pathlib.Path(script)
+            if name is None:
+                name = script_path.name
+            script = script_path.read_text(encoding="utf-8")
+
+        if wrap and not script.startswith("#!"):
+            script = "#!/bin/sh\n" + script
+
+        # nslots/nodes defaulting
+        if nslots is None:
+            if nodes is not None:
+                nslots = nodes
+                exclusive = True
+            else:
+                nslots = 1
+
+        if name is None:
+            name = "batch"
+        if cwd is None:
+            cwd = os.getcwd()
+        if output is None:
+            output = "flux-{{id}}.out"
+
+        js = cls.from_batch_command(
+            script=script,
+            jobname=name,
+            num_slots=nslots,
+            cores_per_slot=cores_per_slot,
+            gpus_per_slot=gpus_per_slot,
+            num_nodes=nodes,
+            broker_opts=broker_opts,
+            exclusive=exclusive,
+            conf=normalize_conf(conf),
+            cwd=cwd,
+            output=output,
+            error=error,
+            input=input,
+            label_io=label_io,
+            unbuffered=unbuffered,
+            queue=queue,
+            bank=bank,
+        )
+        # See from_submit() for why env= and rlimit= are passed explicitly.
+        return js.apply_options(
+            prog="batch",
+            env=kwargs.pop("env", []),
+            rlimit=kwargs.pop("rlimit", []),
+            **kwargs,
+        )
 
     def apply_options(
         self,

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -16,10 +16,24 @@ import math
 import numbers
 import os
 import threading
+from types import SimpleNamespace
 
 import yaml
 from _flux._core import ffi
 from flux import Flux, hostlist, idset
+from flux.cli.plugin import CLIPluginRegistry
+from flux.constraint.parser import ConstraintSyntaxError
+from flux.job._utils import (
+    MiniConstraintParser,
+    URIArg,
+    decode_duration,
+    dependency_array_create,
+    get_filtered_environment,
+    get_filtered_rlimits,
+    jobspec_add_file,
+    parse_jobspec_keyval,
+    parse_signal_option,
+)
 from flux.util import Fileref, del_treedict, parse_fsd, set_treedict
 
 # thread local storage to support shared and cached validation data
@@ -1322,3 +1336,302 @@ class JobspecV1(Jobspec):
         if conf is not None:
             jobspec.add_file("conf.json", conf)
         return jobspec
+
+    def apply_options(
+        self,
+        args=None,
+        *,
+        prog=None,
+        _preinit=True,
+        env=None,
+        rlimit=None,
+        signal=None,
+        taskmap=None,
+        dependency=None,
+        requires=None,
+        shell_options=None,
+        time_limit=None,
+        attributes=None,
+        add_file=None,
+        **kwargs,
+    ):
+        """Apply submission options to this jobspec.
+
+        Modifies the jobspec in-place and returns *self* for method chaining.
+        Options may be passed as explicit keyword arguments, via *args* (an
+        :class:`argparse.Namespace` or any object with matching attributes),
+        or both — keyword arguments take precedence over *args* attributes.
+        All options are optional; absent options are silently ignored.
+
+        The options correspond to ``flux submit`` command-line flags; see
+        :linux:man1:`flux-submit` or run ``flux submit --help`` for general
+        option semantics. Options with non-obvious Python-specific behavior
+        are described in full below.
+
+        Note:
+            ``env`` and ``rlimit`` are only applied when explicitly passed
+            as keyword arguments, or when *args* is provided (the CLI path).
+            Pass ``env=[]`` or ``rlimit=[]`` to propagate the full environment
+            or the default resource-limit set without any filtering rules. To
+            suppress env propagation entirely, pass ``env=["-*"]``.
+
+        Note:
+            ``shell_options`` and ``attributes`` accept plain Python dicts.
+            The CLI-compatible string forms ``setopt`` and ``setattr`` are
+            supported when passed via an *args* namespace (for use by the
+            CLI internally), but are not accepted as keyword arguments.
+            Python code should use ``shell_options`` and ``attributes``, or
+            use :meth:`Jobspec.setattr_shell_option`, :meth:`Jobspec.setattr`.
+
+        Args:
+            args: Optional namespace object (e.g. :class:`argparse.Namespace`)
+                whose attributes supply option values. Explicit keyword
+                arguments override any same-named attribute in *args*. This
+                parameter is mainly used internally by the CLI; most Python
+                code should use keyword arguments directly.
+            prog (str): CLI plugin context name — ``"submit"``, ``"run"``,
+                ``"batch"``, or ``"alloc"``. When set, plugins registered for
+                that command are loaded and their ``modify_jobspec`` hooks are
+                invoked. Defaults to ``None`` (no plugin processing).
+            env (list[str]): Environment filter rules applied to the
+                submitter's environment. Each rule is one of:
+
+                * ``"VAR=VALUE"`` — set *VAR* to *VALUE* in the job
+                  environment, expanding ``$VAR`` references against the
+                  environment built so far.
+                * ``"VAR"`` — import *VAR* from the submitter's environment
+                  (glob patterns are accepted, e.g. ``"SLURM_*"``).
+                * ``"-PATTERN"`` — remove variables matching the glob
+                  *PATTERN*, e.g. ``"-LD_*"``.
+                * ``"^/path/to/file"`` — read additional rules from a file.
+
+                Values containing ``{{…}}`` (e.g. ``"MY_RANK={{rank}}"``)
+                are stored as mustache templates and expanded by the job
+                shell at startup, not at submission time.
+            rlimit (list[str]): Resource-limit propagation rules. Each rule
+                is one of:
+
+                * ``"NAME"`` — propagate ``RLIMIT_NAME`` at its current
+                  value (glob patterns accepted, e.g. ``"*"``).
+                * ``"NAME=VALUE"`` — set ``RLIMIT_NAME`` to *VALUE*; use
+                  ``"unlimited"`` or ``"infinity"`` for ``RLIM_INFINITY``.
+                * ``"-NAME"`` — remove ``RLIMIT_NAME`` from propagation.
+
+                Pass ``rlimit=[]`` to propagate the default set of rlimits
+                (``stack``, ``cpu``, ``fsize``, etc.) without any filtering
+                rules. When *rlimit* is omitted and no *args* namespace is
+                provided, no rlimits are applied (see the Note above).
+            signal (str): Send a signal to the job before its time limit
+                expires. Format: ``"[SIG][@TIME]"`` where *SIG* is a signal
+                name or number (default ``SIGUSR1``) and *TIME* is a duration
+                in Flux Standard Duration (default ``60s``). Examples:
+                ``"USR1@30s"``, ``"TERM@2m"``, ``"@2m"`` (SIGUSR1, 2-minute
+                warning).
+            time_limit (str or float): Job wall-clock limit as a Flux
+                Standard Duration string (e.g. ``"30s"``, ``"1.5h"``,
+                ``"2d"``) or a plain ``float`` number of seconds. See
+                :linux:man7:`flux-standard-duration`. A value of ``0`` means
+                no limit.
+            taskmap (str): Task-to-node mapping scheme, e.g. ``"block"``
+                (default) or ``"cyclic"``. Corresponds to ``--taskmap``.
+            dependency (list[str]): Job dependency URIs, e.g.
+                ``["afterok:f1234abcd", "afterany:f5678ef01"]``. Corresponds
+                to ``--dependency``.
+            requires (list[str]): Node constraint expressions, e.g.
+                ``["host:node1", "rank:0"]``. Multiple entries are
+                AND-combined. Corresponds to ``--requires``.
+            shell_options (dict): Job-shell options as a plain Python dict,
+                e.g. ``{"verbose": 1, "pty": 1}``. Keys and values must be
+                JSON-serializable.
+            attributes (dict): Jobspec attributes as a plain Python dict.
+                Keys may be fully qualified (e.g. ``"system.foo"``) or bare
+                (e.g. ``"foo"``), in which case the ``system.`` namespace is
+                implied. A leading ``"."`` addresses the ``attributes.`` root
+                directly (e.g. ``".user.comment"`` sets
+                ``attributes.user.comment``).
+            add_file (list[str]): Files to attach to the job. Each entry
+                uses one of the following forms:
+
+                * ``"/path/to/file"`` — attach a file from the filesystem;
+                  the name in the jobspec is the basename of the path.
+                * ``"name=/path/to/file"`` — attach a file with an explicit
+                  name.
+                * ``"name=line1\\nline2\\n"`` — attach inline text content
+                  (use ``"\\n"`` for newlines in the string).
+                * ``"name:0755=/path/to/script"`` — attach a file with
+                  explicit octal permissions.
+
+                Corresponds to ``--add-file``.
+
+        Returns:
+            self, to allow method chaining.
+
+        Example:
+
+            Build a jobspec and apply several options at once::
+
+                from flux.job import JobspecV1
+
+                jobspec = JobspecV1.from_command(
+                    ["myapp", "--input", "data.h5"],
+                    num_tasks=16,
+                    cores_per_task=4,
+                ).apply_options(
+                    time_limit="2h",
+                    env=["-LD_PRELOAD", "MY_RANK={{rank}}"],
+                    dependency=["afterok:f1234abcd"],
+                    shell_options={"verbose": 1},
+                    attributes={"system.queue": "gpu"},
+                )
+
+            Attach a helper script and set resource limits::
+
+                jobspec.apply_options(
+                    add_file=["setup.sh=/path/to/setup.sh"],
+                    rlimit=["-*", "nofile=65536"],
+                )
+        """
+        # Collect all named parameters into all_options using locals().
+        #
+        # WHY locals(): every named parameter here corresponds to a supported
+        # option.  Using locals() means adding a new option only requires a new
+        # named parameter — there is no separate list to keep in sync.
+        #
+        # CONSTRAINT: locals() must be called before any other local variable
+        # is assigned.  Any variable introduced above this line is captured and
+        # will appear as an unexpected option key, most likely triggering an
+        # unknown-kwarg error in tests.  New guard variables or temporaries
+        # that must live near the top of the function belong AFTER locals()
+        # (see _env_was_set / _rlimit_was_set below as examples).
+        #
+        # Meta-parameters (self, args, prog, _preinit) are excluded via
+        # _skip; **kwargs is expanded separately to include plugin-defined
+        # option dests.
+        _params = locals()
+        _skip = frozenset({"self", "args", "prog", "_preinit", "kwargs"})
+        all_options = {k: v for k, v in _params.items() if k not in _skip}
+        all_options.update(kwargs)
+
+        # Load plugin registry once — used for kwarg validation and plugins
+        registry = CLIPluginRegistry(prog) if prog else None
+
+        # Validate **kwargs: built-in options are validated by Python itself
+        # (explicit named parameters above)
+        # Only plugin-defined dests reach here:
+        if kwargs:
+            known_plugin_dests = (
+                {opt.dest for opt in registry.options} if registry else set()
+            )
+            unknown = set(kwargs) - known_plugin_dests
+            if unknown:
+                raise TypeError(
+                    "apply_options() got unexpected keyword argument(s): "
+                    + ", ".join(repr(k) for k in sorted(unknown))
+                )
+
+        # Build a unified namespace with three layers of precedence:
+        #   defaults — None for every known key, so merged.key always works
+        #              without getattr fallbacks throughout the body below.
+        #   base     — args namespace values override the None defaults.
+        #   explicit — non-None kwargs override the namespace, ensuring that
+        #              explicitly passed keyword arguments always take priority.
+        base = vars(args) if args is not None else {}
+        defaults = {k: None for k in all_options}
+        explicit = {k: v for k, v in all_options.items() if v is not None}
+        merged = SimpleNamespace(**{**defaults, **base, **explicit})
+
+        # Normalize list-typed parameters: Python callers may pass a bare string
+        # where the CLI always produces a list (argparse nargs="*"). Wrap strings
+        # so downstream code can safely iterate without splitting on characters.
+        for _p in ("requires", "dependency", "env", "rlimit"):
+            if isinstance(getattr(merged, _p, None), str):
+                setattr(merged, _p, [getattr(merged, _p)])
+
+        # Determine if env/rlimit were explicitly provided.  Defined after
+        # locals() so they are not captured in all_options.
+        # - non-None value in all_options: caller passed env= or rlimit= explicitly
+        # - args is not None: CLI path — always propagate using args.env/rlimit
+        _env_was_set = all_options.get("env") is not None or args is not None
+        _rlimit_was_set = all_options.get("rlimit") is not None or args is not None
+
+        # Environment — only applied when explicitly requested (see Note above)
+        if _env_was_set:
+            self.environment, env_expand = get_filtered_environment(merged.env)
+            if env_expand:
+                self.setattr_shell_option("env-expand", env_expand)
+
+        # rlimits — only applied when explicitly requested (see Note above)
+        if _rlimit_was_set:
+            rlimits = get_filtered_rlimits(merged.rlimit)
+            if rlimits:
+                self.setattr_shell_option("rlimit", rlimits)
+
+        # signal
+        if merged.signal:
+            self.setattr_shell_option("signal", parse_signal_option(merged.signal))
+
+        # taskmap
+        if merged.taskmap is not None:
+            self.setattr_shell_option(
+                "taskmap", URIArg(merged.taskmap, "taskmap").entry
+            )
+
+        # dependencies
+        if merged.dependency is not None:
+            self.setattr(
+                "system.dependencies", dependency_array_create(merged.dependency)
+            )
+
+        # constraints
+        if merged.requires is not None:
+            constraint = " ".join(merged.requires)
+            try:
+                self.setattr(
+                    "system.constraints", MiniConstraintParser().parse(constraint)
+                )
+            except ConstraintSyntaxError as exc:
+                raise ValueError(f"--requires='{constraint}': {exc}")
+
+        # setopt strings (namespace-only, CLI path) then shell_options dict
+        for keyval in getattr(merged, "setopt", None) or []:
+            key, val = parse_jobspec_keyval("--setopt", keyval)
+            self.setattr_shell_option(key, val)
+        for key, val in (merged.shell_options or {}).items():
+            self.setattr_shell_option(key, val)
+
+        # time limit
+        if merged.time_limit is not None:
+            self.duration = decode_duration(merged.time_limit)
+
+        # setattr strings (namespace-only, CLI path) then attributes dict
+        for keyval in getattr(merged, "setattr", None) or []:
+            key, val = parse_jobspec_keyval("--setattr", keyval)
+            # No prefix → system. implied; leading '.' → attributes.
+            if not key.startswith((".", "attributes.", "user.", "system.")):
+                key = "system." + key
+            elif key.startswith("."):
+                key = "attributes" + key
+            self.setattr(key, val)
+        for key, val in (merged.attributes or {}).items():
+            if not key.startswith((".", "attributes.", "user.", "system.")):
+                key = "system." + key
+            elif key.startswith("."):
+                key = "attributes" + key
+            self.setattr(key, val)
+
+        # add-file attachments
+        for arg in merged.add_file or []:
+            jobspec_add_file(self, arg)
+
+        # plugins
+        if registry:
+            if _preinit:
+                # Seed missing plugin option defaults (mirrors argparse behavior)
+                for opt in registry.options:
+                    dest = opt.dest
+                    if dest not in merged.__dict__:
+                        merged.__dict__[dest] = opt.kwargs.get("default")
+                registry.preinit(merged)
+            registry.modify_jobspec(merged, self)
+
+        return self

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -1234,8 +1234,8 @@ class JobspecV1(Jobspec):
             conf (dict): optional broker configuration to pass to the
                 child instance brokers. If set, `conf` will be set in the
                 jobspec 'files' (RFC 37 File Archive) attribute as `conf.json`,
-                and broker_opts will be extended to add
-                `-c{{tmpdir}}/conf.json`
+                and a `-c{{tmpdir}}/conf.json` entry is appended to the
+                broker command line.
             **kwargs: Extra named arguments as accepted in
                 :func:`~JobspecV1.from_command`
         """
@@ -1298,12 +1298,12 @@ class JobspecV1(Jobspec):
             conf (dict): optional broker configuration to pass to the
                 child instance brokers. If set, `conf` will be set in the
                 jobspec 'files' (RFC 37 File Archive) attribute as `conf.json`,
-                and broker_opts will be extended to add
-                `-c{{tmpdir}}/conf.json`
+                and a `-c{{tmpdir}}/conf.json` entry is appended to the
+                broker command line.
             **kwargs: Extra named arguments as accepted in
                 :func:`~JobspecV1.from_command`
         """
-        broker_opts = [] if broker_opts is None else broker_opts
+        broker_opts = list(broker_opts) if broker_opts is not None else []
         if conf is not None:
             broker_opts.append("-c{{tmpdir}}/conf.json")
         jobspec = cls.from_command(

--- a/src/bindings/python/flux/job/__init__.py
+++ b/src/bindings/python/flux/job/__init__.py
@@ -9,6 +9,7 @@
 ###############################################################
 
 from flux.job.Jobspec import Jobspec, JobspecV1, validate_jobspec
+from flux.job._utils import BatchConfig
 from flux.job.JobID import id_parse, id_encode, JobID
 from flux.job.kvs import job_kvs, job_kvs_guest
 from flux.job.kill import (

--- a/src/bindings/python/flux/job/_utils.py
+++ b/src/bindings/python/flux/job/_utils.py
@@ -437,6 +437,34 @@ class BatchConfig:
         return get_treedict(self.config or {}, key, default=default)
 
 
+def jobspec_add_file(jobspec, arg):
+    """Process a single --add-file=ARG argument and attach it to jobspec."""
+    perms = None
+    #  Note: Replace any newline escaped by the shell with literal '\n'
+    #  so that newline detection below works for file data passed on
+    #  the command line:
+    name, _, data = arg.replace("\\n", "\n").partition("=")
+    if not data:
+        # No '=' implies path-only argument (no multiline allowed)
+        if "\n" in name:
+            raise ValueError("--add-file: file name missing")
+        data = name
+        name = os.path.basename(data)
+    else:
+        # Check if name specifies permissions after ':'
+        tmpname, _, permstr = name.partition(":")
+        try:
+            perms = int(permstr, base=8)
+            name = tmpname
+        except ValueError:
+            # assume ':' was part of name
+            pass
+    try:
+        jobspec.add_file(name, data, perms=perms)
+    except (TypeError, ValueError, OSError) as exc:
+        raise ValueError(f"--add-file={arg}: {exc}") from None
+
+
 def parse_jobspec_keyval(label, keyval):
     """Parse a key[=value] option as used with --setopt and --setattr
 

--- a/src/bindings/python/flux/job/_utils.py
+++ b/src/bindings/python/flux/job/_utils.py
@@ -437,6 +437,23 @@ class BatchConfig:
         return get_treedict(self.config or {}, key, default=default)
 
 
+def normalize_conf(conf):
+    """Normalize *conf* to a dict for :meth:`from_nest_command`.
+
+    Accepts a plain :class:`dict`, a :class:`~flux.job.BatchConfig`
+    instance, or a string in any form accepted by
+    :meth:`BatchConfig.update` (key=val, JSON, TOML, or a file path).
+    Returns ``None`` when *conf* is ``None``.
+    """
+    if conf is None:
+        return None
+    if isinstance(conf, dict):
+        return conf
+    if isinstance(conf, BatchConfig):
+        return conf.config
+    return BatchConfig().update(str(conf)).config
+
+
 def jobspec_add_file(jobspec, arg):
     """Process a single --add-file=ARG argument and attach it to jobspec."""
     perms = None

--- a/src/bindings/python/flux/job/_utils.py
+++ b/src/bindings/python/flux/job/_utils.py
@@ -1,0 +1,463 @@
+##############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+# Utility functions and classes shared between flux.cli.base and
+# flux.job (Jobspec.apply_options).
+
+import fnmatch
+import json
+import logging
+import os
+import pathlib
+import re
+import resource
+import signal
+from collections import ChainMap
+from itertools import chain
+from string import Template
+from urllib.parse import parse_qs, urlparse
+
+try:
+    import tomllib  # novermin
+except ModuleNotFoundError:
+    from flux.utils import tomli as tomllib
+
+from flux import util
+from flux.constraint.parser import ConstraintParser
+from flux.util import dict_merge, get_treedict, set_treedict
+
+LOGGER = logging.getLogger("flux")
+
+
+def decode_signal(val):
+    """
+    Decode a signal as string or number
+    A string can be of the form 'SIGUSR1' or just 'USR1'
+    """
+    if isinstance(val, int):
+        return val
+    try:
+        return int(val)
+    except ValueError:
+        pass  # Fall back to signal name
+    try:
+        return getattr(signal, val)
+    except AttributeError:
+        pass  # Fall back SIG{name}
+    try:
+        return getattr(signal, f"SIG{val}")
+    except AttributeError:
+        pass  # Fall through to raise ValueError
+    raise ValueError(f"signal '{val}' is invalid")
+
+
+def decode_duration(val):
+    """
+    Decode a duration as a number or string in FSD
+    """
+    if isinstance(val, (float, int)):
+        return val
+    try:
+        return float(val)
+    except ValueError:
+        pass  # Fall back to fsd
+    return util.parse_fsd(val)
+
+
+def parse_signal_option(arg):
+    """
+    Parse the --signal= option argument of the form SIG@TIME, where
+    both signal and time are optional.
+
+    Returns a dict with signal and timeleft members
+    """
+    signo = signal.SIGUSR1
+    tleft = 60
+    if arg is not None:
+        sig, _, time = arg.partition("@")
+        if time:
+            tleft = time
+        if sig:
+            signo = sig
+    try:
+        signum = decode_signal(signo)
+        if signum <= 0:
+            raise ValueError("signal must be > 0")
+    except ValueError as exc:
+        raise ValueError(f"--signal={arg}: {exc}") from None
+
+    try:
+        timeleft = decode_duration(tleft)
+    except ValueError as exc:
+        raise ValueError(f"--signal={arg}: {exc}") from None
+
+    return {"signum": signum, "timeleft": timeleft}
+
+
+class MiniConstraintParser(ConstraintParser):
+    operator_map = {
+        None: "properties",
+        "host": "hostlist",
+        "hosts": "hostlist",
+        "rank": "ranks",
+    }
+    split_values = {"properties": ","}
+    combined_terms = {"properties"}
+
+
+class URIArg:
+    """Convenience class for handling dependencies
+
+    Splits a dependency URI into fields and returns an RFC 26 dependency
+    entry via the entry attribute.
+    """
+
+    def __init__(self, uri, name):
+        # append `:` if missing in uri so that a plain string is treated as
+        # a scheme with no path.
+        if ":" not in uri:
+            uri += ":"
+
+        # replace first ':' with ':FXX' to work around urlparse refusal
+        # to treat integer only path as a scheme:path.
+        self.uri = urlparse(uri.replace(":", ":FXX", 1))
+
+        if not self.uri.scheme or not self.uri.path:
+            raise ValueError(f'Invalid {name} URI "{uri}"')
+
+        self.path = self.uri.path.replace("FXX", "", 1)
+        self.scheme = self.uri.scheme
+
+    @staticmethod
+    def _try_number(value):
+        """Convert value to an int or a float if possible"""
+        for _type in (int, float):
+            try:
+                return _type(value)
+            except ValueError:
+                continue
+        return value
+
+    @property
+    def entry(self):
+        entry = {
+            "scheme": self.scheme,
+            "value": self.path,
+        }
+        if self.uri.query:
+            for key, val in parse_qs(self.uri.query).items():
+                #  val is always a list, but convert to single value
+                #   if it only contains a single item:
+                if len(val) > 1:
+                    entry[key] = [self._try_number(x) for x in val]
+                else:
+                    entry[key] = self._try_number(val[0])
+        return entry
+
+
+def dependency_array_create(uris):
+    return [URIArg(uri, "dependency").entry for uri in uris]
+
+
+def filter_dict(env, pattern, reverseMatch=True):
+    """
+    Filter out all keys that match "pattern" from dict 'env'
+
+    Pattern is assumed to be a shell glob(7) pattern, unless it begins
+    with '/', in which case the pattern is a regex.
+    """
+    if pattern.startswith("/"):
+        pattern = pattern[1:].rstrip("/")
+    else:
+        pattern = fnmatch.translate(pattern)
+    regex = re.compile(pattern)
+    if reverseMatch:
+        return {k: v for k, v in env.items() if not regex.match(k)}
+    return {k: v for k, v in env.items() if regex.match(k)}
+
+
+def get_rlimits(name="*"):
+    """
+    Return set of rlimits matching `name` in a dict
+    """
+    rlimits = {}
+    pattern = f"RLIMIT_{name}".upper()
+    for limit in fnmatch.filter(resource.__dict__.keys(), pattern):
+        soft, hard = resource.getrlimit(getattr(resource, limit))
+        #  Remove RLIMIT_ prefix and lowercase the result for compatibility
+        #  with rlimit shell plugin:
+        rlimits[limit[7:].lower()] = soft
+    if not rlimits:
+        raise ValueError(f'No corresponding rlimit matching "{name}"')
+    return rlimits
+
+
+def list_split(opts):
+    """
+    Return a list by splitting each member of opts on ','
+    """
+    if isinstance(opts, str):
+        opts = [opts]
+    if opts:
+        return list(chain.from_iterable(x.split(",") for x in opts))
+    return []
+
+
+def get_filtered_rlimits(user_rules=None):
+    """
+    Get a filtered set of rlimits based on user rules and defaults
+    """
+    #  We start with the entire set of available rlimits and then apply
+    #  rules to remove or override them. Therefore, the set of default
+    #  rules excludes limits *not* to propagate by default.
+    rules = [
+        "-memlock",
+        "-ofile",
+        "-msgqueue",
+        "-nice",
+        "-rtprio",
+        "-rttime",
+        "-sigpending",
+    ]
+
+    if user_rules:
+        rules.extend(list_split(user_rules))
+
+    rlimits = get_rlimits()
+    for rule in rules:
+        if rule.startswith("-"):
+            # -name removes RLIMIT_{pattern} from propagated rlimits
+            rlimits = filter_dict(rlimits, rule[1:].lower())
+        else:
+            name, *rest = rule.split("=", 1)
+            if not rest:
+                #  limit with no value pulls in current limit(s)
+                rlimits.update(get_rlimits(name.lower()))
+            else:
+                if not hasattr(resource, f"RLIMIT_{name}".upper()):
+                    raise ValueError(f'Invalid rlimit "{name}"')
+                #  limit with value sets limit to that value
+                if rest[0] in ("unlimited", "infinity", "inf"):
+                    value = resource.RLIM_INFINITY
+                else:
+                    try:
+                        value = int(rest[0])
+                    except ValueError:
+                        raise ValueError(f"Invalid value in {name}={rest[0]}")
+                rlimits[name.lower()] = value
+    return rlimits
+
+
+def get_filtered_environment(rules, environ=None):
+    """
+    Filter environment dictionary 'environ' given a list of rules.
+    Each rule can filter, set, or modify the existing environment.
+    """
+    env_expand = {}
+    if environ is None:
+        environ = dict(os.environ)
+    if rules is None:
+        return environ, env_expand
+    for rule in rules:
+        #
+        #  If rule starts with '-' then the rest of the rule is a pattern
+        #   which filters matching environment variables from the
+        #   generated environment.
+        #
+        if rule.startswith("-"):
+            environ = filter_dict(environ, rule[1:])
+        #
+        #  If rule starts with '^', then the result of the rule is a filename
+        #   from which to read more rules.
+        #
+        elif rule.startswith("^"):
+            filename = os.path.expanduser(rule[1:])
+            with open(filename) as envfile:
+                lines = [line.strip() for line in envfile]
+                environ, envx = get_filtered_environment(lines, environ=environ)
+                env_expand.update(envx)
+        #
+        #  Otherwise, the rule is an explicit variable assignment
+        #   VAR=VAL. If =VAL is not provided then VAL refers to the
+        #   value for VAR in the current environment of this process.
+        #
+        #  Quoted shell variables are expanded using values from the
+        #   built environment, not the process environment. So
+        #   --env=PATH=/bin --env=PATH='$PATH:/foo' results in
+        #   PATH=/bin:/foo.
+        #
+        else:
+            var, *rest = rule.split("=", 1)
+            if not rest:
+                #
+                #  VAR alone with no set value pulls in all matching
+                #   variables from current environment that are not already
+                #   in the generated environment.
+                env = filter_dict(os.environ, var, reverseMatch=False)
+                for key, value in env.items():
+                    if key not in environ:
+                        environ[key] = value
+            elif "{{" in rest[0]:
+                #
+                #  Mustache template which should be expanded by job shell.
+                #  Place result in env_expand instead of environ:
+                env_expand[var] = rest[0]
+            else:
+                #
+                #  Template lookup: use jobspec environment first, fallback
+                #   to current process environment using ChainMap:
+                lookup = ChainMap(environ, os.environ)
+                try:
+                    environ[var] = Template(rest[0]).substitute(lookup)
+                except ValueError:
+                    LOGGER.error("--env: Unable to substitute %s", rule)
+                    raise
+                except KeyError as ex:
+                    raise Exception(f"--env: Variable {ex} not found in {rule}")
+    return environ, env_expand
+
+
+class BatchConfig:
+    """Convenience class for handling a --conf=[FILE|KEY=VAL] option
+
+    Iteratively build a "config" dict from successive updates.
+    """
+
+    loaders = {".toml": tomllib.load, ".json": json.load}
+
+    def __init__(self):
+        self.config = None
+
+    def update_string(self, value):
+        # Update config with JSON or TOML string
+        try:
+            conf = json.loads(value)
+        except json.decoder.JSONDecodeError:
+            # Try TOML
+            try:
+                conf = tomllib.loads(value)
+            except tomllib.TOMLDecodeError:
+                raise ValueError(
+                    "--conf: failed to parse multiline as TOML or JSON"
+                ) from None
+        self.config = dict_merge(self.config, conf)
+        return self
+
+    def update_keyval(self, keyval):
+        # dotted key (e.g. resource.noverify=true)
+        key, _, value = keyval.partition("=")
+        try:
+            value = json.loads(value)
+        except json.decoder.JSONDecodeError:
+            value = str(value)
+        try:
+            set_treedict(self.config, key, value)
+        except TypeError as e:
+            raise TypeError(f"failed to set {key} to {value}: {e}")
+        return self
+
+    def update_file(self, path, extension=".toml"):
+        # Update from file in the filesystem
+        try:
+            loader = self.loaders[extension]
+        except KeyError:
+            raise ValueError(f"--conf: {path} must end in .toml or .json")
+        try:
+            with open(path, "rb") as fp:
+                conf = loader(fp)
+        except OSError as exc:
+            raise ValueError(f"--conf: {exc}") from None
+        except (json.decoder.JSONDecodeError, tomllib.TOMLDecodeError) as exc:
+            raise ValueError(f"--conf: parse error: {path}: {exc}") from None
+        self.config = dict_merge(self.config, conf)
+        return self
+
+    def _find_config(self, name):
+        # Find a named config as either TOML or JSON in XDG search path
+        for path in util.xdg_searchpath(subdir="config"):
+            # Take the first matching filename preferring TOML:
+            for ext in (".toml", ".json"):
+                filename = f"{path}/{name}{ext}"
+                if os.path.exists(filename):
+                    return filename, self.loaders[ext]
+        return None, None
+
+    def update_named_config(self, name):
+        # Update from a named configuration file in a standard path or paths.
+        filename, loader = self._find_config(name)
+        if filename is not None:
+            try:
+                with open(filename, "rb") as fp:
+                    self.config = dict_merge(self.config, loader(fp))
+                    return self
+            except (
+                OSError,
+                tomllib.TOMLDecodeError,
+                json.decoder.JSONDecodeError,
+            ) as exc:
+                raise ValueError(f"--conf={name}: {filename}: {exc}") from None
+        raise ValueError(f"--conf: named config '{name}' not found")
+
+    def update(self, value):
+        """
+        Update current config with value using the following rules:
+        - If value contains one or more newlines, parse it as a JSON or
+          TOML string.
+        - Otherwise, if value contains an ``=``, then parse it as a dotted
+          key and value, e.g. ``resource.noverify=true``. The value (part
+          after the ``=``) will be parsed as JSON.
+        - Otherwise, if value ends in ``.toml`` or ``.json`` treat value as
+          a path and attempt to parse contents of file as TOML or JSON.
+        - Otherwise, read a named config from a standard config search path.
+
+        Configuration can be updated iteratively. The end result is available
+        in the ``config`` attribute.
+        """
+        if self.config is None:
+            self.config = {}
+        if "\n" in value:
+            return self.update_string(value)
+        if "=" in value:
+            return self.update_keyval(value)
+        extension = pathlib.Path(value).suffix
+        if extension in (".toml", ".json"):
+            return self.update_file(value, extension)
+        return self.update_named_config(value)
+
+    def get(self, key, default=None):
+        """
+        Get a value from the current config using dotted key form
+        """
+        return get_treedict(self.config or {}, key, default=default)
+
+
+def parse_jobspec_keyval(label, keyval):
+    """Parse a key[=value] option as used with --setopt and --setattr
+
+    Supports ^key=filename to load JSON object from a file
+    """
+    # Split into key, val with a default of 1 if no val given:
+    key, val = (keyval.split("=", 1) + [1])[:2]
+
+    # Support key prefix of ^ to load value from a file
+    if key.startswith("^"):
+        key = key.lstrip("^")
+        with open(val) as filep:
+            try:
+                val = json.load(filep)
+            except (json.JSONDecodeError, TypeError) as exc:
+                raise ValueError(f"{label}: {val}: {exc}") from exc
+    else:
+        try:
+            val = json.loads(val)
+        except (json.JSONDecodeError, TypeError):
+            # val was not a JSON string, keep as is
+            pass
+    return key, val

--- a/src/bindings/python/flux/job/_utils.py
+++ b/src/bindings/python/flux/job/_utils.py
@@ -13,7 +13,6 @@
 
 import fnmatch
 import json
-import logging
 import os
 import pathlib
 import re
@@ -32,8 +31,6 @@ except ModuleNotFoundError:
 from flux import util
 from flux.constraint.parser import ConstraintParser
 from flux.util import dict_merge, get_treedict, set_treedict
-
-LOGGER = logging.getLogger("flux")
 
 
 def decode_signal(val):
@@ -279,10 +276,13 @@ def get_filtered_environment(rules, environ=None):
         #
         elif rule.startswith("^"):
             filename = os.path.expanduser(rule[1:])
-            with open(filename) as envfile:
-                lines = [line.strip() for line in envfile]
-                environ, envx = get_filtered_environment(lines, environ=environ)
-                env_expand.update(envx)
+            try:
+                with open(filename) as envfile:
+                    lines = [line.strip() for line in envfile]
+            except OSError as exc:
+                raise ValueError(f"--env: {exc}") from None
+            environ, envx = get_filtered_environment(lines, environ=environ)
+            env_expand.update(envx)
         #
         #  Otherwise, the rule is an explicit variable assignment
         #   VAR=VAL. If =VAL is not provided then VAL refers to the
@@ -317,10 +317,9 @@ def get_filtered_environment(rules, environ=None):
                 try:
                     environ[var] = Template(rest[0]).substitute(lookup)
                 except ValueError:
-                    LOGGER.error("--env: Unable to substitute %s", rule)
-                    raise
+                    raise ValueError(f"--env: Unable to substitute {rule}")
                 except KeyError as ex:
-                    raise Exception(f"--env: Variable {ex} not found in {rule}")
+                    raise ValueError(f"--env: Variable {ex} not found in {rule}")
     return environ, env_expand
 
 

--- a/src/cmd/flux-modprobe.py
+++ b/src/cmd/flux-modprobe.py
@@ -17,7 +17,7 @@ from collections import deque
 
 import flux
 import flux.kvs
-from flux.cli.base import list_split
+from flux.job._utils import list_split
 from flux.modprobe import Modprobe
 from flux.util import CLIMain, Tree, help_formatter
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -309,6 +309,8 @@ TESTSCRIPTS = \
 	python/t0014-job-kvslookup.py \
 	python/t0015-job-output.py \
 	python/t0016-job-validate.py \
+	python/t0017-job-utils.py \
+	python/t0018-jobspec.py \
 	python/t0019-cli-plugin.py \
 	python/t0020-hostlist.py \
 	python/t0021-idset.py \

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -10,12 +10,10 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import datetime
 import errno
 import json
 import locale
 import os
-import pathlib
 import signal
 import subprocess
 import unittest
@@ -120,49 +118,6 @@ class TestJob(unittest.TestCase):
         jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
         jobid = job.submit(self.fh, jobspec)
         self.assertGreater(jobid, 0)
-
-    def test_09_valid_duration(self):
-        """Test setting Jobspec duration to various valid values"""
-        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
-        for duration in (100, 100.5):
-            delta = datetime.timedelta(seconds=duration)
-            for x in [duration, delta, "{}s".format(duration)]:
-                jobspec.duration = x
-                # duration setter converts value to a float
-                self.assertEqual(jobspec.duration, float(duration))
-
-    def test_10_invalid_duration(self):
-        """Test setting Jobspec duration to various invalid values and types"""
-        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
-        for duration in (-100, -100.5, datetime.timedelta(seconds=-5), "10h5m"):
-            with self.assertRaises(ValueError):
-                jobspec.duration = duration
-        for duration in ([], {}):
-            with self.assertRaises(TypeError):
-                jobspec.duration = duration
-
-    def test_11_cwd_pathlib(self):
-        jobspec_path = pathlib.PosixPath(self.jobspec_dir) / "valid" / "basic_v1.yaml"
-        jobspec = Jobspec.from_yaml_file(jobspec_path)
-        cwd = pathlib.PosixPath("/tmp")
-        jobspec.cwd = cwd
-        self.assertEqual(jobspec.cwd, os.fspath(cwd))
-
-    def test_12_environment(self):
-        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
-        new_env = {"HOME": "foo", "foo": "bar"}
-        jobspec.environment = new_env
-        self.assertEqual(jobspec.environment, new_env)
-
-    def test_12_0_queue(self):
-        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
-        jobspec.queue = "default"
-        self.assertEqual(jobspec.queue, "default")
-
-    def test_12_1_queue_invalid(self):
-        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
-        with self.assertRaises(TypeError):
-            jobspec.queue = 12
 
     def test_13_job_kvs(self):
         jobid = job.submit(self.fh, self.basic_jobspec, waitable=True)
@@ -372,57 +327,6 @@ class TestJob(unittest.TestCase):
         except OSError as err:
             self.assertEqual(err.errno, errno.ENODATA)
         self.assertIs(event, None)
-
-    def test_21_stdio_new_methods(self):
-        """Test official getter/setter methods for stdio properties
-        Ensure for now that output sets the alias "stdout", error sets "stderr"
-        and input sets "stdin".
-        """
-        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
-        streams = {"error": "stderr", "output": "stdout", "input": "stdin"}
-        for name in ("error", "output", "input"):
-            stream = streams[name]
-            self.assertEqual(getattr(jobspec, name), None)
-            for path in ("foo.txt", "bar.md", "foo.json"):
-                setattr(jobspec, name, path)
-                self.assertEqual(getattr(jobspec, name), path)
-                self.assertEqual(getattr(jobspec, stream), path)
-            with self.assertRaises(TypeError):
-                setattr(jobspec, name, None)
-
-    def test_21_stdio(self):
-        """Test getter/setter methods for stdio properties"""
-        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
-        for stream in ("stderr", "stdout", "stdin"):
-            self.assertEqual(getattr(jobspec, stream), None)
-            for path in ("foo.txt", "bar.md", "foo.json"):
-                setattr(jobspec, stream, path)
-                self.assertEqual(getattr(jobspec, stream), path)
-            with self.assertRaises(TypeError):
-                setattr(jobspec, stream, None)
-
-        with self.assertRaises(TypeError):
-            jobspec.unbuffered = 1
-
-        jobspec.unbuffered = True
-        self.assertTrue(jobspec.unbuffered)
-        self.assertEqual(
-            jobspec.getattr("shell.options.output.stderr.buffer.type"), "none"
-        )
-        self.assertEqual(
-            jobspec.getattr("shell.options.output.stdout.buffer.type"), "none"
-        )
-        self.assertEqual(jobspec.getattr("shell.options.output.batch-timeout"), 0.05)
-
-        jobspec.unbuffered = False
-        self.assertFalse(jobspec.unbuffered)
-
-        # jobspec.unbuffered = True keeps modified batch-timeout
-        jobspec.unbuffered = True
-        jobspec.setattr_shell_option("output.batch-timeout", 1.0)
-        jobspec.unbuffered = False
-        self.assertFalse(jobspec.unbuffered)
-        self.assertEqual(jobspec.getattr("shell.options.output.batch-timeout"), 1.0)
 
     def test_22_from_batch_command(self):
         """Test that `from_nest_command` produces a valid jobspec"""
@@ -895,76 +799,6 @@ class TestJob(unittest.TestCase):
             job.timeleft(self.fh)
         except OSError:
             pass
-
-    def test_35_setattr_defaults(self):
-        """Test setattr setting defaults"""
-        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
-        jobspec.setattr("cow", 1)
-        jobspec.setattr("system.cat", 2)
-        jobspec.setattr("user.dog", 3)
-        jobspec.setattr("attributes.system.chicken", 4)
-        jobspec.setattr("attributes.user.duck", 5)
-        jobspec.setattr("attributes.goat", 6)
-        self.assertEqual(jobspec.getattr("cow"), 1)
-        self.assertEqual(jobspec.getattr("system.cow"), 1)
-        self.assertEqual(jobspec.getattr("attributes.system.cow"), 1)
-
-        self.assertEqual(jobspec.getattr("cat"), 2)
-        self.assertEqual(jobspec.getattr("system.cat"), 2)
-        self.assertEqual(jobspec.getattr("attributes.system.cat"), 2)
-
-        self.assertEqual(jobspec.getattr("user.dog"), 3)
-        self.assertEqual(jobspec.getattr("attributes.user.dog"), 3)
-
-        self.assertEqual(jobspec.getattr("chicken"), 4)
-        self.assertEqual(jobspec.getattr("system.chicken"), 4)
-        self.assertEqual(jobspec.getattr("attributes.system.chicken"), 4)
-
-        self.assertEqual(jobspec.getattr("user.duck"), 5)
-        self.assertEqual(jobspec.getattr("attributes.user.duck"), 5)
-
-        self.assertEqual(jobspec.getattr("attributes.goat"), 6)
-
-    def test_36_str(self):
-        """Test string representation of a basic jobspec"""
-        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
-        jobspec.setattr("cow", 1)
-        jobspec.setattr("system.cat", 2)
-        jobspec.setattr("user.dog", 3)
-        jobspec.setattr("attributes.system.chicken", 4)
-        jobspec.setattr("attributes.user.duck", 5)
-        jobspec.setattr("attributes.goat", 6)
-        self.assertEqual(
-            str(jobspec),
-            "{'resources': [{'type': 'slot', 'count': 1, 'label': 'task', 'with': [{'type': 'core', 'count': 1}]}], 'tasks': [{'command': ['app'], 'slot': 'foo', 'count': {'per_slot': 1}}], 'attributes': {'system': {'duration': 0, 'cow': 1, 'cat': 2, 'chicken': 4}, 'user': {'dog': 3, 'duck': 5}, 'goat': 6}, 'version': 1}",
-        )
-
-    def test_37_repr(self):
-        """Test __repr__ method of Jobspec"""
-        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
-        self.assertEqual(eval(repr(jobspec)).jobspec, jobspec.jobspec)
-        jobspec.cwd = "/foo/bar"
-        jobspec.stdout = "/bar/baz"
-        jobspec.duration = 1000.3133
-        self.assertEqual(eval(repr(jobspec)).jobspec, jobspec.jobspec)
-
-    def test_37_test_bad_extra_args(self):
-        """Test extra Jobspec constructor args with bad values"""
-        with self.assertRaises(ValueError):
-            JobspecV1.from_command(["sleep", "0"], duration="1f")
-        with self.assertRaises(ValueError):
-            JobspecV1.from_command(["sleep", "0"], environment="foo")
-        with self.assertRaises(ValueError):
-            JobspecV1.from_command(["sleep", "0"], env_expand=1)
-        with self.assertRaises(ValueError):
-            JobspecV1.from_command(["sleep", "0"], rlimits=True)
-
-    def test_38_environment_default(self):
-        jobspec = JobspecV1.from_command(["sleep", "0"])
-        self.assertEqual(jobspec.environment, dict(os.environ))
-
-        jobspec = JobspecV1.from_command(["sleep", "0"], environment={})
-        self.assertEqual(jobspec.environment, {})
 
 
 if __name__ == "__main__":

--- a/t/python/t0017-job-utils.py
+++ b/t/python/t0017-job-utils.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2024 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import json
+import os
+import signal
+import tempfile
+import unittest
+
+import subflux  # noqa: F401 - sets up PYTHONPATH
+from flux.job import BatchConfig
+from flux.job._utils import decode_signal
+from pycotap import TAPTestRunner
+
+
+class TestBatchConfig(unittest.TestCase):
+    def test_01_update_keyval(self):
+        bc = BatchConfig()
+        bc.update("resource.noverify=true")
+        self.assertEqual(bc.config, {"resource": {"noverify": True}})
+
+    def test_02_update_keyval_string_value(self):
+        bc = BatchConfig()
+        bc.update("system.job.name=myjob")
+        self.assertEqual(bc.config["system"]["job"]["name"], "myjob")
+
+    def test_03_update_multiline_json(self):
+        data = '{"resource": {"noverify": true}}'
+        bc = BatchConfig()
+        bc.update(data + "\n")  # newline forces multiline path
+        self.assertEqual(bc.config, {"resource": {"noverify": True}})
+
+    def test_04_update_multiline_toml(self):
+        data = "[resource]\nnoverify = true\n"
+        bc = BatchConfig()
+        bc.update(data)
+        self.assertEqual(bc.config, {"resource": {"noverify": True}})
+
+    def test_05_update_file_toml(self):
+        data = "[resource]\nnoverify = true\n"
+        with tempfile.NamedTemporaryFile(suffix=".toml", mode="w", delete=False) as fp:
+            fp.write(data)
+            path = fp.name
+        try:
+            bc = BatchConfig()
+            bc.update(path)
+            self.assertEqual(bc.config, {"resource": {"noverify": True}})
+        finally:
+            os.unlink(path)
+
+    def test_06_update_file_json(self):
+        data = json.dumps({"resource": {"noverify": True}})
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False) as fp:
+            fp.write(data)
+            path = fp.name
+        try:
+            bc = BatchConfig()
+            bc.update(path)
+            self.assertEqual(bc.config, {"resource": {"noverify": True}})
+        finally:
+            os.unlink(path)
+
+    def test_07_update_chain_merges(self):
+        bc = BatchConfig()
+        bc.update("a=1")
+        bc.update("b=2")
+        self.assertEqual(bc.config, {"a": 1, "b": 2})
+
+    def test_08_invalid_multiline_raises(self):
+        bc = BatchConfig()
+        with self.assertRaises(ValueError):
+            bc.update("not valid json or toml\n\n")
+
+    def test_09_get(self):
+        bc = BatchConfig()
+        bc.update("resource.noverify=true")
+        self.assertTrue(bc.get("resource.noverify"))
+        self.assertIsNone(bc.get("nonexistent.key"))
+        self.assertEqual(bc.get("nonexistent.key", default="x"), "x")
+
+    def test_10_independent_instances(self):
+        # Verify that two BatchConfig instances don't share state
+        bc1 = BatchConfig()
+        bc2 = BatchConfig()
+        bc1.update("a=1")
+        self.assertIsNone(bc2.config)
+
+
+class TestDecodeSignal(unittest.TestCase):
+    def test_01_int_passthrough(self):
+        self.assertEqual(decode_signal(10), 10)
+
+    def test_02_numeric_string(self):
+        self.assertEqual(decode_signal("10"), 10)
+
+    def test_03_sigusr1_form(self):
+        self.assertEqual(decode_signal("SIGUSR1"), signal.SIGUSR1)
+
+    def test_04_short_form(self):
+        self.assertEqual(decode_signal("USR1"), signal.SIGUSR1)
+
+    def test_05_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            decode_signal("NOTASIGNAL")
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0018-jobspec.py
+++ b/t/python/t0018-jobspec.py
@@ -717,5 +717,246 @@ class TestApplyOptionsWithPlugin(unittest.TestCase):
         # ntasks should still be 1 — preinit mutation was ignored
         self.assertEqual(slot["count"], 1)
 
+
+class TestFromRun(unittest.TestCase):
+    """Tests for JobspecV1.from_submit()."""
+
+    def test_01_basic(self):
+        js = JobspecV1.from_submit(["hostname"])
+        self.assertEqual(js.jobspec["tasks"][0]["command"], ["hostname"])
+
+    def test_02_ntasks(self):
+        js = JobspecV1.from_submit(["myapp"], ntasks=4)
+        # 4 tasks → slot count of 4
+        resources = js.jobspec["resources"]
+        slot = resources[0]
+        self.assertEqual(slot["count"], 4)
+
+    def test_03_time_limit_applied(self):
+        js = JobspecV1.from_submit(["sleep", "1"], time_limit="1h")
+        self.assertEqual(js.duration, 3600.0)
+
+    def test_04_env_applied(self):
+        js = JobspecV1.from_submit(["env"], env=["-PATH"])
+        self.assertNotIn("PATH", js.environment)
+
+    def test_05_dependency_applied(self):
+        js = JobspecV1.from_submit(["app"], dependency=["afterok:f1234"])
+        deps = js.jobspec["attributes"]["system"]["dependencies"]
+        self.assertEqual(deps[0]["scheme"], "afterok")
+
+    def test_06_requires_applied(self):
+        js = JobspecV1.from_submit(["app"], requires=["gpu"])
+        self.assertIn("properties", js.jobspec["attributes"]["system"]["constraints"])
+
+    def test_07_name_set(self):
+        js = JobspecV1.from_submit(["app"], name="myjob")
+        self.assertEqual(js.jobspec["attributes"]["system"]["job"]["name"], "myjob")
+
+    def test_08_nodes_and_ntasks(self):
+        js = JobspecV1.from_submit(["app"], ntasks=8, nodes=2)
+        # node-level resource should appear
+        resources = js.jobspec["resources"]
+        self.assertEqual(resources[0]["type"], "node")
+        self.assertEqual(resources[0]["count"], 2)
+
+    def test_09_returns_jobspecv1(self):
+        js = JobspecV1.from_submit(["app"])
+        self.assertIsInstance(js, JobspecV1)
+
+    def test_10_env_propagated_by_default(self):
+        # from_submit() without env= must still propagate the full environment
+        js = JobspecV1.from_submit(["myapp"])
+        self.assertIsNotNone(js.environment)
+        self.assertIn("PATH", js.environment)
+
+
+class TestFromAlloc(unittest.TestCase):
+    """Tests for JobspecV1.from_alloc()."""
+
+    def test_01_basic(self):
+        js = JobspecV1.from_alloc(nslots=4)
+        # flux broker appears in command
+        command = js.jobspec["tasks"][0]["command"]
+        self.assertIn("flux", command)
+        self.assertIn("broker", command)
+
+    def test_02_nslots_defaults_to_nodes(self):
+        js = JobspecV1.from_alloc(nodes=4)
+        # nslots was set to nodes (4 tasks in the slot)
+        resources = js.jobspec["resources"]
+        self.assertEqual(resources[0]["type"], "node")
+        self.assertEqual(resources[0]["count"], 4)
+
+    def test_03_no_nslots_no_nodes_raises(self):
+        with self.assertRaises(ValueError):
+            JobspecV1.from_alloc()
+
+    def test_04_time_limit_applied(self):
+        js = JobspecV1.from_alloc(nslots=2, time_limit="30m")
+        self.assertEqual(js.duration, 1800.0)
+
+    def test_05_conf_str_embedded(self):
+        js = JobspecV1.from_alloc(nslots=2, conf="resource.noverify=true")
+        files = js.jobspec["attributes"]["system"]["files"]
+        self.assertIn("conf.json", files)
+
+    def test_06_conf_dict_embedded(self):
+        js = JobspecV1.from_alloc(nslots=2, conf={"resource": {"noverify": True}})
+        files = js.jobspec["attributes"]["system"]["files"]
+        self.assertIn("conf.json", files)
+
+    def test_07_bg_sets_rc2_none(self):
+        js = JobspecV1.from_alloc(nslots=4, bg=True)
+        command = js.jobspec["tasks"][0]["command"]
+        self.assertTrue(any("rc2_none" in c for c in command))
+
+    def test_08_bg_sets_pty_capture(self):
+        js = JobspecV1.from_alloc(nslots=4, bg=True)
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["pty"]["capture"], 1)
+
+    def test_09_broker_opts_not_mutated(self):
+        bopts = ["-Sfoo"]
+        JobspecV1.from_alloc(
+            nslots=4, broker_opts=bopts, conf={"resource": {"noverify": True}}
+        )
+        self.assertEqual(bopts, ["-Sfoo"])
+
+    def test_10_cwd_defaults_to_getcwd(self):
+        js = JobspecV1.from_alloc(nslots=1)
+        self.assertEqual(js.cwd, os.getcwd())
+
+    def test_11_dependency_applied(self):
+        js = JobspecV1.from_alloc(nslots=2, dependency=["afterok:f1234"])
+        deps = js.jobspec["attributes"]["system"]["dependencies"]
+        self.assertEqual(deps[0]["scheme"], "afterok")
+
+    def test_12_returns_jobspecv1(self):
+        js = JobspecV1.from_alloc(nslots=1)
+        self.assertIsInstance(js, JobspecV1)
+
+
+class TestFromBatch(unittest.TestCase):
+    """Tests for JobspecV1.from_batch()."""
+
+    SCRIPT = "#!/bin/bash\necho hello\n"
+
+    def test_01_inline_content(self):
+        js = JobspecV1.from_batch(content=self.SCRIPT, nslots=2)
+        files = js.jobspec["attributes"]["system"]["files"]
+        self.assertIn("script", files)
+
+    def test_02_script_from_path(self):
+        with tempfile.NamedTemporaryFile(
+            suffix=".sh", mode="w", delete=False, dir="."
+        ) as f:
+            f.write(self.SCRIPT)
+            fpath = f.name
+        try:
+            js = JobspecV1.from_batch(fpath, nslots=2)
+            self.assertEqual(
+                js.jobspec["attributes"]["system"]["job"]["name"],
+                os.path.basename(fpath),
+            )
+        finally:
+            os.unlink(fpath)
+
+    def test_03_script_from_pathlib(self):
+        with tempfile.NamedTemporaryFile(
+            suffix=".sh", mode="w", delete=False, dir="."
+        ) as f:
+            f.write(self.SCRIPT)
+            fpath = pathlib.Path(f.name)
+        try:
+            js = JobspecV1.from_batch(fpath, nslots=2)
+            self.assertIn("script", js.jobspec["attributes"]["system"]["files"])
+        finally:
+            fpath.unlink()
+
+    def test_04_wrap_prepends_shebang(self):
+        js = JobspecV1.from_batch(content="echo hello\n", nslots=1, wrap=True)
+        data = js.jobspec["attributes"]["system"]["files"]["script"]["data"]
+        self.assertTrue(data.startswith("#!/bin/sh\n"))
+
+    def test_05_no_shebang_raises(self):
+        with self.assertRaises(ValueError):
+            JobspecV1.from_batch(content="echo hello\necho world\n", nslots=1)
+
+    def test_06_output_default(self):
+        js = JobspecV1.from_batch(content=self.SCRIPT, nslots=1)
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["output"]["stdout"]["path"], "flux-{{id}}.out")
+
+    def test_07_cwd_default(self):
+        js = JobspecV1.from_batch(content=self.SCRIPT, nslots=1)
+        self.assertEqual(js.cwd, os.getcwd())
+
+    def test_08_name_defaults_to_batch_for_inline(self):
+        js = JobspecV1.from_batch(content=self.SCRIPT, nslots=1)
+        self.assertEqual(js.jobspec["attributes"]["system"]["job"]["name"], "batch")
+
+    def test_09_nodes_sets_nslots_and_exclusive(self):
+        js = JobspecV1.from_batch(content=self.SCRIPT, nodes=4)
+        resources = js.jobspec["resources"]
+        self.assertEqual(resources[0]["type"], "node")
+        self.assertEqual(resources[0]["count"], 4)
+
+    def test_10_default_nslots_is_one(self):
+        js = JobspecV1.from_batch(content=self.SCRIPT)
+        # With no nslots/nodes, nslots=1: a single slot in resources
+        resources = js.jobspec["resources"]
+        self.assertEqual(resources[0]["count"], 1)
+
+    def test_11_time_limit_applied(self):
+        js = JobspecV1.from_batch(content=self.SCRIPT, nslots=2, time_limit="2h")
+        self.assertEqual(js.duration, 7200.0)
+
+    def test_12_broker_opts_not_mutated(self):
+        bopts = ["-Sfoo"]
+        JobspecV1.from_batch(
+            content=self.SCRIPT,
+            nslots=2,
+            broker_opts=bopts,
+            conf={"resource": {"noverify": True}},
+        )
+        self.assertEqual(bopts, ["-Sfoo"])
+
+    def test_13_dependency_applied(self):
+        js = JobspecV1.from_batch(
+            content=self.SCRIPT, nslots=2, dependency=["afterok:f1234"]
+        )
+        deps = js.jobspec["attributes"]["system"]["dependencies"]
+        self.assertEqual(deps[0]["scheme"], "afterok")
+
+    def test_14_returns_jobspecv1(self):
+        js = JobspecV1.from_batch(content=self.SCRIPT)
+        self.assertIsInstance(js, JobspecV1)
+
+    def test_15_both_script_and_content_raises(self):
+        with self.assertRaises(TypeError):
+            JobspecV1.from_batch("/some/path.sh", content=self.SCRIPT)
+
+    def test_16_neither_script_nor_content_raises(self):
+        with self.assertRaises(TypeError):
+            JobspecV1.from_batch()
+
+    def test_17_name_defaults_to_batch_for_content(self):
+        js = JobspecV1.from_batch(content=self.SCRIPT)
+        self.assertEqual(js.jobspec["attributes"]["system"]["job"]["name"], "batch")
+
+
+class TestFromNestCommand(unittest.TestCase):
+    def test_01_broker_opts_not_mutated(self):
+        bopts = ["-Sfoo"]
+        JobspecV1.from_nest_command(
+            ["myapp"],
+            num_slots=2,
+            broker_opts=bopts,
+            conf={"resource": {"noverify": True}},
+        )
+        self.assertEqual(bopts, ["-Sfoo"])
+
+
 if __name__ == "__main__":
     unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0018-jobspec.py
+++ b/t/python/t0018-jobspec.py
@@ -13,7 +13,12 @@ import datetime
 import json
 import os
 import pathlib
+import shutil
+import signal
+import tempfile
+import textwrap
 import unittest
+from types import SimpleNamespace
 
 import subflux  # noqa: F401 - sets up PYTHONPATH
 from flux.job import JobspecV1
@@ -212,6 +217,505 @@ class TestJobspec(unittest.TestCase):
         jobspec = JobspecV1.from_command(["sleep", "0"], environment={})
         self.assertEqual(jobspec.environment, {})
 
+
+class TestApplyOptions(unittest.TestCase):
+    def _js(self):
+        """Return a fresh single-task jobspec"""
+        return JobspecV1.from_command(["hostname"])
+
+    def test_01_env_always_applied(self):
+        # environment is always set, even with no env rules
+        js = self._js()
+        js.apply_options(SimpleNamespace())
+        self.assertIsNotNone(js.environment)
+        self.assertIn("PATH", js.environment)
+
+    def test_02_env_filter(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace(env=["-PATH"]))
+        self.assertNotIn("PATH", js.environment)
+
+    def test_03_env_expand_shell_option(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace(env=["MY_ID={{id}}"]))
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertIn("env-expand", opts)
+        self.assertEqual(opts["env-expand"]["MY_ID"], "{{id}}")
+
+    def test_04_rlimit_applied(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace())
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertIn("rlimit", opts)
+
+    def test_05_rlimit_none_propagated(self):
+        js = self._js()
+        # -* removes all rlimits; no shell options entry should be present
+        js.apply_options(SimpleNamespace(rlimit=["-*"]))
+        shell = js.jobspec["attributes"]["system"].get("shell", {})
+        opts = shell.get("options", {})
+        self.assertNotIn("rlimit", opts)
+
+    def test_06_dependency(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace(dependency=["afterok:12345"]))
+        deps = js.jobspec["attributes"]["system"]["dependencies"]
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["scheme"], "afterok")
+        self.assertEqual(deps[0]["value"], "12345")
+
+    def test_07_multiple_dependencies(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace(dependency=["afterok:1", "afterany:2"]))
+        deps = js.jobspec["attributes"]["system"]["dependencies"]
+        self.assertEqual(len(deps), 2)
+
+    def test_08_requires_single(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace(requires=["gpu"]))
+        constraints = js.jobspec["attributes"]["system"]["constraints"]
+        self.assertIsNotNone(constraints)
+
+    def test_09_requires_multiple_combined(self):
+        # Multiple --requires values joined with spaces; MiniConstraintParser
+        # combines like "properties" terms into a single list.
+        js = self._js()
+        js.apply_options(SimpleNamespace(requires=["gpu", "ib"]))
+        constraints = js.jobspec["attributes"]["system"]["constraints"]
+        self.assertIsNotNone(constraints)
+        # Two bare property values combine into {"properties": ["gpu", "ib"]}
+        self.assertIn("properties", constraints)
+        self.assertIn("gpu", constraints["properties"])
+        self.assertIn("ib", constraints["properties"])
+
+    def test_10_setattr_system_prefix(self):
+        # key without prefix gets system. prepended
+        js = self._js()
+        js.apply_options(SimpleNamespace(setattr=["mykey=42"]))
+        self.assertEqual(js.jobspec["attributes"]["system"]["mykey"], 42)
+
+    def test_11_setattr_dot_prefix(self):
+        # key starting with '.' maps to attributes.
+        js = self._js()
+        js.apply_options(SimpleNamespace(setattr=[".user.tag=hello"]))
+        self.assertEqual(js.jobspec["attributes"]["user"]["tag"], "hello")
+
+    def test_12_setattr_explicit_system_prefix(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace(setattr=["system.job.name=test"]))
+        self.assertEqual(js.jobspec["attributes"]["system"]["job"]["name"], "test")
+
+    def test_13_setopt(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace(setopt=["verbose=1", "mpi=spectrum"]))
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["verbose"], 1)
+        self.assertEqual(opts["mpi"], "spectrum")
+
+    def test_14_setopt_no_value_defaults_to_1(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace(setopt=["someflag"]))
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["someflag"], 1)
+
+    def test_15_signal(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace(signal="USR1@30s"))
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertIn("signal", opts)
+        self.assertEqual(opts["signal"]["signum"], signal.SIGUSR1)
+
+    def test_16_signal_default(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace(signal="@60s"))
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertIn("signal", opts)
+        self.assertEqual(opts["signal"]["signum"], signal.SIGUSR1)
+
+    def test_17_taskmap(self):
+        js = self._js()
+        js.apply_options(SimpleNamespace(taskmap="block"))
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertIn("taskmap", opts)
+
+    def test_18_add_file_from_data(self):
+        # Data with a newline is treated as inline content, not a file path
+        js = self._js()
+        js.apply_options(SimpleNamespace(add_file=["myfile=line1\nline2"]))
+        files = js.jobspec["attributes"]["system"].get("files", {})
+        self.assertIn("myfile", files)
+
+    def test_19_add_file_name_missing_raises(self):
+        js = self._js()
+        with self.assertRaises(ValueError):
+            js.apply_options(SimpleNamespace(add_file=["line1\nline2"]))
+
+    def test_20_chaining(self):
+        # apply_options() returns self for method chaining
+        js = self._js()
+        result = js.apply_options(SimpleNamespace())
+        self.assertIs(result, js)
+
+    def test_21_prog_none_skips_plugins(self):
+        # prog=None should complete without error (no plugin registry needed)
+        js = self._js()
+        js.apply_options(SimpleNamespace(), prog=None)
+
+    def test_22_missing_attributes_skipped(self):
+        # SimpleNamespace with no attributes shouldn't raise
+        js = self._js()
+        ns = SimpleNamespace()
+        js.apply_options(ns, prog=None)
+        self.assertNotIn("dependencies", js.jobspec["attributes"]["system"])
+        self.assertNotIn("constraints", js.jobspec["attributes"]["system"])
+
+    def test_23_setopt_json_value(self):
+        # setopt should JSON-parse values
+        js = self._js()
+        js.apply_options(SimpleNamespace(setopt=["key=true"]))
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["key"], True)
+
+    def test_24_setopt_load_from_file(self):
+        data = json.dumps({"nested": "value"})
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as fp:
+            fp.write(data)
+            path = fp.name
+        try:
+            js = self._js()
+            js.apply_options(SimpleNamespace(setopt=[f"^myopt={path}"]))
+            opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+            self.assertEqual(opts["myopt"], {"nested": "value"})
+        finally:
+            os.unlink(path)
+
+    def test_25_multiple_apply_options_calls(self):
+        # shell options accumulate across apply_options calls; when args is
+        # passed each time, env is re-applied each call (args is not None path)
+        js = self._js()
+        js.apply_options(SimpleNamespace(setopt=["a=1"]))
+        js.apply_options(SimpleNamespace(setopt=["b=2"]))
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        # Both options should be present
+        self.assertEqual(opts["a"], 1)
+        self.assertEqual(opts["b"], 2)
+
+    def test_26_time_limit_fsd(self):
+        # time_limit in FSD string sets duration in seconds
+        js = self._js()
+        js.apply_options(SimpleNamespace(time_limit="30m"))
+        self.assertEqual(js.duration, 1800.0)
+
+    def test_27_time_limit_seconds(self):
+        # time_limit as float sets duration directly in seconds
+        js = self._js()
+        js.apply_options(SimpleNamespace(time_limit=3600.0))
+        self.assertEqual(js.duration, 3600.0)
+
+    def test_28_time_limit_none_unchanged(self):
+        # time_limit absent leaves duration unchanged
+        js = self._js()
+        js.apply_options(SimpleNamespace())
+        self.assertEqual(js.duration, 0)
+
+    def test_29_kwargs_no_namespace(self):
+        # kwargs alone work without any args namespace
+        js = self._js()
+        js.apply_options(env=["-PATH"], time_limit="1m")
+        self.assertNotIn("PATH", js.environment)
+        self.assertEqual(js.duration, 60.0)
+
+    def test_30_kwargs_override_namespace(self):
+        # kwargs take precedence over namespace attrs of the same name
+        js = self._js()
+        js.apply_options(SimpleNamespace(time_limit="1h"), time_limit="30m")
+        self.assertEqual(js.duration, 1800.0)
+
+    def test_31_shell_options_dict(self):
+        # shell_options dict sets shell options without string parsing
+        js = self._js()
+        js.apply_options(shell_options={"verbose": 1, "pty": 1})
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["verbose"], 1)
+        self.assertEqual(opts["pty"], 1)
+
+    def test_32_shell_options_overrides_setopt(self):
+        # shell_options dict applied after setopt strings so kwargs win
+        js = self._js()
+        js.apply_options(
+            SimpleNamespace(setopt=["verbose=0"]),
+            shell_options={"verbose": 1},
+        )
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["verbose"], 1)
+
+    def test_33_attributes_dict(self):
+        # attributes dict sets jobspec attributes, bare key gets system. prefix
+        js = self._js()
+        js.apply_options(attributes={"foo": "bar", "system.baz": 42})
+        self.assertEqual(js.jobspec["attributes"]["system"]["foo"], "bar")
+        self.assertEqual(js.jobspec["attributes"]["system"]["baz"], 42)
+
+    def test_34_attributes_dot_prefix(self):
+        # leading '.' in attributes dict key maps to attributes.
+        js = self._js()
+        js.apply_options(attributes={".user.mykey": "val"})
+        self.assertEqual(js.jobspec["attributes"]["user"]["mykey"], "val")
+
+    def test_35_unknown_kwarg_raises(self):
+        # unrecognized keyword argument raises TypeError
+        js = self._js()
+        with self.assertRaises(TypeError):
+            js.apply_options(typo_option="bad")
+
+    def test_36_requires_bare_string_normalized(self):
+        # A bare string for requires must be treated as a single constraint term,
+        # not iterated character-by-character.
+        js = self._js()
+        js.apply_options(SimpleNamespace(requires="host:node01"))
+        constraints = js.jobspec["attributes"]["system"]["constraints"]
+        self.assertIsNotNone(constraints)
+        # "host:node01" is a hostlist constraint — should appear as a single value
+        self.assertIn("hostlist", constraints)
+        self.assertEqual(constraints["hostlist"], ["node01"])
+
+    def test_37_dependency_bare_string_normalized(self):
+        # A bare string for dependency must produce exactly one dependency entry.
+        js = self._js()
+        js.apply_options(SimpleNamespace(dependency="afterok:12345"))
+        deps = js.jobspec["attributes"]["system"]["dependencies"]
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["scheme"], "afterok")
+        self.assertEqual(deps[0]["value"], "12345")
+
+    def test_38_env_bare_string_normalized(self):
+        # A bare string for env must be treated as a single filter rule,
+        # not split into individual characters.
+        js = self._js()
+        js.apply_options(SimpleNamespace(env="-PATH"))
+        self.assertNotIn("PATH", js.environment)
+
+    def test_39_rlimit_bare_string_normalized(self):
+        # A bare string for rlimit must be treated as a single rule.
+        js = self._js()
+        js.apply_options(SimpleNamespace(rlimit="-*"))
+        shell = js.jobspec["attributes"]["system"].get("shell", {})
+        opts = shell.get("options", {})
+        self.assertNotIn("rlimit", opts)
+
+    def test_40_env_not_applied_without_args_or_kwarg(self):
+        # apply_options() with no args namespace and no env= kwarg must not
+        # overwrite a pre-set environment.
+        js = self._js()
+        js.environment = {"MY_VAR": "42"}
+        js.apply_options()
+        self.assertEqual(js.environment, {"MY_VAR": "42"})
+
+    def test_41_env_not_reset_on_second_call(self):
+        # A second apply_options() call that omits env= must not reset the
+        # environment set by the first call.
+        js = self._js()
+        js.apply_options(env=["-PATH"])
+        self.assertNotIn("PATH", js.environment)
+        js.apply_options(shell_options={"verbose": 1})
+        # PATH was filtered by the first call; second call must not restore it
+        self.assertNotIn("PATH", js.environment)
+
+
+class TestApplyOptionsWithPlugin(unittest.TestCase):
+    """Test apply_options() interactions with CLI plugins."""
+
+    PLUGIN_CODE = textwrap.dedent(
+        """\
+        from flux.cli.plugin import CLIPlugin
+
+        class TestPlugin(CLIPlugin):
+            def __init__(self, prog, prefix="test"):
+                super().__init__(prog, prefix=prefix)
+                self.add_option("--myopt", default="default_val")
+
+            def modify_jobspec(self, args, jobspec):
+                if args.myopt is not None:
+                    jobspec.setattr_shell_option("test-opt", args.myopt)
+    """
+    )
+
+    def setUp(self):
+        self._plugin_dir = tempfile.mkdtemp()
+        with open(os.path.join(self._plugin_dir, "testplugin.py"), "w") as fp:
+            fp.write(self.PLUGIN_CODE)
+        self._saved_pluginpath = os.environ.get("FLUX_CLI_PLUGINPATH")
+        os.environ["FLUX_CLI_PLUGINPATH"] = self._plugin_dir
+
+    def tearDown(self):
+        shutil.rmtree(self._plugin_dir)
+        if self._saved_pluginpath is None:
+            os.environ.pop("FLUX_CLI_PLUGINPATH", None)
+        else:
+            os.environ["FLUX_CLI_PLUGINPATH"] = self._saved_pluginpath
+
+    def _js(self):
+        return JobspecV1.from_command(["hostname"])
+
+    def test_01_modify_jobspec_called(self):
+        # plugin modify_jobspec is called; kwarg uses the prefixed dest name.
+        # The plugin callback accesses args.myopt (old unprefixed form) which
+        # PluginArgsProxy transparently aliases to the prefixed dest.
+        js = self._js()
+        js.apply_options(prog="submit", test_myopt="hello")
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["test-opt"], "hello")
+
+    def test_02_prefixed_dest_is_valid_kwarg(self):
+        # the prefixed dest (matching the CLI flag) is accepted without TypeError
+        js = self._js()
+        js.apply_options(prog="submit", test_myopt="x")
+
+    def test_03_unknown_kwarg_raises_with_plugin_loaded(self):
+        # unrecognized kwarg raises TypeError even when a plugin is loaded
+        js = self._js()
+        with self.assertRaises(TypeError):
+            js.apply_options(prog="submit", badopt="x")
+
+    def test_04_preinit_seeds_plugin_option_default(self):
+        # _preinit=True seeds missing plugin option defaults before modify_jobspec
+        js = self._js()
+        js.apply_options(prog="submit", _preinit=True)
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["test-opt"], "default_val")
+
+    def test_05_preinit_called_via_from_submit(self):
+        # preinit() is called (default seeding) when using from_submit()
+        js = JobspecV1.from_submit(["hostname"])
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["test-opt"], "default_val")
+
+    def test_07_unprefixed_kwarg_raises_type_error(self):
+        # the old unprefixed dest form (myopt=) is no longer accepted;
+        # callers must use the prefixed form that matches the CLI flag
+        js = self._js()
+        with self.assertRaises(TypeError):
+            js.apply_options(prog="submit", myopt="x")
+
+    def test_08_proxy_setattr_alias_in_callback(self):
+        # a plugin that writes to args via the old unprefixed name in
+        # modify_jobspec should update the namespace via the proxy alias
+        write_plugin = textwrap.dedent(
+            """\
+            from flux.cli.plugin import CLIPlugin
+
+            class WritePlugin(CLIPlugin):
+                def __init__(self, prog, prefix="wp"):
+                    super().__init__(prog, prefix=prefix)
+                    self.add_option("--flag", default="original")
+
+                def modify_jobspec(self, args, jobspec):
+                    args.flag = "rewritten"  # write via old unprefixed name
+                    jobspec.setattr_shell_option("wp-result", args.flag)
+            """
+        )
+        with open(os.path.join(self._plugin_dir, "writeplugin.py"), "w") as fp:
+            fp.write(write_plugin)
+        js = self._js()
+        js.apply_options(prog="submit")
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["wp-result"], "rewritten")
+
+    def test_09_no_prefix_plugin_kwarg_accepted(self):
+        # a plugin with prefix=None has dest equal to the bare option name;
+        # the proxy alias map is empty (identity), so args.mykey passes through
+        noprefix_code = textwrap.dedent(
+            """\
+            from flux.cli.plugin import CLIPlugin
+
+            class NoPrefixPlugin(CLIPlugin):
+                def __init__(self, prog, prefix=None):
+                    super().__init__(prog, prefix=prefix)
+                    self.add_option("--mykey")
+
+                def modify_jobspec(self, args, jobspec):
+                    if args.mykey:
+                        jobspec.setattr_shell_option("np-result", args.mykey)
+            """
+        )
+        with open(os.path.join(self._plugin_dir, "noprefixplugin.py"), "w") as fp:
+            fp.write(noprefix_code)
+        js = self._js()
+        js.apply_options(prog="submit", mykey="bare")
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["np-result"], "bare")
+
+    def test_10_explicit_dest_plugin_kwarg_accepted(self):
+        # a plugin with explicit dest= bypasses alias entirely;
+        # the kwarg must use the custom dest name, not the option flag name
+        explicit_dest_code = textwrap.dedent(
+            """\
+            from flux.cli.plugin import CLIPlugin
+
+            class ExplicitDestPlugin(CLIPlugin):
+                def __init__(self, prog, prefix="ed"):
+                    super().__init__(prog, prefix=prefix)
+                    self.add_option("--my-opt", dest="custom_key")
+
+                def modify_jobspec(self, args, jobspec):
+                    if args.custom_key:
+                        jobspec.setattr_shell_option("ed-result", args.custom_key)
+            """
+        )
+        with open(os.path.join(self._plugin_dir, "explicitdestplugin.py"), "w") as fp:
+            fp.write(explicit_dest_code)
+        js = self._js()
+        js.apply_options(prog="submit", custom_key="val")
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["ed-result"], "val")
+
+    def test_11_two_plugins_both_fire(self):
+        # when two plugins are loaded, both modify_jobspec callbacks run
+        second_code = textwrap.dedent(
+            """\
+            from flux.cli.plugin import CLIPlugin
+
+            class SecondPlugin(CLIPlugin):
+                def __init__(self, prog, prefix="b"):
+                    super().__init__(prog, prefix=prefix)
+                    self.add_option("--bopt")
+
+                def modify_jobspec(self, args, jobspec):
+                    jobspec.setattr_shell_option("b-result", "b-fired")
+            """
+        )
+        with open(os.path.join(self._plugin_dir, "secondplugin.py"), "w") as fp:
+            fp.write(second_code)
+        js = self._js()
+        js.apply_options(prog="submit", test_myopt="first")
+        opts = js.jobspec["attributes"]["system"]["shell"]["options"]
+        self.assertEqual(opts["test-opt"], "first")  # first plugin fired
+        self.assertEqual(opts["b-result"], "b-fired")  # second plugin fired
+
+    def test_06_preinit_structural_mutation_ignored_in_from_submit(self):
+        # preinit() mutations to structural params (ntasks etc.) have no effect
+        # because from_submit() builds the jobspec before apply_options() runs.
+        # This test documents the known limitation: the plugin cannot resize
+        # the job from preinit() when called through from_submit().
+        preinit_code = textwrap.dedent(
+            """\
+            from flux.cli.plugin import CLIPlugin
+
+            class PreinitPlugin(CLIPlugin):
+                def __init__(self, prog, prefix="pre"):
+                    super().__init__(prog, prefix=prefix)
+
+                def preinit(self, args):
+                    # Attempt to override ntasks — has no effect via from_submit()
+                    args.ntasks = 99
+            """
+        )
+        with open(os.path.join(self._plugin_dir, "preinitplugin.py"), "w") as fp:
+            fp.write(preinit_code)
+        js = JobspecV1.from_submit(["hostname"], ntasks=1)
+        slot = js.jobspec["resources"][0]
+        # ntasks should still be 1 — preinit mutation was ignored
+        self.assertEqual(slot["count"], 1)
 
 if __name__ == "__main__":
     unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0018-jobspec.py
+++ b/t/python/t0018-jobspec.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2014 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import datetime
+import json
+import os
+import pathlib
+import unittest
+
+import subflux  # noqa: F401 - sets up PYTHONPATH
+from flux.job import JobspecV1
+from flux.job.Jobspec import Jobspec
+from pycotap import TAPTestRunner
+
+# Minimal valid v1 jobspec for use as a test fixture
+BASIC_JOBSPEC = json.dumps(
+    {
+        "version": 1,
+        "resources": [
+            {
+                "type": "slot",
+                "count": 1,
+                "label": "task",
+                "with": [{"type": "core", "count": 1}],
+            }
+        ],
+        "tasks": [{"command": ["app"], "slot": "foo", "count": {"per_slot": 1}}],
+        "attributes": {"system": {"duration": 0}},
+    }
+)
+
+
+class TestJobspec(unittest.TestCase):
+    """Unit tests for the Jobspec API that do not require a running Flux instance.
+
+    These tests were formerly part of t0010-job.py which requires a Flux instance
+    for most of its tests.
+    """
+
+    def _basic(self):
+        return Jobspec.from_yaml_stream(BASIC_JOBSPEC)
+
+    def test_01_valid_duration(self):
+        """Test setting Jobspec duration to various valid values"""
+        jobspec = self._basic()
+        for duration in (100, 100.5):
+            delta = datetime.timedelta(seconds=duration)
+            for x in [duration, delta, "{}s".format(duration)]:
+                jobspec.duration = x
+                # duration setter converts value to a float
+                self.assertEqual(jobspec.duration, float(duration))
+
+    def test_02_invalid_duration(self):
+        """Test setting Jobspec duration to various invalid values and types"""
+        jobspec = self._basic()
+        for duration in (-100, -100.5, datetime.timedelta(seconds=-5), "10h5m"):
+            with self.assertRaises(ValueError):
+                jobspec.duration = duration
+        for duration in ([], {}):
+            with self.assertRaises(TypeError):
+                jobspec.duration = duration
+
+    def test_03_cwd_pathlib(self):
+        """Test setting cwd to a pathlib.PosixPath"""
+        jobspec = self._basic()
+        cwd = pathlib.PosixPath("/tmp")
+        jobspec.cwd = cwd
+        self.assertEqual(jobspec.cwd, os.fspath(cwd))
+
+    def test_04_environment(self):
+        jobspec = self._basic()
+        new_env = {"HOME": "foo", "foo": "bar"}
+        jobspec.environment = new_env
+        self.assertEqual(jobspec.environment, new_env)
+
+    def test_05_queue(self):
+        jobspec = self._basic()
+        jobspec.queue = "default"
+        self.assertEqual(jobspec.queue, "default")
+
+    def test_06_queue_invalid(self):
+        jobspec = self._basic()
+        with self.assertRaises(TypeError):
+            jobspec.queue = 12
+
+    def test_07_stdio_new_methods(self):
+        """Test official getter/setter methods for stdio properties
+        Ensure for now that output sets the alias "stdout", error sets "stderr"
+        and input sets "stdin".
+        """
+        jobspec = self._basic()
+        streams = {"error": "stderr", "output": "stdout", "input": "stdin"}
+        for name in ("error", "output", "input"):
+            stream = streams[name]
+            self.assertEqual(getattr(jobspec, name), None)
+            for path in ("foo.txt", "bar.md", "foo.json"):
+                setattr(jobspec, name, path)
+                self.assertEqual(getattr(jobspec, name), path)
+                self.assertEqual(getattr(jobspec, stream), path)
+            with self.assertRaises(TypeError):
+                setattr(jobspec, name, None)
+
+    def test_08_stdio(self):
+        """Test getter/setter methods for stdio properties"""
+        jobspec = self._basic()
+        for stream in ("stderr", "stdout", "stdin"):
+            self.assertEqual(getattr(jobspec, stream), None)
+            for path in ("foo.txt", "bar.md", "foo.json"):
+                setattr(jobspec, stream, path)
+                self.assertEqual(getattr(jobspec, stream), path)
+            with self.assertRaises(TypeError):
+                setattr(jobspec, stream, None)
+
+        with self.assertRaises(TypeError):
+            jobspec.unbuffered = 1
+
+        jobspec.unbuffered = True
+        self.assertTrue(jobspec.unbuffered)
+        self.assertEqual(
+            jobspec.getattr("shell.options.output.stderr.buffer.type"), "none"
+        )
+        self.assertEqual(
+            jobspec.getattr("shell.options.output.stdout.buffer.type"), "none"
+        )
+        self.assertEqual(jobspec.getattr("shell.options.output.batch-timeout"), 0.05)
+
+        jobspec.unbuffered = False
+        self.assertFalse(jobspec.unbuffered)
+
+        # jobspec.unbuffered = True keeps modified batch-timeout
+        jobspec.unbuffered = True
+        jobspec.setattr_shell_option("output.batch-timeout", 1.0)
+        jobspec.unbuffered = False
+        self.assertFalse(jobspec.unbuffered)
+        self.assertEqual(jobspec.getattr("shell.options.output.batch-timeout"), 1.0)
+
+    def test_09_setattr_defaults(self):
+        """Test setattr setting defaults"""
+        jobspec = self._basic()
+        jobspec.setattr("cow", 1)
+        jobspec.setattr("system.cat", 2)
+        jobspec.setattr("user.dog", 3)
+        jobspec.setattr("attributes.system.chicken", 4)
+        jobspec.setattr("attributes.user.duck", 5)
+        jobspec.setattr("attributes.goat", 6)
+        self.assertEqual(jobspec.getattr("cow"), 1)
+        self.assertEqual(jobspec.getattr("system.cow"), 1)
+        self.assertEqual(jobspec.getattr("attributes.system.cow"), 1)
+
+        self.assertEqual(jobspec.getattr("cat"), 2)
+        self.assertEqual(jobspec.getattr("system.cat"), 2)
+        self.assertEqual(jobspec.getattr("attributes.system.cat"), 2)
+
+        self.assertEqual(jobspec.getattr("user.dog"), 3)
+        self.assertEqual(jobspec.getattr("attributes.user.dog"), 3)
+
+        self.assertEqual(jobspec.getattr("chicken"), 4)
+        self.assertEqual(jobspec.getattr("system.chicken"), 4)
+        self.assertEqual(jobspec.getattr("attributes.system.chicken"), 4)
+
+        self.assertEqual(jobspec.getattr("user.duck"), 5)
+        self.assertEqual(jobspec.getattr("attributes.user.duck"), 5)
+
+        self.assertEqual(jobspec.getattr("attributes.goat"), 6)
+
+    def test_10_str(self):
+        """Test string representation of a basic jobspec"""
+        jobspec = self._basic()
+        jobspec.setattr("cow", 1)
+        jobspec.setattr("system.cat", 2)
+        jobspec.setattr("user.dog", 3)
+        jobspec.setattr("attributes.system.chicken", 4)
+        jobspec.setattr("attributes.user.duck", 5)
+        jobspec.setattr("attributes.goat", 6)
+        self.assertEqual(
+            str(jobspec),
+            "{'resources': [{'type': 'slot', 'count': 1, 'label': 'task', 'with': [{'type': 'core', 'count': 1}]}], 'tasks': [{'command': ['app'], 'slot': 'foo', 'count': {'per_slot': 1}}], 'attributes': {'system': {'duration': 0, 'cow': 1, 'cat': 2, 'chicken': 4}, 'user': {'dog': 3, 'duck': 5}, 'goat': 6}, 'version': 1}",
+        )
+
+    def test_11_repr(self):
+        """Test __repr__ method of Jobspec"""
+        jobspec = self._basic()
+        self.assertEqual(eval(repr(jobspec)).jobspec, jobspec.jobspec)
+        jobspec.cwd = "/foo/bar"
+        jobspec.stdout = "/bar/baz"
+        jobspec.duration = 1000.3133
+        self.assertEqual(eval(repr(jobspec)).jobspec, jobspec.jobspec)
+
+    def test_12_bad_extra_args(self):
+        """Test extra Jobspec constructor args with bad values"""
+        with self.assertRaises(ValueError):
+            JobspecV1.from_command(["sleep", "0"], duration="1f")
+        with self.assertRaises(ValueError):
+            JobspecV1.from_command(["sleep", "0"], environment="foo")
+        with self.assertRaises(ValueError):
+            JobspecV1.from_command(["sleep", "0"], env_expand=1)
+        with self.assertRaises(ValueError):
+            JobspecV1.from_command(["sleep", "0"], rlimits=True)
+
+    def test_13_environment_default(self):
+        jobspec = JobspecV1.from_command(["sleep", "0"])
+        self.assertEqual(jobspec.environment, dict(os.environ))
+
+        jobspec = JobspecV1.from_command(["sleep", "0"], environment={})
+        self.assertEqual(jobspec.environment, {})
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0019-cli-plugin.py
+++ b/t/python/t0019-cli-plugin.py
@@ -39,7 +39,7 @@ class TestCLIPluginOption(unittest.TestCase):
         # dest is derived from the full prefixed CLI flag name
         opt = CLIPluginOption("--my-option", prefix="site")
         self.assertEqual(opt.name, "--site-my-option")
-        self.assertEqual(opt.kwargs["dest"], "site_my_option")
+        self.assertEqual(opt.dest, "site_my_option")
 
     def test_02_unprefixed_dest_stored_for_alias(self):
         # _unprefixed_dest holds the pre-prefix form for proxy aliasing
@@ -50,19 +50,19 @@ class TestCLIPluginOption(unittest.TestCase):
         # without a prefix, dest and _unprefixed_dest are identical
         opt = CLIPluginOption("--my-option", prefix=None)
         self.assertEqual(opt.name, "--my-option")
-        self.assertEqual(opt.kwargs["dest"], "my_option")
+        self.assertEqual(opt.dest, "my_option")
         self.assertEqual(opt._unprefixed_dest, "my_option")
 
     def test_04_auto_dest_dashes_to_underscores(self):
         # dashes in the prefixed flag name are converted to underscores in dest
         opt = CLIPluginOption("--long-option-name", prefix="site")
-        self.assertEqual(opt.kwargs["dest"], "site_long_option_name")
+        self.assertEqual(opt.dest, "site_long_option_name")
         self.assertEqual(opt._unprefixed_dest, "long_option_name")
 
     def test_05_explicit_dest_used_as_is(self):
         # explicit dest= is accepted unchanged
         opt = CLIPluginOption("--my-option", prefix="site", dest="custom_dest")
-        self.assertEqual(opt.kwargs["dest"], "custom_dest")
+        self.assertEqual(opt.dest, "custom_dest")
 
     def test_06_explicit_dest_no_alias(self):
         # explicit dest= sets _unprefixed_dest to None — no compat alias needed
@@ -226,7 +226,7 @@ class TestConflictDetection(unittest.TestCase):
                 f.write(self.PLUGIN_VENDOR)
             os.environ["FLUX_CLI_PLUGINPATH"] = d
             registry = CLIPluginRegistry("submit")
-            dests = {opt.kwargs["dest"] for opt in registry.options}
+            dests = {opt.dest for opt in registry.options}
             self.assertIn("site_my_option", dests)
             self.assertIn("vendor_my_option", dests)
 

--- a/t/scripts/runpty.py
+++ b/t/scripts/runpty.py
@@ -19,7 +19,7 @@ import time
 from signal import SIGALRM, SIGINT, SIGTERM, SIGUSR1, SIGWINCH, alarm, signal
 
 from flux import util
-from flux.cli.base import decode_duration, decode_signal
+from flux.job._utils import decode_duration, decode_signal
 
 
 def setwinsize(fd, rows, cols):


### PR DESCRIPTION
  This PR aims to solve #7440 through the following steps:

  - Move shared code used by the submission CLI tools from `flux.cli.base` to `flux.job._utils` so it can be used outside the CLI layer.
  - Add `JobspecV1.apply_options()`, which abstracts the option-processing logic from the CLI interfaces. It accepts either an `argparse` `Namespace` (as produced by the CLI tools) or equivalent keyword arguments, making the full set of submission options available to Python users directly. CLI plugins are loaded automatically, so plugin-provided options are also supported.
  - Update all submission CLI tools to use `apply_options()`.
  - Add `JobspecV1.from_submit()`, `.from_alloc()`, and `.from_batch()` convenience factory methods that combine the corresponding low-level methods (`from_command()`, `from_nest_command()`, `from_batch_command()`) with `apply_options()` in a single call, giving Python users a simple interface for creating jobspecs with the same options — including plugin options — as the CLI submission tools.

Fixes #7440