### PR TITLE
support launching test Flux instances with fake resources

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -390,7 +390,8 @@ MAN5_FILES_PRIMARY = \
 	man5/flux-config-kvs.5 \
 	man5/flux-config-policy.5 \
 	man5/flux-config-queues.5 \
-	man5/flux-config-heartbeat.5
+	man5/flux-config-heartbeat.5 \
+	man5/flux-config-fake-resources.5
 
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)

--- a/doc/man5/flux-config-fake-resources.rst
+++ b/doc/man5/flux-config-fake-resources.rst
@@ -1,0 +1,153 @@
+=============================
+flux-config-fake-resources(5)
+=============================
+
+
+DESCRIPTION
+===========
+
+The ``fake-resources`` table activates the ``fake-resources`` modprobe rc1
+task (see :man1:`flux-modprobe`), which encodes a synthetic R from the
+table's contents and installs it in the KVS before the resource module loads.
+The result is a Flux instance that reports an arbitrary fake cluster shape,
+without the underlying hardware to back it.
+
+The intended use is testing — scaling studies, scheduler benchmarks,
+integration and performance tests for tools — at sizes that would be
+prohibitive on real hardware. Fake broker ranks are forced to appear as
+up, but have no network endpoints, so flux-shell cannot launch real jobs
+against them; use the ``system.exec.test.run_duration`` jobspec attribute
+for mock execution.
+
+
+KEYS
+====
+
+nnodes (required)
+   Integer number of synthetic nodes to encode. Must be positive.
+
+cores-per-node (optional)
+   Integer number of cores on each synthetic node. (Default: ``64``).
+
+gpus-per-node (optional)
+   Integer number of GPUs on each synthetic node. ``0`` omits the GPU
+   resource type from R entirely. (Default: ``0``).
+
+host-prefix (optional)
+   String hostname prefix. Nodes are named ``{prefix}0``, ``{prefix}1``,
+   and so on. (Default: ``"fake"``).
+
+hwloc-xml-path (optional)
+   Path to an hwloc XML file describing per-node topology. When set, R is
+   encoded from the XML rather than from the numeric ``cores-per-node`` and
+   ``gpus-per-node`` keys, producing an R with topology structure suitable
+   for locality-aware scheduling.
+
+amend-r (optional)
+   Reference to a Python callable that mutates the encoded R before it is
+   written to the KVS. Two forms are accepted:
+
+   * ``module.path:function_name`` — importlib loads the named module and
+     looks up the function. Useful when the amender ships with a Python
+     package on PYTHONPATH (e.g. a Fluxion JGF helper).
+   * Any value without a ``:`` is interpreted as a filesystem path; the
+     file is loaded as a Python module and its ``amend`` callable is used.
+     Useful when the amender is not available in an installed package.
+
+   The callable signature is ``amend(R, hwloc_xml=None) -> R``. Used to
+   inject scheduler-specific metadata into R (e.g. Fluxion JGF keys,
+   node properties) at broker startup, alongside the synthetic resource
+   shape.
+
+
+EXAMPLE
+=======
+
+::
+
+   [fake-resources]
+   nnodes = 1000
+   cores-per-node = 48
+   gpus-per-node = 4
+   host-prefix = "node"
+
+The equivalent invocation as ``flux start`` arguments - no config file
+required::
+
+   flux start \
+       --conf=fake-resources.nnodes=1000 \
+       --conf=fake-resources.cores-per-node=48 \
+       --conf=fake-resources.gpus-per-node=4 \
+       --conf=fake-resources.host-prefix=node \
+       -- flux resource info
+
+An example using ``amend-r`` to inject scheduler-specific R metadata from
+a local Python file::
+
+   flux start \
+       --conf=fake-resources.nnodes=100 \
+       --conf=fake-resources.amend-r=./my-amender.py \
+       --conf=modules.alternatives.sched=sched-fluxion-qmanager \
+       -- flux resource info
+
+
+AMENDERS
+========
+
+An *amender* is a Python callable that mutates the encoded R before it is
+written to the KVS. Use one to inject metadata that the bare
+``flux R encode`` output doesn't carry — most commonly JGF for Fluxion, but
+also things like node properties or scheduler-specific attributes.
+
+An amender has the following signature:
+
+.. code-block:: python
+
+   def amend(R, hwloc_xml=None):
+       # mutate R in place, or build a new dict; return it
+       R["scheduling"] = {...}
+       return R
+
+The arguments are:
+
+* ``R`` — the parsed R dict produced by ``flux R encode``, ready to mutate.
+  The amender owns it for the duration of the call: either mutate in place
+  and return the same dict, or build a new one and return that.
+* ``hwloc_xml`` — when the ``hwloc-xml-path`` config key was set, this is
+  the file's loaded contents as a string; otherwise it is None. Useful for
+  amenders that derive their additions from the topology.
+
+The return value is what gets written to ``resource.R`` in the KVS.
+
+The ``amend-r`` config key accepts two forms:
+
+* ``module.path:function_name`` — the named module is imported and the
+  named function is looked up. Use this when the amender ships in a Python
+  package on PYTHONPATH.
+* Anything without a colon is treated as a filesystem path; the file is
+  loaded as a Python module and its top-level ``amend()`` function is used.
+
+A minimal example amender, suitable for the path form, that tags every R
+with a marker in the scheduling key:
+
+.. code-block:: python
+
+   # my-amender.py
+   def amend(R, hwloc_xml=None):
+       R["scheduling"] = {"writer": "my:amender", "tag": "test"}
+       return R
+
+See :class:`flux.testing.fake_resources.InjectFakeResources` for the
+underlying API and additional examples.
+
+
+RESOURCES
+=========
+
+.. include:: common/resources.rst
+
+
+SEE ALSO
+========
+
+:man5:`flux-config`, :man1:`flux-modprobe`, :man1:`flux-start`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -384,6 +384,7 @@ man_pages = [
     ('man5/flux-config-job-manager', 'flux-config-job-manager', 'configure Flux job manager service', [author], 5),
     ('man5/flux-config-kvs', 'flux-config-kvs', 'configure Flux kvs service', [author], 5),
     ('man5/flux-config-heartbeat', 'flux-config-heartbeat', 'configure Flux heartbeat service', [author], 5),
+    ('man5/flux-config-fake-resources', 'flux-config-fake-resources', 'configure synthetic resources for Flux test instances', [author], 5),
     ('man5/flux-shell-initrc', 'flux-shell-initrc', 'Flux shell config file', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1195,3 +1195,7 @@ TasksMax
 urandom
 uvm
 UVM
+amender
+amenders
+jgf
+importlib

--- a/etc/modprobe/rc1.py
+++ b/etc/modprobe/rc1.py
@@ -17,6 +17,7 @@ from subprocess import Popen
 import flux.kvs
 import flux.subprocess as sp
 from flux.modprobe import run_all_rc_scripts, task
+from flux.testing.fake_resources import InjectFakeResources
 
 
 def setup(context):
@@ -226,6 +227,38 @@ def slurm_expiration_sync(context):
         ["flux", "slurm-expiration-sync", f"--jobid={jobid}"],
         label="slurm-sync",
     )
+
+
+@task(
+    "fake-resources",
+    ranks="0",
+    before=["resource"],
+    after=["kvs"],
+    needs_config=["fake-resources"],
+)
+def fake_resources(context):
+    """
+    Encode synthetic R from the [fake-resources] config table and write it
+    to ``resource.R`` in the KVS, then set resource module options that
+    prevent verification of the synthetic R against the host's real hwloc
+    topology.
+    """
+    cfg = context.conf_get("fake-resources", {})
+
+    if "nnodes" not in cfg:
+        raise RuntimeError("[fake-resources] table requires the 'nnodes' key")
+
+    InjectFakeResources(
+        nodes=cfg["nnodes"],
+        cores_per_node=cfg.get("cores-per-node", 64),
+        gpus_per_node=cfg.get("gpus-per-node", 0),
+        host_prefix=cfg.get("host-prefix", "fake"),
+        hwloc_xml_path=cfg.get("hwloc-xml-path"),
+        amender=cfg.get("amend-r"),
+        log=print,
+    ).install(context.handle)
+
+    context.setopt("resource", "monitor-force-up noverify", overwrite=True)
 
 
 @task("run-all-rc1", after=["*"])

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -95,6 +95,8 @@ nobase_fluxpy_PYTHON = \
 	shape/__init__.py \
 	abc/journal.py \
 	abc/__init__.py \
+	testing/__init__.py \
+	testing/fake_resources.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/testing/fake_resources.py
+++ b/src/bindings/python/flux/testing/fake_resources.py
@@ -1,0 +1,412 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Fake resource generation and installation for testing.
+
+Provides a :class:`FakeResources` ABC describing a synthetic resource set with
+a flat shape (nodes × cores × gpus), plus an :class:`InjectFakeResources`
+implementation that encodes R via ``flux R encode`` and writes it to the
+``resource.R`` KVS key. Intended for use by the ``fake-resources`` modprobe
+rc1 task (see flux-config-fake-resources(5)), which runs this code before the
+resource module loads so the synthetic R is in place at broker startup.
+"""
+
+import abc
+import importlib
+import json
+import os
+import subprocess
+import sys
+
+import flux
+import flux.kvs
+from flux.idset import IDset
+from flux.importer import import_path
+
+
+def _stderr_log(msg):
+    """Default log function: print ``msg`` to stderr.
+
+    The CLI overrides this with ``LOGGER.info`` (or similar) for prefixed
+    output; tests pass a no-op to suppress noise.
+    """
+    print(msg, file=sys.stderr)
+
+
+def load_amender(spec):
+    """Resolve a TOML ``amend-r`` spec to a callable.
+
+    Two forms are supported:
+
+    * ``module.path:function_name`` — imports ``module.path`` and returns
+      its ``function_name`` attribute. Useful when the amender ships with
+      a Python package on PYTHONPATH (e.g. a Fluxion JGF helper).
+
+    * Anything without a ``:`` is treated as a filesystem path; the file
+      is loaded as a Python module and its ``amend`` callable is returned.
+      Useful for ad-hoc test amenders that don't warrant a package.
+
+    The returned callable should have signature ``amend(R, hwloc_xml=None) ->
+    R``. It is invoked from :meth:`FakeResources.amend_R` when set via the
+    ``amender`` constructor argument.
+
+    Raises :class:`RuntimeError` with a descriptive message on any failure
+    (file not found, import error, missing attribute), so configuration
+    mistakes surface clearly from the modprobe rc1 task rather than as a
+    generic ImportError.
+    """
+    if ":" in spec:
+        mod_name, fn_name = spec.split(":", 1)
+        try:
+            module = importlib.import_module(mod_name)
+        except ImportError as exc:
+            raise RuntimeError(
+                "[fake-resources] amend-r: failed to import "
+                f"module {mod_name!r}: {exc}"
+            )
+        if not hasattr(module, fn_name):
+            raise RuntimeError(
+                f"[fake-resources] amend-r: module {mod_name!r} "
+                f"has no attribute {fn_name!r}"
+            )
+        return getattr(module, fn_name)
+
+    # File-path form
+    path = os.path.expanduser(spec)
+    if not os.path.isfile(path):
+        raise RuntimeError(f"[fake-resources] amend-r: file not found: {path!r}")
+    try:
+        module = import_path(path)
+    except Exception as exc:
+        raise RuntimeError(f"[fake-resources] amend-r: failed to load {path!r}: {exc}")
+    if not hasattr(module, "amend"):
+        raise RuntimeError(
+            f"[fake-resources] amend-r: file {path!r} has no "
+            "'amend' callable at module scope"
+        )
+    return module.amend
+
+
+class FakeResources(abc.ABC):
+    """Abstract base for synthetic resource sets with a flat shape.
+
+    A resource set described as a count of nodes, cores per node, and
+    (optionally) GPUs per node. On-node topology (sockets, NUMA domains) is
+    not modeled here; subclasses or callers needing topology should pass real
+    hwloc XML, which ``flux R encode --local`` will consume, or override
+    :meth:`amend_R` to inject scheduler-specific metadata.
+
+    Subclasses must implement :meth:`install`, which makes the resource set
+    visible to the broker. Subclasses may also override :meth:`amend_R` to
+    mutate the encoded R before it is installed.
+    """
+
+    def __init__(
+        self, nodes, cores_per_node=1, gpus_per_node=0, host_prefix="fake", amender=None
+    ):
+        self.nodes = nodes
+        self.cores_per_node = cores_per_node
+        self.gpus_per_node = gpus_per_node
+        self.host_prefix = host_prefix
+        # amender may be a callable (caller has already resolved it,
+        # or built it inline) or a string in the load_amender(spec)
+        # forms (``module:function`` or a path). String form is
+        # resolved here so the rc1 task and other callers can just
+        # forward the TOML value without thinking about resolution.
+        if isinstance(amender, str):
+            amender = load_amender(amender)
+        self.amender = amender
+
+    @property
+    def total_cores(self):
+        """Total core count across all nodes."""
+        return self.nodes * self.cores_per_node
+
+    @property
+    def total_gpus(self):
+        """Total GPU count across all nodes."""
+        return self.nodes * self.gpus_per_node
+
+    @abc.abstractmethod
+    def install(self):
+        """Make these resources visible to the broker.
+
+        Concrete subclasses may extend this signature with additional
+        arguments.
+        """
+
+    def saturation_count(self, slot_cores=1, slot_gpus=0):
+        """Number of slot-shape jobs needed to saturate this resource set.
+
+        See :func:`saturation_count` for the algorithm. This method is a thin
+        wrapper that pulls ``nodes``, ``cores_per_node``, and
+        ``gpus_per_node`` from ``self``; it exists so callers holding a
+        FakeResources object don't have to unpack its attributes. The function
+        form is what ``flux schedbench`` calls for the real-resource path,
+        where there's no FakeResources object — the shape comes from a
+        ``flux.resource.resource_list`` query.
+        """
+        return saturation_count(
+            self.nodes,
+            self.cores_per_node,
+            self.gpus_per_node,
+            slot_cores=slot_cores,
+            slot_gpus=slot_gpus,
+        )
+
+    def amend_R(self, R, hwloc_xml=None):
+        """Hook to mutate R after generation, before KVS install.
+
+        Subclasses can override directly for complex amendment logic. Callers
+        (typically the fake-resources modprobe rc1 task) can also pass
+        ``amender=`` to the constructor to inject a callable taking ``(R,
+        hwloc_xml=...)`` and returning amended R; the default :meth:`amend_R`
+        defers to it. Subclass overrides take precedence; a subclass that
+        wants to incorporate ``self.amender`` should call ``super().amend_R(R,
+        hwloc_xml=...)``.
+
+        Used to inject scheduler-specific metadata into R — for example,
+        Fluxion JGF keys or property tags. When called against an XML-derived
+        R, ``hwloc_xml`` is the loaded XML string; otherwise it is None.
+        """
+        if self.amender is not None:
+            return self.amender(R, hwloc_xml=hwloc_xml)
+        return R
+
+
+def saturation_count(nodes, cores_per_node, gpus_per_node, slot_cores=1, slot_gpus=0):
+    """Return the number of slot-shape jobs that saturate a flat
+    resource set.
+
+    A ``slot`` is described by its core and GPU counts; this returns the
+    number of such slots that fit across ``nodes`` machines of
+    ``cores_per_node`` cores and ``gpus_per_node`` GPUs each, taking the
+    more-constraining of cores and GPUs into account. Pure arithmetic — no
+    broker access, no FakeResources object required — so it's reusable from
+    code paths that gather the shape from :func:`flux.resource.resource_list`
+    instead.
+
+    Either ``slot_cores`` or ``slot_gpus`` must be positive.
+
+    Non-uniformity note: this assumes uniform cores/GPUs per node. Real broker
+    resources may not be uniform; callers that derive the shape from a broker
+    query typically average across nodes, which can over- or under-estimate
+    true capacity by one slot per heterogeneous node. The error is bounded and
+    not a correctness issue for benchmarks that measure aggregate rates.
+    """
+    if slot_cores < 1 and slot_gpus < 1:
+        raise ValueError("slot_cores or slot_gpus must be positive")
+    per_node = cores_per_node // max(slot_cores, 1)
+    if slot_gpus:
+        per_node = min(per_node, gpus_per_node // slot_gpus)
+    return nodes * per_node
+
+
+def build_R_encode_args(fr):
+    """Build argv for ``flux R encode`` from a :class:`FakeResources`.
+
+    Exposed separately from :class:`InjectFakeResources` so unit tests can
+    verify command construction without requiring a broker.
+
+    Idset-shaped arguments (``-r``, ``-c``, ``-g``) are formatted via
+    :class:`flux.idset.IDset` rather than ``f"0-{n-1}"``. A degenerate
+    single-element range like ``"0-0"`` is rejected when ``flux R encode``
+    parses it as an idset, which silently produced R without the affected
+    resource type (the ``gpus_per_node=1`` case originally surfaced this).
+    :class:`IDset` emits ``"0"`` for a one-element set, which parses cleanly.
+    """
+    n = fr.nodes
+    ranks = IDset()
+    ranks.set(0, n - 1)
+    cores = IDset()
+    cores.set(0, fr.cores_per_node - 1)
+    cmd = [
+        "flux",
+        "R",
+        "encode",
+        f"-r{ranks}",
+        f"-H{fr.host_prefix}[0-{n - 1}]",
+        "-c",
+        str(cores),
+    ]
+    if fr.gpus_per_node > 0:
+        gpus = IDset()
+        gpus.set(0, fr.gpus_per_node - 1)
+        cmd += ["-g", str(gpus)]
+    return cmd
+
+
+class InjectFakeResources(FakeResources):
+    """:class:`FakeResources` that writes synthetic R to the KVS.
+
+    :meth:`install` encodes R from the configured shape (or from an hwloc XML
+    file, if ``hwloc_xml_path`` is set) and writes it to ``resource.R``. The
+    caller is responsible for arranging the write to happen before the
+    resource module reads its initial R, and for setting any resource-module
+    options needed to accept synthetic R (``noverify``, ``monitor-force-up``).
+    The ``fake-resources`` modprobe rc1 task handles both.
+
+    If ``hwloc_xml_path`` is set, R is encoded by passing the XML file to
+    ``flux R encode --xml=FILE`` rather than from the numeric
+    ``cores_per_node`` / ``gpus_per_node`` fields. The XML's loaded contents
+    are passed to :meth:`amend_R` so subclasses can use them.
+
+    The ``log`` argument is a callable taking a single string (default
+    :func:`_stderr_log`). Pass ``LOGGER.info`` to integrate with a CLI's
+    logging configuration, or ``lambda _: None`` to suppress output entirely.
+
+    **Writing an amender**
+
+    An *amender* is a Python callable that mutates the encoded R before it is
+    written to the KVS. Use it to inject scheduler-specific metadata that the
+    bare ``flux R encode`` output doesn't carry, most notably the contents of
+    the scheduling key, but may also include things like node properties or
+    custom attributes for property-based schedulers.
+
+    An amender has the signature::
+
+    def amend(R, hwloc_xml=None): # mutate R in place, or build a new dict
+        R["scheduling"] = {...}
+        return R
+
+    Where:
+
+    * ``R`` is the parsed R dict (RFC 20) produced by ``flux R encode``,
+      ready to mutate. The amender owns it for the duration of the call;
+      either mutate in place and return the same dict, or build a new one
+      and return that.
+    * ``hwloc_xml`` is the contents of the hwloc XML file when
+      ``hwloc_xml_path`` was set on the constructor, or None otherwise.
+      Useful for amenders that derive their additions from the topology
+      (Fluxion's JGF, for example, walks the XML to build a graph).
+    * The return value is what gets written to ``resource.R`` in KVS.
+
+    The amender is passed to the constructor as the ``amender`` argument and
+    may be either:
+
+    * A callable, ready to invoke. Use this when the amender is defined in
+      the same source file or pulled from a Python package the caller
+      already imported.
+    * A string in one of two forms, resolved at construction time via
+      :func:`load_amender`:
+
+      - ``"module.path:function_name"`` — importlib loads ``module.path``
+        and looks up ``function_name``. Use this when the amender ships in
+        a package on PYTHONPATH.
+      - Anything without a colon is treated as a filesystem path; the file
+        is loaded as a Python module and its ``amend`` (literally that
+        name) attribute is used. Use this for ad-hoc test amenders or for
+        passing an amender from a modprobe config without packaging it.
+
+    The string forms are what the ``[fake-resources]`` ``amend-r`` TOML key in
+    flux-config-fake-resources(5) accepts; the rc1 task forwards the TOML
+    value straight to this constructor.
+
+    Subclassing :class:`FakeResources` and overriding :meth:`amend_R` is an
+    alternative to passing an amender — choose subclassing when the amendment
+    logic is non-trivial (multiple methods, internal state) and the callable
+    form when the logic fits in one function. Subclass overrides take
+    precedence over the constructor ``amender``; a subclass that wants to
+    incorporate the constructor amender should call ``super().amend_R(R,
+    hwloc_xml=...)``.
+    """
+
+    def __init__(
+        self,
+        nodes,
+        cores_per_node=1,
+        gpus_per_node=0,
+        host_prefix="fake",
+        hwloc_xml_path=None,
+        verbose=False,
+        log=None,
+        amender=None,
+    ):
+        super().__init__(
+            nodes=nodes,
+            cores_per_node=cores_per_node,
+            gpus_per_node=gpus_per_node,
+            host_prefix=host_prefix,
+            amender=amender,
+        )
+        self.hwloc_xml_path = hwloc_xml_path
+        self.verbose = verbose
+        self.log = log if log is not None else _stderr_log
+
+    def install(self, handle=None):
+        """Encode R from the configured shape and install it into the
+        ``resource.R`` KVS key.
+
+        Args:
+            handle: an open :class:`flux.Flux` handle used for the KVS
+            put + commit. If ``None``, a fresh handle is opened via
+            :class:`flux.Flux()`.
+        """
+        r_json, hwloc_xml = self._encode_R()
+        r_json = self._apply_amend_R(r_json, hwloc_xml)
+        self._install_R(r_json, handle=handle)
+        self.log("Fake resources injected.")
+
+    def _encode_R(self):
+        """
+        Run ``flux R encode`` and return ``(r_json, hwloc_xml_or_None)``.
+        """
+        if self.hwloc_xml_path:
+            # The XML describes a single machine's topology. We pass
+            # ``-r`` and ``-H`` alongside ``--xml=FILE`` so flux R encode
+            # replicates that per-node shape across the configured rank
+            # range, yielding a ``self.nodes``-rank R with hostnames
+            # under the configured ``host_prefix`` instead of the
+            # Machine HostName carried in the XML.
+            cmd = ["flux", "R", "encode", f"--xml={self.hwloc_xml_path}"]
+            if self.nodes == 1:
+                cmd += ["-r", "0", "-H", f"{self.host_prefix}0"]
+            else:
+                cmd += [
+                    "-r",
+                    f"0-{self.nodes - 1}",
+                    "-H",
+                    f"{self.host_prefix}[0-{self.nodes - 1}]",
+                ]
+            if self.verbose:
+                self.log("+ " + " ".join(cmd))
+            result = subprocess.run(cmd, stdout=subprocess.PIPE, check=True)
+            with open(self.hwloc_xml_path) as f:
+                hwloc_xml = f.read()
+            return result.stdout, hwloc_xml
+
+        cmd = build_R_encode_args(self)
+        self.log(
+            f"Encoding fake R: {self.nodes} nodes, "
+            f"{self.cores_per_node} cores/node, "
+            f"{self.gpus_per_node} GPUs/node"
+        )
+        if self.verbose:
+            self.log("+ " + " ".join(cmd))
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, check=True)
+        return result.stdout, None
+
+    def _apply_amend_R(self, r_json, hwloc_xml):
+        """Round-trip R through the amend_R hook."""
+        R = json.loads(r_json)
+        R = self.amend_R(R, hwloc_xml=hwloc_xml)
+        return json.dumps(R).encode()
+
+    def _install_R(self, r_json, handle=None):
+        """Write R into the ``resource.R`` KVS key."""
+        if handle is None:
+            handle = flux.Flux()
+        if self.verbose:
+            self.log("+ kvs put resource.R")
+        flux.kvs.put(handle, "resource.R", r_json, raw=True)
+        flux.kvs.commit(handle)
+
+
+# vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -293,6 +293,7 @@ TESTSCRIPTS = \
 	t3400-overlay-trace.t \
 	t3401-module-trace.t \
 	t4100-slurm-expiration-sync.t \
+	t6010-fake-resources.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -344,7 +344,8 @@ TESTSCRIPTS = \
 	python/t0043-scheduler-pool.py \
 	python/t0045-job-shape-parser.py \
 	python/t0100-modprobe.py \
-	python/t1000-service-add-remove.py
+	python/t1000-service-add-remove.py \
+	python/t6010-fake-resources.py
 
 if HAVE_FLUX_SECURITY
 TESTSCRIPTS += python/t0009-security.py

--- a/t/python/t6010-fake-resources.py
+++ b/t/python/t6010-fake-resources.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+##############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+"""Unit tests for flux.testing.fake_resources.
+
+Pure-Python tests of the slot-math helper, the argv builder, the amend_R hook
+contract, and the ABC's abstract requirement. None of these tests require a
+running broker.
+
+End-to-end behavior (broker actually starts with synthetic R, resource module
+accepts it, scheduler allocates against it, amend_R takes effect) is covered
+by the sharness test t6010-fake-resources.t.
+"""
+
+import os
+import tempfile
+import unittest
+
+import subflux  # noqa: F401 — side-effect import wires PYTHONPATH
+from flux.testing.fake_resources import (
+    FakeResources,
+    InjectFakeResources,
+    load_amender,
+    saturation_count,
+)
+
+
+class TestSaturationCount(unittest.TestCase):
+    """Module-level saturation_count() is pure arithmetic; verify
+    the math against known shapes."""
+
+    def test_cores_only(self):
+        """nnodes=10, 64 cores/node, slot=1 core: 640 slots."""
+        self.assertEqual(saturation_count(10, 64, 0, slot_cores=1), 640)
+
+    def test_cores_wider_slot(self):
+        """nnodes=10, 64 cores/node, slot=5 cores: 120 slots
+        (per_node = 64 // 5 = 12, total = 10 * 12 = 120)."""
+        self.assertEqual(saturation_count(10, 64, 0, slot_cores=5), 120)
+
+    def test_cores_and_gpus_gpu_bound(self):
+        """nnodes=10, 64c/8g, slot=1c/1g: 80 slots (GPU-bound;
+        per_node = min(64, 8) = 8)."""
+        self.assertEqual(
+            saturation_count(10, 64, 8, slot_cores=1, slot_gpus=1),
+            80,
+        )
+
+    def test_cores_and_gpus_cpu_bound(self):
+        """nnodes=4, 4c/8g, slot=2c/1g: 8 slots (CPU-bound;
+        per_node = min(4//2, 8//1) = min(2, 8) = 2)."""
+        self.assertEqual(
+            saturation_count(4, 4, 8, slot_cores=2, slot_gpus=1),
+            8,
+        )
+
+    def test_single_node(self):
+        """nnodes=1 still works (degenerate but valid)."""
+        self.assertEqual(saturation_count(1, 8, 0, slot_cores=1), 8)
+
+    def test_zero_gpu_node_with_zero_gpu_slot(self):
+        """No GPUs requested and none available: ignore the GPU
+        dimension entirely, fall back to core-only math."""
+        self.assertEqual(
+            saturation_count(4, 8, 0, slot_cores=1, slot_gpus=0),
+            32,
+        )
+
+    def test_slot_zero_zero_raises(self):
+        """slot_cores=0 and slot_gpus=0 is meaningless — a slot
+        that requests nothing — and the function should reject it."""
+        with self.assertRaises(ValueError):
+            saturation_count(10, 64, 8, slot_cores=0, slot_gpus=0)
+
+    def test_slot_gpu_only_with_no_node_gpus(self):
+        """Requesting GPU slots on a GPU-less cluster: 0 slots
+        (per_node = min(cores, 0) = 0)."""
+        self.assertEqual(
+            saturation_count(10, 64, 0, slot_cores=0, slot_gpus=1),
+            0,
+        )
+
+    def test_method_form_matches_function_form(self):
+        """FakeResources.saturation_count() is a thin wrapper around
+        the module-level function and must produce identical results."""
+        fr = InjectFakeResources(nodes=10, cores_per_node=64, gpus_per_node=8)
+        for slot_cores, slot_gpus in [(1, 0), (5, 0), (1, 1), (2, 1), (4, 2)]:
+            with self.subTest(slot_cores=slot_cores, slot_gpus=slot_gpus):
+                method = fr.saturation_count(
+                    slot_cores=slot_cores,
+                    slot_gpus=slot_gpus,
+                )
+                func = saturation_count(
+                    fr.nodes,
+                    fr.cores_per_node,
+                    fr.gpus_per_node,
+                    slot_cores=slot_cores,
+                    slot_gpus=slot_gpus,
+                )
+                self.assertEqual(method, func)
+
+
+class TestInjectFakeResourcesInit(unittest.TestCase):
+    """Constructor stores arguments on the instance for use by
+    install() and downstream consumers."""
+
+    def test_required_argument_is_nodes(self):
+        """``nodes`` is the only positional required arg."""
+        fr = InjectFakeResources(nodes=4)
+        self.assertEqual(fr.nodes, 4)
+
+    def test_defaults_match_class_contract(self):
+        """Defaults: 1 core/node, 0 gpus/node, host prefix 'fake',
+        no hwloc XML path, no verbose, default log."""
+        fr = InjectFakeResources(nodes=4)
+        self.assertEqual(fr.cores_per_node, 1)
+        self.assertEqual(fr.gpus_per_node, 0)
+        self.assertEqual(fr.host_prefix, "fake")
+        self.assertIsNone(fr.hwloc_xml_path)
+        self.assertFalse(fr.verbose)
+        self.assertIsNotNone(fr.log)
+
+    def test_total_properties(self):
+        """total_cores / total_gpus are computed properties."""
+        fr = InjectFakeResources(nodes=4, cores_per_node=8, gpus_per_node=2)
+        self.assertEqual(fr.total_cores, 32)
+        self.assertEqual(fr.total_gpus, 8)
+
+    def test_log_callable_override(self):
+        """A user-supplied log callable replaces the default."""
+        captured = []
+        fr = InjectFakeResources(nodes=4, log=captured.append)
+        fr.log("hello")
+        self.assertEqual(captured, ["hello"])
+
+    def test_hwloc_xml_path_stored_verbatim(self):
+        """The path is stored as-is; the file is opened later by
+        _encode_R(). Parse errors and missing files surface at install() time,
+        not construction time."""
+        fr = InjectFakeResources(nodes=1, hwloc_xml_path="/path/to/topo.xml")
+        self.assertEqual(fr.hwloc_xml_path, "/path/to/topo.xml")
+
+
+class TestAmendRHook(unittest.TestCase):
+    """The amend_R hook lets subclasses inject metadata into R
+    before it's written to KVS. Verify default is a no-op and that override
+    semantics work as expected."""
+
+    def test_default_is_noop(self):
+        """Base class amend_R returns R unchanged."""
+        fr = InjectFakeResources(nodes=4)
+        R = {"version": 1, "execution": {"R_lite": []}}
+        result = fr.amend_R(R)
+        self.assertEqual(result, R)
+
+    def test_default_passes_through_xml(self):
+        """When hwloc_xml is provided, the base class still returns
+        R unchanged. The XML is given to the hook in case a subclass wants to
+        consult it, but the default doesn't."""
+        fr = InjectFakeResources(nodes=4)
+        R = {"version": 1}
+        result = fr.amend_R(R, hwloc_xml="<topology></topology>")
+        self.assertEqual(result, R)
+
+    def test_subclass_override_modifies_R(self):
+        """A subclass can return a modified R."""
+
+        class WithProperties(InjectFakeResources):
+            def amend_R(self, R, hwloc_xml=None):
+                R["properties"] = {"bigmem": "0-3"}
+                return R
+
+        fr = WithProperties(nodes=4)
+        R = {"version": 1, "execution": {"R_lite": []}}
+        result = fr.amend_R(R)
+        self.assertIn("properties", result)
+        self.assertEqual(result["properties"], {"bigmem": "0-3"})
+
+    def test_subclass_sees_xml(self):
+        """A subclass that wants to consult the original XML
+        topology gets it via the hwloc_xml parameter."""
+        seen_xml = []
+
+        class XmlAware(InjectFakeResources):
+            def amend_R(self, R, hwloc_xml=None):
+                seen_xml.append(hwloc_xml)
+                return R
+
+        xml = "<topology><object type='Machine'/></topology>"
+        fr = XmlAware(nodes=1)
+        fr.amend_R({}, hwloc_xml=xml)
+        self.assertEqual(seen_xml, [xml])
+
+
+class TestConstructorAmender(unittest.TestCase):
+    """The ``amender=`` constructor parameter lets the default
+    amend_R() delegate to an injected callable, used by the fake-resources
+    modprobe rc1 task to support the ``amend-r`` TOML key without forcing a
+    subclass."""
+
+    def test_amender_defaults_to_None(self):
+        """Without an amender, the attribute is None and amend_R
+        is a no-op."""
+        fr = InjectFakeResources(nodes=4)
+        self.assertIsNone(fr.amender)
+        R = {"version": 1}
+        self.assertEqual(fr.amend_R(R), R)
+
+    def test_amender_callable_stored(self):
+        """The amender callable is stored on the instance verbatim."""
+
+        def my_amender(R, hwloc_xml=None):
+            return R
+
+        fr = InjectFakeResources(nodes=4, amender=my_amender)
+        self.assertIs(fr.amender, my_amender)
+
+    def test_amender_string_resolved_at_construction(self):
+        """A string amender argument is resolved via load_amender at
+        construction time; the resulting callable is stored. This
+        lets the rc1 task pass the TOML value directly without first
+        calling load_amender itself."""
+        amender = InjectFakeResources(
+            nodes=4,
+            amender="os.path:basename",
+        ).amender
+        self.assertIs(amender, os.path.basename)
+
+    def test_amender_invalid_string_raises_at_construction(self):
+        """A malformed string amender raises immediately, not later
+        at amend_R() time; the failure surfaces close to the source
+        of the bad value (the TOML config) rather than deep in the
+        install pipeline."""
+        with self.assertRaises(RuntimeError):
+            InjectFakeResources(nodes=4, amender="no_such_module_xyz:fn")
+
+    def test_default_amend_R_delegates_to_amender(self):
+        """When amender is set, the default amend_R defers to it
+        and returns whatever the amender returns."""
+
+        def my_amender(R, hwloc_xml=None):
+            R["from_amender"] = True
+            return R
+
+        fr = InjectFakeResources(nodes=4, amender=my_amender)
+        result = fr.amend_R({"original": True})
+        self.assertEqual(
+            result,
+            {"original": True, "from_amender": True},
+        )
+
+    def test_amender_receives_hwloc_xml_kwarg(self):
+        """The hwloc_xml argument is passed through to the amender."""
+        seen = []
+
+        def my_amender(R, hwloc_xml=None):
+            seen.append(hwloc_xml)
+            return R
+
+        fr = InjectFakeResources(nodes=4, amender=my_amender)
+        xml = "<topology></topology>"
+        fr.amend_R({}, hwloc_xml=xml)
+        self.assertEqual(seen, [xml])
+
+    def test_subclass_amend_R_overrides_amender(self):
+        """A subclass that overrides amend_R takes precedence over
+        the constructor amender — subclass overrides win, and a subclass that
+        wants to incorporate self.amender should call super().amend_R()
+        explicitly."""
+        amender_called = []
+
+        def my_amender(R, hwloc_xml=None):
+            amender_called.append(True)
+            R["amender"] = True
+            return R
+
+        class SubOverride(InjectFakeResources):
+            def amend_R(self, R, hwloc_xml=None):
+                R["subclass"] = True
+                return R
+
+        fr = SubOverride(nodes=4, amender=my_amender)
+        result = fr.amend_R({})
+        self.assertEqual(result, {"subclass": True})
+        self.assertEqual(amender_called, [])
+
+
+class TestLoadAmender(unittest.TestCase):
+    """load_amender() resolves a TOML amend-r spec to a callable.
+    Two forms: ``module:function`` and a filesystem path with fallback to
+    ``amend`` at module scope. Resolution errors raise RuntimeError with
+    descriptive messages so the rc1 task can surface configuration mistakes
+    clearly."""
+
+    def test_module_function_form_resolves(self):
+        """`module:function` returns the named attribute of the
+        imported module. Uses os.path.basename as a stable stdlib callable —
+        we only verify the lookup mechanism, not the callable's signature
+        (which doesn't match amend_R)."""
+        amender = load_amender("os.path:basename")
+        self.assertIs(amender, os.path.basename)
+
+    def test_module_function_missing_module_raises(self):
+        """Importing a non-existent module produces a clear
+        RuntimeError, not a leaked ImportError."""
+        with self.assertRaises(RuntimeError) as ctx:
+            load_amender("no_such_module_xyz:fn")
+        msg = str(ctx.exception)
+        self.assertIn("amend-r", msg)
+        self.assertIn("no_such_module_xyz", msg)
+
+    def test_module_function_missing_attribute_raises(self):
+        """A real module without the named attribute also raises."""
+        with self.assertRaises(RuntimeError) as ctx:
+            load_amender("os.path:no_such_function_xyz")
+        msg = str(ctx.exception)
+        self.assertIn("amend-r", msg)
+        self.assertIn("no_such_function_xyz", msg)
+
+    def test_file_path_form_resolves(self):
+        """A spec without ':' is loaded as a file; the file's
+        ``amend`` callable is returned."""
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".py",
+            delete=False,
+        ) as f:
+            f.write(
+                "def amend(R, hwloc_xml=None):\n"
+                "    R['from_file'] = True\n"
+                "    return R\n"
+            )
+            path = f.name
+        try:
+            amender = load_amender(path)
+            result = amender({}, hwloc_xml=None)
+            self.assertEqual(result, {"from_file": True})
+        finally:
+            os.unlink(path)
+
+    def test_file_path_missing_file_raises(self):
+        """A path that doesn't exist raises with a clear message."""
+        with self.assertRaises(RuntimeError) as ctx:
+            load_amender("/no/such/path/amender.py")
+        msg = str(ctx.exception).lower()
+        self.assertIn("amend-r", msg)
+        self.assertIn("not found", msg)
+
+    def test_file_without_amend_callable_raises(self):
+        """A file that loads but has no ``amend`` attribute raises."""
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".py",
+            delete=False,
+        ) as f:
+            f.write("def not_amend(R, hwloc_xml=None):\n" "    return R\n")
+            path = f.name
+        try:
+            with self.assertRaises(RuntimeError) as ctx:
+                load_amender(path)
+            msg = str(ctx.exception)
+            self.assertIn("amend-r", msg)
+            self.assertIn("amend", msg)
+        finally:
+            os.unlink(path)
+
+    def test_file_with_syntax_error_raises(self):
+        """A malformed Python file produces a clean error rather
+        than a bare SyntaxError leaking up."""
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".py",
+            delete=False,
+        ) as f:
+            f.write("def amend(R, hwloc_xml=None\n    return R\n")
+            path = f.name
+        try:
+            with self.assertRaises(RuntimeError) as ctx:
+                load_amender(path)
+            self.assertIn("amend-r", str(ctx.exception))
+        finally:
+            os.unlink(path)
+
+
+class TestFakeResourcesIsAbstract(unittest.TestCase):
+    """FakeResources is an ABC; install() is abstract and must be
+    implemented by subclasses."""
+
+    def test_cannot_instantiate_directly(self):
+        with self.assertRaises(TypeError):
+            FakeResources(nodes=4)
+
+    def test_concrete_subclass_works(self):
+        """A trivial subclass that implements install can be
+        instantiated and inherits properties + amend_R default."""
+
+        class _NoOpFR(FakeResources):
+            def install(self):
+                pass
+
+        fr = _NoOpFR(nodes=4, cores_per_node=8, gpus_per_node=2)
+        self.assertEqual(fr.total_cores, 32)
+        self.assertEqual(fr.total_gpus, 8)
+        # Default amend_R is a no-op
+        R = {"version": 1}
+        self.assertEqual(fr.amend_R(R), R)
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner(), buffer=False)

