### PR TITLE
resource: support checkpoint and eventlog truncation

### DIFF
--- a/doc/man5/flux-config-resource.rst
+++ b/doc/man5/flux-config-resource.rst
@@ -156,6 +156,20 @@ journal-max
    default is 100,000. This value takes immediate effect on a configuration
    update.
 
+history
+   (optional) The maximum age in Flux Standard Duration (FSD) of
+   ``resource.eventlog`` entries to be preserved for historical
+   purposes.  When the resource module is reloaded, such as during a
+   flux restart, entries older than the most recent resource state
+   checkpoint are truncated by default.  "0" means truncate all
+   eligible entries; "inf" means never truncate. Default: "0".
+
+.. note::
+   Resource checkpoints were added in flux-core-0.86.0. Prior
+   releases did not create resource checkpoints, so resource eventlog
+   cleanup is not performed the first time Flux is started on that
+   release.
+
 Note that, except where noted above, updates to the resource table are
 ignored until the next Flux restart.
 
@@ -168,6 +182,7 @@ EXAMPLE
    path = "/etc/flux/system/R"
    exclude = "test[3,108]"
    norestrict = true
+   history = "30d"
 
 
 RESOURCES

--- a/src/common/libutil/dirwalk.c
+++ b/src/common/libutil/dirwalk.c
@@ -67,7 +67,8 @@ static void direntry_destroy (struct direntry *e)
  *  Create a direntry under parent dirfd `fd` and path `dir`, from
  *   directory entry `dent`.
  */
-static struct direntry *direntry_create (int fd, const char *dir,
+static struct direntry *direntry_create (int fd,
+                                         const char *dir,
                                          struct dirent *dent)
 {
     struct direntry *e = calloc (1, sizeof (*e));
@@ -271,8 +272,10 @@ void dirwalk_stop (dirwalk_t *d, int errnum)
     d->errnum = errnum;
 }
 
-int dirwalk (const char *path, int flags,
-             dirwalk_filter_f fn, void *arg)
+int dirwalk (const char *path,
+             int flags,
+             dirwalk_filter_f fn,
+             void *arg)
 {
     char *dirpath = NULL;
     int count = -1;
@@ -330,9 +333,12 @@ static int find_f (dirwalk_t *d, void *arg)
     return 0;
 }
 
-zlist_t *dirwalk_find (const char *searchpath, int flags,
-                       const char *pattern, int count,
-                       dirwalk_filter_f fn, void *uarg)
+zlist_t *dirwalk_find (const char *searchpath,
+                       int flags,
+                       const char *pattern,
+                       int count,
+                       dirwalk_filter_f fn,
+                       void *uarg)
 {
     int saved_errno;
     char *copy = NULL;

--- a/src/common/libutil/dirwalk.h
+++ b/src/common/libutil/dirwalk.h
@@ -84,8 +84,11 @@ int dirwalk_isdir (dirwalk_t *d);
  *
  *  zlist must be freed by caller (results are set to autofree).
  */
-zlist_t * dirwalk_find (const char *path, int flags,
-                        const char *pattern, int count,
-                        dirwalk_filter_f fn, void *arg);
+zlist_t * dirwalk_find (const char *path,
+                        int flags,
+                        const char *pattern,
+                        int count,
+                        dirwalk_filter_f fn,
+                        void *arg);
 
 #endif /* !HAVE_UTIL_DIRWALK_H */

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -40,7 +40,9 @@ libresource_la_SOURCES = \
 	drainset.h \
 	drainset.c \
 	upgrade.h \
-	upgrade.c
+	upgrade.c \
+	truncate.h \
+	truncate.c
 
 TESTS = \
 	test_rutil.t \

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -285,7 +285,8 @@ static struct idset *drain_targets_decode (struct drain *drain,
     struct idset *idset;
 
     if (!(idset = inventory_targets_to_ranks (drain->ctx->inventory,
-                                              ranks, errp)))
+                                              ranks,
+                                              errp)))
         return NULL;
     if (idset_count (idset) == 0) {
         errprintf (errp, "idset is empty");

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -648,9 +648,79 @@ done:
     return newids;
 }
 
+/* Recover checkpointed drain state
+ */
+static int load_drain_state (struct drain *drain,
+                             double *checkpoint_timestamp,
+                             flux_error_t *error)
+{
+    flux_future_t *f;
+    double check_timestamp;
+    json_t *drain_state;
+    const char *key;
+    json_t *value;
+    int rc = -1;
+
+    if (!(f = flux_kvs_lookup (drain->ctx->h,
+                               NULL,
+                               0,
+                               RESOURCE_CHECKPOINT))
+        || flux_kvs_lookup_get_unpack (f,
+                                       "{s:f s:o}",
+                                       "timestamp", &check_timestamp,
+                                       "drain_state", &drain_state) < 0) {
+        if (errno == ENOENT) {
+            check_timestamp = 0.0;
+            goto out;
+        }
+        errprintf (error, "failed to load drain-state");
+        goto error;
+    }
+
+    json_object_foreach (drain_state, key, value) {
+        struct idset *idset = NULL;
+        double timestamp;
+        char *nodelist;
+        char *reason;
+
+        if (json_unpack (value,
+                         "{s:f s:s s:s}",
+                         "timestamp", &timestamp,
+                         "nodelist", &nodelist,
+                         "reason", &reason) < 0
+            || !(idset = decode_targets (drain, key, nodelist))) {
+            errprintf (error, "invalid drain state entry");
+            goto error;
+        }
+
+        /* a NULL reason is serialized as an empty string during
+         * checkpoint, convert back to NULL to indicate there is no
+         * reason for the drain
+         */
+        if (reason[0] == '\0')
+            reason = NULL;
+
+        if (draininfo_drain_idset (drain, idset, timestamp, reason, 0) < 0) {
+            errprintf (error, "failed to update drain state");
+            idset_destroy (idset);
+            goto error;
+        }
+
+        idset_destroy (idset);
+    }
+
+out:
+    rc = 0;
+    (*checkpoint_timestamp) = check_timestamp;
+error:
+    flux_future_destroy (f);
+    return rc;
+}
+
 /* Recover drained idset from eventlog.
  */
 static int replay_eventlog (struct drain *drain,
+                            double checkpoint_timestamp,
                             const json_t *eventlog,
                             flux_error_t *error)
 {
@@ -670,6 +740,9 @@ static int replay_eventlog (struct drain *drain,
                 errprintf (error, "line %zu: event parse error", index + 1);
                 return -1;
             }
+            /* no need to replay anything before checkpoint timestamp */
+            if (timestamp < checkpoint_timestamp)
+                continue;
             if (streq (name, "drain")) {
                 int overwrite = 1;
                 const char *nodelist;
@@ -792,6 +865,65 @@ done:
     return rc;
 }
 
+static json_t *drain_get_drain_state (struct drain *drain)
+{
+    json_t *o = NULL;
+    const char *key;
+    json_t *value;
+
+    if (!(o = drain_get_info (drain)))
+        goto error;
+
+    json_object_foreach (o, key, value) {
+        char *nodelist = flux_hostmap_lookup (drain->ctx->h, key, NULL);
+        json_t *nl = NULL;
+        if (!nodelist
+            || !(nl = json_string (nodelist))
+            || json_object_set (value, "nodelist", nl) < 0) {
+            flux_log (drain->ctx->h,
+                      LOG_ERR,
+                      "failed to add nodelist to drain state");
+            json_decref (nl);
+            free (nodelist);
+            goto error;
+        }
+        json_decref (nl);
+        free (nodelist);
+    }
+
+    return o;
+error:
+    json_decref (o);
+    return NULL;
+}
+
+void drain_checkpoint (struct drain *drain)
+{
+    json_t *drain_state = NULL;
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    double timestamp;
+
+    if (flux_attr_get (drain->ctx->h, "broker.recovery-mode"))
+        return;
+
+    if (!(drain_state = drain_get_drain_state (drain))
+        || get_timestamp_now (&timestamp) < 0
+        || !(txn = flux_kvs_txn_create ())
+        || flux_kvs_txn_pack (txn,
+                              0,
+                              RESOURCE_CHECKPOINT,
+                              "{s:f s:O}",
+                              "timestamp", timestamp,
+                              "drain_state", drain_state) < 0
+        || !(f = flux_kvs_commit (drain->ctx->h, NULL, FLUX_KVS_SYNC, txn))
+        || flux_future_get (f, NULL) < 0)
+        flux_log_error (drain->ctx->h, "failed to checkpoint drain state");
+    json_decref (drain_state);
+    flux_kvs_txn_destroy (txn);
+    flux_future_destroy (f);
+}
+
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,  "resource.drain", drain_cb, 0 },
     { FLUX_MSGTYPE_REQUEST,  "resource.undrain", undrain_cb, 0 },
