### PR TITLE
scheduler: add support for generator yield in schedule/forecast loops

### DIFF
--- a/doc/python/scheduler.rst
+++ b/doc/python/scheduler.rst
@@ -94,7 +94,8 @@ to :meth:`~Scheduler.alloc`:
 Allocating resources
 ~~~~~~~~~~~~~~~~~~~~
 
-Pass the jobid and resource request to :meth:`~flux.resource.ResourcePool.alloc`:
+Pass the jobid and resource request to
+:meth:`~flux.resource.ResourcePool.alloc`:
 
 .. code-block:: python
 
@@ -120,10 +121,10 @@ pool object containing only the allocated resources.  Pass it directly to
 
    request.success(alloc)
 
-The pool also records the job's expected expiration (derived from ``request.duration``)
-internally; :meth:`~flux.resource.ResourcePool.free` and start-time
-simulation (via :meth:`~flux.resource.ResourcePool.copy` and
-:meth:`~flux.resource.ResourcePool.job_end_times`) use this state.
+The pool also records the job's expected expiration (derived from
+``request.duration``) internally; :meth:`~flux.resource.ResourcePool.free`
+and start-time simulation (via :meth:`~flux.resource.ResourcePool.copy`
+and :meth:`~flux.resource.ResourcePool.job_end_times`) use this state.
 
 Releasing resources
 ~~~~~~~~~~~~~~~~~~~
@@ -163,8 +164,8 @@ distinct objects are created and stored together on the
 - ``job.resource_request`` — a pool-specific object describing *what the job
   needs*.  Created once from jobspec by
   :meth:`~flux.resource.ResourcePool.parse_resource_request` when the alloc
-  arrives.  For the built-in pools this carries fields for node count, slot count,
-  cores and GPUs per slot, duration, constraints, and exclusivity.
+  arrives.  For the built-in pools this carries fields for node count,
+  slot count, cores and GPUs per slot, duration, constraints, and exclusivity.
   Used by the scheduler during each :meth:`~Scheduler.schedule`
   pass to decide whether resources can be satisfied.  Persists for the
   lifetime of the pending job.
@@ -203,8 +204,8 @@ calling one of:
        Cancelling an alloc request is **not** the same as cancelling the job.
        Job-manager may withdraw an alloc request — for example, to shrink the
        outstanding request count back within the configured ``queue-depth`` —
-       while leaving the job itself in the pending queue.  The job will receive
-       a fresh alloc request when a slot opens up.
+       while leaving the job itself in the pending queue.  The job
+       will receive a fresh alloc request when a slot opens up.
 
 :meth:`request.annotate(annotations) <AllocRequest.annotate>`
     Send an intermediate annotation update while the job is pending.  May be
@@ -287,6 +288,15 @@ following methods:
     necessary; see `Scheduling deferral`_ for details.
     The default implementation is a no-op.
 
+    If :meth:`~Scheduler.schedule` returns a generator the base class
+    advances it **one yield per reactor iteration**, allowing other events
+    to be handled between yields.
+    When a new scheduling event arrives while a generator pass is in progress
+    the base class closes it and starts a fresh pass after the settling delay,
+    ensuring that a newly submitted job or freed resource is considered from
+    the top of the queue without waiting for the current pass to finish.
+    Non-generator implementations remain fully supported.
+
     Example::
 
         def schedule(self):
@@ -301,6 +311,16 @@ following methods:
                 else:
                     job.request.success(alloc)
                 heapq.heappop(self._queue)
+                yield   # let the reactor handle other events between jobs
+
+:meth:`start_schedule(self) <Scheduler.start_schedule>`
+    Called by :meth:`~Scheduler._request_schedule` after updating the
+    interval EWMA.  The default implementation aborts any in-progress
+    generator and arms the one-shot scheduling timer.  Override this
+    method (not :meth:`~Scheduler._request_schedule`) to replace the
+    generator driver — for example, to launch an RPC-based allocation
+    request — while still preserving the ``_sched_pending`` guard that
+    coalesces concurrent scheduling events into a single pass.
 
 :meth:`resource_update(self) <Scheduler.resource_update>`
     Called after each resource state update.  For queue-based schedulers
@@ -323,9 +343,16 @@ following methods:
     jobs with forward-looking estimates such as ``sched.t_estimate``.  The
     base class implementation is a no-op.  Override to post start-time
     estimates (or other planning metadata) without impacting scheduling
-    throughput — :meth:`~Scheduler.forecast` is rate-limited to at most
-    once per :attr:`~Scheduler.FORECAST_PERIOD` seconds so that annotation
-    work is kept off the critical scheduling path during bursts.
+    throughput.
+
+    Supports the same generator protocol as :meth:`~Scheduler.schedule`:
+    add ``yield`` at each desired reactor handoff point — typically after each
+    annotated job — to return control to the reactor between annotations.
+    Unlike the schedule generator, a running forecast generator is **not**
+    aborted when a new scheduling event arrives — it runs to completion.
+    A slightly stale ``t_estimate`` is more useful than none at all, and
+    the simulation snapshot taken at pass start remains internally
+    consistent regardless of real-pool changes mid-pass.
 
     Example (annotating the head-of-queue job with its estimated start time):
 
@@ -401,6 +428,14 @@ The timer uses an adaptive delay tuned automatically at runtime:
   pass per cycle.  A ``DEBUG`` log message is emitted when the delay changes.
 - Once events slow down again the delay resets to zero immediately.
 
+.. note::
+
+   When :meth:`~Scheduler.schedule` is a generator the EWMA duration is
+   **not** updated, so ``sched_delay`` remains 0 and the timer fires on
+   the next reactor iteration with no burst-coalescing window.  Events
+   that arrive while the timer is already armed are still coalesced by
+   the ``_sched_pending`` guard, but there is no adaptive settling period.
+
 Two class attributes control the behaviour and can be overridden on the
 subclass:
 
