### PR TITLE
ci: separate ASAN options by colon not comma

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -18,7 +18,7 @@ jobs:
       timeout-minutes: 40
       env:
         PRELOAD: /usr/lib64/libasan.so.8
-        ASAN_OPTIONS: detect_leaks=0,start_deactivated=true,replace_str=true,verify_asan_link_order=false
+        ASAN_OPTIONS: detect_leaks=0:start_deactivated=true:replace_str=true:verify_asan_link_order=false
         FLUX_TEST_TIMEOUT: 300
         TAP_DRIVER_QUIET: t
       run: >


### PR DESCRIPTION
Problem: Multiple ASAN options are separated by comma in the asan ci workflow.  They should be separated by colon.

Update ASAN_OPTIONS in .github/workflows/asan.yml to use colons.

----

I just noticed this ... official asan documentation always uses colons, and I can't find documentation that commas work.  And several LLMs say use colon.  So I think colons are the way to go.

Edit: should update in flux-sched too if we agree this is correct fix.  flux-security uses colons and appears fine.