### PR TITLE
scheduler: relax pool_class subclass check

### DIFF
--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -67,6 +67,7 @@ from flux.kvs import commit_async as kvs_commit_async
 from flux.kvs import get_key_direct as kvs_get
 from flux.resource import InfeasibleRequest
 from flux.resource.ResourcePool import ResourcePool
+from flux.resource.ResourcePoolImplementation import ResourcePoolImplementation
 
 
 @functools.total_ordering
@@ -1142,13 +1143,21 @@ class Scheduler(BrokerModule):
         if self.pool_class is not None:
             if not (
                 isinstance(self.pool_class, type)
-                and issubclass(self.pool_class, ResourcePool)
+                and issubclass(
+                    self.pool_class, (ResourcePool, ResourcePoolImplementation)
+                )
             ):
                 raise ValueError(
-                    f"pool_class must be a ResourcePool subclass, "
+                    f"pool_class must be a ResourcePool "
+                    f"or ResourcePoolImplementation subclass, "
                     f"got {self.pool_class!r}"
                 )
-            return self.pool_class(R, log=self.log, **self.pool_kwargs)
+            pool = self.pool_class(R, log=self.log, **self.pool_kwargs)
+            if not isinstance(pool, ResourcePool) and not hasattr(pool, "impl"):
+                raise ValueError(
+                    f"{self.pool_class!r} must set self.impl = self during __init__"
+                )
+            return pool
         pool_class = self._pool_class_from_writer(R)
         if pool_class is not None:
             return pool_class(R, log=self.log, **self.pool_kwargs)

--- a/t/python/t0043-scheduler-pool.py
+++ b/t/python/t0043-scheduler-pool.py
@@ -27,6 +27,8 @@ import unittest
 
 import subflux  # noqa: F401 - for PYTHONPATH
 from flux.resource.ResourcePool import ResourcePool
+from flux.resource.ResourcePoolImplementation import ResourcePoolImplementation
+from flux.resource.Rv1Pool import Rv1Pool
 from flux.scheduler import Scheduler
 from pycotap import TAPTestRunner
 
@@ -232,6 +234,40 @@ class TestMakePool(unittest.TestCase):
         sched = self._make_sched(pool_class=TrackingPool, pool_kwargs={"foo": "bar"})
         sched._make_pool(R_SIMPLE)
         self.assertEqual(received, {"foo": "bar"})
+
+    def test_pool_implementation_subclass_accepted(self):
+        """ResourcePoolImplementation subclass is accepted as pool_class."""
+
+        class ImplPool(Rv1Pool):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.impl = self  # required: scheduler accesses pool.impl directly
+
+        # Rv1Pool is a ResourcePoolImplementation subclass but NOT a ResourcePool
+        # subclass — this was rejected before the fix.
+        self.assertFalse(issubclass(ImplPool, ResourcePool))
+        self.assertTrue(issubclass(ImplPool, ResourcePoolImplementation))
+        sched = self._make_sched(pool_class=ImplPool)
+        pool = sched._make_pool(R_SIMPLE)
+        self.assertIsInstance(pool, ImplPool)
+
+    def test_pool_implementation_missing_impl_raises_value_error(self):
+        """ResourcePoolImplementation subclass that omits self.impl = self raises ValueError."""
+
+        class BrokenImplPool(Rv1Pool):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                # deliberately omits self.impl = self
+
+        sched = self._make_sched(pool_class=BrokenImplPool)
+        with self.assertRaises(ValueError):
+            sched._make_pool(R_SIMPLE)
+
+    def test_invalid_pool_class_raises_value_error(self):
+        """Non-ResourcePool, non-ResourcePoolImplementation pool_class raises ValueError."""
+        sched = self._make_sched(pool_class=str)
+        with self.assertRaises(ValueError):
+            sched._make_pool(R_SIMPLE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Problem: pool class validation in `Scheduler._make_pool()` only accepts `ResourcePool` subclasses, rejecting `ResourcePoolImplementation` subclasses that implement the full pool interface and set `self.impl = self`.

Accept either `ResourcePool` or `ResourcePoolImplementation` as valid pool_class bases, allowing implementations like `FluxionJGFPool` to be used directly without wrapping in `ResourcePool`.

Add unit test.