### PR TITLE
broker: add `broker.conf-builtin` RPC

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1235,6 +1235,63 @@ error:
     json_decref (env);
 }
 
+static void broker_conf_builtin_cb (flux_t *h,
+                                    flux_msg_handler_t *mh,
+                                    const flux_msg_t *msg,
+                                    void *arg)
+{
+    json_t *keys;
+    json_t *values = NULL;
+    size_t index;
+    json_t *entry;
+    flux_error_t error;
+
+    err_init (&error);
+
+    if (flux_request_unpack (msg, NULL, "{s:o}", "keys", &keys) < 0)
+        goto error;
+    if (!json_is_array (keys)) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(values = json_object ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    json_array_foreach (keys, index, entry) {
+        const char *key = json_string_value (entry);
+        const char *val;
+
+        if (key && (val = flux_conf_builtin_get (key, FLUX_CONF_AUTO))) {
+            json_t *o;
+            if (!(o = json_string (val))
+                || json_object_set_new (values, key, o) < 0) {
+                // jansson decrefs the new object on failure
+                errno = ENOMEM;
+                goto error;
+            }
+        }
+        else if (key) {
+            // flux_conf_builtin_get returns NULL with EINVAL for unknown key
+            errprintf (&error, "%s: invalid key", key);
+            goto error;
+        }
+    }
+    if (flux_respond_pack (h, msg, "{s:O}", "values", values) < 0)
+        flux_log_error (h, "error responding to broker.conf_builtin");
+    json_decref (values);
+    return;
+error:
+    if (flux_respond_error (h,
+                            msg,
+                            errno,
+                            error.text[0] != '\0' ?
+                            error.text :
+                            NULL) < 0)
+        flux_log_error (h, "error responding to broker.conf_builtin");
+    json_decref (values);
+}
+
 static int route_to_handle (flux_msg_t **msg, void *arg)
 {
     broker_ctx_t *ctx = arg;
@@ -1564,6 +1621,12 @@ static const struct flux_msg_handler_spec htab[] = {
         "broker.setenv",
         broker_setenv_cb,
         0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "broker.conf-builtin",
+        broker_conf_builtin_cb,
+        FLUX_ROLE_ALL
     },
     {
         FLUX_MSGTYPE_REQUEST,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -93,6 +93,7 @@ TESTSCRIPTS = \
 	t0025-broker-state-machine.t \
 	t0027-broker-groups.t \
 	t0040-flux-sproc.t \
+	t0041-broker-conf-builtin.t \
 	t0013-config-file.t \
 	t0014-runlevel.t \
 	t0015-cron.t \

--- a/t/t0041-broker-conf-builtin.t
+++ b/t/t0041-broker-conf-builtin.t
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+test_description='Test broker.conf-builtin RPC'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 1
+
+broker_conf_builtin() {
+    keys=$(printf '"%s",' "$@" | sed 's/,$//') &&
+    flux python -c "import flux; print(flux.Flux().rpc(\"broker.conf-builtin\",{\"keys\":[$keys]}).get_str())"
+}
+
+broker_conf_builtin_eproto() {
+    flux python -c "import flux; print(flux.Flux().rpc(\"broker.conf-builtin\",{}).get_str())"
+}
+
+test_expect_success 'conf-builtin can fetch single key' '
+	broker_conf_builtin confdir >confdir.out &&
+	jq -r -e .values.confdir <confdir.out >confdir.val &&
+	test -n "$(cat confdir.val)"
+'
+
+test_expect_success 'conf-builtin can fetch multiple keys' '
+	broker_conf_builtin confdir python_path exec_path >multi.out &&
+	jq < multi.out &&
+	jq -e ".values | length == 3" < multi.out
+'
+
+test_expect_success 'conf-builtin values are non-empty strings' '
+	broker_conf_builtin confdir >check.out &&
+	test $(jq -r -e .values.confdir <check.out | wc -c) -gt 1
+'
+
+test_expect_success 'conf-builtin fails with invalid key' '
+	test_must_fail broker_conf_builtin invalid_key_name 2>invalid.err &&
+	grep "invalid_key_name" invalid.err
+'
+
+test_expect_success 'conf-builtin fails on first invalid key in batch' '
+	test_must_fail broker_conf_builtin confdir invalid_key python_path 2>batch_invalid.err &&
+	grep "invalid_key" batch_invalid.err
+'
+
+test_expect_success 'conf-builtin without keys field fails with EPROTO' '
+	test_must_fail broker_conf_builtin_eproto 2>eproto.err &&
+	grep "Protocol error" eproto.err
+'
+
+test_expect_success 'conf-builtin with keys as non-array type fails with EPROTO' '
+	test_must_fail flux python -c "import flux; flux.Flux().rpc(\"broker.conf-builtin\",{\"keys\":42}).get()" 2>eproto2.err &&
+	grep "Protocol error" eproto2.err
+'
+
+test_expect_success 'conf-builtin works for simulated guest' '
+	( export FLUX_HANDLE_ROLEMASK=0x2; \
+	  export FLUX_HANDLE_USERID=$(($(id -u)+1)); \
+	  broker_conf_builtin confdir \
+	) >guest.out &&
+	jq -r -e .values.confdir <guest.out
+'
+
+test_expect_success 'conf-builtin returns expected well-known keys' '
+	broker_conf_builtin \
+		confdir \
+		libexecdir \
+		datadir \
+		python_path \
+		exec_path \
+		module_path \
+		shell_path >wellknown.out &&
+	jq -e ".values | length == 7" < wellknown.out &&
+	jq -e ".values.confdir" < wellknown.out &&
+	jq -e ".values.libexecdir" < wellknown.out &&
+	jq -e ".values.datadir" < wellknown.out &&
+	jq -e ".values.python_path" < wellknown.out &&
+	jq -e ".values.exec_path" < wellknown.out &&
+	jq -e ".values.module_path" < wellknown.out &&
+	jq -e ".values.shell_path" < wellknown.out
+'
+
+test_expect_success 'conf-builtin with empty keys array returns empty values' '
+	flux python -c "import flux; print(flux.Flux().rpc(\"broker.conf-builtin\",{\"keys\":[]}).get_str())" >empty.out &&
+	jq -e ".values | length == 0" < empty.out
+'
+
+test_expect_success 'conf-builtin fails with empty string key' '
+	test_must_fail \
+	  flux python -c "import flux; flux.Flux().rpc(\"broker.conf-builtin\",{\"keys\":[\"\"]}).get()" 2>empty_key.err &&
+	grep "invalid key" empty_key.err
+'
+
+test_expect_success 'conf-builtin with keys as string fails with EPROTO' '
+	test_must_fail flux python -c "import flux; flux.Flux().rpc(\"broker.conf-builtin\",{\"keys\":\"string\"}).get()" 2>string_keys.err &&
+	grep "Protocol error" string_keys.err
+'
+
+test_expect_success 'conf-builtin silently skips non-string array elements' '
+	flux python -c "import flux; print(flux.Flux().rpc(\"broker.conf-builtin\",{\"keys\":[\"confdir\", 42, None, \"python_path\"]}).get_str())" >mixed.out &&
+	jq -e ".values | length == 2" < mixed.out &&
+	jq -e ".values.confdir" < mixed.out &&
+	jq -e ".values.python_path" < mixed.out
+'
+
+test_done


### PR DESCRIPTION
Problem: Flux utilities need to query build-time configuration from the running broker, but `flux_conf_builtin_get()` only returns values from the client's compiled-in configuration. This causes issues when the client and broker are different versions or the client is using a side-install.

This PR adds a `broker.conf-builtin` RPC that queries the broker's build-time configuration values via `flux_conf_builtin_get()`. The RPC accepts a JSON array of keys and returns a values object containing the requested configuration. If any key is invalid, the request fails with EINVAL and an error message identifying the invalid key.