--- a/t/t6010-fake-resources.t
+++ b/t/t6010-fake-resources.t
@@ -1,0 +1,174 @@
+#!/bin/sh
+#
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+#
+
+test_description='Test fake-resources modprobe rc1 task'
+
+. $(dirname $0)/sharness.sh
+
+# Each test launches its own `flux start` with a different --conf so
+# each gets a fresh broker; no test_under_flux at the top of the file.
+# The fake-resources task only activates when the [fake-resources]
+# config table is present, so the no-config test verifies a default
+# broker still works.
+
+test_expect_success 'task does not activate without [fake-resources] config' '
+	flux start flux resource list -no {nodelist} > nodelist.out &&
+	! grep -q "fake" nodelist.out
+'
+
+test_expect_success 'minimal --conf with just nnodes succeeds' '
+	flux start --conf=fake-resources.nnodes=4 true
+'
+
+test_expect_success 'nnodes produces requested node count' '
+	flux start --conf=fake-resources.nnodes=4 \
+		flux resource info > nnodes.out &&
+	grep -q "4 Nodes" nnodes.out
+'
+
+test_expect_success 'cores-per-node honored' '
+	flux start --conf=fake-resources.nnodes=4 \
+		--conf=fake-resources.cores-per-node=8 \
+		flux resource info > cores.out &&
+	grep -q "32 Cores" cores.out
+'
+
+test_expect_success 'gpus-per-node honored' '
+	flux start --conf=fake-resources.nnodes=4 \
+		--conf=fake-resources.cores-per-node=2 \
+		--conf=fake-resources.gpus-per-node=2 \
+		flux resource info > gpus.out &&
+	grep -q "8 GPUs" gpus.out
+'
+
+test_expect_success 'host-prefix honored' '
+	flux start --conf=fake-resources.nnodes=4 \
+		--conf=fake-resources.host-prefix=node \
+		flux resource list -no {nodelist} > prefix.out &&
+	grep -q "node" prefix.out &&
+	! grep -q "fake" prefix.out
+'
+
+test_expect_success 'all options compose' '
+	flux start \
+		--conf=fake-resources.nnodes=4 \
+		--conf=fake-resources.cores-per-node=8 \
+		--conf=fake-resources.gpus-per-node=2 \
+		--conf=fake-resources.host-prefix=node \
+		flux resource info > combined.out &&
+	grep -q "4 Nodes" combined.out &&
+	grep -q "32 Cores" combined.out &&
+	grep -q "8 GPUs" combined.out
+'
+
+test_expect_success 'sched-simple allocates jobs against fake R' '
+	flux start --conf=fake-resources.nnodes=4 \
+		--conf=fake-resources.cores-per-node=2 \
+		flux submit --wait \
+			--setattr=system.exec.test.run_duration=0.001s \
+			-N 4 -n 4 true
+'
+
+test_expect_success 'missing nnodes fails broker start' '
+	test_must_fail flux start \
+		--conf=fake-resources.cores-per-node=8 true
+'
+
+# When hwloc-xml-path is set, fake-resources passes --xml=FILE to
+# flux R encode for per-node topology. The rank/host flags are passed
+# alongside so the configured nnodes replicates the per-node shape
+# and the configured host-prefix overrides the Machine HostName in
+# the XML. Tests use lstopo to capture the test runner's local
+# topology — that gives us valid hwloc XML without trying to
+# hand-write one (which flux R encode rejects with "Invalid
+# argument"). Tests are skipped when lstopo isn't available.
+
+test_expect_success 'capture local hwloc topology for hwloc-xml-path tests' '
+	if command -v lstopo >/dev/null 2>&1; then
+		lstopo --of xml local.xml &&
+		test_set_prereq HAVE_LSTOPO
+	elif command -v hwloc-ls >/dev/null 2>&1; then
+		hwloc-ls --of xml local.xml &&
+		test_set_prereq HAVE_LSTOPO
+	fi
+'
+
+test_expect_success HAVE_LSTOPO \
+	'hwloc-xml-path with nnodes=1 uses host-prefix not XML hostname' '
+	flux start --conf=fake-resources.nnodes=1 \
+		--conf=fake-resources.hwloc-xml-path=$(pwd)/local.xml \
+		flux kvs get resource.R >r-1.json &&
+	grep -q "fake0" r-1.json
+'
+
+test_expect_success HAVE_LSTOPO \
+	'hwloc-xml-path with nnodes=4 replicates topology' '
+	flux start --conf=fake-resources.nnodes=4 \
+		--conf=fake-resources.hwloc-xml-path=$(pwd)/local.xml \
+		flux kvs get resource.R >r-4.json &&
+	grep -q "fake\\[0-3\\]" r-4.json
+'
+
+test_expect_success HAVE_LSTOPO \
+	'hwloc-xml-path with custom host-prefix flows through' '
+	flux start --conf=fake-resources.nnodes=4 \
+		--conf=fake-resources.host-prefix=node \
+		--conf=fake-resources.hwloc-xml-path=$(pwd)/local.xml \
+		flux kvs get resource.R >r-hp.json &&
+	grep -q "node\\[0-3\\]" r-hp.json &&
+	test_must_fail grep -q "fake" r-hp.json
+'
+
+# The amend-r TOML key accepts two forms (resolved by
+# flux.testing.fake_resources.load_amender):
+#
+#   * a path to a Python file that defines an ``amend(R, hwloc_xml=None)``
+#     callable at module scope;
+#   * a "module:function" reference imported via importlib.
+#
+# Both should produce a broker whose resource.R contains whatever
+# amendments the callable made. We construct a marker amender and
+# verify the marker key lands in the KVS post-startup.
+
+test_expect_success 'amend-r as file path runs amender on R' '
+	cat <<-EOT >amender_file.py &&
+		def amend(R, hwloc_xml=None):
+		    R["test_marker"] = "from-file"
+		    return R
+	EOT
+	flux start --conf=fake-resources.nnodes=2 \
+		--conf=fake-resources.amend-r=$(pwd)/amender_file.py \
+		flux kvs get resource.R >file-R.out &&
+	grep -q "from-file" file-R.out
+'
+
+test_expect_success 'amend-r as module:function runs amender on R' '
+	mkdir -p amender_pkg &&
+	cat <<-EOT >amender_pkg/__init__.py &&
+		def amend(R, hwloc_xml=None):
+		    R["test_marker"] = "from-module"
+		    return R
+	EOT
+	PYTHONPATH="$(pwd):$PYTHONPATH" flux start \
+		--conf=fake-resources.nnodes=2 \
+		--conf=fake-resources.amend-r=amender_pkg:amend \
+		flux kvs get resource.R >module-R.out &&
+	grep -q "from-module" module-R.out
+'
+
+test_expect_success 'amend-r with missing file fails broker start' '
+	test_must_fail flux start \
+		--conf=fake-resources.nnodes=2 \
+		--conf=fake-resources.amend-r=/no/such/amender.py \
+		true
+'
+
+test_done


