### PR TITLE
WIP: job-exec: optionally constrain sdexec jobs to allocated cores via AllowedCPUs

### DIFF
--- a/doc/guide/admin_config.rst
+++ b/doc/guide/admin_config.rst
@@ -163,6 +163,12 @@ Example file installed path: ``/etc/flux/system/conf.d/system.toml``
  # Run jobs in a systemd user instance
  service = "sdexec"
 
+ # Restrict each job to its allocated cores.  Required when node sharing
+ # (also known as non-exclusive scheduling) is in use, i.e. when multiple
+ # jobs may run concurrently on the same node.
+ # sdexec expands logical core IDs to OS CPU IDs, handling hyperthreading.
+ sdexec-constrain-cores = true
+
  # Limit jobs to a percentage of physical memory
  [exec.sdexec-properties]
  MemoryMax = "95%"
@@ -237,8 +243,9 @@ Example file installed path: ``/etc/flux/system/conf.d/system.toml``
  job-size.max.ncores = 32
 
  # Configure the flux-sched (fluxion) scheduler policies
- # The 'lonodex' match policy selects node-exclusive scheduling, and can be
- # commented out if jobs may share nodes.
+ # The 'lonodex' match policy selects node-exclusive scheduling.  Remove or
+ # comment it out to enable node sharing (non-exclusive scheduling), where
+ # multiple jobs may run concurrently on the same node.
  [sched-fluxion-qmanager]
  queue-policy = "easy"
  [sched-fluxion-resource]

--- a/doc/guide/admin_config.rst
+++ b/doc/guide/admin_config.rst
@@ -123,8 +123,9 @@ Systemd and cgroup unified hierarchy
 
 The flux systemd unit launches a systemd user instance as the flux user.
 It is recommended to use this to run user jobs, as it provides cgroups
-containment and the ability to enforce memory limits.  To do this, Flux
-requires the cgroup version 2 unified hierarchy:
+containment and the ability to enforce resource limits such as memory caps
+and CPU isolation.  To do this, Flux requires the cgroup version 2 unified
+hierarchy:
 
 - The cgroup2 file system must be mounted on  ``/sys/fs/cgroup``
 
@@ -133,6 +134,40 @@ requires the cgroup version 2 unified hierarchy:
 
 - On some systems, add ``cgroup_enable=memory`` to the kernel command line
   (debian 12).
+
+The cgroup controllers needed for resource containment must also be
+delegated to the Flux systemd user instance. Create or update the following
+override files:
+
+``/etc/systemd/system/flux.service.d/override.conf``:
+
+.. code-block:: ini
+
+   [Service]
+   Delegate=cpu cpuset io memory pids
+
+``/etc/systemd/system/user@<flux-uid>.service.d/override.conf``
+(where ``<flux-uid>`` is the numeric UID of the ``flux`` user, e.g. from
+``id -u flux``):
+
+.. code-block:: ini
+
+   [Service]
+   Delegate=cpu cpuset io memory pids
+
+.. note::
+
+   ``cpuset`` delegation is required for ``sdexec-constrain-cores``
+   (``AllowedCPUs`` enforcement), and ``memory`` is required for memory
+   limits (``MemoryMax``).  The remaining controllers (``cpu``, ``io``,
+   ``pids``) are not required but may be useful via ``sdexec-properties``
+   or in future Flux releases.
+
+After creating or modifying these files, reload systemd and restart the
+Flux user instance::
+
+   systemctl daemon-reload
+   systemctl restart user@$(id -u flux).service
 
 The configuration that follows presumes jobs will be launched through systemd,
 although it is not strictly required if your system cannot meet these

--- a/doc/guide/sdexec.rst
+++ b/doc/guide/sdexec.rst
@@ -67,6 +67,28 @@ After calling ``sdexec_start_transient_unit()``, sdexec subscribes to
 ``PropertiesChanged`` signals on the unit's D-Bus object path.  The
 following state transitions drive the response protocol:
 
+.. _post-start-checks:
+
+Post-Start Checks
+=================
+
+Once a unit enters the running state, sdexec runs a series of
+post-start checks before sending the started response to the caller.
+All checks are dispatched through ``sdproc_post_start_checks()``.
+If any check fails, the exec request is failed with ``EIO`` and the
+error message is logged.
+
+Currently the only post-start check is the AllowedCPUs check, which
+is active when ``SDEXEC_CORES`` was set on the request:
+
+- Read ``cpuset.cpus`` from the unit's cgroup via
+  :func:`cgroup_info_init_pid`.
+- Decode it as a Flux idset and compare to the expected CPU set derived
+  from ``SDEXEC_CORES``.
+- If the file is absent or the idsets do not match, fail the request.
+  The most common cause is the cpuset cgroup controller not being
+  delegated to the user systemd instance.
+
 ACTIVE / RUNNING with ExecMainPID set
    Send started response with PID.
 
@@ -91,3 +113,48 @@ escalation:
 2. On first expiry: ``KillUnit`` with SIGTERM is sent; timer is reset.
 3. On second expiry: ``KillUnit`` with SIGKILL is sent; timer is reset.
 4. On third expiry: the request is failed with ``EDEADLK``.
+
+Command Options
+===============
+
+The sdexec module recognizes the following virtual options in the ``opts``
+dict of the JSON command object.  Callers set them via
+:func:`flux_cmd_setopt`.  ``SDEXEC_NAME`` and ``SDEXEC_PROP_*`` are
+handled by ``sdexec_start_transient_unit()``; see :doc:`libsdexec` for
+their full specification.
+
+``SDEXEC_NAME``
+  Name of the transient systemd unit, including the ``.service`` suffix.
+  Required by ``sdexec_start_transient_unit()``; auto-generated from a
+  truncated UUID if not set by the caller.
+
+``SDEXEC_CORES`` *idset*
+  A Flux idset string of logical core indices (0-origin, as in R_lite) to
+  restrict the unit to.  sdexec expands the core indices to OS CPU (PU)
+  indices using the local hwloc topology loaded at module init, then sets
+  ``SDEXEC_PROP_AllowedCPUs`` to the result and ``SDEXEC_PROP_AllowedMemoryNodes``
+  to the NUMA nodes that cover those CPUs.  A post-start check verifies that
+  the kernel applied the CPU constraint; see :ref:`post-start-checks`.
+
+``SDEXEC_STOP_TIMER_SEC`` *seconds*
+  Arm the stop timer with a timeout of *seconds*.  When the unit enters
+  DEACTIVATING state, the timer delivers ``SIGKILL`` (or the signal in
+  ``SDEXEC_STOP_TIMER_SIGNAL``), then after a second expiry abandons the
+  unit and fails the request with ``EDEADLK``.  A negative value disables
+  the timer (default).
+
+``SDEXEC_STOP_TIMER_SIGNAL`` *number*
+  Numerical signal delivered on the first stop-timer expiry instead of
+  ``SIGKILL`` (signal 9).
+
+``SDEXEC_PROP_``\ *NAME* *value*
+  Set the systemd transient unit property *NAME* to *value*.  Properties
+  with special D-Bus type handling are listed in :doc:`libsdexec`.  All
+  others are passed as strings.  See :linux:man5:`systemd.resource-control`
+  for semantics.
+
+``SDEXEC_TEST_EXPECTED_CPUS`` *idset*
+  *Test only — requires* ``sdexec-debug = true``.  Overrides the expected
+  CPU idset used by the post-start AllowedCPUs check.  Set to an idset
+  that cannot match ``cpuset.cpus`` (e.g. ``"99999"``) to force the check
+  to fail for end-to-end testing of the constraint-failure detection path.

--- a/doc/guide/sdexec.rst
+++ b/doc/guide/sdexec.rst
@@ -67,6 +67,28 @@ After calling ``sdexec_start_transient_unit()``, sdexec subscribes to
 ``PropertiesChanged`` signals on the unit's D-Bus object path.  The
 following state transitions drive the response protocol:
 
+.. _post-start-checks:
+
+Post-Start Checks
+=================
+
+Once a unit enters the running state, sdexec runs a series of
+post-start checks before sending the started response to the caller.
+All checks are dispatched through ``sdproc_post_start_checks()``.
+If any check fails, the exec request is failed with ``EIO`` and the
+error message is logged.
+
+Currently the only post-start check is the AllowedCPUs check, which
+is active when ``SDEXEC_CORES`` was set on the request:
+
+- Read ``cpuset.cpus`` from the unit's cgroup via
+  :func:`cgroup_info_init_pid`.
+- Decode it as a Flux idset and compare to the expected CPU set derived
+  from ``SDEXEC_CORES``.
+- If the file is absent or the idsets do not match, fail the request.
+  The most common cause is the cpuset cgroup controller not being
+  delegated to the user systemd instance.
+
 ACTIVE / RUNNING with ExecMainPID set
    Send started response with PID.
 
@@ -91,3 +113,49 @@ escalation:
 2. On first expiry: ``KillUnit`` with SIGTERM is sent; timer is reset.
 3. On second expiry: ``KillUnit`` with SIGKILL is sent; timer is reset.
 4. On third expiry: the request is failed with ``EDEADLK``.
+
+Command Options
+===============
+
+The sdexec module recognizes the following virtual options in the ``opts``
+dict of the JSON command object.  Callers set them via
+:func:`flux_cmd_setopt`.  ``SDEXEC_NAME`` and ``SDEXEC_PROP_*`` are
+handled by ``sdexec_start_transient_unit()``; see :doc:`libsdexec` for
+their full specification.
+
+``SDEXEC_NAME``
+  Name of the transient systemd unit, including the ``.service`` suffix.
+  Required by ``sdexec_start_transient_unit()``; auto-generated from a
+  truncated UUID if not set by the caller.
+
+``SDEXEC_CORES`` *idset*
+  A Flux idset string of logical core indices (0-origin, as in R_lite) to
+  restrict the unit to.  sdexec expands the core indices to OS CPU (PU)
+  indices using the local hwloc topology loaded at module init, then sets
+  ``SDEXEC_PROP_AllowedCPUs`` to the result.  If topology is unavailable
+  the core IDs are used as CPU IDs directly, which is correct on
+  non-hyperthreaded systems.  A post-start check verifies that the kernel
+  applied the constraint; see :ref:`post-start-checks`.
+
+``SDEXEC_STOP_TIMER_SEC`` *seconds*
+  Arm the stop timer with a timeout of *seconds*.  When the unit enters
+  DEACTIVATING state, the timer delivers ``SIGKILL`` (or the signal in
+  ``SDEXEC_STOP_TIMER_SIGNAL``), then after a second expiry abandons the
+  unit and fails the request with ``EDEADLK``.  A negative value disables
+  the timer (default).
+
+``SDEXEC_STOP_TIMER_SIGNAL`` *number*
+  Numerical signal delivered on the first stop-timer expiry instead of
+  ``SIGKILL`` (signal 9).
+
+``SDEXEC_PROP_``\ *NAME* *value*
+  Set the systemd transient unit property *NAME* to *value*.  Properties
+  with special D-Bus type handling are listed in :doc:`libsdexec`.  All
+  others are passed as strings.  See :linux:man5:`systemd.resource-control`
+  for semantics.
+
+``SDEXEC_TEST_EXPECTED_CPUS`` *idset*
+  *Test only — requires* ``sdexec-debug = true``.  Overrides the expected
+  CPU idset used by the post-start AllowedCPUs check.  Set to an idset
+  that cannot match ``cpuset.cpus`` (e.g. ``"99999"``) to force the check
+  to fail for end-to-end testing of the constraint-failure detection path.

