### PR TITLE
flux: add similarity check heuristic

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -442,15 +442,30 @@ static void similar_check (struct similar_cmds *similar,
                            const char *cmd)
 {
     int distance = levenshtein_distance (cmd, similar->argv0);
-    if (distance > 0 && distance <= similar->min) {
-        if (distance < similar->min) {
-            zlist_purge (similar->cmds);
-            similar->min = distance;
+    if (distance > 0) {
+        /* Heuristic: If the invalid command perfectly prefixes the
+         * valid command, we give it a bonus by removing 1 from the
+         * distance.
+         *
+         * If the prefix match is pretty long, they get an extra bonus
+         * and the distance is declared to be 0.
+         */
+        if (strstarts (cmd, similar->argv0)) {
+            if (strlen (similar->argv0) >= 5)
+                distance = 0;
+            else
+                distance--;
         }
-        if (similar_dupcheck (similar, cmd)) {
-            char *cpy = xstrdup (cmd);
-            zlist_append (similar->cmds, cpy);
-            zlist_freefn (similar->cmds, cpy, free, true);
+        if (distance <= similar->min) {
+            if (distance < similar->min) {
+                zlist_purge (similar->cmds);
+                similar->min = distance;
+            }
+            if (similar_dupcheck (similar, cmd)) {
+                char *cpy = xstrdup (cmd);
+                zlist_append (similar->cmds, cpy);
+                zlist_freefn (similar->cmds, cpy, free, true);
+            }
         }
     }
 }

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -873,6 +873,28 @@ test_expect_success 'duplicate commands are not output' '
 	test $count -eq 1
 '
 
+test_expect_success 'commands prefixed with the invalid command are favored' '
+	TEMPDIR1=$(mktemp -d) &&
+	touch $TEMPDIR1/flux-beef &&
+	chmod +x $TEMPDIR1/flux-beef &&
+	touch $TEMPDIR1/flux-mee &&
+	chmod +x $TEMPDIR1/flux-mee &&
+	test_must_fail sh -c "FLUX_EXEC_PATH=$TEMPDIR1 flux bee > invalid6.out 2>&1" &&
+	grep "beef" invalid6.out &&
+	test_must_fail grep "mee" invalid6.out
+'
+
+test_expect_success 'commands with longer prefixes get special treatment' '
+	TEMPDIR1=$(mktemp -d) &&
+	touch $TEMPDIR1/flux-python3.12 &&
+	chmod +x $TEMPDIR1/flux-python3.12 &&
+	touch $TEMPDIR1/flux-python3.157 &&
+	chmod +x $TEMPDIR1/flux-python3.157 &&
+	test_must_fail sh -c "FLUX_EXEC_PATH=$TEMPDIR1 flux python3 > invalid7.out 2>&1" &&
+	grep "python3.12" invalid7.out &&
+	grep "python3.157" invalid7.out
+'
+
 test_expect_success 'at most 3 suggested similar commands are output' '
 	TEMPDIR=$(mktemp -d) &&
 	touch $TEMPDIR/flux-mama &&


### PR DESCRIPTION
Problem: If the user inputs an invalid command, flux will output similar commands that the user maybe meant.  However, if the command perfectly prefixes a valid command, there's a strong likelihood that's the command they really really want.

Add a mild heuristic to give "bonus points" to matches are perfectly prefixed.   And if the prefix match is atleast 5 characters, go ahead and declare the distance to be 0 and consider is a "super strong match".

----

heres an example of why I did this:

before:

```
>src/cmd/flux fs
flux: `fs' is not a flux command.  See 'flux --help'
flux: The most similar commands are
flux: 	fsck
flux: 	kvs
flux: 	R
```

after

```
>src/cmd/flux fs
flux: `fs' is not a flux command.  See 'flux --help'
flux: The most similar command is
flux: 	fsck
```

before

```
>src/cmd/flux python3
flux: `python3' is not a flux command.  See 'flux --help'
flux: The most similar command is
flux: 	python
```
(b/c `python` is closer to `python3` (1 char difference) than `python3.6` (2 char difference))

```
>src/cmd/flux python3
flux: `python3' is not a flux command.  See 'flux --help'
flux: The most similar commands are
flux: 	python3.6
flux: 	python3.473
flux: 	python3.18
```
(those other pythons i just made up so they had extra chars)