### PR DESCRIPTION
Running a test instance with a synthetic resource set has proven to be very useful for many test scenarios. It allows simulating a large available resource set for scheduler, module, and tool scalability testing on a single node. However, generating and loading the fake resource set and unloading and reloading modules properly, while simple, is a somewhat cumbersome process that could be improved. Furthermore, it would be convenient if spinning up a test instance with fake resources could be done easily with a single command for quick interactive tests.

This PR introduces a simple `flux.testing.fake_resources` Python module which handles the generation of fake resource sets, and new modprobe `rc1` task that injects the synthetic R into the KVS before the `resource` module is loaded. The resources are generated from a new `[fake-resources]` config table, where `nnodes` is the only required member. This allows an instance with 1000 nodes to be quickly started via:
```console
$ flux start --conf=fake-resources.nnodes=1000
$ flux resource info
1000 Nodes, 64000 Cores, 0 GPUs
```
(default cores-per-node is currently 64)

Use of an rc1 script was chosen over a `flux fake-resources` or similar command that could mutate a started instance because this removes the awkward requirement to unload the `resource` module and its dependents (including one more scheduler modules and their dependents), and then load them back in the correct order. 

The full supported keys in the `fake-resources` table include:
- nnodes (required)
- cores-per-node (optional, default=64) 
- gpus-per-node (optional, default=0)
- host-prefix (optional, default="fake")
- hwloc-xml-path (optional, if provided build cores-per-node, gpus-per-node from XML)
- amend-r (optional, see details below)

For schedulers like Fluxion, it may be useful to amend R with a `scheduling` key before R is placed in the KVS. The `amend-r` option allows that, described here from the `flux-config-fake-resources(5)` manpage:

```
       amend-r (optional)
              Reference to a Python callable that mutates the encoded R before it
              is written to the KVS. Two forms are accepted:

              • module.path:function_name — importlib loads the named module  and
                looks  up  the  function.  Useful  when  the amender ships with a
                Python package on PYTHONPATH (e.g. a Fluxion JGF helper).

              • Any value without a : is interpreted as a  filesystem  path;  the
                file is loaded as a Python module and its amend callable is used.
                Useful when the amender is not available in an installed package.

              The  callable  signature  is amend(R, hwloc_xml=None) -> R. Used to
              inject scheduler-specific metadata into R (e.g. Fluxion  JGF  keys,
              node  properties)  at  broker  startup, alongside the synthetic re‐
              source shape.
```

With the Python amender, schedulers that support topology can glean this from a provided hwloc XML and add it into the scheduling key, allowing tests and benchmarks to build large clusters of specific node types to test scheduler performance at scale, including locality-aware scheduling in various scenarios.