### PR TITLE
build: bump jansson requirement to v2.11

### DIFF
--- a/config/x_ac_jansson.m4
+++ b/config/x_ac_jansson.m4
@@ -11,7 +11,7 @@
 #
 AC_DEFUN([X_AC_JANSSON], [
 
-    PKG_CHECK_MODULES([JANSSON], [jansson >= 2.9], [], [])
+    PKG_CHECK_MODULES([JANSSON], [jansson >= 2.11], [], [])
 
     ac_save_LIBS="$LIBS"
     LIBS="$LIBS $JANSSON_LIBS"


### PR DESCRIPTION
Problem: `‎src/common/librlist/rlist.c` uses features from `jansson` that were added in v2.11, but only v2.9 is currently required in `x_ac_jansson.m4`

Bump required version to 2.11

Specifically,  one of the `json_pack` format strings uses the `o*` specifier, [which was added in version 2.11](https://jansson.readthedocs.io/en/latest/apiref.html#c.json_int_t:~:text=o*%2C%20O*%20(any%20value)%20%5Bjson_t%20*%5D)

The new specifier was added by me in https://github.com/flux-framework/flux-core/pull/6632, and I'm not sure if this causes any issues with https://github.com/flux-framework/flux-core/pull/5546? But I also note that `flux-sched` has already been using these specifiers since Sep. '24, see https://github.com/flux-framework/flux-sched/pull/1455