### PR TITLE
sdexec-mapper: fix NVIDIA GPU to device mapping

### DIFF
--- a/src/bindings/python/flux/sdexec/map.py
+++ b/src/bindings/python/flux/sdexec/map.py
@@ -299,10 +299,15 @@ class HwlocMapper(ResourceMapper):
                     gpu_index = int(line.split(":", 1)[1].strip())
                     break
 
-        if gpu_index is not None:
-            nvidia_dev = Path(f"{DEV_PREFIX}/nvidia{gpu_index}")
-            if nvidia_dev.exists():
-                devices.append(f"{nvidia_dev} rw")
+        if gpu_index is None:
+            raise OSError(
+                errno.ENODEV,
+                f"GPU {pci_path.name}: Device Minor not found in {info_file}",
+            )
+        nvidia_dev = Path(f"{DEV_PREFIX}/nvidia{gpu_index}")
+        if not nvidia_dev.exists():
+            raise OSError(errno.ENODEV, f"GPU {pci_path.name}: {nvidia_dev} not found")
+        devices.append(f"{nvidia_dev} rw")
 
         for shared_dev in NVIDIA_SHARED_DEVICES:
             dev_path = Path(f"{DEV_PREFIX}/{shared_dev}")
@@ -319,13 +324,14 @@ class HwlocMapper(ResourceMapper):
 
         Returns:
             List of DeviceAllow strings for AMD devices.
-        """
-        devices = []
-        kfd_dev = Path(f"{DEV_PREFIX}/kfd")
-        if kfd_dev.exists():
-            devices.append(f"{kfd_dev} rw")
 
-        return devices
+        Raises:
+            OSError: If /dev/kfd is not found.
+        """
+        kfd_dev = Path(f"{DEV_PREFIX}/kfd")
+        if not kfd_dev.exists():
+            raise OSError(errno.ENODEV, f"GPU {pci_path.name}: {kfd_dev} not found")
+        return [f"{kfd_dev} rw"]
 
     def _discover_gpu_devices(self, pci_addr):
         """Discover all device nodes for a GPU at the given PCI address.
@@ -341,13 +347,19 @@ class HwlocMapper(ResourceMapper):
         pci_path = Path(f"{SYSFS_PCI_DEVICES}/{pci_addr}")
         devices = []
 
-        devices.extend(self._discover_drm_devices(pci_path))
+        drm_devices = self._discover_drm_devices(pci_path)
+        devices.extend(drm_devices)
 
         driver = self._get_driver_name(pci_path)
         if driver:
             if NVIDIA_DRIVER in driver:
                 devices.extend(self._discover_nvidia_devices(pci_path))
             elif AMD_DRIVER in driver:
+                if not drm_devices:
+                    raise OSError(
+                        errno.ENODEV,
+                        f"GPU {pci_addr}: no /dev/dri devices found",
+                    )
                 devices.extend(self._discover_amd_devices(pci_path))
 
         return devices

--- a/src/bindings/python/flux/sdexec/map.py
+++ b/src/bindings/python/flux/sdexec/map.py
@@ -34,7 +34,8 @@ GPU Device Discovery
 device paths needed for compute workloads:
 
 **NVIDIA GPUs:**
-    - ``/dev/nvidia<N>`` — Main GPU device (N matches hwloc GPU ID)
+    - ``/dev/nvidia<N>`` — Main GPU device (N is the kernel Device Minor, read
+      from ``/proc/driver/nvidia/gpus/<pci_addr>/information``)
     - ``/dev/nvidiactl`` — Control device (shared across all GPUs)
     - ``/dev/nvidia-uvm`` — Unified Virtual Memory (required for CUDA)
     - ``/dev/nvidia-uvm-tools`` — UVM tools (optional)
@@ -103,9 +104,6 @@ AMD_DRIVER = "amdgpu"
 
 # NVIDIA shared devices required for compute
 NVIDIA_SHARED_DEVICES = ["nvidiactl", "nvidia-uvm", "nvidia-uvm-tools"]
-
-# Device name prefixes
-DRM_CARD_PREFIX = "card"
 
 
 class ResourceMapper:
@@ -289,16 +287,17 @@ class HwlocMapper(ResourceMapper):
             List of DeviceAllow strings for NVIDIA devices.
         """
         devices = []
-        drm_path = pci_path / "drm"
 
+        # The Device Minor in /proc/driver/nvidia/gpus/<addr>/information is
+        # the authoritative index for /dev/nvidia<N>.  The DRM card number is
+        # assigned independently and must not be used as a substitute.
         gpu_index = None
