### PR TITLE
python: refactor modprobe implementation

### DIFF
--- a/doc/man1/flux-modprobe.rst
+++ b/doc/man1/flux-modprobe.rst
@@ -251,6 +251,11 @@ Each entry in the ``modules`` array supports the following keys:
    ``>`` or ``<`` followed by a single integer. (for example, ``">0"`` to
    load a module all ranks but rank 0.)
 
+**disabled**
+   (optional, boolean) If true, disable this module/task so it will not be
+   loaded during normal startup. Disabled modules can still be loaded
+   explicitly via :command:`flux modprobe load`. Default: false.
+
 **requires**
    (optional, array of string) An array of services this module requires. That
    is, if this module is loaded, the services in *requires* will also be

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -353,8 +353,73 @@ class TaskDB:
         Check if a task/module/service exists in the database.
 
         More efficient than calling get() and catching ValueError.
+        Prefer using 'in' operator which calls __contains__.
         """
         return service in self._services and len(self._services[service]) > 0
+
+    def __contains__(self, service: str) -> bool:
+        """
+        Check if service exists in database (enables 'in' operator).
+
+        Example:
+            if "kvs" in taskdb:
+                task = taskdb.get("kvs")
+        """
+        return self.has(service)
+
+    def __setitem__(self, name: str, task: "Task") -> None:
+        """
+        Add or update task in database (enables dict-like assignment).
+
+        Always succeeds - adds task if new, updates if exists. This is the
+        idiomatic Python way to handle upsert operations, similar to dict.
+
+        Example:
+            taskdb["kvs"] = kvs_task  # Add or update
+
+        Args:
+            name: Task name (must match task.name)
+            task: Task object to add/update
+
+        Raises:
+            ValueError: If name doesn't match task.name
+        """
+        # TaskDB invariant is that tasks are stored first under task.name.
+        # Ensure that's not violated here:
+        if name != task.name:
+            raise ValueError(f"Key '{name}' doesn't match task.name '{task.name}'")
+
+        # Check if task exists in any service
+        found = False
+        for service in self._services:
+            if task.name in self._services[service]:
+                found = True
+                break
+
+        if not found:
+            # Task doesn't exist yet, add it
+            self.add(task)
+            return
+
+        # Update all services where this task should appear
+        for service in (task.name, *task.provides):
+            if service in self._services and task.name in self._services[service]:
+                old_entry = self._services[service][task.name]
+                # Use task.priority directly (dict-like semantics: replacement)
+                self._services[service][task.name] = self.TaskEntry(
+                    task.priority,
+                    old_entry.index,
+                    task,
+                )
+            else:
+                # New service added to provides, add entry with preserved index
+                # Get the insertion index from any existing service
+                for existing_service in self._services:
+                    if task.name in self._services[existing_service]:
+                        old_entry = self._services[existing_service][task.name]
+                        entry = self.TaskEntry(task.priority, old_entry.index, task)
+                        self._services[service][task.name] = entry
+                        break
 
     def has_enabled_provider(self, tasks, service: str) -> bool:
         """
@@ -782,18 +847,16 @@ class DependencySolver:
         for name in result:
             remaining = dependents.get(name, set()) - removed_items
             # Also filter out by real task name in case of aliases
-            try:
-                self.taskdb.get(name)  # Verify task exists
+            if name in self.taskdb:
                 remaining = {
                     dep
                     for dep in remaining
                     if dep not in removed_items
+                    and dep in self.taskdb
                     and self.taskdb.get(dep).name not in removed_items
                 }
-            except ValueError:
-                # Task doesn't exist in taskdb (e.g., nonexistent module)
-                # Just use the remaining set as-is
-                pass
+            # else: Task doesn't exist in taskdb (e.g., nonexistent module)
+            # Just use the remaining set as-is
             if remaining:
                 raise ValueError(
                     f"{name} still in use by " + ", ".join(sorted(remaining))
@@ -1556,11 +1619,7 @@ class Modprobe:
 
     def has_task(self, name):
         """Return True if task exists in taskdb"""
-        try:
-            self.taskdb.get(name)
-            return True
-        except ValueError:
-            return False
+        return name in self.taskdb
 
     def update_module(self, name, entry, new_module=None):
         task = self.get_task(name)
@@ -1570,7 +1629,7 @@ class Modprobe:
             new_module = Module(entry)
         for key in entry.keys():
             setattr(task, key, getattr(new_module, key))
-        self.taskdb.update(task)
+        self.taskdb[task.name] = task
 
     def add_modules(self, file):
         with open(file, "rb") as fp:

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -27,6 +27,10 @@ from flux.idset import IDset
 from flux.utils import tomli as tomllib
 from flux.utils.graphlib import TopologicalSorter
 
+# ==============================================================================
+# SECTION 1: Utility Functions
+# ==============================================================================
+
 
 def run_all_rc_scripts(runlevel):
     """
@@ -101,6 +105,11 @@ def default_flux_confdir():
     return Path(conf_builtin_get("confdir"))
 
 
+# ==============================================================================
+# SECTION 2: Core Data Structures
+# ==============================================================================
+
+
 class RankConditional:
     """
     Conditional rank statement, e.g. ``>0``
@@ -160,6 +169,113 @@ def rank_conditional(arg):
     if arg.startswith((">", "<")):
         cls = RankConditional
     return cls(arg)
+
+
+class TaskDB:
+    """
+    Dict of service/module name to list of tasks sorted such the
+    current default task is at the end of the list.
+    """
+
+    TaskEntry = namedtuple("TaskEntry", ("priority", "index", "task"))
+
+    def __init__(self):
+        self.tasks = defaultdict(list)
+
+    def add(self, task, index=None):
+        for name in (*task.provides, task.name):
+            if index is None:
+                index = len(self.tasks[name])
+            bisect.insort_right(
+                self.tasks[name],
+                self.TaskEntry(task.priority, index, task),
+            )
+
+    def get(self, service):
+        """
+        Return the highest priority task providing ``service`` which is also
+        enabled. If there are no enabled tasks providing ``service``, then
+        return the highest priority task. If no tasks provide ``service``,
+        raise ``ValueError``.
+        """
+        if len(self.tasks[service]) == 0:
+            raise ValueError(f"no such task or module {service}")
+        enabled = list(filter(lambda x: x.task.enabled(), self.tasks[service]))
+        if len(enabled) == 0:
+            return self.tasks[service][-1].task
+        return enabled[-1].task
+
+    def update(self, task):
+        """
+        Update a task object which already resides in the taskdb by removing
+        the task from all service name lists and re-adding it, preserving the
+        original insertion order. This handles any potential update of a task,
+        such as a new ``priority``, or additional ``provides``
+        """
+        for name in (task.name, *task.provides):
+            to_remove = -1
+            for i, entry in enumerate(self.tasks[name]):
+                if entry.task == task:
+                    to_remove = i
+                    break
+            if to_remove < 0:
+                raise ValueError(f"{task.name} not found in taskdb {name} list")
+
+            # remove task from this list and re-insert, preserving the
+            # original insertion index:
+            self.tasks[name].pop(to_remove)
+            self.add(task, index=entry.index)
+
+    def set_alternative(self, service, name, propagate=True):
+        """Select a specific alternative 'name' for service"""
+        lst = self.tasks[service]
+        try:
+            index = next(i for i, x in enumerate(lst) if x.task.name == name)
+        except StopIteration:
+            raise ValueError(f"no module {name} provides {service}")
+
+        # nothing to do if list has length of 1
+        if len(lst) == 1:
+            return
+
+        # bump priority of new task and move to end of list:
+        entry = lst.pop(index)
+        priority = lst[-1].priority
+        lst.append(self.TaskEntry(priority + 1, entry.index, entry.task))
+
+        # now do the same for any other provides in this module
+        if propagate:
+            for provides in set(entry.task.provides) - {service}:
+                self.set_alternative(provides, name, propagate=False)
+
+    def disable(self, service):
+        """disable task/module/service with name 'service'"""
+        if not self.tasks[service]:
+            raise ValueError(f"no such module or task '{service}'")
+        for entry in self.tasks[service]:
+            entry.task.disabled = True
+
+    def enable(self, service):
+        """
+        Force a module/task/service to be enabled even if it would normally
+        be disabled by rank, needs-config, or needs-attr.
+        """
+        if not self.tasks[service]:
+            raise ValueError(f"no such module or task '{service}'")
+        for entry in self.tasks[service]:
+            entry.task.force_enabled = True
+
+    def any_provides(self, tasks, name):
+        """Return True if any task in tasks provides name"""
+        for task in [self.get(x) for x in tasks]:
+            if not task.disabled and name in (task.name, *task.provides):
+                return True
+        return False
+
+
+# ==============================================================================
+# SECTION 3: Task Definitions
+# ==============================================================================
 
 
 class Task:
@@ -405,108 +521,6 @@ class Module(Task):
         }
 
 
-class TaskDB:
-    """
-    Dict of service/module name to list of tasks sorted such the
-    current default task is at the end of the list.
-    """
-
-    TaskEntry = namedtuple("TaskEntry", ("priority", "index", "task"))
-
-    def __init__(self):
-        self.tasks = defaultdict(list)
-
-    def add(self, task, index=None):
-        for name in (*task.provides, task.name):
-            if index is None:
-                index = len(self.tasks[name])
-            bisect.insort_right(
-                self.tasks[name],
-                self.TaskEntry(task.priority, index, task),
-            )
-
-    def get(self, service):
-        """
-        Return the highest priority task providing ``service`` which is also
-        enabled. If there are no enabled tasks providing ``service``, then
-        return the highest priority task. If no tasks provide ``service``,
-        raise ``ValueError``.
-        """
-        if len(self.tasks[service]) == 0:
-            raise ValueError(f"no such task or module {service}")
-        enabled = list(filter(lambda x: x.task.enabled(), self.tasks[service]))
-        if len(enabled) == 0:
-            return self.tasks[service][-1].task
-        return enabled[-1].task
-
-    def update(self, task):
-        """
-        Update a task object which already resides in the taskdb by removing
-        the task from all service name lists and re-adding it, preserving the
-        original insertion order. This handles any potential update of a task,
-        such as a new ``priority``, or additional ``provides``
-        """
-        for name in (task.name, *task.provides):
-            to_remove = -1
-            for i, entry in enumerate(self.tasks[name]):
-                if entry.task == task:
-                    to_remove = i
-                    break
-            if to_remove < 0:
-                raise ValueError(f"{task.name} not found in taskdb {name} list")
-
-            # remove task from this list and re-insert, preserving the
-            # original insertion index:
-            self.tasks[name].pop(to_remove)
-            self.add(task, index=entry.index)
-
-    def set_alternative(self, service, name, propagate=True):
-        """Select a specific alternative 'name' for service"""
-        lst = self.tasks[service]
-        try:
-            index = next(i for i, x in enumerate(lst) if x.task.name == name)
-        except StopIteration:
-            raise ValueError(f"no module {name} provides {service}")
-
-        # nothing to do if list has length of 1
-        if len(lst) == 1:
-            return
-
-        # bump priority of new task and move to end of list:
-        entry = lst.pop(index)
-        priority = lst[-1].priority
-        lst.append(self.TaskEntry(priority + 1, entry.index, entry.task))
-
-        # now do the same for any other provides in this module
-        if propagate:
-            for provides in set(entry.task.provides) - {service}:
-                self.set_alternative(provides, name, propagate=False)
-
-    def disable(self, service):
-        """disable task/module/service with name 'service'"""
-        if not self.tasks[service]:
-            raise ValueError(f"no such module or task '{service}'")
-        for entry in self.tasks[service]:
-            entry.task.disabled = True
-
-    def enable(self, service):
-        """
-        Force a module/task/service to be enabled even if it would normally
-        be disabled by rank, needs-config, or needs-attr.
-        """
-        if not self.tasks[service]:
-            raise ValueError(f"no such module or task '{service}'")
-        for entry in self.tasks[service]:
-            entry.task.force_enabled = True
-
-    def any_provides(self, tasks, name):
-        """Return True if any task in tasks provides name"""
-        for task in [self.get(x) for x in tasks]:
-            if not task.disabled and name in (task.name, *task.provides):
-                return True
-        return False
-
-
 def task(name, **kwargs):
     """
     Decorator for modprobe "rc" task functions.
@@ -562,6 +576,11 @@ def task(name, **kwargs):
         return CodeTask(name, func, **kwargs)
 
     return create_task
+
+
+# ==============================================================================
+# SECTION 4: Execution Context
+# ==============================================================================
 
 
 class Context:
@@ -643,7 +662,7 @@ class Context:
         """Set or unset environment variables in the current process and broker.
 
         Variables set via this method that are not in the broker's env
-        blocklist will be inherited by rc2 and rc3.  A value of None
+        blocklist will be inherited by rc2 and rc3. A value of None
         causes the named variable to be unset.
 
         Note: concurrent calls from unrelated tasks running in parallel are
@@ -652,7 +671,7 @@ class Context:
 
         Args:
             name_or_env: a variable name string, or a dict mapping names
-                to values.  Values may be strings or None to unset.
+                to values. Values may be strings or None to unset.
             value: the value to set, when name_or_env is a string.
 
         Raises:
@@ -763,6 +782,11 @@ class ModuleList:
 
     def lookup(self, name):
         return self.servicemap.get(name, None)
+
+
+# ==============================================================================
+# SECTION 5: Main Orchestrator
+# ==============================================================================
 
 
 class Modprobe:

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -1569,21 +1569,34 @@ class Modprobe:
         return name in self.taskdb
 
     def update_module(self, name, entry, new_module=None):
-        task = self.get_task(name)
+        """
+        Update attributes of an existing module/task.
+
+        Args:
+            name: Task name or service name to look up
+            entry: Dict of attribute updates to apply
+            new_module: Optional pre-constructed Module for attribute source
+
+        Note: 'name' may be a service name (e.g., "feasibility") rather than
+        the actual task name (e.g., "sched-simple"), so we never overwrite
+        task.name during updates.
+        """
+        old_task = self.get_task(name)
+
         if new_module is None:
-            if "name" not in entry:
-                entry["name"] = name
-            new_module = Module(entry)
+            # Validate updates by constructing a Module
+            # Use a copy to avoid mutating caller's dict
+            entry_for_validation = dict(entry)
+            entry_for_validation.setdefault("name", old_task.name)
+            new_module = Module(entry_for_validation)
 
-        # Copy attributes from new_module to task, but never overwrite task.name
-        # (name might be a service name, not the actual task name)
-        for key in entry.keys():
-            if key == "name":
-                continue
-            setattr(task, key, getattr(new_module, key))
+        # Apply each attribute update to the existing task
+        for attr_name in entry.keys():
+            if attr_name != "name":  # Never overwrite task.name
+                setattr(old_task, attr_name, getattr(new_module, attr_name))
 
-        # Update the task in database (preserves index, uses current task.priority)
-        self.taskdb[task.name] = task
+        # Update task in database (preserves index, uses current task.priority)
+        self.taskdb[old_task.name] = old_task
 
     def add_modules(self, file):
         with open(file, "rb") as fp:

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -8,6 +8,92 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
+"""
+Flux modprobe: Task and module orchestration for broker startup/shutdown.
+
+This module implements the Flux modprobe system, which manages broker
+module loading/unloading and task execution during rc1 (startup) and
+rc3 (shutdown). It provides declarative configuration through TOML files
+and Python rc scripts with dependency resolution and precedence ordering.
+
+Architecture
+============
+
+The implementation is organized into several key components:
+
+**TaskDB**: Priority-based task database supporting service alternatives.
+  Stores tasks in a dict-of-dicts structure {service: {name: TaskEntry}}
+  where TaskEntry is a namedtuple(index, task). Priority comes from
+  task.priority. When selecting a task for a service, the highest priority
+  enabled task is chosen.
+
+**DependencySolver**: Dependency resolution engine.
+  Handles recursive requirement resolution (requires), needs filtering,
+  execution order precedence (before/after), and safe module removal.
+
+**ConfigLoader**: Configuration and rc file loading.
+  Manages search paths and loads TOML module config and Python rc files
+  from configurable directories.
+
+**Task**: Base class for modprobe tasks.
+  Represents a task with configuration including ranks, dependencies,
+  and enabled/disabled state. A task can be load/remove of a module (the
+  Module class) or a Python function (CodeTask class: Python function
+  decorated with @task).
+
+**Context**: Execution context passed to all tasks.
+  Provides access to broker configuration, attributes, environment
+  variables, shared data between tasks, and module argument management.
+  Uses thread-local storage to provide an automatic per-thread Flux handle.
+
+**Modprobe**: Main orchestrator class.
+  Coordinates TaskDB, DependencySolver, and ConfigLoader. Provides
+  high-level operations: configure_modules(), load(), remove(), run(),
+  read_rcfile(). Used by flux-modprobe(1) command.
+
+Usage Example
+=============
+
+Creating tasks in rc1.py::
+
+    from flux.modprobe import task
+
+    @task("setup-kvs", ranks="0", after=["kvs"], needs=["kvs"])
+    def setup_kvs(context):
+        # Configure KVS after it loads
+        context.print("Configuring KVS")
+        # ... setup code ...
+
+Using Modprobe programmatically::
+
+    from flux.modprobe import Modprobe
+
+    M = Modprobe(verbose=True)
+    M.configure_modules()
+    M.load(["kvs", "job-manager"])
+    M.run(M.get_deps(["kvs", "job-manager"]))
+
+Configuration
+=============
+
+Module configuration in modprobe.toml::
+
+    [[modules]]
+    name = "kvs"
+    ranks = "all"
+    provides = ["kvs-service"]
+    requires = []
+    after = []
+
+    [[modules]]
+    name = "job-manager"
+    ranks = "0"
+    requires = ["kvs"]
+    after = ["kvs"]
+
+See flux-modprobe(1) for complete configuration documentation.
+"""
+
 import concurrent
 import glob
 import os
