### PR TITLE
python: add logger to BrokerModule class

### DIFF
--- a/doc/python/broker_modules.rst
+++ b/doc/python/broker_modules.rst
@@ -106,6 +106,31 @@ The :attr:`~flux.brokermod.BrokerModule.handle` property returns the
 RPCs, KVS operations, timers, and other watchers.
 
 
+Logging
+-------
+
+:class:`~flux.brokermod.BrokerModule` provides a
+:class:`~flux.brokermod.BrokerLogger` instance as ``self.log``.  Use the
+convenience methods to emit log messages without importing :mod:`syslog`:
+
+.. code-block:: python
+
+   self.log.info("module started")
+   self.log.error(f"handler failed: {exc}")
+
+The full set of methods mirrors syslog severity levels: ``debug``, ``info``,
+``notice``, ``warning``, ``error``, ``critical``, ``alert``, and ``emerg``.
+Log messages appear in :man1:`flux-dmesg` and the broker's stderr.
+
+By default all messages are forwarded to the ring buffer and the broker's
+global log level acts as the filter — consistent with C module behaviour.
+Subclasses may tighten the threshold by setting ``self.log.level``:
+
+.. code-block:: python
+
+   self.log.level = "info"   # suppress debug messages
+
+
 Error handling
 --------------
 

--- a/doc/python/scheduler.rst
+++ b/doc/python/scheduler.rst
@@ -529,20 +529,25 @@ ones and then rejects whatever remains:
 Logging
 -------
 
-Both the scheduler and pool implementations log via ``self.log(level, msg)``,
-where *level* is a :mod:`syslog` priority constant.  The base class filters
-messages against :attr:`~Scheduler.log_level` before forwarding to
-``handle.log``, so only messages at or above the configured severity are
-emitted:
+:attr:`~flux.brokermod.BrokerModule.log` is a
+:class:`~flux.brokermod.BrokerLogger` instance available on every
+:class:`~flux.brokermod.BrokerModule`, including :class:`Scheduler`.  Use
+the convenience methods to emit log messages without importing :mod:`syslog`:
 
 .. code-block:: python
 
-   import syslog
-   self.log(syslog.LOG_DEBUG, f"alloc: {jobid}: {alloc.dumps()}")
-   self.log(syslog.LOG_ERR,   f"unexpected error: {exc}")
+   self.log.debug(f"alloc: {jobid}: {alloc.dumps()}")
+   self.log.info("scheduler ready")
+   self.log.warning(f"unknown pool option {key!r} ignored")
+   self.log.error(f"unexpected error: {exc}")
 
-The default :attr:`~Scheduler.log_level` is ``LOG_INFO``.  Set it at load
-time to enable more verbose output:
+The full set of methods mirrors syslog severity levels: ``debug``, ``info``,
+``notice``, ``warning``, ``error``, ``critical``, ``alert``, and ``emerg``.
+
+Messages are filtered by a severity threshold before being forwarded to
+``handle.log``; only messages at or above the threshold are emitted.  The
+default threshold for :class:`Scheduler` is ``info``.  Set it at load time
+to enable more verbose output:
 
 .. code-block:: console
 
@@ -551,8 +556,8 @@ time to enable more verbose output:
 Valid level names are ``emerg``, ``alert``, ``crit``, ``err``, ``warning``,
 ``notice``, ``info``, and ``debug``.
 
-Pool implementations receive the same ``self.log`` method and should call it
-unconditionally — no ``None`` check is needed.
+Pool implementations receive the same :attr:`~flux.brokermod.BrokerModule.log`
+object and should call it unconditionally.
 
 Log messages appear in :man1:`flux-dmesg` and the broker's stderr.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1093,6 +1093,7 @@ topologies
 blocklist
 OSError
 ValueError
+BrokerLogger
 BrokerModule
 MyModule
 subclasses

--- a/src/bindings/python/flux/brokermod.py
+++ b/src/bindings/python/flux/brokermod.py
@@ -8,8 +8,106 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import syslog
+
 from _flux._core import ffi, lib
 from flux.constants import FLUX_MSGTYPE_EVENT, FLUX_MSGTYPE_REQUEST
