### PR TITLE
fix double-free on jansson *_new() failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,24 @@ jobs:
     - name: Check Spelling
       uses: crate-ci/typos@v1.44.0
 
+  coccinelle:
+    name: coccinelle
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - name: install coccinelle
+      run: sudo apt update; sudo apt install -y coccinelle
+    - name: run coccinelle checks
+      run: |
+        rc=0
+        for f in t/cocci/*.cocci; do
+          echo "checking $f ..."
+          spatch --sp-file $f --dir src/ --very-quiet >spatch.out 2>&1
+          cat spatch.out
+          test ! -s spatch.out || rc=1
+        done
+        exit $rc
+
   python-lint:
     name: python linting
     runs-on: ubuntu-latest

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -560,7 +560,7 @@ static void lsattr_request_cb (flux_t *h,
         if (!(js = json_string (name)))
             goto nomem;
         if (json_array_append_new (names, js) < 0) {
-            json_decref (js);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         name = attr_next (attrs);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1219,7 +1219,7 @@ static void broker_getenv_cb (flux_t *h,
             json_t *o;
             if (!(o = json_string (val))
                 || json_object_set_new (env, name, o) < 0) {
-                json_decref (o);
+                // jansson decrefs the new object on failure
                 errno = ENOMEM;
                 goto error;
             }

--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -1072,7 +1072,7 @@ static json_t *modhash_get_modlist (modhash_t *mh,
 
         if (!(entry = modhash_entry_tojson (p, now, sw))
             || json_array_append_new (mods, entry) < 0) {
-            json_decref (entry);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         p = zhash_next (mh->zh_byuuid);

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -97,7 +97,7 @@ static int attr_cache_to_json (flux_t *h, json_t **cachep)
     while (name) {
         json_t *val = json_string (flux_attr_get (h, name));
         if (!val || json_object_set_new (cache, name, val) < 0) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             goto error;
         }
         name = flux_attr_cache_next (h);

--- a/src/broker/service.c
+++ b/src/broker/service.c
@@ -103,7 +103,7 @@ json_t *service_list_byuuid (struct service_switch *sw, const char *uuid)
             if (!name)
                 goto error;
             if (json_array_append_new (svcs, name) < 0) {
-                json_decref (name);
+                // jansson decrefs the new object on failure
                 goto error;
             }
         }

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -306,7 +306,7 @@ static json_t *args_create (int argc, char **argv)
     for (int i = 0; i < argc; i++) {
         json_t *s = json_string (argv[i]);
         if (!s || json_array_append_new (args, s) < 0) {
-            json_decref (s);
+            // jansson decrefs the new object on failure
             goto error;
         }
     }
@@ -320,7 +320,7 @@ static int set_string (json_t *o, const char *key, const char *val)
 {
     json_t *s = json_string (val);
     if (!s || json_object_set_new (o, key, s) < 0) {
-        json_decref (s);
+        // jansson decrefs the new object on failure
         return -1;
     }
     return 0;
@@ -966,7 +966,7 @@ static int parse_name_list (json_t **result, int ac, char **av)
         json_t *o;
         if (!(o = json_string (av[i]))
             || json_array_append_new (a, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         size_t len = strlen (av[i]);

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -854,7 +854,7 @@ void status_cb (flux_t *h,
                                  "pid", flux_subprocess_pid (cli->p))))
             goto nomem;
         if (json_array_append_new (procs, entry) < 0) {
-            json_decref (entry);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         cli = zlist_next (ctx.clients);

--- a/src/cmd/flux-terminus.c
+++ b/src/cmd/flux-terminus.c
@@ -396,7 +396,7 @@ static json_t *build_cmd (optparse_t *p, int argc, char **argv)
         if (o == NULL)
             goto err;
         if (json_array_append_new (cmd, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto err;
         }
     }

--- a/src/common/libeventlog/eventlog.c
+++ b/src/common/libeventlog/eventlog.c
@@ -60,7 +60,7 @@ static int eventlog_entry_append (json_t *a, const char *event)
         return -1;
 
     if (json_array_append_new (a, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }

--- a/src/common/libfilemap/fileref.c
+++ b/src/common/libfilemap/fileref.c
@@ -51,7 +51,7 @@ static int blobvec_append (json_t *blobvec,
         return -1;
     if (!(o = json_pack ("[I,I,s]", offsetj, blobsizej, blobref))
         || json_array_append_new (blobvec, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }

--- a/src/common/libfluxutil/conf_bootstrap.c
+++ b/src/common/libfluxutil/conf_bootstrap.c
@@ -191,7 +191,7 @@ static int set_string (json_t *o, const char *key, const char *s)
 
     if (!(val = json_string (s))
         || json_object_set_new (o, key, val) < 0) {
-        json_decref (val);
+        // jansson decrefs the new object on failure
         return -1;
     }
     return 0;
@@ -269,7 +269,7 @@ static json_t *rehost_entry (json_t *entry, const char *host)
     if (!(cpy = json_deep_copy (entry))
         || !(o = json_string (host))
         || json_object_set_new (cpy, "host", o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         json_decref (cpy);
         return NULL;
     }
@@ -306,7 +306,7 @@ static int dedup_hosts_entry (struct bootstrap_info *binfo,
         else {
             if (!(obj = rehost_entry (entry, host))
                 || json_object_set_new (hobj, host, obj) < 0) {
-                json_decref (obj);
+                // jansson decrefs the new object on failure
                 goto nomem;
             }
             if (json_array_append (binfo->xhosts, obj) < 0)
@@ -344,7 +344,7 @@ static int parse_hosts (json_t *hosts,
     if (!hosts || json_array_size (hosts) == 0) {
         if (!(entry = json_pack ("{s:s}", "host", hostname))
             || json_array_append_new (binfo->xhosts, entry) < 0) {
-            json_decref (entry);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         return 1;

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -41,7 +41,7 @@ flux_future_t *flux_job_raise (flux_t *h,
     if (note) {
         json_t *o_note = json_string (note);
         if (!o_note || json_object_set_new (o, "note", o_note) < 0) {
-            json_decref (o_note);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }

--- a/src/common/libjob/jobspec1.c
+++ b/src/common/libjob/jobspec1.c
@@ -38,7 +38,7 @@ static json_t *argv_to_json (int argc, char **argv)
         goto nomem;
     for (i = 0; i < argc; i++) {
         if (!(o = json_string (argv[i])) || json_array_append_new (a, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -80,21 +80,16 @@ static int append_op_to_txn (flux_kvs_txn_t *txn,
                              const char *key,
                              json_t *dirent)
 {
-    json_t *op = NULL;
-    int saved_errno;
+    json_t *op;
 
     if (txn_encode_op (key, flags, dirent, &op) < 0)
-        goto error;
+        return -1;
     if (json_array_append_new (txn->ops, op) < 0) {
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
-        goto error;
+        return -1;
     }
     return 0;
-error:
-    saved_errno = errno;
-    json_decref (op);
-    errno = saved_errno;
-    return -1;
 }
 
 int flux_kvs_txn_put_raw (flux_kvs_txn_t *txn,

--- a/src/common/libkvs/kvs_txn_compact.c
+++ b/src/common/libkvs/kvs_txn_compact.c
@@ -181,6 +181,7 @@ static int append_compact (struct compact_key *ck, json_t *ops_new)
         goto error;
 
     if (json_array_set_new (ops_new, ck->index, op) < 0) {
+        op = NULL; // jansson decrefs the new object on failure
         errno = ENOMEM;
         goto error;
     }
@@ -264,7 +265,7 @@ int txn_compact (flux_kvs_txn_t *txn)
                     goto error;
                 }
                 if (json_array_append_new (ops_new, cpy) < 0) {
-                    json_decref (cpy);
+                    // jansson decrefs the new object on failure
                     errno = ENOMEM;
                     goto error;
                 }

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -401,7 +401,7 @@ json_t *treeobj_copy (json_t *obj)
         }
         if (json_object_set_new (cpy, "data", datacpy) < 0) {
             save_errno = errno;
-            json_decref (datacpy);
+            // jansson decrefs the new object on failure
             json_decref (cpy);
             errno = save_errno;
             return NULL;
@@ -437,7 +437,7 @@ int treeobj_append_blobref (json_t *obj, const char *blobref)
         goto done;
     }
     if (json_array_append_new (data, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         goto done;
     }

--- a/src/common/libpmi/bizcard.c
+++ b/src/common/libpmi/bizcard.c
@@ -94,7 +94,7 @@ struct bizcard *bizcard_create (const char *hostname, const char *pubkey)
     if (pubkey) {
         json_t *o = json_string (pubkey);
         if (!o || json_object_set_new (bc->obj, "pubkey", o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }
@@ -165,7 +165,7 @@ int bizcard_uri_append (struct bizcard *bc, const char *uri)
         return -1;
     }
     if (!(o = json_string (uri)) || json_array_append_new (a, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }

--- a/src/common/libpmi/upmi.c
+++ b/src/common/libpmi/upmi.c
@@ -410,7 +410,7 @@ static int upmi_preinit (struct upmi *upmi,
         json_t *o;
         if (!(o = json_string (path))
             || json_object_set_new (payload, "path", o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }

--- a/src/common/libpmi/upmi_config.c
+++ b/src/common/libpmi/upmi_config.c
@@ -97,7 +97,7 @@ static int set_string (json_t *o, const char *key, const char *s)
 
     if (!(val = json_string (s))
         || json_object_set_new (o, key, val) < 0) {
-        json_decref (val);
+        // jansson decrefs the new object on failure
         return -1;
     }
     return 0;

--- a/src/common/libpmi/upmi_single.c
+++ b/src/common/libpmi/upmi_single.c
@@ -63,7 +63,7 @@ static int op_put (flux_plugin_t *p,
         return upmi_seterror (p, args, "error unpacking put arguments");
     if (!(o = json_string (value))
         || json_object_set_new (ctx->kvs, key, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         return upmi_seterror (p, args, "dictionary update error");
     }
     return 0;

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -1771,6 +1771,7 @@ json_t *rlist_to_R (const struct rlist *rl)
 fail:
     json_decref (R);
     json_decref (nodelist);
+    json_decref (properties);
     return NULL;
 }
 

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -1754,6 +1754,7 @@ json_t *rlist_to_R (const struct rlist *rl)
             nodelist = NULL; // jansson decrefs the new object on failure
             goto fail;
         }
+        nodelist = NULL; // now owned by R
     }
     if (properties) {
         if (json_object_set_new (json_object_get (R, "execution"),
@@ -1762,6 +1763,7 @@ json_t *rlist_to_R (const struct rlist *rl)
             properties = NULL; // jansson decrefs the new object on failure
             goto fail;
         }
+        properties = NULL; // now owned by R
     }
     if (rl->scheduling
         && json_object_set (R, "scheduling", rl->scheduling) < 0)

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -1372,7 +1372,7 @@ static json_t * rlist_compressed (const struct rlist *rl)
         if (rnode_avail_total (mrn->rnode) > 0) {
             json_t *entry = multi_rnode_tojson (mrn);
             if (!entry || json_array_append_new (o, entry) != 0) {
-                json_decref (entry);
+                // jansson decrefs the new object on failure
                 goto fail;
             }
         }
@@ -1679,7 +1679,7 @@ static int rlist_json_properties (const struct rlist *rl, json_t **result)
             || !(val = json_string (s))
             || json_object_set_new (o, name, val) < 0) {
             free (s);
-            json_decref (val);
+            // jansson decrefs the new object on failure
             errno = ENOMEM;
             goto out;
         }
@@ -1747,14 +1747,22 @@ json_t *rlist_to_R (const struct rlist *rl)
                            "starttime", rl->starttime,
                            "expiration", rl->expiration)))
         goto fail;
-    if (nodelist
-        && json_object_set_new (json_object_get (R, "execution"),
-                                "nodelist", nodelist) < 0)
-        goto fail;
-    if (properties
-        && json_object_set_new (json_object_get (R, "execution"),
-                                "properties", properties) < 0)
-        goto fail;
+    if (nodelist) {
+        if (json_object_set_new (json_object_get (R, "execution"),
+                                 "nodelist",
+                                 nodelist) < 0) {
+            nodelist = NULL; // jansson decrefs the new object on failure
+            goto fail;
+        }
+    }
+    if (properties) {
+        if (json_object_set_new (json_object_get (R, "execution"),
+                                 "properties",
+                                 properties) < 0) {
+            properties = NULL; // jansson decrefs the new object on failure
+            goto fail;
+        }
+    }
     if (rl->scheduling
         && json_object_set (R, "scheduling", rl->scheduling) < 0)
         goto fail;

--- a/src/common/librouter/usock.c
+++ b/src/common/librouter/usock.c
@@ -854,7 +854,7 @@ json_t *usock_server_stats_get (struct usock_server *server)
         json_t *client;
         if (!(client = usock_client_stats_get (conn))
             || json_array_append_new (clients, client) < 0) {
-            json_decref (client);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         conn = zlist_next (server->connections);

--- a/src/common/libsdexec/property.c
+++ b/src/common/libsdexec/property.c
@@ -104,7 +104,7 @@ flux_future_t *sdexec_property_changed (flux_t *h,
     if (path) {
         json_t *val = json_string (path);
         if (!val || json_object_set_new (o, "path", val) < 0) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }

--- a/src/common/libsdexec/start.c
+++ b/src/common/libsdexec/start.c
@@ -51,7 +51,7 @@ static int prop_add_execstart (json_t *prop, const char *name, json_t *cmdline)
     if (json_unpack (cmdline, "[s]", &arg0) < 0
         || !(o = json_pack ("[s[s[[sOb]]]]", name, "a(sasb)", arg0, cmdline, 0))
         || json_array_append_new (prop, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         return -1;
     }
     return 0;
@@ -95,7 +95,7 @@ static int prop_add_env (json_t *prop, const char *name, json_t *dict)
             if (asprintf (&kv, "%s=%s", k, v) < 0
                 || !(kvo = json_string (kv))
                 || json_array_append_new (a, kvo) < 0) {
-                json_decref (kvo);
+                // jansson decrefs the new object on failure
                 free (kv);
                 goto out;
             }
@@ -104,7 +104,7 @@ static int prop_add_env (json_t *prop, const char *name, json_t *dict)
     }
     if (!(env = json_pack ("[s[sO]]", name, "as", a))
         || json_array_append_new (prop, env) < 0) {
-        json_decref (env);
+        // jansson decrefs the new object on failure
         goto out;
     }
     rc = 0;
@@ -120,7 +120,7 @@ static int prop_add_string (json_t *prop, const char *name, const char *val)
     if (val) {
         if (!(o = json_pack ("[s[ss]]", name, "s", val))
             || json_array_append_new (prop, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             return -1;
         }
     }
@@ -137,7 +137,7 @@ static int prop_add_fd (json_t *prop, const char *name, int val)
     if (val >= 0) {
         if (!(o = json_pack ("[s[si]]", name, "h", val))
             || json_array_append_new (prop, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             return -1;
         }
     }
@@ -150,7 +150,7 @@ static int prop_add_bool (json_t *prop, const char *name, int val)
 
     if (!(o = json_pack ("[s[sb]]", name, "b", val))
         || json_array_append_new (prop, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         return -1;
     }
     return 0;
@@ -183,7 +183,7 @@ static int prop_add_i32 (json_t *prop, const char *name, int32_t val)
 
     if (!(o = json_pack ("[s[sI]]", name, "i", i))
         || json_array_append_new (prop, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         return -1;
     }
     return 0;
@@ -196,7 +196,7 @@ static int prop_add_u32 (json_t *prop, const char *name, uint32_t val)
 
     if (!(o = json_pack ("[s[sI]]", name, "u", i))
         || json_array_append_new (prop, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         return -1;
     }
     return 0;
@@ -209,7 +209,7 @@ static int prop_add_u64 (json_t *prop, const char *name, uint64_t val)
 
     if (!(o = json_pack ("[s[sI]]", name, "t", i))
         || json_array_append_new (prop, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         return -1;
     }
     return 0;
@@ -229,14 +229,14 @@ static int prop_add_bytearray (json_t *prop,
         json_t *vo;
         if (!(vo = json_integer (bytearray[i]))
             || json_array_append_new (a, vo) < 0) {
-            json_decref (vo);
+            // jansson decrefs the new object on failure
             json_decref (a);
             return -1;
         }
     }
     if (!(o = json_pack ("[s[sO]]", name, "ay", a))
         || json_array_append_new (prop, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         json_decref (a);
         return -1;
     }
@@ -276,7 +276,7 @@ static int prop_add_str_pair_array (json_t *prop,
         json_t *pair;
         if (!(pair = json_pack ("[ss]", entry, sp))
             || json_array_append_new (pairs, pair) < 0) {
-            json_decref (pair);
+            // jansson decrefs the new object on failure
             goto out;
         }
         entry = strtok_r (NULL, ",", &saveptr);
@@ -285,7 +285,7 @@ static int prop_add_str_pair_array (json_t *prop,
         goto out;
     if (!(o = json_pack ("[s[sO]]", name, "a(ss)", pairs))
         || json_array_append_new (prop, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         goto out;
     }
     rc = 0;

--- a/src/common/libsubprocess/client.c
+++ b/src/common/libsubprocess/client.c
@@ -145,7 +145,7 @@ static flux_future_t *rpc_send_signed (flux_t *h,
 
     if (!(o = json_string (topic))
         || json_object_set_new (payload, "topic", o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         goto out;
     }
@@ -171,7 +171,7 @@ static flux_future_t *rpc_send_signed (flux_t *h,
         (void) json_object_del (payload, "topic");
         if (!(osig = json_string (signature))
             || json_object_set_new (payload, "signature", osig) < 0) {
-            json_decref (osig);
+            // jansson decrefs the new object on failure
             errno = ENOMEM;
             goto out;
         }

--- a/src/common/libsubprocess/command.c
+++ b/src/common/libsubprocess/command.c
@@ -216,7 +216,7 @@ static json_t * argz_tojson (const char *argz, size_t argz_len)
     while ((arg = argz_next (argz, argz_len, arg))) {
         json_t *val = json_string (arg);
         if (!val || json_array_append_new (o, val)) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             goto err;
         }
     }
@@ -271,7 +271,7 @@ static json_t * envz_tojson (const char *envz, size_t envz_len)
         if (!(value = env_entry_value (entry)))
             continue;
         if (!(v = json_string (value)) || json_object_set_new (o, name, v)) {
-            json_decref (v);
+            // jansson decrefs the new object on failure
             goto err;
         }
     }
@@ -321,7 +321,7 @@ static json_t * zhash_tojson (zhash_t *h)
     while (val) {
         json_t *v = json_string (val);
         if (!v || json_object_set_new (o, zhash_cursor (h), v)) {
-            json_decref (v);
+            // jansson decrefs the new object on failure
             goto err;
         }
         val = zhash_next (h);
@@ -406,7 +406,7 @@ static json_t *channels_tojson (zlist_t *l)
     while (s) {
         json_t *val = json_string (s);
         if (!val || json_array_append_new (o, val)) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             goto err;
         }
         s = zlist_next (l);
@@ -481,7 +481,7 @@ static json_t *msgchans_tojson (zlist_t *l)
     while (cm) {
         json_t *val = json_pack ("{s:s s:s}", "name", cm->name, "uri", cm->uri);
         if (!val || json_array_append_new (o, val) < 0) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             goto err;
         }
         cm = zlist_next (l);
@@ -938,7 +938,7 @@ json_t *cmd_tojson (const flux_cmd_t *cmd)
         if (!(a = json_string (cmd->cwd)))
             goto err;
         if (json_object_set_new (o, "cwd", a) != 0) {
-            json_decref (a);
+            // jansson decrefs the new object on failure
             goto err;
         }
     }
@@ -948,7 +948,7 @@ json_t *cmd_tojson (const flux_cmd_t *cmd)
         if (!(a = json_string (cmd->label)))
             goto err;
         if (json_object_set_new (o, "label", a) != 0) {
-            json_decref (a);
+            // jansson decrefs the new object on failure
             goto err;
         }
     }
@@ -958,7 +958,7 @@ json_t *cmd_tojson (const flux_cmd_t *cmd)
         if (!(a = argz_tojson (cmd->argz, cmd->argz_len)))
             goto err;
         if (json_object_set_new (o, "cmdline", a) != 0) {
-            json_decref (a);
+            // jansson decrefs the new object on failure
             goto err;
         }
     }
@@ -968,7 +968,7 @@ json_t *cmd_tojson (const flux_cmd_t *cmd)
         if (!(a = envz_tojson (cmd->envz, cmd->envz_len)))
             goto err;
         if (json_object_set_new (o, "env", a) != 0) {
-            json_decref (a);
+            // jansson decrefs the new object on failure
             goto err;
         }
     }
@@ -977,7 +977,7 @@ json_t *cmd_tojson (const flux_cmd_t *cmd)
     if (!(a = zhash_tojson (cmd->opts)))
         goto err;
     if (json_object_set_new (o, "opts", a) != 0) {
-        json_decref (a);
+        // jansson decrefs the new object on failure
         goto err;
     }
 
@@ -985,7 +985,7 @@ json_t *cmd_tojson (const flux_cmd_t *cmd)
     if (!(a = channels_tojson (cmd->channels)))
         goto err;
     if (json_object_set_new (o, "channels", a) != 0) {
-        json_decref (a);
+        // jansson decrefs the new object on failure
         goto err;
     }
 
@@ -993,7 +993,7 @@ json_t *cmd_tojson (const flux_cmd_t *cmd)
     if (!(a = msgchans_tojson (cmd->msgchans)))
         goto err;
     if (json_object_set_new (o, "msgchan", a) != 0) {
-        json_decref (a);
+        // jansson decrefs the new object on failure
         goto err;
     }
     return o;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -1018,7 +1018,7 @@ static void server_list_cb (flux_t *h,
         json_t *o = NULL;
         if (!(o = process_info (p))
             || json_array_append_new (procs, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         p = zlistx_next (s->subprocesses);

--- a/src/common/libtaskmap/taskmap.c
+++ b/src/common/libtaskmap/taskmap.c
@@ -780,7 +780,7 @@ json_t *taskmap_encode_json (const struct taskmap *map, int flags)
         if (!o)
             goto error;
         if (json_array_append_new (blocks, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto error;
         }
         block = zlistx_next (map->blocklist);

--- a/src/common/libterminus/terminus.c
+++ b/src/common/libterminus/terminus.c
@@ -620,7 +620,7 @@ static int list_append_session (json_t *l, struct terminus_session *s)
         return -1;
     }
     if (json_array_append_new (l, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }

--- a/src/common/libutil/grudgeset.c
+++ b/src/common/libutil/grudgeset.c
@@ -94,7 +94,7 @@ int grudgeset_add (struct grudgeset **gsetp, const char *val)
     }
     if (!(o = json_string (val))
         || json_array_append_new ((*gsetp)->set, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }

--- a/src/common/libutil/jpath.c
+++ b/src/common/libutil/jpath.c
@@ -33,7 +33,7 @@ static int update_object_recursive (json_t *orig, json_t *val)
                 json_t *o = json_object ();
                 if (!o || json_object_set_new (orig, key, o) < 0) {
                     errno = ENOMEM;
-                    json_decref (o);
+                    // jansson decrefs the new object on failure
                     return -1;
                 }
                 orig_value = o;
@@ -67,7 +67,7 @@ static int jpath_set_destructive (json_t *o,
             if (!(dir = json_object ()))
                 goto nomem;
             if (json_object_set_new (o, path, dir) < 0) {
-                json_decref (dir);
+                // jansson decrefs the new object on failure
                 goto nomem;
             }
         }

--- a/src/common/libutil/tomltk.c
+++ b/src/common/libutil/tomltk.c
@@ -209,7 +209,7 @@ static int array_to_json (toml_array_t *arr, json_t **op)
         else
             break;
         if (json_array_append_new (obj, val) < 0) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }
@@ -256,7 +256,7 @@ static int table_to_json (toml_table_t *tab, json_t **op)
                 goto error;
         }
         if (json_object_set_new (obj, key, val) < 0) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -484,7 +484,7 @@ void checkpoint_get_cb (flux_t *h,
         }
 
         if (json_array_append_new (a, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             errno = ENOMEM;
             goto error;
         }
@@ -606,7 +606,7 @@ static json_t *stats_checkpoints (struct content_sqlite *ctx)
                              "value", value))
             || json_array_append_new (checkpts, o) < 0) {
             json_decref (value);
-            json_decref (o);
+            // jansson decrefs the new object on failure
             errno = ENOMEM;
             goto error;
         }

--- a/src/modules/content/mmap.c
+++ b/src/modules/content/mmap.c
@@ -544,14 +544,14 @@ json_t *content_mmap_get_stats (struct content_mmap *mm)
             json_t *s;
             if (!(s = json_string (reg->fullpath))
                 || json_array_append_new (a, s) < 0) {
-                json_decref (s);
+                // jansson decrefs the new object on failure
                 json_decref (a);
                 goto nomem;
             }
             reg = hola_list_next (mm->tags, key);
         }
         if (json_object_set_new (o, key, a) < 0) {
-            json_decref (a);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         key = hola_hash_next (mm->tags);

--- a/src/modules/groups/groups.c
+++ b/src/modules/groups/groups.c
@@ -251,7 +251,7 @@ static int batch_append (struct groups *g, const char *name, json_t *update)
     if (!(a = json_object_get (g->batch, name))) {
         if (!(a = json_array ())
             || json_object_set_new (g->batch, name, a) < 0) {
-            json_decref (a);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }
@@ -626,7 +626,7 @@ static json_t *make_groups_object (struct groups *g)
         json_t *o;
         if (!(o = obj_from_idset (group->members))
             || json_object_set_new (obj, group->name, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto error;
         }
         group = zhashx_next (g->groups);

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1813,7 +1813,7 @@ static json_t *running_job_stats (struct job_exec_ctx *ctx)
         }
         json_decref (impl_stats);
         if (json_object_set_new (o, idf58 (job->id), entry) < 0) {
-            json_decref (entry);
+            // jansson decrefs the new object on failure
             errno = ENOMEM;
             goto error;
         }
@@ -1849,7 +1849,7 @@ static void stats_cb (flux_t *h,
     }
     if (!(jobs = running_job_stats (ctx))
         || json_object_set_new (o, "jobs", jobs)) {
-        json_decref (jobs);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         goto error;
     }
@@ -1857,7 +1857,7 @@ static void stats_cb (flux_t *h,
         json_t *stats = NULL;
         if (impl->stats && (stats = (*impl->stats) (NULL))) {
             if (json_object_set_new (o, impl->name, stats) < 0) {
-                json_decref (stats);
+                // jansson decrefs the new object on failure
                 errno = ENOMEM;
                 goto error;
             }

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -272,7 +272,7 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
         || !(tmp = json_integer (l->id))
         || json_object_set_new (o, "id", tmp) < 0) {
         errprintf (&error, "error creating response object");
-        json_decref (tmp);
+        // jansson decrefs the new object on failure
         goto enomem;
     }
 
@@ -327,7 +327,7 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
         else
             val = json_string (s);
         if (!val || json_object_set_new (o, keystr, val) < 0) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             errprintf (&error, "%s: error adding value to response", keystr);
             goto enomem;
         }

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -497,7 +497,7 @@ static int batch_add_job (struct batch *batch, struct job *job)
                                 "jobspec", job->jobspec)))
         goto nomem;
     if (json_array_append_new (batch->joblist, jobentry) < 0) {
-        json_decref (jobentry);
+        // jansson decrefs the new object on failure
         goto nomem;
     }
     return 0;

--- a/src/modules/job-list/job_util.c
+++ b/src/modules/job-list/job_util.c
@@ -218,7 +218,7 @@ out:
         return -1;
     }
     if (json_object_set_new (o, attr, val) < 0) {
-        json_decref (val);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }
@@ -263,7 +263,7 @@ json_t *job_to_json (struct job *job, json_t *attrs, flux_error_t *errp)
     if (!(val = json_integer (job->id)))
         goto error_nomem;
     if (json_object_set_new (o, "id", val) < 0) {
-        json_decref (val);
+        // jansson decrefs the new object on failure
         goto error_nomem;
     }
     json_array_foreach (attrs, index, value) {

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -76,7 +76,7 @@ int get_jobs_from_list (json_t *jobs,
             if (!(o = job_to_json (job, attrs, errp)))
                 return -1;
             if (json_array_append_new (jobs, o) < 0) {
-                json_decref (o);
+                // jansson decrefs the new object on failure
                 errno = ENOMEM;
                 return -1;
             }
@@ -201,7 +201,7 @@ static int legacy_list_rpc (flux_t *h,
     if (userid != FLUX_USERID_UNKNOWN) {
         o = json_pack ("{s:[i]}", "userid", userid);
         if (!o || json_array_append_new (a, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto error;
         }
     }
@@ -209,7 +209,7 @@ static int legacy_list_rpc (flux_t *h,
     if (name) {
         o = json_pack ("{s:[s]}", "name", name);
         if (!o || json_array_append_new (a, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto error;
         }
     }
@@ -217,7 +217,7 @@ static int legacy_list_rpc (flux_t *h,
     if (queue) {
         o = json_pack ("{s:[s]}", "queue", queue);
         if (!o || json_array_append_new (a, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto error;
         }
     }
@@ -227,7 +227,7 @@ static int legacy_list_rpc (flux_t *h,
     if (states) {
         o = json_pack ("{s:[i]}", "states", states);
         if (!o || json_array_append_new (a, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto error;
         }
     }
@@ -237,7 +237,7 @@ static int legacy_list_rpc (flux_t *h,
     if (results) {
         o = json_pack ("{s:[i]}", "results", results);
         if (!o || json_array_append_new (a, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto error;
         }
     }
@@ -609,7 +609,7 @@ static int list_attrs_append (json_t *a, const char *attr)
         return -1;
     }
     if (json_array_append_new (a, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -238,7 +238,7 @@ static int object_set_integer (json_t *o,
 {
     json_t *val = json_integer (n);
     if (!val || json_object_set_new (o, key, val) < 0) {
-        json_decref (val);
+        // jansson decrefs the new object on failure
         return -1;
     }
     return 0;
@@ -287,7 +287,7 @@ static json_t *stats_encode (struct job_stats *stats, const char *name)
     if (name) {
         json_t *no = json_string (name);
         if (!no || json_object_set_new (o, "name", no) < 0) {
-            json_decref (no);
+            // jansson decrefs the new object on failure
             json_decref (o);
             errno = ENOMEM;
             return NULL;
@@ -317,7 +317,7 @@ static json_t *queue_stats_encode (struct job_stats_ctx *statsctx)
             return NULL;
         }
         if (json_array_append_new (queues, qo) < 0) {
-            json_decref (qo);
+            // jansson decrefs the new object on failure
             json_decref (queues);
             errno = ENOMEM;
             return NULL;
@@ -344,7 +344,7 @@ static json_t *job_stats_encode (struct job_stats_ctx *statsctx)
     }
 
     if (json_object_set_new (o, "queues", queues) < 0) {
-        json_decref (queues);
+        // jansson decrefs the new object on failure
         json_decref (o);
         errno = ENOMEM;
         return NULL;

--- a/src/modules/job-manager/housekeeping.c
+++ b/src/modules/job-manager/housekeeping.c
@@ -507,7 +507,7 @@ static int set_idset_string (json_t *obj, const char *key, struct idset *ids)
     if (!(s = idset_encode (ids, IDSET_FLAG_RANGE))
         || !(o = json_string (s))
         || json_object_set_new (obj, key, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         free (s);
         return -1;
     }
@@ -654,7 +654,7 @@ json_t *housekeeping_get_stats (struct housekeeping *hk)
         json_t *job;
         if (!(job = housekeeping_get_stats_job (a))
             || json_object_set_new (running, idf58 (a->id), job) < 0) {
-            json_decref (job);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         a = zlistx_next (hk->allocations);

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -524,7 +524,7 @@ int job_event_enqueue (struct job *job, int flags, json_t *entry)
                             "flags", flags,
                             "entry", entry))
         || json_array_append_new (job->event_queue, wrap) < 0) {
-        json_decref (wrap);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1632,7 +1632,7 @@ static json_t *jobtap_plugin_list (struct jobtap *jobtap)
         if (o == NULL)
             goto error;
         if (json_array_append_new (result, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto error;
         }
         p = zlistx_next (jobtap->plugins);

--- a/src/modules/job-manager/list.c
+++ b/src/modules/job-manager/list.c
@@ -68,7 +68,7 @@ int list_append_job (json_t *jobs, struct job *job)
         }
     }
     if (json_array_append_new (jobs, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }

--- a/src/modules/job-manager/plugins/dependency-after.c
+++ b/src/modules/job-manager/plugins/dependency-after.c
@@ -726,7 +726,7 @@ static json_t *deps_to_json (flux_plugin_t *p)
                                      "type", after_typestr (info->type),
                                      "description", info->description))
                 || json_array_append_new (o, entry) < 0) {
-                json_decref (entry);
+                // jansson decrefs the new object on failure
                 goto error;
             }
             ref = zlistx_next (l);

--- a/src/modules/job-manager/plugins/dependency-singleton.c
+++ b/src/modules/job-manager/plugins/dependency-singleton.c
@@ -304,7 +304,7 @@ static json_t *singleton_list_to_json (const char *key)
     while (s) {
         json_t *id = json_integer (s->id);
         if (!id || json_array_append_new (o, id)) {
-            json_decref (id);
+            // jansson decrefs the new object on failure
             goto error;
         }
         s = zlistx_next (l);
@@ -336,7 +336,7 @@ static json_t *singletons_to_json (void)
                                     "count", count,
                                     "singletons", singletons))
             || json_object_set_new (o, key, entry) < 0) {
-            json_decref (entry);
+            // jansson decrefs the new object on failure
             json_decref (singletons);
             goto error;
         }

--- a/src/modules/job-manager/plugins/history.c
+++ b/src/modules/job-manager/plugins/history.c
@@ -183,7 +183,7 @@ static int append_int (json_t *a, json_int_t i)
     json_t *o;
     if (!(o = json_integer (i))
         || json_array_append_new (a, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         return -1;
     }
     return 0;

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -1360,7 +1360,7 @@ static json_t *cmdline_tojson (flux_cmd_t *cmd)
         json_t *arg;
         if ((!(arg = json_string (flux_cmd_arg (cmd, i))))
             || json_array_append_new (o, arg) < 0) {
-            json_decref (arg);
+            // jansson decrefs the new object on failure
             goto error;
         }
     }
@@ -1421,9 +1421,10 @@ static json_t *procs_to_json (zhashx_t *processes)
     proc = zhashx_first (processes);
     while (proc) {
         json_t *entry;
-        if (!(entry = proc_to_json (proc))
-            || json_object_set_new (o, idf58 (proc->id), entry) < 0) {
-            json_decref (entry);
+        if (!(entry = proc_to_json (proc)))
+            goto error;
+        if (json_object_set_new (o, idf58 (proc->id), entry) < 0) {
+            // jansson decrefs the new object on failure
             goto error;
         }
         proc = zhashx_next (processes);

--- a/src/modules/job-manager/prioritize.c
+++ b/src/modules/job-manager/prioritize.c
@@ -234,7 +234,7 @@ int reprioritize_all (struct job_manager *ctx)
             if (job->priority > FLUX_JOB_PRIORITY_MIN) {
                 json_t *entry = json_pack ("[II]", job->id, job->priority);
                 if (!entry || json_array_append_new (priorities, entry) < 0) {
-                    json_decref (entry);
+                    // jansson decrefs the new object on failure
                     flux_log (h, LOG_ERR,
                               "reprioritize: json_pack/append failed");
                         goto error;

--- a/src/modules/job-manager/purge.c
+++ b/src/modules/job-manager/purge.c
@@ -139,7 +139,7 @@ static int process_job_purge (struct purge *purge,
 
     json_t *o = json_integer (job->id);
     if (!o || json_array_append_new (jobs, o)) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -277,7 +277,7 @@ static int set_string (json_t *o, const char *key, const char *val)
 {
     json_t *s = json_string (val);
     if (!s || json_object_set_new (o, key, s) < 0) {
-        json_decref (s);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }
@@ -587,7 +587,7 @@ static void queue_list_cb (flux_t *h,
             json_t *o;
             if (!(o = json_string (q->name))
                 || json_array_append_new (a, o) < 0) {
-                json_decref (o);
+                // jansson decrefs the new object on failure
                 errno = ENOMEM;
                 goto error;
             }

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -92,7 +92,7 @@ static int raise_job_exception_ex (struct job_manager *ctx,
         json_t *val;
         if (!(val = json_integer (userid))
             || json_object_set_new (evctx, "userid", val) < 0) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }
@@ -101,7 +101,7 @@ static int raise_job_exception_ex (struct job_manager *ctx,
         json_t *val;
         if (!(val = json_integer (wait_status))
             || json_object_set_new (evctx, "wait_status", val) < 0) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }
@@ -118,7 +118,7 @@ static int raise_job_exception_ex (struct job_manager *ctx,
         json_t *val;
         if (!(val = json_integer (wait_status))
             || json_object_set_new (pub, "wait_status", val) < 0) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             json_decref (pub);
             goto nomem;
         }

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -70,7 +70,7 @@ static void set_errorf (json_t *errors,
     va_end (ap);
     if (!(o = json_pack ("[Is]", id, buf))
         || json_array_append_new (errors, o)) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         return;
     }
 }

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -1549,7 +1549,7 @@ static void stats_cb (flux_t *h,
         if (!o)
             goto nomem;
         if (json_object_set_new (stats, nsm->ns_name, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         watchers += zlistx_size (nsm->watchers);

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2067,7 +2067,7 @@ static void stats_get_cb (flux_t *h,
             goto nomem;
 
         if (json_object_set_new (nsstats, KVS_PRIMARY_NAMESPACE, s) < 0) {
-            json_decref (s);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -143,7 +143,7 @@ static kvstxn_t *kvstxn_create (kvstxn_mgr_t *ktm,
         if (!(s = json_string (name)))
             goto error_enomem;
         if (json_array_append_new (kt->names, s) < 0) {
-            json_decref (s);
+            // jansson decrefs the new object on failure
             goto error_enomem;
         }
     }
@@ -425,7 +425,7 @@ static int kvstxn_unroll (kvstxn_t *kt, json_t *dir)
             if (!(ktmp = treeobj_create_dirref (ref)))
                 return -1;
             if (json_object_iter_set_new (dir, iter, ktmp) < 0) {
-                json_decref (ktmp);
+                // jansson decrefs the new object on failure
                 errno = ENOMEM;
                 return -1;
             }
@@ -450,7 +450,7 @@ static int kvstxn_unroll (kvstxn_t *kt, json_t *dir)
                 if (!(ktmp = treeobj_create_valref (ref)))
                     return -1;
                 if (json_object_iter_set_new (dir, iter, ktmp) < 0) {
-                    json_decref (ktmp);
+                    // jansson decrefs the new object on failure
                     errno = ENOMEM;
                     return -1;
                 }

--- a/src/modules/overlay/overlay.c
+++ b/src/modules/overlay/overlay.c
@@ -1919,12 +1919,11 @@ static int overlay_health_respond (struct overlay *ov, const flux_msg_t *msg)
             json_t *o;
             if (!(o = json_string (child->error.text))
                 || json_object_set_new (entry, "error", o) < 0) {
-                json_decref (o);
-                // if this fails (unlikely), soldier on
+                // jansson decrefs the new object on failure; soldier on
             }
         }
         if (json_array_append_new (array, entry) < 0) {
-            json_decref (entry);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }

--- a/src/modules/overlay/topology.c
+++ b/src/modules/overlay/topology.c
@@ -341,7 +341,7 @@ json_t *topology_get_json_subtree_at (struct topology *topo, int rank)
         if (!(child = topology_get_json_subtree_at (topo, child_ranks[i])))
             goto error;
         if (json_array_append_new (children, child) < 0) {
-            json_decref (child);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }

--- a/src/modules/resource/drainset.c
+++ b/src/modules/resource/drainset.c
@@ -192,7 +192,7 @@ json_t *drainset_to_json (struct drainset *ds)
             goto nomem;
         }
         if (json_object_set_new (o, s, val) < 0) {
-            ERRNO_SAFE_WRAP (json_decref, val);
+            // jansson decrefs the new object on failure
             ERRNO_SAFE_WRAP (free, s);
             goto error;
         }

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -209,7 +209,7 @@ static int parse_config (struct resource_ctx *ctx,
         if (json_object_set_new (o, "scheduling", scheduling) < 0) {
             errprintf (errp, "failed to set scheduling key in R");
             json_decref (o);
-            json_decref (scheduling);
+            // jansson decrefs the new object on failure
             return -1;
         }
     }

--- a/src/modules/resource/rutil.c
+++ b/src/modules/resource/rutil.c
@@ -95,7 +95,7 @@ int rutil_set_json_idset (json_t *o, const char *key, const struct idset *ids)
 nomem:
     errno = ENOMEM;
     ERRNO_SAFE_WRAP (free, s);
-    ERRNO_SAFE_WRAP (json_decref, val);
+    // jansson decrefs the new object on failure
     return -1;
 }
 
@@ -136,7 +136,7 @@ static int set_string (json_t *o, const char *key, const char *val)
     if (!(oval = json_string (val)))
         goto nomem;
     if (json_object_set_new (o, key, oval) < 0) {
-        json_decref (oval);
+        // jansson decrefs the new object on failure
         goto nomem;
     }
     return 0;

--- a/src/modules/resource/status.c
+++ b/src/modules/resource/status.c
@@ -376,7 +376,7 @@ static json_t *prepare_sched_status_payload (struct status *status,
     else
         o = json_incref (status->R_empty);
     if (!o || json_object_set_new (result, "allocated", o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         goto error;
     }
     return result;

--- a/src/modules/resource/upgrade.c
+++ b/src/modules/resource/upgrade.c
@@ -108,7 +108,7 @@ static int upgrade_drain_context (const char *name,
                       idset,
                       timebuf,
                       reason ? reason : "");
-            json_decref (o);
+            // jansson decrefs the new object on failure
             free (nl);
             return -1;
         }
@@ -160,7 +160,7 @@ static int upgrade_insert_drain_event (json_t *eventlog,
     if (!entry)
         return -1;
     if (json_array_insert_new (eventlog, index, entry) < 0) {
-        json_decref (entry);
+        // jansson decrefs the new object on failure
         errno = ENOMEM;
         return -1;
     }

--- a/src/modules/sdbus/interface.c
+++ b/src/modules/sdbus/interface.c
@@ -88,7 +88,7 @@ static int list_units_tojson (sd_bus_message *m,
             goto out;
         }
         if (json_array_append_new (a, entry) < 0) {
-            json_decref (entry);
+            // jansson decrefs the new object on failure
             e = -ENOMEM;
             goto out;
         }
@@ -98,6 +98,7 @@ static int list_units_tojson (sd_bus_message *m,
     if (e < 0 || (e = sd_bus_message_exit_container (m)) < 0)
         goto out;
     if (json_array_append_new (params, a) < 0) {
+        a = NULL; // jansson decrefs the new object on failure
         e = -ENOMEM;
         goto out;
     }

--- a/src/modules/sdbus/message.c
+++ b/src/modules/sdbus/message.c
@@ -422,7 +422,7 @@ static int sdmsg_get_property_dict (sd_bus_message *m, json_t **op)
             || (e = sdmsg_get_variant (m, &val)) <= 0)
             goto out;
         if (json_object_set_new (dict, key, val) < 0) {
-            json_decref (val);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         if ((e = sd_bus_message_exit_container (m)) < 0)
@@ -480,7 +480,7 @@ int sdmsg_read (sd_bus_message *m, const char *fmt, json_t *o)
         }
         if (json_array_append_new (o, entry) < 0) {
             free (efmt);
-            json_decref (entry);
+            // jansson decrefs the new object on failure
             return -ENOMEM;
         }
         i += strlen (efmt);

--- a/src/modules/sdexec/sdexec.c
+++ b/src/modules/sdexec/sdexec.c
@@ -570,13 +570,13 @@ static int set_dict (json_t *o,
     if (!(dict = json_object_get (o, name))) {
         if (!(dict = json_object ())
             || json_object_set_new (o, name, dict) < 0) {
-            json_decref (dict);
+            // jansson decrefs the new object on failure
             goto nomem;
         }
     }
     if (!(vo = json_string (v))
         || json_object_set_new (dict, k, vo) < 0) {
-        json_decref (vo);
+        // jansson decrefs the new object on failure
         goto nomem;
     }
     return 0;
@@ -1046,7 +1046,7 @@ static void list_cb (flux_t *h,
                                "label", "",
                                "state", "R"))) {
             if (json_array_append_new (procs, o) < 0) {
-                json_decref (o);
+                // jansson decrefs the new object on failure
                 goto nomem;
             }
         }
@@ -1124,11 +1124,12 @@ static void stats_cb (flux_t *h,
         json_t *entry = NULL;
 
         if (!(proc = flux_msg_aux_get (m, "sdproc"))
-            || !(entry = get_proc_stats (proc))
-            || json_object_set_new (procs,
-                                    sdexec_unit_name (proc->unit),
-                                    entry) < 0) {
-            json_decref (entry);
+            || !(entry = get_proc_stats (proc)))
+            goto nomem;
+        if (json_object_set_new (procs,
+                                 sdexec_unit_name (proc->unit),
+                                 entry) < 0) {
+            // jansson decrefs the new object on failure
             goto nomem;
         }
         m = flux_msglist_next (ctx->requests);

--- a/src/modules/sdmon/sdmon.c
+++ b/src/modules/sdmon/sdmon.c
@@ -150,7 +150,7 @@ static int add_units (json_t *units, struct sdmon_bus *bus)
                              "name", sdexec_unit_name (unit),
                              "state", state))
             || json_array_append_new (units, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             errno = ENOMEM;
             return -1;
         }

--- a/src/shell/mpir/proctable.c
+++ b/src/shell/mpir/proctable.c
@@ -191,7 +191,7 @@ json_t *proctable_to_json (struct proctable *p)
         || json_object_set_new (o, "pids", x) < 0
         || !(x = rangelist_to_json (p->ranks))
         || json_object_set_new (o, "ranks", x) < 0) {
-        json_decref (x);
+        // jansson decrefs the new object on failure; x may be NULL
         json_decref (o);
         return NULL;
     }

--- a/src/shell/mpir/rangelist.c
+++ b/src/shell/mpir/rangelist.c
@@ -252,7 +252,7 @@ json_t *range_to_json (struct range *r, int64_t base)
             || !(val = json_integer (r->is_rle ? -range : range))
             || json_array_append_new (o, val) < 0) {
         json_decref (o);
-        json_decref (val);
+        // jansson decrefs the new object on failure; val may be NULL
         return NULL;
     }
     return o;
@@ -286,7 +286,7 @@ static int increment_range_repeat (json_t *range)
         goto error;
     return 0;
 error:
-    json_decref (val);
+    // jansson decrefs the new object on failure; val may be NULL
     return -1;
 }
 
@@ -321,7 +321,7 @@ json_t *rangelist_to_json (struct rangelist *rl)
         if (check_previous_repeat (result, range))
             json_decref (range);
         else if (json_array_append_new (result, range) < 0) {
-            json_decref (range);
+            // jansson decrefs the new object on failure
             goto error;
         }
         base = range_max (r);

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -116,7 +116,7 @@ static int put_dict (json_t *dict, const char *key, const char *val)
     if (!(o = json_string (val)))
         goto nomem;
     if (json_object_set_new (dict, key, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         goto nomem;
     }
     return 0;

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -378,7 +378,7 @@ static int object_set_string (json_t *dict, const char *name, const char *val)
     if (!(o = json_string (val)))
         goto nomem;
     if (json_object_set_new (dict, name, o) < 0) {
-        json_decref (o);
+        // jansson decrefs the new object on failure
         goto nomem;
     }
     return 0;

--- a/src/shell/stage-in.c
+++ b/src/shell/stage-in.c
@@ -68,7 +68,7 @@ json_t *parse_names (const char *s, const char *default_value)
         while ((entry = argz_next (argz, argz_len, entry))) {
             if (!(o = json_string (entry))
                 || json_array_append_new (a, o) < 0) {
-                json_decref (o);
+                // jansson decrefs the new object on failure
                 goto error;
             }
         }
@@ -76,7 +76,7 @@ json_t *parse_names (const char *s, const char *default_value)
     if (json_array_size (a) == 0 && default_value) {
         if (!(o = json_string (default_value))
             || json_array_append_new (a, o) < 0) {
-            json_decref (o);
+            // jansson decrefs the new object on failure
             goto error;
         }
     }

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -310,7 +310,7 @@ static int add_process_info_to_json (flux_subprocess_t *p, json_t *o)
     }
     return 0;
 error:
-    json_decref (obj);
+    // jansson decrefs the new object on failure; obj need not be freed here
     return -1;
 }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -373,7 +373,8 @@ EXTRA_DIST= \
 	job-manager/dumps \
 	flux-resource \
 	module/testmod.py \
-	scheduler/sched-slowgen.py
+	scheduler/sched-slowgen.py \
+	cocci/json_set_new_decref.cocci
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/cocci/json_set_new_decref.cocci
+++ b/t/cocci/json_set_new_decref.cocci
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: LGPL-3.0
+//
+// Detect double-free of json_t value after json_*_new() failure.
+//
+// All jansson json_*_new() functions steal the reference to the value
+// argument whether they succeed or fail — on failure, jansson calls
+// json_decref() on the value internally.  Calling json_decref() on the
+// same value in the caller's error path is therefore a double-free.
+//
+// Covers both forms:
+//
+//   Simple:
+//     if (json_object_set_new(obj, key, val) < 0) { json_decref(val); }
+//
+//   Compound (double-free when the _new call is reached and fails):
+//     if (E || json_object_set_new(obj, key, val) < 0) { json_decref(val); }
+//
+
+// ---- json_object_set_new ----
+
+@@
+expression obj, key, val;
+@@
+* if (json_object_set_new(obj, key, val) < 0) {
+  ...
+* json_decref(val);
+  ...
+  }
+
+@@
+expression obj, key, val, E;
+@@
+* if (E || json_object_set_new(obj, key, val) < 0) {
+  ...
+* json_decref(val);
+  ...
+  }
+
+// ---- json_array_append_new ----
+
+@@
+expression arr, val;
+@@
+* if (json_array_append_new(arr, val) < 0) {
+  ...
+* json_decref(val);
+  ...
+  }
+
+@@
+expression arr, val, E;
+@@
+* if (E || json_array_append_new(arr, val) < 0) {
+  ...
+* json_decref(val);
+  ...
+  }
+
+// ---- json_array_set_new ----
+
+@@
+expression arr, idx, val;
+@@
+* if (json_array_set_new(arr, idx, val) < 0) {
+  ...
+* json_decref(val);
+  ...
+  }
+
+@@
+expression arr, idx, val, E;
+@@
+* if (E || json_array_set_new(arr, idx, val) < 0) {
+  ...
+* json_decref(val);
+  ...
+  }
+
+// ---- json_array_insert_new ----
+
+@@
+expression arr, idx, val;
+@@
+* if (json_array_insert_new(arr, idx, val) < 0) {
+  ...
+* json_decref(val);
+  ...
+  }
+
+@@
+expression arr, idx, val, E;
+@@
+* if (E || json_array_insert_new(arr, idx, val) < 0) {
+  ...
+* json_decref(val);
+  ...
+  }
+
+// ---- json_object_iter_set_new ----
+
+@@
+expression obj, iter, val;
+@@
+* if (json_object_iter_set_new(obj, iter, val) < 0) {
+  ...
+* json_decref(val);
+  ...
+  }
+
+@@
+expression obj, iter, val, E;
+@@
+* if (E || json_object_iter_set_new(obj, iter, val) < 0) {
+  ...
+* json_decref(val);
+  ...
+  }


### PR DESCRIPTION
Problem: jansson's `json_object_set_new()`, `json_object_append_new()`, etc. decref the value argument on failure, stealing the reference even when returning an error.  Many call sites call `json_decref()` on the same value in their error paths. Although failure is unlikely, it would trigger a double-free.
    
Replace the erroneous `json_decref()` calls with a comment to help us remember the unexpected behavior, since we've known about this for a while and haven't taken it to heart.

Fixes #2803

Also, fix an unrelated double free and memory leak on error paths of librlist `rlist_to_R()`.
