### PR TITLE
broker: mark `content.hash` broker attribute immutable

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -425,7 +425,7 @@ content.backing-module
    on rank 0 where the content backing store is active.  Default:
    ``content-sqlite``.
 
-content.hash
+content.hash:ref :`[readonly] <attr_readonly>`
    The selected hash algorithm.  Default ``sha1``.  Other options: ``sha256``.
 
 content.dump

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -155,7 +155,7 @@ static struct registered_attr attrtab[] = {
 
     // content
     { "content.backing-module", 0 },
-    { "content.hash", 0 },
+    { "content.hash", ATTR_IMMUTABLE },
     { "content.dump", ATTR_RUNTIME },
     { "content.restore", ATTR_RUNTIME },
 


### PR DESCRIPTION
Problem: Without the immutable flag, `flux_attr_get("content.hash")` performs a synchronous RPC every time instead of using a cached value. Since job-exec calls `flux_kvs_namespace_create()` for every job start, and that function fetches `content.hash`, this creates a job throughput bottleneck.

Mark content.hash immutable to enable caching. This doubled sched-backfill throughput (321 -> 676 job/s) in testing.