### PR TITLE
sdexec: add support for AllowedMemoryNodes

### DIFF
--- a/doc/guide/libsdexec.rst
+++ b/doc/guide/libsdexec.rst
@@ -166,8 +166,8 @@ Starting Units
       * - MemoryHigh, MemoryMax, MemoryLow, MemoryMin
         - t (uint64)
         - "infinity", "98%", or quantity with K/M/G/T suffix
-      * - AllowedCPUs
-        - s (string)
+      * - AllowedCPUs, AllowedMemoryNodes
+        - ay (byte array)
         - Flux idset notation, e.g. "0,2-4,7"
       * - DeviceAllow
         - a(ss)

--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -200,10 +200,10 @@ OOMScoreAdjust
    systemd instance.
 
 The following unit properties are reserved for use by Flux and should not be
-added to ``sdexec-properties``: AllowedCPUs, Description, Environment,
-ExecStart, KillMode, RemainAfterExit, SendSIGKILL, StandardInputFileDescriptor,
-StandardOutputFileDescriptor, StandardErrorFileDescriptor, TimeoutStopUSec,
-Type, WorkingDirectory.
+added to ``sdexec-properties``: AllowedCPUs, AllowedMemoryNodes,
+Description, Environment, ExecStart, KillMode, RemainAfterExit,
+SendSIGKILL, StandardInputFileDescriptor, StandardOutputFileDescriptor,
+StandardErrorFileDescriptor, TimeoutStopUSec, Type, WorkingDirectory.
 
 
 .. _testexec:

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1161,6 +1161,8 @@ DevicePolicy
 nvidia
 nvidiactl
 rw
+AllowedMemoryNodes
+ay
 BPF
 delegatable
 eBPF

--- a/src/common/libsdexec/start.c
+++ b/src/common/libsdexec/start.c
@@ -328,7 +328,8 @@ static int prop_add (json_t *prop, const char *name, const char *val)
         else
             return -1;
     }
