### PR TITLE
fix flux shutdown --gc

### DIFF
--- a/doc/man1/flux-shutdown.rst
+++ b/doc/man1/flux-shutdown.rst
@@ -40,6 +40,14 @@ deleted KVS content and purged job directories, which accrue over time and
 increase storage overhead and restart time.  It is recommended that the
 :option:`--gc` option be used on a routine basis to optimize Flux.
 
+.. note::
+  In flux-core 0.61.0, garbage collection was made automatic for Flux
+  system instances by setting the ``content.dump`` broker attribute to
+  ``auto`` in the systemd unit file.  A dump occurs each time Flux is
+  stopped, including when :option:`systemctl stop` is used.  When it is known
+  that garbage collection is not needed for a given shutdown, it can be
+  suppressed using :option:`flux shutdown --skip-gc`.
+
 
 OPTIONS
 =======
@@ -81,6 +89,8 @@ OPTIONS
    on instance startup, the content database is truncated and recreated from
    the dump, and the link is removed.  :linux:man8:`systemd-tmpfiles`
    automatically cleans up dump files in ``/var/lib/flux/dump`` after 30 days.
+   This is option is a no-op if the ``content.dump`` broker attribute is
+   already set to ``auto``.
 
 .. option:: --skip-gc
 

--- a/doc/man5/flux-config-kvs.rst
+++ b/doc/man5/flux-config-kvs.rst
@@ -26,8 +26,13 @@ gc-threshold
    (optional) Sets the number of KVS commits (distinct root snapshots)
    after which offline garbage collection is performed by
    :man1:`flux-shutdown`. A value of 100000 may be a good starting
-   point. (Default: garbage collection must be manually requested with
-   `flux-shutdown --gc`).
+   point.
+
+.. note::
+   In a system instance, when brokers are started with systemd, garbage
+   collection is automatic and a configured threshold has no effect.
+   If ``gc-threshold`` is not configured in an instance started another way,
+   it may be manually requested with :option:`flux-shutdown --gc`.
 
 
 EXAMPLE

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -156,8 +156,8 @@ static struct registered_attr attrtab[] = {
     // content
     { "content.backing-module", 0 },
     { "content.hash", 0 },
-    { "content.dump", 0 },
-    { "content.restore", 0 },
+    { "content.dump", ATTR_RUNTIME },
+    { "content.restore", ATTR_RUNTIME },
 
     // cron
     { "cron.directory", 0 },

--- a/src/cmd/builtin/shutdown.c
+++ b/src/cmd/builtin/shutdown.c
@@ -18,6 +18,8 @@
 #include "src/broker/state_machine.h"
 #include "src/common/libkvs/kvs_checkpoint.h"
 #include "src/common/libutil/uri.h"
+#include "src/common/libutil/errprintf.h"
+#include "ccan/str/str.h"
 
 #include "builtin.h"
 
@@ -108,20 +110,67 @@ static void process_updates (flux_future_t *f)
         log_msg_exit ("%s", future_strerror (f, errno));
 }
 
-static int rmattr (flux_t *h, const char *name)
+/* attr.rm is not currently exposed via the Flux C API.
+ */
+static int rmattr (flux_t *h, const char *name, flux_error_t *errp)
 {
     flux_future_t *f;
-    int rc = 0;
+    int rc = -1;
+
     if (!(f = flux_rpc_pack (h,
                              "attr.rm",
                              FLUX_NODEID_ANY,
                              0,
                              "{s:s}",
                              "name", name))
-        || flux_rpc_get (f, NULL) < 0)
-        rc = -1;
+        || flux_rpc_get (f, NULL) < 0) {
+        errprintf (errp, "%s", future_strerror (f, errno));
+        goto done;
+    }
+    rc = 0;
+done:
     flux_future_destroy (f);
     return rc;
+}
+
+/* Configure KVS dump in rc3 by manipulating the content.dump attribute.
+ * N.B. In a system instance, the systemd unit file currently sets
+ * -Scontent.dump=auto -Scontent.restore=auto on the command line.
+ */
+static void configure_kvs_dump (flux_t *h, optparse_t *p)
+{
+    if (optparse_hasopt (p, "gc")) {
+        if (optparse_hasopt (p, "skip-gc") || optparse_hasopt (p, "dump"))
+            log_msg_exit ("--gc is incompatible with --skip-gc or --dump");
+    }
+
+    const char *content_dump = flux_attr_get (h, "content.dump");
+    flux_error_t error;
+
+    if (optparse_hasopt (p, "skip-gc")) {
+        if (content_dump) {
+            if (rmattr (h, "content.dump", &error) < 0)
+                log_err_exit ("rmattr content.dump: %s", error.text);
+            content_dump = NULL;
+        }
+    }
+    else if (optparse_hasopt (p, "dump")) {
+        const char *optarg = optparse_get_str (p, "dump", NULL);
+        if (!content_dump || !streq (content_dump, optarg)) {
+            if (flux_attr_set_ex (h, "content.dump", optarg, false, &error) < 0)
+                log_msg_exit ("setattr content.dump: %s", error.text);
+            content_dump = optarg;
+        }
+    }
+    else if (optparse_hasopt (p, "gc") || gc_threshold_check (h, p)) {
+        if (!content_dump || !streq (content_dump, "auto")) {
+            if (flux_attr_set_ex (h, "content.dump", "auto", false, &error) < 0)
+                log_msg_exit ("setattr content.dump: %s", error.text);
+            content_dump = "auto";
+        }
+    }
+    if (content_dump)
+        log_msg ("shutdown will dump KVS (this may take some time)");
 }
 
 static int subcmd (optparse_t *p, int ac, char *av[])