@@ -434,37 +469,19 @@ submission bursts.
 Forecast deferral
 -----------------
 
-:meth:`~Scheduler.forecast` is triggered after every
-:meth:`~Scheduler.schedule` call, but rate-limited by a separate one-shot
-timer so that annotation work does not accumulate on the critical path during
-scheduling bursts.
+:meth:`~Scheduler.forecast` is called immediately after each
+:meth:`~Scheduler.schedule` pass completes.  Because
+:meth:`~Scheduler.forecast` supports the same generator protocol as
+:meth:`~Scheduler.schedule`, annotation work may be spread across multiple
+reactor iterations to avoid blocking the critical scheduling path.
 
-The mechanism is simpler than the adaptive scheduling timer: after each
-:meth:`~Scheduler.schedule` call the base class calls
-:meth:`~Scheduler._request_forecast`.  If the forecast timer is not already
-armed it is set to fire after :attr:`~Scheduler.FORECAST_PERIOD` seconds
-(default ``1.0``).  Subsequent :meth:`~Scheduler._request_forecast` calls
-while the timer is armed are no-ops, so a burst of N scheduling events
-results in exactly one :meth:`~Scheduler.forecast` call roughly one second
-after the burst begins.
-
-The period can be tuned per-instance at load time::
-
-    flux module load sched-fifo forecast-period=0.5
-
-or overridden on the subclass:
-
-.. code-block:: python
-
-   class MyScheduler(Scheduler):
-       FORECAST_PERIOD = 2.0   # run forecast() at most once every 2 seconds
-
-Because :meth:`~Scheduler.forecast` runs asynchronously after
-:meth:`~Scheduler.schedule`, the data it reads from ``self._queue`` and
-``self.resources`` reflects the state at the time the timer fires, not the
-time the triggering scheduling event occurred.  This is correct: annotations
-should reflect the *current* queue state, not a stale snapshot from a burst
-that has since been partially resolved.
+If a new scheduling event arrives while a forecast generator is in progress,
+the base class leaves it running to completion.  Forecast estimates are
+approximate by design, and a slightly stale ``t_estimate`` is more useful
+than none at all.  The simulation snapshot is taken once at pass start
+(a deep copy of the pool), so it remains internally consistent regardless
+of real-pool changes mid-pass.  A fresh forecast pass is triggered after
+the next :meth:`~Scheduler.schedule` pass completes.
 
 
 Module arguments
@@ -475,7 +492,7 @@ in :func:`mod_main` and are forwarded to ``__init__``:
 
 .. code-block:: console
 
-   $ flux module load my-sched.py queue-depth=8 log-level=debug forecast-period=2.0
+   $ flux module load my-sched.py queue-depth=8 log-level=debug
 
 The base class automatically handles three built-in arguments:
 
@@ -489,14 +506,11 @@ log-level=LEVEL
     ``crit``, ``err``, ``warning``, ``notice``, ``info``, or ``debug``
     (default ``info``).
 
-forecast-period=SECONDS
-    Sets :attr:`~Scheduler.FORECAST_PERIOD` on the instance (default 1.0).
-
-Any argument not consumed by the subclass or the base class is rejected with
-an error at load time, so a typo like ``log_level=debug`` (underscore instead
-of hyphen) is caught immediately.  Subclasses parse their own arguments before
-calling ``super().__init__``, which consumes the built-in ones and then rejects
-whatever remains:
+Any argument not consumed by the subclass or the base class is rejected
+with an error at load time, so a typo like ``log_level=debug`` (underscore
+instead of hyphen) is caught immediately.  Subclasses parse their own
+arguments before calling ``super().__init__``, which consumes the built-in
+ones and then rejects whatever remains:
 
 .. code-block:: python
 
@@ -508,7 +522,7 @@ whatever remains:
                self._my_option = arg[10:]
            else:
                remaining.append(arg)
-       super().__init__(h, *remaining)   # handles queue-depth=, log-level=, forecast-period=
+       super().__init__(h, *remaining)   # handles queue-depth=, log-level=
 
 
 
@@ -541,6 +555,50 @@ Pool implementations receive the same ``self.log`` method and should call it
 unconditionally — no ``None`` check is needed.
 
 Log messages appear in :man1:`flux-dmesg` and the broker's stderr.
+
+
+Statistics
+----------
+
+The base class registers a ``<module-name>.stats-get`` RPC handler that
+calls :meth:`~Scheduler.stats_get` and responds with the returned dict.
+Use :man1:`flux-module` to query it:
+
+.. code-block:: console
+
+   $ flux module stats my-sched
+
+Standard fields reported by the base class:
+
+``sched_passes``
+    Number of completed :meth:`~Scheduler.schedule` passes.
+``sched_yields``
+    Total yields across all :meth:`~Scheduler.schedule` generator passes
+    (always 0 for synchronous schedulers).
+``forecast_passes``, ``forecast_yields``
+    Equivalent counters for :meth:`~Scheduler.forecast` passes
+    (``forecast_yields`` always 0 for synchronous schedulers).
+``sched_delay``
+    Current adaptive burst-coalescing delay in seconds.
+    Always 0 for generator-based schedulers.
+``sched_duration_ewma``
+    EWMA of :meth:`~Scheduler.schedule` wall-clock duration in seconds.
+    Always 0 for generator-based schedulers.
+``sched_interval_ewma``
+    EWMA of time between scheduling requests in seconds.  Tracked for all
+    schedulers but does not affect ``sched_delay`` for generator-based
+    schedulers.
+``pending_jobs``
+    Current number of pending alloc requests in the scheduler queue.
+
+Subclasses can extend the response by overriding :meth:`~Scheduler.stats_get`:
+
+.. code-block:: python
+
+   def stats_get(self):
+       stats = super().stats_get()
+       stats["my_counter"] = self._my_counter
+       return stats
 
 
 Testing

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -138,13 +138,14 @@ class AllocRequest:
         jobid (int): The job ID for this allocation request.
     """
 
-    __slots__ = ("_scheduler", "_msg", "jobid", "_annotated_sched_keys")
+    __slots__ = ("_scheduler", "_msg", "jobid", "_annotated_sched_keys", "_finalized")
 
     def __init__(self, scheduler, msg):
         self._scheduler = scheduler
         self._msg = msg
         self.jobid = msg.payload["id"]
         self._annotated_sched_keys = set()
+        self._finalized = False
 
     def success(self, R, annotations=None, clear=True):
         """Finalize the request with a successful allocation.
