### PR TITLE
improve error messages when sdexec-mapper fails to map cores or GPUs

### DIFF
--- a/src/bindings/python/_flux/_rhwloc_map_build.py
+++ b/src/bindings/python/_flux/_rhwloc_map_build.py
@@ -19,6 +19,9 @@ ffi.set_source(
 ffi.cdef(
     """
 typedef struct rhwloc_map rhwloc_map_t;
+typedef struct {
+    char text[160];
+} flux_error_t;
 
 rhwloc_map_t *rhwloc_map_create (const char *xml);
 void          rhwloc_map_destroy (rhwloc_map_t *m);
@@ -26,11 +29,14 @@ void          rhwloc_map_destroy (rhwloc_map_t *m);
 int  rhwloc_map_count_type (rhwloc_map_t *m, const char *typestr);
 
 int  rhwloc_map_cores (rhwloc_map_t *m,
+                       flux_error_t *errp,
                        const char *cores,
                        char **cpus_out,
                        char **mems_out);
 
-char **rhwloc_map_gpu_pci_addrs (rhwloc_map_t *m, const char *gpus);
+char **rhwloc_map_gpu_pci_addrs (rhwloc_map_t *m,
+                                 const char *gpus,
+                                 flux_error_t *errp);
 
 void rhwloc_map_strv_free (char **strv);
 

--- a/src/bindings/python/flux/sdexec/map.py
+++ b/src/bindings/python/flux/sdexec/map.py
@@ -322,7 +322,7 @@ class HwlocMapper(ResourceMapper):
             < 0
         ):
             errstr = ffi.string(error[0].text).decode("utf-8")
-            raise OSError(ffi.errno, f"rhwloc_map_cores: {errstr}")
+            raise OSError(ffi.errno, f"failed to map cores: {errstr}")
         cpus = ffi.string(cpus_out[0]).decode()
         mems = ffi.string(mems_out[0]).decode()
         lib.free(cpus_out[0])
@@ -478,7 +478,7 @@ class HwlocMapper(ResourceMapper):
         addrs = lib.rhwloc_map_gpu_pci_addrs(self._map, gpus.encode(), error)
         if addrs == ffi.NULL:
             errstr = ffi.string(error[0].text).decode("utf-8")
-            raise OSError(ffi.errno, f"rhwloc_map_gpu_pci_addrs: {errstr}")
+            raise OSError(ffi.errno, f"failed to map GPUs: {errstr}")
         try:
             pci_addrs = []
             i = 0

--- a/src/bindings/python/flux/sdexec/map.py
+++ b/src/bindings/python/flux/sdexec/map.py
@@ -316,8 +316,13 @@ class HwlocMapper(ResourceMapper):
         lib = self._lib
         cpus_out = ffi.new("char **")
         mems_out = ffi.new("char **")
-        if lib.rhwloc_map_cores(self._map, cores.encode(), cpus_out, mems_out) < 0:
-            raise OSError(ffi.errno, "rhwloc_map_cores failed")
+        error = ffi.new("flux_error_t[1]")
+        if (
+            lib.rhwloc_map_cores(self._map, error, cores.encode(), cpus_out, mems_out)
+            < 0
+        ):
+            errstr = ffi.string(error[0].text).decode("utf-8")
+            raise OSError(ffi.errno, f"rhwloc_map_cores: {errstr}")
         cpus = ffi.string(cpus_out[0]).decode()
         mems = ffi.string(mems_out[0]).decode()
         lib.free(cpus_out[0])
@@ -469,9 +474,11 @@ class HwlocMapper(ResourceMapper):
             return {}
         ffi = self._ffi
         lib = self._lib
-        addrs = lib.rhwloc_map_gpu_pci_addrs(self._map, gpus.encode())
+        error = ffi.new("flux_error_t[1]")
+        addrs = lib.rhwloc_map_gpu_pci_addrs(self._map, gpus.encode(), error)
         if addrs == ffi.NULL:
-            raise OSError(ffi.errno, "rhwloc_map_gpu_pci_addrs failed")
+            errstr = ffi.string(error[0].text).decode("utf-8")
+            raise OSError(ffi.errno, f"rhwloc_map_gpu_pci_addrs: {errstr}")
         try:
             pci_addrs = []
             i = 0

--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -23,6 +23,7 @@
 #include "ccan/str/str.h"
 #include "src/common/libutil/read_all.h"
 #include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/errprintf.h"
 
 #include "rnode.h"
 #include "rlist.h"
@@ -267,32 +268,50 @@ const char * rhwloc_hostname (hwloc_topology_t topo)
  *  Returns heap-allocated hwloc_cpuset_t, or NULL on error.
  *  Caller must free with hwloc_bitmap_free().
  */
-hwloc_cpuset_t rhwloc_cores_to_cpuset (hwloc_topology_t topo, const char *cores)
+hwloc_cpuset_t rhwloc_cores_to_cpuset (hwloc_topology_t topo,
+                                       const char *cores,
+                                       flux_error_t *errp)
 {
     hwloc_cpuset_t coreset = NULL;
     hwloc_cpuset_t cpuset = NULL;
     int depth;
     int i;
 
-    if (!topo || !cores)
+    if (!topo || !cores) {
+        errprintf (errp, "Invalid argument");
+        errno = EINVAL;
         return NULL;
+    }
 
     if (!(coreset = hwloc_bitmap_alloc ())
-        || !(cpuset = hwloc_bitmap_alloc ()))
+        || !(cpuset = hwloc_bitmap_alloc ())) {
+        errprintf (errp, "Error allocating hwloc bitmaps");
+        errno = ENOMEM;
         goto err;
+    }
 
-    if (hwloc_bitmap_list_sscanf (coreset, cores) < 0)
+    if (hwloc_bitmap_list_sscanf (coreset, cores) < 0) {
+        errprintf (errp, "invalid core ID string: %s", cores);
+        errno = EINVAL;
         goto err;
+    }
 
     depth = hwloc_get_type_depth (topo, HWLOC_OBJ_CORE);
-    if (depth == HWLOC_TYPE_DEPTH_UNKNOWN || depth == HWLOC_TYPE_DEPTH_MULTIPLE)
+    if (depth == HWLOC_TYPE_DEPTH_UNKNOWN
+        || depth == HWLOC_TYPE_DEPTH_MULTIPLE) {
+        errprintf (errp, "hwloc reports invalid depth for Core objects");
+        errno = EINVAL;
         goto err;
+    }
 
     i = hwloc_bitmap_first (coreset);
     while (i >= 0) {
         hwloc_obj_t core = hwloc_get_obj_by_depth (topo, depth, i);
-        if (!core || !core->cpuset)
+        if (!core || !core->cpuset) {
+            errprintf (errp, "core %d not found in node topology", i);
+            errno = ENOENT;
             goto err;
+        }
         hwloc_bitmap_or (cpuset, cpuset, core->cpuset);
         i = hwloc_bitmap_next (coreset, i);
     }
@@ -410,7 +429,11 @@ hwloc_obj_t *rhwloc_gpu_objects (hwloc_topology_t topo, int *count_out)
     /* Get total count of PCI devices to size the visited array:
      */
     n_pci = hwloc_get_nbobjs_by_type (topo, HWLOC_OBJ_PCI_DEVICE);
-    if (n_pci <= 0 || !(visited = calloc (n_pci, sizeof (*visited))))
+    if (n_pci <= 0) {
+        errno = ENODEV;
+        return NULL;
+    }
+    if (!(visited = calloc (n_pci, sizeof (*visited))))
         return NULL;
 
     /* Traverse topo first to get count of unique GPUs to size result

--- a/src/common/librlist/rhwloc.h
+++ b/src/common/librlist/rhwloc.h
@@ -13,6 +13,8 @@
 
 #include <hwloc.h>
 
+#include "src/common/libflux/types.h" /* flux_error_t */
+
 typedef enum {
     RHWLOC_NO_RESTRICT = 0x1
 } rhwloc_flags_t;
@@ -45,7 +47,8 @@ const char *rhwloc_hostname (hwloc_topology_t topo);
  *  Caller must free with hwloc_bitmap_free().
  */
 hwloc_cpuset_t rhwloc_cores_to_cpuset (hwloc_topology_t topo,
-                                        const char *cores);
+                                        const char *cores,
+                                        flux_error_t *errp);
 
 /*  Return idset string for all cores in hwloc topology object
  */

--- a/src/common/librlist/rhwloc_map.c
+++ b/src/common/librlist/rhwloc_map.c
@@ -17,6 +17,7 @@
 #include <flux/idset.h>
 
 #include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/errprintf.h"
 
 #include "rhwloc.h"
 #include "rhwloc_map.h"
@@ -80,6 +81,7 @@ out:
 }
 
 int rhwloc_map_cores (rhwloc_map_t *m,
+                      flux_error_t *errp,
                       const char *cores,
                       char **cpus_out,
                       char **mems_out)
@@ -91,16 +93,28 @@ int rhwloc_map_cores (rhwloc_map_t *m,
     int rc = -1;
 
     if (!m || !cores || !cpus_out || !mems_out) {
+        errprintf (errp, "Invalid argument");
         errno = EINVAL;
         return -1;
     }
-    if (!(cpuset = rhwloc_cores_to_cpuset (m->topo, cores))
-        || !(nodeset = hwloc_bitmap_alloc ())
-        || hwloc_cpuset_to_nodeset (m->topo, cpuset, nodeset) != 0)
+    if (!(cpuset = rhwloc_cores_to_cpuset (m->topo, cores, errp)))
         goto out;
+    if (!(nodeset = hwloc_bitmap_alloc ())) {
+        errprintf (errp, "Out of memory");
+        errno = ENOMEM;
+        goto out;
+    }
+    if (hwloc_cpuset_to_nodeset (m->topo, cpuset, nodeset) != 0) {
+        errprintf (errp,
+                   "failed to get NUMA nodes for cores: %s",
+                   cores);
+        goto out;
+    }
     if (!(cpus = bitmap_to_idset (cpuset))
-        || !(mems = bitmap_to_idset (nodeset)))
+        || !(mems = bitmap_to_idset (nodeset))) {
+        errprintf (errp, "out of memory");
         goto out;
+    }
     *cpus_out = cpus;
     *mems_out = mems;
     cpus = mems = NULL;
@@ -125,24 +139,34 @@ int rhwloc_map_count_type (rhwloc_map_t *m, const char *type)
 /* Return the PCI address of the GPU osdev object's nearest PCI ancestor
  * as a heap-allocated string, or NULL if no PCI ancestor is found.
  */
-static char *gpu_pci_addr (hwloc_obj_t obj)
+static char *gpu_pci_addr (hwloc_obj_t obj, flux_error_t *errp)
 {
     hwloc_obj_t parent = obj->parent;
     char buf[16]; /* "0000:ff:1f.7" + NUL */
+    char *s;
 
     while (parent && parent->type != HWLOC_OBJ_PCI_DEVICE)
         parent = parent->parent;
-    if (!parent)
+    if (!parent) {
+        errno = ENODEV;
+        errprintf (errp,
+                   "Failed to find PCI ancestor of GPU (logical id=%d)",
+                   obj->logical_index);
         return NULL;
+    }
     snprintf (buf, sizeof (buf), "%04x:%02x:%02x.%x",
               parent->attr->pcidev.domain,
               parent->attr->pcidev.bus,
               parent->attr->pcidev.dev,
               parent->attr->pcidev.func);
-    return strdup (buf);
+    if (!(s = strdup (buf)))
+        errprintf (errp, "Out of memory copying GPU PCI addr");
+    return s;
 }
 
-char **rhwloc_map_gpu_pci_addrs (rhwloc_map_t *m, const char *gpus)
+char **rhwloc_map_gpu_pci_addrs (rhwloc_map_t *m,
+                                 const char *gpus,
+                                 flux_error_t *errp)
 {
     struct idset *gpuset = NULL;
     hwloc_obj_t *gpu_objs = NULL;
@@ -150,21 +174,38 @@ char **rhwloc_map_gpu_pci_addrs (rhwloc_map_t *m, const char *gpus)
     int gpu_count = 0;
 
     if (!m || !gpus) {
+        errprintf (errp, "Invalid argument");
         errno = EINVAL;
         return NULL;
     }
-    if (!(gpuset = idset_decode (gpus)))
+    if (!(gpuset = idset_decode (gpus))) {
+        errprintf (errp, "idset_decode(\"%s\") failed", gpus);
         goto error;
-    if (!(result = calloc (idset_count (gpuset) + 1, sizeof (*result))))
+    }
+    if (!(result = calloc (idset_count (gpuset) + 1, sizeof (*result)))) {
+        errprintf (errp, "Out of memory");
         goto error;
+    }
+    errno = 0;
     if (!(gpu_objs = rhwloc_gpu_objects (m->topo, &gpu_count))
-        && gpu_count > 0)
+        && gpu_count > 0) {
+        errprintf (errp,
+                   "Failed to collect GPU objects from hwloc: %s",
+                   strerror (errno));
         goto error;
+    }
 
     int i = 0;
     unsigned int id = idset_first (gpuset);
     while (id != IDSET_INVALID_ID) {
-        if ((int)id >= gpu_count || !(result[i++] = gpu_pci_addr (gpu_objs[id])))
+        if ((int)id >= gpu_count) {
+            errprintf (errp,
+                       "gpu%d not found in local topology (gpu count=%d)",
+                        id,
+                        gpu_count);
+            goto error;
+        }
+        if (!(result[i++] = gpu_pci_addr (gpu_objs[id], errp)))
             goto error;
         id = idset_next (gpuset, id);
     }

--- a/src/common/librlist/rhwloc_map.h
+++ b/src/common/librlist/rhwloc_map.h
@@ -11,6 +11,8 @@
 #ifndef HAVE_RHWLOC_MAP_H
 #define HAVE_RHWLOC_MAP_H 1
 
+#include "src/common/libflux/types.h" /* flux_error_t */
+
 typedef struct rhwloc_map rhwloc_map_t;
 
 /*  Create a resource mapping context from hwloc topology XML.
@@ -29,6 +31,7 @@ int rhwloc_map_count_type (rhwloc_map_t *m, const char *type);
  *  heap-allocated strings the caller must free().  Returns -1 on error.
  */
 int rhwloc_map_cores (rhwloc_map_t *m,
+                      flux_error_t *errp,
                       const char *cores,
                       char **cpus_out,
                       char **mems_out);
@@ -37,7 +40,9 @@ int rhwloc_map_cores (rhwloc_map_t *m,
  *  address strings in the same order as the input GPU IDs.  Returns NULL
  *  on error.  Caller must free with rhwloc_map_strv_free().
  */
-char **rhwloc_map_gpu_pci_addrs (rhwloc_map_t *m, const char *gpus);
+char **rhwloc_map_gpu_pci_addrs (rhwloc_map_t *m,
+                                 const char *gpus,
+                                 flux_error_t *errp);
 
 /*  Free a NULL-terminated string array.
  */

--- a/src/common/librlist/test/rhwloc.c
+++ b/src/common/librlist/test/rhwloc.c
@@ -14,6 +14,7 @@
 #include <flux/hostlist.h>
 
 #include "src/common/libtap/tap.h"
+#include "src/common/libutil/errprintf.h"
 #include "rlist.h"
 #include "rhwloc.h"
 
@@ -823,33 +824,55 @@ void test_cores_to_cpuset (void)
         BAIL_OUT ("rhwloc_local_topology_load failed");
 
     /* NULL inputs */
+    err_init (&error);
     ok (rhwloc_cores_to_cpuset (NULL, "0", &error) == NULL,
         "rhwloc_cores_to_cpuset topo=NULL returns NULL");
+    like (error.text, "Invalid",
+          "rhwloc_cores_to_cpuset topo=NULL error mentions Invalid");
+    err_init (&error);
     ok (rhwloc_cores_to_cpuset (topo, NULL, &error) == NULL,
         "rhwloc_cores_to_cpuset cores=NULL returns NULL");
+    like (error.text, "Invalid",
+          "rhwloc_cores_to_cpuset cores=NULL error mentions Invalid");
 
     /* Invalid core string */
+    err_init (&error);
     ok (rhwloc_cores_to_cpuset (topo, "x", &error) == NULL,
         "rhwloc_cores_to_cpuset cores=invalid returns NULL");
+    like (error.text, "invalid core",
+          "rhwloc_cores_to_cpuset cores=invalid error mentions invalid core");
+
+    /* Out-of-range core */
+    err_init (&error);
+    ok (rhwloc_cores_to_cpuset (topo, "999", &error) == NULL,
+        "rhwloc_cores_to_cpuset cores=out-of-range returns NULL");
+    like (error.text, "not found",
+          "rhwloc_cores_to_cpuset cores=out-of-range error mentions not found");
 
     /* Core 0 always exists; cpuset must be non-empty and include PU 0
      * (i.e. physical CPU 0 is always in core 0's cpuset) */
+    err_init (&error);
     cpuset = rhwloc_cores_to_cpuset (topo, "0", &error);
     ok (cpuset != NULL && !hwloc_bitmap_iszero (cpuset),
         "rhwloc_cores_to_cpuset cores=0 returns non-empty cpuset");
     ok (cpuset != NULL && hwloc_bitmap_isset (cpuset, 0),
         "rhwloc_cores_to_cpuset cores=0 cpuset includes PU 0");
+    ok (strlen (error.text) == 0,
+        "error.text is empty");
     hwloc_bitmap_free (cpuset);
 
     /* All cores: cpuset must equal full topology cpuset */
     cores = rhwloc_core_idset_string (topo);
     if (!cores)
         BAIL_OUT ("rhwloc_core_idset_string failed");
+    err_init (&error);
     cpuset = rhwloc_cores_to_cpuset (topo, cores, &error);
     ok (cpuset != NULL
         && hwloc_bitmap_isequal (cpuset,
                                  hwloc_topology_get_allowed_cpuset (topo)),
         "rhwloc_cores_to_cpuset all cores cpuset matches topology cpuset");
+    ok (strlen (error.text) == 0,
+        "error.text is empty");
     hwloc_bitmap_free (cpuset);
     free (cores);
 

--- a/src/common/librlist/test/rhwloc.c
+++ b/src/common/librlist/test/rhwloc.c
@@ -815,6 +815,7 @@ void test_cores_to_cpuset (void)
 {
     hwloc_topology_t topo;
     hwloc_cpuset_t cpuset;
+    flux_error_t error;
     char *cores;
 
     topo = rhwloc_local_topology_load (RHWLOC_NO_RESTRICT);
@@ -822,18 +823,18 @@ void test_cores_to_cpuset (void)
         BAIL_OUT ("rhwloc_local_topology_load failed");
 
     /* NULL inputs */
-    ok (rhwloc_cores_to_cpuset (NULL, "0") == NULL,
+    ok (rhwloc_cores_to_cpuset (NULL, "0", &error) == NULL,
         "rhwloc_cores_to_cpuset topo=NULL returns NULL");
-    ok (rhwloc_cores_to_cpuset (topo, NULL) == NULL,
+    ok (rhwloc_cores_to_cpuset (topo, NULL, &error) == NULL,
         "rhwloc_cores_to_cpuset cores=NULL returns NULL");
 
     /* Invalid core string */
-    ok (rhwloc_cores_to_cpuset (topo, "x") == NULL,
+    ok (rhwloc_cores_to_cpuset (topo, "x", &error) == NULL,
         "rhwloc_cores_to_cpuset cores=invalid returns NULL");
 
     /* Core 0 always exists; cpuset must be non-empty and include PU 0
      * (i.e. physical CPU 0 is always in core 0's cpuset) */
-    cpuset = rhwloc_cores_to_cpuset (topo, "0");
+    cpuset = rhwloc_cores_to_cpuset (topo, "0", &error);
     ok (cpuset != NULL && !hwloc_bitmap_iszero (cpuset),
         "rhwloc_cores_to_cpuset cores=0 returns non-empty cpuset");
     ok (cpuset != NULL && hwloc_bitmap_isset (cpuset, 0),
@@ -844,7 +845,7 @@ void test_cores_to_cpuset (void)
     cores = rhwloc_core_idset_string (topo);
     if (!cores)
         BAIL_OUT ("rhwloc_core_idset_string failed");
-    cpuset = rhwloc_cores_to_cpuset (topo, cores);
+    cpuset = rhwloc_cores_to_cpuset (topo, cores, &error);
     ok (cpuset != NULL
         && hwloc_bitmap_isequal (cpuset,
                                  hwloc_topology_get_allowed_cpuset (topo)),

--- a/src/common/librlist/test/rhwloc_map.c
+++ b/src/common/librlist/test/rhwloc_map.c
@@ -13,6 +13,7 @@
 #endif
 
 #include "src/common/libtap/tap.h"
+#include "src/common/libutil/errprintf.h"
 #include "ccan/str/str.h"
 #include "rhwloc_map.h"
 
@@ -162,18 +163,46 @@ void test_cores (void)
         BAIL_OUT ("rhwloc_map_create failed");
 
     /* NULL inputs */
+    err_init (&error);
     ok (rhwloc_map_cores (NULL, &error, "0", &cpus, &mems) == -1
         && errno == EINVAL,
         "rhwloc_map_cores m=NULL returns -1, EINVAL");
+    like (error.text, "Invalid",
+          "rhwloc_map_cores m=NULL error mentions Invalid");
+    err_init (&error);
     ok (rhwloc_map_cores (m, &error, NULL, &cpus, &mems) == -1
         && errno == EINVAL,
         "rhwloc_map_cores cores=NULL returns -1, EINVAL");
+    like (error.text, "Invalid",
+          "rhwloc_map_cores cores=NULL error mentions Invalid");
+    err_init (&error);
     ok (rhwloc_map_cores (m, &error, "0", NULL, &mems) == -1
         && errno == EINVAL,
         "rhwloc_map_cores cpus_out=NULL returns -1, EINVAL");
+    like (error.text, "Invalid",
+          "rhwloc_map_cores cpus_out=NULL error mentions Invalid");
+    err_init (&error);
     ok (rhwloc_map_cores (m, &error, "0", &cpus, NULL) == -1
         && errno == EINVAL,
         "rhwloc_map_cores mems_out=NULL returns -1, EINVAL");
+    like (error.text, "Invalid",
+          "rhwloc_map_cores mems_out=NULL error mentions Invalid");
+
+    /* Invalid core string */
+    err_init (&error);
+    ok (rhwloc_map_cores (m, &error, "x", &cpus, &mems) == -1
+        && errno == EINVAL,
+        "rhwloc_map_cores cores=invalid returns -1, EINVAL");
+    like (error.text, "invalid core",
+          "rhwloc_map_cores cores=invalid error mentions invalid core");
+
+    /* Out-of-range core */
+    err_init (&error);
+    ok (rhwloc_map_cores (m, &error, "999", &cpus, &mems) == -1
+        && errno == ENOENT,
+        "rhwloc_map_cores cores=out-of-range returns -1, ENOENT");
+    like (error.text, "not found",
+          "rhwloc_map_cores cores=out-of-range error mentions not found");
 
     /* Core 0: PUs 0,1 in NUMA node 0 */
     ok (rhwloc_map_cores (m, &error, "0", &cpus, &mems) == 0,
@@ -225,14 +254,21 @@ void test_gpu_pci_addrs (void)
         BAIL_OUT ("rhwloc_map_create failed");
 
     /* NULL inputs */
+    err_init (&error);
     ok (rhwloc_map_gpu_pci_addrs (NULL, "0", &error) == NULL
         && errno == EINVAL,
         "rhwloc_map_gpu_pci_addrs m=NULL returns NULL, EINVAL");
+    like (error.text, "Invalid",
+          "rhwloc_map_gpu_pci_addrs m=NULL error mentions Invalid");
+    err_init (&error);
     ok (rhwloc_map_gpu_pci_addrs (m, NULL, &error) == NULL
         && errno == EINVAL,
         "rhwloc_map_gpu_pci_addrs gpus=NULL returns NULL, EINVAL");
+    like (error.text, "Invalid",
+          "rhwloc_map_gpu_pci_addrs gpus=NULL error mentions Invalid");
 
     /* GPU 0 */
+    err_init (&error);
     addrs = rhwloc_map_gpu_pci_addrs (m, "0", &error);
     ok (addrs != NULL,
         "rhwloc_map_gpu_pci_addrs gpus=0 returns non-NULL");
@@ -242,9 +278,13 @@ void test_gpu_pci_addrs (void)
         addrs && addrs[0] ? addrs[0] : "(null)");
     ok (addrs != NULL && addrs[1] == NULL,
         "rhwloc_map_gpu_pci_addrs gpus=0 result is NULL-terminated");
+    ok (strlen (error.text) == 0,
+        "error.text is zero length");
+
     rhwloc_map_strv_free (addrs);
 
     /* GPU 1 */
+    err_init (&error);
     addrs = rhwloc_map_gpu_pci_addrs (m, "1", &error);
     ok (addrs != NULL,
         "rhwloc_map_gpu_pci_addrs gpus=1 returns non-NULL");
@@ -252,9 +292,12 @@ void test_gpu_pci_addrs (void)
         && streq (addrs[0], "0000:02:00.0"),
         "rhwloc_map_gpu_pci_addrs gpus=1 addrs[0]=\"0000:02:00.0\": got \"%s\"",
         addrs && addrs[0] ? addrs[0] : "(null)");
+    ok (strlen (error.text) == 0,
+        "error.text is zero length");
     rhwloc_map_strv_free (addrs);
 
     /* GPUs 0-1 */
+    err_init (&error);
     addrs = rhwloc_map_gpu_pci_addrs (m, "0-1", &error);
     ok (addrs != NULL,
         "rhwloc_map_gpu_pci_addrs gpus=0-1 returns non-NULL");
@@ -266,12 +309,17 @@ void test_gpu_pci_addrs (void)
         "rhwloc_map_gpu_pci_addrs gpus=0-1 addrs[1]=\"0000:02:00.0\"");
     ok (addrs != NULL && addrs[2] == NULL,
         "rhwloc_map_gpu_pci_addrs gpus=0-1 result is NULL-terminated");
+    ok (strlen (error.text) == 0,
+        "error.text is zero length");
     rhwloc_map_strv_free (addrs);
 
     /* Out-of-range GPU */
+    err_init (&error);
     addrs = rhwloc_map_gpu_pci_addrs (m, "2", &error);
     ok (addrs == NULL,
         "rhwloc_map_gpu_pci_addrs out-of-range GPU returns NULL");
+    like (error.text, "not found",
+          "rhwloc_map_gpu_pci_addrs out-of-range GPU error mentions not found");
 
     rhwloc_map_destroy (m);
 }

--- a/src/common/librlist/test/rhwloc_map.c
+++ b/src/common/librlist/test/rhwloc_map.c
@@ -155,23 +155,28 @@ void test_cores (void)
     rhwloc_map_t *m;
     char *cpus = NULL;
     char *mems = NULL;
+    flux_error_t error;
 
     m = rhwloc_map_create (xml);
     if (!m)
         BAIL_OUT ("rhwloc_map_create failed");
 
     /* NULL inputs */
-    ok (rhwloc_map_cores (NULL, "0", &cpus, &mems) == -1 && errno == EINVAL,
+    ok (rhwloc_map_cores (NULL, &error, "0", &cpus, &mems) == -1
+        && errno == EINVAL,
         "rhwloc_map_cores m=NULL returns -1, EINVAL");
-    ok (rhwloc_map_cores (m, NULL, &cpus, &mems) == -1 && errno == EINVAL,
+    ok (rhwloc_map_cores (m, &error, NULL, &cpus, &mems) == -1
+        && errno == EINVAL,
         "rhwloc_map_cores cores=NULL returns -1, EINVAL");
-    ok (rhwloc_map_cores (m, "0", NULL, &mems) == -1 && errno == EINVAL,
+    ok (rhwloc_map_cores (m, &error, "0", NULL, &mems) == -1
+        && errno == EINVAL,
         "rhwloc_map_cores cpus_out=NULL returns -1, EINVAL");
-    ok (rhwloc_map_cores (m, "0", &cpus, NULL) == -1 && errno == EINVAL,
+    ok (rhwloc_map_cores (m, &error, "0", &cpus, NULL) == -1
+        && errno == EINVAL,
         "rhwloc_map_cores mems_out=NULL returns -1, EINVAL");
 
     /* Core 0: PUs 0,1 in NUMA node 0 */
-    ok (rhwloc_map_cores (m, "0", &cpus, &mems) == 0,
+    ok (rhwloc_map_cores (m, &error, "0", &cpus, &mems) == 0,
         "rhwloc_map_cores cores=0 returns 0");
     ok (cpus != NULL && streq (cpus, "0-1"),
         "rhwloc_map_cores cores=0 cpus=\"0-1\": got \"%s\"",
@@ -183,7 +188,7 @@ void test_cores (void)
     free (mems); mems = NULL;
 
     /* Core 1: PUs 2,3 in NUMA node 0 */
-    ok (rhwloc_map_cores (m, "1", &cpus, &mems) == 0,
+    ok (rhwloc_map_cores (m, &error, "1", &cpus, &mems) == 0,
         "rhwloc_map_cores cores=1 returns 0");
     ok (cpus != NULL && streq (cpus, "2-3"),
         "rhwloc_map_cores cores=1 cpus=\"2-3\": got \"%s\"",
@@ -195,7 +200,7 @@ void test_cores (void)
     free (mems); mems = NULL;
 
     /* Cores 0-1: all PUs, all in NUMA node 0 */
-    ok (rhwloc_map_cores (m, "0-1", &cpus, &mems) == 0,
+    ok (rhwloc_map_cores (m, &error, "0-1", &cpus, &mems) == 0,
         "rhwloc_map_cores cores=0-1 returns 0");
     ok (cpus != NULL && streq (cpus, "0-3"),
         "rhwloc_map_cores cores=0-1 cpus=\"0-3\": got \"%s\"",
@@ -213,19 +218,22 @@ void test_gpu_pci_addrs (void)
 {
     rhwloc_map_t *m;
     char **addrs;
+    flux_error_t error;
 
     m = rhwloc_map_create (xml);
     if (!m)
         BAIL_OUT ("rhwloc_map_create failed");
 
     /* NULL inputs */
-    ok (rhwloc_map_gpu_pci_addrs (NULL, "0") == NULL && errno == EINVAL,
+    ok (rhwloc_map_gpu_pci_addrs (NULL, "0", &error) == NULL
+        && errno == EINVAL,
         "rhwloc_map_gpu_pci_addrs m=NULL returns NULL, EINVAL");
-    ok (rhwloc_map_gpu_pci_addrs (m, NULL) == NULL && errno == EINVAL,
+    ok (rhwloc_map_gpu_pci_addrs (m, NULL, &error) == NULL
+        && errno == EINVAL,
         "rhwloc_map_gpu_pci_addrs gpus=NULL returns NULL, EINVAL");
 
     /* GPU 0 */
-    addrs = rhwloc_map_gpu_pci_addrs (m, "0");
+    addrs = rhwloc_map_gpu_pci_addrs (m, "0", &error);
     ok (addrs != NULL,
         "rhwloc_map_gpu_pci_addrs gpus=0 returns non-NULL");
     ok (addrs != NULL && addrs[0] != NULL
@@ -237,7 +245,7 @@ void test_gpu_pci_addrs (void)
     rhwloc_map_strv_free (addrs);
 
     /* GPU 1 */
-    addrs = rhwloc_map_gpu_pci_addrs (m, "1");
+    addrs = rhwloc_map_gpu_pci_addrs (m, "1", &error);
     ok (addrs != NULL,
         "rhwloc_map_gpu_pci_addrs gpus=1 returns non-NULL");
     ok (addrs != NULL && addrs[0] != NULL
@@ -247,7 +255,7 @@ void test_gpu_pci_addrs (void)
     rhwloc_map_strv_free (addrs);
 
     /* GPUs 0-1 */
-    addrs = rhwloc_map_gpu_pci_addrs (m, "0-1");
+    addrs = rhwloc_map_gpu_pci_addrs (m, "0-1", &error);
     ok (addrs != NULL,
         "rhwloc_map_gpu_pci_addrs gpus=0-1 returns non-NULL");
     ok (addrs != NULL && addrs[0] != NULL
@@ -261,7 +269,7 @@ void test_gpu_pci_addrs (void)
     rhwloc_map_strv_free (addrs);
 
     /* Out-of-range GPU */
-    addrs = rhwloc_map_gpu_pci_addrs (m, "2");
+    addrs = rhwloc_map_gpu_pci_addrs (m, "2", &error);
     ok (addrs == NULL,
         "rhwloc_map_gpu_pci_addrs out-of-range GPU returns NULL");
 

--- a/src/shell/affinity.c
+++ b/src/shell/affinity.c
@@ -196,9 +196,14 @@ static hwloc_cpuset_t *distribute_tasks (hwloc_topology_t topo,
 static hwloc_cpuset_t shell_affinity_get_cpuset (struct shell_affinity *sa,
                                                  const char *cores)
 {
-    hwloc_cpuset_t cpuset = rhwloc_cores_to_cpuset (sa->topo, cores);
+    flux_error_t error;
+    hwloc_cpuset_t cpuset = rhwloc_cores_to_cpuset (sa->topo,
+                                                    cores,
+                                                    &error);
     if (!cpuset)
-        shell_log_error ("affinity: failed to get cpuset for cores: %s", cores);
+        shell_log_error ("affinity: failed to get cpuset for cores: %s: %s",
+                         cores,
+                         error.text);
     return cpuset;
 }
 

--- a/t/t2416-sdexec-constrain-resources.t
+++ b/t/t2416-sdexec-constrain-resources.t
@@ -309,6 +309,45 @@ test_expect_success 'AllowedCPUs check failure drains rank with useful message' 
 '
 
 #
+# Mapper error reporting: sdexec-mapper.lookup returns a useful error message
+# when resource IDs cannot be mapped to the local hwloc topology.
+#
+
+cat >mapper_err.py <<'PYEOF'
+"""Send sdexec-mapper.lookup with a crafted R; on OSError print message and exit 0."""
+import json
+import subprocess
+import sys
+import flux
+
+result = subprocess.run(
+    ["flux", "R", "encode"] + sys.argv[1:],
+    stdout=subprocess.PIPE,
+    check=True,
+)
+R = json.loads(result.stdout)
+h = flux.Flux()
+try:
+    h.rpc("sdexec-mapper.lookup", {"R": R}).get()
+    print("ERROR: lookup succeeded unexpectedly", file=sys.stderr)
+    sys.exit(1)
+except OSError as e:
+    print(str(e))
+PYEOF
+
+test_expect_success 'sdexec-mapper.lookup: out-of-range core returns useful error' '
+	flux python mapper_err.py --cores=999 >core-out-of-range.out &&
+	test_debug "cat core-out-of-range.out" &&
+	grep -i "core" core-out-of-range.out
+'
+
+test_expect_success 'sdexec-mapper.lookup: out-of-range GPU returns useful error' '
+	flux python mapper_err.py --cores=0 --gpus=999 >gpu-out-of-range.out &&
+	test_debug "cat gpu-out-of-range.out" &&
+	grep -i "not found" gpu-out-of-range.out
+'
+
+#
 # Reload config: disable sdexec-constrain-resources, verify constraint removed
 #
 # N.B. do these tests last as they alter the job-exec module config


### PR DESCRIPTION
As noted in #7605 the librlist `rhwloc_map*` functions do not return useful error messages on failure. This doesn't give admins or users anything to go on when sdexec-mapper fails to map resources to systemd properties for a job.

This PR adds `flux_error_t` arguments through the `rhlwoc_map` and underlying `rhwloc` APIs so that functions can provide human-readable error messages. These messages will be provided in any sdexec-mapper error response, and thus will be part of the job exception on launch failure.

For example in the motivating case (GPU ID assigned to job not in local topology)
```console
$ flux R encode -c 0-1 -g 0 |  flux python -c 'import sys,flux; flux.Flux().rpc("sdexec-mapper.lookup", {"R": sys.stdin.read()}).get()' 2>&1 | tail -1
May 13 16:06:38.311820 PDT 2026 sdexec-mapper.err[0]: lookup failed: [Errno 19] failed to map GPUs: gpu0 not found in local topology (gpu count=0)
OSError: [Errno 19] [Errno 19] failed to map GPUs: gpu0 not found in local topology (gpu count=0)
```

Fixes #7605