### PR TITLE
Add support for `flux.cli.plugins` namespace for core-packaged CLI plugins

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -577,13 +577,18 @@ MISCELLANEOUS
 
      $sysconfdir/cli/plugins:$libexecdir/cli/plugins
 
+   Non-conflicting plugins are loaded from the ``flux.cli.plugins`` namespace
+   after all plugins in the search path are loaded.
+
 .. envvar:: FLUX_CLI_PLUGINPATH_OVERRIDE
 
    Override the entire search path for command-line plugins, including
-   ``$sysconfdir/cli/plugins`` and ``$libexecdir/cli/plugins``. Only a
-   colon-delimited list of paths passed to this variable will be
-   observed when this variable is set.
-
+   ``$sysconfdir/cli/plugins`` and ``$libexecdir/cli/plugins``. Plugins are
+   always loaded from a `flux.cli.plugins` namespace. Setting this variable
+   to the empty string will load plugins _only_ from the built-in namespace,
+   while providing a colon-delimited list of paths to this variable loads
+   plugins from those paths, with plugins in the ``flux.cli.plugins``
+   namespace loaded last.
 
 .. _sub_command_environment:
 

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -25,6 +25,7 @@ nobase_fluxpy_PYTHON = \
 	cli/submit.py \
 	cli/fortune.py \
 	cli/plugin.py \
+	cli/plugins/__init__.py \
 	core/__init__.py \
 	core/watchers.py \
 	core/inner.py \

--- a/src/bindings/python/flux/cli/plugin.py
+++ b/src/bindings/python/flux/cli/plugin.py
@@ -17,7 +17,7 @@ from abc import ABC
 from pydoc import ttypager
 
 from flux.conf_builtin import conf_builtin_get
-from flux.importer import import_path
+from flux.importer import import_path, import_plugins
 
 
 class PluginArgsProxy:
@@ -193,6 +193,9 @@ class CLIPlugin(ABC):  # pragma no cover
 class CLIPluginRegistry:
     """Flux CLI plugin registry helper class"""
 
+    default_plugins = []
+    plugin_namespace = "flux.cli.plugins"
+
     def __init__(self, prog):
         self.prog = prog
         self.plugins = []
@@ -218,7 +221,10 @@ class CLIPluginRegistry:
         """
         Return list of dirs to search for CLI plugins.
 
-        If ``FLUX_CLI_PLUGINPATH_OVERRIDE`` is set, return only those
+        If ``FLUX_CLI_PLUGINPATH_OVERRIDE`` is set to "", return empty list
+        (only namespaced plugins will be loaded).
+
+        If ``FLUX_CLI_PLUGINPATH_OVERRIDE`` is set to a path, return only those
         paths (system defaults are suppressed entirely).
 
         Otherwise, prepend any paths from ``FLUX_CLI_PLUGINPATH`` to the
@@ -243,8 +249,7 @@ class CLIPluginRegistry:
 
         return paths
 
-    def _add_plugins(self, path, program):
-        module = import_path(path)
+    def _add_plugins_from_module(self, module, program):
         entries = [
             getattr(module, attr) for attr in dir(module) if not attr.startswith("_")
         ]
@@ -257,13 +262,21 @@ class CLIPluginRegistry:
                 and entry != CLIPlugin
             ):
                 plugin = entry(program)
-                plugin.path = path
+                plugin.path = module.__file__
                 self.plugins.append(plugin)
+
+    def _add_plugins(self, path, program):
+        module = import_path(path)
+        self._add_plugins_from_module(module, program)
 
     def print_plugins(self):
         """Print all of the plugins loaded by _load_plugins."""
         print("Options provided by plugins:")
-        print(f"  Search path: {':'.join(self.plugindirs)}\n")
+        if self.plugindirs:
+            print(f"  Search path: {':'.join(self.plugindirs)}")
+            print(f"  (plus {self.plugin_namespace} namespace)\n")
+        else:
+            print(f"  Searched only {self.plugin_namespace} namespace\n")
         for plugin in self.plugins:
             print(f"{type(plugin).__name__} loaded from {plugin.path}")
             for option in plugin.options:
@@ -272,9 +285,15 @@ class CLIPluginRegistry:
 
     def _load_plugins(self, program):
         """Load all cli plugins from the standard path"""
+        # First load filesystem plugins from search path
         for plugindir in self.plugindirs:
             for path in glob.glob(f"{plugindir}/*.py"):
                 self._add_plugins(path, program)
+        # Then load builtin plugins
+        packaged = import_plugins(self.plugin_namespace)
+        for name in self.default_plugins:
+            if name in packaged:
+                self._add_plugins_from_module(packaged[name], program)
         # keep a dictionary of options:plugin so that conflicts can be checked
         option_dests = {}
         # because the plugin list can change due to conflicting options, iterate

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -5,7 +5,7 @@
 
 # add scripts directory to path
 export PATH="${SHARNESS_TEST_SRCDIR}/scripts:$PATH"
-# ensure no builddir plugins are picked up globally
+# only load namespaced plugins from flux.cli.plugins in tests
 export FLUX_CLI_PLUGINPATH_OVERRIDE=""
 
 #


### PR DESCRIPTION
Following the format of the validator and frobnicator, this PR adds a directory `src/bindings/python/flux/cli/plugins` and imports plugins from it. There are currently no plugins in that directory, but this is a prerequisite to getting the `--resource-shape` option merged. 