+
+
+class BrokerLogger:
+    """Logger bridge from a broker module to the Flux ring buffer.
+
+    Provides convenience methods (``debug``, ``info``, ``notice``,
+    ``warning``, ``error``, ``critical``, ``alert``, ``emerg``).  Also callable as
+    ``log(level, msg)`` so it can serve as a drop-in wrapper for
+    ``handle.log()``.
+
+    The ``level`` attribute is a threshold: messages with a numerically
+    higher syslog priority value (i.e. lower urgency, such as
+    ``LOG_DEBUG``) are silently dropped when they exceed the threshold.
+    The default ``syslog.LOG_DEBUG`` passes all messages through,
+    matching C module behaviour where the broker's global log level is
+    the only filter.
+
+    ``level`` may be assigned a syslog integer constant or a level-name
+    string (e.g. ``"info"``, ``"debug"``); reading ``level`` always
+    returns the integer.
+    """
+
+    LEVEL_NAMES = {
+        "emerg": syslog.LOG_EMERG,
+        "alert": syslog.LOG_ALERT,
+        "crit": syslog.LOG_CRIT,
+        "err": syslog.LOG_ERR,
+        "warning": syslog.LOG_WARNING,
+        "notice": syslog.LOG_NOTICE,
+        "info": syslog.LOG_INFO,
+        "debug": syslog.LOG_DEBUG,
+    }
+    _LEVEL_NAMES_REVERSE = {v: k for k, v in LEVEL_NAMES.items()}
+
+    def __init__(self, h):
+        self._h = h
+        self._level = syslog.LOG_DEBUG
+
+    @property
+    def level(self):
+        """Current log-level threshold as a syslog integer constant."""
+        return self._level
+
+    @level.setter
+    def level(self, value):
+        if isinstance(value, str):
+            name = value.lower()
+            if name not in self.LEVEL_NAMES:
+                raise ValueError(
+                    f"invalid log level {value!r}: "
+                    f"expected one of {', '.join(self.LEVEL_NAMES)}"
+                )
+            self._level = self.LEVEL_NAMES[name]
+        else:
+            try:
+                self._level = int(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"invalid log level {value!r}") from exc
+
+    @property
+    def level_name(self):
+        """Current log level as a name string (e.g. ``'info'``)."""
+        return self._LEVEL_NAMES_REVERSE.get(self._level, str(self._level))
+
+    def __call__(self, level: int, msg: str) -> None:
+        """Emit *msg* at syslog priority *level* if within the threshold.
+
+        Satisfies the ``(level, msg)`` callable contract for classes that
+        accept an injectable logger.
+        """
+        if level <= self._level:
+            self._h.log(level, msg)
+
+    def debug(self, msg: str) -> None:
+        self(syslog.LOG_DEBUG, msg)
+
+    def info(self, msg: str) -> None:
+        self(syslog.LOG_INFO, msg)
+
+    def notice(self, msg: str) -> None:
+        self(syslog.LOG_NOTICE, msg)
+
+    def warning(self, msg: str) -> None:
+        self(syslog.LOG_WARNING, msg)
+
+    def error(self, msg: str) -> None:
+        self(syslog.LOG_ERR, msg)
+
+    def critical(self, msg: str) -> None:
+        self(syslog.LOG_CRIT, msg)
+
+    def alert(self, msg: str) -> None:
+        self(syslog.LOG_ALERT, msg)
+
+    def emerg(self, msg: str) -> None:
+        self(syslog.LOG_EMERG, msg)
 
 
 def request_handler(topic, prefix=True, allow_guest=False):
@@ -88,6 +186,7 @@ class BrokerModule:
         self._name = ffi.string(name_p).decode() if name_p != ffi.NULL else "unknown"
         self._watchers = []
         self._stopped_with_error = False
+        self.log = BrokerLogger(h)
         self._register_handlers()
 
     @property

--- a/src/bindings/python/flux/resource/ResourcePoolImplementation.py
+++ b/src/bindings/python/flux/resource/ResourcePoolImplementation.py
@@ -46,10 +46,11 @@ class ResourcePoolImplementation(ResourceSetImplementation):  # pragma: no cover
     generation: int = 0
 
     def log(self, level: int, msg: str) -> None:
-        """Log a message at *level* (a :mod:`syslog` priority constant).
+        """Log a message at syslog priority *level*.
 
