### PR TITLE
cmd: fix handling of Python subcommands when searching `PATH`

### DIFF
--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -566,7 +566,9 @@ void exec_subcommand (const char *searchpath, bool vopt, int argc, char *argv[])
         exec_subcommand_dir (vopt, NULL, argv, NULL);
         log_err_exit ("%s", argv[0]);
     } else {
-        char *cpy = xstrdup (searchpath);
+        const char *path = getenv ("PATH");
+        char *cpy = path ? xasprintf ("%s:%s", searchpath, path)
+                         : xstrdup (searchpath);
         char *dir, *saveptr = NULL, *a1 = cpy;
 
         while ((dir = strtok_r (a1, ":", &saveptr))) {
@@ -578,11 +580,6 @@ void exec_subcommand (const char *searchpath, bool vopt, int argc, char *argv[])
             a1 = NULL;
         }
         free (cpy);
-        /* Fall back to searching PATH, as git does, so that third-party
-         * flux-* commands installed independently (e.g. via pip) are
-         * found without requiring FLUX_EXEC_PATH to be set manually.
-         */
-        exec_subcommand_dir (vopt, NULL, argv, "flux-");
         log_msg ("`%s' is not a flux command.  See 'flux --help'", argv[0]);
         find_similar_command (searchpath, argv[0]);
         exit (1);

--- a/t/t1102-cmddriver.t
+++ b/t/t1102-cmddriver.t
@@ -192,6 +192,16 @@ test_expect_success 'flux finds flux-* commands in PATH' '
     grep myextcmd-ok myextcmd.out
 '
 
+test_expect_success 'flux finds flux-*.py commands in PATH' '
+    EXTDIR=$(mktemp -d) &&
+    cat >$EXTDIR/flux-mypycmd.py <<-EOF &&
+	print("mypycmd-ok")
+	EOF
+    chmod +x $EXTDIR/flux-mypycmd.py &&
+    PATH=$EXTDIR:$PATH flux mypycmd >mypycmd.out &&
+    grep mypycmd-ok mypycmd.out
+'
+
 # cover a builtin command, a c binary, and a python script
 test_expect_success 'typoed commands are given suggestions on correct commands' '
 	test_must_fail flux dmsg > invalid1.out 2>&1 &&


### PR DESCRIPTION
Oops. The change merged in #7631 only handles compiled executables in `PATH`, not Python subcommands, which end in `.py` and have to be run via `exec_subcommand_py()` to use the Python interpreter.

This PR changes the implementation to just append `PATH` to `FLUX_EXEC_PATH` when set, which is arguably what should have been done in the first place 🤦 It also adds a test to ensure Python subcommands actually work.
