### PR TITLE
Fix ASAN issues in sharness tests

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -492,7 +492,11 @@ dist_check_SCRIPTS = \
 	job-exec/imp-fail.sh \
 	job-list/list-id.py \
 	job-list/job-list-helper.sh \
-	ingest/bad-validate.py
+	ingest/bad-validate.py \
+	asan-scripts/no-asan.sh \
+	asan-scripts/ps \
+	asan-scripts/pkill \
+	asan-scripts/dd
 
 check_PROGRAMS = \
 	content/content_validate \

--- a/t/asan-scripts/dd
+++ b/t/asan-scripts/dd
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Wrapper for dd command to run without ASAN
+dir=$(dirname $0)
+$dir/no-asan.sh dd "$@"

--- a/t/asan-scripts/no-asan.sh
+++ b/t/asan-scripts/no-asan.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Wrapper to run command without ASAN
+#
+# assume called from within asan-scripts directory, so we want to
+# find the non-ASAN command from $PATH
+
+find_non_asan_command() {
+    name=$1
+    oldIFS=$IFS
+    IFS=:
+    for d in $PATH; do
+        if [ -x "$d/$name" ]; then
+            if echo "$d" | grep -q 'asan-scripts'; then
+                continue
+            fi
+            echo "$d/$name"
+            break
+        fi
+    done
+    IFS=$oldIFS
+}
+
+unset LD_PRELOAD
+unset ASAN_OPTIONS
+cmdname=$1
+shift
+realcmd=$(find_non_asan_command $cmdname)
+$realcmd "$@"

--- a/t/asan-scripts/pkill
+++ b/t/asan-scripts/pkill
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Wrapper for pkill command to run without ASAN
+dir=$(dirname $0)
+$dir/no-asan.sh pkill "$@"

--- a/t/asan-scripts/ps
+++ b/t/asan-scripts/ps
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Wrapper for ps command to run without ASAN
+dir=$(dirname $0)
+$dir/no-asan.sh ps "$@"

--- a/t/module/testmod.c
+++ b/t/module/testmod.c
@@ -50,10 +50,20 @@ static void segfault (flux_t *h,
     kill (getpid (), SIGSEGV);
 }
 
+static void killevent (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    flux_log (h, LOG_CRIT, "kill event received: raising SIGKILL");
+    kill (getpid (), SIGKILL);
+}
+
 static struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "info", info, 0 },
     { FLUX_MSGTYPE_EVENT, "panic", panic, 0 },
     { FLUX_MSGTYPE_EVENT, "segfault", segfault, 0 },
+    { FLUX_MSGTYPE_EVENT, "kill", killevent, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -109,7 +119,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     }
 
     const char *module_name = flux_aux_get (h, "flux::name");