-        Set at construction time to the scheduler's filtered ``log`` method so
-        that pool implementations can call ``self.log(syslog.LOG_WARNING, ...)``
+        Replaced at construction time by a :class:`~flux.brokermod.BrokerLogger`
+        instance (or any callable with the same ``(level, msg)`` signature) so
+        that pool implementations can call ``self.log(level, msg)``
         unconditionally.  This no-op default is used when no logger is supplied
         (e.g. in unit tests).
         """

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -52,11 +52,10 @@ import errno
 import functools
 import heapq
 import inspect
-import syslog
 import time
 
 from _flux._core import ffi, lib
-from flux.brokermod import BrokerModule, request_handler
+from flux.brokermod import BrokerLogger, BrokerModule, request_handler
 from flux.constants import FLUX_RPC_STREAMING
 from flux.job import JobID, job_raise_async
 from flux.kvs import KVSTxn
@@ -279,25 +278,6 @@ class Scheduler(BrokerModule):
     #: ``self.pool_kwargs = {"opt": value}``.
     pool_kwargs: dict = {}
 
-    #: Minimum syslog priority level emitted by :meth:`log`.  Messages with a
-    #: numerically higher level (lower priority) are silently dropped.
-    #: Defaults to ``LOG_ERR``; set ``log-level=debug`` at load time for
-    #: verbose pool and scheduler diagnostics.
-    log_level: int = syslog.LOG_INFO
-
-    #: Map of level name strings to syslog priority constants, used when
-    #: parsing the ``log-level=`` module argument.
-    _LOG_LEVEL_NAMES: dict = {
-        "emerg": syslog.LOG_EMERG,
-        "alert": syslog.LOG_ALERT,
-        "crit": syslog.LOG_CRIT,
-        "err": syslog.LOG_ERR,
-        "warning": syslog.LOG_WARNING,
-        "notice": syslog.LOG_NOTICE,
-        "info": syslog.LOG_INFO,
-        "debug": syslog.LOG_DEBUG,
-    }
-
     def __init_subclass__(cls, **kwargs):
         # Automatically call _reject_unknown_args() after each subclass
         # __init__ returns, so that unrecognised module arguments are caught
@@ -328,6 +308,7 @@ class Scheduler(BrokerModule):
 
     def __init__(self, h, *args):
         super().__init__(h, *args)
+        self.log.level = "info"
         self._resources = None
         self._acquire_rpc = None
         self._queue = []  # heapq of PendingJob, ordered by PendingJob.__lt__
@@ -402,12 +383,13 @@ class Scheduler(BrokerModule):
                     )
             elif arg.startswith("log-level="):
                 name = arg[10:].lower()
-                if name not in self._LOG_LEVEL_NAMES:
+                try:
+                    self.log.level = name
+                except ValueError:
                     raise ValueError(
                         f"log-level={name!r} is invalid: "
-                        f"expected one of {', '.join(self._LOG_LEVEL_NAMES)}"
+                        f"expected one of {', '.join(BrokerLogger.LEVEL_NAMES)}"
                     )
-                self.log_level = self._LOG_LEVEL_NAMES[name]
             else:
                 self._pending_args.append(arg)
 
@@ -422,19 +404,6 @@ class Scheduler(BrokerModule):
                 f"unknown argument {self._pending_args[0]!r}: "
                 f"built-in options are queue-depth, log-level"
             )
-
-    # ------------------------------------------------------------------
-    # Logging
-    # ------------------------------------------------------------------
-
-    def log(self, level: int, msg: str) -> None:
-        """Emit *msg* via ``handle.log`` if *level* is at or above :attr:`log_level`.
-
-        Pool implementations receive this method as their ``log`` callable so
-        that both scheduler and pool diagnostics share the same threshold.
-        """
-        if level <= self.log_level:
-            self.handle.log(level, msg)
 
     # ------------------------------------------------------------------
     # Public interface: resource state
@@ -571,13 +540,12 @@ class Scheduler(BrokerModule):
 
         if self._sched_delay != old_delay:
             if self._sched_delay > 0:
-                self.log(
-                    syslog.LOG_DEBUG,
+                self.log.debug(
                     f"sched: burst detected, coalescing delay="
                     f"{self._sched_delay * 1000:.1f}ms",
                 )
             else:
-                self.log(syslog.LOG_DEBUG, "sched: burst ended, delay=0")
+                self.log.debug("sched: burst ended, delay=0")
 
     # ------------------------------------------------------------------
     # Forecast
@@ -653,7 +621,7 @@ class Scheduler(BrokerModule):
         try:
             future.get()
         except OSError as exc:
-            self.log(syslog.LOG_ERR, f"alloc: KVS commit failed: {exc}")
+            self.log.error(f"alloc: KVS commit failed: {exc}")
             self.stop_error()
             return
         resp = {"id": msg.payload["id"], "type": _ALLOC_SUCCESS, "R": R_dict}
@@ -919,7 +887,7 @@ class Scheduler(BrokerModule):
             self._sched_hello()
             self._sched_ready()
         except OSError as exc:
-            self.log(syslog.LOG_ERR, f"initialization failed: {exc}")
+            self.log.error(f"initialization failed: {exc}")
             raise
         super().run()
 
@@ -942,7 +910,7 @@ class Scheduler(BrokerModule):
             )
             self._request_schedule()
         except Exception as exc:
-            self.log(syslog.LOG_ERR, f"alloc callback raised: {exc}")
+            self.log.error(f"alloc callback raised: {exc}")
             self.stop_error()
 
     @request_handler("sched.free", prefix=False)
@@ -953,7 +921,7 @@ class Scheduler(BrokerModule):
             self.free(p["id"], R, final=p.get("final", False))
             self._request_schedule()
         except Exception as exc:
-            self.log(syslog.LOG_ERR, f"free callback raised: {exc}")
+            self.log.error(f"free callback raised: {exc}")
             self.stop_error()
 
     @request_handler("sched.cancel", prefix=False)
@@ -962,7 +930,7 @@ class Scheduler(BrokerModule):
             self.cancel(msg.payload["id"])
             self._request_schedule()
         except Exception as exc:
-            self.log(syslog.LOG_ERR, f"cancel callback raised: {exc}")
+            self.log.error(f"cancel callback raised: {exc}")
             self.stop_error()
 
     @request_handler("sched.prioritize", prefix=False)
@@ -971,7 +939,7 @@ class Scheduler(BrokerModule):
             self.prioritize(msg.payload.get("jobs", []))
             self._request_schedule()
         except Exception as exc:
-            self.log(syslog.LOG_ERR, f"prioritize callback raised: {exc}")
+            self.log.error(f"prioritize callback raised: {exc}")
             self.stop_error()
 
     @request_handler("sched.resource-status", prefix=False)
@@ -985,7 +953,7 @@ class Scheduler(BrokerModule):
             }
             self.handle.respond(msg, resp)
         except Exception as exc:
-            self.log(syslog.LOG_ERR, f"resource-status failed: {exc}")
+            self.log.error(f"resource-status failed: {exc}")
             lib.flux_respond_error(
                 self.handle.handle, msg.handle, errno.EINVAL, str(exc).encode()
             )
@@ -1001,7 +969,7 @@ class Scheduler(BrokerModule):
             self.expiration(msg, jobid, exp)
             self._request_schedule()
         except Exception as exc:
-            self.log(syslog.LOG_ERR, f"expiration callback raised: {exc}")
+            self.log.error(f"expiration callback raised: {exc}")
             lib.flux_respond_error(
                 self.handle.handle, msg.handle, errno.EINVAL, str(exc).encode()
             )
@@ -1011,7 +979,7 @@ class Scheduler(BrokerModule):
         try:
             self.feasibility_check(msg, msg.payload.get("jobspec", {}))
         except Exception as exc:
-            self.log(syslog.LOG_ERR, f"feasibility callback raised: {exc}")
+            self.log.error(f"feasibility callback raised: {exc}")
             errmsg = str(exc).encode()
             if (
                 lib.flux_respond_error(
@@ -1102,7 +1070,7 @@ class Scheduler(BrokerModule):
         # (e.g. during the hello loop) don't repeat the warning.
         known = getattr(self._resources.impl, "known_options", frozenset())
         for key in [k for k in self.pool_kwargs if k not in known]:
-            self.log(syslog.LOG_WARNING, f"pool: ignoring unknown option {key!r}")
+            self.log.warning(f"pool: ignoring unknown option {key!r}")
             del self.pool_kwargs[key]
 
         # All resources start down; first update brings some up
@@ -1121,7 +1089,7 @@ class Scheduler(BrokerModule):
         try:
             data = future.get()
         except OSError as exc:
-            self.log(syslog.LOG_ERR, f"exiting due to resource update failure: {exc}")
+            self.log.error(f"exiting due to resource update failure: {exc}")
             self.stop()
             return
         self._apply_resource_update(data)
@@ -1135,9 +1103,8 @@ class Scheduler(BrokerModule):
             self._resources.mark_down(data["down"])
         if "expiration" in data and data["expiration"] >= 0:
             self._resources.expiration = data["expiration"]
-            self.log(
-                syslog.LOG_INFO,
-                f"resource expiration updated to " f"{data['expiration']:.2f}",
+            self.log.info(
+                f"resource expiration updated to {data['expiration']:.2f}",
             )
         if "shrink" in data:
             from flux.idset import IDset
@@ -1151,10 +1118,7 @@ class Scheduler(BrokerModule):
         try:
             future.get()
         except OSError as exc:
-            self.log(
-                syslog.LOG_ERR,
-                f"error raising fatal exception on {jobid.f58}: {exc}",
-            )
+            self.log.error(f"error raising fatal exception on {jobid.f58}: {exc}")
 
     def _sched_hello(self):
         """Synchronous hello protocol with job-manager (RFC 27).
