### PR TITLE
scheduler: allow pool class to be overridden

### DIFF
--- a/doc/python/scheduler.rst
+++ b/doc/python/scheduler.rst
@@ -81,15 +81,11 @@ type and fields of this object are defined by the pool; scheduler policy code
 treats it as opaque and passes it directly to
 :meth:`~flux.resource.ResourcePool.alloc`.
 
-If you need the raw jobspec dict — for instance, to inspect job attributes in
-an :meth:`~Scheduler.alloc` override — it is passed as the *jobspec* parameter
-to :meth:`~Scheduler.alloc`:
-
-.. code-block:: python
-
-   def alloc(self, request, jobid, priority, userid, t_submit, jobspec):
-       # jobspec is the parsed dict; inspect it before calling super()
-       super().alloc(request, jobid, priority, userid, t_submit, jobspec)
+For the built-in :class:`~flux.resource.Rv1Pool` pools, node and slot counts
+carry RFC 14 ranges (a min and optional max), and non-standard resource
+hierarchies are traversed recursively.  The raw jobspec dict is also accessible
+as ``job.resource_request.jobspec`` for reading site-specific hints from
+``attributes.system``.
 
 Allocating resources
 ~~~~~~~~~~~~~~~~~~~~
@@ -164,8 +160,12 @@ distinct objects are created and stored together on the
 - ``job.resource_request`` — a pool-specific object describing *what the job
   needs*.  Created once from jobspec by
   :meth:`~flux.resource.ResourcePool.parse_resource_request` when the alloc
-  arrives.  For the built-in pools this carries fields for node count,
-  slot count, cores and GPUs per slot, duration, constraints, and exclusivity.
+  arrives.  For the built-in pools this carries node count, slot count, cores
+  and GPUs per slot, duration, constraints, and exclusivity; node and slot
+  counts carry RFC 14 ranges (min/max) and non-standard resource hierarchies
+  are traversed recursively.  The raw jobspec dict is accessible as
+  ``job.resource_request.jobspec`` for reading site-specific
+  ``attributes.system`` hints.
   Used by the scheduler during each :meth:`~Scheduler.schedule`
   pass to decide whether resources can be satisfied.  Persists for the
   lifetime of the pending job.
@@ -494,7 +494,7 @@ in :func:`mod_main` and are forwarded to ``__init__``:
 
    $ flux module load my-sched.py queue-depth=8 log-level=debug
 
