### PR TITLE
doc: add caveat for `--taskmap=hostfile`

### DIFF
--- a/doc/man1/common/job-other-run.rst
+++ b/doc/man1/common/job-other-run.rst
@@ -23,6 +23,15 @@
     the hostfile.  If there are less hosts in the hostfile than tasks
     in the job, then the list of hosts will be reused.
 
+    .. note::
+
+      The ``hostfile`` option controls task placement only — it does
+      not influence which hosts are allocated to the job.  It is most
+      useful within an existing allocation where the allocated hosts
+      are known in advance. If the hosts are not known beforehand, use
+      :option:`--requires=host:HOSTLIST` to constrain the allocation to
+      match the hostfile, though this may delay scheduling.
+
    However, shell plugins may provide other task mapping schemes, so
    check the current job shell configuration for a full list of supported
    taskmap schemes.


### PR DESCRIPTION
Problem: The hostfile taskmap option controls task placement only and does not influence which hosts are allocated to the job.  Users may be surprised when the job fails if the allocated hosts do not match the hostfile.

Add a note explaining that hostfile is most useful within an existing allocation where hosts are known in advance, and suggest `--requires=hosts:HOSTLIST` when they are not.

Fixes #7495