### PR TITLE
add node topology aware scheduling

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -26,10 +26,13 @@ extend-exclude = [
 [default.extend-identifiers]
 gl_pathc = "gl_pathc"
 infp = "infp"
+anc = "anc"
 
 [default.extend-words]
 # in hwloc output
 hsi = "hsi"
+# HPE is a company name (Hewlett Packard Enterprise)
+HPE = "HPE"
 # commonly used names/variables that aren't typos
 fo = "fo"
 ba = "ba"

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -31,7 +31,8 @@ fluxpyso_LTLIBRARIES = \
 	_core.la \
 	_hostlist.la \
 	_idset.la \
-	_rhwloc_map.la
+	_rhwloc_map.la \
+	_rhwloc_treepool.la
 
 fluxpyso_PYTHON = \
 	__init__.py
@@ -47,6 +48,7 @@ EXTRA_DIST = \
 	_hostlist_build.py \
 	_idset_build.py \
 	_rhwloc_map_build.py \
+	_rhwloc_treepool_build.py \
 	make_clean_header.py
 
 STDERR_DEVNULL = $(stderr_devnull_$(V))
@@ -120,6 +122,22 @@ _rhwloc_map_la_LIBADD = \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(common_libs) \
 	$(HWLOC_LIBS)
+
+_rhwloc_treepool.c: $(srcdir)/_rhwloc_treepool_build.py
+	$(AM_V_GEN)$(PYTHON) $< $(STDERR_DEVNULL)
+
+nodist__rhwloc_treepool_la_SOURCES = _rhwloc_treepool.c
+_rhwloc_treepool_la_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/src/common/libccan \
+	$(HWLOC_CFLAGS) \
+	$(JANSSON_CFLAGS)
+_rhwloc_treepool_la_LIBADD = \
+	$(top_builddir)/src/common/librlist/librlist-hwloc.la \
+	$(top_builddir)/src/common/librlist/librlist.la \
+	$(common_libs) \
+	$(HWLOC_LIBS) \
+	$(JANSSON_LIBS)
 
 if HAVE_FLUX_SECURITY
 

--- a/src/bindings/python/_flux/_rhwloc_treepool_build.py
+++ b/src/bindings/python/_flux/_rhwloc_treepool_build.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from cffi import FFI
+
+ffi = FFI()
+
+ffi.set_source(
+    "_flux._rhwloc_treepool",
+    """
+#include "src/common/librlist/rhwloc_treepool.h"
+
+// TODO: remove this when we can use cffi 1.10
+#ifdef __GNUC__
+#pragma GCC visibility push(default)
+#endif
+    """,
+)
+
+ffi.cdef(
+    """
+typedef struct {
+    char text[160];
+} flux_error_t;
+
+char *rhwloc_treepool_topo_to_json (const char *xml, flux_error_t *errp);
+
+void free (void *);
+"""
+)
+
+if __name__ == "__main__":
+    ffi.emit_c_code("_rhwloc_treepool.c")
+    Path("_rhwloc_treepool.c").touch()

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -71,6 +71,7 @@ nobase_fluxpy_PYTHON = \
 	resource/ResourcePool.py \
 	resource/ResourcePoolImplementation.py \
 	resource/Rv1Pool.py \
+	resource/TreePool.py \
 	resource/ResourceCount.py \
 	resource/list.py \
 	resource/status.py \

--- a/src/bindings/python/flux/resource/ResourcePool.py
+++ b/src/bindings/python/flux/resource/ResourcePool.py
@@ -30,16 +30,65 @@ from flux.resource.ResourcePoolImplementation import (
     ResourcePoolImplementation,
 )
 
+_POOL_CLASS_CACHE: dict = {}
+
+
+def _pool_class_from_uri(uri: str):
+    """Resolve a scheduling writer URI to a ResourcePool subclass.
+
+    - ``"module"`` → import ``module`` (falling back to
+      ``flux.resource.module``) → ``mod.pool_class``
+    - ``"module:ClassName"`` → import ``module`` →
+      ``getattr(module, "ClassName")``.
+
+    Results are cached, including failed lookups (``None``).  If a module is
+    not importable at first call, ``None`` is returned on all subsequent
+    calls for the same URI until the cache is cleared.
+    """
+    if uri in _POOL_CLASS_CACHE:
+        return _POOL_CLASS_CACHE[uri]
+    if ":" in uri:
+        module_name, cls_name = uri.split(":", 1)
+    else:
+        module_name, cls_name = uri, None
+    module_name = module_name.replace("-", "_")
+    candidates = [module_name]
+    if "." not in module_name:
+        candidates.append(f"flux.resource.{module_name}")
+    mod = None
+    for candidate in candidates:
+        try:
+            mod = importlib.import_module(candidate)
+            break
+        except ImportError:
+            continue
+    result = None
+    if mod is not None:
+        try:
+            if cls_name:
+                result = getattr(mod, cls_name)
+            else:
+                result = mod.pool_class
+        except AttributeError:
+            pass
+    _POOL_CLASS_CACHE[uri] = result
+    return result
 
 class ResourcePool:
     """Public wrapper for a resource pool implementation.
 
-    Accepts the same argument forms as
-    :class:`~flux.resource.ResourceSet.ResourceSet`:
+    Accepts the following argument forms:
 
     - An R JSON string or parsed dict → dispatches to the correct
       :class:`ResourcePoolImplementation` subclass by version.
     - A :class:`ResourcePoolImplementation` instance → wraps it directly.
+
+    Subclasses preserve their identity through :meth:`alloc` and :meth:`copy`,
+    which rebuild the wrapper with :meth:`_from_impl` (not ``__init__``), so a
+    subclass that overrides ``__init__`` need not special-case an
+    impl-passthrough argument.  The base ``__init__`` still accepts a
+    :class:`ResourcePoolImplementation` directly for callers that wrap one
+    explicitly.
     """
 
     # Expose the module-level exception classes as class attributes so that
@@ -69,6 +118,23 @@ class ResourcePool:
             self.version = 1
         else:
             raise ValueError(f"R version {version} not supported by ResourcePool")
+
+    @classmethod
+    def _from_impl(cls, impl: "ResourcePoolImplementation") -> "ResourcePool":
+        """Wrap an existing implementation without re-running ``__init__``.
+
+        :meth:`alloc` and :meth:`copy` already hold a finished implementation,
+        so they build the wrapper directly instead of routing the impl back
+        through ``__init__``.  This mirrors the implementation layer's own
+        ``_from_state`` factory and means a subclass that overrides
+        ``__init__`` (e.g. to take extra config) does not have to special-case
+        an impl-passthrough argument.  Preserves subclass identity via
+        ``cls.__new__``.
+        """
+        new = cls.__new__(cls)
+        new.impl = impl
+        new.version = getattr(impl, "version", 1)
+        return new
 
     # ------------------------------------------------------------------
     # Generation counter (pool mutation tracking)
@@ -136,7 +202,7 @@ class ResourcePool:
 
     def alloc(self, jobid: int, request) -> "ResourcePool":
         """Allocate resources for *jobid* and return the allocated pool."""
-        return ResourcePool(self.impl.alloc(jobid, request))
+        return self._from_impl(self.impl.alloc(jobid, request))
 
     def check_feasibility(self, request) -> None:
         """Check whether *request* is structurally satisfiable."""
@@ -148,7 +214,7 @@ class ResourcePool:
 
     def copy(self) -> "ResourcePool":
         """Return a full independent copy preserving allocation state."""
-        return ResourcePool(self.impl.copy())
+        return self._from_impl(self.impl.copy())
 
     def to_resource_set(self):
         """Return a topology+availability snapshot as a ResourceSet."""

--- a/src/bindings/python/flux/resource/ResourcePool.py
+++ b/src/bindings/python/flux/resource/ResourcePool.py
@@ -21,6 +21,7 @@ implementation based on the ``version`` field in the R JSON:
 - Version 1 → :class:`~flux.resource.Rv1Pool.Rv1Pool` (pure-Python)
 """
 
+import importlib
 import json
 from collections.abc import Mapping
 
@@ -41,9 +42,9 @@ def _pool_class_from_uri(uri: str):
     - ``"module:ClassName"`` → import ``module`` →
       ``getattr(module, "ClassName")``.
 
-    Results are cached, including failed lookups (``None``).  If a module is
-    not importable at first call, ``None`` is returned on all subsequent
-    calls for the same URI until the cache is cleared.
+    Successful lookups are cached.  Failed lookups (``None``) are not cached,
+    so a transient import failure (e.g. a module not yet on ``sys.path``) does
+    not permanently poison the URI for the life of the interpreter.
     """
     if uri in _POOL_CLASS_CACHE:
         return _POOL_CLASS_CACHE[uri]
@@ -70,9 +71,13 @@ def _pool_class_from_uri(uri: str):
             else:
                 result = mod.pool_class
         except AttributeError:
+            # Module exists but lacks the expected attribute.
             pass
-    _POOL_CLASS_CACHE[uri] = result
+    # Only cache successful lookups; a failed import may succeed later.
+    if result is not None:
+        _POOL_CLASS_CACHE[uri] = result
     return result
+
 
 class ResourcePool:
     """Public wrapper for a resource pool implementation.

--- a/src/bindings/python/flux/resource/ResourcePoolImplementation.py
+++ b/src/bindings/python/flux/resource/ResourcePoolImplementation.py
@@ -60,6 +60,16 @@ class ResourcePoolImplementation(ResourceSetImplementation):  # pragma: no cover
         self.generation += 1
 
     @property
+    def name(self) -> str:
+        """Human-readable pool implementation name.
+
+        Defaults to the class name.  Subclasses may override with a plain
+        class attribute to supply a friendlier name (e.g. ``name = "TreePool"``
+        for ``_TreePoolV1``).
+        """
+        return type(self).__name__
+
+    @property
     def expiration(self) -> float:
         """Resource expiration timestamp (seconds since epoch, 0 = none)."""
         return self.get_expiration()

--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -522,14 +522,7 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                 "slot count specifies discrete valid values that this scheduler "
                 "does not support; use a simple min-max range instead"
             )
-        self._check_feasibility(
-            request.nnodes,
-            request.nslots,
-            request.slot_size,
-            request.exclusive,
-            request.constraint,
-            request.gpu_per_slot,
-        )
+        self._check_feasibility(request)
 
     def alloc(self, jobid: int, request) -> "Rv1Pool":
         """Allocate resources for *jobid* matching *request*.
@@ -556,8 +549,6 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                 "slot count specifies discrete valid values that this scheduler "
                 "does not support; use a simple min-max range instead"
             )
-        nnodes = request.nnodes
-        nslots = request.nslots
         slot_size = request.slot_size
         gpu_per_slot = request.gpu_per_slot
         exclusive = request.exclusive
@@ -588,79 +579,14 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                 if self._matches_constraint(r, i, constraint)
             ]
 
-        # Worst-fit: descending free cores (break ties by free GPUs)
-        candidates.sort(
-            key=lambda x: (len(x[2]), len(x[3])),
-            reverse=True,
-        )
+        candidates = self._sort_candidates(candidates)
 
-        # Greedy selection — each entry is (rank, info, alloc_cores, alloc_gpus)
-        selected: List[Tuple[int, dict, frozenset, frozenset]] = []
+        selected, actual_nslots = self._select_resources(candidates, request)
 
-        if nnodes > 0:
-            nnodes_min = nnodes
-            # nnodes_max: same as min → fixed; larger → bounded range; None → unbounded
-            nnodes_target = request.nnodes_max
-            slots_per_node = nslots // nnodes_min
-            for rank, info, free_cores, free_gpus in candidates:
-                if nnodes_target is not None and len(selected) >= nnodes_target:
-                    break
-                if exclusive:
-                    if len(free_cores) < len(info["cores"]):
-                        continue
-                    alloc_cores = frozenset(free_cores)
-                    alloc_gpus = frozenset(free_gpus)
-                else:
-                    need_cores = slots_per_node * slot_size
-                    need_gpus = slots_per_node * gpu_per_slot
-                    if len(free_cores) < need_cores or len(free_gpus) < need_gpus:
-                        continue
-                    alloc_cores = frozenset(sorted(free_cores)[:need_cores])
-                    alloc_gpus = frozenset(sorted(free_gpus)[:need_gpus])
-                selected.append((rank, info, alloc_cores, alloc_gpus))
-            if len(selected) < nnodes_min:
-                self._check_feasibility(
-                    nnodes, nslots, slot_size, exclusive, constraint, gpu_per_slot
-                )
-                raise InsufficientResources("insufficient resources")
-        else:
-            nslots_min = nslots
-            nslots_target = request.nslots_max  # None → unbounded
-            allocated_slots = 0
-            for rank, info, free_cores, free_gpus in candidates:
-                if nslots_target is not None and allocated_slots >= nslots_target:
-                    break
-                free_core_slots = len(free_cores) // slot_size
-                if gpu_per_slot > 0:
-                    free_gpu_slots = len(free_gpus) // gpu_per_slot
-                    free_slots = min(free_core_slots, free_gpu_slots)
-                else:
-                    free_slots = free_core_slots
-                if nslots_target is not None:
-                    take = min(free_slots, nslots_target - allocated_slots)
-                else:
-                    take = free_slots  # unbounded: take all available on this node
-                if take > 0:
-                    ncores_take = take * slot_size
-                    ngpus_take = take * gpu_per_slot
-                    alloc_cores = frozenset(sorted(free_cores)[:ncores_take])
-                    alloc_gpus = frozenset(sorted(free_gpus)[:ngpus_take])
-                    selected.append((rank, info, alloc_cores, alloc_gpus))
-                    allocated_slots += take
-            if allocated_slots < nslots_min:
-                self._check_feasibility(
-                    nnodes, nslots, slot_size, exclusive, constraint, gpu_per_slot
-                )
-                raise InsufficientResources("insufficient resources")
-
-        # Compute actual allocated slot count for storage in R.
-        if nnodes > 0:
-            actual_nslots = slots_per_node * len(selected)
-        else:
-            actual_nslots = allocated_slots
-
-        # Build result pool and update allocation state on self
-        selected_ranks = {rank for rank, _, _, _ in selected}
+        # Build result pool and update allocation state on self.
+        # selected is [(rank, alloc_cores, alloc_gpus)] — info is looked up
+        # directly so the override never holds a mutable reference to pool state.
+        selected_ranks = {rank for rank, _, _ in selected}
 
         result = object.__new__(Rv1Pool)
         result._expiration = 0.0
@@ -677,7 +603,8 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
         result._job_state = {}
         result.log = self.log
 
