### PR TITLE
WIP: ci: run asan over sharness

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -4,7 +4,7 @@ jobs:
   check-asan:
     name: address-sanitizer check
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 100
     steps:
     - uses: actions/checkout@v6.0.2
       with:
@@ -15,7 +15,7 @@ jobs:
       run: |
         sudo sysctl -w kernel.randomize_va_space=0
     - name: docker-run-checks with ASan
-      timeout-minutes: 40
+      timeout-minutes: 80
       env:
         PRELOAD: /usr/lib64/libasan.so.8
         ASAN_OPTIONS: detect_leaks=0:start_deactivated=true:replace_str=true:verify_asan_link_order=false
@@ -23,7 +23,7 @@ jobs:
         TAP_DRIVER_QUIET: t
       run: >
         src/test/docker/docker-run-checks.sh \
-          --image=fedora40 --unit-test-only -j4 \
+          --image=fedora40 -j4 \
           -- --with-flux-security --enable-sanitizer=address
 
     - name: after failure

--- a/t/module/testmod.c
+++ b/t/module/testmod.c
@@ -50,10 +50,20 @@ static void segfault (flux_t *h,
     kill (getpid (), SIGSEGV);
 }
 
+static void killevent (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    flux_log (h, LOG_CRIT, "kill event received: raising SIGKILL");
+    kill (getpid (), SIGKILL);
+}
+
 static struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "info", info, 0 },
     { FLUX_MSGTYPE_EVENT, "panic", panic, 0 },
     { FLUX_MSGTYPE_EVENT, "segfault", segfault, 0 },
+    { FLUX_MSGTYPE_EVENT, "kill", killevent, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -109,7 +119,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     }
 
     const char *module_name = flux_aux_get (h, "flux::name");
