### PR TITLE
sdexec: support DeviceAllow and DevicePolicy

### DIFF
--- a/doc/guide/libsdexec.rst
+++ b/doc/guide/libsdexec.rst
@@ -173,6 +173,9 @@ Starting Units
         - a(ss)
         - Comma-separated "specifier perms" pairs,
           e.g. "/dev/nvidiactl rw,/dev/nvidia0 rw"
+      * - DevicePolicy
+        - s (string)
+        - "auto", "closed", or "strict"
 
    See :linux:man5:`systemd.resource-control` for property semantics.
 

--- a/doc/guide/libsdexec.rst
+++ b/doc/guide/libsdexec.rst
@@ -169,8 +169,24 @@ Starting Units
       * - AllowedCPUs
         - s (string)
         - Flux idset notation, e.g. "0,2-4,7"
+      * - DeviceAllow
+        - a(ss)
+        - Comma-separated "specifier perms" pairs,
+          e.g. "/dev/nvidiactl rw,/dev/nvidia0 rw"
 
    See :linux:man5:`systemd.resource-control` for property semantics.
+
+   .. note::
+
+      ``DeviceAllow`` and ``DevicePolicy`` are accepted by
+      ``StartTransientUnit`` but are not enforced in the Flux user
+      systemd instance.  Systemd implements device containment via eBPF
+      ``BPF_CGROUP_DEVICE`` programs, which require ``CAP_BPF`` or
+      ``CAP_SYS_ADMIN`` — capabilities the unprivileged Flux user
+      instance does not hold and that cannot be delegated via cgroup
+      ownership.  Per-job device containment will be implemented through
+      the IMP until systemd makes device restriction delegatable without
+      elevated privileges.
 
    Returns a :type:`flux_future_t`.  On error, returns NULL with
    *error* set if non-NULL.

--- a/doc/guide/sdbus.rst
+++ b/doc/guide/sdbus.rst
@@ -93,6 +93,11 @@ variant arrays.
    * - array of basic type
      - aX
      - JSON array, e.g. ``[1, 2, 3]`` for ``ai``
+   * - array of string pairs
+     - a(ss)
+     - JSON array of two-element string arrays,
+       e.g. ``[["/dev/nvidiactl", "rw"], ["/dev/nvidia0", "rw"]]``
+       for ``DeviceAllow`` (device specifier, permissions)
    * - property dictionary
      - a{sv}
      - object, e.g. ``{"ActiveState": ["s", "active"]}``
@@ -125,7 +130,7 @@ extending ``message.c`` and registering the new signature in ``interface.c``.
    * - Property dictionary (a{sv})
      - yes
      - no
-   * - a(sv), a(sasb)
+   * - a(sv), a(sasb), a(ss)
      - no
      - yes
    * - Arbitrary struct (...)
@@ -196,6 +201,28 @@ RPC Interface
       Signal parameters as a JSON array.
 
 
+Exploring the D-Bus Interface
+=============================
+
+The systemd D-Bus object hierarchy can be browsed live with :linux:man1:`busctl`.
+Use ``tree`` to list object paths under the systemd service::
+
+   busctl tree org.freedesktop.systemd1
+
+To list all properties of a running unit with their D-Bus type signatures, use
+``introspect``.  Unit names are encoded as D-Bus object paths by replacing
+special characters with their hex escape (e.g. ``.`` becomes ``_2e``)::
+
+   busctl introspect org.freedesktop.systemd1 \
+       /org/freedesktop/systemd1/unit/some_2eservice \
+       org.freedesktop.systemd1.Service
+
+The same information is available statically in the D-Bus introspection XML
+files installed by the ``systemd-dev`` package under
+``/usr/share/dbus-1/interfaces/``, one file per interface.  These files are
+the authoritative source for property type signatures used in
+``StartTransientUnit`` calls.
+
 ******************
 External Resources
 ******************
@@ -203,3 +230,4 @@ External Resources
 - `D-Bus specification <https://dbus.freedesktop.org/doc/dbus-specification.html>`_
 - `The new sd-bus API of systemd <https://0pointer.net/blog/the-new-sd-bus-api-of-systemd.html>`_
 - `org.freedesktop.systemd1 D-Bus interface <https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.systemd1.html>`_