-    else if (streq (name, "AllowedCPUs")) {
+    else if (streq (name, "AllowedCPUs")
+        || streq (name, "AllowedMemoryNodes")) {
         uint8_t *bitmap;
         size_t size;
 

--- a/src/common/libsdexec/start.h
+++ b/src/common/libsdexec/start.h
@@ -41,6 +41,11 @@
  *   a list of CPU indices.
  *   See also: systemd.resource-control(5).
  *
+ * AllowedMemoryNodes
+ *   Restrict execution to specific NUMA memory nodes. Value is a Flux idset
+ *   representing a list of NUMA node indices.
+ *   See also: systemd.resource-control(5).
+ *
  * DeviceAllow
  *   Control access to device nodes. Value is a comma-separated list of
  *   "specifier perms" pairs, e.g. "/dev/nvidiactl rw,/dev/nvidia0 rw".

--- a/src/common/libsdexec/test/start.c
+++ b/src/common/libsdexec/test/start.c
@@ -52,6 +52,14 @@ void test_inval (void)
         || jpath_set_new (cmd_o_badprop, "opts.SDEXEC_PROP_MemoryMax", o) < 0)
         BAIL_OUT ("error preparing test command with bad property");
 
+    /* bad AllowedMemoryNodes: invalid idset */
+    json_t *cmd_o_badnodes;
+    if (!(cmd_o_badnodes = json_deep_copy (cmd_o))
+        || !(o = json_string ("badvalue"))
+        || jpath_set_new (cmd_o_badnodes,
+                          "opts.SDEXEC_PROP_AllowedMemoryNodes", o) < 0)
+        BAIL_OUT ("error preparing test command with bad AllowedMemoryNodes");
+
     /* bad DeviceAllow: missing perms field */
     json_t *cmd_o_baddevice;
     if (!(cmd_o_baddevice = json_deep_copy (cmd_o))
@@ -132,9 +140,22 @@ void test_inval (void)
     diag ("%s", error.text);
 
     errno = 0;
+    error.text[0] = '\0';
+    ok (sdexec_start_transient_unit (h,         // h
+                                     0,         // rank
+                                     "fail",    // mode
+                                     cmd_o_badnodes, // cmd
+                                     -1, -1, -1, // *_fd
+                                     &error) == NULL
+        && errno == EINVAL,
+        "sdexec_start_transient_unit with bad AllowedMemoryNodes fails with EINVAL");
+    diag ("%s", error.text);
+
+    errno = 0;
     ok (sdexec_start_transient_unit_get (NULL, NULL) < 0 && errno == EINVAL,
         "sdexec_start_transient_unit_get f=NULL fails with EINVAL");
 
+    json_decref (cmd_o_badnodes);
     json_decref (cmd_o_baddevice);
     json_decref (cmd_o_badprop);
     json_decref (cmd_o_noname);
@@ -200,6 +221,20 @@ void test_deviceallow (void)
         "sdexec_start_transient_unit with whitespace-padded DeviceAllow works");
     flux_future_destroy (f);
     json_decref (cmd_o_ws);
+
+    /* AllowedMemoryNodes uses the same bitmap encoding as AllowedCPUs */
+    json_t *cmd_o_nodes = json_deep_copy (cmd_o);
+    if (!cmd_o_nodes
+        || jpath_set_new (cmd_o_nodes,
+                          "opts.SDEXEC_PROP_AllowedMemoryNodes",
+                          json_string ("0-1")) < 0)
+        BAIL_OUT ("error preparing AllowedMemoryNodes command");
+    f = sdexec_start_transient_unit (h, 0, "fail", cmd_o_nodes,
+                                     -1, -1, -1, &error);
+    ok (f != NULL,
+        "sdexec_start_transient_unit with AllowedMemoryNodes works");
+    flux_future_destroy (f);
+    json_decref (cmd_o_nodes);
 
     json_decref (cmd_o);
     flux_cmd_destroy (cmd);

--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -309,6 +309,28 @@ test_expect_success 'sdexec can set unit AllowedCPUs to an empty bitmask' '
 	        t2409-allowedcpus2.service >allowedcpus2.out &&
 	test_cmp allowedcpus2.exp allowedcpus2.out
 '
+test_expect_success 'sdexec can set unit AllowedMemoryNodes property' '
+	cat >allowedmemorynodes.exp <<-EOT &&
+	AllowedMemoryNodes=0
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-allowedmemorynodes.service" \
+	    --setopt=SDEXEC_PROP_AllowedMemoryNodes="0" \
+	    $systemctl --user show --property AllowedMemoryNodes \
+	        t2409-allowedmemorynodes.service >allowedmemorynodes.out &&
+	test_cmp allowedmemorynodes.exp allowedmemorynodes.out
+'
+test_expect_success 'sdexec can set unit AllowedMemoryNodes to an empty bitmask' '
+	cat >allowedmemorynodes2.exp <<-EOT &&
+	AllowedMemoryNodes=
+	EOT
+	$sdexec -r 0 \
+	    --setopt=SDEXEC_NAME="t2409-allowedmemorynodes2.service" \
+	    --setopt=SDEXEC_PROP_AllowedMemoryNodes="" \
+	    $systemctl --user show --property AllowedMemoryNodes \
+	        t2409-allowedmemorynodes2.service >allowedmemorynodes2.out &&
+	test_cmp allowedmemorynodes2.exp allowedmemorynodes2.out
+'
 test_expect_success 'sdexec can set unit DeviceAllow property' '
 	cat >deviceallow.exp <<-EOT &&
 	DeviceAllow=/dev/null rw


### PR DESCRIPTION
Problem : _AllowedMemoryNodes=_ cannot be set via `sdexec`.  It requires explicit support since its value is not a string.

Add it to libsdexec.

See also
- #7549 