### PR TITLE
librlist: fix duplicate GPU detection

### DIFF
--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -325,52 +325,78 @@ out:
     return result;
 }
 
-/*  Return true if the hwloc "backend" type string matches a GPU
- *   which should be indexed as a compute GPU.
+/*  Walk up from obj to the nearest HWLOC_OBJ_PCI_DEVICE ancestor, or NULL.
  */
-static bool backend_is_coproc (const char *s, const char *nvidia_backend)
+static hwloc_obj_t osdev_get_pcidev (hwloc_obj_t obj)
 {
-    /* Only count cudaX or nvmlX, openclX, and rmsiX devices for now */
-    return (streq (s, nvidia_backend)
+    hwloc_obj_t p = obj->parent;
+    while (p && p->type != HWLOC_OBJ_PCI_DEVICE)
+        p = p->parent;
+    return p;
+}
+
+/*  Return true if the hwloc "backend" type string matches a GPU
+ *  which should be indexed as a compute GPU.
+ */
+static bool backend_is_coproc (const char *s)
+{
+    return (streq (s, "CUDA")
+            || streq (s, "NVML")
             || streq (s, "OpenCL")
             || streq (s, "RSMI"));
 }
 
+static bool pcidev_visited (hwloc_obj_t *visited,
+                            int nvisited,
+                            hwloc_obj_t pcidev)
+{
+    if (pcidev) {
+        for (int i = 0; i < nvisited; i++) {
+            if (visited[i] == pcidev)
+                return true;
+        }
+    }
+    return false;
+}
+
 char * rhwloc_gpu_idset_string (hwloc_topology_t topo)
 {
-    int index;
+    int n_pci;
+    int index = 0;
+    int nvisited = 0;
     char *result = NULL;
     hwloc_obj_t obj = NULL;
+    hwloc_obj_t *visited = NULL;
     struct idset *ids = idset_create (0, IDSET_FLAG_AUTOGROW);
 
     if (!ids)
         return NULL;
 
-    /*  NVIDIA GPUs can be found by both the CUDA or NVML Backends.
-     *  We would like to catch either option, but not double count
-     *  if both are present, so make a first pass to see if any CUDA
-     *  osdevs are present, otherwise check NVML in the next loop.
-     */
-    bool isCudaPresent = false;
-    while ((obj = hwloc_get_next_osdev (topo, obj))) {
-        const char *s = hwloc_obj_get_info_by_name (obj, "Backend");
-        if (s && streq (s, "CUDA"))
-            isCudaPresent = true;
-    }
+    if ((n_pci = hwloc_get_nbobjs_by_type (topo, HWLOC_OBJ_PCI_DEVICE)) > 0
+        && !(visited = calloc (n_pci, sizeof (*visited))))
+        goto out;
 
     /*  Manually index GPUs -- os_index does not seem to be valid for
      *  these devices in some cases, and logical index also seems
-     *  incorrect (?)
+     *  incorrect (?).
+     *  Ensure GPUs are not counted twice when they apepar with multiple
+     *  backends by tracking visited devices by the PCI parent.
      */
-    index = 0;
     while ((obj = hwloc_get_next_osdev (topo, obj))) {
-        const char *s = hwloc_obj_get_info_by_name (obj, "Backend");
-        if (s && backend_is_coproc (s, isCudaPresent ? "CUDA" : "NVML"))
-            idset_set (ids, index++);
+        const char *backend = hwloc_obj_get_info_by_name (obj, "Backend");
+        hwloc_obj_t pcidev = osdev_get_pcidev (obj);
+        if (!backend
+            || !backend_is_coproc (backend)
+            || pcidev_visited (visited, nvisited, pcidev))
+            continue;
+        visited[nvisited++] = pcidev;
+        idset_set (ids, index++);
     }
     if (idset_count (ids) > 0)
         result = idset_encode (ids, IDSET_FLAG_RANGE);
+out:
     idset_destroy (ids);
+    ERRNO_SAFE_WRAP (free, visited);
     return result;
 }
 

--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #endif
 
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -340,6 +341,8 @@ static hwloc_obj_t osdev_get_pcidev (hwloc_obj_t obj)
  */
 static bool backend_is_coproc (const char *s)
 {
+    if (s == NULL)
+        return false;
     return (streq (s, "CUDA")
             || streq (s, "NVML")
             || streq (s, "OpenCL")
@@ -359,41 +362,97 @@ static bool pcidev_visited (hwloc_obj_t *visited,
     return false;
 }
 
-char * rhwloc_gpu_idset_string (hwloc_topology_t topo)
+/*  Traverse topology osdevs and accumulate unique compute GPUs.
+ *  visited[vlen] is a caller-provided zeroed work array; vlen bounds
+ *  visited writes. If result != NULL, unique GPU osdev objects are stored
+ *  there up to rlen entries. Returns the count of unique GPUs.
+ */
+static int collect_unique_gpus (hwloc_topology_t topo,
+                                hwloc_obj_t *visited,
+                                int vlen,
+                                hwloc_obj_t *result,
+                                int rlen)
 {
-    int n_pci;
-    int index = 0;
     int nvisited = 0;
-    char *result = NULL;
+    int count = 0;
     hwloc_obj_t obj = NULL;
-    hwloc_obj_t *visited = NULL;
-    struct idset *ids = idset_create (0, IDSET_FLAG_AUTOGROW);
-
-    if (!ids)
-        return NULL;
-
-    if ((n_pci = hwloc_get_nbobjs_by_type (topo, HWLOC_OBJ_PCI_DEVICE)) > 0
-        && !(visited = calloc (n_pci, sizeof (*visited))))
-        goto out;
 
     /*  Manually index GPUs -- os_index does not seem to be valid for
      *  these devices in some cases, and logical index also seems
      *  incorrect (?).
-     *  Ensure GPUs are not counted twice when they apepar with multiple
+     *  Ensure GPUs are not counted twice when they appear with multiple
      *  backends by tracking visited devices by the PCI parent.
      */
     while ((obj = hwloc_get_next_osdev (topo, obj))) {
         const char *backend = hwloc_obj_get_info_by_name (obj, "Backend");
         hwloc_obj_t pcidev = osdev_get_pcidev (obj);
-        if (!backend
-            || !backend_is_coproc (backend)
+        if (!backend_is_coproc (backend)
             || pcidev_visited (visited, nvisited, pcidev))
             continue;
-        visited[nvisited++] = pcidev;
-        idset_set (ids, index++);
+        if (nvisited < vlen)
+            visited[nvisited++] = pcidev;
+        if (result && count < rlen)
+            result[count] = obj;
+        count++;
     }
-    if (idset_count (ids) > 0)
-        result = idset_encode (ids, IDSET_FLAG_RANGE);
+    return count;
+}
+
+hwloc_obj_t *rhwloc_gpu_objects (hwloc_topology_t topo, int *count_out)
+{
+    int n_pci;
+    int count = 0;
+    hwloc_obj_t *visited = NULL;
+    hwloc_obj_t *result = NULL;
+
+    *count_out = 0;
+
+    /* Get total count of PCI devices to size the visited array:
+     */
+    n_pci = hwloc_get_nbobjs_by_type (topo, HWLOC_OBJ_PCI_DEVICE);
+    if (n_pci <= 0 || !(visited = calloc (n_pci, sizeof (*visited))))
+        return NULL;
+
+    /* Traverse topo first to get count of unique GPUs to size result
+     */
+    count = collect_unique_gpus (topo, visited, n_pci, NULL, 0);
+    if (count == 0 || !(result = calloc (count, sizeof (*result))))
+        goto out;
+
+    /* Reset visited and traverse again, this time collecting GPUs
+     * in result
+     */
+    memset (visited, 0, n_pci * sizeof (*visited));
+    collect_unique_gpus (topo, visited, n_pci, result, count);
+    *count_out = count;
+out:
+    ERRNO_SAFE_WRAP (free, visited);
+    return result;
+}
+
+char *rhwloc_gpu_idset_string (hwloc_topology_t topo)
+{
+    int n_pci;
+    int count = 0;
+    char *result = NULL;
+    hwloc_obj_t *visited = NULL;
+    struct idset *ids = NULL;
+
+    /* Count total PCI objects to size visited array:
+     */
+    n_pci = hwloc_get_nbobjs_by_type (topo, HWLOC_OBJ_PCI_DEVICE);
+    if (n_pci <= 0 || !(visited = calloc (n_pci, sizeof (*visited))))
+        return NULL;
+
+    /* Count unique GPUs (no need to collect actual objects):
+     */
+    count = collect_unique_gpus (topo, visited, n_pci, NULL, 0);
+    if (count == 0
+        || !(ids = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || idset_range_set (ids, 0, count - 1) < 0)
+        goto out;
+
+    result = idset_encode (ids, IDSET_FLAG_RANGE);
 out:
     idset_destroy (ids);
     ERRNO_SAFE_WRAP (free, visited);

--- a/src/common/librlist/rhwloc.h
+++ b/src/common/librlist/rhwloc.h
@@ -51,6 +51,13 @@ hwloc_cpuset_t rhwloc_cores_to_cpuset (hwloc_topology_t topo,
  */
 char * rhwloc_core_idset_string (hwloc_topology_t topo);
 
+/*  Return heap-allocated array of unique compute GPU osdev objects from topo
+ *  in hwloc traversal order, one per physical GPU (deduplicated by PCI
+ *  ancestor).  Sets *count_out to the number of entries.  Returns NULL with
+ *  *count_out == 0 when no GPUs are present.  Caller must free().
+ */
+hwloc_obj_t *rhwloc_gpu_objects (hwloc_topology_t topo, int *count_out);
+
 /*  Return idset string for all GPUs in hwloc topology object
  */
 char * rhwloc_gpu_idset_string (hwloc_topology_t topo);

--- a/src/common/librlist/rhwloc_map.c
+++ b/src/common/librlist/rhwloc_map.c
@@ -16,7 +16,6 @@
 #include <string.h>
 #include <flux/idset.h>
 
-#include "ccan/str/str.h"
 #include "src/common/libutil/errno_safe.h"
 
 #include "rhwloc.h"
@@ -114,59 +113,6 @@ out:
     return rc;
 }
 
-/* Return true if the hwloc backend string identifies a compute GPU.
- * Mirrors the logic in rhwloc_gpu_idset_string().
- */
-static bool backend_is_coproc (const char *s, const char *nvidia_backend)
-{
-    return (streq (s, nvidia_backend)
-            || streq (s, "OpenCL")
-            || streq (s, "RSMI"));
-}
-
-/* Collect compute GPU osdev objects from the topology in hwloc order into a
- * heap-allocated array.  Returns the array and sets *count_out, or returns
- * NULL if no GPUs are found or on allocation failure.  Caller must free().
- */
-static hwloc_obj_t *collect_gpu_objects (hwloc_topology_t topo, int *count_out)
-{
-    hwloc_obj_t obj = NULL;
-    hwloc_obj_t *result;
-    bool isCudaPresent = false;
-    const char *nvidia_backend;
-    int count = 0;
-
-    while ((obj = hwloc_get_next_osdev (topo, obj))) {
-        const char *s = hwloc_obj_get_info_by_name (obj, "Backend");
-        if (s && streq (s, "CUDA")) {
-            isCudaPresent = true;
-            break;
-        }
-    }
-    nvidia_backend = isCudaPresent ? "CUDA" : "NVML";
-
-    obj = NULL;
-    while ((obj = hwloc_get_next_osdev (topo, obj))) {
-        const char *s = hwloc_obj_get_info_by_name (obj, "Backend");
-        if (s && backend_is_coproc (s, nvidia_backend))
-            count++;
-    }
-    if (count == 0) {
-        *count_out = 0;
-        return NULL;
-    }
-    if (!(result = calloc (count, sizeof (*result))))
-        return NULL;
-    obj = NULL;
-    int i = 0;
-    while ((obj = hwloc_get_next_osdev (topo, obj)) && i < count) {
-        const char *s = hwloc_obj_get_info_by_name (obj, "Backend");
-        if (s && backend_is_coproc (s, nvidia_backend))
-            result[i++] = obj;
-    }
-    *count_out = count;
-    return result;
-}
 
 /* Return the PCI address of the GPU osdev object's nearest PCI ancestor
  * as a heap-allocated string, or NULL if no PCI ancestor is found.
@@ -203,7 +149,7 @@ char **rhwloc_map_gpu_pci_addrs (rhwloc_map_t *m, const char *gpus)
         goto error;
     if (!(result = calloc (idset_count (gpuset) + 1, sizeof (*result))))
         goto error;
-    if (!(gpu_objs = collect_gpu_objects (m->topo, &gpu_count))
+    if (!(gpu_objs = rhwloc_gpu_objects (m->topo, &gpu_count))
         && gpu_count > 0)
         goto error;
 

--- a/src/common/librlist/test/rhwloc.c
+++ b/src/common/librlist/test/rhwloc.c
@@ -855,6 +855,104 @@ void test_cores_to_cpuset (void)
     hwloc_topology_destroy (topo);
 }
 
+/* Minimal topology: 1 core, 2 PCIDevs each with both CUDA and NVML osdev
+ * children.  Used to verify that each physical GPU is counted once despite
+ * appearing under two backends.
+ */
+static const char xml_multi_backend[] = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<!DOCTYPE topology SYSTEM \"hwloc.dtd\">\n\
+<topology>\n\
+  <object type=\"Machine\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+    <info name=\"HostName\" value=\"testhost\"/>\n\
+    <object type=\"NUMANode\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\" local_memory=\"8589934592\">\n\
+      <object type=\"Package\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+        <object type=\"Core\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+          <object type=\"PU\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+          <object type=\"PU\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+        </object>\n\
+      </object>\n\
+    </object>\n\
+    <object type=\"Bridge\" os_index=\"0\" bridge_type=\"0-1\" depth=\"0\"\
+ bridge_pci=\"0000:[00-02]\">\n\
+      <object type=\"PCIDev\" os_index=\"4096\" name=\"Test GPU 0\"\
+ pci_busid=\"0000:01:00.0\" pci_type=\"0302 [10de:1234] [10de:0000] a1\"\
+ pci_link_speed=\"0.000000\">\n\
+        <object type=\"OSDev\" name=\"cuda0\" osdev_type=\"5\">\n\
+          <info name=\"CoProcType\" value=\"CUDA\"/>\n\
+          <info name=\"Backend\" value=\"CUDA\"/>\n\
+        </object>\n\
+        <object type=\"OSDev\" name=\"nvml0\" osdev_type=\"5\">\n\
+          <info name=\"CoProcType\" value=\"NVML\"/>\n\
+          <info name=\"Backend\" value=\"NVML\"/>\n\
+        </object>\n\
+      </object>\n\
+      <object type=\"PCIDev\" os_index=\"8192\" name=\"Test GPU 1\"\
+ pci_busid=\"0000:02:00.0\" pci_type=\"0302 [10de:1234] [10de:0000] a1\"\
+ pci_link_speed=\"0.000000\">\n\
+        <object type=\"OSDev\" name=\"cuda1\" osdev_type=\"5\">\n\
+          <info name=\"CoProcType\" value=\"CUDA\"/>\n\
+          <info name=\"Backend\" value=\"CUDA\"/>\n\
+        </object>\n\
+        <object type=\"OSDev\" name=\"nvml1\" osdev_type=\"5\">\n\
+          <info name=\"CoProcType\" value=\"NVML\"/>\n\
+          <info name=\"Backend\" value=\"NVML\"/>\n\
+        </object>\n\
+      </object>\n\
+    </object>\n\
+  </object>\n\
+</topology>\n";
+
+void test_gpu_objects (void)
+{
+    hwloc_topology_t topo;
+    hwloc_obj_t *objs;
+    int count;
+    char *s;
+
+    topo = rhwloc_xml_topology_load (xml_multi_backend, RHWLOC_NO_RESTRICT);
+    if (!topo)
+        BAIL_OUT ("failed to load multi-backend GPU topology");
+
+    /* 2 physical GPUs × 2 backends = 4 osdevs; dedup must yield 2 */
+    objs = rhwloc_gpu_objects (topo, &count);
+    ok (count == 2 && objs != NULL,
+        "rhwloc_gpu_objects: 2 dual-backend GPUs deduplicated to count=2");
+    free (objs);
+
+    s = rhwloc_gpu_idset_string (topo);
+    ok (s != NULL && strcmp (s, "0-1") == 0,
+        "rhwloc_gpu_idset_string: 2 dual-backend GPUs gives \"0-1\": got \"%s\"",
+        s ? s : "NULL");
+    free (s);
+
+    hwloc_topology_destroy (topo);
+}
+
 int main (int ac, char *av[])
 {
     plan (NO_PLAN);
@@ -863,6 +961,7 @@ int main (int ac, char *av[])
     test_hwloc (xml1);
     test_xml ();
     test_cores_to_cpuset ();
+    test_gpu_objects ();
 
     done_testing ();
 }


### PR DESCRIPTION
This PR fixes deduplication of GPUs during hwloc topology discovery. Instead of checking specifically for CUDA vs NVML for NVIDIA GPUs, add code to only visit a given PCI ID once during traversal of the topology when collecting GPUs. This should work more generally than the NVIDIA specific check there before, which didn't work on systems where those GPUs were detected as NVML, CUDA, and OpenCL coprocs.

