### PR TITLE
doc: fix empty readthedocs python API pages

### DIFF
--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,3 +1,4 @@
 sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18
 urllib3<2
+ply

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -159,7 +159,7 @@ class BuildMatrix:
                     docker_tag=docker_tag,
                     image=image if image is not None else name,
                     command_args=args.get("command_args", ""),
-                    timeout_minutes=args.get("timeout_minutes", 30),
+                    timeout_minutes=args.get("timeout_minutes"),
                     runner=args["runner"],
                     **kwargs,
                 )


### PR DESCRIPTION
Problem: some autodoc python api pages are empty on readthedocs, e.g.

https://flux-framework.readthedocs.io/projects/flux-core/en/latest/python/autogenerated/flux.constraint.html

`flux.constraint.parser` requires the `ply` package, but the `scripts/requirements-doc.txt` used by readthedocs does not include ply, so autodoc generates empty pages.

I think this was introduced by #7501 which added an import of `flux.constraint.parser` to `flux.job.Jobspec`.

Add `ply` to `scripts/requirements-doc.txt`.

This was split off of #7500