@@ -161,6 +162,7 @@ class AllocRequest:
                 (e.g. ``reason_pending``, ``t_estimate``) are cleaned up
                 without each scheduler needing to track and clear them manually.
         """
+        self._finalized = True
         if not isinstance(R, dict):
             R = R.to_dict()
         if clear and self._annotated_sched_keys:
@@ -177,10 +179,12 @@ class AllocRequest:
         Args:
             note (str, optional): Human-readable reason for the denial.
         """
+        self._finalized = True
         self._scheduler.alloc_deny(self._msg, note)
 
     def cancel(self):
         """Finalize the request indicating it was cancelled."""
+        self._finalized = True
         self._scheduler.alloc_cancel(self._msg)
 
     def annotate(self, annotations):
@@ -188,11 +192,15 @@ class AllocRequest:
 
         May be called any number of times before the request is finalized.
         Keys set here are tracked so that :meth:`success` can automatically
-        clear them.
+        clear them.  Calls after the request is finalized are silently
+        ignored to prevent stale annotations from a still-running forecast
+        generator reaching the job-manager after a cancel.
 
         Args:
             annotations (dict): Annotation dict to attach to the job.
         """
+        if self._finalized:
+            return
         self._annotated_sched_keys.update((annotations or {}).get("sched", {}).keys())
         self._scheduler.alloc_annotate(self._msg, annotations)
 
@@ -351,7 +359,10 @@ class Scheduler(BrokerModule):
         # _forecast_generator: active generator, or None when idle.
         # _forecast_idle: keeps the reactor spinning while a pass is active.
         # _forecast_check: fires each reactor iteration to advance the generator.
+        # _forecast_pending: True if a schedule pass completed while a forecast
+        #   was running; causes _on_forecast_check to restart forecast on finish.
         self._forecast_generator = None
+        self._forecast_pending = False
         self._forecast_idle = h.idle_watcher_create()
         self._forecast_check = h.check_watcher_create(self._on_forecast_check)
         # Scheduling statistics, exposed via the stats-get RPC.
@@ -473,29 +484,29 @@ class Scheduler(BrokerModule):
 
         The default implementation:
 
-        1. Closes any in-progress :meth:`schedule` or :meth:`forecast`
-           generator and stops its yield watchers (resource state is about to
-           change so in-progress results are stale).
+        1. Closes any in-progress :meth:`schedule` generator and stops its
+           yield watchers (queue or resource state is about to change so
+           in-progress allocations are stale).  An in-progress
+           :meth:`forecast` generator is left running to completion: forecast
+           estimates are approximate by nature and a slightly stale
+           ``t_estimate`` is more useful than none at all.
         2. Arms the one-shot scheduling timer with the current adaptive delay
            if it is not already pending.  Subsequent calls while the timer is
            armed are no-ops, coalescing all events in the window into a single
            :meth:`schedule` invocation.
         """
-        # If a schedule or forecast generator pass is in progress, abort it:
-        # close the generator and stop the step watchers.  Resource state is
-        # about to change so any in-progress estimates are stale anyway.
+        # Abort the in-progress schedule generator: queue or resource state is
+        # about to change so any in-progress allocations are stale.
         # The schedule timer will be re-armed below with the adaptive settling
         # delay so the new pass starts cleanly.
+        # The forecast generator (if any) is intentionally left running: its
+        # simulation snapshot was taken at pass start and remains internally
+        # consistent, and a slightly stale t_estimate is better than none.
         if self._sched_generator is not None:
             self._sched_generator.close()
             self._sched_generator = None
             self._sched_idle.stop()
             self._sched_check.stop()
-        if self._forecast_generator is not None:
-            self._forecast_generator.close()
-            self._forecast_generator = None
-            self._forecast_idle.stop()
-            self._forecast_check.stop()
         if not self._sched_pending:
             self._sched_pending = True
             self._sched_timer.reset(after=self._sched_delay)
@@ -575,15 +586,17 @@ class Scheduler(BrokerModule):
     def _request_forecast(self):
         """Start a forecast pass immediately after a schedule() pass completes.
 
-        If a forecast generator is already in progress it is left running;
-        the existing pass already reflects the current state.  A running
-        forecast is aborted by :meth:`_request_schedule` when resource state
-        changes, so stale results are never committed.
+        If a forecast generator is already in progress it is left running to
+        completion; ``_forecast_pending`` is set so that ``_on_forecast_check``
+        will restart the forecast with the updated queue once the current pass
+        finishes.
         """
         if not self._queue:
             return
         if self._forecast_generator is not None:
-            return  # already running — let it finish
+            self._forecast_pending = True  # restart after current pass finishes
+            return
+        self._forecast_pending = False
         result = self.forecast()
         # Same style consistency applies to forecast(): generator or
         # synchronous, but not mixed within a single scheduler.
@@ -602,6 +615,8 @@ class Scheduler(BrokerModule):
             self._forecast_generator = None
             self._forecast_idle.stop()
             self._forecast_check.stop()
+            if self._forecast_pending:
+                self._request_forecast()
 
     # ------------------------------------------------------------------
     # Alloc response implementation (called via AllocRequest)
@@ -825,16 +840,15 @@ class Scheduler(BrokerModule):
         implementation is a no-op.
 
         Triggered automatically after each :meth:`schedule` call completes.
