### PR TITLE
ci: fix push of `flux-core:latest` and `fluxoroma` docker images

### DIFF
--- a/src/test/docker-deploy.sh
+++ b/src/test/docker-deploy.sh
@@ -20,13 +20,6 @@ echo $DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
 log "docker push ${DOCKER_TAG}"
 docker push ${DOCKER_TAG}
 
-#  If this is the bookworm build, then also tag without image name:
-if echo "$DOCKER_TAG" | grep "bookworm" | grep -qv "386"; then
-    t="${DOCKER_REPO}:${GITHUB_TAG:-latest}"
-    log "docker push ${t}"
-    docker tag "$DOCKER_TAG" ${t} && docker push ${t}
-fi
-
 #  If this is the el8 build, then build fluxorama image
 if echo "$DOCKER_TAG" | grep -q "el8"; then
     FLUXORAMA="fluxrm/fluxorama"

--- a/src/test/docker-deploy.sh
+++ b/src/test/docker-deploy.sh
@@ -25,6 +25,10 @@ if echo "$DOCKER_TAG" | grep -q "el8"; then
     FLUXORAMA="fluxrm/fluxorama"
     docker build -t ${FLUXORAMA} src/test/docker/fluxorama
     docker push ${FLUXORAMA}
+    # Derive version from DOCKER_TAG if present (e.g. fluxrm/flux-core:el8-v0.85.0)
+    case "$DOCKER_TAG" in
+        *:el8-*) GITHUB_TAG="${DOCKER_TAG##*:el8-}" ;;
+    esac
     if test -n "$GITHUB_TAG"; then
         t=${FLUXORAMA}:${GITHUB_TAG}
         log "docker push ${t}"

--- a/src/test/docker-manifest.py
+++ b/src/test/docker-manifest.py
@@ -35,19 +35,20 @@ for entry in matrix["include"]:
 # latest docker images after a tag. (See flux-core#7225).
 tags = {k: v for k, v in tags.items() if len(v) > 1 or v[0] != k}
 
-# The bookworm image is the canonical "latest" build. Create a latest
+# The el10 image is the canonical "latest" build. Create a latest
 # manifest (and for tagged releases, also a versioned manifest) pointing
-# to the same per-arch images as the bookworm manifest.
-bookworm_key = f"{DOCKER_REPO}:bookworm"
-if bookworm_key in tags:
-    bookworm_sources = tags[bookworm_key]
+# to the same per-arch images as the el10 manifest.
+latest_distro = "el10"
+latest_key = f"{DOCKER_REPO}:{latest_distro}"
+if latest_key in tags:
+    latest_sources = tags[latest_key]
     github_tag = next(
         (entry["tag"] for entry in matrix["include"] if entry.get("tag")),
         None,
     )
-    tags[f"{DOCKER_REPO}:latest"] = bookworm_sources
+    tags[f"{DOCKER_REPO}:latest"] = latest_sources
     if github_tag:
-        tags[f"{DOCKER_REPO}:{github_tag}"] = bookworm_sources
+        tags[f"{DOCKER_REPO}:{github_tag}"] = latest_sources
 
 for tag in tags.keys():
     print(f"docker manifest create {tag}", *tags[tag])

--- a/src/test/docker-manifest.py
+++ b/src/test/docker-manifest.py
@@ -7,6 +7,8 @@ import json
 import subprocess
 from collections import defaultdict
 
+DOCKER_REPO = "fluxrm/flux-core"
+
 matrix = json.loads(
     subprocess.run(
         ["src/test/generate-matrix.py"], capture_output=True, text=True
@@ -17,7 +19,7 @@ tags = defaultdict(list)
 for entry in matrix["include"]:
     if "DOCKER_TAG" in entry["env"]:
         image = entry["image"]
-        base = f"fluxrm/flux-core:{image}"
+        base = f"{DOCKER_REPO}:{image}"
         docker_tag = entry["env"]["DOCKER_TAG"]
         tags[base].append(docker_tag)
         # This is also a tagged version
@@ -32,6 +34,20 @@ for entry in matrix["include"]:
 # CI from other projects to immediately pick up the new version when pulling
 # latest docker images after a tag. (See flux-core#7225).
 tags = {k: v for k, v in tags.items() if len(v) > 1 or v[0] != k}
+
+# The bookworm image is the canonical "latest" build. Create a latest
+# manifest (and for tagged releases, also a versioned manifest) pointing
+# to the same per-arch images as the bookworm manifest.
+bookworm_key = f"{DOCKER_REPO}:bookworm"
+if bookworm_key in tags:
+    bookworm_sources = tags[bookworm_key]
+    github_tag = next(
+        (entry["tag"] for entry in matrix["include"] if entry.get("tag")),
+        None,
+    )
+    tags[f"{DOCKER_REPO}:latest"] = bookworm_sources
+    if github_tag:
+        tags[f"{DOCKER_REPO}:{github_tag}"] = bookworm_sources
 
 for tag in tags.keys():
     print(f"docker manifest create {tag}", *tags[tag])


### PR DESCRIPTION
Since adding support for multiarch manifests, the push of the `latest` and `fluxorama` docker tags has been broken.

Fix the `latest` tag by moving its generation to `docker-manifest.py`.
Fix an issue with the `fluxorama` push by deriving the tag from `DOCKER_TAG`.

Fixes #7606