### PR TITLE
python: fix output sorting with mixed-type fields in commands using the `OutputFormat` class

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -432,6 +432,7 @@ $(RST_FILES): \
 	man1/common/job-shell-options.rst \
 	man1/common/job-mustache-templates.rst \
 	man1/common/color.rst \
+	man1/common/format-sort.rst \
 	man3/common/resources.rst \
 	man3/common/experimental.rst \
 	man3/common/json_pack.rst \
@@ -537,6 +538,7 @@ EXTRA_DIST = \
 	man1/common/job-shell-options.rst \
 	man1/common/job-mustache-templates.rst \
 	man1/common/color.rst \
+	man1/common/format-sort.rst \
 	man3/common/resources.rst \
 	man3/common/experimental.rst \
 	man3/index.rst \

--- a/doc/man1/common/format-sort.rst
+++ b/doc/man1/common/format-sort.rst
@@ -1,0 +1,21 @@
+If the format string begins with ``sort:k1[,k2,...]``, then ``k1[,k2,...]``
+will be taken to be a comma-separated list of keys on which to sort
+the displayed output. If a sort key starts with ``-``, then the key
+will be sorted in reverse order.
+
+Sort keys can be any valid field name. Fields that may be empty or unset
+will sort before non-empty values. When sorting fields that contain mixed
+types, the sort order is: empty/None < numbers (including booleans) < strings.
+Booleans are treated as numeric values (False=0, True=1).
+
+For example, to sort by a numeric field with empty values first::
+
+   --format='sort:nnodes {id} {nnodes} {status}'
+
+Or to sort in reverse order (largest first, empty values last)::
+
+   --format='sort:-nnodes {id} {nnodes} {status}'
+
+Multiple sort keys can be specified, with earlier keys taking precedence::
+
+   --format='sort:state,-t_submit {id} {state} {t_submit}'

--- a/doc/man1/flux-housekeeping.rst
+++ b/doc/man1/flux-housekeeping.rst
@@ -93,6 +93,8 @@ The :option:`--format` option can be used to specify an output format using
 Python's string format syntax or a defined format by name. For a list of
 built-in and configured formats use :option:`-o help`.
 
+.. include:: common/format-sort.rst
+
 The following field names can be specified for
 :command:`flux housekeeping list`:
 

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -115,7 +115,8 @@ OPTIONS
    Sort jobs based on a list of comma separated keys. If a KEY is preceded
    by a dash ``-``, then the sort order is reversed. Supported keys match
    output field names, e.g. ``id``, ``t_run``, etc. This option overrides
-   any ``sort:`` prefix specified in the current format.
+   any ``sort:`` prefix specified in the current format. See `OUTPUT FORMAT`_
+   for more information on sort keys.
 
 .. option:: --json
 
@@ -272,11 +273,10 @@ following is the format used for the default format:
    {status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} \
    {contextual_time!F:>8h} {contextual_info}
 
-If the format string begins with ``sort:k1[,k2,...]``, then ``k1[,k2,...]``
-will be taken to be a comma-separated list of keys on which to sort
-the displayed output. If a sort key starts with ``-``, then the key
-will be sorted in reverse order. The sort order embedded in the format
- may be overridden on the command line by the :option:`--sort` option.
+.. include:: common/format-sort.rst
+
+The sort order embedded in the format may be overridden on the command line
+by the :option:`--sort` option.
 
 If a format field is preceded by the special string ``?:`` this will
 cause the field to be removed entirely from output if the result would

--- a/doc/man1/flux-queue.rst
+++ b/doc/man1/flux-queue.rst
@@ -213,6 +213,8 @@ A configuration snippet for an existing named format may be
 generated with :option:`--format=get-config=NAME`.  See :man1:`flux-jobs`
 *OUTPUT FORMAT* section for a detailed description of this syntax.
 
+.. include:: common/format-sort.rst
+
 The following field names can be specified:
 
 **queue**

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -437,6 +437,8 @@ existing named format may be generated with :option:`--format=get-config=NAME`.
 See :man1:`flux-jobs` :ref:`flux_jobs_output_format` section for a detailed
 description of this syntax.
 
+.. include:: common/format-sort.rst
+
 Resources are combined into a single line of output when possible depending on
 the supplied output format.  Resource counts are not included in the
 determination of uniqueness.  Therefore, certain output formats will alter the

