### PR TITLE
t: revert potential job-list reload race fix

### DIFF
--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -1239,14 +1239,6 @@ test_expect_success 'flux job list job state timing outputs valid (job running)'
 	fj_wait_event $jobid clean >/dev/null
 '
 
-# `flux module reload job-list` does not ensure `job-list` is actually
-# ready to service requests immediately afterwards (i.e. has list
-# service been setup yet).  This checks to make sure `job-list` is
-# really up and ready.
-wait_job_list_ready() {
-	test_wait_until "flux job list"
-}
-
 #
 # job names
 #
@@ -1280,8 +1272,7 @@ test_expect_success 'flux job lists full path for job name if basename fails on 
 '
 
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify job names preserved across restart' '
@@ -1307,8 +1298,7 @@ test_expect_success 'flux job list outputs cwd' '
 	flux job list -s inactive | grep $jobid | jq -e ".cwd == \"${pwd}\""
 '
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify job cwd preserved across restart' '
@@ -1347,8 +1337,7 @@ test_expect_success 'reconfigure with no queues' '
 '
 
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify job queue preserved across restart' '
@@ -1384,8 +1373,7 @@ test_expect_success 'flux job list outputs project and bank if one set' '
 	flux job list -s inactive | grep $jobid | jq -e ".bank == \"bar\""
 '
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify job project and bank preserved across restart' '
@@ -1522,8 +1510,7 @@ test_expect_success 'flux job list outputs ntasks correctly (cores / per-resourc
 '
 
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify task count preserved across restart' '
@@ -1788,8 +1775,7 @@ test_expect_success 'flux job list does not list ncores if pending & nodes exclu
 '
 
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify core count preserved across restart' '
@@ -1924,8 +1910,7 @@ test_expect_success 'flux job list lists nnodes for pending jobs if nodes reques
 '
 
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify nnodes preserved across restart' '
@@ -1968,8 +1953,7 @@ test_expect_success 'flux job list outputs ranks/nodelist correctly (3 nodes)' '
 '
 
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify ranks/nodelist preserved across restart' '
@@ -2006,8 +1990,7 @@ test_expect_success 'flux job list outputs success correctly (false)' '
 '
 
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify success preserved across restart' '
@@ -2099,8 +2082,7 @@ test_expect_success 'flux job list outputs exceptions correctly (user exception)
 '
 
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify exceptions preserved across restart' '
@@ -2150,8 +2132,7 @@ test_expect_success 'flux job list outputs expiration time when set' '
 '
 
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify expiration time preserved across restart' '
@@ -2173,8 +2154,7 @@ test_expect_success 'flux job list outputs duration time when set' '
 '
 
 test_expect_success 'reload the job-list module' '
-	flux module reload job-list &&
-	wait_job_list_ready
+	flux module reload job-list
 '
 
 test_expect_success 'verify duration preserved across restart' '
@@ -2821,8 +2801,7 @@ restart_from_kvs() {
 	flux module reload job-manager
 	flux module reload -f sched-simple
 	flux module reload -f job-exec
-	flux module load job-list &&
-	wait_job_list_ready
+	flux module load job-list
 }
 
 # N.B. we remove annotations from the alloc event in this test, but it could


### PR DESCRIPTION
Problem: After analysis, it was determined that the patch provided in #7391 to fix a test race does not fix the race, but may in fact mask any race by adding a small delay into the tests.

Revert commit a924daf3abc8e119590ac2ee7a09a2d6e79e2089.