-        If a forecast pass is already in progress it is left running; it will
-        be aborted (and restarted after the next :meth:`schedule` completion)
-        if a scheduling event arrives in the meantime.
+        If a forecast pass is already in progress when a new scheduling event
+        arrives, it is left running to completion; the next forecast pass
+        starts after the current one finishes and the next :meth:`schedule`
+        pass completes.  Forecast estimates are approximate by design, so a
+        slightly stale ``t_estimate`` is preferable to having none at all.
 
         Supports the same **generator protocol** as :meth:`schedule`: add
         ``yield`` at each desired reactor handoff point — typically after each
         annotated job — to return control to the reactor between annotations.
-        If a new scheduling event arrives while a forecast generator is in
-        progress, the base class closes it and discards the partial results —
-        the next :meth:`schedule` completion will trigger a fresh forecast pass.
         """
 
     def expiration(self, msg, jobid, expiration):

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -42,6 +42,7 @@ to override :meth:`schedule`::
                 else:
                     job.request.success(alloc)
                 heapq.heappop(self._queue)
+                yield   # hand control to the reactor
 
     def mod_main(h, *args):
         MyScheduler(h, *args).run()
@@ -50,6 +51,7 @@ to override :meth:`schedule`::
 import errno
 import functools
 import heapq
+import inspect
 import syslog
 import time
 
@@ -224,9 +226,6 @@ class Scheduler(BrokerModule):
       (e.g. ``8``) for limited mode, or the string ``"unlimited"`` (default).
       The base class translates this to the wire format automatically.
       End users may override at load time with ``queue-depth=N|unlimited``.
-    - ``FORECAST_PERIOD`` — minimum seconds between :meth:`forecast` calls
-      (default 1.0); end users may override at load time with
-      ``forecast-period=N``.
 
     Alloc requests are represented by :class:`AllocRequest` objects passed
     to :meth:`alloc`.  Call ``request.success(R)``, ``request.deny(note)``,
@@ -258,13 +257,6 @@ class Scheduler(BrokerModule):
     #: burst rate and scheduling cost; lower values are more stable.
     #: 0.25 converges in roughly 4 samples.
     SCHED_EWMA_ALPHA = 0.25
-
-    #: Minimum interval in seconds between :meth:`forecast` calls.  During
-    #: scheduling bursts :meth:`forecast` is deferred and coalesced so that
-    #: annotation work runs at most once per ``FORECAST_PERIOD`` seconds,
-    #: keeping it off the critical path of job dispatch.  End users may
-    #: override at load time with ``forecast-period=N``.
-    FORECAST_PERIOD = 1.0
 
     #: If True (the default), send ``partial-ok: True`` in the hello RPC so
     #: that job-manager may report partially-freed ranks for running jobs.
@@ -343,12 +335,30 @@ class Scheduler(BrokerModule):
         self._sched_interval_ewma = 0.0
         self._sched_last_request = None
         self._sched_timer = h.timer_watcher_create(0.0, self._on_sched_timer)
-        # Forecast timer: defers forecast() calls to keep annotation work off
-        # the critical scheduling path.  _forecast_pending is True while the
-        # one-shot timer is armed; subsequent _request_forecast() calls while
-        # it is armed are no-ops, coalescing the burst into a single call.
-        self._forecast_pending = False
-        self._forecast_timer = h.timer_watcher_create(0.0, self._on_forecast_timer)
+        # Generator-based scheduling: when schedule() returns a generator,
+        # the base class steps through it one yield at a time so other reactor
+        # events are handled between yields.
+        # _sched_generator: active generator, or None when idle.
+        # _sched_idle: keeps the reactor spinning while a pass is active.
+        # _sched_check: fires each reactor iteration to advance the generator.
+        self._sched_generator = None
+        self._sched_idle = h.idle_watcher_create()
+        self._sched_check = h.check_watcher_create(self._on_sched_check)
+        # Generator-based forecast: runs immediately after each schedule() pass.
+        # With forecast() as a generator the reactor remains live between
+        # annotations, and a new scheduling event aborts any in-progress pass,
+        # so no separate rate-limiting timer is needed.
+        # _forecast_generator: active generator, or None when idle.
+        # _forecast_idle: keeps the reactor spinning while a pass is active.
+        # _forecast_check: fires each reactor iteration to advance the generator.
+        self._forecast_generator = None
+        self._forecast_idle = h.idle_watcher_create()
+        self._forecast_check = h.check_watcher_create(self._on_forecast_check)
+        # Scheduling statistics, exposed via the stats-get RPC.
+        self._sched_passes = 0
+        self._sched_yields = 0
+        self._forecast_passes = 0
+        self._forecast_yields = 0
         self._pending_args = []
         for arg in args:
             if arg.startswith("queue-depth="):
@@ -387,17 +397,6 @@ class Scheduler(BrokerModule):
                         f"expected one of {', '.join(self._LOG_LEVEL_NAMES)}"
                     )
                 self.log_level = self._LOG_LEVEL_NAMES[name]
-            elif arg.startswith("forecast-period="):
-                val = arg[16:]
-                try:
-                    v = float(val)
-                    if v <= 0:
-                        raise ValueError
-                    self.FORECAST_PERIOD = v
-                except ValueError:
-                    raise ValueError(
-                        f"forecast-period must be a positive number, got {val!r}"
-                    )
             else:
                 self._pending_args.append(arg)
 
@@ -410,7 +409,7 @@ class Scheduler(BrokerModule):
         if self._pending_args:
             raise ValueError(
                 f"unknown argument {self._pending_args[0]!r}: "
-                f"built-in options are queue-depth, log-level, forecast-period"
+                f"built-in options are queue-depth, log-level"
             )
 
     # ------------------------------------------------------------------
@@ -443,20 +442,16 @@ class Scheduler(BrokerModule):
         """Request a scheduling pass, coalescing bursts via an adaptive timer.
 
         Records the time of the request and updates the inter-request interval