-        if drm_path.exists():
-            for entry in drm_path.iterdir():
-                if entry.name.startswith(DRM_CARD_PREFIX):
-                    suffix = entry.name[len(DRM_CARD_PREFIX) :]
-                    if suffix.isdigit():
-                        gpu_index = int(suffix)
-                        break
+        info_file = Path("/proc/driver/nvidia/gpus") / pci_path.name / "information"
+        if info_file.exists():
+            for line in info_file.read_text().splitlines():
+                if line.startswith("Device Minor:"):
+                    gpu_index = int(line.split(":", 1)[1].strip())
+                    break
 
         if gpu_index is not None:
             nvidia_dev = Path(f"{DEV_PREFIX}/nvidia{gpu_index}")

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -338,6 +338,7 @@ TESTSCRIPTS = \
 	python/t0040-proctitle.py \
 	python/t0041-resource-count.py \
 	python/t0042-job-manager-alloc-cache.py \
+	python/t0043-sdexec-map.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0043-sdexec-map.py
+++ b/t/python/t0043-sdexec-map.py
@@ -9,8 +9,10 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import errno
 import json
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 import subflux  # noqa: F401 - for PYTHONPATH
@@ -286,6 +288,63 @@ class TestHwlocMapper(unittest.TestCase):
         devices_list = result["DeviceAllow"].split(",")
         kfd_count = sum(1 for d in devices_list if "kfd" in d)
         self.assertEqual(kfd_count, 1, "/dev/kfd should only appear once")
+
+
+class TestDiscoverNvidiaErrors(unittest.TestCase):
+    """Test that _discover_nvidia_devices raises OSError on missing devices."""
+
+    def setUp(self):
+        self.mapper = HwlocMapper(HWLOC_XML)
+        self.pci_path = Path("/sys/bus/pci/devices/0000:01:00.0")
+
+    def tearDown(self):
+        del self.mapper
+
+    def test_proc_info_absent_raises_enodev(self):
+        """ENODEV raised when /proc/driver/nvidia info file does not exist."""
+        with patch.object(Path, "exists", lambda self: False):
+            with self.assertRaises(OSError) as ctx:
+                self.mapper._discover_nvidia_devices(self.pci_path)
+        self.assertEqual(ctx.exception.errno, errno.ENODEV)
+
+    def test_nvidia_dev_absent_raises_enodev(self):
+        """ENODEV raised when Device Minor is found but /dev/nvidia<N> is absent."""
+        info_text = "Model: Test GPU\nDevice Minor: 0\n"
+
+        def exists(p):
+            return "information" in str(p)  # info_file present, /dev/nvidiaN absent
+
+        with patch.object(Path, "exists", exists):
+            with patch.object(Path, "read_text", lambda p, **kw: info_text):
+                with self.assertRaises(OSError) as ctx:
+                    self.mapper._discover_nvidia_devices(self.pci_path)
+        self.assertEqual(ctx.exception.errno, errno.ENODEV)
+
+
+class TestDiscoverAmdErrors(unittest.TestCase):
+    """Test that AMD device discovery raises OSError on missing devices."""
+
+    def setUp(self):
+        self.mapper = HwlocMapper(HWLOC_XML)
+        self.pci_path = Path("/sys/bus/pci/devices/0000:01:00.0")
+
+    def tearDown(self):
+        del self.mapper
+
+    def test_kfd_absent_raises_enodev(self):
+        """ENODEV raised when /dev/kfd does not exist."""
+        with patch.object(Path, "exists", lambda self: False):
+            with self.assertRaises(OSError) as ctx:
+                self.mapper._discover_amd_devices(self.pci_path)
+        self.assertEqual(ctx.exception.errno, errno.ENODEV)
+
+    def test_no_dri_devices_raises_enodev(self):
+        """ENODEV raised when no /dev/dri devices are found for an AMD GPU."""
+        with patch.object(self.mapper, "_discover_drm_devices", return_value=[]):
+            with patch.object(self.mapper, "_get_driver_name", return_value="amdgpu"):
+                with self.assertRaises(OSError) as ctx:
+                    self.mapper._discover_gpu_devices("0000:01:00.0")
+        self.assertEqual(ctx.exception.errno, errno.ENODEV)
 
 
 class TestCustomGpuMapper(unittest.TestCase):

--- a/t/python/t0043-sdexec-map.py
+++ b/t/python/t0043-sdexec-map.py
@@ -10,14 +10,23 @@
 ###############################################################
 
 import errno
+import io
 import json
+import os
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import flux.sdexec.map as m
 import subflux  # noqa: F401 - for PYTHONPATH
