### PR TITLE
python: make `ply` a soft dependency for `JobspecV1`

### DIFF
--- a/src/bindings/python/flux/constraint/parser.py
+++ b/src/bindings/python/flux/constraint/parser.py
@@ -420,6 +420,17 @@ class ConstraintParser:
         p[0] = p[2]
 
 
+class MiniConstraintParser(ConstraintParser):
+    operator_map = {
+        None: "properties",
+        "host": "hostlist",
+        "hosts": "hostlist",
+        "rank": "ranks",
+    }
+    split_values = {"properties": ","}
+    combined_terms = {"properties"}
+
+
 if __name__ == "__main__":
     """
     Test command which can be run as flux python -m flux.constraint.parser

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -23,9 +23,7 @@ import yaml
 from _flux._core import ffi
 from flux import Flux, hostlist, idset
 from flux.cli.plugin import CLIPluginRegistry
-from flux.constraint.parser import ConstraintSyntaxError
 from flux.job._utils import (
-    MiniConstraintParser,
     URIArg,
     decode_duration,
     dependency_array_create,
@@ -2031,6 +2029,11 @@ class JobspecV1(Jobspec):
 
         # constraints
         if merged.requires is not None:
+            from flux.constraint.parser import (  # noqa: PLC0415
+                ConstraintSyntaxError,
+                MiniConstraintParser,
+            )
+
             constraint = " ".join(merged.requires)
             try:
                 self.setattr(

--- a/src/bindings/python/flux/job/_utils.py
+++ b/src/bindings/python/flux/job/_utils.py
@@ -30,7 +30,6 @@ except ModuleNotFoundError:
     from flux.utils import tomli as tomllib
 
 from flux import util
-from flux.constraint.parser import ConstraintParser
 from flux.util import dict_merge, get_treedict, set_treedict
 
 
@@ -97,17 +96,6 @@ def parse_signal_option(arg):
         raise ValueError(f"--signal={arg}: {exc}") from None
 
     return {"signum": signum, "timeleft": timeleft}
-
-
-class MiniConstraintParser(ConstraintParser):
-    operator_map = {
-        None: "properties",
-        "host": "hostlist",
-        "hosts": "hostlist",
-        "rank": "ranks",
-    }
-    split_values = {"properties": ","}
-    combined_terms = {"properties"}
 
 
 class URIArg:


### PR DESCRIPTION
Problem: Importing JobspecV1 unconditionally imports ply via the flux.constraint.parser module, even when the constraint parser is never used.

Move MiniConstraintParser from flux.job._utils into flux.constraint.parser, removing the top-level ConstraintParser import from _utils.py.  Replace the top-level ConstraintSyntaxError and MiniConstraintParser imports in Jobspec.py with a lazy import inside the apply_options() --requires handling block, so ply is only loaded when constraint parsing is actually needed.