### PR TITLE
libflux: fix possible use-after-free

### DIFF
--- a/src/common/libflux/msg_handler.c
+++ b/src/common/libflux/msg_handler.c
@@ -195,10 +195,10 @@ static void dispatch_usecount_decr (struct dispatch *d)
 {
     if (d && --d->usecount == 0) {
         int saved_errno = errno;
-        if (flux_flags_get (d->h) & FLUX_O_CLONE) {
+        if (d->h && flux_flags_get (d->h) & FLUX_O_CLONE)
             dispatch_requeue (d);
+        if (d->unmatched)
             zlist_destroy (&d->unmatched);
-        }
         if (d->handlers) {
             assert (zlist_size (d->handlers) == 0);
             zlist_destroy (&d->handlers);
@@ -224,6 +224,18 @@ static void dispatch_usecount_incr (struct dispatch *d)
 static void dispatch_destroy (void *arg)
 {
     struct dispatch *d = arg;
+    /* The dispatch struct is stored as a part of the flux handle's aux
+     * storage.  So when this destroy function is called, that means
+     * the flux handle is being destroyed.
+     *
+     * If the flux handle is destroyed before the msg handler, we do
+     * not want the message handler to use the flux handle anymore.
+     * Clear the flux handle and destroy handle / reactor associated
+     * data structures.
+     */
+    flux_watcher_destroy (d->w);
+    d->w = NULL;
+    d->h = NULL;
     dispatch_usecount_decr (d);
 }
 

--- a/t/python/t0032-resource-journal.py
+++ b/t/python/t0032-resource-journal.py
@@ -176,9 +176,10 @@ class TestResourceJournalConsumer(unittest.TestCase):
     def test_poll_cb_set_before_start(self):
 
         def cb(event):
+            if event is None:
+                self.fh.reactor_stop()
             if event.is_empty():
                 consumer.stop()
-                self.fh.reactor_stop()
 
         consumer = ResourceJournalConsumer(self.fh, include_sentinel=True)
         consumer.set_callback(cb)


### PR DESCRIPTION
Problem: When a msg handler is created, it internally creates a "dispatch" that can be shared between multiple msg handlers.  This dispatch is stored within a flux handle's aux storage.

If the flux handle is destroyed before the msg handler is destroyed, it could lead to a use-after-free, as the msg handler code may try to use the flux handle,

Solution: When the flux handle is destroyed, internally clear the flux handle and the destroy data structures associated with the flux handle.

Fixes #7543

-----

Notes: I noticed this while working on getting sharness to pass w/ ASAN enabled.  All of sharness passed w/ ASAN, but a ton of asan.logs were sitting around with the stack trace I noted in #7543.  My suspicion is there could be some weird garbage collection cleanup where the flux handle is destroyed before the msg handler.

There are multiple potential solutions, I went back and forth and eventually went with this relatively simple one.

For reviewers, you may think:

"why not use flux_incref() and flux_decref()?"  I tried that, but that didn't work.  Having the reference count goto zero is essential for a disconnect to work, and flux no happy if this is changed.

"why not destroy the entire dispatch object when the flux handle is destroyed?"  I tried that at one point, but some unit tests failed as they dug into the internals of the dispatch object.

It doesn't mean my fix is the best one, but it's what I went with.  Could go with alternate paths as well.

Also, after implementing this fix, one python test continually hung.  Not the test that has a change in this PR, but a different test hung and this test was the culprit.  I have no idea why, other than a suspicion that this use-after-free may have had some unintended side effects that may be hard to predict fallout from.

Other side note, I didn't add a regression test b/c I wasn't sure if i could recreate this exactly.  Longer out, I figure running asan in the testsuite and making sure no "asan.log" files exist after sharness is run is the longer out solution.