-The base class automatically handles three built-in arguments:
+The base class automatically handles four built-in arguments:
 
 queue-depth=N|unlimited
     Maximum number of concurrent outstanding alloc requests (default 8, or
@@ -505,6 +505,15 @@ log-level=LEVEL
     Minimum log severity to emit.  *LEVEL* is one of ``emerg``, ``alert``,
     ``crit``, ``err``, ``warning``, ``notice``, ``info``, or ``debug``
     (default ``info``).
+
+pool-class=URI
+    Select a custom resource pool class at load time.  *URI* is resolved by
+    :meth:`~Scheduler._pool_class_from_uri`: a plain module name imports the
+    Python module and reads its ``pool_class`` attribute; ``module:ClassName``
+    loads a named class from the module.  The module must be importable, so
+    set ``PYTHONPATH`` as needed.  Equivalent to setting
+    :attr:`~Scheduler.pool_class` on the subclass, but applied at load time
+    without subclassing.  See `Pool class hook (pool_class)`_.
 
 Any argument not consumed by the subclass or the base class is rejected
 with an error at load time, so a typo like ``log_level=debug`` (underscore
@@ -641,6 +650,90 @@ replacing the default scheduler with your own:
 See :file:`t/t2306-sched-fifo.t` in the source tree for a comprehensive
 example covering annotations, priority, cancel, drain/undrain, and the
 hello/reload protocol.
+
+
+Customizing the resource pool
+-----------------------------
+
+By default the scheduler uses the built-in
+:class:`~flux.resource.ResourcePool.ResourcePool` version dispatch to
+construct its resource pool.  A custom pool class can be injected without
+modifying the scheduler itself using the pool class hook described below.
+
+Pool class hook (pool_class)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are three ways to bind a custom pool class to a scheduler:
+
+1. **Class attribute** — set :attr:`~Scheduler.pool_class` on the subclass:
+
+   .. code-block:: python
+
+      from flux.scheduler import Scheduler
+
+      class RackScheduler(Scheduler):
+          pool_class = RackPool
+          # must also override schedule() to allocate jobs
+
+2. **Module argument** — pass ``pool-class=URI`` at load time (no subclassing
+   required):
+
+   .. code-block:: console
+
+      $ PYTHONPATH=/path/to/plugins flux module load sched-simple pool-class=rackpool
+
+3. **Writer auto-discovery** — if the system R carries a ``scheduling.writer``
+   URI pointing to a pool implementation, the scheduler loads it automatically
+   without any explicit argument.  See `Writer identification`_.
+
+In all three cases :attr:`~Scheduler.pool_class` must be a
+:class:`~flux.resource.ResourcePool.ResourcePool` subclass.  The scheduler's
+:meth:`~Scheduler._make_pool` helper checks :attr:`~Scheduler.pool_class`
+first (highest priority), then ``scheduling.writer`` auto-discovery, and
+finally falls back to the default :class:`~flux.resource.ResourcePool.ResourcePool`.
+In every case :attr:`~Scheduler.pool_kwargs` are forwarded as keyword
+arguments to the chosen pool constructor.
+
+The pool subclass is responsible for its own version dispatch.  The pattern is
+to map version integers to version-specific implementation classes in an
+``_impl_map`` and construct the right one in ``__init__``:
+
+.. code-block:: python
+
+   class RackPool(ResourcePool):
+       _impl_map = {1: _RackPoolV1}   # extend here to add Rv2 support
+
+       def __init__(self, R, log=None, **kwargs):
+           version = R.get("version", 1) if isinstance(R, Mapping) else 1
+           impl_class = self._impl_map.get(version)
+           if impl_class is None:
+               raise ValueError(f"R version {version} not supported by RackPool")
+           super().__init__(impl_class(R, log=log))
+
+
+The R.scheduling key
+--------------------
+
+R may carry a ``scheduling`` key in its top-level JSON object containing
+scheduler-specific topology metadata.  Schedulers use this key to encode
+information not captured in the standard R execution section — for example,
+rack or chassis membership, network topology, or fabric locality.
+:class:`~flux.resource.Rv1Pool` propagates the ``scheduling`` key to every
+allocated R by default.
+
+Writer identification
+~~~~~~~~~~~~~~~~~~~~~
+
+The ``scheduling`` key is defined by :doc:`rfc:spec_20`.  By convention it
+includes a ``writer`` URI identifying the scheduler that created it; a missing
+``writer`` implies ``fluxion``.
+
+When a scheduler starts and finds a ``scheduling.writer`` URI in the system R,
+:meth:`~Scheduler._pool_class_from_writer` resolves the URI to a pool class
+and :meth:`~Scheduler._make_pool` instantiates it automatically.  This enables
+a sub-instance scheduler to load the same pool class as the parent without any
+explicit configuration — the parent bakes the URI into every allocated R, and
+the sub-instance picks it up on startup.
 
 
 API reference

--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -55,12 +55,13 @@ from flux.resource.Rv1Set import Rv1Set
 
 
 class ResourceRequest:
-    """Parsed resource request extracted from a V1 jobspec.
+    """Parsed resource request extracted from a jobspec.
 
     Returned by :meth:`Rv1Pool.parse_resource_request` and stored on
     :class:`~flux.scheduler.PendingJob`.  Passed to
     :meth:`Rv1Pool.alloc` so that the pool does not need to
-    re-parse jobspec on every scheduling pass.
+    re-parse jobspec on every scheduling pass.  Node and slot counts carry
+    RFC 14 ranges (min/max).
 
     Attributes:
         node_count (ResourceCount | None): RFC 14 node count (scaled by
@@ -76,6 +77,10 @@ class ResourceRequest:
         duration (float): Walltime in seconds; 0.0 means unlimited.
         constraint: RFC 31 constraint expression (dict) or None.
         exclusive (bool): Whole-node exclusive allocation.
+        jobspec (dict): The raw jobspec dict from which this request was parsed.
+            Available for reading site-specific hints from
+            ``attributes.system`` that the standard parser does not extract,
+            or for forwarding the full jobspec to an external resource service.
         nnodes (int): Minimum node count; derived from *node_count*.
         nnodes_max (int | None): Maximum node count; ``None`` for unbounded.
         nslots (int): Minimum total slot count; derived from *slot_count* and
@@ -91,6 +96,7 @@ class ResourceRequest:
         "duration",
         "constraint",
         "exclusive",
+        "jobspec",
     )
 
     def __init__(
@@ -102,6 +108,7 @@ class ResourceRequest:
         duration,
         constraint,
         exclusive,
+        jobspec=None,
     ):
         self.node_count = node_count
         self.slot_count = slot_count
@@ -110,6 +117,7 @@ class ResourceRequest:
         self.duration = duration
         self.constraint = constraint
         self.exclusive = exclusive
+        self.jobspec = jobspec
 
     @property
     def nnodes(self):
@@ -241,6 +249,7 @@ class ResourceRequest:
             float(duration),
             constraint,
             exclusive,
+            jobspec,
         )
 
     @property

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -51,8 +51,10 @@ to override :meth:`schedule`::
 import errno
 import functools
 import heapq
+import importlib.util
 import inspect
 import time
+from typing import Optional
 
 from _flux._core import ffi, lib
 from flux.brokermod import BrokerLogger, BrokerModule, request_handler
@@ -272,11 +274,21 @@ class Scheduler(BrokerModule):
     #: subclasses that support it) to disable partial-ok behaviour.
     hello_partial_ok = True
 
-    #: Extra keyword arguments forwarded to :class:`~flux.resource.ResourcePool`
-    #: (and on to the pool implementation) at construction time.  Subclasses
-    #: that accept pool-specific load-time options should parse them in
-    #: ``__init__`` and store the result here, e.g.
-    #: ``self.pool_kwargs = {"opt": value}``.
+    #: Custom pool class.  When set to a
+    #: :class:`~flux.resource.ResourcePool.ResourcePool` subclass,
+    #: :meth:`_make_pool` instantiates it directly instead of using the default
+    #: :class:`~flux.resource.ResourcePool.ResourcePool` version dispatch.
+    #: The subclass is responsible for its own version dispatch (e.g. via an
+    #: ``_impl_map``).  This is the preferred way to inject a custom pool::
+    #:
+    #:     class MyScheduler(Scheduler):
+    #:         pool_class = MyPool
+    pool_class: Optional[type] = None
+
+    #: Extra keyword arguments forwarded to the pool class at construction time.
+    #: Passed to whichever pool class is selected by :meth:`_make_pool` —
+    #: whether that is :attr:`pool_class`, a writer-discovered class, or the
+    #: default :class:`~flux.resource.ResourcePool`.
     pool_kwargs: dict = {}
 
     def __init_subclass__(cls, **kwargs):
@@ -310,6 +322,7 @@ class Scheduler(BrokerModule):
     def __init__(self, h, *args):
         super().__init__(h, *args)
         self.log.level = "info"
+        self.pool_kwargs = dict(self.pool_kwargs)
         self._resources = None
         self._acquire_rpc = None
         self._queue = []  # heapq of PendingJob, ordered by PendingJob.__lt__
@@ -1052,6 +1065,31 @@ class Scheduler(BrokerModule):
         """Register a dynamic service by name (synchronous)."""
         self.handle.service_register(name).get()
 
+    def _make_pool(self, R):
+        """Construct a resource pool from an R dict or JSON string.
+
+        When :attr:`pool_class` is set on the subclass, instantiates it
+        directly.  :attr:`pool_class` must be a
+        :class:`~flux.resource.ResourcePool.ResourcePool` subclass whose
+        constructor accepts ``(R, log=log)``.  Otherwise delegates to
+        :class:`~flux.resource.ResourcePool.ResourcePool`'s built-in
+        version dispatch.
+        """
+        if self.pool_class is not None:
+            if not (
+                isinstance(self.pool_class, type)
+                and issubclass(self.pool_class, ResourcePool)
+            ):
+                raise ValueError(
+                    f"pool_class must be a ResourcePool subclass, "
+                    f"got {self.pool_class!r}"
+                )
+            return self.pool_class(R, log=self.log, **self.pool_kwargs)
+        pool_class = self._pool_class_from_writer(R)
+        if pool_class is not None:
+            return pool_class(R, log=self.log, **self.pool_kwargs)
+        return ResourcePool(R, log=self.log, **self.pool_kwargs)
+
     def _acquire_resources(self):
         """Issue resource.acquire, process first response synchronously."""
         f = self.handle.rpc("resource.acquire", flags=FLUX_RPC_STREAMING)
@@ -1064,7 +1102,7 @@ class Scheduler(BrokerModule):
         R = data.get("resources")
         if R is None:
             raise OSError("resource.acquire: missing 'resources' field")
-        self._resources = ResourcePool(R, log=self.log, **self.pool_kwargs)
+        self._resources = self._make_pool(R)
 
         # Warn once about any pool_kwargs not recognised by this pool
         # implementation, then prune them so subsequent pool constructions
@@ -1160,12 +1198,12 @@ class Scheduler(BrokerModule):
             if free_ranks:
                 from flux.idset import IDset
 
-                rset = ResourcePool(R_dict, log=self.log, **self.pool_kwargs)
+                rset = self._make_pool(R_dict)
                 rset.remove_ranks(IDset(free_ranks))
                 R_dict = rset.to_dict()
 
             try:
-                R = ResourcePool(R_dict, log=self.log, **self.pool_kwargs)
+                R = self._make_pool(R_dict)
                 self.hello(
                     jobid,
                     data["priority"],

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -80,7 +80,8 @@ class PendingJob:
         request (:class:`AllocRequest`): The open RFC 27 allocation request.
         resource_request: Pool-specific parsed resource request returned by
             :meth:`~ResourcePool.parse_resource_request`; passed to
-            :meth:`~ResourcePool.alloc` when scheduling.
+            :meth:`~ResourcePool.alloc` when scheduling.  The raw jobspec
+            dict is accessible as ``resource_request.jobspec``.
     """
 
     __slots__ = (

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -51,9 +51,11 @@ to override :meth:`schedule`::
 import errno
 import functools
 import heapq
-import importlib.util
+import importlib
 import inspect
+import json
 import time
+import urllib.parse
 from typing import Optional
 
 from _flux._core import ffi, lib
@@ -323,6 +325,7 @@ class Scheduler(BrokerModule):
         super().__init__(h, *args)
         self.log.level = "info"
         self.pool_kwargs = dict(self.pool_kwargs)
+        self._uri_class_cache: dict = {}
         self._resources = None
         self._acquire_rpc = None
         self._queue = []  # heapq of PendingJob, ordered by PendingJob.__lt__
@@ -404,6 +407,12 @@ class Scheduler(BrokerModule):
                         f"log-level={name!r} is invalid: "
                         f"expected one of {', '.join(BrokerLogger.LEVEL_NAMES)}"
                     )
+            elif arg.startswith("pool-class="):
+                uri = arg[len("pool-class=") :]
+                cls = self._pool_class_from_uri(uri)
+                if cls is None:
+                    raise ValueError(f"pool-class={uri!r}: could not load pool class")
+                self.pool_class = cls
             else:
                 self._pending_args.append(arg)
 
@@ -416,7 +425,7 @@ class Scheduler(BrokerModule):
         if self._pending_args:
             raise ValueError(
                 f"unknown argument {self._pending_args[0]!r}: "
-                f"built-in options are queue-depth, log-level"
+                f"built-in options are queue-depth, log-level, pool-class"
             )
 
     # ------------------------------------------------------------------
@@ -1065,15 +1074,70 @@ class Scheduler(BrokerModule):
         """Register a dynamic service by name (synchronous)."""
         self.handle.service_register(name).get()
 
+    def _pool_class_from_writer(self, R):
+        """Return a pool class derived from R.scheduling.writer, or None.
+
+        Per RFC 20, an absent ``scheduling`` key means no custom pool is
+        needed (returns ``None``).  An absent ``writer`` within a present
+        ``scheduling`` key defaults to ``"fluxion"``.  The writer value is
+        passed to :meth:`_pool_class_from_uri` for URI resolution; returns
+        ``None`` when the module cannot be imported.
+        """
+        if isinstance(R, str):
+            R = json.loads(R)
+        if not isinstance(R, dict):
+            return None
+        scheduling = R.get("scheduling")
+        if scheduling is None:
+            return None
+        writer = scheduling.get("writer", "fluxion")
+        return self._pool_class_from_uri(writer)
+
+    def _pool_class_from_uri(self, uri):
+        """Load and return a pool class from a URI string.
+
+        ``module`` or ``module:ClassName``
+            Import the Python module named by *module* (hyphens converted to
+            underscores).  If a *ClassName* component is present it is used as
+            the literal class name (e.g. ``rackpool:RackPool`` →
+            ``getattr(rackpool, "RackPool")``).  If absent, the module's
+            ``pool_class`` attribute is used (e.g. ``rackpool`` →
+            ``rackpool.pool_class``).
+
+        The module must be importable, so ensure the directory containing it
+        is on :data:`sys.path` (e.g. via ``PYTHONPATH``).
+        """
+        if not hasattr(self, "_uri_class_cache"):
+            self._uri_class_cache = {}
+        if uri in self._uri_class_cache:
+            return self._uri_class_cache[uri]
+        parsed = urllib.parse.urlparse(uri)
+        module_name = (parsed.scheme or parsed.path).replace("-", "_")
+        cls_name = parsed.path if parsed.scheme else None
+        try:
+            mod = importlib.import_module(module_name)
+            cls = getattr(mod, cls_name) if cls_name else mod.pool_class
+        except (ImportError, AttributeError):
+            return None
+        self._uri_class_cache[uri] = cls
+        return cls
+
     def _make_pool(self, R):
         """Construct a resource pool from an R dict or JSON string.
 
-        When :attr:`pool_class` is set on the subclass, instantiates it
-        directly.  :attr:`pool_class` must be a
-        :class:`~flux.resource.ResourcePool.ResourcePool` subclass whose
-        constructor accepts ``(R, log=log)``.  Otherwise delegates to
-        :class:`~flux.resource.ResourcePool.ResourcePool`'s built-in
-        version dispatch.
+        Checks, in order:
+
+        1. :attr:`pool_class` set explicitly (e.g. via ``pool-class=`` argument
+           or subclass definition) — instantiated directly.  Raises
+           :exc:`ValueError` if the value is not a
+           :class:`~flux.resource.ResourcePool.ResourcePool` subclass.
+        2. ``R.scheduling.writer`` URI — parsed by
+           :meth:`_pool_class_from_writer` to derive the pool class.
+        3. Default :class:`~flux.resource.ResourcePool.ResourcePool` version
+           dispatch.
+
+        In all three cases :attr:`pool_kwargs` are forwarded as keyword
+        arguments to the chosen constructor.
         """
         if self.pool_class is not None:
             if not (

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -339,6 +339,7 @@ TESTSCRIPTS = \
 	python/t0041-resource-count.py \
 	python/t0042-job-manager-alloc-cache.py \
 	python/t0043-sdexec-map.py \
+	python/t0043-scheduler-pool.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -55,7 +55,14 @@ def rr(
         slot_count = ResourceCount(nslots, nslots_max)
 
     return ResourceRequest(
-        node_count, slot_count, slot_size, gpu_per_slot, duration, constraint, exclusive
+        node_count,
+        slot_count,
+        slot_size,
+        gpu_per_slot,
+        duration,
+        constraint,
+        exclusive,
+        None,
     )
 
 
@@ -666,7 +673,7 @@ class TestRv1PoolCheckFeasibility(unittest.TestCase):
         from flux.idset import IDset
 
         req = ResourceRequest(
-            None, ResourceCount(2, 8, IDset("2,4,8")), 1, 0, 60.0, None, False
+            None, ResourceCount(2, 8, IDset("2,4,8")), 1, 0, 60.0, None, False, None
         )
         with self.assertRaises(InfeasibleRequest):
             self.pool.check_feasibility(req)
@@ -1083,6 +1090,32 @@ class TestFromJobspec(unittest.TestCase):
             with self.subTest(pool=type(pool).__name__):
                 rr = pool.parse_resource_request(jobspec)
                 self.assertIsNone(rr.constraint)
+
+    def test_jobspec_stored_on_request(self):
+        """request.jobspec is the original jobspec dict."""
+        for pool in self._pools():
+            with self.subTest(pool=type(pool).__name__):
+                rr = pool.parse_resource_request(self.VALID_V1)
+                self.assertIs(rr.jobspec, self.VALID_V1)
+
+    def test_jobspec_system_attr_accessible(self):
+        """Site-specific attributes.system hints are accessible via request.jobspec."""
+        jobspec = {
+            "version": 1,
+            "resources": [
+                {"type": "slot", "count": 1, "with": [{"type": "core", "count": 1}]}
+            ],
+            "tasks": [],
+            "attributes": {"system": {"duration": 60.0, "rack_exclusive": True}},
+        }
+        for pool in self._pools():
+            with self.subTest(pool=type(pool).__name__):
+                rr = pool.parse_resource_request(jobspec)
+                self.assertTrue(
+                    rr.jobspec.get("attributes", {})
+                    .get("system", {})
+                    .get("rack_exclusive")
+                )
 
 
 class TestFromJobspecNonV1(unittest.TestCase):

--- a/t/python/t0043-scheduler-pool.py
+++ b/t/python/t0043-scheduler-pool.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Unit tests for Scheduler pool-class selection.
+
+Tests _pool_class_from_uri, _pool_class_from_writer, and _make_pool
+without a running Flux instance.  All three methods are pure Python and
+only use self for attribute access (pool_class, pool_kwargs, log) and
+recursive calls to each other — a lightweight mock suffices.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import textwrap
+import unittest
+
+import subflux  # noqa: F401 - for PYTHONPATH
+from flux.resource.ResourcePool import ResourcePool
+from flux.scheduler import Scheduler
+from pycotap import TAPTestRunner
+
+
+class _MockSched:
+    """Minimal stand-in for Scheduler that exercises pool-selection methods."""
+
+    pool_class = None
+    pool_kwargs = {}
+
+    @staticmethod
+    def log(level, msg):
+        pass
+
+    _pool_class_from_uri = Scheduler._pool_class_from_uri
+    _pool_class_from_writer = Scheduler._pool_class_from_writer
+    _make_pool = Scheduler._make_pool
+
+
+# Minimal single-node R used as input to _make_pool.
+R_SIMPLE = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0", "children": {"core": "0-3"}}],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": ["node0"],
+    },
+}
+
+
+class TestPoolClassFromUri(unittest.TestCase):
+    def setUp(self):
+        self.sched = _MockSched()
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _write_pool_file(self, filename, content):
+        path = os.path.join(self.tmpdir, filename)
+        with open(path, "w") as f:
+            f.write(textwrap.dedent(content))
+        return path
+
+    def _pool_file_content(self, classname):
+        return f"""\
+            from flux.resource.Rv1Pool import Rv1Pool
+            class {classname}(Rv1Pool):
+                pass
+            pool_class = {classname}
+            """
+
+    def test_missing_module_returns_none(self):
+        """Unresolvable module URI returns None without raising."""
+        self.assertIsNone(self.sched._pool_class_from_uri("no_such_module_xyz"))
+
+    def test_module_without_pool_class_attr_returns_none(self):
+        """Module that exists but lacks pool_class returns None."""
+        self.assertIsNone(self.sched._pool_class_from_uri("json"))
+
+    def test_module_uri_pool_class_attr(self):
+        """Plain module URI loads pool_class attribute from the module."""
+        self._write_pool_file("mypool.py", self._pool_file_content("MyPool"))
+        sys.path.insert(0, self.tmpdir)
+        try:
+            cls = self.sched._pool_class_from_uri("mypool")
+            self.assertEqual(cls.__name__, "MyPool")
+        finally:
+            sys.path.pop(0)
+            sys.modules.pop("mypool", None)
+
+    def test_module_uri_explicit_class_name(self):
+        """module:ClassName URI loads the named class from the module."""
+        self._write_pool_file("mypool2.py", self._pool_file_content("MyPool2"))
+        sys.path.insert(0, self.tmpdir)
+        try:
+            cls = self.sched._pool_class_from_uri("mypool2:MyPool2")
+            self.assertEqual(cls.__name__, "MyPool2")
+        finally:
+            sys.path.pop(0)
+            sys.modules.pop("mypool2", None)
+
+
+class TestPoolClassFromWriter(unittest.TestCase):
+    def setUp(self):
+        self.sched = _MockSched()
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _write_pool_file(self, filename, classname):
+        path = os.path.join(self.tmpdir, filename)
+        with open(path, "w") as f:
+            f.write(
+                f"from flux.resource.Rv1Pool import Rv1Pool\n"
+                f"class {classname}(Rv1Pool):\n"
+                f"    pass\n"
+                f"pool_class = {classname}\n"
+            )
+        return path
+
+    def test_no_scheduling_key_returns_none(self):
+        """R without a scheduling key returns None."""
+        self.assertIsNone(self.sched._pool_class_from_writer(R_SIMPLE))
+
+    def test_scheduling_without_writer_tries_fluxion(self):
+        """scheduling key without writer defaults to fluxion; returns None if not installed."""
+        R = dict(R_SIMPLE, scheduling={})
+        # fluxion is not installed in the test environment
+        self.assertIsNone(self.sched._pool_class_from_writer(R))
+
+    def test_scheduling_with_module_writer(self):
+        """scheduling.writer pointing to a module URI loads the class."""
+        self._write_pool_file("writerpool.py", "WriterPool")
+        sys.path.insert(0, self.tmpdir)
+        try:
+            R = dict(R_SIMPLE, scheduling={"writer": "writerpool"})
+            cls = self.sched._pool_class_from_writer(R)
+            self.assertEqual(cls.__name__, "WriterPool")
+        finally:
+            sys.path.pop(0)
+            sys.modules.pop("writerpool", None)
+
+    def test_json_string_input(self):
+        """R supplied as a JSON string is parsed before inspection."""
+        R = dict(R_SIMPLE, scheduling={})
+        self.assertIsNone(self.sched._pool_class_from_writer(json.dumps(R)))
+
+    def test_non_dict_non_str_returns_none(self):
+        """Non-dict, non-str input returns None without raising."""
+        self.assertIsNone(self.sched._pool_class_from_writer(42))
+        self.assertIsNone(self.sched._pool_class_from_writer(None))
+
+
+class TestMakePool(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _make_sched(self, pool_class=None, pool_kwargs=None):
+        sched = _MockSched()
+        sched.pool_class = pool_class
+        sched.pool_kwargs = dict(pool_kwargs or {})
+        return sched
+
+    def _write_pool_file(self, filename, classname):
+        path = os.path.join(self.tmpdir, filename)
+        with open(path, "w") as f:
+            f.write(
+                f"from flux.resource.Rv1Pool import Rv1Pool\n"
+                f"class {classname}(Rv1Pool):\n"
+                f"    pass\n"
+                f"pool_class = {classname}\n"
+            )
+        return path
+
+    def test_explicit_pool_class_wins(self):
+        """pool_class attribute takes priority over scheduling.writer."""
+
+        class WinPool(ResourcePool):
+            pass
+
+        R = dict(
+            R_SIMPLE,
+            scheduling={"writer": "nonexistent_sched_module"},
+        )
+        sched = self._make_sched(pool_class=WinPool)
+        pool = sched._make_pool(R)
+        self.assertIsInstance(pool, WinPool)
+
+    def test_writer_uri_used_when_no_pool_class(self):
+        """scheduling.writer module URI is consulted when pool_class is None."""
+        self._write_pool_file("writermod2.py", "WriterMod2")
+        sys.path.insert(0, self.tmpdir)
+        try:
+            R = dict(R_SIMPLE, scheduling={"writer": "writermod2"})
+            sched = self._make_sched()
+            pool = sched._make_pool(R)
+            self.assertEqual(type(pool).__name__, "WriterMod2")
+        finally:
+            sys.path.pop(0)
+            sys.modules.pop("writermod2", None)
+
+    def test_default_pool_when_no_class_no_writer(self):
+        """Falls back to the default ResourcePool version dispatch."""
+        sched = self._make_sched()
+        pool = sched._make_pool(R_SIMPLE)
+        self.assertIsInstance(pool, ResourcePool)
+
+    def test_pool_kwargs_forwarded_to_explicit_pool_class(self):
+        """pool_kwargs are forwarded to pool_class constructor."""
+        received = {}
+
+        class TrackingPool(ResourcePool):
+            def __init__(self, R, log=None, **kwargs):
+                received.update(kwargs)
+                super().__init__(R, log=log)
+
+        sched = self._make_sched(pool_class=TrackingPool, pool_kwargs={"foo": "bar"})
+        sched._make_pool(R_SIMPLE)
+        self.assertEqual(received, {"foo": "bar"})
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
Problem:  the fluxion REAPI integration proposed #7496 would require a complete replacement of the flux-core `Rv1Pool`, but that's currently inconvenient.

This makes a few changes to support that use case in the future:
- make the full jobspec available in a `ResourceRequest`, so a new resource class's `alloc()` method can access it (as opposed to receiving a simplified Rv1-specific summary)
- add a way for a scheduler to set the resource class and take over the R version based dispatch from the base class
- add URI based pool selection

Peeled off of #7500