### PR TITLE
testsuite: add missing FLUX_TESTS_LOGFILE support

### DIFF
--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+
 test_description='Test json-jobspec *cough* parser *cough*'
 
 . `dirname $0`/sharness.sh

--- a/t/t0023-jobspec1-validate.t
+++ b/t/t0023-jobspec1-validate.t
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+
 test_description='Test the libjob jobspec1 validation'
 
 . `dirname $0`/sharness.sh

--- a/t/t0024-jjc-reader.t
+++ b/t/t0024-jjc-reader.t
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+
 test_description='Test json-jobspec *cough* parser *cough*'
 
 . `dirname $0`/sharness.sh

--- a/t/t0030-marshall.t
+++ b/t/t0030-marshall.t
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+
 test_description='Test message marshalling across versions'
 
 . `dirname $0`/sharness.sh

--- a/t/t0031-constraint-parser.t
+++ b/t/t0031-constraint-parser.t
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+
 test_description='Test python flux.constraint.parser standalone operation'
 
 . `dirname $0`/sharness.sh

--- a/t/t0032-directives-parser.t
+++ b/t/t0032-directives-parser.t
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+
 test_description='Test python flux.job.directives parser operation'
 
 . `dirname $0`/sharness.sh

--- a/t/t0038-rreq-reader.t
+++ b/t/t0038-rreq-reader.t
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+
 test_description='Test Python ResourceRequest.from_jobspec via rreq-reader'
 
 . `dirname $0`/sharness.sh

--- a/t/t1012-kvs-checkpoint.t
+++ b/t/t1012-kvs-checkpoint.t
@@ -1,6 +1,9 @@
 #!/bin/sh
 #
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+
 test_description='Test kvs checkpointing works'
 
 . `dirname $0`/kvs/kvs-helper.sh

--- a/t/t2219-job-manager-restart.t
+++ b/t/t2219-job-manager-restart.t
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+
 test_description='Test flux job manager restart'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2600-job-shell-rcalc.t
+++ b/t/t2600-job-shell-rcalc.t
@@ -1,6 +1,9 @@
 #!/bin/sh
 #
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+
 test_description='Test shell resource calculator (rcalc) functionality'
 
 . `dirname $0`/sharness.sh

--- a/t/t2810-kvs-garbage-collect.t
+++ b/t/t2810-kvs-garbage-collect.t
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+
 test_description='Test offline KVS garbage collection'
 
 . $(dirname $0)/sharness.sh


### PR DESCRIPTION
Problem: Many sharness tests that do not call test_under_flux do not create a debug output file in <test_name>.output because they do not explicitly support appending --logfile to sharness arguments when FLUX_TESTS_LOGFILE is set in the environment.

Support FLUX_TESTS_LOGFILE where necessary across all sharness tests.

Note: in #7538 a test in `t2219-job-manager-restart.t` failed, but we don't have the detailed logs because of this issue. This PR should fix that for this test and others.