### PR TITLE
broker: fix debug logging of module loader pid

### DIFF
--- a/src/broker/modhash.c
+++ b/src/broker/modhash.c
@@ -446,16 +446,7 @@ static int modhash_load_finalize (struct modhash *mh,
         return -1;
     }
     modhash_add (mh, p);
-
-    if (module_is_exec (p)) {
-        flux_log (mh->ctx->h,
-                  LOG_DEBUG,
-                  "insmod %s exec pid=%d",
-                  module_get_name (p),
-                  (int)module_get_pid (p));
-    }
-    else
-        flux_log (mh->ctx->h, LOG_DEBUG, "insmod %s", module_get_name (p));
+    flux_log (mh->ctx->h, LOG_DEBUG, "insmod %s", module_get_name (p));
     return 0;
 }
 

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -556,6 +556,12 @@ static void exec_state_cb (flux_subprocess_t *proc,
 
     switch (state) {
         case FLUX_SUBPROCESS_RUNNING:
+            flux_log (p->h,
+                      LOG_DEBUG,
+                      "%s %s pid=%d",
+                      loader,
+                      module_get_name (p),
+                      (int)flux_subprocess_pid (proc));
             break;
         case FLUX_SUBPROCESS_FAILED:
             module_errprintf (p,
@@ -740,21 +746,6 @@ ssize_t module_get_recv_queue_count (module_t *p)
                       sizeof (count)) < 0)
         return -1;
     return count;
-}
-
-
-bool module_is_exec (module_t *p)
-{
-    if (!p || !p->is_exec)
-        return false;
-    return true;
-}
-
-pid_t module_get_pid (module_t *p)
-{
-    if (!p || !p->is_exec)
-        return -1;
-    return flux_subprocess_pid (p->exec.p);
 }
 
 char *module_name_frompath (const char *path)

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -135,9 +135,6 @@ bool module_is_subscribed (module_t *p, const char *topic);
 ssize_t module_get_send_queue_count (module_t *p);
 ssize_t module_get_recv_queue_count (module_t *p);
 
-bool module_is_exec (module_t *p);
-pid_t module_get_pid (module_t *p);
-
 /* Guess the broker module's name based on its path.
  * Caller must free the returned string.
  */

--- a/t/t0100-modprobe.t
+++ b/t/t0100-modprobe.t
@@ -1607,16 +1607,16 @@ test_expect_success 'modprobe: module exec=True runs module as process' '
 	mkdir modprobe.d &&
 	test_when_finished "rm -rf modprobe.d" &&
 	cat <<-EOF >modprobe.d/exec.toml &&
-	sched-simple.exec = true
+	heartbeat.exec = true
 	EOF
-	FLUX_MODPROBE_PATH=$(pwd) flux modprobe show sched-simple \
+	FLUX_MODPROBE_PATH=$(pwd) flux modprobe show heartbeat \
 		| jq -e ".exec == true" &&
 	FLUX_MODPROBE_PATH=$(pwd) flux start flux dmesg -H >exec.log &&
-	grep sched-simple exec.log &&
-	grep "sched-simple exec" exec.log
+	grep heartbeat exec.log &&
+	grep "module-exec heartbeat" exec.log
 '
 test_expect_success 'modprobe: module exec option can be set in broker config' '
-	flux alloc -N1 --conf=modules.sched-simple.exec=true flux dmesg -H \
-	  | grep "sched-simple exec"
+	flux alloc -N1 --conf=modules.job-manager.exec=true flux dmesg -H \
+	  | grep "module-exec job-manager"
 '
 test_done


### PR DESCRIPTION
Problem: the broker attempts to log the module loader pid immediately after calling flux_rexec() when it is always -1.

Instead of tacking the pid onto the "insmod modname" debug log message, log it separately after the pid is known, e.g.
```
broker.debug[0]: module-python-exec sched-simple pid=78045
broker.debug[0]: module-exec heartbeat pid=79323
```
Moving this log message from modhash.c to module.c, where subprocesses are monitored, allowed the module_is_exec() and module_get_pid() accessors to be eliminated.

Update a couple of tests in the modprobe sharness test to look for the new log message.  Also, fix those tests to exec modules other than sched-simple, no longer a good choice since it was rewritten in python and always runs as a subprocess.

Fixes #7607