### PR TITLE
typo flux-jobs.rst

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -212,7 +212,7 @@ JOB STATUS
 
 Jobs may be observed to pass through five job states in Flux: DEPEND,
 PRIORITY, SCHED, RUN, CLEANUP, and INACTIVE (see Flux RFC 21). Under the
-*state_single* field name, these are abbreviated as D, S, P, R, C, and I
+*state_single* field name, these are abbreviated as D, P, S, R, C, and I
 respectively. For convenience and clarity, the following virtual job
 states also exist: "pending", an alias for DEPEND,PRIORITY,SCHED; "running",
 an alias for RUN,CLEANUP; "active", an alias for "pending,running".


### PR DESCRIPTION
fixed typo in job status abbreviations