-        exponential moving average.  Arms the one-shot scheduling timer if it
-        is not already pending; subsequent calls while the timer is armed are
-        recorded for moving-average purposes but do not re-arm the timer,
-        coalescing all requests in the window into a single :meth:`schedule`
-        call.
+        exponential moving average, then delegates to :meth:`start_schedule`.
 
-        The timer delay starts at zero (fires on the next reactor iteration,
-        same as the previous prepare/check/idle behaviour) and adjusts
-        automatically: when alloc requests arrive faster than :meth:`schedule`
-        can process them, the delay grows toward the measured schedule
-        duration (capped at :attr:`SCHED_DELAY_MAX`) to coalesce the burst.
-        When requests become infrequent again the delay resets to zero,
-        preserving low latency for normal operation.
+        Subclasses that want to replace the generator-based scheduling driver
+        should override :meth:`start_schedule` rather than this method.
+        Overriding :meth:`start_schedule` preserves the EWMA interval tracking
+        done here, which is needed for accurate burst-coalescing delay
+        computation.
         """
+        if not self._queue:
+            return
         now = time.monotonic()
         if self._sched_last_request is not None:
             interval = now - self._sched_last_request
@@ -465,17 +460,85 @@ class Scheduler(BrokerModule):
                 a * interval + (1 - a) * self._sched_interval_ewma
             )
         self._sched_last_request = now
+        self.start_schedule()
+
+    def start_schedule(self):
+        """Arm the scheduling timer, aborting any in-progress generator pass.
+
+        Called by :meth:`_request_schedule` after the EWMA interval update.
+        Override this method (not :meth:`_request_schedule`) to replace the
+        generator-based scheduling loop with an alternative driver, while still
+        benefiting from the burst-coalescing delay computed in
+        :meth:`_request_schedule`.
+
+        The default implementation:
+
+        1. Closes any in-progress :meth:`schedule` or :meth:`forecast`
+           generator and stops its yield watchers (resource state is about to
+           change so in-progress results are stale).
+        2. Arms the one-shot scheduling timer with the current adaptive delay
+           if it is not already pending.  Subsequent calls while the timer is
+           armed are no-ops, coalescing all events in the window into a single
+           :meth:`schedule` invocation.
+        """
+        # If a schedule or forecast generator pass is in progress, abort it:
+        # close the generator and stop the step watchers.  Resource state is
+        # about to change so any in-progress estimates are stale anyway.
+        # The schedule timer will be re-armed below with the adaptive settling
+        # delay so the new pass starts cleanly.
+        if self._sched_generator is not None:
+            self._sched_generator.close()
+            self._sched_generator = None
+            self._sched_idle.stop()
+            self._sched_check.stop()
+        if self._forecast_generator is not None:
+            self._forecast_generator.close()
+            self._forecast_generator = None
+            self._forecast_idle.stop()
+            self._forecast_check.stop()
         if not self._sched_pending:
             self._sched_pending = True
             self._sched_timer.reset(after=self._sched_delay)
 
     def _on_sched_timer(self, *_):
-        """Timer callback: run schedule() and update the adaptive delay."""
+        """Timer callback: invoke schedule() and dispatch the result.
+
+        If ``schedule()`` returns a generator the base class advances it one
+        yield per reactor iteration via the idle/check watcher pair so that
+        other events are handled between yields.  If it returns ``None``
+        (non-generator subclasses) the call completes synchronously as before.
+        """
         self._sched_pending = False
         t0 = time.monotonic()
-        self.schedule()
-        duration = time.monotonic() - t0
+        result = self.schedule()
+        # A scheduler implementation uses one style consistently: either
+        # generator-based (schedule() returns a generator) or synchronous
+        # (returns None).  The check is per-call for convenience; mixing
+        # the two styles within a single scheduler is not supported.
+        if inspect.isgenerator(result):
+            # Hand off to the yield watchers.
+            self._sched_generator = result
+            self._sched_idle.start()
+            self._sched_check.start()
+        else:
+            # Non-generator (old-style) schedule(): update EWMA synchronously.
+            self._update_sched_ewma(time.monotonic() - t0)
+            self._request_forecast()
 
+    def _on_sched_check(self, *_):
+        """Check-watcher callback: advance the generator by one yield."""
+        try:
+            next(self._sched_generator)
+        except StopIteration:
+            self._sched_generator = None
+            self._sched_idle.stop()
+            self._sched_check.stop()
+            # EWMA is not updated for generator-based schedulers: burst-coalescing
+            # delay remains 0 and the timer fires on the next reactor iteration.
+            self._request_forecast()
+
+    def _update_sched_ewma(self, duration):
+        """Update the adaptive scheduling delay from a completed pass duration."""
         a = self.SCHED_EWMA_ALPHA
         self._sched_duration_ewma = a * duration + (1 - a) * self._sched_duration_ewma
 
@@ -502,28 +565,38 @@ class Scheduler(BrokerModule):
             else:
                 self.log(syslog.LOG_DEBUG, "sched: burst ended, delay=0")
 
-        self._request_forecast()
-
     # ------------------------------------------------------------------
-    # Forecast timer
+    # Forecast
     # ------------------------------------------------------------------
 
     def _request_forecast(self):
-        """Request a forecast pass, rate-limited to :attr:`FORECAST_PERIOD`.
+        """Start a forecast pass immediately after a schedule() pass completes.
 
-        Arms the one-shot forecast timer if it is not already pending.
-        Subsequent calls while the timer is armed are no-ops, so a burst of
-        :meth:`schedule` calls results in a single :meth:`forecast` call
-        :attr:`FORECAST_PERIOD` seconds after the first request in the burst.
+        If a forecast generator is already in progress it is left running;
+        the existing pass already reflects the current state.  A running
+        forecast is aborted by :meth:`_request_schedule` when resource state
+        changes, so stale results are never committed.
         """