@@ -161,21 +210,7 @@ static int subcmd (optparse_t *p, int ac, char *av[])
     if (optparse_hasopt (p, "background"))
         flags &= ~FLUX_RPC_STREAMING;
 
-    if (optparse_hasopt (p, "skip-gc")) {
-        if (rmattr (h, "content.dump") < 0)
-            log_err_exit ("error clearing content.dump attribute");
-    }
-
-    if (optparse_hasopt (p, "gc")
-        || optparse_hasopt (p, "dump")
-        || gc_threshold_check (h, p)) {
-        const char *val = optparse_get_str (p, "dump", "auto");
-
-        if (flux_attr_set (h, "content.dump", val) < 0)
-            log_err_exit ("error setting content.dump attribute");
-
-        log_msg ("shutdown will dump KVS (this may take some time)");
-    }
+    configure_kvs_dump (h, p);
 
     /* N.B. set nodeid=FLUX_NODEID_ANY so we get immediate error from
      * broker if run on rank > 0.

--- a/src/cmd/builtin/shutdown.c
+++ b/src/cmd/builtin/shutdown.c
@@ -169,8 +169,25 @@ static void configure_kvs_dump (flux_t *h, optparse_t *p)
             content_dump = "auto";
         }
     }
-    if (content_dump)
-        log_msg ("shutdown will dump KVS (this may take some time)");
+    /* See the etc/modprobe/rc3.py content-dump task.
+     * This replicates a bit of logic from there in order to give the user
+     * of this tool some useful output.
+     */
+    if (content_dump) {
+        char buf[1024];
+
+        if (streq (content_dump, "auto")) {
+            const char *cleanup = flux_attr_get (h, "statedir-cleanup");
+            const char *dir = ".";
+
+            if (!cleanup || streq (cleanup, "0"))
+                dir = flux_attr_get (h, "statedir");
+            snprintf (buf, sizeof (buf), "%s/dump/", dir);
+            content_dump = buf;
+        }
+        log_msg ("shutdown will dump KVS to %s (this may take some time)",
+                 content_dump);
+    }
 }
 
 static int subcmd (optparse_t *p, int ac, char *av[])

--- a/t/t2808-shutdown-cmd.t
+++ b/t/t2808-shutdown-cmd.t
@@ -330,5 +330,24 @@ test_expect_success 'shutdown --skip-gc does not produce dump' '
 	FLUX_URI=$(flux uri --local $(cat jobid8)) flux shutdown --skip-gc &&
 	test_must_fail tar tvf dump/RESTORE
 '
+test_expect_success 'clean up dump files from previous tests' '
+	rm -f dump.tgz &&
+	rm -f dump/RESTORE
+'
+test_expect_success 'submit batch with dump=auto and wait for it to start (9)' '
+	cat >batch.sh <<-EOT &&
+	#!/bin/sh
+	touch job9-has-started
+	flux run sleep 300
+	EOT
+	chmod +x batch.sh &&
+	flux batch -t30m -n1 \
+	    --broker-opts=-Scontent.dump=auto batch.sh >jobid9 &&
+	$waitfile job9-has-started
+'
+test_expect_success 'shutdown --gc does not fail and dump is produced' '
+	FLUX_URI=$(flux uri --local $(cat jobid9)) flux shutdown --gc &&
+	tar tvf dump/RESTORE
+'
 
 test_done


### PR DESCRIPTION
Problem: `flux shutdown --gc` fails with "error setting content.dump attribute" on a system instance.

The systemd unit file  (since 0.61.0) sets `-Scontent.dump=auto` so `--gc` is not normally needed now.  This was not communicated well to our sys admins, and in fact is not even mentioned in the man pages.

When `content.dump` is already set, and `flux shutdown --gc` is specified, the tool tries to set the attribute and fails due to the new restrictions on broker attributes added by  #7348 (in 0.82.0).

This PR
- adds the ATTR_RUNTIME flag to `content.dump`, addressing the root cause of the failure
- adds a test that fails before this change and succeeds after
- adds a note to man pages about automatic GC
- improves handling of dump-related options in `flux-shutdown`, including improving the informational message to show the location of the future dump
- improves attribute error messages in `flux-shutdown`

If we need to backport this fix, I did confirm that only the first commit is needed
- [broker: add ATTR_RUNTIME to content.{dump,restore}](https://github.com/flux-framework/flux-core/commit/362416ce7e35b22bf712fd2deaf1ee71eb1e17da)