@@ -814,10 +946,13 @@ void drain_destroy (struct drain *drain)
     }
 }
 
-struct drain *drain_create (struct resource_ctx *ctx, const json_t *eventlog)
+struct drain *drain_create (struct resource_ctx *ctx,
+                            const json_t *eventlog,
+                            double *checkpoint_timestamp)
 {
     struct drain *drain;
     flux_error_t error;
+    double timestamp = 0.0;
 
     if (!(drain = calloc (1, sizeof (*drain))))
         return NULL;
@@ -828,7 +963,11 @@ struct drain *drain_create (struct resource_ctx *ctx, const json_t *eventlog)
         drain->size = rsize;
     if (!(drain->info = calloc (drain->size, sizeof (drain->info[0]))))
         goto error;
-    if (replay_eventlog (drain, eventlog, &error) < 0) {
+    if (load_drain_state (drain, &timestamp, &error) < 0) {
+        flux_log (ctx->h, LOG_ERR, "%s: %s", RESOURCE_CHECKPOINT, error.text);
+        goto error;
+    }
+    if (replay_eventlog (drain, timestamp, eventlog, &error) < 0) {
         flux_log (ctx->h, LOG_ERR, "%s: %s", RESLOG_KEY, error.text);
         goto error;
     }
@@ -838,6 +977,8 @@ struct drain *drain_create (struct resource_ctx *ctx, const json_t *eventlog)
     }
     if (flux_msg_handler_addvec (ctx->h, htab, drain, &drain->handlers) < 0)
         goto error;
+    if (checkpoint_timestamp)
+        (*checkpoint_timestamp) = timestamp;
     return drain;
 error:
     drain_destroy (drain);

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -41,7 +41,6 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <time.h>
 #include <math.h>
 #include <flux/core.h>
 #include <jansson.h>
@@ -78,15 +77,6 @@ struct drain_init_args {
     struct drain *drain;
     const struct idset *exclude;
 };
-
-static int get_timestamp_now (double *timestamp)
-{
-    struct timespec ts;
-    if (clock_gettime (CLOCK_REALTIME, &ts) < 0)
-        return -1;
-    *timestamp = (1E-9 * ts.tv_nsec) + ts.tv_sec;
-    return 0;
-}
 
 static int draininfo_undrain_rank (struct drain *drain, unsigned int rank)
 {

--- a/src/modules/resource/drain.h
+++ b/src/modules/resource/drain.h
@@ -11,7 +11,11 @@
 #ifndef _FLUX_RESOURCE_DRAIN_H
 #define _FLUX_RESOURCE_DRAIN_H
 
-struct drain *drain_create (struct resource_ctx *ctx, const json_t *eventlog);
+#define RESOURCE_CHECKPOINT "checkpoint.resource"
+
+struct drain *drain_create (struct resource_ctx *ctx,
+                            const json_t *eventlog,
+                            double *checkpoint_timestamp);
 void drain_destroy (struct drain *drain);
 
 struct idset *drain_get (struct drain *drain);
@@ -26,6 +30,9 @@ json_t *drain_get_info  (struct drain *drain);
  * resource.drain RPC.
  */
 int drain_rank (struct drain *drain, uint32_t rank, const char *reason);
+
+/* Checkpointing current drain state */
+void drain_checkpoint (struct drain *drain);
 
 #endif /* !_FLUX_RESOURCE_DRAIN_H */
 

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -405,10 +405,15 @@ static int reload_eventlog (flux_t *h, json_t **eventlog)
         o = NULL;
     }
     else {
-        if (!(o = eventlog_decode (s))) {
-            flux_log (h, LOG_ERR, "%s: decode error", RESLOG_KEY);
-            goto error;
+        if (s) {
+            if (!(o = eventlog_decode (s))) {
+                flux_log (h, LOG_ERR, "%s: decode error", RESLOG_KEY);
+                goto error;
+            }
         }
+        else
+            /* s == NULL, RESLOG_KEY has been set to empty string */
+            o = NULL;
     }
     *eventlog = o;
     flux_future_destroy (f);

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -16,6 +16,8 @@
 #endif
 
 #include <flux/core.h>
+#include <math.h>
+#include <time.h>
 #include <jansson.h>
 
 #include "src/common/libutil/errno_safe.h"
@@ -23,6 +25,7 @@
 #include "src/common/libidset/idset.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/librlist/rlist.h"
+#include "src/common/libutil/fsd.h"
 #include "ccan/str/str.h"
 
 #include "resource.h"
@@ -36,6 +39,7 @@
 #include "rutil.h"
 #include "status.h"
 #include "upgrade.h"
+#include "truncate.h"
 
 /* Parse [resource] table.
  *
@@ -67,6 +71,10 @@
  *
  * journal-max = 100000
  *   Maximum size allowed of the resource journal before it is truncated.
+ *
+ * history = 0
+ *   An amount of time specified in Flux Standard Duration (FSD) to preserve
+ *   resource.eventlog entries.
  */
 
 /* Initialize a resource_config object
@@ -141,12 +149,14 @@ static int parse_config (struct resource_ctx *ctx,
     int no_update_watch = 0;
     int rediscover = 0;
     int journal_max = 100000;
+    const char *history = NULL;
+    double history_time = 0.0;
     json_t *o = NULL;
     json_t *config = NULL;
 
     if (flux_conf_unpack (conf,
                           &error,
-                          "{s?{s?s s?s s?o s?o s?s s?b s?b s?b s?b s?i !}}",
+                          "{s?{s?s s?s s?o s?o s?s s?b s?b s?b s?b s?i s?s !}}",
                           "resource",
                             "path", &path,
                             "scheduling", &scheduling_path,
@@ -157,7 +167,8 @@ static int parse_config (struct resource_ctx *ctx,
                             "noverify", &noverify,
                             "no-update-watch", &no_update_watch,
                             "rediscover", &rediscover,
-                            "journal-max", &journal_max) < 0) {
+                            "journal-max", &journal_max,
+                            "history", &history) < 0) {
         errprintf (errp,
                    "error parsing [resource] configuration: %s",
                    error.text);
@@ -213,6 +224,13 @@ static int parse_config (struct resource_ctx *ctx,
             return -1;
         }
     }
+    if (history) {
+        if (fsd_parse_duration (history, &history_time) < 0) {
+            errprintf (errp, "invalid history time");
+            json_decref (o);
+            return -1;
+        }
+    }
     /* Check systemd.enable so we know whether sdmon.online will be populated.
      * Configuration errors in [systemd] are handled elsewhere.
      */
@@ -233,6 +251,7 @@ static int parse_config (struct resource_ctx *ctx,
         rconfig->rediscover = rediscover ? true : false;
         rconfig->R = o;
         rconfig->systemd_enable = systemd_enable ? true : false;
+        rconfig->history = history_time;
     }
     else
         json_decref (o);
@@ -412,6 +431,8 @@ int parse_args (flux_t *h, int argc,
             config->monitor_force_up = true;
         else if (streq (argv[i], "noverify"))
             config->noverify = true;
+        else if (streq (argv[i], "notruncate"))
+            config->notruncate = true;
         else  {
             flux_log (h, LOG_ERR, "unknown option: %s", argv[i]);
             errno = EINVAL;
@@ -420,7 +441,6 @@ int parse_args (flux_t *h, int argc,
     }
     return 0;
 }
-
 
 int mod_main (flux_t *h, int argc, char **argv)
 {
@@ -454,6 +474,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         goto error;
 
     if (ctx->rank == 0) {
+        double checkpoint_timestamp;
         /*  Create reslog and reload eventlog before initializing
          *  acquire, exclude, and drain subsystems, since these
          *  are required by acquire and exclude.
@@ -477,8 +498,25 @@ int mod_main (flux_t *h, int argc, char **argv)
          */
         if (!(ctx->exclude = exclude_create (ctx, config.exclude_idset)))
             goto error;
-        if (!(ctx->drain = drain_create (ctx, eventlog)))
+        if (!(ctx->drain = drain_create (ctx, eventlog, &checkpoint_timestamp)))
             goto error;
+        if (!isinf (config.history)
+            && !flux_attr_get (ctx->h, "broker.recovery-mode")
+            && !config.notruncate) {
+            json_t *curr_eventlog;
+            if (reslog_sync (ctx->reslog) < 0) {
+                flux_log_error (h, "failed to sync reslog");
+                goto error;
+            }
+            /* must reload eventlog due to reslog_sync() call above */
+            if (reload_eventlog (h, &curr_eventlog) < 0)
+                goto error;
+            truncate_eventlog (ctx,
+                               curr_eventlog,
+                               checkpoint_timestamp,
+                               config.history);
+            json_decref (curr_eventlog);
+        }
     }
     /*  topology is initialized after exclude/drain etc since this
      *  rank may attempt to drain itself due to a topology mismatch.
@@ -497,6 +535,9 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "flux_reactor_run");
         goto error;
     }
+    /* Checkpoint final drain state */
+    if (ctx->rank == 0)
+        drain_checkpoint (ctx->drain);
     resource_config_deinit (&config);
     resource_ctx_destroy (ctx);
     json_decref (eventlog);

--- a/src/modules/resource/resource.h
+++ b/src/modules/resource/resource.h
@@ -18,9 +18,11 @@ struct resource_config {
     bool rediscover;
     bool noverify;
     bool norestrict;
+    bool notruncate;
     bool no_update_watch;
     bool monitor_force_up;
     int journal_max;
+    double history;
     bool systemd_enable; // systemd.enable, not under [resource]
 };
 

--- a/src/modules/resource/rutil.c
+++ b/src/modules/resource/rutil.c
@@ -13,6 +13,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -265,6 +266,15 @@ int rutil_idkey_count (json_t *obj)
     int count = 0;
     (void)rutil_idkey_map (obj, idkey_count_map, &count);
     return count;
+}
+
+int get_timestamp_now (double *timestamp)
+{
+    struct timespec ts;
+    if (clock_gettime (CLOCK_REALTIME, &ts) < 0)
+        return -1;
+    *timestamp = (1E-9 * ts.tv_nsec) + ts.tv_sec;
+    return 0;
 }
 
 /*

--- a/src/modules/resource/rutil.h
+++ b/src/modules/resource/rutil.h
@@ -48,6 +48,9 @@ int rutil_idkey_map (json_t *obj, rutil_idkey_map_f map, void *arg);
  */
 int rutil_idkey_count (json_t *obj);
 
+/* Get current timestamp */
+int get_timestamp_now (double *timestamp);
+
 #endif /* !_FLUX_RESOURCE_RUTIL_H */
 
 

--- a/src/modules/resource/truncate.c
+++ b/src/modules/resource/truncate.c
@@ -1,0 +1,99 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* truncate.c - handle truncation of resource.eventlog
+ *
+ * The resource.eventlog will grow indefinitely if not controlled.
+ *
+ * Remove any events from the eventlog that are older than the most
+ * recent checkpoint of drain state.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <math.h>
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libutil/errprintf.h"
+
+#include "resource.h"
+#include "reslog.h"
+#include "drain.h"
+#include "rutil.h"
+
+void truncate_eventlog (struct resource_ctx *ctx,
+                        const json_t *eventlog,
+                        double checkpoint_timestamp,
+                        double history)
+{
+    json_t *a = NULL;
+    size_t index;
+    json_t *entry;
+    char *newlog = NULL;
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+
+    if (!eventlog)
+        return;
+
+    if (!(a = json_array ())) {
+        flux_log_error (ctx->h, "error creating truncation array");
+        return;
+    }
+
+    /* user desires to keep a configured amount of history, rollback
+     * checkpoint timestamp if necessary
+     */
+    if (history) {
+        double now, tmp;
+        if (get_timestamp_now (&now) < 0) {
+            flux_log_error (ctx->h, "error retrieving current time");
+            return;
+        }
+        tmp = now - history;
+        if (tmp > 0 && tmp < checkpoint_timestamp)
+            checkpoint_timestamp = tmp;
+    }
+
+    json_array_foreach (eventlog, index, entry) {
+        double timestamp;
+
+        if (eventlog_entry_parse (entry, &timestamp, NULL, NULL) < 0) {
+            flux_log_error (ctx->h, "event parse error");
+            goto out;
+        }
+        /* no need to keep anything before checkpoint timestamp */
+        if (timestamp < checkpoint_timestamp)
+            continue;
+        if (json_array_append (a, entry) < 0)
+            goto out;
+    }
+
+    if (!(newlog = eventlog_encode (a))
+        || !(txn = flux_kvs_txn_create ())
+        || flux_kvs_txn_put (txn, 0, RESLOG_KEY, newlog) < 0
+        || !(f = flux_kvs_commit (ctx->h, NULL, 0, txn))
+        || flux_rpc_get (f, NULL) < 0)
+        flux_log_error (ctx->h, "error truncating resource eventlog");
+
+out:
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+    free (newlog);
+    json_decref (a);
+    return;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/truncate.h
+++ b/src/modules/resource/truncate.h
@@ -1,0 +1,23 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_TRUNCATE_H
+#define _FLUX_RESOURCE_TRUNCATE_H
+
+void truncate_eventlog (struct resource_ctx *ctx,
+                        const json_t *eventlog,
+                        double checkpoint_timestamp,
+                        double history);
+
+#endif /* !_FLUX_RESOURCE_TRUNCATE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -200,6 +200,7 @@ TESTSCRIPTS = \
 	t2316-resource-rediscover.t \
 	t2317-resource-shrink.t \
 	t2318-resource-verify.t \
+	t2319-resource-history.t \
 	t2350-resource-list.t \
 	t2351-resource-status-input.t \
 	t2352-resource-cmd-config.t \

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -21,7 +21,7 @@ has_event() {
 # Ensure that module is loaded upstream-to-downstream TBON order
 load_resource () {
 	for rank in $(seq 0 $(($SIZE-1))); do \
-		flux exec -r $rank flux module load resource; \
+		flux exec -r $rank flux module load resource notruncate; \
 	done
 }
 

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -533,7 +533,7 @@ test_expect_success 'drain works when fake resources outnumber actual brokers' '
 	chmod +x test-drain.sh &&
 	flux start --test-size=1 -Shostlist=fake[0-99] ./test-drain.sh
 '
-test_expect_success '' '
+test_expect_success 'reset test by clearing resource info' '
 	flux module remove -f resource &&
 	flux kvs unlink resource.eventlog &&
 	flux module load resource noverify

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -160,7 +160,7 @@ test_expect_success 'drain works with idset' '
 
 test_expect_success 'reload resource module to simulate instance restart' '
 	flux module remove sched-simple &&
-	flux module reload resource noverify &&
+	flux module reload resource noverify notruncate &&
 	waitdown 0 &&
 	flux module load sched-simple
 '
@@ -205,7 +205,7 @@ test_expect_success 'final undrain event has a reason' '
 '
 test_expect_success 'reload resource module to simulate instance restart' '
 	flux module remove sched-simple &&
-	flux module reload resource noverify &&
+	flux module reload resource noverify notruncate &&
 	waitdown 0 &&
 	flux module load sched-simple
 '
@@ -221,7 +221,7 @@ test_expect_success 'reload resource module with one node excluded' '
 	flux module remove sched-simple &&
 	flux module remove resource &&
 	echo "resource.exclude = \"0\"" | flux config load &&
-	flux module load resource noverify &&
+	flux module load resource noverify notruncate &&
 	waitdown 0 &&
 	flux module load sched-simple
 '
@@ -248,7 +248,7 @@ test_expect_success 'reload resource module with no nodes excluded' '
 	flux module remove sched-simple &&
 	flux module remove resource &&
 	echo "resource.exclude = \"\"" | flux config load &&
-	flux module load resource noverify &&
+	flux module load resource noverify notruncate &&
 	waitdown 0 &&
 	flux module load sched-simple
 '
@@ -264,7 +264,7 @@ test_expect_success 'drained rank subsequently excluded is ignored' '
 	flux module remove sched-simple &&
 	flux module remove resource &&
 	echo resource.exclude = \"1\" | flux config load &&
-	flux module load resource noverify &&
+	flux module load resource noverify notruncate &&
 	waitdown 0 &&
 	flux module load sched-simple &&
 	test $(flux resource status -s drain -no {nnodes}) -eq 0 &&
@@ -275,7 +275,7 @@ test_expect_success 'reload resource module with no nodes excluded' '
 	flux module remove sched-simple &&
 	flux module remove resource &&
 	echo "resource.exclude = \"\"" | flux config load &&
-	flux module load resource noverify &&
+	flux module load resource noverify notruncate &&
 	waitdown 0 &&
 	flux module load sched-simple
 '
@@ -554,6 +554,7 @@ test_expect_success 'drain works when fake resources outnumber actual brokers' '
 '
 test_expect_success 'reset test by clearing resource info' '
 	flux module remove -f resource &&
+	flux kvs unlink -f checkpoint.resource &&
 	flux kvs unlink resource.eventlog &&
 	flux module load resource noverify
 '

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -417,6 +417,12 @@ test_expect_success 'flux resource drain works without scheduler loaded' '
 	test $(flux resource status -s drain -no {nnodes}) -eq 1
 '
 
+#
+# N.B. in many of the tests below we overwrite the resource.eventlog
+# to test specific corner cases.  Remove the resource checkpoint so we isolate
+# testing to just the resource eventlog.
+#
+
 test_expect_success 'resource can replay eventlog with pre v0.62 events' '
 	flux kvs put --raw resource.eventlog=- <<-EOT &&
 	{"timestamp":1713893408.8647039,"name":"resource-init","context":{"restart":false,"drain":{},"online":"","exclude":""}}
@@ -431,7 +437,9 @@ test_expect_success 'resource can replay eventlog with pre v0.62 events' '
 	{"timestamp":1713906351.000000,"name":"drain","context":{"idset":"2","reason":"underwear","overwrite":1}}
 	{"timestamp":1713906369.9485908,"name":"resource-init","context":{"restart":true,"drain":{"2":{"timestamp":1713906351.000000,"reason":"underwear"}},"online":"","exclude":""}}
 	EOT
-	flux module reload resource noverify
+	flux module remove resource &&
+	flux kvs unlink -f checkpoint.resource &&
+	flux module load resource noverify
 '
 test_expect_success 'nodes drained in old eventlog are drained after replay' '
 	flux resource drain -n -o "{ranks} {reason}" >legacydrain.out &&
@@ -445,7 +453,9 @@ test_expect_success 'resource can replay eventlog with bad ranks' '
 	flux kvs put --raw resource.eventlog=- <<-EOT &&
 	{"timestamp":1713906351.000000,"name":"drain","context":{"idset":"42","nodelist":"fake42","reason":"","overwrite":0}}
 	EOT
-	flux module reload resource noverify
+	flux module remove resource &&
+	flux kvs unlink -f checkpoint.resource &&
+	flux module load resource noverify
 '
 
 test_expect_success 'no nodes are drained after replay' '
@@ -456,7 +466,9 @@ test_expect_success 'reload resource with two nodes drained' '
 	flux kvs put --raw resource.eventlog=- <<-EOT &&
 	{"timestamp":1713906350.984611,"name":"drain","context":{"idset":"1-2","nodelist":"fake[1-2]","reason":"uvula","overwrite":0}}
 	EOT
-	flux module reload resource noverify
+	flux module remove resource &&
+	flux kvs unlink -f checkpoint.resource &&
+	flux module load resource noverify
 '
 
 test_expect_success 'the correct two nodes are drained after replay' '
@@ -471,7 +483,9 @@ test_expect_success 'reload resource with two nodes remapped' '
 	flux kvs put --raw resource.eventlog=- <<-EOT &&
 	{"timestamp":1713906350.984611,"name":"drain","context":{"idset":"1-2","nodelist":"fake[2-3]","reason":"uvula","overwrite":0}}
 	EOT
-	flux module reload resource noverify
+	flux module remove resource &&
+	flux kvs unlink -f checkpoint.resource &&
+	flux module load resource noverify
 '
 
 test_expect_success 'the remapped nodes are drained after replay' '
@@ -486,7 +500,9 @@ test_expect_success 'reload resource with two nodes remapped, one bad host' '
 	flux kvs put --raw resource.eventlog=- <<-EOT &&
 	{"timestamp":1713906350.984611,"name":"drain","context":{"idset":"1-2","nodelist":"fake[3-4]","reason":"uvula","overwrite":0}}
 	EOT
-	flux module reload resource noverify
+	flux module remove resource &&
+	flux kvs unlink -f checkpoint.resource &&
+	flux module load resource noverify
 '
 
 test_expect_success 'the remapped nodes are drained after replay' '
@@ -499,6 +515,7 @@ test_expect_success 'the remapped nodes are drained after replay' '
 
 test_expect_success 'a malformed event in the eventlog prevents loading' '
 	flux module remove -f resource &&
+	flux kvs unlink -f checkpoint.resource &&
 	flux kvs put --raw resource.eventlog=- <<-EOT &&
 	{}
 	EOT
@@ -506,6 +523,7 @@ test_expect_success 'a malformed event in the eventlog prevents loading' '
 '
 test_expect_success 'a malformed drain context in the eventlog prevents loading' '
 	flux module remove -f resource &&
+	flux kvs unlink -f checkpoint.resource &&
 	flux kvs put --raw resource.eventlog=- <<-EOT &&
 	{"timestamp":1713906350.984611,"name":"drain","context":{}}
 	EOT
@@ -513,6 +531,7 @@ test_expect_success 'a malformed drain context in the eventlog prevents loading'
 '
 test_expect_success 'a malformed undrain context in the eventlog fails' '
 	flux module remove -f resource &&
+	flux kvs unlink -f checkpoint.resource &&
 	flux kvs put --raw resource.eventlog=- <<-EOT &&
 	{"timestamp":1713906350.984611,"name":"undrain","context":{}}
 	EOT

--- a/t/t2319-resource-history.t
+++ b/t/t2319-resource-history.t
@@ -1,0 +1,630 @@
+#!/bin/sh
+
+test_description='Test resource eventlog checkpointing and eventlog truncation'
+
+. `dirname $0`/sharness.sh
+
+SIZE=4
+test_under_flux $SIZE full --test-hosts=fake[0-3]
+
+has_resource_event () {
+	flux kvs eventlog get resource.eventlog | awk '{ print $2 }' | grep $1
+}
+
+# fake hostnames match the ones set on the broker command line
+test_expect_success 'load fake resources' '
+	flux module remove sched-simple &&
+	flux R encode -r 0-3 -c 0-1 -H fake[0-3] >R &&
+	flux resource reload R &&
+	flux module load sched-simple
+'
+
+test_expect_success 'unload resource module' '
+	flux module remove resource
+'
+
+#
+# first set of tests, check drain state checkpoint and truncation by
+# default
+#
+
+test_expect_success 'resource module checkpointed empty drain state' '
+	flux kvs get checkpoint.resource > drain_state1.out &&
+	jq -e ".drain_state == {}" < drain_state1.out
+'
+
+test_expect_success 'load resource module' '
+	flux module load resource noverify
+'
+
+test_expect_success 'drain some nodes' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 0 &&
+	flux resource drain 1 test_reason_1 &&
+	flux resource drain 2-3 test_reason_2_3 &&
+	test $(flux resource status -s drain -no {nnodes}) -eq 3 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status1.out &&
+	cat >drain_status1.exp<<-EOT &&
+	fake1,test_reason_1
+	fake[2-3],test_reason_2_3
+	EOT
+	test_cmp drain_status1.exp drain_status1.out
+'
+
+test_expect_success 'resource eventlog has 2 drain events' '
+	test $(has_resource_event drain | wc -l) -eq 2
+'
+
+test_expect_success 'unload resource module' '
+	flux module remove resource
+'
+
+test_expect_success 'resource module checkpointed current drain state' '
+	flux kvs get checkpoint.resource > drain_state2.out &&
+	jq -e ".drain_state.\"1\".nodelist == \"fake1\"" < drain_state2.out &&
+	jq -e ".drain_state.\"2-3\".nodelist == \"fake[2-3]\"" < drain_state2.out
+'
+
+test_expect_success 'load resource module' '
+	flux module load resource noverify
+'
+
+test_expect_success 'drain status is identical to before the reload' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 3 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status2.out &&
+	cat >drain_status2.exp<<-EOT &&
+	fake1,test_reason_1
+	fake[2-3],test_reason_2_3
+	EOT
+	test_cmp drain_status2.exp drain_status2.out
+'
+
+test_expect_success 'resource eventlog has truncated events' '
+	test $(has_resource_event drain | wc -l) -eq 0
+'
+
+test_expect_success 'unload resource module' '
+	flux module remove resource
+'
+
+test_expect_success 'resource module checkpointed current drain state' '
+	flux kvs get checkpoint.resource > drain_state3.out &&
+	jq -e ".drain_state.\"1\".nodelist == \"fake1\"" < drain_state3.out &&
+	jq -e ".drain_state.\"2-3\".nodelist == \"fake[2-3]\"" < drain_state3.out
+'
+
+#
+# second set of tests check drain state correct if there is no
+# checkpoint (i.e. first time using an updated resource module, or a
+# checkpoint failed)
+#
+
+test_expect_success 'reset test state by clearing kvs resource info' '
+	flux kvs unlink -f resource.eventlog &&
+	flux kvs unlink -f checkpoint.resource &&
+	flux module load resource noverify
+'
+
+test_expect_success 'drain some nodes' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 0 &&
+	flux resource drain 1 test_reason_1 &&
+	flux resource drain 2-3 test_reason_2_3 &&
+	test $(flux resource status -s drain -no {nnodes}) -eq 3 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status3.out &&
+	cat >drain_status3.exp<<-EOT &&
+	fake1,test_reason_1
+	fake[2-3],test_reason_2_3
+	EOT
+	test_cmp drain_status3.exp drain_status3.out
+'
+
+test_expect_success 'unload resource module' '
+	flux module remove resource
+'
+
+test_expect_success 'resource module checkpointed current drain state' '
+	flux kvs get checkpoint.resource > drain_state4.out &&
+	jq -e ".drain_state.\"1\".nodelist == \"fake1\"" < drain_state4.out &&
+	jq -e ".drain_state.\"2-3\".nodelist == \"fake[2-3]\"" < drain_state4.out
+'
+
+test_expect_success 'clear checkpoint to emulate first time using resource module' '
+	flux kvs unlink checkpoint.resource
+'
+
+test_expect_success 'load resource module' '
+	flux module load resource noverify
+'
+
+test_expect_success 'drain status is identical to before the reload, no checkpoint is ok' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 3 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status4.out &&
+	cat >drain_status4.exp<<-EOT &&
+	fake1,test_reason_1
+	fake[2-3],test_reason_2_3
+	EOT
+	test_cmp drain_status4.exp drain_status4.out
+'
+
+test_expect_success 'resource eventlog still has 2 drain events' '
+	test $(has_resource_event drain | wc -l) -eq 2
+'
+
+test_expect_success 'unload resource module' '
+	flux module remove resource
+'
+
+test_expect_success 'resource module checkpointed current drain state' '
+	flux kvs get checkpoint.resource > drain_state5.out &&
+	jq -e ".drain_state.\"1\".nodelist == \"fake1\"" < drain_state5.out &&
+	jq -e ".drain_state.\"2-3\".nodelist == \"fake[2-3]\"" < drain_state5.out
+'
+
+#
+# third set of tests check basic history / eventlog truncation if history set to 0
+#
+
+test_expect_success 'load resource module' '
+	flux module load resource noverify
+'
+
+test_expect_success 'invalid configuration of history results in error' '
+	test_must_fail flux config load <<-EOF
+	[resource]
+	history = "foobar"
+	EOF
+'
+
+test_expect_success 'configure truncation' '
+	flux config load <<-EOF
+	[resource]
+	history = "0"
+	EOF
+'
+
+test_expect_success 'reload resource module' '
+	flux module reload resource noverify
+'
+
+test_expect_success 'drain status is identical to before the reload' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 3 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status5.out &&
+	cat >drain_status5.exp<<-EOT &&
+	fake1,test_reason_1
+	fake[2-3],test_reason_2_3
+	EOT
+	test_cmp drain_status5.exp drain_status5.out
+'
+
+test_expect_success 'resource eventlog truncated, drain events are now gone' '
+	test $(has_resource_event drain | wc -l) -eq 0
+'
+
+#
+# fourth set of tests check basic history / eventlog truncation if history set to inf
+#
+
+test_expect_success 'reset test state by clearing kvs resource info' '
+	flux module remove resource &&
+	flux kvs unlink -f resource.eventlog &&
+	flux kvs unlink -f checkpoint.resource &&
+	flux module load resource noverify
+'
+
+test_expect_success 'drain some nodes' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 0 &&
+	flux resource drain 1 test_reason_1 &&
+	flux resource drain 2-3 test_reason_2_3 &&
+	test $(flux resource status -s drain -no {nnodes}) -eq 3 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status6.out &&
+	cat >drain_status6.exp<<-EOT &&
+	fake1,test_reason_1
+	fake[2-3],test_reason_2_3
+	EOT
+	test_cmp drain_status6.exp drain_status6.out
+'
+
+test_expect_success 'unload resource module' '
+	flux module remove resource
+'
+
+test_expect_success 'resource module checkpointed current drain state' '
+	flux kvs get checkpoint.resource > drain_state6.out &&
+	jq -e ".drain_state.\"1\".nodelist == \"fake1\"" < drain_state6.out &&
+	jq -e ".drain_state.\"2-3\".nodelist == \"fake[2-3]\"" < drain_state6.out
+'
+
+test_expect_success 'configure no truncation' '
+	flux config load <<-EOF
+	[resource]
+	history = "inf"
+	EOF
+'
+
+test_expect_success 'load resource module' '
+	flux module load resource noverify
+'
+
+test_expect_success 'drain status is identical to before the reload' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 3 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status7.out &&
+	cat >drain_status7.exp<<-EOT &&
+	fake1,test_reason_1
+	fake[2-3],test_reason_2_3
+	EOT
+	test_cmp drain_status7.exp drain_status7.out
+'
+
+test_expect_success 'resource eventlog history is preserved' '
+	test $(has_resource_event drain | wc -l) -eq 2
+'
+
+#
+# fifth set of tests check eventlog will replay events that are newer
+# than the most recent drain state checkpoint
+#
+
+test_expect_success 'reset test state by clearing kvs resource info' '
+	flux module remove resource &&
+	flux kvs unlink resource.eventlog &&
+	flux kvs unlink checkpoint.resource &&
+	flux module load resource noverify
+'
+
+test_expect_success 'reconfigure truncation' '
+	flux config load <<-EOF &&
+	[resource]
+	history = "0"
+	EOF
+	flux module reload resource noverify
+'
+
+test_expect_success 'drain a node' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 0 &&
+	flux resource drain 1 test_reason_1 &&
+	test $(flux resource status -s drain -no {nnodes}) -eq 1 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status8.out &&
+	cat >drain_status8.exp<<-EOT &&
+	fake1,test_reason_1
+	EOT
+	test_cmp drain_status8.exp drain_status8.out
+'
+
+test_expect_success 'unload resource module' '
+	flux module remove resource
+'
+
+test_expect_success 'resource module checkpointed current drain state' '
+	flux kvs get checkpoint.resource > drain_state7.out &&
+	jq -e ".drain_state.\"1\".nodelist == \"fake1\"" < drain_state7.out
+'
+
+# to ensure timestamp is in future, pick timestamp way out
+test_expect_success 'resource will replay events after checkpoint' '
+	flux kvs put --raw resource.eventlog=- <<-EOT &&
+	{"timestamp":4000000000.000000,"name":"drain","context":{"idset":"2","nodelist":"fake2","reason":"test_reason_2","overwrite":0}}
+	EOT
+	flux module load resource noverify
+'
+
+test_expect_success 'drain status now includes additional drain from resource.eventlog' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 2 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status9.out &&
+	cat >drain_status9.exp<<-EOT &&
+	fake1,test_reason_1
+	fake2,test_reason_2
+	EOT
+	test_cmp drain_status9.exp drain_status9.out
+'
+
+test_expect_success 'unload resource module' '
+	flux module remove resource
+'
+
+test_expect_success 'resource module checkpointed current drain state' '
+	flux kvs get checkpoint.resource > drain_state8.out &&
+	jq -e ".drain_state.\"1\".nodelist == \"fake1\"" < drain_state8.out &&
+	jq -e ".drain_state.\"2\".nodelist == \"fake2\"" < drain_state8.out
+'
+
+# to ensure timestamp is in future, pick timestamp way out
+test_expect_success 'resource will replay events after checkpoint with bad rank' '
+	flux kvs put --raw resource.eventlog=- <<-EOT &&
+	{"timestamp":4000000001.000000,"name":"drain","context":{"idset":"0","nodelist":"fake3","reason":"test_reason_3","overwrite":0}}
+	EOT
+	flux module load resource noverify
+'
+
+test_expect_success 'drain status now includes additional drain from resource.eventlog' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 3 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status10.out &&
+	cat >drain_status10.exp<<-EOT &&
+	fake1,test_reason_1
+	fake2,test_reason_2
+	fake3,test_reason_3
+	EOT
+	test_cmp drain_status10.exp drain_status10.out
+'
+
+test_expect_success 'unload resource module' '
+	flux module remove resource
+'
+
+test_expect_success 'resource module checkpointed current drain state' '
+	flux kvs get checkpoint.resource > drain_state9.out &&
+	jq -e ".drain_state.\"1\".nodelist == \"fake1\"" < drain_state9.out &&
+	jq -e ".drain_state.\"2\".nodelist == \"fake2\"" < drain_state9.out &&
+	jq -e ".drain_state.\"3\".nodelist == \"fake3\"" < drain_state9.out
+'
+
+# to ensure timestamp is in future, pick timestamp way out
+test_expect_success 'resource will ignore invalid nodes' '
+	flux kvs put --raw resource.eventlog=- <<-EOT &&
+	{"timestamp":4000000002.000000,"name":"drain","context":{"idset":"0","nodelist":"fake13","reason":"test_reason_13","overwrite":0}}
+	EOT
+	flux module load resource noverify
+'
+
+test_expect_success 'drain status stays the same despite fake node in eventlog' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 3 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status11.out &&
+	cat >drain_status11.exp<<-EOT &&
+	fake1,test_reason_1
+	fake2,test_reason_2
+	fake3,test_reason_3
+	EOT
+	test_cmp drain_status11.exp drain_status11.out
+'
+
+#
+# sixth set of tests check that drain reason is preserved correctly
+#
+
+test_expect_success 'reset test state by clearing kvs resource info' '
+	flux module remove resource &&
+	flux kvs unlink resource.eventlog &&
+	flux kvs unlink checkpoint.resource &&
+	flux module load resource noverify
+'
+
+test_expect_success 'drain some nodes, atleast one without a reason' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 0 &&
+	flux resource drain 1 test_reason_1 &&
+	flux resource drain 2 &&
+	test $(flux resource status -s drain -no {nnodes}) -eq 2 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status12.out &&
+	cat >drain_status12.exp<<-EOT &&
+	fake1,test_reason_1
+	fake2,
+	EOT
+	test_cmp drain_status12.exp drain_status12.out
+'
+
+test_expect_success 'resource eventlog has 2 drain events' '
+	test $(has_resource_event drain | wc -l) -eq 2
+'
+
+test_expect_success 'unload resource module' '
+	flux module remove resource
+'
+
+test_expect_success 'resource module checkpointed current drain state' '
+	flux kvs get checkpoint.resource > drain_state10.out &&
+	jq -e ".drain_state.\"1\".nodelist == \"fake1\"" < drain_state10.out &&
+	jq -e ".drain_state.\"2\".nodelist == \"fake2\"" < drain_state10.out
+'
+
+test_expect_success 'load resource module' '
+	flux module load resource noverify
+'
+
+test_expect_success 'drain status is identical to before the reload' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 2 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status13.out &&
+	cat >drain_status13.exp<<-EOT &&
+	fake1,test_reason_1
+	fake2,
+	EOT
+	test_cmp drain_status13.exp drain_status13.out
+'
+
+test_expect_success 'resource eventlog has 0 drain events, eventlog truncated' '
+	test $(has_resource_event drain | wc -l) -eq 0
+'
+
+test_expect_success 'update drain event messages, update of one requires force' '
+	test_must_fail flux resource drain 1 test_reason_1_update &&
+	flux resource drain --force 1 test_reason_1_update &&
+	flux resource drain 2 test_reason_2_update
+'
+
+test_expect_success 'drain status is updated with the new reasons' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 2 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status14.out &&
+	cat >drain_status14.exp<<-EOT &&
+	fake1,test_reason_1_update
+	fake2,test_reason_2_update
+	EOT
+	test_cmp drain_status14.exp drain_status14.out
+'
+
+test_expect_success 'resource eventlog has 2 drain events for the two updates' '
+	test $(has_resource_event drain | wc -l) -eq 2
+'
+
+test_expect_success 'reload resource module' '
+	flux module reload resource noverify
+'
+
+test_expect_success 'drain status is identical to before the reload' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 2 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status15.out &&
+	cat >drain_status15.exp<<-EOT &&
+	fake1,test_reason_1_update
+	fake2,test_reason_2_update
+	EOT
+	test_cmp drain_status15.exp drain_status15.out
+'
+
+test_expect_success 'resource eventlog has 0 drain events, eventlog truncated' '
+	test $(has_resource_event drain | wc -l) -eq 0
+'
+
+#
+# seventh set of tests check that history of eventlog is preserved if requested
+#
+
+test_expect_success 'configure history with non-zero value' '
+	flux config load <<-EOF
+	[resource]
+	history = "100d"
+	EOF
+'
+
+test_expect_success 'reset test and add long ago historical and recent drain data' '
+	flux module remove resource &&
+	flux kvs unlink resource.eventlog &&
+	flux kvs unlink checkpoint.resource &&
+	now=$(date +%s) &&
+	flux kvs eventlog append --timestamp=1000.0 resource.eventlog drain \
+	     "{\"idset\":\"1\",\"nodelist\":\"fake1\",\"reason\":\"test_reason_1\",\"overwrite\":0}" &&
+	flux kvs eventlog append --timestamp=${now} resource.eventlog drain \
+	     "{\"idset\":\"2\",\"nodelist\":\"fake2\",\"reason\":\"test_reason_2\",\"overwrite\":0}" &&
+	flux module load resource noverify
+'
+
+# N.B. note, we cleared the checkpoint of drain state above.  So the
+# first time we reload the resource module, there was no checkpoint,
+# therefore no drain events will be truncated
+
+test_expect_success 'drain status has two drained nodes' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 2 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status16.out &&
+	cat >drain_status16.exp<<-EOT &&
+	fake1,test_reason_1
+	fake2,test_reason_2
+	EOT
+	test_cmp drain_status16.exp drain_status16.out
+'
+
+test_expect_success 'resource eventlog contains two drain events' '
+	test $(has_resource_event drain | wc -l) -eq 2
+'
+
+test_expect_success 'reload resource module' '
+	flux module reload resource noverify
+'
+
+test_expect_success 'drain status still has two drained nodes' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 2 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status17.out &&
+	cat >drain_status17.exp<<-EOT &&
+	fake1,test_reason_1
+	fake2,test_reason_2
+	EOT
+	test_cmp drain_status17.exp drain_status17.out
+'
+
+test_expect_success 'resource eventlog now contains only 1 drain event' '
+	test $(has_resource_event drain | wc -l) -eq 1 &&
+	flux kvs eventlog get resource.eventlog | grep drain | grep fake2
+'
+
+#
+# eighth set of tests check resource.eventlog corner case ok
+#
+
+# N.B. this emulates resource.eventlog completely truncated and then
+# broker is killed
+test_expect_success 'reset test and set resource.eventlog to empty string' '
+	flux module remove resource &&
+	flux kvs unlink resource.eventlog &&
+	flux kvs unlink checkpoint.resource &&
+	flux kvs put resource.eventlog= &&
+	flux module load resource noverify
+'
+
+test_expect_success 'reload resource module for good measure' '
+	flux module reload resource noverify
+'
+
+test_expect_success 'drain status has zero drained nodes' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 0
+'
+
+test_expect_success 'drain a node' '
+	flux resource drain 1 test_reason_1 &&
+	test $(flux resource status -s drain -no {nnodes}) -eq 1 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status18.out &&
+	cat >drain_status18.exp<<-EOT &&
+	fake1,test_reason_1
+	EOT
+	test_cmp drain_status18.exp drain_status18.out
+'
+
+test_expect_success 'reload resource module' '
+	flux module reload resource noverify
+'
+
+test_expect_success 'drain status has one drained nodes' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 1 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status19.out &&
+	cat >drain_status19.exp<<-EOT &&
+	fake1,test_reason_1
+	EOT
+	test_cmp drain_status19.exp drain_status19.out
+'
+
+#
+# ninth set of tests check that special notruncate option works
+#
+
+test_expect_success 'configure history with full truncation' '
+	flux config load <<-EOF
+	[resource]
+	history = "0"
+	EOF
+'
+
+test_expect_success 'reset test state by clearing kvs resource info' '
+	flux module remove resource &&
+	flux kvs unlink resource.eventlog &&
+	flux kvs unlink checkpoint.resource &&
+	flux module load resource noverify
+'
+
+test_expect_success 'drain some nodes' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 0 &&
+	flux resource drain 1 test_reason_1 &&
+	flux resource drain 2 test_reason_2 &&
+	test $(flux resource status -s drain -no {nnodes}) -eq 2 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status20.out &&
+	cat >drain_status20.exp<<-EOT &&
+	fake1,test_reason_1
+	fake2,test_reason_2
+	EOT
+	test_cmp drain_status20.exp drain_status20.out
+'
+
+test_expect_success 'resource eventlog contains two drain events' '
+	test $(has_resource_event drain | wc -l) -eq 2
+'
+
+test_expect_success 'reload resource module without truncation' '
+	flux module reload resource noverify notruncate
+'
+
+test_expect_success 'drain status still has two drained nodes' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 2 &&
+	flux resource drain -no "sort:nodelist {nodelist},{reason}" > drain_status21.out &&
+	cat >drain_status21.exp<<-EOT &&
+	fake1,test_reason_1
+	fake2,test_reason_2
+	EOT
+	test_cmp drain_status21.exp drain_status21.out
+'
+
+test_expect_success 'resource eventlog still contains 2 drain events' '
+	test $(has_resource_event drain | wc -l) -eq 2
+'
+
+test_done

--- a/t/t2353-resource-eventlog.t
+++ b/t/t2353-resource-eventlog.t
@@ -26,10 +26,17 @@ test_expect_success 'unload scheduler' '
 
 for eventlog in ${SHARNESS_TEST_SRCDIR}/resource/resource.eventlog.*; do
 	filename=$(basename $eventlog)
+        #
+        # N.B. below we overwrite the resource.eventlog to test
+        # specific corner cases.  Remove the resource checkpoint so we
+        # isolate testing to just the resource eventlog.
+        #
 	test_expect_success "load test resources $filename" '
 		flux dmesg -C &&
 		flux kvs put --raw resource.eventlog=- <$eventlog &&
-		flux module reload resource noverify
+		flux module remove resource &&
+		flux kvs unlink -f checkpoint.resource &&
+		flux module load resource noverify
 	'
 	test_expect_success 'eventlog upgrade reduced entry count' '
 		flux dmesg | grep "resource.eventlog: reduced"

--- a/t/t2353-resource-eventlog.t
+++ b/t/t2353-resource-eventlog.t
@@ -43,7 +43,7 @@ for eventlog in ${SHARNESS_TEST_SRCDIR}/resource/resource.eventlog.*; do
 	'
 	test_expect_success 'reloading resource module does not rewrite log' '
 		flux dmesg -C &&
-		flux module reload resource noverify &&
+		flux module reload resource noverify notruncate &&
 		flux dmesg >dmesg.out &&
 		test_must_fail grep "resource.eventlog: reduced" dmesg.out
 	'

--- a/t/t2355-resource-journal.t
+++ b/t/t2355-resource-journal.t
@@ -40,7 +40,7 @@ test_expect_success 'resource-define event was posted to the KVS' '
 '
 
 test_expect_success 'reload resource with monitor-force-up' '
-	flux module reload resource monitor-force-up
+	flux module reload resource monitor-force-up notruncate
 '
 test_expect_success 'flux resource eventlog works' '
 	flux resource eventlog -f json --wait=resource-define >forcelog


### PR DESCRIPTION
Problem: The resource.eventlog current can grow without bound.  It is currently replayed from beginning to end to arrive at the
current drain state of nodes in the instance.

Solution: Whenever the resource module is unloaded, checkpoint the current drain state to check.resource.drain_state.  This
gives us the basis by which to truncate the resource.eventlog since we no longer need to replay the full history of the eventlog.

Support an eventlog-truncate and eventlog-truncate-preserve-time configuration option.  This will inform the resource module to
truncate the eventlog if it is able to, and preserve a portion of that eventlog's history if so desired.

Fixes #6132

---

notes: 

wanted to get this PR up before the weekend for initial high level thoughts

I'm not super enamored with my config option names, happy to take suggestions :-)

a few extra tests could be added:

- what if nodes in the drain state checkpoint don't exist anymore?  it shouldn't do anything.
- no truncation in recovery mode

there is possibly a corner case, I need to "flush" the contents of `reslog` before I truncate since an event could be added to reslog, not complete, then i overwrite the resource.eventlog during truncate code.

maybe I should remove the module command line arg of "eventlog-truncate", it was useful in early testing, but maybe shouldn't be there now

