### PR TITLE
improve `resource.sched-status` request scalability

### DIFF
--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -49,7 +49,10 @@ struct alloc {
     flux_watcher_t *idle;
     unsigned int alloc_limit;   // will have a value of 0 in mode=unlimited
     char *sched_sender;         // scheduler uuid for disconnect processing
+    json_t *resource_status_cache;
 };
+
+static void alloc_resource_status_invalidate (struct alloc *alloc);
 
 static void requeue_pending (struct alloc *alloc, struct job *job)
 {
@@ -198,6 +201,7 @@ static void alloc_response_cb (flux_t *h,
             goto teardown;
         }
         job->R_redacted = json_incref (R);
+        alloc_resource_status_invalidate (alloc);
         if (annotations_update_and_publish (ctx, job, annotations) < 0)
             flux_log_error (h, "annotations_update: id=%s", idf58 (id));
 
@@ -341,6 +345,12 @@ static void hello_cb (flux_t *h,
     }
     if (housekeeping_hello_respond (ctx->housekeeping, msg, partial_ok) < 0)
         goto error;
+
+    /* Housekeeping may have let go of partial allocations. Invalidate
+     * cached resource-status response just in case.
+     */
+    alloc_resource_status_invalidate (ctx->alloc);
+
     if (flux_respond_error (h, msg, ENODATA, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     return;
@@ -500,6 +510,7 @@ int alloc_send_free_request (struct alloc *alloc,
                              flux_jobid_t id,
                              bool final)
 {
+    alloc_resource_status_invalidate (alloc);
     if (alloc->scheduler_is_online) {
         if (free_request (alloc, id, R, final) < 0)
             return -1;
@@ -663,11 +674,20 @@ static void resource_status_cb (flux_t *h,
 {
     struct job_manager *ctx = arg;
     struct alloc *alloc = ctx->alloc;
-    struct rlist *rl;
+    struct rlist *rl = NULL;
     json_t *R = NULL;
     flux_error_t error;
     struct job *job;
 
+    if (alloc->resource_status_cache) {
+        if (flux_respond_pack (h,
+                               msg,
+                               "{s:O}",
+                               "allocated",
+                               alloc->resource_status_cache) < 0)
+            flux_log_error (h, "error responding to resource-status request");
+        return;
+    }
     if (!(rl = rlist_create ())) {
         errprintf (&error, "error creating rlist object");
         goto error;
@@ -701,6 +721,7 @@ static void resource_status_cb (flux_t *h,
         errprintf (&error, "error converting rlist to JSON");
         goto error;
     }
+    alloc->resource_status_cache = json_incref (R);
     if (flux_respond_pack (h, msg, "{s:O}", "allocated", R) < 0)
         flux_log_error (h, "error responding to resource-status request");
     json_decref (R);
@@ -729,6 +750,12 @@ void alloc_disconnect_rpc (flux_t *h,
     }
 }
 
+static void alloc_resource_status_invalidate (struct alloc *alloc)
+{
+    json_decref (alloc->resource_status_cache);
+    alloc->resource_status_cache = NULL;
+}
+
 void alloc_ctx_destroy (struct alloc *alloc)
 {
     if (alloc) {
@@ -740,6 +767,7 @@ void alloc_ctx_destroy (struct alloc *alloc)
         zlistx_destroy (&alloc->queue);
         zlistx_destroy (&alloc->sent);
         free (alloc->sched_sender);
+        json_decref (alloc->resource_status_cache);
         free (alloc);
         errno = saved_errno;
     }

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -694,8 +694,7 @@ static void resource_status_cb (flux_t *h,
     }
     job = zhashx_first (alloc->ctx->active_jobs);
     while (job) {
-        if ((job->has_resources && !job->free_posted)
-            && job->R_redacted && !job->alloc_bypass) {
+        if (job->R_redacted && !job->free_posted && !job->alloc_bypass) {
             struct rlist *rl2;
             json_error_t jerror;
 

--- a/src/modules/job-manager/housekeeping.c
+++ b/src/modules/job-manager/housekeeping.c
@@ -485,6 +485,15 @@ int housekeeping_start (struct housekeeping *hk,
         allocation_destroy (a);
         goto skip;
     }
+    /* Note: Though resources have transitioned from a job allocation to
+     * housekeeping, no job-manager.resource-status cache invalidation is
+     * needed here (alloc_resource_status_invalidate()): hk->allocations is
+     * updated synchronously above, and the caller sets job->free_posted=1
+     * in the same reactor loop.
+     *
+     * Therefore, the allocated resource set is unchanged until housekeeping
+     * releases its first resources via alloc_send_free_request().
+     */
     return 0;
 skip:
     return alloc_send_free_request (hk->ctx->alloc, R, id, true);

--- a/src/modules/resource/status.c
+++ b/src/modules/resource/status.c
@@ -39,6 +39,7 @@ struct status {
     struct resource_ctx *ctx;
     flux_msg_handler_t **handlers;
     struct flux_msglist *requests;
+    flux_future_t *pending_status_rpc;
     struct status_cache cache;
     json_t *R_empty;
     bool shrink_down_ranks; // lost ranks are removed from resource set
@@ -384,35 +385,23 @@ error:
     return NULL;
 }
 
-static void remove_request (struct flux_msglist *ml, const flux_msg_t *msg)
-{
-    const flux_msg_t *m;
-
-    m = flux_msglist_first (ml);
-    while (m) {
-        if (m == msg) {
-            flux_msglist_delete (ml); // delete @cursor
-            break;
-        }
-        m = flux_msglist_next (ml);
-    }
-}
-
 /* The job-manager.resource-status RPC has completed.
- * Finish handling resource.sched-status.  Notes:
+ * Build the sched-status payload once and answer all queued requests.
+ * Notes:
  * - Treat ENOSYS from job-manager.resource-status as the empty set.  This
  *   could happen IRL because the resource module loads before job-manager.
- * - Both the future and the message are unreferenced/destroyed
- *   when msg is removed from the status->requests list.
+ * - Multiple concurrent resource.sched-status requests are coalesced: only
+ *   one job-manager RPC is in flight at a time; all queued requests are
+ *   answered here when it completes.
  */
 static void sched_status_continuation (flux_future_t *f, void *arg)
 {
-    const flux_msg_t *msg = flux_future_aux_get (f, "flux::request");
     struct status *status = arg;
     flux_t *h = status->ctx->h;
     flux_error_t error;
     json_t *allocated = NULL;
     json_t *o = NULL;
+    const flux_msg_t *msg;
 
     if (flux_rpc_get_unpack (f, "{s:o}", "allocated", &allocated) < 0
         && errno != ENOSYS) {
@@ -425,22 +414,29 @@ static void sched_status_continuation (flux_future_t *f, void *arg)
         errprintf (&error, "error preparing response: %s", strerror (errno));
         goto error;
     }
-    if (flux_respond_pack (h, msg, "O", o) < 0)
-        flux_log_error (h, "error responding to resource.sched-status");
+    while ((msg = flux_msglist_first (status->requests))) {
+        if (flux_respond_pack (h, msg, "O", o) < 0)
+            flux_log_error (h, "error responding to resource.sched-status");
+        flux_msglist_delete (status->requests);
+    }
     json_decref (o);
-    remove_request (status->requests, msg);
-    return;
+    goto done;
 error:
-    if (flux_respond_error (h, msg, EINVAL, error.text) < 0)
-        flux_log_error (h, "error responding to resource.sched-status");
-    json_decref (o);
-    remove_request (status->requests, msg);
+    while ((msg = flux_msglist_first (status->requests))) {
+        if (flux_respond_error (h, msg, EINVAL, error.text) < 0)
+            flux_log_error (h, "error responding to resource.sched-status");
+        flux_msglist_delete (status->requests);
+    }
+done:
+    flux_future_destroy (f);
+    status->pending_status_rpc = NULL;
 }
 
 /* To answer this query, an RPC must be sent to the job manager to get
- * the set of allocated resources.  Get that started, then place the request
- * on status->requests and continue answering in the RPC continuation.
- * The rest of the information required is local.
+ * the set of allocated resources.  Start a job-manager RPC if one is not
+ * already in flight, then place the request on status->requests.  Concurrent
+ * requests are coalesced: all queued requests are answered together when the
+ * single in-flight RPC completes.
  */
 static void sched_status_cb (flux_t *h,
                              flux_msg_handler_t *mh,
@@ -448,7 +444,6 @@ static void sched_status_cb (flux_t *h,
                              void *arg)
 {
     struct status *status = arg;
-    flux_future_t *f;
     flux_error_t error;
 
     if (flux_request_decode (msg, NULL, NULL) < 0) {
@@ -460,21 +455,20 @@ static void sched_status_cb (flux_t *h,
         errno = EPROTO;
         goto error;
     }
-    if (!(f = flux_rpc (h, "job-manager.resource-status", NULL, 0, 0))
-        || flux_future_then (f, -1, sched_status_continuation, status) < 0
-        || flux_future_aux_set (f, "flux::request", (void *)msg, NULL) < 0
-        || flux_msg_aux_set (msg,
-                             NULL,
-                             f,
-                             (flux_free_f)flux_future_destroy) < 0) {
-        errprintf (&error,
-                   "error sending job-manager.resource-status request: %s",
-                   strerror (errno));
-        flux_future_destroy (f);
-        goto error;
+    if (!status->pending_status_rpc) {
+        flux_future_t *f;
+        if (!(f = flux_rpc (h, "job-manager.resource-status", NULL, 0, 0))
+            || flux_future_then (f, -1, sched_status_continuation, status) < 0) {
+            errprintf (&error,
+                       "error sending job-manager.resource-status request: %s",
+                       strerror (errno));
+            flux_future_destroy (f);
+            goto error;
+        }
+        status->pending_status_rpc = f;
     }
     if (flux_msglist_append (status->requests, msg) < 0) {
-        errprintf (&error, "error saving request mesg: %s", strerror (errno));
+        errprintf (&error, "error saving request: %s", strerror (errno));
         goto error;
     }
     return;
@@ -551,6 +545,7 @@ void status_destroy (struct status *status)
         int saved_errno = errno;
         flux_msg_handler_delvec (status->handlers);
         flux_msglist_destroy (status->requests);
+        flux_future_destroy (status->pending_status_rpc);
         reslog_remove_callback (status->ctx->reslog, reslog_cb, status);
         invalidate_cache (&status->cache, true);
         json_decref (status->R_empty);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -334,6 +334,7 @@ TESTSCRIPTS = \
 	python/t0039-rv1pool.py \
 	python/t0040-proctitle.py \
 	python/t0041-resource-count.py \
+	python/t0042-job-manager-alloc-cache.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0042-job-manager-alloc-cache.py
+++ b/t/python/t0042-job-manager-alloc-cache.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+"""
+Correctness tests for the job-manager.resource-status response cache.
+
+Each test exercises the cache explicitly: the cache is first populated
+with a known value, a lifecycle event is triggered that should invalidate
+it, and then repeated RPCs verify the cache now holds the new correct
+value rather than the stale one.
+"""
+
+import unittest
+
+import flux
+import flux.job
+from flux.job import JobspecV1
+from flux.resource import ResourceSet
+from subflux import rerun_under_flux
+
+
+def __flux_size():
+    return 2
+
+
+def allocated_nnodes(fh):
+    """Return the number of nodes in the job-manager allocated set."""
+    r = fh.rpc("job-manager.resource-status").get()
+    return ResourceSet(r["allocated"]).nnodes
+
+
+class TestResourceStatusCache(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fh = flux.Flux()
+
+    def submit_sleep(self, nnodes=1):
+        jobspec = JobspecV1.from_command(
+            ["sleep", "inf"], num_nodes=nnodes, num_tasks=nnodes
+        )
+        return flux.job.submit(self.fh, jobspec)
+
+    def wait_clean(self, jobid):
+        flux.job.event_wait(self.fh, jobid, "clean", raiseJobException=False)
+
+    def test_01_cache_invalidated_on_alloc(self):
+        """Cache is invalidated when a job acquires resources.
+
+        Populate the cache with an empty allocated set, then submit a job
+        and wait for the alloc event.  Repeated RPCs must reflect the new
+        non-empty set, proving the cache was invalidated rather than
+        serving the stale empty value.
+        """
+        # Populate cache with empty set.
+        self.assertEqual(allocated_nnodes(self.fh), 0)
+
+        jobid = self.submit_sleep(nnodes=1)
+        try:
+            flux.job.event_wait(self.fh, jobid, "alloc")
+            # First RPC: cache miss after invalidation — must return 1, not stale 0.
+            # Subsequent RPCs: cache hits — must remain 1.
+            for _ in range(3):
+                self.assertEqual(allocated_nnodes(self.fh), 1)
+        finally:
+            flux.job.cancel(self.fh, jobid)
+            self.wait_clean(jobid)
+
+    def test_02_cache_invalidated_on_free(self):
+        """Cache is invalidated when a job's resources are freed.
+
+        Populate the cache with a non-empty allocated set, then cancel the
+        job and wait for clean.  Repeated RPCs must return empty, proving
+        the cache was invalidated rather than serving the stale non-empty value.
+        """
+        jobid = self.submit_sleep(nnodes=1)
+        flux.job.event_wait(self.fh, jobid, "alloc")
+
+        # Populate cache with the running job's resources.
+        self.assertEqual(allocated_nnodes(self.fh), 1)
+
+        flux.job.cancel(self.fh, jobid)
+        self.wait_clean(jobid)
+
+        # First RPC: cache miss after invalidation — must return 0, not stale 1.
+        # Subsequent RPCs: cache hits — must remain 0.
+        for _ in range(3):
+            self.assertEqual(allocated_nnodes(self.fh), 0)
+
+    def test_03_cache_correct_across_two_alloc_free_cycles(self):
+        """Cache tracks allocated set correctly across sequential job cycles.
+
+        Run two jobs back-to-back.  After each alloc the cache must show
+        the job's resources; after each free the cache must show empty.
+        This exercises cache invalidation across multiple alloc/free cycles.
+        """
+        for _ in range(2):
+            # Cache should be empty at the start of each cycle.
+            self.assertEqual(allocated_nnodes(self.fh), 0)
+
+            jobid = self.submit_sleep(nnodes=1)
+            flux.job.event_wait(self.fh, jobid, "alloc")
+
+            # Populate cache; verify it holds the correct non-empty value.
+            for _ in range(2):
+                self.assertEqual(allocated_nnodes(self.fh), 1)
+
+            flux.job.cancel(self.fh, jobid)
+            self.wait_clean(jobid)
+
+    def test_04_cache_correct_with_two_concurrent_jobs(self):
+        """Cache reflects the combined allocated set of concurrent jobs.
+
+        Populate the cache with 2 nodes allocated, cancel one job and verify
+        the cache is invalidated to show 1 node, then cancel the second and
+        verify the cache drops to 0.
+        """
+        j1 = self.submit_sleep(nnodes=1)
+        j2 = self.submit_sleep(nnodes=1)
+        flux.job.event_wait(self.fh, j1, "alloc")
+        flux.job.event_wait(self.fh, j2, "alloc")
+
+        # Populate cache with both jobs allocated.
+        for _ in range(2):
+            self.assertEqual(allocated_nnodes(self.fh), 2)
+
+        # Cancel one job; cache must be invalidated to show 1, not stale 2.
+        flux.job.cancel(self.fh, j1)
+        self.wait_clean(j1)
+        for _ in range(2):
+            self.assertEqual(allocated_nnodes(self.fh), 1)
+
+        # Cancel the other; cache must drop to 0, not stale 1.
+        flux.job.cancel(self.fh, j2)
+        self.wait_clean(j2)
+        for _ in range(2):
+            self.assertEqual(allocated_nnodes(self.fh), 0)
+
+
+if __name__ == "__main__":
+    if rerun_under_flux(__flux_size()):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner(), buffer=False)

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -42,7 +42,16 @@ test_expect_success 'flux resource list works on follower ranks' '
 test_expect_success 'results are the same as before' '
 	test_cmp default.out follower.out
 '
-
+test_expect_success 'resource.sched-status: concurrent requests all succeed' '
+	cat <<-"EOF" >concurrent.py &&
+	import flux
+	fh = flux.Flux()
+	futures = [fh.rpc("resource.sched-status") for _ in range(5)]
+	results = [f.get() for f in futures]
+	assert all(r == results[0] for r in results), "concurrent results differ"
+	EOF
+	flux python concurrent.py
+'
 test_expect_success 'flux resource list: FLUX_RESOURCE_LIST_FORMAT_DEFAULT works' '
 	FLUX_RESOURCE_LIST_FORMAT_DEFAULT="{nodelist} {nodelist}" \
 		flux resource list > default_override.out &&

--- a/t/t2354-resource-status.t
+++ b/t/t2354-resource-status.t
@@ -76,6 +76,35 @@ test_expect_success 'flux-resource status works after partial release' '
 test_expect_success 'stop housekeeping tasks' '
 	flux housekeeping kill --all
 '
+get_jm_allocated_nnodes() {
+	flux python -c "
+import flux
+from flux.resource import ResourceSet
+r = flux.Flux().rpc('job-manager.resource-status').get()
+print(ResourceSet(r['allocated']).nnodes)
+"
+}
+test_expect_success 'job-manager resource-status cache: configure housekeeping' '
+	flux config load <<-EOF
+	[job-manager.housekeeping]
+	release-after = "0"
+	command = [ "sleep", "inf" ]
+	EOF
+'
+test_expect_success 'job-manager resource-status cache: populate with empty set' '
+	test $(get_jm_allocated_nnodes) -eq 0
+'
+test_expect_success 'job-manager resource-status cache: correct while job is in housekeeping' '
+	flux run -N1 hostname &&
+	test_debug "flux housekeeping list" &&
+	test $(get_jm_allocated_nnodes) -eq 1 &&
+	test $(get_jm_allocated_nnodes) -eq 1
+'
+test_expect_success 'job-manager resource-status cache: invalidated when housekeeping ends' '
+	flux housekeeping kill --all &&
+	test $(get_jm_allocated_nnodes) -eq 0 &&
+	test $(get_jm_allocated_nnodes) -eq 0
+'
 # issue#7465:
 get_resource_status() {
         flux python -c "import flux; import json; print(json.dumps(flux.Flux().rpc(\"resource.status\").get()))"


### PR DESCRIPTION
This PR fixes a scalability issue in the `resource.sched-status` RPC with many simultaneous requests in a large fragmented instance. In this case, the computational load of preparing responses in the resource and job manager modules for each individual request causes latency to increase rapidly as a function of the number of requests.

This PR includes a stress test (`src/test/flux-rl-stress.py`) to exercise worst case conditions and measure latency of the `resource.sched-status` RPC. Copying results from #7533 for 12000 nodes and 100 simultaneous callers, we see the RPC taking up to 15s, which is not great:

```
=== Injecting fake resources ===
  Encoding fake R: 12000 nodes, 96 cores/node, 4 GPUs/node
  Fake resources injected.

=== Fragmentation setup ===
  Total nodes : 12000
  Drained     : 3600 (30.0%)
  Allocated   : 7200 (60.0%)
  Free        : 1200 (10.0%)
  Pattern     : interleaved

========================================================================
 Round      N      Min   Median     Mean      p95      p99      Max
------------------------------------------------------------------------
     1    100    0.509    7.845    7.846   14.668   15.256   15.256
     2    100    0.211    7.643    7.655   14.532   15.117   15.117
     3    100    0.209    7.631    7.634   14.478   15.060   15.060
     4    100    0.211    7.633    7.629   14.464   15.069   15.069
     5    100    0.208    7.577    7.586   14.379   14.973   14.973
------------------------------------------------------------------------
 TOTAL    500    0.208    7.678    7.670   14.464   15.060   15.256
========================================================================
```

This PR solves this case with two approaches:
1. cache the job-manager.resource-status response in the job-manager and invalidate it when allocated resources change
2. coalesce resource.sched-status requests while a job-manager.resource-status RPC is pending. When the response arrives create the sched-status response payload and send the same payload to all waiting requests.

Results of the same test on this branch:
```
========================================================================
 Round      N      Min   Median     Mean      p95      p99      Max
------------------------------------------------------------------------
     1    100    0.189    0.377    0.371    0.533    0.551    0.551
     2    100    0.060    0.096    0.096    0.123    0.125    0.125
     3    100    0.059    0.100    0.099    0.125    0.127    0.127
     4    100    0.061    0.097    0.097    0.125    0.133    0.133
     5    100    0.060    0.099    0.097    0.124    0.131    0.131
------------------------------------------------------------------------
 TOTAL    500    0.059    0.106    0.152    0.413    0.533    0.551
========================================================================
```

Note: it is questionable if the stress test should be added to the repo via this PR. Happy to drop that commit, but I'm leaving it in for now in case someone wants to try reproducing results.