+- :linux:man5:`systemd.resource-control` — resource control properties including ``DeviceAllow``

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1157,6 +1157,7 @@ observability
 sdproc
 busctl
 DeviceAllow
+DevicePolicy
 nvidia
 nvidiactl
 rw

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1160,3 +1160,6 @@ DeviceAllow
 nvidia
 nvidiactl
 rw
+BPF
+delegatable
+eBPF

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1155,3 +1155,8 @@ libioencode
 memlimit
 observability
 sdproc
+busctl
+DeviceAllow
+nvidia
+nvidiactl
+rw

--- a/src/common/libsdexec/start.c
+++ b/src/common/libsdexec/start.c
@@ -27,6 +27,7 @@
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/parse_size.h"
+#include "src/common/libutil/strstrip.h"
 
 #include "parse.h"
 #include "start.h"
@@ -243,6 +244,57 @@ static int prop_add_bytearray (json_t *prop,
     return 0;
 }
 
+/* Parse comma-separated "specifier perms" pairs such as "/dev/nvidiactl rw"
+ * and add a property of D-Bus type a(ss), as used by DeviceAllow.
+ * See systemd.resource-control(5) for specifier and perms syntax.
+ */
+static int prop_add_str_pair_array (json_t *prop,
+                                    const char *name,
+                                    const char *val)
+{
+    json_t *pairs = NULL;
+    json_t *o = NULL;
+    char *buf = NULL;
+    char *saveptr;
+    char *entry;
+    int rc = -1;
+
+    if (!(pairs = json_array ()))
+        return -1;
+    if (!(buf = strdup (val)))
+        goto out;
+    entry = strtok_r (buf, ",", &saveptr);
+    while (entry) {
+        char *sp;
+        entry = strstrip (entry);
+        if (!(sp = strchr (entry, ' ')))
+            goto out;
+        *sp++ = '\0';
+        sp = strstrip (sp);
+        if (strlen (entry) == 0 || strlen (sp) == 0)
+            goto out;
+        json_t *pair;
+        if (!(pair = json_pack ("[ss]", entry, sp))
+            || json_array_append_new (pairs, pair) < 0) {
+            json_decref (pair);
+            goto out;
+        }
+        entry = strtok_r (NULL, ",", &saveptr);
+    }
+    if (json_array_size (pairs) == 0)
+        goto out;
+    if (!(o = json_pack ("[s[sO]]", name, "a(ss)", pairs))
+        || json_array_append_new (prop, o) < 0) {
+        json_decref (o);
+        goto out;
+    }
+    rc = 0;
+out:
+    free (buf);
+    json_decref (pairs);
+    return rc;
+}
+
 /* Set a property by name. By default, values are strings  Those that are
  * not require explicit conversion from string.
  */
@@ -287,6 +339,10 @@ static int prop_add (json_t *prop, const char *name, const char *val)
             return -1;
         }
         free (bitmap);
+    }
+    else if (streq (name, "DeviceAllow")) {
+        if (prop_add_str_pair_array (prop, name, val) < 0)
+            return -1;
     }
     else if (streq (name, "SendSIGKILL")) {
         bool value;

--- a/src/common/libsdexec/start.h
+++ b/src/common/libsdexec/start.h
@@ -48,6 +48,12 @@
  *   or a combination. Typically paired with DevicePolicy=closed or strict.
  *   See also: systemd.resource-control(5).
  *
+ * DevicePolicy
+ *   Control the default policy for device access. Value is one of "auto",
+ *   "closed", or "strict". Use "closed" or "strict" with DeviceAllow to
+ *   restrict access to only the listed devices.
+ *   See also: systemd.resource-control(5).
+ *
  * Other service unit properties are assumed to be of type string and are
  * set without conversion.  For example, Description may be set to a string
  * that is shown in list-units output.

--- a/src/common/libsdexec/start.h
+++ b/src/common/libsdexec/start.h
@@ -41,6 +41,13 @@
  *   a list of CPU indices.
  *   See also: systemd.resource-control(5).
  *
+ * DeviceAllow
+ *   Control access to device nodes. Value is a comma-separated list of
+ *   "specifier perms" pairs, e.g. "/dev/nvidiactl rw,/dev/nvidia0 rw".
+ *   Specifier is a device path or "char-X"/"block-X" glob; perms is r, w, m,
+ *   or a combination. Typically paired with DevicePolicy=closed or strict.
+ *   See also: systemd.resource-control(5).
+ *
  * Other service unit properties are assumed to be of type string and are
  * set without conversion.  For example, Description may be set to a string
  * that is shown in list-units output.

--- a/src/common/libsdexec/test/start.c
+++ b/src/common/libsdexec/test/start.c
@@ -52,6 +52,13 @@ void test_inval (void)
         || jpath_set_new (cmd_o_badprop, "opts.SDEXEC_PROP_MemoryMax", o) < 0)
         BAIL_OUT ("error preparing test command with bad property");
 
