### PR TITLE
docker: fix docker manifest creation on tags

### DIFF
--- a/src/test/docker-manifest.py
+++ b/src/test/docker-manifest.py
@@ -16,7 +16,14 @@ matrix = json.loads(
 tags = defaultdict(list)
 for entry in matrix["include"]:
     if "DOCKER_TAG" in entry["env"]:
-        tags[entry["image"]].append(entry["env"]["DOCKER_TAG"])
+        image = entry["image"]
+        base = f"fluxrm/flux-core:{image}"
+        docker_tag = entry["env"]["DOCKER_TAG"]
+        tags[base].append(docker_tag)
+        # This is also a tagged version
+        if entry.get("tag"):
+            tag = entry["tag"]
+            tags[f"{base}-{tag}"].append(docker_tag)
 
 # Collect only those images with multiple tags or where image name does
 # not equal tag name. This latter check ensures that non-multi-arch docker
@@ -26,9 +33,8 @@ for entry in matrix["include"]:
 # latest docker images after a tag. (See flux-core#7225).
 tags = {k: v for k, v in tags.items() if len(v) > 1 or v[0] != k}
 
-for image in tags.keys():
-    tag = f"fluxrm/flux-core:{image}"
-    print(f"docker manifest create {tag} ", *tags[image])
-    subprocess.run(["docker", "manifest", "create", tag, *tags[image]])
-    print(f"docker manifest push {tag} ")
+for tag in tags.keys():
+    print(f"docker manifest create {tag}", *tags[tag])
+    subprocess.run(["docker", "manifest", "create", tag, *tags[tag]])
+    print(f"docker manifest push {tag}")
     subprocess.run(["docker", "manifest", "push", tag])


### PR DESCRIPTION
Problem: The docker manifest creation in GitHub CI for new tags is failing to create the `fluxrm/flux-core:{image}-{tag}` tags, so for example a fetch of `fluxrm/flux-core:bookworm-v0.84.0` fails.

The docker manifest script needs to push the tag-named manifests in addition to the new default tags (i.e. `fluxrm/flux-core:bookworm`). When the script is operating on a tag (entry["tag"] is not None), then append the per-architecture images on a list with the tagged name in addition to the default name.

Simplify the script by using the full docker tag names as the keys in the tags dictionary.

Fixes #7529