--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -160,6 +160,19 @@ sdexec-stop-timer-signal
    (optional) Configure the signal used by the stop timer.  By default,
    10 (SIGUSR1, the IMP proxy for SIGKILL) is used.
 
+sdexec-constrain-cores
+   (optional) When set to ``true``, job-exec passes each rank's allocated
+   core idset to sdexec so that the transient systemd unit for each rank is
+   restricted to those cores via the ``AllowedCPUs`` unit property.  This
+   enforces CPU isolation between co-located jobs when node sharing is in use.
+   On hyperthreaded systems, sdexec expands the logical core indices in the
+   allocation to the full set of OS CPU (PU) indices that belong to those
+   cores.  (Default: ``false``).
+
+sdexec-stop-timer-signal
+   (optional) Configure the signal used by the stop timer.  By default,
+   10 (SIGUSR1, the IMP proxy for SIGKILL) is used.
+
 
 .. _sdexec_properties:
 
@@ -204,6 +217,12 @@ added to ``sdexec-properties``: AllowedCPUs, AllowedMemoryNodes,
 Description, Environment, ExecStart, KillMode, RemainAfterExit,
 SendSIGKILL, StandardInputFileDescriptor, StandardOutputFileDescriptor,
 StandardErrorFileDescriptor, TimeoutStopUSec, Type, WorkingDirectory.
+
+.. note::
+   ``AllowedCPUs`` is set automatically by sdexec when
+   ``sdexec-constrain-cores`` is enabled.  Setting it manually in
+   ``sdexec-properties`` would override the per-rank CPU assignment and
+   apply the same fixed CPU mask to every job, which is rarely correct.
 
 
 .. _testexec:
@@ -480,6 +499,14 @@ EXAMPLES
    max-kill-timeout = "15m"
    # Override the default if jobs need even more time for cleanup
    sdexec-stop-timer-sec = 1800  # 30 minutes instead of 15
+
+::
+
+   [exec]
+   service = "sdexec"
+   sdexec-constrain-cores = true
+   [exec.sdexec-properties]
+   MemoryMax = "90%"
 
 ::
 

--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -160,6 +160,19 @@ sdexec-stop-timer-signal
    (optional) Configure the signal used by the stop timer.  By default,
    10 (SIGUSR1, the IMP proxy for SIGKILL) is used.
 
+sdexec-constrain-cores
+   (optional) When set to ``true``, job-exec passes each rank's allocated
+   core idset to sdexec so that the transient systemd unit for each rank is
+   restricted to those cores via the ``AllowedCPUs`` unit property.  This
+   enforces CPU isolation between co-located jobs when node sharing is in use.
+   On hyperthreaded systems, sdexec expands the logical core indices in the
+   allocation to the full set of OS CPU (PU) indices that belong to those
+   cores.  (Default: ``false``).
+
+sdexec-stop-timer-signal
+   (optional) Configure the signal used by the stop timer.  By default,
+   10 (SIGUSR1, the IMP proxy for SIGKILL) is used.
+
 
 .. _sdexec_properties:
 
@@ -204,6 +217,12 @@ added to ``sdexec-properties``: AllowedCPUs, Description, Environment,
 ExecStart, KillMode, RemainAfterExit, SendSIGKILL, StandardInputFileDescriptor,
 StandardOutputFileDescriptor, StandardErrorFileDescriptor, TimeoutStopUSec,
 Type, WorkingDirectory.
+
+.. note::
+   ``AllowedCPUs`` is set automatically by sdexec when
+   ``sdexec-constrain-cores`` is enabled.  Setting it manually in
+   ``sdexec-properties`` would override the per-rank CPU assignment and
+   apply the same fixed CPU mask to every job, which is rarely correct.
 
 
 .. _testexec:
@@ -480,6 +499,14 @@ EXAMPLES
    max-kill-timeout = "15m"
    # Override the default if jobs need even more time for cleanup
    sdexec-stop-timer-sec = 1800  # 30 minutes instead of 15
+
+::
+
+   [exec]
+   service = "sdexec"
+   sdexec-constrain-cores = true
+   [exec.sdexec-properties]
+   MemoryMax = "90%"
 
 ::
 

--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -169,9 +169,19 @@ sdexec-constrain-cores
    allocation to the full set of OS CPU (PU) indices that belong to those
    cores.  (Default: ``false``).
 
-sdexec-stop-timer-signal
-   (optional) Configure the signal used by the stop timer.  By default,
-   10 (SIGUSR1, the IMP proxy for SIGKILL) is used.
+   After each job unit starts, Flux verifies that the expected CPU set is
+   enforced.  This check is necessary because systemd may silently accept
+   ``AllowedCPUs`` without enforcing it if the ``cpuset`` controller is not
+   properly delegated.  If the check fails, Flux drains the node as a likely
+   misconfiguration that would affect all subsequent jobs.
+
+   .. note::
+
+      This feature requires cgroup v2 (unified hierarchy) and the ``cpuset``
+      cgroup controller to be delegated to the Flux user instance.  See the
+      *Systemd and cgroup unified hierarchy* section of the Flux
+      Administrator's Guide for the required systemd override file
+      configuration.
 
 
 .. _sdexec_properties:

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1158,3 +1158,4 @@ sdproc
 hyperthreading
 hyperthreaded
 EIO
+ini

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1166,3 +1166,5 @@ ay
 BPF
 delegatable
 eBPF
+hyperthreading
+hyperthreaded

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1168,3 +1168,6 @@ delegatable
 eBPF
 hyperthreading
 hyperthreaded
+EIO
+ini
+NUMA

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1157,3 +1157,4 @@ observability
 sdproc
 hyperthreading
 hyperthreaded
+EIO

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1155,3 +1155,5 @@ libioencode
 memlimit
 observability
 sdproc
+hyperthreading
+hyperthreaded

--- a/etc/modprobe/modprobe.toml
+++ b/etc/modprobe/modprobe.toml
@@ -116,7 +116,7 @@ needs-config = ["systemd.enable"]
 
 [[modules]]
 name = "sdexec"
-after = ["sdbus"]
+after = ["sdbus", "resource"]
 requires = ["sdbus"]
 needs-config = ["systemd.enable"]
 

--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -262,6 +262,47 @@ const char * rhwloc_hostname (hwloc_topology_t topo)
     return NULL;
 }
 
+/*  Return the union of cpusets for the cores in idset string `cores`.
+ *  Returns heap-allocated hwloc_cpuset_t, or NULL on error.
+ *  Caller must free with hwloc_bitmap_free().
+ */
+hwloc_cpuset_t rhwloc_cores_to_cpuset (hwloc_topology_t topo, const char *cores)
+{
+    hwloc_cpuset_t coreset = NULL;
+    hwloc_cpuset_t cpuset = NULL;
+    int depth;
+    int i;
+
+    if (!topo || !cores)
+        return NULL;
+
+    if (!(coreset = hwloc_bitmap_alloc ())
+        || !(cpuset = hwloc_bitmap_alloc ()))
+        goto err;
+
+    if (hwloc_bitmap_list_sscanf (coreset, cores) < 0)
+        goto err;
+
+    depth = hwloc_get_type_depth (topo, HWLOC_OBJ_CORE);
+    if (depth == HWLOC_TYPE_DEPTH_UNKNOWN || depth == HWLOC_TYPE_DEPTH_MULTIPLE)
+        goto err;
+
+    i = hwloc_bitmap_first (coreset);
+    while (i >= 0) {
+        hwloc_obj_t core = hwloc_get_obj_by_depth (topo, depth, i);
+        if (!core || !core->cpuset)
+            goto err;
+        hwloc_bitmap_or (cpuset, cpuset, core->cpuset);
+        i = hwloc_bitmap_next (coreset, i);
+    }
+    hwloc_bitmap_free (coreset);
+    return cpuset;
+err:
+    hwloc_bitmap_free (coreset);
+    hwloc_bitmap_free (cpuset);
+    return NULL;
+}
+
 /*  Generate a cpuset string for all cores in the current topology
  */
 char *rhwloc_core_idset_string (hwloc_topology_t topo)

--- a/src/common/librlist/rhwloc.h
+++ b/src/common/librlist/rhwloc.h
@@ -40,6 +40,13 @@ char *rhwloc_topology_xml_restrict (const char *xml);
  */
 const char *rhwloc_hostname (hwloc_topology_t topo);
 
+/*  Return the union of cpusets for the cores in idset string `cores`.
+ *  Returns heap-allocated hwloc_cpuset_t, or NULL on error.
+ *  Caller must free with hwloc_bitmap_free().
+ */
+hwloc_cpuset_t rhwloc_cores_to_cpuset (hwloc_topology_t topo,
+                                        const char *cores);
+
 /*  Return idset string for all cores in hwloc topology object
  */
 char * rhwloc_core_idset_string (hwloc_topology_t topo);

--- a/src/common/librlist/test/rhwloc.c
+++ b/src/common/librlist/test/rhwloc.c
@@ -811,6 +811,50 @@ void test_xml ()
     free (xml);
 }
 
+void test_cores_to_cpuset (void)
+{
+    hwloc_topology_t topo;
+    hwloc_cpuset_t cpuset;
+    char *cores;
+
+    topo = rhwloc_local_topology_load (RHWLOC_NO_RESTRICT);
+    if (!topo)
+        BAIL_OUT ("rhwloc_local_topology_load failed");
+
+    /* NULL inputs */
+    ok (rhwloc_cores_to_cpuset (NULL, "0") == NULL,
+        "rhwloc_cores_to_cpuset topo=NULL returns NULL");
+    ok (rhwloc_cores_to_cpuset (topo, NULL) == NULL,
+        "rhwloc_cores_to_cpuset cores=NULL returns NULL");
+
+    /* Invalid core string */
+    ok (rhwloc_cores_to_cpuset (topo, "x") == NULL,
+        "rhwloc_cores_to_cpuset cores=invalid returns NULL");
+
+    /* Core 0 always exists; cpuset must be non-empty and include PU 0
+     * (i.e. physical CPU 0 is always in core 0's cpuset) */
+    cpuset = rhwloc_cores_to_cpuset (topo, "0");
+    ok (cpuset != NULL && !hwloc_bitmap_iszero (cpuset),
+        "rhwloc_cores_to_cpuset cores=0 returns non-empty cpuset");
+    ok (cpuset != NULL && hwloc_bitmap_isset (cpuset, 0),
+        "rhwloc_cores_to_cpuset cores=0 cpuset includes PU 0");
+    hwloc_bitmap_free (cpuset);
+
+    /* All cores: cpuset must equal full topology cpuset */
+    cores = rhwloc_core_idset_string (topo);
+    if (!cores)
+        BAIL_OUT ("rhwloc_core_idset_string failed");
+    cpuset = rhwloc_cores_to_cpuset (topo, cores);
+    ok (cpuset != NULL
+        && hwloc_bitmap_isequal (cpuset,
+                                 hwloc_topology_get_allowed_cpuset (topo)),
+        "rhwloc_cores_to_cpuset all cores cpuset matches topology cpuset");
+    hwloc_bitmap_free (cpuset);
+    free (cores);
+
+    hwloc_topology_destroy (topo);
+}
+
 int main (int ac, char *av[])
 {
     plan (NO_PLAN);
@@ -818,6 +862,7 @@ int main (int ac, char *av[])
     test_hwloc (NULL);
     test_hwloc (xml1);
     test_xml ();
+    test_cores_to_cpuset ();
 
     done_testing ();
 }

