### PR TITLE
python: support namespace package extension via pkgutil

### DIFF
--- a/src/bindings/python/flux/__init__.py
+++ b/src/bindings/python/flux/__init__.py
@@ -11,6 +11,10 @@
 """
 python bindings to flux-core, the main core of the flux resource manager
 """
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
+
 import flux.core.handle
 
 


### PR DESCRIPTION
Problem: The flux Python package does not support namespace package extension, so separately-installed distributions cannot contribute modules to the flux.* namespace. Python finds the first flux/__init__.py on sys.path and stops searching, making it impossible to install e.g. flux.schedbench alongside flux-core.

Python 3.3+ solves this natively via implicit namespace packages: a directory with no __init__.py at all is treated as a namespace package and sys.path is searched exhaustively. That mechanism cannot be used here because flux/__init__.py carries real content (the Flux() factory function and __all__) that cannot be dropped.

Add pkgutil.extend_path() to flux/__init__.py so that other distributions can extend the flux namespace.