### PR TITLE
python: JournalConsumer: only set R and jobspec on alloc and submit events

### DIFF
--- a/src/bindings/python/flux/job/journal.py
+++ b/src/bindings/python/flux/job/journal.py
@@ -32,8 +32,14 @@ class JournalEvent(JournalEventBase):
     def __init__(self, jobid, event, jobspec=None, R=None):
         super().__init__(event)
         self.jobid = JobID(jobid)
-        self.jobspec = jobspec
-        self.R = R
+        self.jobspec = None
+        self.R = None
+        if self.is_empty():
+            return
+        if self.name == "submit":
+            self.jobspec = jobspec
+        elif self.name == "alloc":
+            self.R = R
 
     def is_empty(self):
         """Return True if this event is an empty journal event"""
@@ -45,12 +51,17 @@ class JournalEvent(JournalEventBase):
         if self.is_empty():
             return "-1: End of historical data stream"
         return " ".join(
-            [
-                f"{self.jobid.f58}:",
-                f"{self.timestamp:<0.5f}",
-                self.name,
-                self.context_string,
-            ]
+            filter(
+                None,
+                [
+                    f"{self.jobid.f58}:",
+                    f"{self.timestamp:<0.5f}",
+                    self.name,
+                    self.context_string,
+                    self.jobspec and f"jobspec={self.jobspec}",
+                    self.R and f"R={self.R}",
+                ],
+            )
         )
 
 

--- a/t/python/t0030-journal.py
+++ b/t/python/t0030-journal.py
@@ -87,6 +87,42 @@ class TestJournalConsumer(unittest.TestCase):
         # ensure JournalEvent can be converted to a string:
         print(f"{events[-1]}")
 
+    def test_jobspec_R_placement(self):
+        """verify jobspec is only set on submit and R only on alloc events"""
+        consumer = JournalConsumer(self.fh).start()
+
+        count = 0
+        events = []
+        while True:
+            event = consumer.poll(timeout=5.0)
+            events.append(event)
+            if event.name == "clean":
+                count += 1
+                if count == 4:
+                    break
+        consumer.stop()
+
+        submit_events = [e for e in events if e.name == "submit"]
+        alloc_events = [e for e in events if e.name == "alloc"]
+
+        self.assertGreater(len(submit_events), 0)
+        self.assertGreater(len(alloc_events), 0)
+
+        for event in events:
+            if event.name == "submit":
+                self.assertIsNotNone(event.jobspec)
+                self.assertIsNone(event.R)
+            elif event.name == "alloc":
+                self.assertIsNone(event.jobspec)
+                self.assertIsNotNone(event.R)
+            else:
+                self.assertIsNone(event.jobspec)
+                self.assertIsNone(event.R)
+
+        # verify jobspec/R appear in the string representation
+        self.assertIn("jobspec=", str(submit_events[0]))
+        self.assertIn("R=", str(alloc_events[0]))
+
     def test_async(self):
         events = []
         test_arg2 = 42


### PR DESCRIPTION
This PR contains a small fix for the `flux.job.JournalConsumer` class. Currently, while processing historical events, R and jobspec are set as attributes on _all_ events, but this is not correct and could be confusing since it is a potential difference in behavior between live events.

Only set jobspec/R on submit/alloc events.
