### PR TITLE
add `afterstart` job dependency scheme and deprecate `after`

### DIFF
--- a/doc/man1/common/job-dependencies.rst
+++ b/doc/man1/common/job-dependencies.rst
@@ -41,9 +41,15 @@ The following dependency schemes are built-in:
    not continue. Similarly ``afterok`` behaves like ``&&``: once any job
    fails the rest of the chain is canceled.
 
-after:JOBID
+.. note::
+   The ``after`` scheme is deprecated. Use ``afterstart`` instead.
+
+afterstart:JOBID
    This dependency is satisfied after JOBID starts. The target job must
    have entered the RUN state.
+
+after:JOBID
+   Deprecated alias for ``afterstart``. Use ``afterstart`` instead.
 
 afterany:JOBID
    This dependency is satisfied after JOBID enters the INACTIVE state,

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -530,6 +530,7 @@ afterany
 afterok
 afternotok
 afterexcept
+afterstart
 parsedatetime
 cancelall
 raiseall

--- a/src/bindings/python/flux/job/_utils.py
+++ b/src/bindings/python/flux/job/_utils.py
@@ -18,6 +18,7 @@ import pathlib
 import re
 import resource
 import signal
+import sys
 from collections import ChainMap
 from itertools import chain
 from string import Template
@@ -131,6 +132,13 @@ class URIArg:
 
         self.path = self.uri.path.replace("FXX", "", 1)
         self.scheme = self.uri.scheme
+
+        # Emit deprecation warning for "after" scheme
+        if name == "dependency" and self.scheme == "after":
+            print(
+                "dependency scheme 'after' is deprecated, use 'afterstart'",
+                file=sys.stderr,
+            )
 
     @staticmethod
     def _try_number(value):

