### PR TITLE
docker: add sanitizers to el10 image

### DIFF
--- a/src/test/docker/el10/Dockerfile
+++ b/src/test/docker/el10/Dockerfile
@@ -33,6 +33,9 @@ RUN dnf -y install 'dnf-command(config-manager)' \
 	gcc-c++ \
 	clang \
 	clang-tools-extra \
+	libasan \
+	libtsan \
+	libubsan \
 	make \
 	ninja-build \
 	cmake \


### PR DESCRIPTION
Problem: The el10 docker image does not include libasan, libtsan, and libubsan, so builds with --enable-sanitizer= can't be used in this image.

Add the sanitizer packages to the image.