-        if not self._forecast_pending:
-            self._forecast_pending = True
-            self._forecast_timer.reset(after=self.FORECAST_PERIOD)
+        if not self._queue:
+            return
+        if self._forecast_generator is not None:
+            return  # already running — let it finish
+        result = self.forecast()
+        # Same style consistency applies to forecast(): generator or
+        # synchronous, but not mixed within a single scheduler.
+        if inspect.isgenerator(result):
+            self._forecast_generator = result
+            self._forecast_idle.start()
+            self._forecast_check.start()
 
-    def _on_forecast_timer(self, *_):
-        """Timer callback: run forecast()."""
-        self._forecast_pending = False
-        self.forecast()
+    def _on_forecast_check(self, *_):
+        """Check-watcher callback: advance the forecast generator by one yield."""
+        try:
+            next(self._forecast_generator)
+        except StopIteration:
+            self._forecast_generator = None
+            self._forecast_idle.stop()
+            self._forecast_check.stop()
 
     # ------------------------------------------------------------------
     # Alloc response implementation (called via AllocRequest)
@@ -618,6 +691,38 @@ class Scheduler(BrokerModule):
         events arrive in rapid bursts the timer delay grows to coalesce them
         into fewer :meth:`schedule` calls; when events are infrequent the
         delay returns to zero so that each event is processed promptly.
+
+        **Generator protocol** — if this method returns a generator
+        the base class advances it one yield per reactor iteration, allowing
+        other events (new jobs, free responses, RPCs) to be handled between
+        yields.
+        Yield at each point where reactor responsiveness is desired — typically
+        after each dispatched or denied job, but also when blocking on
+        resources::
+
+            def schedule(self):
+                while self._queue:
+                    job = self._queue[0]
+                    try:
+                        alloc = self.resources.alloc(job.jobid, job.resource_request)
+                    except InsufficientResources:
+                        break
+                    except InfeasibleRequest as exc:
+                        job.request.deny(str(exc))
+                    else:
+                        job.request.success(alloc)
+                    heapq.heappop(self._queue)
+                    yield  # hand control back to the reactor
+
+        When a new scheduling event arrives while a generator pass is in
+        progress the base class closes the generator (triggering any
+        ``finally`` blocks) and starts a fresh pass after the settling delay.
+        This ensures a newly submitted high-priority job or a freed resource
+        is considered from the top of the queue without waiting for the
+        current pass to finish.
+
+        Non-generator ``schedule()`` implementations (no ``yield``) behave
+        exactly as before and remain fully supported.
         """
 
     def hello(self, jobid, priority, userid, t_submit, R):
@@ -714,11 +819,17 @@ class Scheduler(BrokerModule):
         forward-looking annotations) on pending jobs.  The base class
         implementation is a no-op.
 
-        Triggered automatically after each :meth:`schedule` call, but
-        rate-limited to at most once per :attr:`FORECAST_PERIOD` seconds so
-        that annotation work is kept off the critical scheduling path during
-        bursts.  End users may tune the rate with ``forecast-period=N`` at
-        module load time.
+        Triggered automatically after each :meth:`schedule` call completes.
+        If a forecast pass is already in progress it is left running; it will
+        be aborted (and restarted after the next :meth:`schedule` completion)
+        if a scheduling event arrives in the meantime.
+
+        Supports the same **generator protocol** as :meth:`schedule`: add
+        ``yield`` at each desired reactor handoff point — typically after each
+        annotated job — to return control to the reactor between annotations.
+        If a new scheduling event arrives while a forecast generator is in
+        progress, the base class closes it and discards the partial results —
+        the next :meth:`schedule` completion will trigger a fresh forecast pass.
         """
 
     def expiration(self, msg, jobid, expiration):

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -522,6 +522,7 @@ class Scheduler(BrokerModule):
             self._sched_check.start()
         else:
             # Non-generator (old-style) schedule(): update EWMA synchronously.
+            self._sched_passes += 1
             self._update_sched_ewma(time.monotonic() - t0)
             self._request_forecast()
 
@@ -529,7 +530,9 @@ class Scheduler(BrokerModule):
         """Check-watcher callback: advance the generator by one yield."""
         try:
             next(self._sched_generator)
+            self._sched_yields += 1
         except StopIteration:
+            self._sched_passes += 1
             self._sched_generator = None
             self._sched_idle.stop()
             self._sched_check.stop()
@@ -593,7 +596,9 @@ class Scheduler(BrokerModule):
         """Check-watcher callback: advance the forecast generator by one yield."""
         try:
             next(self._forecast_generator)
+            self._forecast_yields += 1
         except StopIteration:
+            self._forecast_passes += 1
             self._forecast_generator = None
             self._forecast_idle.stop()
             self._forecast_check.stop()
@@ -1001,6 +1006,60 @@ class Scheduler(BrokerModule):
                 < 0
             ):
                 self.stop_error()
+
+    @request_handler("stats-get")
+    def _handle_stats_get(self, msg):
+        self.handle.respond(msg, self.stats_get())
+
+    def stats_get(self):
+        """Return a dict of scheduler statistics for the stats-get RPC.
+
+        Called by the built-in ``<module-name>.stats-get`` handler.
+        Subclasses may override to add extra fields; call ``super().stats_get()``
+        and update the returned dict:
+
+        .. code-block:: python
+
+            def stats_get(self):
+                stats = super().stats_get()
+                stats["my_counter"] = self._my_counter
+                return stats
+
+        Standard fields:
+
+        ``sched_passes``
+            Number of completed :meth:`schedule` passes.
+        ``sched_yields``
+            Total yields across all :meth:`schedule` generator passes
+            (always 0 for synchronous schedulers).
+        ``forecast_passes``
+            Number of completed :meth:`forecast` passes.
+        ``forecast_yields``
+            Total yields across all :meth:`forecast` generator passes
+            (always 0 for synchronous schedulers).
+        ``sched_delay``
+            Current adaptive burst-coalescing delay in seconds (0 = immediate).
+            Always 0 for generator-based schedulers.
+        ``sched_duration_ewma``
+            EWMA of :meth:`schedule` wall-clock duration in seconds.
+            Always 0 for generator-based schedulers.
+        ``sched_interval_ewma``
+            EWMA of time between :meth:`_request_schedule` calls in seconds.
+            Tracked for all schedulers but does not affect ``sched_delay``
+            for generator-based schedulers.
+        ``pending_jobs``
+            Current number of pending alloc requests in the scheduler queue.
+        """
+        return {
+            "sched_passes": self._sched_passes,
+            "sched_yields": self._sched_yields,
+            "forecast_passes": self._forecast_passes,
+            "forecast_yields": self._forecast_yields,
+            "sched_delay": self._sched_delay,
+            "sched_duration_ewma": self._sched_duration_ewma,
+            "sched_interval_ewma": self._sched_interval_ewma,
+            "pending_jobs": len(self._queue),
+        }
 
     # ------------------------------------------------------------------
     # Internal: RFC 27 initialization helpers