-        for rank, info, alloc_cores, alloc_gpus in selected:
+        for rank, alloc_cores, alloc_gpus in selected:
+            info = self._ranks[rank]
             result._ranks[rank] = {
                 "hostname": info["hostname"],
                 "cores": alloc_cores,
@@ -800,16 +727,122 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
                 self._ranks[rank]["allocated_cores"] |= oinfo["cores"]
                 self._ranks[rank]["allocated_gpus"] |= oinfo["gpus"]
 
-    def _check_feasibility(
-        self,
-        nnodes: int,
-        nslots: int,
-        slot_size: int,
-        exclusive: bool,
-        constraint,
-        gpu_per_slot: int,
-    ) -> None:
-        """Raise EOVERFLOW if the request can structurally never be satisfied."""
+    def _sort_candidates(self, candidates: list) -> list:
+        """Sort *candidates* for node selection order.
+
+        Default: worst-fit (descending free cores, breaking ties by free GPUs).
+        Subclasses may override to use a different ordering.
+        """
+        return sorted(
+            candidates,
+            key=lambda x: (len(x[2]), len(x[3])),
+            reverse=True,
+        )
+
+    def _select_resources(self, candidates: list, request) -> tuple:
+        """Select resources from *candidates* to satisfy *request*.
+
+        *candidates* is a list of ``(rank, info, free_cores, free_gpus)``
+        tuples, already filtered for availability and sorted by
+        ``_sort_candidates``.
+
+        .. warning::
+           The *info* dict is live pool state shared with the parent Rv1Pool.
+           Subclass overrides **must not mutate** it—mutation will corrupt
+           resource tracking.  Read from *info* only; use the returned
+           ``(rank, alloc_cores, alloc_gpus)`` tuples to specify allocations.
+
+        Returns ``(selected, actual_nslots)`` where *selected* is a list of
+        ``(rank, alloc_cores, alloc_gpus)`` tuples and *actual_nslots* is the
+        total slot count to record in the allocated R (stored as
+        ``execution.nslots``).
+
+        Subclasses may override this method to implement topology-aware
+        selection policies (e.g. locality or exclusivity within a chassis or
+        rack).  The override receives the full candidate list with constraint
+        filtering already applied; it must raise
+        :exc:`~flux.resource.ResourcePoolImplementation.InsufficientResources`
+        if the request cannot be satisfied from the candidates provided.
+        """
+        nnodes = request.nnodes
+        nslots = request.nslots
+        slot_size = request.slot_size
+        gpu_per_slot = request.gpu_per_slot
+        exclusive = request.exclusive
+        selected: List[Tuple[int, frozenset, frozenset]] = []
+
+        if nnodes > 0:
+            nnodes_min = nnodes
+            nnodes_target = request.nnodes_max
+            slots_per_node = nslots // nnodes_min
+            for rank, info, free_cores, free_gpus in candidates:
+                if nnodes_target is not None and len(selected) >= nnodes_target:
+                    break
+                if exclusive:
+                    if len(free_cores) < len(info["cores"]):
+                        continue
+                    alloc_cores = frozenset(free_cores)
+                    alloc_gpus = frozenset(free_gpus)
+                else:
+                    need_cores = slots_per_node * slot_size
+                    need_gpus = slots_per_node * gpu_per_slot
+                    if len(free_cores) < need_cores or len(free_gpus) < need_gpus:
+                        continue
+                    alloc_cores = frozenset(sorted(free_cores)[:need_cores])
+                    alloc_gpus = frozenset(sorted(free_gpus)[:need_gpus])
+                selected.append((rank, alloc_cores, alloc_gpus))
+            if len(selected) < nnodes_min:
+                self._check_feasibility(request)
+                raise InsufficientResources("insufficient resources")
+            actual_nslots = slots_per_node * len(selected)
+        else:
+            nslots_min = nslots
+            nslots_target = request.nslots_max
+            allocated_slots = 0
+            for rank, info, free_cores, free_gpus in candidates:
+                if nslots_target is not None and allocated_slots >= nslots_target:
+                    break
+                free_core_slots = len(free_cores) // slot_size
+                if gpu_per_slot > 0:
+                    free_gpu_slots = len(free_gpus) // gpu_per_slot
+                    free_slots = min(free_core_slots, free_gpu_slots)
+                else:
+                    free_slots = free_core_slots
+                if nslots_target is not None:
+                    take = min(free_slots, nslots_target - allocated_slots)
+                else:
+                    take = free_slots
+                if take > 0:
+                    ncores_take = take * slot_size
+                    ngpus_take = take * gpu_per_slot
+                    alloc_cores = frozenset(sorted(free_cores)[:ncores_take])
+                    alloc_gpus = frozenset(sorted(free_gpus)[:ngpus_take])
+                    selected.append((rank, alloc_cores, alloc_gpus))
+                    allocated_slots += take
+            if allocated_slots < nslots_min:
+                self._check_feasibility(request)
+                raise InsufficientResources("insufficient resources")
+            actual_nslots = allocated_slots
+
+        return selected, actual_nslots
+
+    def _check_feasibility(self, request) -> None:
+        """Raise :exc:`InfeasibleRequest` if *request* can structurally never
+        be satisfied by this pool.
+
+        Subclasses may override to add topology-aware feasibility checks on
+        top of the base size and constraint checks.  Call
+        ``super()._check_feasibility(request)`` first to run the base checks,
+        then add subclass-specific checks.
+        """
+        nnodes = request.nnodes
+        nslots = request.nslots
+        slot_size = request.slot_size
+        exclusive = request.exclusive
+        gpu_per_slot = request.gpu_per_slot
+        constraint = request.constraint
+        if constraint is not None and isinstance(constraint, str):
+            constraint = json.loads(constraint)
         all_candidates = list(self._ranks.items())
         if constraint is not None:
             all_candidates = [

--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -308,18 +308,80 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
     # Rv1Set override: _copy_from_ranks must add pool-specific fields
     # ------------------------------------------------------------------
 
+    @classmethod
+    def _from_state(
+        cls,
+        expiration: float,
+        starttime: float,
+        has_nodelist: bool,
+        properties: dict,
+        ranks: dict,
+        scheduling,
+        job_state: dict,
+        log,
+        generation: int = 0,
+        source=None,
+    ):
+        """Internal factory: construct from explicit state without parsing R JSON.
+
+        Used by :meth:`copy`, :meth:`_copy_from_ranks`, and :meth:`alloc` to
+        create instances without re-parsing R JSON. Subclasses that add instance
+        attributes should override :meth:`_init_from_state` to initialize them
+        from *source*.
+
+        Args:
+            expiration: Expiration timestamp for the pool.
+            starttime: Start timestamp for the pool.
+            has_nodelist: Whether this instance carries a nodelist.
+            properties: Property-to-ranks dict.
+            ranks: Rank dict with pool state.
+            scheduling: R.scheduling value (dict or None).
+            job_state: Job state dict (jobid -> (end_time, alloc)).
+            log: Logger callable or None.
+            generation: Generation counter for change tracking.
+            source: Source instance to copy subclass-specific state from, or None.
+
+        Returns:
+            A new instance of ``cls`` with the given state.
+        """
+        # Create instance without calling __init__ (which expects R JSON)
+        new = object.__new__(cls)
+        new._expiration = expiration
+        new._starttime = starttime
+        new._has_nodelist = has_nodelist
+        new._properties = properties
+        new._ranks = ranks
+        new.scheduling = scheduling
+        new._job_state = job_state
+        # Only set log attribute if non-None (otherwise use base class method)
+        if log is not None:
+            new.log = log
+        new.generation = generation
+        # Allow subclasses to initialize their attributes from source
+        if source is not None:
+            new._init_from_state(source)
+        return new
+
+    def _init_from_state(self, source: "Rv1Pool") -> None:
+        """Initialize subclass-specific attributes when copying from *source*.
+
+        Override this in subclasses that add instance attributes. The base
+        implementation is a no-op; overrides do not need to call
+        ``super()._init_from_state(source)``.
+
+        This replaces the old ``_copy_extra()`` hook and is called by
+        :meth:`_from_state` when *source* is not None.
+        """
+        pass
+
     def _copy_from_ranks(self, rank_set: set) -> "Rv1Pool":
         """Return a new Rv1Pool containing only the given ranks (alloc cleared)."""
-        new = object.__new__(Rv1Pool)
-        new._expiration = self._expiration
-        new._starttime = self._starttime
-        new._has_nodelist = getattr(self, "_has_nodelist", False)
-        new._properties = {
+        properties = {
             prop: ranks & rank_set
             for prop, ranks in self._properties.items()
             if ranks & rank_set
         }
-        new._ranks = {
+        ranks = {
             rank: {
                 "hostname": self._ranks[rank]["hostname"],
                 "cores": self._ranks[rank]["cores"],
@@ -331,10 +393,17 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
             for rank in rank_set
             if rank in self._ranks
         }
-        new.scheduling = self.scheduling
-        new._job_state = {}
-        new.log = self.log
-        return new
+        return type(self)._from_state(
+            expiration=self._expiration,
+            starttime=self._starttime,
+            has_nodelist=getattr(self, "_has_nodelist", False),
+            properties=properties,
+            ranks=ranks,
+            scheduling=self.scheduling,
+            job_state={},
+            log=self.log,
+            source=self,
+        )
 
     # ------------------------------------------------------------------
     # ResourcePoolImplementation — availability management
@@ -588,24 +657,15 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
         # directly so the override never holds a mutable reference to pool state.
         selected_ranks = {rank for rank, _, _ in selected}
 
-        result = object.__new__(Rv1Pool)
-        result._expiration = 0.0
-        result._starttime = 0.0
-        result._has_nodelist = True
-        result._nslots = actual_nslots
-        result._properties = {
+        properties = {
             prop: ranks & selected_ranks
             for prop, ranks in self._properties.items()
             if ranks & selected_ranks
         }
-        result.scheduling = self.scheduling
-        result._ranks = {}
-        result._job_state = {}
-        result.log = self.log
-
+        ranks = {}
         for rank, alloc_cores, alloc_gpus in selected:
             info = self._ranks[rank]
-            result._ranks[rank] = {
+            ranks[rank] = {
                 "hostname": info["hostname"],
                 "cores": alloc_cores,
                 "gpus": alloc_gpus,
@@ -622,6 +682,19 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
             end_time = self._expiration
         else:
             end_time = 0.0
+
+        result = type(self)._from_state(
+            expiration=0.0,
+            starttime=0.0,
+            has_nodelist=True,
+            properties=properties,
+            ranks=ranks,
+            scheduling=self.scheduling,
+            job_state={},
+            log=self.log,
+            source=self,
+        )
+        result._nslots = actual_nslots
         self._job_state[jobid] = (end_time, result)
         self._bump()
         self.log(syslog.LOG_DEBUG, f"alloc: {JobID(jobid).f58}: {result.dumps()}")
@@ -633,22 +706,26 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
 
     def copy(self) -> "Rv1Pool":
         """Return a full independent copy preserving allocation state."""
-        new = object.__new__(Rv1Pool)
-        new.generation = self.generation
-        new._expiration = self._expiration
-        new._starttime = self._starttime
-        new._has_nodelist = getattr(self, "_has_nodelist", False)
-        new._properties = {p: set(s) for p, s in self._properties.items()}
-        new._ranks = {}
+        properties = {p: set(s) for p, s in self._properties.items()}
+        ranks = {}
         for rank, info in self._ranks.items():
-            new._ranks[rank] = dict(info)
-            new._ranks[rank]["allocated_cores"] = set(info["allocated_cores"])
-            new._ranks[rank]["allocated_gpus"] = set(info["allocated_gpus"])
-        new.scheduling = self.scheduling
-        new._job_state = dict(self._job_state)
+            ranks[rank] = dict(info)
+            ranks[rank]["allocated_cores"] = set(info["allocated_cores"])
+            ranks[rank]["allocated_gpus"] = set(info["allocated_gpus"])
         # Do not copy self.log: copies are used for simulation (forecast /
         # shadow-time) and their alloc/free calls must not emit log lines.
-        return new
+        return type(self)._from_state(
+            expiration=self._expiration,
+            starttime=self._starttime,
+            has_nodelist=getattr(self, "_has_nodelist", False),
+            properties=properties,
+            ranks=ranks,
+            scheduling=self.scheduling,
+            job_state=dict(self._job_state),
+            log=None,
+            generation=self.generation,
+            source=self,
+        )
 
     def copy_allocated(self) -> Rv1Set:
         """Return an Rv1Set containing only the allocated resources.
@@ -760,9 +837,12 @@ class Rv1Pool(Rv1Set, ResourcePoolImplementation):
         Subclasses may override this method to implement topology-aware
         selection policies (e.g. locality or exclusivity within a chassis or
         rack).  The override receives the full candidate list with constraint
-        filtering already applied; it must raise
+        filtering already applied.  If the request cannot be satisfied, the
+        override must call ``self._check_feasibility(request)`` before raising
         :exc:`~flux.resource.ResourcePoolImplementation.InsufficientResources`
-        if the request cannot be satisfied from the candidates provided.
+        so that a structurally impossible request is escalated to
+        :exc:`~flux.resource.ResourcePoolImplementation.InfeasibleRequest`
+        rather than retried indefinitely.
         """
         nnodes = request.nnodes
         nslots = request.nslots

--- a/src/bindings/python/flux/resource/TreePool.py
+++ b/src/bindings/python/flux/resource/TreePool.py
@@ -869,7 +869,9 @@ def amend(R, hwloc_xml=None):
     json_str_ptr = lib.rhwloc_treepool_topo_to_json(xml_bytes, errp)
 
     if json_str_ptr == ffi.NULL:
-        errmsg = ffi.string(errp.text).decode("utf-8") if errp.text[0] else "unknown error"
+        errmsg = (
+            ffi.string(errp.text).decode("utf-8") if errp.text[0] else "unknown error"
+        )
         raise RuntimeError(f"rhwloc_treepool_topo_to_json failed: {errmsg}")
 
     try:

--- a/src/bindings/python/flux/resource/TreePool.py
+++ b/src/bindings/python/flux/resource/TreePool.py
@@ -1,0 +1,837 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""TreePool: Rv1Pool extension for sub-node affinity-aware GPU+core allocation.
+
+Reads ``scheduling.children`` from the Rv1 R object to build a sub-node
+topology tree.  GPU+core slots are allocated from the finest topology level
+(e.g. NUMA node) that can satisfy the request, so GPU and core share tight
+locality.  Falls back to coarser levels (socket, whole node) when necessary.
+CPU-only slots use best-fit within the finest fitting level to preserve
+intact groups for future GPU jobs.
+
+``children`` is a list of objects.  Each object has a ``ranks`` key
+(RFC 22 IDset string identifying which broker ranks share this layout)
+and a ``topo`` key holding the node topology object.  ``cores`` and
+``gpus`` within leaf nodes are RFC 22 IDset strings using node-local IDs.
+
+Node with no named topology levels (resources appear directly in *topo*)::
+
+    {"ranks": "0-15", "topo": {"cores": "0-7", "memory": 128}}
+
+Two-socket node (``socket`` array groups cores by physical package)::
+
+    {
+      "ranks": "0-15",
+      "topo": {
+        "socket": [
+          {"numa": [
+            {"cores": "0-14",  "gpus": "0"},
+            {"cores": "15-29", "gpus": "1"}
+          ]},
+          {"numa": [
+            {"cores": "30-44", "gpus": "2"},
+            {"cores": "45-59", "gpus": "3"}
+          ]}
+        ]
+      }
+    }
+
+Levels that carry no useful grouping information MAY be omitted.
+Sites MAY introduce additional locality names (e.g. ``apu``) to create
+aliases or extra containment layers; all named levels are available for
+container-exclusive allocation.
+
+Topology deduplication
+    Large clusters often have only 2-3 distinct node types.  The scheduler
+    stores one topology structure per unique node type rather than one per
+    rank, so memory is O(types × resources_per_type) rather than
+    O(nodes × resources_per_type).
+
+Node-exclusive fast path
+    When a job requests node-exclusive allocation (``exclusive: true`` at
+    the node level, set by the frobnicator as a site policy), every
+    candidate node has its full complement of cores and GPUs free.  At
+    the finest sub-node topology level, groups are guaranteed disjoint, so
+    the per-group core intersection is skipped.  After the affinity helpers
+    confirm that the node can satisfy the slot count, the full node
+    complement is claimed so the node is correctly marked as exclusive.
+"""
+
+import json
+from collections.abc import Mapping
+
+from flux.idset import IDset
+from flux.resource import InsufficientResources
+from flux.resource.ResourceCount import ResourceCount
+from flux.resource.ResourcePool import ResourcePool
+from flux.resource.ResourcePoolImplementation import (
+    InfeasibleRequest,
+    ResourcePoolImplementation,
+)
+from flux.resource.Rv1Pool import ResourceRequest, Rv1Pool
+
+# Guard against pathological (or malicious) jobspec resource nesting.  Real
+# jobspecs nest only a handful of levels (node/slot/core/gpu); this bound is
+# far above any legitimate request but well below Python's recursion limit.
+MAX_RESOURCE_DEPTH = 100
+
+
+def _all_resources(node):
+    """Recursively collect all cores and gpus in a topo node."""
+    cores = frozenset(IDset(node["cores"])) if "cores" in node else frozenset()
+    gpus = frozenset(IDset(node["gpus"])) if "gpus" in node else frozenset()
+    for val in node.values():
+        if isinstance(val, list):
+            for child in val:
+                if isinstance(child, dict):
+                    cc, cg = _all_resources(child)
+                    cores |= cc
+                    gpus |= cg
+    return cores, gpus
+
+
+def _groups_for_container(topo, name):
+    """Return list of (cores_frozenset, gpus_frozenset) for each instance of
+    the named container in topo.  Returns [] if the name is not found.
+
+    Collects all instances at the same depth so that, e.g., searching for
+    "numa" in a two-socket node returns all eight NUMA domains rather than
+    stopping after the first socket's four.
+    """
+    if not topo:
+        return []
+    if name in topo and isinstance(topo[name], list):
+        return [_all_resources(item) for item in topo[name] if isinstance(item, dict)]
+    results = []
+    for val in topo.values():
+        if isinstance(val, list):
+            for item in val:
+                if isinstance(item, dict):
+                    results.extend(_groups_for_container(item, name))
+    return results
+
+
+class TreeResourceRequest(ResourceRequest):
+    """ResourceRequest subclass for TreePool supporting RFC 14 canonical jobspec.
+
+    Extends the base RFC 25 V1 parser with:
+
+    - Container-exclusive allocation: an exclusive leaf vertex whose type is
+      not node/slot/core/gpu is treated as a topo locality name (e.g.
+      ``socket{x}``, ``numa{x}``).  ``container_level`` is set to that type
+      and ``slot_size`` is 0; the actual per-container resource counts are
+      resolved from the pool topology at scheduling time.
+
+    - Node-exclusive without explicit cores: ``slot=N/node{x}`` is valid even
+      without a ``core`` child.  ``slot_size`` is 0; the scheduler claims the
+      full resource complement of the chosen node.  When a ``core`` child is
+      present its count acts as a minimum capability filter.
+    """
+
+    __slots__ = ("container_level",)
+
+    def __init__(self, *args, container_level=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.container_level = container_level
+
+    @classmethod
+    def from_jobspec(cls, jobspec):
+        """Parse a jobspec and return a :class:`TreeResourceRequest`."""
+        resources = jobspec.get("resources", [])
+        if not resources:
+            raise ValueError("jobspec has no resources")
+
+        state = {
+            "nnodes": None,
+            "nslots": None,
+            "slot_size": None,
+            "gpu_per_slot": 0,
+            "exclusive": False,
+            "nodefactor": 1,
+            "slot_above_node": False,
+            "container_level": None,
+        }
+
+        def walk(res_list, nodefactor, depth=0):
+            if depth > MAX_RESOURCE_DEPTH:
+                raise ValueError(
+                    f"jobspec resource nesting exceeds maximum depth "
+                    f"{MAX_RESOURCE_DEPTH}"
+                )
+            for vertex in res_list:
+                rtype = vertex.get("type", "")
+                count = ResourceCount.from_count_spec(vertex.get("count", 1))
+                children = vertex.get("with", [])
+                if rtype == "node":
+                    state["nnodes"] = count
+                    state["nodefactor"] = nodefactor
+                    if state["nslots"] is not None:
+                        state["slot_above_node"] = True
+                    if vertex.get("exclusive", False):
+                        state["exclusive"] = True
+                    if children:
+                        walk(children, nodefactor, depth + 1)
+                else:
+                    new_nf = nodefactor * count.min
+                    if rtype == "slot":
+                        state["nslots"] = count
+                        if vertex.get("exclusive", False):
+                            state["exclusive"] = True
+                    elif rtype == "core":
+                        state["slot_size"] = count.min
+                    elif rtype == "gpu":
+                        state["gpu_per_slot"] = count.min
+                    elif vertex.get("exclusive", False) and not children:
+                        # Exclusive topo-container vertex (e.g. socket{x},
+                        # numa{x}): resource counts resolved from pool topo.
+                        state["container_level"] = rtype
+                    if children:
+                        walk(children, new_nf, depth + 1)
+
+        walk(resources, 1)
+
+        system = jobspec.get("attributes", {}).get("system")
+        if jobspec.get("version") == 1:
+            if system is None:
+                raise ValueError("getting duration: Object item not found: system")
+            if system.get("duration") is None:
+                raise ValueError("getting duration: Object item not found: duration")
+
+        if state["nslots"] is None:
+            raise ValueError("Unable to determine slot count")
+        if (
+            state["slot_size"] is None
+            and state["container_level"] is None
+            and not state["exclusive"]
+        ):
+            raise ValueError("Unable to determine slot size")
+
+        nf = state["nodefactor"]
+        sc = state["nslots"]
+
+        if state["nnodes"] is not None:
+            node_count = state["nnodes"].scaled(nf)
+            if state["slot_above_node"] and nf > 1 and sc.min % nf == 0:
+                # slot is an ancestor of node: the slot count was folded into
+                # the nodefactor, so divide it back out to recover the per-node
+                # slot count.
+                slot_count = ResourceCount(
+                    sc.min // nf,
+                    None if sc.max is None else sc.max // nf,
+                )
+            else:
+                # Either a normal node-above-slot layout, or a slot-above-node
+                # layout whose slot count does not divide evenly into the
+                # nodefactor (only reachable with an intermediate multiplier
+                # vertex between slot and node).  The unfold is ambiguous in
+                # that case, so pass the slot count through unmodified rather
+                # than guess; nslots then reflects the literal jobspec counts.
+                slot_count = sc
+        else:
+            node_count = None
+            slot_count = sc
+
+        exclusive = state["exclusive"]
+        container_level = state["container_level"]
+        # Exclusive slot-only fold: each slot gets one exclusive node.
+        # Skip for container-exclusive: slots pack across nodes by container.
+        if exclusive and node_count is None and container_level is None:
+            node_count = slot_count
+            slot_count = ResourceCount(1, 1)
+        attrs = system or {}
+        duration = attrs.get("duration") or 0.0
+        constraint = attrs.get("constraints") or None
+        return cls(
+            node_count,
+            slot_count,
+            state["slot_size"] if state["slot_size"] is not None else 0,
+            state["gpu_per_slot"],
+            float(duration),
+            constraint,
+            exclusive,
+            jobspec,
+            container_level=container_level,
+        )
+
+
+def _extract_levels(node):
+    """Recursively extract affinity groups at each topology level.
+
+    Returns ``(levels, total_cores, total_gpus)`` where ``levels[0]`` is the
+    finest granularity and ``levels[-1]`` is a synthetic whole-node group
+    (union of all children).  Each entry in *levels* is a list of
+    ``(cores_frozenset, gpus_frozenset)`` groups.  Adjacent identical levels
+    (e.g. a node with a single child whose union equals the parent) are
+    deduplicated.
+    """
+    if "cores" in node:
+        cores = frozenset(IDset(node["cores"]))
+        gpus = frozenset(IDset(node["gpus"])) if "gpus" in node else frozenset()
+        return [[(cores, gpus)]], cores, gpus
+
+    merged = []
+    total_cores = frozenset()
+    total_gpus = frozenset()
+
+    for val in node.values():
+        if not isinstance(val, list):
+            continue
+        for child in val:
+            if not isinstance(child, dict):
+                continue
+            child_levels, cc, cg = _extract_levels(child)
+            total_cores |= cc
+            total_gpus |= cg
+            for i, groups in enumerate(child_levels):
+                if i >= len(merged):
+                    merged.append([])
+                merged[i].extend(groups)
+
+    if total_cores:
+        this_group = (total_cores, total_gpus)
+        if not (merged and set(merged[-1]) == {this_group}):
+            merged.append([this_group])
+
+    return merged, total_cores, total_gpus
+
+
+def _parse_children(children):
+    """Parse ``scheduling.children`` → ``{rank: (levels, topo)}``.
+
+    *children* is a list of objects each with a ``ranks`` key (IDset string)
+    and a ``topo`` key holding the node topology object.
+    """
+    groups_by_rank = {}
+    for entry in children or []:
+        rank_str = entry.get("ranks", "")
+        topo = entry.get("topo")
+        if not rank_str or not topo:
+            continue
+        levels, _, _ = _extract_levels(topo)
+        if levels:
+            for rank in IDset(rank_str):
+                groups_by_rank[rank] = (levels, topo)
+    return groups_by_rank
+
+
+def _dedup_topology(groups_by_rank):
+    """Deduplicate topology so ranks with identical structure share one object.
+
+    Large homogeneous clusters have 2-3 distinct node types; sharing the
+    level structure avoids O(nodes) copies of the same frozensets.
+
+    Returns ``(type_levels, type_topos, rank_type)`` where:
+
+    - ``type_levels``: list of unique level structures (one per node type)
+    - ``type_topos``: list of raw topo dicts (one per node type)
+    - ``rank_type``: ``{rank: type_index}``
+    """
+    canonical_to_idx = {}
+    type_levels = []
+    type_topos = []
+    rank_type = {}
+    for rank, (levels, topo) in groups_by_rank.items():
+        key = tuple(tuple(level) for level in levels)
+        if key not in canonical_to_idx:
+            canonical_to_idx[key] = len(type_levels)
+            type_levels.append(levels)
+            type_topos.append(topo)
+        rank_type[rank] = canonical_to_idx[key]
+    return type_levels, type_topos, rank_type
+
+
+class _TreePoolV1(Rv1Pool):
+    """Rv1Pool subclass providing sub-node affinity-aware GPU+core allocation."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.scheduling is None:
+            raise ValueError("TreePool requires R.scheduling")
+        scheduling = dict(self.scheduling)
+
+        children = scheduling.get("children")
+        if not children:
+            raise ValueError("TreePool requires scheduling.children")
+
+        raw_groups = _parse_children(children)
+        if not raw_groups:
+            raise ValueError("TreePool: children contains no groups")
+
+        # Children rank keys may be the enclosing instance's ranks; map them to
+        # pool-rank space via sorted-zip.
+        sorted_orig = sorted(raw_groups)
+        if len(sorted_orig) != len(self._ranks):
+            raise ValueError(
+                f"TreePool: rank count mismatch: "
+                f"{len(sorted_orig)} in children vs {len(self._ranks)} in pool"
+            )
+        rank_remap = dict(zip(sorted_orig, range(len(self._ranks))))
+        # The remap targets pool-rank space (range(N)); _rank_type is keyed in
+        # that space so _rank_topo/_rank_levels can index it directly.  This
+        # relies on the pool's own ranks being exactly that zero-origin range.
+        # The resource module guarantees this today: R from resource.acquire is
+        # always 0-origin contiguous (see inventory.c -- configured/discovered R
+        # is 0-origin, and sub-instance R is renumbered from zero on load).  The
+        # check below is defense-in-depth: if that cross-component contract ever
+        # changes, fail loudly here rather than silently mapping every rank to
+        # node type 0.
+        if set(self._ranks) != set(rank_remap.values()):
+            raise ValueError(
+                f"TreePool: pool ranks {sorted(self._ranks)} are not the "
+                f"zero-origin range required for topology remapping"
+            )
+        remapped = {
+            rank_remap[o]: (lvls, topo) for o, (lvls, topo) in raw_groups.items()
+        }
+        # Deduplicate: homogeneous clusters share the level structure
+        # across all ranks of the same node type.
+        self._type_levels, self._type_topo, self._rank_type = _dedup_topology(remapped)
+        # Rewrite children with remapped ranks for sub-instances.
+        new_children = []
+        for entry in children:
+            rank_str = entry.get("ranks", "")
+            new_ranks = {rank_remap[r] for r in IDset(rank_str) if r in rank_remap}
+            if new_ranks:
+                new_entry = dict(entry)
+                new_entry["ranks"] = str(IDset(new_ranks))
+                new_children.append(new_entry)
+        scheduling["children"] = new_children
+
+        self.scheduling = scheduling
+
+    name = "TreePool"
+
+    def parse_resource_request(self, jobspec):
+        """Parse jobspec using the TreePool-specific request parser."""
+        return TreeResourceRequest.from_jobspec(jobspec)
+
+    def _init_from_state(self, source):
+        # type_levels and type_topo are read-only after __init__; share refs.
+        self._type_levels = source._type_levels
+        self._type_topo = source._type_topo
+        self._rank_type = source._rank_type
+
+    def alloc(self, jobid, request):
+        result = super().alloc(jobid, request)
+        if result.scheduling:
+            result.scheduling = dict(result.scheduling)
+            allocated_set = set(result._ranks)
+            # Trim children ranks to only the allocated nodes so the sub-instance
+            # rank count matches its pool size.
+            if "children" in result.scheduling:
+                new_children = []
+                for entry in result.scheduling["children"]:
+                    kept = frozenset(IDset(entry.get("ranks", ""))) & allocated_set
+                    if kept:
+                        new_entry = dict(entry)
+                        new_entry["ranks"] = str(IDset(kept))
+                        new_children.append(new_entry)
+                result.scheduling["children"] = new_children
+        return result
+
+    def _rank_levels(self, rank):
+        """Return the sub-node level list for *rank*; empty list if no topology."""
+        if not self._type_levels:
+            return []
+        return self._type_levels[self._rank_type[rank]]
+
+    def _rank_topo(self, rank):
+        """Return the raw topo dict for *rank*; empty dict if no topology."""
+        if not self._type_topo:
+            return {}
+        return self._type_topo[self._rank_type[rank]]
+
+    def _check_feasibility(self, request):
+        """Override to handle container-exclusive requests before base checks."""
+        container_level = getattr(request, "container_level", None)
+        if container_level is not None:
+            nslots = request.nslots
+            nnodes = request.nnodes
+            # Honor any RFC 31 constraint: only ranks the request is allowed to
+            # land on count toward availability, matching the constraint
+            # filtering the base alloc() applies to candidates.
+            constraint = request.constraint
+            if constraint is not None and isinstance(constraint, str):
+                constraint = json.loads(constraint)
+            per_rank = [
+                len(_groups_for_container(self._rank_topo(rank), container_level))
+                for rank, info in self._ranks.items()
+                if constraint is None
+                or self._matches_constraint(rank, info, constraint)
+            ]
+            if nnodes > 0:
+                # The request spreads nslots containers across nnodes distinct
+                # nodes (nslots // nnodes each), mirroring the allocation in
+                # _container_exclusive_select.  Count nodes that can supply a
+                # full per-node share rather than the raw container total.
+                containers_per_node = nslots // nnodes
+                eligible = sum(1 for n in per_rank if n >= containers_per_node)
+                if eligible < nnodes:
+                    raise InfeasibleRequest(
+                        f"unsatisfiable request: need {nnodes} node(s) with "
+                        f"{containers_per_node} exclusive '{container_level}' "
+                        f"container(s) each, only {eligible} eligible"
+                    )
+                return
+            total_containers = sum(per_rank)
+            if total_containers < nslots:
+                raise InfeasibleRequest(
+                    f"unsatisfiable request: need {nslots} exclusive "
+                    f"'{container_level}' container(s), only "
+                    f"{total_containers} available"
+                )
+            return
+        super()._check_feasibility(request)
+
+    def _container_take_from_rank(
+        self, rank, free_cores, free_gpus, container_level, max_take
+    ):
+        """Take up to *max_take* exclusive containers from one rank.
+
+        Returns ``(alloc_cores, alloc_gpus, ntaken)``.  *max_take* of None
+        means take every free container on the rank.
+        """
+        groups = _groups_for_container(self._rank_topo(rank), container_level)
+        free_groups = [
+            (gc, gg) for gc, gg in groups if gc <= free_cores and gg <= free_gpus
+        ]
+        if max_take is not None:
+            free_groups = free_groups[:max_take]
+        if not free_groups:
+            return frozenset(), frozenset(), 0
+        alloc_cores = frozenset().union(*(gc for gc, _ in free_groups))
+        alloc_gpus = frozenset().union(*(gg for _, gg in free_groups))
+        return alloc_cores, alloc_gpus, len(free_groups)
+
+    def _container_exclusive_select(self, candidates, request):
+        """Select container-exclusive allocations (e.g. socket{{x}}, numa{{x}}).
+
+        With an explicit node count the request is spread across that many
+        distinct nodes, taking ``nslots // nnodes`` containers from each, so a
+        ``node{{N}}`` request is not collapsed onto a single node that happens
+        to supply enough containers.  Without a node count, containers are
+        packed across candidates until the slot count is met.
+        """
+        container_level = getattr(request, "container_level", None)
+        nnodes = request.nnodes
+        nslots = request.nslots
+        selected = []
+
+        if nnodes > 0:
+            containers_per_node = nslots // nnodes
+            nnodes_target = request.nnodes_max
+            for rank, info, free_cores, free_gpus in candidates:
+                if nnodes_target is not None and len(selected) >= nnodes_target:
+                    break
+                alloc_cores, alloc_gpus, n = self._container_take_from_rank(
+                    rank, free_cores, free_gpus, container_level, containers_per_node
+                )
+                if n < containers_per_node:
+                    continue
+                selected.append((rank, alloc_cores, alloc_gpus))
+            if len(selected) < nnodes:
+                self._check_feasibility(request)
+                raise InsufficientResources("insufficient resources")
+            return selected, containers_per_node * len(selected)
+
+        nslots_target = request.nslots_max
+        allocated_slots = 0
+        for rank, info, free_cores, free_gpus in candidates:
+            if nslots_target is not None and allocated_slots >= nslots_target:
+                break
+            max_take = (
+                nslots_target - allocated_slots if nslots_target is not None else None
+            )
+            alloc_cores, alloc_gpus, n = self._container_take_from_rank(
+                rank, free_cores, free_gpus, container_level, max_take
+            )
+            if n > 0:
+                selected.append((rank, alloc_cores, alloc_gpus))
+                allocated_slots += n
+
+        if allocated_slots < nslots:
+            self._check_feasibility(request)
+            raise InsufficientResources("insufficient resources")
+        return selected, allocated_slots
+
+    def _affinity_alloc_from_rank(
+        self, rank, free_cores, free_gpus, request, max_slots=None, exclusive=False
+    ):
+        """Allocate affinity-local GPU slots from one rank.
+
+        Iterates levels finest→coarsest.  Within each level, allocates from
+        groups in order until *max_slots* is reached or the rank is exhausted.
+
+        When *exclusive* is True (node-exclusive allocation) all cores and GPUs
+        on the node are free.  At the finest level (lvl_idx==0) groups are
+        disjoint, so the intersection with remaining resources is skipped.
+        Coarser levels still use the intersection because prior fine-level
+        allocations may have removed cores that appear in a coarser group.
+        """
+        slot_size = request.slot_size
+        gpu_per_slot = request.gpu_per_slot
+        if slot_size == 0:
+            # node{x} without core constraint: caller's exclusive override
+            # claims all resources; signal one slot satisfied.
+            return frozenset(), frozenset(), 1
+        remaining_cores = set(free_cores)
+        remaining_gpus = set(free_gpus)
+        rank_cores = set()
+        rank_gpus = set()
+        nslots = 0
+
+        for lvl_idx, level_groups in enumerate(self._rank_levels(rank)):
+            for group_cores, group_gpus in level_groups:
+                if exclusive and lvl_idx == 0:
+                    # Finest level: all group resources are free and groups are
+                    # disjoint — use group sets directly without intersection.
+                    avail_cores = set(group_cores)
+                    avail_gpus = set(group_gpus)
+                else:
+                    avail_cores = remaining_cores & group_cores
+                    avail_gpus = remaining_gpus & group_gpus
+                while len(avail_cores) >= slot_size and len(avail_gpus) >= gpu_per_slot:
+                    if max_slots is not None and nslots >= max_slots:
+                        return frozenset(rank_cores), frozenset(rank_gpus), nslots
+                    taken_cores = frozenset(sorted(avail_cores)[:slot_size])
+                    taken_gpus = frozenset(sorted(avail_gpus)[:gpu_per_slot])
+                    rank_cores |= taken_cores
+                    rank_gpus |= taken_gpus
+                    remaining_cores -= taken_cores
+                    remaining_gpus -= taken_gpus
+                    avail_cores -= taken_cores
+                    avail_gpus -= taken_gpus
+                    nslots += 1
+
+        return frozenset(rank_cores), frozenset(rank_gpus), nslots
+
+    def _cpu_alloc_from_rank(
+        self, rank, free_cores, request, max_slots=None, exclusive=False
+    ):
+        """Allocate CPU-only slots from one rank.
+
+        Finds the finest level where any group can accommodate *slot_size* cores,
+        then uses best-fit (fewest-available-first) within that level to preserve
+        intact groups for future GPU jobs.
+
+        When *exclusive* is True the node's full core complement is available;
+        group checks and scoring use the group sets directly without intersection.
+        """
+        slot_size = request.slot_size
+        if slot_size == 0:
+            return frozenset(), 1
+        remaining = set(free_cores)
+        rank_cores = set()
+        nslots = 0
+
+        levels = self._rank_levels(rank)
+        chosen_groups = None
+        use_excl = False
+        for lvl_idx, level_groups in enumerate(levels):
+            if exclusive and lvl_idx == 0:
+                if any(len(gc) >= slot_size for gc, _gg in level_groups):
+                    chosen_groups = level_groups
+                    use_excl = True
+                    break
+            else:
+                if any(len(remaining & gc) >= slot_size for gc, _gg in level_groups):
+                    chosen_groups = level_groups
+                    break
+
+        if chosen_groups is None:
+            return frozenset(), 0
+
+        # Best-fit: fewest-available-first preserves intact groups for GPU jobs.
+        if use_excl:
+            scored = sorted(
+                ((len(gc), gc) for gc, _gg in chosen_groups), key=lambda t: t[0]
+            )
+        else:
+            scored = sorted(
+                ((len(remaining & gc), gc) for gc, _gg in chosen_groups),
+                key=lambda t: t[0],
+            )
+        for _avail, group_cores in scored:
+            avail = set(group_cores) if use_excl else (remaining & group_cores)
+            while len(avail) >= slot_size:
+                if max_slots is not None and nslots >= max_slots:
+                    return frozenset(rank_cores), nslots
+                taken = frozenset(sorted(avail)[:slot_size])
+                rank_cores |= taken
+                remaining -= taken
+                avail -= taken
+                nslots += 1
+
+        return frozenset(rank_cores), nslots
+
+    def _sort_candidates(self, candidates):
+        """Best-fit: ascending free cores so partially-used nodes are preferred."""
+        return sorted(candidates, key=lambda x: (len(x[2]), len(x[3])))
+
+    def _select_resources(self, candidates, request):
+        """Apply sub-node affinity selection to *candidates*.
+
+        Candidates arrive best-fit sorted (via ``_sort_candidates``).  Falls
+        through to the base class only when no sub-node topology is present.
+        Exclusive requests use the affinity fast-path in the helpers to
+        validate node eligibility, then claim the full node.
+        """
+        if not self._type_levels:
+            return super()._select_resources(candidates, request)
+        if getattr(request, "container_level", None) is not None:
+            return self._container_exclusive_select(candidates, request)
+        if request.gpu_per_slot == 0:
+            return self._cpu_select(candidates, request)
+        return self._gpu_select(candidates, request)
+
+    def _cpu_select(self, candidates, request):
+        """CPU-only selection using finest-level best-fit packing."""
+        exclusive = request.exclusive
+        nnodes = request.nnodes
+        nslots = request.nslots
+        selected = []
+
+        if nnodes > 0:
+            slots_per_node = nslots // nnodes
+            nnodes_target = request.nnodes_max
+            for rank, info, free_cores, free_gpus in candidates:
+                if nnodes_target is not None and len(selected) >= nnodes_target:
+                    break
+                alloc_cores, n = self._cpu_alloc_from_rank(
+                    rank,
+                    free_cores,
+                    request,
+                    max_slots=slots_per_node,
+                    exclusive=exclusive,
+                )
+                if n < slots_per_node:
+                    continue
+                if exclusive:
+                    alloc_cores = frozenset(free_cores)
+                    alloc_gpus = frozenset(free_gpus)
+                else:
+                    alloc_gpus = frozenset()
+                selected.append((rank, alloc_cores, alloc_gpus))
+            if len(selected) < nnodes:
+                self._check_feasibility(request)
+                raise InsufficientResources("insufficient resources")
+            actual_nslots = slots_per_node * len(selected)
+        else:
+            nslots_target = request.nslots_max
+            allocated_slots = 0
+            for rank, info, free_cores, free_gpus in candidates:
+                if nslots_target is not None and allocated_slots >= nslots_target:
+                    break
+                max_s = (
+                    nslots_target - allocated_slots
+                    if nslots_target is not None
+                    else None
+                )
+                alloc_cores, n = self._cpu_alloc_from_rank(
+                    rank, free_cores, request, max_slots=max_s, exclusive=exclusive
+                )
+                if n > 0:
+                    selected.append((rank, alloc_cores, frozenset()))
+                    allocated_slots += n
+            if allocated_slots < nslots:
+                self._check_feasibility(request)
+                raise InsufficientResources("insufficient resources")
+            actual_nslots = allocated_slots
+
+        return selected, actual_nslots
+
+    def _gpu_select(self, candidates, request):
+        """GPU slot selection with affinity-local core+GPU pairing."""
+        exclusive = request.exclusive
+        nnodes = request.nnodes
+        nslots = request.nslots
+        selected = []
+
+        if nnodes > 0:
+            slots_per_node = nslots // nnodes
+            nnodes_target = request.nnodes_max
+            for rank, info, free_cores, free_gpus in candidates:
+                if nnodes_target is not None and len(selected) >= nnodes_target:
+                    break
+                alloc_cores, alloc_gpus, n = self._affinity_alloc_from_rank(
+                    rank,
+                    free_cores,
+                    free_gpus,
+                    request,
+                    max_slots=slots_per_node,
+                    exclusive=exclusive,
+                )
+                if n < slots_per_node:
+                    continue
+                if exclusive:
+                    alloc_cores = frozenset(free_cores)
+                    alloc_gpus = frozenset(free_gpus)
+                selected.append((rank, alloc_cores, alloc_gpus))
+            if len(selected) < nnodes:
+                self._check_feasibility(request)
+                raise InsufficientResources("insufficient resources")
+            actual_nslots = slots_per_node * len(selected)
+        else:
+            nslots_target = request.nslots_max
+            allocated_slots = 0
+            for rank, info, free_cores, free_gpus in candidates:
+                if nslots_target is not None and allocated_slots >= nslots_target:
+                    break
+                max_s = (
+                    nslots_target - allocated_slots
+                    if nslots_target is not None
+                    else None
+                )
+                alloc_cores, alloc_gpus, n = self._affinity_alloc_from_rank(
+                    rank,
+                    free_cores,
+                    free_gpus,
+                    request,
+                    max_slots=max_s,
+                    exclusive=exclusive,
+                )
+                if n > 0:
+                    selected.append((rank, alloc_cores, alloc_gpus))
+                    allocated_slots += n
+            if allocated_slots < nslots:
+                self._check_feasibility(request)
+                raise InsufficientResources("insufficient resources")
+            actual_nslots = allocated_slots
+
+        return selected, actual_nslots
+
+
+class TreePool(ResourcePool):
+    """Version-dispatching pool with sub-node affinity-aware GPU+core allocation.
+
+    Wraps :class:`_TreePoolV1` for Rv1 resources.  Set
+    :attr:`~flux.scheduler.Scheduler.pool_class` to this class or pass
+    ``pool-class=TreePool`` to sched-simple.
+
+    To support a future R version, add a version-specific implementation
+    class and extend ``_impl_map``.
+    """
+
+    _impl_map = {1: _TreePoolV1}
+
+    def __init__(self, R, log=None, **kwargs):
+        if not isinstance(R, ResourcePoolImplementation):
+            if isinstance(R, str):
+                R = json.loads(R)
+            version = R.get("version", 1) if isinstance(R, Mapping) else 1
+            impl_class = self._impl_map.get(version)
+            if impl_class is None:
+                raise ValueError(f"R version {version} not supported by TreePool")
+            R = impl_class(R, log=log, **kwargs)
+        super().__init__(R)
+
+
+pool_class = TreePool

--- a/src/bindings/python/flux/resource/TreePool.py
+++ b/src/bindings/python/flux/resource/TreePool.py
@@ -835,3 +835,53 @@ class TreePool(ResourcePool):
 
 
 pool_class = TreePool
+
+
+def amend(R, hwloc_xml=None):
+    """Amender for fake-resources: add R.scheduling with TreePool topology.
+
+    When ``hwloc_xml`` is None (``fake-resources.hwloc-xml-path`` not set),
+    R is returned unchanged — no scheduling key is added.  When XML is
+    provided, calls ``rhwloc_treepool_topo_to_json()`` via CFFI to derive
+    the topology and builds the ``scheduling`` key into R.
+
+    Configure via::
+
+        --conf=fake-resources.hwloc-xml-path=<topology.xml>
+        --conf=fake-resources.amend-r=flux.resource.TreePool:amend
+    """
+    # No XML configured: return R unchanged before any other work (and before
+    # importing the CFFI extension, which is only needed to parse XML).
+    if hwloc_xml is None:
+        return R
+
+    ranks = IDset()
+    for entry in R.get("execution", {}).get("R_lite", []):
+        ranks |= IDset(entry["rank"])
+    if not ranks:
+        return R
+
+    from _flux._rhwloc_treepool import ffi, lib
+
+    # Convert XML to TreePool topology JSON
+    xml_bytes = hwloc_xml.encode("utf-8")
+    errp = ffi.new("flux_error_t *")
+    json_str_ptr = lib.rhwloc_treepool_topo_to_json(xml_bytes, errp)
+
+    if json_str_ptr == ffi.NULL:
+        errmsg = ffi.string(errp.text).decode("utf-8") if errp.text[0] else "unknown error"
+        raise RuntimeError(f"rhwloc_treepool_topo_to_json failed: {errmsg}")
+
+    try:
+        json_str = ffi.string(json_str_ptr).decode("utf-8")
+        topo_dict = json.loads(json_str)
+    finally:
+        lib.free(json_str_ptr)
+
+    # Build scheduling object with writer and children
+    R["scheduling"] = {
+        "writer": "TreePool",
+        "children": [{"ranks": str(ranks), "topo": topo_dict}],
+    }
+
+    return R

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -1105,8 +1105,11 @@ class Scheduler(BrokerModule):
             ``pool_class`` attribute is used (e.g. ``rackpool`` →
             ``rackpool.pool_class``).
 
-        The module must be importable, so ensure the directory containing it
-        is on :data:`sys.path` (e.g. via ``PYTHONPATH``).
+        For bare names without dots (e.g. ``AffinityPool``), the resolver
+        also tries ``flux.resource.<name>`` so that built-in pool classes
+        shipped in :mod:`flux.resource` can be referenced without a fully
+        qualified module path.  An explicit ``PYTHONPATH`` entry takes
+        precedence because the bare-name import is attempted first.
         """
         if not hasattr(self, "_uri_class_cache"):
             self._uri_class_cache = {}
@@ -1115,10 +1118,21 @@ class Scheduler(BrokerModule):
         parsed = urllib.parse.urlparse(uri)
         module_name = (parsed.scheme or parsed.path).replace("-", "_")
         cls_name = parsed.path if parsed.scheme else None
+        candidates = [module_name]
+        if "." not in module_name:
+            candidates.append(f"flux.resource.{module_name}")
+        mod = None
+        for candidate in candidates:
+            try:
+                mod = importlib.import_module(candidate)
+                break
+            except ImportError:
+                continue
+        if mod is None:
+            return None
         try:
-            mod = importlib.import_module(module_name)
             cls = getattr(mod, cls_name) if cls_name else mod.pool_class
-        except (ImportError, AttributeError):
+        except AttributeError:
             return None
         self._uri_class_cache[uri] = cls
         return cls

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -1328,6 +1328,7 @@ class Scheduler(BrokerModule):
         self.log.info(
             f"ready: queue-depth={depth}"
             f" log-level={self.log.level_name}"
+            f" pool-class={self._resources.impl.name}"
             f" Rv{self.resources.version}"
             f" {self.resources.dumps()}",
         )

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -51,11 +51,10 @@ to override :meth:`schedule`::
 import errno
 import functools
 import heapq
-import importlib
 import inspect
 import json
 import time
-import urllib.parse
+from collections.abc import Mapping
 from typing import Optional
 
 from _flux._core import ffi, lib
@@ -66,7 +65,7 @@ from flux.kvs import KVSTxn
 from flux.kvs import commit_async as kvs_commit_async
 from flux.kvs import get_key_direct as kvs_get
 from flux.resource import InfeasibleRequest
-from flux.resource.ResourcePool import ResourcePool
+from flux.resource.ResourcePool import ResourcePool, _pool_class_from_uri
 from flux.resource.ResourcePoolImplementation import ResourcePoolImplementation
 
 
@@ -326,7 +325,6 @@ class Scheduler(BrokerModule):
         super().__init__(h, *args)
         self.log.level = "info"
         self.pool_kwargs = dict(self.pool_kwargs)
-        self._uri_class_cache: dict = {}
         self._resources = None
         self._acquire_rpc = None
         self._queue = []  # heapq of PendingJob, ordered by PendingJob.__lt__
@@ -410,7 +408,7 @@ class Scheduler(BrokerModule):
                     )
             elif arg.startswith("pool-class="):
                 uri = arg[len("pool-class=") :]
-                cls = self._pool_class_from_uri(uri)
+                cls = _pool_class_from_uri(uri)
                 if cls is None:
                     raise ValueError(f"pool-class={uri!r}: could not load pool class")
                 self.pool_class = cls
@@ -1075,68 +1073,6 @@ class Scheduler(BrokerModule):
         """Register a dynamic service by name (synchronous)."""
         self.handle.service_register(name).get()
 
-    def _pool_class_from_writer(self, R):
-        """Return a pool class derived from R.scheduling.writer, or None.
-
-        Per RFC 20, an absent ``scheduling`` key means no custom pool is
-        needed (returns ``None``).  An absent ``writer`` within a present
-        ``scheduling`` key defaults to ``"fluxion"``.  The writer value is
-        passed to :meth:`_pool_class_from_uri` for URI resolution; returns
-        ``None`` when the module cannot be imported.
-        """
-        if isinstance(R, str):
-            R = json.loads(R)
-        if not isinstance(R, dict):
-            return None
-        scheduling = R.get("scheduling")
-        if scheduling is None:
-            return None
-        writer = scheduling.get("writer", "fluxion")
-        return self._pool_class_from_uri(writer)
-
-    def _pool_class_from_uri(self, uri):
-        """Load and return a pool class from a URI string.
-
-        ``module`` or ``module:ClassName``
-            Import the Python module named by *module* (hyphens converted to
-            underscores).  If a *ClassName* component is present it is used as
-            the literal class name (e.g. ``rackpool:RackPool`` →
-            ``getattr(rackpool, "RackPool")``).  If absent, the module's
-            ``pool_class`` attribute is used (e.g. ``rackpool`` →
-            ``rackpool.pool_class``).
-
-        For bare names without dots (e.g. ``AffinityPool``), the resolver
-        also tries ``flux.resource.<name>`` so that built-in pool classes
-        shipped in :mod:`flux.resource` can be referenced without a fully
-        qualified module path.  An explicit ``PYTHONPATH`` entry takes
-        precedence because the bare-name import is attempted first.
-        """
-        if not hasattr(self, "_uri_class_cache"):
-            self._uri_class_cache = {}
-        if uri in self._uri_class_cache:
-            return self._uri_class_cache[uri]
-        parsed = urllib.parse.urlparse(uri)
-        module_name = (parsed.scheme or parsed.path).replace("-", "_")
-        cls_name = parsed.path if parsed.scheme else None
-        candidates = [module_name]
-        if "." not in module_name:
-            candidates.append(f"flux.resource.{module_name}")
-        mod = None
-        for candidate in candidates:
-            try:
-                mod = importlib.import_module(candidate)
-                break
-            except ImportError:
-                continue
-        if mod is None:
-            return None
-        try:
-            cls = getattr(mod, cls_name) if cls_name else mod.pool_class
-        except AttributeError:
-            return None
-        self._uri_class_cache[uri] = cls
-        return cls
-
     def _make_pool(self, R):
         """Construct a resource pool from an R dict or JSON string.
 
@@ -1146,13 +1082,15 @@ class Scheduler(BrokerModule):
            or subclass definition) — instantiated directly.  Raises
            :exc:`ValueError` if the value is not a
            :class:`~flux.resource.ResourcePool.ResourcePool` subclass.
-        2. ``R.scheduling.writer`` URI — parsed by
-           :meth:`_pool_class_from_writer` to derive the pool class.
+        2. ``R.scheduling.writer`` URI — resolved via
+           :func:`~flux.resource.ResourcePool._pool_class_from_uri` to find a
+           custom pool class.  An absent ``writer`` key defaults to
+           ``"fluxion"``; an absent ``scheduling`` key skips this step.
         3. Default :class:`~flux.resource.ResourcePool.ResourcePool` version
            dispatch.
 
-        In all three cases :attr:`pool_kwargs` are forwarded as keyword
-        arguments to the chosen constructor.
+        In all cases :attr:`pool_kwargs` are forwarded as keyword arguments
+        to the chosen constructor.
         """
         if self.pool_class is not None:
             if not (
@@ -1172,9 +1110,15 @@ class Scheduler(BrokerModule):
                     f"{self.pool_class!r} must set self.impl = self during __init__"
                 )
             return pool
-        pool_class = self._pool_class_from_writer(R)
-        if pool_class is not None:
-            return pool_class(R, log=self.log, **self.pool_kwargs)
+        if isinstance(R, str):
+            R = json.loads(R)
+        if isinstance(R, Mapping):
+            scheduling = R.get("scheduling")
+            if scheduling is not None:
+                writer = scheduling.get("writer", "fluxion")
+                pool_cls = _pool_class_from_uri(writer)
+                if pool_cls is not None:
+                    return pool_cls(R, log=self.log, **self.pool_kwargs)
         return ResourcePool(R, log=self.log, **self.pool_kwargs)
 
     def _acquire_resources(self):

--- a/src/common/librlist/Makefile.am
+++ b/src/common/librlist/Makefile.am
@@ -32,6 +32,8 @@ librlist_la_SOURCES = \
 librlist_hwloc_la_SOURCES = \
 	rhwloc.c \
 	rhwloc.h \
+	rhwloc_treepool.c \
+	rhwloc_treepool.h \
 	rhwloc_map.c \
 	rhwloc_map.h
 
@@ -53,7 +55,8 @@ TESTS = \
 	test_match.t \
 	test_rlist.t \
 	test_rhwloc.t \
-	test_rhwloc_map.t
+	test_rhwloc_map.t \
+	test_rhwloc_treepool.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -121,4 +124,16 @@ test_rhwloc_map_t_LDADD = \
 	$(test_ldadd) \
 	$(HWLOC_LIBS)
 test_rhwloc_map_t_LDFLAGS = \
+	$(test_ldflags)
+
+test_rhwloc_treepool_t_SOURCES = \
+	test/rhwloc_treepool.c
+test_rhwloc_treepool_t_CPPFLAGS = \
+	$(test_cppflags)
+test_rhwloc_treepool_t_LDADD = \
+	librlist-hwloc.la \
+	librlist.la \
+	$(test_ldadd) \
+	$(HWLOC_LIBS)
+test_rhwloc_treepool_t_LDFLAGS = \
 	$(test_ldflags)

--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -19,6 +19,7 @@
 #include <sys/utsname.h>
 
 #include <flux/idset.h>
+#include <jansson.h>
 
 #include "ccan/str/str.h"
 #include "src/common/libutil/read_all.h"
@@ -333,23 +334,33 @@ err:
     return NULL;
 }
 
-/*  Generate a cpuset string for all cores in the current topology
+/*  Generate a cpuset string for cores in the current topology.
+ *  If cpuset is non-NULL, only include cores whose cpuset is included in it.
  */
-char *rhwloc_core_idset_string (hwloc_topology_t topo)
+char *rhwloc_core_idset_string (hwloc_topology_t topo, hwloc_bitmap_t cpuset)
 {
     char *result = NULL;
     struct idset *ids = NULL;
     int depth = hwloc_get_type_depth (topo, HWLOC_OBJ_CORE);
+
+    if (depth < 0)
+        return NULL;
 
     if (!(ids = idset_create (0, IDSET_FLAG_AUTOGROW)))
         goto out;
 
     for (int i = 0; i < hwloc_get_nbobjs_by_depth(topo, depth); i++) {
         hwloc_obj_t core = hwloc_get_obj_by_depth (topo, depth, i);
-        idset_set (ids, core->logical_index);
+        if (cpuset == NULL
+            || (core->cpuset
+                && hwloc_bitmap_isincluded (core->cpuset, cpuset))) {
+            if (idset_set (ids, core->logical_index) < 0)
+                goto out;
+        }
     }
 
-    result = idset_encode (ids, IDSET_FLAG_RANGE);
+    if (idset_count (ids) > 0)
+        result = idset_encode (ids, IDSET_FLAG_RANGE);
 out:
     idset_destroy (ids);
     return result;
@@ -357,7 +368,7 @@ out:
 
 /*  Walk up from obj to the nearest HWLOC_OBJ_PCI_DEVICE ancestor, or NULL.
  */
-static hwloc_obj_t osdev_get_pcidev (hwloc_obj_t obj)
+hwloc_obj_t rhwloc_osdev_get_pcidev (hwloc_obj_t obj)
 {
     hwloc_obj_t p = obj->parent;
     while (p && p->type != HWLOC_OBJ_PCI_DEVICE)
@@ -434,7 +445,7 @@ static int collect_unique_gpus (hwloc_topology_t topo,
      */
     while ((obj = hwloc_get_next_osdev (topo, obj))) {
         const char *backend = hwloc_obj_get_info_by_name (obj, "Backend");
-        hwloc_obj_t pcidev = osdev_get_pcidev (obj);
+        hwloc_obj_t pcidev = rhwloc_osdev_get_pcidev (obj);
         if (!backend_is_coproc (backend)
             || (dedup && gpu_identity_visited (visited,
                                                nvisited,
@@ -569,7 +580,7 @@ struct rlist *rlist_from_hwloc (int rank, const char *xml)
         topo = rhwloc_local_topology_load (0);
     if (!topo)
         goto fail;
-    if (!(ids = rhwloc_core_idset_string (topo))
+    if (!(ids = rhwloc_core_idset_string (topo, NULL))
         || !(name = rhwloc_hostname (topo)))
         goto fail;
 

--- a/src/common/librlist/rhwloc.h
+++ b/src/common/librlist/rhwloc.h
@@ -12,6 +12,7 @@
 #define HAVE_UTIL_RHWLOC_H 1
 
 #include <hwloc.h>
+#include <jansson.h>
 
 #include "src/common/libflux/types.h" /* flux_error_t */
 
@@ -47,12 +48,19 @@ const char *rhwloc_hostname (hwloc_topology_t topo);
  *  Caller must free with hwloc_bitmap_free().
  */
 hwloc_cpuset_t rhwloc_cores_to_cpuset (hwloc_topology_t topo,
-                                        const char *cores,
-                                        flux_error_t *errp);
+                                       const char *cores,
+                                       flux_error_t *errp);
 
-/*  Return idset string for all cores in hwloc topology object
+/*  Return idset string for cores in hwloc topology object.
+ *  If cpuset is non-NULL, only include cores whose cpuset is included in it.
  */
-char * rhwloc_core_idset_string (hwloc_topology_t topo);
+char * rhwloc_core_idset_string (hwloc_topology_t topo,
+                                   hwloc_bitmap_t cpuset);
+
+/*  Walk obj's parent chain and return the first HWLOC_OBJ_PCI_DEVICE
+ *  ancestor, or NULL if none.
+ */
+hwloc_obj_t rhwloc_osdev_get_pcidev (hwloc_obj_t obj);
 
 /*  Return heap-allocated array of unique compute GPU osdev objects from topo
  *  in hwloc traversal order, one per physical GPU (deduplicated by PCI

--- a/src/common/librlist/rhwloc_treepool.c
+++ b/src/common/librlist/rhwloc_treepool.c
@@ -1,0 +1,775 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* rhwloc_treepool.c - TreePool topo object from hwloc */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <flux/idset.h>
+#include <jansson.h>
+
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/errno_safe.h"
+#include "ccan/array_size/array_size.h"
+#include "rhwloc.h"
+#include "rhwloc_treepool.h"
+
+#define BYTES_PER_GIB (1024ULL * 1024 * 1024)
+
+/* Context for building TreePool topology objects.
+ * Bundles parameters that are threaded through all helper functions.
+ */
+struct topo_build_ctx {
+    hwloc_topology_t topo;       /* hwloc topology being walked */
+    hwloc_obj_t *gpus;           /* array of GPU objects */
+    int ngpus;                   /* count of GPUs */
+    struct idset *emitted_gpus;  /* tracks which GPUs have been assigned */
+    bool found_mem;              /* set to true if any memory is emitted */
+};
+
+/* Maps hwloc object types to TreePool scheduling properties.
+ * Names come from RFC 49; types absent from that spec use NULL here and
+ * fall back to hwloc_obj_type_string() so new hwloc types are picked up
+ * automatically without a code change.
+ */
+struct obj_class {
+    hwloc_obj_type_t type;
+    bool is_cpu_container;
+    const char *topo_name;  /* RFC 49 name, or NULL for hwloc_obj_type_string() */
+};
+
+static const struct obj_class obj_classes[] = {
+    { HWLOC_OBJ_PACKAGE,  true,  "socket" },  /* RFC 49 */
+    { HWLOC_OBJ_DIE,      true,  NULL     },
+    { HWLOC_OBJ_GROUP,    true,  NULL     },
+    { HWLOC_OBJ_NUMANODE, false, "numa"   },  /* RFC 49 */
+};
+
+static const struct obj_class *obj_class_get (hwloc_obj_type_t type)
+{
+    for (size_t i = 0; i < ARRAY_SIZE (obj_classes); i++)
+        if (obj_classes[i].type == type)
+            return &obj_classes[i];
+    return NULL;
+}
+
+/* Return true if obj is a scheduling-relevant CPU-side container. */
+static bool object_is_cpu_container (hwloc_obj_t obj)
+{
+    if (!obj || !obj->cpuset)
+        return false;
+    const struct obj_class *cls = obj_class_get (obj->type);
+    return cls && cls->is_cpu_container;
+}
+
+/* Return the RFC 49 topo key for obj, falling back to the hwloc type
+ * string for types not defined in the spec. */
+static const char *object_topo_name (hwloc_obj_t obj)
+{
+    const struct obj_class *cls = obj_class_get (obj->type);
+    if (cls && cls->topo_name)
+        return cls->topo_name;
+    return hwloc_obj_type_string (obj->type);
+}
+
+/* Return true if 'ancestor' appears anywhere in obj's parent chain. */
+static bool obj_is_under (hwloc_obj_t obj, hwloc_obj_t ancestor)
+{
+    for (hwloc_obj_t p = obj->parent; p != NULL; p = p->parent)
+        if (p == ancestor)
+            return true;
+    return false;
+}
+
+/* Return true if GPU (OSDev) belongs to topology object 'obj'.
+ * Tries tree walk first (works in hwloc 1.x where NUMANode/Package appear
+ * in the PCIDev parent chain), then falls back to cpuset containment (hwloc
+ * 2.x attaches I/O objects to their closest normal CPU ancestor, so NUMANode
+ * is not in the PCIDev parent chain but Package is).
+ */
+static bool gpu_belongs_to_obj (hwloc_obj_t gpu, hwloc_obj_t obj)
+{
+    hwloc_obj_t pcidev = rhwloc_osdev_get_pcidev (gpu);
+    if (!pcidev)
+        return false;
+    if (obj_is_under (pcidev, obj))
+        return true;
+    if (!obj->cpuset)
+        return false;
+    hwloc_obj_t anc = pcidev->parent;
+    while (anc && !anc->cpuset)
+        anc = anc->parent;
+    return anc && hwloc_bitmap_isincluded (anc->cpuset, obj->cpuset);
+}
+
+/* Common helper for building GPU idset strings.
+ * If only_residual is true, only includes GPUs not already in 'emitted'.
+ * Records placed GPU indices in 'emitted' if non-NULL.
+ * Returns idset string or NULL if no GPUs match.  Caller frees.
+ */
+static char *build_gpu_idset (hwloc_obj_t obj,
+                              hwloc_obj_t *gpus,
+                              int ngpus,
+                              struct idset *emitted,
+                              bool only_residual)
+{
+    struct idset *ids;
+    char *result = NULL;
+
+    if (!gpus || ngpus <= 0)
+        return NULL;
+    if (only_residual && !emitted)
+        return NULL;
+    if (!(ids = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        return NULL;
+    for (int i = 0; i < ngpus; i++) {
+        if (only_residual && idset_test (emitted, i))
+            continue;
+        if (gpu_belongs_to_obj (gpus[i], obj)) {
+            if (idset_set (ids, i) < 0)
+                goto out;
+            if (emitted && idset_set (emitted, i) < 0)
+                goto out;
+        }
+    }
+    if (idset_count (ids) > 0)
+        result = idset_encode (ids, IDSET_FLAG_RANGE);
+out:
+    idset_destroy (ids);
+    return result;
+}
+
+/* Return idset string of GPU indices belonging to 'obj', or NULL if none.
+ * Indices placed are also recorded in 'emitted' if non-NULL.
+ */
+static char *gpus_idset_for_obj (hwloc_obj_t obj,
+                                 hwloc_obj_t *gpus,
+                                 int ngpus,
+                                 struct idset *emitted)
+{
+    return build_gpu_idset (obj, gpus, ngpus, emitted, false);
+}
+
+/* Return idset string of GPU indices belonging to 'obj' that have NOT yet
+ * been emitted (i.e., not in 'emitted').  Records newly emitted indices in
+ * 'emitted'.  Returns NULL if none.  Caller frees.
+ */
+static char *residual_gpus_for_obj (hwloc_obj_t obj,
+                                    hwloc_obj_t *gpus,
+                                    int ngpus,
+                                    struct idset *emitted)
+{
+    return build_gpu_idset (obj, gpus, ngpus, emitted, true);
+}
+
+/* Collect NUMA nodes whose cpuset is included in 'cpuset'.
+ * Returns count; if numas non-NULL stores up to max pointers there.
+ */
+static int collect_numa_for_cpuset (hwloc_topology_t topo,
+                                    hwloc_bitmap_t cpuset,
+                                    hwloc_obj_t *numas,
+                                    int max)
+{
+    int n = hwloc_get_nbobjs_by_type (topo, HWLOC_OBJ_NUMANODE);
+    int count = 0;
+
+    for (int i = 0; i < n; i++) {
+        hwloc_obj_t numa = hwloc_get_obj_by_type (topo, HWLOC_OBJ_NUMANODE, i);
+        if (!numa || !numa->cpuset || hwloc_bitmap_iszero (numa->cpuset))
+            continue;
+        if (!hwloc_bitmap_isincluded (numa->cpuset, cpuset))
+            continue;
+        if (numas && count < max)
+            numas[count] = numa;
+        count++;
+    }
+    return count;
+}
+
+/* Find CPU containers that are direct (or indirect-through-boring) normal
+ * children of 'parent' whose cpuset is a subset of 'scope'.  Descends
+ * through non-container, non-Core/PU objects (e.g. L3Cache).
+ * Returns count; stores up to max pointers in out[] if non-NULL.
+ */
+static int find_cpu_containers (hwloc_obj_t parent,
+                                hwloc_bitmap_t scope,
+                                hwloc_obj_t *out,
+                                int max)
+{
+    int n_direct = 0;
+
+    for (unsigned i = 0; i < parent->arity; i++) {
+        hwloc_obj_t child = parent->children[i];
+        if (!child || !child->cpuset || hwloc_bitmap_iszero (child->cpuset))
+            continue;
+        if (!hwloc_bitmap_isincluded (child->cpuset, scope))
+            continue;
+        if (object_is_cpu_container (child))
+            n_direct++;
+    }
+    if (n_direct > 0) {
+        int count = 0;
+        for (unsigned i = 0; i < parent->arity; i++) {
+            hwloc_obj_t child = parent->children[i];
+            if (!child || !child->cpuset || hwloc_bitmap_iszero (child->cpuset))
+                continue;
+            if (!hwloc_bitmap_isincluded (child->cpuset, scope))
+                continue;
+            if (object_is_cpu_container (child)) {
+                if (out && count < max)
+                    out[count] = child;
+                count++;
+            }
+        }
+        return count;
+    }
+    /* No containers at this level: descend through boring intermediates. */
+    int total = 0;
+    for (unsigned i = 0; i < parent->arity; i++) {
+        hwloc_obj_t child = parent->children[i];
+        if (!child || !child->cpuset || hwloc_bitmap_iszero (child->cpuset))
+            continue;
+        if (!hwloc_bitmap_isincluded (child->cpuset, scope))
+            continue;
+        if (child->type == HWLOC_OBJ_CORE || child->type == HWLOC_OBJ_PU)
+            continue;
+        total += find_cpu_containers (child,
+                                      scope,
+                                      out ? out + total : NULL,
+                                      out ? max - total : 0);
+    }
+    return total;
+}
+
+/* Build a leaf JSON entry from a cpuset with no NUMA children.
+ * Emits cores and any GPUs belonging to obj; no memory (caller's fallback).
+ * Sets errno on failure.
+ */
+static json_t *cpuset_leaf_json (struct topo_build_ctx *ctx,
+                                 hwloc_obj_t obj,
+                                 flux_error_t *errp)
+{
+    char *cores = rhwloc_core_idset_string (ctx->topo, obj->cpuset);
+    char *gpu_ids = NULL;
+    json_t *o = NULL;
+
+    /* Validate cores before claiming GPUs: gpus_idset_for_obj() records the
+     * GPUs it returns into ctx->emitted_gpus as a side effect, so claiming
+     * them only after the leaf is known-good avoids consuming GPUs for a leaf
+     * that is then discarded. */
+    if (!cores) {
+        errprintf (errp,
+                   "%s[%u]: no Core objects found in cpuset",
+                   hwloc_obj_type_string (obj->type),
+                   obj->logical_index);
+        errno = EINVAL;
+        goto out;
+    }
+    gpu_ids = gpus_idset_for_obj (obj, ctx->gpus, ctx->ngpus, ctx->emitted_gpus);
+    if (!(o = json_object ())
+        || json_object_set_new (o, "cores", json_string (cores)) < 0) {
+        errprintf (errp, "failed to create leaf JSON object");
+        goto err;
+    }
+    if (gpu_ids
+        && json_object_set_new (o, "gpus", json_string (gpu_ids)) < 0) {
+        errprintf (errp, "failed to add gpus to leaf JSON object");
+        goto err;
+    }
+    goto out;
+err:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    o = NULL;
+out:
+    ERRNO_SAFE_WRAP (free, cores);
+    ERRNO_SAFE_WRAP (free, gpu_ids);
+    return o;
+}
+
+/* Build a leaf JSON entry from a NUMANode.
+ * Emits cores, GPUs, and local memory.  Sets ctx->found_mem if memory > 0.
+ * Sets errno and errp on failure.
+ */
+static json_t *numa_leaf_json (struct topo_build_ctx *ctx,
+                               hwloc_obj_t numa,
+                               flux_error_t *errp)
+{
+    char *cores = rhwloc_core_idset_string (ctx->topo, numa->cpuset);
+    char *gpu_ids = NULL;
+    /* attr is guaranteed for a real NUMANODE, but guard anyway since the
+     * topology may originate from untrusted XML. */
+    uint64_t mem_gib = numa->attr
+                       ? numa->attr->numanode.local_memory / BYTES_PER_GIB
+                       : 0;
+    json_t *o = NULL;
+
+    /* Validate cores before claiming GPUs: gpus_idset_for_obj() records the
+     * GPUs it returns into ctx->emitted_gpus as a side effect, so claiming
+     * them only after the leaf is known-good avoids consuming GPUs for a leaf
+     * that is then discarded. */
+    if (!cores) {
+        errprintf (errp,
+                   "NUMANode[%u]: no Core objects found in cpuset",
+                   numa->logical_index);
+        errno = EINVAL;
+        goto out;
+    }
+    gpu_ids = gpus_idset_for_obj (numa, ctx->gpus, ctx->ngpus, ctx->emitted_gpus);
+    if (!(o = json_object ())
+        || json_object_set_new (o, "cores", json_string (cores)) < 0) {
+        errprintf (errp, "failed to create NUMA leaf JSON object");
+        goto err;
+    }
+    if (gpu_ids
+        && json_object_set_new (o, "gpus", json_string (gpu_ids)) < 0) {
+        errprintf (errp, "failed to add gpus to NUMA leaf JSON object");
+        goto err;
+    }
+    if (mem_gib > 0) {
+        if (json_object_set_new (o,
+                                 "memory",
+                                 json_integer ((json_int_t)mem_gib)) < 0) {
+            errprintf (errp, "failed to add memory to NUMA leaf JSON object");
+            goto err;
+        }
+        ctx->found_mem = true;
+    }
+    goto out;
+err:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    o = NULL;
+out:
+    ERRNO_SAFE_WRAP (free, cores);
+    ERRNO_SAFE_WRAP (free, gpu_ids);
+    return o;
+}
+
+/* Forward declaration for recursive calls */
+static json_t *build_topo_obj (struct topo_build_ctx *ctx,
+                               hwloc_obj_t obj,
+                               flux_error_t *errp);
+
+/* Attach residual GPUs (not claimed by children) to a topo object.
+ * Returns 0 on success, -1 on failure with errno and errp set.
+ */
+static int attach_residual_gpus (json_t *topo_obj,
+                                 hwloc_obj_t obj,
+                                 struct topo_build_ctx *ctx,
+                                 flux_error_t *errp)
+{
+    char *gpu_ids = residual_gpus_for_obj (obj,
+                                           ctx->gpus,
+                                           ctx->ngpus,
+                                           ctx->emitted_gpus);
+    if (gpu_ids) {
+        if (json_object_set_new (topo_obj, "gpus", json_string (gpu_ids)) < 0) {
+            ERRNO_SAFE_WRAP (free, gpu_ids);
+            errprintf (errp, "failed to add residual gpus to topo object");
+            return -1;
+        }
+        ERRNO_SAFE_WRAP (free, gpu_ids);
+    }
+    return 0;
+}
+
+/* Attach machine total memory to node-level topo object as fallback.
+ * Used when no lower-level objects reported memory (e.g., NUMA node spans
+ * multiple packages). Only attaches if found_mem is false and total > 0.
+ * Returns 0 on success, -1 on failure with errno and errp set.
+ */
+static int attach_fallback_memory (json_t *node_obj,
+                                   uint64_t total_machine_mem,
+                                   bool found_mem,
+                                   flux_error_t *errp)
+{
+    if (found_mem || total_machine_mem == 0)
+        return 0;
+
+    uint64_t mem_gib = total_machine_mem / BYTES_PER_GIB;
+    if (mem_gib > 0) {
+        if (json_object_set_new (node_obj,
+                                 "memory",
+                                 json_integer ((json_int_t)mem_gib)) < 0) {
+            errprintf (errp, "failed to add memory to topo object");
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* Attach any unplaced GPUs to the node-level topo object.
+ * GPUs that were never assigned at any lower scope level are collected
+ * and placed at node scope as a fallback.
+ * Returns 0 on success, -1 on failure with errno and errp set.
+ */
+static int attach_unplaced_gpus (json_t *node_obj,
+                                 struct topo_build_ctx *ctx,
+                                 flux_error_t *errp)
+{
+    struct idset *node_ids;
+    char *s = NULL;
+    int rc = -1;
+
+    if (ctx->ngpus <= 0)
+        return 0;
+
+    if (!(node_ids = idset_create (0, IDSET_FLAG_AUTOGROW))) {
+        errprintf (errp, "failed to create node_ids idset");
+        return -1;
+    }
+
+    for (int g = 0; g < ctx->ngpus; g++) {
+        if (!idset_test (ctx->emitted_gpus, g)) {
+            if (idset_set (node_ids, g) < 0) {
+                errprintf (errp, "failed to set node_ids idset");
+                goto out;
+            }
+        }
+    }
+
+    if (idset_count (node_ids) > 0) {
+        if (!(s = idset_encode (node_ids, IDSET_FLAG_RANGE))) {
+            errprintf (errp, "failed to encode node ids");
+            goto out;
+        }
+        if (json_object_set_new (node_obj, "gpus", json_string (s)) < 0) {
+            errprintf (errp, "failed to add gpus to topo object");
+            goto out;
+        }
+    }
+
+    rc = 0;
+out:
+    ERRNO_SAFE_WRAP (free, s);
+    idset_destroy (node_ids);
+    return rc;
+}
+
+/* Unwrap transparent Group wrappers to find the real hardware boundary name.
+ * hwloc 2.x may insert Group around each NUMANode→Package from 1.x XML.
+ * Returns the topology name for the first actual hardware container found.
+ */
+static const char *unwrap_group_name (struct topo_build_ctx *ctx,
+                                      hwloc_obj_t *containers,
+                                      int ncontainers)
+{
+    const char *name = object_topo_name (containers[0]);
+
+    if (containers[0]->type != HWLOC_OBJ_GROUP)
+        return name;
+
+    hwloc_obj_t probe = containers[0];
+    while (probe->type == HWLOC_OBJ_GROUP) {
+        hwloc_obj_t inner;
+        if (find_cpu_containers (probe, probe->cpuset, &inner, 1) != 1) {
+            /* No CPU containers; check if Group wraps NUMA nodes */
+            int nnuma = collect_numa_for_cpuset (ctx->topo,
+                                                 probe->cpuset,
+                                                 NULL,
+                                                 0);
+            if (nnuma > 0)
+                return "numa";
+            break;
+        }
+        probe = inner;
+    }
+    if (probe != containers[0])
+        name = object_topo_name (probe);
+    return name;
+}
+
+/* Build a topo object from a list of CPU containers.
+ * Single container is folded (recursive); multiple are grouped under type name.
+ * Sets errno on failure.
+ */
+static json_t *build_containers_topo (struct topo_build_ctx *ctx,
+                                      hwloc_obj_t obj,
+                                      hwloc_obj_t *containers,
+                                      int ncontainers,
+                                      flux_error_t *errp)
+{
+    json_t *result = NULL;
+
+    if (ncontainers == 1) {
+        /* Single container: fold without adding a wrapper level. */
+        result = build_topo_obj (ctx, containers[0], errp);
+        /* errno already set by recursive call */
+        return result;
+    }
+
+    /* Multiple containers: build array under type name */
+    const char *name = unwrap_group_name (ctx, containers, ncontainers);
+    json_t *arr = json_array ();
+    if (!arr) {
+        errprintf (errp, "failed to create container array");
+        return NULL;
+    }
+
+    for (int i = 0; i < ncontainers; i++) {
+        json_t *child = build_topo_obj (ctx, containers[i], errp);
+        if (!child) {
+            /* errno already set by recursive call */
+            json_decref (arr);
+            return NULL;
+        }
+        if (json_array_append_new (arr, child) < 0) {
+            json_decref (arr);
+            errprintf (errp, "failed to append container to array");
+            return NULL;
+        }
+    }
+
+    if (!(result = json_object ())
+        || json_object_set_new (result, name, arr) < 0) {
+        ERRNO_SAFE_WRAP (json_decref, result);
+        /* arr reference stolen by json_object_set_new even on failure */
+        errprintf (errp, "failed to create container result object");
+        return NULL;
+    }
+
+    /* Attach residual GPUs not claimed by any child */
+    if (attach_residual_gpus (result, obj, ctx, errp) < 0) {
+        ERRNO_SAFE_WRAP (json_decref, result);
+        return NULL;
+    }
+
+    return result;
+}
+
+/* Build a topo object from NUMA nodes within a scope.
+ * Single NUMA is folded into leaf; multiple are grouped under "numa".
+ * Sets errno on failure.
+ */
+static json_t *build_numa_topo (struct topo_build_ctx *ctx,
+                                hwloc_obj_t obj,
+                                hwloc_obj_t *numas,
+                                int nnuma,
+                                flux_error_t *errp)
+{
+    json_t *result = NULL;
+
+    if (nnuma == 1) {
+        /* Single NUMA: fold into leaf. */
+        result = numa_leaf_json (ctx, numas[0], errp);
+        /* errno already set by numa_leaf_json */
+        return result;
+    }
+
+    /* Multiple NUMA: build array */
+    json_t *numa_arr = json_array ();
+    if (!numa_arr) {
+        errprintf (errp, "failed to create NUMA array");
+        return NULL;
+    }
+
+    for (int i = 0; i < nnuma; i++) {
+        json_t *leaf = numa_leaf_json (ctx, numas[i], errp);
+        if (!leaf) {
+            /* errno already set by numa_leaf_json */
+            json_decref (numa_arr);
+            return NULL;
+        }
+        if (json_array_append_new (numa_arr, leaf) < 0) {
+            json_decref (numa_arr);
+            errprintf (errp, "failed to append NUMA leaf to array");
+            return NULL;
+        }
+    }
+
+    if (!(result = json_object ())
+        || json_object_set_new (result, "numa", numa_arr) < 0) {
+        ERRNO_SAFE_WRAP (json_decref, result);
+        /* numa_arr reference stolen by json_object_set_new even on failure */
+        errprintf (errp, "failed to create NUMA result object");
+        return NULL;
+    }
+
+    /* Attach residual GPUs not placed by any NUMA child */
+    if (attach_residual_gpus (result, obj, ctx, errp) < 0) {
+        ERRNO_SAFE_WRAP (json_decref, result);
+        return NULL;
+    }
+
+    return result;
+}
+
+/* Recursively build a topo object for the scope defined by hwloc obj.
+ *
+ * Traversal order is determined by the actual tree:
+ *   1. If CPU containers (Package, Die, Group, …) exist as children of obj,
+ *      group them under their type name.  A single container is folded.
+ *   2. Otherwise, if NUMA nodes fall within obj's cpuset, group them under
+ *      "numa".  A single NUMA is folded into a leaf.
+ *   3. Otherwise emit a leaf (cores + GPUs) directly.
+ *
+ * After processing children, any GPUs that belong to obj but were not
+ * claimed by a child are attached at this scope level.
+ *
+ * GPU indices emitted at any level are recorded in emitted_gpus.
+ * found_mem is set to true if memory is emitted at any level.
+ */
+static json_t *build_topo_obj (struct topo_build_ctx *ctx,
+                               hwloc_obj_t obj,
+                               flux_error_t *errp)
+{
+    json_t *result = NULL;
+
+    /* Try CPU containers (Package, Die, Group, ...) */
+    int ncontainers = find_cpu_containers (obj, obj->cpuset, NULL, 0);
+    if (ncontainers > 0) {
+        hwloc_obj_t *containers = calloc (ncontainers, sizeof (*containers));
+        if (!containers) {
+            errprintf (errp, "failed to allocate containers array");
+            return NULL;
+        }
+        find_cpu_containers (obj, obj->cpuset, containers, ncontainers);
+
+        result = build_containers_topo (ctx, obj, containers, ncontainers, errp);
+        ERRNO_SAFE_WRAP (free, containers);
+        return result;
+    }
+
+    /* No CPU containers: try NUMA nodes */
+    int nnuma = collect_numa_for_cpuset (ctx->topo, obj->cpuset, NULL, 0);
+    if (nnuma == 0) {
+        /* No NUMA nodes: emit leaf directly */
+        return cpuset_leaf_json (ctx, obj, errp);
+    }
+
+    hwloc_obj_t *numas = calloc (nnuma, sizeof (*numas));
+    if (!numas) {
+        errprintf (errp, "failed to allocate NUMA array");
+        return NULL;
+    }
+    collect_numa_for_cpuset (ctx->topo, obj->cpuset, numas, nnuma);
+
+    result = build_numa_topo (ctx, obj, numas, nnuma, errp);
+    ERRNO_SAFE_WRAP (free, numas);
+    return result;
+}
+
+/* Build a TreePool topo object from hwloc topology.
+ * Returns the topo object (not the complete scheduling key).
+ * Sets errno and errp on failure.
+ */
+json_t *rhwloc_treepool_topo (hwloc_topology_t topo, flux_error_t *errp)
+{
+    hwloc_obj_t machine;
+    json_t *node_obj = NULL;
+    json_t *result = NULL;
+    uint64_t total_machine_mem = 0;
+    struct topo_build_ctx ctx = {
+        .topo = topo,
+        .gpus = NULL,
+        .ngpus = 0,
+        .emitted_gpus = NULL,
+        .found_mem = false,
+    };
+
+    if (!topo) {
+        errprintf (errp, "topo is NULL");
+        errno = EINVAL;
+        return NULL;
+    }
+
+    machine = hwloc_get_root_obj (topo);
+    if (!machine || !machine->cpuset) {
+        errprintf (errp, "no machine root object in topology");
+        errno = EINVAL;
+        return NULL;
+    }
+
+    /* rhwloc_gpu_objects() returns NULL both when there are no GPUs (ENODEV
+     * or zero unique GPUs) and on allocation failure (ENOMEM).  Distinguish
+     * the two so a genuine failure is not silently treated as "no GPUs",
+     * which would emit a node with its GPUs missing.
+     */
+    errno = 0;
+    ctx.gpus = rhwloc_gpu_objects (topo, &ctx.ngpus);
+    if (!ctx.gpus && errno == ENOMEM) {
+        errprintf (errp, "could not collect GPU objects: %s", strerror (errno));
+        goto out;
+    }
+
+    int nnuma_total = hwloc_get_nbobjs_by_type (topo, HWLOC_OBJ_NUMANODE);
+    for (int i = 0; i < nnuma_total; i++) {
+        hwloc_obj_t n = hwloc_get_obj_by_type (topo, HWLOC_OBJ_NUMANODE, i);
+        /* attr is guaranteed for a real NUMANODE, but guard anyway since the
+         * topology may originate from untrusted XML. */
+        if (n && n->attr)
+            total_machine_mem += n->attr->numanode.local_memory;
+    }
+
+    if (!(ctx.emitted_gpus = idset_create (0, IDSET_FLAG_AUTOGROW))) {
+        errprintf (errp, "could not create gpus idset: %s", strerror (errno));
+        goto out;
+    }
+
+    if (!(node_obj = build_topo_obj (&ctx, machine, errp)))
+        goto out;
+
+    /* Fallback: attach machine total memory and unplaced GPUs at node scope. */
+    if (attach_fallback_memory (node_obj,
+                                total_machine_mem,
+                                ctx.found_mem,
+                                errp) < 0)
+        goto out;
+    if (attach_unplaced_gpus (node_obj, &ctx, errp) < 0)
+        goto out;
+
+    result = node_obj;
+    node_obj = NULL;
+out:
+    ERRNO_SAFE_WRAP (idset_destroy, ctx.emitted_gpus);
+    ERRNO_SAFE_WRAP (json_decref, node_obj);
+    ERRNO_SAFE_WRAP (free, ctx.gpus);
+    return result;
+}
+
+char *rhwloc_treepool_topo_to_json (const char *xml, flux_error_t *errp)
+{
+    hwloc_topology_t topo;
+    json_t *topo_json = NULL;
+    char *result = NULL;
+
+    if (!xml) {
+        errno = EINVAL;
+        errprintf (errp, "xml argument is NULL");
+        return NULL;
+    }
+
+    if (!(topo = rhwloc_xml_topology_load (xml, RHWLOC_NO_RESTRICT))) {
+        errprintf (errp, "failed to load hwloc topology from XML");
+        return NULL;
+    }
+
+    if (!(topo_json = rhwloc_treepool_topo (topo, errp)))
+        goto done;
+
+    if (!(result = json_dumps (topo_json, JSON_COMPACT))) {
+        errprintf (errp, "json_dumps failed");
+        errno = ENOMEM;
+        goto done;
+    }
+
+done:
+    ERRNO_SAFE_WRAP (json_decref, topo_json);
+    ERRNO_SAFE_WRAP (hwloc_topology_destroy, topo);
+    return result;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/librlist/rhwloc_treepool.h
+++ b/src/common/librlist/rhwloc_treepool.h
@@ -1,0 +1,34 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_RHWLOC_TREEPOOL_H
+#define HAVE_RHWLOC_TREEPOOL_H 1
+
+#include <jansson.h>
+#include <hwloc.h>
+
+#include "src/common/libflux/types.h" /* flux_error_t */
+
+/*  Build TreePool topology object (RFC 49) from hwloc topology.
+ *  Returns a JSON object describing the node's sub-node resource layout
+ *  (cores, GPUs, memory organized by socket/NUMA/etc).  Caller must
+ *  json_decref().  Returns NULL on failure with errno set and errp filled
+ *  if non-NULL.
+ */
+json_t *rhwloc_treepool_topo (hwloc_topology_t topo, flux_error_t *errp);
+
+/*  Convenience wrapper: load hwloc topology from XML and convert to TreePool
+ *  JSON string.  Loads topology without CPU binding restriction (so the full
+ *  node topology is visible).  Caller must free() the returned string.
+ *  Returns NULL on failure with errno set and errp filled if non-NULL.
+ */
+char *rhwloc_treepool_topo_to_json (const char *xml, flux_error_t *errp);
+
+#endif /* !HAVE_RHWLOC_TREEPOOL_H */

--- a/src/common/librlist/test/rhwloc.c
+++ b/src/common/librlist/test/rhwloc.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #endif
 #include <flux/hostlist.h>
+#include <jansson.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/errprintf.h"
@@ -862,7 +863,7 @@ void test_cores_to_cpuset (void)
     hwloc_bitmap_free (cpuset);
 
     /* All cores: cpuset must equal full topology cpuset */
-    cores = rhwloc_core_idset_string (topo);
+    cores = rhwloc_core_idset_string (topo, NULL);
     if (!cores)
         BAIL_OUT ("rhwloc_core_idset_string failed");
     err_init (&error);
@@ -976,6 +977,7 @@ void test_gpu_objects (void)
 
     hwloc_topology_destroy (topo);
 }
+
 
 int main (int ac, char *av[])
 {

--- a/src/common/librlist/test/rhwloc_treepool.c
+++ b/src/common/librlist/test/rhwloc_treepool.c
@@ -1,0 +1,598 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Test TreePool topology generation */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <jansson.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/errprintf.h"
+#include "rhwloc.h"
+#include "rhwloc_treepool.h"
+
+/* NPS1 single package: 2 cores, 8 GiB */
+static const char xml_nps1_1pkg[] = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<!DOCTYPE topology SYSTEM \"hwloc.dtd\">\n\
+<topology>\n\
+  <object type=\"Machine\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+    <info name=\"HostName\" value=\"testhost\"/>\n\
+    <object type=\"NUMANode\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\" local_memory=\"8589934592\">\n\
+      <object type=\"Package\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+        <object type=\"Core\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+          <object type=\"PU\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+        </object>\n\
+        <object type=\"Core\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+          <object type=\"PU\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+        </object>\n\
+      </object>\n\
+    </object>\n\
+  </object>\n\
+</topology>\n";
+
+/* NPS1 two packages: 2 sockets, each with 2 cores and 8 GiB */
+static const char xml_nps1_2pkg[] = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<!DOCTYPE topology SYSTEM \"hwloc.dtd\">\n\
+<topology>\n\
+  <object type=\"Machine\" os_index=\"0\"\
+ cpuset=\"0x0000000f\" complete_cpuset=\"0x0000000f\"\
+ online_cpuset=\"0x0000000f\" allowed_cpuset=\"0x0000000f\"\
+ nodeset=\"0x00000003\" complete_nodeset=\"0x00000003\"\
+ allowed_nodeset=\"0x00000003\">\n\
+    <info name=\"HostName\" value=\"testhost\"/>\n\
+    <object type=\"NUMANode\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\" local_memory=\"8589934592\">\n\
+      <object type=\"Package\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+        <object type=\"Core\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+          <object type=\"PU\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+        </object>\n\
+        <object type=\"Core\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+          <object type=\"PU\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+        </object>\n\
+      </object>\n\
+    </object>\n\
+    <object type=\"NUMANode\" os_index=\"1\"\
+ cpuset=\"0x0000000c\" complete_cpuset=\"0x0000000c\"\
+ online_cpuset=\"0x0000000c\" allowed_cpuset=\"0x0000000c\"\
+ nodeset=\"0x00000002\" complete_nodeset=\"0x00000002\"\
+ allowed_nodeset=\"0x00000002\" local_memory=\"8589934592\">\n\
+      <object type=\"Package\" os_index=\"1\"\
+ cpuset=\"0x0000000c\" complete_cpuset=\"0x0000000c\"\
+ online_cpuset=\"0x0000000c\" allowed_cpuset=\"0x0000000c\"\
+ nodeset=\"0x00000002\" complete_nodeset=\"0x00000002\"\
+ allowed_nodeset=\"0x00000002\">\n\
+        <object type=\"Core\" os_index=\"2\"\
+ cpuset=\"0x00000004\" complete_cpuset=\"0x00000004\"\
+ online_cpuset=\"0x00000004\" allowed_cpuset=\"0x00000004\"\
+ nodeset=\"0x00000002\" complete_nodeset=\"0x00000002\"\
+ allowed_nodeset=\"0x00000002\">\n\
+          <object type=\"PU\" os_index=\"2\"\
+ cpuset=\"0x00000004\" complete_cpuset=\"0x00000004\"\
+ online_cpuset=\"0x00000004\" allowed_cpuset=\"0x00000004\"\
+ nodeset=\"0x00000002\" complete_nodeset=\"0x00000002\"\
+ allowed_nodeset=\"0x00000002\"/>\n\
+        </object>\n\
+        <object type=\"Core\" os_index=\"3\"\
+ cpuset=\"0x00000008\" complete_cpuset=\"0x00000008\"\
+ online_cpuset=\"0x00000008\" allowed_cpuset=\"0x00000008\"\
+ nodeset=\"0x00000002\" complete_nodeset=\"0x00000002\"\
+ allowed_nodeset=\"0x00000002\">\n\
+          <object type=\"PU\" os_index=\"3\"\
+ cpuset=\"0x00000008\" complete_cpuset=\"0x00000008\"\
+ online_cpuset=\"0x00000008\" allowed_cpuset=\"0x00000008\"\
+ nodeset=\"0x00000002\" complete_nodeset=\"0x00000002\"\
+ allowed_nodeset=\"0x00000002\"/>\n\
+        </object>\n\
+      </object>\n\
+    </object>\n\
+  </object>\n\
+</topology>\n";
+
+/* No packages: 2 NUMA nodes with cores directly beneath, 4 GiB each */
+static const char xml_no_pkg[] = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<!DOCTYPE topology SYSTEM \"hwloc.dtd\">\n\
+<topology>\n\
+  <object type=\"Machine\" os_index=\"0\"\
+ cpuset=\"0x0000000f\" complete_cpuset=\"0x0000000f\"\
+ online_cpuset=\"0x0000000f\" allowed_cpuset=\"0x0000000f\"\
+ nodeset=\"0x00000003\" complete_nodeset=\"0x00000003\"\
+ allowed_nodeset=\"0x00000003\">\n\
+    <info name=\"HostName\" value=\"testhost\"/>\n\
+    <object type=\"NUMANode\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\" local_memory=\"4294967296\">\n\
+      <object type=\"Core\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+        <object type=\"PU\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+      </object>\n\
+      <object type=\"Core\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+        <object type=\"PU\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+      </object>\n\
+    </object>\n\
+    <object type=\"NUMANode\" os_index=\"1\"\
+ cpuset=\"0x0000000c\" complete_cpuset=\"0x0000000c\"\
+ online_cpuset=\"0x0000000c\" allowed_cpuset=\"0x0000000c\"\
+ nodeset=\"0x00000002\" complete_nodeset=\"0x00000002\"\
+ allowed_nodeset=\"0x00000002\" local_memory=\"4294967296\">\n\
+      <object type=\"Core\" os_index=\"2\"\
+ cpuset=\"0x00000004\" complete_cpuset=\"0x00000004\"\
+ online_cpuset=\"0x00000004\" allowed_cpuset=\"0x00000004\"\
+ nodeset=\"0x00000002\" complete_nodeset=\"0x00000002\"\
+ allowed_nodeset=\"0x00000002\">\n\
+        <object type=\"PU\" os_index=\"2\"\
+ cpuset=\"0x00000004\" complete_cpuset=\"0x00000004\"\
+ online_cpuset=\"0x00000004\" allowed_cpuset=\"0x00000004\"\
+ nodeset=\"0x00000002\" complete_nodeset=\"0x00000002\"\
+ allowed_nodeset=\"0x00000002\"/>\n\
+      </object>\n\
+      <object type=\"Core\" os_index=\"3\"\
+ cpuset=\"0x0000000c\" complete_cpuset=\"0x0000000c\"\
+ online_cpuset=\"0x0000000c\" allowed_cpuset=\"0x0000000c\"\
+ nodeset=\"0x00000002\" complete_nodeset=\"0x00000002\"\
+ allowed_nodeset=\"0x00000002\">\n\
+        <object type=\"PU\" os_index=\"3\"\
+ cpuset=\"0x00000008\" complete_cpuset=\"0x00000008\"\
+ online_cpuset=\"0x00000008\" allowed_cpuset=\"0x00000008\"\
+ nodeset=\"0x00000002\" complete_nodeset=\"0x00000002\"\
+ allowed_nodeset=\"0x00000002\"/>\n\
+      </object>\n\
+    </object>\n\
+  </object>\n\
+</topology>\n";
+
+/* GPU under NUMANode: single package with 1 GPU */
+static const char xml_nps1_gpu[] = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<!DOCTYPE topology SYSTEM \"hwloc.dtd\">\n\
+<topology>\n\
+  <object type=\"Machine\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+    <info name=\"HostName\" value=\"testhost\"/>\n\
+    <object type=\"NUMANode\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\" local_memory=\"8589934592\">\n\
+      <object type=\"Package\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+        <object type=\"Core\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+          <object type=\"PU\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+        </object>\n\
+        <object type=\"Core\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+          <object type=\"PU\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+        </object>\n\
+      </object>\n\
+    </object>\n\
+    <object type=\"Bridge\" os_index=\"0\" bridge_type=\"0-1\" depth=\"0\"\
+ bridge_pci=\"0000:[00-01]\">\n\
+      <object type=\"PCIDev\" os_index=\"4096\" name=\"Test GPU 0\"\
+ pci_busid=\"0000:01:00.0\" pci_type=\"0302 [10de:1234] [10de:0000] a1\"\
+ pci_link_speed=\"0.000000\">\n\
+        <object type=\"OSDev\" name=\"cuda0\" osdev_type=\"5\">\n\
+          <info name=\"CoProcType\" value=\"CUDA\"/>\n\
+          <info name=\"Backend\" value=\"CUDA\"/>\n\
+        </object>\n\
+      </object>\n\
+    </object>\n\
+  </object>\n\
+</topology>\n";
+
+/* Test basic TreePool topology generation */
+void test_basic_topologies (void)
+{
+    hwloc_topology_t topo;
+    json_t *result, *arr, *e;
+    const char *s;
+
+    /* NPS1 single package: single-element socket collapses to flat leaf */
+    topo = rhwloc_xml_topology_load (xml_nps1_1pkg, RHWLOC_NO_RESTRICT);
+    if (!topo)
+        BAIL_OUT ("failed to load xml_nps1_1pkg topology");
+    result = rhwloc_treepool_topo (topo, NULL);
+    hwloc_topology_destroy (topo);
+    ok (result != NULL,
+        "NPS1 1-pkg returns non-NULL");
+    ok (json_object_get (result, "socket") == NULL,
+        "NPS1 1-pkg topo has no socket array (collapsed)");
+    s = json_string_value (json_object_get (result, "cores"));
+    ok (s && strcmp (s, "0-1") == 0,
+        "NPS1 1-pkg topo.cores == \"0-1\"");
+    ok (json_integer_value (json_object_get (result, "memory")) == 8,
+        "NPS1 1-pkg topo.memory == 8");
+    json_decref (result);
+
+    /* NPS1 two packages: two socket entries, each folding its sole NUMA */
+    topo = rhwloc_xml_topology_load (xml_nps1_2pkg, RHWLOC_NO_RESTRICT);
+    if (!topo)
+        BAIL_OUT ("failed to load xml_nps1_2pkg topology");
+    result = rhwloc_treepool_topo (topo, NULL);
+    hwloc_topology_destroy (topo);
+    ok (result != NULL,
+        "NPS1 2-pkg returns non-NULL");
+    arr = json_object_get (result, "socket");
+    ok (json_is_array (arr) && json_array_size (arr) == 2,
+        "NPS1 2-pkg topo.socket has 2 entries");
+    e = json_array_get (arr, 0);
+    s = json_string_value (json_object_get (e, "cores"));
+    ok (s && strcmp (s, "0-1") == 0,
+        "NPS1 2-pkg topo.socket[0].cores == \"0-1\"");
+    ok (json_integer_value (json_object_get (e, "memory")) == 8,
+        "NPS1 2-pkg topo.socket[0].memory == 8");
+    e = json_array_get (arr, 1);
+    s = json_string_value (json_object_get (e, "cores"));
+    ok (s && strcmp (s, "2-3") == 0,
+        "NPS1 2-pkg topo.socket[1].cores == \"2-3\"");
+    ok (json_integer_value (json_object_get (e, "memory")) == 8,
+        "NPS1 2-pkg topo.socket[1].memory == 8");
+    json_decref (result);
+
+    /* No packages: two NUMA nodes directly in topo */
+    topo = rhwloc_xml_topology_load (xml_no_pkg, RHWLOC_NO_RESTRICT);
+    if (!topo)
+        BAIL_OUT ("failed to load xml_no_pkg topology");
+    result = rhwloc_treepool_topo (topo, NULL);
+    hwloc_topology_destroy (topo);
+    ok (result != NULL,
+        "no-pkg returns non-NULL");
+    arr = json_object_get (result, "numa");
+    ok (json_is_array (arr) && json_array_size (arr) == 2,
+        "no-pkg topo.numa has 2 entries");
+    e = json_array_get (arr, 0);
+    s = json_string_value (json_object_get (e, "cores"));
+    ok (s && strcmp (s, "0-1") == 0,
+        "no-pkg topo.numa[0].cores == \"0-1\"");
+    ok (json_integer_value (json_object_get (e, "memory")) == 4,
+        "no-pkg topo.numa[0].memory == 4");
+    e = json_array_get (arr, 1);
+    s = json_string_value (json_object_get (e, "cores"));
+    ok (s && strcmp (s, "2-3") == 0,
+        "no-pkg topo.numa[1].cores == \"2-3\"");
+    ok (json_integer_value (json_object_get (e, "memory")) == 4,
+        "no-pkg topo.numa[1].memory == 4");
+    json_decref (result);
+
+    /* GPU at Machine level (hwloc 2.x I/O placement): single socket collapses,
+     * GPU assigned to NUMA via cpuset matching. Tests gpu_belongs_to_obj()
+     * fallback path for I/O devices not in CPU object parent chain.
+     */
+    topo = rhwloc_xml_topology_load (xml_nps1_gpu, RHWLOC_NO_RESTRICT);
+    if (!topo)
+        BAIL_OUT ("failed to load xml_nps1_gpu topology");
+    result = rhwloc_treepool_topo (topo, NULL);
+    hwloc_topology_destroy (topo);
+    ok (result != NULL,
+        "GPU topology returns non-NULL");
+    s = json_string_value (json_object_get (result, "gpus"));
+    ok (s && strcmp (s, "0") == 0,
+        "GPU topology topo.gpus == \"0\"");
+    ok (json_integer_value (json_object_get (result, "memory")) == 8,
+        "GPU topology topo.memory == 8");
+    json_decref (result);
+}
+
+/* Topology with NUMA node with zero memory */
+static const char xml_zero_mem_numa[] = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<!DOCTYPE topology SYSTEM \"hwloc.dtd\">\n\
+<topology>\n\
+  <object type=\"Machine\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+    <info name=\"HostName\" value=\"testhost\"/>\n\
+    <object type=\"NUMANode\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\" local_memory=\"0\">\n\
+      <object type=\"Package\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+        <object type=\"Core\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+          <object type=\"PU\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+        </object>\n\
+        <object type=\"Core\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+          <object type=\"PU\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\"/>\n\
+        </object>\n\
+      </object>\n\
+    </object>\n\
+  </object>\n\
+</topology>\n";
+
+/* Topology with L3 cache between Package and Core */
+static const char xml_with_cache[] = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<!DOCTYPE topology SYSTEM \"hwloc.dtd\">\n\
+<topology>\n\
+  <object type=\"Machine\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+    <info name=\"HostName\" value=\"testhost\"/>\n\
+    <object type=\"NUMANode\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\" local_memory=\"8589934592\">\n\
+      <object type=\"Package\" os_index=\"0\"\
+ cpuset=\"0x00000003\" complete_cpuset=\"0x00000003\"\
+ online_cpuset=\"0x00000003\" allowed_cpuset=\"0x00000003\"\
+ nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\"\
+ allowed_nodeset=\"0x00000001\">\n\
+        <object type=\"L3Cache\" cpuset=\"0x00000003\"\
+ complete_cpuset=\"0x00000003\" online_cpuset=\"0x00000003\"\
+ allowed_cpuset=\"0x00000003\" cache_size=\"16777216\"\
+ depth=\"3\" cache_linesize=\"64\" cache_associativity=\"16\"\
+ cache_type=\"0\">\n\
+          <object type=\"Core\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\">\n\
+            <object type=\"PU\" os_index=\"0\"\
+ cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\"\
+ online_cpuset=\"0x00000001\" allowed_cpuset=\"0x00000001\"/>\n\
+          </object>\n\
+          <object type=\"Core\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\">\n\
+            <object type=\"PU\" os_index=\"1\"\
+ cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\"\
+ online_cpuset=\"0x00000002\" allowed_cpuset=\"0x00000002\"/>\n\
+          </object>\n\
+        </object>\n\
+      </object>\n\
+    </object>\n\
+  </object>\n\
+</topology>\n";
+
+
+/* Test error paths and errno handling */
+void test_error_paths (void)
+{
+    json_t *result;
+    flux_error_t error;
+
+    /* NULL topology */
+    err_init (&error);
+    errno = 0;
+    result = rhwloc_treepool_topo (NULL, &error);
+    ok (result == NULL,
+        "NULL topology returns NULL");
+    ok (errno == EINVAL,
+        "NULL topology sets errno=EINVAL (got %d)", errno);
+    ok (error.text[0] != '\0',
+        "NULL topology sets error message");
+    diag ("error: %s", error.text);
+
+    /* NULL xml string */
+    err_init (&error);
+    errno = 0;
+    char *json_str = rhwloc_treepool_topo_to_json (NULL, &error);
+    ok (json_str == NULL,
+        "NULL xml returns NULL");
+    ok (errno == EINVAL,
+        "NULL xml sets errno=EINVAL");
+    ok (error.text[0] != '\0',
+        "NULL xml sets error message");
+    diag ("error: %s", error.text);
+
+}
+
+/* Test rhwloc_treepool_topo_to_json(), the entry point used by the Python
+ * FFI bindings.  test_error_paths() only covers its NULL-argument guard;
+ * exercise the success round-trip and the malformed-XML failure branch.
+ */
+void test_to_json (void)
+{
+    flux_error_t error;
+    char *json_str;
+    json_t *parsed;
+    const char *s;
+
+    /* Valid XML round-trips to a parseable JSON topology string */
+    err_init (&error);
+    errno = 0;
+    json_str = rhwloc_treepool_topo_to_json (xml_nps1_1pkg, &error);
+    ok (json_str != NULL,
+        "valid xml returns non-NULL json string");
+    if (!json_str)
+        diag ("error: %s", error.text);
+    parsed = json_str ? json_loads (json_str, 0, NULL) : NULL;
+    ok (parsed != NULL,
+        "returned json string parses");
+    s = json_string_value (json_object_get (parsed, "cores"));
+    ok (s && strcmp (s, "0-1") == 0,
+        "round-trip json topo.cores == \"0-1\"");
+    json_decref (parsed);
+    free (json_str);
+
+    /* Malformed XML fails with errno set and error message filled */
+    err_init (&error);
+    errno = 0;
+    json_str = rhwloc_treepool_topo_to_json ("<not valid hwloc xml>",
+                                             &error);
+    ok (json_str == NULL,
+        "malformed xml returns NULL");
+    ok (errno != 0,
+        "malformed xml sets errno (got %d)", errno);
+    ok (error.text[0] != '\0',
+        "malformed xml sets error message");
+    diag ("error: %s", error.text);
+}
+
+/* Test advanced topology structures */
+void test_advanced_topologies (void)
+{
+    hwloc_topology_t topo;
+    json_t *result;
+    const char *s;
+
+    /* Topology with zero-memory NUMA node */
+    topo = rhwloc_xml_topology_load (xml_zero_mem_numa, RHWLOC_NO_RESTRICT);
+    if (!topo)
+        BAIL_OUT ("failed to load xml_zero_mem_numa topology");
+    result = rhwloc_treepool_topo (topo, NULL);
+    hwloc_topology_destroy (topo);
+    ok (result != NULL,
+        "zero-memory NUMA topology returns non-NULL");
+    s = json_string_value (json_object_get (result, "cores"));
+    ok (s && strcmp (s, "0-1") == 0,
+        "zero-memory NUMA topo.cores == \"0-1\"");
+    ok (json_object_get (result, "memory") == NULL,
+        "zero-memory NUMA has no memory field (0 GiB rounds down)");
+    json_decref (result);
+
+    /* Topology with L3 cache between Package and Core (boring intermediate) */
+    topo = rhwloc_xml_topology_load (xml_with_cache, RHWLOC_NO_RESTRICT);
+    if (!topo)
+        BAIL_OUT ("failed to load xml_with_cache topology");
+    result = rhwloc_treepool_topo (topo, NULL);
+    hwloc_topology_destroy (topo);
+    ok (result != NULL,
+        "topology with L3 cache returns non-NULL");
+    s = json_string_value (json_object_get (result, "cores"));
+    ok (s && strcmp (s, "0-1") == 0,
+        "L3 cache topology descends through cache to find cores");
+    ok (json_integer_value (json_object_get (result, "memory")) == 8,
+        "L3 cache topology memory == 8");
+    json_decref (result);
+}
+
+int main (int ac, char *av[])
+{
+    plan (NO_PLAN);
+
+    test_basic_topologies ();
+    test_error_paths ();
+    test_to_json ();
+    test_advanced_topologies ();
+
+    done_testing ();
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -347,6 +347,7 @@ TESTSCRIPTS = \
 	python/t0042-job-manager-alloc-cache.py \
 	python/t0043-sdexec-map.py \
 	python/t0043-scheduler-pool.py \
+	python/t0044-tree-pool.py \
 	python/t0045-job-shape-parser.py \
 	python/t0046-job-watcher.py \
 	python/t0047-flux-argument-parser.py \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -201,6 +201,9 @@ TESTSCRIPTS = \
 	t2317-resource-shrink.t \
 	t2318-resource-verify.t \
 	t2319-resource-history.t \
+	t2320-sched-treepool.t \
+	t2321-sched-treepool-tva.t \
+	t2322-sched-treepool-tvb.t \
 	t2350-resource-list.t \
 	t2351-resource-status-input.t \
 	t2352-resource-cmd-config.t \
@@ -393,6 +396,7 @@ EXTRA_DIST= \
 	module/testmod.py \
 	scheduler/sched-slowgen.py \
 	scheduler/sched_tree_amender.py \
+	scheduler/sched-tree-subclass.py \
 	cocci/json_set_new_decref.cocci
 
 dist_check_SCRIPTS = \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -392,6 +392,7 @@ EXTRA_DIST= \
 	flux-resource \
 	module/testmod.py \
 	scheduler/sched-slowgen.py \
+	scheduler/sched_tree_amender.py \
 	cocci/json_set_new_decref.cocci
 
 dist_check_SCRIPTS = \

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -435,6 +435,111 @@ class TestRv1PoolWorstFit(unittest.TestCase):
         self.assertNotIn(1, a._ranks)
 
 
+class TestRv1PoolSelectResourcesOverride(unittest.TestCase):
+    """_select_resources is an overridable hook."""
+
+    R_uneven = {
+        "version": 1,
+        "execution": {
+            "R_lite": [
+                {"rank": "0", "children": {"core": "0-3"}},
+                {"rank": "1", "children": {"core": "0-1"}},
+            ],
+            "starttime": 0,
+            "expiration": 0,
+            "nodelist": ["big", "small"],
+        },
+    }
+
+    def test_override_controls_resource_selection(self):
+        """Subclass can reverse candidate order to implement best-fit."""
+
+        class BestFitPool(Rv1Pool):
+            def _select_resources(self, candidates, request):
+                return super()._select_resources(list(reversed(candidates)), request)
+
+        pool = BestFitPool(self.R_uneven)
+        # Default (worst-fit) picks rank0; best-fit should pick rank1 (smaller)
+        a = pool.alloc(1, rr(0, 1, 1))
+        self.assertIn(1, a._ranks)
+        self.assertNotIn(0, a._ranks)
+
+    def test_override_can_raise_insufficient(self):
+        """Override may raise InsufficientResources to block an allocation."""
+
+        class NoSmallPool(Rv1Pool):
+            def _select_resources(self, candidates, request):
+                # Reject any candidate with fewer than 4 cores
+                filtered = [
+                    (r, i, fc, fg)
+                    for r, i, fc, fg in candidates
+                    if len(i["cores"]) >= 4
+                ]
+                return super()._select_resources(filtered, request)
+
+        pool = NoSmallPool(self.R_uneven)
+        # rank1 has only 2 cores and is filtered out; rank0 satisfies the request
+        a = pool.alloc(1, rr(0, 1, 1))
+        self.assertIn(0, a._ranks)
+        # Requesting 2 nodes fails — only one has enough cores
+        with self.assertRaises(InsufficientResources):
+            pool.alloc(2, rr(2, 2, 1))
+
+
+class _RecordingPool(Rv1Pool):
+    """Rv1Pool subclass that records the candidates list on each _select_resources call."""
+
+    def __init__(self, R, *args, **kwargs):
+        super().__init__(R, *args, **kwargs)
+        self.last_candidates = None
+
+    def _select_resources(self, candidates, request):
+        self.last_candidates = list(candidates)
+        return super()._select_resources(candidates, request)
+
+
+class TestSelectResourcesAvailability(unittest.TestCase):
+    """_select_resources candidates reflect current availability state."""
+
+    def _alloc_or_try(self, pool, req):
+        """Attempt alloc, tolerating InsufficientResources (candidates still recorded)."""
+        try:
+            pool.alloc(1, req)
+        except InsufficientResources:
+            pass
+
+    def test_mark_down_excludes_rank_from_candidates(self):
+        pool = _RecordingPool(R_4x4)
+        pool.mark_down("0")
+        self._alloc_or_try(pool, rr(1, 1, 1))
+        candidate_ranks = {c[0] for c in pool.last_candidates}
+        self.assertNotIn(0, candidate_ranks)
+
+    def test_mark_down_all_yields_empty_candidates(self):
+        pool = _RecordingPool(R_4x4)
+        pool.mark_down("all")
+        self._alloc_or_try(pool, rr(1, 1, 1))
+        self.assertEqual(pool.last_candidates, [])
+
+    def test_mark_up_restores_rank_to_candidates(self):
+        pool = _RecordingPool(R_4x4)
+        pool.mark_down("0")
+        pool.mark_up("0")
+        self._alloc_or_try(pool, rr(1, 1, 1))
+        candidate_ranks = {c[0] for c in pool.last_candidates}
+        self.assertIn(0, candidate_ranks)
+
+    def test_remove_ranks_excludes_rank_from_candidates(self):
+        from flux.idset import IDset
+
+        pool = _RecordingPool(R_4x4)
+        pool.remove_ranks(IDset("0"))
+        self._alloc_or_try(pool, rr(1, 1, 1))
+        candidate_ranks = {c[0] for c in pool.last_candidates}
+        self.assertNotIn(0, candidate_ranks)
+
+
+
 class TestRv1PoolExclusive(unittest.TestCase):
     def setUp(self):
         self.pool = Rv1Pool(R_4x4)
@@ -677,6 +782,39 @@ class TestRv1PoolCheckFeasibility(unittest.TestCase):
         )
         with self.assertRaises(InfeasibleRequest):
             self.pool.check_feasibility(req)
+
+    def test_constraint_as_json_string(self):
+        """Constraint passed as a JSON string is parsed correctly."""
+        import json
+
+        pool = Rv1Pool(R_props)
+        # "fast" nodes have 4 cores total; 10 is infeasible.
+        # Pass the constraint as a JSON string rather than a dict to exercise
+        # the json.loads() path in _check_feasibility.
+        req = ResourceRequest(
+            None,
+            ResourceCount(10, 10),
+            1,
+            0,
+            60.0,
+            json.dumps({"properties": ["fast"]}),
+            False,
+        )
+        with self.assertRaises(InfeasibleRequest):
+            pool.check_feasibility(req)
+
+    def test_subclass_can_extend_check_feasibility(self):
+        """Subclass can add checks via super()._check_feasibility(request)."""
+
+        class StrictPool(Rv1Pool):
+            def _check_feasibility(self, request):
+                super()._check_feasibility(request)
+                if request.nnodes > 2:
+                    raise InfeasibleRequest("at most 2 nodes allowed")
+
+        StrictPool(R_4x4).check_feasibility(rr(2, 2, 1))  # should pass
+        with self.assertRaises(InfeasibleRequest):
+            StrictPool(R_4x4).check_feasibility(rr(3, 3, 1))  # subclass rejects
 
 
 class TestRv1PoolCopy(unittest.TestCase):

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -539,7 +539,6 @@ class TestSelectResourcesAvailability(unittest.TestCase):
         self.assertNotIn(0, candidate_ranks)
 
 
-
 class TestRv1PoolExclusive(unittest.TestCase):
     def setUp(self):
         self.pool = Rv1Pool(R_4x4)
@@ -1511,6 +1510,83 @@ class TestRangeAlloc(unittest.TestCase):
         )
         self.assertEqual(req.nnodes, 2)
         self.assertEqual(req.nnodes_max, 2)
+
+
+class _TaggedPool(Rv1Pool):
+    """Minimal Rv1Pool subclass that adds one extra attribute."""
+
+    def __init__(self, R, *args, **kwargs):
+        super().__init__(R, *args, **kwargs)
+        self.tag = "tagged"
+
+    def _init_from_state(self, source):
+        self.tag = source.tag
+
+
+class TestSubclassCopy(unittest.TestCase):
+    """copy(), _copy_from_ranks(), and alloc() must preserve subclass identity."""
+
+    def _make_pool(self):
+        return _TaggedPool(R_4x4)
+
+    def _simple_request(self, pool):
+        return pool.parse_resource_request(
+            {
+                "version": 1,
+                "resources": [
+                    {
+                        "type": "node",
+                        "count": 1,
+                        "with": [
+                            {
+                                "type": "slot",
+                                "count": 1,
+                                "with": [{"type": "core", "count": 1}],
+                            }
+                        ],
+                    }
+                ],
+                "tasks": [],
+                "attributes": {"system": {"duration": 0.0}},
+            }
+        )
+
+    def test_copy_preserves_subclass_type(self):
+        pool = self._make_pool()
+        c = pool.copy()
+        self.assertIsInstance(c, _TaggedPool)
+
+    def test_copy_calls_init_from_state(self):
+        pool = self._make_pool()
+        c = pool.copy()
+        self.assertEqual(c.tag, "tagged")
+
+    def test_alloc_preserves_subclass_type(self):
+        pool = self._make_pool()
+        req = self._simple_request(pool)
+        result = pool.alloc(1, req)
+        self.assertIsInstance(result, _TaggedPool)
+
+    def test_alloc_calls_init_from_state(self):
+        pool = self._make_pool()
+        req = self._simple_request(pool)
+        result = pool.alloc(1, req)
+        self.assertEqual(result.tag, "tagged")
+
+    def test_copy_from_ranks_preserves_subclass_type(self):
+        pool = self._make_pool()
+        req = self._simple_request(pool)
+        alloc = pool.alloc(1, req)
+        # _copy_from_ranks is exercised via free() with a partial rank set
+        subset = alloc._copy_from_ranks(set(alloc._ranks.keys()))
+        self.assertIsInstance(subset, _TaggedPool)
+
+    def test_copy_from_ranks_calls_init_from_state(self):
+        pool = self._make_pool()
+        req = self._simple_request(pool)
+        alloc = pool.alloc(1, req)
+        subset = alloc._copy_from_ranks(set(alloc._ranks.keys()))
+        self.assertEqual(subset.tag, "tagged")
 
 
 if __name__ == "__main__":

--- a/t/python/t0043-scheduler-pool.py
+++ b/t/python/t0043-scheduler-pool.py
@@ -11,10 +11,9 @@
 
 """Unit tests for Scheduler pool-class selection.
 
-Tests _pool_class_from_uri, _pool_class_from_writer, and _make_pool
-without a running Flux instance.  All three methods are pure Python and
-only use self for attribute access (pool_class, pool_kwargs, log) and
-recursive calls to each other — a lightweight mock suffices.
+Tests _pool_class_from_uri and _make_pool without a running Flux
+instance.  Scheduler methods only need self for attribute access
+(pool_class, pool_kwargs, log) — a lightweight mock suffices.
 """
 
 import json
@@ -26,7 +25,11 @@ import textwrap
 import unittest
 
 import subflux  # noqa: F401 - for PYTHONPATH
-from flux.resource.ResourcePool import ResourcePool
+from flux.resource.ResourcePool import (
+    _POOL_CLASS_CACHE,
+    ResourcePool,
+    _pool_class_from_uri,
+)
 from flux.resource.ResourcePoolImplementation import ResourcePoolImplementation
 from flux.resource.Rv1Pool import Rv1Pool
 from flux.scheduler import Scheduler
@@ -43,8 +46,6 @@ class _MockSched:
     def log(level, msg):
         pass
 
-    _pool_class_from_uri = Scheduler._pool_class_from_uri
-    _pool_class_from_writer = Scheduler._pool_class_from_writer
     _make_pool = Scheduler._make_pool
 
 
@@ -62,11 +63,11 @@ R_SIMPLE = {
 
 class TestPoolClassFromUri(unittest.TestCase):
     def setUp(self):
-        self.sched = _MockSched()
         self.tmpdir = tempfile.mkdtemp()
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
+        _POOL_CLASS_CACHE.clear()
 
     def _write_pool_file(self, filename, content):
         path = os.path.join(self.tmpdir, filename)
@@ -84,18 +85,18 @@ class TestPoolClassFromUri(unittest.TestCase):
 
     def test_missing_module_returns_none(self):
         """Unresolvable module URI returns None without raising."""
-        self.assertIsNone(self.sched._pool_class_from_uri("no_such_module_xyz"))
+        self.assertIsNone(_pool_class_from_uri("no_such_module_xyz"))
 
     def test_module_without_pool_class_attr_returns_none(self):
         """Module that exists but lacks pool_class returns None."""
-        self.assertIsNone(self.sched._pool_class_from_uri("json"))
+        self.assertIsNone(_pool_class_from_uri("json"))
 
     def test_module_uri_pool_class_attr(self):
         """Plain module URI loads pool_class attribute from the module."""
         self._write_pool_file("mypool.py", self._pool_file_content("MyPool"))
         sys.path.insert(0, self.tmpdir)
         try:
-            cls = self.sched._pool_class_from_uri("mypool")
+            cls = _pool_class_from_uri("mypool")
             self.assertEqual(cls.__name__, "MyPool")
         finally:
             sys.path.pop(0)
@@ -106,63 +107,26 @@ class TestPoolClassFromUri(unittest.TestCase):
         self._write_pool_file("mypool2.py", self._pool_file_content("MyPool2"))
         sys.path.insert(0, self.tmpdir)
         try:
-            cls = self.sched._pool_class_from_uri("mypool2:MyPool2")
+            cls = _pool_class_from_uri("mypool2:MyPool2")
             self.assertEqual(cls.__name__, "MyPool2")
         finally:
             sys.path.pop(0)
             sys.modules.pop("mypool2", None)
 
-
-class TestPoolClassFromWriter(unittest.TestCase):
-    def setUp(self):
-        self.sched = _MockSched()
-        self.tmpdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.tmpdir)
-
-    def _write_pool_file(self, filename, classname):
-        path = os.path.join(self.tmpdir, filename)
-        with open(path, "w") as f:
-            f.write(
-                f"from flux.resource.Rv1Pool import Rv1Pool\n"
-                f"class {classname}(Rv1Pool):\n"
-                f"    pass\n"
-                f"pool_class = {classname}\n"
-            )
-        return path
-
-    def test_no_scheduling_key_returns_none(self):
-        """R without a scheduling key returns None."""
-        self.assertIsNone(self.sched._pool_class_from_writer(R_SIMPLE))
-
-    def test_scheduling_without_writer_tries_fluxion(self):
-        """scheduling key without writer defaults to fluxion; returns None if not installed."""
-        R = dict(R_SIMPLE, scheduling={})
-        # fluxion is not installed in the test environment
-        self.assertIsNone(self.sched._pool_class_from_writer(R))
-
-    def test_scheduling_with_module_writer(self):
-        """scheduling.writer pointing to a module URI loads the class."""
-        self._write_pool_file("writerpool.py", "WriterPool")
+    def test_failed_lookup_not_cached(self):
+        """A failed lookup is not cached, so a URI that is unresolvable at
+        first call resolves once its module becomes importable."""
+        self.assertIsNone(_pool_class_from_uri("latepool"))
+        # Now make it importable; the earlier None must not have been cached.
+        self._write_pool_file("latepool.py", self._pool_file_content("LatePool"))
         sys.path.insert(0, self.tmpdir)
         try:
-            R = dict(R_SIMPLE, scheduling={"writer": "writerpool"})
-            cls = self.sched._pool_class_from_writer(R)
-            self.assertEqual(cls.__name__, "WriterPool")
+            cls = _pool_class_from_uri("latepool")
+            self.assertIsNotNone(cls, "failed lookup was cached and not retried")
+            self.assertEqual(cls.__name__, "LatePool")
         finally:
             sys.path.pop(0)
-            sys.modules.pop("writerpool", None)
-
-    def test_json_string_input(self):
-        """R supplied as a JSON string is parsed before inspection."""
-        R = dict(R_SIMPLE, scheduling={})
-        self.assertIsNone(self.sched._pool_class_from_writer(json.dumps(R)))
-
-    def test_non_dict_non_str_returns_none(self):
-        """Non-dict, non-str input returns None without raising."""
-        self.assertIsNone(self.sched._pool_class_from_writer(42))
-        self.assertIsNone(self.sched._pool_class_from_writer(None))
+            sys.modules.pop("latepool", None)
 
 
 class TestMakePool(unittest.TestCase):
@@ -171,6 +135,7 @@ class TestMakePool(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
+        _POOL_CLASS_CACHE.clear()
 
     def _make_sched(self, pool_class=None, pool_kwargs=None):
         sched = _MockSched()
@@ -220,6 +185,21 @@ class TestMakePool(unittest.TestCase):
         """Falls back to the default ResourcePool version dispatch."""
         sched = self._make_sched()
         pool = sched._make_pool(R_SIMPLE)
+        self.assertIsInstance(pool, ResourcePool)
+
+    def test_scheduling_without_writer_tries_fluxion_fallback(self):
+        """R with scheduling but no writer key tries fluxion then falls back."""
+        R = dict(R_SIMPLE, scheduling={})
+        sched = self._make_sched()
+        # fluxion is not installed in the test environment, so the default
+        # "fluxion" writer resolves to None and ResourcePool is used.
+        pool = sched._make_pool(R)
+        self.assertIsInstance(pool, ResourcePool)
+
+    def test_json_string_input(self):
+        """R supplied as a JSON string is parsed before writer dispatch."""
+        sched = self._make_sched()
+        pool = sched._make_pool(json.dumps(R_SIMPLE))
         self.assertIsInstance(pool, ResourcePool)
 
     def test_pool_kwargs_forwarded_to_explicit_pool_class(self):

--- a/t/python/t0044-tree-pool.py
+++ b/t/python/t0044-tree-pool.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Unit tests for TreePool: NUMA-affinity GPU+core allocation."""
+
+import copy
+import json
+import unittest
+
+import subflux  # noqa: F401,E402 - configures PYTHONPATH for flux imports
+from flux.idset import IDset  # noqa: E402
+from flux.resource import InfeasibleRequest, InsufficientResources  # noqa: E402
+from flux.resource.ResourceCount import ResourceCount  # noqa: E402
+from flux.resource.Rv1Pool import ResourceRequest  # noqa: E402
+from flux.resource.TreePool import TreePool  # noqa: E402
+from pycotap import TAPTestRunner  # noqa: E402
+
+_UNSET = object()
+
+
+def rr(
+    nnodes=0,
+    nslots=1,
+    slot_size=1,
+    gpu_per_slot=0,
+    exclusive=False,
+    nnodes_max=_UNSET,
+    nslots_max=_UNSET,
+):
+    """Build a ResourceRequest from flat parameters."""
+    if nnodes_max is _UNSET:
+        nnodes_max = nnodes
+    if nslots_max is _UNSET:
+        nslots_max = nslots
+    if nnodes > 0:
+        spn = nslots // nnodes
+        node_count = ResourceCount(nnodes, nnodes_max)
+        slot_count = ResourceCount(spn, spn)
+    else:
+        node_count = None
+        slot_count = ResourceCount(nslots, nslots_max)
+    return ResourceRequest(
+        node_count, slot_count, slot_size, gpu_per_slot, 0.0, None, exclusive, None
+    )
+
+
+# 2 nodes, 8 cores (0-7) + 2 GPUs (0-1) each.
+# 2 sockets per node, each with 1 NUMA child:
+#   socket 0: cores 0-3, gpu 0
+#   socket 1: cores 4-7, gpu 1
+_SOCKETS_2 = [
+    {"numa": [{"cores": "0-3", "gpus": "0"}]},
+    {"numa": [{"cores": "4-7", "gpus": "1"}]},
+]
+R_2NODE = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0-1", "children": {"core": "0-7", "gpu": "0-1"}}],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": ["gpu0", "gpu1"],
+    },
+    "scheduling": {
+        "writer": "TreePool",
+        "children": [{"ranks": "0-1", "topo": {"socket": _SOCKETS_2}}],
+    },
+}
+
+# 1 node, 2 sockets, each with 4 cores + 1 GPU.
+R_1NODE = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0", "children": {"core": "0-7", "gpu": "0-1"}}],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": ["gpu0"],
+    },
+    "scheduling": {
+        "writer": "TreePool",
+        "children": [{"ranks": "0", "topo": {"socket": _SOCKETS_2}}],
+    },
+}
+
+# 2 nodes (ranks 0-1), 8 cores + 2 GPUs each, with 2 NUMA domains per node:
+#   numa 0: cores 0-3, gpu 0   |   numa 1: cores 4-7, gpu 1
+# A node carrying more than one container is what exposes whether
+# container-exclusive selection honors the requested node count.
+R_2NODE_2NUMA = {
+    "version": 1,
+    "execution": {
+        "R_lite": [{"rank": "0-1", "children": {"core": "0-7", "gpu": "0-1"}}],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": ["n0", "n1"],
+    },
+    "scheduling": {
+        "writer": "TreePool",
+        "children": [
+            {
+                "ranks": "0-1",
+                "topo": {
+                    "numa": [
+                        {"cores": "0-3", "gpus": "0"},
+                        {"cores": "4-7", "gpus": "1"},
+                    ]
+                },
+            }
+        ],
+    },
+}
+
+
+# Same as R_2NODE_2NUMA but with a property on each rank: rank 0 is "fast",
+# rank 1 is "slow".  Used to exercise constraint-aware feasibility checks for
+# container-exclusive requests.
+R_2NODE_2NUMA_PROPS = copy.deepcopy(R_2NODE_2NUMA)
+R_2NODE_2NUMA_PROPS["execution"]["properties"] = {"fast": "0", "slow": "1"}
+
+
+def container_exclusive_jobspec(
+    nnodes, containers_per_node, level="numa", constraint=None
+):
+    """Jobspec: node{nnodes} -> slot{containers_per_node} -> {level}{exclusive}."""
+    attributes = {"system": {"duration": 0.0}}
+    if constraint is not None:
+        attributes["system"]["constraints"] = constraint
+    return {
+        "version": 1,
+        "resources": [
+            {
+                "type": "node",
+                "count": nnodes,
+                "with": [
+                    {
+                        "type": "slot",
+                        "count": containers_per_node,
+                        "with": [{"type": level, "count": 1, "exclusive": True}],
+                    }
+                ],
+            }
+        ],
+        "attributes": attributes,
+    }
+
+
+class TestTreePoolConstruct(unittest.TestCase):
+    def test_valid_init(self):
+        pool = TreePool(copy.deepcopy(R_2NODE))
+        self.assertIn(0, pool.impl._rank_type)
+        self.assertIn(1, pool.impl._rank_type)
+
+    def test_from_json_string(self):
+        pool = TreePool(json.dumps(R_2NODE))
+        self.assertEqual(len(pool.impl._rank_type), 2)
+
+    def test_missing_scheduling_raises(self):
+        R = copy.deepcopy(R_2NODE)
+        del R["scheduling"]
+        with self.assertRaises(ValueError):
+            TreePool(R)
+
+    def test_missing_children_raises(self):
+        R = copy.deepcopy(R_2NODE)
+        R["scheduling"] = {"writer": "TreePool"}
+        with self.assertRaises(ValueError):
+            TreePool(R)
+
+    def test_empty_children_raises(self):
+        R = copy.deepcopy(R_2NODE)
+        R["scheduling"]["children"] = []
+        with self.assertRaises(ValueError):
+            TreePool(R)
+
+    def test_rank_count_mismatch_raises(self):
+        R = copy.deepcopy(R_2NODE)
+        R["scheduling"]["children"].append(
+            {
+                "ranks": "2",
+                "topo": {"socket": [{"numa": [{"cores": "0-3", "gpus": "0"}]}]},
+            }
+        )
+        with self.assertRaises(ValueError):
+            TreePool(R)
+
+    def test_non_zero_origin_pool_raises(self):
+        """Topology remap requires a zero-origin pool; a non-zero-origin
+        R_lite must fail loudly rather than silently map every rank to node
+        type 0 (the remap targets range(N), so _rank_type would not cover the
+        actual rank keys).
+
+        The resource module always hands the scheduler 0-origin R, so this
+        case does not arise in practice; the guard is defense-in-depth against
+        that contract changing, and this test pins the loud-failure behavior.
+        """
+        R = copy.deepcopy(R_2NODE)
+        R["execution"]["R_lite"] = [
+            {"rank": "10-11", "children": {"core": "0-7", "gpu": "0-1"}}
+        ]
+        R["scheduling"]["children"] = [
+            {"ranks": "10-11", "topo": {"socket": _SOCKETS_2}}
+        ]
+        with self.assertRaises(ValueError):
+            TreePool(R)
+
+    def test_children_rank_keys_remapped(self):
+        """Children ranks are re-mapped to match pool-rank space."""
+        R = copy.deepcopy(R_2NODE)
+        R["scheduling"]["children"] = [
+            {"ranks": "10", "topo": {"socket": _SOCKETS_2}},
+            {"ranks": "11", "topo": {"socket": _SOCKETS_2}},
+        ]
+        pool = TreePool(R)
+        self.assertIn(0, pool.impl._rank_type)
+        self.assertIn(1, pool.impl._rank_type)
+        self.assertNotIn(10, pool.impl._rank_type)
+
+    def test_idset_range_key_equivalent_to_per_rank(self):
+        """A single IDset range key covers all ranks identically to per-rank keys."""
+        # R_2NODE already uses a range key "0-1"
+        pool_range = TreePool(copy.deepcopy(R_2NODE))
+        # Build per-rank version with separate entries
+        R_perrank = copy.deepcopy(R_2NODE)
+        R_perrank["scheduling"]["children"] = [
+            {"ranks": "0", "topo": {"socket": _SOCKETS_2}},
+            {"ranks": "1", "topo": {"socket": _SOCKETS_2}},
+        ]
+        pool_perrank = TreePool(R_perrank)
+        self.assertEqual(pool_range.impl._type_levels, pool_perrank.impl._type_levels)
+
+    def test_idset_range_key_with_remapping(self):
+        """IDset range key with non-zero original ranks is correctly re-mapped."""
+        R = copy.deepcopy(R_2NODE)
+        R["scheduling"]["children"] = [
+            {"ranks": "10-11", "topo": {"socket": _SOCKETS_2}}
+        ]
+        pool = TreePool(R)
+        self.assertIn(0, pool.impl._rank_type)
+        self.assertIn(1, pool.impl._rank_type)
+        self.assertNotIn(10, pool.impl._rank_type)
+        self.assertNotIn(11, pool.impl._rank_type)
+        children = pool.impl.scheduling["children"]
+        children_ranks = frozenset(
+            r for e in children for r in IDset(e.get("ranks", ""))
+        )
+        self.assertEqual(children_ranks, frozenset([0, 1]))
+
+    def test_type_dedup_homogeneous(self):
+        """Identical topology on all ranks → one shared type object."""
+        pool = TreePool(copy.deepcopy(R_2NODE))
+        # Both ranks are homogeneous; deduplication must yield one type.
+        self.assertEqual(len(pool.impl._type_levels), 1)
+        self.assertEqual(pool.impl._rank_type[0], pool.impl._rank_type[1])
+
+    def test_type_dedup_heterogeneous(self):
+        """Different topologies on two ranks → two distinct type objects."""
+        R = copy.deepcopy(R_2NODE)
+        R["scheduling"]["children"] = [
+            {"ranks": "0", "topo": {"socket": _SOCKETS_2}},
+            {
+                "ranks": "1",
+                "topo": {"socket": [{"numa": [{"cores": "0-7", "gpus": "0"}]}]},
+            },
+        ]
+        pool = TreePool(R)
+        self.assertEqual(len(pool.impl._type_levels), 2)
+        self.assertNotEqual(pool.impl._rank_type[0], pool.impl._rank_type[1])
+
+
+class TestTreePoolAlloc(unittest.TestCase):
+    def setUp(self):
+        self.pool = TreePool(copy.deepcopy(R_2NODE))
+
+    def _assert_affinity(self, pool, result):
+        """Assert each rank's allocated GPUs and cores share an affinity group."""
+        checked = 0
+        for rank, rinfo in result.impl._ranks.items():
+            alloc_cores = rinfo["cores"]
+            alloc_gpus = rinfo["gpus"]
+            if not alloc_gpus:
+                continue
+            checked += 1
+            levels = pool.impl._rank_levels(rank)
+            self.assertTrue(
+                any(
+                    alloc_cores <= g_cores and alloc_gpus <= g_gpus
+                    for level_groups in levels
+                    for g_cores, g_gpus in level_groups
+                ),
+                f"rank {rank}: cores {alloc_cores} and gpus {alloc_gpus} "
+                f"violate affinity",
+            )
+        self.assertGreater(checked, 0, "no GPU-bearing rank was checked for affinity")
+
+    def test_single_gpu_slot_affinity(self):
+        """1-core 1-GPU slot: core and GPU must be in the same socket."""
+        result = self.pool.alloc(1, rr(nslots=1, slot_size=1, gpu_per_slot=1))
+        self._assert_affinity(self.pool, result)
+
+    def test_full_group_slot_affinity(self):
+        """4-core 1-GPU slot: fills one socket, affinity holds."""
+        result = self.pool.alloc(1, rr(nslots=1, slot_size=4, gpu_per_slot=1))
+        self._assert_affinity(self.pool, result)
+        rank_info = list(result.impl._ranks.values())[0]
+        self.assertEqual(len(rank_info["gpus"]), 1)
+
+    def test_cpu_only_ignores_affinity(self):
+        """CPU-only request succeeds without NUMA constraint."""
+        result = self.pool.alloc(1, rr(nslots=1, slot_size=8, gpu_per_slot=0))
+        self.assertEqual(len(result.impl._ranks), 1)
+        rank_info = list(result.impl._ranks.values())[0]
+        self.assertEqual(len(rank_info["cores"]), 8)
+        self.assertEqual(len(rank_info["gpus"]), 0)
+
+    def test_cpu_only_packs_into_partial_group(self):
+        """CPU-only slots prefer partially-used groups, leaving intact groups free."""
+        pool = TreePool(copy.deepcopy(R_1NODE))
+        pool.alloc(1, rr(nslots=1, slot_size=2, gpu_per_slot=0))
+        result2 = pool.alloc(2, rr(nslots=1, slot_size=2, gpu_per_slot=0))
+        cores2 = result2.impl._ranks[0]["cores"]
+        self.assertTrue(
+            cores2 <= frozenset(range(4)),
+            f"expected cores in group 0 (0-3), got {sorted(cores2)}",
+        )
+
+    def test_cpu_only_span_group_falls_back_to_base(self):
+        """CPU-only slot larger than any single group falls back to base worst-fit."""
+        pool = TreePool(copy.deepcopy(R_1NODE))
+        result = pool.alloc(1, rr(nslots=1, slot_size=6, gpu_per_slot=0))
+        rank_info = result.impl._ranks[0]
+        self.assertEqual(len(rank_info["cores"]), 6)
+        self.assertEqual(len(rank_info["gpus"]), 0)
+
+    def test_two_slots_fill_one_node(self):
+        """Two (4-core, 1-GPU) slots consume both sockets on one node."""
+        result = self.pool.alloc(1, rr(nslots=2, slot_size=4, gpu_per_slot=1))
+        self.assertEqual(len(result.impl._ranks), 1)
+        rank_info = list(result.impl._ranks.values())[0]
+        self.assertEqual(len(rank_info["cores"]), 8)
+        self.assertEqual(len(rank_info["gpus"]), 2)
+
+    def test_node_based_gpu_request(self):
+        """Node-based (nnodes=1) GPU request uses affinity allocation."""
+        result = self.pool.alloc(1, rr(nnodes=1, nslots=1, slot_size=4, gpu_per_slot=1))
+        self._assert_affinity(self.pool, result)
+        self.assertEqual(len(result.impl._ranks), 1)
+
+    def test_cross_socket_gpu_slot_uses_whole_node(self):
+        """5-core+1-GPU slot exceeds any socket group but succeeds via whole-node fallback."""
+        result = self.pool.alloc(1, rr(nslots=1, slot_size=5, gpu_per_slot=1))
+        rank_info = list(result.impl._ranks.values())[0]
+        self.assertEqual(len(rank_info["cores"]), 5)
+        self.assertEqual(len(rank_info["gpus"]), 1)
+
+    def test_infeasible_slot_too_many_gpus(self):
+        """1-core+3-GPU slot is infeasible (groups have at most 1 GPU)."""
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.alloc(1, rr(nslots=1, slot_size=1, gpu_per_slot=3))
+
+    def test_cpu_only_oversized_is_infeasible(self):
+        """CPU-only job exceeding total capacity raises InfeasibleRequest."""
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.alloc(1, rr(nslots=1, slot_size=64, gpu_per_slot=0))
+
+    def test_children_trimmed_to_allocated_ranks(self):
+        """Allocated R's children covers only the ranks used by the job."""
+        result = self.pool.alloc(1, rr(nnodes=1, nslots=1, slot_size=1, gpu_per_slot=1))
+        allocated_ranks = frozenset(result.impl._ranks.keys())
+        children = result.impl.scheduling.get("children", [])
+        children_ranks = frozenset(
+            r for e in children for r in IDset(e.get("ranks", ""))
+        )
+        self.assertEqual(children_ranks, allocated_ranks)
+
+    def test_full_allocation_children_complete(self):
+        """Allocating all nodes preserves full children rank coverage."""
+        result = self.pool.alloc(1, rr(nnodes=2, nslots=2, slot_size=1, gpu_per_slot=1))
+        children = result.impl.scheduling.get("children", [])
+        children_ranks = frozenset(
+            r for e in children for r in IDset(e.get("ranks", ""))
+        )
+        self.assertEqual(children_ranks, frozenset([0, 1]))
+
+    def test_sequential_single_gpu_allocations_affinity(self):
+        """Two sequential single-slot GPU allocations are each affinity-local."""
+        r1 = self.pool.alloc(1, rr(nslots=1, slot_size=4, gpu_per_slot=1))
+        r2 = self.pool.alloc(2, rr(nslots=1, slot_size=4, gpu_per_slot=1))
+        self._assert_affinity(self.pool, r1)
+        self._assert_affinity(self.pool, r2)
+        for rank in set(r1.impl._ranks) & set(r2.impl._ranks):
+            self.assertTrue(
+                r1.impl._ranks[rank]["cores"].isdisjoint(r2.impl._ranks[rank]["cores"])
+            )
+
+    def test_insufficient_after_full_allocation(self):
+        """Slot request fails with InsufficientResources when pool is exhausted."""
+        self.pool.alloc(1, rr(nslots=2, slot_size=4, gpu_per_slot=1))
+        self.pool.alloc(2, rr(nslots=2, slot_size=4, gpu_per_slot=1))
+        with self.assertRaises(InsufficientResources):
+            self.pool.alloc(3, rr(nslots=1, slot_size=1, gpu_per_slot=1))
+
+    def test_check_feasibility_infeasible(self):
+        """check_feasibility raises InfeasibleRequest when GPUs exceed node capacity."""
+        req = rr(nslots=1, slot_size=1, gpu_per_slot=3)
+        with self.assertRaises(InfeasibleRequest):
+            self.pool.check_feasibility(req)
+
+    def test_check_feasibility_feasible(self):
+        """check_feasibility passes for a request that fits within a socket."""
+        req = rr(nslots=1, slot_size=4, gpu_per_slot=1)
+        self.pool.check_feasibility(req)  # must not raise
+
+
+class TestTreePoolSingleNode(unittest.TestCase):
+    """Tests against a single-node pool to simplify rank reasoning."""
+
+    def setUp(self):
+        self.pool = TreePool(copy.deepcopy(R_1NODE))
+
+    def _assert_affinity(self, result):
+        checked = 0
+        for rank, rinfo in result.impl._ranks.items():
+            alloc_cores = rinfo["cores"]
+            alloc_gpus = rinfo["gpus"]
+            if not alloc_gpus:
+                continue
+            checked += 1
+            levels = self.pool.impl._rank_levels(rank)
+            self.assertTrue(
+                any(
+                    alloc_cores <= g_cores and alloc_gpus <= g_gpus
+                    for level_groups in levels
+                    for g_cores, g_gpus in level_groups
+                ),
+                f"rank {rank}: cores {alloc_cores} gpus {alloc_gpus} "
+                f"not in one affinity group",
+            )
+        self.assertGreater(checked, 0, "no GPU-bearing rank was checked for affinity")
+
+    def test_group0_allocation(self):
+        """First 4-core+1-GPU slot uses group 0 (cores 0-3, GPU 0)."""
+        result = self.pool.alloc(1, rr(nslots=1, slot_size=4, gpu_per_slot=1))
+        self._assert_affinity(result)
+        rinfo = result.impl._ranks[0]
+        gpus = rinfo["gpus"]
+        cores = rinfo["cores"]
+        if 0 in gpus:
+            self.assertTrue(cores <= frozenset(range(4)))
+        else:
+            self.assertTrue(cores <= frozenset(range(4, 8)))
+
+    def test_second_slot_uses_other_group(self):
+        """After first group is used, second allocation uses the other group."""
+        r1 = self.pool.alloc(1, rr(nslots=1, slot_size=4, gpu_per_slot=1))
+        r2 = self.pool.alloc(2, rr(nslots=1, slot_size=4, gpu_per_slot=1))
+        self._assert_affinity(r1)
+        self._assert_affinity(r2)
+        cores1 = r1.impl._ranks[0]["cores"]
+        cores2 = r2.impl._ranks[0]["cores"]
+        self.assertTrue(cores1.isdisjoint(cores2), "second alloc overlaps first")
+
+    def test_third_slot_insufficient(self):
+        """Third slot request fails after both groups are consumed."""
+        self.pool.alloc(1, rr(nslots=1, slot_size=4, gpu_per_slot=1))
+        self.pool.alloc(2, rr(nslots=1, slot_size=4, gpu_per_slot=1))
+        with self.assertRaises(InsufficientResources):
+            self.pool.alloc(3, rr(nslots=1, slot_size=1, gpu_per_slot=1))
+
+    def test_cpu_packing_preserves_group_for_gpu_job(self):
+        """CPU-only packing leaves an intact group available for a subsequent GPU job."""
+        self.pool.alloc(1, rr(nslots=1, slot_size=2, gpu_per_slot=0))
+        result = self.pool.alloc(2, rr(nslots=1, slot_size=4, gpu_per_slot=1))
+        self._assert_affinity(result)
+        rinfo = result.impl._ranks[0]
+        self.assertTrue(
+            rinfo["cores"] <= frozenset(range(4, 8)),
+            f"GPU job should use intact group 1, got cores {sorted(rinfo['cores'])}",
+        )
+
+    def test_children_trimmed_single_node(self):
+        """Single-node pool: children trimmed to rank 0."""
+        result = self.pool.alloc(1, rr(nslots=1, slot_size=1, gpu_per_slot=1))
+        children = result.impl.scheduling.get("children", [])
+        children_ranks = frozenset(
+            r for e in children for r in IDset(e.get("ranks", ""))
+        )
+        self.assertEqual(children_ranks, frozenset([0]))
+
+
+class TestTreePoolExclusive(unittest.TestCase):
+    """Tests for exclusive node allocation path through TreePool affinity logic."""
+
+    def setUp(self):
+        self.pool = TreePool(copy.deepcopy(R_2NODE))
+
+    def test_exclusive_gpu_claims_full_node(self):
+        """Exclusive GPU request: affinity validates the node, full complement claimed.
+        nslots must reflect the requested slot count, not the blocked core count."""
+        result = self.pool.alloc(
+            1, rr(nnodes=1, nslots=1, slot_size=4, gpu_per_slot=1, exclusive=True)
+        )
+        self.assertEqual(len(result.impl._ranks), 1)
+        rinfo = list(result.impl._ranks.values())[0]
+        self.assertEqual(len(rinfo["cores"]), 8, "exclusive must claim all 8 cores")
+        self.assertEqual(len(rinfo["gpus"]), 2, "exclusive must claim all 2 GPUs")
+        self.assertEqual(result.impl._nslots, 1, "nslots must not be inflated")
+
+    def test_exclusive_cpu_claims_full_node(self):
+        """Exclusive CPU-only request: full core AND GPU complement is claimed so
+        the node is truly exclusive.  nslots must not be inflated."""
+        result = self.pool.alloc(
+            1, rr(nnodes=1, nslots=1, slot_size=4, gpu_per_slot=0, exclusive=True)
+        )
+        self.assertEqual(len(result.impl._ranks), 1)
+        rinfo = list(result.impl._ranks.values())[0]
+        self.assertEqual(len(rinfo["cores"]), 8, "exclusive must claim all 8 cores")
+        self.assertEqual(len(rinfo["gpus"]), 2, "exclusive must claim all 2 GPUs")
+        self.assertEqual(result.impl._nslots, 1, "nslots must not be inflated")
+
+    def test_sequential_exclusive_use_separate_nodes(self):
+        """Two sequential exclusive allocations land on different nodes."""
+        r1 = self.pool.alloc(
+            1, rr(nnodes=1, nslots=1, slot_size=4, gpu_per_slot=1, exclusive=True)
+        )
+        r2 = self.pool.alloc(
+            2, rr(nnodes=1, nslots=1, slot_size=4, gpu_per_slot=1, exclusive=True)
+        )
+        ranks1 = set(r1.impl._ranks)
+        ranks2 = set(r2.impl._ranks)
+        self.assertTrue(
+            ranks1.isdisjoint(ranks2), "exclusive allocs must land on different nodes"
+        )
+
+    def test_exclusive_prevents_double_booking(self):
+        """After exclusive alloc, second job cannot use the same node."""
+        self.pool.alloc(
+            1, rr(nnodes=1, nslots=1, slot_size=4, gpu_per_slot=1, exclusive=True)
+        )
+        # Only one node remains free; exhaust it with another exclusive alloc.
+        self.pool.alloc(
+            2, rr(nnodes=1, nslots=1, slot_size=4, gpu_per_slot=1, exclusive=True)
+        )
+        # Pool is now fully exclusive — third request must fail.
+        with self.assertRaises(InsufficientResources):
+            self.pool.alloc(
+                3, rr(nnodes=1, nslots=1, slot_size=1, gpu_per_slot=1, exclusive=True)
+            )
+
+    def test_exclusive_coarser_level_slot(self):
+        """Exclusive slot_size=6 exceeds any socket group (4 cores): validated at
+        the whole-node (coarser) level, which only fires outside the lvl_idx==0
+        fast-path.  Full 8-core complement must still be claimed."""
+        result = self.pool.alloc(
+            1, rr(nnodes=1, nslots=1, slot_size=6, gpu_per_slot=0, exclusive=True)
+        )
+        self.assertEqual(len(result.impl._ranks), 1)
+        rinfo = list(result.impl._ranks.values())[0]
+        self.assertEqual(len(rinfo["cores"]), 8, "exclusive must claim all 8 cores")
+
+    def test_exclusive_multi_slot_spans_groups(self):
+        """Exclusive alloc of 2 slots/node (one per socket group) validates both
+        finest-level groups then claims the full node complement.
+        nslots must be 2, not inflated by the extra blocked cores."""
+        result = self.pool.alloc(
+            1, rr(nnodes=1, nslots=2, slot_size=4, gpu_per_slot=1, exclusive=True)
+        )
+        self.assertEqual(len(result.impl._ranks), 1)
+        rinfo = list(result.impl._ranks.values())[0]
+        self.assertEqual(len(rinfo["cores"]), 8, "exclusive must claim all 8 cores")
+        self.assertEqual(len(rinfo["gpus"]), 2, "exclusive must claim all 2 GPUs")
+        self.assertEqual(result.impl._nslots, 2, "nslots must not be inflated")
+
+
+class TestContainerExclusiveNodeCount(unittest.TestCase):
+    """A multi-node container-exclusive request must span the requested number
+    of distinct nodes rather than packing every container onto one node.
+
+    _container_exclusive_select() consults request.nnodes and takes
+    ``nslots // nnodes`` containers per node, so a node{N} request spreads
+    across N distinct nodes instead of collapsing onto a single node that
+    could supply all the requested containers.
+    """
+
+    def _alloc(self, R, jobspec):
+        pool = TreePool(copy.deepcopy(R))
+        req = pool.parse_resource_request(jobspec)
+        return req, pool.alloc(1, req)
+
+    def test_two_node_request_spans_two_nodes(self):
+        req, result = self._alloc(
+            R_2NODE_2NUMA, container_exclusive_jobspec(2, containers_per_node=1)
+        )
+        used = sorted(result.impl._ranks.keys())
+        self.assertEqual(req.nnodes, 2)
+        self.assertEqual(
+            len(used), 2, f"2-node request placed on {len(used)} node(s): {used}"
+        )
+
+    def test_two_node_request_one_container_per_node(self):
+        _, result = self._alloc(
+            R_2NODE_2NUMA, container_exclusive_jobspec(2, containers_per_node=1)
+        )
+        # One numa container == 4 cores; no node should receive two containers.
+        for rank, info in result.impl._ranks.items():
+            self.assertEqual(
+                len(info["cores"]),
+                4,
+                f"rank {rank} got {len(info['cores'])} cores (expected one container)",
+            )
+
+    def test_constrained_container_request_honors_constraint(self):
+        """A container-exclusive request constrained to a property set must
+        only count containers on matching ranks.  Here a 2-node request is
+        pinned to "fast" (rank 0 only), so feasibility must fail rather than
+        counting rank 1's containers toward the total."""
+        pool = TreePool(copy.deepcopy(R_2NODE_2NUMA_PROPS))
+        jobspec = container_exclusive_jobspec(
+            2, containers_per_node=1, constraint={"properties": ["fast"]}
+        )
+        req = pool.parse_resource_request(jobspec)
+        with self.assertRaises(InfeasibleRequest):
+            pool.check_feasibility(req)
+
+    def test_constrained_container_request_feasible_on_matching_rank(self):
+        """The same constraint is feasible for a 1-node request: rank 0 (fast)
+        alone supplies the single requested container."""
+        pool = TreePool(copy.deepcopy(R_2NODE_2NUMA_PROPS))
+        jobspec = container_exclusive_jobspec(
+            1, containers_per_node=1, constraint={"properties": ["fast"]}
+        )
+        req = pool.parse_resource_request(jobspec)
+        # Should not raise.
+        pool.check_feasibility(req)
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/scheduler/sched-tree-subclass.py
+++ b/t/scheduler/sched-tree-subclass.py
@@ -1,0 +1,43 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Minimal scheduler subclass using pool_class to bind TreePool.
+
+Tests the ``if self.pool_class is not None`` path in
+:meth:`~flux.scheduler.Scheduler._make_pool`.
+"""
+
+import heapq
+
+from flux.resource import InfeasibleRequest, InsufficientResources
+from flux.resource.TreePool import TreePool
+from flux.scheduler import Scheduler
+
+
+class TreeSubclassScheduler(Scheduler):
+    pool_class = TreePool
+
+    def schedule(self):
+        while self._queue:
+            job = self._queue[0]
+            try:
+                alloc = self.resources.alloc(job.jobid, job.resource_request)
+            except InsufficientResources:
+                break
+            except InfeasibleRequest as exc:
+                job.request.deny(str(exc))
+            else:
+                job.request.success(alloc)
+            heapq.heappop(self._queue)
+            yield
+
+
+def mod_main(h, *args):
+    TreeSubclassScheduler(h, *args).run()

--- a/t/scheduler/sched_tree_amender.py
+++ b/t/scheduler/sched_tree_amender.py
@@ -1,0 +1,99 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""fake-resources amend-r module: inject TreePool scheduling key.
+
+Topology functions take core and GPU counts from R itself and partition
+them evenly across the requested hierarchy.  Reference via the
+``module:function`` form of the fake-resources ``amend-r`` config key::
+
+    --conf=fake-resources.amend-r=sched_tree_amender:cluster_a
+
+The directory containing this file must be on PYTHONPATH so importlib can
+find it.  Adding a new topology means adding a function that calls
+``_inject(R, _make_topo(R, nsockets=..., nnuma_per_socket=...))``.
+"""
+
+from flux.idset import IDset
+
+
+def _all_ranks(R):
+    """IDset string covering every rank present in R_lite."""
+    result = IDset()
+    for entry in R.get("execution", {}).get("R_lite", []):
+        result |= IDset(entry["rank"])
+    return str(result)
+
+
+def _make_topo(R, nsockets, nnuma_per_socket=0):
+    """Build a TreePool topo dict from R's actual core/GPU counts.
+
+    Cores and GPUs are read from the first R_lite entry and divided
+    evenly across the leaf groups implied by the hierarchy.  Raises
+    ValueError if the counts don't divide evenly.
+    """
+    r_lite = R.get("execution", {}).get("R_lite", [])
+    children = r_lite[0].get("children", {}) if r_lite else {}
+    cores = sorted(IDset(children["core"])) if "core" in children else []
+    gpus = sorted(IDset(children["gpu"])) if "gpu" in children else []
+
+    nleaves = nsockets * nnuma_per_socket if nnuma_per_socket else nsockets
+    if not cores:
+        raise ValueError("R_lite has no cores")
+    if len(cores) % nleaves:
+        raise ValueError(
+            f"{len(cores)} cores not divisible by {nleaves} leaf groups "
+            f"({nsockets} socket(s) × {nnuma_per_socket or 1} NUMA)"
+        )
+    if gpus and len(gpus) % nleaves:
+        raise ValueError(
+            f"{len(gpus)} GPUs not divisible by {nleaves} leaf groups"
+        )
+
+    cpl = len(cores) // nleaves
+    gpl = len(gpus) // nleaves if gpus else 0
+
+    def leaf(i):
+        node = {"cores": str(IDset(cores[i * cpl:(i + 1) * cpl]))}
+        if gpl:
+            node["gpus"] = str(IDset(gpus[i * gpl:(i + 1) * gpl]))
+        return node
+
+    if nnuma_per_socket:
+        return {
+            "socket": [
+                {"numa": [leaf(s * nnuma_per_socket + n)
+                          for n in range(nnuma_per_socket)]}
+                for s in range(nsockets)
+            ]
+        }
+    return {"socket": [leaf(s) for s in range(nsockets)]}
+
+
+def _inject(R, topo):
+    R["scheduling"] = {
+        "writer": "TreePool",
+        "children": [{"ranks": _all_ranks(R), "topo": topo}],
+    }
+    return R
+
+
+def cluster_a(R, hwloc_xml=None):
+    """Xeon/Nvidia SNC4 (RFC 49 Cluster A): 2 sockets × 4 NUMA."""
+    return _inject(R, _make_topo(R, nsockets=2, nnuma_per_socket=4))
+
+
+def cluster_b(R, hwloc_xml=None):
+    """HPE Cray EX MI300A (RFC 49 Cluster B): 4 packages, no NUMA."""
+    return _inject(R, _make_topo(R, nsockets=4))
+
+
+# Default for file-path form of amend-r.
+amend = cluster_a

--- a/t/t2320-sched-treepool.t
+++ b/t/t2320-sched-treepool.t
@@ -1,0 +1,159 @@
+#!/bin/sh
+
+test_description='sched-simple pool-class: TreePool sub-node affinity'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+# Sierra topology (IBM Power9 + NVIDIA V100): 4 nodes, 2 sockets × 22 cores
+#   + 2 GPUs/socket = 44 cores, 4 GPUs per node.  HBM NUMANodes have empty
+#   cpusets in hwloc 2.x and are filtered; only sockets appear in the tree.
+SIERRA_XML="${SHARNESS_TEST_SRCDIR}/hwloc-data/sierra.xml"
+
+test_under_flux 1 full \
+    --conf=fake-resources.nnodes=4 \
+    --conf=fake-resources.hwloc-xml-path="${SIERRA_XML}" \
+    --conf=fake-resources.amend-r=flux.resource.TreePool:amend
+
+EXEC_TEST='--setattr=system.exec.test.run_duration=3600s'
+
+test_expect_success 'reload sched-simple with pool-class=TreePool' '
+    flux module reload sched-simple pool-class=TreePool
+'
+
+test_expect_success 'allocated R carries scheduling.children with writer key' '
+    jobid=$(flux submit $EXEC_TEST -N1 -n1 -c1 -g1 sleep inf) &&
+    flux job wait-event --timeout=10 ${jobid} alloc &&
+    flux job info ${jobid} R | jq -e ".scheduling.children" &&
+    flux job info ${jobid} R | jq -e ".scheduling.writer == \"TreePool\""
+'
+test_expect_success 'allocated children trimmed to the one assigned node' '
+    flux job info ${jobid} R | jq -e ".scheduling.children | length == 1" &&
+    flux job info ${jobid} R |
+        jq -e ".scheduling.children[0].ranks | test(\"-\") | not"
+'
+test_expect_success 'cleanup running jobs' '
+    flux cancel --all &&
+    flux queue drain --timeout=30s
+'
+
+test_expect_success 'GPU+cross-socket slot succeeds via best-effort fallback' '
+    jobid=$(flux submit $EXEC_TEST -N1 -n1 -c23 -g1 sleep inf) &&
+    flux job wait-event --timeout=10 ${jobid} alloc
+'
+test_expect_success 'cleanup running jobs' '
+    flux cancel --all &&
+    flux queue drain --timeout=30s
+'
+
+test_expect_success 'GPU slot exceeding node GPU count is permanently denied' '
+    jobid=$(flux submit -N1 -n1 -c1 -g5 sleep inf) &&
+    flux job wait-event --timeout=10 ${jobid} exception
+'
+
+test_expect_success 'best-fit: two GPU+core slots pack onto the same node, different socket' '
+    job0=$(flux submit $EXEC_TEST -N1 -n1 -c1 -g1 sleep inf) &&
+    job1=$(flux submit $EXEC_TEST -N1 -n1 -c1 -g1 sleep inf) &&
+    flux job wait-event --timeout=10 ${job0} alloc &&
+    flux job wait-event --timeout=10 ${job1} alloc &&
+    rank0=$(flux job info ${job0} R | jq -r ".execution.R_lite[0].rank") &&
+    rank1=$(flux job info ${job1} R | jq -r ".execution.R_lite[0].rank") &&
+    test "$rank0" = "$rank1" &&
+    gpu0=$(flux job info ${job0} R | jq -r ".execution.R_lite[0].children.gpu") &&
+    gpu1=$(flux job info ${job1} R | jq -r ".execution.R_lite[0].children.gpu") &&
+    test "$gpu0" != "$gpu1"
+'
+test_expect_success 'cleanup running jobs' '
+    flux cancel --all &&
+    flux queue drain --timeout=30s
+'
+
+# Fill all GPUs across all 4 Sierra nodes (4 nodes × 4 GPUs = 16 slots),
+# then verify that a CPU-only job still allocates despite no free GPUs anywhere.
+test_expect_success 'CPU-only job runs when all GPUs in pool are exhausted' '
+    gpujob=$(flux submit $EXEC_TEST -N4 -n16 -c1 -g1 sleep inf) &&
+    flux job wait-event --timeout=30 ${gpujob} alloc &&
+    cpujob=$(flux submit $EXEC_TEST -N1 -n1 -c1 sleep inf) &&
+    flux job wait-event --timeout=10 ${cpujob} alloc
+'
+test_expect_success 'cleanup running jobs' '
+    flux cancel --all &&
+    flux queue drain --timeout=30s
+'
+
+test_expect_success 'exclusive single-slot job: nslots is 1, not inflated' '
+    jobid=$(flux submit $EXEC_TEST --exclusive -N1 -n1 -c1 -g1 sleep inf) &&
+    flux job wait-event --timeout=10 ${jobid} alloc &&
+    flux job info ${jobid} R | jq -e ".execution.nslots == 1"
+'
+test_expect_success 'cleanup running jobs' '
+    flux cancel --all &&
+    flux queue drain --timeout=30s
+'
+
+test_expect_success 'exclusive two-slot job: nslots is 2, not inflated' '
+    jobid=$(flux submit $EXEC_TEST --exclusive -N1 -n2 -c1 -g1 sleep inf) &&
+    flux job wait-event --timeout=10 ${jobid} alloc &&
+    flux job info ${jobid} R | jq -e ".execution.nslots == 2"
+'
+test_expect_success 'cleanup running jobs' '
+    flux cancel --all &&
+    flux queue drain --timeout=30s
+'
+
+test_expect_success 'sequential exclusive jobs land on different nodes' '
+    job0=$(flux submit $EXEC_TEST --exclusive -N1 -n1 -c1 -g1 sleep inf) &&
+    job1=$(flux submit $EXEC_TEST --exclusive -N1 -n1 -c1 -g1 sleep inf) &&
+    flux job wait-event --timeout=10 ${job0} alloc &&
+    flux job wait-event --timeout=10 ${job1} alloc &&
+    rank0=$(flux job info ${job0} R | jq ".execution.R_lite[0].rank") &&
+    rank1=$(flux job info ${job1} R | jq ".execution.R_lite[0].rank") &&
+    test "$rank0" != "$rank1"
+'
+test_expect_success 'cleanup running jobs' '
+    flux cancel --all &&
+    flux queue drain --timeout=30s
+'
+
+test_expect_success 'exclusive jobs fill all nodes; 5th stays pending' '
+    ids= &&
+    for i in $(seq 1 4); do
+        ids="${ids} $(flux submit $EXEC_TEST \
+            --exclusive -N1 -n1 -c1 -g1 sleep inf)"
+    done &&
+    for id in ${ids}; do
+        flux job wait-event --timeout=30 ${id} alloc
+    done &&
+    overflow=$(flux submit $EXEC_TEST --exclusive -N1 -n1 -c1 -g1 sleep inf) &&
+    ! flux job wait-event --timeout=5 ${overflow} alloc
+'
+test_expect_success 'cleanup running jobs' '
+    flux cancel --all &&
+    flux queue drain --timeout=30s
+'
+
+test_expect_success 'unload sched-simple' '
+    flux module remove sched-simple
+'
+
+# Test pool_class class-attribute path: a Scheduler subclass that binds
+# TreePool via pool_class so no pool-class= argument or writer key is needed.
+TREE_SUBCLASS="${SHARNESS_TEST_SRCDIR}/scheduler/sched-tree-subclass.py"
+
+test_expect_success 'load sched-tree-subclass (pool_class class attribute)' '
+    flux module load ${TREE_SUBCLASS}
+'
+
+test_expect_success 'pool_class attr: GPU+core job allocates with affinity' '
+    jobid=$(flux submit $EXEC_TEST -N1 -n1 -c1 -g1 sleep inf) &&
+    flux job wait-event --timeout=10 ${jobid} alloc &&
+    flux cancel ${jobid} &&
+    flux job wait-event --timeout=10 ${jobid} clean
+'
+
+test_expect_success 'unload sched-tree-subclass' '
+    flux module remove sched-tree-subclass
+'
+
+test_done

--- a/t/t2321-sched-treepool-tva.t
+++ b/t/t2321-sched-treepool-tva.t
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+test_description='sched-simple TreePool RFC 49 Cluster A test vectors'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+# Cluster A: Dell PowerEdge XE9680 (2-socket Xeon, SNC4)
+#   2 sockets × 4 NUMA domains × 15 cores + 1 GPU per NUMA
+#   = 120 cores, 8 GPUs per node, 16 nodes
+#
+# sched_tree_amender uses the module:function form of amend-r, so its
+# directory must be on PYTHONPATH for importlib to find it by name.
+export PYTHONPATH="${SHARNESS_TEST_SRCDIR}/scheduler${PYTHONPATH:+:${PYTHONPATH}}"
+
+test_under_flux 1 full \
+    --conf=fake-resources.nnodes=16 \
+    --conf=fake-resources.cores-per-node=120 \
+    --conf=fake-resources.gpus-per-node=8 \
+    --conf=fake-resources.amend-r=sched_tree_amender:cluster_a
+
+EXEC_TEST='--setattr=system.exec.test.run_duration=3600s'
+
+test_expect_success 'reload sched-simple with pool-class=TreePool' '
+    flux module reload sched-simple pool-class=TreePool
+'
+
+# RFC 49 test vectors (Cluster A: Xeon/Nvidia, SNC4, 2 sockets x 4 NUMA x 15 cores + 1 GPU)
+# Allocations are cumulative to demonstrate topology-aware placement.
+n=0
+while read shape rlite; do
+    n=$((n+1))
+    test_expect_success "TVA${n}: --resources-shape='${shape}'" "
+        jobid=\$(flux submit $EXEC_TEST \
+            --resources-shape='${shape}' sleep inf) &&
+        flux job wait-event --timeout=10 \$jobid alloc &&
+        flux job info \$jobid R |
+            jq -e '.execution.R_lite[0] == ${rlite}'
+    "
+done <<'EOF'
+slot=1/node=1/[core=8;gpu=1] {"rank":"0","children":{"core":"0-7","gpu":"0"}}
+slot=1/node=1/[core=8;gpu=1] {"rank":"0","children":{"core":"15-22","gpu":"1"}}
+node/slot=8/[core=15;gpu=1] {"rank":"1","children":{"core":"0-119","gpu":"0-7"}}
+slot=4/node/core=120 {"rank":"2-5","children":{"core":"0-119"}}
+slot=1/node=1/core=4 {"rank":"0","children":{"core":"8-11"}}
+slot=1/node=1/[core=15;gpu=1] {"rank":"0","children":{"core":"30-44","gpu":"2"}}
+node/slot=6/[core=15;gpu=1] {"rank":"6","children":{"core":"0-89","gpu":"0-5"}}
+slot=1/node=1/[core=60;gpu=4] {"rank":"0","children":{"core":"60-119","gpu":"4-7"}}
+slot=1/numa{x} {"rank":"0","children":{"core":"45-59","gpu":"3"}}
+slot=1/socket{x} {"rank":"7","children":{"core":"0-59","gpu":"0-3"}}
+slot=1/node{x} {"rank":"8","children":{"core":"0-119","gpu":"0-7"}}
+EOF
+
+test_expect_success 'cleanup: cancel all TVA jobs' '
+    flux cancel --all &&
+    flux queue drain --timeout=60s
+'
+
+test_expect_success 'unload sched-simple' '
+    flux module remove sched-simple
+'
+
+test_done

--- a/t/t2322-sched-treepool-tvb.t
+++ b/t/t2322-sched-treepool-tvb.t
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+test_description='sched-simple TreePool RFC 49 Cluster B test vectors'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+# Cluster B: HPE Cray EX / AMD MI300A
+#   4 packages × 24 cores + 1 GPU per package
+#   = 96 cores, 4 GPUs per node, 1152 nodes
+#
+# sched_tree_amender uses the module:function form of amend-r, so its
+# directory must be on PYTHONPATH for importlib to find it by name.
+export PYTHONPATH="${SHARNESS_TEST_SRCDIR}/scheduler${PYTHONPATH:+:${PYTHONPATH}}"
+
+test_under_flux 1 full \
+    --conf=fake-resources.nnodes=1152 \
+    --conf=fake-resources.cores-per-node=96 \
+    --conf=fake-resources.gpus-per-node=4 \
+    --conf=fake-resources.amend-r=sched_tree_amender:cluster_b
+
+EXEC_TEST='--setattr=system.exec.test.run_duration=3600s'
+
+test_expect_success 'reload sched-simple with pool-class=TreePool' '
+    flux module reload sched-simple pool-class=TreePool
+'
+
+# RFC 49 test vectors (Cluster B: MI300A, 4 packages × 24 cores + 1 GPU)
+# Allocations are cumulative to demonstrate topology-aware placement.
+n=0
+while read shape rlite; do
+    n=$((n+1))
+    test_expect_success "TVB${n}: --resources-shape='${shape}'" "
+        jobid=\$(flux submit $EXEC_TEST \
+            --resources-shape='${shape}' sleep inf) &&
+        flux job wait-event --timeout=10 \$jobid alloc &&
+        flux job info \$jobid R |
+            jq -e '.execution.R_lite[0] == ${rlite}'
+    "
+done <<'EOF'
+slot=1/node=1/[core=24;gpu=1] {"rank":"0","children":{"core":"0-23","gpu":"0"}}
+slot=1/node=1/[core=24;gpu=1] {"rank":"0","children":{"core":"24-47","gpu":"1"}}
+node/slot=4/[core=24;gpu=1] {"rank":"1","children":{"core":"0-95","gpu":"0-3"}}
+slot=4/node/[core=96;gpu=4] {"rank":"2-5","children":{"core":"0-95","gpu":"0-3"}}
+slot=1/node=1/core=8 {"rank":"0","children":{"core":"48-55"}}
+slot=1/node=1/[core=24;gpu=1] {"rank":"0","children":{"core":"72-95","gpu":"3"}}
+node/slot=3/[core=24;gpu=1] {"rank":"6","children":{"core":"0-71","gpu":"0-2"}}
+slot=1/socket{x} {"rank":"6","children":{"core":"72-95","gpu":"3"}}
+slot=1/node{x} {"rank":"7","children":{"core":"0-95","gpu":"0-3"}}
+EOF
+
+test_expect_success 'cleanup: cancel all TVB jobs' '
+    flux cancel --all &&
+    flux queue drain --timeout=60s
+'
+
+test_expect_success 'unload sched-simple' '
+    flux module remove sched-simple
+'
+
+test_done


### PR DESCRIPTION
This is a new ResourcePool class that essentially puts a digested form of the hwloc node topology in the `R.scheduling` key and uses it to make topology-aware scheduling choices, such as scheduling cores and gpus from the same NUMA node together.  See also
- flux-framework/rfc#518
- [proposed RFC 49](https://flux-framework--518.org.readthedocs.build/projects/flux-rfc/en/518/spec_49.html)

Quick start:
```
$ flux start
$ flux R encode --local --scheduling TreePool >R.treepool
$ flux module remove sched-simple
$ flux resource reload R.treepool
$ flux module load sched-simple
```

This is a very early WIP.

