### PR TITLE
dependency-after: satisfy `afterany` on job cancellation

### DIFF
--- a/doc/man1/common/job-dependencies.rst
+++ b/doc/man1/common/job-dependencies.rst
@@ -29,31 +29,40 @@ The following dependency schemes are built-in:
    that the target job cannot be found.
 
 .. note::
-   The ``after*`` dependency schemes below only satisfy dependencies for
-   jobs that entered the RUN state. A job that is canceled while pending
-   does not satisfy the `afterany` or `afternotok` dependencies. Thus,
-   canceling a job with a chain of dependencies causes all jobs in the
-   chain to be canceled.
+   Most ``after*`` dependency schemes require that the target job enters
+   the RUN state. Only ``afterany`` can be satisfied by a job that is
+   canceled while pending, since it is satisfied after ANY outcome.
+
+   A helpful analogy: dependency chains behave like shell command separators.
+   ``afterany`` is like ``;`` (run regardless of result), while
+   ``afternotok`` and ``afterexcept`` are like ``||`` (run only on
+   failure). Just as a chain of ``||`` commands terminates when one
+   succeeds, a chain of ``afternotok`` jobs should terminate when canceled,
+   not continue. Similarly ``afterok`` behaves like ``&&``: once any job
+   fails the rest of the chain is canceled.
 
 after:JOBID
-   This dependency is satisfied after JOBID starts.
+   This dependency is satisfied after JOBID starts. The target job must
+   have entered the RUN state.
 
 afterany:JOBID
    This dependency is satisfied after JOBID enters the INACTIVE state,
-   regardless of the result
+   regardless of the result. This is the only ``after*`` dependency that
+   can be satisfied even if the target job is canceled before starting.
 
 afterok:JOBID
    This dependency is satisfied after JOBID enters the INACTIVE state
-   with a successful result.
+   with a successful result. The target job must have entered the RUN state.
 
 afternotok:JOBID
    This dependency is satisfied after JOBID enters the INACTIVE state
-   with an unsuccessful result.
+   with an unsuccessful result. The target job must have entered the RUN
+   state.
 
 afterexcept:JOBID
    This dependency is satisfied when JOBID enters the INACTIVE state
    and a fatal job exception caused the transition to CLEANUP (e.g.,
-   node failure, timeout, cancel, etc.).
+   node failure, timeout). The target job must have entered the RUN state.
 
 singleton
    This dependency is satisfied when there are no other active jobs