--- a/src/modules/sched-backfill.py
+++ b/src/modules/sched-backfill.py
@@ -248,7 +248,7 @@ class BackfillScheduler(Scheduler):
 
         if self._try_alloc(head):
             heapq.heappop(self._queue)
-            self.schedule()  # new head may also be immediately schedulable
+            yield from self.schedule()  # chain generator so reactor stays live during recursion
             return
 
         # Head is blocked — compute its shadow time (EASY reservation).
@@ -269,6 +269,7 @@ class BackfillScheduler(Scheduler):
                 )
             else:
                 kept.append(job)
+            yield
 
         self._queue = kept
         heapq.heapify(self._queue)

--- a/src/modules/sched-fifo.py
+++ b/src/modules/sched-fifo.py
@@ -81,6 +81,7 @@ class FIFOScheduler(Scheduler):
             if not self._try_alloc(job):
                 break  # head blocked — stop to preserve FIFO ordering
             heapq.heappop(self._queue)
+            yield
 
     def _sim_alloc(self, sim, jobid, rr, t_floor):
         """Allocate a resource request in a simulation pool.
@@ -170,6 +171,7 @@ class FIFOScheduler(Scheduler):
                     if job._last_annotation != t_est:
                         job._last_annotation = t_est
                         job.request.annotate({"sched": {"t_estimate": t_est}})
+                    yield
                     continue
                 # Map sim time 0 (no advancement needed) to current wall clock.
                 t_est = max(t, _time.time()) if t is not None else None
@@ -183,6 +185,7 @@ class FIFOScheduler(Scheduler):
 
             if not can_estimate or t is None:
                 can_estimate = False
+                yield
                 continue
 
             # Advance the FIFO floor: the next job cannot start before this one.
@@ -192,6 +195,7 @@ class FIFOScheduler(Scheduler):
                 t_prev = t
             else:
                 can_estimate = False  # unknown end time — cannot chain further
+            yield
 
     def _try_alloc(self, job):
         """Attempt to allocate resources for a job.

--- a/src/modules/sched-simple.py
+++ b/src/modules/sched-simple.py
@@ -91,8 +91,9 @@ class SimpleScheduler(FIFOScheduler):
                         }
                     }
                 )
+                yield
             return
-        super().forecast()
+        yield from super().forecast()
 
     def expiration(self, msg, jobid, expiration):
         if self.debug_test(DEBUG_EXPIRATION_UPDATE_DENY):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -187,6 +187,7 @@ TESTSCRIPTS = \
 	t2305-sched-slow.t \
 	t2306-sched-fifo.t \
 	t2307-sched-backfill.t \
+	t2308-sched-generator.t \
 	t2310-resource-module.t \
 	t2311-resource-drain.t \
 	t2312-resource-exclude.t \
@@ -368,7 +369,8 @@ EXTRA_DIST= \
 	batch \
 	job-manager/dumps \
 	flux-resource \
