### PR TITLE
cmd: fix possible use-after-free in imp_exec_helper

### DIFF
--- a/src/cmd/builtin/imp_exec_helper.c
+++ b/src/cmd/builtin/imp_exec_helper.c
@@ -74,7 +74,7 @@ static char *get_unit_path (flux_t *h, const char *invocation_id)
                              "sdbus.call",
                              FLUX_NODEID_ANY,
                              0,
-                             "{s:s s:[o]}",
+                             "{s:s s:[O]}",
                              "member", "GetUnitByInvocationID",
                              "params", bytes))
         || flux_rpc_get_unpack (f, "{s:[s]}", "params", &path) < 0)


### PR DESCRIPTION
Problem: On some systems, `flux imp_exec_helper` crashes due to a use-after-free in get_unit_path(). The `bytes` parameter is passed with `o` to `flux_rpc_pack()` which means the reference is stolen, but the function calls `json_decref(bytes)` on exit.

Remove the unecessary `json_decref()` call. The error path is freed by `log_msg_exit()`, so this is the simplest solution for the situation.