### PR TITLE
libterminus: fix use after free

### DIFF
--- a/src/common/libterminus/pty.c
+++ b/src/common/libterminus/pty.c
@@ -506,8 +506,8 @@ static void pty_read (flux_reactor_t *r,
         if (errno == EIO) {
             flux_watcher_stop (pty->fdw);
             pty->wait_on_close = false;
-            check_pty_complete (pty);
             pty_client_monitor_send_eof (pty);
+            check_pty_complete (pty);
             return;
         }
         llog_error (pty, "read: %s", strerror (errno));


### PR DESCRIPTION
Problem: In pty_read() in libterminus, check_pty_complete() can free the contents of pty.  The line right after this call is pty_client_monitor_send_eof(), which attempts to use pty. This can lead to a use-after-free bug.

Call pty_client_monitor_send_eof() before check_pty_complete().