### PR TITLE
doc: remove `-B` as `--broker-opts` short option

### DIFF
--- a/doc/man1/common/job-other-batch.rst
+++ b/doc/man1/common/job-other-batch.rst
@@ -47,7 +47,7 @@
    interactively attach to the job (though it will print any errors or
    output).
 
-.. option:: -B, --broker-opts=OPT
+.. option:: --broker-opts=OPT
 
    Pass specified options to the Flux brokers of the new instance. This
    option may be specified multiple times.


### PR DESCRIPTION
Problem: `-B` is listed as a short option for `--broker-opts`, but it is now a short option for specifying a bank instead.

Remove that short option in the manual page.