--- a/src/common/libsdexec/test/parse.c
+++ b/src/common/libsdexec/test/parse.c
@@ -79,6 +79,13 @@ const struct tab_bitmap btab[] = {
     { "0",              { 1, 0, 0, 0 },     1, true },
     { "0-2,8",          { 7, 1, 0, 0 },     2, true },
     { "8-15,16-23",     { 0, 255, 255, 0 }, 3, true },
+    // HT-style CPU sets produced by cores_to_cpus() expansion:
+    // 4-core system with SMT=2, siblings at +4 offset (e.g. cores 0-3
+    // map to CPUs 0-3 and 4-7)
+    { "0,4",            { 0x11, 0, 0, 0 },  1, true },
+    { "0-3,4-7",        { 0xff, 0, 0, 0 },  1, true },
+    // siblings at +16 offset (common on larger NUMA systems)
+    { "0-3,16-19",      { 0x0f, 0, 0x0f, 0 },  3, true },
 };
 
 void test_bitmap (void)

--- a/src/common/libutil/cgroup.c
+++ b/src/common/libutil/cgroup.c
@@ -148,7 +148,7 @@ static char *remove_leading_dotdot (char *relpath)
 }
 
 /*
- *  Look up the current cgroup relative path from /proc/self/cgroup.
+ *  Look up the cgroup relative path from /proc/<pid>/cgroup.
  *
  *  If cgroup->unified is true, then look for the first entry where
  *   'subsys' is an empty string.
@@ -157,7 +157,7 @@ static char *remove_leading_dotdot (char *relpath)
  *
  *  See NOTES: /proc/[pid]/cgroup in cgroups(7).
  */
-static int cgroup_init_path (struct cgroup_info *cgroup)
+static int cgroup_init_path_pid (struct cgroup_info *cgroup, pid_t pid)
 {
     int rc = -1;
     int n;
@@ -165,8 +165,10 @@ static int cgroup_init_path (struct cgroup_info *cgroup)
     size_t size = 0;
     char *line = NULL;
     int saved_errno;
+    char path[32];
 
-    if (!(fp = fopen ("/proc/self/cgroup", "r")))
+    snprintf (path, sizeof (path), "/proc/%d/cgroup", (int)pid);
+    if (!(fp = fopen (path, "r")))
         return -1;
 
     while ((n = getline (&line, &size, fp)) >= 0) {
@@ -272,12 +274,17 @@ static int cgroup_init_mount_dir_and_type (struct cgroup_info *cg)
     return -1;
 }
 
-int cgroup_info_init (struct cgroup_info *cgroup)
+int cgroup_info_init_pid (struct cgroup_info *cgroup, pid_t pid)
 {
     if (cgroup_init_mount_dir_and_type (cgroup) < 0
-        || cgroup_init_path (cgroup) < 0)
+        || cgroup_init_path_pid (cgroup, pid) < 0)
         return -1;
     return 0;
+}
+
+int cgroup_info_init (struct cgroup_info *cgroup)
+{
+    return cgroup_info_init_pid (cgroup, getpid ());
 }
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/common/libutil/cgroup.h
+++ b/src/common/libutil/cgroup.h
@@ -23,6 +23,12 @@ struct cgroup_info {
 
 int cgroup_info_init (struct cgroup_info *cgroup);
 
+/* Like cgroup_info_init(), but reads /proc/<pid>/cgroup instead of
+ * /proc/self/cgroup, allowing the cgroup path of another process to be
+ * determined.
+ */
+int cgroup_info_init_pid (struct cgroup_info *cgroup, pid_t pid);
+
 const char *cgroup_path_to (struct cgroup_info *cgroup, const char *name);
 
 /* Parse value from cgroup file

--- a/src/common/libutil/test/cgroup.c
+++ b/src/common/libutil/test/cgroup.c
@@ -11,6 +11,8 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <string.h>
+#include <unistd.h>
 #include "src/common/libtap/tap.h"
 #include "ccan/array_size/array_size.h"
 
@@ -74,6 +76,35 @@ void test_memory (struct cgroup_info *cgroup)
     end_skip;
 }
 
+void test_init_pid (struct cgroup_info *cgroup)
+{
+    struct cgroup_info cg;
+    int rc;
+
+    /* cgroup_info_init_pid (getpid()) should give the same path as
+     * cgroup_info_init(), since cgroup_info_init() is defined in terms of it.
+     */
+    rc = cgroup_info_init_pid (&cg, getpid ());
+    ok (rc == 0, "cgroup_info_init_pid (getpid()) succeeds");
+
+    skip (rc < 0, 1, "cgroup_info_init_pid (getpid()) failed");
+    ok (strcmp (cgroup->path, cg.path) == 0,
+        "cgroup_info_init_pid (getpid()) path matches cgroup_info_init()");
+    if (rc == 0)
+        diag ("path: %s", cg.path);
+    end_skip;
+
+    /* pid 1 (init/systemd) is always present and should have a cgroup */
+    rc = cgroup_info_init_pid (&cg, 1);
+    ok (rc == 0, "cgroup_info_init_pid (1) succeeds");
+    if (rc == 0)
+        diag ("pid 1 cgroup: %s", cg.path);
+
+    /* pid 0 (idle process) has no /proc/0 entry and should fail */
+    rc = cgroup_info_init_pid (&cg, 0);
+    ok (rc < 0, "cgroup_info_init_pid (0) fails as expected");
+}
+
 int main(int argc, char** argv)
 {
     struct cgroup_info cgroup;
@@ -86,6 +117,7 @@ int main(int argc, char** argv)
         plan (NO_PLAN);
         test_cpu (&cgroup);
         test_memory (&cgroup);
+        test_init_pid (&cgroup);
     }
     done_testing();
 }

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -253,13 +253,17 @@ sdexec_la_SOURCES = \
 	sdexec/sdexec.c
 sdexec_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
-	$(LIBUUID_CFLAGS)
+	$(LIBUUID_CFLAGS) \
+	$(HWLOC_CFLAGS)
 sdexec_la_LIBADD = \
 	$(top_builddir)/src/common/libsdexec/libsdexec.la \
+	$(top_builddir)/src/common/librlist/librlist-hwloc.la \
+	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(LIBUUID_LIBS) \
-	$(JANSSON_LIBS)
+	$(JANSSON_LIBS) \
+	$(HWLOC_LIBS)
 sdexec_la_LDFLAGS = $(fluxmod_ldflags) -module
 
 sdbus_la_SOURCES =

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -26,6 +26,11 @@
  *                               subprocesses: "rexec" or "sdexec".
  *    "barrier-timeout":F      - Specify timeout for start barrier in floating
  *                               point seconds.
+ *    "sdexec-test-expected-cpus":s
+ *                             - Override the expected CPU idset used by the
+ *                               sdexec post-start AllowedCPUs check.  Requires
+ *                               sdexec-debug = true.  Intended for testing the
+ *                               constraint-failure detection path.
  * }
  *
  */
