### PR TITLE
cmd: add `flux admin system-scripts` to list status and details of prolog, epilog, and housekeeping configuration

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -38,6 +38,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-run.1 \
 	man1/flux-bulksubmit.1 \
 	man1/flux-alloc.1 \
+	man1/flux-admin.1 \
 	man1/flux-batch.1 \
 	man1/flux-multi-prog.1 \
 	man1/flux-job.1 \

--- a/doc/guide/admin_config.rst
+++ b/doc/guide/admin_config.rst
@@ -377,6 +377,47 @@ housekeeping scripts from the following locations (in order):
    The location of ``$libexecdir`` is system dependent, but can be determined
    from :command:`pkg-config --variable=fluxlibexecdir flux-core`.
 
+Verifying Script Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :command:`flux admin system-scripts` to view the current configuration and
+verify which scripts will be executed:
+
+.. code-block:: console
+
+   $ flux admin system-scripts
+   prolog: enabled (per-rank=true)
+     system: /usr/libexec/flux/prolog.d
+       ✓ 01-syslog.sh
+     site: /etc/flux/system/prolog.d
+       ✓ 10-local-setup.sh
+
+   epilog: enabled (per-rank=true)
+     system: /usr/libexec/flux/epilog.d
+       ✓ 01-cleanup.sh
+
+   housekeeping: not configured
+
+This command shows:
+
+- Whether each system script type is enabled or configured
+- The execution mode:
+
+  - ``per-rank=true``: scripts execute on all allocated nodes
+  - ``per-rank=false``: scripts execute only on rank 0
+
+  Note: The ``per-rank`` setting controls *where* scripts execute, not *which* scripts
+  execute. The same scripts from the directories are used in both modes.
+
+- Which scripts will be executed and from which directories. Scripts are shown when
+  using the default ``flux-imp run <type>`` command (used when no explicit command
+  is configured). Custom commands show the command itself instead of script directories.
+- Whether scripts are executable (✓) or not (✗)
+- If a legacy single-file script is present, which skips the ``.d`` directory
+
+Use :option:`flux admin system-scripts -v` to show script locations even when
+not configured.
+
 Script Environment
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/man1/flux-admin.rst
+++ b/doc/man1/flux-admin.rst
@@ -1,0 +1,124 @@
+.. flux-help-description: Flux administration subcommands
+
+==============
+flux-admin(1)
+==============
+
+
+SYNOPSIS
+========
+
+| **flux** **admin** **system-scripts** [*-v, --verbose*] [*--color=WHEN*]
+| **flux** **admin** **cleanup-push** [*COMMAND...*]
+
+
+DESCRIPTION
+===========
+
+:program:`flux admin` provides subcommands for Flux instance administration.
+
+
+COMMANDS
+========
+
+system-scripts
+--------------
+
+.. program:: flux admin system-scripts
+
+:program:`flux admin system-scripts` displays the status and configuration
+of system scripts (prolog, epilog, and housekeeping) for the current Flux
+instance.
+
+For each script type (prolog, epilog, housekeeping), the command shows:
+
+- Configuration status (enabled, not configured, or configured but inactive)
+- Execution mode (per-rank=true or per-rank=false for prolog/epilog)
+- Release settings (for housekeeping)
+- The actual command that will execute (if using a custom command)
+- Scripts that will be executed (if using the default flux-imp command)
+
+**Script Execution Logic:**
+
+System scripts from directories are only executed when the configured command
+is the default :command:`flux-imp run <type>` command. When a custom command is
+configured, the directory scripts are bypassed and only the custom command
+executes.
+
+When using the default command, scripts are discovered and executed in this order:
+
+1. **system:** ``<libexecdir>/flux/<type>.d/`` - Package-provided scripts (always executed)
+2. **site:** Either:
+
+   - Legacy single-file script at ``<sysconfdir>/flux/system/<type>`` if present
+     (this skips the site scripts directory for backwards compatibility), OR
+   - Scripts in ``<sysconfdir>/flux/system/<type>.d/`` site directory
+
+In other words, if a legacy single-file script exists, it runs instead of the
+site scripts directory. System scripts always run regardless.
+
+.. option:: -v, --verbose
+
+   Show scripts even when the system is not configured. In non-verbose mode,
+   only configured systems are shown with full details.
+
+.. option:: --color=WHEN
+
+   Control when to use color in output. *WHEN* can be ``always``, ``never``,
+   or ``auto`` (default). The ``NO_COLOR`` environment variable also disables
+   color output.
+
+
+**EXAMPLES:**
+
+Check prolog/epilog/housekeeping status::
+
+    $ flux admin system-scripts
+    prolog: enabled (per-rank=false)
+      command: /usr/bin/custom-prolog.sh
+
+    epilog: not configured
+    housekeeping: not configured
+
+View scripts that would execute with default command::
+
+    $ flux admin system-scripts -v
+    prolog: enabled (per-rank=false)
+      system: /usr/libexec/flux/prolog.d
+        ✓ 01-setup.sh
+        ✓ 99-finalize.sh
+      site: /etc/flux/system/prolog.d
+        ✓ 10-custom.sh
+
+    epilog: not configured
+    housekeeping: not configured
+
+cleanup-push
+------------
+
+.. program:: flux admin cleanup-push
+
+:program:`flux admin cleanup-push` adds a command to run after completion of
+the initial program, before rc3. The command is pushed to the front of the
+list of cleanup commands.
+
+If *COMMAND* is not provided as arguments, commands are read one per line
+from standard input and pushed in reverse order to retain their order.
+
+**EXAMPLE:**
+
+Add a cleanup command::
+
+    $ flux admin cleanup-push "rm -rf /tmp/flux-job-*"
+
+
+RESOURCES
+=========
+
+.. include:: common/resources.rst
+
+
+SEE ALSO
+========
+
+:man1:`flux-config`, :man1:`flux-housekeeping`, :man7:`flux-jobtap-plugins`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -58,6 +58,7 @@ man_pages = [
     ('man1/flux-run', 'flux-run', 'run a Flux job interactively', [author], 1),
     ('man1/flux-bulksubmit', 'flux-bulksubmit', 'submit jobs in bulk to a Flux instance', [author], 1),
     ('man1/flux-alloc', 'flux-alloc', 'allocate a new Flux instance for interactive use', [author], 1),
+    ('man1/flux-admin', 'flux-admin', 'Flux administration subcommands', [author], 1),
     ('man1/flux-batch', 'flux-batch', 'submit a batch script to Flux', [author], 1),
     ('man1/flux-multi-prog', 'flux-multi-prog', 'run a parallel program with a different executable and arguments for each task', [author], 1),
     ('man1/flux-job', 'flux-job', 'Job Housekeeping Tool', [author], 1),

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -1304,7 +1304,13 @@ _flux_config()
 _flux_admin()
 {
     local cmd=$1
-    local subcmds="cleanup-push"
+    local subcmds="cleanup-push system-scripts"
+
+    local system_scripts_OPTS="\
+        -v \
+        --verbose \
+        --color= \
+    "
 
     if [[ $cmd != "admin" ]]; then
         var="${cmd//-/_}_OPTS"

--- a/src/cmd/flux-admin.py
+++ b/src/cmd/flux-admin.py
@@ -9,11 +9,65 @@
 ##############################################################
 
 import argparse
+import errno
+import locale
 import logging
+import os
 import sys
+from pathlib import Path
 
 import flux
+import flux.util
+from flux.conf_builtin import conf_builtin_get
 from flux.rpc import RPC
+
+# ANSI color codes
+COLOR_GREEN = "\033[32m"
+COLOR_RED = "\033[31m"
+COLOR_YELLOW = "\033[33m"
+COLOR_RESET = "\033[0m"
+COLOR_DIM = "\033[2m"
+
+
+def colorize(text, color, color_enabled):
+    """Add ANSI color to text if color is enabled."""
+    if color_enabled:
+        return f"{color}{text}{COLOR_RESET}"
+    return text
+
+
+def print_script_list(scripts, color_enabled):
+    """Print a list of scripts with executable status markers."""
+    if scripts:
+        for name, is_exec in scripts:
+            if is_exec:
+                mark = colorize("✓", COLOR_GREEN, color_enabled)
+            else:
+                mark = colorize("✗ not executable", COLOR_RED, color_enabled)
+            print(f"    {mark} {name}")
+    else:
+        print(colorize("    (no scripts)", COLOR_DIM, color_enabled))
+
+
+def print_script_directory(label, path, scripts, color_enabled):
+    """Print script directory header and contents."""
+    dir_label = colorize(f"{label}:", COLOR_DIM, color_enabled)
+    dir_path = colorize(str(path), COLOR_DIM, color_enabled)
+    print(f"  {dir_label} {dir_path}")
+    print_script_list(scripts, color_enabled)
+
+
+def print_legacy_file(legacy_path, color_enabled):
+    """Print legacy file with executable status under site: label."""
+    dir_label = colorize("site:", COLOR_DIM, color_enabled)
+    print(f"  {dir_label}")
+    is_exec = bool(legacy_path.stat().st_mode & 0o111)
+    if is_exec:
+        mark = colorize("✓", COLOR_GREEN, color_enabled)
+    else:
+        mark = colorize("✗", COLOR_RED, color_enabled)
+    location = colorize("(legacy, skips site scripts)", COLOR_DIM, color_enabled)
+    print(f"    {mark} {legacy_path} {location}")
 
 
 def cleanup_push(args):
@@ -37,6 +91,445 @@ def cleanup_push(args):
     ).get()
 
 
+def get_broker_builtin_config(handle, keys):
+    """Get builtin configuration from broker or fall back to local.
+
+    Args:
+        handle: Optional Flux handle to query broker
+        keys: List of config keys to fetch
+
+    Returns:
+        dict mapping keys to values
+    """
+    # Default to local config
+    config = {key: conf_builtin_get(key) for key in keys}
+
+    # Override with broker config if handle available
+    if handle:
+        try:
+            result = handle.rpc("broker.conf-builtin", {"keys": keys}).get()
+            config.update(result["values"])
+        except (OSError, KeyError):
+            pass  # Keep defaults
+
+    return config
+
+
+def get_script_paths(prog_type, builtin_config=None, imp_path=None):
+    """Get the directory paths where system scripts are stored.
+
+    For testing purposes, paths can be overridden via environment variables:
+    - FLUX_SYSTEM_SCRIPTS_LIBEXECDIR: Override libexecdir
+    - FLUX_SYSTEM_SCRIPTS_CONFDIR: Override confdir
+
+    Args:
+        prog_type: One of "prolog", "epilog", or "housekeeping"
+        builtin_config: Optional dict with libexecdir and confdir keys.
+            If None, uses local conf_builtin_get()
+        imp_path: Optional path to flux-imp from running instance
+            (for validation)
+
+    Returns:
+        dict with keys:
+            - system_path: Package-provided scripts directory
+            - sysconf_path: Site configuration scripts directory
+            - legacy_path: Legacy single-file path (for backwards compat)
+            - imp_path_mismatch: True if imp_path doesn't match libexecdir
+    """
+    # Get config, defaulting to local if not provided
+    if builtin_config is None:
+        builtin_config = {
+            "libexecdir": conf_builtin_get("libexecdir"),
+            "confdir": conf_builtin_get("confdir"),
+        }
+
+    # Allow override via environment variables for testing
+    libexecdir = os.environ.get(
+        "FLUX_SYSTEM_SCRIPTS_LIBEXECDIR", builtin_config.get("libexecdir")
+    )
+    confdir = os.environ.get(
+        "FLUX_SYSTEM_SCRIPTS_CONFDIR", builtin_config.get("confdir")
+    )
+
+    # libexecdir already includes /flux (e.g., /usr/libexec/flux)
+    system_path = Path(libexecdir) / f"{prog_type}.d"
+    flux_sysconfdir = Path(confdir) / "flux" / "system"
+    legacy_path = flux_sysconfdir / prog_type
+    sysconf_path = flux_sysconfdir / f"{prog_type}.d"
+
+    # Check if imp_path matches our detected libexecdir
+    imp_path_mismatch = False
+    if imp_path:
+        path = Path(imp_path)
+        if path.name == "flux-imp" and path.parent.name == "flux":
+            expected_libexec = path.parent
+            if str(expected_libexec) != str(libexecdir):
+                imp_path_mismatch = True
+
+    return {
+        "system_path": system_path,
+        "sysconf_path": sysconf_path,
+        "legacy_path": legacy_path,
+        "imp_path_mismatch": imp_path_mismatch,
+    }
+
+
+def scan_scripts(directory):
+    """Scan a directory for executable script files.
+
+    Scripts are sorted using locale collation order to match shell behavior.
+
+    Args:
+        directory: Path object to scan
+
+    Returns:
+        List of tuples (filename, is_executable)
+    """
+    scripts = []
+    try:
+        # Sort using locale collation to match shell/flux-run-system-scripts
+        entries = sorted(directory.iterdir(), key=lambda p: locale.strxfrm(p.name))
+        for entry in entries:
+            if entry.is_file():
+                is_executable = bool(entry.stat().st_mode & 0o111)
+                scripts.append((entry.name, is_executable))
+    except (FileNotFoundError, NotADirectoryError, PermissionError):
+        # Directory doesn't exist or not accessible, return empty list
+        pass
+
+    return scripts
+
+
+def uses_script_directories(prog_type, config):
+    """Check if configured command will execute scripts from directories.
+
+    Scripts in {libexecdir}/flux/{prog}.d and {sysconfdir}/flux/system/{prog}.d
+    are only executed when the command is the default flux-imp command.
+    Custom commands bypass these directories entirely.
+
+    When perilog is configured without an explicit command, it defaults to
+    ["{imp_path}", "run", "{prog_type}"] if exec.imp is set.
+
+    Args:
+        prog_type: One of "prolog", "epilog", or "housekeeping"
+        config: Configuration dictionary (may be None)
+
+    Returns:
+        bool: True if scripts from directories will be executed
+    """
+    if not config:
+        return False
+
+    command = config.get("command")
+
+    # If no command is explicitly set in config, perilog uses the default
+    # flux-imp command (assuming exec.imp is set), which executes scripts
+    if not command:
+        return True
+
+    # Check if command is the default flux-imp command
+    # Command may be ["flux-imp", "run", "prolog"] or
+    # ["/full/path/to/flux-imp", "run", "prolog"]
+    if len(command) < 2:
+        return False
+
+    # Check if first arg ends with flux-imp and second arg is "run"
+    if command[0].endswith("flux-imp") and command[1] == "run":
+        # Third arg should match prog_type (or be empty string for legacy)
+        if len(command) >= 3:
+            return command[2] == prog_type or command[2] == ""
+        return False
+
+    return False
+
+
+def show_prog_config(
+    prog_type,
+    config,
+    verbose=False,
+    color_enabled=True,
+    builtin_config=None,
+    imp_path=None,
+    warn_mismatch=False,
+    plugin_loaded=True,
+    status_callback=None,
+):
+    """Show configuration and scripts for a system script type.
+
+    Args:
+        prog_type: "prolog", "epilog", or "housekeeping"
+        config: Configuration dictionary from flux config
+        verbose: Show scripts even when not configured
+        color_enabled: Use ANSI color codes
+        builtin_config: Optional dict with broker builtin config (libexecdir, confdir)
+        imp_path: Path to flux-imp from running instance (to derive libexecdir)
+        warn_mismatch: Whether to show warning if imp_path doesn't match
+        plugin_loaded: Whether perilog plugin is loaded (perilog only)
+        status_callback: Optional function(config, color_enabled) -> str
+            that returns the status info string (e.g., "per-rank=true")
+    """
+    # Get and scan script paths first
+    paths = get_script_paths(
+        prog_type, builtin_config=builtin_config, imp_path=imp_path
+    )
+
+    # Warn if there's a mismatch between running instance and detected paths
+    if warn_mismatch and paths.get("imp_path_mismatch"):
+        warning = colorize(
+            "Warning: flux-imp path mismatch - scripts may not be found",
+            COLOR_YELLOW,
+            color_enabled,
+        )
+        print(warning, file=sys.stderr)
+
+    # Check for legacy single-file
+    legacy_path = paths["legacy_path"]
+    has_legacy = legacy_path.exists() and legacy_path.is_file()
+
+    # Scan directories
+    system_scripts = scan_scripts(paths["system_path"])
+    sysconf_scripts = scan_scripts(paths["sysconf_path"])
+
+    has_scripts = has_legacy or system_scripts or sysconf_scripts
+    is_configured = config and len(config) > 0
+
+    # In non-verbose mode, don't show anything if not configured
+    if not is_configured and not verbose:
+        status = colorize("not configured", COLOR_DIM, color_enabled)
+        print(f"▸ {prog_type}: {status}")
+        print()
+        return
+
+    # Warn if configured but plugin not loaded (perilog only)
+    if is_configured and not plugin_loaded:
+        status = colorize("configured but inactive", COLOR_YELLOW, color_enabled)
+        print(f"▸ {prog_type}: {status}")
+        print(colorize("  (perilog plugin not loaded)", COLOR_YELLOW, color_enabled))
+        return
+
+    # Show configuration status
+    if is_configured:
+        status = colorize("enabled", COLOR_GREEN, color_enabled)
+        info = status_callback(config, color_enabled) if status_callback else ""
+        status_line = f"▸ {prog_type}: {status}"
+        if info:
+            status_line += f" ({info})"
+        print(status_line)
+
+        # If using custom command, show what will actually execute
+        if not uses_script_directories(prog_type, config):
+            command = config.get("command", [])
+            cmd_str = " ".join(command)
+            print(f"  command: {cmd_str}")
+    else:
+        status = colorize("not configured", COLOR_YELLOW, color_enabled)
+        print(f"▸ {prog_type}: {status}")
+
+    # Show scripts/paths if they will be executed OR in verbose mode
+    # when not configured
+    uses_scripts = uses_script_directories(prog_type, config)
+    show_scripts = (is_configured and uses_scripts) or (
+        not is_configured and verbose and has_scripts
+    )
+
+    if show_scripts:
+        # When using flux-imp command, always show paths (even if empty)
+        # so users can verify
+        # In verbose mode when not configured, show all scripts that would
+        # be run
+        if system_scripts or uses_scripts:
+            print_script_directory(
+                "system", paths["system_path"], system_scripts, color_enabled
+            )
+
+        # Show legacy file (if present, it skips sysconf_path)
+        # or sysconf scripts:
+        if has_legacy:
+            print_legacy_file(legacy_path, color_enabled)
+        elif sysconf_scripts or uses_scripts:
+            print_script_directory(
+                "site", paths["sysconf_path"], sysconf_scripts, color_enabled
+            )
+
+    print()
+
+
+def show_perilog_config(
+    prog_type,
+    config,
+    verbose=False,
+    color_enabled=True,
+    plugin_loaded=True,
+    builtin_config=None,
+    imp_path=None,
+    warn_mismatch=True,
+):
+    """Show configuration and scripts for prolog or epilog.
+
+    Args:
+        prog_type: "prolog" or "epilog"
+        config: Configuration dictionary from flux config
+        verbose: Show scripts even when not configured
+        color_enabled: Use ANSI color codes
+        plugin_loaded: Whether perilog plugin is loaded
+        builtin_config: Optional dict with broker builtin config
+        imp_path: Path to flux-imp from running instance (to derive libexecdir)
+        warn_mismatch: Whether to show warning if imp_path doesn't match
+    """
+
+    def perilog_status_info(cfg, color_enabled):
+        """Format perilog-specific status info (per-rank setting)."""
+        per_rank = cfg.get("per-rank", cfg.get("per_rank", False))
+        return f"per-rank={str(per_rank).lower()}"
+
+    show_prog_config(
+        prog_type,
+        config,
+        verbose,
+        color_enabled,
+        builtin_config,
+        imp_path,
+        warn_mismatch,
+        plugin_loaded,
+        perilog_status_info,
+    )
+
+
+def show_housekeeping_config(
+    config, verbose=False, color_enabled=True, builtin_config=None, imp_path=None
+):
+    """Show configuration and scripts for housekeeping.
+
+    Args:
+        config: Configuration dictionary from flux config
+        verbose: Show scripts even when not configured
+        color_enabled: Use ANSI color codes
+        builtin_config: Optional dict with broker builtin config
+        imp_path: Path to flux-imp from running instance (to derive libexecdir)
+    """
+
+    def housekeeping_status_info(cfg, color_enabled):
+        """Format housekeeping-specific status info (release-after setting)."""
+        release_after = cfg.get("release-after")
+        if release_after:
+            return f"release after {release_after}"
+        else:
+            return "batch release"
+
+    show_prog_config(
+        "housekeeping",
+        config,
+        verbose,
+        color_enabled,
+        builtin_config,
+        imp_path,
+        warn_mismatch=False,
+        plugin_loaded=True,
+        status_callback=housekeeping_status_info,
+    )
+
+
+def system_scripts(args):
+    """
+    Show system script configuration for prolog, epilog, and housekeeping.
+    """
+    verbose = args.verbose
+    color_enabled = args.color.enabled
+
+    try:
+        h = flux.Flux()
+    except OSError:
+        # If we can't connect to flux, we can still show what scripts would be
+        # run based on the filesystem (in verbose mode)
+        h = None
+
+    # Try to get configuration from flux
+    prolog_config = None
+    epilog_config = None
+    housekeeping_config = None
+    perilog_plugin_loaded = False
+    imp_path = None
+
+    if h:
+        # Try to get exec.imp path to derive libexecdir from running instance
+        try:
+            imp_path = h.conf_get("exec.imp")
+        except (OSError, FileNotFoundError):
+            # exec.imp not configured, use default pathsfrom conf_builtin_get()
+            pass
+
+        # Check if perilog plugin is loaded
+        got_eperm = False
+        try:
+            result = h.rpc("job-manager.jobtap-query", {"name": "perilog.so"}).get()
+            if result and "conf" in result:
+                perilog_plugin_loaded = True
+                prolog_config = result["conf"].get("prolog", {})
+                epilog_config = result["conf"].get("epilog", {})
+        except OSError as exc:
+            if exc.errno == errno.EPERM:
+                # Guest user can't query jobtap, need to get config from broker
+                warning = colorize(
+                    "Warning: only instance owner can query perilog.so status",
+                    COLOR_YELLOW,
+                    color_enabled,
+                )
+                print(warning, file=sys.stderr)
+                got_eperm = True
+            # Otherwise plugin not loaded (ENOENT) or other error,
+            # fall through to conf_get()
+
+        # If plugin not loaded (or got EPERM), get configs from broker
+        # Note: conf_get() caches config, so subsequent calls are fast
+        if not perilog_plugin_loaded:
+            try:
+                prolog_config = h.conf_get("job-manager.prolog")
+                epilog_config = h.conf_get("job-manager.epilog")
+                # If we got EPERM and config exists, assume plugin is loaded
+                if got_eperm and (prolog_config or epilog_config):
+                    perilog_plugin_loaded = True
+            except (OSError, FileNotFoundError):
+                # Config not set or not accessible, leave as None
+                pass
+
+        # Get housekeeping config (uses cached config if available)
+        try:
+            housekeeping_config = h.conf_get("job-manager.housekeeping")
+        except (OSError, FileNotFoundError):
+            # Config not set or not accessible, leave as None
+            pass
+
+    # Get broker builtin config once to avoid redundant RPCs
+    builtin_config = (
+        get_broker_builtin_config(h, ["libexecdir", "confdir"]) if h else None
+    )
+
+    # Show configurations (warn about path mismatch only once)
+    show_perilog_config(
+        "prolog",
+        prolog_config,
+        verbose,
+        color_enabled,
+        perilog_plugin_loaded,
+        builtin_config,
+        imp_path,
+        warn_mismatch=True,
+    )
+    show_perilog_config(
+        "epilog",
+        epilog_config,
+        verbose,
+        color_enabled,
+        perilog_plugin_loaded,
+        builtin_config,
+        imp_path,
+        warn_mismatch=False,
+    )
+    show_housekeeping_config(
+        housekeeping_config, verbose, color_enabled, builtin_config, imp_path
+    )
+
+
 LOGGER = logging.getLogger("flux-admin")
 
 
@@ -55,6 +548,23 @@ def main():
         "cmdline", help="Command line", nargs=argparse.REMAINDER
     )
     cleanup_push_parser.set_defaults(func=cleanup_push)
