### PR TITLE
doc: fix typo in flux-jobs(1)

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -212,7 +212,7 @@ JOB STATUS
 
 Jobs may be observed to pass through five job states in Flux: DEPEND,
 PRIORITY, SCHED, RUN, CLEANUP, and INACTIVE (see Flux RFC 21). Under the
-*state_single* field name, these are abbreviated as D, S, P, R, C, and I
+*state_single* field name, these are abbreviated as D, P, S, R, C, and I
 respectively. For convenience and clarity, the following virtual job
 states also exist: "pending", an alias for DEPEND,PRIORITY,SCHED; "running",
 an alias for RUN,CLEANUP; "active", an alias for "pending,running".


### PR DESCRIPTION
Problem: Job state abbreviations are listed out of order.

Solution: Put P (pending) before S (sched).

@gonsie asked me to redo the commit message/branch conventions for her. Thanks, Elsa, for catching this!