--- a/src/modules/job-manager/plugins/dependency-after.c
+++ b/src/modules/job-manager/plugins/dependency-after.c
@@ -69,7 +69,7 @@ static const char * after_typestr (enum after_type type)
 
 static int after_type_parse (const char *s, enum after_type *tp)
 {
-    if (streq (s, "after"))
+    if (streq (s, "after") || streq (s, "afterstart"))
         *tp = AFTER_START;
     else if (streq (s, "afterany"))
         *tp = AFTER_ANY;
@@ -772,6 +772,7 @@ static int query_cb (flux_plugin_t *p,
 
 static const struct flux_plugin_handler tab[] = {
     { "job.dependency.after",      dependency_after_cb, NULL },
+    { "job.dependency.afterstart", dependency_after_cb, NULL },
     { "job.dependency.afterok",    dependency_after_cb, NULL },
     { "job.dependency.afterany",   dependency_after_cb, NULL },
     { "job.dependency.afternotok", dependency_after_cb, NULL },

--- a/src/modules/job-manager/plugins/dependency-after.c
+++ b/src/modules/job-manager/plugins/dependency-after.c
@@ -375,6 +375,17 @@ static int dependency_after_cb (flux_plugin_t *p,
                                        "invalid dependency scheme: %s",
                                        scheme);
 
+    /*  Emit deprecation warning for "after" scheme
+     */
+    if (streq (scheme, "after")) {
+        (void) flux_jobtap_raise_exception (p,
+                                            id,
+                                            "dependency",
+                                            3,
+                                            "dependency scheme 'after' is "
+                                            "deprecated, use 'afterstart'");
+    }
+
     /*  Parse the value argument, which must be a valid jobid
      *  Do not allow FLUX_JOBID_ANY/FLUX_JOBTAP_CURRENT_JOBID to be specified
      */

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -32,6 +32,27 @@ test_expect_success 'dependency=afterstart:invalid rejects invalid target jobids
 	grep "\"bar\" is not a valid jobid" after:bar.err &&
 	grep "job not found" after:1234.err
 '
+test_expect_success 'dependency=after emits deprecation warning' '
+	jobid=$(flux submit --urgency=hold hostname) &&
+	id=$(flux submit --dependency=after:$jobid hostname 2>after.err) &&
+	flux job wait-event -t 15 $id dependency-add &&
+	grep "deprecated" after.err &&
+	grep "afterstart" after.err &&
+	flux job eventlog $id | grep "deprecated" &&
+	flux job eventlog $id | grep "afterstart" &&
+	flux cancel $id &&
+	flux cancel $jobid
+'
+test_expect_success 'dependency=afterstart does not emit deprecation warning' '
+	jobid=$(flux submit --urgency=hold hostname) &&
+	id=$(flux submit --dependency=afterstart:$jobid hostname 2>afterstart.err) &&
+	flux job wait-event -t 15 $id dependency-add &&
+	test_must_fail grep deprecated afterstart.err &&
+	flux job eventlog $id > afterstart.eventlog &&
+	test_must_fail grep deprecated afterstart.eventlog &&
+	flux cancel $id &&
+	flux cancel $jobid
+'
 test_expect_success FLUX_SECURITY 'after* dependencies will not work on another user job' '
 	jobid=$(flux submit sleep 300) &&
 	test_debug "echo submitted job $jobid" &&

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -19,7 +19,7 @@ submit_as_alternate_user()
 		flux job submit --flags=signed job.signed
 }
 
-test_expect_success 'dependency=after:invalid rejects invalid target jobids' '
+test_expect_success 'dependency=afterstart:invalid rejects invalid target jobids' '
 	test_expect_code 1 flux bulksubmit \
 		--dependency={} \
 		--log-stderr={}.err \
@@ -32,7 +32,7 @@ test_expect_success 'dependency=after:invalid rejects invalid target jobids' '
 	grep "\"bar\" is not a valid jobid" after:bar.err &&
 	grep "job not found" after:1234.err
 '
-test_expect_success FLUX_SECURITY 'dependency=after will not work on another user job' '
+test_expect_success FLUX_SECURITY 'after* dependencies will not work on another user job' '
 	jobid=$(flux submit sleep 300) &&
 	test_debug "echo submitted job $jobid" &&
 	test_expect_code 1 submit_as_alternate_user \
@@ -45,29 +45,29 @@ test_expect_success FLUX_SECURITY 'dependency=after will not work on another use
 test_expect_success 'disable ingest validator' '
 	flux module reload -f job-ingest disable-validator
 '
-test_expect_success 'dependency=after rejects invalid dependency' '
+test_expect_success 'dependency=afterstart rejects invalid dependency' '
 	flux run --dry-run hostname | \
 	  jq ".attributes.system.dependencies[0] = \
-		{\"scheme\":\"after\", \"value\": 1}" >job.json &&
+		{\"scheme\":\"afterstart\", \"value\": 1}" >job.json &&
 	test_expect_code 1 flux job submit job.json
 '
 test_expect_success 'reenable ingest validator' '
 	flux module reload -f job-ingest
 '
-test_expect_success 'dependency=after works' '
+test_expect_success 'dependency=afterstart works' '
 	jobid=$(flux submit --urgency=hold hostname) &&
-	depid=$(flux submit --dependency=after:$jobid hostname) &&
+	depid=$(flux submit --dependency=afterstart:$jobid hostname) &&
 	flux job wait-event -vt 15 $depid dependency-add &&
 	test_debug "echo checking that job ${depid} is in DEPEND state" &&
 	test "$(flux jobs -no {state} $depid)" = "DEPEND" &&
 	flux job urgency $jobid default &&
 	flux job wait-event -vt 15 $depid clean
 '
-test_expect_success 'dependency=after does not release job until start event' '
+test_expect_success 'dependency=afterstart does not release job until start event' '
 	jobid=$(flux submit \
 		--setattr=system.exec.test.override=1 \
 		--setattr=system.exec.test.run_duration=0.001s true) &&
-	depid=$(flux submit --dependency=after:$jobid hostname) &&
+	depid=$(flux submit --dependency=afterstart:$jobid hostname) &&
 	flux job wait-event -t 15 $depid dependency-add &&
 	flux job wait-event -t 15 $jobid alloc &&
 	test_debug "echo antecedent in RUN state, but no start event" &&
@@ -80,16 +80,16 @@ test_expect_success 'dependency=after does not release job until start event' '
 	flux job wait-event -t 15 $depid clean &&
 	flux job wait-event -t 15 $jobid clean
 '
-test_expect_success 'dependency=after works when antecedent is running' '
+test_expect_success 'dependency=afterstart works when antecedent is running' '
 	jobid=$(flux submit sleep 300) &&
 	flux job wait-event -vt 15 $jobid start &&
-	depip=$(flux submit --dependency=after:$jobid hostname) &&
+	depip=$(flux submit --dependency=afterstart:$jobid hostname) &&
 	flux job wait-event -vt 15 $depid clean &&
 	flux cancel $jobid
 '
-test_expect_success 'dependency=after generates exception for failed job' '
+test_expect_success 'dependency=afterstart generates exception for failed job' '
 	jobid=$(flux submit --urgency=hold hostname) &&
-	depid=$(flux submit --dependency=after:$jobid hostname) &&
+	depid=$(flux submit --dependency=afterstart:$jobid hostname) &&
 	flux job wait-event -vt 15 $depid dependency-add &&
 	test_debug "echo checking that job ${depid} is in DEPEND state" &&
 	test "$(flux jobs -no {state} $depid)" = "DEPEND" &&
@@ -264,11 +264,11 @@ test_expect_success 'dependency=afterexcept works for INACTIVE jobs' '
 	flux run -vvv --dependency=afterexcept:${exc_id} true &&
 	test_must_fail flux submit --dependency=afterexcept:${successid} true
 '
-test_expect_success 'dependency=after works for INACTIVE jobs' '
+test_expect_success 'dependency=afterstart works for INACTIVE jobs' '
 	run_timeout 15 \
 		flux bulksubmit --wait --watch \
 		--job-name=after:{} \
-		--dependency=after:{} \
+		--dependency=afterstart:{} \
 		echo after:{} ::: ${job1} ${job2} ${job3}
 '
 test_expect_success 'dependency=afterany works for INACTIVE jobs' '
@@ -293,14 +293,14 @@ test_expect_success 'dependency=afternotok works for INACTIVE job' '
 		echo afterany:{} ::: ${job2} ${job3} &&
 	test_must_fail flux run --dependency=afternotok:${job1} hostname
 '
-test_expect_success 'dependency=after fails for INACTIVE canceled job' '
+test_expect_success 'dependency=afterstart fails for INACTIVE canceled job' '
 	job4=$(flux submit --urgency=hold hostname) &&
 	flux cancel ${job4} &&
-	test_must_fail flux run --dependency=after:${job4} hostname
+	test_must_fail flux run --dependency=afterstart:${job4} hostname
 '
 test_expect_success 'jobs with dependencies can be safely canceled' '
 	jobid=$(flux submit --urgency=hold hostname) &&
-	depid=$(flux submit --dependency=after:$jobid hostname) &&
+	depid=$(flux submit --dependency=afterstart:$jobid hostname) &&
 	flux cancel $depid &&
 	flux job urgency $jobid default &&
 	flux job wait-event -vt 15 $jobid clean
@@ -310,7 +310,7 @@ test_expect_success 'flux jobtap query dependency-after works' '
 	test_debug "jq -S . query-none.json" &&
 	jq -e ".dependencies | length == 0" query-none.json &&
 	jobid=$(flux submit --urgency=hold hostname) &&
-	depid=$(flux submit --dependency=after:$jobid hostname) &&
+	depid=$(flux submit --dependency=afterstart:$jobid hostname) &&
 	flux jobtap query .dependency-after > query.json &&
 	test_debug "jq -S . query.json" &&
 	jq -e ".dependencies | length == 1" query.json &&


### PR DESCRIPTION
The `after:JOBID` dependency is ambiguous and causes confusion because it does not clearly convey that it is satisfied after jobs _start_, not complete.

Replace `after` with `afterstart` and deprecate `after`. When using `after`, deprecation warnings are emitted in two places: in the submission CLI when `--dependency=after:JOBID` is used, and also as a severity=3 job exception in the dependency-after jobtap plugin itself (in case jobspecs are directly submitted)

At some point in the future we can remove `after`.

This is built on top of #7570 to avoid conflicts.