### PR TITLE
kvs: fix memory leak on namespace lookup failure

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1292,6 +1292,15 @@ static lookup_t *lookup_common (flux_t *h,
                                   flags,
                                   h)))
             goto done;
+
+        if (flux_msg_aux_set (msg,
+                              "lookup_handle",
+                              lh,
+                              (flux_free_f)lookup_destroy) < 0) {
+            flux_log_error (ctx->h, "%s: flux_msg_aux_set", __FUNCTION__);
+            lookup_destroy (lh);
+            goto done;
+        }
     }
     else {
         int err;
@@ -1319,24 +1328,12 @@ static lookup_t *lookup_common (flux_t *h,
         root = getroot (ctx, ns, mh, msg, &stall);
         assert (!root);
 
-        if (stall) {
-            if (flux_msg_aux_set (msg, "lookup_handle", lh, NULL) < 0) {
-                flux_log_error (ctx->h, "%s: flux_msg_aux_set", __FUNCTION__);
-                goto done;
-            }
+        if (stall)
             goto stall;
-        }
         goto done;
     }
     else if (lret == LOOKUP_PROCESS_LOAD_MISSING_REFS) {
         struct kvs_cb_data cbd;
-
-        /* do not destroy lookup_handle on message destruction, we
-         * manage it in here */
-        if (flux_msg_aux_set (msg, "lookup_handle", lh, NULL) < 0) {
-            flux_log_error (ctx->h, "%s: flux_msg_aux_set", __FUNCTION__);
-            goto done;
-        }
 
         if (!(wait = wait_create_msg_handler (h, mh, msg, ctx, replay_cb)))
             goto done;
@@ -1367,8 +1364,6 @@ static lookup_t *lookup_common (flux_t *h,
     rc = 0;
 done:
     wait_destroy (wait);
-    if (rc < 0)
-        lookup_destroy (lh);
     (*stall) = false;
     return (rc == 0) ? lh : NULL;
 
@@ -1401,7 +1396,8 @@ static void lookup_request_cb (flux_t *h,
     }
     if (flux_respond_pack (h, msg, "{ s:O }", "val", val) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
-    lookup_destroy (lh);
+    /* N.B. lookup_handle 'lh' owned by message, will be destroyed
+     * when message destroyed */
     json_decref (val);
     request_tracking_remove (ctx, msg);
     return;
@@ -1409,7 +1405,6 @@ error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     request_tracking_remove (ctx, msg);
-    lookup_destroy (lh);
 }
 
 /* similar to kvs.lookup, but root_ref / root_seq returned to caller.
@@ -1467,7 +1462,8 @@ static void lookup_plus_request_cb (flux_t *h,
                                "rootref", root_ref) < 0)
             flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     }
-    lookup_destroy (lh);
+    /* N.B. lookup_handle 'lh' owned by message, will be destroyed
+     * when message destroyed */
     json_decref (val);
     request_tracking_remove (ctx, msg);
     return;
@@ -1475,7 +1471,6 @@ error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     request_tracking_remove (ctx, msg);
-    lookup_destroy (lh);
 }
 
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1233,7 +1233,6 @@ static lookup_t *lookup_common (flux_t *h,
     int flags;
     const char *ns = NULL;
     const char *key;
-    json_t *val = NULL;
     json_t *root_dirent = NULL;
     lookup_t *lh = NULL;
     const char *root_ref = NULL;
@@ -1368,10 +1367,8 @@ static lookup_t *lookup_common (flux_t *h,
     rc = 0;
 done:
     wait_destroy (wait);
-    if (rc < 0) {
+    if (rc < 0)
         lookup_destroy (lh);
-        json_decref (val);
-    }
     (*stall) = false;
     return (rc == 0) ? lh : NULL;
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1475,6 +1475,7 @@ error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     request_tracking_remove (ctx, msg);
+    lookup_destroy (lh);
 }
 
 


### PR DESCRIPTION
Problem: A lookup handle is currently destroyed after a lookup has completed (successfully or w/ error).  However, a failure path
exists where if a nemsapce does not exist, a different error path will be taken and the lookup handle will not be destroyed.  This of course is a memory leak.

Solution: Have the request message own the lookup handle.  Therefore the lookup handle will be destroyed when the request message is ultimately destroyed.  With this implementation, the error path no longer matters.

Fixes #7443

---

Side note, I was a little worried this could add slowness to the KVS but some throughput testing shows no change.  (In fact, this PR performed better than the master branch.  However, that likely is due to system variability.)  I initially thought `libutil/aux` was a zhash, but it ends up being a simple struct list, so it probably has little impact.