@@ -1187,10 +1151,7 @@ class Scheduler(BrokerModule):
             try:
                 R_dict = kvs_get(self.handle, key)
             except OSError:
-                self.log(
-                    syslog.LOG_ERR,
-                    f"hello: failed to look up R for job {JobID(jobid).f58}",
-                )
+                self.log.error(f"hello: failed to look up R for job {JobID(jobid).f58}")
                 f.reset()
                 continue
 
@@ -1212,12 +1173,10 @@ class Scheduler(BrokerModule):
                     R,
                 )
             except Exception as exc:
-                self.log(
-                    syslog.LOG_ERR,
+                self.log.error(
                     f"hello callback failed for job {JobID(jobid).f58}: {exc}",
                 )
-                self.log(
-                    syslog.LOG_ERR,
+                self.log.error(
                     f"raising fatal exception on running job id={JobID(jobid).f58}",
                 )
                 f_raise = job_raise_async(
@@ -1254,13 +1213,9 @@ class Scheduler(BrokerModule):
         except OSError as exc:
             raise OSError(f"sched-ready failed: {exc}") from exc
 
-        level_name = {v: k for k, v in self._LOG_LEVEL_NAMES.items()}.get(
-            self.log_level, str(self.log_level)
-        )
-        self.log(
-            syslog.LOG_INFO,
+        self.log.info(
             f"ready: queue-depth={depth}"
-            f" log-level={level_name}"
+            f" log-level={self.log.level_name}"
             f" Rv{self.resources.version}"
             f" {self.resources.dumps()}",
         )

--- a/src/modules/sched-backfill.py
+++ b/src/modules/sched-backfill.py
@@ -47,7 +47,6 @@ Reference:
 """
 
 import heapq
-import syslog
 import time
 
 from _flux._core import lib
@@ -263,10 +262,7 @@ class BackfillScheduler(Scheduler):
                 shadow is not None and duration > 0.0 and now + duration <= shadow
             )
             if can_backfill and self._try_alloc(job, backfill=head.jobid):
-                self.log(
-                    syslog.LOG_DEBUG,
-                    f"backfill: {JobID(job.jobid).f58} (shadow={shadow:.0f})",
-                )
+                self.log.debug(f"backfill: {JobID(job.jobid).f58} (shadow={shadow:.0f})")
             else:
                 kept.append(job)
             yield

--- a/src/modules/sched-simple.py
+++ b/src/modules/sched-simple.py
@@ -27,8 +27,6 @@ following queue-depth aliases are also accepted::
 import errno
 import importlib.util
 import os
-import syslog
-
 from flux.job import JobID
 
 # sched-fifo is co-installed in the same directory; the hyphen in its name
@@ -72,8 +70,7 @@ class SimpleScheduler(FIFOScheduler):
     def hello(self, jobid, priority, userid, t_submit, R):
         """Register alloc and emit C sched-simple compatible DEBUG hello log."""
         super().hello(jobid, priority, userid, t_submit, R)
-        self.log(
-            syslog.LOG_DEBUG,
+        self.log.debug(
             f"hello: id={JobID(jobid).f58} priority={priority} "
             f"userid={userid} t_submit={t_submit:.1f}",
         )

--- a/t/python/t0038-brokermod.py
+++ b/t/python/t0038-brokermod.py
@@ -12,12 +12,14 @@
 # Unit tests for flux.brokermod (BrokerModule, request_handler, event_handler).
 # A broker is not required; the flux handle is mocked.
 
+import syslog
 import types
 import unittest
 from unittest.mock import MagicMock, patch
 
 import subflux  # noqa: F401 - To set up PYTHONPATH
 from flux.brokermod import (
+    BrokerLogger,
     BrokerModule,
     event_handler,
     request_handler,
@@ -318,6 +320,154 @@ class TestResolveEntryPoint(unittest.TestCase):
 
         mod = _make_mod(mod_main=mod_main, MyMod=MyMod)
         self.assertIs(resolve_entry_point(mod), mod_main)
+
+
+class TestBrokerLogger(unittest.TestCase):
+    def _make_logger(self):
+        mock_h = MagicMock()
+        return BrokerLogger(mock_h), mock_h
+
+    def test_default_level_is_debug(self):
+        """Default level passes all messages through (LOG_DEBUG)."""
+        logger, _ = self._make_logger()
+        self.assertEqual(logger.level, syslog.LOG_DEBUG)
+
+    def test_debug_calls_handle_log(self):
+        logger, mock_h = self._make_logger()
+        logger.debug("hi")
+        mock_h.log.assert_called_once_with(syslog.LOG_DEBUG, "hi")
+
+    def test_info_calls_handle_log(self):
+        logger, mock_h = self._make_logger()
+        logger.info("hi")
+        mock_h.log.assert_called_once_with(syslog.LOG_INFO, "hi")
+
+    def test_notice_calls_handle_log(self):
+        logger, mock_h = self._make_logger()
+        logger.notice("hi")
+        mock_h.log.assert_called_once_with(syslog.LOG_NOTICE, "hi")
+
+    def test_warning_calls_handle_log(self):
+        logger, mock_h = self._make_logger()
+        logger.warning("hi")
+        mock_h.log.assert_called_once_with(syslog.LOG_WARNING, "hi")
+
+    def test_error_calls_handle_log(self):
+        logger, mock_h = self._make_logger()
+        logger.error("hi")
+        mock_h.log.assert_called_once_with(syslog.LOG_ERR, "hi")
+
+    def test_critical_calls_handle_log(self):
+        logger, mock_h = self._make_logger()
+        logger.critical("hi")
+        mock_h.log.assert_called_once_with(syslog.LOG_CRIT, "hi")
+
+    def test_alert_calls_handle_log(self):
+        logger, mock_h = self._make_logger()
+        logger.alert("hi")
+        mock_h.log.assert_called_once_with(syslog.LOG_ALERT, "hi")
+
+    def test_emerg_calls_handle_log(self):
+        logger, mock_h = self._make_logger()
+        logger.emerg("hi")
+        mock_h.log.assert_called_once_with(syslog.LOG_EMERG, "hi")
+
+    def test_call_interface_passes_through(self):
+        """__call__(level, msg) forwards to handle.log when level is within threshold."""
+        logger, mock_h = self._make_logger()
+        logger(syslog.LOG_ERR, "raw")
+        mock_h.log.assert_called_once_with(syslog.LOG_ERR, "raw")
+
+    def test_message_below_threshold_is_dropped(self):
+        """Messages with priority lower than level are silently dropped."""
+        logger, mock_h = self._make_logger()
+        logger.level = "info"  # LOG_INFO=6; LOG_DEBUG=7 is below threshold
+        logger.debug("dropped")
+        mock_h.log.assert_not_called()
+
+    def test_message_at_threshold_is_passed(self):
+        """Messages exactly at the threshold are forwarded."""
+        logger, mock_h = self._make_logger()
+        logger.level = "info"
+        logger.info("kept")
+        mock_h.log.assert_called_once_with(syslog.LOG_INFO, "kept")
+
+    def test_message_above_threshold_is_passed(self):
+        """Messages with higher urgency than threshold are always forwarded."""
+        logger, mock_h = self._make_logger()
+        logger.level = "info"
+        logger.error("kept")
+        mock_h.log.assert_called_once_with(syslog.LOG_ERR, "kept")
+
+    def test_set_level_string(self):
+        """level setter accepts a level-name string and stores the integer."""
+        logger, _ = self._make_logger()
+        logger.level = "warning"
+        self.assertEqual(logger.level, syslog.LOG_WARNING)
+
+    def test_set_level_int(self):
+        """level setter accepts a syslog integer constant directly."""
+        logger, _ = self._make_logger()
+        logger.level = syslog.LOG_ERR
+        self.assertEqual(logger.level, syslog.LOG_ERR)
+
+    def test_set_level_invalid_string_raises(self):
+        """level setter raises ValueError for an unknown level name."""
+        logger, _ = self._make_logger()
+        with self.assertRaises(ValueError) as ctx:
+            logger.level = "verbose"
+        self.assertIn("verbose", str(ctx.exception))
+
+    def test_set_level_invalid_type_raises(self):
+        """level setter raises ValueError for a non-integer, non-string value."""
+        logger, _ = self._make_logger()
+        with self.assertRaises(ValueError):
+            logger.level = [1, 2, 3]
+
+    def test_level_name_property(self):
+        """level_name returns the string name matching the current level."""
+        logger, _ = self._make_logger()
+        logger.level = syslog.LOG_INFO
+        self.assertEqual(logger.level_name, "info")
+
+    def test_level_name_unknown_int(self):
+        """level_name falls back to the integer string for unknown values."""
+        logger, _ = self._make_logger()
+        logger.level = 99
+        self.assertEqual(logger.level_name, "99")
+
+    def test_broker_module_has_log_attribute(self):
+        """BrokerModule.__init__ creates a self.log BrokerLogger instance."""
+        mock_h = MagicMock()
+        mock_ffi = MagicMock()
+        mock_lib = MagicMock()
+        mock_ffi.string.return_value = b"mymod"
+        with patch("flux.brokermod.ffi", mock_ffi), patch(
+            "flux.brokermod.lib", mock_lib
+        ):
+
+            class Mod(BrokerModule):
+                pass
+
+            mod = Mod(mock_h)
+        self.assertIsInstance(mod.log, BrokerLogger)
+
+    def test_broker_module_log_forwards_to_handle(self):
+        """mod.log.error() reaches handle.log() on the underlying Flux handle."""
+        mock_h = MagicMock()
+        mock_ffi = MagicMock()
+        mock_lib = MagicMock()
+        mock_ffi.string.return_value = b"mymod"
+        with patch("flux.brokermod.ffi", mock_ffi), patch(
+            "flux.brokermod.lib", mock_lib
+        ):
+
+            class Mod(BrokerModule):
+                pass
+
+            mod = Mod(mock_h)
+        mod.log.error("boom")
+        mock_h.log.assert_called_once_with(syslog.LOG_ERR, "boom")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, Python broker modules don't have a built in logging interface. They have to use the `handle.log()` interface or build a custom interface like is done in the `Scheduler` class.

This PR adds a Pythonic logger interface `BrokerLogger` to `flux.brokermod` and assigns it to `self.log` at initialization. Python broker modules can log simply with `self.log.info()`, `self.log.error()` etc, without having to import `syslog` and use syslog level constants. The class also acts as a callable, so `self.log (level, msg)` is supported for backwards compatibility or interfaces that expect to able to call `log()` (e.g. `ResourcePool` classes).

The bespoke logger in the `Scheduler` and derived classes is replaced, and calls simplified to remove use of `syslog` constants.

The `ResourcePool` classes are left alone (besides one docstring update), because the contract is for a more basic `log(level, msg)` interface and that continues working.

The end result is that all Python broker modules have a logger interface ready for use, not just schedulers.
