### PR TITLE
job-manager: fix inappropriate LOG_ERR message

### DIFF
--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -202,8 +202,10 @@ static void alloc_response_cb (flux_t *h,
         }
         job->R_redacted = json_incref (R);
         alloc_resource_status_invalidate (alloc);
-        if (annotations_update_and_publish (ctx, job, annotations) < 0)
-            flux_log_error (h, "annotations_update: id=%s", idf58 (id));
+        if (annotations) {
+            if (annotations_update_and_publish (ctx, job, annotations) < 0)
+                flux_log_error (h, "annotations_update: id=%s", idf58 (id));
+        }
 
         /*  Only modify job state after annotation event is published
          */


### PR DESCRIPTION
Problem: RFC 27 specifies that the annotations field in a `sched.alloc` SUCCESS response is optional, but the alloc response callback calls `annotations_update_and_publish()` unconditionally.  When a scheduler omits annotations, the NULL pointer fails the json_is_object() check in `annotations_update()` and logs a spurious EINVAL error.

Guard the call with a NULL check so absent annotations are silently ignored, as the RFC intends.

This was split off of #7500