+    /* bad DeviceAllow: missing perms field */
+    json_t *cmd_o_baddevice;
+    if (!(cmd_o_baddevice = json_deep_copy (cmd_o))
+        || !(o = json_string ("/dev/nvidiactl"))
+        || jpath_set_new (cmd_o_baddevice, "opts.SDEXEC_PROP_DeviceAllow", o) < 0)
+        BAIL_OUT ("error preparing test command with bad DeviceAllow");
+
     errno = 0;
     error.text[0] = '\0';
     ok (sdexec_start_transient_unit (NULL,      // h
@@ -113,9 +120,22 @@ void test_inval (void)
     diag ("%s", error.text);
 
     errno = 0;
+    error.text[0] = '\0';
+    ok (sdexec_start_transient_unit (h,         // h
+                                     0,         // rank
+                                     "fail",    // mode
+                                     cmd_o_baddevice, // cmd
+                                     -1, -1, -1, // *_fd
+                                     &error) == NULL
+        && errno == EINVAL,
+        "sdexec_start_transient_unit with bad DeviceAllow fails with EINVAL");
+    diag ("%s", error.text);
+
+    errno = 0;
     ok (sdexec_start_transient_unit_get (NULL, NULL) < 0 && errno == EINVAL,
         "sdexec_start_transient_unit_get f=NULL fails with EINVAL");
 
+    json_decref (cmd_o_baddevice);
     json_decref (cmd_o_badprop);
     json_decref (cmd_o_noname);
     json_decref (cmd_o);
@@ -124,11 +144,74 @@ void test_inval (void)
     flux_close (h);
 }
 
+void test_deviceallow (void)
+{
+    char *av[] = { "/bin/ls", NULL };
+    int ac = 1;
+    flux_t *h;
+    flux_future_t *f;
+    flux_cmd_t *cmd;
+    json_t *cmd_o = NULL;
+    flux_error_t error;
+
+    if (!(h = flux_open ("loop://", 0)))
+        BAIL_OUT ("could not create loop flux_t handle for testing");
+    if (!(cmd = flux_cmd_create (ac, av, environ))
+        || flux_cmd_setopt (cmd, "SDEXEC_NAME", "foo.service") < 0
+        || !(cmd_o = cmd_tojson (cmd)))
+        BAIL_OUT ("could not create command object for testing");
+
+    /* single entry */
+    json_t *cmd_o_single = json_deep_copy (cmd_o);
+    if (!cmd_o_single
+        || jpath_set_new (cmd_o_single,
+                          "opts.SDEXEC_PROP_DeviceAllow",
+                          json_string ("/dev/null rw")) < 0)
+        BAIL_OUT ("error preparing single DeviceAllow command");
+    f = sdexec_start_transient_unit (h, 0, "fail", cmd_o_single,
+                                     -1, -1, -1, &error);
+    ok (f != NULL, "sdexec_start_transient_unit with single DeviceAllow works");
+    flux_future_destroy (f);
+    json_decref (cmd_o_single);
+
+    /* multiple entries */
+    json_t *cmd_o_multi = json_deep_copy (cmd_o);
+    if (!cmd_o_multi
+        || jpath_set_new (cmd_o_multi,
+                          "opts.SDEXEC_PROP_DeviceAllow",
+                          json_string ("/dev/null rw,/dev/zero r")) < 0)
+        BAIL_OUT ("error preparing multi DeviceAllow command");
+    f = sdexec_start_transient_unit (h, 0, "fail", cmd_o_multi,
+                                     -1, -1, -1, &error);
+    ok (f != NULL, "sdexec_start_transient_unit with multiple DeviceAllow works");
+    flux_future_destroy (f);
+    json_decref (cmd_o_multi);
+
+    /* whitespace padding around entries and perms */
+    json_t *cmd_o_ws = json_deep_copy (cmd_o);
+    if (!cmd_o_ws
+        || jpath_set_new (cmd_o_ws,
+                          "opts.SDEXEC_PROP_DeviceAllow",
+                          json_string (" /dev/null  rw , /dev/zero  r ")) < 0)
+        BAIL_OUT ("error preparing whitespace DeviceAllow command");
+    f = sdexec_start_transient_unit (h, 0, "fail", cmd_o_ws,
+                                     -1, -1, -1, &error);
+    ok (f != NULL,
+        "sdexec_start_transient_unit with whitespace-padded DeviceAllow works");
+    flux_future_destroy (f);
+    json_decref (cmd_o_ws);
+
+    json_decref (cmd_o);
+    flux_cmd_destroy (cmd);
+    flux_close (h);
+}
+
 int main (int ac, char *av[])
 {
     plan (NO_PLAN);
 
     test_inval ();
+    test_deviceallow ();
 
     done_testing ();
 }

--- a/src/modules/sdbus/message.c
+++ b/src/modules/sdbus/message.c
@@ -195,10 +195,14 @@ int sdmsg_put (sd_bus_message *m, const char *fmt, json_t *o)
         e = sdmsg_put_array (m, "(sasb)", o);
     else if (fmt[0] == 'a' && strlen (fmt) == 2)
         e = sdmsg_put_array (m, &fmt[1], o);
+    else if (streq (fmt, "a(ss)"))
+        e = sdmsg_put_array (m, "(ss)", o);
     else if (streq (fmt, "(sv)"))
         e = sdmsg_put_struct (m, "sv", o);
     else if (streq (fmt, "(sasb)"))
         e = sdmsg_put_struct (m, "sasb", o);
+    else if (streq (fmt, "(ss)"))
+        e = sdmsg_put_struct (m, "ss", o);
     else if (streq (fmt, "v"))
         e = sdmsg_put_variant (m, o);
     else if (strlen (fmt) == 1)
@@ -225,6 +229,8 @@ int sdmsg_write (sd_bus_message *m, const char *fmt, json_t *o)
         if (strstarts (&fmt[i], "a(sasb)"))
             efmt = strndup (&fmt[i], 7);
         else if (strstarts (&fmt[i], "a(sv)"))
+            efmt = strndup (&fmt[i], 5);
+        else if (strstarts (&fmt[i], "a(ss)"))
             efmt = strndup (&fmt[i], 5);
         else if (fmt[i] == 'a' && strlen (&fmt[i]) > 1)
             efmt = strndup (&fmt[i], 2);

--- a/src/modules/sdbus/test/message.c
+++ b/src/modules/sdbus/test/message.c
@@ -457,6 +457,64 @@ void test_property_array (sd_bus *bus)
     sd_bus_message_unref (m);
 }
 
