### PR TITLE
t: add new ASAN specific sharness test

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -23,7 +23,7 @@ jobs:
         TAP_DRIVER_QUIET: t
       run: >
         src/test/docker/docker-run-checks.sh \
-          --image=fedora40 --unit-test-only -j4 \
+          --image=fedora40 --asan-test-only -j4 \
           -- --with-flux-security --enable-sanitizer=address
 
     - name: after failure

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -15,7 +15,7 @@
 #  CPPCHECK      Run cppcheck if set to "t"
 #  DISTCHECK     Run `make distcheck` if set
 #  RECHECK       Run `make recheck` if `make check` fails the first time
-#  UNIT_TEST_ONLY Only run `make check` under ./src
+#  ASAN_TEST_ONLY Only run `make check` under ./src and asan tests under ./t
 #  QUICK_CHECK   Run only `make TESTS=` and a simple test
 #  PRELOAD       Set as LD_PRELOAD for make and tests
 #  POISON        Install poison libflux and flux(1) in image
@@ -173,8 +173,8 @@ if test -n "$PRELOAD" ; then
   CHECKCMDS="/usr/bin/env 'LD_PRELOAD=$PRELOAD' ${CHECKCMDS}"
 fi
 
-if test -n "$UNIT_TEST_ONLY"; then
-  CHECKCMDS="(cd src && $CHECKCMDS)"
+if test -n "$ASAN_TEST_ONLY"; then
+  CHECKCMDS="(cd src && $CHECKCMDS && cd ../t && make check TESTS=t5001-asan.t)"
 fi
 
 if test -n "$QUICK_CHECK"; then

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -25,7 +25,7 @@ declare -r prog=${0##*/}
 die() { echo -e "$prog: $@"; exit 1; }
 
 #
-declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,unit-test-only,quick-check,inception,platform:,workdir:,system"
+declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,asan-test-only,quick-check,inception,platform:,workdir:,system"
 declare -r short_opts="hqIdi:S:j:t:D:Prup:"
 declare usage="
 Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
@@ -49,7 +49,7 @@ Options:\n\
  -j, --jobs=N                  Value for make -j (default=$JOBS)\n
  -d, --distcheck               Run 'make distcheck' instead of 'make check'\n\
  -r, --recheck                 Run 'make recheck' after failure\n\
- -u, --unit-test-only          Only run unit tests\n\
+ -a, --asan-test-only          Only run asan tests\n\
      --quick-check             Only run 'make check TESTS=' and one basic test\n\
  -P, --no-poison               Do not install poison libflux and flux(1)\n\
  -D, --build-directory=DIRNAME Name of a subdir to build in, will be made\n\
@@ -85,7 +85,7 @@ while true; do
       -I|--interactive)            INTERACTIVE="/bin/bash";    shift   ;;
       -d|--distcheck)              DISTCHECK=t;                shift   ;;
       -r|--recheck)                RECHECK=t;                  shift   ;;
-      -u|--unit-test-only)         UNIT_TEST_ONLY=t;           shift   ;;
+      -a|--asan-test-only)         ASAN_TEST_ONLY=t;           shift   ;;
       --quick-check)               QUICK_CHECK=t;              shift   ;;
       -D|--build-directory)        BUILD_DIR="$2";             shift 2 ;;
       --build-arg)                 BUILD_ARG=" --build-arg $2" shift 2 ;;
@@ -213,7 +213,7 @@ export INCEPTION
 export JOBS
 export DISTCHECK
 export RECHECK
-export UNIT_TEST_ONLY
+export ASAN_TEST_ONLY
 export QUICK_CHECK
 export BUILD_DIR
 export COVERAGE
@@ -257,7 +257,7 @@ else
         -e CPPCHECK \
         -e DISTCHECK \
         -e RECHECK \
-        -e UNIT_TEST_ONLY \
+        -e ASAN_TEST_ONLY \
         -e QUICK_CHECK \
         -e chain_lint \
         -e JOBS \