--- a/doc/man1/flux-sproc.rst
+++ b/doc/man1/flux-sproc.rst
@@ -45,6 +45,8 @@ List active and zombie subprocesses.
    field names include **pid**, **state**, **label**, **rank**, and **cmd**.
    The default format is ``{pid:>9} {state:<2} {label:<12} {cmd}``.
 
+   .. include:: common/format-sort.rst
+
 .. option:: -n, --no-header
 
    Suppress printing of header line.

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1098,3 +1098,4 @@ MyModule
 subclasses
 CLI
 cli
+booleans

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -12,6 +12,7 @@ import argparse
 import base64
 import copy
 import errno
+import functools
 import glob
 import json
 import logging
@@ -665,6 +666,139 @@ class AltField:
         return str(self).__format__(fmt)
 
 
+@functools.total_ordering
+class DisplayValue:
+    """Comparable wrapper for display-formatted values in OutputFormat sorting.
+
+    This class exists to handle the common case in Flux CLI tools where
+    optional fields are formatted as empty strings (""), hyphens ("-"), or
+    None for display purposes, but need to sort sensibly alongside numeric
+    and string values.
+
+    For example, in ``flux jobs`` output, the ``nnodes`` field may be:
+    - An integer like 4 (for allocated jobs)
+    - An empty string "" (for jobs that haven't been allocated yet)
+    - A hyphen "-" (explicitly showing "not applicable")
+
+    When sorting such fields, Python 3's strict type checking prevents
+    comparing strings directly with integers. This class solves that by
+    normalizing values into a comparable form with a clear, documented
+    sort order.
+
+    Sort Order:
+        1. None, empty strings (""), and hyphens ("-") - all treated as "unset"
+        2. Numbers (int, float, bool, and numeric strings like "100")
+        3. Non-numeric strings
+
+    Design Rationale:
+        - **Treat None/""/"-" identically**: From a user's perspective,
+          these all mean "field is unset" and should group together at the
+          start of sorted output (or end, if reverse sorted).
+
+        - **Treat bools as numbers**: Python's semantics where False==0
+          and True==1 make this intuitive. Alternative (bools as separate
+          category) would mean False < True < 0 < 1 < 2, which is surprising.
+
+        - **Parse numeric strings**: Strings that can be parsed as floats
+          are treated as numeric for sorting. This ensures "10" and 100
+          compare numerically (10 < 100), not by type precedence where
+          all numbers would sort before all strings (100 < "10").
+
+        - **Pre-compute type order**: The type_order and sort_value are
+          computed once in __init__ rather than on every comparison,
+          trading memory for speed.
+
+    Performance:
+        - Uses __slots__ to avoid per-instance dict overhead
+        - No exception handling in hot path (type checks are deterministic)
+        - Works with Python's stable sort for predictable ordering
+
+    Example:
+        >>> items = [Item(nnodes=100), Item(nnodes=""), Item(nnodes="5")]
+        >>> sorted(items, key=lambda x: DisplayValue(x.nnodes))
+        [Item(nnodes=""), Item(nnodes="5"), Item(nnodes=100)]
+        # Note: "5" is parsed as numeric and compares with 100 numerically
+
+        >>> DisplayValue(None) < DisplayValue(0)
+        True
+        >>> DisplayValue("10") < DisplayValue(100)  # "10" parsed as 10.0
+        True
+        >>> DisplayValue(5) < DisplayValue("foo")  # "foo" is non-numeric string
+        True
+    """
+
+    __slots__ = ("value", "_type_order", "_sort_value")
+
+    EMPTY = 0  # None, "", "-" - all unset values
+    NUMERIC = 1  # int, float, bool, numeric strings
+    STRING = 2  # non-numeric strings
+
+    def __init__(self, value):
+        """Initialize a DisplayValue wrapper for sorting.
+
+        Args:
+            value: The raw value to wrap (can be None, str, int, float,
+            bool, etc.)
+        """
+        self.value = value
+
+        # Classify value into one of three type categories for sorting
+        # Category 0: Unset/empty values (sort first)
+        if value is None or value == "" or value == "-":
+            self._type_order = self.EMPTY
+            # Placeholder; not actually compared within category
+            self._sort_value = 0
+
+        # Category 1: Numeric values (including booleans)
+        # Note: Check bool first since bool is a subclass of int in Python
+        elif isinstance(value, (bool, int, float)):
+            self._type_order = self.NUMERIC
+            self._sort_value = float(value)
+
+        # Category 2: Other types - try to parse as numeric first
+        # This ensures "10" and 10 compare numerically, not by type precedence
+        else:
+            # Attempt numeric conversion for types like Decimal,
+            # numpy types, or strings
+            try:
+                # Try direct conversion first (faster for numeric types)
+                numeric_value = float(value)
+                self._type_order = self.NUMERIC
+                self._sort_value = numeric_value
+            except (ValueError, TypeError):
+                # Direct conversion failed, try string conversion
+                try:
+                    numeric_value = float(str(value))
+                    self._type_order = self.NUMERIC
+                    self._sort_value = numeric_value
+                except (ValueError, TypeError):
+                    # Not a number - use string comparison
+                    self._type_order = self.STRING
+                    self._sort_value = str(value)
+
+    def __eq__(self, other):
+        """Test equality by comparing type_order and sort_value."""
+        return (self._type_order, self._sort_value) == (
+            other._type_order,
+            other._sort_value,
+        )
+
+    def __lt__(self, other):
+        """Test less-than by comparing type_order first, then sort_value."""
+        return (self._type_order, self._sort_value) < (
+            other._type_order,
+            other._sort_value,
+        )
+
+    def __repr__(self):
+        """Return readable representation for debugging."""
+        return (
+            f"DisplayValue({self.value!r}, "
+            f"type_order={self._type_order}, "
+            f"sort_value={self._sort_value!r})"
+        )
+
+
 class OutputFormat:
     """Extended output format container class for Flux utilities.
 
@@ -1194,9 +1328,20 @@ class OutputFormat:
             items (list): list of items to sort. Note that the list is
                 sorted in place and then returned.
         """