+
+    system_scripts_parser = subparsers.add_parser(
+        "system-scripts",
+        formatter_class=flux.util.help_formatter(),
+        help="Show configured system scripts (prolog, epilog, housekeeping)",
+    )
+    system_scripts_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show scripts even when not configured",
+    )
+    system_scripts_parser.add_argument(
+        "--color",
+        action=flux.util.ColorAction,
+    )
+    system_scripts_parser.set_defaults(func=system_scripts)
 
     args = parser.parse_args()
     args.func(args)

--- a/src/cmd/flux-admin.py
+++ b/src/cmd/flux-admin.py
@@ -535,6 +535,8 @@ LOGGER = logging.getLogger("flux-admin")
 
 @flux.util.CLIMain(LOGGER)
 def main():
+    sys.stdout = open(sys.stdout.fileno(), "w", encoding="utf8")
+
     parser = argparse.ArgumentParser(prog="flux-admin")
     subparsers = parser.add_subparsers(
         title="subcommands", description="", dest="subcommand"

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -108,6 +108,7 @@ TESTSCRIPTS = \
 	t0024-jjc-reader.t \
 	t0026-flux-R.t \
 	t0090-content-enospc.t \
+	t0099-admin-system-scripts.t \
 	t0100-modprobe.t \
 	t0800-completion.t \
 	t1000-kvs.t \

--- a/t/t0099-admin-system-scripts.t
+++ b/t/t0099-admin-system-scripts.t
@@ -1,0 +1,456 @@
+#!/bin/sh
+
+test_description='Test flux admin system-scripts command'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 2 full
+
+test_expect_success 'flux admin system-scripts command exists' '
+	flux admin system-scripts --help
+'
+
+test_expect_success 'flux admin system-scripts runs without error' '
+	flux admin system-scripts >basic.out 2>&1
+'
+
+test_expect_success 'default output shows all three systems' '
+	test_debug "cat basic.out" &&
+	grep -q "prolog:" basic.out &&
+	grep -q "epilog:" basic.out &&
+	grep -q "housekeeping:" basic.out
+'
+
+test_expect_success 'default output is concise (no scripts shown when not configured)' '
+	test_must_fail grep -q "system:" basic.out &&
+	test_must_fail grep -q "site:" basic.out
+'
+
+test_expect_success 'help output includes verbose option' '
+	flux admin system-scripts --help >help.out 2>&1 &&
+	grep -q "verbose" help.out &&
+	grep -q "color" help.out
+'
+
+test_expect_success 'color=never option works' '
+	flux admin system-scripts -v --color=never >no_color.out 2>&1 &&
+	test_must_fail grep -F "$(printf "\033")" no_color.out
+'
+
+test_expect_success 'color=always option produces ANSI codes' '
+	flux admin system-scripts -v --color=always >with_color.out 2>&1 &&
+	grep -F "$(printf "\033")" with_color.out
+'
+
+test_expect_success 'NO_COLOR environment variable works' '
+	NO_COLOR=1 flux admin system-scripts -v >no_color_env.out 2>&1 &&
+	test_must_fail grep -F "$(printf "\033")" no_color_env.out
+'
+
+# Test with script files using overridden paths
+test_expect_success 'create test script directories' '
+	mkdir -p test_scripts/flux/prolog.d &&
+	mkdir -p test_scripts/flux/epilog.d &&
+	mkdir -p test_scripts/flux/housekeeping.d &&
+	mkdir -p test_scripts/flux/system/prolog.d &&
+	mkdir -p test_scripts/flux/system/epilog.d &&
+	mkdir -p test_scripts/flux/system/housekeeping.d
+'
+
+test_expect_success 'create executable test scripts' '
+	cat >test_scripts/flux/prolog.d/01-test.sh <<-"EOF" &&
+	#!/bin/bash
+	echo "test prolog"
+	EOF
+	chmod +x test_scripts/flux/prolog.d/01-test.sh &&
+	cat >test_scripts/flux/system/prolog.d/50-site.sh <<-"EOF" &&
+	#!/bin/bash
+	echo "site prolog"
+	EOF
+	chmod +x test_scripts/flux/system/prolog.d/50-site.sh &&
+	cat >test_scripts/flux/epilog.d/02-test.sh <<-"EOF" &&
+	#!/bin/bash
+	echo "test epilog"
+	EOF
+	chmod +x test_scripts/flux/epilog.d/02-test.sh
+'
+
+test_expect_success 'create non-executable script' '
+	cat >test_scripts/flux/system/epilog.d/broken.sh <<-"EOF" &&
+	#!/bin/bash
+	echo "broken"
+	EOF
+	chmod -x test_scripts/flux/system/epilog.d/broken.sh
+'
+
+test_expect_success 'create legacy housekeeping script' '
+	cat >test_scripts/flux/system/housekeeping <<-"EOF" &&
+	#!/bin/bash
+	echo "legacy housekeeping"
+	EOF
+	chmod +x test_scripts/flux/system/housekeeping
+'
+
+test_expect_success 'scripts in sorted order' '
+	cat >test_scripts/flux/prolog.d/00-first.sh <<-"EOF" &&
+	#!/bin/bash
+	EOF
+	chmod +x test_scripts/flux/prolog.d/00-first.sh &&
+	cat >test_scripts/flux/prolog.d/99-last.sh <<-"EOF" &&
+	#!/bin/bash
+	EOF
+	chmod +x test_scripts/flux/prolog.d/99-last.sh
+'
+
+test_expect_success 'verbose mode shows scripts even when not configured' '
+	FLUX_SYSTEM_SCRIPTS_LIBEXECDIR=$(pwd)/test_scripts/flux \
+	FLUX_SYSTEM_SCRIPTS_CONFDIR=$(pwd)/test_scripts \
+	flux admin system-scripts >normal.out 2>&1 &&
+	FLUX_SYSTEM_SCRIPTS_LIBEXECDIR=$(pwd)/test_scripts/flux \
+	FLUX_SYSTEM_SCRIPTS_CONFDIR=$(pwd)/test_scripts \
+	flux admin system-scripts -v >verbose.out 2>&1 &&
+	test_debug "cat normal.out" &&
+	test_debug "cat verbose.out" &&
+	grep "not configured" normal.out &&
+	grep "not configured" verbose.out &&
+	test_must_fail grep "system:" normal.out &&
+	grep "system:.*prolog.d" verbose.out
+'
+
+test_expect_success 'command scans test script directories with env override' '
+	FLUX_SYSTEM_SCRIPTS_LIBEXECDIR=$(pwd)/test_scripts/flux \
+	FLUX_SYSTEM_SCRIPTS_CONFDIR=$(pwd)/test_scripts \
+	flux admin system-scripts -v >scripts.out &&
+	test_debug "cat scripts.out"
+'
+
+test_expect_success 'system scripts shown in output' '
+	grep "system:.*test_scripts/flux/prolog.d" scripts.out
+'
+
+test_expect_success 'site scripts shown in output' '
+	grep "site:.*test_scripts/flux/system/epilog.d" scripts.out
+'
+
+test_expect_success 'scripts appear in sorted order' '
+	sed -n "/system:.*prolog.d/,/site:/p" scripts.out >prolog_scripts.out &&
+	grep -o "[0-9][0-9]-.*\.sh" prolog_scripts.out >order.out &&
+	cat >expected_order.out <<-EOF &&
+	00-first.sh
+	01-test.sh
+	99-last.sh
+	EOF
+	test_cmp expected_order.out order.out
+'
+
+test_expect_success 'non-executable script marked correctly' '
+	grep "✗ not executable.*broken.sh" scripts.out
+'
+
+test_expect_success 'legacy script shown with path and note' '
+	grep "✓.*test_scripts/flux/system/housekeeping.*(legacy, skips site scripts)" scripts.out
+'
+
+test_expect_success 'directories are ignored in script scan' '
+	mkdir -p test_scripts/flux/prolog.d/subdir &&
+	FLUX_SYSTEM_SCRIPTS_LIBEXECDIR=$(pwd)/test_scripts/flux \
+	FLUX_SYSTEM_SCRIPTS_CONFDIR=$(pwd)/test_scripts \
+	flux admin system-scripts -v >nosubdir.out 2>&1 &&
+	test_must_fail grep -q "subdir" nosubdir.out
+'
+
+test_expect_success 'create legacy prolog to test site script skipping' '
+	cat >test_scripts/flux/system/prolog <<-"EOF" &&
+	#!/bin/bash
+	echo "legacy prolog"
+	EOF
+	chmod +x test_scripts/flux/system/prolog &&
+	cat >test_scripts/flux/system/prolog.d/should-be-skipped.sh <<-"EOF" &&
+	#!/bin/bash
+	echo "should not appear"
+	EOF
+	chmod +x test_scripts/flux/system/prolog.d/should-be-skipped.sh
+'
+
+test_expect_success 'legacy script skips site scripts' '
+	FLUX_SYSTEM_SCRIPTS_LIBEXECDIR=$(pwd)/test_scripts/flux \
+	FLUX_SYSTEM_SCRIPTS_CONFDIR=$(pwd)/test_scripts \
+	flux admin system-scripts -v >legacy_skip.out 2>&1 &&
+	sed -n "/^.* prolog:/,/^.* epilog:/p" \
+		legacy_skip.out >prolog_legacy.out &&
+	test_debug "cat prolog_legacy.out" &&
+	grep "legacy, skips site scripts" prolog_legacy.out &&
+	test_must_fail grep "should-be-skipped" prolog_legacy.out
+'
+
+test_expect_success 'system scripts still shown with legacy present' '
+	grep "system:.*test_scripts/flux/prolog.d" prolog_legacy.out
+'
+
+# Test imp_path mismatch detection
+test_expect_success 'load config with exec.imp matching test libexecdir' '
+	flux config load <<-EOF
+	[exec]
+	imp = "$(pwd)/test_scripts/flux/flux-imp"
+	EOF
+'
+
+test_expect_success 'no mismatch warning when imp_path matches libexecdir' '
+	FLUX_SYSTEM_SCRIPTS_LIBEXECDIR=$(pwd)/test_scripts/flux \
+	FLUX_SYSTEM_SCRIPTS_CONFDIR=$(pwd)/test_scripts \
+	flux admin system-scripts -v >no_mismatch.out 2>&1 &&
+	test_debug "cat no_mismatch.out" &&
+	test_must_fail grep -i "mismatch" no_mismatch.out
+'
+
+test_expect_success 'load config with exec.imp NOT matching test libexecdir' '
+	flux config load <<-EOF
+	[exec]
+	imp = "/different/path/flux/flux-imp"
+	EOF
+'
+
+test_expect_success 'mismatch warning shown when imp_path differs from libexecdir' '
+	FLUX_SYSTEM_SCRIPTS_LIBEXECDIR=$(pwd)/test_scripts/flux \
+	FLUX_SYSTEM_SCRIPTS_CONFDIR=$(pwd)/test_scripts \
+	flux admin system-scripts -v >mismatch.out 2>&1 &&
+	test_debug "cat mismatch.out" &&
+	grep -i "mismatch" mismatch.out &&
+	grep -i "scripts may not be found" mismatch.out
+'
+
+test_expect_success 'mismatch warning only shown once (for prolog, not epilog)' '
+	grep -c "mismatch" mismatch.out >count.out &&
+	test $(cat count.out) -eq 1
+'
+
+test_expect_success 'unload exec.imp config for remaining tests' '
+	flux config load <<-EOF
+	EOF
+'
+
+# Test with live configuration
+test_expect_success 'load perilog plugin for config tests' '
+	flux jobtap load perilog.so
+'
+
+test_expect_success 'load prolog configuration' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	command = [ "true" ]
+	timeout = "30m"
+	EOF
+	flux admin system-scripts >with_prolog.out 2>&1 &&
+	test_debug "cat with_prolog.out"
+'
+
+test_expect_success 'output shows prolog as enabled' '
+	grep "prolog: enabled" with_prolog.out
+'
+
+test_expect_success 'output shows prolog mode' '
+	grep "per-rank=false" with_prolog.out
+'
+
+test_expect_success 'custom command shown in output' '
+	grep "command: true" with_prolog.out
+'
+
+test_expect_success 'custom command does not show scripts' '
+	test_must_fail grep "system:" with_prolog.out &&
+	test_must_fail grep "site:" with_prolog.out
+'
+
+test_expect_success 'load prolog with default flux-imp command' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	command = [ "flux-imp", "run", "prolog" ]
+	EOF
+	flux admin system-scripts >default_cmd.out 2>&1 &&
+	test_debug "cat default_cmd.out"
+'
+
+test_expect_success 'default command shows scripts' '
+	grep "prolog: enabled" default_cmd.out &&
+	test_must_fail grep "command:" default_cmd.out
+'
+
+test_expect_success 'load per-rank prolog configuration' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	command = [ "hostname" ]
+	per-rank = true
+	timeout = "10m"
+	EOF
+	flux admin system-scripts >per_rank.out 2>&1 &&
+	test_debug "cat per_rank.out"
+'
+
+test_expect_success 'output shows per-rank mode' '
+	grep "per-rank=true" per_rank.out
+'
+
+test_expect_success 'load epilog configuration' '
+	flux config load <<-EOF &&
+	[job-manager.epilog]
+	command = [ "true" ]
+	EOF
+	flux admin system-scripts >with_epilog.out 2>&1 &&
+	test_debug "cat with_epilog.out"
+'
+
+test_expect_success 'output shows epilog as enabled' '
+	grep "epilog: enabled" with_epilog.out
+'
+
+test_expect_success 'epilog shows as enabled with per-rank setting' '
+	grep "per-rank=false" with_epilog.out
+'
+
+test_expect_success 'load both prolog and epilog' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	command = [ "true" ]
+	[job-manager.epilog]
+	command = [ "true" ]
+	EOF
+	flux admin system-scripts >both.out 2>&1 &&
+	test_debug "cat both.out"
+'
+
+test_expect_success 'both systems show as enabled' '
+	grep "prolog: enabled" both.out &&
+	grep "epilog: enabled" both.out
+'
+
+test_expect_success 'load housekeeping configuration' '
+	flux config load <<-EOF &&
+	[job-manager.housekeeping]
+	command = [ "true" ]
+	release-after = "5m"
+	EOF
+	flux admin system-scripts >with_hk.out 2>&1 &&
+	test_debug "cat with_hk.out"
+'
+
+test_expect_success 'housekeeping shows as enabled' '
+	grep "housekeeping: enabled" with_hk.out
+'
+
+test_expect_success 'housekeeping shows release-after setting' '
+	grep "release after 5m" with_hk.out
+'
+
+test_expect_success 'housekeeping custom command shown' '
+	grep "command: true" with_hk.out
+'
+
+test_expect_success 'load housekeeping with default flux-imp command' '
+	flux config load <<-EOF &&
+	[job-manager.housekeeping]
+	command = [ "flux-imp", "run", "housekeeping" ]
+	EOF
+	flux admin system-scripts -v >hk_default.out 2>&1 &&
+	test_debug "cat hk_default.out"
+'
+
+test_expect_success 'housekeeping default command shows scripts in verbose mode' '
+	grep "housekeeping: enabled" hk_default.out &&
+	test_must_fail grep "command:" hk_default.out
+'
+
+test_expect_success 'clear config returns to not configured' '
+	echo "{}" | flux config load &&
+	flux admin system-scripts >cleared.out 2>&1 &&
+	test_debug "cat cleared.out" &&
+	grep "prolog: not configured" cleared.out &&
+	grep "epilog: not configured" cleared.out &&
+	grep "housekeeping: not configured" cleared.out
+'
+
+test_expect_success 'invalid config does not break command' '
+	test_must_fail flux config load <<-EOF 2>load_error.out &&
+	[job-manager.prolog]
+	command = "not-an-array"
+	EOF
+	test_debug "cat load_error.out" &&
+	flux admin system-scripts >after_error.out 2>&1 &&
+	test_debug "cat after_error.out" &&
+	test -s after_error.out
+'
+
+test_expect_success 'unload perilog plugin' '
+	flux jobtap remove perilog.so
+'
+
+test_expect_success 'configure prolog without plugin loaded' '
+	flux config load <<-EOF &&
+	[job-manager.prolog]
+	command = [ "true" ]
+	EOF
+	flux admin system-scripts >no_plugin.out 2>&1 &&
+	test_debug "cat no_plugin.out"
+'
+
+test_expect_success 'shows warning when configured but plugin not loaded' '
+	grep "configured but inactive" no_plugin.out &&
+	grep "perilog plugin not loaded" no_plugin.out
+'
+
+test_expect_success 'reload perilog plugin for rank 1 test' '
+	flux jobtap load perilog.so
+'
+
+test_expect_success 'configure prolog for rank 1 test' '
+	flux config load <<-EOF
+	[job-manager.prolog]
+	command = [ "true" ]
+	per-rank = true
+	EOF
+'
+
+test_expect_success 'command works from rank 1' '
+	flux exec -r 1 flux admin system-scripts >rank1.out 2>&1 &&
+	test_debug "cat rank1.out"
+'
+
+test_expect_success 'rank 1 shows correct configuration' '
+	grep "prolog: enabled" rank1.out &&
+	grep "per-rank=true" rank1.out &&
+	grep "command: true" rank1.out
+'
+
+# Test as non-instance owner (guest user)
+test_expect_success 'configure prolog and housekeeping for guest test' '
+	flux config load <<-EOF
+	[job-manager.prolog]
+	command = [ "true" ]
+	per-rank = true
+	[job-manager.housekeeping]
+	command = [ "true" ]
+	release-after = "5m"
+	EOF
+'
+
+test_expect_success 'simulate guest user with FLUX_HANDLE_USERID and ROLEMASK' '
+	FLUX_HANDLE_USERID=9999 FLUX_HANDLE_ROLEMASK=0x2 \
+		flux admin system-scripts >guest.out 2>&1 &&
+	test_debug "cat guest.out"
+'
+
+test_expect_success 'guest sees warning about perilog plugin status' '
+	grep -i "only instance owner can query perilog.so status" guest.out
+'
+
+test_expect_success 'guest still sees prolog configuration from broker config' '
+	grep "prolog: enabled" guest.out &&
+	grep "per-rank=true" guest.out
+'
+
+test_expect_success 'guest sees housekeeping configuration' '
+	grep "housekeeping: enabled" guest.out &&
+	grep "release after 5m" guest.out
+'
+
+test_done
+


### PR DESCRIPTION
It was brought up in this week's meeting that a command to print what is going to run for prolog, epilog, and housekeeping would be very useful. While working on new prolog/housekeeping scripts for use with flux-pam, I came to heartily agree.

This PR introduces `flux admin system-scripts`, which prints the configuration status of prolog, epilog, and housekeeping along with what scripts will actually be run. For example on corona:
```
▸ prolog: enabled (per-rank=true)
  system: /usr/libexec/flux/prolog.d
    ✓ slingshot-cxi-alloc.sh
    ✓ zstop_nnf_clientmount.sh
  site:
    ✓ /etc/flux/system/prolog (legacy, skips site scripts)

▸ epilog: not configured

▸ housekeeping: enabled (release after 30s)
  system: /usr/libexec/flux/housekeeping.d
    ✓ slingshot-cxi-cleanup.sh
  site:
    ✓ /etc/flux/system/housekeeping (legacy, skips site scripts)
```

The script handles the unfortunately diverse array of possible conditions for configuration of these scripts, including but not limited to:
  - configuration status (enabled/not configured/inactive)
  - per-rank or rank 0 only for prolog/epilog
  - scripts from both system and site directories with executable status
  - custom commands when configured (vs the default of `flux-imp run {prolog,epilog,housekeeping}`
  - legacy single-file scripts (shows they skip site directory)
  - Works for guest users (non-instance owners) with appropriate warnings
  - Verbose mode explores unconfigured systems to see available scripts
  - Warns about common issues: perilog plugin not loaded (if running as instance owner), unexpected flux-imp path (e.g. if running from a builddir against system instance with differing builtin conf)