@@ -814,15 +900,26 @@ class DependencySolver:
 
 class ConfigLoader:
     """
-    Handles configuration and RC file loading for modprobe.
+    Configuration and rc file loading with search path management.
 
-    This class encapsulates the logic for:
-    - Building searchpaths from environment variables and config
-    - Locating TOML configuration files
-    - Locating Python RC script files
-    - Expanding .d directories in the searchpath
+    ConfigLoader handles all file I/O for modprobe configuration,
+    separating I/O concerns from business logic. It manages search paths
+    for both TOML module config files and Python rc scripts.
 
-    Separated from Modprobe class for clarity and testability.
+    Search Path:
+        Default search path is built from:
+        - Built-in: $datadir/modprobe or $libexecdir/modprobe
+        - FLUX_MODPROBE_PATH (replaces default)
+        - FLUX_MODPROBE_PATH_PREPEND (added before default)
+        - FLUX_MODPROBE_PATH_APPEND (added after default)
+
+    File Discovery:
+        TOML: modprobe.toml and modprobe.d/*.toml
+        RC:   rc1.py, rc1.d/*.py (or rc3.py, rc3.d/*.py)
+
+    Attributes:
+        searchpath (dict): Paths for 'toml' and 'py' file types
+        print (callable): Function for verbose output
     """
 
     def __init__(self, searchpath, print_func):
