### PR TITLE
flux-job: provide exception message for debugged jobs that fail before start

### DIFF
--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -685,25 +685,44 @@ void attach_output_start (struct attach_ctx *ctx)
 static void valid_or_exit_for_debug (struct attach_ctx *ctx)
 {
     flux_future_t *f = NULL;
-    char *attrs = "[\"state\"]";
+    char *attrs = "[\"state\","
+                   "\"exception_occurred\","
+                   "\"exception_severity\","
+                   "\"exception_type\","
+                   "\"exception_note\"]";
+    int exception_occurred = 0;
+    int exception_severity = -1;
+    const char *exception_type = NULL;
+    const char *exception_note = NULL;
     flux_job_state_t state = FLUX_JOB_STATE_INACTIVE;
 
     if (!(f = flux_job_list_id (ctx->h, ctx->id, attrs)))
         log_err_exit ("flux_job_list_id");
 
-    if (flux_rpc_get_unpack (f, "{s:{s:i}}", "job", "state", &state) < 0)
+    if (flux_rpc_get_unpack (f,
+                             "{s:{s:i s?b s?i s?s s?s}}",
+                             "job",
+                              "state", &state,
+                              "exception_occurred", &exception_occurred,
+                              "exception_severity", &exception_severity,
+                              "exception_type", &exception_type,
+                              "exception_note", &exception_note) < 0)
         log_err_exit ("Invalid job id (%s) for debugging", ctx->jobid);
-
-    flux_future_destroy (f);
 
     if (state != FLUX_JOB_STATE_NEW
         && state != FLUX_JOB_STATE_DEPEND
         && state != FLUX_JOB_STATE_PRIORITY
         && state != FLUX_JOB_STATE_SCHED
         && state != FLUX_JOB_STATE_RUN) {
+        if (exception_occurred && exception_severity == 0)
+            log_msg ("job.exception %s type=%s severity=0 %s",
+                     ctx->jobid,
+                     exception_type ? exception_type : "unknown",
+                     exception_note ? exception_note : "");
         log_msg_exit ("cannot debug job that has finished running");
     }
 
+    flux_future_destroy (f);
     return;
 }
 

--- a/t/t2611-debug-emulate.t
+++ b/t/t2611-debug-emulate.t
@@ -75,7 +75,18 @@ test_expect_success 'debugger: attaching to a finished job must fail' '
 test_expect_success 'debug-emulate: attaching to a failed job must fail' '
 	jobid=$(flux submit -n 2 ./bad_cmd) &&
 	flux job wait-event -vt ${TIMEOUT} ${jobid} finish &&
-	test_must_fail flux job attach --debug-emulate ${jobid}
+	test_must_fail flux job attach --debug-emulate ${jobid} 2>bad_cmd.err &&
+	test_debug "cat bad_cmd.err" &&
+	grep "start failed" bad_cmd.err
+'
+
+test_expect_success \
+	'debug-emulate: attaching to unsatisfiable job provides exception note' '
+	jobid=$(flux submit -N1000 hostname) &&
+	flux job wait-event -vt ${TIMEOUT} ${jobid} clean &&
+	test_must_fail flux job attach --debug-emulate ${jobid} 2>unsatisfy.err &&
+	test_debug "cat unsatisfy.err" &&
+	grep "unsatisfiable request" unsatisfy.err
 '
 
 test_expect_success 'debugger: totalview_jobid is set for attach mode' '


### PR DESCRIPTION
When a job is launched under debugger control and fails before tasks are started for the debugger to attach - for example, due to an unsatisfiable resource request or a missing executable - flux job attach prints only the generic "cannot debug job that has finished running" message with no indication of why.

This PR simply has the inactive-job fetch exception details alongside the job state and prints it before falling through to the generic message, giving users actionable output.