--- a/src/test/docker/docker-run-systest.sh
+++ b/src/test/docker/docker-run-systest.sh
@@ -209,7 +209,7 @@ checks_group "$msg" \
     -e CPPCHECK=$CPPCHECK \
     -e DISTCHECK=$DISTCHECK \
     -e RECHECK=$RECHECK \
-    -e UNIT_TEST_ONLY=$UNIT_TEST_ONLY \
+    -e ASAN_TEST_ONLY=$ASAN_TEST_ONLY \
     -e chain_lint=$chain_lint \
     -e JOBS=$JOBS \
     -e USER=$USER \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -49,6 +49,7 @@ clean-local:
 LONGTESTSCRIPTS = \
 	t9000-system.t \
 	t5000-valgrind.t \
+	t5001-asan.t \
 	t3100-flux-in-flux.t \
 	t3200-instance-restart.t \
 	t3202-instance-restart-testexec.t \

--- a/t/asan/asan-workload.sh
+++ b/t/asan/asan-workload.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo FLUX_URI=$FLUX_URI
+exitcode=0
+
+for file in ${SHARNESS_TEST_SRCDIR:-..}/asan/workload.d/*; do
+	echo Running $(basename $file)
+	$file
+	rc=$?
+	if test $rc -gt 0; then
+		echo "$(basename $file): Failed with rc=$rc" >&2
+		exitcode=1
+	fi
+done
+exit $exitcode

--- a/t/asan/workload.d/job
+++ b/t/asan/workload.d/job
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+NJOBS=${NJOBS:-10}
+
+flux submit --cc="1-$NJOBS" --wait \
+	flux lptest 78 2

--- a/t/asan/workload.d/job-cancel
+++ b/t/asan/workload.d/job-cancel
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+set -x
+
+#  Test job cancel
+id=$(flux submit sleep 60)
+flux job wait-event ${id} start
+flux cancel ${id}
+flux job wait-event ${id} clean

--- a/t/asan/workload.d/job-info
+++ b/t/asan/workload.d/job-info
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+set -x
+
+# Test info fetch
+
+id=$(flux submit -n 1 true)
+flux job attach ${id}
+
+flux job info ${id} eventlog >/dev/null
+flux job info ${id} jobspec >/dev/null
+flux job info ${id} R >/dev/null

--- a/t/asan/workload.d/job-list
+++ b/t/asan/workload.d/job-list
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+set -x
+
+# Test job list
+
+# launch a few jobs just to ensure there are jobs to list
+flux submit -n 1 true
+flux submit -n 1 false
+
+flux jobs -a -A

--- a/t/asan/workload.d/job-multinode
+++ b/t/asan/workload.d/job-multinode
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+NJOBS=${NJOBS:-2}
+
+flux submit --cc="1-$NJOBS" -N2 --wait hostname
+

--- a/t/asan/workload.d/job-sdexec
+++ b/t/asan/workload.d/job-sdexec
@@ -1,0 +1,27 @@
+if ! flux version | grep systemd; then
+    echo "flux was not built with systemd"
+    exit 0
+fi
+if ! systemctl --user show --property Version; then
+    echo "user systemd is not running"
+    exit 0
+fi
+if ! busctl --user status >/dev/null; then
+    echo "user dbus is not running"
+    exit 0
+fi
+
+flux module load sdbus
+flux module load sdexec
+
+NJOBS=${NJOBS:-10}
+
+for i in `seq 1 ${NJOBS}`
+do
+    flux submit --wait \
+        --setattr system.exec.bulkexec.service=sdexec \
+        flux lptest 78 2
+done
+
+flux module remove sdexec
+flux module remove sdbus

--- a/t/asan/workload.d/job-wait
+++ b/t/asan/workload.d/job-wait
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+set -x
+
+# Test job wait
+
+id=$(flux submit --flags waitable true)
+flux job wait ${id}
+
+# No leaks if zombie persists
+id=$(flux submit --flags waitable true)
+flux job wait-event ${id} clean

--- a/t/asan/workload.d/resource
+++ b/t/asan/workload.d/resource
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+flux submit --wait-event=alloc sleep inf
+
+flux resource drain 0
+
+# calls both resource.status and resource.sched-status
+flux resource status
+
+# second call should use cached values
+flux resource status
+
+flux resource undrain 0
+
+# Cancel the sleep job and wait for it to complete
+flux cancel $(flux job last)
+flux queue drain

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -146,6 +146,7 @@ test_expect_success 'flux exec exits with code 126 for non executable' '
 	grep "Permission denied" exec.stderr2
 '
 
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
 test_expect_success NO_ASAN 'flux exec passes non-zero exit status' '
 	test_expect_code 2 flux exec -n sh -c "exit 2" &&
 	test_expect_code 3 flux exec -n sh -c "exit 3" &&
@@ -158,6 +159,7 @@ test_expect_success 'flux exec fails with --with-imp if no IMP configured' '
 	grep "exec\.imp path not found in config" exec-no-imp.out
 '
 
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
 test_expect_success NO_ASAN 'flux exec outputs tasks with errors' '
 	! flux exec -n sh -c "exit 2" > 2.out 2>&1 &&
         grep "\[0-3\]: Exit 2" 2.out &&

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -164,7 +164,8 @@ test_expect_success 'simulated module segfault causes module to exit' '
 	sh -c "while flux module stats testmod; do true; done" &&
 	flux dmesg >segfault.out
 '
-test_expect_success 'segfault is reported' '
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
+test_expect_success NO_ASAN 'segfault is reported' '
 	grep "killed by Segmentation fault" segfault.out
 '
 test_expect_success 'broker treats this the same as spurious module exit' '

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -3,6 +3,8 @@
 test_description='Test flux cron service'
 
 . $(dirname $0)/sharness.sh
+
+# N.B. skip under ASAN, LD_PRELOAD is modified
 if ! test_have_prereq NO_ASAN; then
     skip_all='skipping faketime tests since AddressSanitizer is active'
     test_done

--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -46,7 +46,9 @@ test_expect_success 'flux-shell: per-resource type=node works' '
 	EOF
 	test_cmp per-node.expected per-node.out
 '
-test_expect_success 'flux-shell: historical batch jobspec still work' '
+# N.B. legacy test jobspecs may not setup things correctly to allow
+# ASAN (e.g. overwrite environment), so disable under ASAN
+test_expect_success NO_ASAN 'flux-shell: historical batch jobspec still work' '
 	for spec in $SHARNESS_TEST_SRCDIR/batch/jobspec/*.json; do
 		input=$(basename $spec) &&
 		cat $spec |

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -59,7 +59,8 @@ test_expect_success 'flux-shell: exit-on-error catches lost shell' '
 	test_must_fail run_timeout 30 flux run \
 		-n2 -N2 -o exit-on-error ./test2.sh
 '
-test_expect_success 'flux-shell: create script - rank 1 kills itself with SIGSEGV' '
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
+test_expect_success NO_ASAN 'flux-shell: create script - rank 1 kills itself with SIGSEGV' '
 	cat >sigtest.sh <<-"EOT" &&
 	#!/bin/sh
 	test $FLUX_TASK_RANK -eq 1 && kill -SEGV $$
@@ -67,12 +68,12 @@ test_expect_success 'flux-shell: create script - rank 1 kills itself with SIGSEG
 	EOT
 	chmod +x sigtest.sh
 '
-test_expect_success 'flux-shell: exit-on-error preserves failing task signal in finish status' '
+test_expect_success NO_ASAN 'flux-shell: exit-on-error preserves failing task signal in finish status' '
 	jobid=$(flux submit -n2 -o exit-on-error ./sigtest.sh) &&
 	flux job wait-event -t 30 $jobid finish | grep "status=35584" &&
 	flux job eventlog $jobid | grep exception | grep "Segmentation fault"
 '
-test_expect_success 'flux-shell: exit-timeout preserves failing task signal in finish status' '
+test_expect_success NO_ASAN 'flux-shell: exit-timeout preserves failing task signal in finish status' '
 	jobid=$(flux submit -n2 -o exit-timeout=1s ./sigtest.sh) &&
 	flux job wait-event -t 30 $jobid finish | grep "status=35584" &&
 	flux job eventlog $jobid | grep exception | grep "Segmentation fault"

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -110,7 +110,7 @@ test_expect_success NO_ASAN 'flux batch: job results are expected' '
 	grep "size=2 nodes=2" flux-${id4}.out &&
 	grep "size=2 nodes=2" flux-${id5}.out
 '
-test_expect_success MULTICORE 'flux batch: exclusive flag worked' '
+test_expect_success NO_ASAN,MULTICORE 'flux batch: exclusive flag worked' '
 	test $(flux job info ${id4} R | flux R decode --count=core) -gt 2 &&
 	test $(flux job info ${id5} R | flux R decode --count=core) -gt 2
 '

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -91,6 +91,7 @@ test_expect_success 'flux batch --exclusive works' '
 		jq -S ".resources[0]" | \
 		jq -e ".type == \"node\" and .exclusive"
 '
+# N.B. slow under ASAN, skip
 test_expect_success NO_ASAN 'flux batch: submit a series of jobs' '
 	id1=$(flux batch --flags=waitable -n1 batch-script.sh) &&
 	id2=$(flux batch --flags=waitable -n4 batch-script.sh) &&

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -16,6 +16,7 @@ run_program() {
 	run_timeout $timeout flux run $OPTS -n${ntasks} -N${nnodes} $*
 }
 
+# N.B. set NO_ASAN, we are modifying LD_PRELOAD
 test_expect_success NO_ASAN "spectrum mpi only enabled with option" '
 	LD_PRELOAD_saved=${LD_PRELOAD} &&
 	unset LD_PRELOAD &&
@@ -28,6 +29,7 @@ test_expect_success NO_ASAN "spectrum mpi only enabled with option" '
 	grep /opt/ibm/spectrum spectrum.out
 '
 
+# N.B. set NO_ASAN, we are modifying LD_PRELOAD
 test_expect_success NO_ASAN "spectrum mpi also enabled with spectrum@version" '
 	LD_PRELOAD_saved=${LD_PRELOAD} &&
 	unset LD_PRELOAD &&

--- a/t/t5001-asan.t
+++ b/t/t5001-asan.t
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+test_description='Run broker under asan with a small workload'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+if test_have_prereq NO_ASAN; then
+    skip_all='skipping asan tests since AddressSanitizer not active'
+    test_done
+fi
+
+ASAN_WORKLOAD=${SHARNESS_TEST_SRCDIR}/asan/asan-workload.sh
+
+ASAN_NBROKERS=${ASAN_NBROKERS:-2}
+
+# Allow jobs to run under sdexec in test, if available
+cat >asan.toml <<-EOT
+[exec]
+service-override = true
+EOT
+
+test_expect_success \
+  "reports no new errors on $ASAN_NBROKERS broker run" '
+	run_timeout 300 \
+	flux start -s ${ASAN_NBROKERS} \
+		--test-exit-timeout=120 \
+		--config-path=asan.toml \
+		 ${ASAN_WORKLOAD}
+'
+test_done


### PR DESCRIPTION
Per some discussion in #7537, instead of trying to run ASAN for all of sharness, make a asan specific sharness test that covers a "core minimal" set of stuff.

I largely mirrored the testing setup from `t5000-valgrind`.  For the time being, I just copied the workload from `t/valgrind/workload.d` into a new `t/asan/workload.d`, but over time these tests will likely diverge.  (There was an offline discussion over the fact the valgrind tests probably need a little more coverage.)

I also updated things so asan would run under CI.

I tested to make sure this setup worked by 1) adding a workload that submitted a job that would segfault and 2) intentionally adding a use-after-free into  the broker (these changes were obviously removed before submitting this PR).

I brought over some of my fixes from #7558, b/c I figure it was good cleanup anyways.