+
+        def make_sort_key(attr_name):
+            """Create a sort key that wraps values in DisplayValue for mixed-type sorting.
+
+            DisplayValue handles the common case where display-formatted fields contain
+            mixed types (None, empty strings, numbers, booleans, strings) by normalizing
+            them into a comparable form. See DisplayValue docstring for sort order details.
+            """
+            getter = attrgetter(attr_name)
+            return lambda item: DisplayValue(getter(item))
+
         # Apply any requested sort:
         for key, reverse in reversed(self.sort_keys):
-            items.sort(key=attrgetter(key), reverse=reverse)
+            items.sort(key=make_sort_key(key), reverse=reverse)
         return items
 
     def print_items(self, items, no_header=False, width=-1, pre=None, post=None):

--- a/t/python/t0024-util.py
+++ b/t/python/t0024-util.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import subflux  # noqa: F401 - To set up PYTHONPATH
 from flux.util import (
     ColorAction,
+    DisplayValue,
     OutputFormat,
     UtilDatetime,
     del_treedict,
@@ -265,6 +266,130 @@ class TestOutputFormat(unittest.TestCase):
         formatter.set_sort_keys("f")
         formatter.sort_items(items)
         self.assertListEqual(items, [z, d, a])
+
+    def test_sort_mixed_types(self):
+        """Test sorting fields with mixed types (issue #7517)"""
+        # Create items with mixed types - some fields are empty strings,
+        # others are numbers
+        a = Item("a", "", 2.2)  # empty int
+        b = Item("b", 10, "")  # empty float
+        c = Item("c", 5, 1.5)  # both set
+        d = Item("d", "", "")  # both empty
+
+        # Sort by integer field with mixed types (empty strings and ints)
+        items = [c, a, b, d]
+        formatter = OutputFormat("{s}:{i}:{f}", headings=self.headings)
+        formatter.set_sort_keys("i")
+        formatter.sort_items(items)
+        # Empty strings should sort before numbers
+        self.assertListEqual(items, [a, d, c, b])
+
+        # Sort by float field with mixed types (empty strings and floats)
+        items = [c, a, b, d]
+        formatter.set_sort_keys("f")
+        formatter.sort_items(items)
+        # Empty strings should sort before numbers
+        self.assertListEqual(items, [b, d, c, a])
+
+        # Reverse sort with mixed types
+        items = [c, a, b, d]
+        formatter.set_sort_keys("-i")
+        formatter.sort_items(items)
+        # Numbers (reversed) should sort before empty strings
+        # Empty strings with equal keys maintain input order (stable sort)
+        self.assertListEqual(items, [b, c, a, d])
+
+        # Test with booleans in the mix
+        e = Item("e", True, 3.3)
+        f = Item("f", False, 4.4)
+        g = Item("g", 1, 5.5)
+        items = [g, e, a, f, c]
+        formatter.set_sort_keys("i")
+        formatter.sort_items(items)
+        # Order: empty < False(0) < True(1) == 1 < 5
+        # True and 1 are numerically equal, so stable sort preserves input
+        # order (g before e)
+        self.assertListEqual(items, [a, f, g, e, c])
+
+        # Test with string types - numeric strings parse as numbers
+        h = Item("h", "100", 6.6)  # string that looks like number
+        i = Item("i", "abc", 7.7)  # regular string
+        j = Item("j", "10", 8.8)  # another numeric string
+        items = [i, c, h, a, j]
+        formatter.set_sort_keys("i")
+        formatter.sort_items(items)
+        # Order: empty < numbers (5 < 10 < 100, parsed from strings) < non-numeric strings
+        self.assertListEqual(items, [a, c, j, h, i])
+
+        # Test None, hyphen, and unset values
+        k = Item("k", None, 9.9)  # None value
+        hyphen = Item("l", "-", 10.0)  # hyphen (also treated as unset)
+        items = [c, k, a, hyphen]
+        formatter.set_sort_keys("i")
+        formatter.sort_items(items)
+        # Order: None/empty/hyphen all sort first, then numbers
+        # Within unset values, stable sort maintains input order
+        self.assertListEqual(items, [k, a, hyphen, c])
+
+        # Test negative numbers (int and string)
+        m = Item("m", -5, 11.0)  # negative int
+        n = Item("n", "-10", 12.0)  # negative numeric string
+        items = [c, m, n, a]
+        formatter.set_sort_keys("i")
+        formatter.sort_items(items)
+        # Order: empty < -10 < -5 < 5
+        self.assertListEqual(items, [a, n, m, c])
+
+        # Test float strings
+        o = Item("o", "3.14", 13.0)  # float string
+        p = Item("p", "2.5", 14.0)  # another float string
+        items = [c, o, p]
+        formatter.set_sort_keys("i")
+        formatter.sort_items(items)
+        # Order: 2.5 < 3.14 < 5
+        self.assertListEqual(items, [p, o, c])
+
+    def test_display_value(self):
+        """Test DisplayValue class corner cases directly"""
+        # Partially numeric strings should fall back to string comparison
+        # "10abc" cannot be parsed as float, so sorts as string after numbers
+        self.assertTrue(DisplayValue(100) < DisplayValue("10abc"))
+        self.assertTrue(DisplayValue("10abc") < DisplayValue("abc"))
+
+        # Scientific notation should parse as numeric
+        self.assertTrue(DisplayValue("1e5") < DisplayValue(1000000))
+        self.assertEqual(
+            DisplayValue("1e5")._type_order, DisplayValue.NUMERIC
+        )  # numeric type
+        self.assertAlmostEqual(DisplayValue("1e5")._sort_value, 100000.0)
+
+        # Equality: numeric string should equal numeric value
+        self.assertEqual(DisplayValue("10"), DisplayValue(10))
+        self.assertEqual(DisplayValue("10.0"), DisplayValue(10.0))
+        self.assertEqual(DisplayValue(True), DisplayValue(1))
+
+        # All unset values should be equal
+        self.assertEqual(DisplayValue(None), DisplayValue(""))
+        self.assertEqual(DisplayValue(""), DisplayValue("-"))
+        self.assertEqual(DisplayValue(None), DisplayValue("-"))
+
+        # Type order verification
+        self.assertEqual(DisplayValue(None)._type_order, DisplayValue.EMPTY)  # unset
+        self.assertEqual(DisplayValue("")._type_order, DisplayValue.EMPTY)  # unset
+        self.assertEqual(DisplayValue("-")._type_order, DisplayValue.EMPTY)  # unset
+        self.assertEqual(DisplayValue(5)._type_order, DisplayValue.NUMERIC)  # numeric
+        self.assertEqual(
+            DisplayValue("10")._type_order, DisplayValue.NUMERIC
+        )  # parsed numeric
+        self.assertEqual(DisplayValue("abc")._type_order, DisplayValue.STRING)  # string
+
+        # Negative numbers
+        self.assertTrue(DisplayValue("-10") < DisplayValue("10"))
+        self.assertTrue(DisplayValue("-10") < DisplayValue(0))
+
+        # Float vs int - should compare numerically
+        self.assertEqual(DisplayValue(5), DisplayValue(5.0))
+        self.assertEqual(DisplayValue("5"), DisplayValue(5.0))
 
     def test_issue6530(self):
         a = Item("1234567890", 0, 2.2)

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -684,4 +684,14 @@ test_expect_success 'list.hidden-queues not overwritten when format added in sep
 test_expect_success 'cleanup jobs' '
 	flux cancel $(cat job2A.id) $(cat job2B.id)
 '
+test_expect_success 'flux resource list: can sort by nnodes (issue #7517)' '
+	flux resource list -o "sort:nnodes {nnodes} {state}" \
+		>list-sort-nnodes.out &&
+	test_debug "cat list-sort-nnodes.out"
+'
+test_expect_success 'flux resource list: can reverse sort by nnodes (issue #7517)' '
+	flux resource list -o "sort:-nnodes {nnodes} {state}" \
+		>list-sort-nnodes-rev.out &&
+	test_debug "cat list-sort-nnodes-rev.out"
+'
 test_done

--- a/t/t2351-resource-status-input.t
+++ b/t/t2351-resource-status-input.t
@@ -271,4 +271,24 @@ test_expect_success 'flux-resource status: all torpid ranks shown without drain 
 	EOF
 	test_cmp torpid-only.expected torpid-only.out
 '
+test_expect_success 'flux-resource status: can sort by nnodes (issue #7517)' '
+	INPUT=${INPUTDIR}/drain.json &&
+	flux resource status --from-stdin -o "sort:nnodes {nnodes} {state}" \
+		< $INPUT >sort-nnodes.out 2>&1 &&
+	test_debug "cat sort-nnodes.out"
+'
+test_expect_success 'flux-resource status: can sort by timestamp (issue #7517)' '
+	INPUT=${INPUTDIR}/drain.json &&
+	flux resource status --from-stdin \
+		-o "sort:timestamp {timestamp!d:%b%d} {nnodes} {state}" \
+		< $INPUT >sort-timestamp.out 2>&1 &&
+	test_debug "cat sort-timestamp.out"
+'
+test_expect_success 'flux-resource status: can reverse sort by nnodes (issue #7517)' '
+	INPUT=${INPUTDIR}/drain.json &&
+	flux resource status --from-stdin \
+		-o "sort:-nnodes {nnodes} {state}" \
+		< $INPUT >sort-nnodes-rev.out 2>&1 &&
+	test_debug "cat sort-nnodes-rev.out"
+'
 test_done

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1273,6 +1273,26 @@ test_expect_success 'flux-jobs invalid sort key throws exception' '
 	test_must_fail flux jobs -a --sort=foo 2>sort.error &&
 	grep "Invalid sort key: foo" sort.error
 '
+# The following tests are reproducers for issue #7517 where sorting fields
+# with mixed types (empty strings and numeric values) caused command failure.
+# These tests verify the command succeeds without crashing.
+test_expect_success 'flux-jobs can sort by nnodes with mixed empty values (issue #7517)' '
+	flux jobs -a -o "sort:nnodes {id.f58} {nnodes}" >sort-nnodes.out &&
+	test_debug "cat sort-nnodes.out"
+'
+test_expect_success 'flux-jobs can sort by ntasks with mixed empty values (issue #7517)' '
+	flux jobs -a -o "sort:ntasks {id.f58} {ntasks}" >sort-ntasks.out &&
+	test_debug "cat sort-ntasks.out"
+'
+test_expect_success 'flux-jobs can reverse sort mixed-type fields (issue #7517)' '
+	flux jobs -a -o "sort:-nnodes {id.f58} {nnodes}" >sort-nnodes-rev.out &&
+	test_debug "cat sort-nnodes-rev.out"
+'
+test_expect_success 'empty values sort before numeric values' '
+	flux jobs -ano "sort:nnodes {nnodes:h}" >sort-nnodes-order.out &&
+	head -1 sort-nnodes-order.out | grep -q "^-$" &&
+	tail -1 sort-nnodes-order.out | grep -q "^[0-9]"
+'
 
 #
 # format header tests.


### PR DESCRIPTION
This PR adds `DisplayValue` class to handle sorting of display-formatted values in the `OutputFormat` class used by `flux jobs`, `flux resource status`, `flux resource list` etc. This fixes errors reported with mixed-type sorting in #7517. Fields formatted as empty strings, hyphens, or None now sort correctly alongside numeric and string values.

The sort order implemented here is: empty/None < numbers (including booleans) < strings

This PR also extends the tests and documentation around the `OutputFormat` `sort:` prefix key.

Fixes #7517