### PR TITLE
build: missing shebangs and non-executable scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-files: '^(src/modules/.*\.py|src/bindings/python/flux|src/cmd|t/(rc|python)|t/scripts/.*\.py|etc/)'
+files: '^(src/(modules/.*\.py|bindings/python/flux|broker/.*\.py|cmd)|t/(rc|python|scripts/.*\.py)|etc/)'
 exclude: "^(src/bindings/python/_flux/|src/bindings/python/flux/utils/|t/python/tap)"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -6,6 +6,7 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
+      - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
       - id: end-of-file-fixer
       - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ files: '^(src/(modules/.*\.py|bindings/python/flux|broker/.*\.py|cmd)|t/(rc|pyth
 exclude: "^(src/bindings/python/_flux/|src/bindings/python/flux/utils/|t/python/tap)"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -15,7 +15,7 @@ tmpfiles_DATA = flux.conf
 dist_cron_DATA = \
 	kvs-backup.cron
 
-nobase_dist_fluxlibexec_SCRIPTS = \
+nobase_dist_fluxlibexec_DATA = \
 	modprobe/rc1.py \
 	modprobe/rc3.py
 

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -100,5 +100,4 @@ completions/flux: completions/flux.pre completions/get_builtins.sh
 	$(srcdir)/completions/get_builtins.sh \
 	$(top_srcdir)/src/cmd/builtin >> $@
 
-bashcomp_SCRIPTS = \
-	completions/flux
+bashcomp_DATA =	completions/flux

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -14,14 +14,14 @@ fluxluadir =     $(luadir)/flux
 fluxometerdir =  $(luadir)/fluxometer
 fluxluaexecdir = $(luaexecdir)/flux
 
-nobase_dist_lua_SCRIPTS = \
+nobase_dist_lua_DATA = \
 	flux/timer.lua \
 	flux/alt_getopt.lua \
 	flux/posix.lua \
 	flux/shell.lua \
 	flux/Subcommander.lua
 
-nobase_dist_fluxometer_SCRIPTS = \
+nobase_dist_fluxometer_DATA = \
 	Test/Builder/NoOutput.lua \
 	Test/Builder/SocketOutput.lua \
 	Test/Builder/Tester.lua \

--- a/src/broker/flux-module-python-exec.py
+++ b/src/broker/flux-module-python-exec.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2026 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-admin.py
+++ b/src/cmd/flux-admin.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2020 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-alloc.py
+++ b/src/cmd/flux-alloc.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2023 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-batch.py
+++ b/src/cmd/flux-batch.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2023 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-bulksubmit.py
+++ b/src/cmd/flux-bulksubmit.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2023 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-cancel.py
+++ b/src/cmd/flux-cancel.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2023 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-fortune.py
+++ b/src/cmd/flux-fortune.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2023 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-hostlist.py
+++ b/src/cmd/flux-hostlist.py
@@ -1,3 +1,4 @@
+#!/bin/false
 #############################################################
 # Copyright 2024 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-housekeeping.py
+++ b/src/cmd/flux-housekeeping.py
@@ -1,3 +1,4 @@
+#!/bin/false
 #############################################################
 # Copyright 2024 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-job-frobnicator.py
+++ b/src/cmd/flux-job-frobnicator.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ###############################################################
 # Copyright 2022 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-job-validator.py
+++ b/src/cmd/flux-job-validator.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ###############################################################
 # Copyright 2021 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2019 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-modprobe.py
+++ b/src/cmd/flux-modprobe.py
@@ -1,3 +1,4 @@
+#!/bin/false
 #############################################################
 # Copyright 2024 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-multi-prog.py
+++ b/src/cmd/flux-multi-prog.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ###############################################################
 # Copyright 2025 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2023 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-pstree.py