@@ -59,6 +64,7 @@ struct exec_ctx {
     struct jobinfo *job;
 
     const char * mock_exception;   /* fake exception */
+    const char *sdexec_test_expected_cpus; /* override for post-start check */
     struct idset *barrier_pending_ranks;
     int barrier_enter_count;
     int barrier_completion_count;
@@ -137,13 +143,15 @@ static struct exec_ctx *exec_ctx_create (struct jobinfo *job,
     if (json_unpack_ex (job->jobspec,
                         &error,
                         0,
-                        "{s?{s?{s?{s?{s?s s?s s?F !}}}}}",
+                        "{s?{s?{s?{s?{s?s s?s s?s s?F !}}}}}",
                         "attributes",
                           "system",
                             "exec",
                               "bulkexec",
                                 "service", &service,
                                 "mock_exception", &ctx->mock_exception,
+                                "sdexec-test-expected-cpus",
+                                    &ctx->sdexec_test_expected_cpus,
                                 "barrier-timeout", &barrier_timeout) < 0) {
         errprintf (errp,
                    "failed to unpack system.exec.bulkexec for %s: %s",
@@ -614,13 +622,19 @@ static struct bulk_exec_ops exec_ops = {
  * indices using the physical topology.  This is not currently an issue
  * because sdexec is only used at the top-level instance.
  */
-static int sdexec_cmd_set_rank_opts (struct jobinfo *job,
+static int sdexec_cmd_set_rank_opts (struct exec_ctx *ctx,
                                      flux_cmd_t *cmd,
                                      unsigned int r)
 {
     if (config_get_sdexec_constrain_cores ()) {
-        const char *cores = resource_set_rank_cores (job->R, r);
+        const char *cores = resource_set_rank_cores (ctx->job->R, r);
         if (cores && flux_cmd_setopt (cmd, "SDEXEC_CORES", cores) < 0)
+            return -1;
+    }
+    if (ctx->sdexec_test_expected_cpus) {
+        if (flux_cmd_setopt (cmd,
+                             "SDEXEC_TEST_EXPECTED_CPUS",
+                             ctx->sdexec_test_expected_cpus) < 0)
             return -1;
     }
     return 0;
@@ -630,20 +644,21 @@ static int sdexec_cmd_set_rank_opts (struct jobinfo *job,
  * When true, exec_init() pushes one cmd per rank instead of one for all ranks.
  * Update this predicate when adding new per-rank sdexec options.
  */
-static bool sdexec_needs_per_rank_cmds (void)
+static bool sdexec_needs_per_rank_cmds (struct exec_ctx *ctx)
 {
-    return config_get_sdexec_constrain_cores ();
+    return config_get_sdexec_constrain_cores ()
+        || ctx->sdexec_test_expected_cpus != NULL;
 }
 
 /* Push one bulk_exec cmd per rank, each with rank-specific sdexec options.
  * Used in place of a single bulk_exec_push_cmd() call when per-rank options
  * need to be set.  Returns 0 on success, -1 on error.
  */
-static int sdexec_push_per_rank_cmds (struct jobinfo *job,
-                                      struct bulk_exec *exec,
+static int sdexec_push_per_rank_cmds (struct bulk_exec *exec,
                                       const struct idset *ranks,
                                       flux_cmd_t *cmd)
 {
+    struct exec_ctx *ctx = bulk_exec_aux_get (exec, "ctx");
     unsigned int r = idset_first (ranks);
     while (r != IDSET_INVALID_ID) {
         flux_cmd_t *rcmd = NULL;
@@ -653,7 +668,7 @@ static int sdexec_push_per_rank_cmds (struct jobinfo *job,
         if (!(rcmd = flux_cmd_copy (cmd))
             || !(rset = idset_create (0, IDSET_FLAG_AUTOGROW))
             || idset_set (rset, r) < 0
-            || sdexec_cmd_set_rank_opts (job, rcmd, r) < 0) {
+            || sdexec_cmd_set_rank_opts (ctx, rcmd, r) < 0) {
             flux_cmd_destroy (rcmd);
             idset_destroy (rset);
             return -1;
@@ -785,8 +800,8 @@ static int exec_init (struct jobinfo *job)
      * each transient unit can be configured for its own allocation.
      * Otherwise push a single command covering all ranks (the common case).
      */
-    if (streq (service, "sdexec") && sdexec_needs_per_rank_cmds ()) {
-        if (sdexec_push_per_rank_cmds (job, exec, ranks, cmd) < 0) {
+    if (streq (service, "sdexec") && sdexec_needs_per_rank_cmds (ctx)) {
+        if (sdexec_push_per_rank_cmds (exec, ranks, cmd) < 0) {
             flux_log_error (job->h, "exec_init: sdexec per-rank cmd setup");
             goto err;
         }

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -581,6 +581,70 @@ static struct bulk_exec_ops exec_ops = {
     .on_error =     error_cb
 };
 
+/* Set per-rank sdexec options on `cmd` for rank `r`.
+ * Returns 0 on success, -1 on error.
+ * Add new per-rank sdexec virtual options here (e.g. SDEXEC_GPUS).
+ *
+ * N.B. Core indices in R_lite are remapped to 0-origin within a subinstance.
+ * SDEXEC_CORES will therefore be wrong if sdexec is ever used within a
+ * subinstance, since sdexec must map logical core indices to OS CPU (PU)
+ * indices using the physical topology.  This is not currently an issue
+ * because sdexec is only used at the top-level instance.
+ */
+static int sdexec_cmd_set_rank_opts (struct jobinfo *job,
+                                     flux_cmd_t *cmd,
+                                     unsigned int r)
+{
+    if (config_get_sdexec_constrain_cores ()) {
+        const char *cores = resource_set_rank_cores (job->R, r);
+        if (cores && flux_cmd_setopt (cmd, "SDEXEC_CORES", cores) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+/* Return true if any per-rank sdexec options need to be set.
+ * When true, exec_init() pushes one cmd per rank instead of one for all ranks.
+ * Update this predicate when adding new per-rank sdexec options.
+ */
+static bool sdexec_needs_per_rank_cmds (void)
+{
+    return config_get_sdexec_constrain_cores ();
+}
+
+/* Push one bulk_exec cmd per rank, each with rank-specific sdexec options.
+ * Used in place of a single bulk_exec_push_cmd() call when per-rank options
+ * need to be set.  Returns 0 on success, -1 on error.
+ */
+static int sdexec_push_per_rank_cmds (struct jobinfo *job,
+                                      struct bulk_exec *exec,
+                                      const struct idset *ranks,
+                                      flux_cmd_t *cmd)
+{
+    unsigned int r = idset_first (ranks);
+    while (r != IDSET_INVALID_ID) {
+        flux_cmd_t *rcmd = NULL;
+        struct idset *rset = NULL;
+        int rc;
+
+        if (!(rcmd = flux_cmd_copy (cmd))
+            || !(rset = idset_create (0, IDSET_FLAG_AUTOGROW))
+            || idset_set (rset, r) < 0
+            || sdexec_cmd_set_rank_opts (job, rcmd, r) < 0) {
+            flux_cmd_destroy (rcmd);
+            idset_destroy (rset);
+            return -1;
+        }
+        rc = bulk_exec_push_cmd (exec, rset, rcmd, 0);
+        flux_cmd_destroy (rcmd);
+        idset_destroy (rset);
+        if (rc < 0)
+            return -1;
+        r = idset_next (ranks, r);
+    }
+    return 0;
+}
+
 static int exec_init (struct jobinfo *job)
 {
     flux_cmd_t *cmd = NULL;
@@ -694,9 +758,21 @@ static int exec_init (struct jobinfo *job)
         flux_log_error (job->h, "exec_init: flux_cmd_argv_append");
         goto err;
     }
-    if (bulk_exec_push_cmd (exec, ranks, cmd, 0) < 0) {
-        flux_log_error (job->h, "exec_init: bulk_exec_push_cmd");
-        goto err;
+    /* When per-rank sdexec options are needed, push one cmd per rank so
+     * each transient unit can be configured for its own allocation.
+     * Otherwise push a single command covering all ranks (the common case).
+     */
+    if (streq (service, "sdexec") && sdexec_needs_per_rank_cmds ()) {
+        if (sdexec_push_per_rank_cmds (job, exec, ranks, cmd) < 0) {
+            flux_log_error (job->h, "exec_init: sdexec per-rank cmd setup");
+            goto err;
+        }
+    }
+    else {
+        if (bulk_exec_push_cmd (exec, ranks, cmd, 0) < 0) {
+            flux_log_error (job->h, "exec_init: bulk_exec_push_cmd");
+            goto err;
+        }
     }
     flux_cmd_destroy (cmd);
     job->data = exec;

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -413,6 +413,29 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
                                  hostname,
                                  rank);
         }
+        else if (errnum == EIO) {
+            /*  EIO from sdexec indicates a post-start constraint check failed
+             *  (e.g. AllowedCPUs not enforced by the kernel).  Drain the rank
+             *  since the node is likely misconfigured and all subsequent jobs
+             *  would also run unconstrained.
+             */
+            char ranks[16];
+            snprintf (ranks, sizeof (ranks), "%d", rank);
+            (void) jobinfo_drain_ranks (job,
+                                        ranks,
+                                        "sdexec constraint check failed "
+                                        "on %s for job %s: %s",
+                                        hostname,
+                                        idf58 (job->id),
+                                        flux_subprocess_fail_error (p));
+            jobinfo_fatal_error (job,
+                                 0,
+                                 "sdexec constraint check failed "
+                                 "on %s (rank %d): %s",
+                                 hostname,
+                                 rank,
+                                 flux_subprocess_fail_error (p));
+        }
         else {
             jobinfo_fatal_error (job,
                                  0,

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -39,6 +39,7 @@ struct exec_config {
     json_t *sdexec_properties;
     int sdexec_stop_timer_sec;
     int sdexec_stop_timer_signal;
+    int sdexec_constrain_cores;
     double default_barrier_timeout;
 };
 
@@ -86,6 +87,11 @@ json_t *config_get_sdexec_properties (void)
     return exec_conf.sdexec_properties;
 }
 
+bool config_get_sdexec_constrain_cores (void)
+{
+    return exec_conf.sdexec_constrain_cores ? true : false;
+}
+
 static int derive_sdexec_stop_timer_sec (void)
 {
     int value = exec_conf.sdexec_stop_timer_sec;
@@ -129,7 +135,7 @@ int config_get_stats (json_t **config_stats)
 {
     json_t *o = NULL;
 
-    if (!(o = json_pack ("{s:s? s:s? s:s? s:s? s:i s:f s:i s:i}",
+    if (!(o = json_pack ("{s:s? s:s? s:s? s:s? s:i s:f s:i s:i s:i}",
                          "default_cwd", default_cwd,
                          "default_job_shell", exec_conf.default_job_shell,
                          "flux_imp_path", exec_conf.flux_imp_path,
@@ -141,7 +147,9 @@ int config_get_stats (json_t **config_stats)
                          "sdexec_stop_timer_sec",
                          derive_sdexec_stop_timer_sec (),
                          "sdexec_stop_timer_signal",
-                         exec_conf.sdexec_stop_timer_signal))) {
+                         exec_conf.sdexec_stop_timer_signal,
+                         "sdexec_constrain_cores",
+                         exec_conf.sdexec_constrain_cores))) {
         errno = ENOMEM;
         return -1;
     }
@@ -172,6 +180,7 @@ static void exec_config_init (struct exec_config *ec)
     ec->sdexec_properties = NULL;
     ec->sdexec_stop_timer_sec = -1;
     ec->sdexec_stop_timer_signal = 10; // SIGUSR1
+    ec->sdexec_constrain_cores = 0;
     ec->default_barrier_timeout = 1800.;
 }
 
@@ -266,6 +275,19 @@ int config_setup (flux_t *h,
                 return -1;
             }
         }
+    }
+
+    /*  Check configuration for exec.sdexec-constrain-cores */
+    if (flux_conf_unpack (conf,
+                          &err,
+                          "{s?{s?b}}",
+                          "exec",
+                            "sdexec-constrain-cores",
+                              &tmpconf.sdexec_constrain_cores) < 0) {
+        errprintf (errp,
+                   "error reading config value exec.sdexec-constrain-cores: %s",
+                   err.text);
+        return -1;
     }
 
     /*  Check configuration for exec.stop-timer-* */

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -30,6 +30,8 @@ const char *config_get_exec_service (void);
 
 json_t *config_get_sdexec_properties (void);
 
+bool config_get_sdexec_constrain_cores (void);
+
 bool config_get_exec_service_override (void);
 
 double config_get_default_barrier_timeout (void);

--- a/src/modules/job-exec/rset.c
+++ b/src/modules/job-exec/rset.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #endif
 #include <errno.h>
+#include <stdbool.h>
 #include "src/common/libutil/errno_safe.h"
 #include "rset.h"
 
@@ -157,6 +158,37 @@ struct resource_set *resource_set_create (const char *R, json_error_t *errp)
 const struct idset *resource_set_ranks (struct resource_set *r)
 {
     return r->ranks;
+}
+
+const char *resource_set_rank_cores (struct resource_set *r, unsigned int rank)
+{
+    int i;
+    json_t *entry;
+
+    if (!r || !r->R_lite) {
+        errno = EINVAL;
+        return NULL;
+    }
+    json_array_foreach (r->R_lite, i, entry) {
+        const char *ranks_str;
+        const char *cores_str;
+        struct idset *ranks;
+
+        if (json_unpack (entry,
+                         "{s:s s:{s:s}}",
+                         "rank", &ranks_str,
+                         "children",
+                           "core", &cores_str) < 0)
+            continue;
+        if (!(ranks = idset_decode (ranks_str)))
+            continue;
+        bool found = idset_test (ranks, rank);
+        idset_destroy (ranks);
+        if (found)
+            return cores_str;
+    }
+    errno = ENOENT;
+    return NULL;
 }
 
 double resource_set_starttime (struct resource_set *r)

--- a/src/modules/job-exec/rset.h
+++ b/src/modules/job-exec/rset.h
@@ -31,6 +31,12 @@ uint32_t resource_set_nth_rank (struct resource_set *r, int n);
 
 uint32_t resource_set_rank_index (struct resource_set *r, uint32_t rank);
 
+/* Return the core idset string for broker rank `rank` from R_lite, or NULL
+ * if the rank is not found or has no core assignment.  The returned pointer
+ * is owned by the resource_set and is valid for the lifetime of `r`.
+ */
+const char *resource_set_rank_cores (struct resource_set *r, unsigned int rank);
+
 double resource_set_starttime (struct resource_set *rset);
 
 double resource_set_expiration (struct resource_set *rset);

--- a/src/modules/job-exec/test/rset.c
+++ b/src/modules/job-exec/test/rset.c
@@ -110,6 +110,83 @@ struct resource_set_test tests[] = {
     RESOURCE_SET_TEST_END
 };
 
+/* R with two R_lite entries so we can verify per-group core lookup */
+#define MULTI_ENTRY_R \
+    "{ \"version\": 1," \
+    "  \"execution\": { " \
+    "    \"R_lite\": " \
+    "       [ {\"rank\": \"0-1\", " \
+    "          \"children\": { \"core\": \"0-3\" } " \
+    "         }," \
+    "         {\"rank\": \"2-3\", " \
+    "          \"children\": { \"core\": \"4-7\" } " \
+    "         } " \
+    "       ] " \
+    "    } " \
+    "}"
+
+void test_rank_cores ()
+{
+    json_error_t err;
+    struct resource_set *r;
+    const char *cores;
+
+    /* NULL resource_set */
+    ok (resource_set_rank_cores (NULL, 0) == NULL && errno == EINVAL,
+        "resource_set_rank_cores (NULL, 0) returns EINVAL");
+
+    /* Single-entry R: all ranks in range map to the same cores */
+    r = resource_set_create (BASIC_R, &err);
+    if (r == NULL)
+        BAIL_OUT ("resource_set_create: %s", err.text);
+
+    cores = resource_set_rank_cores (r, 0);
+    is (cores, "0-3", "rank_cores: rank 0 -> \"0-3\" in single-entry R");
+
+    cores = resource_set_rank_cores (r, 2);
+    is (cores, "0-3", "rank_cores: rank 2 -> \"0-3\" in single-entry R");
+
+    ok (resource_set_rank_cores (r, 5) == NULL && errno == ENOENT,
+        "rank_cores: rank not in R returns NULL/ENOENT");
+
+    resource_set_destroy (r);
+
+    /* Multi-entry R: each rank group returns its own cores */
+    r = resource_set_create (MULTI_ENTRY_R, &err);
+    if (r == NULL)
+        BAIL_OUT ("resource_set_create: %s", err.text);
+
+    cores = resource_set_rank_cores (r, 0);
+    is (cores, "0-3", "rank_cores: rank 0 -> \"0-3\" in multi-entry R");
+
+    cores = resource_set_rank_cores (r, 1);
+    is (cores, "0-3", "rank_cores: rank 1 -> \"0-3\" in multi-entry R");
+
+    cores = resource_set_rank_cores (r, 2);
+    is (cores, "4-7", "rank_cores: rank 2 -> \"4-7\" in multi-entry R");
+
+    cores = resource_set_rank_cores (r, 3);
+    is (cores, "4-7", "rank_cores: rank 3 -> \"4-7\" in multi-entry R");
+
+    ok (resource_set_rank_cores (r, 99) == NULL && errno == ENOENT,
+        "rank_cores: rank not in multi-entry R returns NULL/ENOENT");
+
+    resource_set_destroy (r);
+
+    /* Alternate (non-contiguous) ranks */
+    r = resource_set_create (BASIC_ALT_RANKS, &err);
+    if (r == NULL)
+        BAIL_OUT ("resource_set_create: %s", err.text);
+
+    cores = resource_set_rank_cores (r, 14);
+    is (cores, "0-3", "rank_cores: rank 14 -> \"0-3\" in alt-ranks R");
+
+    ok (resource_set_rank_cores (r, 1) == NULL && errno == ENOENT,
+        "rank_cores: rank 1 not in alt-ranks R returns NULL/ENOENT");
+
+    resource_set_destroy (r);
+}
+
 void test_rank_conversions ()
 {
     json_error_t err;
@@ -194,6 +271,7 @@ int main (int ac, char *av[])
     }
 
     test_rank_conversions ();
+    test_rank_cores ();
 
     done_testing ();
 }

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -48,6 +48,7 @@
 #include "src/common/libsdexec/channel.h"
 #include "src/common/libsdexec/unit.h"
 #include "src/common/libsdexec/property.h"
+#include "src/common/librlist/rhwloc.h"
 
 #define MODULE_NAME "sdexec"
 
@@ -58,6 +59,7 @@ struct sdexec_ctx {
     flux_msg_handler_t **handlers;
     struct flux_msglist *requests; // each exec request "owns" an sdproc
     struct flux_msglist *kills;
+    hwloc_topology_t topo;         // local topology for core->CPU expansion
 };
 
 enum stop_timer_state {
@@ -1271,11 +1273,36 @@ static struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END
 };
 
+/* Fetch hwloc XML from the local broker's resource module and load a topology
+ * from it.  This avoids the cost of local topology rediscovery since the
+ * resource module has already done it.  Returns NULL on failure (non-fatal).
+ */
+static hwloc_topology_t sdexec_load_topo (flux_t *h)
+{
+    flux_future_t *f;
+    const char *xml;
+    hwloc_topology_t topo = NULL;
+
+    if (!(f = flux_rpc (h, "resource.topo-get", NULL, FLUX_NODEID_ANY, 0))
+        || flux_rpc_get (f, &xml) < 0
+        || !(topo = rhwloc_xml_topology_load (xml, RHWLOC_NO_RESTRICT))) {
+        flux_log (h,
+                  LOG_WARNING,
+                  "sdexec: could not fetch hwloc topology from resource "
+                  "module: %s; AllowedCPUs core expansion unavailable",
+                  future_strerror (f, errno));
+    }
+    flux_future_destroy (f);
+    return topo;
+}
+
 static void sdexec_ctx_destroy (struct sdexec_ctx *ctx)
 {
     if (ctx) {
         int saved_errno = errno;
         flux_msg_handler_delvec (ctx->handlers);
+        if (ctx->topo)
+            hwloc_topology_destroy (ctx->topo);
         if (ctx->requests) {
             const flux_msg_t *msg;
             msg = flux_msglist_first (ctx->requests);
@@ -1310,6 +1337,7 @@ static struct sdexec_ctx *sdexec_ctx_create (flux_t *h)
     if (!(ctx->requests = flux_msglist_create ())
         || !(ctx->kills = flux_msglist_create ()))
         goto error;
+    ctx->topo = sdexec_load_topo (h); // NULL is non-fatal
     return ctx;
 error:
     sdexec_ctx_destroy (ctx);

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -49,6 +49,7 @@
 #include "src/common/libsdexec/unit.h"
 #include "src/common/libsdexec/property.h"
 #include "src/common/librlist/rhwloc.h"
+#include "src/common/libidset/idset.h"
 
 #define MODULE_NAME "sdexec"
 
@@ -684,6 +685,66 @@ static struct channel *create_out_channel (flux_t *h,
                                          arg);
 }
 
+/* Expand a Flux core idset string (logical core indices) to an OS CPU idset
+ * string (hwloc PU indices) using the supplied topology.  Handles
+ * hyperthreading: each logical core may cover multiple OS CPUs.
+ * Returns a heap-allocated string the caller must free(), or NULL on error.
+ */
+static char *cores_to_cpus (hwloc_topology_t topo, const char *cores)
+{
+    hwloc_cpuset_t cpuset = rhwloc_cores_to_cpuset (topo, cores);
+    struct idset *result = idset_create (0, IDSET_FLAG_AUTOGROW);
+    char *out = NULL;
+    int i;
+
+    if (!cpuset || !result)
+        goto done;
+    i = hwloc_bitmap_first (cpuset);
+    while (i >= 0) {
+        idset_set (result, i);
+        i = hwloc_bitmap_next (cpuset, i);
+    }
+    out = idset_encode (result, IDSET_FLAG_RANGE);
+done:
+    hwloc_bitmap_free (cpuset);
+    idset_destroy (result);
+    return out;
+}
+
+/* Translate any SDEXEC_CORES set in proc->cmd to AllowedCPUs using
+ * local hwloc topology.
+ */
+static int sdproc_set_allowed_cpus (struct sdexec_ctx *ctx, struct sdproc *proc)
+{
+    const char *cores;
+    char *allowed_cpus = NULL;
+    int rc = -1;
+
+    if (get_dict (proc->cmd, "opts", "SDEXEC_CORES", &cores) == 0) {
+        if (ctx->topo)
+            allowed_cpus = cores_to_cpus (ctx->topo, cores);
+        if (!allowed_cpus) {
+            flux_log (ctx->h,
+                      LOG_WARNING,
+                      "sdexec: AllowedCPUs core expansion failed for "
+                      "\"%s\"; using core IDs directly",
+                      cores);
+            allowed_cpus = strdup (cores);
+        }
+        if (!allowed_cpus
+            || set_dict (proc->cmd,
+                         "opts",
+                         "SDEXEC_PROP_AllowedCPUs",
+                         allowed_cpus) < 0) {
+            goto out;
+        }
+    }
+    rc = 0;
+out:
+    ERRNO_SAFE_WRAP (free, allowed_cpus);
+    return rc;
+}
+
 static struct sdproc *sdproc_create (struct sdexec_ctx *ctx,
                                      json_t *cmd,
                                      int flags)
@@ -714,6 +775,14 @@ static struct sdproc *sdproc_create (struct sdexec_ctx *ctx,
         errno = ENOMEM;
         goto error;
     }
+    /* If SDEXEC_CORES is set, expand the logical core idset to OS CPU IDs
+     * using the local hwloc topology and set SDEXEC_PROP_AllowedCPUs so
+     * start.c will apply the restriction to the transient unit.
+     * Falls back to using core IDs directly if topology is unavailable.
+     */
+    if (sdproc_set_allowed_cpus (ctx, proc) < 0)
+        goto error;
+
     /* Enable the stop timer by setting the SDEXEC_STOP_TIMER_SEC option to
      * a value in seconds.  The stop timer is disabled by default.
      * sOptionally set SDEXEC_STOP_TIMER_SIGNAL to a numerical signal

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -49,6 +49,7 @@
 #include "src/common/libsdexec/unit.h"
 #include "src/common/libsdexec/property.h"
 #include "src/common/librlist/rhwloc.h"
+#include "src/common/libidset/idset.h"
 
 #define MODULE_NAME "sdexec"
 
@@ -684,6 +685,86 @@ static struct channel *create_out_channel (flux_t *h,
                                          arg);
 }
 
+/* Encode an hwloc bitmap to a string using idset with IDSET_FLAG_RANGE
+ */
+static char *bitmap_encode (hwloc_bitmap_t bitmap)
+{
+    int i;
+    char *result = NULL;
+    struct idset *idset = idset_create (0, IDSET_FLAG_AUTOGROW);
+
+    if (!idset)
+        return NULL;
+
+    i = hwloc_bitmap_first (bitmap);
+    while (i >= 0) {
+        if (idset_set (idset, i) < 0)
+            goto out;
+        i = hwloc_bitmap_next (bitmap, i);
+    }
+    result = idset_encode (idset, IDSET_FLAG_RANGE);
+
+out:
+    idset_destroy (idset);
+    return result;
+}
+
+/* Translate any SDEXEC_CORES set in proc->cmd to AllowedCPUs and
+ * AllowedMemoryNodes using local hwloc topology.
+ */
+static int sdproc_set_allowed_cpus (struct sdexec_ctx *ctx, struct sdproc *proc)
+{
+    const char *cores;
+    hwloc_cpuset_t cpuset = NULL;
+    hwloc_bitmap_t nodeset = NULL;
+    char *allowed_cpus = NULL;
+    char *allowed_mems = NULL;
+    int rc = -1;
+
+    if (get_dict (proc->cmd, "opts", "SDEXEC_CORES", &cores) == 0) {
+        if (!(cpuset = rhwloc_cores_to_cpuset (ctx->topo, cores))
+            || !(nodeset = hwloc_bitmap_alloc ())
+            || hwloc_cpuset_to_nodeset (ctx->topo, cpuset, nodeset) != 0) {
+            flux_log (ctx->h,
+                      LOG_ERR,
+                      "Failed to get cpuset and nodeset for cores %s",
+                      cores);
+            goto out;
+        }
+        if (!(allowed_cpus = bitmap_encode (cpuset))
+            || !(allowed_mems = bitmap_encode (nodeset))) {
+            flux_log (ctx->h,
+                      LOG_ERR,
+                      "Failed to encode cpuset and/or nodeset for cores %s",
+                      cores);
+            goto out;
+        }
+        if (set_dict (proc->cmd,
+                      "opts",
+                      "SDEXEC_PROP_AllowedCPUs",
+                      allowed_cpus) < 0
+            || set_dict (proc->cmd,
+                         "opts",
+                         "SDEXEC_PROP_AllowedMemoryNodes",
+                         allowed_mems) < 0) {
+            flux_log (ctx->h,
+                      LOG_ERR,
+                      "Failed to set AllowedCPUs/AllowedMemoryNodes to %s/%s",
+                      allowed_cpus,
+                      allowed_mems);
+
+            goto out;
+        }
+    }
+    rc = 0;
+out:
+    ERRNO_SAFE_WRAP (hwloc_bitmap_free, cpuset);
+    ERRNO_SAFE_WRAP (hwloc_bitmap_free, nodeset);
+    ERRNO_SAFE_WRAP (free, allowed_cpus);
+    ERRNO_SAFE_WRAP (free, allowed_mems);
+    return rc;
+}
+
 static struct sdproc *sdproc_create (struct sdexec_ctx *ctx,
                                      json_t *cmd,
                                      int flags)
@@ -714,6 +795,14 @@ static struct sdproc *sdproc_create (struct sdexec_ctx *ctx,
         errno = ENOMEM;
         goto error;
     }
+    /* If SDEXEC_CORES is set, expand the logical core idset to OS CPU IDs
+     * using the local hwloc topology and set SDEXEC_PROP_AllowedCPUs so
+     * start.c will apply the restriction to the transient unit.
+     * Falls back to using core IDs directly if topology is unavailable.
+     */
+    if (sdproc_set_allowed_cpus (ctx, proc) < 0)
+        goto error;
+
     /* Enable the stop timer by setting the SDEXEC_STOP_TIMER_SEC option to
      * a value in seconds.  The stop timer is disabled by default.
      * sOptionally set SDEXEC_STOP_TIMER_SIGNAL to a numerical signal

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -872,6 +872,21 @@ static struct sdproc *sdproc_create (struct sdexec_ctx *ctx,
     if (sdproc_set_allowed_cpus (ctx, proc) < 0)
         goto error;
 
+    /* SDEXEC_TEST_EXPECTED_CPUS overrides the expected CPU idset used by the
+     * post-start AllowedCPUs check.  Only available when sdexec-debug is true
+     * so it cannot be set in production.  Used by the test suite to inject a
+     * deliberate mismatch and verify that constraint failures are detected.
+     */
+    if (sdexec_debug) {
+        const char *test_cpus;
+        if (get_dict (proc->cmd, "opts", "SDEXEC_TEST_EXPECTED_CPUS",
+                      &test_cpus) == 0) {
+            free (proc->expected_cpus);
+            if (!(proc->expected_cpus = strdup (test_cpus)))
+                goto error;
+        }
+    }
+
     /* Enable the stop timer by setting the SDEXEC_STOP_TIMER_SEC option to
      * a value in seconds.  The stop timer is disabled by default.
      * sOptionally set SDEXEC_STOP_TIMER_SIGNAL to a numerical signal

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -909,7 +909,7 @@ static struct sdproc *sdproc_create (struct sdexec_ctx *ctx,
 
     /* Enable the stop timer by setting the SDEXEC_STOP_TIMER_SEC option to
      * a value in seconds.  The stop timer is disabled by default.
-     * sOptionally set SDEXEC_STOP_TIMER_SIGNAL to a numerical signal
+     * Optionally set SDEXEC_STOP_TIMER_SIGNAL to a numerical signal
      * value to use instead of SIGKILL.
      */
     if (get_dict_int (proc->cmd,

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -36,6 +36,7 @@
 
 #include "src/common/libsubprocess/client.h"
 #include "src/common/libioencode/ioencode.h"
+#include "src/common/libutil/cgroup.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/fdutils.h"
@@ -99,6 +100,8 @@ struct sdproc {
     int errnum;
     const char *errstr;
     flux_error_t error;
+
+    char *expected_cpus;  /* expected AllowedCPUs idset string, or NULL */
 
     struct sdexec_ctx *ctx;
 };
@@ -308,6 +311,79 @@ static void reset_continuation (flux_future_t *f, void *arg)
     }
 }
 
+/* Verify that cpuset.cpus in the unit's cgroup matches
+ * the expected AllowedCPUs idset.  Returns 0 on success, -1 with errp set
+ * if the constraint was not applied (controller not delegated, or mismatch).
+ */
+static int sdproc_check_allowed_cpus (struct sdproc *proc, flux_error_t *errp)
+{
+    struct cgroup_info cg;
+    char buf[PATH_MAX];
+    FILE *fp;
+    const char *fpath;
+    struct idset *expected = NULL;
+    struct idset *actual = NULL;
+    int rc = -1;
+
+    if (cgroup_info_init_pid (&cg, sdexec_unit_pid (proc->unit)) < 0) {
+        errprintf (errp,
+                   "AllowedCPUs: cannot read cgroup for pid %d: %s",
+                   (int)sdexec_unit_pid (proc->unit),
+                   strerror (errno));
+        return -1;
+    }
+    if (!(fpath = cgroup_path_to (&cg, "cpuset.cpus"))) {
+        errprintf (errp, "AllowedCPUs: cgroup path too long");
+        return -1;
+    }
+    if (!(fp = fopen (fpath, "r"))) {
+        errprintf (errp,
+                   "AllowedCPUs not enforced: %s unavailable "
+                   "(is cpuset controller delegated to the user instance?)",
+                   fpath);
+        return -1;
+    }
+    if (!fgets (buf, sizeof (buf), fp)) {
+        errprintf (errp, "AllowedCPUs: failed to read %s", fpath);
+        fclose (fp);
+        return -1;
+    }
+    fclose (fp);
+    buf[strcspn (buf, "\n")] = '\0';
+
+    if (!(expected = idset_decode (proc->expected_cpus))
+        || !(actual = idset_decode (buf))) {
+        errprintf (errp, "AllowedCPUs: failed to parse cpuset");
+        goto done;
+    }
+    if (!idset_equal (expected, actual)) {
+        errprintf (errp,
+                   "AllowedCPUs not enforced: expected %s got %s "
+                   "(is cpuset controller delegated to the user instance?)",
+                   proc->expected_cpus,
+                   buf);
+        goto done;
+    }
+    rc = 0;
+done:
+    idset_destroy (expected);
+    idset_destroy (actual);
+    return rc;
+}
+
+/* Run post-start checks once the unit has entered the running state.
+ * Returns 0 if all checks pass, -1 with errp set if any check fails.
+ * Add new post-start checks here (e.g. sdproc_check_allowed_devices()).
+ */
+static int sdproc_post_start_checks (struct sdproc *proc, flux_error_t *errp)
+{
+    if (proc->expected_cpus) {
+        if (sdproc_check_allowed_cpus (proc, errp) < 0)
+            return -1;
+    }
+    return 0;
+}
+
 /* sdbus.subscribe sent a PropertiesChanged response for a particular unit.
  * Advance the proc->unit state accordingly and send exec responses as needed.
  * call finalize_exec_request_if_done() in case this update is the last thing
@@ -340,6 +416,16 @@ static void property_changed_continuation (flux_future_t *f, void *arg)
      */
     if (!proc->started_response_sent) {
         if (sdexec_unit_has_started (proc->unit)) {
+            flux_error_t check_error;
+            if (sdproc_post_start_checks (proc, &check_error) < 0) {
+                flux_log (h,
+                          LOG_ERR,
+                          "%s: post-start check failed: %s",
+                          sdexec_unit_name (proc->unit),
+                          check_error.text);
+                exec_respond_error (proc, EIO, check_error.text);
+                return;
+            }
             if (flux_respond_pack (h,
                                    proc->msg,
                                    "{s:s s:I}",
@@ -544,6 +630,7 @@ static void sdproc_destroy (struct sdproc *proc)
         flux_watcher_destroy (proc->stop.timer);
         json_decref (proc->cmd);
         flux_msglist_destroy (proc->write_requests);
+        free (proc->expected_cpus);
         free (proc);
         errno = saved_errno;
     }
@@ -738,6 +825,8 @@ static int sdproc_set_allowed_cpus (struct sdexec_ctx *ctx, struct sdproc *proc)
                          allowed_cpus) < 0) {
             goto out;
         }
+        if (!(proc->expected_cpus = strdup (allowed_cpus)))
+            goto out;
     }
     rc = 0;
 out:

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -36,6 +36,7 @@
 
 #include "src/common/libsubprocess/client.h"
 #include "src/common/libioencode/ioencode.h"
+#include "src/common/libutil/cgroup.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/fdutils.h"
@@ -99,6 +100,8 @@ struct sdproc {
     int errnum;
     const char *errstr;
     flux_error_t error;
+
+    char *expected_cpus;  /* expected AllowedCPUs idset string, or NULL */
 
     struct sdexec_ctx *ctx;
 };
@@ -308,6 +311,79 @@ static void reset_continuation (flux_future_t *f, void *arg)
     }
 }
 
+/* Verify that cpuset.cpus in the unit's cgroup matches
+ * the expected AllowedCPUs idset.  Returns 0 on success, -1 with errp set
+ * if the constraint was not applied (controller not delegated, or mismatch).
+ */
+static int sdproc_check_allowed_cpus (struct sdproc *proc, flux_error_t *errp)
+{
+    struct cgroup_info cg;
+    char buf[256]; /* allow enough space for huge AllowedCPUs list */
+    FILE *fp;
+    const char *fpath;
+    struct idset *expected = NULL;
+    struct idset *actual = NULL;
+    int rc = -1;
+
+    if (cgroup_info_init_pid (&cg, sdexec_unit_pid (proc->unit)) < 0) {
+        errprintf (errp,
+                   "AllowedCPUs: cannot read cgroup for pid %d: %s",
+                   (int)sdexec_unit_pid (proc->unit),
+                   strerror (errno));
+        return -1;
+    }
+    if (!(fpath = cgroup_path_to (&cg, "cpuset.cpus"))) {
+        errprintf (errp, "AllowedCPUs: cgroup path too long");
+        return -1;
+    }
+    if (!(fp = fopen (fpath, "r"))) {
+        errprintf (errp,
+                   "AllowedCPUs not enforced: %s unavailable "
+                   "(is cpuset controller delegated to the user instance?)",
+                   fpath);
+        return -1;
+    }
+    if (!fgets (buf, sizeof (buf), fp)) {
+        errprintf (errp, "AllowedCPUs: failed to read %s", fpath);
+        fclose (fp);
+        return -1;
+    }
+    fclose (fp);
+    buf[strcspn (buf, "\n")] = '\0';
+
+    if (!(expected = idset_decode (proc->expected_cpus))
+        || !(actual = idset_decode (buf))) {
+        errprintf (errp, "AllowedCPUs: failed to parse cpuset");
+        goto done;
+    }
+    if (!idset_equal (expected, actual)) {
+        errprintf (errp,
+                   "AllowedCPUs not enforced: expected %s got %s "
+                   "(is cpuset controller delegated to the user instance?)",
+                   proc->expected_cpus,
+                   buf);
+        goto done;
+    }
+    rc = 0;
+done:
+    idset_destroy (expected);
+    idset_destroy (actual);
+    return rc;
+}
+
+/* Run post-start checks once the unit has entered the running state.
+ * Returns 0 if all checks pass, -1 with errp set if any check fails.
+ * Add new post-start checks here (e.g. sdproc_check_allowed_devices()).
+ */
+static int sdproc_post_start_checks (struct sdproc *proc, flux_error_t *errp)
+{
+    if (proc->expected_cpus) {
+        if (sdproc_check_allowed_cpus (proc, errp) < 0)
+            return -1;
+    }
+    return 0;
+}
+
 /* sdbus.subscribe sent a PropertiesChanged response for a particular unit.
  * Advance the proc->unit state accordingly and send exec responses as needed.
  * call finalize_exec_request_if_done() in case this update is the last thing
@@ -340,6 +416,16 @@ static void property_changed_continuation (flux_future_t *f, void *arg)
      */
     if (!proc->started_response_sent) {
         if (sdexec_unit_has_started (proc->unit)) {
+            flux_error_t check_error;
+            if (sdproc_post_start_checks (proc, &check_error) < 0) {
+                flux_log (h,
+                          LOG_ERR,
+                          "%s: post-start check failed: %s",
+                          sdexec_unit_name (proc->unit),
+                          check_error.text);
+                exec_respond_error (proc, EIO, check_error.text);
+                return;
+            }
             if (flux_respond_pack (h,
                                    proc->msg,
                                    "{s:s s:I}",
@@ -544,6 +630,7 @@ static void sdproc_destroy (struct sdproc *proc)
         flux_watcher_destroy (proc->stop.timer);
         json_decref (proc->cmd);
         flux_msglist_destroy (proc->write_requests);
+        free (proc->expected_cpus);
         free (proc);
         errno = saved_errno;
     }
@@ -756,6 +843,8 @@ static int sdproc_set_allowed_cpus (struct sdexec_ctx *ctx, struct sdproc *proc)
             goto out;
         }
     }
+    proc->expected_cpus = allowed_cpus;
+    allowed_cpus = NULL;
     rc = 0;
 out:
     ERRNO_SAFE_WRAP (hwloc_bitmap_free, cpuset);

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -892,6 +892,21 @@ static struct sdproc *sdproc_create (struct sdexec_ctx *ctx,
     if (sdproc_set_allowed_cpus (ctx, proc) < 0)
         goto error;
 
+    /* SDEXEC_TEST_EXPECTED_CPUS overrides the expected CPU idset used by the
+     * post-start AllowedCPUs check.  Only available when sdexec-debug is true
+     * so it cannot be set in production.  Used by the test suite to inject a
+     * deliberate mismatch and verify that constraint failures are detected.
+     */
+    if (sdexec_debug) {
+        const char *test_cpus;
+        if (get_dict (proc->cmd, "opts", "SDEXEC_TEST_EXPECTED_CPUS",
+                      &test_cpus) == 0) {
+            free (proc->expected_cpus);
+            if (!(proc->expected_cpus = strdup (test_cpus)))
+                goto error;
+        }
+    }
+
     /* Enable the stop timer by setting the SDEXEC_STOP_TIMER_SEC option to
      * a value in seconds.  The stop timer is disabled by default.
      * sOptionally set SDEXEC_STOP_TIMER_SIGNAL to a numerical signal

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -48,6 +48,7 @@
 #include "src/common/libsdexec/channel.h"
 #include "src/common/libsdexec/unit.h"
 #include "src/common/libsdexec/property.h"
+#include "src/common/librlist/rhwloc.h"
 
 #define MODULE_NAME "sdexec"
 
@@ -58,6 +59,7 @@ struct sdexec_ctx {
     flux_msg_handler_t **handlers;
     struct flux_msglist *requests; // each exec request "owns" an sdproc
     struct flux_msglist *kills;
+    hwloc_topology_t topo;         // local topology for core->CPU expansion
 };
 
 enum stop_timer_state {
@@ -1271,11 +1273,35 @@ static struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END
 };
 
+/* Fetch hwloc XML from the local broker's resource module and load a topology
+ * from it. This avoids the cost of local topology rediscovery since the
+ * resource module has already done it. Returns NULL on failure.
+ */
+static hwloc_topology_t sdexec_load_topo (flux_t *h)
+{
+    flux_future_t *f;
+    const char *xml;
+    hwloc_topology_t topo = NULL;
+
+    if (!(f = flux_rpc (h, "resource.topo-get", NULL, FLUX_NODEID_ANY, 0))
+        || flux_rpc_get (f, &xml) < 0
+        || !(topo = rhwloc_xml_topology_load (xml, RHWLOC_NO_RESTRICT))) {
+        flux_log (h,
+                  LOG_ERR,
+                  "Failed to fetch hwloc topology: %s ",
+                  future_strerror (f, errno));
+    }
+    flux_future_destroy (f);
+    return topo;
+}
+
 static void sdexec_ctx_destroy (struct sdexec_ctx *ctx)
 {
     if (ctx) {
         int saved_errno = errno;
         flux_msg_handler_delvec (ctx->handlers);
+        if (ctx->topo)
+            hwloc_topology_destroy (ctx->topo);
         if (ctx->requests) {
             const flux_msg_t *msg;
             msg = flux_msglist_first (ctx->requests);
@@ -1308,7 +1334,8 @@ static struct sdexec_ctx *sdexec_ctx_create (flux_t *h)
         || !(ctx->local_uri = strdup (s)))
         goto error;
     if (!(ctx->requests = flux_msglist_create ())
-        || !(ctx->kills = flux_msglist_create ()))
+        || !(ctx->kills = flux_msglist_create ())
+        || !(ctx->topo = sdexec_load_topo (h)))
         goto error;
     return ctx;
 error:

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -889,7 +889,7 @@ static struct sdproc *sdproc_create (struct sdexec_ctx *ctx,
 
     /* Enable the stop timer by setting the SDEXEC_STOP_TIMER_SEC option to
      * a value in seconds.  The stop timer is disabled by default.
-     * sOptionally set SDEXEC_STOP_TIMER_SIGNAL to a numerical signal
+     * Optionally set SDEXEC_STOP_TIMER_SIGNAL to a numerical signal
      * value to use instead of SIGKILL.
      */
     if (get_dict_int (proc->cmd,

--- a/src/shell/affinity.c
+++ b/src/shell/affinity.c
@@ -21,6 +21,7 @@
 #include <flux/shell.h>
 
 #include "ccan/str/str.h"
+#include "src/common/librlist/rhwloc.h"
 
 #include "builtins.h"
 
@@ -195,56 +196,10 @@ static hwloc_cpuset_t *distribute_tasks (hwloc_topology_t topo,
 static hwloc_cpuset_t shell_affinity_get_cpuset (struct shell_affinity *sa,
                                                  const char *cores)
 {
-    int depth, i;
-    hwloc_cpuset_t coreset = NULL;
-    hwloc_cpuset_t resultset = NULL;
-
-    if (!(coreset = hwloc_bitmap_alloc ())
-        || !(resultset = hwloc_bitmap_alloc ())) {
-        shell_log_errno ("hwloc_bitmap_alloc");
-        goto err;
-    }
-
-    /*  Parse cpus as bitmap list
-     */
-    if (hwloc_bitmap_list_sscanf (coreset, cores) < 0) {
-        shell_log_error ("affinity: failed to read core list: %s", cores);
-        goto err;
-    }
-
-    /*  Find depth of type core in this topology:
-     */
-    depth = hwloc_get_type_depth (sa->topo, HWLOC_OBJ_CORE);
-    if (depth == HWLOC_TYPE_DEPTH_UNKNOWN
-        || depth == HWLOC_TYPE_DEPTH_MULTIPLE) {
-        shell_log_error ("hwloc_get_type_depth (CORE) returned nonsense");
-        goto err;
-    }
-
-    /*  Get the union of all allocated cores' cpusets into sa->cpuset
-     */
-    i = hwloc_bitmap_first (coreset);
-    while (i >= 0) {
-        hwloc_obj_t core = hwloc_get_obj_by_depth (sa->topo, depth, i);
-        if (!core) {
-            shell_log_error ("affinity: core%d not in topology", i);
-            goto err;
-        }
-        if (!core->cpuset) {
-            shell_log_error ("affinity: core%d cpuset is null", i);
-            goto err;
-        }
-        hwloc_bitmap_or (resultset, resultset, core->cpuset);
-        i = hwloc_bitmap_next (coreset, i);
-    }
-    hwloc_bitmap_free (coreset);
-    return resultset;
-err:
-    if (coreset)
-        hwloc_bitmap_free (coreset);
-    if (resultset)
-        hwloc_bitmap_free (resultset);
-    return NULL;
+    hwloc_cpuset_t cpuset = rhwloc_cores_to_cpuset (sa->topo, cores);
+    if (!cpuset)
+        shell_log_error ("affinity: failed to get cpuset for cores: %s", cores);
+    return cpuset;
 }
 
 static char *cpuset_to_string (hwloc_cpuset_t cpuset)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -216,6 +216,7 @@ TESTSCRIPTS = \
 	t2411-sdexec-job.t \
 	t2412-sdmon.t \
 	t2413-sdmon-resource.t \
+	t2414-sdexec-constrain-cores.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \
 	t2600-job-shell-rcalc.t \

--- a/t/t2414-sdexec-constrain-cores.t
+++ b/t/t2414-sdexec-constrain-cores.t
@@ -1,0 +1,187 @@
+#!/bin/sh
+# ci=system
+test_description='Test sdexec cgroups cpuset controller manipulation
+
+Test that Flux can restrict jobs to their allocated cores via the
+AllowedCPUs systemd unit property when exec.sdexec-constrain-cores is
+enabled.  The cpuset cgroup controller is used to verify the constraint.
+
+See also:
+https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
+https://docs.kernel.org/admin-guide/cgroup-v2.html#cpuset
+'
+
+. $(dirname $0)/sharness.sh
+
+if ! flux version | grep systemd; then
+	skip_all="flux was not built with systemd"
+	test_done
+fi
+if ! systemctl --user show --property Version; then
+	skip_all="user systemd is not running"
+	test_done
+fi
+if ! busctl --user status >/dev/null; then
+	skip_all="user dbus is not running"
+	test_done
+fi
+if ! systemctl show user@$(id -u) -p DelegateControllers | grep cpuset; then
+	skip_all="cgroups cpuset controller is not delegated"
+	test_done
+fi
+if ! test_flux_security_version 0.14.0; then
+	skip_all="requires flux-security >= v0.14, got ${FLUX_SECURITY_VERSION}"
+	test_done
+fi
+
+mkdir -p config
+cat >config/config.toml <<EOT
+[systemd]
+enable = true
+sdexec-debug = true
+[exec]
+service = "sdexec"
+sdexec-constrain-cores = true
+EOT
+
+cat >getcg.sh <<'EOT2'
+#!/bin/sh
+cat $(flux cgroup path)/$1
+EOT2
+chmod +x getcg.sh
+
+# Count CPUs in cpuset list notation, e.g. "0-3,8-11" -> 8
+cat >count_cpus.py <<'EOT3'
+import sys
+from flux.idset import IDset
+print(len(IDset(sys.stdin.read().strip())))
+EOT3
+
+test_under_flux 2 full --config-path=$(pwd)/config
+
+getcg=$(pwd)/getcg.sh
+
+# The cpuset controller is only written to cpuset.subtree_control by systemd
+# when a unit first requests AllowedCPUs, so cgroup.controllers won't list it
+# yet. Probe by running a job with an explicit AllowedCPUs and checking that
+# cpuset.cpus.effective is readable:
+if ! flux exec --service sdexec \
+        --setopt=SDEXEC_PROP_AllowedCPUs=0 \
+        $getcg cpuset.cpus.effective >/dev/null 2>&1; then
+	skip_all="cpuset cgroup controller not functional in sdexec units"
+	test_done
+fi
+
+ncores=$(flux resource list -i 0 -s free -n -o '{ncores}')
+test "${ncores:-0}" -gt 2 && test_set_prereq MULTICORE
+
+test_expect_success 'exec.sdexec-constrain-cores is set' '
+	flux config get exec.sdexec-constrain-cores &&
+	test "$(flux config get exec.sdexec-constrain-cores)" = "true" &&
+	flux module stats job-exec \
+	  | jq -e ".\"bulk-exec\".config.sdexec_constrain_cores == 1"
+'
+
+#
+# basic: cpuset.cpus.effective is set and non-empty for a constrained job
+#
+test_expect_success 'cpuset.cpus.effective is set for a 1-core job' '
+	flux run -n1 -c1 $getcg cpuset.cpus.effective >cpus1core.out &&
+	test_debug "echo 1-core cpuset: $(cat cpus1core.out)" &&
+	test -s cpus1core.out
+'
+
+#
+# With MULTICORE: more cores -> more CPUs in cpuset
+#
+test_expect_success MULTICORE '2-core job cpuset contains more CPUs than 1-core job' '
+	flux run -n1 -c2 $getcg cpuset.cpus.effective >cpus2core.out &&
+	test_debug "echo 2-core cpuset: $(cat cpus2core.out)" &&
+	n1=$(python3 $(pwd)/count_cpus.py <cpus1core.out) &&
+	n2=$(python3 $(pwd)/count_cpus.py <cpus2core.out) &&
+	test $n2 -gt $n1
+'
+
+#
+# With MULTICORE: multiple nodes
+#
+test_expect_success MULTICORE 'multinode, multicore job works' '
+	flux run -n2 -c2 -N2 --label-io \
+	    $getcg cpuset.cpus.effective >multinode.out &&
+	test_debug "cat multinode.out" &&
+	sed -n s/^0://p multinode.out >node0.out &&
+	sed -n s/^1://p multinode.out >node1.out &&
+	flux job info $(flux job last) R > R.multinode.json &&
+	count0=$(flux R decode --include=0 --count=core < R.multinode.json) &&
+	test_debug "echo count0=$count0" &&
+	count1=$(flux R decode --include=1 --count=core < R.multinode.json) &&
+	test_debug "echo count1=$count1" &&
+	n0=$(python3 $(pwd)/count_cpus.py <node0.out) &&
+	n1=$(python3 $(pwd)/count_cpus.py <node1.out) &&
+	test_debug "echo got $n0 cores on node0, expected $count0" &&
+	test_debug "echo got $n1 cores on node1, expected $count1" &&
+	test $count0 -eq $n0 &&
+	test $count1 -eq $n1
+'
+
+test_expect_success MULTICORE 'all-cores job cpuset covers all system CPUs' '
+	flux run -n1 -c${ncores} $getcg cpuset.cpus.effective >cpusall.out &&
+	test_debug "echo all-core cpuset: $(cat cpusall.out)" &&
+	nall=$(python3 $(pwd)/count_cpus.py <cpusall.out) &&
+	n1=$(python3 $(pwd)/count_cpus.py <cpus1core.out) &&
+	test $nall -gt $n1
+'
+
+#
+# Reload config: disable sdexec-constrain-cores, verify constraint removed
+#
+# N.B. do these tests last as they alter the job-exec module config
+#
+
+test_expect_success 'disable sdexec-constrain-cores via config reload' '
+	cat >config/config.toml <<-EOT &&
+	[systemd]
+	enable = true
+	sdexec-debug = true
+	[exec]
+	service = "sdexec"
+	EOT
+	flux config reload
+'
+
+cat >getcpus.sh <<'EOF'
+#!/bin/sh
+awk '/^Cpus_allowed_list/ {print $2}' /proc/self/status
+EOF
+chmod +x getcpus.sh
+
+# Note: without sdexec-constrain-cores, cpuset.cpus.effective may not exist
+# in the job cgroup, so use Cpus_allowed_list in the following test:
+test_expect_success MULTICORE 'without sdexec-constrain-cores, 1-core job gets full system cpuset' '
+	flux run -n1 -c1 -o cpu-affinity=off ./getcpus.sh \
+	    > cpus1unconstrained.out &&
+	test_debug \
+	    "echo unconstrained 1-core cpuset: $(cat cpus1unconstrained.out)" &&
+	./getcpus.sh >unconstrained.expected &&
+	test_cmp unconstrained.expected cpus1unconstrained.out
+'
+
+test_expect_success 're-enable sdexec-constrain-cores via config reload' '
+	cat >config/config.toml <<-EOT &&
+	[systemd]
+	enable = true
+	sdexec-debug = true
+	[exec]
+	service = "sdexec"
+	sdexec-constrain-cores = true
+	EOT
+	flux config reload
+'
+
+test_expect_success 'after re-enable, 1-core job cpuset is restricted again' '
+	flux run -n1 -c1 $getcg cpuset.cpus.effective >cpus1re.out &&
+	test_debug "echo re-enabled 1-core cpuset: $(cat cpus1re.out)" &&
+	test_cmp cpus1core.out cpus1re.out
+'
+
+test_done

--- a/t/t2414-sdexec-constrain-cores.t
+++ b/t/t2414-sdexec-constrain-cores.t
@@ -133,6 +133,27 @@ test_expect_success MULTICORE 'all-cores job cpuset covers all system CPUs' '
 '
 
 #
+# Sad path: post-start AllowedCPUs check failure drains rank
+#
+# SDEXEC_TEST_EXPECTED_CPUS injects a wrong expected CPU idset (requires
+# sdexec-debug = true, which is set in the test config).  The mismatch
+# triggers the post-start check to fail, causing job-exec to drain the rank.
+# The drained rank is undrained at the end so later tests can still run.
+#
+test_expect_success 'AllowedCPUs check failure drains rank with useful message' '
+	test_when_finished "flux resource drain -no {ranks} | xargs -r flux resource undrain" &&
+	flux submit -n1 -c1 \
+	    --setattr=exec.bulkexec.sdexec-test-expected-cpus=9998-9999 \
+	    hostname &&
+	flux job wait-event -vt 60 $(flux job last) exception &&
+	flux job wait-event -t 60 $(flux job last) clean &&
+	drained=$(flux resource drain -no {ranks}) &&
+	test_debug "flux resource drain" &&
+	test -n "$drained" &&
+	flux resource drain -i $drained -no {reason} | grep AllowedCPUs
+'
+
+#
 # Reload config: disable sdexec-constrain-cores, verify constraint removed
 #
 # N.B. do these tests last as they alter the job-exec module config


### PR DESCRIPTION
This PR adds support for constraining jobs to allocated cores when `sdexec` is enabled and a new configuration option `exec.sdexec-constrain-cores` is set to `true`.

In this case, `job-exec` sends a separate command for each rank with a `SDEXEC_CORES` option set to the cores allocated in R on that rank. Then `sdexec` translates those logical core ids to system CPUs expected by the systemd `AllowedCPUs` using hwloc. This is the same translation done in the job shell affinity plugin now (The code is now shared).

For this to work requires cgroups v2 with unified namespace and cpuset controller must be delegated to the flux user systemd instance. I'll be testing this on my cluster once I get all nodes converted to `systemd.unified_cgroup_hierarchy=1`
 