-    const char *topics[] = { "panic", "segfault" };
+    const char *topics[] = { "panic", "segfault", "kill" };
 
     for (int i = 0; i < ARRAY_SIZE (topics); i++) {
         char topic[256];

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -5,6 +5,10 @@
 
 # add scripts directory to path
 export PATH="${SHARNESS_TEST_SRCDIR}/scripts:$PATH"
+# prefix asan-scripts directory if running with ASAN
+if flux version | grep -q +asan; then
+    export PATH="${SHARNESS_TEST_SRCDIR}/asan-scripts:$PATH"
+fi
 # only load namespaced plugins from flux.cli.plugins in tests
 export FLUX_CLI_PLUGINPATH_OVERRIDE=""
 

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -656,8 +656,10 @@ test_expect_success 'flux-help command list can be extended' '
 	grep "^test two commands" help2.out &&
 	grep "a test two" help2.out
 '
+# N.B. Set NO_ASAN, as there appears to be errors in 'man', which is executed
+# internally in `flux help`.
 command -v man >/dev/null && test_set_prereq HAVE_MAN
-test_expect_success HAVE_MAN 'flux-help command can display manpages for subcommands' '
+test_expect_success NO_ASAN,HAVE_MAN 'flux-help command can display manpages for subcommands' '
 	PWD=$(pwd) &&
 	mkdir -p man/man1 &&
 	cat <<-EOF > man/man1/flux-foo.1 &&
@@ -667,7 +669,7 @@ test_expect_success HAVE_MAN 'flux-help command can display manpages for subcomm
 	EOF
 	MANPATH=${PWD}/man FLUX_IGNORE_NO_DOCS=y flux help foo | grep "^FOO(1)"
 '
-test_expect_success HAVE_MAN 'flux-help command can display manpages for api calls' '
+test_expect_success NO_ASAN,HAVE_MAN 'flux-help command can display manpages for api calls' '
 	PWD=$(pwd) &&
 	mkdir -p man/man3 &&
 	cat <<-EOF > man/man3/flux_foo.3 &&

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -146,6 +146,7 @@ test_expect_success 'flux exec exits with code 126 for non executable' '
 	grep "Permission denied" exec.stderr2
 '
 
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
 test_expect_success NO_ASAN 'flux exec passes non-zero exit status' '
 	test_expect_code 2 flux exec -n sh -c "exit 2" &&
 	test_expect_code 3 flux exec -n sh -c "exit 3" &&
@@ -158,6 +159,7 @@ test_expect_success 'flux exec fails with --with-imp if no IMP configured' '
 	grep "exec\.imp path not found in config" exec-no-imp.out
 '
 
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
 test_expect_success NO_ASAN 'flux exec outputs tasks with errors' '
 	! flux exec -n sh -c "exit 2" > 2.out 2>&1 &&
         grep "\[0-3\]: Exit 2" 2.out &&

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -164,7 +164,8 @@ test_expect_success 'simulated module segfault causes module to exit' '
 	sh -c "while flux module stats testmod; do true; done" &&
 	flux dmesg >segfault.out
 '
-test_expect_success 'segfault is reported' '
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
+test_expect_success NO_ASAN 'segfault is reported' '
 	grep "killed by Segmentation fault" segfault.out
 '
 test_expect_success 'broker treats this the same as spurious module exit' '

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -158,18 +158,27 @@ test_expect_success NO_CHAIN_LINT 'start background streaming RPC' '
 test_expect_success NO_CHAIN_LINT 'wait for first response to RPC' '
 	$waitfile -t 15 stream.out
 '
-test_expect_success 'simulated module segfault causes module to exit' '
+# N.B. simulated segfault will lead to an error log being generated.
+# So when running under ASAN, skip this test and run the next one,
+# which will just kill the module.
+test_expect_success NO_ASAN 'simulated module segfault causes module to exit (sigsegv)' '
 	flux dmesg -C &&
 	flux event pub testmod.segfault &&
 	sh -c "while flux module stats testmod; do true; done" &&
-	flux dmesg >segfault.out
+	flux dmesg >module_fail.out
+'
+test_expect_success ASAN 'make module exit (kill)' '
+	flux dmesg -C &&
+	flux event pub testmod.kill &&
+	sh -c "while flux module stats testmod; do true; done" &&
+	flux dmesg >module_fail.out
 '
 # N.B. skip under ASAN, as it may capture segfault signal and report differently
 test_expect_success NO_ASAN 'segfault is reported' '
-	grep "killed by Segmentation fault" segfault.out
+	grep "killed by Segmentation fault" module_fail.out
 '
 test_expect_success 'broker treats this the same as spurious module exit' '
-	grep "module runtime failure" segfault.out
+	grep "module runtime failure" module_fail.out
 '
 test_expect_success NO_CHAIN_LINT 'streaming RPC was terminated' '
 	pid=$(cat stream.pid) &&

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -3,6 +3,8 @@
 test_description='Test flux cron service'
 
 . $(dirname $0)/sharness.sh
+
+# N.B. skip under ASAN, LD_PRELOAD is modified
 if ! test_have_prereq NO_ASAN; then
     skip_all='skipping faketime tests since AddressSanitizer is active'
     test_done

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -131,10 +131,12 @@ test_expect_success 'pty: no hang when invalid command is run under pty' '
 # Note: test below uses printf(1) to send [Ctrl-SPACE (NUL), newline, Ctrl-D]
 # over the pty connection and expects ^@ (the standard representation of NUL)
 # to appear in output.
+#
+# N.B. set NO_ASAN, results in cat: memory exhausted error
 nul_ctrl_d() {
 	python3 -c 'print("\x00\n\x04", end=None)'
 }
-test_expect_success 'pty: NUL (Ctrl-SPACE) character not dropped' '
+test_expect_success NO_ASAN 'pty: NUL (Ctrl-SPACE) character not dropped' '
 	nul_ctrl_d | flux run -vvv -o pty.interactive -o pty.capture cat -v &&
 	flux job eventlog -HL -p output $(flux job last) &&
 	flux job eventlog -HL -p output $(flux job last) | grep \\^@

--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -46,8 +46,11 @@ test_expect_success 'flux-shell: per-resource type=node works' '
 	EOF
 	test_cmp per-node.expected per-node.out
 '
-test_expect_success 'flux-shell: historical batch jobspec still work' '
+# N.B. legacy test jobspecs may not setup things correctly to allow
+# ASAN (e.g. overwrite environment), so disable under ASAN
+test_expect_success NO_ASAN 'flux-shell: historical batch jobspec still work' '
 	for spec in $SHARNESS_TEST_SRCDIR/batch/jobspec/*.json; do
+                echo $spec
 		input=$(basename $spec) &&
 		cat $spec |
 		    jq -S ".attributes.system.environment.PATH=\"$PATH\"" |

--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -46,7 +46,9 @@ test_expect_success 'flux-shell: per-resource type=node works' '
 	EOF
 	test_cmp per-node.expected per-node.out
 '
-test_expect_success 'flux-shell: historical batch jobspec still work' '
+# N.B. legacy test jobspecs may not setup things correctly to allow
+# ASAN (e.g. overwrite environment), so disable under ASAN
+test_expect_success NO_ASAN 'flux-shell: historical batch jobspec still work' '
 	for spec in $SHARNESS_TEST_SRCDIR/batch/jobspec/*.json; do
 		input=$(basename $spec) &&
 		cat $spec |

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -59,7 +59,8 @@ test_expect_success 'flux-shell: exit-on-error catches lost shell' '
 	test_must_fail run_timeout 30 flux run \
 		-n2 -N2 -o exit-on-error ./test2.sh
 '
-test_expect_success 'flux-shell: create script - rank 1 kills itself with SIGSEGV' '
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
+test_expect_success NO_ASAN 'flux-shell: create script - rank 1 kills itself with SIGSEGV' '
 	cat >sigtest.sh <<-"EOT" &&
 	#!/bin/sh
 	test $FLUX_TASK_RANK -eq 1 && kill -SEGV $$
@@ -67,12 +68,12 @@ test_expect_success 'flux-shell: create script - rank 1 kills itself with SIGSEG
 	EOT
 	chmod +x sigtest.sh
 '
-test_expect_success 'flux-shell: exit-on-error preserves failing task signal in finish status' '
+test_expect_success NO_ASAN 'flux-shell: exit-on-error preserves failing task signal in finish status' '
 	jobid=$(flux submit -n2 -o exit-on-error ./sigtest.sh) &&
 	flux job wait-event -t 30 $jobid finish | grep "status=35584" &&
 	flux job eventlog $jobid | grep exception | grep "Segmentation fault"
 '
-test_expect_success 'flux-shell: exit-timeout preserves failing task signal in finish status' '
+test_expect_success NO_ASAN 'flux-shell: exit-timeout preserves failing task signal in finish status' '
 	jobid=$(flux submit -n2 -o exit-timeout=1s ./sigtest.sh) &&
 	flux job wait-event -t 30 $jobid finish | grep "status=35584" &&
 	flux job eventlog $jobid | grep exception | grep "Segmentation fault"

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -110,7 +110,7 @@ test_expect_success NO_ASAN 'flux batch: job results are expected' '
 	grep "size=2 nodes=2" flux-${id4}.out &&
 	grep "size=2 nodes=2" flux-${id5}.out
 '
-test_expect_success MULTICORE 'flux batch: exclusive flag worked' '
+test_expect_success NO_ASAN,MULTICORE 'flux batch: exclusive flag worked' '
 	test $(flux job info ${id4} R | flux R decode --count=core) -gt 2 &&
 	test $(flux job info ${id5} R | flux R decode --count=core) -gt 2
 '

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -119,7 +119,7 @@ test_expect_success NO_ASAN 'flux batch: job results are expected' '
 	grep "size=2 nodes=2" flux-${id4}.out &&
 	grep "size=2 nodes=2" flux-${id5}.out
 '
-test_expect_success MULTICORE 'flux batch: exclusive flag worked' '
+test_expect_success NO_ASAN,MULTICORE 'flux batch: exclusive flag worked' '
 	test $(flux job info ${id4} R | flux R decode --count=core) -gt 2 &&
 	test $(flux job info ${id5} R | flux R decode --count=core) -gt 2
 '

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -100,6 +100,7 @@ test_expect_success 'flux batch --exclusive works' '
 		jq -S ".resources[0]" | \
 		jq -e ".type == \"node\" and .exclusive"
 '
+# N.B. slow under ASAN, skip
 test_expect_success NO_ASAN 'flux batch: submit a series of jobs' '
 	id1=$(flux batch --flags=waitable -n1 batch-script.sh) &&
 	id2=$(flux batch --flags=waitable -n4 batch-script.sh) &&

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -191,7 +191,9 @@ test_expect_success 'flux-uri mock testing of slurm resolver works' '
 	test_debug "cat squeue2.err" &&
 	grep -i "empty nodelist" squeue2.err
 '
-test_expect_success 'setup fake csm_allocation_query for mock lsf testing' '
+# N.B. Internally the lsf resolver will eventually run 'ps', which hangs
+# under ASAN.  So set NO_ASAN for lsf tests below.
+test_expect_success NO_ASAN 'setup fake csm_allocation_query for mock lsf testing' '
 	cat <<-EOF >csm_allocation_query &&
 	#!/bin/sh
 	test -n "\$LSF_FAIL" && exit 4
@@ -203,7 +205,7 @@ test_expect_success 'setup fake csm_allocation_query for mock lsf testing' '
 	export CSM_ALLOCATION_QUERY=$(pwd)/csm_allocation_query &&
 	export FLUX_SSH=${SHARNESS_TEST_SRCDIR}/scripts/tssh
 '
-test_expect_success 'flux-uri mock testing of lsf resolver works' '
+test_expect_success NO_ASAN 'flux-uri mock testing of lsf resolver works' '
 	echo $FLUX_URI >lsf.exp &&
 	SHELL=/bin/sh flux uri --local lsf:$LSB_JOBID >lsf.out &&
 	test_cmp lsf.exp lsf.out

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -16,6 +16,7 @@ run_program() {
 	run_timeout $timeout flux run $OPTS -n${ntasks} -N${nnodes} $*
 }
 
+# N.B. set NO_ASAN, we are modifying LD_PRELOAD
 test_expect_success NO_ASAN "spectrum mpi only enabled with option" '
 	LD_PRELOAD_saved=${LD_PRELOAD} &&
 	unset LD_PRELOAD &&
@@ -28,6 +29,7 @@ test_expect_success NO_ASAN "spectrum mpi only enabled with option" '
 	grep /opt/ibm/spectrum spectrum.out
 '
 
+# N.B. set NO_ASAN, we are modifying LD_PRELOAD
 test_expect_success NO_ASAN "spectrum mpi also enabled with spectrum@version" '
 	LD_PRELOAD_saved=${LD_PRELOAD} &&
 	unset LD_PRELOAD &&

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -121,7 +121,8 @@ test_expect_success 'job FLUX_JOB_ID_PATH=/id' '
 test_expect_success 'flux_open("/") works at top-level' '
 	flux python -c "import flux; print(flux.Flux(\"/\").attr_get(\"instance-level\"));"
 '
-test_expect_success 'flux_open(3) accepts path-like URIs: "/", "../.." etc' '
+# N.B. Set NO_ASAN, suspected python related false positives w/ ASAN, See #7624
+test_expect_success NO_ASAN 'flux_open(3) accepts path-like URIs: "/", "../.." etc' '
 	cat <<-EOF >flux_open.py &&
 	import unittest
 	import flux

--- a/t/t3306-system-routercrash.t
+++ b/t/t3306-system-routercrash.t
@@ -52,7 +52,8 @@ test_expect_success 'construct FLUX_URI for rank 2 (child of 1)' '
 
 # Choice of signal 11 (SIGSEGV) is deliberate here.
 # The broker should not trap this signal - see flux-framework/flux-core#4230.
-test_expect_success 'kill -11 broker 1' '
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
+test_expect_success NO_ASAN 'kill -11 broker 1' '
 	$startctl kill 1 11 &&
 	test_expect_code 139 $startctl wait 1
 '

--- a/t/t3306-system-routercrash.t
+++ b/t/t3306-system-routercrash.t
@@ -52,9 +52,19 @@ test_expect_success 'construct FLUX_URI for rank 2 (child of 1)' '
 
 # Choice of signal 11 (SIGSEGV) is deliberate here.
 # The broker should not trap this signal - see flux-framework/flux-core#4230.
-test_expect_success 'kill -11 broker 1' '
+# N.B. under ASAN, the segfault signal will result in a log file being
+# generated and broker will exit with different error code.  Skip and see
+# following test for ASAN workaround.
+test_expect_success NO_ASAN 'kill -11 broker 1' '
 	$startctl kill 1 11 &&
 	test_expect_code 139 $startctl wait 1
+'
+
+# N.B. prior test will not work under ASAN but we still need broker to
+# die for later tests.  Send SIGKILL when running under ASAN.
+test_expect_success ASAN 'kill -9 broker 1' '
+	$startctl kill 1 9 &&
+	test_expect_code 137 $startctl wait 1
 '
 
 test_expect_success 'wait broker.online to reach count of one' '


### PR DESCRIPTION
Fix various ASAN failures in sharness tests.  Most fixes are by adding NO_ASAN to tests, in which ASAN leads to unexpected behavior changes.  ~~One use-after-free was corrected in libterminus.~~ (Edit: Changed my mind, will move that fix to #7539)

Note that a number of hangs still exist in sharness with ASAN.  Those are being dealt with separately.