### PR TITLE
docker: update default flux-security version to v0.15.0

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -16,7 +16,7 @@ JOBS=2
 MOUNT_HOME_ARGS="--volume=$HOME:$HOME -e HOME"
 
 if test "$PROJECT" = "flux-core"; then
-  FLUX_SECURITY_VERSION=0.14.0
+  FLUX_SECURITY_VERSION=0.15.0
   POISON=t
 fi
 


### PR DESCRIPTION
Problem: The docker-run-checks.sh script encodes flux-security v0.14 as the default version to use in CI, but the latest version is v0.15.

Update the default FLUX_SECURITY_VERSION in docker-run-checks.sh to v0.15.