### PR TITLE
add `flux schedbench` benchmark framework

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -61,6 +61,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-housekeeping.1 \
 	man1/flux-modprobe.1 \
 	man1/flux-sproc.1 \
+	man1/flux-schedbench.1 \
 	man1/flux-python.1
 
 # These files are generated as clones of a primary page.

--- a/doc/man1/flux-schedbench.rst
+++ b/doc/man1/flux-schedbench.rst
@@ -1,0 +1,567 @@
+==================
+flux-schedbench(1)
+==================
+
+
+SYNOPSIS
+========
+
+| **flux** **schedbench** **run** *TEST* [*OPTIONS*]
+| **flux** **schedbench** **sweep** [*TEST*] [*OPTIONS*]
+| **flux** **schedbench** **report** *TEST* [*OPTIONS*]
+
+
+DESCRIPTION
+===========
+
+.. program:: flux schedbench
+
+:program:`flux schedbench` runs scheduler benchmarks against fake or real
+resources and saves the results for later reporting.
+
+By default, :program:`flux schedbench run` launches a fresh Flux subinstance
+configured with fake resources via the fake-resources modprobe rc1 task
+(see :man5:`flux-config-fake-resources`) and re-execs itself inside that
+subinstance to run the benchmark. With ``--exec``, no subinstance is
+launched and real jobs run against the broker the user is currently
+connected to.
+
+:program:`flux schedbench sweep` runs a cross-product of benchmark
+configurations as parallel Flux jobs against the outer instance, sharing
+one results file and one live dashboard.  Single-value parameters stay
+fixed across the sweep; comma lists and RFC 45 ranges become sweep axes.
+Use ``--from FILE.toml`` for structured definitions including multi-module
+scheduler recipes.
+
+
+COMMANDS
+========
+
+run
+---
+
+.. program:: flux schedbench run
+
+:program:`flux schedbench run` runs a named benchmark (see `BENCHMARKS`_
+below) and appends the result to the results file.
+
+.. option:: -N, --nodes=N
+
+   Fake-resource node count for the launched subinstance (default: 4).
+   Ignored with :option:`--exec` — the real broker's resources are used
+   instead.
+
+.. option:: -c, --cores-per-node=C
+
+   Cores per node in the fake resource set (default: 64). Ignored with
+   :option:`--exec`.
+
+.. option:: -g, --gpus-per-node=G
+
+   GPUs per node in the fake resource set (default: 8). Ignored with
+   :option:`--exec`.
+
+.. option:: --hwloc-xml-path=PATH
+
+   Path to an hwloc XML file describing per-node topology. Passed to
+   the subinstance as ``--conf=fake-resources.hwloc-xml-path=PATH``;
+   the XML's per-node shape is replicated across
+   :option:`--nodes`. Useful for benchmarking topology-aware schedulers
+   (e.g. Fluxion). The path is also recorded in the results file so
+   reports can show which run used which topology. Ignored with
+   :option:`--exec`.
+
+.. option:: --amend-r=SPEC
+
+   Reference to a Python amender that mutates R before it is written
+   to KVS. ``SPEC`` is either a ``module:function`` reference or a
+   path to a file with an ``amend()`` callable at module scope; see
+   :man5:`flux-config-fake-resources` for the amender contract.
+   Passed to the subinstance as
+   ``--conf=fake-resources.amend-r=SPEC``. Typically paired with
+   :option:`--hwloc-xml-path` to inject scheduler-specific topology
+   metadata (Fluxion JGF, node properties, etc.) into R. The spec
+   is recorded in the results file. Ignored with :option:`--exec`.
+
+.. option:: --scheduler=NAME
+
+   Scheduler module to load in the fake-resources subinstance (default:
+   ``sched-simple``). Implemented by passing
+   ``--conf=modules.alternatives.sched=NAME`` to the underlying
+   :man1:`flux-start`. Ignored with :option:`--exec`.
+
+.. option:: --scheduler-options=OPTS
+
+   Module options string for the scheduler, shlex-parsed into a list and
+   encoded into the subinstance config as
+   ``--conf=modules.sched.args=["opt1", "opt2"]``. Ignored with
+   :option:`--exec`.
+
+.. option:: -o, --extra-start-options=OPTS
+
+   Extra arguments to pass through to the underlying :man1:`flux-start`
+   when launching the fake-resources subinstance; shlex-parsed. May be
+   given multiple times. Useful for setting broker attributes
+   (``--setattr=...``) or other conf keys that schedbench doesn't have
+   a dedicated flag for. Ignored with :option:`--exec`.
+
+.. option:: -x, --exec
+
+   Run real jobs against the current enclosing instance — no fake
+   resources, no subinstance launch. Use when running inside an
+   allocation where the broker's currently-loaded scheduler and
+   currently-up resources are what you want to benchmark.
+
+.. option:: --watcher=NAME
+
+   Event-watcher implementation (default: ``journal``). The journal
+   watcher imposes a single subscription on kvs-watch; the per-job watcher
+   opens one subscription per job, useful for measuring watcher overhead
+   under high job counts. Valid values are ``journal`` and ``per-job``.
+
+.. option:: -n, --njobs=N
+
+   Number of jobs to submit (default: 1000). Used by throughput and
+   locality; ignored by fill-machine, which computes its job count
+   from the resource shape.
+
+.. option:: --slot-cores=K
+
+   Cores per slot (default: 1). The total cores requested by each
+   job is ``--slot-cores * --nslots``.
+
+.. option:: --slot-gpus=K
+
+   GPUs per slot (default: 0). The total GPUs requested by each job
+   is ``--slot-gpus * --nslots``.
+
+.. option:: --nslots=N
+
+   Slots per job (locality only; default: 1). Each slot requests
+   :option:`--slot-cores` cores and :option:`--slot-gpus` GPUs;
+   locality scores how well the scheduler packs each slot into a
+   single locality domain.
+
+.. option:: --duration=SPEC
+
+   Job duration (locality only; default: ``0.1s``). ``SPEC`` is one
+   of:
+
+   * an FSD string (e.g. ``0.1s``, ``2m``) — every job runs that
+     long;
+   * ``fill`` — jobs never complete; the benchmark saturates the
+     cluster and cancels everything once placement is observed;
+   * ``random[:LO-HI]`` — uniform random duration per job (default
+     range ``0.1s-1.0s``).
+
+.. option:: --tag=LABEL
+
+   Free-form label stored in the results metadata for filtering and
+   reporting.
+
+.. option:: --results-file=PATH
+
+   Results file path (default: ``./schedbench-results.json``). The file
+   is created if absent; new runs append to the existing record list.
+
+.. option:: --no-save
+
+   Don't append to the results file. Useful for ad-hoc runs that
+   shouldn't pollute the persistent record.
+
+.. option:: --ui=auto|on|off
+
+   Interactive terminal UI: ``auto`` (default) enables it when stdout is a
+   TTY and :option:`--quiet` is not set; ``on`` forces it; ``off`` falls
+   back to the JSON event stream.
+
+.. option:: --color=auto|always|never
+
+   Color output for the terminal UI: ``auto`` (default) honors NO_COLOR and
+   TERM; ``always`` / ``never`` force.
+
+.. option:: -q, --quiet
+
+   Emit only terminal events (``test.start``, ``result``,
+   ``test.complete``, ``test.error``). On a non-TTY stdout, produces a
+   single JSON object containing the result metrics.
+
+.. option:: -v, --verbose
+
+   Emit progress, info, and metric events from the benchmark.
+
+
+report
+------
+
+.. program:: flux schedbench report
+
+:program:`flux schedbench report` pretty-prints results for a single
+benchmark from the results file.
+
+.. option:: --results-file=PATH
+
+   Results file path (default: ``./schedbench-results.json``).
+
+.. option:: --filter=KEY=VAL
+
+   Show only runs matching *KEY=VAL*. May be given multiple times;
+   filters combine with AND semantics. Common keys: ``tag``, ``watcher``,
+   ``scheduler.name``, ``real_exec``.
+
+.. option:: -o, --format=FORMAT
+
+   Output format. May be a named format (``default``, ``long``, ``csv``,
+   or any user-defined format from
+   ``~/.config/flux/flux-schedbench-report-TEST.toml``; pass ``help`` to
+   list available names), or a literal Python-style format string.
+
+.. option:: --sort=KEY,...
+
+   Sort rows by one or more keys. Prefix a key with ``-`` for descending
+   order.
+
+.. option:: --no-header
+
+   Omit the header row.
+
+
+sweep
+-----
+
+.. program:: flux schedbench sweep
+
+:program:`flux schedbench sweep` runs a cross-product of benchmark
+configurations and writes all results to a single results file with
+shared sweep metadata.  Each point in the matrix becomes one child
+:program:`flux schedbench run` invocation submitted as a Flux job to the
+outer instance; the dispatcher tracks them in parallel through a single
+:class:`flux.job.JobWatcher` and renders progress to a live dashboard.
+
+Sweep flags mirror :program:`flux schedbench run` (same names, same
+semantics), with one extension: every axis-capable flag accepts either a
+single value (fixed across the sweep) or a multi-value spec that becomes
+a sweep axis.  Multi-value specs are:
+
+* a comma list — ``--nodes=4,8,16``
+* an RFC 45 range — ``--nodes=4-1024:2:*`` (4 to 1024, step ×2)
+* a Python list in TOML — ``njobs = [4096, 8192]``
+
+The axis-capable flags are: :option:`--nodes`, :option:`--cores-per-node`,
+:option:`--gpus-per-node`, :option:`--njobs`, :option:`--slot-cores`,
+:option:`--slot-gpus`, :option:`--hwloc-xml-path`, :option:`--amend-r`,
+:option:`--scheduler`, :option:`--scheduler-options`, :option:`--watcher`,
+:option:`--tag`, and the *TEST* positional itself (which accepts a comma
+list for a multi-benchmark sweep).
+
+The sweep itself runs against the outer Flux instance.  To run a sweep
+without a pre-existing outer instance, wrap in :man1:`flux-start`::
+
+    flux start -s 1 -- flux schedbench sweep ...
+
+Sweep-only flags:
+
+.. option:: --from=PATH
+
+   Load sweep parameters and scheduler recipes from a TOML file.  CLI
+   flag values for the same parameters take precedence over file values.
+   See `SWEEP TOML FORMAT`_ below.
+
+.. option:: --sweep-name=NAME
+
+   Human-readable label for this sweep, stored in every record's
+   ``sweep.name`` field.  Default: a timestamp-based name.
+
+.. option:: --per-run-nodes=N
+
+   Nodes to allocate to each child Flux job (default: 1).  The child
+   schedbench process spawns a fake-resources subinstance inside its
+   allocation, so for fake-resources benchmarks one outer node per child
+   is sufficient regardless of the per-run :option:`--nodes` value.
+
+The standard ``run``-side flags also apply (:option:`--results-file`,
+:option:`--no-save`, :option:`--ui`, :option:`--color`, :option:`--conf`,
+:option:`--real-exec`).
+
+
+SWEEP TOML FORMAT
+=================
+
+A sweep definition file is a TOML document; the whole file is the sweep
+(no outer ``[sweep]`` wrapper).  Top-level scalars become fixed
+parameters; top-level lists and RFC 45 strings become sweep axes.
+Structured sections (``[[scheduler]]``, ``[conf]``) configure dispatch.
+
+A complete example, using Fluxion from a build directory::
+
+    # Optional sweep label.  Auto-generated if omitted.
+    name = "fluxion-vs-simple"
+
+    # Top-level parameters.  Single values are fixed across the
+    # sweep; lists and RFC 45 ranges become axes.
+    test = "throughput"
+    nodes = "16-1024:2"            # axis: 16, 32, 64, ..., 1024
+    njobs = [4096, 8192]           # axis: explicit list
+    cores_per_node = 64            # fixed: scalar
+    real_exec = false              # fixed: scalar
+
+    # Conf entries forwarded to every child run as --conf=KEY=VALUE.
+    # Equivalent to passing --conf=KEY=VALUE on the sweep command line.
+    [conf]
+    "resource.noverify" = true
+
+    # [[scheduler]] array-of-tables: each entry contributes one value
+    # to the implicit "scheduler" axis.  ``name`` is the axis label and
+    # appears in records / dashboard / report rows.
+    [[scheduler]]
+    name = "simple"
+
+    [[scheduler]]
+    name = "fluxion"
+    env = [
+      "FLUXION_HOME=/home/user/git/flux-sched",
+      "FLUX_MODPROBE_PATH_APPEND=$FLUXION_HOME/etc/modprobe",
+      "FLUX_PYTHONPATH_PREPEND=$FLUXION_HOME/src/python",
+      "FLUX_MODULE_PATH_PREPEND=$FLUXION_HOME/resource/modules:$FLUXION_HOME/qmanager/modules",
+    ]
+
+    [[scheduler.modules]]
+    name = "sched-fluxion-resource"
+    options = "policy=high"
+
+    [[scheduler.modules]]
+    name = "sched-fluxion-qmanager"
+
+Scheduler recipe fields:
+
+``name`` (required)
+    Axis value used in records, the dashboard, and report rows.  Also
+    the default ``module`` to force-load when no ``modules`` block is
+    given (so a shorthand block with just ``name = "sched-backfill"``
+    means "force-load sched-backfill").
+
+``module`` (optional)
+    Scheduler module name to force-load via
+    ``--conf=modules.alternatives.sched=NAME``.  Defaults to ``name``
+    in shorthand-form blocks (just ``name``, no ``modules``).  When
+    ``modules`` is present, ``module`` defaults to ``None`` — no
+    ``--scheduler`` override, modprobe picks the default via priority
+    resolution.
+
+``modules`` (optional)
+    List of ``{name, options}`` tables.  Each entry's ``options`` (if
+    present) is encoded as ``--conf=modules.<name>.args=[...]`` for the
+    child run.  Order is informational; modprobe decides load order
+    from dependencies.
+
+``conf`` (optional)
+    Table of additional ``--conf=KEY=VALUE`` entries applied only when
+    this recipe is selected (in addition to the sweep's top-level
+    ``[conf]``).  Useful for scheduler-specific tuning.
+
+``env`` (optional)
+    List of :class:`flux.job.JobspecV1.from_submit`-style env filter
+    rules applied to the child job's environment.  Each rule is one of:
+
+    * ``"VAR=VALUE"`` — set; ``$VAR`` / ``${VAR}`` expand against the
+      env built by earlier rules
+    * ``"VAR"`` or ``"GLOB*"`` — import from the submitter env
+    * ``"-PATTERN"`` — delete matching variables
+    * ``"^/path"`` — read additional rules from a file
+
+    The submitter environment is preserved by default; rules only add
+    or remove.  As a convenience, a dict ``env = { K = "V", ... }`` is
+    accepted and converted to ``["K=V", ...]`` rules — handy for the
+    simple "set these vars" case without inter-rule ``$VAR``
+    references.
+
+Common TOML pitfall — keys placed after sub-table headers attach to the
+*sub-table*, not the parent.  Place top-level keys (``env``, ``conf``)
+*before* any ``[[scheduler.modules]]`` headers, since headers terminate
+the current scope::
+
+    # CORRECT
+    [[scheduler]]
+    name = "fluxion"
+    env = [...]              # belongs to [[scheduler]]
+
+    [[scheduler.modules]]
+    name = "sched-fluxion-resource"
+
+    # WRONG — env attaches to the module entry, not the scheduler
+    [[scheduler]]
+    name = "fluxion"
+
+    [[scheduler.modules]]
+    name = "sched-fluxion-resource"
+    env = [...]              # attaches to the module — error
+
+The TOML parser raises a hard error for unknown keys in
+``[[scheduler]]`` and ``[[scheduler.modules]]`` blocks to surface this
+errors immediately rather than silently dropping the misplaced key.
+
+
+BENCHMARKS
+==========
+
+throughput
+   Submit *N* jobs as fast as possible and measure submit, alloc,
+   ingest, and clean rates. Use :option:`--njobs` to control the job
+   count and :option:`--slot-cores` / :option:`--slot-gpus` to
+   control per-job resource requirements. Headline metric:
+   ``throughput`` (jobs/sec, broker-side from submit to clean).
+
+fill-machine
+   Submit jobs sized to saturate the resource set; measure
+   time-to-fill, then cancel and measure cleanup. Use
+   :option:`--slot-cores` and :option:`--slot-gpus` to control
+   per-job requirements; the job count is computed from the
+   resource shape. Headline metric: ``time_to_fill`` (seconds from
+   first submit to last ``start`` event).
+
+locality
+   Submit multi-slot jobs and score each placement against an hwloc
+   topology. A slot is "satisfied" when its cores and GPUs all
+   share a single locality domain (by default the NUMA node
+   identified by hwloc's ``nodeset`` attribute). Use
+   :option:`--nslots`, :option:`--slot-cores`, and
+   :option:`--slot-gpus` to shape the request, and
+   :option:`--duration` to control job lifetime. Requires
+   :option:`--hwloc-xml-path` — the predicate needs the topology to
+   score against. Headline metric: ``mean_locality_score`` (mean
+   per-job satisfied / requested slots, in ``[0, 1]``).
+
+
+EXAMPLES
+========
+
+Run a basic throughput benchmark against a 4-node fake cluster (the
+defaults), saving to the default results file::
+
+   $ flux schedbench run throughput --njobs=500
+
+Benchmark against a larger fake cluster and tag the run::
+
+   $ flux schedbench run throughput -N 100 --cores-per-node=32 \
+       --njobs=10000 --tag=large-throughput
+
+Benchmark against an alternative scheduler::
+
+   $ flux schedbench run throughput -N 100 \
+       --scheduler=sched-fluxion-qmanager \
+       --scheduler-options="queue-depth=64"
+
+Benchmark Fluxion with topology-aware scheduling against a synthetic 100-node
+cluster, using the local machine's hwloc topology replicated per node and a
+Fluxion JGF amender to populate ``R["scheduling"]``::
+
+   $ lstopo --of xml local.xml
+   $ flux schedbench run throughput -N 100 \
+       --hwloc-xml-path=./local.xml \
+       --amend-r=./fluxion_amender.py \
+       --scheduler=sched-fluxion-qmanager
+
+Measure placement quality on a synthetic NUMA-rich topology — how well does
+the scheduler keep each 4-core slot inside a single NUMA domain?::
+
+   $ lstopo -i "package:2 numa:4 core:8 pu:1" --of xml > syn.xml
+   $ flux schedbench run locality -N 16 --hwloc-xml-path=./syn.xml \
+       --nslots=2 --slot-cores=4 --njobs=200
+
+Compare locality and throughput trade-offs across schedulers by running both
+benchmarks against each and reading the headline metrics from the same
+results file::
+
+   $ for sched in sched-simple sched-fluxion-qmanager; do
+   >     flux schedbench run locality -N 16 \
+   >         --hwloc-xml-path=./syn.xml --scheduler=$sched \
+   >         --tag=$sched --nslots=2 --slot-cores=4 --njobs=200
+   > done
+   $ flux schedbench report locality --sort=-mean_locality_score
+
+Benchmark inside a real allocation against real hardware::
+
+   $ flux alloc -N 4 -- flux schedbench run throughput --exec --njobs=500
+
+Sweep node counts and schedulers in a single run, with a 1-node child
+per point::
+
+   $ flux alloc -N 16 -- flux schedbench sweep throughput \
+       --nodes=16,64,256,1024 \
+       --scheduler=sched-simple,sched-backfill \
+       --njobs=10000
+
+Sweep from a TOML file with a fluxion recipe — multi-module load plus
+env overlay::
+
+   $ cat smoke.toml
+   test = "fill-machine"
+   nodes = "16-1024:2"
+   njobs = 49152
+
+   [[scheduler]]
+   name = "fluxion"
+   env = [
+     "FLUXION_HOME=/home/user/git/flux-sched",
+     "FLUX_MODPROBE_PATH_APPEND=$FLUXION_HOME/etc/modprobe",
+   ]
+   [[scheduler.modules]]
+   name = "sched-fluxion-resource"
+   [[scheduler.modules]]
+   name = "sched-fluxion-qmanager"
+   $ flux start -s 1 -- flux schedbench sweep --from=smoke.toml
+
+Pretty-print results for one benchmark::
+
+   $ flux schedbench report throughput
+
+Export results to CSV for downstream plotting::
+
+   $ flux schedbench report throughput -o csv > throughput.csv
+
+Show only runs with a particular tag, sorted by throughput descending::
+
+   $ flux schedbench report throughput --filter=tag=large-throughput \
+       --sort=-throughput
+
+Show all runs from a single sweep, sorted by node count::
+
+   $ flux schedbench report fill-machine --filter=sweep.name=smoke \
+       --sort=nodes
+
+
+FILES
+=====
+
+``./schedbench-results.json``
+   Default results file written by :program:`flux schedbench run` and read
+   by :program:`flux schedbench report`. Override with
+   :option:`--results-file`.
+
+``~/.config/flux/flux-schedbench-report-TEST.toml``
+   Per-benchmark user-defined output formats consumed by
+   :program:`flux schedbench report -o FORMAT`. See :man5:`flux-config`
+   for general format syntax.
+
+
+ENVIRONMENT
+===========
+
+FLUX_SCHEDBENCH_ISOLATED
+   Set to ``1`` by :program:`flux schedbench run` when launching the inner
+   schedbench invocation inside the fake-resources subinstance. The inner
+   invocation checks this variable as a recursion guard and runs the
+   benchmark directly rather than launching another subinstance. Users
+   should not normally set this.
+
+
+RESOURCES
+=========
+
+.. include:: common/resources.rst
+
+
+SEE ALSO
+========
+
+:man5:`flux-config-fake-resources`, :man1:`flux-start`, :man1:`flux-alloc`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -75,6 +75,7 @@ man_pages = [
     ('man1/flux-housekeeping', 'flux-housekeeping', 'list and terminate housekeeping tasks', [author], 1),
     ('man1/flux-modprobe', 'flux-modprobe', 'efficient and extensible task and module manager', [author], 1),
     ('man1/flux-sproc', 'flux-sproc', 'manage flux subprocesses', [author], 1),
+    ('man1/flux-schedbench', 'flux-schedbench', 'run benchmarks against fake or real resources', [author], 1),
     ('man1/flux-python', 'flux-python', 'invoke Python interpreter with Flux bindings available', [author], 1),
     ('man3/flux_attr_get', 'flux_attr_set', 'get/set Flux broker attributes', [author], 3),
     ('man3/flux_attr_get', 'flux_attr_set_ex', 'get/set Flux broker attributes', [author], 3),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -789,6 +789,8 @@ misconfiguration
 ogpu
 opmi
 printenv
+XML
+XML's
 XMLFILE
 initio
 mortem
@@ -1199,3 +1201,15 @@ amender
 amenders
 jgf
 importlib
+csv
+schedbench
+ui
+njobs
+benchmarking
+hwloc
+hwloc's
+nodeset
+numa
+pu
+backfill
+hoc

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -2474,6 +2474,139 @@ _flux_python3()
     return 0
 }
 
+_flux_schedbench()
+{
+    local cmd=$1
+    local subcmds="run sweep report"
+    local tests="throughput fill-machine locality"
+    local split=false
+
+    local general_OPTS="-h --help"
+
+    # Flags shared by both `run` and `sweep`.  In sweep mode, the
+    # axis-capable parameter flags (--nodes, --njobs, --scheduler,
+    # etc.) accept comma lists and RFC 45 ranges in addition to a
+    # single value — the completion logic is the same either way
+    # since we don't try to complete inside a multi-value spec.
+    local common_OPTS="\
+        -N --nodes= \
+        -c --cores-per-node= \
+        -g --gpus-per-node= \
+        -n --njobs= \
+        --slot-cores= \
+        --slot-gpus= \
+        --hwloc-xml-path= \
+        --amend-r= \
+        --scheduler= \
+        --scheduler-options= \
+        --conf= \
+        -x --exec \
+        --watcher= \
+        --tag= \
+        --results-file= \
+        --no-save \
+        --ui= \
+        --color= \
+        $tests \
+    "
+
+    local run_OPTS="\
+        $common_OPTS \
+        -o --extra-start-options= \
+        -q --quiet \
+        -v --verbose \
+    "
+
+    local sweep_OPTS="\
+        $common_OPTS \
+        --from= \
+        --sweep-name= \
+        --per-run-nodes= \
+    "
+
+    local report_OPTS="\
+        --results-file= \
+        --filter= \
+        -o --format= \
+        --sort= \
+        --no-header \
+        $tests \
+    "
+
+    _flux_split_longopt && split=true
+
+    # Value completion: enumerated choices for options with fixed
+    # values, file-path completion for PATH-typed args. Options that
+    # take values but have no useful suggestion (integer counts, free
+    # strings) fall through to the bare `return` at the bottom of the
+    # case so bash offers nothing.
+    case $prev in
+        --scheduler)
+            COMPREPLY=($(compgen -W \
+                "sched-simple sched-fluxion-qmanager" -- "$cur"))
+            return
+            ;;
+        --watcher)
+            COMPREPLY=($(compgen -W "journal per-job" -- "$cur"))
+            return
+            ;;
+        --ui)
+            COMPREPLY=($(compgen -W "auto on off" -- "$cur"))
+            return
+            ;;
+        --color)
+            COMPREPLY=($(compgen -W "auto always never" -- "$cur"))
+            return
+            ;;
+        --format)
+            # report subcommand: -o long form, named format choices.
+            COMPREPLY=($(compgen -W \
+                "default long csv help" -- "$cur"))
+            return
+            ;;
+        -o)
+            # -o is overloaded: --format on report, --extra-start-options
+            # on run. Dispatch by current subcommand. (On run, falls
+            # through to the bare-return branch since extra-start-options
+            # is free-form.)
+            if [[ $cmd == "report" ]]; then
+                COMPREPLY=($(compgen -W \
+                    "default long csv help" -- "$cur"))
+                return
+            fi
+            return
+            ;;
+        --hwloc-xml-path | --amend-r | --results-file | --from)
+            compopt -o default 2>/dev/null
+            COMPREPLY=()
+            return
+            ;;
+        -N | --nodes | -c | --cores-per-node | -g | --gpus-per-node | \
+            -n | --njobs | --slot-cores | --slot-gpus | \
+            --scheduler-options | --extra-start-options | --conf | \
+            --tag | --filter | --sort | \
+            --sweep-name | --per-run-nodes)
+            return
+            ;;
+    esac
+    $split && return
+
+    if [[ $cur == --*= ]]; then
+        COMPREPLY=()
+        return 0
+    fi
+    if [[ $cmd != "schedbench" ]]; then
+        var="${cmd//-/_}_OPTS"
+        COMPREPLY=( $(compgen -W "${!var} ${general_OPTS}" -- "$cur") )
+    else
+        COMPREPLY=( $(compgen -W "${general_OPTS} ${subcmds}" -- "$cur") )
+    fi
+    if [[ "${COMPREPLY[@]}" == *= ]]; then
+        compopt -o nospace
+    fi
+    return 0
+}
+
 _flux_core()
 {
     FLUX_OPTS="-v --verbose -V --version -p --parent -r --root"
@@ -2629,6 +2762,9 @@ _flux_core()
         ;;
     sproc)
         _flux_sproc $subcmd
+        ;;
+    schedbench)
+        _flux_schedbench $subcmd
         ;;
     help)
         COMPREPLY=( $(compgen -W "${cmds}" -- "$cur") )

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -102,6 +102,7 @@ nobase_fluxpy_PYTHON = \
 	testing/events.py \
 	testing/schedbench/__init__.py \
 	testing/schedbench/benchmarks.py \
+	testing/schedbench/results.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -100,6 +100,8 @@ nobase_fluxpy_PYTHON = \
 	testing/job_watcher.py \
 	testing/bulkrun.py \
 	testing/events.py \
+	testing/schedbench/__init__.py \
+	testing/schedbench/benchmarks.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -106,6 +106,7 @@ nobase_fluxpy_PYTHON = \
 	testing/schedbench/results.py \
     testing/schedbench/_ansi.py \
 	testing/schedbench/ui.py \
+	testing/schedbench/sweep.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -102,6 +102,7 @@ nobase_fluxpy_PYTHON = \
 	testing/events.py \
 	testing/schedbench/__init__.py \
 	testing/schedbench/benchmarks.py \
+	testing/schedbench/locality.py \
 	testing/schedbench/results.py \
     testing/schedbench/_ansi.py \
 	testing/schedbench/ui.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -97,6 +97,7 @@ nobase_fluxpy_PYTHON = \
 	abc/__init__.py \
 	testing/__init__.py \
 	testing/fake_resources.py \
+	testing/job_watcher.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -98,6 +98,7 @@ nobase_fluxpy_PYTHON = \
 	testing/__init__.py \
 	testing/fake_resources.py \
 	testing/job_watcher.py \
+	testing/bulkrun.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -99,6 +99,7 @@ nobase_fluxpy_PYTHON = \
 	testing/fake_resources.py \
 	testing/job_watcher.py \
 	testing/bulkrun.py \
+	testing/events.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -103,6 +103,7 @@ nobase_fluxpy_PYTHON = \
 	testing/schedbench/__init__.py \
 	testing/schedbench/benchmarks.py \
 	testing/schedbench/results.py \
+	testing/schedbench/ui.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -103,6 +103,7 @@ nobase_fluxpy_PYTHON = \
 	testing/schedbench/__init__.py \
 	testing/schedbench/benchmarks.py \
 	testing/schedbench/results.py \
+    testing/schedbench/_ansi.py \
 	testing/schedbench/ui.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \

--- a/src/bindings/python/flux/testing/bulkrun.py
+++ b/src/bindings/python/flux/testing/bulkrun.py
@@ -1,0 +1,428 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Bulk job submission and event observation.
+
+Submit one or more batches of jobs against a Flux instance, observe
+their main-eventlog events via a pluggable :class:`JobEventWatcher`,
+and return aggregate measurements as a :class:`BulkRunResult`.
+"""
+
+import os
+import time
+from collections import defaultdict
+
+import flux.job
+from flux.testing.job_watcher import default_watcher_factory
+
+_TERMINAL_EVENT = "clean"
+
+
+class BulkRunResult:
+    """Aggregate result of a :class:`BulkRun` execution.
+
+    Attributes:
+        jobs: mapping of jobid (int) to a dict of ``{event_name: event}``
+            for the events listed in the run's ``events_of_interest``.
+            When more than one batch was pushed, each per-jobid dict
+            also contains a ``"_batch"`` key whose value is the batch
+            index returned by :meth:`BulkRun.push_jobs`.
+        script_runtime (float): Wall time of :meth:`BulkRun.run`,
+            measured with :func:`time.monotonic`.
+        submit_attempted (int): Total number of submissions attempted
+            (sum of ``count`` across all :meth:`BulkRun.push_jobs`
+            calls).
+        submit_failures (list[dict]): One entry per submit RPC that
+            failed (the broker rejected the request). Each entry has
+            keys ``"batch"`` (the batch index), ``"submit_index"``
+            (the global per-submission index, 0-based across all
+            batches), and ``"error"`` (the exception message as a
+            string). Failed submits do not appear in :attr:`jobs` —
+            they have no jobid and produce no events — but the
+            count is preserved here so callers can surface
+            submission-time errors.
+    """
+
+    def __init__(self, jobs, script_runtime, submit_attempted, submit_failures):
+        self.jobs = jobs
+        self.script_runtime = script_runtime
+        self.submit_attempted = submit_attempted
+        self.submit_failures = submit_failures
+
+    @property
+    def njobs(self):
+        """Number of successfully-submitted jobs in this result."""
+        return len(self.jobs)
+
+    def first_event_t(self, name):
+        """Earliest broker timestamp recorded across all jobs for an event.
+
+        Raises:
+            ValueError: if no job recorded an event of this name.
+        """
+        ts = [j[name].timestamp for j in self.jobs.values() if name in j]
+        if not ts:
+            raise ValueError("no job recorded event {0!r}".format(name))
+        return min(ts)
+
+    def last_event_t(self, name):
+        """Latest broker timestamp recorded across all jobs for an event.
+
+        Raises:
+            ValueError: if no job recorded an event of this name.
+        """
+        ts = [j[name].timestamp for j in self.jobs.values() if name in j]
+        if not ts:
+            raise ValueError("no job recorded event {0!r}".format(name))
+        return max(ts)
+
+    def jobids_with(self, name):
+        """List of jobids that recorded an event of the given name."""
+        return [jid for jid, evs in self.jobs.items() if name in evs]
+
+
+class BulkRun:
+    """Submit a batch of jobs, observe their lifecycle, return aggregates.
+
+    Submit-and-react-and-summarize: queue one or more batches via
+    :meth:`push_jobs`, then call :meth:`run` to burst-submit them all
+    and drive the reactor until every submitted job reaches its
+    terminal event.
+
+    The :class:`JobEventWatcher` used to observe events is pluggable
+    via the ``watcher_factory`` constructor argument; the default
+    factory returns a :class:`JournalEventWatcher`.
+
+    Callback hooks let callers wire phase transitions and streaming
+    inspection without subclassing:
+
+      * :meth:`add_event_cb` — invoked for every event on every
+        tracked job.
+      * :meth:`add_bulk_event_cb` — invoked once when every
+        successfully-submitted job has seen a named event.
+
+    Reactor termination paths:
+
+      1. Default — all successfully-submitted jobs reach ``clean``.
+         RFC 21 guarantees that ``clean`` is the last event for every
+         job (including exception-terminated ones), so this path
+         covers all normal cases.
+      2. Explicit — a callback calls :meth:`stop`. Used when a
+         caller has decided the run is complete before terminal
+         events arrive naturally.
+
+    Submit failures (broker rejection of a submit RPC) are recorded
+    in :attr:`BulkRunResult.submit_failures` rather than raised; the
+    failing jobids never appear in :attr:`BulkRunResult.jobs` and do
+    not affect termination accounting. Callers should inspect
+    ``submit_failures`` and surface a warning when non-empty.
+
+    Time semantics follow the convention in
+    ``src/test/throughput.py``:
+
+      * Script-side timing uses :func:`time.monotonic`
+        (:attr:`BulkRunResult.script_runtime`).
+      * Broker-side timing uses each event's ``timestamp`` field,
+        accessible via :meth:`BulkRunResult.first_event_t` and
+        :meth:`BulkRunResult.last_event_t`.
+
+    Args:
+        handle: an open :class:`flux.Flux` handle.
+        events_of_interest: iterable of event names to record per
+            jobid. Other events still trigger callbacks but are not
+            stored in the result.
+        watcher_factory: callable taking a Flux handle and returning
+            a :class:`JobEventWatcher`.
+    """
+
+    def __init__(
+        self,
+        handle,
+        *,
+        events_of_interest=("submit", "alloc", "clean"),
+        watcher_factory=default_watcher_factory,
+    ):
+        self.handle = handle
+        self._events_of_interest = set(events_of_interest)
+        self._watcher = watcher_factory(handle)
+
+        # Configuration accumulated before run().
+        self._batches = []  # list of (jobspec_str, count)
+        self._total_pushed = 0  # sum of all batch counts
+
+        # State accumulated during run().
+        self._jobs = {}  # jobid -> {event_name: event}
+        self._jobid_to_batch = {}  # jobid -> batch index
+        self._submits_completed = 0  # submit RPC responses received
+        self._submit_failures = []  # list of {"batch": idx, "error": str}
+        self._terminal_jobids = set()
+        self._stop_requested = False
+        self._running = False
+
+        # Callbacks.
+        self._per_event_cbs = []
+        self._bulk_event_cbs = defaultdict(list)
+        self._seen_per_event = defaultdict(set)
+        self._bulk_fired = set()
+
+    # -- Configuration (before run()) ----------------------------------
+
+    def push_jobs(self, jobspec, count=1):
+        """Queue ``count`` copies of ``jobspec`` for submission.
+
+        Multiple calls before :meth:`run` queue heterogeneous batches
+        (for example, a mix of small and large jobspecs) which are
+        all submitted in a single :meth:`run` invocation.
+
+        Args:
+            jobspec: a :class:`flux.job.JobspecV1` (or any object with
+                a ``dumps()`` method returning a JSON string), or a
+                pre-serialized JSON string. The jobspec is serialized
+                once here, not per-submission.
+            count: number of copies to submit.
+
+        Returns:
+            int: the batch index (0 for the first call, 1 for the
+            second, ...). Per-jobid records in
+            :attr:`BulkRunResult.jobs` carry a ``"_batch"`` key with
+            this value when more than one batch was pushed.
+
+        Raises:
+            RuntimeError: if called after :meth:`run` has begun.
+            ValueError: if ``count`` is not a positive integer.
+        """
+        if self._running:
+            raise RuntimeError("push_jobs() forbidden after run()")
+        if not isinstance(count, int) or count < 1:
+            raise ValueError(
+                "count must be a positive integer, got {0!r}".format(count)
+            )
+        if hasattr(jobspec, "dumps"):
+            spec_str = jobspec.dumps()
+        else:
+            spec_str = jobspec
+        idx = len(self._batches)
+        self._batches.append((spec_str, count))
+        self._total_pushed += count
+        return idx
+
+    def add_event_cb(self, cb):
+        """Register a per-event callback.
+
+        ``cb(bulk_run, jobid, event)`` is invoked on the reactor
+        thread for every event on every tracked job, regardless of
+        whether the event name is in ``events_of_interest``.
+        """
+        self._per_event_cbs.append(cb)
+
+    def add_bulk_event_cb(self, event_name, cb):
+        """Register a bulk-event callback for ``event_name``.
+
+        ``cb(bulk_run)`` is invoked on the reactor thread once when
+        every successfully-submitted job has seen at least one event
+        of name ``event_name``. Multiple callbacks may be registered
+        for the same event name; all fire when the threshold is met.
+        Each ``event_name`` fires at most once per run.
+        """
+        self._bulk_event_cbs[event_name].append(cb)
+
+    # -- Reactor / job control (during run()) --------------------------
+
+    def stop(self):
+        """Request reactor exit.
+
+        Schedules an exit from :meth:`run`'s reactor loop. The
+        currently-executing callback finishes; subsequent in-flight
+        callbacks may still run before the reactor returns.
+        """
+        if not self._stop_requested:
+            self._stop_requested = True
+            self.handle.reactor_stop()
+
+    def cancelall(self):
+        """Cancel every job owned by the current user.
+
+        Sends a single ``job-manager.raiseall`` RPC with a cancel
+        exception. Faster than per-jobid cancellation at scale,
+        but cancels *all* jobs owned by the user — relies on the
+        caller being the only producer of jobs in this Flux
+        instance.
+
+        Synchronous: blocks until the broker acknowledges the
+        request. Safe to call from within a reactor callback;
+        the flux reactor supports nested invocation while a
+        future waits for its response.
+
+        Does not wait for resulting ``clean`` events; callers
+        that need to observe cancellation completion should
+        register an :meth:`add_bulk_event_cb` for ``"clean"``.
+        """
+        self.handle.rpc(
+            "job-manager.raiseall",
+            {
+                "type": "cancel",
+                "severity": 0,
+                "userid": os.getuid(),
+                "states": 0xFF,
+                "dry_run": False,
+            },
+        ).get()
+
+    # -- Execution -----------------------------------------------------
+
+    def run(self):
+        """Submit queued batches and drive the reactor to completion.
+
+        Returns:
+            :class:`BulkRunResult`
+
+        Raises:
+            RuntimeError: if no batches have been queued, or if
+                :meth:`run` has already been called on this instance.
+        """
+        if self._running:
+            raise RuntimeError("run() called twice on the same BulkRun")
+        if not self._batches:
+            raise RuntimeError("run() called with no batches queued")
+        self._running = True
+
+        t_start = time.monotonic()
+
+        # Start the watcher before submitting. add_job-after-start
+        # is safe: JournalEventWatcher buffers events for jobids it
+        # hasn't yet been told about, and the per-job watcher only
+        # ever sees events for jobids we've registered.
+        self._watcher.start(self._on_event)
+
+        # Burst-submit every queued batch. submit_idx counts each
+        # individual submission globally (0-based, across all
+        # batches) so per-submission failures can be reported as
+        # an idset rather than 5000 identical lines.
+        submit_idx = 0
+        for batch_idx, (spec_str, count) in enumerate(self._batches):
+            for _ in range(count):
+                future = flux.job.submit_async(self.handle, spec_str)
+                future.then(self._submit_cb, (batch_idx, submit_idx))
+                submit_idx += 1
+
+        self.handle.reactor_run()
+
+        self._watcher.stop()
+
+        t_end = time.monotonic()
+
+        # If multiple batches were pushed, annotate per-jobid records
+        # with their batch index. Single-batch runs leave the dicts
+        # un-cluttered.
+        if len(self._batches) > 1:
+            for jobid, evs in self._jobs.items():
+                evs["_batch"] = self._jobid_to_batch[jobid]
+
+        return BulkRunResult(
+            jobs=self._jobs,
+            script_runtime=t_end - t_start,
+            submit_attempted=self._total_pushed,
+            submit_failures=self._submit_failures,
+        )
+
+    # -- Internal callbacks --------------------------------------------
+
+    def _submit_cb(self, future, info):
+        """Invoked when a submit RPC response arrives.
+
+        ``info`` is a (batch_idx, submit_idx) tuple packed in
+        :meth:`run`'s submission loop. submit_idx is the global
+        per-submission index (0-based, across all batches).
+        """
+        batch_idx, submit_idx = info
+        self._submits_completed += 1
+        try:
+            jobid = int(future.get_id())
+        except OSError as exc:
+            # The broker rejected this submit. No jobid was assigned
+            # and no events will arrive for this entry; record the
+            # failure so the caller can surface it, then check whether
+            # this completed the last outstanding submit.
+            self._submit_failures.append(
+                {
+                    "batch": batch_idx,
+                    "submit_index": submit_idx,
+                    "error": str(exc),
+                }
+            )
+            self._maybe_terminate()
+            return
+        self._jobs[jobid] = {}
+        self._jobid_to_batch[jobid] = batch_idx
+        self._watcher.add_job(jobid)
+
+        # Re-check bulk-event firing: completing submits is a
+        # precondition, and this submit may have been the last one.
+        for name in list(self._bulk_event_cbs):
+            self._maybe_fire_bulk(name)
+        self._maybe_terminate()
+
+    def _on_event(self, jobid, event):
+        """Invoked by the watcher for each event on each tracked job."""
+        jobid = int(jobid)
+
+        # Per-event callbacks fire for every event.
+        for cb in self._per_event_cbs:
+            cb(self, jobid, event)
+
+        # Record event if of interest. self._jobs[jobid] is always present
+        # here: _submit_cb populates it before calling watcher.add_job(),
+        # and the watcher only delivers events for registered jobids.
+        if event.name in self._events_of_interest:
+            self._jobs[jobid][event.name] = event
+
+        # Bulk-event accounting: track the first occurrence of each
+        # event name per jobid.
+        if jobid not in self._seen_per_event[event.name]:
+            self._seen_per_event[event.name].add(jobid)
+            self._maybe_fire_bulk(event.name)
+
+        # Terminal accounting.
+        if event.name == _TERMINAL_EVENT and jobid not in self._terminal_jobids:
+            self._terminal_jobids.add(jobid)
+            self._maybe_terminate()
+
+    def _maybe_fire_bulk(self, event_name):
+        """Fire the bulk-event callback for ``event_name`` if its
+        preconditions are met."""
+        if event_name in self._bulk_fired:
+            return
+        if event_name not in self._bulk_event_cbs:
+            return
+        if not self._all_submits_done():
+            return
+        if len(self._seen_per_event[event_name]) < len(self._jobs):
+            return
+        self._bulk_fired.add(event_name)
+        for cb in list(self._bulk_event_cbs[event_name]):
+            cb(self)
+
+    def _maybe_terminate(self):
+        """Stop the reactor if every successfully-submitted job has
+        reached its terminal event."""
+        if self._stop_requested:
+            return
+        if not self._all_submits_done():
+            return
+        if len(self._terminal_jobids) < len(self._jobs):
+            return
+        self._stop_requested = True
+        self.handle.reactor_stop()
+
+    def _all_submits_done(self):
+        return self._submits_completed >= self._total_pushed
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/testing/events.py
+++ b/src/bindings/python/flux/testing/events.py
@@ -1,0 +1,181 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Event emission in Flux EventLog (RFC 18) format for tests.
+
+Benchmarks and other tests use :class:`TestEventEmitter` to emit a
+JSON-line event stream to stdout. A frontend UI (or any line-
+oriented consumer such as ``jq``) reads the stream and renders
+progress, stage transitions, and final results without needing to
+know test-specific details — the contract is the event names and
+the shape of their ``context`` payloads.
+
+**Polarity**: events go to stdout (parseable JSON, exactly one
+object per line); logs, warnings, and tracebacks go to stderr.
+Mixing prose into stdout breaks parsing. Use :meth:`emitter.log`
+for unstructured messages.
+
+**Verbosity**: ``QUIET`` emits only the events a results consumer
+needs (``test.start``, ``result``, ``test.complete``, and
+``test.error``). ``NORMAL`` adds ``stage`` and ``warning``.
+``VERBOSE`` adds ``progress``, ``info``, and ``metric`` for live
+UI consumption.
+"""
+
+import json
+import sys
+import time
+
+# Verbosity levels
+QUIET = 0
+NORMAL = 1
+VERBOSE = 2
+
+# Per-event minimum verbosity required for emission. Events whose
+# minimum is higher than the emitter's current verbosity are
+# silently dropped.
+_EVENT_MIN_VERBOSITY = {
+    "test.start": QUIET,
+    "test.complete": QUIET,
+    "test.error": QUIET,
+    "result": QUIET,
+    "stage": NORMAL,
+    "warning": NORMAL,
+    "progress": VERBOSE,
+    "info": VERBOSE,
+    "metric": VERBOSE,
+}
+
+
+class TestEventEmitter:
+    """Emit Flux EventLog format events (RFC 18) to stdout.
+
+    Lives in :mod:`flux.testing.events`. The ``Test*`` prefix is
+    safe under unittest (which discovers by ``TestCase`` subclassing)
+    and the ``__test__ = False`` marker prevents pytest from
+    collecting it if pytest is ever used.
+
+    Args:
+      verbosity: one of :data:`QUIET`, :data:`NORMAL`,
+          :data:`VERBOSE`. Default :data:`NORMAL`.
+      stream: file-like object that receives events. Default
+          :data:`sys.stdout`. Tests pass a :class:`io.StringIO` to
+          capture events.
+    """
+
+    __test__ = False
+
+    def __init__(self, verbosity=NORMAL, stream=None):
+        self.verbosity = verbosity
+        self._stream = stream if stream is not None else sys.stdout
+
+    def emit(self, name, context=None):
+        """Emit an event subject to the configured verbosity.
+
+        Events below the configured verbosity threshold are silently
+        dropped. The event is serialized as a single JSON line and
+        flushed immediately so live consumers can tail the stream.
+        """
+        if _EVENT_MIN_VERBOSITY.get(name, QUIET) > self.verbosity:
+            return
+        event = {"timestamp": time.time(), "name": name}
+        if context:
+            event["context"] = context
+        print(json.dumps(event), file=self._stream, flush=True)
+
+    # ----- Required events -----
+
+    def test_start(self, test_name, stages, config=None):
+        """Signal test start. Provides UI metadata.
+
+        Args:
+          test_name: human-readable test name (e.g. ``"throughput"``).
+          stages: list of stage names the test will go through.
+          config: optional dict of test configuration, attached for
+              results storage and UI display.
+        """
+        ctx = {"test_name": test_name, "stages": list(stages)}
+        if config is not None:
+            ctx["config"] = config
+        self.emit("test.start", ctx)
+
+    def stage(self, stage, stage_index, total_stages):
+        """Signal entering a named stage. Used for progress tracking."""
+        self.emit(
+            "stage",
+            {
+                "stage": stage,
+                "stage_index": stage_index,
+                "total_stages": total_stages,
+            },
+        )
+
+    def progress(self, current, total, unit, rate=None):
+        """Report progress within the current stage.
+
+        Callers control emission frequency (e.g. every 100 items);
+        no internal rate-limiting in MVP.
+        """
+        ctx = {"current": current, "total": total, "unit": unit}
+        if rate is not None:
+            ctx["rate"] = rate
+        self.emit("progress", ctx)
+
+    def result(self, metrics):
+        """Emit final test results.
+
+        ``metrics`` is an arbitrary key-value mapping; the UI displays
+        keys and values without interpreting them.
+        """
+        self.emit("result", {"metrics": dict(metrics)})
+
+    def test_complete(self, duration):
+        """Signal successful test completion."""
+        self.emit("test.complete", {"duration": duration})
+
+    def test_error(self, error):
+        """Signal test failure with an error message."""
+        self.emit("test.error", {"error": error})
+
+    # ----- Optional events -----
+
+    def info(self, message):
+        """Informational message (emitted only at VERBOSE)."""
+        self.emit("info", {"message": message})
+
+    def warning(self, message):
+        """Non-fatal warning (emitted at NORMAL or VERBOSE)."""
+        self.emit("warning", {"message": message})
+
+    def metric(self, name, value, unit=None):
+        """Emit an intermediate (non-final) metric.
+
+        Distinct from :meth:`result`, which carries the final
+        aggregated metrics. ``metric`` is for live dashboards
+        tracking values during execution.
+        """
+        ctx = {"name": name, "value": value}
+        if unit is not None:
+            ctx["unit"] = unit
+        self.emit("metric", ctx)
+
+    # ----- Unstructured logging (stderr) -----
+
+    def log(self, message):
+        """Write an unstructured message to stderr.
+
+        Unlike :meth:`info` (which emits an event to stdout), this
+        is for prose log output that should not be parsed by event
+        consumers. Always written, regardless of verbosity.
+        """
+        print(message, file=sys.stderr, flush=True)
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/testing/job_watcher.py
+++ b/src/bindings/python/flux/testing/job_watcher.py
@@ -1,0 +1,240 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Job event watching for testing infrastructure.
+
+Defines :class:`JobEventWatcher`, an abstract interface for delivering
+main-eventlog events to a callback, and two concrete implementations:
+
+  * :class:`JournalEventWatcher` wraps :class:`flux.job.JournalConsumer`,
+    obtaining events for every job in the instance via a single
+    subscription and filtering to the registered jobid set.
+
+  * :class:`PerJobEventWatcher` opens one
+    :func:`flux.job.event_watch_async` future per registered jobid.
+"""
+
+import time
+from abc import ABC, abstractmethod
+
+import flux.job
+from flux.job.journal import JournalConsumer
+
+
+class JobEventWatcher(ABC):
+    """Abstract interface for delivering job events to a callback.
+
+    Implementations deliver main-eventlog events for explicitly-tracked
+    jobids. The contract is that ``on_event(jobid, event)`` is invoked
+    on the reactor thread for each main-eventlog event on each
+    registered jobid.
+
+    Lifecycle:
+
+      1. Construct with a Flux handle.
+      2. :meth:`add_job` registers a jobid to be tracked. May be
+         called before or after :meth:`start`. Events received for
+         a jobid before its registration are queued and delivered
+         when :meth:`add_job` is called for that jobid.
+      3. :meth:`start` begins the event stream.
+      4. :meth:`stop` releases watcher resources. The caller drives
+         the reactor until it exits naturally.
+
+    Event objects passed to ``on_event`` have at minimum:
+
+      * ``name`` (str)
+      * ``timestamp`` (float, epoch seconds)
+      * ``context`` (dict)
+
+    Implementations may additionally populate ``R`` and ``jobspec``
+    attributes when the underlying source provides them inline.
+    Callers should access these via :func:`getattr` with a default of
+    ``None``.
+    """
+
+    # Future work: a JobWatcher-backed implementation that also
+    # forwards output and guest.exec eventlog events would fit this
+    # interface unchanged — it would track a jobid set and filter to
+    # main-eventlog events (or extend the contract to expose
+    # additional eventlogs).
+
+    def __init__(self, handle):
+        self.handle = handle
+
+    @abstractmethod
+    def add_job(self, jobid):
+        """Register a jobid to be tracked. Events for this jobid will
+        be delivered to the ``on_event`` callback set in :meth:`start`.
+        """
+
+    @abstractmethod
+    def start(self, on_event):
+        """Start the watcher. ``on_event(jobid, event)`` is invoked
+        on the reactor thread for every main-eventlog event on every
+        tracked jobid.
+        """
+
+    @abstractmethod
+    def stop(self):
+        """Stop the watcher. Drains in-flight events; the caller must
+        still drive the reactor until it exits naturally.
+        """
+
+
+class JournalEventWatcher(JobEventWatcher):
+    """:class:`JobEventWatcher` backed by the job-manager events journal.
+
+    A single :class:`flux.job.JournalConsumer` subscription delivers
+    events for every job in the instance; events for unregistered
+    jobids are filtered out in an internal callback.
+
+    The consumer is started with ``full=True`` and ``since`` set to
+    the watcher's construction time. This catches events that occur
+    between consumer construction and the subscription becoming
+    active, while filtering out unrelated history. ``include_sentinel``
+    is left at its default of ``False`` so the historical-to-live
+    transition is transparent to callers.
+
+    add_job-after-start is supported. Events that arrive for a
+    jobid before :meth:`add_job` registers it are buffered and
+    replayed on the registering call, in arrival order. This
+    closes a race intrinsic to the journal-plus-async-submit pattern:
+    the journal can deliver a submit event before the submit RPC's
+    response has reached the caller's callback.
+
+    Warning: the internal buffer (``_buffered``) is unbounded. In a
+    shared Flux instance where other users are also submitting jobs,
+    events for those foreign jobids will accumulate in the buffer for
+    the lifetime of the watcher. Use :class:`PerJobEventWatcher` in
+    that case, or ensure this watcher is used in an isolated instance.
+    """
+
+    # Future work: cap the per-watcher buffer size for use in shared
+    # Flux instances, where events for jobids that are never
+    # registered (because they belong to other producers) would
+    # otherwise accumulate.
+
+    def __init__(self, handle):
+        super().__init__(handle)
+        self._tracked = set()
+        self._consumer = None
+        self._on_event = None
+        self._since = time.time()
+        # Per-jobid buffers for events that arrived before add_job()
+        # registered the jobid. Drained on add_job() in arrival order.
+        self._buffered = {}
+
+    def add_job(self, jobid):
+        jobid = int(jobid)
+        self._tracked.add(jobid)
+        # Replay any events that arrived for this jobid before
+        # registration. Replay happens on the calling thread.
+        for event in self._buffered.pop(jobid, ()):
+            self._on_event(event.jobid, event)
+
+    def start(self, on_event):
+        self._on_event = on_event
+        self._consumer = JournalConsumer(self.handle, full=True, since=self._since)
+        self._consumer.set_callback(self._journal_cb)
+        self._consumer.start()
+
+    def stop(self):
+        if self._consumer is not None:
+            self._consumer.stop()
+
+    def _journal_cb(self, event):
+        if event is None:
+            # End-of-stream after stop(); no further events arrive.
+            return
+        if event.is_empty():
+            # Sentinel marking historical-to-live transition.
+            # Suppressed by include_sentinel=False; ignore defensively.
+            return
+        jobid = int(event.jobid)
+        if jobid in self._tracked:
+            self._on_event(event.jobid, event)
+        else:
+            self._buffered.setdefault(jobid, []).append(event)
+
+
+class PerJobEventWatcher(JobEventWatcher):
+    """:class:`JobEventWatcher` backed by per-job ``event_watch_async``.
+
+    One :func:`flux.job.event_watch_async` future is opened per
+    registered jobid. Each future fires its callback once per event
+    until end-of-stream, after which the future is reset.
+
+    Events returned by ``event_watch_async`` are
+    :class:`~flux.eventlog.EventLogEvent`-shaped (``name``,
+    ``timestamp``, ``context``); they do not carry inline ``R`` or
+    ``jobspec``. Callers needing those should fall back to
+    :func:`flux.job.kvs_lookup`.
+    """
+
+    def __init__(self, handle):
+        super().__init__(handle)
+        self._on_event = None
+        self._futures = {}  # jobid -> future
+        self._pending_jobs = []  # jobids added before start()
+
+    def add_job(self, jobid):
+        jobid = int(jobid)
+        if self._on_event is None:
+            self._pending_jobs.append(jobid)
+        else:
+            self._start_watch(jobid)
+
+    def start(self, on_event):
+        self._on_event = on_event
+        for jobid in self._pending_jobs:
+            self._start_watch(jobid)
+        self._pending_jobs = []
+
+    def stop(self):
+        """No-op: per-job futures complete naturally when each job's
+        eventlog ends.
+
+        Warning: unlike :class:`JournalEventWatcher`, this method does
+        not preempt in-flight watches. If jobs are still active when
+        ``stop()`` is called, their event-watch futures remain active
+        until those jobs reach a terminal state. Callers that need to
+        stop promptly should cancel all tracked jobs first (e.g. via
+        :meth:`BulkRun.cancelall`) and wait for their ``clean`` events.
+        """
+
+    def _start_watch(self, jobid):
+        future = flux.job.event_watch_async(self.handle, jobid)
+        future.then(self._event_cb, jobid)
+        self._futures[jobid] = future
+
+    def _event_cb(self, future, jobid):
+        try:
+            event = future.get_event()
+        except OSError:
+            event = None
+        if event is None:
+            self._futures.pop(jobid, None)
+            future.reset()
+            return
+        self._on_event(jobid, event)
+        future.reset()
+
+
+def default_watcher_factory(handle):
+    """Return the default :class:`JobEventWatcher` implementation.
+
+    :class:`JournalEventWatcher` is preferred: it imposes a single
+    subscription on ``kvs-watch`` regardless of jobid count, and
+    exposes inline ``R`` and ``jobspec`` data on the relevant events.
+    """
+    return JournalEventWatcher(handle)
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/testing/schedbench/__init__.py
+++ b/src/bindings/python/flux/testing/schedbench/__init__.py
@@ -23,6 +23,7 @@ from flux.testing.schedbench.benchmarks import (
     simple_jobspec,
 )
 from flux.testing.schedbench.results import BenchmarkResults
+from flux.testing.schedbench.ui import TerminalEmitter
 
 # Benchmark subclasses auto-register in BENCHMARKS via
 # Benchmark.__init_subclass__, so importing a module that defines
@@ -51,6 +52,7 @@ __all__ = (
     "Benchmark",
     "BenchmarkResults",
     "FillMachineBenchmark",
+    "TerminalEmitter",
     "ThroughputBenchmark",
     "simple_jobspec",
 )

--- a/src/bindings/python/flux/testing/schedbench/__init__.py
+++ b/src/bindings/python/flux/testing/schedbench/__init__.py
@@ -1,0 +1,55 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""flux.testing.schedbench: scheduler benchmarking infrastructure.
+
+Public API is re-exported from the submodules so callers can write
+``from flux.testing.schedbench import ThroughputBenchmark`` rather
+than walking the full module path.
+"""
+
+from flux.testing.schedbench.benchmarks import (
+    BENCHMARKS,
+    Benchmark,
+    FillMachineBenchmark,
+    ThroughputBenchmark,
+    simple_jobspec,
+)
+
+# Benchmark subclasses auto-register in BENCHMARKS via
+# Benchmark.__init_subclass__, so importing a module that defines
+# one is enough — no explicit registration step.
+#
+# Third-party plugins (not currently in use) can register without
+# touching flux-core via setuptools entry points in the group
+# ``flux.testing.schedbench.benchmarks``. To enable, append after
+# the in-tree imports above:
+#
+#     from importlib.metadata import entry_points
+#     for ep in entry_points(group="flux.testing.schedbench.benchmarks"):
+#         try:
+#             ep.load()  # importing triggers __init_subclass__
+#         except Exception as exc:
+#             import warnings
+#             warnings.warn(f"schedbench plugin {ep.name!r}: {exc}")
+#
+# Plugin authors then declare in their pyproject.toml:
+#
+#     [project.entry-points."flux.testing.schedbench.benchmarks"]
+#     my-bench = "my_pkg.my_module"
+
+__all__ = (
+    "BENCHMARKS",
+    "Benchmark",
+    "BenchmarkResults",
+    "FillMachineBenchmark",
+    "ThroughputBenchmark",
+    "simple_jobspec",
+)

--- a/src/bindings/python/flux/testing/schedbench/__init__.py
+++ b/src/bindings/python/flux/testing/schedbench/__init__.py
@@ -22,6 +22,7 @@ from flux.testing.schedbench.benchmarks import (
     ThroughputBenchmark,
     simple_jobspec,
 )
+from flux.testing.schedbench.results import BenchmarkResults
 
 # Benchmark subclasses auto-register in BENCHMARKS via
 # Benchmark.__init_subclass__, so importing a module that defines

--- a/src/bindings/python/flux/testing/schedbench/__init__.py
+++ b/src/bindings/python/flux/testing/schedbench/__init__.py
@@ -22,6 +22,10 @@ from flux.testing.schedbench.benchmarks import (
     ThroughputBenchmark,
     simple_jobspec,
 )
+from flux.testing.schedbench.locality import (
+    LocalityBenchmark,
+    LocalityPredicate,
+)
 from flux.testing.schedbench.results import BenchmarkResults
 from flux.testing.schedbench.ui import TerminalEmitter
 
@@ -52,7 +56,11 @@ __all__ = (
     "Benchmark",
     "BenchmarkResults",
     "FillMachineBenchmark",
+    "LocalityBenchmark",
+    "LocalityPredicate",
     "TerminalEmitter",
     "ThroughputBenchmark",
     "simple_jobspec",
 )
+
+# vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/testing/schedbench/_ansi.py
+++ b/src/bindings/python/flux/testing/schedbench/_ansi.py
@@ -1,0 +1,134 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Shared ANSI terminal constants and helpers for schedbench UIs.
+
+Both :mod:`flux.testing.schedbench.ui` (single-run UI) and
+:mod:`flux.testing.schedbench.sweep` (sweep dashboard) use the same
+ANSI escape vocabulary, glyph sets, and terminal-detection helpers.
+Centralising them here means a terminal-quirk fix only lands once.
+"""
+
+import os
+
+__all__ = [
+    "_BAR_CHARS_ASCII",
+    "_BAR_CHARS_UNICODE",
+    "_BOLD",
+    "_CURSOR_HIDE",
+    "_CURSOR_SHOW",
+    "_CURSOR_UP_FMT",
+    "_DIM",
+    "_ERASE_TO_EOL",
+    "_FG_CYAN",
+    "_FG_GREEN",
+    "_FG_RED",
+    "_FG_YELLOW",
+    "_GLYPHS_ASCII",
+    "_GLYPHS_UNICODE",
+    "_REDRAW_INTERVAL_S",
+    "_RESET",
+    "_SYNC_BEGIN",
+    "_SYNC_END",
+    "_color_supported",
+    "_isatty",
+    "_safe_glyphs",
+]
+
+# ANSI escape sequences. One constant per code so readers don't
+# need to remember escape numbers.
+_ESC = "\x1b["
+_RESET = _ESC + "0m"
+_BOLD = _ESC + "1m"
+_DIM = _ESC + "2m"
+_FG_RED = _ESC + "31m"
+_FG_GREEN = _ESC + "32m"
+_FG_YELLOW = _ESC + "33m"
+_FG_CYAN = _ESC + "36m"
+
+# Cursor / line control.
+_CURSOR_UP_FMT = _ESC + "{0}A"
+# Erase from cursor to end of line. Appended to every rendered line so
+# new content scrubs leftover from the previous frame — avoids the
+# erase-then-redraw blank flash that older terminals show.
+_ERASE_TO_EOL = _ESC + "K"
+# Hide / show cursor across the redraw loop.
+_CURSOR_HIDE = _ESC + "?25l"
+_CURSOR_SHOW = _ESC + "?25h"
+# DEC mode 2026 (synchronized output): terminals that recognise this
+# batch all writes between BEGIN and END into one screen update.
+# iTerm, alacritty, kitty, wezterm, and recent xterm support it;
+# rxvt-unicode and older terminals ignore it as an unknown private mode.
+_SYNC_BEGIN = _ESC + "?2026h"
+_SYNC_END = _ESC + "?2026l"
+
+# Stage status glyphs. Picked to render cleanly on any terminal that
+# handles UTF-8; see :func:`_safe_glyphs` for the ASCII fallback path.
+_GLYPHS_UNICODE = {
+    "pending": "·",
+    "active": "▶",
+    "done": "✓",
+    "failed": "✗",
+}
+_GLYPHS_ASCII = {
+    "pending": ".",
+    "active": ">",
+    "done": "+",
+    "failed": "x",
+}
+
+# Progress bar cells. Solid block for completed portion, light shade for
+# the remainder.
+_BAR_CHARS_UNICODE = ("█", "░")
+_BAR_CHARS_ASCII = ("#", "-")
+
+# Minimum delay between repaints (~20 Hz). Fast enough to feel responsive
+# without spending the program's whole time budget in render code.
+_REDRAW_INTERVAL_S = 0.05
+
+
+def _isatty(stream):
+    try:
+        return stream.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def _color_supported(stream, color):
+    """Resolve ``--color={auto,always,never}`` against the environment.
+
+    Returns True iff colored escape sequences should be emitted on
+    ``stream``.
+    """
+    if color == "never":
+        return False
+    if color == "always":
+        return True
+    # auto
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("TERM") == "dumb":
+        return False
+    return _isatty(stream)
+
+
+def _safe_glyphs():
+    """Return True if the terminal can render the Unicode glyphs we use.
+
+    UTF-8 is the only safe assumption; check the relevant env vars.
+    """
+    for var in ("LC_ALL", "LC_CTYPE", "LANG"):
+        v = os.environ.get(var, "")
+        if "UTF-8" in v.upper() or "UTF8" in v.upper():
+            return True
+    return False
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/testing/schedbench/benchmarks.py
+++ b/src/bindings/python/flux/testing/schedbench/benchmarks.py
@@ -127,6 +127,15 @@ class Benchmark(ABC):
     stages = ()
     description = None  # optional human prose shown in --help group header
 
+    #: The benchmark's canonical headline outcome, as a
+    #: ``(metric_key, unit)`` tuple — e.g. ``("throughput", "job/s")``
+    #: or ``("mean_locality_score", "")``.  The sweep dashboard uses
+    #: this to render each row's "result=N unit" column.
+    #:
+    #: Subclasses should override.  ``None`` (the default) means the
+    #: sweep falls back to a heuristic pick from SUMMARY_METRICS.
+    RESULT = None
+
     #: Ordered tuple of ``(result_key, label, kind)`` triples declaring
     #: which result-dict keys appear in the post-run metrics table and
     #: how they're rendered. ``kind`` selects a formatter / unit in
@@ -519,6 +528,8 @@ class ThroughputBenchmark(Benchmark):
         ("ingest_rate", "ingest rate", "rate"),
     )
 
+    RESULT = ("throughput", "job/s")
+
     #: Report-only metadata. ``REPORT_HEADINGS`` lists every field that may
     #: appear in a ``flux schedbench report throughput`` output, mapping the
     #: field name (as referenced in format strings) to its column header.
@@ -821,6 +832,8 @@ class FillMachineBenchmark(Benchmark):
         ("start_rate", "start rate", "rate"),
         ("cancel_rate", "cancel rate", "rate"),
     )
+
+    RESULT = ("alloc_rate", "job/s")
 
     #: Report-only metadata; see ThroughputBenchmark for the pattern.
     #: Fill-machine's headline metric is ``time_to_fill`` plus the per-phase

--- a/src/bindings/python/flux/testing/schedbench/benchmarks.py
+++ b/src/bindings/python/flux/testing/schedbench/benchmarks.py
@@ -1,0 +1,1090 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Built-in scheduler benchmarks for flux-schedbench.
+
+This module composes the lower-level testing infrastructure
+(:mod:`flux.testing.bulkrun`, :mod:`flux.testing.fake_resources`,
+:mod:`flux.testing.events`) into a registry of ready-to-run benchmarks.
+
+Each benchmark subclasses :class:`Benchmark` and provides:
+
+- a ``name`` class attribute (the ``TEST`` positional for
+  ``flux schedbench run``);
+- a ``stages`` tuple (phase names emitted via ``emitter.stage()``);
+- ``REPORT_HEADINGS`` and ``REPORT_FORMATS`` class attributes for
+  ``flux schedbench report``;
+- a :meth:`Benchmark.run` body;
+- :meth:`Benchmark.from_args` to construct from CLI args;
+- optionally :meth:`Benchmark.register_options` to add
+  benchmark-specific CLI flags (auto-passed through to subinstance
+  launches), and :meth:`Benchmark.config_dict` for per-run config
+  shown in the TerminalEmitter header.
+
+The :data:`BENCHMARKS` registry maps a benchmark's ``name`` to its
+class for CLI lookup. New benchmarks defined in this module are
+added to that dict at the bottom; benchmarks defined in peer
+modules (e.g. :mod:`flux.testing.schedbench.locality`) are merged
+in by the package ``__init__``.
+
+Rate measurement convention
+---------------------------
+
+Every benchmarked duration in these classes uses ``t_submit_start`` (the
+script-side wall-clock at the start of ``bulk.run()``) as its **left
+endpoint**. The broker's ``submit`` event is emitted by the ``job-ingest``
+service, *not* the broker proper: when the user calls
+``flux.job.submit_async()``, the RPC arrives at ``job-ingest``, which then
+runs the jobspec through its pipeline (validation, optional jobspec
+transformations, userid checks) and **only then** posts the ``submit`` event.
+``result.first_event_t("submit")`` is therefore the moment the *first* job
+finished ingest processing — not the moment the script started submitting. The
+ingest pipeline is real work the user paid for; a benchmark that excluded it
+would understate how long submission actually took (and inflate the
+corresponding rates). Using ``t_submit_start`` captures every millisecond from
+"user pressed enter" forward.
+
+The **right endpoints** for the headline rates (``submit_rate``,
+``alloc_rate``, ``start_rate``, ``cancel_rate``) are script-observed
+(``t_all_X``), not broker-side (``last_event_t``). Reason: the user-relevant
+question is "how fast did all jobs reach phase X *as far as my program could
+tell*", which includes the watcher-delivery latency between the broker
+emitting the last event and the script receiving it. The broker-emit times are
+still recorded as ``t_last_X_event`` so downstream tooling can derive either
+window.
+
+The one exception is ``ingest_rate`` (throughput and fill-machine), which
+intentionally uses ``last_event_t("submit")`` on the right endpoint. It's a
+separate, meaningful measurement — "how fast can job-ingest accept
+submissions" — independent of watcher overhead. Pair it with ``submit_rate``
+to size the watcher-delivery delay (e.g. when comparing journal vs per-job
+watchers).
+
+``throughput`` uses ``last_event_t("clean")`` on the right so it matches the
+broker-side definition users expect to compare across systems; its
+script-observed counterpart is ``script_throughput``, derived from
+``result.script_runtime``. This deliberately diverges from
+``src/test/throughput.py``'s definition (which uses
+``first_event_t("submit")`` on the left and so excludes the first job's ingest
+processing time): the two numbers will not match, and ours is the more honest
+representation of end-to-end work.
+"""
+
+import time
+from abc import ABC, abstractmethod
+
+from flux.idset import IDset
+from flux.job import JobspecV1
+from flux.testing.bulkrun import BulkRun
+from flux.testing.fake_resources import saturation_count
+
+#: Registry of benchmark name → class. Populated automatically by
+#: :meth:`Benchmark.__init_subclass__` when a concrete subclass is
+#: defined (any class with a non-None ``name`` attribute). New
+#: benchmarks are just a subclass of :class:`Benchmark` — no manual
+#: registration step is required, regardless of which module the
+#: subclass lives in.
+BENCHMARKS = {}
+
+
+class Benchmark(ABC):
+    """Base class for flux-schedbench benchmarks.
+
+    Subclasses customize four pieces of behavior:
+
+    - :attr:`name` — short slug used as the ``TEST`` positional for
+      ``flux schedbench run`` and as the key in :data:`BENCHMARKS`.
+    - :attr:`stages` — ordered tuple of phase names emitted to the UI
+      via ``emitter.stage()``. Drives the progress bar's stage
+      indicator.
+    - :class:`REPORT_HEADINGS` and :class:`REPORT_FORMATS` (class
+      attributes) — column metadata for ``flux schedbench report``.
+    - :meth:`run` — the actual benchmark body.
+
+    Three optional classmethods customize how the CLI surface
+    plumbs through to the benchmark:
+
+    - :meth:`register_options` — add benchmark-specific argparse
+      options. Default: no-op (the benchmark uses only the common
+      options on ``flux schedbench run``). Options registered here
+      are automatically passed through to subinstance launches.
+    - :meth:`from_args` — construct an instance from parsed argv
+      plus the broker-resolved cluster shape. Must be overridden;
+      the default raises ``NotImplementedError``.
+    - :meth:`config_dict` — return per-benchmark fields to include
+      in the ``test.start`` event's ``context['config']`` dict (for
+      the TerminalEmitter's run-parameter display). Default: empty.
+    """
+
+    name = None
+    stages = ()
+    description = None  # optional human prose shown in --help group header
+
+    #: Ordered tuple of ``(result_key, label, kind)`` triples declaring
+    #: which result-dict keys appear in the post-run metrics table and
+    #: how they're rendered. ``kind`` selects a formatter / unit in
+    #: :func:`flux.testing.schedbench.ui._format_metric` — currently
+    #: ``"count"``, ``"rate"``, ``"seconds"``, ``"fraction"``. Keys
+    #: absent from a given result dict are silently skipped, so this
+    #: tuple can mention metrics that only some runs produce.
+    #:
+    #: Subclasses must redefine this with their own headline metrics.
+    #: Order matters because the table renders top-to-bottom: put the
+    #: headline metric near the top. Empty default catches the
+    #: "forgot to declare" case at run-time as an empty metrics
+    #: table.
+    SUMMARY_METRICS = ()
+
+    def __init_subclass__(cls, **kwargs):
+        """Auto-register concrete subclasses in :data:`BENCHMARKS`.
+
+        A subclass with a non-None :attr:`name` is treated as a
+        concrete benchmark and added to the registry by name.
+        Abstract intermediates (e.g. a shared base class for related
+        benchmarks) leave :attr:`name` as ``None`` and skip
+        registration.
+
+        Re-registering the same class (e.g. via ``importlib.reload``)
+        is idempotent: the identity check distinguishes a reload from
+        a real collision. Genuine duplicates (different class, same
+        name) raise so silent shadowing between modules is caught at
+        import time.
+
+        Subclasses that forget to implement an abstract method still
+        register here (Python populates ``__abstractmethods__`` after
+        ``__init_subclass__`` returns), but ``abc.ABC`` makes them
+        fail at instantiation with a clear message about which
+        method is missing.
+        """
+        super().__init_subclass__(**kwargs)
+        if cls.name is None:
+            return
+        existing = BENCHMARKS.get(cls.name)
+        if existing is cls:
+            return  # idempotent re-registration (e.g. importlib.reload)
+        if existing is not None:
+            raise RuntimeError(
+                f"duplicate benchmark name: {cls.name!r} "
+                f"(already registered by {existing.__name__}, "
+                f"new {cls.__name__})"
+            )
+        BENCHMARKS[cls.name] = cls
+
+    @classmethod
+    def register_options(cls, group):
+        """Add this benchmark's argparse options to ``group``.
+
+        Default no-op: the benchmark uses only the common options that
+        ``flux schedbench run`` defines for every benchmark (``-N``,
+        ``--njobs``, ``--slot-cores``, etc.). Subclasses with unique
+        options override this method and call ``group.add_argument()``
+        as usual; the framework discovers the registered flags by
+        introspection and includes them in the subinstance-launch
+        passthrough.
+
+        Args:
+            group: an :class:`argparse._ArgumentGroup` created by the
+                framework with title ``"{name} options"``.
+        """
+
+    @classmethod
+    @abstractmethod
+    def from_args(cls, args, resources, watcher_factory):
+        """Construct an instance from parsed argv.
+
+        Args:
+            args: the :class:`argparse.Namespace` from
+                ``parse_args()``. Free to read any attribute the
+                class's :meth:`register_options` added, plus the
+                shared ones (``njobs``, ``slot_cores``, ``slot_gpus``,
+                ``real_exec``, etc.).
+            resources: shape dict from ``_query_real_resources``
+                (keys ``nodes``, ``cores_per_node``, ``gpus_per_node``).
+                Use to compute saturation counts or check for the
+                presence of GPUs. Ignore if the benchmark is purely
+                user-driven.
+            watcher_factory: callable taking a flux handle and
+                returning a :class:`JobEventWatcher`. Pass through to
+                the benchmark constructor's ``watcher_factory=``
+                argument.
+        """
+
+    @abstractmethod
+    def run(self, handle, emitter):
+        """Run the benchmark; return the result dict.
+
+        Args:
+            handle: a connected :class:`flux.Flux` handle.
+            emitter: the UI emitter; call ``.stage(name, idx, total)``
+                at phase boundaries and forward progress events to
+                whatever stages :attr:`stages` declares.
+
+        Returns:
+            A dict of result keys to scalar values. Keys named in
+            :attr:`SUMMARY_METRICS` appear in the post-run table;
+            other keys are preserved in the results JSON for later
+            analysis (timestamps, distributions, etc.).
+        """
+
+    @classmethod
+    def config_dict(cls, args):
+        """Return per-benchmark fields for the ``test.start`` event's
+        ``context['config']`` dict.
+
+        Used by the TerminalEmitter to display run parameters in
+        the header. Common fields (nodes, scheduler, watcher,
+        real_exec) are added by the framework; this method
+        contributes only fields specific to the benchmark.
+
+        Default: empty dict. Subclasses with notable per-run
+        parameters (job count, slot shape, duration, etc.) override.
+        """
+        return {}
+
+
+def simple_jobspec(
+    slot_cores=1, slot_gpus=0, mock=True, mock_run_duration="0.001s", command=("true",)
+):
+    """Build a minimal :class:`JobspecV1` for a one-task slot.
+
+    Two execution modes:
+
+    * ``mock=True`` (default): the broker simulates execution
+      via the ``system.exec.test.run_duration`` attribute.
+      ``command`` is irrelevant because the test exec
+      implementation never invokes it; the default
+      ``("true",)`` is fine. ``mock_run_duration`` controls how
+      long the broker pretends the job runs; the special value
+      ``"0"`` makes the simulated job never finish on its own
+      (FillMachineBenchmark uses this so cancellation drives
+      termination).
+
+    * ``mock=False``: the broker really runs ``command`` and
+      no test-duration attribute is set. Throughput-style
+      benchmarks default to ``("true",)`` for a near-zero real
+      duration; benchmarks that need long-lived jobs (e.g.
+      fill-machine real mode) pass ``("sleep", "inf")`` and
+      rely on cancellation.
+
+    Args:
+        slot_cores: Cores per task. Default 1.
+        slot_gpus: GPUs per task. Default 0 (the attribute is omitted entirely
+            from the request when zero).
+        mock: Select mock vs real execution per above.
+        mock_run_duration: Simulated duration string (e.g. ``"0.001s"`` or
+            ``"0"``). Ignored when ``mock`` is False.
+        command: Argv. Used as-is when ``mock=False``; the broker ignores it
+            when ``mock=True`` but it's still recorded on the jobspec.
+
+    Returns:
+        :class:`flux.job.JobspecV1` configured per the arguments.
+    """
+    kwargs = {"cores_per_task": slot_cores}
+    if slot_gpus:
+        kwargs["gpus_per_task"] = slot_gpus
+    if mock:
+        kwargs["attributes"] = {
+            "system.exec.test.run_duration": mock_run_duration,
+        }
+    return JobspecV1.from_submit(list(command), **kwargs)
+
+
+#: Maximum number of unique-error groups to enumerate in a diagnostic message.
+#: The full list is available on the BulkRunResult; this just caps the message
+#: size.
+_DIAGNOSTIC_GROUP_CAP = 10
+
+
+#: Heading labels common to every benchmark's report output. Each benchmark
+#: class extends this dict in its own ``REPORT_HEADINGS`` with metrics
+#: specific to that benchmark (e.g. ``throughput`` for ThroughputBenchmark,
+#: ``time_to_fill`` for FillMachineBenchmark). Centralizing shared columns
+#: here keeps the abbreviations consistent across reports — SCHED always means
+#: scheduler, JOBS always means job count, etc. The 'test' field is
+#: intentionally absent: ``flux schedbench report`` requires a TEST argument
+#: so a TEST column would be redundant on every row.
+COMMON_REPORT_HEADINGS = {
+    "time": "TIME",
+    "scheduler": "SCHED",
+    "tag": "TAG",
+    "watcher": "WATCHER",
+    "nodes": "NODES",
+    "cores": "CORES",
+    "gpus": "GPUS",
+    "njobs": "JOBS",
+    "submit_rate": "SUBMIT",
+    "ingest_rate": "INGEST",
+    "alloc_rate": "ALLOC",
+    "real_exec": "REAL",
+}
+
+
+class Tracker:
+    """Per-event-type counter that drives UI progress emission.
+
+    The progress event pattern in both benchmarks repeats: count incoming
+    events of a given type, emit a progress event at every Nth count plus on
+    the final count, and (sometimes) defer emission until a phase boundary has
+    been crossed (so an early event doesn't overwrite the wrong stage's bar).
+    This class encapsulates that pattern.
+
+    Args: total: expected final count (typically ``njobs``). label: unit
+    string passed to ``emitter.progress`` (e.g. ``"job"``, ``"cancel"``).
+    gate: optional zero-arg predicate; when it returns False, :meth:`step`
+    increments the counter but suppresses progress emission. Used to defer
+    emission until a phase boundary has flipped some condition true (e.g.
+    ``lambda: t_all_submitted[0] is not None``).
+    """
+
+    #: Emit progress every this many steps (plus the final one). Keeps the
+    #: redraw rate sane at scale: 8192 jobs produce 82 progress events per
+    #: phase, comfortably within the TerminalEmitter's 20Hz throttle.
+    _STEP_INTERVAL = 100
+
+    def __init__(self, total, label, gate=None):
+        self.count = 0
+        self.total = total
+        self.label = label
+        self._gate = gate
+
+    def step(self, emitter):
+        """Increment the counter; emit a progress event if the
+        gate (if any) is open and the count hits an interval boundary or the
+        final value."""
+        self.count += 1
+        if self._gate is not None and not self._gate():
+            return
+        if self.count % self._STEP_INTERVAL == 0 or self.count == self.total:
+            emitter.progress(self.count, self.total, self.label)
+
+    def flush(self, emitter):
+        """Emit current count as a progress event without
+        stepping. Called at a phase boundary when the gate has just flipped
+        open, to surface any progress that accumulated while it was closed."""
+        if self.count > 0:
+            emitter.progress(self.count, self.total, self.label)
+
+
+def failure_diagnostic(result, header):
+    """Build a multi-line error message from broker-reported causes.
+
+    ``header`` is the first line (the benchmark's description of what went
+    wrong). Subsequent lines list job counts at each lifecycle phase, the
+    OSError strings from BulkRun's submit_async failures
+    (``result.submit_failures``), and the broker's note from each recorded
+    ``"exception"`` event (which requires ``"exception"`` in
+    ``events_of_interest``). The caller raises a ``RuntimeError`` with the
+    returned string; this function just formats it.
+
+    Identical errors are de-duplicated: submit failures are grouped by error
+    string and the submission indices that hit each are encoded as an
+    :class:`flux.idset.IDset` (e.g. ``0-1023: <error>`` rather than 1024
+    identical lines). Exception events are grouped by (type, severity, note)
+    and shown as a count plus a sample jobid.
+    """
+    lines = [header]
+
+    n_requested = result.submit_attempted
+    n_submit_failed = len(result.submit_failures)
+    n_submitted = result.njobs
+    lines.append(
+        "  jobs: {0} requested, {1} submitted, {2} submit-failed".format(
+            n_requested,
+            n_submitted,
+            n_submit_failed,
+        )
+    )
+    if n_submitted > 0:
+        for event_name in ("alloc", "start", "clean"):
+            n = len(result.jobids_with(event_name))
+            lines.append(
+                "  {0}/{1} reached event {2!r}".format(
+                    n,
+                    n_submitted,
+                    event_name,
+                )
+            )
+
+    if result.submit_failures:
+        # Group by error string; encode each group's submission indices as an
+        # idset. Most-common error first.
+        groups = {}
+        for f in result.submit_failures:
+            groups.setdefault(f["error"], []).append(f.get("submit_index", -1))
+        ordered = sorted(
+            groups.items(),
+            key=lambda kv: (-len(kv[1]), kv[0]),
+        )
+        lines.append("Submit failures (from submit_async response):")
+        for err, indices in ordered[:_DIAGNOSTIC_GROUP_CAP]:
+            valid = [i for i in indices if i >= 0]
+            if valid:
+                idset = IDset()
+                for i in valid:
+                    idset.set(i)
+                prefix = str(idset)
+            else:
+                # Backward-compat: BulkRun without submit_index support — just
+                # show count.
+                prefix = "{0} submissions".format(len(indices))
+            lines.append("  {0}: {1}".format(prefix, err))
+        extra = len(ordered) - _DIAGNOSTIC_GROUP_CAP
+        if extra > 0:
+            lines.append(
+                "  ... and {0} more unique error(s)".format(extra),
+            )
+
+    exception_jobids = result.jobids_with("exception")
+    if exception_jobids:
+        # Group by (type, severity, note); show count plus a sample jobid.
+        # Jobids in flux aren't contiguous so an idset isn't useful here — a
+        # count + one example is enough to look the job up in the eventlog.
+        groups = {}
+        for jid in exception_jobids:
+            ev = result.jobs[jid]["exception"]
+            ctx = getattr(ev, "context", {}) or {}
+            key = (
+                ctx.get("type", "?"),
+                ctx.get("severity", "?"),
+                ctx.get("note", ""),
+            )
+            groups.setdefault(key, []).append(jid)
+        ordered = sorted(
+            groups.items(),
+            key=lambda kv: (-len(kv[1]), kv[0]),
+        )
+        lines.append("Job exceptions (from main eventlog):")
+        for (etype, severity, note), jobids in ordered[:_DIAGNOSTIC_GROUP_CAP]:
+            lines.append(
+                "  {0} job(s) (sample jobid {1}): "
+                "type={2} severity={3} note={4!r}".format(
+                    len(jobids),
+                    jobids[0],
+                    etype,
+                    severity,
+                    note,
+                )
+            )
+        extra = len(ordered) - _DIAGNOSTIC_GROUP_CAP
+        if extra > 0:
+            lines.append(
+                "  ... and {0} more unique exception(s)".format(extra),
+            )
+
+    if not result.submit_failures and not exception_jobids:
+        lines.append(
+            "No submit failures or exception events recorded. "
+            "Jobs may be stuck pending; check `flux jobs -a`."
+        )
+
+    return "\n".join(lines)
+
+
+class ThroughputBenchmark(Benchmark):
+    """Burst-submit N tiny jobs and measure aggregate throughput.
+
+    Mirrors the metric set produced by ``src/test/throughput.py``
+    (``throughput`` and ``script_throughput``) and adds ``submit_rate`` and
+    ``alloc_rate`` so a slow scheduler isn't masked by a fast broker or vice
+    versa.
+
+    The benchmark uses the default :class:`BulkRun` lifecycle (wait for all
+    ``clean`` events, then exit the reactor); no bulk-event callbacks are
+    wired. Progress is counted against ``clean`` events.
+
+    Uses only the common ``flux schedbench run`` options (``--njobs``,
+    ``--slot-cores``, ``--slot-gpus``); :meth:`register_options` inherits the
+    no-op default.
+    """
+
+    name = "throughput"
+    stages = ("submit", "execute")
+
+    #: ``throughput`` is the headline (broker-driven jobs/sec measured
+    #: through to ``clean``); ``script_throughput`` is the script-wall
+    #: cousin (includes overhead of the benchmark process itself).
+    SUMMARY_METRICS = (
+        ("njobs", "jobs", "count"),
+        ("throughput", "throughput", "rate"),
+        ("script_throughput", "script throughput", "rate"),
+        ("submit_rate", "submit rate", "rate"),
+        ("alloc_rate", "alloc rate", "rate"),
+        ("ingest_rate", "ingest rate", "rate"),
+    )
+
+    #: Report-only metadata. ``REPORT_HEADINGS`` lists every field that may
+    #: appear in a ``flux schedbench report throughput`` output, mapping the
+    #: field name (as referenced in format strings) to its column header.
+    #: Identity fields are inherited from :data:`COMMON_REPORT_HEADINGS`;
+    #: metrics specific to this benchmark are listed inline.
+    #: ``REPORT_FORMATS`` provides named output formats consumed by
+    #: ``UtilConfig.get_format_string()`` — see :func:`_BenchmarkReportConfig`
+    #: in flux-schedbench.py. When a metric is added later that may be missing
+    #: from older results files, prefix its format spec with ``?:`` so
+    #: OutputFormat filters the column out of tables that contain only
+    #: pre-metric rows.
+    REPORT_HEADINGS = {
+        **COMMON_REPORT_HEADINGS,
+        "throughput": "THRPUT",
+        "script_throughput": "SCRTHRU",
+    }
+
+    REPORT_FORMATS = {
+        "default": {
+            "description": "Throughput summary: identity columns plus "
+            "submit, alloc, and throughput rates",
+            "format": "{scheduler:<14.14+}  {real_exec:<4}  "
+            "?:{tag:<8.8+}  "
+            "{nodes:>5}  {njobs:>6}  "
+            "{submit_rate:>7.0f}  {alloc_rate:>7.0f}  "
+            "{throughput:>7.0f}",
+        },
+        "long": {
+            "description": "All throughput config and metric columns",
+            "format": "{time:<16.16}  {scheduler:<14.14+}  "
+            "{real_exec:<4}  "
+            "?:{tag:<8.8+}  ?:{watcher:<8.8+}  "
+            "{nodes:>5}  {cores:>5}  {gpus:>4}  {njobs:>6}  "
+            "{submit_rate:>7.0f}  {alloc_rate:>7.0f}  "
+            "?:{ingest_rate:>7.0f}  {throughput:>7.0f}  "
+            "{script_throughput:>7.0f}",
+        },
+    }
+
+    #: Mock-exec duration string passed to the broker via
+    #: ``system.exec.test.run_duration``. Minimal so the broker spends almost
+    #: no time in "executing" state, exposing the scheduling/dispatch pipeline
+    #: as the rate-limiting step.
+    _MOCK_RUN_DURATION = "0.001s"
+
+    def __init__(
+        self,
+        njobs=1000,
+        slot_cores=1,
+        slot_gpus=0,
+        watcher_factory=None,
+        real_exec=False,
+    ):
+        self.njobs = njobs
+        self.slot_cores = slot_cores
+        self.slot_gpus = slot_gpus
+        self.watcher_factory = watcher_factory
+        self.real_exec = real_exec
+
+    @classmethod
+    def from_args(cls, args, resources, watcher_factory):
+        """Construct from parsed argv. Throughput is resource-agnostic
+        (job count comes from --njobs, not from the resource shape)."""
+        del resources
+        return cls(
+            njobs=args.njobs,
+            slot_cores=args.slot_cores,
+            slot_gpus=args.slot_gpus,
+            watcher_factory=watcher_factory,
+            real_exec=args.real_exec,
+        )
+
+    @classmethod
+    def config_dict(cls, args):
+        return {
+            "njobs": args.njobs,
+            "slot_cores": args.slot_cores,
+            "slot_gpus": args.slot_gpus,
+        }
+
+    def _build_jobspec(self):
+        """Construct the per-job spec for this benchmark's mode.
+
+        Mock mode pins a short ``mock_run_duration`` to keep execution out of
+        the critical path. Real mode runs the default ``true`` command —
+        instant exit, so the measurement is still scheduler+exec overhead with
+        no meaningful per-job work. Callers wanting longer real jobs would
+        need a future ``--command`` flag.
+        """
+        if self.real_exec:
+            return simple_jobspec(
+                slot_cores=self.slot_cores,
+                slot_gpus=self.slot_gpus,
+                mock=False,
+            )
+        return simple_jobspec(
+            slot_cores=self.slot_cores,
+            slot_gpus=self.slot_gpus,
+            mock=True,
+            mock_run_duration=self._MOCK_RUN_DURATION,
+        )
+
+    def run(self, handle, emitter):
+        """Run the benchmark against ``handle``; emit progress to ``emitter``.
+
+        Args:
+            handle: Open :class:`flux.Flux` handle pointing at an instance
+                with resources and a scheduler available (either via
+                fake-resources injection or a real allocation, depending on
+                the CLI mode).
+            emitter: :class:`flux.testing.events.TestEventEmitter`.
+
+        Returns:
+            dict of metric names to numeric values: ``njobs``,
+            ``submit_rate``, ``alloc_rate``, ``throughput``,
+            ``script_throughput``.
+        """
+        # Phase-completion timestamps captured client-side. add_bulk_event_cb
+        # fires once when every successfully-submitted job has seen the named
+        # event AND every submit RPC has responded (see BulkRun docs). For
+        # "submit" this is the moment the script knows all jobs are submitted.
+        t_all_submitted = [None]
+        t_all_alloc = [None]
+        t_all_clean = [None]
+
+        def on_all_submitted(_bulk):
+            t_all_submitted[0] = time.time()
+            # Phase boundary: all jobs are now in the broker. Hand off to the
+            # execute stage so the UI's progress bar restarts from zero and
+            # tracks clean events.
+            emitter.stage("execute", 1, 2)
+            # If clean events fired during the submit phase (mock-exec is fast
+            # and the broker ingest batcher can be slow at scale, so some jobs
+            # can run to completion before every submit is ack'd), surface
+            # their accumulated count now. The clean tracker's gate suppressed
+            # emission while we were in the submit stage; the metrics in the
+            # result dict are unaffected by any of this because they're
+            # computed from broker event timestamps, not UI progress.
+            clean_tracker.flush(emitter)
+
+        def on_all_alloc(_bulk):
+            t_all_alloc[0] = time.time()
+
+        def on_all_clean(_bulk):
+            t_all_clean[0] = time.time()
+
+        # Two-phase progress: submit events drive the submit bar
+        # unconditionally; clean events drive the execute bar only once
+        # on_all_submitted has flipped the gate open.
+        submit_tracker = Tracker(self.njobs, "job")
+        clean_tracker = Tracker(
+            self.njobs,
+            "job",
+            gate=lambda: t_all_submitted[0] is not None,
+        )
+
+        def on_event(_bulk, _jobid, ev):
+            if ev.name == "submit":
+                submit_tracker.step(emitter)
+            elif ev.name == "clean":
+                clean_tracker.step(emitter)
+
+        emitter.stage("submit", 0, 2)
+        bulk_kwargs = {
+            "events_of_interest": ("submit", "alloc", "exception", "clean"),
+        }
+        if self.watcher_factory is not None:
+            bulk_kwargs["watcher_factory"] = self.watcher_factory
+        bulk = BulkRun(handle, **bulk_kwargs)
+        bulk.push_jobs(self._build_jobspec(), self.njobs)
+        bulk.add_event_cb(on_event)
+        bulk.add_bulk_event_cb("submit", on_all_submitted)
+        bulk.add_bulk_event_cb("alloc", on_all_alloc)
+        bulk.add_bulk_event_cb("clean", on_all_clean)
+
+        # All script-side timestamps are time.time() (Unix epoch seconds) so
+        # they live in the same domain as RFC 18 event timestamps and can be
+        # subtracted directly.
+        t_submit_start = time.time()
+        result = bulk.run()
+        t_done = time.time()
+
+        # Sanity checks before the rate calculations crash with ValueErrors
+        # from last_event_t() on a degenerate run. If no jobs successfully
+        # submitted, every event lookup raises. If submits succeeded but no
+        # job reached clean, the throughput formula has no upper endpoint.
+        # Either way, surface the broker's reported causes (submit failure
+        # strings, exception event notes) before failing.
+        if result.njobs == 0:
+            raise RuntimeError(
+                failure_diagnostic(
+                    result,
+                    "throughput: all submits failed",
+                )
+            )
+        if t_all_clean[0] is None:
+            raise RuntimeError(
+                failure_diagnostic(
+                    result,
+                    "throughput: no job reached 'clean' event",
+                )
+            )
+
+        # Rate-denominator convention. See the module docstring at the top of
+        # this file for the full rationale; the short version is: the headline
+        # rates (submit_rate, alloc_rate) use script-observed endpoints, which
+        # is what the user actually experienced. The broker-side equivalent
+        # for submit is exposed separately as ingest_rate (it's a distinct,
+        # useful measure — how fast can job-ingest accept submissions — but
+        # it's not the answer to "how fast did I submit jobs").
+        #
+        # Left endpoint: always t_submit_start (script wall-clock at the start
+        # of bulk.run()) so the rate captures every millisecond the user
+        # waited, including ingest processing of the first job.
+        #
+        # Right endpoints: for headline rates, use t_all_X (script saw all
+        # jobs reach phase X). For ingest_rate, use last_event_t("submit")
+        # (broker emitted last submit event); the gap between the two captures
+        # watcher-delivery overhead.
+        submit_rate = result.njobs / (t_all_submitted[0] - t_submit_start)
+        alloc_rate = result.njobs / (t_all_alloc[0] - t_submit_start)
+        # ingest_rate: how fast job-ingest accepted submissions (broker-side,
+        # no watcher latency). Pair with submit_rate to measure watcher
+        # overhead.
+        ingest_rate = result.njobs / (result.last_event_t("submit") - t_submit_start)
+        # Throughput: full pipeline from the moment the script started
+        # submitting to when the last job cleaned (broker-side right edge for
+        # the headline number; the script-observed equivalent is
+        # script_throughput below). This intentionally diverges from
+        # src/test/throughput.py's definition (which uses
+        # first_event_t("submit") on the left and so excludes the first job's
+        # ingest processing time). Including ingest matches the user's actual
+        # experience of the whole submission-to-completion duration.
+        throughput = result.njobs / (result.last_event_t("clean") - t_submit_start)
+        script_throughput = result.njobs / result.script_runtime
+
+        return {
+            "njobs": result.njobs,
+            # Raw timestamps (Unix epoch seconds, wall-clock). Downstream
+            # tooling can derive any rate from these.
+            "t_submit_start": t_submit_start,
+            "t_all_submitted": t_all_submitted[0],
+            "t_first_submit_event": result.first_event_t("submit"),
+            "t_last_submit_event": result.last_event_t("submit"),
+            "t_all_alloc": t_all_alloc[0],
+            "t_last_alloc_event": result.last_event_t("alloc"),
+            "t_all_clean": t_all_clean[0],
+            "t_last_clean_event": result.last_event_t("clean"),
+            "t_done": t_done,
+            # Derived rates (jobs/sec) for convenience.
+            "submit_rate": submit_rate,
+            "alloc_rate": alloc_rate,
+            "ingest_rate": ingest_rate,
+            "throughput": throughput,
+            "script_throughput": script_throughput,
+        }
+
+
+class FillMachineBenchmark(Benchmark):
+    """Saturate a resource set, then cancel-and-cleanup.
+
+    Submits ``njobs`` jobs sized to ``slot_cores`` / ``slot_gpus`` that never
+    finish on their own — mock mode uses ``mock_run_duration="0"`` (broker
+    pretends infinite), real mode uses ``("sleep", "inf")``. When every job
+    has reached ``start``, fires ``cancelall()``; when every job has reached
+    ``clean``, stops the reactor.
+
+    ``njobs`` is derived from the resource set, not the CLI ``--njobs``:
+    :meth:`from_args` calls :func:`saturation_count` against the resolved
+    resource shape so the benchmark's job count tracks whatever cluster
+    (synthetic or real) it's running on.
+
+    Reports:
+
+    - ``time_to_fill``: seconds from the first ``submit`` event to
+      the last ``start`` event (how long to fully populate the
+      machine).
+    - ``cancel_rate``: jobs cancelled per second, measured from
+      cancel-issued (wall-clock) to the last ``clean`` event.
+    - ``submit_rate``, ``alloc_rate``, ``start_rate``: per-event-type
+      bookkeeping rates.
+
+    Uses only the common ``flux schedbench run`` options
+    (``--slot-cores``, ``--slot-gpus``; ``--njobs`` is ignored as the job
+    count is resource-derived). :meth:`register_options` inherits the no-op
+    default.
+    """
+
+    name = "fill-machine"
+    stages = ("submit", "fill", "cancel")
+
+    #: Headline is ``time_to_fill``; the other rates measure each
+    #: phase (submit → ingest → alloc → start; cancel for teardown).
+    SUMMARY_METRICS = (
+        ("njobs", "jobs", "count"),
+        ("time_to_fill", "fill time", "seconds"),
+        ("submit_rate", "submit rate", "rate"),
+        ("ingest_rate", "ingest rate", "rate"),
+        ("alloc_rate", "alloc rate", "rate"),
+        ("start_rate", "start rate", "rate"),
+        ("cancel_rate", "cancel rate", "rate"),
+    )
+
+    #: Report-only metadata; see ThroughputBenchmark for the pattern.
+    #: Fill-machine's headline metric is ``time_to_fill`` plus the per-phase
+    #: rates (start, cancel).
+    REPORT_HEADINGS = {
+        **COMMON_REPORT_HEADINGS,
+        "start_rate": "START",
+        "cancel_rate": "CANCEL",
+        "time_to_fill": "TFILL",
+    }
+
+    REPORT_FORMATS = {
+        "default": {
+            "description": "Fill-machine summary: identity columns plus "
+            "submit/start/cancel rates and time-to-fill",
+            "format": "{scheduler:<14.14+}  {real_exec:<4}  "
+            "?:{tag:<8.8+}  "
+            "{nodes:>5}  {njobs:>6}  "
+            "{submit_rate:>7.0f}  {start_rate:>7.0f}  "
+            "{cancel_rate:>7.0f}  {time_to_fill:>7.2f}",
+        },
+        "long": {
+            "description": "All fill-machine config and metric columns",
+            "format": "{time:<16.16}  {scheduler:<14.14+}  "
+            "{real_exec:<4}  "
+            "?:{tag:<8.8+}  ?:{watcher:<8.8+}  "
+            "{nodes:>5}  {cores:>5}  {gpus:>4}  {njobs:>6}  "
+            "{submit_rate:>7.0f}  {alloc_rate:>7.0f}  "
+            "?:{ingest_rate:>7.0f}  {start_rate:>7.0f}  "
+            "{cancel_rate:>7.0f}  {time_to_fill:>7.2f}",
+        },
+    }
+
+    #: Mock-exec duration "0" makes the broker pretend the job runs forever;
+    #: cancel terminates it. Real-mode uses a ``sleep inf`` command instead —
+    #: same semantics, real process. Both rely on cancellation rather than
+    #: natural termination, so the cancel_rate metric measures the actual rate
+    #: of broker-driven cleanup either way.
+    _MOCK_RUN_DURATION = "0"
+    _REAL_COMMAND = ("sleep", "inf")
+
+    def __init__(
+        self, njobs, slot_cores=1, slot_gpus=0, watcher_factory=None, real_exec=False
+    ):
+        self.njobs = njobs
+        self.slot_cores = slot_cores
+        self.slot_gpus = slot_gpus
+        self.watcher_factory = watcher_factory
+        self.real_exec = real_exec
+
+    @classmethod
+    def from_args(cls, args, resources, watcher_factory):
+        """Construct from parsed argv. ``njobs`` is computed from the
+        resource set via :func:`saturation_count` so the count tracks
+        the cluster's actual shape, not the CLI default; the user's
+        ``--njobs`` value is ignored."""
+        njobs = saturation_count(
+            resources["nodes"],
+            resources["cores_per_node"],
+            resources["gpus_per_node"],
+            slot_cores=args.slot_cores,
+            slot_gpus=args.slot_gpus,
+        )
+        return cls(
+            njobs=njobs,
+            slot_cores=args.slot_cores,
+            slot_gpus=args.slot_gpus,
+            watcher_factory=watcher_factory,
+            real_exec=args.real_exec,
+        )
+
+    @classmethod
+    def config_dict(cls, args):
+        return {
+            "slot_cores": args.slot_cores,
+            "slot_gpus": args.slot_gpus,
+            # njobs is derived from the resource set at run() time, not
+            # taken from CLI. Downstream consumers should look at the
+            # result's njobs field for the actual count.
+        }
+
+    def _build_jobspec(self):
+        """Construct the per-job spec, selecting the
+        cancel-driven shape for mock vs. real mode.
+
+        Mock uses ``mock_run_duration="0"`` so the broker pretends the job is
+        still running until the cancel event arrives. Real mode uses ``sleep
+        inf`` for the same effect via an actual long-lived process.
+        """
+        if self.real_exec:
+            return simple_jobspec(
+                slot_cores=self.slot_cores,
+                slot_gpus=self.slot_gpus,
+                mock=False,
+                command=self._REAL_COMMAND,
+            )
+        return simple_jobspec(
+            slot_cores=self.slot_cores,
+            slot_gpus=self.slot_gpus,
+            mock=True,
+            mock_run_duration=self._MOCK_RUN_DURATION,
+        )
+
+    def run(self, handle, emitter):
+        """Run the benchmark; return aggregate metrics.
+
+        Args:
+            handle: Open :class:`flux.Flux` handle.
+            emitter: :class:`flux.testing.events.TestEventEmitter`.
+
+        Returns:
+            dict with ``njobs``, ``time_to_fill``, ``submit_rate``,
+            ``alloc_rate``, ``start_rate``, ``cancel_rate``.
+        """
+        njobs = self.njobs
+
+        # Phase-completion timestamps captured client-side. All are
+        # time.time() (Unix epoch seconds) so they live in the same domain as
+        # RFC 18 event timestamps and can be subtracted directly.
+        t_all_submitted = [None]
+        t_all_alloc = [None]
+        t_all_start = [None]
+        t_cancel_issued = [None]
+        t_all_clean = [None]
+
+        # Three-phase progress: submit events drive the submit bar
+        # unconditionally; start events drive the fill bar once
+        # on_all_submitted opens its gate; clean events drive the cancel bar
+        # once on_all_started opens its.
+        submit_tracker = Tracker(njobs, "job")
+        start_tracker = Tracker(
+            njobs,
+            "job",
+            gate=lambda: t_all_submitted[0] is not None,
+        )
+        clean_tracker = Tracker(
+            njobs,
+            "cancel",
+            gate=lambda: t_cancel_issued[0] is not None,
+        )
+
+        def on_event(_bulk, _jobid, ev):
+            if ev.name == "submit":
+                submit_tracker.step(emitter)
+            elif ev.name == "start":
+                start_tracker.step(emitter)
+            elif ev.name == "clean":
+                clean_tracker.step(emitter)
+
+        def on_all_submitted(_bulk):
+            t_all_submitted[0] = time.time()
+            # Phase boundary: every job is in the broker. Hand off to the fill
+            # stage so the UI bar restarts against start-event count. Surface
+            # any start events that arrived during the submit phase so the
+            # fill bar starts at the right value.
+            emitter.stage("fill", 1, 3)
+            start_tracker.flush(emitter)
+
+        def on_all_alloc(_bulk):
+            t_all_alloc[0] = time.time()
+
+        def on_all_started(bulk):
+            t_all_start[0] = time.time()
+            # Stamp cancel-issued before the cancelall() RPC and the UI render
+            # so the cancel_rate denominator reflects when cancellation was
+            # actually requested, not when the progress bar finished painting.
+            t_cancel_issued[0] = time.time()
+            bulk.cancelall()
+            emitter.stage("cancel", 2, 3)
+            # Don't stop the reactor yet — wait for the resulting clean events
+            # so we can measure the cancellation rate. If any clean events
+            # arrived during the fill phase (would only happen on a job
+            # failure since mock_run_duration="0" / "sleep inf" both forbid
+            # natural completion), surface their count now so the cancel bar
+            # starts at the right value rather than jumping ahead at the next
+            # 100-event boundary.
+            clean_tracker.flush(emitter)
+
+        def on_all_clean(bulk):
+            t_all_clean[0] = time.time()
+            bulk.stop()
+
+        bulk_kwargs = {
+            "events_of_interest": ("submit", "alloc", "start", "exception", "clean"),
+        }
+        if self.watcher_factory is not None:
+            bulk_kwargs["watcher_factory"] = self.watcher_factory
+        bulk = BulkRun(handle, **bulk_kwargs)
+        bulk.push_jobs(self._build_jobspec(), njobs)
+        bulk.add_event_cb(on_event)
+        bulk.add_bulk_event_cb("submit", on_all_submitted)
+        bulk.add_bulk_event_cb("alloc", on_all_alloc)
+        bulk.add_bulk_event_cb("start", on_all_started)
+        bulk.add_bulk_event_cb("clean", on_all_clean)
+
+        emitter.stage("submit", 0, 3)
+        t_submit_start = time.time()
+        result = bulk.run()
+        t_done = time.time()
+
+        # Sanity check: if on_all_started never fired, jobs went submit →
+        # exception → clean without reaching the "start" event, bypassing the
+        # cancel phase entirely. Surface a useful diagnostic before the rate
+        # calculations crash with a deep ValueError from
+        # result.last_event_t("start"). Both submit-RPC failures (OSError from
+        # future.get_id()) and exception events (the broker's note explaining
+        # why the job didn't run) are available on the BulkRunResult.
+        if t_all_start[0] is None:
+            raise RuntimeError(
+                failure_diagnostic(
+                    result,
+                    "fill-machine: no job reached 'start' event",
+                )
+            )
+
+        # time_to_fill: how long from when the script started submitting
+        # (t_submit_start) until the last job reached "start" — i.e. the
+        # machine was saturated. The right endpoint is broker-side because by
+        # then every job has finished ingest and reached running state. See
+        # the module docstring for why we use t_submit_start on the left
+        # rather than first_event_t("submit").
+        time_to_fill = result.last_event_t("start") - t_submit_start
+
+        # Rate-denominator convention matches ThroughputBenchmark: headline
+        # rates use script-observed endpoints, with ingest_rate exposed
+        # separately as the broker-side submit measurement. See the module
+        # docstring for the full rationale.
+        submit_rate = njobs / (t_all_submitted[0] - t_submit_start)
+        alloc_rate = njobs / (t_all_alloc[0] - t_submit_start)
+        start_rate = njobs / (t_all_start[0] - t_submit_start)
+        # ingest_rate: how fast job-ingest accepted submissions (broker-side,
+        # no watcher latency). Pair with submit_rate to measure watcher
+        # overhead.
+        ingest_rate = njobs / (result.last_event_t("submit") - t_submit_start)
+        # cancel_rate: from cancel-issued (script wall-clock) to the moment
+        # the script saw every job clean. Both endpoints are script-side so
+        # the rate matches what the user actually experienced during cleanup.
+        cancel_rate = njobs / (t_all_clean[0] - t_cancel_issued[0])
+
+        return {
+            "njobs": njobs,
+            # Raw timestamps (Unix epoch seconds, wall-clock). Downstream
+            # tooling can derive any rate from these.
+            "t_submit_start": t_submit_start,
+            "t_all_submitted": t_all_submitted[0],
+            "t_first_submit_event": result.first_event_t("submit"),
+            "t_last_submit_event": result.last_event_t("submit"),
+            "t_all_alloc": t_all_alloc[0],
+            "t_last_alloc_event": result.last_event_t("alloc"),
+            "t_all_start": t_all_start[0],
+            "t_first_start_event": result.first_event_t("start"),
+            "t_last_start_event": result.last_event_t("start"),
+            "t_cancel_issued": t_cancel_issued[0],
+            "t_all_clean": t_all_clean[0],
+            "t_last_clean_event": result.last_event_t("clean"),
+            "t_done": t_done,
+            # Derived rates (jobs/sec) for convenience.
+            "time_to_fill": time_to_fill,
+            "submit_rate": submit_rate,
+            "alloc_rate": alloc_rate,
+            "start_rate": start_rate,
+            "ingest_rate": ingest_rate,
+            "cancel_rate": cancel_rate,
+        }
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/testing/schedbench/locality.py
+++ b/src/bindings/python/flux/testing/schedbench/locality.py
@@ -1,0 +1,879 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Locality benchmark for flux-schedbench.
+
+Submits multi-slot jobs and scores how well the scheduler packs each
+slot's cores and GPUs into a single locality domain. See
+:class:`LocalityBenchmark` for CLI options and
+:class:`LocalityPredicate` for the scoring rule.
+"""
+
+import logging
+import random
+import time
+import xml.etree.ElementTree as ET
+from collections import Counter
+
+import flux.util
+from flux.idset import IDset
+from flux.job import JobspecV1
+from flux.testing.bulkrun import BulkRun
+from flux.testing.fake_resources import saturation_count
+from flux.testing.schedbench.benchmarks import (
+    COMMON_REPORT_HEADINGS,
+    Benchmark,
+    Tracker,
+    failure_diagnostic,
+)
+
+LOGGER = logging.getLogger("flux-schedbench.locality")
+
+
+#: hwloc OSDev name prefixes that indicate compute-capable GPU
+#: backends. Used to distinguish compute GPUs from Linux DRM
+#: display nodes (which appear as ``card*``, ``renderD*``,
+#: ``controlD*`` under the same PCIDev) when the OSDev's
+#: ``osdev_type`` alone is ambiguous.
+_COMPUTE_GPU_PREFIXES = ("cuda", "opencl", "rsmi", "nvml", "nvidia")
+
+
+def _is_compute_gpu(obj):
+    """Return True if an OSDev element represents a compute-
+    capable GPU.
+
+    hwloc classifies GPUs inconsistently across backends:
+
+    - CUDA / OpenCL devices arrive as ``osdev_type=5`` (CoProc).
+    - RSMI / NVML / NVIDIA devices arrive as ``osdev_type=1``
+      (GPU) with a backend-specific name.
+    - Linux DRM display nodes also arrive as ``osdev_type=1``
+      with names like ``card0`` / ``renderD128`` / ``controlD64``.
+
+    The combined criterion is therefore: any CoProc, OR an
+    osdev_type=1 device whose name starts with a known
+    compute-backend prefix. This correctly catches all four
+    compute backends while still excluding display-only DRM
+    nodes.
+
+    The flux C-level resource module performs the equivalent
+    classification authoritatively; if a future hwloc backend
+    appears that this Python list doesn't cover, the right
+    long-term fix is to expose that classifier through the
+    Python bindings rather than extending this list. For a
+    testing-only module the list is sufficient.
+    """
+    osdev_type = obj.get("osdev_type")
+    if osdev_type == "5":
+        return True
+    if osdev_type == "1":
+        name = obj.get("name", "")
+        return any(name.startswith(p) for p in _COMPUTE_GPU_PREFIXES)
+    return False
+
+
+def _parse_duration_mode(spec):
+    """Parse --duration into ``(mode, lo, hi)``.
+
+    Modes are ``"fixed"`` (single FSD; ``lo == hi == spec``),
+    ``"fill"`` (never-completing; both None), or ``"random"``
+    (uniform in [lo, hi], default range ``0.1s-1.0s``).
+    """
+    if spec == "fill":
+        return ("fill", None, None)
+    if spec == "random":
+        return ("random", "0.1s", "1.0s")
+    if spec.startswith("random:"):
+        lo, _, hi = spec[len("random:") :].partition("-")
+        if not (lo and hi):
+            raise ValueError(f"--duration=random:LO-HI: malformed range in {spec!r}")
+        return ("random", lo, hi)
+    # Anything else parses as a fixed FSD; raises on bad input.
+    flux.util.parse_fsd(spec)
+    return ("fixed", spec, spec)
+
+
+def _parse_idset_string(s):
+    """Parse an idset like ``"0-7,16,20-23"`` into a list of ints."""
+    return list(IDset(s)) if s else []
+
+
+class LocalityPredicate:
+    """Per-slot locality scorer driven by an hwloc XML topology.
+
+    Indexes each core and CoProc GPU by its locality domain — by
+    default the hwloc ``nodeset`` attribute (NUMA-node membership).
+    :meth:`score_job` then evaluates a job's R: a slot is satisfied
+    iff its cores and GPUs all share a domain. The fake-resources
+    rc1 task replicates one node's topology across all ranks, so a
+    single XML applies to every rank.
+
+    Cores and GPUs are keyed by **sequential document-order index**
+    (0, 1, 2, ...), mirroring how ``flux R encode`` and the
+    :mod:`fluxion` JGF amender number resources. Keying by hwloc's
+    ``os_index`` is not safe: on multi-socket AMD systems os_index
+    collides between packages (the kernel uses per-socket physical
+    CPU IDs), and the GPU OSDev's trailing-digit name does not
+    necessarily match the scheduler's GPU index (e.g. AMD's
+    ``opencl0d3`` is the fourth GPU in document order, but the
+    digit is ``3`` only by coincidence).
+
+    Override :meth:`_domain_of` to change the locality rule.
+    Nodeset is the right default for modern hardware where NUMA is
+    the meaningful boundary.
+
+    Attributes:
+        core_domain: dict from sequential core index to domain id
+            (the nodeset string from the XML).
+        gpu_domain: dict from sequential GPU index to domain id.
+    """
+
+    def __init__(self, hwloc_xml):
+        self.core_domain = {}
+        self.gpu_domain = {}
+        self.hostname = None
+        # Sequential counters: cores and CoProc OSDevs are
+        # numbered 0..N-1 in document order, mirroring how flux R
+        # encode and the fluxion amender number resources. We
+        # cannot key on hwloc's os_index because on dual-socket
+        # AMD systems os_index can collide between packages (the
+        # kernel reuses physical CPU IDs per socket), and we
+        # cannot key on the OSDev name's trailing digit because
+        # for AMD OpenCL devices (opencl0d3 etc.) that digit
+        # disagrees with what the amender's get_next_id assigns.
+        self._next_core_id = 0
+        self._next_gpu_id = 0
+        # PCIDev elements that have already contributed a GPU.
+        # A physical GPU can expose multiple compute OSDev faces
+        # (e.g. cuda0 + nvml0 for NVIDIA when both backends are
+        # loaded, or opencl0d0 + rsmi0 for AMD) under one
+        # PCIDev. Without deduplication these would count as
+        # separate GPUs and inflate the schedulable pool.
+        self._seen_pci = set()
+        root = ET.fromstring(hwloc_xml)
+        self._extract_hostname(root)
+        self._index_topology(root, [])
+
+    def _extract_hostname(self, root):
+        """Pull HostName from a top-level ``<info>`` element, if
+        present. hwloc emits ``<info name="HostName" value="..."/>``
+        either as a child of the root or under the Machine object;
+        ``root.iter`` finds it in either place. Recording this
+        lets results files identify which physical topology a
+        benchmark ran against."""
+        for info in root.iter("info"):
+            if info.get("name") == "HostName":
+                self.hostname = info.get("value")
+                return
+
+    def describe(self):
+        """Return a dict summarizing what was indexed from the XML.
+
+        Useful for diagnosing mismatches between the predicate's
+        view of a topology and the IDs that appear in a job's R.
+        If ``score_job`` returns 0 for an obviously local job,
+        compare ``describe()["core_domain"].keys()`` with the
+        cores listed in R: any core ID in R that isn't a key
+        here will be silently treated as not-local.
+
+        Returns:
+            dict with keys ``hostname`` (from the XML's HostName
+            info element, or None), ``core_count``, ``gpu_count``,
+            ``domains`` (sorted list of unique domain ids),
+            ``core_domain``, and ``gpu_domain`` (the full maps,
+            sorted).
+        """
+        return {
+            "hostname": self.hostname,
+            "core_count": len(self.core_domain),
+            "gpu_count": len(self.gpu_domain),
+            "domains": sorted(
+                set(self.core_domain.values()) | set(self.gpu_domain.values())
+            ),
+            "core_domain": dict(sorted(self.core_domain.items())),
+            "gpu_domain": dict(sorted(self.gpu_domain.items())),
+        }
+
+    def summary(self):
+        """Human-readable summary of the indexed topology, with
+        a per-domain breakdown.
+
+        Format: a header line with overall counts, then one line
+        per domain showing its cores and GPUs as compact idsets.
+        Use to confirm the predicate's view matches the expected
+        topology before trusting score values from a run.
+
+        Example output for an AMD corona node::
+
+            host=corona11, 48 cores, 4 gpus, 8 domains
+              0: core[0-5]
+              1: core[6-11], gpu[0]
+              2: core[12-17], gpu[1]
+              3: core[18-23]
+              4: core[24-29]
+              5: core[30-35], gpu[2]
+              6: core[36-41]
+              7: core[42-47], gpu[3]
+
+        Domains are numbered by the first resource (lowest core
+        ID, or lowest GPU ID for GPU-only domains) for stable
+        ordering. The numeric labels are display-only; the
+        underlying domain identifiers (nodeset strings) appear
+        in :meth:`describe`'s ``core_domain`` / ``gpu_domain``
+        maps.
+        """
+        header = []
+        if self.hostname:
+            header.append(f"host={self.hostname}")
+        header.append(f"{len(self.core_domain)} cores")
+        header.append(f"{len(self.gpu_domain)} gpus")
+
+        # Invert: domain -> sorted list of cores / gpus.
+        cores_by_dom = {}
+        gpus_by_dom = {}
+        for cid, dom in self.core_domain.items():
+            cores_by_dom.setdefault(dom, []).append(cid)
+        for gid, dom in self.gpu_domain.items():
+            gpus_by_dom.setdefault(dom, []).append(gid)
+        all_doms = set(cores_by_dom) | set(gpus_by_dom)
+        header.append(f"{len(all_doms)} domains")
+        head_str = ", ".join(header)
+
+        if not all_doms:
+            return head_str
+
+        # Order domains by first-resource ID so output is stable
+        # and reads top-to-bottom the way the topology was walked.
+        # Core-bearing domains come first, sorted by first core;
+        # GPU-only domains sort after, by first GPU. (Mixing
+        # core and GPU IDs in one sort key reads counter-
+        # intuitively when GPU 0 sits in a domain that has
+        # higher-numbered cores than another, all-cores domain.)
+        def _first(dom):
+            cs = cores_by_dom.get(dom)
+            if cs:
+                return (0, cs[0])
+            return (1, gpus_by_dom[dom][0])
+
+        lines = [head_str]
+        for i, dom in enumerate(sorted(all_doms, key=_first)):
+            bits = []
+            if cores_by_dom.get(dom):
+                bits.append(f"core[{IDset(cores_by_dom[dom])}]")
+            if gpus_by_dom.get(dom):
+                bits.append(f"gpu[{IDset(gpus_by_dom[dom])}]")
+            lines.append(f"  {i}: {', '.join(bits)}")
+        return "\n".join(lines)
+
+    def _domain_of(self, obj, ancestor_chain):
+        """Return the locality-domain id for ``obj``.
+
+        Default: the hwloc ``nodeset`` attribute, falling back to
+        the nearest ancestor's nodeset for objects (like GPU
+        OSDevs) that don't carry one directly. Returns None if
+        nothing in the chain has a nodeset.
+
+        Override for alternative locality rules: socket granularity
+        (nearest Package's ``cpuset``), L3 cache (nearest Cache
+        with ``depth="3"``), or strict-NUMA-only (return None when
+        no nodeset).
+        """
+        ns = obj.get("nodeset")
+        if ns:
+            return ns
+        for ancestor in reversed(ancestor_chain):
+            ns = ancestor.get("nodeset")
+            if ns:
+                return ns
+        return None
+
+    def _index_topology(self, obj, ancestors):
+        """Walk the XML tree, recording cores and CoProc OSDevs
+        with sequential IDs in document order."""
+        ancestors.append(obj)
+        try:
+            otype = obj.get("type")
+            if otype == "Core":
+                dom = self._domain_of(obj, ancestors[:-1])
+                if dom is not None:
+                    self.core_domain[self._next_core_id] = dom
+                # Always increment so subsequent core IDs stay
+                # aligned with what R produces, even if some core
+                # somehow lacks a domain.
+                self._next_core_id += 1
+            elif otype == "OSDev" and _is_compute_gpu(obj):
+                # See :func:`_is_compute_gpu` for the criterion.
+                # CUDA / OpenCL appear as osdev_type=5 (CoProc);
+                # RSMI / NVML / NVIDIA appear as osdev_type=1 (GPU)
+                # alongside Linux DRM display nodes (card*, renderD*,
+                # controlD*) — the name filter distinguishes the two.
+                #
+                # Dedupe: a single physical GPU can expose multiple
+                # compute OSDev faces under one PCIDev (e.g. NVIDIA
+                # with both CUDA and NVML backends loaded, or AMD
+                # with both OpenCL and RSMI). Count only the first
+                # face per PCIDev so the schedulable pool reflects
+                # physical devices, not backend instances.
+                pci_key = None
+                for ancestor in reversed(ancestors[:-1]):
+                    if ancestor.get("type") == "PCIDev":
+                        pci_key = id(ancestor)
+                        break
+                if pci_key is None or pci_key not in self._seen_pci:
+                    if pci_key is not None:
+                        self._seen_pci.add(pci_key)
+                    dom = self._domain_of(obj, ancestors[:-1])
+                    if dom is not None:
+                        self.gpu_domain[self._next_gpu_id] = dom
+                    self._next_gpu_id += 1
+            for child in obj:
+                self._index_topology(child, ancestors)
+        finally:
+            ancestors.pop()
+
+    def score_job(self, r_dict, slot_cores, slot_gpus, nslots):
+        """Score one job's placement.
+
+        Returns ``(satisfied, total)`` where ``total == nslots`` and
+        ``satisfied`` is the number of slots whose cores and GPUs
+        all share a single domain. Capped at ``nslots`` so the
+        per-job ratio is bounded by 1.0.
+        """
+        satisfied = 0
+        for entry in r_dict.get("execution", {}).get("R_lite", []):
+            n_ranks = len(_parse_idset_string(entry.get("rank", "")))
+            ch = entry.get("children", {})
+            satisfied += n_ranks * self._count_on_rank(
+                _parse_idset_string(ch.get("core", "")),
+                _parse_idset_string(ch.get("gpu", "")),
+                slot_cores,
+                slot_gpus,
+            )
+        return (min(satisfied, nslots), nslots)
+
+    def score_job_verbose(self, r_dict, slot_cores, slot_gpus, nslots):
+        """Like :meth:`score_job` but returns the per-R_lite-entry
+        breakdown alongside the score.
+
+        Use when ``score_job`` produces unexpected results. The
+        breakdown identifies the two common failure modes:
+
+        - **ID-scheme mismatch**: ``unknown_cores`` / ``unknown_gpus``
+          contain IDs that appeared in R but not in
+          :attr:`core_domain` / :attr:`gpu_domain`. The predicate
+          treats unknown IDs as not-local; if R is using a
+          different ID scheme than the XML walk produces, scores
+          will silently come out lower than reality.
+
+        - **Domain split**: ``cores_by_domain`` and
+          ``gpus_by_domain`` show how the rank's resources
+          distribute. A satisfied slot needs both cores and (if
+          ``slot_gpus > 0``) GPUs from the same domain in
+          quantities matching the slot shape.
+
+        Returns:
+            dict with keys ``satisfied``, ``total``, and
+            ``breakdown`` (a list of per-R_lite-entry dicts).
+            JSON-serializable.
+        """
+        breakdown = []
+        satisfied_total = 0
+        for entry in r_dict.get("execution", {}).get("R_lite", []):
+            rank_str = entry.get("rank", "")
+            ranks = _parse_idset_string(rank_str)
+            ch = entry.get("children", {})
+            cores = _parse_idset_string(ch.get("core", ""))
+            gpus = _parse_idset_string(ch.get("gpu", ""))
+            unknown_c = [c for c in cores if c not in self.core_domain]
+            unknown_g = [g for g in gpus if g not in self.gpu_domain]
+            c_by_dom = Counter(
+                self.core_domain[c] for c in cores if c in self.core_domain
+            )
+            g_by_dom = Counter(self.gpu_domain[g] for g in gpus if g in self.gpu_domain)
+            per_rank = self._count_on_rank(
+                cores,
+                gpus,
+                slot_cores,
+                slot_gpus,
+            )
+            satisfied_total += len(ranks) * per_rank
+            breakdown.append(
+                {
+                    "ranks": rank_str,
+                    "n_ranks": len(ranks),
+                    "cores": list(cores),
+                    "gpus": list(gpus),
+                    "unknown_cores": unknown_c,
+                    "unknown_gpus": unknown_g,
+                    "cores_by_domain": dict(c_by_dom),
+                    "gpus_by_domain": dict(g_by_dom),
+                    "slots_satisfied_per_rank": per_rank,
+                }
+            )
+        return {
+            "satisfied": min(satisfied_total, nslots),
+            "total": nslots,
+            "breakdown": breakdown,
+        }
+
+    def _count_on_rank(self, cores, gpus, slot_cores, slot_gpus):
+        """Complete slots that fit in a single domain on one rank."""
+        c = Counter(self.core_domain[i] for i in cores if i in self.core_domain)
+        if not slot_gpus:
+            return sum(n // slot_cores for n in c.values())
+        g = Counter(self.gpu_domain[i] for i in gpus if i in self.gpu_domain)
+        return sum(min(c[d] // slot_cores, g[d] // slot_gpus) for d in c)
+
+
+def _r_from_event(ev):
+    """Return R from a journal alloc event, or None.
+
+    The journal watcher (JournalConsumer) attaches R as the ``R``
+    property on alloc events; the per-job eventlog watcher does
+    not, and the caller must fall back to a KVS lookup.
+    """
+    return getattr(ev, "R", None)
+
+
+class LocalityBenchmark(Benchmark):
+    """Submit multi-slot jobs and score per-slot locality.
+
+    Submits ``njobs`` jobs of ``nslots`` slots each, with each slot
+    requesting ``slot_cores`` cores and ``slot_gpus`` GPUs. The
+    duration mode controls job lifetime:
+
+    * fixed FSD (default ``0.1s``): every job runs that long.
+    * ``fill``: jobs never complete; saturate then cancel.
+    * ``random[:LO-HI]``: uniform random duration per job
+      (default range ``0.1s-1.0s``).
+
+    Each job's placement is scored by :class:`LocalityPredicate`
+    as its alloc event arrives — the journal watcher carries R
+    in the event context (no extra lookup); the per-job eventlog
+    watcher takes one KVS lookup per alloc. Headline metric is
+    the mean per-job locality fraction. Requires
+    ``--hwloc-xml-path``.
+    """
+
+    name = "locality"
+    stages = ("submit", "execute")
+    description = (
+        "Score how well the scheduler packs each slot's cores and "
+        "GPUs into a single locality domain (NUMA/socket)."
+    )
+
+    #: Locality score is the headline. ``num_jobs_scored`` is a
+    #: confidence indicator — divergence from ``njobs`` means some
+    #: alloc events came in without R available, reducing the
+    #: sample size behind the mean.
+    SUMMARY_METRICS = (
+        ("njobs", "jobs", "count"),
+        ("mean_locality_score", "locality score", "fraction"),
+        ("num_jobs_scored", "jobs scored", "count"),
+        ("throughput", "throughput", "rate"),
+        ("submit_rate", "submit rate", "rate"),
+        ("alloc_rate", "alloc rate", "rate"),
+    )
+
+    REPORT_HEADINGS = {
+        **COMMON_REPORT_HEADINGS,
+        "nslots": "NSLOTS",
+        "duration": "DUR",
+        "mean_locality_score": "LOC",
+        "throughput": "THRPUT",
+    }
+
+    REPORT_FORMATS = {
+        "default": {
+            "description": "Locality summary: identity columns plus "
+            "the headline locality score and throughput",
+            "format": "{scheduler:<14.14+}  {real_exec:<4}  "
+            "?:{tag:<8.8+}  "
+            "{nodes:>5}  {njobs:>6}  {nslots:>6}  "
+            "?:{duration:<14.14+}  "
+            "{mean_locality_score:>5.3f}  {throughput:>7.0f}",
+        },
+        "long": {
+            "description": "All locality config and metric columns",
+            "format": "{time:<16.16}  {scheduler:<14.14+}  "
+            "{real_exec:<4}  "
+            "?:{tag:<8.8+}  ?:{watcher:<8.8+}  "
+            "{nodes:>5}  {cores:>5}  {gpus:>4}  {njobs:>6}  "
+            "{nslots:>6}  ?:{duration:<14.14+}  "
+            "{submit_rate:>7.0f}  {alloc_rate:>7.0f}  "
+            "{mean_locality_score:>5.3f}  {throughput:>7.0f}",
+        },
+    }
+
+    def __init__(
+        self,
+        njobs,
+        slot_cores=1,
+        slot_gpus=0,
+        nslots=1,
+        duration_mode="fixed",
+        duration_lo="0.1s",
+        duration_hi="0.1s",
+        hwloc_xml=None,
+        watcher_factory=None,
+        real_exec=False,
+    ):
+        if hwloc_xml is None:
+            raise ValueError(
+                "LocalityBenchmark requires hwloc_xml; pass "
+                "--hwloc-xml-path on the CLI"
+            )
+        self.njobs = njobs
+        self.slot_cores = slot_cores
+        self.slot_gpus = slot_gpus
+        self.nslots = nslots
+        self.duration_mode = duration_mode
+        self.duration_lo = duration_lo
+        self.duration_hi = duration_hi
+        self.predicate = LocalityPredicate(hwloc_xml)
+        self.watcher_factory = watcher_factory
+        self.real_exec = real_exec
+
+    @classmethod
+    def register_options(cls, group):
+        group.add_argument(
+            "--duration",
+            default="0.1s",
+            metavar="FSD|fill|random[:LO-HI]",
+            help="job duration mode: an FSD string for fixed "
+            "duration (e.g. '0.1s'), 'fill' to saturate the "
+            "cluster with never-completing jobs and cancel after "
+            "placement is observed, or 'random[:LO-HI]' for "
+            "uniform random durations (default range: "
+            "0.1s-1.0s). Default: 0.1s.",
+        )
+        group.add_argument(
+            "--nslots",
+            type=int,
+            default=1,
+            metavar="N",
+            help="slots per job (default: 1). Each slot requests "
+            "--slot-cores cores and --slot-gpus GPUs.",
+        )
+
+    @classmethod
+    def from_args(cls, args, resources, watcher_factory):
+        if not getattr(args, "hwloc_xml_path", None):
+            raise ValueError(
+                "locality benchmark requires --hwloc-xml-path "
+                "(hwloc XML describing the per-node topology)"
+            )
+        with open(args.hwloc_xml_path) as f:
+            hwloc_xml = f.read()
+        mode, lo, hi = _parse_duration_mode(args.duration)
+        # fill mode ignores --njobs and saturates instead. Each
+        # job's footprint is nslots * slot_{cores,gpus} per rank.
+        if mode == "fill":
+            njobs = saturation_count(
+                resources["nodes"],
+                resources["cores_per_node"],
+                resources["gpus_per_node"],
+                slot_cores=args.nslots * args.slot_cores,
+                slot_gpus=args.nslots * args.slot_gpus,
+            )
+        else:
+            njobs = args.njobs
+        bench = cls(
+            njobs=njobs,
+            slot_cores=args.slot_cores,
+            slot_gpus=args.slot_gpus,
+            nslots=args.nslots,
+            duration_mode=mode,
+            duration_lo=lo or "0.1s",
+            duration_hi=hi or "0.1s",
+            hwloc_xml=hwloc_xml,
+            watcher_factory=watcher_factory,
+            real_exec=args.real_exec,
+        )
+        # Log the predicate summary HERE, not in run(): from_args
+        # is invoked during _build_benchmark before the framework
+        # calls emitter.test_start(), so log output here sits
+        # outside the UI's live-redraw region (alongside the
+        # existing "launching: ..." log line) and stays visible.
+        # A LOGGER.info from inside run() lands inside the live
+        # region and gets overwritten by the next UI redraw.
+        if getattr(args, "verbose", False):
+            LOGGER.info(
+                "locality predicate: %s",
+                bench.predicate.summary(),
+            )
+        return bench
+
+    @classmethod
+    def config_dict(cls, args):
+        return {
+            "njobs": args.njobs,
+            "slot_cores": args.slot_cores,
+            "slot_gpus": args.slot_gpus,
+            "nslots": args.nslots,
+            "duration": args.duration,
+        }
+
+    def _build_jobspec(self, duration_fsd):
+        """Build a jobspec.
+
+        Pass an FSD string for a normal-duration job, or ``None``
+        for a job that never completes naturally (used for
+        ``--duration=fill``).
+        """
+        kwargs = {
+            "ntasks": self.nslots,
+            "cores_per_task": self.slot_cores,
+        }
+        if self.slot_gpus:
+            kwargs["gpus_per_task"] = self.slot_gpus
+        if self.real_exec:
+            sleep_arg = (
+                "inf"
+                if duration_fsd is None
+                else str(flux.util.parse_fsd(duration_fsd))
+            )
+            return JobspecV1.from_submit(["sleep", sleep_arg], **kwargs)
+        kwargs["attributes"] = {
+            "system.exec.test.run_duration": (
+                "0" if duration_fsd is None else duration_fsd
+            ),
+        }
+        return JobspecV1.from_submit(["true"], **kwargs)
+
+    def run(self, handle, emitter):
+        """Submit jobs, observe placement, score, return metrics."""
+        # 1-element lists carry phase timestamps across closures.
+        t_all_submitted = [None]
+        t_all_alloc = [None]
+        t_all_done = [None]
+        # Per-job locality scores and breakdowns accumulate here
+        # as alloc events arrive. The journal watcher carries R
+        # in the event context (synchronous score); the per-job
+        # eventlog watcher does not, so we kick off an async KVS
+        # lookup whose .then() callback does the scoring without
+        # blocking the reactor.
+        scores = []
+        breakdowns = []
+        # In-flight async KVS lookups. Fill mode defers bulk.stop()
+        # until this hits zero so no allocations go unscored.
+        pending_lookups = [0]
+        deferred_stop_bulk = [None]
+
+        submit_tracker = Tracker(self.njobs, "job")
+        done_tracker = Tracker(
+            self.njobs,
+            "job",
+            gate=lambda: t_all_submitted[0] is not None,
+        )
+        # In fill mode, alloc is the terminal event (jobs are then
+        # cancelled); otherwise clean is terminal.
+        done_event = "alloc" if self.duration_mode == "fill" else "clean"
+
+        def score_r(r, jobid=None):
+            # Always use the verbose path so the per-job
+            # breakdown can be included in the results file —
+            # the overhead per job is negligible, and inspecting
+            # a recorded run's R-mapping is the primary tool for
+            # diagnosing surprising scores.
+            breakdown = self.predicate.score_job_verbose(
+                r,
+                self.slot_cores,
+                self.slot_gpus,
+                self.nslots,
+            )
+            satisfied = breakdown["satisfied"]
+            total = breakdown["total"]
+            scores.append(satisfied / total if total else 0)
+            breakdowns.append(
+                {
+                    "jobid": (flux.job.JobID(jobid).f58 if jobid is not None else None),
+                    **breakdown,
+                }
+            )
+
+        def make_lookup_complete(jobid):
+            """Build a .then() callback that knows its jobid so
+            recorded breakdowns can be labelled with the job they
+            describe. (Bare closure over loop variable wouldn't
+            work — every late callback would see the last jobid.)"""
+
+            def on_lookup_complete(future):
+                pending_lookups[0] -= 1
+                try:
+                    data = future.get_decode()
+                except OSError:
+                    data = []
+                for entry in data:
+                    r = entry.get("R")
+                    if r is not None:
+                        score_r(r, jobid)
+                        break
+                # If fill-mode stop was deferred waiting on us, fire
+                # it now that the last lookup has drained.
+                if deferred_stop_bulk[0] is not None and pending_lookups[0] == 0:
+                    bulk = deferred_stop_bulk[0]
+                    deferred_stop_bulk[0] = None
+                    bulk.stop()
+
+            return on_lookup_complete
+
+        def on_event(_bulk, jobid, ev):
+            if ev.name == "submit":
+                submit_tracker.step(emitter)
+            elif ev.name == "alloc":
+                r = _r_from_event(ev)
+                if r is not None:
+                    score_r(r, jobid)
+                else:
+                    # Per-job watcher: R isn't in the event, fetch
+                    # asynchronously and let .then() score it.
+                    pending_lookups[0] += 1
+                    lookup = flux.job.JobKVSLookup(
+                        handle,
+                        ids=[jobid],
+                        keys=["R"],
+                    )
+                    lookup.fetch_data().then(
+                        make_lookup_complete(jobid),
+                    )
+                if done_event == "alloc":
+                    done_tracker.step(emitter)
+            elif ev.name == done_event:
+                done_tracker.step(emitter)
+
+        def on_all_submitted(_bulk):
+            t_all_submitted[0] = time.time()
+            emitter.stage("execute", 1, 2)
+            done_tracker.flush(emitter)
+
+        def on_all_alloc(bulk):
+            t_all_alloc[0] = time.time()
+            if self.duration_mode == "fill":
+                # All allocated; cancel them. R lookups already
+                # in flight need to drain before we stop the
+                # reactor so no allocations go unscored.
+                t_all_done[0] = time.time()
+                bulk.cancelall()
+                if pending_lookups[0] == 0:
+                    bulk.stop()
+                else:
+                    deferred_stop_bulk[0] = bulk
+
+        def on_all_clean(_bulk):
+            if self.duration_mode != "fill":
+                t_all_done[0] = time.time()
+
+        bulk_kwargs = {
+            "events_of_interest": (
+                "submit",
+                "alloc",
+                "exception",
+                "clean",
+            ),
+        }
+        if self.watcher_factory is not None:
+            bulk_kwargs["watcher_factory"] = self.watcher_factory
+        bulk = BulkRun(handle, **bulk_kwargs)
+
+        # Submit.  fixed/fill share one jobspec across all jobs;
+        # random builds one jobspec per job since each has its own
+        # sampled duration.
+        if self.duration_mode == "fixed":
+            bulk.push_jobs(self._build_jobspec(self.duration_lo), self.njobs)
+        elif self.duration_mode == "fill":
+            bulk.push_jobs(self._build_jobspec(None), self.njobs)
+        elif self.duration_mode == "random":
+            lo_sec = flux.util.parse_fsd(self.duration_lo)
+            hi_sec = flux.util.parse_fsd(self.duration_hi)
+            for _ in range(self.njobs):
+                d = random.uniform(lo_sec, hi_sec)
+                bulk.push_jobs(
+                    self._build_jobspec(flux.util.fsd(d)),
+                    1,
+                )
+        else:
+            raise ValueError(f"unknown duration mode: {self.duration_mode!r}")
+
+        bulk.add_event_cb(on_event)
+        bulk.add_bulk_event_cb("submit", on_all_submitted)
+        bulk.add_bulk_event_cb("alloc", on_all_alloc)
+        bulk.add_bulk_event_cb("clean", on_all_clean)
+
+        emitter.stage("submit", 0, 2)
+        t_submit_start = time.time()
+        result = bulk.run()
+        t_done_wall = time.time()
+
+        if result.njobs == 0:
+            raise RuntimeError(
+                failure_diagnostic(
+                    result,
+                    "locality: all submits failed",
+                )
+            )
+        if t_all_alloc[0] is None:
+            raise RuntimeError(
+                failure_diagnostic(
+                    result,
+                    "locality: no job reached 'alloc' event",
+                )
+            )
+        if not scores:
+            raise RuntimeError(
+                failure_diagnostic(
+                    result,
+                    "locality: no R values could be scored",
+                )
+            )
+
+        # Rate-denominator convention matches the other benchmarks;
+        # see benchmarks.py module docstring for the rationale.
+        submit_rate = result.njobs / (t_all_submitted[0] - t_submit_start)
+        alloc_rate = result.njobs / (t_all_alloc[0] - t_submit_start)
+        end_time = t_all_done[0] or t_done_wall
+        throughput = result.njobs / (end_time - t_submit_start)
+
+        if self.duration_mode == "fixed":
+            duration_str = self.duration_lo
+        elif self.duration_mode == "fill":
+            duration_str = "fill"
+        else:
+            duration_str = f"random:{self.duration_lo}-{self.duration_hi}"
+
+        return {
+            "njobs": result.njobs,
+            "nslots": self.nslots,
+            "duration": duration_str,
+            "duration_mode": self.duration_mode,
+            "t_submit_start": t_submit_start,
+            "t_all_submitted": t_all_submitted[0],
+            "t_all_alloc": t_all_alloc[0],
+            "t_all_done": t_all_done[0],
+            "t_done": t_done_wall,
+            "submit_rate": submit_rate,
+            "alloc_rate": alloc_rate,
+            "throughput": throughput,
+            "mean_locality_score": sum(scores) / len(scores),
+            "num_jobs_scored": len(scores),
+            "locality_score_distribution": scores,
+            # Recorded for post-hoc analysis: the predicate's
+            # view of the topology (lets a reader confirm the
+            # right XML was used, and exposes the core_domain /
+            # gpu_domain maps for inspection), and a per-job
+            # breakdown (cores/gpus by domain, unknown IDs in R,
+            # slots satisfied per rank) — the primary tool for
+            # explaining why a score came out the way it did.
+            "locality_topology": self.predicate.describe(),
+            "locality_score_breakdown": breakdowns,
+        }
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/testing/schedbench/locality.py
+++ b/src/bindings/python/flux/testing/schedbench/locality.py
@@ -482,6 +482,8 @@ class LocalityBenchmark(Benchmark):
         ("alloc_rate", "alloc rate", "rate"),
     )
 
+    RESULT = ("mean_locality_score", "")
+
     REPORT_HEADINGS = {
         **COMMON_REPORT_HEADINGS,
         "nslots": "NSLOTS",

--- a/src/bindings/python/flux/testing/schedbench/results.py
+++ b/src/bindings/python/flux/testing/schedbench/results.py
@@ -1,0 +1,102 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Append-only JSON results storage for flux-schedbench.
+
+:class:`BenchmarkResults` is a thin persistence layer for the
+per-run records the CLI accumulates. It stores aggregate metrics
+only (no per-job data) so files stay small (~1-2 KB per run) and
+machine-readable. The CLI builds a complete run record dict with
+all metadata and benchmark results, calls :meth:`add_run`, then
+:meth:`save`; the JSON file is written atomically via tmp+rename.
+
+The file format is ``{"runs": [<record>, ...]}`` — a single top-
+level object with a ``runs`` array, one entry per benchmark
+invocation. The record shape is defined in the design doc's
+"Results Storage" section.
+"""
+
+import json
+import os
+import time
+
+
+class BenchmarkResults:
+    """Append-only JSON store for benchmark run records.
+
+    Args:
+      path: filesystem path to the results file. The file is
+          created on first :meth:`save` if it does not yet exist;
+          if it exists, its contents are loaded on construction.
+
+    Usage::
+
+        results = BenchmarkResults("schedbench-results.json")
+        results.add_run({"test_name": "throughput", ...})
+        results.save()
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self.runs = self._load()
+
+    def add_run(self, run):
+        """Append a run record to the in-memory list.
+
+        ``timestamp`` (Unix seconds) and ``iso_timestamp`` (UTC
+        ``YYYY-MM-DDTHH:MM:SSZ``) are added if not already present.
+        The record is not persisted until :meth:`save` is called.
+
+        Returns the appended record (with timestamp fields filled).
+        """
+        run = dict(run)
+        run.setdefault("timestamp", time.time())
+        run.setdefault(
+            "iso_timestamp",
+            time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ",
+                time.gmtime(run["timestamp"]),
+            ),
+        )
+        self.runs.append(run)
+        return run
+
+    def get_runs(self):
+        """Return a shallow copy of the in-memory runs list."""
+        return list(self.runs)
+
+    def save(self):
+        """Persist runs to disk atomically.
+
+        Writes to ``<path>.tmp`` then renames over the existing file.
+        :func:`os.replace` is atomic on POSIX and Windows, so a
+        partial write cannot leave the file in a half-formed state.
+        """
+        tmp = self.path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump({"runs": self.runs}, f, indent=2)
+            f.write("\n")
+        # os.replace is atomic on POSIX only when tmp and self.path
+        # are on the same filesystem. Both live in the same directory
+        # by construction (tmp = self.path + ".tmp"), so this holds.
+        os.replace(tmp, self.path)
+
+    def _load(self):
+        """Load existing runs from disk, or return [] if the file
+        does not yet exist."""
+        try:
+            with open(self.path) as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            return []
+        return data.get("runs", [])
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/testing/schedbench/sweep.py
+++ b/src/bindings/python/flux/testing/schedbench/sweep.py
@@ -1,0 +1,2253 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Multi-benchmark sweep runner for flux schedbench.
+
+A sweep generates a cross-product of benchmark configurations from a
+parameter matrix and dispatches each combination as a child
+``flux schedbench run`` invocation.  Results are appended to the
+same flat results file as single runs, each tagged with a ``sweep``
+sub-object recording the run's axis values and position in the
+matrix.
+
+This is a single self-contained module combining the three concerns
+of the sweep feature:
+
+* **Matrix layer** — parsing input (CLI flags or TOML file),
+  expanding the cross-product, and producing :class:`RunSpec`
+  instances ready for dispatch.  (:func:`parse_rfc45_range`,
+  :func:`parse_axis_spec`, :class:`RunSpec`, :class:`SweepMatrix`.)
+
+* **UI layer** — :class:`TerminalSweepEmitter` (live TTY dashboard
+  with progress bars, status counts, active and recent run
+  sections) and :class:`LineSweepEmitter` (plain text, one line
+  per state transition, for non-TTY output).  Same flicker
+  mitigation as the single-run UI (DEC 2026 + per-line erase,
+  single-write frames, cursor-hide, 20Hz throttle).
+
+* **Dispatch layer** — :func:`run_flux` submits each run as a
+  Flux job to the outer instance, running them in parallel via a
+  single :class:`flux.job.JobWatcher`.  Children consume their
+  :class:`RunSpec` instances from :meth:`SweepMatrix.expand`;
+  per-run scheduler-recipe env overlays are applied via
+  ``JobspecV1.from_submit``'s env filter rules.  The dispatcher
+  parses each child's JSON event stream into emitter callbacks
+  and writes sweep-tagged records to the shared results file.
+  Sweeps without an outer Flux instance can be run under
+  ``flux start -s 1 -- flux schedbench sweep ...``.
+"""
+
+import getpass
+import itertools
+import json
+import os
+import random
+import re
+import shlex
+import socket
+import sys
+import time
+
+# tomllib added to standard library in Python 3.11
+# flux-core minimum is Python 3.6.
+try:
+    import tomllib  # novermin
+except ModuleNotFoundError:
+    from flux.utils import tomli as tomllib
+
+try:
+    from dataclasses import dataclass, field  # novermin
+except ModuleNotFoundError:
+    from flux.utils.dataclasses import dataclass, field
+
+from flux.testing.schedbench import BENCHMARKS, BenchmarkResults
+from flux.testing.schedbench._ansi import (
+    _BAR_CHARS_ASCII,
+    _BAR_CHARS_UNICODE,
+    _BOLD,
+    _CURSOR_HIDE,
+    _CURSOR_SHOW,
+    _CURSOR_UP_FMT,
+    _DIM,
+    _ERASE_TO_EOL,
+    _FG_CYAN,
+    _FG_GREEN,
+    _FG_RED,
+    _GLYPHS_ASCII,
+    _GLYPHS_UNICODE,
+    _REDRAW_INTERVAL_S,
+    _RESET,
+    _SYNC_BEGIN,
+    _SYNC_END,
+    _color_supported,
+    _isatty,
+    _safe_glyphs,
+)
+
+# ===========================================================
+# Matrix layer
+# ===========================================================
+#: RFC 45 operators we recognize.  ``+`` is additive (step by operand),
+#: ``*`` is multiplicative (multiply by operand each step), ``^`` is
+#: exponential (raise to the operand each step).  Maps the operator
+#: char to a function ``(value, operand) -> next_value``.
+_RFC45_OPS = {
+    "+": lambda v, op: v + op,
+    "*": lambda v, op: v * op,
+    "^": lambda v, op: v**op,
+}
+
+
+def parse_rfc45_range(spec):
+    """Parse an RFC 45 range string into a list of values.
+
+    Forms (per `RFC 45 <https://flux-framework.readthedocs.io/projects/
+    flux-rfc/en/latest/spec_45.html>`_)::
+
+        min-max                # additive, step 1
+        min-max:operand        # additive, step operand
+        min-max:operand:op     # operator op (+, *, ^)
+        [min-max:operand:op]   # brackets optional
+
+    Open-ended forms (``min+:operand:op``) are rejected — a sweep
+    needs a finite list.
+
+    Returns a list of ints in ascending order.  Raises
+    :class:`ValueError` for malformed input or unknown operators.
+    """
+    s = spec.strip()
+    if s.startswith("[") and s.endswith("]"):
+        s = s[1:-1].strip()
+    if "+" in s.split(":", 1)[0]:
+        # The first colon-separated field is the range; '+' there
+        # would mean open-ended.
+        raise ValueError(
+            f"open-ended RFC 45 ranges not allowed in a sweep "
+            f"(spec must be finite): {spec!r}"
+        )
+    parts = s.split(":")
+    if len(parts) > 3:
+        raise ValueError(f"too many colons in RFC 45 spec: {spec!r}")
+    if "-" not in parts[0]:
+        raise ValueError(f"missing min-max in RFC 45 spec: {spec!r}")
+    lo_s, hi_s = parts[0].split("-", 1)
+    try:
+        lo = int(lo_s)
+        hi = int(hi_s)
+        operand = int(parts[1]) if len(parts) > 1 else 1
+    except ValueError as exc:
+        raise ValueError(f"non-integer field in RFC 45 spec: {spec!r}") from exc
+    op = parts[2] if len(parts) > 2 else "+"
+    if op not in _RFC45_OPS:
+        raise ValueError(
+            f"unknown RFC 45 operator {op!r} in {spec!r}; "
+            f"valid operators: {sorted(_RFC45_OPS)}"
+        )
+    if lo > hi:
+        raise ValueError(f"min > max in RFC 45 spec: {spec!r}")
+    step = _RFC45_OPS[op]
+    out = []
+    v = lo
+    while v <= hi:
+        out.append(v)
+        nxt = step(v, operand)
+        if nxt <= v:
+            # Operand of 1 with * or 0 with + would never advance.
+            # Don't loop forever; treat as "single-value range."
+            break
+        v = nxt
+    return out
+
+
+# Heuristic: spec looks like RFC 45 if it has range syntax (``-`` or
+# ``:`` or surrounding brackets) and contains no commas.  Anything
+# else is a comma-separated discrete list.  ``sched-simple`` and
+# similar hyphenated string values fall through to the comma-list
+# path because non-numeric characters break the regex below.
+_RFC45_LIKE = re.compile(r"^\[?\d+-\d+(:\d+(:[+*^])?)?\]?$")
+
+
+def parse_axis_spec(spec):
+    """Parse an axis SPEC into a list of values.
+
+    Accepts:
+
+    * RFC 45 range strings (``1-8``, ``1-32:8``, ``1-1024:2:*``,
+      ``[1-256:2:^]``) — expanded numerically.
+    * Comma-separated lists (``sched-simple,sched-fluxion-qmanager``
+      or ``100,1000,10000``) — each element coerced to int / float
+      / bool / str.
+    * A bare single value with no commas or range syntax — returns
+      a one-element list.
+
+    Coercion: ``true``/``false`` (case-insensitive) → bool, decimal
+    integers → int, decimals with ``.`` → float, anything else →
+    str.  Strings that look numeric but mean labels can be quoted
+    at the shell level.
+    """
+    spec = spec.strip()
+    if _RFC45_LIKE.match(spec):
+        return parse_rfc45_range(spec)
+    return [_coerce(v.strip()) for v in spec.split(",")]
+
+
+def _coerce(v):
+    """Best-guess coercion for a single string axis value."""
+    if v.lower() in ("true", "yes"):
+        return True
+    if v.lower() in ("false", "no"):
+        return False
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        pass
+    return v
+
+
+def _coerce_param_value(raw):
+    """Coerce one top-level TOML parameter value into a list of
+    one-or-more axis values.  Centralizes the shape handling for
+    :meth:`SweepMatrix.from_file`:
+
+    * ``list`` (TOML array) -> values as-is (each coerced if str)
+    * ``str`` -> parsed as RFC 45 range, comma list, or single
+      value via :func:`parse_axis_spec`
+    * ``int``/``float``/``bool`` -> one-element list
+
+    Always returns a list, even for the single-value case, so
+    callers can uniformly check ``len(values) == 1`` to decide
+    fixed vs axis.
+    """
+    if isinstance(raw, list):
+        return [_coerce(v) if isinstance(v, str) else v for v in raw]
+    if isinstance(raw, str):
+        return parse_axis_spec(raw)
+    return [raw]
+
+
+def _make_scheduler_recipe(name, options=None):
+    """Build a simple scheduler recipe from a name.
+
+    Used for CLI-provided scheduler axis values like
+    ``--scheduler=sched-simple,sched-backfill`` where there's no
+    ``[[scheduler]]`` block to consult.  ``module`` defaults to
+    ``name``: a CLI ``--scheduler=sched-backfill`` is shorthand
+    for "force-load ``sched-backfill``", matching the CLI's
+    existing semantic.  ``options`` becomes the args entry for
+    that module, threading the existing
+    ``--scheduler-options=OPTS`` CLI flag through the recipe.
+
+    Returns a dict matching :func:`_recipe_from_block`'s shape so
+    the dispatch layer can treat both uniformly — ``env`` is a
+    list of :meth:`JobspecV1.from_submit`-style filter rules
+    (empty for the CLI-synthesized case).
+    """
+    modules = []
+    if options:
+        modules.append({"name": name, "options": options})
+    return {
+        "name": name,
+        "module": name,
+        "modules": modules,
+        "conf": {},
+        "env": [],
+    }
+
+
+#: Allowed top-level keys in a ``[[scheduler]]`` block.  Used by
+#: :func:`_recipe_from_block` to reject misscoped keys (a common
+#: TOML pitfall: a key placed after a ``[[scheduler.modules]]``
+#: header attaches to the module entry instead of the parent
+#: scheduler).  Hard error rather than a warning since the dispatch
+#: UI swallows stderr noise — silent misscoping has bitten us.
+_KNOWN_SCHEDULER_KEYS = frozenset(
+    {
+        "name",
+        "module",
+        "modules",
+        "conf",
+        "env",
+    }
+)
+
+#: Allowed keys in a ``[[scheduler.modules]]`` entry.  Anything
+#: else almost certainly means a parent-scoped key got captured
+#: by this sub-table; raise rather than silently drop.
+_KNOWN_MODULE_KEYS = frozenset({"name", "options"})
+
+
+def _recipe_from_block(block):
+    """Normalize a TOML ``[[scheduler]]`` block into a recipe dict.
+
+    Required field is ``name`` (the axis value / display label).
+    All other fields are optional and refine the recipe:
+
+    * ``module`` -> scheduler module to force-load via
+      ``modules.alternatives.sched``.  When omitted, the default
+      depends on whether the block is in *shorthand form* (just
+      ``name``, no other config) or *full form* (with ``modules``
+      / other config):
+
+      - **Shorthand** (``[[scheduler]] name = "sched-backfill"``):
+        ``module`` defaults to ``name`` — equivalent to the CLI
+        ``--scheduler=sched-backfill``.
+      - **Full form** (``modules`` set, no ``module``): no
+        alternative override.  ``--scheduler`` is not emitted;
+        modprobe loads whatever it would load by default
+        (typically Fluxion on a system with its modprobe config
+        on the path).  Per-module args still apply.
+
+      To opt out of the shorthand default explicitly when no
+      other config is present, set ``module = ""``.
+
+    * ``modules`` -> list of ``{name, options}`` per-module args
+      overrides.  Does NOT dictate load order — modprobe handles
+      dependencies and load order from its own config.  ``options``
+      threads through as ``--conf=modules.<name>.args=[...]``.
+    * ``conf`` -> dict of runtime conf entries (read by modules
+      via ``flux_conf_get()``, distinct from load-time args).
+    * ``env`` -> list of :meth:`flux.job.JobspecV1.from_submit`
+      env filter rules applied to the submitter's environment:
+
+      - ``"VAR=VALUE"`` sets *VAR*, expanding ``$VAR`` references
+        against the env built so far (so rules can reference
+        earlier rules: define ``FLUXION_HOME=…`` then use
+        ``FOO=$FLUXION_HOME/…``).
+      - ``"VAR"`` (or glob ``"SLURM_*"``) imports from the
+        submitter env.
+      - ``"-PATTERN"`` removes vars matching glob *PATTERN*.
+      - ``"^/path"`` reads additional rules from a file.
+
+      As a convenience, a dict ``env = { K = "V", ... }`` is
+      accepted and converted to ``["K=V", ...]`` rules — handy
+      for the common "set these vars" case without ``$VAR``
+      cross-references.  Submitter env is preserved by default
+      (no rules = no filtering); rules ADD or REMOVE selectively.
+
+    Each module entry must have at least ``name``; ``options`` is
+    optional.
+    """
+    if "name" not in block:
+        raise ValueError("[[scheduler]] block missing 'name'")
+    name = block["name"]
+    unknown = set(block) - _KNOWN_SCHEDULER_KEYS
+    if unknown:
+        raise ValueError(
+            f"[[scheduler]] {name!r}: unknown key(s) "
+            f"{sorted(unknown)}.  Known keys: "
+            f"{sorted(_KNOWN_SCHEDULER_KEYS)}.  This often "
+            f"means a key got misscoped under a sub-table — "
+            f"TOML attaches keys to the most recently-opened "
+            f"table, so a top-level key placed after a "
+            f"[[scheduler.modules]] or [scheduler.env] header "
+            f"ends up nested inside that sub-table.  Move the "
+            f"key above any sub-table headers."
+        )
+    if "module" in block:
+        module = block["module"] or None
+    elif "modules" in block:
+        module = None
+    else:
+        module = name
+    modules = [dict(m) for m in (block.get("modules") or [])]
+    for m in modules:
+        if "name" not in m:
+            raise ValueError(f"[[scheduler]] {name!r}: module entry missing " f"'name'")
+        unknown_mod = set(m) - _KNOWN_MODULE_KEYS
+        if unknown_mod:
+            raise ValueError(
+                f"[[scheduler]] {name!r}: module entry "
+                f"{m['name']!r} has unknown key(s) "
+                f"{sorted(unknown_mod)}.  Known keys: "
+                f"{sorted(_KNOWN_MODULE_KEYS)}.  This usually "
+                f"means a parent-scoped key got captured by "
+                f"the [[scheduler.modules]] sub-table — TOML "
+                f"attaches keys to the most recently-opened "
+                f"table.  Move the key above the "
+                f"[[scheduler.modules]] header(s)."
+            )
+    raw_env = block.get("env") or []
+    if isinstance(raw_env, dict):
+        # Convenience: dict form -> ["K=V"] rules.  Quoting V is
+        # the caller's problem; we pass through verbatim so $VAR
+        # expansion (handled by from_submit's rule engine) still
+        # works on values originating from the dict form.
+        env = [f"{k}={v}" for k, v in raw_env.items()]
+    elif isinstance(raw_env, list):
+        for entry in raw_env:
+            if not isinstance(entry, str):
+                raise ValueError(
+                    f"[[scheduler]] {name!r}: env entries must be "
+                    f"strings (got {type(entry).__name__})"
+                )
+        env = list(raw_env)
+    else:
+        raise ValueError(
+            f"[[scheduler]] {name!r}: env must be a list of "
+            f"rule strings or a dict (got "
+            f"{type(raw_env).__name__})"
+        )
+    return {
+        "name": name,
+        "module": module,
+        "modules": modules,
+        "conf": dict(block.get("conf") or {}),
+        "env": env,
+    }
+
+
+def _format_conf_value(value):
+    """Render a TOML-parsed value as the right-hand side of a
+    ``--conf=KEY=VALUE`` flag.
+
+    flux start's ``--conf=`` parser accepts TOML/JSON syntax on
+    the RHS, so:
+
+    * ``bool`` -> ``true`` / ``false`` (TOML literal, lowercase)
+    * ``list`` / ``dict`` -> JSON-encoded (a valid TOML/JSON
+      inline array or table — both parse identically here).
+      Without this, ``str(list)`` produces Python-repr output
+      with single quotes that's neither valid TOML nor JSON and
+      flux start rejects it.
+    * everything else -> ``str(value)`` (numbers and strings
+      round-trip fine).
+
+    Used for both the file's ``[conf]`` section and per-recipe
+    ``conf`` dicts on ``[[scheduler]]`` blocks.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (list, dict)):
+        return json.dumps(value)
+    return str(value)
+
+
+@dataclass
+class RunSpec:
+    """One row of an expanded sweep matrix.
+
+    Attributes:
+        axes: ordered dict mapping axis name -> value for this run
+        fixed: non-axis parameters (applied to every run in the sweep)
+        run_index: 0-based position in the expansion
+        total: total number of runs in the expansion (for display)
+        conf: list of user-supplied ``--conf KEY=VALUE`` strings
+            (applied to every run, like ``fixed`` but forwarded as
+            ``--conf=`` flags rather than as native run options)
+        varying_axes: set of axis names that have more than one
+            value in the parent matrix.  When set, the dashboard's
+            per-row axis summary skips other axes (they're
+            effectively-fixed, redundant ink).  Defaults to empty;
+            in that case all axes show.
+        axis_column_widths: per-axis maximum-formatted-value width,
+            so :meth:`axis_summary` pads each value into a column
+            and rows line up tabularly.  Populated by
+            :meth:`SweepMatrix.expand`; defaults to empty (no
+            per-column padding, just space-separated).
+        scheduler_recipe: optional resolved scheduler recipe dict
+            for this run (the ``[[scheduler]]`` block matched by
+            this run's scheduler axis value, or a synthesized
+            single-module recipe for a CLI-only name).  When
+            present, :meth:`argv` emits the recipe's modules and
+            runtime conf as child ``--conf`` flags; the dispatch
+            layer reads ``recipe['env']`` for per-run environment
+            overlays.  None for sweeps without any scheduler axis.
+    """
+
+    axes: dict
+    fixed: dict
+    run_index: int
+    total: int
+    conf: list = field(default_factory=list)
+    varying_axes: set = field(default_factory=set)
+    axis_column_widths: dict = field(default_factory=dict)
+    scheduler_recipe: dict = field(default_factory=dict)
+
+    def test_name(self):
+        """Return the test (benchmark) name for this run.  Resolved
+        from the ``test`` axis if present, falling back to the
+        fixed-args ``test`` key.  Empty string if neither is set
+        (which is an invalid config — every run needs a test).
+        """
+        return self.axes.get("test") or self.fixed.get("test", "")
+
+    def axis_summary(self):
+        """A short, human-readable summary of this run's axis
+        values for the dashboard, with per-axis column padding so
+        rows line up.
+
+        Special-cases:
+
+        * ``test`` is omitted (the identity column shows it).
+        * ``scheduler`` values render bare (just the value, no
+          ``scheduler=`` prefix, no ``sched-`` prefix) since
+          scheduler names like ``simple`` and ``fluxion-qmanager``
+          are unambiguous from context.
+        * If ``varying_axes`` is set, any axis that's
+          effectively-fixed across the matrix is omitted.
+        * If ``axis_column_widths`` is set, each value is left-padded
+          to its axis's column width — so ``simple`` (6 chars) and
+          ``backfill`` (8 chars) both occupy 8-char columns and the
+          next axis lines up across rows.
+        """
+        bits = []
+        for k, v in self.axes.items():
+            if k == "test":
+                continue
+            if self.varying_axes and k not in self.varying_axes:
+                continue
+            value = _format_axis_value(k, v)
+            width = self.axis_column_widths.get(k, 0)
+            bits.append(value.ljust(width))
+        return "  ".join(bits)
+
+    def argv(self):
+        """Generate the argv list for ``flux schedbench run`` that
+        executes this run.  Does not include the ``flux schedbench``
+        prefix or any UI/output flags — the dispatch layer adds
+        those uniformly across all runs.
+
+        The ``test`` axis (or fixed ``test`` value) becomes the
+        positional argument; other axes and fixed values become
+        ``--flag value`` pairs using the canonical long-form name.
+
+        ``scheduler`` and ``scheduler_options`` are special-cased:
+        instead of emitting them naively, the resolved
+        :attr:`scheduler_recipe` (when present) drives the
+        scheduler arguments.  The recipe carries an optional
+        ``module`` (which module to force-load, defaulting to the
+        recipe's ``name``; maps to ``--scheduler=NAME`` and thence
+        to ``--conf=modules.alternatives.sched=NAME``) plus a list
+        of per-module args overrides and runtime ``conf`` entries.
+        modprobe handles the actual module loading, dependencies,
+        and load order from its own config — schedbench only
+        expresses overrides to that, never the load plan itself.
+
+        For a single-module recipe synthesized from CLI
+        ``--scheduler=NAME --scheduler-options=OPTS``, this reduces
+        to ``--scheduler=NAME --conf=modules.NAME.args=[OPTS]``.
+        For a multi-module recipe (e.g. Fluxion with custom args
+        for both qmanager and resource), each module's options
+        become a ``--conf=modules.<name>.args=[...]`` entry; the
+        recipe's ``module`` picks which module advertises ``sched``.
+        """
+        params = {**self.fixed, **self.axes}
+        test = params.pop("test", None)
+        if test is None:
+            raise ValueError("RunSpec missing required 'test' axis or fixed value")
+        # Scheduler args come from the recipe — pop the raw values
+        # so the generic loop below doesn't double-emit them.
+        params.pop("scheduler", None)
+        params.pop("scheduler_options", None)
+
+        argv = ["run", str(test)]
+        for k, v in params.items():
+            flag = "--" + k.replace("_", "-")
+            if isinstance(v, bool):
+                # Boolean axes turn into a flag-or-nothing.  The
+                # only such axis we currently care about is
+                # ``real_exec`` -> ``--exec``.
+                if k == "real_exec" and v:
+                    argv.append("--exec")
+                elif v:
+                    argv.append(flag)
+                # False bool: omit (CLI default is False)
+            else:
+                argv.extend([flag, str(v)])
+
+        # Scheduler from recipe.  modprobe handles the actual
+        # module loading and dependency resolution — including
+        # which scheduler module gets loaded by default (driven by
+        # priority and whatever ``FLUX_MODPROBE_PATH_APPEND``
+        # points at).  The recipe's role is to express
+        # *overrides*: ``module`` says which scheduler to
+        # force-load (mapping to ``modules.alternatives.sched``)
+        # and defaults to the recipe's ``name`` — so a simple
+        # block like ``[[scheduler]] name = "sched-backfill"``
+        # behaves exactly like CLI ``--scheduler=sched-backfill``.
+        # The ``modules`` list provides per-module args overrides;
+        # ``conf`` provides runtime conf entries.
+        recipe = self.scheduler_recipe
+        if recipe:
+            if recipe.get("module"):
+                argv.extend(["--scheduler", str(recipe["module"])])
+            for mod in recipe.get("modules", []):
+                if mod.get("options"):
+                    opts_list = shlex.split(mod["options"])
+                    argv.extend(
+                        [
+                            "--conf",
+                            f"modules.{mod['name']}.args=" f"{json.dumps(opts_list)}",
+                        ]
+                    )
+            for key, value in recipe.get("conf", {}).items():
+                argv.extend(
+                    [
+                        "--conf",
+                        f"{key}={_format_conf_value(value)}",
+                    ]
+                )
+
+        for entry in self.conf:
+            argv.extend(["--conf", entry])
+        return argv
+
+
+class SweepMatrix:
+    """Expanded representation of a sweep's parameter matrix.
+
+    Holds the axis declarations (ordered: declaration order ==
+    cross-product nesting order) and the fixed non-axis parameters.
+    Call :meth:`expand` to enumerate :class:`RunSpec` instances.
+
+    Instances are typically built via :meth:`from_cli` or
+    :meth:`from_file`; the constructor is exposed mainly for tests.
+    """
+
+    def __init__(self, axes, fixed, name=None, conf=None, scheduler_recipes=None):
+        self.axes = dict(axes)
+        self.fixed = dict(fixed)
+        self.name = name or _default_sweep_name()
+        self.conf = list(conf or [])
+        #: name -> recipe dict ({name, module, modules, conf, env}).
+        #: Populated by :meth:`from_file` from ``[[scheduler]]``
+        #: blocks; consulted by :meth:`_resolve_recipe` when expanding
+        #: to attach the matching recipe to each :class:`RunSpec`.
+        #: Empty when no file recipes are defined (all schedulers
+        #: fall back to simple single-module synthesis at expansion
+        #: time).
+        self.scheduler_recipes = dict(scheduler_recipes or {})
+
+    def _resolve_recipe(self, name, scheduler_options=None):
+        """Return the recipe dict for scheduler ``name``.
+
+        File-defined ``[[scheduler]]`` recipes win — their
+        ``module`` / ``modules`` / ``conf`` / ``env`` are the
+        authoritative config and ``scheduler_options`` is ignored
+        when one applies (the recipe carries its own per-module
+        options).
+
+        For names that don't match a file recipe (the common case
+        of CLI-only schedulers like ``sched-simple``), synthesize
+        a recipe via :func:`_make_scheduler_recipe`: ``module`` is
+        the name (so ``--scheduler=NAME`` means force-load NAME,
+        matching CLI semantics) and the optional
+        ``scheduler_options`` becomes that module's args.
+        """
+        if name in self.scheduler_recipes:
+            return self.scheduler_recipes[name]
+        return _make_scheduler_recipe(name, options=scheduler_options)
+
+    @classmethod
+    def from_cli(cls, params, name=None, conf=None):
+        """Build from already-parsed CLI parameter values.
+
+        ``params`` is a dict mapping parameter name to a list of
+        values.  Single-element lists become fixed parameters;
+        multi-element lists become sweep axes.  This is the shape
+        produced by :func:`cmd_sweep` after running each axis-capable
+        argument through :func:`parse_axis_spec`.
+        """
+        axes = {}
+        fixed = {}
+        for key, values in params.items():
+            if not values:
+                continue
+            if len(values) == 1:
+                fixed[key] = values[0]
+            else:
+                axes[key] = list(values)
+        return cls(axes=axes, fixed=fixed, name=name, conf=conf)
+
+    @classmethod
+    def from_file(cls, path, cli_overrides=None, cli_conf=None):
+        """Load a TOML sweep definition.
+
+        The whole file is the sweep definition — no outer ``[sweep]``
+        wrapper.  Schema::
+
+            # Sweep name (optional; auto-generated if omitted).
+            name = "fluxion-vs-simple"
+
+            # Parameters at top level.  Scalars are fixed across
+            # the sweep; lists and idset/range strings become axes.
+            test = "throughput"
+            nodes = "16-1024:2"            # axis: RFC 45 range
+            njobs = [4096, 8192]           # axis: explicit list
+            cores_per_node = 64            # fixed: scalar
+
+            # Optional [[scheduler]] array-of-tables: each entry
+            # contributes one value to the implicit ``scheduler``
+            # axis.  The block's ``name`` is the scheduler axis
+            # value used in records and the dashboard.  Additional
+            # fields (modules, env) describe how to load the
+            # scheduler in the child instance.
+            [[scheduler]]
+            name = "simple"
+            modules = [{ name = "sched-simple" }]
+
+            [[scheduler]]
+            name = "fluxion"
+            modules = [
+              { name = "sched-fluxion-resource", options = "policy=high" },
+              { name = "sched-fluxion-qmanager", options = "..." },
+            ]
+            env = { FLUX_MODULE_PATH = "/path/to/sched/modules" }
+
+            # Conf entries forwarded to every child run as
+            # --conf=KEY=VALUE.  Same semantics as the CLI --conf.
+            [conf]
+            "resource.noverify" = true
+
+        ``cli_overrides`` is a dict mapping parameter name to a
+        list of values that REPLACE the file's value for that
+        parameter (CLI wins).  ``cli_conf`` is a list of additional
+        ``--conf`` entries appended to the file's ``[conf]``.
+        """
+        with open(path, "rb") as f:
+            doc = tomllib.load(f)
+
+        # Pull out the structured sections; everything else at
+        # top level is a parameter.
+        name = doc.pop("name", None)
+        conf_section = doc.pop("conf", {})
+        scheduler_blocks = doc.pop("scheduler", None)
+
+        axes = {}
+        fixed = {}
+        for key, raw in doc.items():
+            values = _coerce_param_value(raw)
+            if len(values) == 1:
+                fixed[key] = values[0]
+            else:
+                axes[key] = values
+
+        # [[scheduler]] entries become the scheduler axis and
+        # populate ``scheduler_recipes``.  Each block's ``name``
+        # is the axis value (and dashboard/record label); the
+        # block's ``modules`` / ``conf`` / ``env`` fields are
+        # consulted at dispatch time to expand into child
+        # ``--scheduler=...`` / ``--conf=...`` args plus a
+        # per-run environment overlay.
+        scheduler_recipes = {}
+        if scheduler_blocks:
+            sched_names = []
+            for block in scheduler_blocks:
+                recipe = _recipe_from_block(block)
+                if recipe["name"] in scheduler_recipes:
+                    raise ValueError(
+                        f"{path}: duplicate [[scheduler]] name " f"{recipe['name']!r}"
+                    )
+                scheduler_recipes[recipe["name"]] = recipe
+                sched_names.append(recipe["name"])
+            if "scheduler" in axes or "scheduler" in fixed:
+                raise ValueError(
+                    f"{path}: scheduler given both as a plain "
+                    f"parameter and as [[scheduler]] blocks; "
+                    f"pick one form"
+                )
+            if len(sched_names) == 1:
+                fixed["scheduler"] = sched_names[0]
+            else:
+                axes["scheduler"] = sched_names
+
+        # CLI overrides replace file values wholesale.  Single
+        # values land in fixed; lists land in axes.
+        for k, values in (cli_overrides or {}).items():
+            # Remove any existing entry in the other bucket first.
+            axes.pop(k, None)
+            fixed.pop(k, None)
+            if len(values) == 1:
+                fixed[k] = values[0]
+            else:
+                axes[k] = list(values)
+
+        # Conf entries: file's [conf] dict flattened into the
+        # KEY=VALUE string form the CLI takes.
+        conf = []
+        for k, v in conf_section.items():
+            conf.append(f"{k}={_format_conf_value(v)}")
+        conf.extend(cli_conf or [])
+
+        return cls(
+            axes=axes,
+            fixed=fixed,
+            name=name,
+            conf=conf,
+            scheduler_recipes=scheduler_recipes,
+        )
+
+    def expand(self):
+        """Enumerate :class:`RunSpec` instances over the full
+        cross-product of axes, in declaration order (outer-to-inner
+        per the dict insertion order).  Yields lazily.
+
+        Computes per-axis column widths (the longest formatted value
+        for each varying axis) and threads them into each RunSpec
+        so the dashboard's per-row axis summary renders in proper
+        columns, not just space-separated.
+
+        Resolves the per-run scheduler recipe via
+        :meth:`_resolve_recipe`: each run's ``scheduler`` axis
+        value (or the fixed ``scheduler``) is looked up in
+        ``scheduler_recipes`` from a TOML ``[[scheduler]]`` block;
+        if absent, a simple single-module recipe is synthesized
+        from the name and any ``scheduler_options``.  The recipe
+        rides on each :class:`RunSpec` so :meth:`RunSpec.argv` can
+        emit recipe-driven scheduler args without a back-reference
+        to the matrix.
+        """
+        if not self.axes:
+            raise ValueError("sweep has no axes; nothing to expand")
+        keys = list(self.axes.keys())
+        value_lists = [self.axes[k] for k in keys]
+        total = 1
+        for vl in value_lists:
+            if not vl:
+                raise ValueError(f"axis {keys[value_lists.index(vl)]!r} has no values")
+            total *= len(vl)
+        varying = self.varying_axes()
+        col_widths = _per_axis_column_widths(self.axes, varying)
+        for i, combo in enumerate(itertools.product(*value_lists)):
+            axes = dict(zip(keys, combo))
+            # Scheduler can come from axis or fixed; scheduler_options
+            # likewise.  Axis values shadow fixed values (the standard
+            # precedence used by argv()).
+            sched_name = axes.get("scheduler") or self.fixed.get("scheduler")
+            sched_opts = axes.get("scheduler_options") or self.fixed.get(
+                "scheduler_options"
+            )
+            recipe = self._resolve_recipe(sched_name, sched_opts) if sched_name else {}
+            yield RunSpec(
+                axes=axes,
+                fixed=self.fixed,
+                run_index=i,
+                total=total,
+                conf=list(self.conf),
+                varying_axes=varying,
+                axis_column_widths=col_widths,
+                scheduler_recipe=recipe,
+            )
+
+    def axes_summary(self):
+        """One-line description of the sweep's varying axes, for the
+        dashboard title.  Axes with a single value are
+        effectively-fixed and contribute nothing to comparing one
+        run against another, so they're omitted here to keep the
+        title line short enough to fit on narrow terminals."""
+        bits = []
+        for k, values in self.axes.items():
+            if len(values) <= 1:
+                continue
+            if len(values) <= 4:
+                bits.append(f"{k}={{{','.join(str(v) for v in values)}}}")
+            else:
+                bits.append(f"{k}={{{values[0]}…{values[-1]}, " f"n={len(values)}}}")
+        return " × ".join(bits) if bits else "(single configuration)"
+
+    def varying_axes(self):
+        """Set of axis names that have more than one value.  Passed
+        to :class:`RunSpec` instances by :meth:`expand` so the
+        dashboard's per-row axis summaries only show the axes that
+        actually distinguish one row from another."""
+        return {k for k, vl in self.axes.items() if len(vl) > 1}
+
+
+def _format_axis_value(k, v):
+    """Render one axis value the way :meth:`RunSpec.axis_summary`
+    will display it: bare for ``scheduler`` (no ``scheduler=`` and
+    no ``sched-`` prefix), ``key=value`` for everything else.
+
+    Used both by the per-row renderer and by
+    :func:`_per_axis_column_widths` to compute consistent column
+    widths from a matrix's full value lists.
+    """
+    if k == "scheduler" and isinstance(v, str):
+        return v.replace("sched-", "")
+    return f"{k}={v}"
+
+
+def _per_axis_column_widths(axes, varying):
+    """Compute the max formatted-value width for each varying axis,
+    given the matrix's full ``axes`` (axis name -> list of values).
+    Stored on each :class:`RunSpec` so per-row rendering can pad to
+    matching column widths."""
+    widths = {}
+    for k in varying:
+        widths[k] = max(
+            (len(_format_axis_value(k, v)) for v in axes[k]),
+            default=0,
+        )
+    return widths
+
+
+def _default_sweep_name():
+    """Generate a sweep name from the current timestamp.  Users
+    can override via ``--sweep-name`` or the file's ``name`` key."""
+    return f"sweep-{time.strftime('%Y%m%dT%H%M%S')}"
+
+
+def generate_sweep_id():
+    """Globally-unique id for one sweep invocation.  Used as the
+    primary key for cross-referencing runs in the results file."""
+    return (
+        f"sweep-{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}"
+        f"-{random.getrandbits(32):08x}"
+    )
+
+
+# ===========================================================
+# UI layer
+# ===========================================================
+
+# ANSI constants, glyph sets, and terminal helpers are shared with ui.py
+# via flux.testing.schedbench._ansi (imported at the top of this module).
+
+#: Layout knobs.  Mini progress bars in active rows are short — the
+#: row already carries identity + stage + count, so the bar is
+#: glanceable rather than the headline.
+_MINI_BAR_WIDTH = 11
+#: Match any ANSI CSI escape sequence (the only kind we emit:
+#: colors, cursor moves, line erase, DEC private modes).  Used by
+#: :func:`_truncate_visible` to ignore zero-width control bytes
+#: when measuring or trimming a line.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def _truncate_visible(s, width):
+    """Truncate ``s`` so its visible (escape-free) length is at most
+    ``width``, leaving any in-flight ANSI styling untouched.
+
+    Designed to prevent terminal line-wrap in the live dashboard.
+    A wrapped logical line becomes two visual rows, which throws off
+    the cursor-up bookkeeping used to overwrite previous frames and
+    causes them to stack vertically.
+
+    Naive single-pass: walk characters, preserve any ANSI escape we
+    encounter, count only non-escape characters against the budget.
+    Append a final ``\\x1b[0m`` reset if we may have truncated
+    inside an active styled span (the closing ``_RESET`` of that
+    span would otherwise be lost).
+    """
+    if not s:
+        return s
+    if len(_ANSI_RE.sub("", s)) <= width:
+        return s
+    out = []
+    visible = 0
+    saw_escape = False
+    i = 0
+    n = len(s)
+    while i < n and visible < width:
+        if s[i] == "\x1b":
+            m = _ANSI_RE.match(s, i)
+            if m:
+                out.append(m.group(0))
+                saw_escape = True
+                i = m.end()
+                continue
+        out.append(s[i])
+        visible += 1
+        i += 1
+    if saw_escape:
+        out.append(_RESET)
+    return "".join(out)
+
+
+def _fmt_elapsed(seconds):
+    """Compact mm:ss style for the active/elapsed columns."""
+    seconds = max(0.0, seconds)
+    m, s = divmod(int(seconds), 60)
+    return f"{m:d}m {s:02d}s"
+
+
+#: Maximum number of run rows visible in the unified list at once.
+#: For sweeps with more runs than this, the list windows around the
+#: active region with elision indicators above and below.  Chosen
+#: to leave room on a typical 24-row terminal for the title block,
+#: aggregate bar, and footer while still showing enough runs for
+#: context.
+_MAX_VISIBLE_RUNS = 12
+
+
+class _RunState:
+    """Per-run state for the unified-list dashboard.
+
+    Every run in the sweep gets exactly one ``_RunState`` instance,
+    created at sweep_start time with ``status="pending"`` and
+    updated in place as the run transitions through the lifecycle
+    (active -> done or failed).  The dashboard's per-row rendering
+    reads this state to choose glyph, color, and trailing content
+    — but the *row itself* never moves once assigned, which is the
+    whole point of the design.
+    """
+
+    __slots__ = (
+        "run_index",
+        "test_name",
+        "axes",
+        "status",
+        "stage",
+        "current",
+        "total",
+        "started_at",
+        "completed_at",
+        "metric_display",
+        "error_message",
+    )
+
+    def __init__(self, run_index, test_name, axes):
+        self.run_index = run_index
+        self.test_name = test_name
+        self.axes = dict(axes)
+        self.status = "pending"
+        self.stage = ""
+        self.current = 0
+        self.total = 0
+        self.started_at = None
+        self.completed_at = None
+        self.metric_display = ""
+        self.error_message = ""
+
+
+class TerminalSweepEmitter:
+    """Render sweep progress as a calm, professional dashboard.
+
+    The dashboard is a unified, ordered list of all runs in the
+    sweep — one row per run, glyph and trailing content evolving
+    in place as the run transitions pending -> active -> done (or
+    failed).  No section migrations, no row reordering, no
+    "completed" pane that shifts when something finishes; a run's
+    row is its row for the whole sweep.
+
+    For sweeps too large to fit on screen, the list windows around
+    the active region with elision indicators ("+ N earlier" /
+    "+ N later") at the boundaries.  Slides are infrequent —
+    usually one row at a time as the active frontier advances —
+    rather than every-transition churn.
+
+    Constructor args:
+        stream: output stream (default sys.stdout)
+        color: ``"auto"`` / ``"always"`` / ``"never"``
+        ascii_only: force ASCII glyphs and bar characters; auto-
+            detected from locale if omitted
+    """
+
+    def __init__(self, stream=None, color="auto", ascii_only=None):
+        self._stream = stream if stream is not None else sys.stdout
+        self._color = _color_supported(self._stream, color)
+        self._ascii = ascii_only if ascii_only is not None else not _safe_glyphs()
+        self._is_tty = _isatty(self._stream)
+        self._glyphs = _GLYPHS_ASCII if self._ascii else _GLYPHS_UNICODE
+        self._bar_chars = _BAR_CHARS_ASCII if self._ascii else _BAR_CHARS_UNICODE
+        self._sep = "-" if self._ascii else "·"
+
+        # Sweep-level state.
+        self._sweep_name = None
+        self._axes_summary = ""
+        self._total = 0
+        self._headline_metric_key = None
+        self._headline_metric_unit = ""
+
+        # Per-run state — the entire sweep's worth, populated at
+        # sweep_start.  Indexed by run_index; each entry is one
+        # _RunState that lives in its assigned row for the whole
+        # sweep.
+        self._all_runs = []
+
+        # Column layout for the tabular run list.  Set at
+        # sweep_start by :meth:`_compute_columns`.  Each entry is a
+        # dict: ``{name, header, width, align, getter}`` where
+        # ``getter(rs)`` returns the cell string for the given run.
+        # The STATUS column is special: it has no fixed width and
+        # composes its content dynamically based on rs.status.
+        self._columns = []
+
+        # Rendering state.
+        self._start_time = None
+        self._end_time = None
+        self._last_render_lines = 0
+        self._last_render_t = 0.0
+        self._cursor_hidden = False
+
+    # ----- Public surface (called by SweepRunner) -----
+
+    def sweep_start(
+        self,
+        name,
+        total,
+        axes_summary,
+        headline_metric=None,
+        axis_col_width=None,
+        max_active_visible=None,
+        run_summaries=None,
+    ):
+        """Initialize the dashboard for a new sweep.
+
+        Args:
+            name: human-readable sweep name (from --sweep-name or
+                generated default)
+            total: number of runs in the expansion
+            axes_summary: one-line description of axes (from
+                :meth:`SweepMatrix.axes_summary`)
+            headline_metric: ``(key, label, unit)`` triple naming
+                the per-row result metric.
+            axis_col_width: unused in the unified design (axis
+                columns size themselves per-axis).  Accepted for
+                signature back-compat.
+            max_active_visible: unused — the unified design shows
+                all active rows in their permanent positions,
+                bounded only by the visible window.  Accepted for
+                signature back-compat.
+            run_summaries: sequence of ``(test_name, axis_summary,
+                per_axis_values)`` tuples describing every run in
+                the sweep, in expansion order.  ``per_axis_values``
+                is the run's ``RunSpec.axes`` dict.  When supplied,
+                the dashboard pre-allocates a row per run and
+                computes accurate per-axis column widths up front.
+                If omitted, rows are added lazily as ``run_started``
+                fires (less ideal — the layout shifts the first
+                few times because column widths weren't known).
+        """
+        self._sweep_name = name
+        self._total = total
+        self._axes_summary = axes_summary
+        if headline_metric is not None:
+            key, _label, unit = headline_metric
+            self._headline_metric_key = key
+            self._headline_metric_unit = unit
+
+        # Pre-populate the run list from the dispatcher's manifest.
+        # Each tuple: (test_name, axes_dict).  axis_summary strings
+        # are no longer needed — the tabular renderer reads values
+        # directly from the axes dict per-column.
+        if run_summaries is not None:
+            self._all_runs = [
+                _RunState(i, test_name, axes_dict)
+                for i, (test_name, axes_dict) in enumerate(run_summaries)
+            ]
+            self._compute_columns(run_summaries)
+        else:
+            self._all_runs = []
+            self._columns = []
+
+        self._start_time = time.time()
+        if self._is_tty:
+            self._stream.write(_CURSOR_HIDE)
+            self._cursor_hidden = True
+        self._redraw(force=True)
+
+    def run_started(self, run_index, axis_summary, test_name):
+        # axis_summary is unused by the tabular renderer (it reads
+        # axes per-column from the pre-populated run state) but
+        # kept in the signature for back-compat with dispatchers
+        # that still pass it.
+        del axis_summary
+        rs = self._get_or_create_run(run_index, test_name)
+        rs.status = "active"
+        rs.started_at = time.time()
+        rs.stage = ""
+        rs.current = 0
+        rs.total = 0
+        self._redraw()
+
+    def run_event(self, run_index, event_name, ctx):
+        """Process a stage/progress event for an active run."""
+        if run_index >= len(self._all_runs):
+            return
+        rs = self._all_runs[run_index]
+        if rs.status != "active":
+            return
+        if event_name == "stage":
+            rs.stage = ctx.get("stage", "")
+            rs.current = 0
+            rs.total = 0
+        elif event_name == "progress":
+            rs.current = ctx.get("current", 0)
+            rs.total = ctx.get("total", 0)
+        self._redraw()
+
+    def run_completed(self, run_index, metrics):
+        if run_index >= len(self._all_runs):
+            return
+        rs = self._all_runs[run_index]
+        rs.status = "done"
+        rs.completed_at = time.time()
+        if self._headline_metric_key:
+            rs.metric_display = self._format_metric_value(
+                metrics.get(self._headline_metric_key)
+            )
+        self._redraw(force=True)
+
+    def run_failed(self, run_index, error):
+        if run_index >= len(self._all_runs):
+            return
+        rs = self._all_runs[run_index]
+        rs.status = "failed"
+        rs.completed_at = time.time()
+        rs.error_message = str(error).splitlines()[0] if error else "unknown error"
+        self._redraw(force=True)
+
+    def sweep_complete(self):
+        self._end_time = time.time()
+        self._redraw(force=True, final=True)
+        self._show_cursor()
+
+    # ----- Column / layout helpers -----
+
+    def _get_or_create_run(self, run_index, test_name):
+        """Lazy fallback when sweep_start didn't pre-populate the
+        run list.  Extends ``_all_runs`` to fit ``run_index``."""
+        while run_index >= len(self._all_runs):
+            i = len(self._all_runs)
+            self._all_runs.append(_RunState(i, "", {}))
+        rs = self._all_runs[run_index]
+        if not rs.test_name:
+            rs.test_name = test_name
+        return rs
+
+    def _compute_columns(self, run_summaries):
+        """Build the column layout from the full run manifest.
+
+        Columns:
+
+        * ``BENCHMARK`` — always present.  Width = max test-name
+          width across the sweep, padded to the header.
+        * One column per *varying* axis (axes with more than one
+          value across the sweep).  Effectively-fixed axes are
+          omitted since they'd be the same in every row.  Numeric
+          axes right-align; string axes left-align.  Column header
+          is the axis name uppercased.
+        * ``STATUS`` — the dynamic column.  No fixed width; its
+          content composes the lifecycle info (progress bar +
+          counts for active runs, the result for done runs, the
+          error for failed runs, nothing for pending).
+
+        Each column is a dict with the fields ``name``, ``header``,
+        ``width``, ``align``, and ``getter``.  ``getter`` is a
+        function that receives a ``_RunState`` and returns the cell
+        string for that row.  STATUS uses ``getter=None`` since its
+        content is composed dynamically by :meth:`_render_status_cell`.
+        """
+        # BENCHMARK column.
+        test_names = {t for t, _x in run_summaries}
+        test_width = max(
+            (len(t) for t in test_names),
+            default=0,
+        )
+        bench_width = max(test_width, len("BENCHMARK"))
+        self._columns = [
+            {
+                "name": "test",
+                "header": "BENCHMARK",
+                "width": bench_width,
+                "align": "left",
+                "getter": lambda rs: rs.test_name,
+            }
+        ]
+
+        # Discover varying axes from the manifest.  Preserve the
+        # axes' declaration order (first run's dict insertion
+        # order); that matches the CLI flag order the user typed.
+        if run_summaries:
+            axis_order = list(run_summaries[0][1].keys())
+        else:
+            axis_order = []
+        axis_value_sets = {k: set() for k in axis_order}
+        for _t, axes_dict in run_summaries:
+            for k, v in axes_dict.items():
+                axis_value_sets.setdefault(k, set()).add(v)
+                if k not in axis_order:
+                    axis_order.append(k)
+
+        for axis_name in axis_order:
+            values = axis_value_sets[axis_name]
+            if len(values) <= 1:
+                # Effectively-fixed across the sweep — no column.
+                continue
+            header = axis_name.upper()
+            value_widths = max(len(str(v)) for v in values)
+            width = max(value_widths, len(header))
+            is_numeric = all(
+                isinstance(v, (int, float)) and not isinstance(v, bool) for v in values
+            )
+            align = "right" if is_numeric else "left"
+            # Bind axis_name into the lambda's default arg to avoid
+            # late-binding closure pitfalls.
+            self._columns.append(
+                {
+                    "name": axis_name,
+                    "header": header,
+                    "width": width,
+                    "align": align,
+                    "getter": lambda rs, k=axis_name: str(rs.axes.get(k, "")),
+                }
+            )
+
+        # STATUS column — no fixed width; renders dynamically.
+        self._columns.append(
+            {
+                "name": "status",
+                "header": "STATUS",
+                "width": 0,
+                "align": "left",
+                "getter": None,
+            }
+        )
+
+    # ----- Rendering -----
+
+    def _show_cursor(self):
+        if self._cursor_hidden and self._is_tty:
+            self._stream.write(_CURSOR_SHOW)
+            self._stream.flush()
+            self._cursor_hidden = False
+
+    def _redraw(self, force=False, final=False):
+        now = time.time()
+        if not force and (now - self._last_render_t) < _REDRAW_INTERVAL_S:
+            return
+        self._last_render_t = now
+
+        lines = self._render_lines()
+        new_count = len(lines)
+        width = self._term_width()
+
+        # Pad shrinking frames so trailing lines from the prior
+        # frame get scrubbed by _ERASE_TO_EOL.
+        emitted_count = max(new_count, self._last_render_lines)
+        if new_count < emitted_count:
+            lines = lines + [""] * (emitted_count - new_count)
+
+        # Truncate each line to the terminal width so it never
+        # wraps to a second visual row.  Logical-line wrap would
+        # make our cursor-up count (in logical lines) drift below
+        # what the cursor actually needs to traverse (visual lines),
+        # producing the frame-stacking glitch on narrow terminals.
+        # Leave one column of slack for terminals that consider a
+        # cursor at column == width to be on the next line already.
+        lines = [_truncate_visible(line, width - 1) for line in lines]
+
+        parts = []
+        if self._is_tty:
+            parts.append(_SYNC_BEGIN)
+            if self._last_render_lines > 0:
+                parts.append(_CURSOR_UP_FMT.format(self._last_render_lines))
+        parts.append("\n".join(line + _ERASE_TO_EOL for line in lines))
+        parts.append("\n")
+        if self._is_tty:
+            parts.append(_SYNC_END)
+
+        self._stream.write("".join(parts))
+        self._stream.flush()
+        # Track EMITTED count (including padding) — next frame's
+        # cursor-up must rewind over everything we actually wrote,
+        # not just the logical-content count.
+        self._last_render_lines = emitted_count
+
+    def _c(self, code, text):
+        return code + text + _RESET if self._color else text
+
+    def _term_width(self):
+        try:
+            return max(40, os.get_terminal_size(self._stream.fileno()).columns)
+        except (AttributeError, ValueError, OSError):
+            return 100
+
+    def _render_lines(self):
+        out = []
+        width = self._term_width()
+        sep = self._sep
+
+        # Header.
+        title = (
+            self._c(_BOLD, "flux schedbench sweep")
+            + " "
+            + sep
+            + " "
+            + (self._sweep_name or "")
+        )
+        out.append(title)
+        if self._axes_summary:
+            out.append(self._c(_DIM, f"  {self._axes_summary}"))
+        out.append("")
+
+        # Aggregate progress bar with inline stats.
+        out.append("  " + self._render_aggregate_bar(width))
+        out.append("")
+
+        # Column header row.
+        out.append(self._render_header_row())
+
+        # Unified run list.  Window around the active region for
+        # large sweeps; show all rows otherwise.
+        ellipsis = "..." if self._ascii else "⋯"
+        visible, n_above, n_below = self._select_visible_runs()
+        if n_above > 0:
+            out.append(
+                self._c(
+                    _DIM,
+                    f"   {ellipsis}  {n_above} earlier",
+                )
+            )
+        for rs in visible:
+            out.append(self._render_run_row(rs))
+        if n_below > 0:
+            out.append(
+                self._c(
+                    _DIM,
+                    f"   {ellipsis}  {n_below} more pending",
+                )
+            )
+
+        # Footer when complete.
+        if self._end_time is not None:
+            out.append("")
+            out.append(self._render_final_footer())
+
+        return out
+
+    def _render_header_row(self):
+        """Render the column header line in dim bold.
+
+        Layout matches :meth:`_render_run_row` exactly so columns
+        line up: glyph-column placeholder (3 chars), then each
+        column header padded to its width with 2-char separators.
+        """
+        parts = ["    "]  # placeholder for the glyph column
+        for col in self._columns:
+            if col["name"] == "status":
+                header_text = col["header"]
+            elif col["align"] == "right":
+                header_text = col["header"].rjust(col["width"])
+            else:
+                header_text = col["header"].ljust(col["width"])
+            parts.append(self._c(_BOLD, self._c(_DIM, header_text)))
+            parts.append("  ")
+        return "".join(parts).rstrip()
+
+    def _render_run_row(self, rs):
+        """Render one run's tabular row.  The glyph column carries
+        the lifecycle state (color-coded); the data columns hold
+        per-axis values; the STATUS column composes lifecycle
+        content dynamically."""
+        parts = [f"  {self._glyph_for(rs.status)} "]
+        for col in self._columns:
+            if col["name"] == "status":
+                parts.append(self._render_status_cell(rs))
+            else:
+                value = col["getter"](rs)
+                if col["align"] == "right":
+                    parts.append(value.rjust(col["width"]))
+                else:
+                    parts.append(value.ljust(col["width"]))
+            parts.append("  ")
+        return "".join(parts).rstrip()
+
+    def _render_status_cell(self, rs):
+        """Compose the STATUS column's content based on the run's
+        lifecycle state.  Pending = empty (visual quiet); active =
+        stage + mini bar + count + elapsed; done = the result;
+        failed = the error message."""
+        if rs.status == "active":
+            stage_col = (rs.stage or "").ljust(8)
+            bar = self._render_mini_bar(rs.current, rs.total)
+            count = (f"{rs.current}/{rs.total}" if rs.total > 0 else "").rjust(9)
+            elapsed_s = time.time() - rs.started_at if rs.started_at else 0
+            elapsed = _fmt_elapsed(elapsed_s)
+            return f"{stage_col}  {bar}  {count}  {elapsed}"
+        if rs.status == "done":
+            return self._c(_FG_GREEN, rs.metric_display)
+        if rs.status == "failed":
+            return self._c(_FG_RED, f"error: {rs.error_message}")
+        return ""  # pending
+
+    def _select_visible_runs(self):
+        """Choose which subset of ``_all_runs`` to display.
+
+        Returns ``(visible_runs, n_elided_above, n_elided_below)``.
+
+        For sweeps with at most ``_MAX_VISIBLE_RUNS`` runs, returns
+        everything.  For larger sweeps, picks a contiguous window
+        with one critical constraint: **every active row must be
+        visible**.  This matters for parallel dispatch — without
+        it, a slow earlier run anchors the window on itself and
+        later-but-actively-running siblings disappear into the
+        bottom elision (the "more pending" group), even though
+        they're not pending at all.
+
+        When active rows fit within the budget, the window adds
+        context biased ~2/3 below / 1/3 above so the user sees
+        forward motion.  When the active span itself exceeds the
+        budget (a slow earlier run plus active later ones, with
+        many intervening completed rows), the window grows to
+        cover them all — exceeding _MAX_VISIBLE_RUNS in that
+        uncommon case, which is the right tradeoff: showing all
+        in-progress work beats clamping to a fixed row count.
+        """
+        n = len(self._all_runs)
+        if n <= _MAX_VISIBLE_RUNS:
+            return self._all_runs, 0, 0
+
+        active_indices = [
+            i for i, rs in enumerate(self._all_runs) if rs.status == "active"
+        ]
+
+        if active_indices:
+            first_active = active_indices[0]
+            last_active = active_indices[-1]
+            span = last_active - first_active + 1
+            if span >= _MAX_VISIBLE_RUNS:
+                # Active region alone fills the budget.  Show
+                # exactly that span — completed rows interleaved
+                # between active ones come along for the ride.
+                start = first_active
+                end = last_active + 1
+            else:
+                # Active rows fit; remaining slots are context.
+                # 1/3 above the first active row, 2/3 below the
+                # last — biased toward upcoming work.
+                budget = _MAX_VISIBLE_RUNS - span
+                before = min(first_active, budget // 3)
+                start = max(0, first_active - before)
+                end = min(n, start + _MAX_VISIBLE_RUNS)
+                if end - start < _MAX_VISIBLE_RUNS:
+                    # Near the end of the matrix; pull start
+                    # back so the window stays full.
+                    start = max(0, end - _MAX_VISIBLE_RUNS)
+            return self._all_runs[start:end], start, n - end
+
+        # No active runs (between submissions or post-sweep):
+        # anchor on the next pending row, or the end if all done.
+        anchor = None
+        for i, rs in enumerate(self._all_runs):
+            if rs.status == "pending":
+                anchor = i
+                break
+        if anchor is None:
+            anchor = n - 1
+        anchor_pos_in_window = _MAX_VISIBLE_RUNS // 3
+        start = max(0, anchor - anchor_pos_in_window)
+        end = min(n, start + _MAX_VISIBLE_RUNS)
+        start = max(0, end - _MAX_VISIBLE_RUNS)
+        return self._all_runs[start:end], start, n - end
+
+    def _glyph_for(self, status):
+        """Glyph + color for a run's lifecycle state.  Pending is
+        dim (de-emphasized), active is bright cyan (the eye's focus
+        target during a sweep), done is green, failed is red."""
+        g = self._glyphs
+        if status == "active":
+            return self._c(_FG_CYAN, g["active"])
+        if status == "done":
+            return self._c(_FG_GREEN, g["done"])
+        if status == "failed":
+            return self._c(_FG_RED, g["failed"])
+        # pending
+        return self._c(_DIM, g["pending"])
+
+    def _render_aggregate_bar(self, width):
+        """Aggregate bar with inline counts and elapsed time.
+        Single line at the top of the dashboard — the at-a-glance
+        "how is the sweep going" indicator."""
+        fill, empty = self._bar_chars
+        n_done = sum(1 for rs in self._all_runs if rs.status == "done")
+        n_failed = sum(1 for rs in self._all_runs if rs.status == "failed")
+        completed = n_done + n_failed
+        total = max(1, self._total)
+        bar_width = max(20, min(width - 50, 50))
+        ratio = completed / total
+        filled = int(round(ratio * bar_width))
+        bar_str = fill * filled + empty * (bar_width - filled)
+        pct = int(ratio * 100)
+        color = (
+            _FG_GREEN
+            if completed == self._total and n_failed == 0
+            else (_FG_RED if n_failed else _FG_CYAN)
+        )
+        # Compose the inline stats: "X/N (P%)  elapsed  failed-if-any"
+        stats = f"  {completed}/{self._total} ({pct}%)"
+        if self._start_time is not None:
+            elapsed = (
+                self._end_time if self._end_time else time.time()
+            ) - self._start_time
+            stats += "  " + self._c(_DIM, _fmt_elapsed(elapsed))
+        if n_failed > 0:
+            stats += "  " + self._c(
+                _FG_RED, f"{self._glyphs['failed']} {n_failed} failed"
+            )
+        return self._c(color, bar_str) + stats
+
+    def _render_mini_bar(self, current, total):
+        fill, empty = self._bar_chars
+        if total <= 0:
+            return self._c(_DIM, empty * _MINI_BAR_WIDTH)
+        ratio = min(1.0, current / total)
+        filled = int(round(ratio * _MINI_BAR_WIDTH))
+        bar = fill * filled + empty * (_MINI_BAR_WIDTH - filled)
+        return self._c(_FG_CYAN, bar)
+
+    def _format_metric_value(self, value):
+        """Format the per-row headline metric for the dashboard.
+
+        Renders as ``result=N [unit]`` regardless of which underlying
+        metric the benchmark designates as its headline.  Uniform
+        display lets the user scan across rows (and across mixed-
+        test sweeps) without tracking which column means what.
+
+        Uses integer-with-commas for any magnitude ≥ 1, three
+        decimals for sub-1 ratios, scientific notation below
+        0.001.
+        """
+        if value is None:
+            return ""
+        try:
+            v = float(value)
+        except (TypeError, ValueError):
+            return f"result={value}"
+        av = abs(v)
+        if av >= 1:
+            num = f"{v:,.0f}"
+        elif av >= 0.001:
+            num = f"{v:.3f}"
+        else:
+            num = f"{v:.2e}"
+        unit = self._headline_metric_unit
+        if unit:
+            return f"result={num} {unit}"
+        return f"result={num}"
+
+    def _counts(self):
+        """Return ``(n_done, n_failed, n_active, n_pending)`` from
+        the unified run list."""
+        n_done = 0
+        n_failed = 0
+        n_active = 0
+        for rs in self._all_runs:
+            if rs.status == "done":
+                n_done += 1
+            elif rs.status == "failed":
+                n_failed += 1
+            elif rs.status == "active":
+                n_active += 1
+        n_pending = self._total - n_done - n_failed - n_active
+        return n_done, n_failed, n_active, max(0, n_pending)
+
+    def _render_final_footer(self):
+        n_done, n_failed, _n_active, _n_pending = self._counts()
+        completed = n_done + n_failed
+        elapsed = (self._end_time or time.time()) - (self._start_time or 0)
+        line = (
+            f"  {completed}/{self._total} complete · "
+            f"{n_failed} failed · {_fmt_elapsed(elapsed)} elapsed"
+        )
+        return self._c(_BOLD, line)
+
+
+class LineSweepEmitter:
+    """Plain-text sweep emitter for non-TTY output.
+
+    One line per significant state transition: sweep start, run
+    start, run completion (with headline metric), run failure
+    (with brief error), and a closing summary line.  Per-run
+    progress events from child runs are dropped — line-per-run is
+    the level of detail this mode aims for.
+
+    Sweep is the top-level tool, so we don't bother emitting a
+    structured event stream from it: there is nothing above sweep
+    that would consume one.  Anything that wants the full event
+    stream of an individual benchmark should run ``flux schedbench
+    run`` directly with ``--ui=off``.
+    """
+
+    def __init__(self, stream=None):
+        self._stream = stream if stream is not None else sys.stderr
+        self._total = 0
+        self._sweep_name = None
+        self._headline_metric_key = None
+        self._headline_metric_unit = ""
+        self._n_ok = 0
+        self._n_failed = 0
+        self._start_time = None
+
+    def _line(self, text):
+        print(text, file=self._stream, flush=True)
+
+    # --- Public surface (matches TerminalSweepEmitter) ---
+
+    def sweep_start(
+        self,
+        name,
+        total,
+        axes_summary,
+        headline_metric=None,
+        axis_col_width=None,
+        max_active_visible=None,
+        run_summaries=None,
+    ):
+        # axis_col_width, max_active_visible, and run_summaries
+        # are dashboard layout concerns; the line emitter has none
+        # of those.  Accepted for interface parity with
+        # TerminalSweepEmitter so the dispatcher can call either
+        # without branching.
+        self._sweep_name = name
+        self._total = total
+        if headline_metric:
+            self._headline_metric_key = headline_metric[0]
+            self._headline_metric_unit = headline_metric[2]
+        self._start_time = time.time()
+        self._line(f"sweep {name}: {total} runs · {axes_summary}")
+
+    def run_started(self, run_index, axis_summary, test_name):
+        self._line(
+            f"  [{run_index + 1:>{len(str(self._total))}}/"
+            f"{self._total}] start  {test_name}  {axis_summary}"
+        )
+
+    def run_event(self, run_index, event_name, ctx):
+        pass  # per-child progress is not surfaced in line mode
+
+    def run_completed(self, run_index, metrics):
+        self._n_ok += 1
+        metric_str = self._format_metric(metrics)
+        self._line(
+            f"  [{run_index + 1:>{len(str(self._total))}}/"
+            f"{self._total}] ok     {metric_str}"
+        )
+
+    def run_failed(self, run_index, error):
+        self._n_failed += 1
+        msg = str(error).splitlines()[0] if error else "unknown"
+        self._line(
+            f"  [{run_index + 1:>{len(str(self._total))}}/"
+            f"{self._total}] FAIL   error: {msg}"
+        )
+
+    def sweep_complete(self):
+        elapsed = time.time() - (self._start_time or time.time())
+        self._line(
+            f"sweep {self._sweep_name}: {self._n_ok} ok, "
+            f"{self._n_failed} failed, {elapsed:.1f}s elapsed"
+        )
+
+    def _format_metric(self, metrics):
+        """See :meth:`TerminalSweepEmitter._format_metric_value` for
+        the rationale.  Renders as ``result=N [unit]`` so the line
+        log reads uniformly across benchmarks."""
+        if not self._headline_metric_key or not metrics:
+            return ""
+        v = metrics.get(self._headline_metric_key)
+        if v is None:
+            return ""
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            return f"result={v}"
+        av = abs(f)
+        if av >= 1:
+            num = f"{f:,.0f}"
+        elif av >= 0.001:
+            num = f"{f:.3f}"
+        else:
+            num = f"{f:.2e}"
+        if self._headline_metric_unit:
+            return f"result={num} {self._headline_metric_unit}"
+        return f"result={num}"
+
+
+# ===========================================================
+# Dispatch layer
+# ===========================================================
+
+
+def _pick_headline_metric(bench_cls):
+    """Choose the per-row headline metric for the sweep dashboard.
+
+    Prefers an explicit ``RESULT`` declaration on the benchmark
+    class — a ``(key, unit)`` tuple naming the canonical outcome.
+    Example declarations:
+
+    .. code-block:: python
+
+        class Throughput(Benchmark):
+            RESULT = ("throughput", "job/s")
+
+        class FillMachine(Benchmark):
+            RESULT = ("alloc_rate", "job/s")
+
+        class Locality(Benchmark):
+            RESULT = ("mean_locality_score", "")    # dimensionless
+
+    The sweep renders all benchmarks uniformly as ``result=N unit``
+    so a mixed-test sweep can be scanned in one glance — the user
+    doesn't have to track which column shows what.
+
+    Falls back to a heuristic pick from ``SUMMARY_METRICS`` (first
+    entry whose unit isn't ``"count"``) for benchmarks that haven't
+    declared ``RESULT`` yet.  Returns ``(key, label, unit)`` or
+    ``None``.
+    """
+    result = getattr(bench_cls, "RESULT", None)
+    if result is not None:
+        key = result[0]
+        unit = result[1] if len(result) > 1 else ""
+        # Synthesize a (key, label, unit) triple so the rest of
+        # the dashboard code can treat RESULT and SUMMARY_METRICS
+        # interchangeably.  The label is unused by the sweep
+        # display itself (we render as "result=N") but is kept
+        # populated for consistency with the existing shape.
+        return (key, key, unit)
+    metrics = getattr(bench_cls, "SUMMARY_METRICS", None) or []
+    if not metrics:
+        return None
+    for entry in metrics:
+        if len(entry) >= 3 and entry[2] != "count":
+            return entry
+    return metrics[0]
+
+
+def _prep_emitter_sweep_start(matrix, runs, emitter, max_active_visible):
+    """Common sweep_start setup shared by serial and Flux dispatch.
+
+    Computes the headline metric and identity column width from the
+    expanded run set and fires :meth:`sweep_start` on the emitter
+    with a full manifest so it can pre-allocate rows + columns.
+    """
+    bench_cls = BENCHMARKS.get(runs[0].test_name())
+    headline = _pick_headline_metric(bench_cls)
+    axis_col_width = min(
+        max(len(f"{r.test_name()}  {r.axis_summary()}") for r in runs),
+        60,
+    )
+    emitter.sweep_start(
+        name=matrix.name,
+        total=len(runs),
+        axes_summary=matrix.axes_summary(),
+        headline_metric=headline,
+        axis_col_width=axis_col_width,
+        max_active_visible=max_active_visible,
+        run_summaries=[(r.test_name(), r.axes) for r in runs],
+    )
+
+
+def run_flux(
+    matrix, sweep_id, results_file, emitter, flux_schedbench_cmd=None, per_run_nodes=1
+):
+    """Run a sweep by submitting each run as a Flux job.
+
+    The outer Flux instance handles scheduling: all jobs are
+    submitted up front and Flux runs them in parallel up to
+    whatever resources are available.  No sweep-level concurrency
+    cap — that's Flux's job by design.
+
+    Uses a single :class:`flux.job.JobWatcher` for all submitted
+    jobs (the class that powers ``flux submit --watch`` and
+    ``flux bulksubmit --watch``).  Output is consumed via
+    JobWatcher's ``output_callback`` API: the watcher invokes
+    ``on_output(jobid, stream, data)`` with raw output chunks,
+    which the sweep buffers per (jobid, stream) and parses as
+    one JSON event per complete line.  We submit children with
+    ``unbuffered=True`` so events surface live in the dashboard
+    rather than being held in the child's stdio buffer; the
+    consumer-side line buffering compensates for the resulting
+    chunk-boundary uncertainty.
+
+    Per-job lifecycle state (running, complete, failed) is read
+    from the watcher's internal :class:`JobProgressBar.jobs` dict
+    after :meth:`reactor_run` returns — JobWatcher uses this dict
+    for its own tracking regardless of whether the progress bar
+    itself is displayed.
+
+    Args:
+        matrix: :class:`SweepMatrix` (already expanded by the caller)
+        sweep_id: unique sweep identifier; embedded in every record
+        results_file: path to append records to (None = don't save)
+        emitter: dashboard / event sink
+        flux_schedbench_cmd: command prefix for each child;
+            defaults to ``["flux", "schedbench"]``
+        per_run_nodes: nodes to allocate to each child Flux job.
+            Defaults to 1 (enough for fake-resources benchmarks).
+
+    Returns ``(n_ok, n_failed)``.
+    """
+    # Deferred imports — only the Flux dispatch path needs the
+    # Python bindings.
+    import flux
+    import flux.job
+    from flux.job import JobWatcher
+
+    if flux_schedbench_cmd is None:
+        flux_schedbench_cmd = ["flux", "schedbench"]
+    # Raises ConnectionError or similar if no broker — by design:
+    # let the real Flux error surface rather than pre-flighting.
+    handle = flux.Flux()
+    runs = list(matrix.expand())
+    _prep_emitter_sweep_start(
+        matrix,
+        runs,
+        emitter,
+        max_active_visible=min(len(runs), 8),
+    )
+    saver = BenchmarkResults(results_file) if results_file else None
+
+    counters = {"n_ok": 0, "n_failed": 0}
+
+    # Per-job state keyed by ``int(jobid)`` for the output callback
+    # lookup.  Insertion order is preserved (3.7+ dict ordering),
+    # so iterating gives submission order.  The ``jobid`` field
+    # carries the original JobID object — needed by
+    # ``watcher.add_jobid`` and not derivable from the int key.
+    state_by_jobid = {}
+
+    for rs in runs:
+        argv = _build_child_argv(rs, flux_schedbench_cmd)
+        # Job name shows up in `flux jobs` output for in-flight
+        # debugging.  sweep_id alone is ambiguous (every run in
+        # the sweep would share it), so include the run index too.
+        job_name = f"schedbench-{sweep_id}-{rs.run_index}"
+        try:
+            jobspec = _build_sweep_jobspec(
+                argv,
+                per_run_nodes,
+                job_name,
+                env_rules=(rs.scheduler_recipe or {}).get("env", []),
+            )
+            jobid = flux.job.submit(handle, jobspec)
+        except Exception as exc:  # noqa: BLE001
+            err = f"submit failed: {exc}"
+            emitter.run_failed(rs.run_index, err)
+            counters["n_failed"] += 1
+            _save_record(saver, rs, sweep_id, matrix.name, None, None, err)
+            continue
+        state_by_jobid[int(jobid)] = {
+            "rs": rs,
+            "jobid": jobid,
+            "started_signaled": False,
+            "completed_signaled": False,
+            "config": None,
+            "metrics": None,
+            "error": None,
+        }
+
+    # If every submit failed, nothing to watch.
+    if not state_by_jobid:
+        emitter.sweep_complete()
+        return counters["n_ok"], counters["n_failed"]
+
+    # Per-(jobid, stream) partial-line buffer.  Required because
+    # we submit with unbuffered=True (so events surface live in
+    # the dashboard), which means JobWatcher may hand us chunks
+    # that span line boundaries.
+    output_partial = {}
+
+    def on_output(jobid, stream, data):
+        """JobWatcher output callback: invoked with raw chunks of
+        child output.  We buffer per (jobid, stream) and dispatch
+        one parsed event per complete line.  At EOF, JobWatcher
+        invokes us with ``stream=None`` — we flush any remaining
+        partial line then.
+        """
+        state = state_by_jobid.get(int(jobid))
+        if state is None:
+            return
+        if stream is None:
+            for stream_name in ("stdout", "stderr"):
+                key = (int(jobid), stream_name)
+                tail = output_partial.pop(key, "")
+                if tail:
+                    _route_line(state, tail)
+            return
+        key = (int(jobid), stream)
+        buf = output_partial.get(key, "") + data
+        lines = buf.split("\n")
+        # Trailing element is the incomplete tail (or "" if data
+        # ended on a newline) — stash for the next call.
+        output_partial[key] = lines[-1]
+        for line in lines[:-1]:
+            _route_line(state, line)
+
+    def _route_line(state, line):
+        """Process one complete line of child output.
+
+        Fires :meth:`run_started` on the first line seen.  Parses
+        the line as a JSON event and hands it to
+        :func:`_apply_child_event`, then checks whether a
+        ``result`` event was just persisted — if so, fires
+        :meth:`run_completed` live so the dashboard row flips
+        green as soon as the benchmark finishes (without waiting
+        for every other run in the sweep).
+        """
+        rs = state["rs"]
+        if not state["started_signaled"]:
+            state["started_signaled"] = True
+            emitter.run_started(
+                rs.run_index,
+                rs.axis_summary(),
+                rs.test_name(),
+            )
+        line = line.strip()
+        if not line:
+            return
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            # Non-JSON output (shouldn't happen with --ui=off but
+            # be defensive — e.g. stderr noise from the child).
+            return
+        _apply_child_event(event, state, rs.run_index, emitter)
+        # Live completion: the `result` event is the signal that
+        # the benchmark finished successfully and metrics are
+        # available.  Fire immediately so the dashboard updates
+        # while the rest of the sweep continues, rather than
+        # waiting for the post-reactor finalize loop.
+        if state["metrics"] is not None and not state["completed_signaled"]:
+            state["completed_signaled"] = True
+            emitter.run_completed(rs.run_index, state["metrics"])
+            counters["n_ok"] += 1
+            _save_record(
+                saver,
+                rs,
+                sweep_id,
+                matrix.name,
+                state["metrics"],
+                state["config"],
+                None,
+            )
+
+    # Single JobWatcher for the whole sweep.  No progress bar — we
+    # have our own dashboard.  output_callback replaces the
+    # stdout/stderr file routing entirely (see watcher.py: when
+    # output_callback is set, lines are dispatched through it
+    # instead of being written to the configured streams).
+    watcher = JobWatcher(
+        handle,
+        watch=True,
+        progress=False,
+        output_callback=on_output,
+    )
+    for state in state_by_jobid.values():
+        watcher.add_jobid(state["jobid"])
+
+    # JobWatcher hooks itself into the reactor via event_watch_async
+    # when jobs are added; reactor_run blocks until all watched
+    # jobs reach the wait event ("clean" by default — fully exited
+    # and KVS cleaned up).
+    handle.reactor_run()
+
+    # Finalize: any state that hasn't already signaled completion
+    # is a failure — either no ``result`` event was emitted, the
+    # child reported ``test.error`` explicitly, or the job's
+    # eventlog ended in a non-clean state (jobstatus.status
+    # reflects what JobWatcher saw on the eventlog).  Successful
+    # runs already fired :meth:`run_completed` live from
+    # :func:`_route_line` when the result event arrived.
+    for jobid_obj, jobstatus in watcher.progress.jobs.items():
+        state = state_by_jobid.get(int(jobid_obj))
+        if state is None or state["completed_signaled"]:
+            continue
+        rs = state["rs"]
+        if state["error"]:
+            err = state["error"]
+        elif jobstatus.status == "failed":
+            err = f"job failed (exitcode {jobstatus.exitcode})"
+        else:
+            err = "child produced no result event"
+        emitter.run_failed(rs.run_index, err)
+        counters["n_failed"] += 1
+        _save_record(saver, rs, sweep_id, matrix.name, None, state["config"], err)
+
+    emitter.sweep_complete()
+    return counters["n_ok"], counters["n_failed"]
+
+
+def _build_sweep_jobspec(argv, num_nodes, name, env_rules=None):
+    """Construct a JobspecV1 for one sweep child via the
+    :meth:`JobspecV1.from_submit` interface — the same constructor
+    used elsewhere in schedbench so all option-handling is
+    consistent with the ``flux submit`` CLI.
+
+    Each child runs as a single task on one allocated node with
+    exclusive access; the child schedbench process itself spawns
+    a subinstance (``flux start``) inside that allocation, so we
+    don't need many cores at the outer-job level.  ``cwd`` is
+    inherited from the sweep process so the child sees the same
+    PATH / PYTHONPATH / FLUX_*_PATH.
+
+    ``env_rules`` is a list of :meth:`from_submit`-style env
+    filter rules (``"VAR=VAL"`` / ``"VAR"`` / ``"-PATTERN"`` /
+    ``"^/path"``).  ``from_submit`` imports the submitter env by
+    default and applies these as additive / subtractive overlays
+    — recipe-added variables compose with the existing
+    environment instead of replacing it, and ``"VAR=$OTHER..."``
+    rules expand against the env built so far.  ``None`` or empty
+    means no rules — full submitter env passes through.
+
+    ``unbuffered=True`` is essential: the child emits one JSON
+    event per line on stdout, and Python's default block buffering
+    on non-TTY stdout would delay events until each buffer fills
+    — defeating the point of live JobWatcher output streaming.
+    With unbuffered set, each event surfaces in the sweep
+    dashboard as soon as the child emits it.
+
+    ``name`` shows up in ``flux jobs`` output so individual sweep
+    children are identifiable while the sweep is running (useful
+    for debugging hangs and for targeted cancellation).
+    """
+    from flux.job import JobspecV1
+
+    kwargs = dict(
+        ntasks=1,
+        nodes=num_nodes,
+        cores_per_task=1,
+        exclusive=True,
+        cwd=os.getcwd(),
+        unbuffered=True,
+        name=name,
+    )
+    if env_rules:
+        kwargs["env"] = list(env_rules)
+    return JobspecV1.from_submit(argv, **kwargs)
+
+
+def _build_child_argv(rs, flux_schedbench_cmd):
+    """Construct argv for one child run.  Forces ``--ui=off`` and
+    ``-v`` (verbose) so we get the full event stream including
+    progress, and ``--no-save`` so the sweep is the authority on
+    what lands in the results file.
+
+    ``flux_schedbench_cmd`` is a list of tokens — typically
+    ``["flux", "schedbench"]`` — that prefixes the child invocation.
+    """
+    argv = list(flux_schedbench_cmd) + rs.argv()
+    argv.extend(["--ui=off", "-v", "--no-save"])
+    return argv
+
+
+def _apply_child_event(event, state, run_index, emitter):
+    """Apply one parsed JSON event from a child's TestEventEmitter
+    to per-run ``state``.  Dispatches ``stage`` / ``progress``
+    events to the emitter immediately; ``test.start`` / ``result``
+    / ``test.error`` get persisted into the state dict (keys
+    ``config`` / ``metrics`` / ``error``).  Used by both the
+    serial dispatcher (with a local dict) and the Flux dispatcher
+    (with the per-job state dict).
+    """
+    name = event.get("name", "")
+    ctx = event.get("context", {})
+    if name in ("stage", "progress"):
+        emitter.run_event(run_index, name, ctx)
+    elif name == "test.start":
+        state["config"] = ctx.get("config")
+    elif name == "result":
+        state["metrics"] = ctx.get("metrics") or {}
+    elif name == "test.error":
+        state["error"] = ctx.get("error") or "child reported error"
+    # test.complete: nothing to do here; the dispatchers detect
+    # completion via either the result event (live) or stream-EOF /
+    # eventlog FINISH (in finalization).
+
+
+def _save_record(saver, rs, sweep_id, sweep_name, metrics, config, error):
+    """Build and persist a record for one run.  No-op when
+    ``saver`` is ``None`` (e.g. ``--no-save`` and in-memory test
+    cases) so callers don't need to repeat the if-saver-then guard
+    around every outcome.
+    """
+    if saver is None:
+        return
+    saver.add_run(
+        _build_record(
+            rs,
+            sweep_id,
+            sweep_name,
+            metrics,
+            config,
+            error,
+        )
+    )
+    saver.save()
+
+
+def _build_record(rs, sweep_id, sweep_name, metrics, config, error):
+    """Assemble the JSON record for one sweep run.
+
+    Mirrors the shape of single-run records produced by
+    :func:`flux-schedbench._run_record` so the report tool sees a
+    uniform schema, with an additional ``sweep`` sub-object carrying
+    the run's matrix position.  Resources / scheduler details come
+    from the child's ``test.start`` config (captured during the
+    event-stream parse) — no second broker query required.
+
+    Errored runs get the same record shell with ``metrics=None`` and
+    an ``error`` field; downstream the report tool can filter them
+    out via ``--filter`` or surface them explicitly.
+    """
+    test_name = rs.test_name()
+    cfg = config or {}
+    resources = {
+        "nodes": cfg.get("nodes", ""),
+        "cores_per_node": cfg.get("cores_per_node", ""),
+        "gpus_per_node": cfg.get("gpus_per_node", ""),
+        "hwloc_xml_path": (
+            rs.fixed.get("hwloc_xml_path", "") or rs.axes.get("hwloc_xml_path", "")
+        ),
+        "amend_r": (rs.fixed.get("amend_r", "") or rs.axes.get("amend_r", "")),
+    }
+    record = {
+        "test_name": test_name,
+        "tag": rs.fixed.get("tag", ""),
+        "host": socket.gethostname(),
+        "user": getpass.getuser(),
+        "schedbench_version": "0.1.0",
+        "flux_core_version": None,
+        "real_exec": cfg.get("real_exec", False),
+        "scheduler": {
+            "name": cfg.get("scheduler", ""),
+            "options": (
+                rs.fixed.get("scheduler_options", "")
+                or rs.axes.get("scheduler_options", "")
+            ),
+            "version": None,
+        },
+        "resources": resources,
+        "watcher": cfg.get("watcher", ""),
+        "benchmarks": {
+            test_name: {
+                # The full test.start config dict — duplicates the
+                # values used to populate top-level resources /
+                # scheduler / etc., plus the per-benchmark fields
+                # (njobs, slot_cores, slot_gpus, ...) that aren't
+                # represented at the top level.  Persisting it here
+                # lets the report tool surface config-only fields on
+                # rows whose ``results`` are absent (e.g. an
+                # OOM-killed run that never emitted ``result``).
+                "config": dict(cfg),
+                "results": metrics if metrics is not None else {},
+            },
+        },
+        "sweep": {
+            "id": sweep_id,
+            "name": sweep_name,
+            "run_index": rs.run_index,
+            "total": rs.total,
+            "axes": rs.axes,
+            "fixed": rs.fixed,
+        },
+    }
+    if error is not None:
+        record["error"] = error
+    return record
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/testing/schedbench/ui.py
+++ b/src/bindings/python/flux/testing/schedbench/ui.py
@@ -1,0 +1,682 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Terminal UI emitter for flux-schedbench.
+
+Drop-in alternative to :class:`flux.testing.events.TestEventEmitter` for
+interactive use. Same public method surface (``test_start``, ``stage``,
+``progress``, ``result``, ``test_complete``, ``test_error``, ``info``,
+``warning``, ``metric``, ``log``) — the benchmark code is identical; the CLI
+picks an emitter at startup based on TTY detection and the ``--ui`` flag.
+
+Rendering layout::
+
+flux schedbench · <test_name> <resource summary> <jobspec summary> ·
+<scheduler> · <watcher>
+
+<glyph> <stage>  <bar>  <count>  <elapsed>  <rate> ...
+
+<metrics table on completion> <elapsed> elapsed
+
+The block re-renders in place via ANSI cursor moves (cursor-up, then each
+line written with an inline erase-to-end-of-line). Redraws throttle to
+roughly 20Hz to avoid flicker; a final render is always forced on completion
+or error so the latest counts are visible. Each frame is wrapped in DEC
+mode 2026 synchronized output so capable terminals batch the update.
+
+Colors are 16-color ANSI only, opt-out via ``NO_COLOR``, ``--color=never``, or
+non-TTY ``stream``. No external dependencies.
+"""
+
+import os
+import sys
+import time
+
+from flux.testing.events import _EVENT_MIN_VERBOSITY, QUIET, VERBOSE
+from flux.testing.schedbench._ansi import (
+    _BAR_CHARS_ASCII,
+    _BAR_CHARS_UNICODE,
+    _BOLD,
+    _CURSOR_HIDE,
+    _CURSOR_SHOW,
+    _CURSOR_UP_FMT,
+    _DIM,
+    _ERASE_TO_EOL,
+    _FG_CYAN,
+    _FG_GREEN,
+    _FG_RED,
+    _FG_YELLOW,
+    _GLYPHS_ASCII,
+    _GLYPHS_UNICODE,
+    _REDRAW_INTERVAL_S,
+    _RESET,
+    _SYNC_BEGIN,
+    _SYNC_END,
+    _color_supported,
+    _isatty,
+    _safe_glyphs,
+)
+
+# Per-status visual style for stage lines: (glyph_color, glyph_key,
+# name_color). ``name_color`` of ``None`` means render the stage
+# name un-styled. The renderer pulls one row by status rather than
+# walking an if/elif chain. Bar color uses a separate table below
+# since "done" maps to a different presentation (fully-filled bar
+# unconditionally) that doesn't fit the same shape.
+_STAGE_STYLES = {
+    "done": (_FG_GREEN, "done", None),
+    "active": (_FG_YELLOW, "active", _BOLD),
+    "failed": (_FG_RED, "failed", _FG_RED),
+    "pending": (_DIM, "pending", _DIM),
+}
+
+# Bar color by status for the in-progress / pending / failed cases
+# (the "done" status is handled inline since it also forces a
+# full-width fill regardless of the recorded count).
+_BAR_COLORS = {
+    "active": _FG_CYAN,
+    "failed": _FG_RED,
+    "pending": _DIM,
+}
+
+# Layout constants. Stage names cap at 7 chars ("cleanup"); count fits
+# "1024/1024" = 9; rate fits "5,000 jobs/sec" with room to grow. Bar grows up
+# to 40 cells on wide terminals (was 28 — needlessly tight).
+_STAGE_NAME_WIDTH = 7
+_COUNT_WIDTH = 9
+_DEFAULT_WIDTH = 80
+_MIN_BAR_WIDTH = 8
+_MAX_BAR_WIDTH = 40
+_ELAPSED_WIDTH = 6
+_RATE_WIDTH = 14
+
+
+class TerminalEmitter:
+    """Render schedbench events as a live multi-line terminal UI.
+
+    Implements the same public methods as
+    :class:`flux.testing.events.TestEventEmitter` so the CLI can pick either
+    emitter at startup without the benchmark code knowing the difference.
+
+    Args: verbosity: filter threshold; events below the threshold are dropped.
+    Defaults to :data:`VERBOSE` since the UI needs ``progress`` and ``metric``
+    to display anything interesting. stream: file-like object that receives
+    the rendered UI. Defaults to :data:`sys.stdout`. color: ``"auto"``
+    (default), ``"always"``, or ``"never"``. ascii_only: force ASCII glyphs
+    and bar characters. If omitted, autodetects via locale env vars.
+    """
+
+    __test__ = False
+
+    def __init__(self, verbosity=VERBOSE, stream=None, color="auto", ascii_only=None):
+        self.verbosity = verbosity
+        self._stream = stream if stream is not None else sys.stdout
+        self._color = _color_supported(self._stream, color)
+        self._ascii = ascii_only if ascii_only is not None else not _safe_glyphs()
+
+        # Cached terminal-capability flags. ``stream`` is captured
+        # here and never reassigned, so isatty() at construction
+        # time is a stable answer; checking once saves three to
+        # four syscalls per redraw.
+        self._is_tty = _isatty(self._stream)
+
+        # Glyph and bar-character lookup tables, frozen at init so
+        # render paths do dict lookups rather than re-branching on
+        # ``self._ascii`` every call.
+        self._glyphs = _GLYPHS_ASCII if self._ascii else _GLYPHS_UNICODE
+        self._bar_chars = _BAR_CHARS_ASCII if self._ascii else _BAR_CHARS_UNICODE
+        # Inline separators used in the header row.
+        self._sep = "-" if self._ascii else "·"
+        self._times = " x " if self._ascii else " × "
+
+        # Run state.
+        self._test_name = None
+        self._config = None
+        self._stage_names = []
+        self._stages = {}  # name → dict of state
+        self._current_stage = None
+        self._metrics = None
+        self._summary_metrics = ()
+        self._error = None
+        self._start_time = None
+        self._end_time = None
+
+        # Rendering state.
+        self._last_render_lines = 0
+        self._last_render_t = 0.0
+        self._cursor_hidden = False
+
+    # ----- Glyph / color helpers (resolve once per draw) -----
+
+    def _c(self, code, text):
+        """Wrap ``text`` in ANSI color ``code`` iff color is on."""
+        if not self._color:
+            return text
+        return code + text + _RESET
+
+    # ----- Public API matching TestEventEmitter -----
+
+    def emit(self, name, context=None):
+        """Generic event hook. Mostly unused; the typed methods
+        below cover the schedbench event names. Kept so consumers that call
+        ``emitter.emit("info", ...)`` directly still work."""
+        if _EVENT_MIN_VERBOSITY.get(name, QUIET) > self.verbosity:
+            return
+        # Dispatch to the typed entry points so state updates flow through the
+        # same paths regardless of caller style.
+        ctx = context or {}
+        if name == "test.start":
+            self.test_start(
+                ctx.get("test_name", "?"),
+                ctx.get("stages", []),
+                ctx.get("config"),
+            )
+        elif name == "stage":
+            self.stage(
+                ctx.get("stage", ""),
+                ctx.get("stage_index", 0),
+                ctx.get("total_stages", 1),
+            )
+        elif name == "progress":
+            self.progress(
+                ctx.get("current", 0),
+                ctx.get("total", 0),
+                ctx.get("unit", ""),
+                ctx.get("rate"),
+            )
+        elif name == "result":
+            self.result(ctx.get("metrics", {}))
+        elif name == "test.complete":
+            self.test_complete(ctx.get("duration", 0.0))
+        elif name == "test.error":
+            self.test_error(ctx.get("error", ""))
+
+    def test_start(self, test_name, stages, config=None):
+        self._test_name = test_name
+        self._stage_names = list(stages)
+        self._stages = {
+            s: {
+                "current": 0,
+                "total": 0,
+                "unit": "",
+                "started": None,
+                "finished": None,
+                "status": "pending",
+            }
+            for s in self._stage_names
+        }
+        self._config = config or {}
+        self._start_time = time.time()
+        # In quiet mode we render only at test_complete / test_error, so we
+        # never paint mid-run and don't need to hide the cursor. _redraw below
+        # is a no-op at QUIET.
+        if self.verbosity != QUIET and self._is_tty:
+            self._stream.write(_CURSOR_HIDE)
+            self._cursor_hidden = True
+        self._redraw(force=True)
+
+    def stage(self, stage, stage_index, total_stages):
+        del stage_index, total_stages  # available in _stage_names
+        # Mark previous active stage as done (it transitioned out of being
+        # current). The benchmarks emit each stage in order, so anything we
+        # entered before this call has finished its work even if its progress
+        # count didn't reach total (e.g., the cancel stage in fill-machine has
+        # no progress events).
+        if self._current_stage is not None:
+            prev = self._stages[self._current_stage]
+            prev["status"] = "done"
+            prev["finished"] = time.time()
+        self._current_stage = stage
+        if stage in self._stages:
+            self._stages[stage]["status"] = "active"
+            self._stages[stage]["started"] = time.time()
+        self._redraw(force=True)
+
+    def progress(self, current, total, unit, rate=None):
+        del rate  # we compute it from elapsed
+        if _EVENT_MIN_VERBOSITY["progress"] > self.verbosity:
+            return
+        if self._current_stage is None:
+            return
+        st = self._stages[self._current_stage]
+        st["current"] = current
+        st["total"] = total
+        st["unit"] = unit
+        self._redraw()
+
+    def result(self, metrics):
+        self._metrics = dict(metrics)
+        # The final render happens on test_complete/test_error; don't redraw
+        # yet (avoids a flash of partial metrics alongside a still-active
+        # progress bar).
+
+    def set_summary_metrics(self, summary_metrics):
+        """Set the spec for the post-run metrics table.
+
+        The spec is an iterable of ``(key, label, kind)`` triples —
+        typically a benchmark's ``SUMMARY_METRICS`` class attribute.
+        Each key is looked up in the result dict at render time;
+        missing keys are silently skipped. ``kind`` selects a
+        formatter in :func:`_format_metric`.
+
+        This is a TerminalEmitter-specific concern: the JSON-event
+        emitters (TestEventEmitter, _ResultOnlyEmitter) carry the
+        full result dict and don't render a table, so they don't
+        implement this method. Callers that want to set the spec
+        check ``hasattr(emitter, "set_summary_metrics")`` first.
+        """
+        self._summary_metrics = tuple(summary_metrics)
+
+    def test_complete(self, duration):
+        del duration  # we compute it from _start_time/_end_time
+        self._finalize_run("done")
+
+    def test_error(self, error):
+        self._error = error
+        self._finalize_run("failed")
+
+    def _finalize_run(self, active_stage_status):
+        """Shared end-of-run cleanup for both completion and error paths:
+        promote any still-active stage to its terminal status, record the
+        end time, do the final forced redraw, and restore the cursor.
+
+        ``active_stage_status`` is what to assign to the current stage
+        if it's still in the ``"active"`` state. ``test_complete`` passes
+        ``"done"``; ``test_error`` passes ``"failed"``.
+        """
+        if self._current_stage is not None:
+            st = self._stages[self._current_stage]
+            if st["status"] == "active":
+                st["status"] = active_stage_status
+                st["finished"] = time.time()
+        self._end_time = time.time()
+        self._redraw(force=True, final=True)
+        self._show_cursor()
+
+    def info(self, message):
+        pass  # informational chatter doesn't appear in the UI
+
+    def warning(self, message):
+        # Warnings are above-the-UI noise; print to stderr so they don't
+        # disrupt the redrawing block on stdout.
+        print("warning: " + str(message), file=sys.stderr, flush=True)
+
+    def metric(self, name, value, unit=None):
+        pass  # intermediate metrics not displayed
+
+    def log(self, message):
+        # Free-form log lines go to stderr (same policy as TestEventEmitter)
+        # so they don't disturb the redrawing stdout block.
+        print(message, file=sys.stderr, flush=True)
+
+    # ----- Internal: rendering -----
+
+    def _show_cursor(self):
+        if self._cursor_hidden and self._is_tty:
+            self._stream.write(_CURSOR_SHOW)
+            self._stream.flush()
+            self._cursor_hidden = False
+
+    def _redraw(self, force=False, final=False):
+        # In quiet mode we want exactly one render — the final results block —
+        # so suppress every mid-run paint. The final test_complete /
+        # test_error call passes final=True to bypass this gate. Nothing else
+        # does.
+        if self.verbosity == QUIET and not final:
+            return
+
+        now = time.time()
+        if not force and (now - self._last_render_t) < _REDRAW_INTERVAL_S:
+            return
+        self._last_render_t = now
+
+        lines = self._render_lines()
+        new_count = len(lines)
+
+        # If the new frame has fewer lines than the previous, pad
+        # with empties: those padded lines are still emitted with
+        # _ERASE_TO_EOL appended below, which scrubs the orphan
+        # content from the old frame at those positions.
+        if new_count < self._last_render_lines:
+            lines = lines + [""] * (self._last_render_lines - new_count)
+
+        # Build the entire frame as a single string and write it
+        # in one syscall, so the terminal never sees a partial
+        # frame from a fragmented write. Wrap in DEC mode 2026
+        # synchronized output (capable terminals batch the update;
+        # others ignore the sequence) and rely on per-line
+        # _ERASE_TO_EOL so even terminals that don't honour 2026
+        # never see a blank-screen state between erase and redraw.
+        parts = []
+        if self._is_tty:
+            parts.append(_SYNC_BEGIN)
+            if self._last_render_lines > 0:
+                parts.append(_CURSOR_UP_FMT.format(self._last_render_lines))
+        parts.append("\n".join(line + _ERASE_TO_EOL for line in lines))
+        parts.append("\n")
+        if self._is_tty:
+            parts.append(_SYNC_END)
+
+        self._stream.write("".join(parts))
+        self._stream.flush()
+        self._last_render_lines = new_count
+
+    def _term_width(self):
+        """Return the actual terminal width by querying the
+        stream's controlling TTY directly. We deliberately do not use
+        ``shutil.get_terminal_size``, which prefers the ``COLUMNS``
+        environment variable — that can be stale when the schedbench command
+        runs as a subprocess (e.g., under ``flux start``) inheriting an env
+        var the parent shell set for a different window size.
+        ``os.get_terminal_size`` on the stream's fd goes straight to
+        TIOCGWINSZ and gets the real width.
+        """
+        try:
+            cols = os.get_terminal_size(self._stream.fileno()).columns
+        except (AttributeError, ValueError, OSError):
+            cols = _DEFAULT_WIDTH
+        return max(cols, 40)
+
+    def _render_lines(self):
+        """Produce the full block as a list of lines (no
+        trailing newlines on individual entries; the writer joins with ``\n``
+        and appends one trailing newline)."""
+        out = []
+        sep = self._sep
+
+        # Header.
+        if self._test_name is not None:
+            title = (
+                self._c(_BOLD, "flux schedbench") + " " + sep + " " + self._test_name
+            )
+            out.append(title)
+
+        if self._config:
+            cfg = self._config
+            res_parts = []
+            if "nodes" in cfg:
+                res_parts.append(_pluralize(cfg["nodes"], "node"))
+            if "cores_per_node" in cfg:
+                res_parts.append(_pluralize(cfg["cores_per_node"], "core"))
+            if cfg.get("gpus_per_node"):
+                res_parts.append(_pluralize(cfg["gpus_per_node"], "GPU"))
+            misc = []
+            if "scheduler" in cfg:
+                misc.append(cfg["scheduler"])
+            if "watcher" in cfg:
+                misc.append(f"{cfg['watcher']} watcher")
+            # "real execution" annotates the noteworthy case only; mock is the
+            # default and stays unannotated to keep the header tight. The flag
+            # also lands in the results JSON and the REAL report column, so
+            # this is a glance-level cue rather than the primary record.
+            if cfg.get("real_exec"):
+                misc.append("real execution")
+            res_line = "  " + self._times.join(res_parts)
+            if misc:
+                res_line += " " + sep + " " + (" " + sep + " ").join(misc)
+            out.append(self._c(_DIM, res_line))
+
+        out.append("")
+
+        # Stage lines. In quiet mode the entire stage block is omitted — the
+        # user asked not to see progress, and the results summary below
+        # carries the per-rate/timing numbers that make the stage block
+        # redundant.
+        if self.verbosity != QUIET:
+            width = self._term_width()
+            for name in self._stage_names:
+                out.append(self._render_stage_line(name, width))
+
+            out.append("")
+
+        # Metrics (final view only).
+        if self._metrics:
+            for line in self._render_metrics_lines():
+                out.append(line)
+            out.append("")
+
+        # Error block.
+        if self._error:
+            for line in self._error.splitlines():
+                out.append("  " + self._c(_FG_RED, line))
+            out.append("")
+
+        # Footer: elapsed.
+        elapsed = self._elapsed_str()
+        if elapsed:
+            out.append(self._c(_DIM, "  " + elapsed))
+
+        return out
+
+    def _render_stage_line(self, stage, width):
+        st = self._stages[stage]
+        status = st["status"]
+
+        glyph_color, glyph_key, name_color = _STAGE_STYLES[status]
+        glyph = self._c(glyph_color, self._glyphs[glyph_key])
+        name_text = self._c(name_color, stage) if name_color else stage
+
+        # Stage name column. Pad based on display width (color codes don't
+        # count toward padding).
+        pad = max(0, _STAGE_NAME_WIDTH - len(stage))
+        name_col = name_text + (" " * pad)
+
+        # Count and bar.
+        current = st["current"]
+        total = st["total"]
+        count_str = f"{current}/{total}" if total > 0 else ""
+        count_col = count_str.rjust(_COUNT_WIDTH)
+
+        # Compute bar width. The fixed columns account for every inter-column
+        # 2-space gap plus the four fixed-width columns. The bar grows up to
+        # _MAX_BAR_WIDTH on wide terminals. We stop 1 char short of the
+        # reported width to avoid the VT100 "phantom column": writing exactly
+        # into the rightmost column doesn't wrap until the next character —
+        # terminals disagree about whether \n in that state acts as one or two
+        # newlines. Staying under the edge sidesteps the question.
+        fixed = (
+            2  # leading indent
+            + 1
+            + 1  # glyph + space
+            + _STAGE_NAME_WIDTH
+            + 2  # gap: name → bar
+            + 2  # gap: bar → count
+            + _COUNT_WIDTH
+            + 2  # gap: count → elapsed
+            + _ELAPSED_WIDTH
+            + 2  # gap: elapsed → rate
+            + _RATE_WIDTH
+            + 1  # phantom-column safety margin
+        )
+        bar_width = max(
+            _MIN_BAR_WIDTH,
+            min(_MAX_BAR_WIDTH, width - fixed),
+        )
+        bar_col = self._render_bar(current, total, bar_width, status)
+
+        # Elapsed and rate (only when meaningful). Rate keeps the full unit
+        # string from the progress event ("832 job/s") instead of a one-letter
+        # abbreviation — the column is wide enough now.
+        elapsed_col = ""
+        rate_col = ""
+        if st["started"] is not None:
+            end = st["finished"] if st["finished"] else time.time()
+            dt = end - st["started"]
+            elapsed_col = f"{dt:5.2f}s"
+            if current > 0 and dt > 0 and status in ("active", "done"):
+                rate = current / dt
+                unit = st["unit"] or ""
+                rate_col = f"{rate:5.0f} {unit}/s" if unit else f"{rate:5.0f} /s"
+
+        # Trailing whitespace on empty trailing columns (pending stages have
+        # no elapsed/rate) was the second half of the wrap bug — even after
+        # fixing the bar-width math, an empty rate column padded to
+        # _RATE_WIDTH adds 14 spaces of bloat per pending line. rstrip handles
+        # that.
+        #
+        # The rate column is *left*-justified within _RATE_WIDTH so the
+        # numeric portion lines up across stages even when the unit string
+        # lengths differ. With rjust, a stage using "job/s" (5 chars) would
+        # have its number pushed 3 columns right of a stage using "cancel/s"
+        # (8 chars), since both strings right-end at the same column. With
+        # ljust, the number's column is fixed by the "{:>5.0f}" prefix and
+        # only the unit string extends to the right. Line-level rstrip removes
+        # the ljust padding so the phantom-column safety margin still works.
+        line = (
+            "  "
+            + glyph
+            + " "
+            + name_col
+            + "  "
+            + bar_col
+            + "  "
+            + count_col
+            + "  "
+            + elapsed_col.rjust(_ELAPSED_WIDTH)
+            + "  "
+            + rate_col.ljust(_RATE_WIDTH)
+        )
+        return line.rstrip()
+
+    def _render_bar(self, current, total, width, status):
+        fill, empty = self._bar_chars
+        # A done stage renders a fully-filled bar regardless of the recorded
+        # count. Some stages (e.g. fill-machine's cancel stage) emit no
+        # progress events, so total stays at 0; showing an empty bar there
+        # would suggest nothing happened. "Done" is the source of truth here.
+        if status == "done":
+            return self._c(_FG_GREEN, fill * width)
+        if total <= 0:
+            ratio = 0.0
+        else:
+            ratio = min(1.0, current / total)
+        filled = int(round(ratio * width))
+        bar = fill * filled + empty * (width - filled)
+        return self._c(_BAR_COLORS[status], bar)
+
+    def _render_metrics_lines(self):
+        """Format the final metrics table.
+
+        Iterates ``self._summary_metrics`` (set by :meth:`result`) which
+        comes from the running benchmark's ``SUMMARY_METRICS`` class
+        attribute. Keys absent from the result dict are silently
+        skipped, so benchmarks can list metrics that only some runs
+        produce. Each row has three columns: label (left-aligned,
+        padded to the longest label), number (right-aligned, padded
+        to the longest number), unit (dim, left-aligned).
+        """
+        rows = []
+        for key, label, kind in self._summary_metrics:
+            if key not in self._metrics:
+                continue
+            num, unit = _format_metric(self._metrics[key], kind)
+            rows.append((label, num, unit))
+        if not rows:
+            return []
+
+        label_w = max(len(r[0]) for r in rows)
+        num_w = max(len(r[1]) for r in rows)
+        out = []
+        for label, num, unit in rows:
+            line = (
+                "  "
+                + label.ljust(label_w + 2)
+                + self._c(_BOLD, num.rjust(num_w))
+                + "  "
+                + self._c(_DIM, unit)
+            )
+            out.append(line.rstrip())
+        return out
+
+    def _elapsed_str(self):
+        if self._start_time is None:
+            return ""
+        end = self._end_time if self._end_time else time.time()
+        dt = end - self._start_time
+        sep = " - " if self._ascii else " · "
+        suffix = " elapsed"
+        if self._end_time and self._error is None:
+            suffix += sep + self._c(_FG_GREEN, "ok")
+        elif self._end_time and self._error is not None:
+            suffix += sep + self._c(_FG_RED, "failed")
+        return f"{dt:.2f}s" + suffix
+
+
+def _format_count(value, unit=None):
+    # Label is "jobs"; suppressing the unit avoids a redundant
+    # "jobs ... jobs" row in the metrics table.
+    return (f"{int(value):,}", "")
+
+
+def _format_fraction(value, unit=None):
+    # A ratio in [0, 1] (e.g. locality score). Three decimals give
+    # 0.001 resolution — finer than the 1-in-1000 slots that a
+    # typical locality run produces. No unit.
+    return (f"{float(value):.3f}", "")
+
+
+def _format_seconds(value, unit=None):
+    return (f"{float(value):.2f}", "s")
+
+
+def _format_rate(value, unit="job/s"):
+    # Rate precision adapts to magnitude: rates >= 1000 don't need
+    # decimals, while rates < 100 benefit from two.
+    v = float(value)
+    if v >= 1000:
+        return (f"{v:,.0f}", unit)
+    if v >= 100:
+        return (f"{v:,.1f}", unit)
+    return (f"{v:,.2f}", unit)
+
+
+#: Dispatch table for :func:`_format_metric`. Adding a new ``kind``
+#: is a single entry here — the renderer iterates ``SUMMARY_METRICS``
+#: without knowing the available kinds in advance, so benchmarks can
+#: reference any kind name listed in this dict.
+_METRIC_FORMATTERS = {
+    "count": _format_count,
+    "fraction": _format_fraction,
+    "seconds": _format_seconds,
+    "rate": _format_rate,
+}
+
+
+def _format_metric(value, kind):
+    """Format ``value`` for display in the metrics table.
+
+    Returns a ``(number, unit)`` tuple so the renderer can
+    right-align the number column independently of the unit
+    column. ``kind`` may include a unit override separated by
+    ``:``, e.g. ``"rate:node/s"`` to display a rate whose natural
+    unit is not ``job/s``. Unknown base-kind strings fall back to
+    ``str(value)`` with the override unit (or ``""``).
+    """
+    base_kind = kind
+    unit_override = None
+    if ":" in kind:
+        base_kind, unit_override = kind.split(":", 1)
+    formatter = _METRIC_FORMATTERS.get(base_kind)
+    if formatter is None:
+        return (str(value), unit_override or "")
+    if unit_override is not None:
+        return formatter(value, unit_override)
+    return formatter(value)
+
+
+def _pluralize(n, label):
+    """Format ``"{n} {label}[s]"`` with English singular/plural.
+    Picks an "s" suffix for n != 1 (covers 0 and >=2). The pluralization is
+    naive; resource labels in this codebase all take a simple -s plural
+    (node/nodes, core/cores, GPU/GPUs)."""
+    return f"{n} {label}" if n == 1 else f"{n} {label}s"
+
+
+# vi: ts=4 sw=4 expandtab

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -134,6 +134,7 @@ dist_fluxcmd_SCRIPTS = \
 	flux-modprobe.py \
 	flux-sproc.py \
 	flux-slurm-expiration-sync.py \
+	flux-schedbench.py \
 	flux-python$(PYTHON_VERSION)
 
 fluxcmd_PROGRAMS = \

--- a/src/cmd/flux-schedbench.py
+++ b/src/cmd/flux-schedbench.py
@@ -1,0 +1,1056 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""flux schedbench: run scheduler benchmarks, save results, report.
+
+By default, ``flux schedbench run`` launches a fresh Flux subinstance
+configured with fake resources (via the fake-resources modprobe rc1 task)
+and re-execs itself inside that subinstance to run the benchmark. With
+``--exec``, no subinstance is launched and real jobs run against the
+broker the user is currently connected to.
+
+Subcommands: run     Run a named benchmark and append the result to the
+results file. report  Pretty-print the results file as a table.
+"""
+
+import argparse
+import getpass
+import json
+import logging
+import os
+import shlex
+import socket
+import sys
+import time
+
+import flux
+import flux.resource
+from flux.modprobe import ModuleList
+from flux.testing.events import (
+    NORMAL,
+    QUIET,
+    VERBOSE,
+    TestEventEmitter,
+)
+from flux.testing.job_watcher import (
+    JournalEventWatcher,
+    PerJobEventWatcher,
+)
+from flux.testing.schedbench import BENCHMARKS, Benchmark, BenchmarkResults
+from flux.testing.schedbench.ui import TerminalEmitter
+from flux.util import CLIMain, OutputFormat, UtilConfig, get_treedict, help_formatter
+
+LOGGER = logging.getLogger("flux-schedbench")
+SCHEDBENCH_VERSION = "0.1.0"
+
+#: Sentinel env var set on the outer schedbench process when it re-execs
+#: itself inside a fake-resources subinstance via ``flux start``. The inner
+#: invocation checks for this to short-circuit recursive launching and run
+#: the benchmark in the broker it's already attached to (see :func:`cmd_run`).
+_ISOLATED_ENV_VAR = "FLUX_SCHEDBENCH_ISOLATED"
+
+#: Maps --watcher NAME to a factory taking a Flux handle. The factory is
+#: passed to BulkRun via the benchmark constructor; omitting it (None) keeps
+#: BulkRun's default (journal).
+_WATCHERS = {
+    "journal": JournalEventWatcher,
+    "per-job": PerJobEventWatcher,
+}
+
+
+def _add_common_run_opts(parser):
+    """Add common --opts for 'flux schedbench run' to the parser."""
+    parser.add_argument(
+        "-N",
+        "--nodes",
+        type=int,
+        default=4,
+        metavar="N",
+        help="fake-resource node count for the launched "
+        "subinstance (default: 4; ignored with --exec — the "
+        "real broker's resources are used instead)",
+    )
+    parser.add_argument(
+        "-c",
+        "--cores-per-node",
+        type=int,
+        default=64,
+        metavar="C",
+        help="cores per node (default: 64; ignored with --exec)",
+    )
+    parser.add_argument(
+        "-g",
+        "--gpus-per-node",
+        type=int,
+        default=8,
+        metavar="G",
+        help="GPUs per node (default: 8; ignored with --exec)",
+    )
+    parser.add_argument(
+        "-n",
+        "--njobs",
+        type=int,
+        default=1000,
+        metavar="N",
+        help="number of jobs to submit (default: 1000). Each "
+        "benchmark uses this differently: throughput and locality "
+        "submit exactly this many; fill-machine derives its job "
+        "count from the resource set and ignores this value; "
+        "locality's --duration=fill mode likewise overrides.",
+    )
+    parser.add_argument(
+        "--slot-cores",
+        type=int,
+        default=1,
+        metavar="K",
+        help="cores per slot (default: 1). Per-task core "
+        "requirement for jobs submitted by this benchmark.",
+    )
+    parser.add_argument(
+        "--slot-gpus",
+        type=int,
+        default=0,
+        metavar="K",
+        help="GPUs per slot (default: 0). Per-task GPU requirement "
+        "for jobs submitted by this benchmark.",
+    )
+    parser.add_argument(
+        "--hwloc-xml-path",
+        metavar="PATH",
+        help="path to an hwloc XML file describing per-node "
+        "topology; passed to the subinstance as "
+        "--conf=fake-resources.hwloc-xml-path=PATH. The XML's "
+        "per-node shape is replicated across --nodes. Useful for "
+        "testing topology-aware schedulers (e.g. Fluxion). "
+        "Ignored with --exec.",
+    )
+    parser.add_argument(
+        "--amend-r",
+        metavar="SPEC",
+        help="reference to a Python amender that mutates R before "
+        "it is written to KVS, in either ``module:function`` form "
+        "or as a path to a file with an ``amend()`` callable "
+        "(see flux-config-fake-resources(5) AMENDERS section). "
+        "Passed to the subinstance as "
+        "--conf=fake-resources.amend-r=SPEC. Typically paired with "
+        "--hwloc-xml-path to inject scheduler-specific topology "
+        "metadata into R. Ignored with --exec.",
+    )
+    parser.add_argument(
+        "--scheduler",
+        default="sched-simple",
+        metavar="NAME",
+        help="scheduler module to load in the fake-resources "
+        "subinstance via --conf=modules.alternatives.sched "
+        "(default: sched-simple). Ignored with --exec — in "
+        "--exec mode, the broker's currently-loaded scheduler "
+        "is used as-is. In both modes, the recorded scheduler "
+        "name is read from the broker post-setup via the "
+        "sched-service lookup — so the results record reflects "
+        "what was actually loaded, not what was requested.",
+    )
+    parser.add_argument(
+        "--scheduler-options",
+        metavar="OPTS",
+        help="module options string for the scheduler; "
+        "shlex-parsed into a list and encoded into the "
+        "subinstance config as "
+        '--conf=modules.sched.args=["opt1", "opt2"]. '
+        "Ignored with --exec.",
+    )
+    parser.add_argument(
+        "--conf",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="extra config setting forwarded to the underlying "
+        "`flux start` as --conf=KEY=VALUE. May be given multiple "
+        "times. Convenience for the common case of "
+        "-o '--conf=KEY=VALUE'; equivalent to that form but "
+        "shorter, and accumulates across multiple uses. Ignored "
+        "with --exec.",
+    )
+    parser.add_argument(
+        "-o",
+        "--extra-start-options",
+        action="append",
+        default=[],
+        metavar="OPTS",
+        help="extra arguments to pass through to the underlying "
+        "`flux start` when launching the fake-resources "
+        "subinstance; shlex-parsed. May be given multiple "
+        "times. Useful for broker attributes (--setattr=...) "
+        "and other non-config flags; for plain --conf=KEY=VALUE "
+        "settings prefer the dedicated --conf option above. "
+        "Ignored with --exec.",
+    )
+    parser.add_argument(
+        "-x",
+        "--exec",
+        dest="real_exec",
+        action="store_true",
+        help="run real jobs against the current enclosing "
+        "instance (no fake resources, no subinstance launch). "
+        "Use when running inside an allocation where the "
+        "broker's currently-loaded scheduler and currently-up "
+        "resources are what you want to benchmark.",
+    )
+    parser.add_argument(
+        "--watcher",
+        choices=sorted(_WATCHERS.keys()),
+        default="journal",
+        help="event-watcher implementation (default: journal). "
+        "The journal watcher imposes a single subscription on "
+        "kvs-watch; the per-job watcher opens one subscription "
+        "per job, useful for measuring watcher overhead under "
+        "high job counts.",
+    )
+    parser.add_argument(
+        "--tag",
+        metavar="LABEL",
+        default="",
+        help="free-form label stored in results metadata",
+    )
+    parser.add_argument(
+        "--results-file",
+        default="./schedbench-results.json",
+        metavar="PATH",
+        help="results file path (default: ./schedbench-results.json)",
+    )
+    parser.add_argument(
+        "--no-save",
+        action="store_true",
+        help="don't append to the results file",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="emit only terminal events (test.start, result, "
+        "test.complete, test.error); forces JSON output",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="emit progress/info/metric events",
+    )
+    parser.add_argument(
+        "--ui",
+        choices=("auto", "on", "off"),
+        default="auto",
+        help=(
+            "interactive terminal UI: 'auto' (default) enables "
+            "it when stdout is a TTY and --quiet is not set; "
+            "'on' forces it; 'off' falls back to the JSON event "
+            "stream"
+        ),
+    )
+    parser.add_argument(
+        "--color",
+        choices=("auto", "always", "never"),
+        default="auto",
+        help=(
+            "color output for the terminal UI: 'auto' (default) "
+            "honors NO_COLOR and TERM; 'always' / 'never' force"
+        ),
+    )
+
+
+#: Maps benchmark name -> {arg dest: long-form CLI flag} for options the
+#: benchmark added via :meth:`Benchmark.register_options`. Populated at
+#: ``parse_args()`` time by :func:`_register_benchmark_options` and read at
+#: subinstance-launch time by :func:`_passthrough_argv`. The auto-passthrough
+#: design assumes any option a benchmark registers is meaningful to the inner
+#: schedbench invocation (controls how the benchmark runs); no per-option
+#: opt-in is needed.
+_PER_BENCH_PASSTHROUGH = {}
+
+
+def _long_form_flag(action):
+    """Return the canonical CLI flag for an argparse action.
+
+    Prefers the first ``--long`` form (the convention for option names in
+    record-keeping); falls back to the first option string if no long form is
+    present (single-letter-only options, which the benchmarks don't currently
+    use).
+    """
+    return next(
+        (s for s in action.option_strings if s.startswith("--")),
+        action.option_strings[0],
+    )
+
+
+def _register_benchmark_options(run_parser, bench_cls):
+    """Add ``bench_cls``'s benchmark-specific options to ``run_parser``.
+
+    If the benchmark inherits the no-op :meth:`Benchmark.register_options`
+    default, no argument group is added (keeps the ``--help`` output clean
+    for benchmarks that use only the common options). Otherwise an argument
+    group titled ``"{name} options"`` is added, the benchmark's
+    ``register_options`` is called against it, and the resulting actions are
+    introspected to populate :data:`_PER_BENCH_PASSTHROUGH` for the launcher.
+
+    The classmethod-inheritance check compares ``__func__`` rather than the
+    bound methods directly: each ``cls.register_options`` access creates a
+    fresh bound method, so ``cls.foo is Base.foo`` is always False even when
+    the subclass inherits Base's implementation unchanged. The underlying
+    ``__func__`` attribute is the same function object across both classes
+    when no override is present.
+    """
+    if bench_cls.register_options.__func__ is Benchmark.register_options.__func__:
+        _PER_BENCH_PASSTHROUGH[bench_cls.name] = {}
+        return
+    group = run_parser.add_argument_group(
+        f"{bench_cls.name} options",
+        description=bench_cls.description,
+    )
+    bench_cls.register_options(group)
+    _PER_BENCH_PASSTHROUGH[bench_cls.name] = {
+        action.dest: _long_form_flag(action)
+        for action in group._group_actions
+        if action.dest != "help" and action.option_strings
+    }
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="flux-schedbench",
+        formatter_class=help_formatter(),
+        description=(
+            "Run scheduler benchmarks against fake resources and "
+            "save aggregate metrics"
+        ),
+    )
+    sub = parser.add_subparsers(dest="subcommand")
+    sub.required = True  # subparsers(required=) requires Python 3.7+
+
+    # `flux schedbench run TEST ...`
+    run_p = sub.add_parser(
+        "run",
+        help="run a benchmark",
+        formatter_class=help_formatter(),
+    )
+    run_p.add_argument(
+        "test",
+        choices=sorted(BENCHMARKS.keys()),
+        help="benchmark to run",
+    )
+    _add_common_run_opts(run_p)
+
+    # Register per-benchmark options. Each benchmark class can add its
+    # own flags via a register_options() classmethod; the framework
+    # discovers them by walking the resulting argument group's actions
+    # and uses that to drive subinstance passthrough (see
+    # _PER_BENCH_PASSTHROUGH below). Benchmarks that use only the
+    # common options inherit the no-op default and don't get a group
+    # at all (keeps --help clean).
+    for name in sorted(BENCHMARKS.keys()):
+        _register_benchmark_options(run_p, BENCHMARKS[name])
+
+    # `flux schedbench report ...`
+    rep_p = sub.add_parser(
+        "report",
+        help="pretty-print results for a single benchmark",
+        formatter_class=help_formatter(),
+    )
+    rep_p.add_argument(
+        "test",
+        choices=sorted(BENCHMARKS.keys()),
+        metavar="TEST",
+        help="benchmark to report on (rows of other tests are " "filtered out)",
+    )
+    rep_p.add_argument(
+        "--results-file",
+        default="./schedbench-results.json",
+        metavar="PATH",
+        help="results file path (default: ./schedbench-results.json)",
+    )
+    rep_p.add_argument(
+        "--filter",
+        action="append",
+        default=[],
+        metavar="KEY=VAL",
+        help="show only runs matching KEY=VAL; may be given " "multiple times",
+    )
+    rep_p.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        default="default",
+        metavar="FORMAT",
+        help="output format: a named format ('default', 'long', "
+        "'csv', or any user-defined format from "
+        "~/.config/flux/flux-schedbench-report-<test>.toml; "
+        "'help' lists available names) or a literal "
+        "Python-style format string",
+    )
+    rep_p.add_argument(
+        "--sort",
+        type=str,
+        default="",
+        metavar="KEY,...",
+        help="sort by one or more keys (prefix with '-' for " "descending)",
+    )
+    rep_p.add_argument(
+        "--no-header",
+        action="store_true",
+        help="omit the header row",
+    )
+
+    return parser.parse_args()
+
+
+def _detect_scheduler(handle):
+    """Return the name of the module currently providing the
+    ``sched`` service, or ``None`` if no scheduler is loaded.
+
+    Scheduler modules (``sched-simple``, ``sched-fluxion-qmanager``, etc.) all
+    advertise the ``sched`` service. ``ModuleList`` indexes loaded modules by
+    their advertised services, so this is the single source of truth for "what
+    scheduler is the broker actually using right now" — independent of the CLI
+    ``--scheduler`` argument, which only controls what the subinstance asks
+    modprobe to load. Used in both modes so the recorded ``scheduler.name``
+    always reflects broker reality (catches typos in ``--scheduler``, makes
+    ``--exec`` records honest about what's loaded).
+    """
+    return ModuleList(handle).lookup("sched")
+
+
+def _query_real_resources(handle):
+    """Snapshot the broker's currently-up resources.
+
+    Used in both --exec mode and inside an isolated subinstance to size
+    benchmarks (e.g. fill-machine's saturation count) and fill the resources
+    block in the results record. In --exec mode the broker has real
+    hardware; inside the subinstance it has the synthetic R installed by the
+    fake-resources rc1 task. The query is the same either way.
+
+    Caveat: assumes uniform cores/GPUs per node, computing averages with floor
+    division. Most HPC allocations are uniform; non-uniform setups will see
+    rounded averages. ``saturation_count`` will accordingly under-count by up
+    to one slot per heterogeneous node — bounded enough that aggregate-rate
+    measurements remain meaningful.
+    """
+    rl = flux.resource.resource_list(handle).get()
+    up = rl.up
+    nodes = up.nnodes
+    if nodes == 0:
+        raise RuntimeError(
+            "no resources are up on this broker; --exec needs "
+            "an allocation with at least one online node"
+        )
+    return {
+        "nodes": nodes,
+        "cores_per_node": up.ncores // nodes,
+        "gpus_per_node": up.ngpus // nodes,
+    }
+
+
+def _build_benchmark(args, resources):
+    """Construct the benchmark instance from CLI args.
+
+    Delegates to the benchmark class's :meth:`from_args` classmethod, which
+    knows which CLI args and resource-shape values its constructor needs.
+    ``resources`` is the resolved shape dict (real-broker query or fake
+    resources via the rc1 task in the subinstance); ``from_args`` may use it
+    (fill-machine computes saturation count) or ignore it (throughput is
+    resource-agnostic).
+    """
+    return BENCHMARKS[args.test].from_args(
+        args,
+        resources,
+        watcher_factory=_WATCHERS[args.watcher],
+    )
+
+
+class _ResultOnlyEmitter:
+    """Emitter for ``--quiet`` on a non-TTY stdout.
+
+    Silently drops every benchmark event except the final ``result``, which is
+    printed as a single JSON object on stdout. Matches the public surface of
+    TerminalEmitter and TestEventEmitter so cmd_run and the benchmark classes
+    don't need to know which emitter is in use. Lifecycle and progress events
+    are no-ops; errors flow through the normal LOGGER path and the process
+    exit code, leaving stdout silent so consumers piping to e.g. ``jq`` see
+    either a single result object or nothing.
+    """
+
+    def __init__(self, stream=None):
+        self._stream = stream if stream is not None else sys.stdout
+
+    def test_start(self, test_name, stages, config=None):
+        pass
+
+    def stage(self, stage, stage_index, total_stages):
+        pass
+
+    def progress(self, current, total, unit, rate=None):
+        pass
+
+    def warning(self, message):
+        pass
+
+    def info(self, message):
+        pass
+
+    def metric(self, name, value, unit=None):
+        pass
+
+    def log(self, message):
+        pass
+
+    def result(self, metrics):
+        # Emit the bare metrics dict, not an event envelope. Downstream tools
+        # (jq, plotting scripts) get a clean JSON object with no unwrapping
+        # required.
+        print(json.dumps(metrics), file=self._stream, flush=True)
+
+    def test_complete(self, duration):
+        pass
+
+    def test_error(self, error):
+        pass
+
+
+def _select_emitter(args):
+    """Pick the emitter based on resolved UI mode and --quiet.
+
+    Two axes:
+
+    1. ``--ui={auto,on,off}`` chooses between the live TerminalEmitter and the
+    JSON-event TestEventEmitter. ``auto`` (the default) picks TerminalEmitter
+    iff stdout is a TTY, otherwise the JSON stream — so a developer gets the
+    rich UI in their terminal but a script redirecting stdout gets parseable
+    JSON without configuration.
+
+    2. ``--quiet`` narrows the output. On a TTY this still gives a
+    human-readable summary — title, config, and the results block — but with
+    no progress bars, stage lines, or INFO log messages. Off a TTY ``--quiet``
+    produces a single JSON object (the metrics dict) and nothing else; errors
+    go to stderr only.
+
+    The TerminalEmitter consults its ``verbosity`` to decide whether to render
+    mid-run; passing QUIET there gives the quiet-summary behavior. Off-TTY
+    quiet uses the dedicated :class:`_ResultOnlyEmitter` rather than a
+    verbosity tweak on TestEventEmitter because the goal is a single ``{...}``
+    line on stdout, not a stripped-down event stream.
+    """
+    ui = args.ui
+    if ui == "auto":
+        ui = "on" if sys.stdout.isatty() else "off"
+
+    if ui == "on":
+        verbosity = QUIET if args.quiet else VERBOSE
+        return TerminalEmitter(verbosity=verbosity, color=args.color)
+
+    # ui == "off"
+    if args.quiet:
+        return _ResultOnlyEmitter()
+    return TestEventEmitter(verbosity=NORMAL)
+
+
+def _flux_version(handle):
+    """Best-effort: return broker version string, or None if unavailable."""
+    try:
+        return handle.attr_get("version")
+    except (OSError, AttributeError):
+        return None
+
+
+def _config_dict(args, resources, scheduler_name):
+    """The test.start event's context['config']: human-readable
+    parameters of this run.
+
+    ``resources`` and ``scheduler_name`` are the resolved values from the
+    broker (post-setup), not the CLI defaults. Building the dict from them
+    rather than from ``args.nodes`` / ``args.scheduler`` keeps the
+    TerminalEmitter header accurate under ``--exec``, where the CLI values are
+    unspecified and the real ones come from :func:`_query_real_resources` and
+    :func:`_detect_scheduler`.
+
+    Per-benchmark fields (job count, slot shape, duration mode, etc.) come
+    from :meth:`Benchmark.config_dict` so adding a new benchmark with custom
+    config fields is a one-classmethod change on the benchmark class.
+    """
+    cfg = {
+        "nodes": resources["nodes"],
+        "cores_per_node": resources["cores_per_node"],
+        "gpus_per_node": resources["gpus_per_node"],
+        "scheduler": scheduler_name,
+        "watcher": args.watcher,
+        "real_exec": args.real_exec,
+    }
+    cfg.update(BENCHMARKS[args.test].config_dict(args))
+    return cfg
+
+
+def _run_record(args, resources, scheduler_name, metrics, flux_version):
+    """Build the result-file record for this run.
+
+    ``resources`` carries the resolved shape (real or fake);
+    ``scheduler_name`` is the broker's currently-loaded sched module, looked
+    up post-setup (so it matches what actually ran, not what was requested);
+    ``args.real_exec`` flags which mode produced the run. Schema is identical
+    for both modes so reports and downstream tools don't have to branch.
+    """
+    return {
+        "test_name": args.test,
+        "tag": args.tag,
+        "host": socket.gethostname(),
+        "user": getpass.getuser(),
+        "schedbench_version": SCHEDBENCH_VERSION,
+        "flux_core_version": flux_version,
+        "real_exec": args.real_exec,
+        "scheduler": {
+            "name": scheduler_name,
+            "options": args.scheduler_options or "",
+            "version": None,
+        },
+        "resources": {
+            **resources,
+            "hwloc_xml_path": args.hwloc_xml_path or "",
+            "amend_r": args.amend_r or "",
+        },
+        "watcher": args.watcher,
+        "benchmarks": {
+            args.test: {"results": metrics},
+        },
+    }
+
+
+#: Argparse dest -> CLI flag for common args that should be passed verbatim
+#: to the inner schedbench invocation when launching a subinstance.
+#: Resource-shape args (nodes, cores_per_node, gpus_per_node), --scheduler,
+#: --conf, and --extra-start-options are consumed at the launcher level
+#: (encoded into --conf= or appended to flux start argv) and are NOT in
+#: this table.
+#: --scheduler-options, --hwloc-xml-path, and --amend-r are passed through
+#: for the JSON record only — the subinstance broker already has them baked
+#: into its config; the inner schedbench just stores the user's intent in
+#: the run record so reports can show which run used which topology /
+#: amender. Per-benchmark options are passed through automatically via
+#: :data:`_PER_BENCH_PASSTHROUGH` and don't need to be listed here.
+_PASSTHROUGH = {
+    "watcher": "--watcher",
+    "tag": "--tag",
+    "results_file": "--results-file",
+    "ui": "--ui",
+    "color": "--color",
+    "njobs": "--njobs",
+    "slot_cores": "--slot-cores",
+    "slot_gpus": "--slot-gpus",
+    "scheduler_options": "--scheduler-options",
+    "hwloc_xml_path": "--hwloc-xml-path",
+    "amend_r": "--amend-r",
+}
+
+#: Argparse dest -> CLI flag for boolean args. Emitted in the inner
+#: invocation only when the boolean is True.
+_PASSTHROUGH_FLAGS = {
+    "no_save": "--no-save",
+    "quiet": "-q",
+    "verbose": "-v",
+}
+
+
+def _passthrough_argv(args):
+    """Reconstruct argv for the inner schedbench invocation.
+
+    Emits the subcommand and TEST positional, then walks the common-option
+    passthrough table, the per-benchmark passthrough table (populated at
+    parse-args time from each benchmark's :meth:`register_options`), and
+    finally the boolean-flag table. Empty-string values are skipped (they
+    would be no-ops anyway). Boolean flags are emitted only when set.
+    """
+    argv = [args.subcommand, args.test]
+
+    def emit(table):
+        """Append ``--flag VALUE`` pairs for every non-empty entry in
+        ``table`` (a dest->flag mapping)."""
+        for dest, flag in table.items():
+            value = getattr(args, dest, None)
+            if value is None or value == "":
+                continue
+            argv.extend([flag, str(value)])
+
+    emit(_PASSTHROUGH)
+    # Per-benchmark options, discovered at parse-args time. Anything the
+    # active benchmark's register_options() added flows through verbatim.
+    emit(_PER_BENCH_PASSTHROUGH.get(args.test, {}))
+
+    for dest, flag in _PASSTHROUGH_FLAGS.items():
+        if getattr(args, dest, False):
+            argv.append(flag)
+    return argv
+
+
+def _launch_isolated(args):
+    """Re-exec under ``flux start --conf=fake-resources.* ...`` so the
+    benchmark runs against a fresh subinstance with synthetic resources.
+
+    The launched ``flux start`` invocation:
+
+    * sets ``[fake-resources]`` config keys from --nodes / --cores-per-node /
+      --gpus-per-node so the fake-resources modprobe rc1 task installs
+      synthetic R at broker startup (see flux-config-fake-resources(5));
+    * sets ``modules.alternatives.sched`` when --scheduler is non-default,
+      so the chosen scheduler module loads in place of sched-simple;
+    * sets ``modules.sched.args`` from --scheduler-options (shlex-parsed
+      into a TOML inline array) when provided;
+    * appends any --extra-start-options verbatim (shlex-parsed) for
+      escape-hatch use (broker attrs, additional conf, etc).
+
+    The inner schedbench invocation is rebuilt from the parsed args via
+    :func:`_passthrough_argv`, with :data:`_ISOLATED_ENV_VAR` set in env
+    to short-circuit recursive launching. The current process is replaced
+    via :func:`os.execvpe`; this function does not return.
+    """
+    conf_flags = [
+        f"--conf=fake-resources.nnodes={args.nodes}",
+        f"--conf=fake-resources.cores-per-node={args.cores_per_node}",
+        f"--conf=fake-resources.gpus-per-node={args.gpus_per_node}",
+    ]
+    if args.hwloc_xml_path:
+        conf_flags.append(f"--conf=fake-resources.hwloc-xml-path={args.hwloc_xml_path}")
+    if args.amend_r:
+        conf_flags.append(f"--conf=fake-resources.amend-r={args.amend_r}")
+    if args.scheduler != "sched-simple":
+        conf_flags.append(f"--conf=modules.alternatives.sched={args.scheduler}")
+    if args.scheduler_options:
+        # shlex-split user input into a TOML inline array. json.dumps
+        # produces a string of the form '["opt1", "opt2"]' which is
+        # syntactically valid TOML for an inline array of strings.
+        opts_list = shlex.split(args.scheduler_options)
+        conf_flags.append(f"--conf=modules.sched.args={json.dumps(opts_list)}")
+
+    # User-supplied --conf entries. Each value already carries its
+    # own KEY=VALUE; we prepend the --conf= prefix here so flux start
+    # sees them as ordinary config flags. These layer on top of the
+    # schedbench-managed entries above — TOML merge order is "later
+    # wins", so a user --conf= that targets a key schedbench also
+    # writes will override it.
+    conf_flags.extend(f"--conf={entry}" for entry in args.conf)
+
+    extra = []
+    for raw in args.extra_start_options:
+        extra.extend(shlex.split(raw))
+
+    cmd = [
+        "flux",
+        "start",
+        "-s",
+        "1",
+        *conf_flags,
+        *extra,
+        "--",
+        "flux",
+        "schedbench",
+        *_passthrough_argv(args),
+    ]
+    env = {**os.environ, _ISOLATED_ENV_VAR: "1"}
+
+    if args.verbose:
+        LOGGER.info(
+            "launching: %s",
+            " ".join(shlex.quote(a) for a in cmd),
+        )
+
+    try:
+        os.execvpe(cmd[0], cmd, env)
+    except OSError as exc:
+        raise RuntimeError(
+            f"failed to launch `{cmd[0]}`: {exc}; " f"is the flux command in PATH?"
+        )
+
+
+def cmd_run(args):
+    """Execute a single benchmark run.
+
+    Three dispatch paths:
+
+    * ``--exec``: run real jobs in the user's current broker. No
+      subinstance launch; the broker's currently-loaded scheduler and
+      currently-up resources are used as-is.
+
+    * ``FLUX_SCHEDBENCH_ISOLATED`` set in env (see :data:`_ISOLATED_ENV_VAR`):
+      we are the inner schedbench invocation launched by an outer call. The
+      surrounding broker has the configured fake resources installed by the
+      fake-resources modprobe rc1 task; run the benchmark in it.
+
+    * Neither: launch a fake-resources subinstance via ``flux start`` and
+      re-exec this command inside it. See :func:`_launch_isolated`.
+    """
+    if args.real_exec or os.environ.get(_ISOLATED_ENV_VAR):
+        _run_in_broker(args)
+    else:
+        _launch_isolated(args)  # does not return
+
+
+def _run_in_broker(args):
+    """Run the benchmark in the current broker.
+
+    The broker may have real or fake resources; either way, we query its
+    state via the resource module and run the benchmark against what's
+    there. ``args.real_exec`` controls whether the benchmark uses mock
+    or real job execution; the resources block in the JSON record
+    reflects whatever the broker actually has.
+    """
+    handle = flux.Flux()
+    resources = _query_real_resources(handle)
+
+    scheduler_name = _detect_scheduler(handle)
+    if scheduler_name is None:
+        raise RuntimeError(
+            "no scheduler module is loaded (no module provides "
+            "the 'sched' service). With --exec, load one before "
+            "running (e.g. `flux module load sched-simple`); "
+            "without --exec, this should have been arranged by "
+            "the fake-resources rc1 task — check the broker's "
+            "modprobe configuration."
+        )
+
+    bench = _build_benchmark(args, resources)
+
+    emitter = _select_emitter(args)
+    # The metrics-table spec is a TerminalEmitter-only concern (other
+    # emitters carry the full result dict over their event stream
+    # for downstream tools to format).  hasattr opt-in keeps event
+    # emitters in flux.testing.events independent of schedbench-UI
+    # specifics.
+    if hasattr(emitter, "set_summary_metrics"):
+        emitter.set_summary_metrics(type(bench).SUMMARY_METRICS)
+    emitter.test_start(
+        args.test,
+        stages=bench.stages,
+        config=_config_dict(args, resources, scheduler_name),
+    )
+
+    t0 = time.monotonic()
+    try:
+        metrics = bench.run(handle, emitter)
+    except Exception as exc:  # noqa: BLE001
+        emitter.test_error(str(exc))
+        raise
+    duration = time.monotonic() - t0
+
+    emitter.result(metrics)
+    emitter.test_complete(duration=duration)
+
+    if not args.no_save:
+        results = BenchmarkResults(args.results_file)
+        results.add_run(
+            _run_record(
+                args,
+                resources,
+                scheduler_name,
+                metrics,
+                _flux_version(handle),
+            ),
+        )
+        results.save()
+
+
+def _parse_filters(filter_args):
+    """Parse --filter KEY=VAL strings into a list of (key, val) pairs."""
+    parsed = []
+    for f in filter_args:
+        if "=" not in f:
+            raise ValueError(f"--filter must be KEY=VAL form, got: {f!r}")
+        key, val = f.split("=", 1)
+        parsed.append((key, val))
+    return parsed
+
+
+def _matches_filters(run, filters):
+    """Does ``run`` match every ``(key, val)`` filter?
+
+    Keys may be dotted to reach into nested dicts via
+    :func:`flux.util.get_treedict`. The JSON schema groups related
+    fields under ``scheduler``, ``resources``, etc., and filters need
+    to reach into those groups (e.g. ``scheduler.name=sched-simple``,
+    ``resources.nodes=100``). Values are compared as strings since
+    they come from the CLI that way — the JSON record's bools, ints,
+    and strings all get ``str()``-rendered before comparison.
+    """
+    for key, val in filters:
+        if str(get_treedict(run, key)) != val:
+            return False
+    return True
+
+
+class _BenchmarkReportConfig(UtilConfig):
+    """User-customizable named-format registry for one benchmark.
+
+    Wraps :class:`flux.util.UtilConfig` so the benchmark's builtin
+    ``REPORT_FORMATS`` are available to :meth:`get_format_string` along with
+    any user-defined formats loaded from
+    ``~/.config/flux/flux-schedbench-report-<benchmark>.toml``. Each benchmark
+    gets its own config namespace so users adding a ``myformat`` for
+    throughput don't pollute fill-machine's report.
+
+    Auto-generates a ``csv`` format from the benchmark's ``REPORT_HEADINGS``
+    when the benchmark doesn't define one explicitly: this keeps CSV output in
+    sync with the field schema without per-benchmark duplication. Benchmarks
+    that want different column ordering can override ``csv`` in their
+    ``REPORT_FORMATS``.
+    """
+
+    def __init__(self, bench_cls):
+        formats = dict(bench_cls.REPORT_FORMATS)
+        if "csv" not in formats:
+            formats["csv"] = {
+                "description": "All fields, comma-separated (for plotting)",
+                "format": _csv_format_for(bench_cls.REPORT_HEADINGS),
+            }
+        super().__init__(
+            name=f"flux-schedbench-report-{bench_cls.name}",
+            initial_dict={"formats": formats},
+        )
+
+    def validate(self, path, config):
+        for key, value in config.items():
+            if key == "formats":
+                self.validate_formats(path, value)
+            else:
+                raise ValueError(f"{path}: invalid key {key}")
+
+
+def _csv_format_for(headings):
+    """Build a CSV format string from a benchmark's headings.
+
+    Returns ``"{f1},{f2},...,{fN}"`` for each key in headings, preserving
+    insertion order. No format specs are used so missing/None values render as
+    empty cells (per ``""`` in :data:`OutputFormat.empty_outputs`), which is
+    exactly what spreadsheets and pandas expect.
+    """
+    return ",".join(f"{{{k}}}" for k in headings)
+
+
+class _ReportRow:
+    """Flat attribute view of a results-file run for OutputFormat.
+
+    Every field named in the benchmark's ``REPORT_HEADINGS`` is initialized to
+    ``""`` so OutputFormat's ``?:`` sentinel works (the empty-string check in
+    ``empty_outputs()`` picks it up) and CSV cells for missing data render
+    empty rather than ``"None"``. Values are then overwritten from the run
+    record where applicable. The row never raises ``AttributeError`` for a
+    heading-listed field — older results that predate a metric just get ``""``
+    for it.
+    """
+
+    def __init__(self, run, bench_cls):
+        for key in bench_cls.REPORT_HEADINGS:
+            setattr(self, key, "")
+        self.time = run.get("iso_timestamp", "")
+        sched = run.get("scheduler") or {}
+        self.scheduler = sched.get("name", "")
+        self.tag = run.get("tag", "")
+        self.watcher = run.get("watcher", "")
+        res = run.get("resources") or {}
+        self.nodes = res.get("nodes", "")
+        self.cores = res.get("cores_per_node", "")
+        self.gpus = res.get("gpus_per_node", "")
+        # real_exec is a boolean in the JSON; rendered as Y/N so the column
+        # reads at a glance and is consistent in CSV too (no NaN cells for
+        # pandas). Older records without the field render as "N" — correct,
+        # since the feature postdates them and those runs were all mock.
+        self.real_exec = "Y" if run.get("real_exec") else "N"
+        # Per-test metric dict lives at benchmarks[test_name].results. Use the
+        # run's recorded test_name (not bench_cls.name) so a rename of the
+        # benchmark class doesn't strand old records.
+        test = run.get("test_name", "")
+        metrics = (run.get("benchmarks") or {}).get(test, {}).get("results", {})
+        for key, value in metrics.items():
+            if key in bench_cls.REPORT_HEADINGS:
+                setattr(self, key, value)
+
+        # Final normalization: convert any None to "". Two ways None leaks
+        # into a row: (a) argparse stores unset string options like --tag as
+        # None, which _run_record propagates to the JSON; .get(key, default)
+        # only returns default when the key is *absent*, not when its value is
+        # explicitly None — so tag-less runs leave self.tag=None here even
+        # though we passed "" as the default. (b) An older results file may
+        # have a metric stored as None. Both cases would otherwise blow up at
+        # format time because numeric/precision specs reject None (and even
+        # the string spec "<8.8" fails with "unsupported format string passed
+        # to NoneType.__format__"). Defending here keeps the renderer simple
+        # and tolerant.
+        for key in bench_cls.REPORT_HEADINGS:
+            if getattr(self, key) is None:
+                setattr(self, key, "")
+
+
+def cmd_report(args):
+    """Pretty-print results for a single benchmark.
+
+    Loads the benchmark's report config (builtin + user TOML), resolves ``-o``
+    against named formats, applies ``--sort`` and ``--filter``, and delegates
+    to :meth:`OutputFormat.print_items` for rendering. An implicit filter
+    restricts rows to the requested benchmark so the output is always per-test
+    (no cross-benchmark column confusion).
+    """
+    bench_cls = BENCHMARKS[args.test]
+
+    results = BenchmarkResults(args.results_file)
+    runs = results.get_runs()
+
+    filters = _parse_filters(args.filter)
+    filters.append(("test_name", args.test))
+    runs = [r for r in runs if _matches_filters(r, filters)]
+
+    if not runs:
+        LOGGER.error(
+            "no %s runs match the given filters",
+            args.test,
+        )
+        sys.exit(1)
+
+    config = _BenchmarkReportConfig(bench_cls).load()
+    try:
+        fmt_str = config.get_format_string(args.format)
+        formatter = OutputFormat(
+            fmt_str,
+            headings=bench_cls.REPORT_HEADINGS,
+        )
+    except ValueError as err:
+        raise ValueError(f"invalid format: {err}")
+
+    if args.sort:
+        try:
+            formatter.set_sort_keys(args.sort)
+        except ValueError as err:
+            raise ValueError(f"invalid sort key: {err}")
+
+    rows = [_ReportRow(r, bench_cls) for r in runs]
+    formatter.print_items(rows, no_header=args.no_header)
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+    args = parse_args()
+    # `run` accepts -q/--quiet but `report` does not, so guard the attribute
+    # lookup. When set, raise the log level past INFO so callback-based info
+    # logging from helpers goes silent. WARNING and above still pass through
+    # — those are real issues the user needs to see regardless of quiet mode.
+    # Results-bearing events flow through the emitter, not the logger, so the
+    # result event is unaffected.
+    if getattr(args, "quiet", False):
+        LOGGER.setLevel(logging.WARNING)
+    if args.subcommand == "run":
+        cmd_run(args)
+    elif args.subcommand == "report":
+        cmd_report(args)
+
+
+if __name__ == "__main__":
+    main()
+
+# vi: ts=4 sw=4 expandtab

--- a/src/cmd/flux-schedbench.py
+++ b/src/cmd/flux-schedbench.py
@@ -29,6 +29,7 @@ import shlex
 import socket
 import sys
 import time
+from collections import ChainMap
 
 import flux
 import flux.resource
@@ -65,75 +66,81 @@ _WATCHERS = {
 }
 
 
-def _add_common_run_opts(parser):
-    """Add common --opts for 'flux schedbench run' to the parser."""
+def _add_common_run_opts(parser, sweep_mode=False):
+    """Add common --opts for ``flux schedbench run`` (and ``sweep``).
+
+    When ``sweep_mode=True``, axis-capable parameter flags
+    (--nodes, --njobs, --scheduler, etc.) take string values that
+    the sweep dispatcher parses as axis specs — a comma list like
+    ``16,32,64`` or an RFC 45 range like ``16-1024:2`` becomes a
+    sweep axis with multiple values; a scalar stays fixed across
+    the whole sweep.  Defaults switch to ``None`` so missing flags
+    don't accidentally pollute the matrix.  Run-only meta flags
+    (--quiet, --verbose, --extra-start-options) are omitted.
+    """
+
+    def _param(type_, default, metavar):
+        """Type/default/metavar kwargs for an axis-capable param
+        flag — string axis-spec in sweep_mode, native type in run
+        mode."""
+        if sweep_mode:
+            return dict(type=str, default=None, metavar="V")
+        return dict(type=type_, default=default, metavar=metavar)
+
     parser.add_argument(
         "-N",
         "--nodes",
-        type=int,
-        default=4,
-        metavar="N",
         help="fake-resource node count for the launched "
         "subinstance (default: 4; ignored with --exec — the "
         "real broker's resources are used instead)",
+        **_param(int, 4, "N"),
     )
     parser.add_argument(
         "-c",
         "--cores-per-node",
-        type=int,
-        default=64,
-        metavar="C",
         help="cores per node (default: 64; ignored with --exec)",
+        **_param(int, 64, "C"),
     )
     parser.add_argument(
         "-g",
         "--gpus-per-node",
-        type=int,
-        default=8,
-        metavar="G",
         help="GPUs per node (default: 8; ignored with --exec)",
+        **_param(int, 8, "G"),
     )
     parser.add_argument(
         "-n",
         "--njobs",
-        type=int,
-        default=1000,
-        metavar="N",
         help="number of jobs to submit (default: 1000). Each "
         "benchmark uses this differently: throughput and locality "
         "submit exactly this many; fill-machine derives its job "
         "count from the resource set and ignores this value; "
         "locality's --duration=fill mode likewise overrides.",
+        **_param(int, 1000, "N"),
     )
     parser.add_argument(
         "--slot-cores",
-        type=int,
-        default=1,
-        metavar="K",
         help="cores per slot (default: 1). Per-task core "
         "requirement for jobs submitted by this benchmark.",
+        **_param(int, 1, "K"),
     )
     parser.add_argument(
         "--slot-gpus",
-        type=int,
-        default=0,
-        metavar="K",
         help="GPUs per slot (default: 0). Per-task GPU requirement "
         "for jobs submitted by this benchmark.",
+        **_param(int, 0, "K"),
     )
     parser.add_argument(
         "--hwloc-xml-path",
-        metavar="PATH",
         help="path to an hwloc XML file describing per-node "
         "topology; passed to the subinstance as "
         "--conf=fake-resources.hwloc-xml-path=PATH. The XML's "
         "per-node shape is replicated across --nodes. Useful for "
         "testing topology-aware schedulers (e.g. Fluxion). "
         "Ignored with --exec.",
+        **_param(str, None, "PATH"),
     )
     parser.add_argument(
         "--amend-r",
-        metavar="SPEC",
         help="reference to a Python amender that mutates R before "
         "it is written to KVS, in either ``module:function`` form "
         "or as a path to a file with an ``amend()`` callable "
@@ -142,11 +149,10 @@ def _add_common_run_opts(parser):
         "--conf=fake-resources.amend-r=SPEC. Typically paired with "
         "--hwloc-xml-path to inject scheduler-specific topology "
         "metadata into R. Ignored with --exec.",
+        **_param(str, None, "SPEC"),
     )
     parser.add_argument(
         "--scheduler",
-        default="sched-simple",
-        metavar="NAME",
         help="scheduler module to load in the fake-resources "
         "subinstance via --conf=modules.alternatives.sched "
         "(default: sched-simple). Ignored with --exec — in "
@@ -155,15 +161,16 @@ def _add_common_run_opts(parser):
         "name is read from the broker post-setup via the "
         "sched-service lookup — so the results record reflects "
         "what was actually loaded, not what was requested.",
+        **_param(str, "sched-simple", "NAME"),
     )
     parser.add_argument(
         "--scheduler-options",
-        metavar="OPTS",
         help="module options string for the scheduler; "
         "shlex-parsed into a list and encoded into the "
         "subinstance config as "
         '--conf=modules.sched.args=["opt1", "opt2"]. '
         "Ignored with --exec.",
+        **_param(str, None, "OPTS"),
     )
     parser.add_argument(
         "--conf",
@@ -177,20 +184,21 @@ def _add_common_run_opts(parser):
         "shorter, and accumulates across multiple uses. Ignored "
         "with --exec.",
     )
-    parser.add_argument(
-        "-o",
-        "--extra-start-options",
-        action="append",
-        default=[],
-        metavar="OPTS",
-        help="extra arguments to pass through to the underlying "
-        "`flux start` when launching the fake-resources "
-        "subinstance; shlex-parsed. May be given multiple "
-        "times. Useful for broker attributes (--setattr=...) "
-        "and other non-config flags; for plain --conf=KEY=VALUE "
-        "settings prefer the dedicated --conf option above. "
-        "Ignored with --exec.",
-    )
+    if not sweep_mode:
+        parser.add_argument(
+            "-o",
+            "--extra-start-options",
+            action="append",
+            default=[],
+            metavar="OPTS",
+            help="extra arguments to pass through to the underlying "
+            "`flux start` when launching the fake-resources "
+            "subinstance; shlex-parsed. May be given multiple "
+            "times. Useful for broker attributes (--setattr=...) "
+            "and other non-config flags; for plain --conf=KEY=VALUE "
+            "settings prefer the dedicated --conf option above. "
+            "Ignored with --exec.",
+        )
     parser.add_argument(
         "-x",
         "--exec",
@@ -202,20 +210,34 @@ def _add_common_run_opts(parser):
         "broker's currently-loaded scheduler and currently-up "
         "resources are what you want to benchmark.",
     )
-    parser.add_argument(
-        "--watcher",
-        choices=sorted(_WATCHERS.keys()),
-        default="journal",
-        help="event-watcher implementation (default: journal). "
-        "The journal watcher imposes a single subscription on "
-        "kvs-watch; the per-job watcher opens one subscription "
-        "per job, useful for measuring watcher overhead under "
-        "high job counts.",
-    )
+    # --watcher has a fixed choice set in run mode; in sweep mode
+    # it becomes axis-capable and choices come off (the child
+    # validates each axis value as it spawns).
+    if sweep_mode:
+        parser.add_argument(
+            "--watcher",
+            type=str,
+            default=None,
+            metavar="V",
+            help="event-watcher implementation (axis-capable). "
+            "Same semantics as `run`'s --watcher; in sweep mode "
+            "accepts a comma list like ``journal,per-job``.",
+        )
+    else:
+        parser.add_argument(
+            "--watcher",
+            choices=sorted(_WATCHERS.keys()),
+            default="journal",
+            help="event-watcher implementation (default: journal). "
+            "The journal watcher imposes a single subscription on "
+            "kvs-watch; the per-job watcher opens one subscription "
+            "per job, useful for measuring watcher overhead under "
+            "high job counts.",
+        )
     parser.add_argument(
         "--tag",
         metavar="LABEL",
-        default="",
+        default=("" if not sweep_mode else None),
         help="free-form label stored in results metadata",
     )
     parser.add_argument(
@@ -229,19 +251,20 @@ def _add_common_run_opts(parser):
         action="store_true",
         help="don't append to the results file",
     )
-    parser.add_argument(
-        "-q",
-        "--quiet",
-        action="store_true",
-        help="emit only terminal events (test.start, result, "
-        "test.complete, test.error); forces JSON output",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="emit progress/info/metric events",
-    )
+    if not sweep_mode:
+        parser.add_argument(
+            "-q",
+            "--quiet",
+            action="store_true",
+            help="emit only terminal events (test.start, result, "
+            "test.complete, test.error); forces JSON output",
+        )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            action="store_true",
+            help="emit progress/info/metric events",
+        )
     parser.add_argument(
         "--ui",
         choices=("auto", "on", "off"),
@@ -405,7 +428,73 @@ def parse_args():
         help="omit the header row",
     )
 
+    # `flux schedbench sweep ...`
+    swp_p = sub.add_parser(
+        "sweep",
+        help="run a parameter-matrix sweep of benchmarks",
+        formatter_class=help_formatter(),
+    )
+    # Same positional + flag shape as ``run`` — but every
+    # axis-capable value may be a single scalar OR a comma list /
+    # RFC 45 range; multi-value forms become sweep axes.  The test
+    # positional is optional in sweep mode (it can come from the
+    # TOML file via --from instead); choices=... is dropped so
+    # multi-test sweeps like ``throughput,locality`` work.
+    swp_p.add_argument(
+        "test",
+        nargs="?",
+        metavar="TEST",
+        help="benchmark to run (comma list for a multi-test "
+        "sweep; may be omitted if provided by --from)",
+    )
+    _add_common_run_opts(swp_p, sweep_mode=True)
+
+    # Sweep-only meta flags.
+    swp_p.add_argument(
+        "--from",
+        dest="from_file",
+        metavar="PATH",
+        help="load sweep definition from a TOML file; CLI flag "
+        "values for the same parameters take precedence",
+    )
+    swp_p.add_argument(
+        "--sweep-name",
+        metavar="NAME",
+        help="human-readable label for this sweep (default: a " "timestamp-based name)",
+    )
+    swp_p.add_argument(
+        "--per-run-nodes",
+        type=int,
+        default=1,
+        metavar="N",
+        help="nodes to allocate to each child Flux job "
+        "(default: 1, enough for fake-resources benchmarks)",
+    )
+
     return parser.parse_args()
+
+
+#: Argparse destinations for axis-capable sweep parameters.  These
+#: are the flags whose values are parsed via :func:`parse_axis_spec`
+#: in :func:`cmd_sweep` to determine whether each one becomes a
+#: fixed parameter (single value) or a sweep axis (multi-value).
+#: The list is the single source of truth; flags themselves are
+#: declared by :func:`_add_common_run_opts` in sweep mode.
+_SWEEP_AXIS_DESTS = (
+    "test",
+    "nodes",
+    "cores_per_node",
+    "gpus_per_node",
+    "njobs",
+    "slot_cores",
+    "slot_gpus",
+    "hwloc_xml_path",
+    "amend_r",
+    "scheduler",
+    "scheduler_options",
+    "watcher",
+    "tag",
+)
 
 
 def _detect_scheduler(handle):
@@ -554,7 +643,15 @@ def _select_emitter(args):
     # ui == "off"
     if args.quiet:
         return _ResultOnlyEmitter()
-    return TestEventEmitter(verbosity=NORMAL)
+    # In --ui=off mode `-v` upgrades the event stream from NORMAL
+    # (test.start/stage/result/test.complete only) to VERBOSE
+    # (adds progress/info/metric events).  Without this upgrade,
+    # `--ui=off -v` would silently produce the same event stream
+    # as `--ui=off` alone — surprising on its own and a problem
+    # for the sweep dashboard, which needs progress events for
+    # the per-run mini bars.
+    verbosity = VERBOSE if args.verbose else NORMAL
+    return TestEventEmitter(verbosity=verbosity)
 
 
 def _flux_version(handle):
@@ -592,14 +689,25 @@ def _config_dict(args, resources, scheduler_name):
     return cfg
 
 
-def _run_record(args, resources, scheduler_name, metrics, flux_version):
+def _run_record(
+    args,
+    resources,
+    scheduler_name,
+    config,
+    metrics,
+    flux_version,
+):
     """Build the result-file record for this run.
 
     ``resources`` carries the resolved shape (real or fake);
     ``scheduler_name`` is the broker's currently-loaded sched module, looked
     up post-setup (so it matches what actually ran, not what was requested);
-    ``args.real_exec`` flags which mode produced the run. Schema is identical
-    for both modes so reports and downstream tools don't have to branch.
+    ``args.real_exec`` flags which mode produced the run.  ``config`` is the
+    test.start event's config dict (see :func:`_config_dict`) — persisted
+    under ``benchmarks[test]`` alongside ``results`` so the report tool can
+    surface per-benchmark configuration (njobs, slot_cores, ...) on rows
+    whose ``results`` are absent.  Schema is identical for both real and
+    mock modes so reports and downstream tools don't have to branch.
     """
     return {
         "test_name": args.test,
@@ -621,7 +729,10 @@ def _run_record(args, resources, scheduler_name, metrics, flux_version):
         },
         "watcher": args.watcher,
         "benchmarks": {
-            args.test: {"results": metrics},
+            args.test: {
+                "config": dict(config),
+                "results": metrics,
+            },
         },
     }
 
@@ -827,10 +938,11 @@ def _run_in_broker(args):
     # specifics.
     if hasattr(emitter, "set_summary_metrics"):
         emitter.set_summary_metrics(type(bench).SUMMARY_METRICS)
+    config = _config_dict(args, resources, scheduler_name)
     emitter.test_start(
         args.test,
         stages=bench.stages,
-        config=_config_dict(args, resources, scheduler_name),
+        config=config,
     )
 
     t0 = time.monotonic()
@@ -851,6 +963,7 @@ def _run_in_broker(args):
                 args,
                 resources,
                 scheduler_name,
+                config,
                 metrics,
                 _flux_version(handle),
             ),
@@ -934,21 +1047,124 @@ def _csv_format_for(headings):
     return ",".join(f"{{{k}}}" for k in headings)
 
 
+class _MissingMetric:
+    """Sentinel for a missing report-row value.
+
+    Renders so that failed/incomplete runs are immediately visible
+    in the report table, following the Flux empty-display convention
+    (single ``-`` hyphen, as used by ``:h`` in :class:`UtilFormatter`
+    and recognized by :class:`DisplayValue` for sort equivalence).
+    Behaviour depends on the format spec:
+
+    * **Numeric specs** (``f``/``d``/``g``/``e``/etc.) -> ``-``
+      right-aligned in the column.  A row missing all its metric
+      values (a benchmark that errored out, an OOM-killed run,
+      etc.) appears as a sequence of ``-`` cells, distinguishing
+      it from real data at a glance.  This is the float-precision
+      counterpart to ``:h`` — ``:h`` strips the type letter and
+      converts to a string format, which loses ``.2f``-style
+      precision.  The sentinel keeps the numeric column width
+      while substituting the hyphen marker.
+    * **String specs** and **width-only specs** (no numeric type
+      letter) -> width-padded blank.  Avoids confusion in identity
+      columns like ``scheduler`` and ``real_exec`` where ``-``
+      would imply data we don't have rather than data that failed.
+    * **No spec** (CSV / ``str()``) -> empty string, so spreadsheets
+      see empty cells rather than a ``-`` literal.
+
+    Without this sentinel, a missing ``time_to_fill`` formatted as
+    ``>7.2f`` raises ``Unknown format code 'f' for object of type
+    'str'`` and aborts the whole report.
+
+    Sort and empty-detection compatibility:
+
+    * ``str(_MISSING) == ""`` -> :class:`DisplayValue` categorizes
+      as EMPTY (group with ``None`` / ``""`` / ``"-"``), so sorting
+      by a column with missing values puts the failed rows at the
+      start (or end, with reverse sort).
+    * ``_MISSING == ""`` -> :class:`OutputFormat`'s ``?:`` empty-skip
+      sentinel treats the field as empty.
+    * ``str(_MISSING) in empty_outputs()`` -> :class:`UtilFormatter`'s
+      ``:h`` substitution would map _MISSING to ``-`` itself (the
+      sentinel composes with the existing convention rather than
+      conflicting with it).
+    """
+
+    #: Format-spec type letters that mean "numeric value".  Stripped
+    #: of fill / align / sign / etc. — only the type letter matters
+    #: for the missing-marker decision.  Includes Python's full
+    #: numeric set; ``%`` is a presentation type for floats.
+    _NUMERIC_TYPES = frozenset("bcdefgnoxEFGX%")
+
+    def __format__(self, spec):
+        if not spec:
+            return ""
+        # Flux's OutputFormat may add a trailing ``+`` ellipsis
+        # extension; strip before inspecting the type letter.
+        spec_core = spec.rstrip("+")
+        is_numeric = spec_core and spec_core[-1] in self._NUMERIC_TYPES
+        # Empirically determine the rendered width by probing
+        # ``spec_core`` (the extension-stripped form) with samples
+        # of each base type.  The ``+`` extension affects content,
+        # not width, so probing without it gives the right answer
+        # for the flux-extended specs that Python's ``format()``
+        # otherwise rejects.  Falls through to empty string if no
+        # sample accepts the spec — rare; degrades gracefully.
+        for sample in (0.0, 0, ""):
+            try:
+                width = len(format(sample, spec_core))
+            except (ValueError, TypeError):
+                continue
+            if is_numeric:
+                # Right-align the hyphen marker in the column —
+                # matches the convention used by ``:h`` in
+                # :class:`UtilFormatter` and by :class:`DisplayValue`
+                # for "this field is empty / not applicable".
+                return "-".rjust(width) if width >= 1 else ""
+            return " " * width
+        LOGGER.debug(
+            "_MissingMetric: no sample accepted spec %r; returning empty", spec
+        )
+        return ""
+
+    def __str__(self):
+        return ""
+
+    def __bool__(self):
+        return False
+
+    def __eq__(self, other):
+        return other == "" or other is self
+
+    def __hash__(self):
+        return hash("")
+
+    def __repr__(self):
+        return "<missing>"
+
+
+#: Module-level singleton used in :class:`_ReportRow` for every
+#: heading-named field until a real value is set.  One instance
+#: shared across all rows — equality is by value not identity.
+_MISSING = _MissingMetric()
+
+
 class _ReportRow:
     """Flat attribute view of a results-file run for OutputFormat.
 
-    Every field named in the benchmark's ``REPORT_HEADINGS`` is initialized to
-    ``""`` so OutputFormat's ``?:`` sentinel works (the empty-string check in
-    ``empty_outputs()`` picks it up) and CSV cells for missing data render
-    empty rather than ``"None"``. Values are then overwritten from the run
-    record where applicable. The row never raises ``AttributeError`` for a
-    heading-listed field — older results that predate a metric just get ``""``
-    for it.
+    Every field named in the benchmark's ``REPORT_HEADINGS`` is
+    initialized to :data:`_MISSING` (a :class:`_MissingMetric`
+    sentinel that formats safely under both string-spec and
+    numeric-spec columns and compares equal to ``""``).  Values
+    are then overwritten from the run record where applicable.
+    The row never raises ``AttributeError`` for a heading-listed
+    field — older results that predate a metric just get the
+    sentinel for it, which renders as a width-padded blank cell.
     """
 
     def __init__(self, run, bench_cls):
         for key in bench_cls.REPORT_HEADINGS:
-            setattr(self, key, "")
+            setattr(self, key, _MISSING)
         self.time = run.get("iso_timestamp", "")
         sched = run.get("scheduler") or {}
         self.scheduler = sched.get("name", "")
@@ -963,29 +1179,47 @@ class _ReportRow:
         # pandas). Older records without the field render as "N" — correct,
         # since the feature postdates them and those runs were all mock.
         self.real_exec = "Y" if run.get("real_exec") else "N"
-        # Per-test metric dict lives at benchmarks[test_name].results. Use the
-        # run's recorded test_name (not bench_cls.name) so a rename of the
-        # benchmark class doesn't strand old records.
+        # Per-test data lives at benchmarks[test_name].  Use the
+        # run's recorded test_name (not bench_cls.name) so a rename
+        # of the benchmark class doesn't strand old records.
+        # ``config`` carries the parameters the benchmark was set
+        # up with (njobs, slot_cores, slot_gpus, ...) and is written
+        # at test.start — so it's present even for runs that errored
+        # out before producing a result.  ``results`` carries the
+        # measured outputs and is only present on success.
+        #
+        # ChainMap encodes the precedence directly: results-wins-
+        # over-config.  Keys present in both (notably ``njobs`` —
+        # benchmarks echo the input count as a result metric) take
+        # the results value, which for partial runs may differ from
+        # the configured count.  Keys only in config (e.g. ``njobs``
+        # on a failed run that never emitted results) still surface,
+        # so failed rows show their configuration alongside the
+        # missing-measurement markers.
         test = run.get("test_name", "")
-        metrics = (run.get("benchmarks") or {}).get(test, {}).get("results", {})
-        for key, value in metrics.items():
+        test_data = (run.get("benchmarks") or {}).get(test) or {}
+        for key, value in ChainMap(
+            test_data.get("results") or {},
+            test_data.get("config") or {},
+        ).items():
             if key in bench_cls.REPORT_HEADINGS:
                 setattr(self, key, value)
 
-        # Final normalization: convert any None to "". Two ways None leaks
-        # into a row: (a) argparse stores unset string options like --tag as
-        # None, which _run_record propagates to the JSON; .get(key, default)
-        # only returns default when the key is *absent*, not when its value is
-        # explicitly None — so tag-less runs leave self.tag=None here even
-        # though we passed "" as the default. (b) An older results file may
-        # have a metric stored as None. Both cases would otherwise blow up at
-        # format time because numeric/precision specs reject None (and even
-        # the string spec "<8.8" fails with "unsupported format string passed
-        # to NoneType.__format__"). Defending here keeps the renderer simple
-        # and tolerant.
+        # Final normalization: convert any None to :data:`_MISSING`.
+        # Two ways None leaks into a row: (a) argparse stores unset
+        # string options like --tag as None, which _run_record
+        # propagates to the JSON; .get(key, default) only returns
+        # default when the key is *absent*, not when its value is
+        # explicitly None — so tag-less runs leave self.tag=None
+        # here even though we passed "" as the default.  (b) An
+        # older results file may have a metric stored as None.  Both
+        # cases would otherwise blow up at format time because
+        # numeric/precision specs reject None.  Routing through the
+        # sentinel handles both string- and numeric-spec columns
+        # uniformly.
         for key in bench_cls.REPORT_HEADINGS:
             if getattr(self, key) is None:
-                setattr(self, key, "")
+                setattr(self, key, _MISSING)
 
 
 def cmd_report(args):
@@ -1033,7 +1267,100 @@ def cmd_report(args):
     formatter.print_items(rows, no_header=args.no_header)
 
 
-@flux.util.CLIMain(LOGGER)
+def cmd_sweep(args):
+    """Execute a parameter-matrix sweep.
+
+    Reads ``run``-shaped flags from the CLI: each axis-capable
+    value (--nodes, --njobs, --scheduler, ...) is interpreted as
+    an axis spec by :func:`parse_axis_spec` — a single value stays
+    fixed across the sweep, a comma list or RFC 45 range becomes
+    a sweep axis.  The cross-product of axes drives the matrix.
+
+    Optional ``--from FILE`` loads structured sweep definitions
+    (multi-module scheduler recipes, env overlays) from a TOML
+    file; CLI values for the same parameters take precedence.
+
+    Each run is dispatched as a parallel Flux job submitted to the
+    outer instance.  To run a sweep without a pre-existing outer
+    instance, wrap the command in ``flux start``::
+
+        flux start -s 1 -- flux schedbench sweep ...
+    """
+    from flux.testing.schedbench.sweep import (
+        LineSweepEmitter,
+        SweepMatrix,
+        TerminalSweepEmitter,
+        generate_sweep_id,
+        parse_axis_spec,
+        run_flux,
+    )
+
+    # Parse each axis-capable arg via parse_axis_spec.  A None or
+    # empty value means "not specified on the CLI" — those don't
+    # enter the matrix (file values, or run defaults, supply them).
+    params = {}
+    for dest in _SWEEP_AXIS_DESTS:
+        v = getattr(args, dest, None)
+        if v is None or v == "":
+            continue
+        params[dest] = parse_axis_spec(v)
+    if args.real_exec:
+        params["real_exec"] = [True]
+
+    if args.from_file:
+        matrix = SweepMatrix.from_file(
+            args.from_file,
+            cli_overrides=params,
+            cli_conf=args.conf,
+        )
+    else:
+        if not params:
+            raise ValueError(
+                "no parameters specified for sweep; pass "
+                "run-style flags (e.g. --nodes=16,32) or use --from"
+            )
+        matrix = SweepMatrix.from_cli(
+            params=params,
+            name=args.sweep_name,
+            conf=args.conf,
+        )
+
+    if args.sweep_name:
+        matrix.name = args.sweep_name
+
+    # Emitter selection: dashboard on TTY, line emitter otherwise.
+    ui = args.ui
+    if ui == "auto":
+        ui = "on" if sys.stdout.isatty() else "off"
+    if ui == "on":
+        emitter = TerminalSweepEmitter(color=args.color)
+    else:
+        emitter = LineSweepEmitter()
+
+    sweep_id = generate_sweep_id()
+    results_file = None if args.no_save else args.results_file
+
+    # Lack of a running outer broker surfaces as a flux.Flux()
+    # construction error inside run_flux, which is more informative
+    # than a pre-flight env-var check — and points users at the
+    # right fix (wrap in `flux start`).
+    n_ok, n_failed = run_flux(
+        matrix=matrix,
+        sweep_id=sweep_id,
+        results_file=results_file,
+        emitter=emitter,
+        per_run_nodes=args.per_run_nodes,
+    )
+    if n_failed:
+        LOGGER.warning(
+            "sweep complete with %d failure(s) of %d total",
+            n_failed,
+            n_ok + n_failed,
+        )
+    return 0 if n_failed == 0 else 1
+
+
+@CLIMain(LOGGER)
 def main():
     args = parse_args()
     # `run` accepts -q/--quiet but `report` does not, so guard the attribute
@@ -1048,6 +1375,8 @@ def main():
         cmd_run(args)
     elif args.subcommand == "report":
         cmd_report(args)
+    elif args.subcommand == "sweep":
+        cmd_sweep(args)
 
 
 if __name__ == "__main__":

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -350,6 +350,7 @@ TESTSCRIPTS = \
 	python/t6000-testing.py \
 	python/t6010-fake-resources.py \
 	python/t6030-testing-benchmarks.py \
+	python/t6031-testing-schedbench-locality.py \
 	python/t6040-testing-ui.py
 
 if HAVE_FLUX_SECURITY

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -348,7 +348,8 @@ TESTSCRIPTS = \
 	python/t0100-modprobe.py \
 	python/t1000-service-add-remove.py \
 	python/t6000-testing.py \
-	python/t6010-fake-resources.py
+	python/t6010-fake-resources.py \
+	python/t6030-testing-benchmarks.py
 
 if HAVE_FLUX_SECURITY
 TESTSCRIPTS += python/t0009-security.py

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -349,7 +349,8 @@ TESTSCRIPTS = \
 	python/t1000-service-add-remove.py \
 	python/t6000-testing.py \
 	python/t6010-fake-resources.py \
-	python/t6030-testing-benchmarks.py
+	python/t6030-testing-benchmarks.py \
+	python/t6040-testing-ui.py
 
 if HAVE_FLUX_SECURITY
 TESTSCRIPTS += python/t0009-security.py

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -347,6 +347,7 @@ TESTSCRIPTS = \
 	python/t0046-job-watcher.py \
 	python/t0100-modprobe.py \
 	python/t1000-service-add-remove.py \
+	python/t6000-testing.py \
 	python/t6010-fake-resources.py
 
 if HAVE_FLUX_SECURITY

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -294,6 +294,7 @@ TESTSCRIPTS = \
 	t3401-module-trace.t \
 	t4100-slurm-expiration-sync.t \
 	t6010-fake-resources.t \
+	t6020-schedbench.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \

--- a/t/python/t6000-testing.py
+++ b/t/python/t6000-testing.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+#
+# flux.testing.bulkrun and flux.testing.job_watcher tests
+#
+# Exercises BulkRun and the two JobEventWatcher implementations
+# (JournalEventWatcher, PerJobEventWatcher) against a real Flux
+# instance running real jobs.
+#
+
+import json
+import os
+import sys
+import unittest
+from io import StringIO
+
+import flux
+from flux.job import JobspecV1
+from flux.testing.bulkrun import BulkRun
+from flux.testing.events import (
+    NORMAL,
+    QUIET,
+    VERBOSE,
+    TestEventEmitter,
+)
+from flux.testing.job_watcher import PerJobEventWatcher
+from subflux import rerun_under_flux
+
+
+def __flux_size():
+    return 4
+
+
+def _trivial_jobspec():
+    """Minimal jobspec that runs 'true' and exits immediately."""
+    return JobspecV1.from_submit(["true"])
+
+
+def _sleep_jobspec(seconds):
+    """Jobspec that runs 'sleep' for the given duration."""
+    return JobspecV1.from_submit(["sleep", str(seconds)])
+
+
+def _mock_jobspec(mock_run_duration="0.001s", args=("sleep", "30")):
+    """Jobspec with mock execution.
+
+    Pairs system.exec.test.run_duration with a command that would take much
+    longer if actually executed; the broker should honor run_duration and
+    finish in simulated time, not actual time. The default args of sleep 30
+    paired with mock_run_duration 0.001s give a strict test: a broker that
+    ignored run_duration would actually run sleep 30 and the bulk would take
+    30+ seconds per slot.
+
+    Parameter name mirrors :func:`flux.testing.schedbench.simple_jobspec` for
+    consistency across the testing utilities, even though this helper is
+    private to the bulkrun tests and constructs the jobspec directly rather
+    than going through simple_jobspec.
+    """
+    return JobspecV1.from_submit(
+        list(args),
+        attributes={"system.exec.test.run_duration": mock_run_duration},
+    )
+
+
+def _wait_for_queue_drain(handle, timeout=30):
+    """Block until the broker has no active jobs (queue empty).
+
+    Wraps the ``job-manager.drain`` RPC, the same primitive ``flux queue
+    drain`` uses. Used by tests that leave jobs running (e.g. via stop()) to
+    ensure cleanup has actually completed before returning, rather than
+    relying on an arbitrary sleep that may not be long enough on a slow
+    machine.
+    """
+    future = handle.rpc("job-manager.drain")
+    future.wait_for(timeout)
+    future.get()
+
+
+def _parse_events(buf):
+    """Parse all events from a captured StringIO emitter stream."""
+    text = buf.getvalue().strip()
+    if not text:
+        return []
+    return [json.loads(line) for line in text.split("\n")]
+
+
+class _BaseTestCase(unittest.TestCase):
+    """Print the running test name to fd 2 at the start of each test.
+
+    pycotap's TAPTestRunner captures sys.stderr per test and emits the
+    contents as TAP diagnostics *after* the result line, which defeats the
+    hang-debugging purpose: a test that hangs never reaches the point where
+    the buffer is flushed, so its "Starting" line never appears. Writing
+    directly to fd 2 with os.write bypasses pycotap's sys.stderr capture and
+    shows the test name before the work starts.
+    """
+
+    def setUp(self):
+        name = self.id().rpartition(".")[2]
+        os.write(2, f"# Starting: {name}\n".encode())
+
+
+class TestBulkRunBasic(_BaseTestCase):
+    """Basic submission, observation, and result aggregation."""
+
+    def test_journal_watcher_happy_path(self):
+        """20 trivial jobs through the default (journal) watcher reach
+        clean"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        bulk.push_jobs(_trivial_jobspec(), 20)
+        result = bulk.run()
+
+        self.assertEqual(result.njobs, 20)
+        self.assertEqual(len(result.jobids_with("clean")), 20)
+        self.assertEqual(len(result.submit_failures), 0)
+        self.assertEqual(result.submit_attempted, 20)
+        self.assertGreater(result.script_runtime, 0)
+        self.assertGreater(
+            result.last_event_t("submit") - result.first_event_t("submit"),
+            0,
+        )
+        self.assertGreater(
+            result.last_event_t("clean") - result.first_event_t("submit"),
+            0,
+        )
+
+    def test_per_job_watcher_happy_path(self):
+        """Same workload via PerJobEventWatcher; equivalent counts"""
+        h = flux.Flux()
+        bulk = BulkRun(h, watcher_factory=PerJobEventWatcher)
+        bulk.push_jobs(_trivial_jobspec(), 20)
+        result = bulk.run()
+
+        self.assertEqual(result.njobs, 20)
+        self.assertEqual(len(result.jobids_with("clean")), 20)
+        self.assertEqual(len(result.submit_failures), 0)
+
+    def test_journal_inline_R(self):
+        """Journal watcher populates inline R on alloc events"""
+        h = flux.Flux()
+        bulk = BulkRun(h, events_of_interest=("submit", "alloc", "clean"))
+        bulk.push_jobs(_trivial_jobspec(), 5)
+        result = bulk.run()
+
+        alloc_jobids = result.jobids_with("alloc")
+        self.assertGreater(len(alloc_jobids), 0)
+        for jobid in alloc_jobids:
+            alloc_event = result.jobs[jobid]["alloc"]
+            self.assertIsNotNone(getattr(alloc_event, "R", None))
+
+    def test_multi_batch(self):
+        """Multiple push_jobs() calls produce a result with batch indices"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        idx0 = bulk.push_jobs(_trivial_jobspec(), 5)
+        idx1 = bulk.push_jobs(_trivial_jobspec(), 3)
+        self.assertEqual(idx0, 0)
+        self.assertEqual(idx1, 1)
+        result = bulk.run()
+
+        self.assertEqual(result.njobs, 8)
+        batch_counts = {0: 0, 1: 0}
+        for jobid, evs in result.jobs.items():
+            self.assertIn("_batch", evs)
+            batch_counts[evs["_batch"]] += 1
+        self.assertEqual(batch_counts[0], 5)
+        self.assertEqual(batch_counts[1], 3)
+
+    def test_single_batch_omits_batch_key(self):
+        """Single-batch runs don't add the _batch key to per-jobid records"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        bulk.push_jobs(_trivial_jobspec(), 5)
+        result = bulk.run()
+        for jobid, evs in result.jobs.items():
+            self.assertNotIn("_batch", evs)
+
+    def test_run_with_no_batches(self):
+        """run() before push_jobs() raises RuntimeError"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        with self.assertRaises(RuntimeError):
+            bulk.run()
+
+    def test_run_twice_raises(self):
+        """run() called twice raises RuntimeError"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        bulk.push_jobs(_trivial_jobspec(), 1)
+        bulk.run()
+        with self.assertRaises(RuntimeError):
+            bulk.run()
+
+    def test_push_after_run_raises(self):
+        """push_jobs() after run() raises RuntimeError"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        bulk.push_jobs(_trivial_jobspec(), 1)
+        bulk.run()
+        with self.assertRaises(RuntimeError):
+            bulk.push_jobs(_trivial_jobspec(), 1)
+
+    def test_invalid_count_raises(self):
+        """push_jobs() with non-positive count raises ValueError"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        with self.assertRaises(ValueError):
+            bulk.push_jobs(_trivial_jobspec(), 0)
+        with self.assertRaises(ValueError):
+            bulk.push_jobs(_trivial_jobspec(), -1)
+
+
+class TestBulkRunCallbacks(_BaseTestCase):
+    """add_event_cb, add_bulk_event_cb, and stop()."""
+
+    def test_event_cb_fires_for_every_event(self):
+        """add_event_cb is invoked for every event on every tracked job"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        seen = []
+        bulk.add_event_cb(lambda b, jid, ev: seen.append((jid, ev.name)))
+        bulk.push_jobs(_trivial_jobspec(), 5)
+        result = bulk.run()
+
+        names_per_jobid = {}
+        for jid, name in seen:
+            names_per_jobid.setdefault(jid, set()).add(name)
+        for jid in result.jobs:
+            self.assertIn("submit", names_per_jobid.get(jid, set()))
+            self.assertIn("clean", names_per_jobid.get(jid, set()))
+        self.assertGreater(len(seen), result.njobs)
+
+    def test_bulk_event_cb_ordering(self):
+        """add_bulk_event_cb fires after the last event of the named type"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+
+        cleans_seen = [0]
+        cleans_seen_at_fire = []
+
+        def on_event(b, jid, ev):
+            if ev.name == "clean":
+                cleans_seen[0] += 1
+
+        def on_all_clean(b):
+            cleans_seen_at_fire.append(cleans_seen[0])
+
+        bulk.add_event_cb(on_event)
+        bulk.add_bulk_event_cb("clean", on_all_clean)
+        bulk.push_jobs(_trivial_jobspec(), 10)
+        result = bulk.run()
+
+        self.assertEqual(
+            len(cleans_seen_at_fire),
+            1,
+            "bulk-event callback should fire exactly once",
+        )
+        self.assertEqual(
+            cleans_seen_at_fire[0],
+            result.njobs,
+            "bulk-event callback should fire after the last clean",
+        )
+
+    def test_bulk_event_cb_multiple_callbacks(self):
+        """Multiple callbacks for the same event name all fire"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        fired = [0, 0]
+        bulk.add_bulk_event_cb("clean", lambda b: fired.__setitem__(0, fired[0] + 1))
+        bulk.add_bulk_event_cb("clean", lambda b: fired.__setitem__(1, fired[1] + 1))
+        bulk.push_jobs(_trivial_jobspec(), 5)
+        bulk.run()
+        self.assertEqual(fired, [1, 1])
+
+    def test_stop_returns_promptly(self):
+        """stop() from a callback returns from run() before all jobs finish"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        submit_count = [0]
+
+        def on_event(b, jid, ev):
+            if ev.name == "submit":
+                submit_count[0] += 1
+                if submit_count[0] >= 5:
+                    b.stop()
+
+        bulk.add_event_cb(on_event)
+        # Long-running so they cannot finish naturally during the test.
+        # Smaller count keeps cleanup quick.
+        bulk.push_jobs(_sleep_jobspec(300), 10)
+        result = bulk.run()
+
+        try:
+            self.assertLess(len(result.jobids_with("clean")), 10)
+            self.assertLess(result.script_runtime, 30)
+        finally:
+            # Cancel leftover jobs and wait for the queue to drain before
+            # returning, so the next test's submissions aren't starved for
+            # resources held by these jobs.
+            bulk.cancelall()
+            _wait_for_queue_drain(h)
+
+
+class TestMockExecution(_BaseTestCase):
+    """Verify the broker honors system.exec.test.run_duration."""
+
+    def test_mock_execution_runs(self):
+        """Mock-exec jobs reach clean without errors"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        bulk.push_jobs(_mock_jobspec(mock_run_duration="0.001s"), 10)
+        result = bulk.run()
+        self.assertEqual(result.njobs, 10)
+        self.assertEqual(len(result.jobids_with("clean")), 10)
+        self.assertEqual(len(result.submit_failures), 0)
+
+    def test_mock_execution_simulates_time(self):
+        """Broker simulates the requested duration, not the real command's"""
+        h = flux.Flux()
+        bulk = BulkRun(h)
+        # Command would take 30s if actually executed; mock_run_duration is
+        # 1ms. A broker that ignored run_duration would actually run sleep 30
+        # and the bulk would take 30+ seconds.
+        bulk.push_jobs(
+            _mock_jobspec(
+                mock_run_duration="0.001s",
+                args=("sleep", "30"),
+            ),
+            10,
+        )
+        result = bulk.run()
+        self.assertEqual(result.njobs, 10)
+        self.assertEqual(len(result.jobids_with("clean")), 10)
+        self.assertLess(result.script_runtime, 10.0)
+
+    def test_mock_execution_zero_duration_with_cancel(self):
+        """Mock-exec mock_run_duration=0 jobs (never finish) terminate
+        via cancel"""
+        h = flux.Flux()
+        njobs = int(h.attr_get("size"))
+        bulk = BulkRun(h, events_of_interest=("submit", "alloc", "clean"))
+        bulk.add_bulk_event_cb("alloc", lambda b: b.cancelall())
+        bulk.push_jobs(
+            _mock_jobspec(mock_run_duration="0", args=("sleep", "30")),
+            njobs,
+        )
+        result = bulk.run()
+        self.assertEqual(result.njobs, njobs)
+        self.assertEqual(len(result.jobids_with("clean")), njobs)
+
+
+class TestBulkRunCancellation(_BaseTestCase):
+    """cancelall() end-to-end."""
+
+    def test_cancelall_from_bulk_event_cb(self):
+        """cancelall() in a bulk-event callback brings all jobs to clean"""
+        h = flux.Flux()
+        # Using more jobs than brokers in the test instance may cause hang
+        njobs = int(h.attr_get("size"))
+        bulk = BulkRun(h, events_of_interest=("submit", "alloc", "clean"))
+        bulk.add_bulk_event_cb("alloc", lambda b: b.cancelall())
+        bulk.push_jobs(_sleep_jobspec(300), njobs)
+        result = bulk.run()
+
+        self.assertEqual(result.njobs, njobs)
+        self.assertEqual(len(result.jobids_with("clean")), njobs)
+
+
+class TestEvents(_BaseTestCase):
+    """TestEventEmitter (flux.testing.events) emits RFC 18 events.
+
+    Pure-Python tests; the broker is not consulted. They run under the same
+    subflux invocation as the broker-dependent tests, but use a StringIO
+    stream rather than stdout so the captured output is parseable.
+    """
+
+    def test_event_format(self):
+        """Emitted event matches the RFC 18 Flux EventLog format"""
+        buf = StringIO()
+        emitter = TestEventEmitter(verbosity=VERBOSE, stream=buf)
+        emitter.progress(50, 100, unit="jobs", rate=10.5)
+
+        events = _parse_events(buf)
+        self.assertEqual(len(events), 1)
+        ev = events[0]
+        # timestamp present and a numeric type
+        self.assertIn("timestamp", ev)
+        self.assertIsInstance(ev["timestamp"], (int, float))
+        # name and context payload
+        self.assertEqual(ev["name"], "progress")
+        self.assertEqual(ev["context"]["current"], 50)
+        self.assertEqual(ev["context"]["total"], 100)
+        self.assertEqual(ev["context"]["unit"], "jobs")
+        # optional rate field
+        self.assertEqual(ev["context"]["rate"], 10.5)
+
+    def test_quiet_keeps_only_terminal_and_result(self):
+        """QUIET emits start, result, complete; drops stage and below"""
+        buf = StringIO()
+        emitter = TestEventEmitter(verbosity=QUIET, stream=buf)
+        emitter.test_start("t", stages=["s1"])
+        emitter.stage("s1", stage_index=0, total_stages=1)
+        emitter.progress(1, 100, unit="jobs")
+        emitter.warning("ignored at QUIET")
+        emitter.info("also ignored")
+        emitter.result({"x": 1})
+        emitter.test_complete(duration=0.5)
+
+        names = [e["name"] for e in _parse_events(buf)]
+        self.assertEqual(names, ["test.start", "result", "test.complete"])
+
+    def test_normal_drops_progress_keeps_stage(self):
+        """NORMAL keeps stage/warning; drops progress/info/metric"""
+        buf = StringIO()
+        emitter = TestEventEmitter(verbosity=NORMAL, stream=buf)
+        emitter.test_start("test", stages=["s1"])
+        emitter.stage("s1", stage_index=0, total_stages=1)
+        emitter.progress(50, 100, unit="jobs")  # dropped at NORMAL
+        emitter.info("dropped at NORMAL")
+        emitter.warning("kept at NORMAL")
+        emitter.result({"throughput": 42})
+        emitter.test_complete(duration=1.0)
+
+        names = [e["name"] for e in _parse_events(buf)]
+        self.assertEqual(
+            names,
+            ["test.start", "stage", "warning", "result", "test.complete"],
+        )
+
+    def test_verbose_emits_optional_events(self):
+        """VERBOSE adds progress/info/metric on top of NORMAL"""
+        buf = StringIO()
+        emitter = TestEventEmitter(verbosity=VERBOSE, stream=buf)
+        emitter.info("setting up")
+        emitter.warning("slow alloc")
+        emitter.metric("submit_rate", 1250.3, unit="jobs/sec")
+        emitter.progress(1, 1, unit="jobs")
+
+        events = _parse_events(buf)
+        names = sorted(e["name"] for e in events)
+        self.assertEqual(names, ["info", "metric", "progress", "warning"])
+        # Verify metric's optional unit field round-tripped correctly
+        metric_event = next(e for e in events if e["name"] == "metric")
+        self.assertEqual(metric_event["context"]["name"], "submit_rate")
+        self.assertEqual(metric_event["context"]["value"], 1250.3)
+        self.assertEqual(metric_event["context"]["unit"], "jobs/sec")
+
+    def test_log_writes_to_stderr_regardless_of_verbosity(self):
+        """log() writes to stderr, never to the event stream"""
+        buf = StringIO()
+        emitter = TestEventEmitter(verbosity=QUIET, stream=buf)
+
+        old_stderr = sys.stderr
+        sys.stderr = StringIO()
+        try:
+            emitter.log("test message")
+            # Stderr got the prose; the event stream remained empty
+            self.assertIn("test message", sys.stderr.getvalue())
+            self.assertEqual(buf.getvalue(), "")
+        finally:
+            sys.stderr = old_stderr
+
+    def test_test_start_carries_config(self):
+        """Optional config field on test.start is attached when provided"""
+        buf = StringIO()
+        emitter = TestEventEmitter(verbosity=NORMAL, stream=buf)
+        emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={"njobs": 1000, "scheduler": "sched-simple"},
+        )
+        events = _parse_events(buf)
+        self.assertEqual(len(events), 1)
+        ctx = events[0]["context"]
+        self.assertEqual(ctx["test_name"], "throughput")
+        self.assertEqual(ctx["stages"], ["execute"])
+        self.assertEqual(ctx["config"], {"njobs": 1000, "scheduler": "sched-simple"})
+
+    def test_unknown_event_name_defaults_to_quiet(self):
+        """emit() with an unrecognized name treats it as QUIET-level"""
+        buf = StringIO()
+        emitter = TestEventEmitter(verbosity=QUIET, stream=buf)
+        emitter.emit("custom.event", {"k": "v"})
+
+        events = _parse_events(buf)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["name"], "custom.event")
+
+    def test_test_error_emits_at_quiet(self):
+        """test_error emits at QUIET (terminal-failure events always pass)"""
+        buf = StringIO()
+        emitter = TestEventEmitter(verbosity=QUIET, stream=buf)
+        emitter.test_error("Resource allocation failed")
+
+        events = _parse_events(buf)
+        self.assertEqual(len(events), 1)
+        ev = events[0]
+        self.assertEqual(ev["name"], "test.error")
+        self.assertEqual(ev["context"]["error"], "Resource allocation failed")
+
+    def test_emit_without_context_omits_context_key(self):
+        """Events with no context payload omit the 'context' key entirely"""
+        # Stripping the key (rather than emitting "context": {}) matches the
+        # RFC 18 contract that context is optional, and keeps the event stream
+        # tidy for consumers that test `if "context" in ev`.
+        buf = StringIO()
+        emitter = TestEventEmitter(verbosity=VERBOSE, stream=buf)
+        emitter.emit("info")  # no context arg
+
+        events = _parse_events(buf)
+        self.assertEqual(len(events), 1)
+        self.assertNotIn("context", events[0])
+
+    def test_emit_flushes_after_write(self):
+        """emit() flushes the stream so live consumers can tail"""
+        # Use a custom stream that distinguishes write() from flush();
+        # StringIO doesn't surface that distinction.
+
+        class _FlushCountingStream:
+            def __init__(self):
+                self.writes = []
+                self.flushes = 0
+
+            def write(self, s):
+                self.writes.append(s)
+
+            def flush(self):
+                self.flushes += 1
+
+        stream = _FlushCountingStream()
+        emitter = TestEventEmitter(verbosity=NORMAL, stream=stream)
+        emitter.stage("s1", stage_index=0, total_stages=1)
+        emitter.stage("s2", stage_index=1, total_stages=2)
+
+        # Each emit() should have triggered at least one flush so a UI tailing
+        # the stream sees events promptly.
+        self.assertGreaterEqual(stream.flushes, 2)
+
+
+if __name__ == "__main__":
+    if rerun_under_flux(__flux_size()):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner(), buffer=False)

--- a/t/python/t6030-testing-benchmarks.py
+++ b/t/python/t6030-testing-benchmarks.py
@@ -1,0 +1,1235 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+#
+# flux.testing.schedbench tests
+#
+# Pure-Python tests for simple_jobspec(), plus broker-requiring
+# integration tests for ThroughputBenchmark and FillMachineBenchmark
+# against a real single-rank Flux instance.
+#
+
+import math
+import os
+import tempfile
+import unittest
+
+import flux
+import flux.resource
+from flux.job.stats import JobStats
+from flux.testing.events import QUIET, TestEventEmitter
+from flux.testing.fake_resources import (
+    InjectFakeResources,
+    saturation_count,
+)
+from flux.testing.job_watcher import (
+    JournalEventWatcher,
+    PerJobEventWatcher,
+)
+from flux.testing.schedbench import (
+    BENCHMARKS,
+    BenchmarkResults,
+    FillMachineBenchmark,
+    ThroughputBenchmark,
+    simple_jobspec,
+)
+from flux.testing.schedbench.benchmarks import (
+    Tracker,
+    failure_diagnostic,
+)
+from subflux import rerun_under_flux
+
+
+def __flux_size():
+    return 1
+
+
+class _BaseTestCase(unittest.TestCase):
+    """Print the running test name to fd 2 at the start of each test.
+
+    pycotap's TAPTestRunner captures sys.stderr per test and emits the
+    contents as TAP diagnostics *after* the result line, which defeats the
+    hang-debugging purpose: a test that hangs never reaches the point where
+    the buffer is flushed, so its "Starting" line never appears. Writing
+    directly to fd 2 with os.write bypasses pycotap's sys.stderr capture and
+    shows the test name before the work starts.
+    """
+
+    def setUp(self):
+        name = self.id().rpartition(".")[2]
+        os.write(2, f"# Starting: {name}\n".encode())
+
+    def _inject(self, **kw):
+        """
+        Install fake resources into the test broker, reloading the
+        resource and sched-simple modules so they see the synthetic R.
+
+        flux.testing.fake_resources.InjectFakeResources.install() only
+        writes R to the KVS; the resource module reads R at startup and
+        caches it, so a live mutation requires unloading and reloading.
+        Production use goes through the fake-resources modprobe rc1 task
+        (see flux-config-fake-resources(5)) which runs before resource
+        loads; tests get to be pragmatic.
+        """
+        h = flux.Flux()
+        for module in ("sched-simple", "resource"):
+            try:
+                h.rpc("module.remove", {"name": module}).get()
+            except FileNotFoundError:
+                pass
+        fake = InjectFakeResources(**kw)
+        fake.install(h)
+        h.rpc(
+            "module.load",
+            {
+                "path": "resource",
+                "args": ["monitor-force-up", "noverify"],
+                "exec": False,
+            },
+        ).get()
+        h.rpc("module.load", {"path": "sched-simple", "args": [], "exec": False}).get()
+        return h, fake
+
+
+def _silent_emitter():
+    """Return an emitter that drops everything below QUIET.
+
+    Even QUIET still emits test.start / result / test.complete to stdout,
+    which would interleave with TAP output. Use an explicit
+    /dev/null-equivalent stream so the event channel goes nowhere.
+    """
+    return TestEventEmitter(verbosity=QUIET, stream=open("/dev/null", "w"))
+
+
+class _StageRecorder:
+    """Duck-typed emitter that records stage() and progress() calls.
+
+    Used in the benchmark "run invariants" tests to verify the benchmark
+    actually traversed every expected stage. Methods are intentionally minimal
+    — benchmarks only call stage() and progress() on the emitter, so we record
+    those and ignore the rest. If a benchmark grows new emitter call sites,
+    this class will raise AttributeError, which is the desired feedback.
+    """
+
+    def __init__(self):
+        self.stages = []
+        self.progress_calls = []
+
+    def stage(self, stage, stage_index, total_stages):
+        self.stages.append(stage)
+
+    def progress(self, current, total, unit, rate=None):
+        self.progress_calls.append((current, total, unit))
+
+
+class TestSimpleJobspec(unittest.TestCase):
+    """simple_jobspec() builds JobspecV1 with the right attributes."""
+
+    def test_default_includes_mock_execution(self):
+        """Default sets system.exec.test.run_duration to the default"""
+        spec = simple_jobspec()
+        run_duration = spec.attributes["system"]["exec"]["test"]["run_duration"]
+        self.assertEqual(run_duration, "0.001s")
+
+    def test_mock_false_omits_mock_execution(self):
+        """mock=False drops the mock-exec attribute entirely.
+
+        This is the real-execution code path: the broker actually runs the
+        jobspec's command rather than simulating it.
+        """
+        spec = simple_jobspec(mock=False)
+        # The "system.exec.test" subtree should not exist when mock is False.
+        # Either the key is absent or the path is incomplete.
+        sys_attrs = spec.attributes.get("system", {})
+        exec_attrs = sys_attrs.get("exec", {}).get("test", {})
+        self.assertNotIn("run_duration", exec_attrs)
+
+    def test_mock_run_duration_zero_for_infinite_jobs(self):
+        """mock_run_duration='0' makes a never-finishing
+        simulated job (used by fill-machine's mock mode)"""
+        spec = simple_jobspec(mock_run_duration="0")
+        run_duration = spec.attributes["system"]["exec"]["test"]["run_duration"]
+        self.assertEqual(run_duration, "0")
+
+    def test_mock_false_uses_supplied_command(self):
+        """mock=False propagates command into the jobspec tasks
+        (mock=True paths don't use the command, so the broker only honors it
+        in real mode)."""
+        spec = simple_jobspec(mock=False, command=("sleep", "inf"))
+        tasks = spec.tasks
+        self.assertEqual(tasks[0]["command"], ["sleep", "inf"])
+
+    def test_slot_gpus_zero_omits_gpus_per_task(self):
+        """slot_gpus=0 keeps gpus_per_task out of the request entirely"""
+        spec = simple_jobspec(slot_cores=2, slot_gpus=0)
+        # Walk the resource tree looking for a "gpu" node; should be absent.
+        gpu_count = self._count_resource(spec.resources, "gpu")
+        self.assertEqual(gpu_count, 0)
+
+    def test_slot_gpus_positive_adds_gpus_per_task(self):
+        """slot_gpus>0 adds a gpu resource node to the request"""
+        spec = simple_jobspec(slot_cores=2, slot_gpus=3)
+        gpu_count = self._count_resource(spec.resources, "gpu")
+        self.assertEqual(gpu_count, 3)
+
+    def test_slot_cores_passes_through(self):
+        """slot_cores translates to cores_per_task"""
+        spec = simple_jobspec(slot_cores=4)
+        core_count = self._count_resource(spec.resources, "core")
+        self.assertEqual(core_count, 4)
+
+    def test_custom_command_passes_through(self):
+        """command tuple is passed to JobspecV1 as the task argv"""
+        spec = simple_jobspec(command=("/bin/echo", "hello"))
+        argv = spec.tasks[0]["command"]
+        self.assertEqual(argv, ["/bin/echo", "hello"])
+
+    def _count_resource(self, resources, resource_type):
+        """Walk a JobspecV1 resource tree and sum count for a type."""
+        total = 0
+        for node in resources or []:
+            if node.get("type") == resource_type:
+                total += node.get("count", 0)
+            total += self._count_resource(
+                node.get("with"),
+                resource_type,
+            )
+        return total
+
+
+class TestTracker(unittest.TestCase):
+    """Unit tests for the internal Tracker helper that drives
+    per-event progress emission in both benchmarks. Pure Python (no broker
+    required) — the tracker only depends on having an object with a
+    ``progress(current, total, label)`` method."""
+
+    class _Emitter:
+        """Records every progress() call as a tuple."""
+
+        def __init__(self):
+            self.events = []
+
+        def progress(self, current, total, label, rate=None):
+            del rate
+            self.events.append((current, total, label))
+
+    def test_emits_at_interval_and_final(self):
+        """Plain tracker emits every 100 steps plus on the final
+        step (for totals not divisible by 100)."""
+        e = self._Emitter()
+        t = Tracker(250, "job")
+        for _ in range(250):
+            t.step(e)
+        self.assertEqual(
+            e.events,
+            [(100, 250, "job"), (200, 250, "job"), (250, 250, "job")],
+        )
+
+    def test_no_emit_when_count_below_interval(self):
+        """Total smaller than the interval should still emit on
+        the final step, even though no interval boundary is hit."""
+        e = self._Emitter()
+        t = Tracker(50, "job")
+        for _ in range(50):
+            t.step(e)
+        self.assertEqual(e.events, [(50, 50, "job")])
+
+    def test_gate_suppresses_emit_but_counts(self):
+        """A closed gate counts steps but suppresses emission;
+        opening it doesn't retroactively emit — call flush() for that.
+        Subsequent steps with the gate open emit normally."""
+        e = self._Emitter()
+        open_gate = [False]
+        t = Tracker(250, "job", gate=lambda: open_gate[0])
+        for _ in range(150):
+            t.step(e)
+        self.assertEqual(t.count, 150)
+        self.assertEqual(e.events, [])
+        open_gate[0] = True
+        # Opening the gate alone doesn't emit.
+        self.assertEqual(e.events, [])
+        # The next step that hits an interval boundary emits.
+        for _ in range(50):
+            t.step(e)
+        self.assertEqual(e.events, [(200, 250, "job")])
+
+    def test_flush_emits_current_count(self):
+        """flush() emits the current count once, without
+        stepping — used at phase boundaries to surface state accumulated while
+        the gate was closed."""
+        e = self._Emitter()
+        t = Tracker(250, "job")
+        # Step the counter to 150 by stepping under a closed gate so no events
+        # fire yet.
+        open_gate = [False]
+        t._gate = lambda: open_gate[0]
+        for _ in range(150):
+            t.step(e)
+        self.assertEqual(e.events, [])
+        # Flush emits the accumulated count.
+        open_gate[0] = True
+        t.flush(e)
+        self.assertEqual(e.events, [(150, 250, "job")])
+        # The counter is unchanged by flush.
+        self.assertEqual(t.count, 150)
+
+    def test_flush_with_zero_count_is_noop(self):
+        """flush() on a fresh tracker (count=0) emits nothing.
+        Used by ThroughputBenchmark.on_all_submitted: in the common case no
+        clean events fired during submit phase and the flush should be
+        silent."""
+        e = self._Emitter()
+        t = Tracker(100, "job")
+        t.flush(e)
+        self.assertEqual(e.events, [])
+
+    def test_label_passes_through(self):
+        """The label argument is forwarded verbatim — used to
+        distinguish 'job' progress from 'cancel' progress in fill-machine."""
+        e = self._Emitter()
+        t = Tracker(100, "cancel")
+        for _ in range(100):
+            t.step(e)
+        self.assertEqual(e.events, [(100, 100, "cancel")])
+
+
+class TestBenchmarkMetadata(unittest.TestCase):
+    """Class-level metadata exposed for CLI lookup."""
+
+    def test_throughput_name(self):
+        """ThroughputBenchmark.name is the CLI-facing identifier"""
+        self.assertEqual(ThroughputBenchmark.name, "throughput")
+
+    def test_throughput_stages(self):
+        """ThroughputBenchmark advertises 'submit' then 'execute'"""
+        self.assertEqual(
+            ThroughputBenchmark.stages,
+            ("submit", "execute"),
+        )
+
+    def test_fill_machine_name(self):
+        """FillMachineBenchmark.name is the CLI-facing identifier"""
+        self.assertEqual(FillMachineBenchmark.name, "fill-machine")
+
+    def test_fill_machine_stages(self):
+        """FillMachineBenchmark advertises submit, fill, cancel"""
+        self.assertEqual(
+            FillMachineBenchmark.stages,
+            ("submit", "fill", "cancel"),
+        )
+
+    def test_benchmarks_registry_has_built_ins(self):
+        """BENCHMARKS maps each benchmark name to its class.
+
+        Not asserting an exact length here because locality (and any
+        future benchmark module imported by the package's __init__)
+        also auto-registers — the registry is open-ended by design.
+        """
+        self.assertIs(BENCHMARKS["throughput"], ThroughputBenchmark)
+        self.assertIs(BENCHMARKS["fill-machine"], FillMachineBenchmark)
+
+
+class TestReportMetadata(unittest.TestCase):
+    """Per-benchmark ``REPORT_HEADINGS`` and ``REPORT_FORMATS``
+    metadata used by ``flux schedbench report``. The class-level metadata is
+    what makes per-test reporting work — these tests exist to catch drift when
+    REPORT_HEADINGS or REPORT_FORMATS are edited (a typo in either would
+    otherwise silently misformat or break at runtime). For each benchmark
+    class we check that:
+
+    1. Every field referenced in every REPORT_FORMATS entry is declared in
+    REPORT_HEADINGS (catches typos in format strings, removed-field drift). 2.
+    REPORT_HEADINGS contains all the identity columns from
+    COMMON_REPORT_HEADINGS (catches accidental shadowing in per-benchmark
+    dicts). 3. A ``default`` format exists (the CLI default). 4. Each
+    REPORT_FORMATS entry has both ``description`` and ``format`` keys (the
+    shape UtilConfig expects).
+    """
+
+    #: Every registered benchmark gets these checks. Auto-derived
+    #: from the registry so new benchmarks (built-in or plugin) are
+    #: covered without test edits.
+    BENCH_CLASSES = tuple(BENCHMARKS.values())
+
+    def _format_fields(self, fmt_str):
+        """Extract field names from a format string the same way
+        ``OutputFormat`` does. Returns a list (not a set) so we can assert on
+        the order the fields appear."""
+        from string import Formatter
+
+        names = []
+        for _, field_name, _, _ in Formatter().parse(fmt_str):
+            if field_name:
+                # Strip any "!conv" suffix and ".attr" lookups; schedbench
+                # formats don't use either today, but this matches
+                # OutputFormat's behavior.
+                base = field_name.split(".")[0].split("!")[0]
+                names.append(base)
+        return names
+
+    def test_every_format_field_in_headings(self):
+        """Every {field} in every REPORT_FORMATS entry must
+        appear in the benchmark's REPORT_HEADINGS. This is the
+        drift-prevention test: editing REPORT_FORMATS to use a field name that
+        doesn't exist in headings would cause OutputFormat to raise
+        ValueError("Unknown format field") at runtime, breaking ``flux
+        schedbench report``."""
+        for cls in self.BENCH_CLASSES:
+            for fmt_name, fmt_spec in cls.REPORT_FORMATS.items():
+                fields = self._format_fields(fmt_spec["format"])
+                unknown = [f for f in fields if f not in cls.REPORT_HEADINGS]
+                self.assertEqual(
+                    unknown,
+                    [],
+                    msg=(
+                        f"{cls.__name__}.REPORT_FORMATS[{fmt_name!r}] "
+                        f"references unknown fields: {unknown}"
+                    ),
+                )
+
+    def test_common_headings_inherited(self):
+        """REPORT_HEADINGS must include every key from the
+        common heading dict so identity columns (time, scheduler, nodes, ...)
+        are spelled consistently across benchmarks."""
+        from flux.testing.schedbench.benchmarks import (
+            COMMON_REPORT_HEADINGS,
+        )
+
+        for cls in self.BENCH_CLASSES:
+            for key, value in COMMON_REPORT_HEADINGS.items():
+                self.assertIn(
+                    key,
+                    cls.REPORT_HEADINGS,
+                    msg=f"{cls.__name__} missing common key {key!r}",
+                )
+                self.assertEqual(
+                    cls.REPORT_HEADINGS[key],
+                    value,
+                    msg=(
+                        f"{cls.__name__}.REPORT_HEADINGS[{key!r}] "
+                        f"shadows common label: "
+                        f"{cls.REPORT_HEADINGS[key]!r} vs {value!r}"
+                    ),
+                )
+
+    def test_default_format_present(self):
+        """Each benchmark must define a 'default' format because
+        that's the argparse fallback when -o is unset."""
+        for cls in self.BENCH_CLASSES:
+            self.assertIn(
+                "default",
+                cls.REPORT_FORMATS,
+                msg=f"{cls.__name__} missing 'default' format",
+            )
+
+    def test_format_entries_have_required_keys(self):
+        """Each REPORT_FORMATS entry must be a dict with
+        ``description`` and ``format`` keys (the shape
+        ``UtilConfig.validate_formats`` expects)."""
+        for cls in self.BENCH_CLASSES:
+            for fmt_name, fmt_spec in cls.REPORT_FORMATS.items():
+                self.assertIsInstance(
+                    fmt_spec,
+                    dict,
+                    msg=f"{cls.__name__}.{fmt_name} is not a dict",
+                )
+                self.assertIn("description", fmt_spec)
+                self.assertIn("format", fmt_spec)
+                self.assertIsInstance(fmt_spec["format"], str)
+                self.assertIsInstance(fmt_spec["description"], str)
+
+
+class TestThroughputBenchmark(_BaseTestCase):
+    """ThroughputBenchmark runs against a real broker with fake R."""
+
+    def test_throughput_basic_run(self):
+        """50-job run produces all four positive rate metrics"""
+        h, fake = self._inject(nodes=4, cores_per_node=4)
+        m = ThroughputBenchmark(njobs=50).run(h, _silent_emitter())
+
+        self.assertEqual(m["njobs"], 50)
+        self.assertGreater(m["submit_rate"], 0)
+        self.assertGreater(m["alloc_rate"], 0)
+        self.assertGreater(m["throughput"], 0)
+        self.assertGreater(m["script_throughput"], 0)
+
+    def test_throughput_with_gpus(self):
+        """slot_gpus>0 still completes when fake R has GPUs"""
+        h, fake = self._inject(
+            nodes=4,
+            cores_per_node=4,
+            gpus_per_node=2,
+        )
+        m = ThroughputBenchmark(
+            njobs=20,
+            slot_cores=1,
+            slot_gpus=1,
+        ).run(h, _silent_emitter())
+
+        self.assertEqual(m["njobs"], 20)
+        self.assertGreater(m["throughput"], 0)
+
+    def test_throughput_njobs_matches_input(self):
+        """The njobs result equals what was submitted"""
+        h, fake = self._inject(nodes=4, cores_per_node=4)
+        m = ThroughputBenchmark(njobs=25).run(h, _silent_emitter())
+        self.assertEqual(m["njobs"], 25)
+
+    def test_throughput_watcher_swap_equivalent_results(self):
+        """Journal and per-job watchers both produce a complete,
+        well-ordered metric set with positive rates and the same njobs. They
+        differ in script-side timing (watcher overhead), but every invariant
+        the benchmark guarantees must hold for either choice. Catches a
+        watcher-factory threading bug — if watcher_factory weren't being
+        passed through to BulkRun, one of these would fail or hang."""
+        for name, factory in (
+            ("journal", lambda h: JournalEventWatcher(h)),
+            ("per-job", lambda h: PerJobEventWatcher(h)),
+        ):
+            with self.subTest(watcher=name):
+                h, fake = self._inject(nodes=4, cores_per_node=4)
+                m = ThroughputBenchmark(
+                    njobs=20,
+                    watcher_factory=factory,
+                ).run(h, _silent_emitter())
+
+                self.assertEqual(m["njobs"], 20)
+                # All headline rates must be finite and positive. ingest_rate
+                # is the broker-side submit measure; submit_rate is the
+                # script-observed counterpart.
+                for key in (
+                    "submit_rate",
+                    "alloc_rate",
+                    "ingest_rate",
+                    "throughput",
+                    "script_throughput",
+                ):
+                    self.assertTrue(
+                        math.isfinite(m[key]),
+                        "{0}/{1} = {2}".format(name, key, m[key]),
+                    )
+                    self.assertGreater(
+                        m[key],
+                        0,
+                        "{0}/{1} = {2}".format(name, key, m[key]),
+                    )
+
+                # Script-observed submit_rate cannot exceed the broker-side
+                # ingest_rate within the same run: the script's bulk callback
+                # fires only after the watcher has delivered every submit
+                # event, so the script's window is no shorter than the
+                # broker's.
+                self.assertLessEqual(
+                    m["submit_rate"],
+                    m["ingest_rate"] * 1.001,
+                )
+
+    def test_throughput_run_invariants(self):
+        """Stages emitted, jobs submitted+completed, metrics
+        finite/positive, timestamps monotonically ordered, resources released"""
+        h, fake = self._inject(nodes=4, cores_per_node=4)
+
+        # Snapshot job counts before the benchmark so we can isolate this
+        # run's submissions from any from prior tests (the broker accumulates
+        # inactive jobs across the whole subflux session).
+        before = JobStats(h).update_sync()
+
+        rec = _StageRecorder()
+        m = ThroughputBenchmark(njobs=20).run(h, rec)
+
+        after = JobStats(h).update_sync()
+
+        # The benchmark advertises two stages ("submit" then "execute") and
+        # must actually traverse both; otherwise on_event never wired up or
+        # on_all_submitted didn't fire.
+        self.assertEqual(rec.stages, ["submit", "execute"])
+
+        # Exactly 20 new jobs reached the broker and all transitioned to
+        # inactive. Catches "njobs was reported correctly but fewer jobs
+        # actually got submitted" silently.
+        self.assertEqual(after.total - before.total, 20)
+        self.assertEqual(after.inactive - before.inactive, 20)
+        # Mock-exec jobs return 0, so all 20 should be counted as successful —
+        # not failed/canceled/timeout.
+        self.assertEqual(after.successful - before.successful, 20)
+        self.assertEqual(after.failed - before.failed, 0)
+
+        # Every rate metric must be finite and positive — catches inf/nan from
+        # divide-by-zero on degenerate event spans.
+        for key in (
+            "submit_rate",
+            "alloc_rate",
+            "ingest_rate",
+            "throughput",
+            "script_throughput",
+        ):
+            self.assertTrue(math.isfinite(m[key]), "{0} = {1}".format(key, m[key]))
+            self.assertGreater(m[key], 0, "{0} = {1}".format(key, m[key]))
+
+        # Watcher overhead invariant: submit_rate is the script-observed rate
+        # (njobs / (t_all_submitted - t_submit_start)); ingest_rate is the
+        # broker-side counterpart (njobs / (t_last_submit_event -
+        # t_submit_start)). The script's bulk callback fires after the
+        # broker's last event is delivered, so the script's denominator is at
+        # least as long, hence submit_rate <= ingest_rate. A violation would
+        # mean the bulk callback and broker event timestamps are out of order.
+        self.assertLessEqual(
+            m["submit_rate"],
+            m["ingest_rate"] * 1.001,
+        )
+
+        # The full timestamp set is present. Downstream tools rely on the
+        # exact key names, so check them explicitly.
+        for key in (
+            "t_submit_start",
+            "t_all_submitted",
+            "t_first_submit_event",
+            "t_last_submit_event",
+            "t_all_alloc",
+            "t_last_alloc_event",
+            "t_all_clean",
+            "t_last_clean_event",
+            "t_done",
+        ):
+            self.assertIn(key, m)
+            self.assertTrue(
+                math.isfinite(m[key]),
+                "{0} = {1}".format(key, m[key]),
+            )
+
+        # Timestamp orderings, split into chains the implementation actually
+        # guarantees. A single monotonic chain across script and broker times
+        # isn't valid: flux pipelines events, so a broker-side first-Y event
+        # can precede a script-side all-X bulk-callback firing.
+
+        # Script-side callback ordering (BulkRun fires bulk callbacks
+        # sequentially in lifecycle order; bulk.run returns after
+        # on_all_clean):
+        self.assertLessEqual(m["t_submit_start"], m["t_all_submitted"])
+        self.assertLessEqual(m["t_all_submitted"], m["t_all_alloc"])
+        self.assertLessEqual(m["t_all_alloc"], m["t_all_clean"])
+        self.assertLessEqual(m["t_all_clean"], m["t_done"])
+
+        # Within-event-type broker ordering:
+        self.assertLessEqual(
+            m["t_first_submit_event"],
+            m["t_last_submit_event"],
+        )
+
+        # Cross-event-type broker ordering by per-job causality: the job that
+        # has last_X also has X before its own Y, and that Y ≤ last_Y over all
+        # jobs.
+        self.assertLessEqual(
+            m["t_last_submit_event"],
+            m["t_last_alloc_event"],
+        )
+        self.assertLessEqual(
+            m["t_last_alloc_event"],
+            m["t_last_clean_event"],
+        )
+
+        # Watcher delivery latency: broker emits each event before the
+        # script's matching bulk callback fires.
+        self.assertLessEqual(
+            m["t_last_submit_event"],
+            m["t_all_submitted"],
+        )
+        self.assertLessEqual(
+            m["t_last_alloc_event"],
+            m["t_all_alloc"],
+        )
+        self.assertLessEqual(
+            m["t_last_clean_event"],
+            m["t_all_clean"],
+        )
+
+        # Submit starts in the script before the broker sees any submit event.
+        self.assertLessEqual(
+            m["t_submit_start"],
+            m["t_first_submit_event"],
+        )
+
+        # Both throughput numerators are njobs. Denominators: throughput uses
+        # last_clean_event - t_submit_start (broker-side right edge,
+        # script-side left edge). script_runtime measures from BulkRun
+        # construction to bulk.run() return, which always wraps the broker
+        # event window (last_clean_event is delivered to the script before
+        # bulk.run() returns). So script_runtime >= the throughput
+        # denominator, hence script_throughput <= throughput. 1% slop for
+        # floats.
+        self.assertLessEqual(
+            m["script_throughput"],
+            m["throughput"] * 1.01,
+        )
+
+        # All resources should be free again: jobs completed and the scheduler
+        # released their slots.
+        rl = flux.resource.resource_list(h).get()
+        self.assertEqual(rl.allocated.nnodes, 0)
+
+
+class TestFillMachineBenchmark(_BaseTestCase):
+    """FillMachineBenchmark saturates fake R, cancels, measures."""
+
+    def test_fill_machine_cpu_and_gpu(self):
+        """4x4x2 with 1c/1g slot saturates at 8 jobs"""
+        h, fake = self._inject(
+            nodes=4,
+            cores_per_node=4,
+            gpus_per_node=2,
+        )
+        njobs = saturation_count(
+            fake.nodes,
+            fake.cores_per_node,
+            fake.gpus_per_node,
+            slot_cores=1,
+            slot_gpus=1,
+        )
+        m = FillMachineBenchmark(
+            njobs=njobs,
+            slot_cores=1,
+            slot_gpus=1,
+        ).run(h, _silent_emitter())
+
+        self.assertEqual(m["njobs"], 8)
+        self.assertGreater(m["time_to_fill"], 0)
+        self.assertGreater(m["cancel_rate"], 0)
+        self.assertGreater(m["submit_rate"], 0)
+        self.assertGreater(m["alloc_rate"], 0)
+        self.assertGreater(m["start_rate"], 0)
+
+    def test_fill_machine_cpu_only(self):
+        """4x4 with 1c slot saturates at 16 jobs"""
+        h, fake = self._inject(nodes=4, cores_per_node=4)
+        njobs = saturation_count(
+            fake.nodes,
+            fake.cores_per_node,
+            fake.gpus_per_node,
+            slot_cores=1,
+        )
+        m = FillMachineBenchmark(
+            njobs=njobs,
+            slot_cores=1,
+        ).run(h, _silent_emitter())
+
+        self.assertEqual(m["njobs"], 16)
+        self.assertGreater(m["time_to_fill"], 0)
+        self.assertGreater(m["cancel_rate"], 0)
+
+    def test_fill_machine_wider_slot(self):
+        """Slot wider than 1 core reduces saturation count"""
+        h, fake = self._inject(nodes=4, cores_per_node=4)
+        njobs = saturation_count(
+            fake.nodes,
+            fake.cores_per_node,
+            fake.gpus_per_node,
+            slot_cores=2,
+        )
+        m = FillMachineBenchmark(
+            njobs=njobs,
+            slot_cores=2,
+        ).run(h, _silent_emitter())
+
+        # 4 nodes x (4 cores / 2 cores per slot) = 8 jobs
+        self.assertEqual(m["njobs"], 8)
+
+    def test_fill_machine_njobs_matches_saturation_count(self):
+        """The benchmark submits exactly the njobs it was given,
+        which is what callers — including flux-schedbench — get from
+        saturation_count on the resource shape. This is the end-to-end check
+        that the public saturation_count helper and FillMachineBenchmark's
+        njobs argument compose to produce a fully-packed broker."""
+        h, fake = self._inject(
+            nodes=4,
+            cores_per_node=4,
+            gpus_per_node=2,
+        )
+        expected = saturation_count(
+            fake.nodes,
+            fake.cores_per_node,
+            fake.gpus_per_node,
+            slot_cores=1,
+            slot_gpus=1,
+        )
+        bench = FillMachineBenchmark(
+            njobs=expected,
+            slot_cores=1,
+            slot_gpus=1,
+        )
+        m = bench.run(h, _silent_emitter())
+        self.assertEqual(m["njobs"], expected)
+
+    def test_fill_machine_run_invariants(self):
+        """All three stages emitted, jobs canceled, metrics
+        finite/positive, timestamps monotonically ordered, resources
+        released"""
+        h, fake = self._inject(nodes=4, cores_per_node=4)
+
+        before = JobStats(h).update_sync()
+
+        njobs = saturation_count(
+            fake.nodes,
+            fake.cores_per_node,
+            fake.gpus_per_node,
+            slot_cores=1,
+        )
+        rec = _StageRecorder()
+        m = FillMachineBenchmark(
+            njobs=njobs,
+            slot_cores=1,
+        ).run(h, rec)
+
+        after = JobStats(h).update_sync()
+
+        # The benchmark must traverse submit → fill → cancel in order. If
+        # "fill" is missing, on_all_submitted never fired. If "cancel" is
+        # missing, on_all_started never fired (i.e., not all jobs reached
+        # "start"). Either gap indicates a real bug.
+        self.assertEqual(rec.stages, ["submit", "fill", "cancel"])
+
+        njobs = m["njobs"]
+        # All njobs reached the broker and transitioned to inactive.
+        self.assertEqual(after.total - before.total, njobs)
+        self.assertEqual(after.inactive - before.inactive, njobs)
+        # Every job was canceled (not completed naturally — they had
+        # mock_run_duration="0" so they only exit via cancel). JobStats counts
+        # canceled jobs under "failed" as well.
+        self.assertEqual(after.canceled - before.canceled, njobs)
+        self.assertEqual(after.successful - before.successful, 0)
+
+        # Every rate metric must be finite and positive.
+        for key in (
+            "time_to_fill",
+            "submit_rate",
+            "alloc_rate",
+            "start_rate",
+            "ingest_rate",
+            "cancel_rate",
+        ):
+            self.assertTrue(math.isfinite(m[key]), "{0} = {1}".format(key, m[key]))
+            self.assertGreater(m[key], 0, "{0} = {1}".format(key, m[key]))
+
+        # Watcher overhead invariant: submit_rate (script-observed) is bounded
+        # above by ingest_rate (broker-side). See ThroughputBenchmark for the
+        # derivation.
+        self.assertLessEqual(
+            m["submit_rate"],
+            m["ingest_rate"] * 1.001,
+        )
+
+        # The full timestamp set is present. Downstream tools rely on the
+        # exact key names, so check them explicitly.
+        for key in (
+            "t_submit_start",
+            "t_all_submitted",
+            "t_first_submit_event",
+            "t_last_submit_event",
+            "t_all_alloc",
+            "t_last_alloc_event",
+            "t_all_start",
+            "t_first_start_event",
+            "t_last_start_event",
+            "t_cancel_issued",
+            "t_all_clean",
+            "t_last_clean_event",
+            "t_done",
+        ):
+            self.assertIn(key, m)
+            self.assertTrue(
+                math.isfinite(m[key]),
+                "{0} = {1}".format(key, m[key]),
+            )
+
+        # Timestamp orderings. The previous version of this test asserted a
+        # single 12-element monotonic chain spanning script-side and
+        # broker-side timestamps, but flux pipelines events: by the time
+        # BulkRun's on_all_alloc fires (script-side, last job's alloc
+        # delivered), the broker has often already emitted the first start
+        # event for an earlier job. Pipelining breaks "all-of-phase-X before
+        # any-of-phase-Y" assumptions whenever they cross the script/broker
+        # boundary. The split below captures only what the implementation
+        # actually guarantees.
+
+        # (1) Script-side callback ordering. BulkRun fires the bulk callbacks
+        # sequentially in lifecycle order; cancel is issued from inside
+        # on_all_started; bulk.run() returns after on_all_clean.
+        self.assertLessEqual(m["t_submit_start"], m["t_all_submitted"])
+        self.assertLessEqual(m["t_all_submitted"], m["t_all_alloc"])
+        self.assertLessEqual(m["t_all_alloc"], m["t_all_start"])
+        self.assertLessEqual(m["t_all_start"], m["t_cancel_issued"])
+        self.assertLessEqual(m["t_cancel_issued"], m["t_all_clean"])
+        self.assertLessEqual(m["t_all_clean"], m["t_done"])
+
+        # (2) Within-event-type broker ordering: first ≤ last.
+        self.assertLessEqual(
+            m["t_first_submit_event"],
+            m["t_last_submit_event"],
+        )
+        self.assertLessEqual(
+            m["t_first_start_event"],
+            m["t_last_start_event"],
+        )
+
+        # (3) Cross-event-type broker ordering by per-job causality. For each
+        # job, submit < alloc < start < clean. The job that has the latest X
+        # event had its X event before its own Y event (Y after X in
+        # lifecycle), and its Y event ≤ the latest Y event across all jobs. So
+        # last_X ≤ last_Y. This does NOT extend to first_X vs last_Y across
+        # phases.
+        self.assertLessEqual(
+            m["t_last_submit_event"],
+            m["t_last_alloc_event"],
+        )
+        self.assertLessEqual(
+            m["t_last_alloc_event"],
+            m["t_last_start_event"],
+        )
+        self.assertLessEqual(
+            m["t_last_start_event"],
+            m["t_last_clean_event"],
+        )
+
+        # (4) Watcher delivery latency: the broker emits each event before the
+        # script's bulk callback for that event type fires (the watcher
+        # delivers events into BulkRun, which then aggregates into the bulk
+        # callback).
+        self.assertLessEqual(
+            m["t_last_submit_event"],
+            m["t_all_submitted"],
+        )
+        self.assertLessEqual(
+            m["t_last_alloc_event"],
+            m["t_all_alloc"],
+        )
+        self.assertLessEqual(
+            m["t_last_start_event"],
+            m["t_all_start"],
+        )
+        self.assertLessEqual(
+            m["t_last_clean_event"],
+            m["t_all_clean"],
+        )
+
+        # (5) Submit starts in the script before the broker observes any
+        # submit event.
+        self.assertLessEqual(
+            m["t_submit_start"],
+            m["t_first_submit_event"],
+        )
+
+        # (6) Cancel-then-clean: cancel is issued from on_all_started, so it
+        # precedes any subsequent clean event in the broker.
+        self.assertLessEqual(
+            m["t_cancel_issued"],
+            m["t_last_clean_event"],
+        )
+
+        # After cancel-and-cleanup, all allocated resources should be released
+        # back to free.
+        rl = flux.resource.resource_list(h).get()
+        self.assertEqual(rl.allocated.nnodes, 0)
+
+
+class TestBenchmarkResults(unittest.TestCase):
+    """BenchmarkResults round-trips and writes atomically."""
+
+    def setUp(self):
+        # Each test gets its own temp directory so files are isolated;
+        # tempfile.TemporaryDirectory cleans up on tearDown.
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.path = os.path.join(self._tmpdir.name, "results.json")
+
+    def test_load_missing_file_yields_empty(self):
+        """Constructing against a nonexistent path gives an empty store"""
+        results = BenchmarkResults(self.path)
+        self.assertEqual(results.get_runs(), [])
+
+    def test_add_run_appends_in_memory(self):
+        """add_run grows the in-memory list but does not write"""
+        results = BenchmarkResults(self.path)
+        results.add_run({"test_name": "throughput"})
+        self.assertEqual(len(results.get_runs()), 1)
+        # File on disk should still not exist
+        self.assertFalse(os.path.exists(self.path))
+
+    def test_add_run_sets_timestamps(self):
+        """add_run fills timestamp and iso_timestamp if absent"""
+        results = BenchmarkResults(self.path)
+        record = results.add_run({"test_name": "throughput"})
+        self.assertIn("timestamp", record)
+        self.assertIn("iso_timestamp", record)
+        # iso_timestamp is YYYY-MM-DDTHH:MM:SSZ form
+        self.assertRegex(
+            record["iso_timestamp"],
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$",
+        )
+
+    def test_add_run_preserves_provided_timestamp(self):
+        """A caller-supplied timestamp is not overwritten"""
+        results = BenchmarkResults(self.path)
+        record = results.add_run(
+            {
+                "test_name": "throughput",
+                "timestamp": 1234567890.0,
+            }
+        )
+        self.assertEqual(record["timestamp"], 1234567890.0)
+
+    def test_save_and_reload_round_trip(self):
+        """A run record survives save → load via a new instance"""
+        a = BenchmarkResults(self.path)
+        a.add_run(
+            {
+                "test_name": "throughput",
+                "host": "testhost",
+                "benchmarks": {
+                    "throughput": {
+                        "results": {"njobs": 100, "throughput": 250.5},
+                    },
+                },
+            }
+        )
+        a.save()
+
+        b = BenchmarkResults(self.path)
+        runs = b.get_runs()
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(runs[0]["test_name"], "throughput")
+        self.assertEqual(runs[0]["host"], "testhost")
+        self.assertEqual(
+            runs[0]["benchmarks"]["throughput"]["results"]["throughput"],
+            250.5,
+        )
+
+    def test_save_appends_across_instances(self):
+        """A second instance preserves prior runs and adds more"""
+        a = BenchmarkResults(self.path)
+        a.add_run({"test_name": "throughput"})
+        a.save()
+
+        b = BenchmarkResults(self.path)
+        b.add_run({"test_name": "fill-machine"})
+        b.save()
+
+        c = BenchmarkResults(self.path)
+        names = [r["test_name"] for r in c.get_runs()]
+        self.assertEqual(names, ["throughput", "fill-machine"])
+
+    def test_save_atomic_no_tmp_leak(self):
+        """After save(), the .tmp file is renamed away (not left behind)"""
+        results = BenchmarkResults(self.path)
+        results.add_run({"test_name": "throughput"})
+        results.save()
+        # The tmp file should have been renamed; only the final path remains.
+        self.assertTrue(os.path.exists(self.path))
+        self.assertFalse(os.path.exists(self.path + ".tmp"))
+
+    def test_save_overwrites_atomically(self):
+        """Re-saving over an existing file replaces it cleanly"""
+        a = BenchmarkResults(self.path)
+        a.add_run({"test_name": "throughput"})
+        a.save()
+        size_one_run = os.path.getsize(self.path)
+
+        # Append another run and re-save; file should grow.
+        a.add_run({"test_name": "fill-machine"})
+        a.save()
+        size_two_runs = os.path.getsize(self.path)
+        self.assertGreater(size_two_runs, size_one_run)
+
+
+class _FakeEvent:
+    """Minimal stand-in for the event objects BulkRun records,
+    just enough for failure_diagnostic to read context."""
+
+    def __init__(self, context):
+        self.name = "exception"
+        self.timestamp = 1000.0
+        self.context = context
+
+
+class _FakeBulkRunResult:
+    """Minimal stand-in for BulkRunResult: just the attributes
+    failure_diagnostic reads."""
+
+    def __init__(
+        self,
+        njobs,
+        attempted,
+        submit_failures,
+        exception_jobs=None,
+        alloc=0,
+        start=0,
+        clean=0,
+    ):
+        self.njobs = njobs
+        self.submit_attempted = attempted
+        self.submit_failures = submit_failures
+        self.jobs = {}
+        for jid, ctx in (exception_jobs or {}).items():
+            self.jobs[jid] = {"exception": _FakeEvent(ctx)}
+        self._counts = {"alloc": alloc, "start": start, "clean": clean}
+
+    def jobids_with(self, name):
+        if name == "exception":
+            return [jid for jid in self.jobs if "exception" in self.jobs[jid]]
+        return list(range(self._counts.get(name, 0)))
+
+
+class TestFailureDiagnostic(unittest.TestCase):
+    """failure_diagnostic groups identical errors into idsets
+    so a 1000-jobs-all-failed scenario renders as one line."""
+
+    def test_uniform_failures_collapse_to_idset(self):
+        """1024 submissions all with the same error → one line."""
+        r = _FakeBulkRunResult(
+            njobs=0,
+            attempted=1024,
+            submit_failures=[
+                {"batch": 0, "submit_index": i, "error": "rejected"}
+                for i in range(1024)
+            ],
+        )
+        msg = failure_diagnostic(r, "throughput: all submits failed")
+        # The 1024 submission indices collapse into a single "0-1023:" prefix
+        # on a single line.
+        self.assertIn("0-1023: rejected", msg)
+        self.assertEqual(msg.count("rejected"), 1)
+
+    def test_mixed_failures_grouped_separately(self):
+        """Two distinct errors with shuffled arrival order are
+        both reported, each with a correct idset."""
+        fails = []
+        for i in range(800):
+            fails.append({"batch": 0, "submit_index": i, "error": "error A"})
+        for i in range(800, 1000):
+            fails.append({"batch": 0, "submit_index": i, "error": "error B"})
+        # Shuffle to simulate out-of-order arrival.
+        import random
+
+        random.Random(42).shuffle(fails)
+
+        r = _FakeBulkRunResult(
+            njobs=0,
+            attempted=1000,
+            submit_failures=fails,
+        )
+        msg = failure_diagnostic(r, "throughput: all submits failed")
+        self.assertIn("0-799: error A", msg)
+        self.assertIn("800-999: error B", msg)
+
+    def test_most_common_error_listed_first(self):
+        """Groups are ordered by failure count descending."""
+        fails = [{"batch": 0, "submit_index": i, "error": "rare"} for i in range(2)] + [
+            {"batch": 0, "submit_index": i + 2, "error": "common"} for i in range(100)
+        ]
+        r = _FakeBulkRunResult(
+            njobs=0,
+            attempted=102,
+            submit_failures=fails,
+        )
+        msg = failure_diagnostic(r, "throughput: all submits failed")
+        common_pos = msg.find("common")
+        rare_pos = msg.find("rare")
+        self.assertGreater(common_pos, 0)
+        self.assertGreater(rare_pos, common_pos)
+
+    def test_exception_events_grouped_by_note(self):
+        """Identical exception notes report once with a count."""
+        exceptions = {}
+        for jid in range(100, 1100):
+            exceptions[jid] = {
+                "type": "alloc",
+                "severity": 0,
+                "note": "unsatisfiable resource request",
+            }
+        r = _FakeBulkRunResult(
+            njobs=1000,
+            attempted=1000,
+            submit_failures=[],
+            exception_jobs=exceptions,
+            alloc=0,
+            start=0,
+            clean=1000,
+        )
+        msg = failure_diagnostic(
+            r,
+            "fill-machine: no job reached 'start' event",
+        )
+        self.assertIn("1000 job(s)", msg)
+        self.assertIn("'unsatisfiable resource request'", msg)
+        # Exactly one summary line, not 1000 individual lines.
+        self.assertEqual(msg.count("type=alloc"), 1)
+
+    def test_pending_hint_when_no_errors_recorded(self):
+        """If nothing reached an expected event AND no failures
+        were recorded, the user gets pointed at `flux jobs -a`."""
+        r = _FakeBulkRunResult(
+            njobs=4,
+            attempted=4,
+            submit_failures=[],
+            exception_jobs={},
+        )
+        msg = failure_diagnostic(
+            r,
+            "fill-machine: no job reached 'start' event",
+        )
+        self.assertIn("flux jobs -a", msg)
+
+    def test_phase_counts_in_header_section(self):
+        """The header section reports requested / submitted /
+        failed plus counts at each lifecycle phase."""
+        r = _FakeBulkRunResult(
+            njobs=10,
+            attempted=12,
+            submit_failures=[
+                {"batch": 0, "submit_index": 10, "error": "x"},
+                {"batch": 0, "submit_index": 11, "error": "x"},
+            ],
+            alloc=10,
+            start=0,
+            clean=10,
+        )
+        msg = failure_diagnostic(
+            r,
+            "fill-machine: no job reached 'start' event",
+        )
+        self.assertIn("12 requested", msg)
+        self.assertIn("10 submitted", msg)
+        self.assertIn("2 submit-failed", msg)
+        self.assertIn("10/10 reached event 'alloc'", msg)
+        self.assertIn("0/10 reached event 'start'", msg)
+
+    def test_backward_compat_no_submit_index(self):
+        """submit_failures entries lacking 'submit_index' (e.g.,
+        from older BulkRun versions) still render — just as a count rather
+        than an idset."""
+        r = _FakeBulkRunResult(
+            njobs=0,
+            attempted=3,
+            submit_failures=[
+                {"batch": 0, "error": "error A"},
+                {"batch": 0, "error": "error A"},
+                {"batch": 0, "error": "error B"},
+            ],
+        )
+        msg = failure_diagnostic(r, "throughput: all submits failed")
+        self.assertIn("2 submissions: error A", msg)
+        self.assertIn("1 submissions: error B", msg)
+
+
+if __name__ == "__main__":
+    if rerun_under_flux(__flux_size()):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner(), buffer=False)
+
+# vi: ts=4 sw=4 expandtab

--- a/t/python/t6031-testing-schedbench-locality.py
+++ b/t/python/t6031-testing-schedbench-locality.py
@@ -1,0 +1,1120 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Unit tests for flux.testing.schedbench.locality.
+
+The benchmark's :class:`LocalityPredicate` is pure logic (hwloc XML
++ R dict -> score), so it earns straightforward unit tests without
+needing a broker. Test topologies are built programmatically via
+ElementTree so each test reads as a self-contained scenario rather
+than a reference into a separately-shipped fixture file.
+"""
+
+import unittest
+import xml.etree.ElementTree as ET
+
+import subflux  # noqa: F401
+from flux.testing.schedbench import LocalityPredicate
+from flux.testing.schedbench.locality import (
+    _parse_duration_mode,
+    _parse_idset_string,
+    _r_from_event,
+)
+
+# ---------------------------------------------------------------
+# Topology fixture builder
+# ---------------------------------------------------------------
+
+
+def _build_topo(domains):
+    """Build a minimal hwloc XML topology string.
+
+    Each entry in ``domains`` is a dict::
+
+        {"nodeset": "0x1",
+         "cores":  [0, 1, 2, 3],      # core os_index values (optional)
+         "gpus":   ["cuda0", ...]}    # GPU OSDev names (optional)
+
+    Cores carry the domain's nodeset directly; GPUs are wrapped in a
+    PCIDev that carries the nodeset, exercising the predicate's
+    "OSDev inherits nodeset from its parent" path.
+
+    Returns the XML as a string suitable for
+    :class:`LocalityPredicate`.
+    """
+    root = ET.Element("topology", version="2.0")
+    machine = ET.SubElement(root, "object", type="Machine")
+    for dom in domains:
+        ns = dom["nodeset"]
+        # A Group with a NUMANode sibling is how modern hwloc
+        # actually structures NUMA, even though our predicate
+        # doesn't depend on the Group/NUMANode pair specifically —
+        # it reads ``nodeset`` off whichever ancestor has one.
+        grp = ET.SubElement(machine, "object", type="Group", nodeset=ns)
+        ET.SubElement(grp, "object", type="NUMANode", nodeset=ns)
+        for core_idx in dom.get("cores", []):
+            ET.SubElement(
+                grp,
+                "object",
+                type="Core",
+                os_index=str(core_idx),
+                nodeset=ns,
+            )
+        for gpu_name in dom.get("gpus", []):
+            # PCIDev carries the nodeset; OSDev (the GPU) does not.
+            # This exercises the ancestor-chain fallback in
+            # _domain_of. osdev_type=5 is hwloc's CoProc
+            # encoding for compute GPUs.
+            pci = ET.SubElement(grp, "object", type="PCIDev", nodeset=ns)
+            ET.SubElement(
+                pci,
+                "object",
+                type="OSDev",
+                name=gpu_name,
+                osdev_type="5",
+            )
+    return ET.tostring(root, encoding="unicode")
+
+
+def _r(rank="0", core="", gpu=""):
+    """Build a minimal RFC 20 R dict with one R_lite entry."""
+    children = {"core": core}
+    if gpu:
+        children["gpu"] = gpu
+    return {
+        "execution": {
+            "R_lite": [{"rank": rank, "children": children}],
+        },
+    }
+
+
+# ---------------------------------------------------------------
+# LocalityPredicate
+# ---------------------------------------------------------------
+
+
+class TestLocalityPredicateIndexing(unittest.TestCase):
+    """How the predicate maps cores and GPUs to domain identifiers."""
+
+    def test_cores_indexed_by_nodeset(self):
+        """Each Core's domain id is the hwloc nodeset attribute."""
+        xml = _build_topo(
+            [
+                {"nodeset": "0x1", "cores": [0, 1]},
+                {"nodeset": "0x2", "cores": [2, 3]},
+            ]
+        )
+        pred = LocalityPredicate(xml)
+        self.assertEqual(pred.core_domain[0], "0x1")
+        self.assertEqual(pred.core_domain[1], "0x1")
+        self.assertEqual(pred.core_domain[2], "0x2")
+        self.assertEqual(pred.core_domain[3], "0x2")
+
+    def test_two_cores_same_nodeset_share_domain(self):
+        """Cores with the same nodeset share an id; the
+        identifier is opaque but stable per nodeset."""
+        xml = _build_topo([{"nodeset": "0x1", "cores": [0, 1, 2, 3]}])
+        pred = LocalityPredicate(xml)
+        self.assertEqual(
+            len({pred.core_domain[i] for i in (0, 1, 2, 3)}),
+            1,
+        )
+
+    def test_gpu_inherits_nodeset_from_pcidev(self):
+        """OSDev (GPU) doesn't carry its own nodeset; it
+        inherits the enclosing PCIDev's via the ancestor walk
+        in :meth:`_domain_of`."""
+        xml = _build_topo(
+            [
+                {"nodeset": "0x1", "cores": [0], "gpus": ["cuda0"]},
+                {"nodeset": "0x2", "cores": [1], "gpus": ["cuda1"]},
+            ]
+        )
+        pred = LocalityPredicate(xml)
+        self.assertEqual(pred.gpu_domain[0], "0x1")
+        self.assertEqual(pred.gpu_domain[1], "0x2")
+
+    def test_gpus_indexed_sequentially_in_document_order(self):
+        """GPUs are keyed by their position in document order
+        (0, 1, 2, ...), not by the digit in their OSDev name.
+
+        For AMD OpenCL devices named ``opencl0d{N}``, the digit
+        happens to match document order only by convention. The
+        amender uses sequential numbering (``int("0d3")`` raises
+        and falls back to ``get_next_id``), so the predicate
+        does the same to keep IDs aligned with R.
+        """
+        xml = _build_topo(
+            [
+                {"nodeset": "0x1", "gpus": ["nvidia7"]},
+                {"nodeset": "0x2", "gpus": ["nvidia3"]},
+            ]
+        )
+        pred = LocalityPredicate(xml)
+        # First GPU walked (nvidia7) -> id 0; second (nvidia3) -> 1.
+        self.assertEqual(pred.gpu_domain[0], "0x1")
+        self.assertEqual(pred.gpu_domain[1], "0x2")
+
+    def test_cores_indexed_sequentially_in_document_order(self):
+        """Cores are keyed by their position in document order,
+        not by the hwloc ``os_index`` attribute, even if os_index
+        is present and non-contiguous.
+
+        Real-world reason: on multi-socket AMD systems hwloc
+        reports per-socket physical CPU IDs that collide between
+        packages, so an os_index-keyed map silently overwrites
+        half the cores when both sockets are present.
+        """
+        # Hand-written XML with sparse, non-contiguous os_index
+        # values — mimics what hwloc emits on AMD Zen.
+        xml = """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="NUMANode" nodeset="0x1"/>
+      <object type="Core" os_index="0" nodeset="0x1"/>
+      <object type="Core" os_index="1" nodeset="0x1"/>
+      <object type="Core" os_index="2" nodeset="0x1"/>
+      <object type="Core" os_index="4" nodeset="0x1"/>
+      <object type="Core" os_index="5" nodeset="0x1"/>
+      <object type="Core" os_index="6" nodeset="0x1"/>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        # All 6 cores in domain 0x1, keyed by sequential 0..5
+        # (NOT by os_index, which would have a gap at 3 and max 6).
+        self.assertEqual(sorted(pred.core_domain.keys()), [0, 1, 2, 3, 4, 5])
+        self.assertTrue(all(d == "0x1" for d in pred.core_domain.values()))
+
+    def test_os_index_collision_does_not_lose_cores(self):
+        """Two cores with the same os_index in different
+        packages must both be indexed. This is the corona11.xml
+        regression: dual-socket AMD systems reuse physical CPU
+        IDs per socket, and the previous os_index-keyed scheme
+        silently dropped half the cores."""
+        xml = """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Package">
+      <object type="Group" nodeset="0x1">
+        <object type="NUMANode" nodeset="0x1"/>
+        <object type="Core" os_index="0" nodeset="0x1"/>
+        <object type="Core" os_index="1" nodeset="0x1"/>
+      </object>
+    </object>
+    <object type="Package">
+      <object type="Group" nodeset="0x2">
+        <object type="NUMANode" nodeset="0x2"/>
+        <object type="Core" os_index="0" nodeset="0x2"/>
+        <object type="Core" os_index="1" nodeset="0x2"/>
+      </object>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        # All 4 cores indexed under unique sequential ids,
+        # mapping to their respective NUMA domains in walk order.
+        self.assertEqual(len(pred.core_domain), 4)
+        self.assertEqual(pred.core_domain[0], "0x1")
+        self.assertEqual(pred.core_domain[1], "0x1")
+        self.assertEqual(pred.core_domain[2], "0x2")
+        self.assertEqual(pred.core_domain[3], "0x2")
+
+    def test_display_gpus_not_counted(self):
+        """Linux DRM nodes (card*, renderD*, controlD*) appear in
+        hwloc XML as OSDev with osdev_type=1 and sit alongside
+        the CoProc OSDev under the same PCIDev. They're three
+        faces of one physical device, not three GPUs, and aren't
+        schedulable compute — the predicate must skip them.
+
+        Without this check, a system with one AMD GPU would
+        score as four GPUs (card / renderD / controlD / opencl)
+        and overcount the schedulable pool by 4x.
+        """
+        # Build the XML by hand so we can mix osdev_type=1
+        # (display) and osdev_type=5 (CoProc) under one PCIDev.
+        xml = """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="NUMANode" nodeset="0x1"/>
+      <object type="PCIDev" nodeset="0x1">
+        <object type="OSDev" name="card0" osdev_type="1"/>
+        <object type="OSDev" name="renderD128" osdev_type="1"/>
+        <object type="OSDev" name="controlD64" osdev_type="1"/>
+        <object type="OSDev" name="opencl0d0" osdev_type="5"/>
+      </object>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        # Only the CoProc node makes it in, with id 0.
+        self.assertEqual(list(pred.gpu_domain.keys()), [0])
+
+    def test_display_only_card_yields_no_gpus(self):
+        """A PCIDev with display OSDev nodes but no CoProc
+        (e.g. an integrated VGA controller, or an older AMD
+        driver without OpenCL loaded) contributes zero GPUs to
+        the schedulable pool — the corresponding NUMA domain
+        appears in the topology but has no gpu_domain entry."""
+        xml = """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="NUMANode" nodeset="0x1"/>
+      <object type="Core" os_index="0" nodeset="0x1"/>
+      <object type="PCIDev" nodeset="0x1">
+        <object type="OSDev" name="card0" osdev_type="1"/>
+        <object type="OSDev" name="controlD64" osdev_type="1"/>
+      </object>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        # Core still indexed (id 0); no GPUs registered.
+        self.assertIn(0, pred.core_domain)
+        self.assertEqual(pred.gpu_domain, {})
+
+    def test_rsmi_gpus_counted_despite_osdev_type_1(self):
+        """AMD ROCm devices arrive from the RSMI backend with
+        ``osdev_type=1`` (GPU) — the same value Linux DRM
+        display nodes use. A pure osdev_type=5 filter would
+        miss them; the predicate must use a combined name +
+        type criterion.
+
+        Regression test for an actual corona system that
+        reported 0 GPUs because only osdev_type=5 was matched.
+        """
+        xml = """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="NUMANode" nodeset="0x1"/>
+      <object type="PCIDev" nodeset="0x1">
+        <object type="OSDev" name="rsmi0" osdev_type="1"/>
+      </object>
+    </object>
+    <object type="Group" nodeset="0x2">
+      <object type="NUMANode" nodeset="0x2"/>
+      <object type="PCIDev" nodeset="0x2">
+        <object type="OSDev" name="rsmi1" osdev_type="1"/>
+      </object>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        self.assertEqual(len(pred.gpu_domain), 2)
+        self.assertEqual(pred.gpu_domain[0], "0x1")
+        self.assertEqual(pred.gpu_domain[1], "0x2")
+
+    def test_nvml_gpus_counted_despite_osdev_type_1(self):
+        """NVIDIA NVML backend also reports compute GPUs as
+        osdev_type=1 with name nvml{N}. Same path as RSMI."""
+        xml = """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="PCIDev" nodeset="0x1">
+        <object type="OSDev" name="nvml0" osdev_type="1"/>
+      </object>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        self.assertEqual(list(pred.gpu_domain.keys()), [0])
+
+    def test_drm_display_with_no_compute_backend_yields_no_gpus(self):
+        """A PCIDev with only osdev_type=1 nodes whose names
+        match neither the compute prefix list nor anything
+        else — purely display."""
+        xml = """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="PCIDev" nodeset="0x1">
+        <object type="OSDev" name="card0" osdev_type="1"/>
+        <object type="OSDev" name="renderD128" osdev_type="1"/>
+        <object type="OSDev" name="controlD64" osdev_type="1"/>
+      </object>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        self.assertEqual(pred.gpu_domain, {})
+
+    def test_dedupe_multiple_compute_faces_per_pcidev(self):
+        """One physical GPU can expose multiple compute OSDev
+        faces under one PCIDev: NVIDIA with both CUDA and NVML
+        loaded, AMD with both OpenCL and RSMI. Each face passes
+        :func:`_is_compute_gpu` independently. Without dedupe
+        the predicate would count one card as two GPUs."""
+        xml = """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="NUMANode" nodeset="0x1"/>
+      <object type="PCIDev" nodeset="0x1">
+        <object type="OSDev" name="cuda0" osdev_type="5"/>
+        <object type="OSDev" name="nvml0" osdev_type="1"/>
+      </object>
+    </object>
+    <object type="Group" nodeset="0x2">
+      <object type="NUMANode" nodeset="0x2"/>
+      <object type="PCIDev" nodeset="0x2">
+        <object type="OSDev" name="opencl0d0" osdev_type="5"/>
+        <object type="OSDev" name="rsmi0" osdev_type="1"/>
+      </object>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        # 2 PCIDevs, each with two compute faces → 2 GPUs total.
+        self.assertEqual(len(pred.gpu_domain), 2)
+        self.assertEqual(pred.gpu_domain[0], "0x1")
+        self.assertEqual(pred.gpu_domain[1], "0x2")
+
+    def test_dedupe_does_not_skip_separate_pcidevs(self):
+        """Two PCIDevs each containing one CoProc OSDev — the
+        dedup must scope to each PCIDev independently, not
+        globally."""
+        xml = """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="PCIDev" nodeset="0x1">
+        <object type="OSDev" name="cuda0" osdev_type="5"/>
+      </object>
+    </object>
+    <object type="Group" nodeset="0x2">
+      <object type="PCIDev" nodeset="0x2">
+        <object type="OSDev" name="cuda1" osdev_type="5"/>
+      </object>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        self.assertEqual(len(pred.gpu_domain), 2)
+
+    def test_dedupe_preserves_sequential_ids(self):
+        """When a duplicate face is skipped, the sequential GPU
+        counter must NOT advance — otherwise downstream IDs in
+        R would mismatch the predicate's domain map."""
+        xml = """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="PCIDev" nodeset="0x1">
+        <object type="OSDev" name="cuda0" osdev_type="5"/>
+        <object type="OSDev" name="nvml0" osdev_type="1"/>
+      </object>
+    </object>
+    <object type="Group" nodeset="0x2">
+      <object type="PCIDev" nodeset="0x2">
+        <object type="OSDev" name="cuda1" osdev_type="5"/>
+        <object type="OSDev" name="nvml1" osdev_type="1"/>
+      </object>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        # GPU IDs must be 0 and 1 (sequential, no gap from
+        # the deduped nvml0/nvml1 faces).
+        self.assertEqual(sorted(pred.gpu_domain.keys()), [0, 1])
+
+
+class TestLocalityPredicateDescribe(unittest.TestCase):
+    """The :meth:`describe` diagnostic helper."""
+
+    def test_describe_returns_shape(self):
+        xml = _build_topo(
+            [
+                {"nodeset": "0x1", "cores": [0, 1], "gpus": ["cuda0"]},
+                {"nodeset": "0x2", "cores": [2, 3], "gpus": ["cuda1"]},
+            ]
+        )
+        pred = LocalityPredicate(xml)
+        info = pred.describe()
+        self.assertIsNone(info["hostname"])  # _build_topo emits no HostName
+        self.assertEqual(info["core_count"], 4)
+        self.assertEqual(info["gpu_count"], 2)
+        self.assertEqual(sorted(info["domains"]), ["0x1", "0x2"])
+        self.assertEqual(set(info["core_domain"].keys()), {0, 1, 2, 3})
+        self.assertEqual(set(info["gpu_domain"].keys()), {0, 1})
+
+    def test_describe_is_serializable(self):
+        """describe() output should be JSON-friendly so it can
+        be embedded in the results file."""
+        import json
+
+        xml = _build_topo([{"nodeset": "0x1", "cores": [0, 1]}])
+        pred = LocalityPredicate(xml)
+        # Should not raise.
+        json.dumps(pred.describe())
+
+    def test_hostname_extracted_from_xml(self):
+        """``<info name="HostName" value="..."/>`` anywhere in
+        the XML is picked up so results files can identify which
+        topology was scored. Real hwloc XMLs put this at the root
+        or under the Machine object — both work."""
+        xml = """\
+<topology version="2.0">
+  <info name="HostName" value="corona11"/>
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="Core" os_index="0" nodeset="0x1"/>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        self.assertEqual(pred.hostname, "corona11")
+        self.assertEqual(pred.describe()["hostname"], "corona11")
+
+    def test_hostname_absent_when_xml_omits_it(self):
+        xml = _build_topo([{"nodeset": "0x1", "cores": [0]}])
+        pred = LocalityPredicate(xml)
+        self.assertIsNone(pred.hostname)
+
+
+class TestLocalityPredicateSummary(unittest.TestCase):
+    """The :meth:`summary` human-readable description, used in
+    verbose startup output. Returns a header with counts plus a
+    per-domain breakdown line showing which cores and GPUs each
+    domain contains."""
+
+    def test_summary_header_includes_counts(self):
+        xml = _build_topo(
+            [
+                {"nodeset": "0x1", "cores": [0, 1], "gpus": ["cuda0"]},
+                {"nodeset": "0x2", "cores": [2, 3], "gpus": ["cuda1"]},
+            ]
+        )
+        s = LocalityPredicate(xml).summary()
+        head = s.splitlines()[0]
+        self.assertIn("4 cores", head)
+        self.assertIn("2 gpus", head)
+        self.assertIn("2 domains", head)
+
+    def test_summary_includes_hostname_when_present(self):
+        xml = """\
+<topology version="2.0">
+  <info name="HostName" value="corona11"/>
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="Core" os_index="0" nodeset="0x1"/>
+    </object>
+  </object>
+</topology>"""
+        pred = LocalityPredicate(xml)
+        self.assertIn("host=corona11", pred.summary())
+
+    def test_summary_omits_hostname_when_absent(self):
+        xml = _build_topo([{"nodeset": "0x1", "cores": [0]}])
+        s = LocalityPredicate(xml).summary()
+        self.assertNotIn("host=", s)
+
+    def test_summary_breakdown_per_domain(self):
+        """One indented line per domain showing its cores and
+        GPUs as compact idsets. Domains with both cores and a
+        GPU show both; domains with only cores show only cores."""
+        xml = _build_topo(
+            [
+                {"nodeset": "0x1", "cores": [0, 1, 2, 3, 4, 5]},
+                {"nodeset": "0x2", "cores": [6, 7, 8, 9, 10, 11], "gpus": ["cuda0"]},
+                {"nodeset": "0x4", "cores": [12, 13, 14, 15, 16, 17]},
+            ]
+        )
+        s = LocalityPredicate(xml).summary()
+        lines = s.splitlines()
+        # Header + 3 domain lines.
+        self.assertEqual(len(lines), 4)
+        self.assertIn("core[0-5]", lines[1])
+        self.assertNotIn("gpu", lines[1])
+        self.assertIn("core[6-11]", lines[2])
+        self.assertIn("gpu[0]", lines[2])
+        self.assertIn("core[12-17]", lines[3])
+        self.assertNotIn("gpu", lines[3])
+
+    def test_summary_compact_idset_with_gaps(self):
+        """Non-contiguous cores within a domain render as
+        comma-separated ranges (e.g. ``0-2,4-5``)."""
+        # Hand-write XML so we can put non-contiguous cores in
+        # one domain without _build_topo's monotonic id sequence
+        # masking the case.
+        xml = """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Group" nodeset="0x1">
+      <object type="Core" os_index="0" nodeset="0x1"/>
+      <object type="Core" os_index="1" nodeset="0x1"/>
+      <object type="Core" os_index="2" nodeset="0x1"/>
+    </object>
+    <object type="Group" nodeset="0x2">
+      <object type="Core" os_index="3" nodeset="0x2"/>
+    </object>
+    <object type="Group" nodeset="0x1">
+      <object type="Core" os_index="4" nodeset="0x1"/>
+      <object type="Core" os_index="5" nodeset="0x1"/>
+    </object>
+  </object>
+</topology>"""
+        # Sequential ids in document order: 0,1,2 then 3 then 4,5.
+        # Cores 0-2 and 4-5 share domain 0x1 -> idset "0-2,4-5".
+        s = LocalityPredicate(xml).summary()
+        self.assertIn("core[0-2,4-5]", s)
+
+    def test_summary_no_domains_returns_header_only(self):
+        """An empty topology gives just the header line."""
+        xml = '<topology><object type="Machine"></object></topology>'
+        s = LocalityPredicate(xml).summary()
+        self.assertEqual(len(s.splitlines()), 1)
+        self.assertIn("0 cores", s)
+        self.assertIn("0 domains", s)
+
+
+class TestLocalityPredicateScoreJobVerbose(unittest.TestCase):
+    """The :meth:`score_job_verbose` diagnostic helper. The
+    breakdown it returns is the primary tool for debugging score
+    anomalies in production runs."""
+
+    def _topo_2numa_with_gpus(self):
+        return _build_topo(
+            [
+                {"nodeset": "0x1", "cores": [0, 1, 2, 3], "gpus": ["cuda0"]},
+                {"nodeset": "0x2", "cores": [4, 5, 6, 7], "gpus": ["cuda1"]},
+            ]
+        )
+
+    def test_verbose_reports_satisfied_total(self):
+        """The top-level (satisfied, total) matches score_job."""
+        pred = LocalityPredicate(self._topo_2numa_with_gpus())
+        r = _r(core="0-3,4-7", gpu="0-1")
+        plain = pred.score_job(r, 2, 1, 2)
+        verbose = pred.score_job_verbose(r, 2, 1, 2)
+        self.assertEqual(
+            (verbose["satisfied"], verbose["total"]),
+            plain,
+        )
+
+    def test_verbose_breakdown_one_entry_per_r_lite(self):
+        """Each R_lite entry produces one breakdown entry."""
+        pred = LocalityPredicate(self._topo_2numa_with_gpus())
+        r = {
+            "execution": {
+                "R_lite": [
+                    {"rank": "0", "children": {"core": "0-1", "gpu": "0"}},
+                    {"rank": "1", "children": {"core": "4-5", "gpu": "1"}},
+                ]
+            }
+        }
+        verbose = pred.score_job_verbose(r, 2, 1, 2)
+        self.assertEqual(len(verbose["breakdown"]), 2)
+
+    def test_verbose_lists_unknown_cores(self):
+        """Core IDs in R that aren't in the topology surface as
+        ``unknown_cores`` — the signature symptom of an ID-scheme
+        mismatch between R and the XML."""
+        pred = LocalityPredicate(self._topo_2numa_with_gpus())
+        r = _r(core="0,1,99")
+        verbose = pred.score_job_verbose(r, 1, 0, 3)
+        b = verbose["breakdown"][0]
+        self.assertEqual(b["unknown_cores"], [99])
+        self.assertEqual(sorted(b["cores"]), [0, 1, 99])
+
+    def test_verbose_lists_unknown_gpus(self):
+        """Likewise for GPUs."""
+        pred = LocalityPredicate(self._topo_2numa_with_gpus())
+        r = _r(core="0-3", gpu="42")
+        verbose = pred.score_job_verbose(r, 2, 1, 2)
+        b = verbose["breakdown"][0]
+        self.assertEqual(b["unknown_gpus"], [42])
+
+    def test_verbose_cores_by_domain_distribution(self):
+        """The cores-by-domain map shows how the rank's cores
+        spread across domains."""
+        pred = LocalityPredicate(self._topo_2numa_with_gpus())
+        # 3 cores in NUMA 0, 1 in NUMA 1 — the lopsided case.
+        r = _r(core="0,1,2,4")
+        verbose = pred.score_job_verbose(r, 2, 0, 2)
+        b = verbose["breakdown"][0]
+        self.assertEqual(b["cores_by_domain"], {"0x1": 3, "0x2": 1})
+
+    def test_verbose_serializable(self):
+        """JSON-emit safe — the breakdown can be logged as a
+        debug event."""
+        import json
+
+        pred = LocalityPredicate(self._topo_2numa_with_gpus())
+        r = _r(core="0-3", gpu="0")
+        json.dumps(pred.score_job_verbose(r, 2, 1, 2))
+
+
+class TestLocalityPredicateScoringMatrix(unittest.TestCase):
+    """Parametric coverage across diverse topology shapes.
+
+    Each test method describes one scenario (topology + R + slot
+    spec + expected score). Adding a regression test for a new
+    topology shape means dropping in another method here. The
+    failure message includes the case description so a broken
+    case is easy to identify in TAP output."""
+
+    def _check(self, topo, r, slot, expected_satisfied, expected_total=None):
+        """Build pred from ``topo`` and assert
+        ``score_job(r, *slot)`` equals ``(expected_satisfied,
+        expected_total or slot[2])``."""
+        xml = _build_topo(topo)
+        pred = LocalityPredicate(xml)
+        if expected_total is None:
+            expected_total = slot[2]  # nslots
+        actual = pred.score_job(r, *slot)
+        self.assertEqual(
+            actual,
+            (expected_satisfied, expected_total),
+            f"score_job({slot}) -> {actual}, "
+            f"expected ({expected_satisfied}, {expected_total})",
+        )
+
+    # --- Topology shape: single NUMA ---------------------------
+
+    def test_single_numa_perfect_pack(self):
+        """1 NUMA, 4 cores, 2-core slots, 2 slots — all local."""
+        self._check(
+            [{"nodeset": "0x1", "cores": [0, 1, 2, 3]}],
+            _r(core="0-3"),
+            slot=(2, 0, 2),
+            expected_satisfied=2,
+        )
+
+    def test_single_numa_slot_larger_than_domain(self):
+        """Slot wants more cores than a single domain has —
+        zero slots can be satisfied."""
+        self._check(
+            [{"nodeset": "0x1", "cores": [0, 1]}],
+            _r(core="0-1"),
+            slot=(4, 0, 1),
+            expected_satisfied=0,
+        )
+
+    # --- Topology shape: symmetric multi-NUMA ------------------
+
+    def test_dual_numa_balanced_full(self):
+        """Two NUMAs, both fully used, slots fit cleanly."""
+        self._check(
+            [{"nodeset": "0x1", "cores": [0, 1]}, {"nodeset": "0x2", "cores": [2, 3]}],
+            _r(core="0-3"),
+            slot=(2, 0, 2),
+            expected_satisfied=2,
+        )
+
+    def test_quad_numa_lopsided_slot_pair(self):
+        """3 cores in one NUMA + 1 in another, asking for 2-core
+        slots: 3//2=1 satisfied in the first NUMA, 1//2=0 in the
+        second."""
+        self._check(
+            [
+                {"nodeset": "0x1", "cores": [0, 1, 2, 3]},
+                {"nodeset": "0x2", "cores": [4, 5, 6, 7]},
+            ],
+            _r(core="0-2,4"),
+            slot=(2, 0, 2),
+            expected_satisfied=1,
+        )
+
+    # --- Topology shape: heterogeneous NUMA sizes --------------
+
+    def test_heterogeneous_numa_sizes(self):
+        """One small NUMA (2 cores), one large (8 cores). With a
+        4-core slot and 2 slots requested, only the large NUMA
+        can hold a slot (2//4=0 and 8//4=2, capped at nslots=2)."""
+        self._check(
+            [
+                {"nodeset": "0x1", "cores": [0, 1]},
+                {"nodeset": "0x2", "cores": [2, 3, 4, 5, 6, 7, 8, 9]},
+            ],
+            _r(core="0-9"),
+            slot=(4, 0, 2),
+            expected_satisfied=2,
+        )
+
+    # --- Topology shape: GPU-sparse ---------------------------
+
+    def test_gpu_sparse_only_one_numa_has_gpu(self):
+        """Two NUMAs but only one has a GPU; a 2-core+1-GPU slot
+        can be satisfied only in the GPU-bearing NUMA."""
+        self._check(
+            [
+                {"nodeset": "0x1", "cores": [0, 1, 2, 3]},
+                {"nodeset": "0x2", "cores": [4, 5, 6, 7], "gpus": ["cuda0"]},
+            ],
+            _r(core="0-7", gpu="0"),
+            slot=(2, 1, 2),
+            expected_satisfied=1,
+        )
+
+    def test_gpu_sparse_no_satisfying_numa(self):
+        """Cores in one NUMA, GPU in another — no slot satisfied."""
+        self._check(
+            [
+                {"nodeset": "0x1", "cores": [0, 1]},
+                {"nodeset": "0x2", "gpus": ["cuda0"]},
+            ],
+            _r(core="0-1", gpu="0"),
+            slot=(2, 1, 1),
+            expected_satisfied=0,
+        )
+
+    def test_gpu_constraint_ignored_when_slot_gpus_zero(self):
+        """slot_gpus=0 means GPU presence is irrelevant; the
+        same R that fails the GPU-required version succeeds."""
+        self._check(
+            [
+                {"nodeset": "0x1", "cores": [0, 1]},
+                {"nodeset": "0x2", "gpus": ["cuda0"]},
+            ],
+            _r(core="0-1", gpu="0"),
+            slot=(2, 0, 1),
+            expected_satisfied=1,
+        )
+
+    # --- Topology shape: multi-rank R --------------------------
+
+    def test_multi_rank_uniform_placement(self):
+        """A single R_lite entry that spans 4 ranks with the
+        same children — 4 ranks × 1 satisfied slot/rank = 4
+        slots, capped at nslots=4."""
+        self._check(
+            [
+                {"nodeset": "0x1", "cores": [0, 1, 2, 3]},
+                {"nodeset": "0x2", "cores": [4, 5, 6, 7]},
+            ],
+            _r(rank="0-3", core="0-1"),
+            slot=(2, 0, 4),
+            expected_satisfied=4,
+        )
+
+    def test_multi_rank_score_capped_at_nslots(self):
+        """If the per-rank count would exceed nslots, the
+        return value caps at nslots so the ratio stays in [0, 1]."""
+        self._check(
+            [{"nodeset": "0x1", "cores": [0, 1, 2, 3]}],
+            _r(rank="0-9", core="0-1"),
+            # 10 ranks × 1 slot = 10, but nslots=2 caps it.
+            slot=(2, 0, 2),
+            expected_satisfied=2,
+        )
+
+    # --- Edge cases --------------------------------------------
+
+    def test_empty_r_lite_scores_zero(self):
+        """An R with no R_lite entries scores zero, but total
+        still reflects nslots."""
+        self._check(
+            [{"nodeset": "0x1", "cores": [0, 1]}],
+            {"execution": {"R_lite": []}},
+            slot=(1, 0, 4),
+            expected_satisfied=0,
+        )
+
+    def test_unknown_resources_silently_dropped(self):
+        """Cores in R that aren't in the topology are treated as
+        not-local rather than raising. (Use score_job_verbose to
+        surface the mismatch when this is unexpected.)"""
+        self._check(
+            [{"nodeset": "0x1", "cores": [0, 1, 2, 3]}],
+            _r(core="0,1,2,99"),
+            slot=(2, 0, 2),
+            # 3 known cores in NUMA 0; 3//2 = 1 slot satisfied.
+            expected_satisfied=1,
+        )
+
+
+class TestLocalityPredicateScoring(unittest.TestCase):
+    """Per-job scoring: how slots map to satisfied / total."""
+
+    def _topo_4numa(self):
+        """16 cores across 4 NUMA domains, 4 cores each."""
+        return _build_topo(
+            [
+                {"nodeset": "0x1", "cores": [0, 1, 2, 3]},
+                {"nodeset": "0x2", "cores": [4, 5, 6, 7]},
+                {"nodeset": "0x4", "cores": [8, 9, 10, 11]},
+                {"nodeset": "0x8", "cores": [12, 13, 14, 15]},
+            ]
+        )
+
+    def test_all_in_one_domain(self):
+        """Job using only NUMA 0's cores scores 1.0 — every slot
+        fits in the same domain."""
+        pred = LocalityPredicate(self._topo_4numa())
+        satisfied, total = pred.score_job(
+            _r(core="0-3"),
+            slot_cores=2,
+            slot_gpus=0,
+            nslots=2,
+        )
+        self.assertEqual((satisfied, total), (2, 2))
+
+    def test_even_split_across_domains(self):
+        """Job split with whole slots on each of two domains
+        scores 1.0 — every slot still fits in some domain."""
+        pred = LocalityPredicate(self._topo_4numa())
+        satisfied, total = pred.score_job(
+            _r(core="0-1,4-5"),
+            slot_cores=2,
+            slot_gpus=0,
+            nslots=2,
+        )
+        self.assertEqual((satisfied, total), (2, 2))
+
+    def test_lopsided_split(self):
+        """Cores 0,1,2 in NUMA 0 + core 4 in NUMA 1 with
+        slot_cores=2: NUMA 0 fits 1 complete slot (3//2=1),
+        NUMA 1 fits 0 (1//2=0). Score = 1/2."""
+        pred = LocalityPredicate(self._topo_4numa())
+        satisfied, total = pred.score_job(
+            _r(core="0-2,4"),
+            slot_cores=2,
+            slot_gpus=0,
+            nslots=2,
+        )
+        self.assertEqual((satisfied, total), (1, 2))
+
+    def test_multi_rank_r_lite(self):
+        """An R_lite entry that spans 2 ranks with identical
+        allocations counts each rank's satisfied slots."""
+        pred = LocalityPredicate(self._topo_4numa())
+        # Each of 2 ranks gets cores 0-1: 1 slot satisfied per
+        # rank * 2 ranks = 2 satisfied.
+        satisfied, total = pred.score_job(
+            _r(rank="0-1", core="0-1"),
+            slot_cores=2,
+            slot_gpus=0,
+            nslots=2,
+        )
+        self.assertEqual((satisfied, total), (2, 2))
+
+    def test_gpu_constraint_satisfied(self):
+        """Slot wanting cores + a GPU is satisfied when both
+        sit in the same domain."""
+        xml = _build_topo(
+            [
+                {"nodeset": "0x1", "cores": [0, 1], "gpus": ["cuda0"]},
+                {"nodeset": "0x2", "cores": [2, 3], "gpus": ["cuda1"]},
+            ]
+        )
+        pred = LocalityPredicate(xml)
+        # Each domain has the cores + the GPU for 1 slot of 2c+1g.
+        satisfied, total = pred.score_job(
+            _r(core="0-3", gpu="0-1"),
+            slot_cores=2,
+            slot_gpus=1,
+            nslots=2,
+        )
+        self.assertEqual((satisfied, total), (2, 2))
+
+    def test_gpu_constraint_unsatisfied_across_domains(self):
+        """Cores on domain A + GPU on domain B can't form a
+        slot that requires both. Score = 0."""
+        xml = _build_topo(
+            [
+                {"nodeset": "0x1", "cores": [0, 1]},
+                {"nodeset": "0x2", "gpus": ["cuda1"]},
+            ]
+        )
+        pred = LocalityPredicate(xml)
+        satisfied, total = pred.score_job(
+            _r(core="0-1", gpu="1"),
+            slot_cores=2,
+            slot_gpus=1,
+            nslots=1,
+        )
+        self.assertEqual((satisfied, total), (0, 1))
+
+    def test_gpu_count_zero_branch(self):
+        """slot_gpus=0 means GPU presence is irrelevant; only
+        core packing matters."""
+        pred = LocalityPredicate(self._topo_4numa())
+        satisfied, total = pred.score_job(
+            _r(core="0-3"),
+            slot_cores=2,
+            slot_gpus=0,
+            nslots=2,
+        )
+        self.assertEqual(satisfied, 2)
+
+    def test_score_capped_at_nslots(self):
+        """If R has more resources than the job requested
+        (shouldn't happen but defensive), the satisfied count
+        is capped at ``nslots`` so the ratio is bounded by 1."""
+        pred = LocalityPredicate(self._topo_4numa())
+        # 16 cores requested, would yield 8 satisfied slots with
+        # slot_cores=2, but nslots=2 means score caps at 2.
+        satisfied, total = pred.score_job(
+            _r(core="0-15"),
+            slot_cores=2,
+            slot_gpus=0,
+            nslots=2,
+        )
+        self.assertEqual(satisfied, 2)
+        self.assertEqual(total, 2)
+
+    def test_empty_r_lite(self):
+        """A job R with no R_lite entries scores (0, nslots)."""
+        pred = LocalityPredicate(self._topo_4numa())
+        satisfied, total = pred.score_job(
+            {"execution": {"R_lite": []}},
+            slot_cores=1,
+            slot_gpus=0,
+            nslots=4,
+        )
+        self.assertEqual((satisfied, total), (0, 4))
+
+    def test_unknown_resources_silently_dropped(self):
+        """Cores in R that aren't in the topology are treated
+        as if they don't exist — they neither contribute to
+        nor break a slot. This means a mismatch between the
+        hwloc XML and the actual R will show as missing
+        locality rather than a hard error."""
+        pred = LocalityPredicate(self._topo_4numa())
+        # Core 99 is not in the topology; only 0-1 count.
+        satisfied, total = pred.score_job(
+            _r(core="0-1,99"),
+            slot_cores=2,
+            slot_gpus=0,
+            nslots=1,
+        )
+        self.assertEqual((satisfied, total), (1, 1))
+
+
+class TestLocalityPredicateOverride(unittest.TestCase):
+    """``_domain_of`` is the documented extension point — verify
+    that overriding it actually changes the scoring outcome."""
+
+    def test_override_uses_cpuset_instead_of_nodeset(self):
+        """A subclass keying off ``cpuset`` rather than
+        ``nodeset`` produces different domain groupings, hence
+        different scores."""
+        xml = ET.tostring(
+            ET.fromstring(
+                """\
+<topology version="2.0">
+  <object type="Machine">
+    <object type="Package" cpuset="0x000f">
+      <object type="Core" os_index="0" cpuset="0x0001" nodeset="0x1"/>
+      <object type="Core" os_index="1" cpuset="0x0002" nodeset="0x2"/>
+    </object>
+    <object type="Package" cpuset="0x00f0">
+      <object type="Core" os_index="2" cpuset="0x0010" nodeset="0x4"/>
+    </object>
+  </object>
+</topology>"""
+            ),
+            encoding="unicode",
+        )
+
+        class PackagePredicate(LocalityPredicate):
+            def _domain_of(self, obj, ancestor_chain):
+                # Walk up looking for a Package's cpuset rather
+                # than any nodeset.
+                for ancestor in reversed(ancestor_chain):
+                    if ancestor.get("type") == "Package":
+                        return ancestor.get("cpuset")
+                return None
+
+        pred = PackagePredicate(xml)
+        # Cores 0 and 1 have different NUMAs but share Package 0;
+        # the override puts them in one domain.
+        self.assertEqual(pred.core_domain[0], pred.core_domain[1])
+        self.assertNotEqual(pred.core_domain[1], pred.core_domain[2])
+
+
+# ---------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------
+
+
+class TestParseDurationMode(unittest.TestCase):
+
+    def test_fixed_fsd(self):
+        self.assertEqual(
+            _parse_duration_mode("0.1s"),
+            ("fixed", "0.1s", "0.1s"),
+        )
+
+    def test_fill_keyword(self):
+        self.assertEqual(_parse_duration_mode("fill"), ("fill", None, None))
+
+    def test_random_default_range(self):
+        self.assertEqual(
+            _parse_duration_mode("random"),
+            ("random", "0.1s", "1.0s"),
+        )
+
+    def test_random_explicit_range(self):
+        self.assertEqual(
+            _parse_duration_mode("random:0.5s-2s"),
+            ("random", "0.5s", "2s"),
+        )
+
+    def test_random_missing_hyphen_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_duration_mode("random:0.5s")
+
+    def test_invalid_fsd_raises(self):
+        # parse_fsd raises on garbage; we propagate it as ValueError.
+        with self.assertRaises(ValueError):
+            _parse_duration_mode("not-a-duration")
+
+
+class TestParseIdsetString(unittest.TestCase):
+
+    def test_empty_returns_empty_list(self):
+        self.assertEqual(_parse_idset_string(""), [])
+
+    def test_single_value(self):
+        self.assertEqual(_parse_idset_string("5"), [5])
+
+    def test_range(self):
+        self.assertEqual(_parse_idset_string("0-3"), [0, 1, 2, 3])
+
+    def test_mixed_list_and_ranges(self):
+        self.assertEqual(
+            _parse_idset_string("0-2,5,7-8"),
+            [0, 1, 2, 5, 7, 8],
+        )
+
+
+class TestRFromEvent(unittest.TestCase):
+    """:func:`_r_from_event` reads R off the journal alloc event's
+    ``R`` property; absent means caller falls back to KVS."""
+
+    def test_returns_R_attribute(self):
+        class FakeEvent:
+            R = {"execution": {"R_lite": [{"rank": "0"}]}}
+
+        self.assertEqual(
+            _r_from_event(FakeEvent()),
+            {"execution": {"R_lite": [{"rank": "0"}]}},
+        )
+
+    def test_returns_none_when_absent(self):
+        class FakeEvent:
+            name = "alloc"
+
+        self.assertIsNone(_r_from_event(FakeEvent()))
+
+
+if __name__ == "__main__":
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner())
+
+# vi: ts=4 sw=4 expandtab

--- a/t/python/t6040-testing-ui.py
+++ b/t/python/t6040-testing-ui.py
@@ -1,0 +1,556 @@
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""Unit tests for :class:`flux.testing.schedbench.ui.TerminalEmitter`.
+
+Pure-Python tests: the emitter writes to a :class:`io.StringIO` rather than a
+real terminal, so no broker is required and the rendered output can be
+inspected directly.
+
+Tests assert on substring presence rather than exact byte layouts so future
+column-width tuning doesn't break the suite. ANSI escape sequences are
+stripped from the captured output before substring checks unless the test
+specifically verifies color behavior.
+"""
+
+import io
+import os
+import re
+import sys
+import unittest
+
+# Required to set PYTHONPATH for the in-tree layout sharness runs us from. We
+# don't call rerun_under_flux (these tests don't need a broker), but the
+# import itself must still run.
+import subflux  # noqa: F401
+from flux.testing.events import NORMAL, VERBOSE
+from flux.testing.schedbench.ui import (
+    TerminalEmitter,
+    _color_supported,
+    _pluralize,
+)
+
+# Strip ANSI CSI sequences from a string. Used to verify rendered content
+# without depending on color/cursor escape bytes.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def _strip_ansi(s):
+    return _ANSI_RE.sub("", s)
+
+
+def _last_frame(stream):
+    """Split the captured stream into rendered frames (separated
+    by cursor-up + erase-to-end-of-screen sequences) and return the last one
+    with ANSI codes stripped. This is what the user would see at the end of
+    the run."""
+    raw = stream.getvalue()
+    frames = re.split(r"\x1b\[\d+A\x1b\[J", raw)
+    return _strip_ansi(frames[-1])
+
+
+class TestPluralize(unittest.TestCase):
+
+    def test_singular(self):
+        self.assertEqual(_pluralize(1, "node"), "1 node")
+        self.assertEqual(_pluralize(1, "GPU"), "1 GPU")
+
+    def test_plural_for_zero_and_many(self):
+        self.assertEqual(_pluralize(0, "node"), "0 nodes")
+        self.assertEqual(_pluralize(2, "core"), "2 cores")
+        self.assertEqual(_pluralize(64, "core"), "64 cores")
+
+
+class TestColorSupported(unittest.TestCase):
+    """Color resolution from --color and the environment."""
+
+    def setUp(self):
+        # Snapshot env so per-test mutations don't leak. The _color_supported
+        # function reads NO_COLOR and TERM.
+        self._saved_env = {k: os.environ.get(k) for k in ("NO_COLOR", "TERM")}
+
+    def tearDown(self):
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_never_disables_regardless_of_tty(self):
+        os.environ.pop("NO_COLOR", None)
+        self.assertFalse(_color_supported(sys.stdout, "never"))
+
+    def test_always_enables_regardless_of_tty(self):
+        os.environ["NO_COLOR"] = "1"  # would normally disable
+        self.assertTrue(_color_supported(io.StringIO(), "always"))
+
+    def test_auto_disabled_by_no_color_env(self):
+        os.environ["NO_COLOR"] = "1"
+        # Even a "real" tty stream should give False under NO_COLOR.
+        self.assertFalse(_color_supported(sys.stdout, "auto"))
+
+    def test_auto_disabled_by_dumb_term(self):
+        os.environ.pop("NO_COLOR", None)
+        os.environ["TERM"] = "dumb"
+        self.assertFalse(_color_supported(sys.stdout, "auto"))
+
+    def test_auto_disabled_on_non_tty(self):
+        os.environ.pop("NO_COLOR", None)
+        os.environ.pop("TERM", None)
+        # StringIO is not a tty; isatty() returns False.
+        self.assertFalse(_color_supported(io.StringIO(), "auto"))
+
+
+#: Default summary spec installed by ``_BaseEmitterTest.setUp``.
+#: Covers the metric keys exercised by the rendering tests below;
+#: tests that need a different spec (e.g. to exercise the
+#: ``fraction`` kind) call ``self.emitter.set_summary_metrics(...)``
+#: themselves to override.
+_DEFAULT_SUMMARY_SPEC = (
+    ("njobs", "jobs", "count"),
+    ("throughput", "throughput", "rate"),
+    ("submit_rate", "submit rate", "rate"),
+    ("alloc_rate", "alloc rate", "rate"),
+)
+
+
+class _BaseEmitterTest(unittest.TestCase):
+    """Shared setup: a StringIO stream, color disabled, ASCII
+    safe-mode disabled so we exercise the Unicode glyphs."""
+
+    def setUp(self):
+        self.stream = io.StringIO()
+        self.emitter = TerminalEmitter(
+            verbosity=VERBOSE,
+            stream=self.stream,
+            color="never",
+            ascii_only=False,
+        )
+        self.emitter.set_summary_metrics(_DEFAULT_SUMMARY_SPEC)
+
+
+class TestTestStart(_BaseEmitterTest):
+
+    def test_renders_test_name_in_header(self):
+        self.emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={"nodes": 4, "cores_per_node": 64},
+        )
+        frame = _last_frame(self.stream)
+        self.assertIn("flux schedbench", frame)
+        self.assertIn("throughput", frame)
+
+    def test_renders_resource_summary(self):
+        self.emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={
+                "nodes": 4,
+                "cores_per_node": 64,
+                "gpus_per_node": 8,
+                "scheduler": "sched-simple",
+                "watcher": "journal",
+            },
+        )
+        frame = _last_frame(self.stream)
+        self.assertIn("4 nodes", frame)
+        self.assertIn("64 cores", frame)
+        self.assertIn("8 GPUs", frame)
+        self.assertIn("sched-simple", frame)
+        self.assertIn("journal watcher", frame)
+
+    def test_omits_gpus_when_zero(self):
+        """gpus_per_node=0 means the run is cores-only; the
+        header shouldn't read '0 GPUs'."""
+        self.emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={"nodes": 4, "cores_per_node": 8, "gpus_per_node": 0},
+        )
+        frame = _last_frame(self.stream)
+        self.assertNotIn("GPU", frame)
+
+    def test_real_exec_annotates_header(self):
+        """real_exec=True appends 'real execution' after the
+        watcher, so a glance at the header tells the user this run actually
+        ran jobs rather than simulating them. The annotation lives next to
+        watcher because both are broker-mode descriptors — not a top-level
+        field like node count."""
+        self.emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={
+                "nodes": 4,
+                "cores_per_node": 64,
+                "gpus_per_node": 0,
+                "scheduler": "sched-simple",
+                "watcher": "journal",
+                "real_exec": True,
+            },
+        )
+        frame = _last_frame(self.stream)
+        self.assertIn("real execution", frame)
+
+    def test_mock_exec_unannotated(self):
+        """real_exec=False (default mode) leaves the header
+        unannotated — mock is the common case and a 'mock execution' tag would
+        clutter every run without adding signal."""
+        self.emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={
+                "nodes": 4,
+                "cores_per_node": 64,
+                "gpus_per_node": 0,
+                "scheduler": "sched-simple",
+                "watcher": "journal",
+                "real_exec": False,
+            },
+        )
+        frame = _last_frame(self.stream)
+        self.assertNotIn("real execution", frame)
+        self.assertNotIn("mock execution", frame)
+
+    def test_renders_all_stages_as_pending(self):
+        """Before any stage event, every stage should appear with
+        the pending glyph."""
+        self.emitter.test_start(
+            "fill-machine",
+            stages=["fill", "cancel", "cleanup"],
+            config={"nodes": 2, "cores_per_node": 2},
+        )
+        frame = _last_frame(self.stream)
+        self.assertIn("fill", frame)
+        self.assertIn("cancel", frame)
+        self.assertIn("cleanup", frame)
+        # Pending glyph (the centered dot) appears for each stage.
+        self.assertGreaterEqual(frame.count("·"), 3)
+
+
+class TestStageTransitions(_BaseEmitterTest):
+
+    def test_stage_marks_active_glyph(self):
+        self.emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={},
+        )
+        self.emitter.stage("execute", 0, 1)
+        frame = _last_frame(self.stream)
+        # Active glyph (right-pointing triangle) on the current row.
+        self.assertIn("▶", frame)
+
+    def test_previous_stage_marked_done_on_next_stage(self):
+        """When stage() transitions to the next stage, the
+        previous one should switch from active to done."""
+        self.emitter.test_start(
+            "fill-machine",
+            stages=["fill", "cancel", "cleanup"],
+            config={},
+        )
+        self.emitter.stage("fill", 0, 3)
+        self.emitter.stage("cancel", 1, 3)
+        frame = _last_frame(self.stream)
+        # Done glyph for fill, active for cancel.
+        self.assertIn("✓", frame)
+        # Active glyph for cancel.
+        self.assertIn("▶", frame)
+
+
+class TestProgress(_BaseEmitterTest):
+
+    def test_progress_updates_count(self):
+        self.emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={},
+        )
+        self.emitter.stage("execute", 0, 1)
+        self.emitter.progress(512, 1024, "job")
+        # Force a final render (default throttle would skip the second
+        # progress call).
+        self.emitter._redraw(force=True)
+        frame = _last_frame(self.stream)
+        self.assertIn("512/1024", frame)
+
+    def test_progress_ignored_below_verbosity(self):
+        """At NORMAL verbosity, progress events are dropped (the UI is
+        informationally degraded but still renders stage transitions).
+        """
+        e = TerminalEmitter(
+            verbosity=NORMAL,
+            stream=self.stream,
+            color="never",
+            ascii_only=False,
+        )
+        e.test_start("throughput", stages=["execute"], config={})
+        e.stage("execute", 0, 1)
+        e.progress(512, 1024, "job")
+        e._redraw(force=True)
+        frame = _last_frame(self.stream)
+        # Count should not appear since the progress event was below
+        # threshold.
+        self.assertNotIn("512/1024", frame)
+
+
+class TestCompletion(_BaseEmitterTest):
+
+    def test_metrics_rendered_on_complete(self):
+        self.emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={},
+        )
+        self.emitter.stage("execute", 0, 1)
+        self.emitter.progress(1024, 1024, "job")
+        self.emitter.result(
+            {
+                "throughput": 753.6,
+                "submit_rate": 832.5,
+                "njobs": 1024,
+            }
+        )
+        self.emitter.test_complete(duration=2.4)
+        frame = _last_frame(self.stream)
+        # Labels (human-readable, not the raw key names).
+        self.assertIn("throughput", frame)
+        self.assertIn("submit rate", frame)
+        self.assertIn("jobs", frame)
+        # Values formatted with adaptive rate precision: 832.5 is in the
+        # 100-999 range so it gets 1 decimal place.
+        self.assertIn("832.5", frame)
+        self.assertIn("753.6", frame)
+        # Integer count uses thousands separator.
+        self.assertIn("1,024", frame)
+        # Units appear alongside numbers.
+        self.assertIn("job/s", frame)
+        # Footer shows ok status.
+        self.assertIn("ok", frame)
+
+    def test_raw_timestamps_filtered_out(self):
+        """``t_*`` keys are dropped from the displayed table; the
+        UI shows only curated derived metrics. The raw timestamps are still
+        preserved in the results JSON file for analysis — just not in the
+        on-screen summary."""
+        self.emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={},
+        )
+        self.emitter.stage("execute", 0, 1)
+        self.emitter.result(
+            {
+                "throughput": 700.0,
+                "t_submit_start": 1778509870.41,
+                "t_all_submitted": 1778509872.49,
+                "t_first_submit_event": 1778509870.63,
+                "t_last_submit_event": 1778509871.32,
+            }
+        )
+        self.emitter.test_complete(duration=2.4)
+        frame = _last_frame(self.stream)
+        # The curated metric is shown.
+        self.assertIn("throughput", frame)
+        self.assertIn("700", frame)
+        # The raw timestamp labels do not appear — neither the key names nor
+        # the unformatted epoch values.
+        self.assertNotIn("t_submit_start", frame)
+        self.assertNotIn("t_first_submit_event", frame)
+        self.assertNotIn("1,778,509,870", frame)
+        self.assertNotIn("1778509870", frame)
+
+    def test_adaptive_rate_precision(self):
+        """Rate formatting adjusts decimals to magnitude: ≥1000
+        no decimals, ≥100 one decimal, otherwise two decimals. Keeps the
+        column readable across HPC-scale ranges."""
+        self.emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={},
+        )
+        self.emitter.stage("execute", 0, 1)
+        self.emitter.result(
+            {
+                "submit_rate": 5234.7,  # ≥1000 → "5,235"
+                "alloc_rate": 234.56,  # ≥100  → "234.6"
+                "throughput": 12.345,  # <100  → "12.35"
+            }
+        )
+        self.emitter.test_complete(duration=1.0)
+        frame = _last_frame(self.stream)
+        self.assertIn("5,235", frame)
+        self.assertIn("234.6", frame)
+        self.assertIn("12.35", frame)
+
+    def test_active_stage_finalized_to_done(self):
+        """If test_complete fires while a stage is still active
+        (no explicit final progress event reaching total), the stage
+        transitions to done so the bar appears full."""
+        self.emitter.test_start(
+            "throughput",
+            stages=["execute"],
+            config={},
+        )
+        self.emitter.stage("execute", 0, 1)
+        self.emitter.progress(500, 1024, "job")  # not yet at total
+        self.emitter.result({"throughput": 100.0})
+        self.emitter.test_complete(duration=1.0)
+        frame = _last_frame(self.stream)
+        # Done glyph appears even though count never hit total.
+        self.assertIn("✓", frame)
+
+
+class TestErrorPath(_BaseEmitterTest):
+
+    def test_error_displays_diagnostic(self):
+        self.emitter.test_start(
+            "fill-machine",
+            stages=["fill", "cancel", "cleanup"],
+            config={},
+        )
+        self.emitter.stage("fill", 0, 3)
+        diag = (
+            "fill-machine: no job reached 'start' event\n"
+            "  jobs: 4 requested, 4 submitted, 0 submit-failed\n"
+            "  0/4 reached event 'alloc'"
+        )
+        self.emitter.test_error(diag)
+        frame = _last_frame(self.stream)
+        # Failed glyph on the fill row, diagnostic text below.
+        self.assertIn("✗", frame)
+        self.assertIn("no job reached", frame)
+        self.assertIn("4 requested", frame)
+        # Footer shows failed status.
+        self.assertIn("failed", frame)
+
+
+class TestStreamPolarity(_BaseEmitterTest):
+    """log() and warning() must go to stderr, not the UI stream
+    on stdout — otherwise prose breaks the redrawing block."""
+
+    def test_warning_writes_to_stderr_not_ui_stream(self):
+        # Redirect stderr so we can inspect what was written.
+        saved_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            self.emitter.warning("disk space low")
+            self.assertEqual(self.stream.getvalue(), "")
+            self.assertIn("disk space low", sys.stderr.getvalue())
+        finally:
+            sys.stderr = saved_stderr
+
+    def test_log_writes_to_stderr_not_ui_stream(self):
+        saved_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            self.emitter.log("some prose")
+            self.assertEqual(self.stream.getvalue(), "")
+            self.assertIn("some prose", sys.stderr.getvalue())
+        finally:
+            sys.stderr = saved_stderr
+
+
+class TestColorAndAscii(unittest.TestCase):
+
+    def test_color_never_omits_escape_codes(self):
+        """No ANSI sequences should appear in the output stream
+        when color is explicitly disabled."""
+        stream = io.StringIO()
+        e = TerminalEmitter(
+            verbosity=VERBOSE,
+            stream=stream,
+            color="never",
+            ascii_only=False,
+        )
+        e.test_start("throughput", stages=["execute"], config={"nodes": 4})
+        e.stage("execute", 0, 1)
+        e.test_complete(duration=0.1)
+        # Cursor-control sequences ARE present (they're how the block
+        # redraws); colors are not. Filter to SGR (style) sequences which end
+        # in 'm'.
+        raw = stream.getvalue()
+        sgr = re.findall(r"\x1b\[[0-9;]*m", raw)
+        self.assertEqual(sgr, [])
+
+    def test_color_always_emits_escape_codes(self):
+        stream = io.StringIO()
+        e = TerminalEmitter(
+            verbosity=VERBOSE,
+            stream=stream,
+            color="always",
+            ascii_only=False,
+        )
+        e.test_start("throughput", stages=["execute"], config={})
+        raw = stream.getvalue()
+        sgr = re.findall(r"\x1b\[[0-9;]*m", raw)
+        self.assertGreater(len(sgr), 0)
+
+    def test_ascii_mode_uses_safe_glyphs(self):
+        stream = io.StringIO()
+        e = TerminalEmitter(
+            verbosity=VERBOSE,
+            stream=stream,
+            color="never",
+            ascii_only=True,
+        )
+        e.test_start("throughput", stages=["execute"], config={})
+        e.stage("execute", 0, 1)
+        e.progress(50, 100, "job")
+        e._redraw(force=True)
+        e.test_complete(duration=1.0)
+        frame = _last_frame(stream)
+        # Unicode glyphs should be absent under ASCII mode.
+        for g in ("·", "▶", "✓", "✗", "█", "░"):
+            self.assertNotIn(g, frame)
+        # Done glyph in ASCII mode is "+".
+        self.assertIn("+", frame)
+
+
+class TestRedrawThrottling(unittest.TestCase):
+    """progress() calls in quick succession must not redraw on
+    every call — the cost would dominate at scale (thousands of job events). A
+    50ms throttle is sufficient."""
+
+    def test_unforced_redraws_throttle(self):
+        stream = io.StringIO()
+        e = TerminalEmitter(
+            verbosity=VERBOSE,
+            stream=stream,
+            color="never",
+            ascii_only=False,
+        )
+        e.test_start("throughput", stages=["execute"], config={})
+        e.stage("execute", 0, 1)
+        # Reset render timestamp so the very first throttled progress call
+        # lands in the throttle window.
+        e._last_render_t = e._last_render_t or 0
+        # Hammer with 50 progress events; they should not all produce frames
+        # (the throttle kicks in for unforced redraws).
+        before = stream.getvalue().count("execute")
+        for i in range(50):
+            e.progress(i, 100, "job")
+        after = stream.getvalue().count("execute")
+        # Each frame contains one "execute" occurrence. We expect FAR fewer
+        # than 50 frames given the 50ms throttle and the negligible cost of
+        # the loop.
+        self.assertLess(after - before, 50)
+
+
+if __name__ == "__main__":
+    # Emit TAP output so sharness can parse per-test pass/fail results. Unlike
+    # t6000/t6010/t6030, this file's tests are pure-Python (no broker
+    # required) so rerun_under_flux is not needed.
+    from pycotap import TAPTestRunner
+
+    unittest.main(testRunner=TAPTestRunner(), buffer=False)
+
+
+# vi: ts=4 sw=4 expandtab

--- a/t/t0800-completion.t
+++ b/t/t0800-completion.t
@@ -67,7 +67,7 @@ __get_flux_subcommands() {
           modprobe sproc proxy update hostlist dump restore R keygen logger \
           post-job-event fsck startlog pmi uptime version env cgroup \
           heaptrace lptest relay python python3.13 getattr setattr lsattr \
-          content admin help"
+          content admin schedbench help"
 }
 
 # Temp file used to capture COMPREPLY across function calls
@@ -301,6 +301,124 @@ test_expect_success 'pmi get: completes --ranks' '
 test_expect_success 'pmi exchange: completes --count' '
     run_completion "flux pmi exchange --" &&
     completion_has "--count="
+'
+
+#
+# flux-schedbench
+#
+test_expect_success 'schedbench: completes subcommands' '
+    run_completion "flux schedbench " &&
+    completion_has "run" &&
+    completion_has "sweep" &&
+    completion_has "report"
+'
+test_expect_success 'schedbench run: completes long options' '
+    run_completion "flux schedbench run --" &&
+    completion_has "--nodes=" &&
+    completion_has "--cores-per-node=" &&
+    completion_has "--gpus-per-node=" &&
+    completion_has "--hwloc-xml-path=" &&
+    completion_has "--amend-r=" &&
+    completion_has "--exec"
+'
+test_expect_success 'schedbench run: completes short options' '
+    run_completion "flux schedbench run -" &&
+    completion_has "-N" &&
+    completion_has "-c" &&
+    completion_has "-g" &&
+    completion_has "-x"
+'
+test_expect_success 'schedbench run: --scheduler completes scheduler names' '
+    run_completion "flux schedbench run --scheduler " &&
+    completion_has "sched-simple" &&
+    completion_has "sched-fluxion-qmanager"
+'
+test_expect_success 'schedbench run: --watcher completes journal and per-job' '
+    run_completion "flux schedbench run --watcher " &&
+    completion_has "journal" &&
+    completion_has "per-job"
+'
+test_expect_success 'schedbench run: --ui completes auto/on/off' '
+    run_completion "flux schedbench run --ui " &&
+    completion_has "auto" &&
+    completion_has "on" &&
+    completion_has "off"
+'
+test_expect_success 'schedbench run: --color completes auto/always/never' '
+    run_completion "flux schedbench run --color " &&
+    completion_has "auto" &&
+    completion_has "always" &&
+    completion_has "never"
+'
+test_expect_success 'schedbench run: positional completes test names' '
+    run_completion "flux schedbench run " &&
+    completion_has "throughput" &&
+    completion_has "fill-machine" &&
+    completion_has "locality"
+'
+test_expect_success 'schedbench run: -o (extra-start-options) takes free-form value' '
+    run_completion "flux schedbench run -o " &&
+    completion_empty
+'
+test_expect_success 'schedbench run: --hwloc-xml-path delegates to file completion' '
+    run_completion "flux schedbench run --hwloc-xml-path " &&
+    completion_empty
+'
+test_expect_success 'schedbench run: --amend-r delegates to file completion' '
+    run_completion "flux schedbench run --amend-r " &&
+    completion_empty
+'
+test_expect_success 'schedbench sweep: completes long options' '
+    run_completion "flux schedbench sweep --" &&
+    completion_has "--nodes=" &&
+    completion_has "--scheduler=" &&
+    completion_has "--njobs=" &&
+    completion_has "--from=" &&
+    completion_has "--sweep-name=" &&
+    completion_has "--per-run-nodes="
+'
+test_expect_success 'schedbench sweep: positional completes test names' '
+    run_completion "flux schedbench sweep " &&
+    completion_has "throughput" &&
+    completion_has "fill-machine" &&
+    completion_has "locality"
+'
+test_expect_success 'schedbench sweep: --from delegates to file completion' '
+    run_completion "flux schedbench sweep --from " &&
+    completion_empty
+'
+test_expect_success 'schedbench sweep: --scheduler completes scheduler names' '
+    run_completion "flux schedbench sweep --scheduler " &&
+    completion_has "sched-simple" &&
+    completion_has "sched-fluxion-qmanager"
+'
+test_expect_success 'schedbench sweep: --sweep-name takes free-form value' '
+    run_completion "flux schedbench sweep --sweep-name " &&
+    completion_empty
+'
+test_expect_success 'schedbench sweep: --per-run-nodes takes free-form value' '
+    run_completion "flux schedbench sweep --per-run-nodes " &&
+    completion_empty
+'
+test_expect_success 'schedbench report: completes long options' '
+    run_completion "flux schedbench report --" &&
+    completion_has "--results-file=" &&
+    completion_has "--filter=" &&
+    completion_has "--format=" &&
+    completion_has "--sort=" &&
+    completion_has "--no-header"
+'
+test_expect_success 'schedbench report: -o completes format names' '
+    run_completion "flux schedbench report -o " &&
+    completion_has "default" &&
+    completion_has "long" &&
+    completion_has "csv"
+'
+test_expect_success 'schedbench report: positional completes test names' '
+    run_completion "flux schedbench report " &&
+    completion_has "throughput" &&
+    completion_has "fill-machine" &&
+    completion_has "locality"
 '
 
 #

--- a/t/t6020-schedbench.t
+++ b/t/t6020-schedbench.t
@@ -1,0 +1,643 @@
+#!/bin/sh
+
+test_description='Test flux schedbench'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1
+
+test_expect_success 'schedbench run: throughput writes results file' '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 \
+		--gpus-per-node=0 \
+		--njobs=20 \
+		--tag=test-throughput \
+		--results-file=throughput.json &&
+	test -f throughput.json &&
+	grep -q "\"test_name\": \"throughput\"" throughput.json &&
+	grep -q "\"tag\": \"test-throughput\"" throughput.json &&
+	grep -q "\"njobs\": 20" throughput.json
+'
+
+test_expect_success 'schedbench run uses default -N=4' '
+	flux schedbench run throughput \
+		--cores-per-node=2 --gpus-per-node=0 \
+		--njobs=10 --results-file=default-n.json &&
+	grep -q "\"nodes\": 4" default-n.json
+'
+
+test_expect_success 'schedbench run records full resource shape' '
+	flux schedbench run throughput \
+		-N 8 --cores-per-node=4 --gpus-per-node=2 \
+		--njobs=20 --results-file=shape.json &&
+	grep -q "\"nodes\": 8" shape.json &&
+	grep -q "\"cores_per_node\": 4" shape.json &&
+	grep -q "\"gpus_per_node\": 2" shape.json
+'
+
+# FLUX_SCHEDBENCH_ISOLATED=1 is the recursion guard: when the
+# launcher re-execs schedbench inside the fake-resources
+# subinstance, it sets this env var so the inner invocation runs
+# in the broker rather than launching another subinstance. We
+# verify the guard works by setting the var externally — the
+# resulting run executes in test_under_flux's 1-node broker
+# rather than the 4-node subinstance --N would otherwise create.
+test_expect_success 'FLUX_SCHEDBENCH_ISOLATED=1 skips subinstance launch' '
+	FLUX_SCHEDBENCH_ISOLATED=1 flux schedbench run throughput \
+		--njobs=4 --no-save --ui=off >isolated.out &&
+	grep -q "\"nodes\": 1" isolated.out
+'
+
+# The fill-machine sharness sub-cases below cover two resource
+# shapes: a cores-only run for the baseline cancel-and-cleanup
+# path, and a 1-GPU-per-node variant. The GPU variant catches a
+# regression in `flux R encode`'s idset argument formatting that
+# previously produced R without GPUs whenever gpus_per_node was
+# 1 (the degenerate `-g 0-0` range failed to parse). See the
+# IDset usage in fake_resources.build_R_encode_args for the
+# fix. t6010 has the in-process GPU allocation regression test.
+test_expect_success 'schedbench run: fill-machine writes results file' '
+	flux schedbench run fill-machine \
+		-N 2 --cores-per-node=2 \
+		--gpus-per-node=0 \
+		--slot-cores=1 \
+		--results-file=fillmachine.json &&
+	test -f fillmachine.json &&
+	grep -q "\"test_name\": \"fill-machine\"" fillmachine.json &&
+	grep -q "\"njobs\": 4" fillmachine.json
+'
+
+test_expect_success 'schedbench run: fill-machine with 1 GPU/node' '
+	flux schedbench run fill-machine \
+		-N 2 --cores-per-node=2 \
+		--gpus-per-node=1 \
+		--slot-cores=1 --slot-gpus=1 \
+		--results-file=fillmachine-gpu.json &&
+	test -f fillmachine-gpu.json &&
+	grep -q "\"test_name\": \"fill-machine\"" fillmachine-gpu.json &&
+	grep -q "\"njobs\": 2" fillmachine-gpu.json
+'
+
+test_expect_success 'schedbench run --no-save skips results file' '
+	rm -f no-save.json &&
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 \
+		--gpus-per-node=0 \
+		--njobs=10 --no-save --results-file=no-save.json &&
+	test ! -e no-save.json
+'
+
+test_expect_success 'schedbench run --scheduler-options stored in record' '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 --gpus-per-node=0 \
+		--scheduler-options="queue-depth=42" \
+		--njobs=10 --results-file=sched-opts.json &&
+	grep -q "\"options\": \"queue-depth=42\"" sched-opts.json
+'
+
+# --hwloc-xml-path and --amend-r are convenience flags that
+# translate to --conf=fake-resources.* on the launched subinstance,
+# and are passed through to the inner schedbench invocation so they
+# appear in the results record (so reports can show which run used
+# which topology / amender). Tests capture local hwloc XML via
+# hwloc-ls since flux R encode rejects hand-written minimal XML.
+
+test_expect_success 'capture local hwloc topology for schedbench tests' '
+	if command -v hwloc-ls >/dev/null 2>&1; then
+		hwloc-ls --of xml local.xml &&
+		test_set_prereq HAVE_LSTOPO
+	fi
+'
+
+test_expect_success HAVE_LSTOPO \
+	'schedbench run --hwloc-xml-path replicates topology + records path' '
+	flux schedbench run throughput \
+		-N 4 --hwloc-xml-path=$(pwd)/local.xml \
+		--njobs=10 --results-file=hwloc.json &&
+	grep -q "\"hwloc_xml_path\":" hwloc.json &&
+	grep -q "local.xml" hwloc.json
+'
+
+test_expect_success HAVE_LSTOPO \
+	'schedbench run --amend-r runs amender and records spec' '
+	cat <<-EOT >schedbench_amender.py &&
+		def amend(R, hwloc_xml=None):
+		    R["schedbench_marker"] = "amended"
+		    return R
+	EOT
+	flux schedbench run throughput \
+		-N 4 --hwloc-xml-path=$(pwd)/local.xml \
+		--amend-r=$(pwd)/schedbench_amender.py \
+		--njobs=10 --results-file=amend.json &&
+	grep -q "\"amend_r\":" amend.json &&
+	grep -q "schedbench_amender.py" amend.json
+'
+
+#
+# Locality benchmark sub-cases. These verify the locality
+# benchmark's plumbing (CLI options, duration modes, required
+# arguments) and that the predicate produces a score in [0, 1] for
+# real placements. The math is unit-tested in t6031; here we
+# check end-to-end integration with the broker, scheduler, and
+# results pipeline. A trivial-topology case asserts a specific
+# score (1.0 on a single-NUMA topology where any placement is
+# necessarily local) to catch silent regressions in the predicate
+# integration.
+#
+
+test_expect_success HAVE_LSTOPO \
+	'schedbench run: locality writes results file with score' '
+	flux schedbench run locality \
+		-N 4 --hwloc-xml-path=$(pwd)/local.xml \
+		--njobs=10 --tag=test-locality \
+		--results-file=locality.json &&
+	test -f locality.json &&
+	grep -q "\"test_name\": \"locality\"" locality.json &&
+	grep -q "\"tag\": \"test-locality\"" locality.json &&
+	grep -q "\"mean_locality_score\":" locality.json &&
+	grep -q "\"num_jobs_scored\":" locality.json &&
+	grep -q "\"locality_score_distribution\":" locality.json
+'
+
+test_expect_success \
+	'schedbench run: locality requires --hwloc-xml-path' '
+	test_must_fail flux schedbench run locality \
+		-N 4 --njobs=4 --no-save --ui=off 2>locality-no-xml.out &&
+	grep -qi "hwloc.xml.path" locality-no-xml.out
+'
+
+test_expect_success HAVE_LSTOPO \
+	'schedbench run: locality --duration=fill saturates and cancels' '
+	flux schedbench run locality --duration=fill \
+		-N 4 --hwloc-xml-path=$(pwd)/local.xml \
+		--no-save --ui=off >locality-fill.out &&
+	grep -q "\"name\": \"result\"" locality-fill.out &&
+	grep -q "\"mean_locality_score\":" locality-fill.out &&
+	grep -q "\"duration\": \"fill\"" locality-fill.out
+'
+
+test_expect_success HAVE_LSTOPO \
+	'schedbench run: locality --duration=random accepts range' '
+	flux schedbench run locality --duration=random:0.1s-0.3s \
+		-N 2 --hwloc-xml-path=$(pwd)/local.xml \
+		--njobs=4 --no-save --ui=off >locality-rand.out &&
+	grep -q "\"name\": \"result\"" locality-rand.out &&
+	grep -q "\"duration\": \"random:0.1s-0.3s\"" locality-rand.out
+'
+
+test_expect_success HAVE_LSTOPO \
+	'schedbench run: locality on single-NUMA topology scores 1.0' '
+	hwloc-ls -i "package:1 numa:1 core:4 pu:1" --of xml --no-io \
+		>single-numa.xml &&
+	flux schedbench run locality \
+		-N 4 --hwloc-xml-path=$(pwd)/single-numa.xml \
+		--slot-cores=1 --njobs=8 \
+		--results-file=single-numa.json &&
+	grep -qE "\"mean_locality_score\":\s*1\.0+" single-numa.json
+'
+
+test_expect_success HAVE_LSTOPO \
+	'schedbench run: locality --nslots groups multiple slots per job' '
+	flux schedbench run locality \
+		-N 4 --hwloc-xml-path=$(pwd)/local.xml \
+		--nslots=2 --slot-cores=1 --njobs=4 \
+		--results-file=locality-nslots.json &&
+	grep -q "\"nslots\": 2" locality-nslots.json
+'
+
+# --extra-start-options is shlex-parsed and passed verbatim to
+# the underlying flux start. We don't have a direct way from
+# inside schedbench to confirm the broker attribute was set, so
+# this is an indirect test: a typo in the launcher's argv
+# construction (e.g. forgetting shlex.split, or quoting wrong)
+# would cause flux start to reject the option and broker startup
+# to fail. Reaching the result event means the option was
+# accepted.
+test_expect_success 'schedbench run --extra-start-options passes through' '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 --gpus-per-node=0 \
+		--extra-start-options="--setattr=log-stderr-level=6" \
+		--njobs=10 --no-save --ui=off \
+		>extra.out &&
+	grep -q "\"name\": \"result\"" extra.out
+'
+
+# --conf is a first-class accumulating flag that forwards each
+# KEY=VALUE to `flux start --conf=KEY=VALUE`. Same indirect
+# acceptance test as --extra-start-options: reaching the result
+# event means flux start accepted the config.
+test_expect_success 'schedbench run --conf passes through' '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 --gpus-per-node=0 \
+		--conf=resource.noverify=true \
+		--njobs=10 --no-save --ui=off \
+		>conf.out &&
+	grep -q "\"name\": \"result\"" conf.out
+'
+
+test_expect_success 'schedbench run --conf accumulates across multiple uses' '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 --gpus-per-node=0 \
+		--conf=resource.noverify=true \
+		--conf=resource.norestrict=true \
+		--njobs=10 --no-save --ui=off \
+		>conf-multi.out &&
+	grep -q "\"name\": \"result\"" conf-multi.out
+'
+
+# --exec sub-cases:
+
+test_expect_success 'schedbench run throughput --exec succeeds' '
+	flux schedbench run throughput --exec \
+		--njobs=4 --no-save --ui=off >exec-throughput.out &&
+	grep -q "\"name\": \"result\"" exec-throughput.out &&
+	grep -q "\"real_exec\":" exec-throughput.out
+'
+
+test_expect_success 'schedbench run throughput --exec records real_exec=true' '
+	rm -f exec.json &&
+	flux schedbench run throughput --exec \
+		--njobs=4 --results-file=exec.json --ui=off >/dev/null &&
+	grep -q "\"real_exec\": true" exec.json
+'
+
+test_expect_success 'schedbench run fill-machine --exec succeeds' '
+	flux schedbench run fill-machine --exec \
+		--no-save --ui=off >exec-fm.out &&
+	grep -q "\"name\": \"result\"" exec-fm.out &&
+	grep -q "time_to_fill" exec-fm.out
+'
+
+test_expect_success 'schedbench report renders REAL column' '
+	flux schedbench report throughput \
+		--results-file=exec.json >exec-report.out &&
+	head -1 exec-report.out | grep -q "REAL"
+'
+
+# UI-mode coverage. Sharness redirects stdout to a file so
+# isatty() is false during these tests; --ui=auto correctly
+# falls back to JSON. --ui=off makes the fallback explicit
+# (covers the path users will take when piping to jq), and
+# --ui=on forces the terminal renderer even on a non-TTY so
+# we exercise the rendering path itself. Color is disabled to
+# keep the substring grep robust against escape sequences.
+test_expect_success 'schedbench run --ui=off emits JSON event stream' '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 \
+		--gpus-per-node=0 \
+		--njobs=4 --no-save \
+		--ui=off >ui-off.out &&
+	grep -q "\"name\": \"test.start\"" ui-off.out &&
+	grep -q "\"name\": \"test.complete\"" ui-off.out
+'
+
+test_expect_success 'schedbench run --ui=on renders terminal block' '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 \
+		--gpus-per-node=0 \
+		--njobs=4 --no-save \
+		--ui=on --color=never >ui-on.out &&
+	grep -q "flux schedbench" ui-on.out &&
+	grep -q "throughput" ui-on.out &&
+	grep -q "elapsed" ui-on.out
+'
+
+test_expect_success "schedbench run --quiet --ui=on shows results without progress" '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 \
+		--gpus-per-node=0 \
+		--njobs=4 --no-save \
+		--ui=on --quiet >ui-quiet.out 2>ui-quiet.err &&
+	grep -q "flux schedbench" ui-quiet.out &&
+	grep -q "throughput" ui-quiet.out &&
+	test_must_fail grep -q "█" ui-quiet.out
+'
+
+test_expect_success "schedbench run --quiet suppresses INFO log messages" '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 \
+		--gpus-per-node=0 \
+		--njobs=4 --no-save --quiet \
+		>quiet-info.out 2>quiet-info.err &&
+	test_must_fail grep -q "^flux-schedbench: INFO:" quiet-info.err &&
+	test_must_fail grep -q "^flux-schedbench: INFO:" quiet-info.out
+'
+
+test_expect_success "schedbench run --quiet non-TTY emits single JSON object" '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 \
+		--gpus-per-node=0 \
+		--njobs=4 --no-save --quiet --ui=off \
+		>quiet-json.out 2>&1 &&
+	test "$(wc -l <quiet-json.out)" -eq 1 &&
+	grep -q "\"throughput\":" quiet-json.out &&
+	python3 -c "import json,sys; json.loads(open(\"quiet-json.out\").read())"
+'
+
+test_expect_success 'schedbench report TEST prints a table header' '
+	flux schedbench report throughput \
+		--results-file=throughput.json >report.out &&
+	head -1 report.out | grep -q "SCHED" &&
+	head -1 report.out | grep -q "JOBS"
+'
+
+test_expect_success "schedbench report TEST prints headline metric column" '
+	flux schedbench report throughput \
+		--results-file=throughput.json >report.out &&
+	head -1 report.out | grep -q "THRPUT"
+'
+
+test_expect_success "schedbench report -o long includes extra columns" '
+	flux schedbench report throughput -o long \
+		--results-file=throughput.json >long.out &&
+	head -1 long.out | grep -q "ALLOC"
+'
+
+test_expect_success "schedbench report -o csv emits comma-separated output" '
+	flux schedbench report throughput -o csv \
+		--results-file=throughput.json >csv.out &&
+	head -1 csv.out | grep -q "," &&
+	head -1 csv.out | grep -q "SCHED"
+'
+
+test_expect_success "schedbench report --no-header skips header row" '
+	flux schedbench report throughput --no-header \
+		--results-file=throughput.json >noheader.out &&
+	head -1 noheader.out >noheader-first.out &&
+	test_must_fail grep -q "SCHED" noheader-first.out
+'
+
+test_expect_success "schedbench report --filter on top-level key" '
+	flux schedbench report throughput \
+		--results-file=throughput.json \
+		--filter=tag=test-throughput \
+		>match-top.out &&
+	grep -q "sched-simple" match-top.out
+'
+
+test_expect_success "schedbench report --filter on nested key (scheduler.name)" '
+	flux schedbench report throughput \
+		--results-file=throughput.json \
+		--filter=scheduler.name=sched-simple \
+		>match-nested.out &&
+	grep -q "sched-simple" match-nested.out
+'
+
+test_expect_success "schedbench report --filter on doubly-nested key (resources.nodes)" '
+	flux schedbench report throughput \
+		--results-file=throughput.json \
+		--filter=resources.nodes=4 \
+		>match-deep.out &&
+	grep -q "sched-simple" match-deep.out
+'
+
+test_expect_success "schedbench report --filter no-match exits nonzero" '
+	test_must_fail flux schedbench report throughput \
+		--results-file=throughput.json \
+		--filter=tag=nonexistent-tag \
+		>no-match.out 2>&1 &&
+	grep -q "no .* match" no-match.out
+'
+
+test_expect_success "schedbench report --filter missing intermediate key" '
+	test_must_fail flux schedbench report throughput \
+		--results-file=throughput.json \
+		--filter=scheduler.bogus=anything \
+		>missing-key.out 2>&1 &&
+	grep -q "no .* match" missing-key.out
+'
+
+# --sort and multi-filter need at least two distinct rows to
+# exercise meaningfully. Create them in their own results file
+# with distinct tags and njobs values so the sort order is
+# unambiguous and the multi-filter case has a row to retain
+# (multi-A) and a row to exclude (multi-B).
+test_expect_success "schedbench report --sort orders rows by metric" '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 --gpus-per-node=0 \
+		--tag=multi-A --njobs=10 \
+		--results-file=multi.json &&
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 --gpus-per-node=0 \
+		--tag=multi-B --njobs=30 \
+		--results-file=multi.json &&
+	flux schedbench report throughput \
+		--results-file=multi.json --sort=njobs \
+		>sorted.out &&
+	grep -n "multi-A\|multi-B" sorted.out >order.out &&
+	head -1 order.out | grep -q "multi-A"
+'
+
+test_expect_success "schedbench report multiple --filter args combine" '
+	flux schedbench report throughput \
+		--results-file=multi.json \
+		--filter=tag=multi-A \
+		--filter=watcher=journal \
+		>multi-filter.out &&
+	grep -q "multi-A" multi-filter.out &&
+	test_must_fail grep -q "multi-B" multi-filter.out
+'
+
+test_expect_success "schedbench report missing file is an error" '
+	test_must_fail flux schedbench report throughput \
+		--results-file=does-not-exist.json
+'
+
+test_expect_success "schedbench report requires a TEST argument" '
+	test_must_fail flux schedbench report \
+		--results-file=throughput.json 2>noarg.out &&
+	grep -q "required" noarg.out
+'
+
+test_expect_success 'schedbench run requires TEST argument' '
+	test_must_fail flux schedbench run 2>missing-test.out &&
+	grep -qi "required\|the following arguments" missing-test.out
+'
+
+test_expect_success 'schedbench run: invalid benchmark name fails' '
+	test_must_fail flux schedbench run no-such-benchmark -N 4
+'
+
+test_expect_success 'schedbench run --watcher=per-job runs and records watcher' '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 \
+		--gpus-per-node=0 \
+		--watcher=per-job --njobs=20 \
+		--results-file=perjob.json &&
+	grep -q "\"watcher\": \"per-job\"" perjob.json
+'
+
+test_expect_success 'schedbench run --watcher=journal is the default' '
+	flux schedbench run throughput \
+		-N 4 --cores-per-node=2 \
+		--gpus-per-node=0 \
+		--njobs=20 \
+		--results-file=journal.json &&
+	grep -q "\"watcher\": \"journal\"" journal.json
+'
+
+test_expect_success 'schedbench run --watcher=bogus rejected at argparse' '
+	test_must_fail flux schedbench run throughput \
+		-N 4 --watcher=bogus
+'
+
+test_expect_success 'flux schedbench --help lists subcommands' '
+	flux schedbench --help >help.out &&
+	grep -q "run" help.out &&
+	grep -q "sweep" help.out &&
+	grep -q "report" help.out
+'
+
+#
+# Sweep dispatch (flux schedbench sweep): exercises the parallel
+# Flux-job dispatch path against the outer test broker.  Each child
+# is a `flux schedbench run` invocation submitted as a 1-node job;
+# the outer broker schedules them serially under test_under_flux 1.
+#
+
+test_expect_success 'schedbench sweep: basic CLI sweep writes records' '
+	flux schedbench sweep throughput \
+		--nodes=4,8 \
+		--cores-per-node=2 --gpus-per-node=0 \
+		--njobs=20 \
+		--ui=off \
+		--sweep-name=basic \
+		--results-file=sweep-basic.json &&
+	test -f sweep-basic.json &&
+	grep -q "\"sweep\":" sweep-basic.json &&
+	grep -q "\"name\": \"basic\"" sweep-basic.json
+'
+
+test_expect_success 'schedbench sweep: --from TOML loads sweep definition' '
+	cat >sweep.toml <<-EOF &&
+	name = "from-toml"
+	test = "throughput"
+	nodes = [4, 8]
+	cores_per_node = 2
+	gpus_per_node = 0
+	njobs = 20
+	EOF
+	flux schedbench sweep --from=sweep.toml --ui=off \
+		--results-file=sweep-toml.json &&
+	test -f sweep-toml.json &&
+	grep -q "\"name\": \"from-toml\"" sweep-toml.json
+'
+
+test_expect_success 'schedbench sweep: CLI overrides TOML param' '
+	flux schedbench sweep --from=sweep.toml --ui=off \
+		--njobs=10 \
+		--sweep-name=cli-override \
+		--results-file=sweep-override.json &&
+	grep -q "\"njobs\": 10" sweep-override.json &&
+	! grep -q "\"njobs\": 20" sweep-override.json
+'
+
+test_expect_success 'schedbench sweep: records carry sweep block' '
+	# Each record must have sweep.{id,name,run_index,total,axes,fixed}
+	# so the report tool can filter / group by sweep.
+	grep -q "\"run_index\":" sweep-basic.json &&
+	grep -q "\"axes\":" sweep-basic.json &&
+	grep -q "\"total\": 2" sweep-basic.json
+'
+
+test_expect_success 'schedbench sweep: records carry config block' '
+	# Per-test config block lets the report tool surface config-only
+	# fields (notably njobs) for runs whose results are absent.
+	grep -q "\"config\":" sweep-basic.json &&
+	grep -q "\"results\":" sweep-basic.json
+'
+
+test_expect_success 'schedbench sweep: --no-save skips results file' '
+	rm -f sweep-nosave.json &&
+	flux schedbench sweep throughput \
+		--nodes=4,8 \
+		--cores-per-node=2 --gpus-per-node=0 \
+		--njobs=20 \
+		--ui=off --no-save \
+		--results-file=sweep-nosave.json &&
+	test ! -f sweep-nosave.json
+'
+
+test_expect_success 'schedbench sweep: bad TOML (env after subtable) rejected' '
+	# TOML scoping pitfall: a key placed after [[scheduler.modules]]
+	# attaches to the module entry, not the parent scheduler block.
+	# The recipe parser hard-errors so the user sees the mistake
+	# immediately rather than silently dropping the misplaced key.
+	cat >bad-scope.toml <<-EOF &&
+	test = "throughput"
+	nodes = [4, 8]
+	cores_per_node = 2
+	gpus_per_node = 0
+	njobs = 20
+
+	[[scheduler]]
+	name = "fluxion"
+
+	[[scheduler.modules]]
+	name = "sched-fluxion-resource"
+	env = ["FOO=bar"]
+	EOF
+	test_must_fail flux schedbench sweep --from=bad-scope.toml \
+		--ui=off --no-save 2>err.out &&
+	grep -q "env" err.out
+'
+
+#
+# Report rendering: empty / missing fields produce a single-hyphen
+# marker for numeric columns (Flux empty-display convention), width-
+# padded blank for string columns, and empty cells in CSV.  This is
+# the failure path: a run that OOM-killed or otherwise died before
+# emitting `result` leaves benchmarks[test].results empty.  Older
+# records that predate a metric also exercise this path.
+#
+
+test_expect_success 'schedbench report handles record with empty results' '
+	cat >missing-data.json <<-EOF &&
+	{
+	  "runs": [
+	    {
+	      "test_name": "fill-machine",
+	      "iso_timestamp": "2026-05-19T00:00:00Z",
+	      "tag": "", "watcher": "journal", "real_exec": false,
+	      "scheduler": {"name": "sched-simple", "options": "",
+	                    "version": null},
+	      "resources": {"nodes": 4, "cores_per_node": 2,
+	                    "gpus_per_node": 0,
+	                    "hwloc_xml_path": "", "amend_r": ""},
+	      "benchmarks": {
+	        "fill-machine": {
+	          "config": {"nodes": 4, "cores_per_node": 2,
+	                     "gpus_per_node": 0,
+	                     "scheduler": "sched-simple",
+	                     "watcher": "journal", "real_exec": false,
+	                     "njobs": 100, "slot_cores": 1,
+	                     "slot_gpus": 0},
+	          "results": {}
+	        }
+	      },
+	      "error": "OOM killed"
+	    }
+	  ]
+	}
+	EOF
+	flux schedbench report fill-machine \
+		--results-file=missing-data.json >report.out 2>&1 &&
+	# Identity columns from config are populated:
+	grep -q "sched-simple" report.out &&
+	grep -q "100" report.out &&
+	# Numeric measurement columns render the hyphen marker:
+	grep -q " -" report.out
+'
+
+test_expect_success 'schedbench report CSV empties missing cells' '
+	# In CSV mode, missing values render as empty cells (no hyphen)
+	# so spreadsheets and pandas see empty cells rather than a
+	# "-" literal which would force a string dtype on the column.
+	flux schedbench report fill-machine -o csv \
+		--results-file=missing-data.json >report.csv 2>&1 &&
+	# The data row should have empty cells where metrics are missing
+	# — multiple consecutive commas (no value between them).
+	grep -q ",," report.csv
+'
+
+test_done


### PR DESCRIPTION
### Problem

Flux currently lacks tooling for quickly spinning up benchmarks and tests at varying sizes, scheduler configurations, etc. The usual pattern is to write a one-off test for a specific scenario, post it in an issue, and abandon it.

This PR adds `flux schedbench`, a benchmark harness built on top of the fake-resources facility from #7619. It pulls in components from existing one-off tests (notably an enhanced BulkRun interface from `throughput.py`) and introduces new ones intended to be reusable: a test event emitter, an append-capable results file format, and a pluggable job event watcher class.

`flux schedbench` is designed to run benchmark sweeps — for example, resource scale-up combined with multiple schedulers and permuted config deltas — but for now runs only as a standalone tool.

Note: if this feels like too much to land in flux-core, the code is self-contained under flux.testing.schedbench and could be split into its own subproject. For now, it seems useful to have a benchmarking framework available directly in the build tree.
### What's included

#### New `flux.testing` Python modules

- `BulkRun` interface for submitting jobs and getting callbacks at transition points
- structured events emitter for benchmarks that allow them to easily be monitored from the harness
- Test JobWatcher class that can watch job events via the job-manager journal for reduced perturbation of results with many thousands of jobs. Fallback to per-job eventlog watching (easily swapped for comparison runs)

#### Harness (`flux.testing.schedbench` package)

- A `Benchmark` abstract base class
- `BenchmarkResults`: append-only JSON results file with stable schema for downstream tooling
- Real time UI that monitors benchmark events with a progress meter when running benchmarks in a tty

#### Benchmarks

- **`throughput`** — submits N jobs and measures submit/alloc/throughput rates end-to-end. The headline scheduler benchmark.
- **`fill-machine`** — saturates the resource set with long-running jobs and measures start/cancel rates plus time-to-fill. Meant to measure the time a scheduler takes to fully load a large allocation with many small jobs.
- **`locality`** — submits N jobs against a topology-aware resource set and scores each job's placement against a NUMA/affinity domain model derived from hwloc. Reports a mean locality score alongside throughput.

New Benchmarks should be easy to drop in to `flux.testing.schedbench` by subclassing `flux.testing.schedbench.Benchmark`.

#### CLI: `flux schedbench`

`run TEST` flags:
- `--nodes` / `--cores-per-node` / `--gpus-per-node` — forwarded as fake-resources config to a launched subinstance
- `--exec` — run real jobs against the user's current broker instead of launching a subinstance
- `--scheduler NAME` / `--scheduler-options OPTS`
- `--hwloc-xml-path PATH` / `--amend-r SPEC` for topology injection
- `--conf KEY=VALUE` (accumulating; first-class shortcut for `flux start --conf=...` passthrough)
- `-o`/`--extra-start-options OPTS` for arbitrary `flux start` passthrough
- `--watcher journal|per-job`
- `--tag LABEL` / `--results-file PATH` / `--no-save`
- `-q`/`-v`, `--ui auto|on|off`, `--color auto|always|never`
- Per-benchmark options are auto-discovered via `Benchmark.register_options` and auto-passed-through to the inner invocation

`report TEST` flags:
- `--format` / `-o` resolves against built-in named formats and user-defined formats from `~/.config/flux/flux-schedbench-report-<test>.toml`
- `--filter KEY=VAL` (multi-use; dotted paths reach into nested record fields like `scheduler.name=...`)
- `--sort KEY,...` (prefix with `-` for descending)
- Auto-generated CSV format from `REPORT_HEADINGS` when the benchmark doesn't define one explicitly

#### Locality-specific machinery

- `LocalityPredicate` (in `flux.testing.schedbench.locality`): parses hwloc XML into a `(core_id → nodeset, gpu_id → nodeset)` model. Sequential indexing in document order (correct on dual-socket AMD where `os_index` collides between packages). Compute-GPU detection across all four hwloc backends (CUDA/OpenCL as CoProc, RSMI/NVML/NVIDIA as GPU+name-prefix); display DRM nodes correctly excluded. PCIDev-level deduplication so multi-backend exposure (CUDA+NVML, OpenCL+RSMI on a single physical card) counts as one device.

### Examples

#### Running a benchmark

```
$ src/cmd/flux schedbench run throughput -N1000 --cores-per-node 48 --gpus-per-node 4 --slot-cores=4 --slot-gpus=1 --njobs=4096
flux schedbench · throughput
  1000 nodes × 48 cores × 4 GPUs · sched-simple · journal watcher

  ✓ submit   ███████████████████████████████  4096/4096   1.39s   2937 job/s
  ✓ execute  ███████████████████████████████  4096/4096   4.40s    930 job/s

  jobs               4,096
  throughput         707.1  job/s
  script throughput  707.1  job/s
  submit rate        2,939  job/s
  alloc rate         707.8  job/s
  ingest rate        6,522  job/s

  5.80s elapsed · ok
```

#### Swap in a different scheduler

```
$ src/cmd/flux schedbench run throughput --scheduler=sched-backfill -N1000 --cores-per-node 48 --gpus-per-node 4 --slot-cores=4 --slot-gpus=1 --njobs=4096
flux schedbench · throughput
  1000 nodes × 48 cores × 4 GPUs · sched-backfill · journal watcher

  ✓ submit   ███████████████████████████████  4096/4096   1.35s   3045 job/s
  ✓ execute  ███████████████████████████████  4096/4096   5.13s    798 job/s

  jobs               4,096
  throughput         633.2  job/s
  script throughput  633.1  job/s
  submit rate        3,048  job/s
  alloc rate         762.5  job/s
  ingest rate        6,864  job/s

  6.48s elapsed · ok
```

#### Locality benchmark with topology

```
$ src/cmd/flux schedbench run locality -v --hwloc-xml-path=./topo.xml --slot-cores=3
flux-schedbench.locality: INFO: locality predicate: 16 cores, 0 gpus, 4 domains
  0: core[0-3]
  1: core[4-7]
  2: core[8-11]
  3: core[12-15]
flux schedbench · locality
  4 nodes × 16 cores · sched-simple · journal watcher

  ✓ submit   ███████████████████████████████  1000/1000   0.41s   2455 job/s
  ✓ execute  ███████████████████████████████  1000/1000   5.96s    168 job/s

  jobs            1,000
  locality score  0.600
  jobs scored     1,000
  throughput      157.2  job/s
  submit rate     2,455  job/s
  alloc rate      159.9  job/s

  6.36s elapsed · ok
```

#### Reporting

```
$ src/cmd/flux schedbench report throughput
SCHED           REAL  NODES    JOBS   SUBMIT    ALLOC   THRPUT
sched-simple    N        10    4092    10669     1079      885
sched-simple    N        10    4092    11069     1041      860
sched-simple    N        10    4092     6578      827      869
sched-simple    N        10    4092     6793      844      884
sched-simple    N        10    4096     6943      851      889
```
```
$ /tmp/flux/bin/flux schedbench report locality
SCHED           REAL  NODES    JOBS  NSLOTS  DUR               LOC   THRPUT
sched-fluxion+  N      1000    8192       1  0.1s            0.122      745
sched-fluxion+  N      1000    8192       1  0.1s            0.122      617
sched-fluxion+  N       128    4096       1  0.01s           1.000       43
sched-fluxion+  N       128    4096       2  0.01s           1.000       45
```

#### CSV for downstream plotting

```
$ /tmp/flux/bin/flux schedbench report locality -o csv
TIME,SCHED,TAG,WATCHER,NODES,CORES,GPUS,JOBS,SUBMIT,INGEST,ALLOC,REAL,NSLOTS,DUR,LOC,THRPUT
2026-05-15T13:49:47Z,sched-fluxion-qmanager,,journal,1000,16,0,8192,2863.926320183399,,752.5009045081564,N,1,0.1s,0.1220703125,744.5211379091165
2026-05-15T13:52:39Z,sched-fluxion-qmanager,,journal,1000,48,4,8192,3119.66960014084,,623.9097089006881,N,1,0.1s,0.1220703125,617.4625594071883
```

### Real-execution mode against the current instance

```
$ flux schedbench run throughput -xn 1024
flux schedbench · throughput
  4 nodes × 14 cores · sched-simple · journal watcher · real execution

  ✓ submit   ███████████████████████████████  1024/1024   0.40s   2542 job/s
  ✓ execute  ███████████████████████████████  1024/1024   2.12s    483 job/s

  jobs               1,024
  throughput         406.3  job/s
  script throughput  406.2  job/s
  submit rate        2,550  job/s
  alloc rate         416.1  job/s
  ingest rate        6,760  job/s

  2.52s elapsed · ok
```

### Testing

- **t6020** (sharness): CLI tests for all three benchmarks, `--conf` plumbing, `--exec` mode, `--extra-start-options`, results-file roundtrip, report formats
- **t6030** (Python unit): `Benchmark` ABC contract, `BulkRun`, event system, `BenchmarkResults`, test-resource fixture
- **t6031** (Python unit): `LocalityPredicate` — indexing edge cases, the four GPU-backend regression cases, PCIDev dedup, scoring matrix, describe/summary shape, R-from-event parsing
- **t6040** (Python unit): `TerminalEmitter` rendering — 28 tests covering layout, ASCII fallback, color modes, verbosity gating

### Documentation

- `flux-schedbench(1)` man page covering all three benchmarks, common and per-benchmark options, `--conf`, `--exec` mode
- Module-level docstrings on every package module describing the public contract

---