### PR TITLE
fix `flux job attach` statusline display when queues are stopped

### DIFF
--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -92,6 +92,10 @@ struct optparse_option attach_opts[] = {
     { .name = "debug-emulate", .has_arg = 0, .flags = OPTPARSE_OPT_HIDDEN,
       .usage = "Set MPIR_being_debugged for testing",
     },
+    { .name = "queue-check-interval", .has_arg = 1, .arginfo = "SECONDS",
+      .flags = OPTPARSE_OPT_HIDDEN,
+      .usage = "Set interval to check queue state for testing",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -145,6 +149,7 @@ struct attach_ctx {
     int prolog_running;
     bool fatal_exception;
     int last_queue_update;
+    int queue_check_interval;
     char *queue;
     bool queue_stopped;
     zlist_t *tail_output;
@@ -1229,11 +1234,12 @@ static void attach_notify (struct attach_ctx *ctx,
 
         /* If waiting for resources, fetch/update queue status periodically */
         if (strstarts (base_msg, "waiting for resources")) {
+            int last_queue_dt = dt - ctx->last_queue_update;
             if (!ctx->queue) {
                 fetch_job_queue (ctx);
             }
             else if (ctx->last_queue_update <= 0
-                     || (dt - ctx->last_queue_update >= 10)) {
+                     || (last_queue_dt >= ctx->queue_check_interval)) {
                 ctx->last_queue_update = dt;
                 fetch_queue_status (ctx);
             }
@@ -1535,6 +1541,9 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
     ctx.p = p;
     ctx.readonly = optparse_hasopt (p, "read-only");
     ctx.unbuffered = optparse_hasopt (p, "unbuffered");
+    ctx.queue_check_interval = optparse_get_int (p,
+                                                 "queue-check-interval",
+                                                 10);
 
     if (optparse_hasopt (p, "stdin-ranks") && ctx.readonly)
         log_msg_exit ("Do not use --stdin-ranks with --read-only");

--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -1101,13 +1101,18 @@ static void fetch_job_queue (struct attach_ctx *ctx)
         flux_future_destroy (f);
 }
 
-static const char *attach_notify_msg (struct attach_ctx *ctx,
-                                      struct attach_event *event)
+/* Get the base status message for the current job state.
+ * Returns a clean message without decorations (e.g., queue info).
+ * This is the "base truth" of what state the job is in.
+ */
+static const char *get_base_status_msg (struct attach_ctx *ctx,
+                                        struct attach_event *event)
 {
     const char *msg;
     int severity;
 
     if (!event) {
+        /* Timer callback - return saved base message */
         msg = ctx->status_msg;
     }
     else if (streq (event->name, "submit")) {
@@ -1161,6 +1166,47 @@ static const char *attach_notify_msg (struct attach_ctx *ctx,
     return msg;
 }
 
+/* Build the full statusline message by adding decorations/annotations
+ * to the base message. Decorations include queue status, etc.
+ *
+ * This function is called on every statusline update and builds a fresh
+ * message, making it easy to add/remove decorations dynamically.
+ *
+ * Returns the decorated message, which may point to buf if decorations
+ * were added, or base_msg if no decorations are needed.
+ */
+static const char *build_statusline_msg (struct attach_ctx *ctx,
+                                         const char *base_msg,
+                                         char *buf,
+                                         size_t buf_size)
+{
+    const char *msg = base_msg;
+
+    /* Add queue stopped annotation if:
+     * 1. The queue is currently stopped
+     * 2. The job is waiting for resources (the relevant state)
+     */
+    if (ctx->queue_stopped
+        && ctx->queue
+        && strstarts (base_msg, "waiting for resources")) {
+        int n = snprintf (buf,
+                         buf_size,
+                         "%s (%s queue stopped)",
+                         base_msg,
+                         ctx->queue);
+        if (n > 0 && n < buf_size)
+            msg = buf;
+    }
+
+    /* Future decorations can be added here, e.g.:
+     * - Dependency information: "waiting for resources (dep: jobid)"
+     * - Priority info: "waiting for resources (priority: 100)"
+     * - Expected start time: "waiting for resources (ETA: 5m)"
+     */
+
+    return msg;
+}
+
 static void attach_notify (struct attach_ctx *ctx,
                            struct attach_event *event,
                            double ts)
@@ -1172,16 +1218,17 @@ static void attach_notify (struct attach_ctx *ctx,
         int dt = ts - ctx->timestamp_zero;
         int width = 80;
         struct winsize w;
-        char buf[64];
-        const char *msg;
+        char buf[128];
+        const char *base_msg;
+        const char *display_msg;
         char *msgcpy;
 
-        if (!(msg = attach_notify_msg (ctx, event)))
+        /* Get the base status message (clean, no decorations) */
+        if (!(base_msg = get_base_status_msg (ctx, event)))
             return;
 
-        if (strstarts (msg, "waiting for resources")) {
-            /*  Fetch job queue so queue status can be checked
-             */
+        /* If waiting for resources, fetch/update queue status periodically */
+        if (strstarts (base_msg, "waiting for resources")) {
             if (!ctx->queue) {
                 fetch_job_queue (ctx);
             }
@@ -1190,21 +1237,14 @@ static void attach_notify (struct attach_ctx *ctx,
                 ctx->last_queue_update = dt;
                 fetch_queue_status (ctx);
             }
-            /*  Amend status if queue is stopped:
-             */
-            if (ctx->queue_stopped) {
-                if (snprintf (buf,
-                              sizeof (buf),
-                              "%s (%s queue stopped)",
-                              msg,
-                              ctx->queue) < sizeof (buf))
-                    msg = buf;
-            }
         }
 
+        /* Build the full display message with decorations */
+        display_msg = build_statusline_msg (ctx, base_msg, buf, sizeof (buf));
+
+        /* Display the statusline if active */
         if (ctx->statusline) {
-            /* Adjust width of status so timer is right justified:
-             */
+            /* Adjust width of status so timer is right justified */
             if (ioctl(0, TIOCGWINSZ, &w) == 0)
                 width = w.ws_col;
             width -= 10 + strlen (ctx->jobid) + 10;
@@ -1213,15 +1253,16 @@ static void attach_notify (struct attach_ctx *ctx,
                      "\rflux-job: %s %-*s %02d:%02d:%02d\r",
                      ctx->jobid,
                      width,
-                     msg,
+                     display_msg,
                      dt/3600,
                      (dt/60) % 60,
                      dt % 60);
         }
 
-        /*  Save current statusline message for future callbacks:
+        /* Save only the base message (no decorations) for future callbacks.
+         * This ensures we always have a clean starting point.
          */
-        if ((msgcpy = strdup (msg))) {
+        if ((msgcpy = strdup (base_msg))) {
             free (ctx->status_msg);
             ctx->status_msg = msgcpy;
         }

--- a/t/scripts/runpty.py
+++ b/t/scripts/runpty.py
@@ -179,17 +179,28 @@ class ExpectEntry:
 
     An entry has the form
 
-        {"expect":s, "send":s, "timeout"?i}
+        {"expect":s, "send":s, "timeout"?i, "exit"?b}
+        or
+        {"expect":s, "command":s, "timeout"?i, "exit"?b}
 
     Where 'expect' is a pattern, 'send' is the string to send as input
-    after the expected pattern matches, and 'timeout' is an optional
-    integer number of seconds after which the pattern match times out.
+    after the expected pattern matches, 'command' is a shell command to
+    execute when the pattern matches, 'exit' is an optional boolean that
+    causes runpty to exit successfully after the match, and 'timeout' is
+    an optional integer number of seconds after which the pattern match
+    times out.
+
+    Either 'send' or 'command' may be specified, but not both.
     """
 
     def __init__(self, entry):
         self.expect = re.compile(entry["expect"])
-        self.send = entry["send"]
+        self.send = entry.get("send")
+        self.command = entry.get("command")
+        self.exit = entry.get("exit", False)
         self.timeout = int(entry.get("timeout", 60.0))
+        if self.send and self.command:
+            raise ValueError("Cannot specify both 'send' and 'command'")
 
     def __str__(self):
         return self.expect.pattern
@@ -242,14 +253,19 @@ class Expecter:
 
     def pop(self):
         """
-        Return the current data to send after a match and advance to the
-        next expected pattern.
+        Return the current entry after a match and advance to the
+        next expected pattern. Returns a tuple of (send_data, command, exit)
+        where send_data is bytes to write to pty (or None), command
+        is a shell command to execute (or None), and exit is a boolean
+        indicating whether runpty should exit successfully after this match.
         """
         if self.current:
-            data = self.current.send
+            send_data = self.current.send.encode("utf-8") if self.current.send else None
+            command = self.current.command
+            should_exit = self.current.exit
             self.next()
-            return data.encode("utf-8")
-        return None
+            return (send_data, command, should_exit)
+        return (None, None, False)
 
 
 class TTYBuffer:
@@ -440,7 +456,20 @@ def main():
         def read_tty():
             buf.read()
             if expect.match(buf.peek()):
-                os.write(fd, expect.pop())
+                send_data, command, should_exit = expect.pop()
+                if send_data:
+                    os.write(fd, send_data)
+                if command:
+                    os.system(command)
+                if should_exit:
+                    # Pattern matched and exit requested - terminate child
+                    # and exit successfully regardless of child exit status
+                    try:
+                        os.kill(pid, SIGTERM)
+                    except ProcessLookupError:
+                        pass
+                    loop.call_later(0.1, sys.exit, 0)
+                    return
             buf.send_data(ofile.write_entry)
             if buf.eof:
                 loop.stop()

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -95,6 +95,48 @@ test_expect_success NO_CHAIN_LINT 'attach: --show-status notes stopped named que
 	flux config load </dev/null &&
 	flux queue status
 '
+test_expect_success NO_CHAIN_LINT 'attach: --show-status does not duplicate queue stopped message' '
+	flux config load <<-EOF &&
+	[queues.a]
+	EOF
+	flux queue stop --verbose --all &&
+	jobid=$(flux submit -q a hostname) &&
+	$runpty -f asciicast -o dup-check.out \
+		flux job attach --show-status $jobid &
+	pid=$! &&
+	waitfile.lua -v -t 15 -p "a queue stopped" dup-check.out &&
+	sleep 3 &&
+	flux queue start --all &&
+	wait $pid &&
+	flux config load </dev/null &&
+	test_must_fail grep "queue stopped.*queue stopped" dup-check.out
+'
+test_expect_success 'attach: --show-status clears queue stopped when queue starts' '
+	flux config load <<-EOF &&
+	[queues.test]
+	EOF
+	test_when_finished "flux config load </dev/null" &&
+	flux queue stop --verbose --all &&
+	flux resource drain 0-3 &&
+	test_when_finished "flux resource undrain 0-3" &&
+	jobid=$(flux submit -q test hostname) &&
+	cat >clear-stopped-expect.json <<-EOF &&
+	[
+	    {
+	      "expect": "test queue stopped",
+              "command": "flux queue start --all"
+            },
+	    {
+              "expect": "waiting for resources\\\\s+00:",
+              "exit": true
+            }
+	]
+	EOF
+	$runpty -f asciicast -o clear-stopped.out \
+		--expect clear-stopped-expect.json \
+		--timeout=30 \
+		flux job attach --queue-check-interval=1 --show-status $jobid
+'
 test_expect_success NO_CHAIN_LINT 'attach: ignores non-fatal exceptions' '
 	flux queue stop &&
 	test_when_finished "flux queue start" &&


### PR DESCRIPTION
There is a bug in the `flux job attach` status line display where the `(<name> queue stopped)` message gets appended instead of replacing the existing same message, resulting in confusing duplication. This occurs when the queue name is short (like `pall`), depending on terminal width.

The existing implementation of the status line is brittle and was the likely cause of this error when the queue state was added to the informational message. Improve the status line code by generating the entire message on each update, making it clearer how the code works, and more extensible if we want to add different messages in the future.

In order to test more easily, this work extends the `runpty.py` test helper to run commands or exit immediately when expected patterns in output occur, then uses this feature for the tests.

Additionally, to avoid the hard-coded 10s queue update interval, a new hidden option is added to `flux job attach` to set the queue update interval so tests can proceed faster than minimum 10s.