+void test_str_pair_array (sd_bus *bus)
+{
+    json_t *o;
+    json_error_t error;
+    sd_bus_message *m;
+    const char *fmt = "a(sv)";
+    const char *key;
+    const char *path1, *perms1;
+    const char *path2, *perms2;
+
+    /* Encode a property with value type a(ss): array of (path, perms) pairs,
+     * as used by the systemd DeviceAllow property.
+     */
+    if (!(o = json_pack_ex (&error,
+                            0,
+                            "[[s[s[[ss][ss]]]]]",
+                            "DeviceAllow",
+                            "a(ss)",
+                            "/dev/nvidiactl", "rw",
+                            "/dev/nvidia0", "r")))
+        BAIL_OUT ("error creating a(ss) property object: %s", error.text);
+    diagjson (o);
+
+    if (sd_bus_message_new (bus, &m, SD_BUS_MESSAGE_METHOD_CALL) < 0)
+        BAIL_OUT ("could not create message");
+    ok (sdmsg_put (m, fmt, o) == 0,
+        "sdmsg_put of a(ss) property works");
+    if (sd_bus_message_seal (m, 42, 0) < 0
+        || sd_bus_message_rewind (m, true) < 0)
+        BAIL_OUT ("could not finalize message");
+    diagmsg (m);
+
+    ok (sd_bus_message_enter_container (m, 'a', "(sv)") > 0
+        && sd_bus_message_enter_container (m, 'r', "sv") > 0
+        && sd_bus_message_read (m, "s", &key) > 0
+        && streq (key, "DeviceAllow")
+        && sd_bus_message_enter_container (m, 'v', "a(ss)") > 0
+        && sd_bus_message_enter_container (m, 'a', "(ss)") > 0
+        && sd_bus_message_enter_container (m, 'r', "ss") > 0
+        && sd_bus_message_read (m, "ss", &path1, &perms1) > 0
+        && streq (path1, "/dev/nvidiactl")
+        && streq (perms1, "rw")
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_enter_container (m, 'r', "ss") > 0
+        && sd_bus_message_read (m, "ss", &path2, &perms2) > 0
+        && streq (path2, "/dev/nvidia0")
+        && streq (perms2, "r")
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_exit_container (m) > 0
+        && sd_bus_message_exit_container (m) > 0,
+        "successfully read back a(ss) DeviceAllow property");
+
+    json_decref (o);
+    sd_bus_message_unref (m);
+}
+
 int main (int argc, char **argv)
 {
     sd_bus *bus;
@@ -481,6 +539,7 @@ int main (int argc, char **argv)
     test_variant_as (bus);
     test_variant_unknown (bus);
     test_property_array (bus);
+    test_str_pair_array (bus);
 
     sd_bus_flush (bus);
     sd_bus_close (bus);

--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -334,6 +334,15 @@ test_expect_success 'sdexec can set unit DeviceAllow with multiple entries' '
 	sort deviceallow2.out >deviceallow2.out.sorted &&
 	test_cmp deviceallow2.exp.sorted deviceallow2.out.sorted
 '
+test_expect_success 'sdexec can set unit DevicePolicy property' '
+	echo "DevicePolicy=closed" >devicepolicy.exp &&
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-devicepolicy.service" \
+	    --setopt=SDEXEC_PROP_DevicePolicy="closed" \
+	    $systemctl --user show --property DevicePolicy \
+	        t2409-devicepolicy.service >devicepolicy.out &&
+	test_cmp devicepolicy.exp devicepolicy.out
+'
 test_expect_success 'sdexec can set unit OOMScoreAdjust' '
 	echo "OOMScoreAdjust=100" >oomscoreadjust.exp &&
 	$sdexec -r 0 \

--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -309,6 +309,31 @@ test_expect_success 'sdexec can set unit AllowedCPUs to an empty bitmask' '
 	        t2409-allowedcpus2.service >allowedcpus2.out &&
 	test_cmp allowedcpus2.exp allowedcpus2.out
 '
+test_expect_success 'sdexec can set unit DeviceAllow property' '
+	cat >deviceallow.exp <<-EOT &&
+	DeviceAllow=/dev/null rw
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-deviceallow.service" \
+	    --setopt=SDEXEC_PROP_DeviceAllow="/dev/null rw" \
+	    $systemctl --user show --property DeviceAllow \
+	        t2409-deviceallow.service >deviceallow.out &&
+	test_cmp deviceallow.exp deviceallow.out
+'
+test_expect_success 'sdexec can set unit DeviceAllow with multiple entries' '
+	cat >deviceallow2.exp <<-EOT &&
+	DeviceAllow=/dev/null rw
+	DeviceAllow=/dev/zero r
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-deviceallow2.service" \
+	    --setopt=SDEXEC_PROP_DeviceAllow="/dev/null rw,/dev/zero r" \
+	    $systemctl --user show --property DeviceAllow \
+	        t2409-deviceallow2.service >deviceallow2.out &&
+	sort deviceallow2.exp >deviceallow2.exp.sorted &&
+	sort deviceallow2.out >deviceallow2.out.sorted &&
+	test_cmp deviceallow2.exp.sorted deviceallow2.out.sorted
+'
 test_expect_success 'sdexec can set unit OOMScoreAdjust' '
 	echo "OOMScoreAdjust=100" >oomscoreadjust.exp &&
 	$sdexec -r 0 \


### PR DESCRIPTION
Problem: we need to restrict gpus in nodes that can be allocated non-exclusively.

This is a small step that just adds support for communicating DeviceAllow and DevicePolicy to systemd via sdexec.
There will need to be work similar to #7544 to tie this to an allocation and determine the correct device names/numbers.

Marking WIP as I'd like to test the actual device restriction (sharness tests do verify that the properties can be set to intended values, but not that they have the intended effect).