-    const char *topics[] = { "panic", "segfault" };
+    const char *topics[] = { "panic", "segfault", "kill" };
 
     for (int i = 0; i < ARRAY_SIZE (topics); i++) {
         char topic[256];

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -656,8 +656,10 @@ test_expect_success 'flux-help command list can be extended' '
 	grep "^test two commands" help2.out &&
 	grep "a test two" help2.out
 '
+# N.B. Set NO_ASAN, as there appears to be errors in 'man', which is executed
+# internally in `flux help`.
 command -v man >/dev/null && test_set_prereq HAVE_MAN
-test_expect_success HAVE_MAN 'flux-help command can display manpages for subcommands' '
+test_expect_success NO_ASAN,HAVE_MAN 'flux-help command can display manpages for subcommands' '
 	PWD=$(pwd) &&
 	mkdir -p man/man1 &&
 	cat <<-EOF > man/man1/flux-foo.1 &&
@@ -667,7 +669,7 @@ test_expect_success HAVE_MAN 'flux-help command can display manpages for subcomm
 	EOF
 	MANPATH=${PWD}/man FLUX_IGNORE_NO_DOCS=y flux help foo | grep "^FOO(1)"
 '
-test_expect_success HAVE_MAN 'flux-help command can display manpages for api calls' '
+test_expect_success NO_ASAN,HAVE_MAN 'flux-help command can display manpages for api calls' '
 	PWD=$(pwd) &&
 	mkdir -p man/man3 &&
 	cat <<-EOF > man/man3/flux_foo.3 &&

--- a/t/t0005-exec-jobid.t
+++ b/t/t0005-exec-jobid.t
@@ -152,6 +152,13 @@ test_expect_success SIGN_WRAP 'signed exec uses signed write requests' '
 	flux exec --jobid=$sign_jobid --sign cat <test.txt >output.txt &&
 	test_cmp test.txt output.txt
 '
+# N.B. The 'ps' command below hangs under ASAN.  Temporarily unset LD_PRELOAD
+# so 'ps' works in the check below.
+SAVE_LD_PRELOAD=${LD_PRELOAD}
+if test_have_prereq ASAN; then
+    LD_PRELOAD=""
+fi
+
 # The version of stdbuf(1) in older versions of uutils/coreutils does
 # not exec() its argument but instead remains the parent and collects
 # exit status. This version does not forward signals to children, so
@@ -160,6 +167,8 @@ test_expect_success SIGN_WRAP 'signed exec uses signed write requests' '
 if test $(stdbuf --output=L sh -c 'ps -q $PPID -o comm=') != "stdbuf"; then
 	test_set_prereq WORKING_STDBUF
 fi
+
+LD_PRELOAD=${SAVE_LD_PRELOAD}
 
 waitfile=$SHARNESS_TEST_SRCDIR/scripts/waitfile.lua
 test_expect_success WORKING_STDBUF,SIGN_WRAP \

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -203,14 +203,24 @@ test_expect_success 'I/O -- long lines' '
 	test_cmp output expected
 '
 
+# N.B. The 'ps' command below hangs under ASAN.  Temporarily unset LD_PRELOAD
+# so 'ps' works in the check below.
+SAVE_LD_PRELOAD=${LD_PRELOAD}
+if test_have_prereq ASAN; then
+    LD_PRELOAD=""
+fi
+
 # The version of stdbuf(1) in older versions of uutils/coreutils does
 # not exec() its argument but instead remains the parent and collects
 # exit status. This version does not forward signals to children, so
 # it breaks the test below. Detect versions of stdbuf that don't exec
 # their arguments and skip the test if found.
+
 if test $(stdbuf --output=L sh -c 'ps -q $PPID -o comm=') != "stdbuf"; then
     test_set_prereq WORKING_STDBUF
 fi
+
+LD_PRELOAD=${SAVE_LD_PRELOAD}
 
 waitfile=$SHARNESS_TEST_SRCDIR/scripts/waitfile.lua
 test_expect_success WORKING_STDBUF 'signal forwarding works' '

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -146,6 +146,7 @@ test_expect_success 'flux exec exits with code 126 for non executable' '
 	grep "Permission denied" exec.stderr2
 '
 
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
 test_expect_success NO_ASAN 'flux exec passes non-zero exit status' '
 	test_expect_code 2 flux exec -n sh -c "exit 2" &&
 	test_expect_code 3 flux exec -n sh -c "exit 3" &&
@@ -158,6 +159,7 @@ test_expect_success 'flux exec fails with --with-imp if no IMP configured' '
 	grep "exec\.imp path not found in config" exec-no-imp.out
 '
 
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
 test_expect_success NO_ASAN 'flux exec outputs tasks with errors' '
 	! flux exec -n sh -c "exit 2" > 2.out 2>&1 &&
         grep "\[0-3\]: Exit 2" 2.out &&

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -164,7 +164,8 @@ test_expect_success 'simulated module segfault causes module to exit' '
 	sh -c "while flux module stats testmod; do true; done" &&
 	flux dmesg >segfault.out
 '
-test_expect_success 'segfault is reported' '
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
+test_expect_success NO_ASAN 'segfault is reported' '
 	grep "killed by Segmentation fault" segfault.out
 '
 test_expect_success 'broker treats this the same as spurious module exit' '

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -158,18 +158,27 @@ test_expect_success NO_CHAIN_LINT 'start background streaming RPC' '
 test_expect_success NO_CHAIN_LINT 'wait for first response to RPC' '
 	$waitfile -t 15 stream.out
 '
-test_expect_success 'simulated module segfault causes module to exit' '
+# N.B. simulated segfault will lead to an error log being generated.
+# So when running under ASAN, skip this test and run the next one,
+# which will just kill the module.
+test_expect_success NO_ASAN 'simulated module segfault causes module to exit (sigsegv)' '
 	flux dmesg -C &&
 	flux event pub testmod.segfault &&
 	sh -c "while flux module stats testmod; do true; done" &&
-	flux dmesg >segfault.out
+	flux dmesg >module_fail.out
+'
+test_expect_success ASAN 'make module exit (kill)' '
+	flux dmesg -C &&
+	flux event pub testmod.kill &&
+	sh -c "while flux module stats testmod; do true; done" &&
+	flux dmesg >module_fail.out
 '
 # N.B. skip under ASAN, as it may capture segfault signal and report differently
 test_expect_success NO_ASAN 'segfault is reported' '
-	grep "killed by Segmentation fault" segfault.out
+	grep "killed by Segmentation fault" module_fail.out
 '
 test_expect_success 'broker treats this the same as spurious module exit' '
-	grep "module runtime failure" segfault.out
+	grep "module runtime failure" module_fail.out
 '
 test_expect_success NO_CHAIN_LINT 'streaming RPC was terminated' '
 	pid=$(cat stream.pid) &&

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -271,6 +271,21 @@ waitgrep() {
 	return 1
 }
 
+# N.B. The 'pkill' command in test below hangs under ASAN.  Disable
+# LD_PRELOAD if ASAN is enabled.
+
+no_asan_pkill() {
+    local rc
+    SAVE_LD_PRELOAD=${LD_PRELOAD}
+    if test_have_prereq ASAN; then
+        LD_PRELOAD=""
+    fi
+    pkill "$@"
+    rc=$?
+    LD_PRELOAD=${SAVE_LD_PRELOAD}
+    return "$rc"
+}
+
 # RFC 2606 reserves the .invalid domain for testing
 test_expect_success NO_CHAIN_LINT 'a warning is printed when upstream URI has unknown host' '
 	mkdir conf8b &&
@@ -289,11 +304,12 @@ test_expect_success NO_CHAIN_LINT 'a warning is printed when upstream URI has un
 	echo $! >warn.pid &&
 	waitgrep "unable to resolve upstream peer" warn.err 30
 '
+
 # In case warn.pid actually refers to a libtool wrapper, try pkill(1) -P
 # first to kill its children, then kill(1).  See flux-framework/flux-core#5275.
 test_expect_success NO_CHAIN_LINT 'clean up broker from previous test' '
 	warnpid=$(cat warn.pid) &&
-	pkill -15 -P $warnpid || kill -15 $warnpid
+	no_asan_pkill -15 -P $warnpid || kill -15 $warnpid
 '
 
 getport() {

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -3,6 +3,8 @@
 test_description='Test flux cron service'
 
 . $(dirname $0)/sharness.sh
+
+# N.B. skip under ASAN, LD_PRELOAD is modified
 if ! test_have_prereq NO_ASAN; then
     skip_all='skipping faketime tests since AddressSanitizer is active'
     test_done

--- a/t/t2406-job-exec-cleanup.t
+++ b/t/t2406-job-exec-cleanup.t
@@ -40,12 +40,28 @@ test_expect_success 'job-exec: run test program that blocks SIGTERM' '
 	pid=$(flux kvs get -WN ${ns} ${dir}.pid) &&
 	test_debug "echo script running as pid=$pid"
 '
+
+# N.B. The 'ps' command in test below hangs under ASAN.  Disable
+# LD_PRELOAD if ASAN is enabled.
+
+no_asan_ps() {
+    local rc
+    SAVE_LD_PRELOAD=${LD_PRELOAD}
+    if test_have_prereq ASAN; then
+        LD_PRELOAD=""
+    fi
+    ps "$@"
+    rc=$?
+    LD_PRELOAD=${SAVE_LD_PRELOAD}
+    return "$rc"
+}
+
 test_expect_success 'job-exec: ensure cancellation kills job' '
 	test_debug "echo Canceling $id" &&
 	flux cancel $id &&
 	test_debug "flux job attach -vEX $id || :" &&
 	test_expect_code 137 flux job status $id &&
-	test_must_fail ps -q $pid
+	test_must_fail no_asan_ps -q $pid
 '
 # Note: increase max-kill-count here to ensure job doesn't disappear from
 # job-exec while we're testing kill-timeout:

--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -46,8 +46,11 @@ test_expect_success 'flux-shell: per-resource type=node works' '
 	EOF
 	test_cmp per-node.expected per-node.out
 '
-test_expect_success 'flux-shell: historical batch jobspec still work' '
+# N.B. legacy test jobspecs may not setup things correctly to allow
+# ASAN (e.g. overwrite environment), so disable under ASAN
+test_expect_success NO_ASAN 'flux-shell: historical batch jobspec still work' '
 	for spec in $SHARNESS_TEST_SRCDIR/batch/jobspec/*.json; do
+                echo $spec
 		input=$(basename $spec) &&
 		cat $spec |
 		    jq -S ".attributes.system.environment.PATH=\"$PATH\"" |

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -59,7 +59,8 @@ test_expect_success 'flux-shell: exit-on-error catches lost shell' '
 	test_must_fail run_timeout 30 flux run \
 		-n2 -N2 -o exit-on-error ./test2.sh
 '
-test_expect_success 'flux-shell: create script - rank 1 kills itself with SIGSEGV' '
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
+test_expect_success NO_ASAN 'flux-shell: create script - rank 1 kills itself with SIGSEGV' '
 	cat >sigtest.sh <<-"EOT" &&
 	#!/bin/sh
 	test $FLUX_TASK_RANK -eq 1 && kill -SEGV $$
@@ -67,12 +68,12 @@ test_expect_success 'flux-shell: create script - rank 1 kills itself with SIGSEG
 	EOT
 	chmod +x sigtest.sh
 '
-test_expect_success 'flux-shell: exit-on-error preserves failing task signal in finish status' '
+test_expect_success NO_ASAN 'flux-shell: exit-on-error preserves failing task signal in finish status' '
 	jobid=$(flux submit -n2 -o exit-on-error ./sigtest.sh) &&
 	flux job wait-event -t 30 $jobid finish | grep "status=35584" &&
 	flux job eventlog $jobid | grep exception | grep "Segmentation fault"
 '
-test_expect_success 'flux-shell: exit-timeout preserves failing task signal in finish status' '
+test_expect_success NO_ASAN 'flux-shell: exit-timeout preserves failing task signal in finish status' '
 	jobid=$(flux submit -n2 -o exit-timeout=1s ./sigtest.sh) &&
 	flux job wait-event -t 30 $jobid finish | grep "status=35584" &&
 	flux job eventlog $jobid | grep exception | grep "Segmentation fault"

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -110,7 +110,7 @@ test_expect_success NO_ASAN 'flux batch: job results are expected' '
 	grep "size=2 nodes=2" flux-${id4}.out &&
 	grep "size=2 nodes=2" flux-${id5}.out
 '
-test_expect_success MULTICORE 'flux batch: exclusive flag worked' '
+test_expect_success NO_ASAN,MULTICORE 'flux batch: exclusive flag worked' '
 	test $(flux job info ${id4} R | flux R decode --count=core) -gt 2 &&
 	test $(flux job info ${id5} R | flux R decode --count=core) -gt 2
 '

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -91,6 +91,7 @@ test_expect_success 'flux batch --exclusive works' '
 		jq -S ".resources[0]" | \
 		jq -e ".type == \"node\" and .exclusive"
 '
+# N.B. slow under ASAN, skip
 test_expect_success NO_ASAN 'flux batch: submit a series of jobs' '
 	id1=$(flux batch --flags=waitable -n1 batch-script.sh) &&
 	id2=$(flux batch --flags=waitable -n4 batch-script.sh) &&

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -191,7 +191,9 @@ test_expect_success 'flux-uri mock testing of slurm resolver works' '
 	test_debug "cat squeue2.err" &&
 	grep -i "empty nodelist" squeue2.err
 '
-test_expect_success 'setup fake csm_allocation_query for mock lsf testing' '
+# N.B. Internally the lsf resolver will eventually run 'ps', which hangs
+# under ASAN.  So set NO_ASAN for lsf tests below.
+test_expect_success NO_ASAN 'setup fake csm_allocation_query for mock lsf testing' '
 	cat <<-EOF >csm_allocation_query &&
 	#!/bin/sh
 	test -n "\$LSF_FAIL" && exit 4
@@ -203,7 +205,7 @@ test_expect_success 'setup fake csm_allocation_query for mock lsf testing' '
 	export CSM_ALLOCATION_QUERY=$(pwd)/csm_allocation_query &&
 	export FLUX_SSH=${SHARNESS_TEST_SRCDIR}/scripts/tssh
 '
-test_expect_success 'flux-uri mock testing of lsf resolver works' '
+test_expect_success NO_ASAN 'flux-uri mock testing of lsf resolver works' '
 	echo $FLUX_URI >lsf.exp &&
 	SHELL=/bin/sh flux uri --local lsf:$LSB_JOBID >lsf.out &&
 	test_cmp lsf.exp lsf.out

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -16,6 +16,7 @@ run_program() {
 	run_timeout $timeout flux run $OPTS -n${ntasks} -N${nnodes} $*
 }
 
+# N.B. set NO_ASAN, we are modifying LD_PRELOAD
 test_expect_success NO_ASAN "spectrum mpi only enabled with option" '
 	LD_PRELOAD_saved=${LD_PRELOAD} &&
 	unset LD_PRELOAD &&
@@ -28,6 +29,7 @@ test_expect_success NO_ASAN "spectrum mpi only enabled with option" '
 	grep /opt/ibm/spectrum spectrum.out
 '
 
+# N.B. set NO_ASAN, we are modifying LD_PRELOAD
 test_expect_success NO_ASAN "spectrum mpi also enabled with spectrum@version" '
 	LD_PRELOAD_saved=${LD_PRELOAD} &&
 	unset LD_PRELOAD &&

--- a/t/t3306-system-routercrash.t
+++ b/t/t3306-system-routercrash.t
@@ -52,9 +52,19 @@ test_expect_success 'construct FLUX_URI for rank 2 (child of 1)' '
 
 # Choice of signal 11 (SIGSEGV) is deliberate here.
 # The broker should not trap this signal - see flux-framework/flux-core#4230.
-test_expect_success 'kill -11 broker 1' '
+# N.B. under ASAN, the segfault signal will result in a log file being
+# generated and broker will exit with different error code.  Skip and see
+# following test for ASAN workaround.
+test_expect_success NO_ASAN 'kill -11 broker 1' '
 	$startctl kill 1 11 &&
 	test_expect_code 139 $startctl wait 1
+'
+
+# N.B. prior test will not work under ASAN but we still need broker to
+# die for later tests.  Send SIGKILL when running under ASAN.
+test_expect_success ASAN 'kill -9 broker 1' '
+	$startctl kill 1 9 &&
+	test_expect_code 137 $startctl wait 1
 '
 
 test_expect_success 'wait broker.online to reach count of one' '


### PR DESCRIPTION
Problem: The asan CI tests only run against unit tests in the src/ directory.  This is because tests did not pass or some tests hung.
This is no longer the case.

Run asan over the entire testsuite under t/.  Increase timeouts as the tests are expected to take more time.

----

WIP: we'll see how much time asan takes.  could adjust those timeouts as needed.

Built on top of #7538

Edit: I did not add any log file checks to `check-annotate.sh` yet.  Wanted to see how far this builder went first.  It's possible it'll take so long we will decide not to run.