+++ b/src/cmd/flux-pstree.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2021 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2022 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2019 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-run.py
+++ b/src/cmd/flux-run.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2023 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-slurm-expiration-sync.py
+++ b/src/cmd/flux-slurm-expiration-sync.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ###############################################################
 # Copyright 2026 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-sproc.py
+++ b/src/cmd/flux-sproc.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ###############################################################
 # Copyright 2025 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-submit.py
+++ b/src/cmd/flux-submit.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2023 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-update.py
+++ b/src/cmd/flux-update.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2023 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-uri.py
+++ b/src/cmd/flux-uri.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2021 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/flux-watch.py
+++ b/src/cmd/flux-watch.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2023 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/cmd/py-runner.py
+++ b/src/cmd/py-runner.py
@@ -1,3 +1,4 @@
+#!/bin/false
 ##############################################################
 # Copyright 2023 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -35,11 +35,12 @@ libmodule_builtins_la_LIBADD = \
 	$(builddir)/overlay/liboverlay.la
 libmodule_builtins_la_LDFLAGS = $(san_ld_zdef_flag)
 
-dist_fluxmod_SCRIPTS = \
+dist_fluxmod_SCRIPTS = sdexec-mapper.py
+
+dist_fluxmod_DATA = \
 	sched-fifo.py \
 	sched-backfill.py \
-	sched-simple.py \
-	sdexec-mapper.py
+	sched-simple.py
 
 fluxmod_LTLIBRARIES = \
 	content.la \

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS = \
 shellrcdir = \
 	$(fluxconfdir)/shell
 
-nobase_dist_shellrc_SCRIPTS = \
+nobase_dist_shellrc_DATA = \
 	initrc.lua \
 	lua.d/openmpi.lua \
 	lua.d/mpi/spectrum.lua

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -31,8 +31,7 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/config/tap-driver.sh
 PY_LOG_DRIVER = $(PYTHON) $(top_srcdir)/config/tap-driver.py
 
-lua_SCRIPTS = \
-	fluxometer.lua
+lua_DATA = fluxometer.lua
 
 install-data-local:
 	$(INSTALL) -m644 fluxometer/conf.lua.installed \

--- a/t/python/tap/pycotap/__init__.py
+++ b/t/python/tap/pycotap/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding=utf-8
 
 # Copyright (c) 2015 Remko Tronçon (https://el-tramo.be)

--- a/t/scripts/groups.py
+++ b/t/scripts/groups.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 ###############################################################
 # Copyright 2021 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/t/scripts/sign-as.py
+++ b/t/scripts/sign-as.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 
 from flux.security import SecurityContext

--- a/t/scripts/sqlite-query.py
+++ b/t/scripts/sqlite-query.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 ###############################################################
 # Copyright 2019 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/t/scripts/sqlite-write.py
+++ b/t/scripts/sqlite-write.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 ###############################################################
 # Copyright 2025 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/t/scripts/startctl.py
+++ b/t/scripts/startctl.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 ###############################################################
 # Copyright 2021 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)


### PR DESCRIPTION
Problem: my RPM build complains about executable files missing shebangs, and removes the executable bit, including from cmd scripts where it must be set.

Change to installing files that should not be executable using Automake's `_DATA` variable type instead of `_SCRIPTS`, and add a `#!/bin/false` shebang to cmd scripts that must remain executable.

This is basically a follow-on to https://github.com/flux-framework/flux-accounting/pull/873 which started because I realized certain sub-commands were not visible to the CLI in my RPMs due to missing shebangs. In that PR I added a `#!/usr/bin/env python3` shebang to match the other `flux-accounting` cmd scripts, but when putting this PR together I noticed that the handful of cmd scripts in `flux-core` that _did_ already have shebangs (such as [flux-jobtap.py](https://github.com/flux-framework/flux-core/blob/master/src/cmd/flux-jobtap.py#L1)) used `#!/bin/false`, as did the two cmd scripts in `flux-sched`. So I'm open to rework this if a different solution is preferred, but I hope this will help improve robustness for RPM packaging!