-	module/testmod.py
+	module/testmod.py \
+	scheduler/sched-slowgen.py
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/scheduler/sched-slowgen.py
+++ b/t/scheduler/sched-slowgen.py
@@ -1,0 +1,60 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Slow generator scheduler for testing reactor liveness and abort/restart.
+
+A minimal FIFO scheduler whose ``schedule()`` yields after every allocation
+attempt, including blocked ones.  This maximises the number of reactor
+iterations per pass so that tests can confirm the reactor remains live during
+scheduling without relying on wall-clock timing.
+
+The scheduler is intentionally simple: it stops at the first job that cannot
+be immediately allocated (FIFO ordering), matching :class:`FIFOScheduler`
+semantics.  There is no forecast implementation.
+
+Load with::
+
+    flux module load sched-slowgen.py
+
+The ``flux module stats sched-slowgen`` output includes the base-class fields
+(``sched_passes``, ``sched_yields``, etc.) which tests use to verify that
+yielding is actually occurring.
+"""
+
+import heapq
+
+from flux.resource import InfeasibleRequest, InsufficientResources
+from flux.scheduler import Scheduler
+
+
+class SlowGenScheduler(Scheduler):
+    """FIFO scheduler that yields on every iteration for reactor-liveness testing."""
+
+    #: Expose the full queue so that burst-submission tests see all jobs.
+    queue_depth = "unlimited"
+
+    def schedule(self):
+        while self._queue:
+            job = self._queue[0]
+            try:
+                alloc = self.resources.alloc(job.jobid, job.resource_request)
+            except InsufficientResources:
+                yield  # yield even when blocked so reactor stays live
+                break
+            except InfeasibleRequest as exc:
+                job.request.deny(str(exc))
+            else:
+                job.request.success(alloc)
+            heapq.heappop(self._queue)
+            yield
+
+
+def mod_main(h, *args):
+    SlowGenScheduler(h, *args).run()

--- a/t/t2308-sched-generator.t
+++ b/t/t2308-sched-generator.t
@@ -1,0 +1,130 @@
+#!/bin/sh
+
+test_description='test scheduler generator protocol and stats-get RPC'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+SCHED_SLOWGEN=${SHARNESS_TEST_SRCDIR}/scheduler/sched-slowgen.py
+
+test_under_flux 2 job
+
+# Shorthand: query a single stats field as a number
+sched_stat() {
+	flux module stats sched-slowgen | jq ".$1"
+}
+
+test_expect_success 'unload sched-simple, load sched-slowgen' '
+	flux module unload sched-simple &&
+	flux module load ${SCHED_SLOWGEN}
+'
+
+# -------------------------------------------------------------------
+# stats-get: basic shape
+# -------------------------------------------------------------------
+
+test_expect_success 'stats-get returns expected fields' '
+	flux module stats sched-slowgen >stats.json &&
+	jq -e ".sched_passes >= 0" stats.json &&
+	jq -e ".sched_yields >= 0" stats.json &&
+	jq -e ".forecast_passes >= 0" stats.json &&
+	jq -e ".forecast_yields >= 0" stats.json &&
+	jq -e ".sched_delay >= 0" stats.json &&
+	jq -e ".sched_duration_ewma >= 0" stats.json &&
+	jq -e ".sched_interval_ewma >= 0" stats.json &&
+	jq -e ".pending_jobs >= 0" stats.json
+'
+
+# -------------------------------------------------------------------
+# stats-get: sched_passes increments after a scheduling pass
+# -------------------------------------------------------------------
+
+test_expect_success 'record sched_passes before submitting a job' '
+	sched_stat sched_passes >passes_before.txt
+'
+test_expect_success 'submit and run a job' '
+	flux run -N1 true
+'
+test_expect_success 'sched_passes incremented after job ran' '
+	passes_before=$(cat passes_before.txt) &&
+	passes_after=$(sched_stat sched_passes) &&
+	test "$passes_after" -gt "$passes_before"
+'
+
+# -------------------------------------------------------------------
+# stats-get: sched_yields > 0 after a multi-job pass
+# Submit more jobs than available slots so the queue is non-trivial.
+# The slow scheduler yields after every alloc attempt (including when
+# blocked), so sched_yields must be non-zero — confirming the reactor
+# received control during the pass.
+# -------------------------------------------------------------------
+
+test_expect_success 'unload job-exec to prevent job execution' '
+	flux module unload job-exec
+'
+test_expect_success 'submit 4 jobs on a 2-slot instance' '
+	sched_stat sched_passes >passes_before4.txt &&
+	for i in $(seq 1 4); do
+		flux submit -N1 true
+	done
+'
+test_expect_success 'wait for scheduler to process the queue' '
+	passes_before=$(cat passes_before4.txt) &&
+	test_wait_until "test \$(sched_stat sched_passes) -gt $passes_before"
+'
+test_expect_success 'sched_yields > 0 confirms reactor ran during pass' '
+	yields=$(sched_stat sched_yields) &&
+	test "$yields" -gt 0
+'
+test_expect_success 'pending_jobs reflects pending jobs' '
+	depth=$(sched_stat pending_jobs) &&
+	test "$depth" -gt 0
+'
+test_expect_success 'cancel all pending jobs and reload job-exec' '
+	flux cancel --all &&
+	flux module load job-exec
+'
+
+# -------------------------------------------------------------------
+# generator abort/restart: a higher-priority job submitted while a
+# pass is in progress is still scheduled correctly.
+#
+# Fill both slots with long-running jobs, submit two lower-priority
+# pending jobs, then submit a higher-priority job.  After the running
+# jobs finish, the higher-priority job should run before the others.
+# -------------------------------------------------------------------
+
+test_expect_success 'fill both slots with running jobs' '
+	flux submit -N1 sleep 3600 >running1.id &&
+	flux submit -N1 sleep 3600 >running2.id &&
+	flux job wait-event --timeout=10 $(cat running1.id) alloc &&
+	flux job wait-event --timeout=10 $(cat running2.id) alloc
+'
+test_expect_success 'submit two low-priority pending jobs' '
+	flux submit -N1 --urgency=1 true >low1.id &&
+	flux submit -N1 --urgency=1 true >low2.id
+'
+test_expect_success 'submit a high-priority job' '
+	flux submit -N1 --urgency=31 true >high.id
+'
+test_expect_success 'cancel the running jobs to free resources' '
+	flux cancel $(cat running1.id) &&
+	flux cancel $(cat running2.id)
+'
+test_expect_success 'high-priority job runs before low-priority jobs' '
+	run_timeout 30 flux job wait-event $(cat high.id) clean &&
+	for id in $(cat low1.id) $(cat low2.id); do
+		flux job wait-event --timeout=30 $id clean
+	done &&
+	high_t=$(flux job eventlog $(cat high.id) | awk "/alloc/{print \$1; exit}") &&
+	low1_t=$(flux job eventlog $(cat low1.id) | awk "/alloc/{print \$1; exit}") &&
+	awk "BEGIN { exit ($high_t < $low1_t) ? 0 : 1 }"
+'
+
+test_expect_success 'reload sched-simple' '
+	flux module unload sched-slowgen &&
+	flux module load sched-simple
+'
+
+test_done


### PR DESCRIPTION
Problem: the python schedulers call a `schedule()` loop whenever the pool or the request priority list changes, with some rate and queue depth limiting.  However, while in the loop, the reactor is not responsive.  The pattern is repeated again, after `schedule()` with `forecast()` for predicting future start times.

Change the scheduler framework so that the `schedule()` and `forecast()` loops can optionally return a generator, which occurs naturally if the function calls `yield`.  prep/idle watchers repeatedly resume the loop until complete.  In addition, since it no longer blocks the reactor, let `forecast()` run to completion, forward-simulating on its deep copy of the pool, rather than aborting it immediately when the pool changes.

The `Scheduler` class now registers a default `stats-get` RPC method so `flux module stats <scheduler>` now allows access to some internal metrics used in test.