### PR TITLE
python: improve handling of the `sort:` prefix in `UtilFormat`

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -830,6 +830,7 @@ class OutputFormat:
 
     formatter = UtilFormatter
     headings: Mapping[str, str] = {}
+    _sort_prefix_re = re.compile(r"sort:([^{\s]+)")
 
     class HeaderFormatter(UtilFormatter):
         """Custom formatter for flux utilities header row.
@@ -879,16 +880,12 @@ class OutputFormat:
         #  self.sort_keys is a list of (key(str), reverse(bool)) tuples.
         self.sort_keys = []
         if self.format_list and self.format_list[0][0].startswith("sort:"):
-            #  Remove sort:keys, prefix from format_list, replace with
-            #   empty string:
+            #  Remove sort:keys prefix from format_list,
+            #  replace with empty string:
             sort_spec = self.format_list[0][0]
             self.format_list[0][0] = ""
-
-            #  Store sort keys for later use
-            self.set_sort_keys(sort_spec[5:])
-
-            #  Strip sort_spec from beginning of fmt
-            fmt = fmt.lstrip(sort_spec)
+            #  Parse and strip the sort prefix from fmt
+            fmt = self._parse_and_strip_sort_prefix(sort_spec, fmt)
 
         #  Save format after removal of sort keys:
         self.fmt = fmt
@@ -1298,6 +1295,36 @@ class OutputFormat:
 
         #  Return new format string:
         return self._sort_prefix() + "".join(self._fmt_tuple(*x) for x in format_list)
+
+    def _parse_and_strip_sort_prefix(self, sort_spec, fmt):
+        """
+        Extract sort keys from a sort prefix and strip it from the format
+        string.
+
+        The sort prefix has the form "sort:key1,key2,-key3" followed
+        by whitespace or the start of the format string. This method
+        extracts only the key names, stopping at the first whitespace or
+        '{' character to avoid accidentally including punctuation from
+        the format string itself (issue #7590).
+
+        Args:
+            sort_spec (str): The text portion from format_list[0][0]
+            starting with "sort:"
+            fmt (str): The original format string
+
+        Returns:
+            str: The format string with the sort prefix removed
+        """
+        match = self._sort_prefix_re.match(sort_spec)
+        if match:
+            sort_keys_str = match.group(1)
+            self.set_sort_keys(sort_keys_str)
+            # Strip "sort:keys" and exactly one trailing space if present
+            prefix_len = len("sort:") + len(sort_keys_str)
+            fmt = fmt[prefix_len:]
+            if fmt.startswith(" "):
+                fmt = fmt[1:]
+        return fmt
 
     def set_sort_keys(self, sort_keys):
         """

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -880,12 +880,10 @@ class OutputFormat:
         #  self.sort_keys is a list of (key(str), reverse(bool)) tuples.
         self.sort_keys = []
         if self.format_list and self.format_list[0][0].startswith("sort:"):
-            #  Remove sort:keys prefix from format_list,
-            #  replace with empty string:
-            sort_spec = self.format_list[0][0]
-            self.format_list[0][0] = ""
-            #  Parse and strip the sort prefix from fmt
-            fmt = self._parse_and_strip_sort_prefix(sort_spec, fmt)
+            #  Remove sort:keys prefix from format_list and fmt
+            fmt, self.format_list[0][0] = self._parse_and_strip_sort_prefix(
+                self.format_list[0][0], fmt
+            )
 
         #  Save format after removal of sort keys:
         self.fmt = fmt
@@ -1114,7 +1112,9 @@ class OutputFormat:
     def _sort_prefix(self):
         if self.sort_keys:
             keys = [f"-{x}" if rev else x for x, rev in self.sort_keys]
-            return "sort:" + ",".join(keys) + " "
+            # Add trailing space only if original format had one
+            space = " " if getattr(self, "_sort_has_trailing_space", True) else ""
+            return "sort:" + ",".join(keys) + space
         return ""
 
     def get_format(self, orig=False, include_sort_prefix=True):
@@ -1301,30 +1301,38 @@ class OutputFormat:
         Extract sort keys from a sort prefix and strip it from the format
         string.
 
-        The sort prefix has the form "sort:key1,key2,-key3" followed
-        by whitespace or the start of the format string. This method
-        extracts only the key names, stopping at the first whitespace or
-        '{' character to avoid accidentally including punctuation from
-        the format string itself (issue #7590).
+        The sort prefix has the form "sort:key1,key2,-key3" followed by
+        whitespace or the start of the format string, which may contain
+        arbitrary characters the user wants to print. This method extracts
+        only the key names, stopping at the first whitespace or '{' character
+        to avoid accidentally including punctuation from the format string
+        itself (issue #7590).
 
         Args:
             sort_spec (str): The text portion from format_list[0][0]
-            starting with "sort:"
+                             starting with "sort:"
             fmt (str): The original format string
 
         Returns:
             str: The format string with the sort prefix removed
+            str: Remainder of string in format_list[0][0] not consumed
         """
         match = self._sort_prefix_re.match(sort_spec)
         if match:
             sort_keys_str = match.group(1)
             self.set_sort_keys(sort_keys_str)
-            # Strip "sort:keys" and exactly one trailing space if present
+            # Strip "sort:keys" and track if there was a trailing space
             prefix_len = len("sort:") + len(sort_keys_str)
+            # Save the rest of the string
+            rest = sort_spec[prefix_len:]
             fmt = fmt[prefix_len:]
             if fmt.startswith(" "):
+                self._sort_has_trailing_space = True
                 fmt = fmt[1:]
-        return fmt
+                rest = rest[1:]
+            else:
+                self._sort_has_trailing_space = False
+        return fmt, rest
 
     def set_sort_keys(self, sort_keys):
         """

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -1312,6 +1312,9 @@ class OutputFormat:
         self.sort_keys = []
         for key in sort_keys.split(","):
             key = key.strip()
+            # Skip empty keys (ignore trailing, double ',')
+            if not key:
+                continue
             reverse = False
             if key.startswith("-"):
                 reverse = True

--- a/t/python/t0024-util.py
+++ b/t/python/t0024-util.py
@@ -267,6 +267,56 @@ class TestOutputFormat(unittest.TestCase):
         formatter.sort_items(items)
         self.assertListEqual(items, [z, d, a])
 
+    def test_sort_empty_keys(self):
+        """Test that empty sort keys are skipped (issue #7590)"""
+        a = Item("a", 0, 2.2)
+        d = Item("d", 33, 1.1)
+        z = Item("z", 11, 1.0)
+
+        items = [z, a, d]
+        formatter = OutputFormat("{s}:{i}:{f}", headings=self.headings)
+
+        # Trailing comma should be ignored
+        formatter.set_sort_keys("s,")
+        formatter.sort_items(items)
+        self.assertListEqual(items, [a, d, z])
+
+        # Double comma should be ignored
+        items = [z, a, d]
+        formatter.set_sort_keys("s,,i")
+        formatter.sort_items(items)
+        self.assertListEqual(items, [a, d, z])
+
+        # Leading comma should be ignored
+        items = [z, a, d]
+        formatter.set_sort_keys(",s")
+        formatter.sort_items(items)
+        self.assertListEqual(items, [a, d, z])
+
+        # Multiple trailing commas
+        items = [z, a, d]
+        formatter.set_sort_keys("s,,,")
+        formatter.sort_items(items)
+        self.assertListEqual(items, [a, d, z])
+
+        # Whitespace-only key should be ignored
+        items = [z, a, d]
+        formatter.set_sort_keys("s,  ,i")
+        formatter.sort_items(items)
+        self.assertListEqual(items, [a, d, z])
+
+        # Multiple empty keys with whitespace variations
+        items = [z, a, d]
+        formatter.set_sort_keys(" , s , , i , ")
+        formatter.sort_items(items)
+        self.assertListEqual(items, [a, d, z])
+
+        # Reverse sort with empty keys
+        items = [z, a, d]
+        formatter.set_sort_keys("-s,,")
+        formatter.sort_items(items)
+        self.assertListEqual(items, [z, d, a])
+
     def test_sort_mixed_types(self):
         """Test sorting fields with mixed types (issue #7517)"""
         # Create items with mixed types - some fields are empty strings,

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -543,4 +543,62 @@ test_expect_success 'load scheduler' '
 	flux module load sched-simple
 '
 
+# Tests for issue #7590: sort key parsing with commas in format string
+test_expect_success 'drain two nodes with different reasons for sorting tests' '
+	flux resource drain 0 aardvark &&
+	flux resource drain 1 zebra
+'
+test_expect_success 'flux resource drain: sort keys work with comma in format (issue #7590)' '
+	flux resource drain -n -o "sort:reason {reason},{nodelist}" \
+		>drain-sort-comma.out &&
+	test_debug "cat drain-sort-comma.out" &&
+	cat >drain-sort-comma.exp <<-EOT &&
+	aardvark,fake0
+	zebra,fake1
+	EOT
+	test_cmp drain-sort-comma.exp drain-sort-comma.out
+'
+test_expect_success 'flux resource drain: multiple spaces after sort: preserved in output' '
+	flux resource drain -n -o "sort:reason  {reason} {nodelist}" \
+		>drain-sort-spaces.out &&
+	test_debug "cat drain-sort-spaces.out" &&
+	cat >drain-sort-spaces.exp <<-EOT &&
+	 aardvark fake0
+	 zebra fake1
+	EOT
+	test_cmp drain-sort-spaces.exp drain-sort-spaces.out
+'
+test_expect_success 'flux resource drain: tab after sort: preserved in output' '
+	flux resource drain -n -o "sort:reason	{reason} {nodelist}" \
+		>drain-sort-tab.out &&
+	test_debug "cat drain-sort-tab.out" &&
+	printf "\taardvark fake0\n\tzebra fake1\n" >drain-sort-tab.exp &&
+	test_cmp drain-sort-tab.exp drain-sort-tab.out
+'
+test_expect_success \
+'flux resource drain: other characters after sort: preserved in output' '
+	flux resource drain -n -o "sort:reason == {reason},{nodelist}" \
+		>drain-sort-other.out &&
+	test_debug "cat drain-sort-other.out" &&
+	cat <<-EOF >drain-sort-other.exp &&
+	== aardvark,fake0
+	== zebra,fake1
+	EOF
+	test_cmp drain-sort-other.exp drain-sort-other.out
+'
+test_expect_success \
+'flux resource drain: reverse sort works with comma in format' '
+	flux resource drain -n -o "sort:-reason {reason},{nodelist}" \
+		>drain-rsort-comma.out &&
+	test_debug "cat drain-rsort-comma.out" &&
+	cat >drain-rsort-comma.exp <<-EOT &&
+	zebra,fake1
+	aardvark,fake0
+	EOT
+	test_cmp drain-rsort-comma.exp drain-rsort-comma.out
+'
+test_expect_success 'undrain nodes for cleanup' '
+	flux resource undrain 0-1
+'
+
 test_done


### PR DESCRIPTION
As noted in #7590, there are some missing corner cases in handling of the `OutputFormat` `sort:` prefix. Any case that results in an empty sort key, e.g. trailing `,`, two commas in a row `,,` etc, results in an empty sort key and a confusing `Invalid sort key: ` error. This also could occur if one of the excluded fields for deduplication is first in the output format followed by a comma, because output formats are rewritten without those fields so `sort:nodelist {nodelist},{reason}` becomes `sort:nodelist ,{reason}` during deduplication runs.

The main fix is to ignore empty sort keys. However, at the same time it seemed good to improve handling of the format prefix that follows the `sort:` fields, so that is done here too. Now extra whitespace is preserved instead of eaten by the sort prefix, and separating the sort fields from the actual format is generally more robust.

Fixes #7590 