@@ -940,7 +1037,47 @@ class ConfigLoader:
 
 class Task:
     """
-    Class representing a modprobe task and associated configuration
+    Base class representing a modprobe task and its configuration.
+
+    A Task represents a unit of work in the modprobe system with
+    associated configuration controlling when and where it runs. Tasks
+    can be broker modules (Module subclass) or Python functions
+    (CodeTask subclass).
+
+    Configuration Attributes:
+        name (str): Unique task identifier
+        ranks (RankConditional|RankIDset): Ranks where task executes
+        provides (list): Service names this task provides (alternatives)
+        requires (list): Tasks/services that must be active when this runs
+        needs (list): Tasks/services that must be enabled for this to
+            enable
+        before (list): Tasks/services this must run before
+        after (list): Tasks/services this must run after
+        needs_attrs (list): Required broker attributes
+        needs_config (list): Required config keys
+        needs_env (list): Required environment variables
+        disabled (bool): Whether task is explicitly disabled
+        priority (int): Priority for service alternative selection
+            (default 100)
+
+    Special Values:
+        - before=["*"]: Run before all other tasks (cannot also use after)
+        - after=["*"]: Run after all other tasks (cannot also use before)
+        - Specs starting with "!" are inverted (must NOT be set)
+
+    Runtime Attributes:
+        starttime (float): Task start timestamp (set during execution)
+        endtime (float): Task end timestamp (set during execution)
+        force_enabled (bool): Override disabled state (internal use)
+
+    Enabling Logic:
+        A task is enabled if ALL of the following are true:
+        1. Not explicitly disabled via disabled=True
+        2. Runs on the current broker rank
+        3. All needs_config keys are set (or not set if prefixed with !)
+        4. All needs_attrs attributes are set (or not set if !)
+        5. All needs_env variables are set (or not set if !)
+        6. All tasks in needs list are also enabled
     """
 
     VALID_ARGS = {
@@ -1245,9 +1382,35 @@ def task(name, **kwargs):
 
 class Context:
     """
-    Context object passed to all modprobe tasks.
-    Allows the passage of data between tasks, simple access to broker
-    configuration and attributes, addition of module arguments, etc.
+    Execution context passed to all modprobe tasks.
+
+    Context provides task functions with access to broker state,
+    configuration, and shared data. It enables tasks to query and modify
+    the environment, communicate with the broker, and share data with
+    other tasks.
+
+    Key Features:
+        - Broker access: Configuration, attributes, RPCs via Flux handle
+        - Environment: Get/set variables in current process and broker
+        - Shared data: Store/retrieve arbitrary data between tasks
+        - Module arguments: Configure module load-time arguments
+        - Thread safety: Per-thread Flux handles via thread-local storage
+
+    Common Methods:
+        handle: Flux handle for broker communication (thread-local)
+        rank: Current broker rank
+        conf_get(key): Get broker config value
+        attr_get(attr): Get broker attribute
+        getenv(var): Get environment variable (local or broker)
+        setenv(name, value): Set environment variable (local and broker)
+        set(key, value) / get(key): Store/retrieve shared data
+        setopt(module, options): Configure module arguments
+        rpc(topic, args): Send RPC to broker
+
+    Attributes:
+        verbose (bool): Verbose output mode
+        dry_run (bool): Dry-run mode (print without executing)
+        modprobe (Modprobe): Parent Modprobe instance
     """
 
     tls = threading.local()
@@ -1310,7 +1473,22 @@ class Context:
         return self._broker_env_cache[var]
 
     def getenv(self, var, default=None):
-        """Get env var value locally or from local broker"""
+        """
+        Get environment variable value from local process or broker.
+
+        Checks the local process environment first, then falls back to
+        querying the broker via RPC. This is useful because the broker
+        may filter some variables from rc1/rc3 environments (e.g., those
+        set by resource managers or launchers). Results from broker are
+        cached.
+
+        Args:
+            var: Environment variable name
+            default: Value to return if variable is not set
+
+        Returns:
+            Variable value (str) or default if not set
+        """
         value = os.environ.get(var)
         if value is None:
             value = self._broker_getenv(var)
@@ -1365,8 +1543,19 @@ class Context:
 
     def setopt(self, module, options, overwrite=False):
         """
-        Append option to module opts. ``option`` may contain multiple options
-        separated by whitespace.
+        Add module load-time arguments.
+
+        Appends options to a module's argument list (or overwrites if
+        overwrite=True). Options can be a single string with
+        whitespace-separated arguments.
+
+        Args:
+            module: Module name
+            options: Options string (whitespace-separated)
+            overwrite: Replace all existing options (default False)
+
+        Example:
+            context.setopt("kvs", "checkpoint-period=10m")
         """
         if overwrite:
             self.module_args_overwrite[module] = True
@@ -1374,8 +1563,19 @@ class Context:
         self.module_args[module].extend(options.split())
 
     def getopts(self, name, default=None, also=None):
-        """Get module opts for module 'name'
-        If also is provided, append any module options for those names as well
+        """
+        Get module load-time arguments.
+
+        Retrieves the argument list for a module, optionally including
+        arguments from related modules.
+
+        Args:
+            name: Module name
+            default: Default arguments (used if no overwrite occurred)
+            also: List of additional module names whose args to include
+
+        Returns:
+            List of argument strings
         """
         lst = [name]
         if also is not None:
@@ -1388,7 +1588,15 @@ class Context:
         return result
 
     def bash(self, command):
-        """Execute command under ``bash -c``"""
+        """
+        Execute shell command via bash -c.
+
+        Args:
+            command: Shell command string
+
+        Raises:
+            RuntimeError: If command exits non-zero or is killed by signal
+        """
         process = subprocess.run(["bash", "-c", command])
         if process.returncode != 0:
             if process.returncode > 0:
@@ -1399,7 +1607,15 @@ class Context:
                 raise RuntimeError(f"bash: died by signal {process.returncode}")
 
     def load_modules(self, modules):
-        """Set a list of modules to load by name"""
+        """
+        Schedule modules to be loaded during task execution.
+
+        Adds modules to the active task list so they will be loaded when
+        run() is called. Typically used in setup() functions.
+
+        Args:
+            modules: List of module names to load
+        """
         self.modprobe.activate_modules(modules)
 
     def remove_modules(self, modules=None):
@@ -1451,7 +1667,34 @@ class ModuleList:
 
 class Modprobe:
     """
-    The modprobe main class. Intended for use by flux-modprobe(1).
+    Main orchestrator for flux-modprobe task and module management.
+
+    Modprobe coordinates TaskDB, DependencySolver, and ConfigLoader to
+    provide high-level operations for module loading/unloading and task
+    execution. Used by flux-modprobe(1) command and available for
+    programmatic use.
+
+    Key Operations:
+        configure_modules(): Load module config from TOML files
+        load(modules): Load modules and their dependencies
+        remove(modules): Unload modules and unused dependencies
+        read_rcfile(name): Load and execute rc Python scripts
+        run(deps): Execute tasks in dependency order
+
+    Attributes:
+        taskdb (TaskDB): Task database
+        context (Context): Execution context
+        solver (DependencySolver): Dependency resolver
+        loader (ConfigLoader): Configuration loader
+        handle (Flux): Flux handle (from context)
+        rank (int): Broker rank
+        exitcode (int): Exit code (0=success, 1=failure)
+        timing (list): Optional timing data for performance analysis
+
+    Args:
+        timing (bool): Enable timing instrumentation (default False)
+        verbose (bool): Enable verbose output (default False)
+        dry_run (bool): Print actions without executing (default False)
     """
 
     def __init__(self, timing=False, verbose=False, dry_run=False):
@@ -1531,8 +1774,7 @@ class Modprobe:
 
     def add_active_task(self, task):
         """Add a task to the task db and active tasks list"""
-        # Only add to taskdb if it doesn't exist yet (to preserve priority
-        # bumps from set_alternative() calls)
+        # Only add to taskdb if it doesn't exist yet (avoids duplicate entries)
         if not self.has_task(task.name):
             self.add_task(task)
         self._active_tasks.append(task.name)
@@ -1640,7 +1882,15 @@ class Modprobe:
 
     def configure_modules(self):
         """
-        Load module configuration from TOML config.
+        Load module configuration from TOML config files.
+
+        Reads all modprobe.toml and modprobe.d/*.toml files from the
+        search path, adding module definitions to the task database.
+        Also applies any module configuration overrides from broker
+        config.
+
+        Returns:
+            self: For method chaining
         """
         for file in self.loader.get_toml_files():
             self.print(f"loading {file}")
@@ -1683,6 +1933,17 @@ class Modprobe:
         return result
 
     def solve(self, tasks, timing=True, ignore_disabled=False):
+        """
+        Recursively resolve all requirements for the given tasks.
+
+        Args:
+            tasks: Iterable of task/module names
+            timing: Record timing data (default True)
+            ignore_disabled: Include disabled tasks (default False)
+
+        Returns:
+            List of task names including all recursive requirements
+        """
         t0 = self.timestamp
         result = self.solver.solve_requirements(tasks, ignore_disabled=ignore_disabled)
         if timing:
@@ -1696,7 +1957,20 @@ class Modprobe:
         return self.solver._process_before(tasks, deps)
 
     def get_deps(self, tasks):
-        """Return dependencies for tasks as dict of names to predecessor list"""
+        """
+        Build execution order precedence graph for tasks.
+
+        Constructs a dict mapping task names to lists of predecessors
+        (tasks that must complete before each task can start). Respects
+        before/after constraints and handles special before=["*"] and
+        after=["*"] cases.
+
+        Args:
+            tasks: Iterable of task names
+
+        Returns:
+            Dict of {task_name: [predecessor_list]} for topological sort
+        """
         t0 = self.timestamp
         deps = self.solver.solve_execution_order(tasks)
         self.add_timing("deps", t0)
@@ -1709,7 +1983,16 @@ class Modprobe:
         return self.solver.get_requires(tasks)
 
     def run(self, deps):
-        """Run all tasks in deps in precedence order"""
+        """
+        Execute tasks in parallel respecting precedence constraints.
+
+        Uses ThreadPoolExecutor to run tasks concurrently when their
+        dependencies are satisfied. Tasks are executed in topological
+        order based on the deps precedence graph.
+
+        Args:
+            deps: Dict of {task_name: [predecessors]} from get_deps()
+        """
         t0 = self.timestamp
         sorter = TopologicalSorter(deps)
         sorter.prepare()
@@ -1773,6 +2056,17 @@ class Modprobe:
             setup(self.context)
 
     def read_rcfile(self, name):
+        """
+        Load and execute Python rc files.
+
+        Loads rc Python files from search path (e.g., rc1.py, rc1.d/*.py)
+        and registers @task-decorated functions. Also executes setup()
+        function if present in any loaded module.
+
+        Args:
+            name: RC file basename (e.g., "rc1", "rc3") or absolute path
+                to a .py file
+        """
         # For absolute file path, just add tasks from single file:
         if name.endswith(".py"):
             self.print(f"loading {name}")
@@ -1907,7 +2201,20 @@ class Modprobe:
             self.add_active_task(task)
 
     def remove(self, modules):
-        """Remove loaded modules"""
+        """
+        Unload modules and any unused dependencies.
+
+        Finds all modules that can be safely removed (no remaining
+        dependents) and unloads them in reverse load order.
+
+        Args:
+            modules: List of module names to remove, or ["all"] to remove
+                all loaded modules
+
+        Raises:
+            ValueError: If a specified module is not loaded or still has
+                active dependents
+        """
         tasks, deps = self._solve_modules_remove(modules)
         [self.get_task(x).set_remove() for x in deps.keys()]
         self.run(deps)

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -799,6 +799,127 @@ class DependencySolver:
         return result
 
 
+class ConfigLoader:
+    """
+    Handles configuration and RC file loading for modprobe.
+
+    This class encapsulates the logic for:
+    - Building searchpaths from environment variables and config
+    - Locating TOML configuration files
+    - Locating Python RC script files
+    - Expanding .d directories in the searchpath
+
+    Separated from Modprobe class for clarity and testability.
+    """
+
+    def __init__(self, searchpath, print_func):
+        """
+        Initialize configuration loader.
+
+        Args:
+            searchpath: Dict of {"toml": [paths...], "py": [paths...]}
+            print_func: Function to call for debug output
+        """
+        self.searchpath = searchpath
+        self.print = print_func
+
+    def get_toml_files(self):
+        """
+        Return all modprobe config toml files found in the following order:
+         - Always read ``{fluxdatadir}/modprobe/modprobe.toml``
+         - for dir in self.searchpath: read ``{dir}/modprobe.d/*.toml``
+
+        Returns:
+            List of absolute paths to TOML files
+        """
+        files = []
+        builtin_toml_config = (
+            Path(conf_builtin_get("datadir")) / "modprobe" / "modprobe.toml"
+        )
+        self.print(f"checking {builtin_toml_config}")
+        if builtin_toml_config.exists():
+            files.append(str(builtin_toml_config))
+        files.extend(self._searchpath_expand())
+        return files
+
+    def get_rc_files(self, name="rc1"):
+        """
+        Return all modprobe rc *.py files found in the following order:
+         - Always read ``{fluxdatadir}/modprobe/{name}.py`` (e.g. ``rc1.py``)
+         - for dir in self.searchpath: read ``{dir}/{name}.d/*.py``
+
+        Args:
+            name: RC file basename (e.g., "rc1", "rc3")
+
+        Returns:
+            List of absolute paths to Python RC files
+        """
+        files = []
+        builtin_rc_file = (
+            Path(conf_builtin_get("libexecdir")) / "modprobe" / f"{name}.py"
+        )
+        self.print(f"checking {builtin_rc_file}")
+        if builtin_rc_file.exists():
+            files.append(str(builtin_rc_file))
+        files.extend(self._searchpath_expand(name=name, ext="py"))
+        return files
+
+    def _searchpath_expand(self, name="modprobe", ext="toml"):
+        """
+        Expand searchpath for extension ``ext`` based on configured paths.
+
+        Args:
+            name: Base name for .d directory (e.g., "modprobe", "rc1")
+            ext: File extension to search for (e.g., "toml", "py")
+
+        Returns:
+            List of absolute paths to files found
+        """
+        files = []
+        for directory in self.searchpath[ext]:
+            self.print(f"checking {directory}/{name}.d/*.{ext}")
+            if Path(directory).exists():
+                files.extend(sorted(glob.glob(f"{directory}/{name}.d/*.{ext}")))
+        return files
+
+    @staticmethod
+    def build_searchpath(builtindir="datadir"):
+        """
+        Build searchpath list from environment variables and config.
+
+        Returns list of dirs in ``FLUX_MODPROBE_PATH`` if set, otherwise
+        returns the default modprobe search path.
+
+        Args:
+            builtindir: base path for builtin/package path. Should
+                be either "datadir" or "libexecdir".
+
+        Returns:
+            List of directory paths (duplicates removed)
+        """
+        searchpath = []
+        if "FLUX_MODPROBE_PATH" in os.environ:
+            searchpath = filter(
+                lambda s: s and not s.isspace(),
+                os.environ["FLUX_MODPROBE_PATH"].split(":"),
+            )
+        else:
+            pkgdir = conf_builtin_get(builtindir)
+            confdir = conf_builtin_get("confdir")
+            searchpath = [f"{pkgdir}/modprobe", f"{confdir}/modprobe"]
+
+        if "FLUX_MODPROBE_PATH_APPEND" in os.environ:
+            searchpath.extend(
+                filter(
+                    lambda s: s and not s.isspace(),
+                    os.environ["FLUX_MODPROBE_PATH_APPEND"].split(":"),
+                )
+            )
+
+        # return searchpath without duplicates
+        return list(OrderedDict.fromkeys(searchpath))
+
+
 # ==============================================================================
 # SECTION 3: Task Definitions
 # ==============================================================================
@@ -1334,10 +1455,13 @@ class Modprobe:
         # Initialize dependency solver
         self.solver = DependencySolver(self.taskdb, self.context)
 
-        self.searchpath = {
-            "toml": self._get_searchpath(),
-            "py": self._get_searchpath(builtindir="libexecdir"),
+        # Initialize configuration loader
+        searchpath = {
+            "toml": ConfigLoader.build_searchpath(),
+            "py": ConfigLoader.build_searchpath(builtindir="libexecdir"),
         }
+        self.loader = ConfigLoader(searchpath, self.print)
+        self.searchpath = searchpath  # Keep for backward compatibility
 
         # Active tasks are those added via the @task decorator, and
         # which will be active by default when running "all" tasks:
@@ -1468,79 +1592,6 @@ class Modprobe:
                 # Allow <module>.key to update an existing configured module:
                 self.update_module(name, entry)
 
-    def _get_searchpath(self, builtindir="datadir"):
-        """
-        Return list of dirs in ``FLUX_MODPROBE_PATH`` if set, o/w returns the
-        default modprobe search path.
-        Args:
-            builtindir (str): base path for builtin/package path. Should
-                be either "datadir" or "libexecdir".
-        """
-        searchpath = []
-        if "FLUX_MODPROBE_PATH" in os.environ:
-            searchpath = filter(
-                lambda s: s and not s.isspace(),
-                os.environ["FLUX_MODPROBE_PATH"].split(":"),
-            )
-        else:
-            pkgdir = conf_builtin_get(builtindir)
-            confdir = conf_builtin_get("confdir")
-            searchpath = [f"{pkgdir}/modprobe", f"{confdir}/modprobe"]
-
-        if "FLUX_MODPROBE_PATH_APPEND" in os.environ:
-            searchpath.extend(
-                filter(
-                    lambda s: s and not s.isspace(),
-                    os.environ["FLUX_MODPROBE_PATH_APPEND"].split(":"),
-                )
-            )
-
-        # return searchpath without duplicates
-        return list(OrderedDict.fromkeys(searchpath))
-
-    def _searchpath_expand(self, name="modprobe", ext="toml"):
-        """
-        Expand searchpath for extension ``ext`` based on configured paths.
-        """
-        files = []
-        for directory in self.searchpath[ext]:
-            self.print(f"checking {directory}/{name}.d/*.{ext}")
-            if Path(directory).exists():
-                files.extend(sorted(glob.glob(f"{directory}/{name}.d/*.{ext}")))
-        return files
-
-    def _get_toml_files(self):
-        """
-        Return all modprobe config toml files found in the following order
-         - Always read ``{fluxdatadir}/modprobe/modprobe.toml``
-         - for dir in self.searchpath: read ``{dir}/modprobe.d/*.toml``
-        """
-        files = []
-        builtin_toml_config = (
-            Path(conf_builtin_get("datadir")) / "modprobe" / "modprobe.toml"
-        )
-        self.print(f"checking {builtin_toml_config}")
-        if builtin_toml_config.exists():
-            files.append(str(builtin_toml_config))
-        files.extend(self._searchpath_expand())
-        return files
-
-    def _get_rc_files(self, name="rc1"):
-        """
-        Return all modprobe rc *.py files found in the following order
-         - Always read ``{fluxdatadir}/modprobe/{name}.py`` (e.g. ``rc1.py``)
-         - for dir in self.searchpath: read ``{dir}/{name}.d/*.py``
-        """
-        files = []
-        builtin_rc_file = (
-            Path(conf_builtin_get("libexecdir")) / "modprobe" / f"{name}.py"
-        )
-        self.print(f"checking {builtin_rc_file}")
-        if builtin_rc_file.exists():
-            files.append(str(builtin_rc_file))
-        files.extend(self._searchpath_expand(name=name, ext="py"))
-        return files
-
     def _update_modules_from_config(self):
         """Update modules using broker config
         Process a [modules] table in config support the following keys:
@@ -1562,7 +1613,7 @@ class Modprobe:
         """
         Load module configuration from TOML config.
         """
-        for file in self._get_toml_files():
+        for file in self.loader.get_toml_files():
             self.print(f"loading {file}")
             self.add_modules(file)
 
@@ -1700,7 +1751,7 @@ class Modprobe:
             return
 
         # O/w, load all rc files in configured search path:
-        for file in self._get_rc_files(name):
+        for file in self.loader.get_rc_files(name):
             self.print(f"loading {file}")
             self._load_file(file)
 

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -121,7 +121,7 @@ class RankConditional:
         return rank < self.rank
 
     def __str__(self):
-        s = ">" if self.gt else ">"
+        s = ">" if self.gt else "<"
         return f"{s}{self.rank}"
 
 

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -8,7 +8,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import bisect
 import concurrent
 import glob
 import os
@@ -173,102 +172,164 @@ def rank_conditional(arg):
 
 class TaskDB:
     """
-    Dict of service/module name to list of tasks sorted such the
-    current default task is at the end of the list.
+    Task database supporting service alternatives and priority-based selection.
+
+    Structure: {service: {task_name: TaskEntry(priority, index, task)}}
+
+    Tasks are stored in a dict-of-dicts structure where each service maps to
+    a dict of task names to entries. Each entry is a TaskEntry namedtuple with
+    priority (int), insertion index (int), and task object. When selecting a
+    task for a service, the highest priority enabled task is chosen. If no
+    enabled tasks exist, the highest priority task overall is returned
+    regardless of enabled status.
     """
 
-    TaskEntry = namedtuple("TaskEntry", ("priority", "index", "task"))
+    TaskEntry = namedtuple("TaskEntry", ["priority", "index", "task"])
 
     def __init__(self):
-        self.tasks = defaultdict(list)
+        # {service: {task_name: TaskEntry(priority, index, task)}}
+        self._services = defaultdict(dict)
+        self._insertion_counter = 0
 
-    def add(self, task, index=None):
-        for name in (*task.provides, task.name):
-            if index is None:
-                index = len(self.tasks[name])
-            bisect.insort_right(
-                self.tasks[name],
-                self.TaskEntry(task.priority, index, task),
-            )
+    def add(self, task: "Task", index: int = None) -> None:
+        """Add task to database for its name and all services it provides"""
+        if index is None:
+            index = self._insertion_counter
+            self._insertion_counter += 1
+        entry = self.TaskEntry(task.priority, index, task)
+        for service in (task.name, *task.provides):
+            self._services[service][task.name] = entry
 
-    def get(self, service):
+    def get(self, service: str) -> "Task":
         """
-        Return the highest priority task providing ``service`` which is also
-        enabled. If there are no enabled tasks providing ``service``, then
-        return the highest priority task. If no tasks provide ``service``,
-        raise ``ValueError``.
+        Return the highest priority task providing ``service`` which is not
+        disabled. If there are no non-disabled tasks providing ``service``,
+        then return the highest priority task regardless of disabled status.
+        If no tasks provide ``service``, raise ``ValueError``.
+
+        Note: Only checks the `disabled` flag, not the full `enabled()` method
+        which requires context for rank/config/attr checks.
         """
-        if len(self.tasks[service]) == 0:
+        if service not in self._services or len(self._services[service]) == 0:
             raise ValueError(f"no such task or module {service}")
-        enabled = list(filter(lambda x: x.task.enabled(), self.tasks[service]))
-        if len(enabled) == 0:
-            return self.tasks[service][-1].task
-        return enabled[-1].task
 
-    def update(self, task):
+        tasks = self._services[service]
+        # Find non-disabled tasks with highest (priority, index)
+        not_disabled = {
+            name: entry for name, entry in tasks.items() if not entry.task.disabled
+        }
+        if not not_disabled:
+            # Return highest priority task even if disabled
+            return max(tasks.values(), key=lambda e: (e.priority, e.index)).task
+        return max(not_disabled.values(), key=lambda e: (e.priority, e.index)).task
+
+    def update(self, task: "Task") -> None:
         """
-        Update a task object which already resides in the taskdb by removing
-        the task from all service name lists and re-adding it, preserving the
-        original insertion order. This handles any potential update of a task,
-        such as a new ``priority``, or additional ``provides``
+        Update an existing task in the database, or add it if not found.
+
+        Updates the task object in place, preserving the original insertion
+        order. Handles updates to priority, provides list, and other attributes.
+
+        WARNING: If the task does not exist, it will be added automatically.
+        Use has() first if you need strict update-only semantics.
+
+        Args:
+            task: Task object to update (identified by task.name)
         """
-        for name in (task.name, *task.provides):
-            to_remove = -1
-            for i, entry in enumerate(self.tasks[name]):
-                if entry.task == task:
-                    to_remove = i
-                    break
-            if to_remove < 0:
-                raise ValueError(f"{task.name} not found in taskdb {name} list")
+        # First check if task exists in any service
+        found = False
+        for service in self._services:
+            if task.name in self._services[service]:
+                found = True
+                break
 
-            # remove task from this list and re-insert, preserving the
-            # original insertion index:
-            self.tasks[name].pop(to_remove)
-            self.add(task, index=entry.index)
-
-    def set_alternative(self, service, name, propagate=True):
-        """Select a specific alternative 'name' for service"""
-        lst = self.tasks[service]
-        try:
-            index = next(i for i, x in enumerate(lst) if x.task.name == name)
-        except StopIteration:
-            raise ValueError(f"no module {name} provides {service}")
-
-        # nothing to do if list has length of 1
-        if len(lst) == 1:
+        if not found:
+            # Task doesn't exist yet, add it
+            self.add(task)
             return
 
-        # bump priority of new task and move to end of list:
-        entry = lst.pop(index)
-        priority = lst[-1].priority
-        lst.append(self.TaskEntry(priority + 1, entry.index, entry.task))
+        # Update all services where this task should appear
+        for service in (task.name, *task.provides):
+            if service in self._services and task.name in self._services[service]:
+                old_entry = self._services[service][task.name]
+                # Preserve insertion order but update priority and task
+                self._services[service][task.name] = self.TaskEntry(
+                    task.priority,
+                    old_entry.index,
+                    task,
+                )
+            else:
+                # New service added to provides, add entry with preserved index
+                # Get the insertion index from any existing service
+                for existing_service in self._services:
+                    if task.name in self._services[existing_service]:
+                        index = self._services[existing_service][task.name].index
+                        entry = self.TaskEntry(task.priority, index, task)
+                        self._services[service][task.name] = entry
+                        break
 
-        # now do the same for any other provides in this module
+    def set_alternative(self, service: str, name: str, propagate: bool = True) -> None:
+        """Select a specific alternative 'name' for service"""
+        if service not in self._services:
+            raise ValueError(f"no such service {service}")
+        if name not in self._services[service]:
+            raise ValueError(f"no module {name} provides {service}")
+
+        tasks = self._services[service]
+        # nothing to do if only one alternative
+        if len(tasks) == 1:
+            return
+
+        # Find max priority and bump selected alternative above it
+        max_priority = max(e.priority for e in tasks.values())
+        entry = tasks[name]
+        tasks[name] = self.TaskEntry(max_priority + 1, entry.index, entry.task)
+
+        # Propagate to other services this task provides
         if propagate:
-            for provides in set(entry.task.provides) - {service}:
-                self.set_alternative(provides, name, propagate=False)
+            task = entry.task
+            for other_service in task.provides:
+                if other_service != service:
+                    self.set_alternative(other_service, name, propagate=False)
 
-    def disable(self, service):
-        """disable task/module/service with name 'service'"""
-        if not self.tasks[service]:
+    def disable(self, service: str) -> None:
+        """Disable all tasks providing this task/module/service"""
+        if service not in self._services or not self._services[service]:
             raise ValueError(f"no such module or task '{service}'")
-        for entry in self.tasks[service]:
+        for entry in self._services[service].values():
             entry.task.disabled = True
 
-    def enable(self, service):
+    def enable(self, service: str) -> None:
         """
         Force a module/task/service to be enabled even if it would normally
         be disabled by rank, needs-config, or needs-attr.
         """
-        if not self.tasks[service]:
+        if service not in self._services or not self._services[service]:
             raise ValueError(f"no such module or task '{service}'")
-        for entry in self.tasks[service]:
+        for entry in self._services[service].values():
             entry.task.force_enabled = True
 
-    def any_provides(self, tasks, name):
-        """Return True if any task in tasks provides name"""
+    def has(self, service: str) -> bool:
+        """
+        Check if a task/module/service exists in the database.
+
+        More efficient than calling get() and catching ValueError.
+        """
+        return service in self._services and len(self._services[service]) > 0
+
+    def has_enabled_provider(self, tasks, service: str) -> bool:
+        """
+        Check if any non-disabled task in tasks provides the given service.
+
+        Args:
+            tasks: Iterable of task names to check
+            service: Service name to look for
+
+        Returns:
+            True if at least one non-disabled task provides service
+        """
         for task in [self.get(x) for x in tasks]:
-            if not task.disabled and name in (task.name, *task.provides):
+            if not task.disabled and service in (task.name, *task.provides):
                 return True
         return False
 
@@ -865,7 +926,10 @@ class Modprobe:
 
     def add_active_task(self, task):
         """Add a task to the task db and active tasks list"""
-        self.add_task(task)
+        # Only add to taskdb if it doesn't exist yet (to preserve priority
+        # bumps from set_alternative() calls)
+        if not self.has_task(task.name):
+            self.add_task(task)
         self._active_tasks.append(task.name)
 
     def get_task(self, name, default=None):

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -262,51 +262,6 @@ class TaskDB:
             raise ValueError(f"task {task_name} does not provide {service}")
         return self._services[service][task_name]
 
-    def update(self, task: "Task") -> None:
-        """
-        Update an existing task in the database, or add it if not found.
-
-        Updates the task object in place, preserving the original insertion
-        order. Handles updates to priority, provides list, and other attributes.
-
-        WARNING: If the task does not exist, it will be added automatically.
-        Use has() first if you need strict update-only semantics.
-
-        Args:
-            task: Task object to update (identified by task.name)
-        """
-        # First check if task exists in any service
-        found = False
-        for service in self._services:
-            if task.name in self._services[service]:
-                found = True
-                break
-
-        if not found:
-            # Task doesn't exist yet, add it
-            self.add(task)
-            return
-
-        # Update all services where this task should appear
-        for service in (task.name, *task.provides):
-            if service in self._services and task.name in self._services[service]:
-                old_entry = self._services[service][task.name]
-                # Preserve insertion order but update priority and task
-                self._services[service][task.name] = self.TaskEntry(
-                    task.priority,
-                    old_entry.index,
-                    task,
-                )
-            else:
-                # New service added to provides, add entry with preserved index
-                # Get the insertion index from any existing service
-                for existing_service in self._services:
-                    if task.name in self._services[existing_service]:
-                        index = self._services[existing_service][task.name].index
-                        entry = self.TaskEntry(task.priority, index, task)
-                        self._services[service][task.name] = entry
-                        break
-
     def set_alternative(self, service: str, name: str, propagate: bool = True) -> None:
         """Select a specific alternative 'name' for service"""
         if service not in self._services:
@@ -348,15 +303,6 @@ class TaskDB:
         for entry in self._services[service].values():
             entry.task.force_enabled = True
 
-    def has(self, service: str) -> bool:
-        """
-        Check if a task/module/service exists in the database.
-
-        More efficient than calling get() and catching ValueError.
-        Prefer using 'in' operator which calls __contains__.
-        """
-        return service in self._services and len(self._services[service]) > 0
-
     def __contains__(self, service: str) -> bool:
         """
         Check if service exists in database (enables 'in' operator).
@@ -365,7 +311,7 @@ class TaskDB:
             if "kvs" in taskdb:
                 task = taskdb.get("kvs")
         """
-        return self.has(service)
+        return service in self._services and len(self._services[service]) > 0
 
     def __setitem__(self, name: str, task: "Task") -> None:
         """

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -379,6 +379,8 @@ class TaskDB:
             True if at least one non-disabled task provides service
         """
         for x in tasks:
+            if x not in self:
+                continue
             task = self.get(x)
             if not task.disabled and service in (task.name, *task.provides):
                 return True

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -175,20 +175,24 @@ class TaskDB:
     """
     Task database supporting service alternatives and priority-based selection.
 
-    Structure: {service: {task_name: TaskEntry(priority, index, task)}}
+    Structure: {service: {task_name: TaskEntry(index, task)}}
 
     Tasks are stored in a dict-of-dicts structure where each service maps to
     a dict of task names to entries. Each entry is a TaskEntry namedtuple with
-    priority (int), insertion index (int), and task object. When selecting a
-    task for a service, the highest priority enabled task is chosen. If no
-    enabled tasks exist, the highest priority task overall is returned
-    regardless of enabled status.
+    insertion index (int) and task object. Priority comes from task.priority.
+
+    Priority Model:
+    - task.priority is the single source of truth
+    - set_alternative() boosts task.priority to ensure the task will be
+      the highest priority alternative. This affects all services the
+      task provides
+    - Priority updates via config/TOML set task.priority globally
     """
 
-    TaskEntry = namedtuple("TaskEntry", ["priority", "index", "task"])
+    TaskEntry = namedtuple("TaskEntry", ["index", "task"])
 
     def __init__(self):
-        # {service: {task_name: TaskEntry(priority, index, task)}}
+        # {service: {task_name: TaskEntry(index, task)}}
         self._services = defaultdict(dict)
         self._insertion_counter = 0
 
@@ -197,7 +201,7 @@ class TaskDB:
         if index is None:
             index = self._insertion_counter
             self._insertion_counter += 1
-        entry = self.TaskEntry(task.priority, index, task)
+        entry = self.TaskEntry(index, task)
         for service in (task.name, *task.provides):
             self._services[service][task.name] = entry
 
@@ -221,8 +225,8 @@ class TaskDB:
         }
         if not not_disabled:
             # Return highest priority task even if disabled
-            return max(tasks.values(), key=lambda e: (e.priority, e.index)).task
-        return max(not_disabled.values(), key=lambda e: (e.priority, e.index)).task
+            return max(tasks.values(), key=lambda e: (e.task.priority, e.index)).task
+        return max(not_disabled.values(), key=lambda e: (e.task.priority, e.index)).task
 
     def get_all(self, service: str) -> List["Task"]:
         """
@@ -239,7 +243,9 @@ class TaskDB:
             return []
         tasks = self._services[service]
         # Sort by (priority, index) ascending
-        sorted_entries = sorted(tasks.values(), key=lambda e: (e.priority, e.index))
+        sorted_entries = sorted(
+            tasks.values(), key=lambda e: (e.task.priority, e.index)
+        )
         return [e.task for e in sorted_entries]
 
     def get_entry(self, service: str, task_name: str):
@@ -262,8 +268,14 @@ class TaskDB:
             raise ValueError(f"task {task_name} does not provide {service}")
         return self._services[service][task_name]
 
-    def set_alternative(self, service: str, name: str, propagate: bool = True) -> None:
-        """Select a specific alternative 'name' for service"""
+    def set_alternative(self, service: str, name: str) -> None:
+        """
+        Select a specific alternative 'name' for service.
+
+        Boosts task.priority above all other tasks providing this service.
+        Since priority is global to the task, this affects all services
+        the task provides.
+        """
         if service not in self._services:
             raise ValueError(f"no such service {service}")
         if name not in self._services[service]:
@@ -275,16 +287,11 @@ class TaskDB:
             return
 
         # Find max priority and bump selected alternative above it
-        max_priority = max(e.priority for e in tasks.values())
+        max_priority = max(e.task.priority for e in tasks.values())
         entry = tasks[name]
-        tasks[name] = self.TaskEntry(max_priority + 1, entry.index, entry.task)
 
-        # Propagate to other services this task provides
-        if propagate:
-            task = entry.task
-            for other_service in task.provides:
-                if other_service != service:
-                    self.set_alternative(other_service, name, propagate=False)
+        # Update task.priority - this affects all services the task provides
+        entry.task.priority = max_priority + 1
 
     def disable(self, service: str) -> None:
         """Disable all tasks providing this task/module/service"""
@@ -317,9 +324,6 @@ class TaskDB:
         """
         Add or update task in database (enables dict-like assignment).
 
-        Always succeeds - adds task if new, updates if exists. This is the
-        idiomatic Python way to handle upsert operations, similar to dict.
-
         Example:
             taskdb["kvs"] = kvs_task  # Add or update
 
@@ -335,7 +339,7 @@ class TaskDB:
         if name != task.name:
             raise ValueError(f"Key '{name}' doesn't match task.name '{task.name}'")
 
-        # Check if task exists in any service
+        # Check if task exists
         found = False
         for service in self._services:
             if task.name in self._services[service]:
@@ -343,7 +347,6 @@ class TaskDB:
                 break
 
         if not found:
-            # Task doesn't exist yet, add it
             self.add(task)
             return
 
@@ -351,19 +354,16 @@ class TaskDB:
         for service in (task.name, *task.provides):
             if service in self._services and task.name in self._services[service]:
                 old_entry = self._services[service][task.name]
-                # Use task.priority directly (dict-like semantics: replacement)
                 self._services[service][task.name] = self.TaskEntry(
-                    task.priority,
                     old_entry.index,
                     task,
                 )
             else:
-                # New service added to provides, add entry with preserved index
-                # Get the insertion index from any existing service
+                # New service added to provides
                 for existing_service in self._services:
                     if task.name in self._services[existing_service]:
                         old_entry = self._services[existing_service][task.name]
-                        entry = self.TaskEntry(task.priority, old_entry.index, task)
+                        entry = self.TaskEntry(old_entry.index, task)
                         self._services[service][task.name] = entry
                         break
 
@@ -446,10 +446,9 @@ class DependencySolver:
 
         if viable:
             # Return highest priority viable task
-            # Use TaskEntry priority (respects set_alternative bumps), not Task.priority
             def priority_key(t):
                 entry = self.taskdb.get_entry(service, t.name)
-                return (entry.priority, entry.index)
+                return (entry.task.priority, entry.index)
 
             return max(viable, key=priority_key)
 
@@ -1575,8 +1574,15 @@ class Modprobe:
             if "name" not in entry:
                 entry["name"] = name
             new_module = Module(entry)
+
+        # Copy attributes from new_module to task, but never overwrite task.name
+        # (name might be a service name, not the actual task name)
         for key in entry.keys():
+            if key == "name":
+                continue
             setattr(task, key, getattr(new_module, key))
+
+        # Update the task in database (preserves index, uses current task.priority)
         self.taskdb[task.name] = task
 
     def add_modules(self, file):

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -18,6 +18,7 @@ import time
 from collections import OrderedDict, defaultdict, namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Dict, List, Set
 
 import flux
 import flux.importer
@@ -223,7 +224,7 @@ class TaskDB:
             return max(tasks.values(), key=lambda e: (e.priority, e.index)).task
         return max(not_disabled.values(), key=lambda e: (e.priority, e.index)).task
 
-    def get_all(self, service: str) -> list:
+    def get_all(self, service: str) -> List["Task"]:
         """
         Return all tasks providing ``service``, sorted by (priority, index).
 
@@ -491,7 +492,7 @@ class DependencySolver:
                 return True
         return False
 
-    def solve_requirements(self, tasks, ignore_disabled=False) -> list:
+    def solve_requirements(self, tasks, ignore_disabled=False) -> List[str]:
         """
         Recursively find all requirements of tasks.
 
@@ -542,7 +543,7 @@ class DependencySolver:
 
         return result
 
-    def solve_needs(self, tasks) -> list:
+    def solve_needs(self, tasks) -> List[str]:
         """
         Filter out tasks where needs constraints are not met.
 
@@ -591,7 +592,7 @@ class DependencySolver:
         # Return new list with removed tasks filtered out
         return [name for name in tasks_list if name not in removed]
 
-    def solve_execution_order(self, tasks) -> dict:
+    def solve_execution_order(self, tasks) -> Dict[str, List[str]]:
         """
         Build precedence graph for tasks based on before/after constraints.
 
@@ -681,7 +682,7 @@ class DependencySolver:
                     if successor in deps:
                         deps[successor].append(task.name)
 
-    def get_requires(self, tasks) -> dict:
+    def get_requires(self, tasks) -> Dict[str, List[str]]:
         """
         Get forward requires dependency map for tasks.
 
@@ -697,7 +698,7 @@ class DependencySolver:
             deps[task.name] = list(task.requires)
         return deps
 
-    def get_reverse_requires(self, tasks) -> dict:
+    def get_reverse_requires(self, tasks) -> Dict[str, Set[str]]:
         """
         Get reverse requires dependency map for tasks.
 
@@ -716,7 +717,9 @@ class DependencySolver:
                 rdeps[req].add(task.name)
         return rdeps
 
-    def solve_removal(self, dependencies: dict, modules_to_remove) -> list:
+    def solve_removal(
+        self, dependencies: Dict[str, List[str]], modules_to_remove
+    ) -> List[str]:
         """
         Find modules that can be safely removed.
 
@@ -823,7 +826,7 @@ class ConfigLoader:
         self.searchpath = searchpath
         self.print = print_func
 
-    def get_toml_files(self):
+    def get_toml_files(self) -> List[str]:
         """
         Return all modprobe config toml files found in the following order:
          - Always read ``{fluxdatadir}/modprobe/modprobe.toml``
@@ -842,7 +845,7 @@ class ConfigLoader:
         files.extend(self._searchpath_expand())
         return files
 
-    def get_rc_files(self, name="rc1"):
+    def get_rc_files(self, name="rc1") -> List[str]:
         """
         Return all modprobe rc *.py files found in the following order:
          - Always read ``{fluxdatadir}/modprobe/{name}.py`` (e.g. ``rc1.py``)
@@ -864,7 +867,7 @@ class ConfigLoader:
         files.extend(self._searchpath_expand(name=name, ext="py"))
         return files
 
-    def _searchpath_expand(self, name="modprobe", ext="toml"):
+    def _searchpath_expand(self, name="modprobe", ext="toml") -> List[str]:
         """
         Expand searchpath for extension ``ext`` based on configured paths.
 
@@ -883,7 +886,7 @@ class ConfigLoader:
         return files
 
     @staticmethod
-    def build_searchpath(builtindir="datadir"):
+    def build_searchpath(builtindir="datadir") -> List[str]:
         """
         Build searchpath list from environment variables and config.
 

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -1768,7 +1768,11 @@ class Modprobe:
     def _set_all_alternatives(self, modules):
         # Set all modules as the current selected alternatives:
         for module in modules:
-            task = self.get_task(module)
+            try:
+                task = self.get_task(module)
+            except ValueError:
+                # Module not in taskdb (e.g., disabled or not configured)
+                continue
             for service in task.provides:
                 self.set_alternative(service, task.name)
 

--- a/src/bindings/python/flux/modprobe.py
+++ b/src/bindings/python/flux/modprobe.py
@@ -223,6 +223,44 @@ class TaskDB:
             return max(tasks.values(), key=lambda e: (e.priority, e.index)).task
         return max(not_disabled.values(), key=lambda e: (e.priority, e.index)).task
 
+    def get_all(self, service: str) -> list:
+        """
+        Return all tasks providing ``service``, sorted by (priority, index).
+
+        Args:
+            service: Service or task name to look up
+
+        Returns:
+            List of Task objects sorted from lowest to highest priority.
+            Empty list if service doesn't exist.
+        """
+        if service not in self._services:
+            return []
+        tasks = self._services[service]
+        # Sort by (priority, index) ascending
+        sorted_entries = sorted(tasks.values(), key=lambda e: (e.priority, e.index))
+        return [e.task for e in sorted_entries]
+
+    def get_entry(self, service: str, task_name: str):
+        """
+        Get TaskEntry for a specific task providing a service.
+
+        Args:
+            service: Service name
+            task_name: Task name
+
+        Returns:
+            TaskEntry with priority, index, and task
+
+        Raises:
+            ValueError: If service or task not found
+        """
+        if service not in self._services:
+            raise ValueError(f"no such service {service}")
+        if task_name not in self._services[service]:
+            raise ValueError(f"task {task_name} does not provide {service}")
+        return self._services[service][task_name]
+
     def update(self, task: "Task") -> None:
         """
         Update an existing task in the database, or add it if not found.
@@ -328,10 +366,437 @@ class TaskDB:
         Returns:
             True if at least one non-disabled task provides service
         """
-        for task in [self.get(x) for x in tasks]:
+        for x in tasks:
+            task = self.get(x)
             if not task.disabled and service in (task.name, *task.provides):
                 return True
         return False
+
+
+class DependencySolver:
+    """
+    Handles all dependency resolution for modprobe tasks.
+
+    This class encapsulates the complex logic for resolving task dependencies,
+    including:
+    - Finding all required dependencies (requires)
+    - Filtering tasks based on needs constraints
+    - Building execution order precedence graphs (before/after)
+    - Finding safely removable modules
+
+    Separated from Modprobe class for clarity and testability.
+    """
+
+    def __init__(self, taskdb, context):
+        """
+        Initialize dependency solver.
+
+        Args:
+            taskdb: TaskDB instance for task lookup
+            context: Context instance for checking enabled status
+        """
+        self.taskdb = taskdb
+        self.context = context
+
+    def resolve_service(self, service: str, ignore_needs: bool = False):
+        """
+        Resolve service name to actual task, considering needs constraints.
+
+        Returns the highest priority task providing `service` that:
+        1. Is enabled (passes enabled() check with context)
+        2. Has all its needs satisfied (unless ignore_needs=True)
+
+        Falls back to highest priority task if no viable tasks exist.
+
+        Args:
+            service: Service or task name to resolve
+            ignore_needs: If True, skip needs checking (for explicit loads)
+
+        Returns:
+            Task object
+
+        Raises:
+            ValueError: If service doesn't exist in taskdb
+        """
+        candidates = self.taskdb.get_all(service)
+        if not candidates:
+            raise ValueError(f"no such task or module {service}")
+
+        # Find viable candidates (enabled + needs satisfied)
+        viable = []
+        for task in candidates:
+            if not task.enabled(self.context):
+                continue
+            if ignore_needs or self._needs_satisfied(task):
+                viable.append(task)
+
+        if viable:
+            # Return highest priority viable task
+            # Use TaskEntry priority (respects set_alternative bumps), not Task.priority
+            def priority_key(t):
+                entry = self.taskdb.get_entry(service, t.name)
+                return (entry.priority, entry.index)
+
+            return max(viable, key=priority_key)
+
+        # Fallback: return highest priority task even if not viable
+        return candidates[-1]  # get_all returns sorted, so last is highest
+
+    def _needs_satisfied(self, task, checking=None) -> bool:
+        """
+        Check if all of task's needs are satisfiable.
+
+        A need is satisfiable if there exists an enabled task providing
+        that service whose needs are also satisfied (checked recursively).
+
+        Args:
+            task: Task to check
+            checking: Set of task names currently being checked (prevents cycles)
+
+        Returns:
+            True if all needs are satisfied, False otherwise
+        """
+        if checking is None:
+            checking = set()
+
+        if task.name in checking:
+            return False  # Circular dependency
+
+        checking.add(task.name)
+
+        for need in task.needs:
+            if not self._has_enabled_provider(need, checking):
+                return False
+
+        return True
+
+    def _has_enabled_provider(self, service: str, checking: set) -> bool:
+        """
+        Check if any enabled task with satisfied needs provides this service.
+
+        Args:
+            service: Service name to check
+            checking: Set of task names being checked (prevents cycles)
+
+        Returns:
+            True if an enabled provider with satisfied needs exists
+        """
+        candidates = self.taskdb.get_all(service)
+        for task in candidates:
+            if not task.enabled(self.context):
+                continue
+            if task.name in checking:
+                continue  # Skip if we're already checking this task
+            if self._needs_satisfied(task, checking):
+                return True
+        return False
+
+    def solve_requirements(self, tasks, ignore_disabled=False) -> list:
+        """
+        Recursively find all requirements of tasks.
+
+        Args:
+            tasks: Iterable of task names to solve
+            ignore_disabled: If True, include disabled tasks in result
+
+        Returns:
+            List of task names including all required dependencies.
+            Disabled tasks are skipped unless ignore_disabled=True.
+            Does not modify input.
+        """
+        result = self._solve_requirements_impl(tasks, set(), set(), ignore_disabled)
+        return list(result)
+
+    def _solve_requirements_impl(self, tasks, visited, skipped, ignore_disabled):
+        """
+        Internal recursive implementation of solve_requirements.
+
+        Args:
+            tasks: Iterable of task names to solve
+            visited: Set of already-visited tasks (prevents infinite recursion)
+            skipped: Set of skipped (disabled) tasks
+            ignore_disabled: If True, include disabled tasks in result
+
+        Returns:
+            Set of task names including all required dependencies
+        """
+        result = set()
+        to_visit = [x for x in tasks if x not in visited]
+
+        for name in to_visit:
+            # Use resolve_service to get the right task (considering needs)
+            task = self.resolve_service(name, ignore_needs=ignore_disabled)
+            if ignore_disabled or task.enabled(self.context):
+                result.add(task.name)
+            else:
+                skipped.add(task.name)
+            visited.add(task.name)
+            if task.requires:
+                rset = self._solve_requirements_impl(
+                    tasks=task.requires,
+                    visited=visited,
+                    skipped=skipped,
+                    ignore_disabled=ignore_disabled,
+                )
+                result.update(rset)
+
+        return result
+
+    def solve_needs(self, tasks) -> list:
+        """
+        Filter out tasks where needs constraints are not met.
+
+        When a task is removed because a needed service is not available,
+        all tasks that need it are also recursively removed.
+
+        Args:
+            tasks: Iterable of task names
+
+        Returns:
+            New list of task names with unsatisfied needs removed.
+            Does not modify input.
+        """
+        # Work on a copy to avoid mutating caller's data
+        tasks_list = list(tasks)
+        removed = set()
+
+        def mark_for_removal(task_name):
+            """Recursively mark task and its dependents for removal"""
+            if task_name in removed or task_name not in tasks_list:
+                return
+
+            removed.add(task_name)
+
+            # Find what this task provides
+            task = self.resolve_service(task_name, ignore_needs=False)
+            provides_set = set((task.name, *task.provides))
+
+            # Mark all tasks that need this task for removal
+            for name in tasks_list:
+                if name not in removed:
+                    x = self.resolve_service(name, ignore_needs=False)
+                    if not provides_set.isdisjoint(x.needs):
+                        mark_for_removal(name)
+
+        # Check each task's needs
+        for name in tasks_list:
+            if name in removed:
+                continue
+            task = self.resolve_service(name, ignore_needs=False)
+            for need in task.needs:
+                if not self.taskdb.has_enabled_provider(tasks_list, need):
+                    mark_for_removal(name)
+                    break
+
+        # Return new list with removed tasks filtered out
+        return [name for name in tasks_list if name not in removed]
+
+    def solve_execution_order(self, tasks) -> dict:
+        """
+        Build precedence graph for tasks based on before/after constraints.
+
+        Args:
+            tasks: List/set of task names
+
+        Returns:
+            Dict mapping task names to list of predecessor task names
+
+        Note: If tasks is a set, a copy is made internally to avoid mutating
+        the input. Lists are always converted to sets internally.
+        """
+        if not isinstance(tasks, set):
+            tasks = set(tasks)
+        else:
+            tasks = set(tasks)  # Make a copy to avoid mutating caller's set
+        deps = {}
+
+        # Cache resolve_service calls to avoid repeated lookups
+        resolve_cache = {}
+
+        def resolve_cached(name):
+            if name not in resolve_cache:
+                resolve_cache[name] = self.resolve_service(name, ignore_needs=False)
+            return resolve_cache[name]
+
+        # Ensure tasks set contains all provides and the actual task name
+        # (since presence in the set determines if a task is included in
+        # the predecessor list below)
+        provides = set()
+        for task in tasks:
+            # Use resolve_service to get the right task (considering needs)
+            task = resolve_cached(task)
+            provides.add(task.name)
+            provides.update(task.provides)
+        tasks.update(provides)
+
+        for name in tasks:
+            task = resolve_cached(name)
+            if "*" in task.after:
+                # Add all tasks to deps (except those that also specify "*"
+                # in their 'after' list)
+                resolved_tasks = [(x, resolve_cached(x)) for x in tasks]
+                deps[task.name] = [
+                    t.name for x, t in resolved_tasks if "*" not in t.after
+                ]
+            else:
+                after_tasks = [resolve_cached(x).name for x in task.after]
+                deps[task.name] = [x for x in after_tasks if x in tasks]
+
+        # Process before constraints
+        self._process_before(tasks, deps, resolve_cache)
+
+        return deps
+
+    def _process_before(self, tasks, deps, resolve_cache=None):
+        """
+        Process task.before constraints by appending to successor predecessor lists.
+
+        Args:
+            tasks: Set of task names
+            deps: Dict of task names to predecessor lists (modified in place)
+            resolve_cache: Optional dict cache for resolve_service results
+        """
+        if resolve_cache is None:
+            resolve_cache = {}
+
+        def resolve_cached(name):
+            if name not in resolve_cache:
+                resolve_cache[name] = self.resolve_service(name, ignore_needs=False)
+            return resolve_cache[name]
+
+        def deps_add_all(name):
+            """Add name as a predecessor to all entries in deps"""
+            for task in [resolve_cached(x) for x in deps.keys()]:
+                if "*" not in task.before:
+                    deps[task.name].append(name)
+
+        for name in tasks:
+            task = resolve_cached(name)
+            for successor in task.before:
+                if successor == "*":
+                    deps_add_all(task.name)
+                else:
+                    # resolve real successor name:
+                    successor = resolve_cached(successor).name
+                    if successor in deps:
+                        deps[successor].append(task.name)
+
+    def get_requires(self, tasks) -> dict:
+        """
+        Get forward requires dependency map for tasks.
+
+        Args:
+            tasks: Iterable of task names
+
+        Returns:
+            Dict mapping each task name to list of tasks it requires
+        """
+        deps = {}
+        for name in tasks:
+            task = self.resolve_service(name, ignore_needs=False)
+            deps[task.name] = list(task.requires)
+        return deps
+
+    def get_reverse_requires(self, tasks) -> dict:
+        """
+        Get reverse requires dependency map for tasks.
+
+        Args:
+            tasks: Iterable of task names
+
+        Returns:
+            Dict mapping each task name to set of tasks that require it
+        """
+        rdeps = {}
+        for name in tasks:
+            task = self.resolve_service(name, ignore_needs=False)
+            for req in task.requires:
+                if req not in rdeps:
+                    rdeps[req] = set()
+                rdeps[req].add(task.name)
+        return rdeps
+
+    def solve_removal(self, dependencies: dict, modules_to_remove) -> list:
+        """
+        Find modules that can be safely removed.
+
+        Given a set of modules to remove and their dependency lists, finds
+        additional modules that can be removed because they no longer have
+        any dependents.
+
+        Args:
+            dependencies: Dict of modules to their dependency list
+            modules_to_remove: Iterable of modules to remove
+
+        Returns:
+            New list of modules that can be safely removed (includes original
+            modules plus cascaded removals). Does not modify inputs.
+
+        Raises:
+            ValueError: If any module to remove still has dependents
+        """
+        # Build reverse dependency map
+        dependents = {}
+        for dependent, reqs in dependencies.items():
+            for req in reqs:
+                if req not in dependents:
+                    dependents[req] = set()
+                dependents[req].add(dependent)
+
+        # Start with the items we're told to remove
+        removed_items = set(modules_to_remove)
+        result = list(modules_to_remove)
+
+        # Keep track of items to check in this iteration
+        modules_to_check = set(modules_to_remove)
+
+        while modules_to_check:
+            next_modules_to_check = set()
+
+            for removed_item in modules_to_check:
+                # Find all dependencies of the removed item (items it depended on)
+                if removed_item in dependencies:
+                    for dependency in dependencies[removed_item]:
+                        # Skip if this dependency is already being removed
+                        if dependency in removed_items:
+                            continue
+
+                        # Check if this dependency still has other items depending on it
+                        remaining_dependents = (
+                            dependents.get(dependency, set()) - removed_items
+                        )
+
+                        # If no remaining dependents, it can be removed
+                        if not remaining_dependents:
+                            removed_items.add(dependency)
+                            result.append(dependency)
+                            next_modules_to_check.add(dependency)
+
+            modules_to_check = next_modules_to_check
+
+        # Check if any removed modules still have dependents
+        # (build a clean view of dependents with removed items filtered out)
+        for name in result:
+            remaining = dependents.get(name, set()) - removed_items
+            # Also filter out by real task name in case of aliases
+            try:
+                self.taskdb.get(name)  # Verify task exists
+                remaining = {
+                    dep
+                    for dep in remaining
+                    if dep not in removed_items
+                    and self.taskdb.get(dep).name not in removed_items
+                }
+            except ValueError:
+                # Task doesn't exist in taskdb (e.g., nonexistent module)
+                # Just use the remaining set as-is
+                pass
+            if remaining:
+                raise ValueError(
+                    f"{name} still in use by " + ", ".join(sorted(remaining))
+                )
+
+        return result
 
 
 # ==============================================================================
@@ -866,6 +1331,9 @@ class Modprobe:
         self.handle = self.context.handle
         self.rank = self.handle.get_rank()
 
+        # Initialize dependency solver
+        self.solver = DependencySolver(self.taskdb, self.context)
+
         self.searchpath = {
             "toml": self._get_searchpath(),
             "py": self._get_searchpath(builtindir="libexecdir"),
@@ -933,8 +1401,31 @@ class Modprobe:
         self._active_tasks.append(task.name)
 
     def get_task(self, name, default=None):
-        """Return current task providing string 'name'"""
+        """
+        Return task by name from taskdb.
+
+        Note: This does NOT do service resolution. For service-aware lookup
+        (e.g., "sched" -> actual scheduler module), use resolve_service().
+        """
         return self.taskdb.get(name)
+
+    def resolve_service(self, name, ignore_needs=False):
+        """
+        Resolve service name to actual task using needs-aware resolution.
+
+        This is the public API for service resolution. It considers:
+        - Task enabled/disabled status
+        - Needs constraints (unless ignore_needs=True)
+        - Priority and alternatives
+
+        Args:
+            name: Service or task name to resolve
+            ignore_needs: If True, skip needs checking
+
+        Returns:
+            Task object that would be loaded for this service
+        """
+        return self.solver.resolve_service(name, ignore_needs)
 
     def has_task(self, name):
         """Return True if task exists in taskdb"""
@@ -1093,64 +1584,27 @@ class Modprobe:
 
     def _solve_tasks_recursive(self, tasks, visited=None, skipped=None):
         """Recursively find all requirements of 'tasks'"""
-
-        if visited is None:
-            visited = set()
-        if skipped is None:
-            skipped = set()
-        result = set()
-        to_visit = [x for x in tasks if x not in visited]
-
-        for name in to_visit:
-            task = self.get_task(name)
-            if task.enabled(self.context):
-                result.add(task.name)
-            else:
-                skipped.add(task.name)
-            visited.add(task.name)
-            if task.requires:
-                rset = self._solve_tasks_recursive(
-                    tasks=task.requires, visited=visited, skipped=skipped
-                )
-                result.update(rset)
-
-        return result
+        # New solver API doesn't expose visited/skipped (private impl detail)
+        # Legacy wrapper for backward compatibility if needed
+        return self.solver.solve_requirements(tasks)
 
     def _process_needs(self, tasks):
         """Remove all tasks in tasks where task.needs is not met"""
-
-        def remove_task_recursive(tasks, task):
-            # When a task is removed, recursively remove tasks that
-            # needed it:
+        result = self.solver.solve_needs(tasks)
+        # The new API returns a new list and doesn't call modprobe.disable().
+        # We need to detect what was removed and disable those tasks.
+        removed = set(tasks) - set(result)
+        for name in removed:
             try:
-                tasks.remove(task.name)
-            except ValueError:
-                # If task.name is not in current set of tasks it may be a
-                # provider, so disable the task instead:
-                self.disable(task.name)
-                return
-            provides_set = set((task.name, *task.provides))
-            for name in tasks:
-                x = self.get_task(name)
-                if not provides_set.isdisjoint(x.needs):
-                    # Task x needs task, remove it
-                    remove_task_recursive(tasks, x)
+                self.taskdb.disable(name)
+            except (ValueError, KeyError):
+                # Task may not exist or may be a provider alias
+                pass
+        return result
 
-        # Iterate over a copy of tasks list, removing tasks for which one
-        # or more "needs" is not satisfied. When removing a task, tasks
-        # that "need" that task are removed (recursively applied)
-        for name in tasks.copy():
-            task = self.get_task(name)
-            for need in task.needs:
-                if not self.taskdb.any_provides(tasks, need):
-                    if name in tasks:
-                        remove_task_recursive(tasks, task)
-
-        return tasks
-
-    def solve(self, tasks, timing=True):
+    def solve(self, tasks, timing=True, ignore_disabled=False):
         t0 = self.timestamp
-        result = self._solve_tasks_recursive(tasks)
+        result = self.solver.solve_requirements(tasks, ignore_disabled=ignore_disabled)
         if timing:
             self.add_timing("solve", t0)
         return result
@@ -1159,74 +1613,20 @@ class Modprobe:
         """Process any task.before by appending this task's name to all
         successor's predecessor list.
         """
-
-        def deps_add_all(name):
-            """Add name as a predecessor to all entries in deps"""
-            for task in [self.get_task(x) for x in deps.keys()]:
-                if "*" not in task.before:
-                    deps[task.name].append(name)
-
-        for name in tasks:
-            task = self.get_task(name)
-            for successor in task.before:
-                if successor == "*":
-                    deps_add_all(task.name)
-                else:
-                    # resolve real successor name:
-                    successor = self.get_task(successor).name
-                    if successor in deps:
-                        deps[successor].append(task.name)
+        return self.solver._process_before(tasks, deps)
 
     def get_deps(self, tasks):
         """Return dependencies for tasks as dict of names to predecessor list"""
         t0 = self.timestamp
-        if not isinstance(tasks, set):
-            tasks = set(tasks)
-        deps = {}
-
-        # Ensure tasks set contains all provides and the actual task name
-        # (since presence in the set determines if a task is included in
-        #  the predecessor list below)
-        provides = set()
-        for task in tasks:
-            task = self.get_task(task)
-            provides.add(task.name)
-            provides.update(task.provides)
-        tasks.update(provides)
-
-        for name in tasks:
-            task = self.get_task(name)
-            if "*" in task.after:
-                # Add all tasks to deps (except those that also specify "*"
-                # in their 'after' list)
-                deps[task.name] = [
-                    self.get_task(x).name
-                    for x in tasks
-                    if "*" not in self.get_task(x).after
-                ]
-            else:
-                after_tasks = [self.get_task(x).name for x in task.after]
-                deps[task.name] = [x for x in after_tasks if x in tasks]
-        self._process_before(tasks, deps)
+        deps = self.solver.solve_execution_order(tasks)
         self.add_timing("deps", t0)
-
         return deps
 
     def get_requires(self, tasks, reverse=False):
         """Return dependencies for tasks as dicts of names to dependencies"""
-        deps = {}
-        for name in tasks:
-            task = self.get_task(name)
-            deps[task.name] = list(task.requires)
         if reverse:
-            rdeps = {}
-            for dependent, reqs in deps.items():
-                for req in reqs:
-                    if req not in rdeps:
-                        rdeps[req] = set()
-                    rdeps[req].add(dependent)
-            return rdeps
-        return deps
+            return self.solver.get_reverse_requires(tasks)
+        return self.solver.get_requires(tasks)
 
     def run(self, deps):
         """Run all tasks in deps in precedence order"""
@@ -1331,9 +1731,16 @@ class Modprobe:
         Raises:
             FileExistsError: Target modules (and all their dependencies)
                 are already loaded, so there is nothing to do.
+
+        Note:
+            This method uses ignore_disabled=True to allow loading modules
+            that are disabled by configuration. This enables explicit loading
+            of non-default alternatives or disabled modules.
         """
         mlist = ModuleList(self.handle)
-        needed_modules = [x for x in self.solve(modules) if x not in mlist]
+        needed_modules = [
+            x for x in self.solve(modules, ignore_disabled=True) if x not in mlist
+        ]
 
         # Ensure explicitly requested modules are the current alternatives
         self._set_all_alternatives(needed_modules)
@@ -1357,66 +1764,7 @@ class Modprobe:
         Returns:
             list: modules that can be safely removed (including original list)
         """
-        dependents = {}
-        for dependent, reqs in dependencies.items():
-            for req in reqs:
-                if req not in dependents:
-                    dependents[req] = set()
-                dependents[req].add(dependent)
-
-        # Start with the items we're told to remove
-        removed_items = set(modules_to_remove)
-        newly_removable = []
-
-        # Keep track of items to check in this iteration
-        modules_to_check = set(modules_to_remove)
-
-        while modules_to_check:
-            next_modules_to_check = set()
-
-            for removed_item in modules_to_check:
-                # Find all dependencies of the removed item
-                # (items it depended on)
-                if removed_item in dependencies:
-                    for dependency in dependencies[removed_item]:
-                        # Skip if this dependency is already being removed
-                        if dependency in removed_items:
-                            continue
-
-                        # Check if this dependency still has other items
-                        # depending on it
-                        remaining_dependents = (
-                            dependents.get(dependency, set()) - removed_items
-                        )
-
-                        # If no remaining dependents, it can be removed
-                        if not remaining_dependents:
-                            removed_items.add(dependency)
-                            newly_removable.append(dependency)
-                            next_modules_to_check.add(dependency)
-
-            modules_to_check = next_modules_to_check
-
-        # Add newly removed items to list of items to remove
-        modules_to_remove.extend(newly_removable)
-
-        # Discard elements from dependents if they are being removed
-        for name in modules_to_remove:
-            for deps in dependents.values():
-                # discard both the name to remove and the real name
-                # of the task in case they are different
-                # (e.g. sched vs sched-simple):
-                deps.discard(name)
-                deps.discard(self.get_task(name).name)
-
-        # Raise an error if any removed modules still have dependents
-        for name in modules_to_remove:
-            if dependents.get(name):
-                raise ValueError(
-                    f"{name} still in use by " + ", ".join(dependents[name])
-                )
-
-        return modules_to_remove
+        return self.solver.solve_removal(dependencies, modules_to_remove)
 
     def _solve_modules_remove(self, modules=None):
         """Solve for a set of currently loaded modules to remove"""

--- a/src/cmd/flux-modprobe.py
+++ b/src/cmd/flux-modprobe.py
@@ -96,7 +96,7 @@ def show(args):
     M = Modprobe().configure_modules()
     set_alternatives(M, args.set_alternative)
     disable_modules(M, args.disable)
-    print(json.dumps(M.get_task(args.module).to_dict(), default=str))
+    print(json.dumps(M.resolve_service(args.module).to_dict(), default=str))
 
 
 def remove(args):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -340,6 +340,7 @@ TESTSCRIPTS = \
 	python/t0042-job-manager-alloc-cache.py \
 	python/t0043-sdexec-map.py \
 	python/t0043-scheduler-pool.py \
+	python/t0100-modprobe.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0100-modprobe.py
+++ b/t/python/t0100-modprobe.py
@@ -12,7 +12,7 @@
 import unittest
 
 import subflux  # noqa: F401
-from flux.modprobe import Task, TaskDB
+from flux.modprobe import DependencySolver, Task, TaskDB
 from pycotap import TAPTestRunner
 
 
@@ -302,6 +302,487 @@ class TestTaskDB(unittest.TestCase):
         # module-b is NOT automatically disabled by TaskDB
         # (that logic lives in Modprobe._process_needs)
         self.assertFalse(task_b.disabled)
+
+
+class MockContext:
+    """Minimal mock context for DependencySolver tests"""
+
+    def __init__(self, rank=0):
+        self.rank = rank
+        self._attrs = {}
+        self._config = {}
+        self._env = {}
+
+    def attr_get(self, attr, default=None):
+        return self._attrs.get(attr, default)
+
+    def conf_get(self, key, default=None):
+        return self._config.get(key, default)
+
+    def getenv(self, var, default=None):
+        return self._env.get(var, default)
+
+
+class TestDependencySolver(unittest.TestCase):
+    """Test DependencySolver implementation"""
+
+    def setUp(self):
+        """Set up common test fixtures"""
+        self.db = TaskDB()
+        self.context = MockContext()
+        self.solver = DependencySolver(self.db, self.context)
+
+    def test_solve_requirements_basic(self):
+        """Basic requirement resolution"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", requires=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        result = self.solver.solve_requirements(["module-b"])
+        # Returns list, not set
+        self.assertEqual(set(result), {"module-a", "module-b"})
+
+    def test_solve_requirements_nested(self):
+        """Nested requirements (A requires B requires C)"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", requires=["module-a"])
+        task_c = Task("module-c", requires=["module-b"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        result = self.solver.solve_requirements(["module-c"])
+        self.assertEqual(set(result), {"module-a", "module-b", "module-c"})
+
+    def test_solve_requirements_multiple(self):
+        """Task with multiple requirements"""
+        task_a = Task("module-a")
+        task_b = Task("module-b")
+        task_c = Task("module-c", requires=["module-a", "module-b"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        result = self.solver.solve_requirements(["module-c"])
+        self.assertEqual(set(result), {"module-a", "module-b", "module-c"})
+
+    def test_solve_requirements_disabled_skipped(self):
+        """Disabled tasks are skipped but don't error"""
+        task_a = Task("module-a", disabled=True)
+        task_b = Task("module-b", requires=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        result = self.solver.solve_requirements(["module-b"])
+        # module-a is disabled, so not included
+        self.assertEqual(set(result), {"module-b"})
+
+    def test_solve_requirements_circular(self):
+        """Circular dependencies don't cause infinite loop"""
+        task_a = Task("module-a", requires=["module-b"])
+        task_b = Task("module-b", requires=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        result = self.solver.solve_requirements(["module-a"])
+        # Both should be included, visited set prevents infinite loop
+        self.assertEqual(set(result), {"module-a", "module-b"})
+
+    def test_solve_requirements_nonexistent_raises(self):
+        """Nonexistent requirement raises ValueError"""
+        task_a = Task("module-a", requires=["nonexistent"])
+        self.db.add(task_a)
+
+        with self.assertRaises(ValueError):
+            self.solver.solve_requirements(["module-a"])
+
+    def test_solve_requirements_rank_disabled(self):
+        """Tasks disabled by rank are skipped"""
+        task_a = Task("module-a", ranks="0")
+        task_b = Task("module-b", requires=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        # Set context rank to 1, so module-a is disabled
+        self.context.rank = 1
+        result = self.solver.solve_requirements(["module-b"])
+        self.assertEqual(set(result), {"module-b"})
+
+    def test_solve_needs_basic(self):
+        """Basic needs satisfaction - no mutation"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", needs=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        tasks = ["module-a", "module-b"]
+        result = self.solver.solve_needs(tasks)
+        # Both should remain since module-a provides what module-b needs
+        self.assertEqual(set(result), {"module-a", "module-b"})
+        # Input should not be mutated
+        self.assertEqual(tasks, ["module-a", "module-b"])
+
+    def test_solve_needs_missing_provider(self):
+        """Task removed when needed provider missing - no mutation"""
+        task_a = Task("module-a", needs=["module-b"])
+        self.db.add(task_a)
+
+        tasks = ["module-a"]
+        result = self.solver.solve_needs(tasks)
+        # module-a removed because module-b is not in tasks
+        self.assertEqual(result, [])
+        # Input should not be mutated
+        self.assertEqual(tasks, ["module-a"])
+
+    def test_solve_needs_disabled_provider(self):
+        """Task removed when all providers are disabled"""
+        task_a = Task("module-a", disabled=True)
+        task_b = Task("module-b", needs=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        tasks = ["module-a", "module-b"]
+        result = self.solver.solve_needs(tasks)
+        # module-b removed because module-a is disabled
+        self.assertEqual(set(result), {"module-a"})
+
+    def test_solve_needs_multiple_providers(self):
+        """Needs satisfied if any provider is enabled"""
+        task_a = Task("module-a", provides=["service"], disabled=True)
+        task_b = Task("module-b", provides=["service"])
+        task_c = Task("module-c", needs=["service"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        tasks = ["module-a", "module-b", "module-c"]
+        result = self.solver.solve_needs(tasks)
+        # All remain because module-b provides enabled service
+        self.assertEqual(set(result), {"module-a", "module-b", "module-c"})
+
+    def test_solve_needs_recursive_removal(self):
+        """Removing task cascades to tasks that need it"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", needs=["module-a"])
+        task_c = Task("module-c", needs=["module-b"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        # Don't include module-a in tasks
+        tasks = ["module-b", "module-c"]
+        result = self.solver.solve_needs(tasks)
+        # Both removed: module-b needs module-a, module-c needs module-b
+        self.assertEqual(result, [])
+
+    def test_solve_needs_force_enabled_not_protected(self):
+        """Current behavior: force_enabled doesn't prevent needs removal"""
+        task_a = Task("module-a", needs=["nonexistent"])
+        task_a.force_enabled = True
+        self.db.add(task_a)
+
+        tasks = ["module-a"]
+        original_tasks = tasks.copy()
+        result = self.solver.solve_needs(tasks)
+        # Current behavior: still removed despite force_enabled
+        self.assertEqual(result, [])
+        # Input not mutated
+        self.assertEqual(tasks, original_tasks)
+
+    def test_solve_execution_order_basic(self):
+        """Basic before/after constraints"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", after=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        deps = self.solver.solve_execution_order(["module-a", "module-b"])
+        # module-b depends on module-a
+        self.assertEqual(deps["module-b"], ["module-a"])
+        self.assertEqual(deps["module-a"], [])
+
+    def test_solve_execution_order_before(self):
+        """Before constraints create reverse dependencies"""
+        task_a = Task("module-a", before=["module-b"])
+        task_b = Task("module-b")
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        deps = self.solver.solve_execution_order(["module-a", "module-b"])
+        # module-b depends on module-a (due to before)
+        self.assertEqual(deps["module-b"], ["module-a"])
+        self.assertEqual(deps["module-a"], [])
+
+    def test_solve_execution_order_wildcard_after(self):
+        """after=['*'] means after all other tasks"""
+        task_a = Task("module-a")
+        task_b = Task("module-b")
+        task_c = Task("module-c", after=["*"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        deps = self.solver.solve_execution_order(["module-a", "module-b", "module-c"])
+        # module-c depends on both module-a and module-b
+        self.assertIn("module-a", deps["module-c"])
+        self.assertIn("module-b", deps["module-c"])
+
+    def test_solve_execution_order_wildcard_before(self):
+        """before=['*'] means before all other tasks"""
+        task_a = Task("module-a", before=["*"])
+        task_b = Task("module-b")
+        task_c = Task("module-c")
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        deps = self.solver.solve_execution_order(["module-a", "module-b", "module-c"])
+        # module-b and module-c both depend on module-a
+        self.assertIn("module-a", deps["module-b"])
+        self.assertIn("module-a", deps["module-c"])
+
+    def test_solve_execution_order_with_provides(self):
+        """Tasks accessible by provides are included in graph"""
+        task_a = Task("module-a", provides=["service-x"])
+        task_b = Task("module-b", after=["service-x"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        deps = self.solver.solve_execution_order(["module-a", "module-b"])
+        # module-b depends on module-a (resolved via service-x)
+        self.assertEqual(deps["module-b"], ["module-a"])
+
+    def test_get_requires_basic(self):
+        """Basic requires dependency map"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", requires=["module-a"])
+        task_c = Task("module-c", requires=["module-a", "module-b"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        deps = self.solver.get_requires(["module-a", "module-b", "module-c"])
+        self.assertEqual(deps["module-a"], [])
+        self.assertEqual(deps["module-b"], ["module-a"])
+        self.assertEqual(set(deps["module-c"]), {"module-a", "module-b"})
+
+    def test_get_reverse_requires(self):
+        """Reverse requires map shows who requires what"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", requires=["module-a"])
+        task_c = Task("module-c", requires=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        rdeps = self.solver.get_reverse_requires(["module-a", "module-b", "module-c"])
+        # module-a is required by module-b and module-c
+        self.assertEqual(rdeps["module-a"], {"module-b", "module-c"})
+
+    def test_solve_removal_basic(self):
+        """Basic module removal cascades to unused dependencies - no mutation"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", requires=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        deps = {"module-a": [], "module-b": ["module-a"]}
+        modules_to_remove = ["module-b"]
+        original_modules = modules_to_remove.copy()
+        result = self.solver.solve_removal(deps, modules_to_remove)
+        # Both removed: module-b explicitly, module-a cascaded (no longer needed)
+        self.assertEqual(set(result), {"module-a", "module-b"})
+        # Input not mutated
+        self.assertEqual(modules_to_remove, original_modules)
+
+    def test_solve_removal_cascading(self):
+        """Removing module cascades to dependencies"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", requires=["module-a"])
+        task_c = Task("module-c", requires=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        deps = {"module-a": [], "module-b": ["module-a"], "module-c": ["module-a"]}
+        result = self.solver.solve_removal(deps, ["module-b", "module-c"])
+        # All three removed: module-b, module-c, and module-a (no longer needed)
+        self.assertEqual(set(result), {"module-a", "module-b", "module-c"})
+
+    def test_solve_removal_with_dependents_raises(self):
+        """Cannot remove module with active dependents"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", requires=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        deps = {"module-a": [], "module-b": ["module-a"]}
+        with self.assertRaises(ValueError) as ctx:
+            self.solver.solve_removal(deps, ["module-a"])
+        self.assertIn("still in use", str(ctx.exception))
+        self.assertIn("module-b", str(ctx.exception))
+
+    def test_solve_removal_deep_cascade(self):
+        """Deep dependency chain removal"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", requires=["module-a"])
+        task_c = Task("module-c", requires=["module-b"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        deps = {
+            "module-a": [],
+            "module-b": ["module-a"],
+            "module-c": ["module-b"],
+        }
+        result = self.solver.solve_removal(deps, ["module-c"])
+        # All cascade: module-c -> module-b -> module-a
+        self.assertEqual(set(result), {"module-a", "module-b", "module-c"})
+
+    def test_solve_removal_shared_dependency(self):
+        """Shared dependency not removed if still needed"""
+        task_a = Task("module-a")
+        task_b = Task("module-b", requires=["module-a"])
+        task_c = Task("module-c", requires=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        deps = {"module-a": [], "module-b": ["module-a"], "module-c": ["module-a"]}
+        result = self.solver.solve_removal(deps, ["module-b"])
+        # Only module-b removed, module-a still needed by module-c
+        self.assertEqual(set(result), {"module-b"})
+
+    def test_solve_removal_missing_module_silent(self):
+        """Removing nonexistent module doesn't error (current behavior)"""
+        task_a = Task("module-a")
+        self.db.add(task_a)
+
+        deps = {"module-a": []}
+        # nonexistent-module not in deps, but should not error
+        result = self.solver.solve_removal(deps, ["nonexistent-module"])
+        self.assertEqual(result, ["nonexistent-module"])
+
+    def test_solve_requirements_ignore_disabled_false(self):
+        """Default behavior: disabled tasks are skipped"""
+        task_a = Task("module-a", disabled=True)
+        task_b = Task("module-b", requires=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        result = self.solver.solve_requirements(["module-b"], ignore_disabled=False)
+        # module-a is disabled, should not be included
+        self.assertEqual(set(result), {"module-b"})
+
+    def test_solve_requirements_ignore_disabled_true(self):
+        """With ignore_disabled=True, disabled tasks are included"""
+        task_a = Task("module-a", disabled=True)
+        task_b = Task("module-b", requires=["module-a"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+
+        result = self.solver.solve_requirements(["module-b"], ignore_disabled=True)
+        # module-a is disabled but should be included
+        self.assertEqual(set(result), {"module-a", "module-b"})
+
+    def test_solve_requirements_ignore_disabled_nested(self):
+        """ignore_disabled works recursively through requirements"""
+        task_a = Task("module-a", disabled=True)
+        task_b = Task("module-b", requires=["module-a"], disabled=True)
+        task_c = Task("module-c", requires=["module-b"])
+        self.db.add(task_a)
+        self.db.add(task_b)
+        self.db.add(task_c)
+
+        # Without ignore_disabled
+        result1 = self.solver.solve_requirements(["module-c"], ignore_disabled=False)
+        self.assertEqual(set(result1), {"module-c"})
+
+        # With ignore_disabled
+        result2 = self.solver.solve_requirements(["module-c"], ignore_disabled=True)
+        self.assertEqual(set(result2), {"module-a", "module-b", "module-c"})
+
+    def test_solve_requirements_ignore_disabled_directly_requested(self):
+        """ignore_disabled includes directly requested disabled module"""
+        task_a = Task("module-a", disabled=True)
+        self.db.add(task_a)
+
+        # Without ignore_disabled - skipped
+        result1 = self.solver.solve_requirements(["module-a"], ignore_disabled=False)
+        self.assertEqual(result1, [])
+
+        # With ignore_disabled - included
+        result2 = self.solver.solve_requirements(["module-a"], ignore_disabled=True)
+        self.assertEqual(result2, ["module-a"])
+
+    def test_resolve_service_prefers_lower_priority_with_satisfied_needs(self):
+        """
+        resolve_service should select lower-priority module when higher-priority
+        module has unsatisfied needs. This is the fluxion scenario.
+        """
+        # Create a module that high-priority module needs, but don't add it to taskdb
+        # (simulating that it's not available)
+
+        # Low priority module with no needs (like sched-simple)
+        simple = Task("sched-simple", provides=["sched"], priority=50)
+
+        # High priority module with unmet needs (like sched-fluxion-qmanager)
+        fluxion = Task(
+            "sched-fluxion-qmanager",
+            provides=["sched"],
+            needs=["resource"],  # resource module doesn't exist
+            priority=500,
+        )
+
+        self.db.add(simple)
+        self.db.add(fluxion)
+
+        # resolve_service should return simple, not fluxion, because fluxion's needs aren't met
+        result = self.solver.resolve_service("sched")
+        self.assertEqual(
+            result.name,
+            "sched-simple",
+            "Should select lower-priority sched-simple when fluxion needs not met",
+        )
+
+    def test_resolve_service_disabled_alternative_not_in_active_tasks(self):
+        """
+        When a high-priority alternative is disabled via priority bump but not loaded,
+        it should not be attempted to remove during rc3. This is the rc3 shutdown issue.
+        """
+        # Simulate the scenario:
+        # 1. default-module provides "test-service" at priority 100
+        # 2. high-priority-alt provides "test-service" at priority 500
+        # 3. set_alternative("test-service", "high-priority-alt") bumps priority to 501
+        # 4. But high-priority-alt is disabled, so only default-module is loaded
+        # 5. During rc3, we should only try to remove default-module, not high-priority-alt
+
+        default = Task("default-module", provides=["test-service"], priority=100)
+        high_pri = Task(
+            "high-priority-alt", provides=["test-service"], priority=500, disabled=True
+        )
+
+        self.db.add(default)
+        self.db.add(high_pri)
+
+        # Simulate what happens when user sets alternative but module is disabled
+        self.db.set_alternative("test-service", "high-priority-alt")
+
+        # resolve_service should return the enabled module (default-module)
+        # even though high-priority-alt has a higher priority
+        result = self.solver.resolve_service("test-service")
+        self.assertEqual(
+            result.name,
+            "default-module",
+            "Should return enabled module when alternative is disabled",
+        )
+
+        # Verify the disabled module is not selected even with its priority bump
+        # This prevents it from being added to active_tasks list and attempted removal in rc3
+        result2 = self.solver.resolve_service("test-service", ignore_needs=False)
+        self.assertEqual(result2.name, "default-module")
 
 
 if __name__ == "__main__":

--- a/t/python/t0100-modprobe.py
+++ b/t/python/t0100-modprobe.py
@@ -104,7 +104,7 @@ class TestTaskDB(unittest.TestCase):
 
         # Update first task priority but not above second
         task_first.priority = 75
-        db.update(task_first)
+        db["module-a"] = task_first
 
         # Second should still win due to insertion order
         retrieved = db.get("service")
@@ -112,7 +112,7 @@ class TestTaskDB(unittest.TestCase):
 
         # Update first task priority above second
         task_first.priority = 150
-        db.update(task_first)
+        db["module-a"] = task_first
 
         # Now first should win due to priority
         retrieved = db.get("service")
@@ -258,11 +258,11 @@ class TestTaskDB(unittest.TestCase):
         db.add(task)
 
         # Should find by name
-        self.assertTrue(db.has("module-a"))
+        self.assertTrue("module-a" in db)
         # Should find by provides
-        self.assertTrue(db.has("service-x"))
+        self.assertTrue("service-x" in db)
         # Should not find nonexistent
-        self.assertFalse(db.has("nonexistent"))
+        self.assertFalse("nonexistent" in db)
 
     def test_enable_does_not_cascade_to_requires(self):
         """Enable does not cascade to required tasks (by design)"""
@@ -471,41 +471,6 @@ class TestTaskDB(unittest.TestCase):
         self.assertIn("doesn't match task.name", str(ctx.exception))
         self.assertIn("wrong-name", str(ctx.exception))
         self.assertIn("kvs", str(ctx.exception))
-
-    def test_setitem_preserves_priority_bump(self):
-        """__setitem__ works correctly with priority bumps from set_alternative"""
-        from flux.modprobe import Module
-
-        db = TaskDB()
-        low = Module({"name": "low", "provides": ["service"], "priority": 50})
-        high = Module({"name": "high", "provides": ["service"], "priority": 500})
-
-        db.add(low)
-        db.add(high)
-
-        # High priority wins initially
-        self.assertEqual(db.get("service").name, "high")
-
-        # Set alternative to boost low priority
-        db.set_alternative("service", "low")
-        self.assertEqual(db.get("service").name, "low")
-
-        # Use setitem to update low (e.g., change some attribute)
-        low.disabled = False  # Dummy change
-        db["low"] = low
-
-        # Priority bump should be preserved (low still wins)
-        self.assertEqual(db.get("service").name, "low")
-
-    def test_has_method_still_works(self):
-        """has() method still works for backward compatibility"""
-        db = TaskDB()
-        task = Task("test")
-        db.add(task)
-
-        # Old API should still work
-        self.assertTrue(db.has("test"))
-        self.assertFalse(db.has("nonexistent"))
 
 
 class MockContext:

--- a/t/python/t0100-modprobe.py
+++ b/t/python/t0100-modprobe.py
@@ -303,6 +303,102 @@ class TestTaskDB(unittest.TestCase):
         # (that logic lives in Modprobe._process_needs)
         self.assertFalse(task_b.disabled)
 
+    def test_set_alternative_priority_bump(self):
+        """set_alternative() correctly bumps priority above alternatives"""
+        from flux.modprobe import Module
+
+        db = TaskDB()
+
+        low = Module({"name": "low", "provides": ["service"]})
+        high = Module({"name": "high", "priority": 500, "provides": ["service"]})
+
+        db.add(low)
+        db.add(high)
+
+        # High priority module should win initially
+        self.assertEqual(db.get("service").name, "high")
+
+        # Set alternative to low priority module
+        db.set_alternative("service", "low")
+
+        # Now low should win despite lower original priority
+        self.assertEqual(db.get("service").name, "low")
+
+        # Verify priority was actually bumped above high
+        entry = db._services["service"]["low"]
+        self.assertGreater(entry.priority, 500)
+
+    def test_set_alternative_with_disabled(self):
+        """set_alternative() works correctly when alternatives are disabled"""
+        from flux.modprobe import Module
+
+        db = TaskDB()
+
+        sched_simple = Module(
+            {"name": "sched-simple", "provides": ["sched", "feasibility"]}
+        )
+
+        advanced = Module(
+            {
+                "name": "advanced-scheduler",
+                "priority": 500,
+                "provides": ["sched", "feasibility"],
+            }
+        )
+
+        db.add(sched_simple)
+        db.add(advanced)
+
+        # Disable the high-priority alternative
+        db.disable("advanced-scheduler")
+
+        # Low priority module should win when high priority is disabled
+        self.assertEqual(db.get("feasibility").name, "sched-simple")
+
+        # Set alternative to force sched-simple
+        db.set_alternative("sched", "sched-simple")
+
+        # Should still return sched-simple
+        self.assertEqual(db.get("feasibility").name, "sched-simple")
+
+        # Re-enable advanced-scheduler
+        advanced.disabled = False
+
+        # sched-simple should still win due to priority bump
+        self.assertEqual(db.get("feasibility").name, "sched-simple")
+
+    def test_add_does_not_preserve_priority_bump(self):
+        """taskdb.add() on existing task overwrites priority bumps (this is the bug)"""
+        from flux.modprobe import Module
+
+        db = TaskDB()
+
+        sched_simple = Module(
+            {"name": "sched-simple", "provides": ["sched", "feasibility"]}
+        )
+
+        advanced = Module(
+            {
+                "name": "advanced-scheduler",
+                "priority": 500,
+                "provides": ["sched", "feasibility"],
+            }
+        )
+
+        db.add(sched_simple)
+        db.add(advanced)
+
+        # Set alternative to force sched-simple
+        db.set_alternative("sched", "sched-simple")
+        self.assertEqual(db.get("feasibility").name, "sched-simple")
+
+        # Calling add() again on the same task overwrites the priority bump
+        # This is the bug that add_active_task() had to work around
+        db.add(sched_simple)
+
+        # Priority bump was lost - advanced-scheduler wins again
+        self.assertEqual(db.get("feasibility").name, "advanced-scheduler")
+
 
 class MockContext:
     """Minimal mock context for DependencySolver tests"""

--- a/t/python/t0100-modprobe.py
+++ b/t/python/t0100-modprobe.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2024 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+
+import subflux  # noqa: F401
+from flux.modprobe import Task, TaskDB
+from pycotap import TAPTestRunner
+
+
+class TestTaskDB(unittest.TestCase):
+    """Test TaskDB implementation"""
+
+    def test_add_task_basic(self):
+        """Add a task and retrieve it by name"""
+        db = TaskDB()
+        task = Task("test-task")
+        db.add(task)
+        retrieved = db.get("test-task")
+        self.assertEqual(retrieved.name, "test-task")
+        self.assertIs(retrieved, task)
+
+    def test_add_task_with_provides(self):
+        """Task provides multiple services"""
+        db = TaskDB()
+        task = Task("module-a", provides=["service-x", "service-y"])
+        db.add(task)
+
+        # Should be retrievable by name
+        self.assertIs(db.get("module-a"), task)
+        # Should be retrievable by any provides
+        self.assertIs(db.get("service-x"), task)
+        self.assertIs(db.get("service-y"), task)
+
+    def test_get_nonexistent_raises(self):
+        """Getting nonexistent service raises ValueError"""
+        db = TaskDB()
+        with self.assertRaises(ValueError) as ctx:
+            db.get("nonexistent")
+        self.assertIn("no such task or module", str(ctx.exception))
+
+    def test_get_highest_priority(self):
+        """Multiple alternatives - picks highest priority"""
+        db = TaskDB()
+        task_low = Task("module-a", provides=["service"], priority=10)
+        task_high = Task("module-b", provides=["service"], priority=100)
+        task_medium = Task("module-c", provides=["service"], priority=50)
+
+        db.add(task_low)
+        db.add(task_high)
+        db.add(task_medium)
+
+        # Should return highest priority
+        retrieved = db.get("service")
+        self.assertEqual(retrieved.name, "module-b")
+        self.assertEqual(retrieved.priority, 100)
+
+    def test_get_prefers_enabled(self):
+        """Picks enabled task over higher priority disabled task"""
+        db = TaskDB()
+        task_high = Task("module-a", provides=["service"], priority=100)
+        task_low = Task("module-b", provides=["service"], priority=10)
+
+        db.add(task_high)
+        db.add(task_low)
+
+        # Disable the high priority task
+        task_high.disabled = True
+
+        # Should return lower priority enabled task
+        retrieved = db.get("service")
+        self.assertEqual(retrieved.name, "module-b")
+        self.assertEqual(retrieved.priority, 10)
+
+    def test_get_insertion_order_tiebreaker(self):
+        """When priorities equal, later insertion wins"""
+        db = TaskDB()
+        task_first = Task("module-a", provides=["service"], priority=100)
+        task_second = Task("module-b", provides=["service"], priority=100)
+
+        db.add(task_first)
+        db.add(task_second)
+
+        # Should return later insertion when priorities equal
+        retrieved = db.get("service")
+        self.assertEqual(retrieved.name, "module-b")
+
+    def test_update_preserves_order(self):
+        """Update doesn't change insertion order"""
+        db = TaskDB()
+        task_first = Task("module-a", provides=["service"], priority=50)
+        task_second = Task("module-b", provides=["service"], priority=100)
+
+        db.add(task_first)
+        db.add(task_second)
+
+        # Update first task priority but not above second
+        task_first.priority = 75
+        db.update(task_first)
+
+        # Second should still win due to insertion order
+        retrieved = db.get("service")
+        self.assertEqual(retrieved.name, "module-b")
+
+        # Update first task priority above second
+        task_first.priority = 150
+        db.update(task_first)
+
+        # Now first should win due to priority
+        retrieved = db.get("service")
+        self.assertEqual(retrieved.name, "module-a")
+
+    def test_set_alternative(self):
+        """Selecting alternative bumps priority"""
+        db = TaskDB()
+        task_a = Task("module-a", provides=["service"], priority=10)
+        task_b = Task("module-b", provides=["service"], priority=20)
+        task_c = Task("module-c", provides=["service"], priority=15)
+
+        db.add(task_a)
+        db.add(task_b)
+        db.add(task_c)
+
+        # Initially, module-b should win (highest priority)
+        self.assertEqual(db.get("service").name, "module-b")
+
+        # Select module-a as alternative
+        db.set_alternative("service", "module-a")
+
+        # Now module-a should win (priority bumped above max)
+        self.assertEqual(db.get("service").name, "module-a")
+
+    def test_set_alternative_propagates(self):
+        """Setting alternative propagates to all provides"""
+        db = TaskDB()
+        task_a = Task("module-a", provides=["svc-x", "svc-y"], priority=10)
+        task_b = Task("module-b", provides=["svc-x", "svc-y"], priority=20)
+
+        db.add(task_a)
+        db.add(task_b)
+
+        # Select module-a for svc-x (should propagate to svc-y)
+        db.set_alternative("svc-x", "module-a")
+
+        # Both services should now return module-a
+        self.assertEqual(db.get("svc-x").name, "module-a")
+        self.assertEqual(db.get("svc-y").name, "module-a")
+
+    def test_set_alternative_no_propagate(self):
+        """Setting alternative with propagate=False only affects one service"""
+        db = TaskDB()
+        task_a = Task("module-a", provides=["svc-x", "svc-y"], priority=10)
+        task_b = Task("module-b", provides=["svc-x", "svc-y"], priority=20)
+
+        db.add(task_a)
+        db.add(task_b)
+
+        # Select module-a for svc-x without propagation
+        db.set_alternative("svc-x", "module-a", propagate=False)
+
+        # Only svc-x should return module-a
+        self.assertEqual(db.get("svc-x").name, "module-a")
+        # svc-y should still return module-b
+        self.assertEqual(db.get("svc-y").name, "module-b")
+
+    def test_set_alternative_nonexistent_service(self):
+        """Setting alternative for nonexistent service raises"""
+        db = TaskDB()
+        with self.assertRaises(ValueError) as ctx:
+            db.set_alternative("nonexistent", "module-a")
+        self.assertIn("no such service", str(ctx.exception))
+
+    def test_set_alternative_nonexistent_module(self):
+        """Setting alternative to nonexistent module raises"""
+        db = TaskDB()
+        task = Task("module-a", provides=["service"])
+        db.add(task)
+
+        with self.assertRaises(ValueError) as ctx:
+            db.set_alternative("service", "nonexistent")
+        self.assertIn("no module nonexistent provides", str(ctx.exception))
+
+    def test_disable_task(self):
+        """Disabling affects get()"""
+        db = TaskDB()
+        task_a = Task("module-a", provides=["service"])
+        task_b = Task("module-b", provides=["service"])
+
+        db.add(task_a)
+        db.add(task_b)
+
+        # Disable all tasks providing service
+        db.disable("service")
+
+        # Both should be disabled
+        self.assertTrue(task_a.disabled)
+        self.assertTrue(task_b.disabled)
+
+        # get() should still return highest priority (even if disabled)
+        result = db.get("service")
+        self.assertIn(result.name, ["module-a", "module-b"])
+
+    def test_enable_task(self):
+        """Force enable overrides conditions"""
+        db = TaskDB()
+        task = Task("module-a", disabled=True)
+        db.add(task)
+
+        # Task is disabled
+        self.assertTrue(task.disabled)
+
+        # Force enable
+        db.enable("module-a")
+
+        # Should now be force-enabled
+        self.assertTrue(task.force_enabled)
+
+    def test_has_enabled_provider(self):
+        """has_enabled_provider returns True if any non-disabled task provides service"""
+        db = TaskDB()
+        task_a = Task("module-a", provides=["service-x"])
+        task_b = Task("module-b", provides=["service-y"])
+
+        db.add(task_a)
+        db.add(task_b)
+
+        # Should find service-x
+        self.assertTrue(db.has_enabled_provider(["module-a", "module-b"], "service-x"))
+        # Should find service-y
+        self.assertTrue(db.has_enabled_provider(["module-a", "module-b"], "service-y"))
+        # Should not find nonexistent
+        self.assertFalse(
+            db.has_enabled_provider(["module-a", "module-b"], "nonexistent")
+        )
+
+    def test_has_enabled_provider_disabled_task(self):
+        """has_enabled_provider returns False for disabled tasks"""
+        db = TaskDB()
+        task = Task("module-a", provides=["service"])
+        task.disabled = True
+        db.add(task)
+
+        # Should not find service from disabled task
+        self.assertFalse(db.has_enabled_provider(["module-a"], "service"))
+
+    def test_has(self):
+        """has() returns True if task/service exists"""
+        db = TaskDB()
+        task = Task("module-a", provides=["service-x"])
+        db.add(task)
+
+        # Should find by name
+        self.assertTrue(db.has("module-a"))
+        # Should find by provides
+        self.assertTrue(db.has("service-x"))
+        # Should not find nonexistent
+        self.assertFalse(db.has("nonexistent"))
+
+    def test_enable_does_not_cascade_to_requires(self):
+        """Enable does not cascade to required tasks (by design)"""
+        db = TaskDB()
+        task_a = Task("module-a", requires=["module-b"], disabled=True)
+        task_b = Task("module-b", disabled=True)
+
+        db.add(task_a)
+        db.add(task_b)
+
+        # Enable module-a
+        db.enable("module-a")
+
+        # module-a should be force-enabled
+        self.assertTrue(task_a.force_enabled)
+        # module-b should NOT be force-enabled (by design)
+        self.assertFalse(task_b.force_enabled)
+        self.assertTrue(task_b.disabled)
+
+    def test_disable_with_needs_semantics(self):
+        """Disabling a task affects tasks that need it (handled by Modprobe)"""
+        # Note: The cascading disable for 'needs' is handled in
+        # Modprobe._process_needs(), not in TaskDB.
+        # TaskDB.disable() only disables the specific task.
+        db = TaskDB()
+        task_a = Task("module-a")
+        task_b = Task("module-b", needs=["module-a"])
+
+        db.add(task_a)
+        db.add(task_b)
+
+        # Disable module-a at TaskDB level
+        db.disable("module-a")
+
+        # module-a is disabled
+        self.assertTrue(task_a.disabled)
+        # module-b is NOT automatically disabled by TaskDB
+        # (that logic lives in Modprobe._process_needs)
+        self.assertFalse(task_b.disabled)
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())
+
+
+# vi: ts=4 sw=4 expandtab

--- a/t/python/t0100-modprobe.py
+++ b/t/python/t0100-modprobe.py
@@ -399,6 +399,114 @@ class TestTaskDB(unittest.TestCase):
         # Priority bump was lost - advanced-scheduler wins again
         self.assertEqual(db.get("feasibility").name, "advanced-scheduler")
 
+    def test_contains_operator(self):
+        """__contains__ enables 'in' operator for existence checks"""
+        db = TaskDB()
+        task = Task("kvs", provides=["kvs-service"])
+        db.add(task)
+
+        # Test 'in' operator for task name
+        self.assertTrue("kvs" in db)
+        self.assertFalse("nonexistent" in db)
+
+        # Test 'in' operator for provided services
+        self.assertTrue("kvs-service" in db)
+
+        # Test with disabled task (should still be 'in' the db)
+        task.disabled = True
+        self.assertTrue("kvs" in db)
+
+    def test_setitem_add_new_task(self):
+        """__setitem__ can add a new task"""
+        db = TaskDB()
+        task = Task("job-manager")
+
+        # Add via dict-like syntax
+        db["job-manager"] = task
+
+        # Verify it was added
+        self.assertTrue("job-manager" in db)
+        self.assertIs(db.get("job-manager"), task)
+
+    def test_setitem_update_existing_task(self):
+        """__setitem__ can update an existing task"""
+        db = TaskDB()
+        task = Task("sched", priority=100)
+        db.add(task)
+
+        # Update the task
+        task.priority = 200
+        db["sched"] = task
+
+        # Verify update worked
+        retrieved = db.get("sched")
+        self.assertEqual(retrieved.priority, 200)
+        self.assertIs(retrieved, task)
+
+    def test_setitem_with_provides(self):
+        """__setitem__ works with tasks that provide services"""
+        from flux.modprobe import Module
+
+        db = TaskDB()
+        module = Module({"name": "sched-simple", "provides": ["sched", "feasibility"]})
+
+        # Add via setitem
+        db["sched-simple"] = module
+
+        # Verify accessible via all names
+        self.assertTrue("sched-simple" in db)
+        self.assertTrue("sched" in db)
+        self.assertTrue("feasibility" in db)
+        self.assertIs(db.get("sched"), module)
+
+    def test_setitem_validates_key_matches_name(self):
+        """__setitem__ raises ValueError if key doesn't match task.name"""
+        db = TaskDB()
+        task = Task("kvs")
+
+        # Should raise if key doesn't match
+        with self.assertRaises(ValueError) as ctx:
+            db["wrong-name"] = task
+
+        self.assertIn("doesn't match task.name", str(ctx.exception))
+        self.assertIn("wrong-name", str(ctx.exception))
+        self.assertIn("kvs", str(ctx.exception))
+
+    def test_setitem_preserves_priority_bump(self):
+        """__setitem__ works correctly with priority bumps from set_alternative"""
+        from flux.modprobe import Module
+
+        db = TaskDB()
+        low = Module({"name": "low", "provides": ["service"], "priority": 50})
+        high = Module({"name": "high", "provides": ["service"], "priority": 500})
+
+        db.add(low)
+        db.add(high)
+
+        # High priority wins initially
+        self.assertEqual(db.get("service").name, "high")
+
+        # Set alternative to boost low priority
+        db.set_alternative("service", "low")
+        self.assertEqual(db.get("service").name, "low")
+
+        # Use setitem to update low (e.g., change some attribute)
+        low.disabled = False  # Dummy change
+        db["low"] = low
+
+        # Priority bump should be preserved (low still wins)
+        self.assertEqual(db.get("service").name, "low")
+
+    def test_has_method_still_works(self):
+        """has() method still works for backward compatibility"""
+        db = TaskDB()
+        task = Task("test")
+        db.add(task)
+
+        # Old API should still work
+        self.assertTrue(db.has("test"))
+        self.assertFalse(db.has("nonexistent"))
+
 
 class MockContext:
     """Minimal mock context for DependencySolver tests"""

--- a/t/python/t0100-modprobe.py
+++ b/t/python/t0100-modprobe.py
@@ -154,23 +154,6 @@ class TestTaskDB(unittest.TestCase):
         self.assertEqual(db.get("svc-x").name, "module-a")
         self.assertEqual(db.get("svc-y").name, "module-a")
 
-    def test_set_alternative_no_propagate(self):
-        """Setting alternative with propagate=False only affects one service"""
-        db = TaskDB()
-        task_a = Task("module-a", provides=["svc-x", "svc-y"], priority=10)
-        task_b = Task("module-b", provides=["svc-x", "svc-y"], priority=20)
-
-        db.add(task_a)
-        db.add(task_b)
-
-        # Select module-a for svc-x without propagation
-        db.set_alternative("svc-x", "module-a", propagate=False)
-
-        # Only svc-x should return module-a
-        self.assertEqual(db.get("svc-x").name, "module-a")
-        # svc-y should still return module-b
-        self.assertEqual(db.get("svc-y").name, "module-b")
-
     def test_set_alternative_nonexistent_service(self):
         """Setting alternative for nonexistent service raises"""
         db = TaskDB()
@@ -325,8 +308,8 @@ class TestTaskDB(unittest.TestCase):
         self.assertEqual(db.get("service").name, "low")
 
         # Verify priority was actually bumped above high
-        entry = db._services["service"]["low"]
-        self.assertGreater(entry.priority, 500)
+        task = db.get("low")
+        self.assertGreater(task.priority, 500)
 
     def test_set_alternative_with_disabled(self):
         """set_alternative() works correctly when alternatives are disabled"""
@@ -367,8 +350,8 @@ class TestTaskDB(unittest.TestCase):
         # sched-simple should still win due to priority bump
         self.assertEqual(db.get("feasibility").name, "sched-simple")
 
-    def test_add_does_not_preserve_priority_bump(self):
-        """taskdb.add() on existing task overwrites priority bumps (this is the bug)"""
+    def test_add_preserves_priority_boost(self):
+        """taskdb.add() preserves priority boost (boost modifies task.priority)"""
         from flux.modprobe import Module
 
         db = TaskDB()
@@ -388,16 +371,15 @@ class TestTaskDB(unittest.TestCase):
         db.add(sched_simple)
         db.add(advanced)
 
-        # Set alternative to force sched-simple
+        # Set alternative to force sched-simple (boosts task.priority)
         db.set_alternative("sched", "sched-simple")
         self.assertEqual(db.get("feasibility").name, "sched-simple")
 
-        # Calling add() again on the same task overwrites the priority bump
-        # This is the bug that add_active_task() had to work around
+        # Calling add() again still uses the boosted task.priority
         db.add(sched_simple)
 
-        # Priority bump was lost - advanced-scheduler wins again
-        self.assertEqual(db.get("feasibility").name, "advanced-scheduler")
+        # Priority boost is preserved - sched-simple still wins
+        self.assertEqual(db.get("feasibility").name, "sched-simple")
 
     def test_contains_operator(self):
         """__contains__ enables 'in' operator for existence checks"""

--- a/t/t0100-modprobe.t
+++ b/t/t0100-modprobe.t
@@ -1300,6 +1300,57 @@ test_expect_success 'modprobe: FLUX_MODPROBE_DISABLE works in rc1' '
 		FLUX_RC_USE_MODPROBE=t \
 		    flux start flux module list | grep sched-simple
 '
+test_expect_success 'modprobe: rc3 with disabled high-priority alternatives' '
+	mkdir -p rc3-alt-test/modprobe.d &&
+	cat >rc3-alt-test/modprobe.d/alts.toml <<-EOF &&
+	[[modules]]
+	name = "default-module"
+	module = "sched-simple"
+	provides = ["test-service"]
+	after = ["job-manager"]
+	requires = ["job-manager"]
+
+	[[modules]]
+	name = "high-priority-alt"
+	module = "sched-simple"
+	priority = 500
+	provides = ["test-service"]
+	after = ["job-manager"]
+	requires = ["job-manager"]
+	EOF
+	FLUX_MODPROBE_PATH=$(pwd)/rc3-alt-test \
+	    FLUX_MODPROBE_DISABLE=high-priority-alt \
+		FLUX_RC_USE_MODPROBE=t \
+		    flux start --setattr=log-stderr-level=6 /bin/true \
+		    >rc3-alt.log 2>&1 &&
+	test_must_fail grep "high-priority-alt.*module not found" rc3-alt.log &&
+	test_must_fail grep "rc3 Exited (rc=1)" rc3-alt.log &&
+	test_must_fail grep "not properly shut down" rc3-alt.log
+'
+test_expect_success 'modprobe: needs-aware resolution prefers viable low-priority module' '
+	mkdir -p needs-test/modprobe.d &&
+	cat >needs-test/modprobe.d/alts.toml <<-EOF &&
+	[[modules]]
+	name = "simple-module"
+	module = "sched-simple"
+	provides = ["test-sched"]
+	priority = 50
+	after = ["job-manager"]
+	requires = ["job-manager"]
+
+	[[modules]]
+	name = "advanced-module"
+	module = "sched-simple"
+	provides = ["test-sched"]
+	priority = 500
+	needs = ["nonexistent-module"]
+	after = ["job-manager"]
+	requires = ["job-manager"]
+	EOF
+	FLUX_MODPROBE_PATH=$(pwd)/needs-test \
+		flux modprobe show test-sched >needs-test.json &&
+	cat needs-test.json | jq -e ".name == \"simple-module\""
+'
 test_expect_success 'modprobe: explicit load can load non-default module' '
 	FLUX_MODPROBE_PATH=$(pwd) \
 	    flux modprobe load --dry-run basic-scheduler >basic-load.out &&
@@ -1308,6 +1359,36 @@ test_expect_success 'modprobe: explicit load can load non-default module' '
 	load basic-scheduler
 	EOF
 	test_cmp basic-load.expected basic-load.out
+'
+test_expect_success 'modprobe: load can load disabled module' '
+	FLUX_MODPROBE_PATH=$(pwd) \
+	    FLUX_MODPROBE_DISABLE=basic-scheduler \
+	    flux modprobe load --dry-run basic-scheduler >disabled-load.out &&
+	test_debug cat disabled-load.out &&
+	cat <<-EOF >disabled-load.expected &&
+	load basic-scheduler
+	EOF
+	test_cmp disabled-load.expected disabled-load.out
+'
+test_expect_success 'modprobe: load can load disabled module via toml' '
+	cat <<-EOF >modprobe.d/002-disabled.toml &&
+	[[modules]]
+	name = "test-disabled-module"
+	disabled = true
+	ranks = "0"
+	provides = ["test-service"]
+	requires = ["job-manager", "another-disabled-module"]
+	[[modules]]
+	name = "another-disabled-module"
+	ranks = "0"
+	disabled = true
+	EOF
+	FLUX_MODPROBE_PATH=$(pwd) \
+	    flux modprobe load --dry-run test-disabled-module \
+	        >disabled-toml-load.out &&
+	test_debug "cat disabled-toml-load.out" &&
+	grep -q "load test-disabled-module" disabled-toml-load.out &&
+	grep -q "load another-disabled-module" disabled-toml-load.out
 '
 test_expect_success 'modprobe: --set-alternative detects bad input' '
 	( export FLUX_MODPROBE_PATH=$(pwd) &&


### PR DESCRIPTION
This PR represents a refactor and improvement of modprobe with Claude's assistance, with the goal of improving maintainability, testability, and clarity of the code. Along the way at least one bug was fixed. The process of the refactor represented by the commit history here was:

1. Extract some leaky abstractions into distinct, testable classes: TaskDB, DependencySolver, ConfigLoader
2. Add unit tests for each class to ensure they work as designed
4. Simplify interfaces where possible. The biggest simplification was the removal of two level priority between TaskDB tasks and TaskEntry objects, which was the source of a lot of confusion and bugs
5. Add missing tests discovered by external breakage found along the way
6. Improve docstring documentation

The one bug fix is that `flux modprobe load` now works to load modules and their requirements even if they would be disabled by configuration, for example `flux modprobe load sdexec` loads `sdbus`, `sdexec-mapper` and `sdexec` in the correct order. (Previously it would do nothing and say "All required modules are loaded")

Edit: I should also mention the result is more efficient, but I don't think it matters for the small number of "tasks" we're dealing with in typical rc1/rc3.