### PR TITLE
.github: conditionally evaluate testenv build strategy

### DIFF
--- a/.github/workflows/testenv.yml
+++ b/.github/workflows/testenv.yml
@@ -65,6 +65,7 @@ jobs:
   build-amd64-container:
     name: build new testenv container for amd64
     needs: [setup]
+    if: needs.setup.outputs.distros
     strategy:
       matrix:
         distro: ${{ fromJson(needs.setup.outputs.distros) }}
@@ -98,6 +99,7 @@ jobs:
   build-arm64-container:
     name: build new testenv container for arm64
     needs: [setup]
+    if: needs.setup.outputs.distros
     strategy:
       matrix:
         distro: ${{ fromJson(needs.setup.outputs.distros) }}


### PR DESCRIPTION
Problem: Github is currently evaluating the build strategy for the testenv.yml workflow even when no containers need to be rebuilt, and failing when the list of distros to build is empty.

Solution: add a falsy check for needs.setup.output.distros to ensure this value has data to trigger the job.