--- a/src/modules/job-manager/plugins/dependency-after.c
+++ b/src/modules/job-manager/plugins/dependency-after.c
@@ -30,7 +30,7 @@ static zlistx_t *global_reflist = NULL;
  */
 enum after_type {
     AFTER_START =   0x1,
-    AFTER_FINISH =  0x2,
+    AFTER_ANY =     0x2,  /* afterany */
     AFTER_SUCCESS = 0x4,
     AFTER_FAILURE = 0x8,
     AFTER_EXCEPT  = 0x10
@@ -55,7 +55,7 @@ static const char * after_typestr (enum after_type type)
     switch (type) {
         case AFTER_START:
             return "after-start";
-        case AFTER_FINISH:
+        case AFTER_ANY:
             return "after-finish";
         case AFTER_SUCCESS:
             return "after-success";
@@ -72,7 +72,7 @@ static int after_type_parse (const char *s, enum after_type *tp)
     if (streq (s, "after"))
         *tp = AFTER_START;
     else if (streq (s, "afterany"))
-        *tp = AFTER_FINISH;
+        *tp = AFTER_ANY;
     else if (streq (s, "afterok"))
         *tp = AFTER_SUCCESS;
     else if (streq (s, "afternotok"))
@@ -280,11 +280,15 @@ static int dependency_handle_inactive (flux_plugin_t *p,
                                        "dependency: failed to get %ss result",
                                        jobid);
 
-    /*  If the target job did not enter RUN state, immediately raise an
-     *  exception since after* dependencies only apply to jobs that actually
-     *  ran:
+    /*  If the target job did not enter RUN state, raise an exception for
+     *  all dependencies except 'afterany'. Only 'afterany' can be satisfied
+     *  if the job was canceled before starting since it is satisfied after
+     *  ANY outcome. The other dependency types ('after', 'afterok',
+     *  'afternotok', 'afterexcept') require the job to have actually run
+     *  to avoid unexpected behavior (see issue #6555).
      */
-    if (!flux_jobtap_job_event_posted (p, afterid, "alloc"))
+    if (type != AFTER_ANY
+        && !flux_jobtap_job_event_posted (p, afterid, "alloc"))
         return flux_jobtap_reject_job (p,
                                        args,
                                        "dependency: after: %s never started",
@@ -603,25 +607,28 @@ static int release_dependent_jobs (flux_plugin_t *p,
     }
 
     /*  If this job never entered RUN state (i.e. got an exception before
-     *  the alloc event), then none of the after* dependencies can be
-     *  satisfied. Immediately raise exception(s).
+     *  the alloc event), then only the afterany (AFTER_ANY) dependency
+     *  can be satisfied. All other after* dependencies require the job to
+     *  have run. Release afterany dependencies and raise exceptions on the
+     *  rest. See issue #6555 for why afternotok must not be satisfied here.
      */
     if (!flux_jobtap_job_event_posted (p, FLUX_JOBTAP_CURRENT_JOB, "alloc")) {
+        release_all (p, l, AFTER_ANY);
         raise_exceptions (p, l, "job never started");
         return 0;
     }
 
-    /*  O/w, release dependent jobs based on requisite job result.
+    /*  Release dependent jobs based on requisite job result.
      *  Entries will be removed from the list as they are processed.
      */
     if (result != FLUX_JOB_RESULT_COMPLETED) {
-        int typemask = AFTER_FINISH | AFTER_FAILURE;
+        int typemask = AFTER_ANY | AFTER_FAILURE;
         if (end_event_name && streq (end_event_name, "exception"))
             typemask |= AFTER_EXCEPT;
         release_all (p, l, typemask);
     }
     else
-        release_all (p, l, AFTER_FINISH | AFTER_SUCCESS);
+        release_all (p, l, AFTER_ANY | AFTER_SUCCESS);
 
     /*  Any remaining dependencies can't now be satisfied.
      *   Raise exceptions on any remaining members of list `l`

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -197,7 +197,7 @@ test_expect_success 'chain of afternotok jobs are canceled if one fails before s
 	id4=$(flux submit --dependency=afternotok:$id3 hostname) &&
 	flux cancel $id &&
 	for i in $id2 $id3 $id4; do
-	    flux job wait-event -vt 15 -m type=dependency $id2 exception
+	    flux job wait-event -vt 15 -m type=dependency $i exception
 	done
 '
 test_expect_success 'chain of afternotok jobs are canceled if one succeeds' '
@@ -207,7 +207,7 @@ test_expect_success 'chain of afternotok jobs are canceled if one succeeds' '
 	id4=$(flux submit --dependency=afternotok:$id3 hostname) &&
 	flux job urgency $id default &&
 	for i in $id2 $id3 $id4; do
-	    flux job wait-event -vt 15 -m type=dependency $id2 exception
+	    flux job wait-event -vt 15 -m type=dependency $i exception
 	done
 '
 test_expect_success 'dependency=afterexcept works' '

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -265,9 +265,6 @@ test_expect_success 'dependency=afternotok works for INACTIVE job' '
 		echo afterany:{} ::: ${job2} ${job3} &&
 	test_must_fail flux run --dependency=afternotok:${job1} hostname
 '
-test_expect_success 'afternotok fails for INACTIVE job with no start event' '
-	test_must_fail flux run --dependency=afternotok:${canceled_job} hostname
-'
 test_expect_success 'dependency=after fails for INACTIVE canceled job' '
 	job4=$(flux submit --urgency=hold hostname) &&
 	flux cancel ${job4} &&

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -184,11 +184,39 @@ test_expect_success 'dependency=afternotok works' '
 	flux job wait-event -vt 15 \
 		-m type=dependency $ok1 exception
 '
+test_expect_success 'dependency=afterany works for job canceled before start' '
+	canceled_job=$(flux submit --urgency=hold hostname) &&
+	id2=$(flux submit --dependency=afterany:$canceled_job hostname) &&
+	flux cancel $canceled_job &&
+	flux job wait-event -vt 15 $id2 clean
+'
 test_expect_success 'dependency=afternotok only applies to jobs that start' '
 	canceled_job=$(flux submit --urgency=hold false) &&
 	id2=$(flux submit --dependency=afternotok:$canceled_job hostname) &&
 	flux cancel $canceled_job &&
 	flux job wait-event -vt 15 -m type=dependency $id2 exception
+'
+test_expect_success 'dependency=afterexcept only applies to jobs that start' '
+	canceled_job=$(flux submit --urgency=hold hostname) &&
+	id2=$(flux submit --dependency=afterexcept:$canceled_job hostname) &&
+	flux cancel $canceled_job &&
+	flux job wait-event -vt 15 -m type=dependency $id2 exception
+'
+test_expect_success 'dependency=afterok only applies to jobs that start' '
+	canceled_job=$(flux submit --urgency=hold hostname) &&
+	id2=$(flux submit --dependency=afterok:$canceled_job hostname) &&
+	flux cancel $canceled_job &&
+	flux job wait-event -vt 15 -m type=dependency $id2 exception
+'
+test_expect_success 'chain of afterany jobs continues if one is canceled before start' '
+	id=$(flux submit --urgency=hold hostname) &&
+	id2=$(flux submit --dependency=afterany:$id hostname) &&
+	id3=$(flux submit --dependency=afterany:$id2 hostname) &&
+	id4=$(flux submit --dependency=afterany:$id3 hostname) &&
+	flux cancel $id &&
+	for i in $id2 $id3 $id4; do
+	    flux job wait-event -vt 15 $i clean
+	done
 '
 test_expect_success 'chain of afternotok jobs are canceled if one fails before start' '
 	id=$(flux submit --urgency=hold false) &&


### PR DESCRIPTION
This PR addresses #7565 by changing the behavior of `afterany` to be satisfied whenever the antecedent job reaches the INACTIVE state. Other after* schemes are left with the current behavior due to the issue described in #6555.