+from flux.idset import IDset
 from flux.sdexec.map import HwlocMapper, ResourceMapper
 from pycotap import TAPTestRunner
+
+os.environ["PATH"] = (
+    os.path.dirname(subflux.flux_exe) + os.pathsep + os.environ.get("PATH", "")
+)
 
 
 def make_R(rank=0, cores=None, gpus=None):
@@ -353,9 +362,6 @@ class TestCustomGpuMapper(unittest.TestCase):
     def setUp(self):
         class NvidiaMapper(HwlocMapper):
             def map_gpus(self, gpus):
-                # Custom implementation returning vendor-specific device paths.
-                from flux.idset import IDset
-
                 if not gpus:
                     return {}
                 return {
@@ -526,14 +532,11 @@ class TestMain(unittest.TestCase):
 
     def _run_main(self, args, xml=HWLOC_XML):
         """Run main() with patched topology XML; return parsed JSON output."""
-        import io
-
-        import flux.sdexec.map as m
-
         captured = io.StringIO()
-        with patch.object(m, "_get_system_xml", return_value=xml):
-            with patch("sys.stdout", captured):
-                ret = m.main(args)
+        with patch.object(m, "_get_system_xml", return_value=xml), patch(
+            "sys.stdout", captured
+        ):
+            ret = m.main(args)
         self.assertEqual(ret, 0)
         return json.loads(captured.getvalue())
 
@@ -549,21 +552,15 @@ class TestMain(unittest.TestCase):
         self.assertEqual(result["AllowedMemoryNodes"], "0")
 
     def test_cores_and_gpus(self):
-        import io
-
-        import flux.sdexec.map as m
-
         fake_devs = {"0000:01:00.0": ["/dev/dri/renderD128 rw"]}
         captured = io.StringIO()
-        with patch.object(m, "_get_system_xml", return_value=HWLOC_XML):
-            with patch.object(
-                m.HwlocMapper,
-                "_discover_gpu_devices",
-                autospec=True,
-                side_effect=lambda self, addr: fake_devs.get(addr, []),
-            ):
-                with patch("sys.stdout", captured):
-                    ret = m.main(["--cores=0", "--gpus=0"])
+        with patch.object(m, "_get_system_xml", return_value=HWLOC_XML), patch.object(
+            m.HwlocMapper,
+            "_discover_gpu_devices",
+            autospec=True,
+            side_effect=lambda self, addr: fake_devs.get(addr, []),
+        ), patch("sys.stdout", captured):
+            ret = m.main(["--cores=0", "--gpus=0"])
         self.assertEqual(ret, 0)
         result = json.loads(captured.getvalue())
         self.assertEqual(result["AllowedCPUs"], "0-1")
@@ -571,17 +568,10 @@ class TestMain(unittest.TestCase):
         self.assertEqual(result["DevicePolicy"], "closed")
 
     def test_xml_file(self):
-        import os
-        import tempfile
-
-        import flux.sdexec.map as m
-
         with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as fh:
             fh.write(HWLOC_XML)
             fname = fh.name
         try:
-            import io
-
             captured = io.StringIO()
             with patch("sys.stdout", captured):
                 ret = m.main(["--xml", fname, "--cores=0"])
@@ -592,13 +582,10 @@ class TestMain(unittest.TestCase):
             os.unlink(fname)
 
     def test_error_returns_nonzero(self):
-        import flux.sdexec.map as m
-
-        with patch.object(m, "_get_system_xml", return_value=HWLOC_XML):
-            with patch.object(
-                m.HwlocMapper, "map", side_effect=OSError("mock failure")
-            ):
-                ret = m.main(["--cores=0"])
+        with patch.object(m, "_get_system_xml", return_value=HWLOC_XML), patch.object(
+            m.HwlocMapper, "map", side_effect=OSError("mock failure")
+        ):
+            ret = m.main(["--cores=0"])
         self.assertEqual(ret, 1)
 
 


### PR DESCRIPTION
This PR fixes a bad assumption in the NVIDIA GPU mapping code in the `HwlocMapper` in `flux.sdexec.map`. The current code assumes `/dev/nvidiaX` index correlates to `/dev/dri/cardN`, but this doesn't seem to be the case. The fix uses `/proc/driver/nvidia/gpus/<pci addr>/information` instead.

This has only been tested on one system, but should provide reasonable default behavior for now. If the mapping is incorrect, sites can always load a custom mapper derived from `HwlocMapper`.

Additionally, promote some silent error cases to exceptions so that unexpected missing devices cause job failure instead of missing devices in `DeviceAllow` (which would be more difficult to debug)