### PR TITLE
python: fix `ply` ImportError

### DIFF
--- a/src/bindings/python/setup.py
+++ b/src/bindings/python/setup.py
@@ -14,11 +14,12 @@ from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 cffi_dep = "cffi>=1.1"
+ply_dep = "ply>=3.9"
 setup(
     name="flux",
     version="0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1a1",
     description="Bindings to the flux resource manager API",
     setup_requires=[cffi_dep],
     cffi_modules=["_flux/_core_build.py:ffi"],
-    install_requires=[cffi_dep],
+    install_requires=[cffi_dep, ply_dep],
 )


### PR DESCRIPTION
Problem: commit https://github.com/flux-framework/flux-core/commit/c4740640812f5931c92b2f2d5d44f1283d19867b made
the flux.job.Jobspec module import an Exception type from the
flux.constraint.parser module, but that module imports a package
`ply` that is not required by `setup.py`. This means that installing
Flux's python bindings via `pip` will yield a broken install that
raises `ImportError`s unless the `ply` package is installed
independently.

Add `ply` to `setup.py`.

Example traceback:

```
packages/ats/atsMachines/fluxScheduled.py", line 47, in init
    import flux.job
  File "/usr/lib64/flux/python3.6/flux/job/__init__.py", line 11, in <module>
    from flux.job.Jobspec import Jobspec, JobspecV1, validate_jobspec
  File "/usr/lib64/flux/python3.6/flux/job/Jobspec.py", line 26, in <module>
    from flux.constraint.parser import ConstraintSyntaxError
  File "/usr/lib64/flux/python3.6/flux/constraint/parser.py", line 15, in <module>
    import ply.yacc as yacc
ModuleNotFoundError: No module named 'ply'
```