### PR TITLE
configure: correct invalid description on results

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,7 +157,7 @@ if test "x$san_enabled" != "xno" || test "x$has_deepbind" = "xno" ; then
             [deepbind is unsupported with asan, musl and so-forth])
 else
   AC_DEFINE([FLUX_DEEPBIND], [RTLD_DEEPBIND],
-            [deepbind is unsupported with asan, musl and so-forth])
+            [RTLD_DEEPBIND supported])
 fi
 
 # N.B. /usr/bin/rsh is a symlink to preferred remote shell on some systems


### PR DESCRIPTION
Problem: The check for RTLD_DEEPBIND in configure output the same message no matter if RTLD_DEEPBIND was supported or not.

Update supported path to something more reasonable.

Fixes #7560