### PR TITLE
github: fix testenv workflow on merge

### DIFF
--- a/.github/workflows/testenv.yml
+++ b/.github/workflows/testenv.yml
@@ -116,7 +116,7 @@ jobs:
     if: contains(needs.setup.outputs.distros, 'bookworm')
     strategy:
       matrix:
-        distro: ${{ fromJson(needs.setup.outputs.distros) }}
+        distro: ['bookworm']
     timeout-minutes: 90
     runs-on: ubuntu-latest
     env:
@@ -126,15 +126,12 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Set up QEMU
-        if: matrix.distro == 'bookworm'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        if: matrix.distro == 'bookworm'
         uses: docker/setup-buildx-action@v4.0.0
 
       - name: Build and tar 386 image
-        if: matrix.distro == 'bookworm'
         run: |
           mkdir -p out
           docker buildx build \
@@ -144,7 +141,6 @@ jobs:
             -f src/test/docker/${{ matrix.distro }}/Dockerfile .
 
       - name: Upload 386 container tarball
-        if: matrix.distro == 'bookworm'
         uses: actions/upload-artifact@v7.0.0
         with:
           name: testenv-${{ matrix.distro }}-386
@@ -229,7 +225,7 @@ jobs:
     if: contains(needs.setup.outputs.distros, 'bookworm')
     strategy:
       matrix:
-        distro: ${{ fromJson(needs.setup.outputs.distros) }}
+        distro: ['bookworm']
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -241,25 +237,21 @@ jobs:
       - run: git fetch --tags || true
 
       - name: Set up QEMU
-        if: matrix.distro == 'bookworm'
         uses: docker/setup-qemu-action@v3
 
       - name: Download 386 artifact
-        if: matrix.distro == 'bookworm'
         uses: actions/download-artifact@v8.0.1
         with:
           name: testenv-${{ matrix.distro }}-386
           path: artifacts
 
       - name: Load images from tarballs
-        if: matrix.distro == 'bookworm'
         run: |
           set -euo pipefail
           docker load -i artifacts/testenv-${{ matrix.distro }}-386.tar
           docker images | head -n 50
 
       - name: Verify 386 image architecture
-        if: matrix.distro == 'bookworm'
         run: |
           ARCH=$(docker run --rm \
             ${DOCKERHUB_REPO}/testenv:${{ matrix.distro }}-386 \
@@ -269,7 +261,6 @@ jobs:
             || { echo "ERROR: expected i386, got ${ARCH}"; exit 1; }
 
       - name: run docker-run-checks
-        if: matrix.distro == 'bookworm'
         run: |
           src/test/docker/docker-run-checks.sh -i ${{ matrix.distro }}-386 \
             --platform linux/386 -j 4 --recheck --
@@ -286,10 +277,13 @@ jobs:
       - test-amd64-container
       - test-arm64-container
       - test-386-container
+      - build-386-container
     if: >
       always() &&
       needs.test-amd64-container.result == 'success' &&
       needs.test-arm64-container.result == 'success' &&
+      (needs.build-386-container.result == 'success' ||
+       needs.build-386-container.result == 'skipped') &&
       (needs.test-386-container.result == 'success' ||
        needs.test-386-container.result == 'skipped')
     strategy:

--- a/src/test/docker/bookworm/Dockerfile
+++ b/src/test/docker/bookworm/Dockerfile
@@ -76,8 +76,8 @@ RUN apt-get update \
 # mapped into the container and contains the same libraries
  ;  for PY in python3.11 ; do \
         sudo $PY -m pip install --upgrade --ignore-installed \
-        --break-system-packages \
-	    "markupsafe==2.0.0" \
+            --break-system-packages \
+	        "markupsafe==2.0.0" \
             "typing_extensions>=4.1" \
             coverage cffi ply six pyyaml "jsonschema>=2.6,<4.0" \
             sphinx sphinx-rtd-theme sphinxcontrib-spelling; \

--- a/src/test/docker/el10/Dockerfile
+++ b/src/test/docker/el10/Dockerfile
@@ -92,6 +92,7 @@ COPY src/test/docker/el10/config.site /usr/share/config.site
 # use non-local connectors on a system with virtual NICs, since we're in a
 # docker container, prevent this
 ENV PSM3_HAL=loopback
+
 # hwloc tries to look for opengl devices  by connecting to a port that might
 # sometimes be an x11 port, but more often for us is munge, turn it off
 ENV HWLOC_COMPONENTS=-gl

--- a/src/test/docker/testenv-affected-distros.sh
+++ b/src/test/docker/testenv-affected-distros.sh
@@ -22,7 +22,12 @@ while IFS= read -r path; do
         distro=${distro%%/*}
         case "$distro" in
           checks|fluxorama) ;;
-          *) echo "$distro" ;;
+          *)
+            # Skip distros whose Dockerfile no longer exists (e.g. deleted)
+            if [ -f "${SCRIPT_DIR}/${distro}/Dockerfile" ]; then
+              echo "$distro"
+            fi
+            ;;
         esac
         ;;
       scripts/*)


### PR DESCRIPTION
In the recent merge of #7506, several problems were witnessed in the `testenv` rebuild workflow:

 - image rebuilds were attempted for _deleted_ Dockerfiles. Obviously these failed immediately.
 - 386 builds were started for all distros instead of only bookworm
 - it was observed that the publish step could be triggered even if the 386 build for bookworm failed because the test step is skipped when a build fails

This PR fixes these cases. The el10 and bookworm Dockerfiles are also touched here to force their rebuild since they failed in the last PR.