### PR TITLE
librlist: allow missing HostName in hwloc XML

### DIFF
--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -257,11 +257,21 @@ char *rhwloc_local_topology_xml (rhwloc_flags_t rflags)
 
 const char * rhwloc_hostname (hwloc_topology_t topo)
 {
+    static char hostname[_POSIX_HOST_NAME_MAX + 1];
+    const char *name;
     int depth = hwloc_get_type_depth (topo, HWLOC_OBJ_MACHINE);
     hwloc_obj_t obj = hwloc_get_obj_by_depth (topo, depth, 0);
-    if (obj)
-        return hwloc_obj_get_info_by_name(obj, "HostName");
-    return NULL;
+
+    if (obj && (name = hwloc_obj_get_info_by_name (obj, "HostName")))
+        return name;
+    /* Fall back to local hostname if HostName not available
+     */
+    if (hostname[0] == '\0') {
+        if (gethostname (hostname, sizeof (hostname)) < 0)
+            return NULL;
+        hostname[sizeof (hostname) - 1] = '\0'; // POSIX doesn't guarantee NUL
+    }
+    return hostname;
 }
 
 /*  Return the union of cpusets for the cores in idset string `cores`.

--- a/t/t0026-flux-R.t
+++ b/t/t0026-flux-R.t
@@ -75,6 +75,14 @@ test_expect_success 'flux R encode --xml works' '
 	test_debug "echo encode XML = $result" &&
 	test "$result" = "rank0/core[0-43],gpu[0-3]"
 '
+command -v hwloc-ls >/dev/null && test_set_prereq HWLOC_LS
+test_expect_success HWLOC_LS 'flux R encode --xml works with synthetic XML' '
+    hwloc-ls --of xml -i "numa:2 core:3 pu:1" >test.xml &&
+    flux R encode --xml test.xml > R.synthetic &&
+    result=$(flux R decode --short < R.synthetic) &&
+    test_debug "echo encode synthetic XML = $result" &&
+    test "$result" = "rank0/core[0-5]"
+'
 test_expect_success 'flux R encode --xml works with AMD RSMI gpus' '
 	flux R encode --xml=$SHARNESS_TEST_SRCDIR/hwloc-data/corona.xml \
 	    > R.corona &&


### PR DESCRIPTION
Problem: If there's a missing HostName in hwloc XML then librlist fails to encode R from that XML. But this is a useful use case, since hwloc synthetic topologies don't normally include a hostname in the generated XML.

Fall back to the current hostname if there's no HostName in the XML. Add a test.