### PR TITLE
resource: batch events in initial `resource.journal` responses

### DIFF
--- a/src/modules/resource/reslog.c
+++ b/src/modules/resource/reslog.c
@@ -336,19 +336,58 @@ int reslog_add_callback (struct reslog *reslog, reslog_cb_f cb, void *arg)
     return 0;
 }
 
+static int flush_batch (flux_t *h, const flux_msg_t *msg, json_t *batch)
+{
+    if (json_array_size (batch) == 0)
+        return 0;
+    if (flux_respond_pack (h, msg, "{s:O}", "events", batch) < 0)
+        return -1;
+    json_array_clear (batch);
+    return 0;
+}
+
 // returns true if streaming should continue
 static bool send_backlog (struct reslog *reslog, const flux_msg_t *msg)
 {
     flux_t *h = reslog->ctx->h;
-    json_t *entry = zlistx_first (reslog->eventlog);
+    json_t *batch;
+    json_t *entry;
+
+    if (!(batch = json_array ()))
+        goto error;
+    entry = zlistx_first (reslog->eventlog);
     while (entry) {
-        if (notify_one_consumer (reslog, msg, entry) < 0)
-            goto error;
+        if (match_event (entry, "resource-define")) {
+            /* resource-define carries R in its own response. Flush th
+             * current batch first, then respond with just this event.
+             */
+            json_t *R = inventory_get (reslog->ctx->inventory);
+            if (flush_batch (h, msg, batch) < 0
+                || flux_respond_pack (h,
+                                      msg,
+                                      "{s:[O] s:O}",
+                                      "events", entry,
+                                      "R", R) < 0)
+                goto error_batch;
+        }
+        else {
+            if (json_array_append (batch, entry) < 0) {
+                errno = ENOMEM;
+                goto error_batch;
+            }
+            if (json_array_size (batch) >= 100
+                && flush_batch (h, msg, batch) < 0)
+                goto error_batch;
+        }
         entry = zlistx_next (reslog->eventlog);
     }
-    if (flux_respond_pack (h, msg, "{s:[]}", "events") < 0) // delimiter
-        goto error;
+    if (flush_batch (h, msg, batch) < 0
+        || flux_respond_pack (h, msg, "{s:[]}", "events") < 0) // sentinel
+        goto error_batch;
+    json_decref (batch);
     return true;
+error_batch:
+    json_decref (batch);
 error:
     flux_log_error (h, "error responding to journal request");
     return false;

--- a/t/python/t0032-resource-journal.py
+++ b/t/python/t0032-resource-journal.py
@@ -217,6 +217,41 @@ class TestResourceJournalConsumer(unittest.TestCase):
                 self.assertEqual(R.nnodes, 4)
                 consumer.stop()
 
+    def test_backlog_batching(self):
+        """Test that a large backlog spanning multiple batches is delivered"""
+        # Generate enough events to exceed the send_backlog() batch size of 100.
+        # Each drain+undrain cycle adds 2 events to the resource eventlog.
+        n_cycles = 55
+        reason = "backlog-batch-test"
+        for _ in range(n_cycles):
+            self.fh.rpc("resource.drain", {"targets": "0", "reason": reason}).get()
+            self.fh.rpc("resource.undrain", {"targets": "0"}).get()
+
+        # Connect a consumer after all events are already in the backlog
+        consumer = ResourceJournalConsumer(self.fh, include_sentinel=True).start()
+        events = []
+        while True:
+            event = consumer.poll(timeout=30.0)
+            if event.is_empty():
+                break
+            events.append(event)
+        consumer.stop()
+
+        # Verify all drain events with our unique reason were received.
+        # If batching were broken, events past the batch boundary would be lost.
+        received = sum(
+            1 for e in events if e.name == "drain" and e.context.get("reason") == reason
+        )
+        self.assertEqual(received, n_cycles)
+
+        # Events must be time ordered
+        self.assertTrue(
+            all(
+                events[i].timestamp <= events[i + 1].timestamp
+                for i in range(len(events) - 1)
+            )
+        )
+
     def test_event_after_history(self):
         """Test that a consumer gets new events after history is processed"""
 


### PR DESCRIPTION
As observed in #7533, the resource module sends one response per event when consumers request the journal in the `resource.journal` RPC. In the worst case, this sends 100K messages since the default `journal_max = 100000`.

The protocol already supports an array of events per message. Batch up to 100 events together in the response. This reduces the count of initial messages by 100x and should be a good tradeoff between message size and count.