### PR TITLE
librlist: fix overzealous GPU duplicate check when loading topology

### DIFF
--- a/doc/man7/flux-environment.rst
+++ b/doc/man7/flux-environment.rst
@@ -414,6 +414,20 @@ components or writing tests.
    non-empty value and is ignored if :envvar:`FLUX_HWLOC_XMLFILE` is
    not set.
 
+.. envvar:: FLUX_HWLOC_GPU_NO_DEDUP
+
+   By default, Flux removes duplicate GPU devices that appear under multiple
+   hwloc discovery methods. For example, a physical NVIDIA GPU may be discovered
+   by CUDA, NVML, and OpenCL, but Flux counts it as one GPU. This duplicate
+   removal preserves AMD partitioned GPUs (CPX/TPX modes) where a single
+   physical GPU is split into multiple logical devices that share a PCI device
+   but have the same discovery method.
+
+   If set to any non-empty value, duplicate removal is completely disabled
+   and all GPU device objects reported by hwloc are counted. This is primarily
+   useful for testing or as an escape hatch if the duplicate removal logic
+   causes problems in the field.
+
 .. envvar:: FLUX_URI_RESOLVE_LOCAL
 
    If set, force :man1:`flux-uri` and the URI resolver embedded in other

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -378,6 +378,8 @@ EHOSTUNREACH
 ap
 MSGID
 NULL's
+NVML
+OpenCL
 ORed
 PRI
 procid
@@ -440,7 +442,9 @@ params
 sched
 setopt
 unsetenv
+CPX
 CUDA
+DEDUP
 GPU
 GPUs
 cpu
@@ -503,6 +507,7 @@ rc
 rcpath
 searchpath
 sysconfdir
+TPX
 TRACEME
 WIFEXTED
 builtin

--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -416,7 +416,14 @@ static int collect_unique_gpus (hwloc_topology_t topo,
 {
     int nvisited = 0;
     int count = 0;
+    bool dedup = true;
     hwloc_obj_t obj = NULL;
+
+    /*  Allow disabling deduplication via environment variable as an escape
+     *  hatch in case this logic causes problems in the field.
+     */
+    if (getenv ("FLUX_HWLOC_GPU_NO_DEDUP"))
+        dedup = false;
 
     /*  Manually index GPUs -- os_index does not seem to be valid for
      *  these devices in some cases, and logical index also seems
@@ -429,7 +436,10 @@ static int collect_unique_gpus (hwloc_topology_t topo,
         const char *backend = hwloc_obj_get_info_by_name (obj, "Backend");
         hwloc_obj_t pcidev = osdev_get_pcidev (obj);
         if (!backend_is_coproc (backend)
-            || gpu_identity_visited (visited, nvisited, pcidev, backend))
+            || (dedup && gpu_identity_visited (visited,
+                                               nvisited,
+                                               pcidev,
+                                               backend)))
             continue;
         if (nvisited < vlen) {
             visited[nvisited].pcidev = pcidev;

--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -378,13 +378,25 @@ static bool backend_is_coproc (const char *s)
             || streq (s, "RSMI"));
 }
 
-static bool pcidev_visited (hwloc_obj_t *visited,
-                            int nvisited,
-                            hwloc_obj_t pcidev)
+/*  Structure to track unique GPU identities by PCI device and backend.
+ *  Deduplicates GPUs appearing under multiple backends (e.g., CUDA and
+ *  OpenCL for the same physical NVIDIA GPU), while preserving AMD CPX/TPX
+ *  partitioned GPUs which share a PCI device but are distinct logical GPUs.
+ */
+struct gpu_identity {
+    hwloc_obj_t pcidev;
+    const char *backend;
+};
+
+static bool gpu_identity_visited (struct gpu_identity *visited,
+                                  int nvisited,
+                                  hwloc_obj_t pcidev,
+                                  const char *backend)
 {
-    if (pcidev) {
+    if (pcidev && backend) {
         for (int i = 0; i < nvisited; i++) {
-            if (visited[i] == pcidev)
+            if (visited[i].pcidev == pcidev
+                && !streq (visited[i].backend, backend))
                 return true;
         }
     }
@@ -397,7 +409,7 @@ static bool pcidev_visited (hwloc_obj_t *visited,
  *  there up to rlen entries. Returns the count of unique GPUs.
  */
 static int collect_unique_gpus (hwloc_topology_t topo,
-                                hwloc_obj_t *visited,
+                                struct gpu_identity *visited,
                                 int vlen,
                                 hwloc_obj_t *result,
                                 int rlen)
@@ -409,17 +421,21 @@ static int collect_unique_gpus (hwloc_topology_t topo,
     /*  Manually index GPUs -- os_index does not seem to be valid for
      *  these devices in some cases, and logical index also seems
      *  incorrect (?).
-     *  Ensure GPUs are not counted twice when they appear with multiple
-     *  backends by tracking visited devices by the PCI parent.
+     *  Deduplicate GPUs that appear with multiple backends (e.g., CUDA
+     *  and OpenCL for the same NVIDIA GPU), while preserving AMD partitioned
+     *  GPUs (CPX/TPX) which share a PCI device but have the same backend.
      */
     while ((obj = hwloc_get_next_osdev (topo, obj))) {
         const char *backend = hwloc_obj_get_info_by_name (obj, "Backend");
         hwloc_obj_t pcidev = osdev_get_pcidev (obj);
         if (!backend_is_coproc (backend)
-            || pcidev_visited (visited, nvisited, pcidev))
+            || gpu_identity_visited (visited, nvisited, pcidev, backend))
             continue;
-        if (nvisited < vlen)
-            visited[nvisited++] = pcidev;
+        if (nvisited < vlen) {
+            visited[nvisited].pcidev = pcidev;
+            visited[nvisited].backend = backend;
+            nvisited++;
+        }
         if (result && count < rlen)
             result[count] = obj;
         count++;
@@ -431,7 +447,7 @@ hwloc_obj_t *rhwloc_gpu_objects (hwloc_topology_t topo, int *count_out)
 {
     int n_pci;
     int count = 0;
-    hwloc_obj_t *visited = NULL;
+    struct gpu_identity *visited = NULL;
     hwloc_obj_t *result = NULL;
 
     *count_out = 0;
@@ -446,17 +462,17 @@ hwloc_obj_t *rhwloc_gpu_objects (hwloc_topology_t topo, int *count_out)
     if (!(visited = calloc (n_pci, sizeof (*visited))))
         return NULL;
 
-    /* Traverse topo first to get count of unique GPUs to size result
+    /* Allocate result for worst case (all PCI devices are GPUs), then
+     * traverse once to collect unique GPUs
      */
-    count = collect_unique_gpus (topo, visited, n_pci, NULL, 0);
-    if (count == 0 || !(result = calloc (count, sizeof (*result))))
+    if (!(result = calloc (n_pci, sizeof (*result))))
         goto out;
-
-    /* Reset visited and traverse again, this time collecting GPUs
-     * in result
-     */
-    memset (visited, 0, n_pci * sizeof (*visited));
-    collect_unique_gpus (topo, visited, n_pci, result, count);
+    count = collect_unique_gpus (topo, visited, n_pci, result, n_pci);
+    if (count == 0) {
+        free (result);
+        result = NULL;
+        goto out;
+    }
     *count_out = count;
 out:
     ERRNO_SAFE_WRAP (free, visited);
@@ -467,7 +483,7 @@ static struct idset *rhwloc_gpu_idset (hwloc_topology_t topo)
 {
     int n_pci;
     int count = 0;
-    hwloc_obj_t *visited = NULL;
+    struct gpu_identity *visited = NULL;
     struct idset *ids = NULL;
 
     /* Count total PCI objects to size visited array:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -107,6 +107,7 @@ TESTSCRIPTS = \
 	t0023-jobspec1-validate.t \
 	t0024-jjc-reader.t \
 	t0026-flux-R.t \
+	t0042-rhwloc-gpu-dedup.t \
 	t0090-content-enospc.t \
 	t0099-admin-system-scripts.t \
 	t0100-modprobe.t \
@@ -588,6 +589,10 @@ check_LTLIBRARIES = \
 dist_check_DATA = \
 	hwloc-data/sierra.xml \
 	hwloc-data/corona.xml \
+	hwloc-data/ipa20.xml \
+	hwloc-data/tuo.SPX.xml \
+	hwloc-data/tuo.TPX.xml \
+	hwloc-data/tuo.CPX.xml \
 	valgrind/valgrind.supp
 
 test_ldadd = \

--- a/t/hwloc-data/ipa20.xml
+++ b/t/hwloc-data/ipa20.xml
@@ -1,0 +1,1944 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x000000ff" complete_nodeset="0x000000ff" allowed_nodeset="0x000000ff" gp_index="1">
+    <info name="DMIProductName" value="PowerEdge XE8640"/>
+    <info name="DMIProductVersion" value=""/>
+    <info name="DMIBoardVendor" value="Dell Inc."/>
+    <info name="DMIBoardName" value="0TVHHH"/>
+    <info name="DMIBoardVersion" value="A00"/>
+    <info name="DMIChassisVendor" value="Dell Inc."/>
+    <info name="DMIChassisType" value="23"/>
+    <info name="DMIChassisVersion" value=""/>
+    <info name="DMIChassisAssetTag" value=""/>
+    <info name="DMIBIOSVendor" value="Dell Inc."/>
+    <info name="DMIBIOSVersion" value="2.8.2"/>
+    <info name="DMIBIOSDate" value="10/30/2025"/>
+    <info name="DMISysVendor" value="Dell Inc."/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/user.slice/user-6885.slice/session-339.scope"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="5.14.0-611.55.1.2toss.t5.x86_64"/>
+    <info name="OSVersion" value="#1 SMP PREEMPT_DYNAMIC Fri May 15 07:56:42 PDT 2026"/>
+    <info name="HostName" value="testhost-nvidia"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="2.12.2"/>
+    <info name="ProcessName" value="lstopo"/>
+    <object type="Package" os_index="0" cpuset="0x000000ff,0xffffffff,0xffff0000,,0x00ffffff,0xffffffff" complete_cpuset="0x000000ff,0xffffffff,0xffff0000,,0x00ffffff,0xffffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" gp_index="3">
+      <info name="CPUVendor" value="GenuineIntel"/>
+      <info name="CPUFamilyNumber" value="6"/>
+      <info name="CPUModelNumber" value="143"/>
+      <info name="CPUModel" value="Intel(R) Xeon(R) Platinum 8480+"/>
+      <info name="CPUStepping" value="8"/>
+      <object type="L3Cache" os_index="0" cpuset="0x000000ff,0xffffffff,0xffff0000,,0x00ffffff,0xffffffff" complete_cpuset="0x000000ff,0xffffffff,0xffff0000,,0x00ffffff,0xffffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" gp_index="10" cache_size="110100480" depth="3" cache_linesize="64" cache_associativity="15" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="Group" cpuset="0x3fff0000,,,0x00003fff" complete_cpuset="0x3fff0000,,,0x00003fff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="800" kind="1001" subkind="0">
+          <object type="NUMANode" os_index="0" cpuset="0x3fff0000,,,0x00003fff" complete_cpuset="0x3fff0000,,,0x00003fff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="792" local_memory="540245127168">
+            <page_type size="4096" count="131895783"/>
+            <page_type size="2097152" count="0"/>
+            <page_type size="1073741824" count="0"/>
+          </object>
+          <object type="L2Cache" os_index="0" cpuset="0x00010000,,,0x00000001" complete_cpuset="0x00010000,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="0" cpuset="0x00010000,,,0x00000001" complete_cpuset="0x00010000,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="0" cpuset="0x00010000,,,0x00000001" complete_cpuset="0x00010000,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010000,,,0x00000001" complete_cpuset="0x00010000,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6"/>
+                  <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="680"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="1" cpuset="0x00020000,,,0x00000002" complete_cpuset="0x00020000,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="1" cpuset="0x00020000,,,0x00000002" complete_cpuset="0x00020000,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="1" cpuset="0x00020000,,,0x00000002" complete_cpuset="0x00020000,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020000,,,0x00000002" complete_cpuset="0x00020000,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13"/>
+                  <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="681"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="2" cpuset="0x00040000,,,0x00000004" complete_cpuset="0x00040000,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="2" cpuset="0x00040000,,,0x00000004" complete_cpuset="0x00040000,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="2" cpuset="0x00040000,,,0x00000004" complete_cpuset="0x00040000,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040000,,,0x00000004" complete_cpuset="0x00040000,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19"/>
+                  <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="682"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="3" cpuset="0x00080000,,,0x00000008" complete_cpuset="0x00080000,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="3" cpuset="0x00080000,,,0x00000008" complete_cpuset="0x00080000,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="3" cpuset="0x00080000,,,0x00000008" complete_cpuset="0x00080000,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00080000,,,0x00000008" complete_cpuset="0x00080000,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25"/>
+                  <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="683"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="4" cpuset="0x00100000,,,0x00000010" complete_cpuset="0x00100000,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="4" cpuset="0x00100000,,,0x00000010" complete_cpuset="0x00100000,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="4" cpuset="0x00100000,,,0x00000010" complete_cpuset="0x00100000,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00100000,,,0x00000010" complete_cpuset="0x00100000,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31"/>
+                  <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="684"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="5" cpuset="0x00200000,,,0x00000020" complete_cpuset="0x00200000,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="5" cpuset="0x00200000,,,0x00000020" complete_cpuset="0x00200000,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="5" cpuset="0x00200000,,,0x00000020" complete_cpuset="0x00200000,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00200000,,,0x00000020" complete_cpuset="0x00200000,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37"/>
+                  <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="685"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="6" cpuset="0x00400000,,,0x00000040" complete_cpuset="0x00400000,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="6" cpuset="0x00400000,,,0x00000040" complete_cpuset="0x00400000,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="6" cpuset="0x00400000,,,0x00000040" complete_cpuset="0x00400000,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00400000,,,0x00000040" complete_cpuset="0x00400000,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43"/>
+                  <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="686"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="7" cpuset="0x00800000,,,0x00000080" complete_cpuset="0x00800000,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="52" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="7" cpuset="0x00800000,,,0x00000080" complete_cpuset="0x00800000,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="50" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="7" cpuset="0x00800000,,,0x00000080" complete_cpuset="0x00800000,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="51" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x00800000,,,0x00000080" complete_cpuset="0x00800000,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="47">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="49"/>
+                  <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="687"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="8" cpuset="0x01000000,,,0x00000100" complete_cpuset="0x01000000,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="58" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="8" cpuset="0x01000000,,,0x00000100" complete_cpuset="0x01000000,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="56" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="8" cpuset="0x01000000,,,0x00000100" complete_cpuset="0x01000000,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="57" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x01000000,,,0x00000100" complete_cpuset="0x01000000,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="53">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="55"/>
+                  <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="688"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="9" cpuset="0x02000000,,,0x00000200" complete_cpuset="0x02000000,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="64" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="9" cpuset="0x02000000,,,0x00000200" complete_cpuset="0x02000000,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="62" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="9" cpuset="0x02000000,,,0x00000200" complete_cpuset="0x02000000,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="63" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x02000000,,,0x00000200" complete_cpuset="0x02000000,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="59">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="61"/>
+                  <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="689"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="10" cpuset="0x04000000,,,0x00000400" complete_cpuset="0x04000000,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="70" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="10" cpuset="0x04000000,,,0x00000400" complete_cpuset="0x04000000,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="68" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="10" cpuset="0x04000000,,,0x00000400" complete_cpuset="0x04000000,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="69" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x04000000,,,0x00000400" complete_cpuset="0x04000000,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="65">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="67"/>
+                  <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="690"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="11" cpuset="0x08000000,,,0x00000800" complete_cpuset="0x08000000,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="76" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="11" cpuset="0x08000000,,,0x00000800" complete_cpuset="0x08000000,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="74" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="11" cpuset="0x08000000,,,0x00000800" complete_cpuset="0x08000000,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="75" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x08000000,,,0x00000800" complete_cpuset="0x08000000,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="71">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="73"/>
+                  <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="691"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="12" cpuset="0x10000000,,,0x00001000" complete_cpuset="0x10000000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="82" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="12" cpuset="0x10000000,,,0x00001000" complete_cpuset="0x10000000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="80" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="12" cpuset="0x10000000,,,0x00001000" complete_cpuset="0x10000000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="81" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x10000000,,,0x00001000" complete_cpuset="0x10000000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="77">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="79"/>
+                  <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="692"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="13" cpuset="0x20000000,,,0x00002000" complete_cpuset="0x20000000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="88" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="13" cpuset="0x20000000,,,0x00002000" complete_cpuset="0x20000000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="86" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="13" cpuset="0x20000000,,,0x00002000" complete_cpuset="0x20000000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="87" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x20000000,,,0x00002000" complete_cpuset="0x20000000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="83">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="85"/>
+                  <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="693"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="863" bridge_type="0-1" depth="0" bridge_pci="0000:[00-03]">
+            <object type="Bridge" gp_index="832" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:0c.0" pci_type="0604 [8086:1bbc] [1028:0b74] 11" pci_link_speed="0.615385">
+              <object type="PCIDev" gp_index="829" pci_busid="0000:01:00.0" pci_type="0200 [14e4:165f] [1028:0a6b] 00" pci_link_speed="0.615385">
+                <object type="OSDev" gp_index="880" name="eno8303" osdev_type="2">
+                  <info name="Address" value="c4:cb:e1:a7:42:9c"/>
+                </object>
+              </object>
+              <object type="PCIDev" gp_index="852" pci_busid="0000:01:00.1" pci_type="0200 [14e4:165f] [1028:0a6b] 00" pci_link_speed="0.615385">
+                <object type="OSDev" gp_index="878" name="eno8403" osdev_type="2">
+                  <info name="Address" value="c4:cb:e1:a7:42:9d"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="851" bridge_type="1-1" depth="1" bridge_pci="0000:[02-03]" pci_busid="0000:00:0e.0" pci_type="0604 [8086:1bbe] [1028:0b74] 11" pci_link_speed="0.615385">
+              <object type="Bridge" gp_index="821" bridge_type="1-1" depth="2" bridge_pci="0000:[03-03]" pci_busid="0000:02:00.0" pci_type="0604 [1556:be00] [0000:0000] 02" pci_link_speed="0.615385">
+                <object type="PCIDev" gp_index="810" pci_busid="0000:03:00.0" pci_type="0300 [102b:0536] [1028:0b74] 04" pci_link_speed="0.000000"/>
+              </object>
+            </object>
+            <object type="PCIDev" gp_index="845" pci_busid="0000:00:18.0" pci_type="0106 [8086:1bf2] [1028:0b74] 11" pci_link_speed="0.000000"/>
+            <object type="PCIDev" gp_index="833" pci_busid="0000:00:19.0" pci_type="0106 [8086:1bd2] [1028:0b74] 11" pci_link_speed="0.000000"/>
+          </object>
+          <object type="Bridge" gp_index="866" bridge_type="0-1" depth="0" bridge_pci="0000:[6b-6b]">
+            <object type="PCIDev" gp_index="857" pci_busid="0000:6b:00.0" pci_type="0b40 [8086:4940] [8086:0000] 40" pci_link_speed="0.000000"/>
+          </object>
+          <object type="Bridge" gp_index="867" bridge_type="0-1" depth="0" bridge_pci="0000:[6d-6d]">
+            <object type="PCIDev" gp_index="840" pci_busid="0000:6d:00.0" pci_type="0b40 [8086:2710] [8086:0000] 00" pci_link_speed="0.000000"/>
+          </object>
+        </object>
+        <object type="Group" cpuset="0x00000fff,0xc0000000,,,0x0fffc000" complete_cpuset="0x00000fff,0xc0000000,,,0x0fffc000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="801" kind="1001" subkind="0">
+          <object type="NUMANode" os_index="1" cpuset="0x00000fff,0xc0000000,,,0x0fffc000" complete_cpuset="0x00000fff,0xc0000000,,,0x0fffc000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="793" local_memory="541157969920">
+            <page_type size="4096" count="132118645"/>
+            <page_type size="2097152" count="0"/>
+            <page_type size="1073741824" count="0"/>
+          </object>
+          <object type="L2Cache" os_index="14" cpuset="0x40000000,,,0x00004000" complete_cpuset="0x40000000,,,0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="94" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="14" cpuset="0x40000000,,,0x00004000" complete_cpuset="0x40000000,,,0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="92" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="14" cpuset="0x40000000,,,0x00004000" complete_cpuset="0x40000000,,,0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="93" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x40000000,,,0x00004000" complete_cpuset="0x40000000,,,0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="89">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="91"/>
+                  <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="694"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="15" cpuset="0x80000000,,,0x00008000" complete_cpuset="0x80000000,,,0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="100" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="15" cpuset="0x80000000,,,0x00008000" complete_cpuset="0x80000000,,,0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="98" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="15" cpuset="0x80000000,,,0x00008000" complete_cpuset="0x80000000,,,0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="99" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="15" cpuset="0x80000000,,,0x00008000" complete_cpuset="0x80000000,,,0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="95">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="97"/>
+                  <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="695"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="16" cpuset="0x00000001,,,,0x00010000" complete_cpuset="0x00000001,,,,0x00010000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="106" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="16" cpuset="0x00000001,,,,0x00010000" complete_cpuset="0x00000001,,,,0x00010000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="104" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="16" cpuset="0x00000001,,,,0x00010000" complete_cpuset="0x00000001,,,,0x00010000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="105" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00000001,,,,0x00010000" complete_cpuset="0x00000001,,,,0x00010000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="101">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="103"/>
+                  <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="696"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="17" cpuset="0x00000002,,,,0x00020000" complete_cpuset="0x00000002,,,,0x00020000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="112" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="17" cpuset="0x00000002,,,,0x00020000" complete_cpuset="0x00000002,,,,0x00020000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="110" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="17" cpuset="0x00000002,,,,0x00020000" complete_cpuset="0x00000002,,,,0x00020000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="111" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00000002,,,,0x00020000" complete_cpuset="0x00000002,,,,0x00020000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="107">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="109"/>
+                  <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="697"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="18" cpuset="0x00000004,,,,0x00040000" complete_cpuset="0x00000004,,,,0x00040000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="118" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="18" cpuset="0x00000004,,,,0x00040000" complete_cpuset="0x00000004,,,,0x00040000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="116" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="18" cpuset="0x00000004,,,,0x00040000" complete_cpuset="0x00000004,,,,0x00040000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="117" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00000004,,,,0x00040000" complete_cpuset="0x00000004,,,,0x00040000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="113">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="115"/>
+                  <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="698"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="19" cpuset="0x00000008,,,,0x00080000" complete_cpuset="0x00000008,,,,0x00080000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="124" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="19" cpuset="0x00000008,,,,0x00080000" complete_cpuset="0x00000008,,,,0x00080000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="122" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="19" cpuset="0x00000008,,,,0x00080000" complete_cpuset="0x00000008,,,,0x00080000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="123" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x00000008,,,,0x00080000" complete_cpuset="0x00000008,,,,0x00080000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="119">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="121"/>
+                  <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="699"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="20" cpuset="0x00000010,,,,0x00100000" complete_cpuset="0x00000010,,,,0x00100000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="130" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="20" cpuset="0x00000010,,,,0x00100000" complete_cpuset="0x00000010,,,,0x00100000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="128" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="20" cpuset="0x00000010,,,,0x00100000" complete_cpuset="0x00000010,,,,0x00100000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="129" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00000010,,,,0x00100000" complete_cpuset="0x00000010,,,,0x00100000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="125">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="127"/>
+                  <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="700"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="21" cpuset="0x00000020,,,,0x00200000" complete_cpuset="0x00000020,,,,0x00200000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="136" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="21" cpuset="0x00000020,,,,0x00200000" complete_cpuset="0x00000020,,,,0x00200000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="134" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="21" cpuset="0x00000020,,,,0x00200000" complete_cpuset="0x00000020,,,,0x00200000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="135" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00000020,,,,0x00200000" complete_cpuset="0x00000020,,,,0x00200000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="131">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="133"/>
+                  <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="701"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="22" cpuset="0x00000040,,,,0x00400000" complete_cpuset="0x00000040,,,,0x00400000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="142" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="22" cpuset="0x00000040,,,,0x00400000" complete_cpuset="0x00000040,,,,0x00400000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="140" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="22" cpuset="0x00000040,,,,0x00400000" complete_cpuset="0x00000040,,,,0x00400000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="141" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00000040,,,,0x00400000" complete_cpuset="0x00000040,,,,0x00400000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="137">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="139"/>
+                  <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="702"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="23" cpuset="0x00000080,,,,0x00800000" complete_cpuset="0x00000080,,,,0x00800000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="148" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="23" cpuset="0x00000080,,,,0x00800000" complete_cpuset="0x00000080,,,,0x00800000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="146" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="23" cpuset="0x00000080,,,,0x00800000" complete_cpuset="0x00000080,,,,0x00800000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="147" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="23" cpuset="0x00000080,,,,0x00800000" complete_cpuset="0x00000080,,,,0x00800000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="143">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="145"/>
+                  <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="703"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="24" cpuset="0x00000100,,,,0x01000000" complete_cpuset="0x00000100,,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="154" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="24" cpuset="0x00000100,,,,0x01000000" complete_cpuset="0x00000100,,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="152" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="24" cpuset="0x00000100,,,,0x01000000" complete_cpuset="0x00000100,,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="153" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x00000100,,,,0x01000000" complete_cpuset="0x00000100,,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="149">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="151"/>
+                  <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="704"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="25" cpuset="0x00000200,,,,0x02000000" complete_cpuset="0x00000200,,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="160" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="25" cpuset="0x00000200,,,,0x02000000" complete_cpuset="0x00000200,,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="158" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="25" cpuset="0x00000200,,,,0x02000000" complete_cpuset="0x00000200,,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="159" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x00000200,,,,0x02000000" complete_cpuset="0x00000200,,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="155">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="157"/>
+                  <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="705"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="26" cpuset="0x00000400,,,,0x04000000" complete_cpuset="0x00000400,,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="166" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="26" cpuset="0x00000400,,,,0x04000000" complete_cpuset="0x00000400,,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="164" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="26" cpuset="0x00000400,,,,0x04000000" complete_cpuset="0x00000400,,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="165" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x00000400,,,,0x04000000" complete_cpuset="0x00000400,,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="161">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="163"/>
+                  <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="706"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="27" cpuset="0x00000800,,,,0x08000000" complete_cpuset="0x00000800,,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="172" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="27" cpuset="0x00000800,,,,0x08000000" complete_cpuset="0x00000800,,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="170" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="27" cpuset="0x00000800,,,,0x08000000" complete_cpuset="0x00000800,,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="171" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="27" cpuset="0x00000800,,,,0x08000000" complete_cpuset="0x00000800,,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="167">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="169"/>
+                  <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="707"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="865" bridge_type="0-1" depth="0" bridge_pci="0000:[59-60]">
+            <object type="Bridge" gp_index="820" bridge_type="1-1" depth="1" bridge_pci="0000:[5a-60]" pci_busid="0000:59:01.0" pci_type="0604 [8086:352a] [8086:0000] 04" pci_link_speed="63.015385">
+              <object type="Bridge" gp_index="848" bridge_type="1-1" depth="2" bridge_pci="0000:[5b-60]" pci_busid="0000:5a:00.0" pci_type="0604 [1000:c030] [1028:236b] b0" pci_link_speed="63.015385">
+                <object type="Bridge" gp_index="861" bridge_type="1-1" depth="3" bridge_pci="0000:[5e-5e]" pci_busid="0000:5b:02.0" pci_type="0604 [1000:c030] [1028:236b] b0" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="1"/>
+                  <object type="PCIDev" gp_index="816" pci_busid="0000:5e:00.0" pci_type="0207 [15b3:1021] [15b3:0041] 00" pci_link_speed="63.015385">
+                    <object type="OSDev" gp_index="881" name="ibp94s0" osdev_type="2">
+                      <info name="Address" value="00:00:10:47:fe:80:00:00:00:00:00:00:a0:88:c2:03:00:09:70:4e"/>
+                      <info name="Port" value="1"/>
+                    </object>
+                    <object type="OSDev" gp_index="884" name="mlx5_2" osdev_type="3">
+                      <info name="NodeGUID" value="a088:c203:0009:704e"/>
+                      <info name="SysImageGUID" value="a088:c203:0009:704e"/>
+                      <info name="Port1State" value="1"/>
+                      <info name="Port1LID" value="0xffff"/>
+                      <info name="Port1LMC" value="0"/>
+                      <info name="Port1GID0" value="fe80:0000:0000:0000:a088:c203:0009:704e"/>
+                    </object>
+                  </object>
+                </object>
+                <object type="Bridge" gp_index="844" bridge_type="1-1" depth="3" bridge_pci="0000:[5f-5f]" pci_busid="0000:5b:03.0" pci_type="0604 [1000:c030] [1028:236b] b0" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="24"/>
+                  <object type="PCIDev" gp_index="860" pci_busid="0000:5f:00.0" pci_type="0302 [10de:2330] [10de:16c0] a1" pci_link_speed="63.015385">
+                    <object type="OSDev" gp_index="887" name="opencl0d1" subtype="OpenCL" osdev_type="5">
+                      <info name="Backend" value="OpenCL"/>
+                      <info name="OpenCLDeviceType" value="GPU"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="OpenCLPlatformIndex" value="0"/>
+                      <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
+                      <info name="OpenCLPlatformDeviceIndex" value="1"/>
+                      <info name="OpenCLComputeUnits" value="132"/>
+                      <info name="OpenCLGlobalMemorySize" value="83026944"/>
+                    </object>
+                    <object type="OSDev" gp_index="891" name="cuda1" subtype="CUDA" osdev_type="5">
+                      <info name="Backend" value="CUDA"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="CUDAGlobalMemorySize" value="83026944"/>
+                      <info name="CUDAL2CacheSize" value="51200"/>
+                      <info name="CUDAMultiProcessors" value="132"/>
+                      <info name="CUDACoresPerMP" value="128"/>
+                      <info name="CUDASharedMemorySizePerMP" value="48"/>
+                    </object>
+                    <object type="OSDev" gp_index="895" name="nvml1" subtype="NVML" osdev_type="1">
+                      <info name="Backend" value="NVML"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="NVIDIASerial" value="0000000000000"/>
+                      <info name="NVIDIAUUID" value="GPU-00000000-0000-0000-0000-000000000000"/>
+                    </object>
+                  </object>
+                </object>
+                <object type="Bridge" gp_index="825" bridge_type="1-1" depth="3" bridge_pci="0000:[60-60]" pci_busid="0000:5b:1f.0" pci_type="0604 [1000:c030] [1028:236b] b0" pci_link_speed="63.015385">
+                  <object type="PCIDev" gp_index="818" pci_busid="0000:60:00.0" pci_type="0107 [1000:00b2] [1028:236b] b0" pci_link_speed="63.015385"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Group" cpuset="0x03fff000,,,0x000003ff,0xf0000000" complete_cpuset="0x03fff000,,,0x000003ff,0xf0000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="802" kind="1001" subkind="0">
+          <object type="NUMANode" os_index="2" cpuset="0x03fff000,,,0x000003ff,0xf0000000" complete_cpuset="0x03fff000,,,0x000003ff,0xf0000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="794" local_memory="541157969920">
+            <page_type size="4096" count="132118645"/>
+            <page_type size="2097152" count="0"/>
+            <page_type size="1073741824" count="0"/>
+          </object>
+          <object type="L2Cache" os_index="28" cpuset="0x00001000,,,,0x10000000" complete_cpuset="0x00001000,,,,0x10000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="178" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="28" cpuset="0x00001000,,,,0x10000000" complete_cpuset="0x00001000,,,,0x10000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="176" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="28" cpuset="0x00001000,,,,0x10000000" complete_cpuset="0x00001000,,,,0x10000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="177" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x00001000,,,,0x10000000" complete_cpuset="0x00001000,,,,0x10000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="173">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="175"/>
+                  <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="708"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="29" cpuset="0x00002000,,,,0x20000000" complete_cpuset="0x00002000,,,,0x20000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="184" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="29" cpuset="0x00002000,,,,0x20000000" complete_cpuset="0x00002000,,,,0x20000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="182" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="29" cpuset="0x00002000,,,,0x20000000" complete_cpuset="0x00002000,,,,0x20000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="183" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x00002000,,,,0x20000000" complete_cpuset="0x00002000,,,,0x20000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="179">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="181"/>
+                  <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="709"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="30" cpuset="0x00004000,,,,0x40000000" complete_cpuset="0x00004000,,,,0x40000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="190" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="30" cpuset="0x00004000,,,,0x40000000" complete_cpuset="0x00004000,,,,0x40000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="188" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="30" cpuset="0x00004000,,,,0x40000000" complete_cpuset="0x00004000,,,,0x40000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="189" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x00004000,,,,0x40000000" complete_cpuset="0x00004000,,,,0x40000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="185">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="187"/>
+                  <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="710"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="31" cpuset="0x00008000,,,,0x80000000" complete_cpuset="0x00008000,,,,0x80000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="196" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="31" cpuset="0x00008000,,,,0x80000000" complete_cpuset="0x00008000,,,,0x80000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="194" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="31" cpuset="0x00008000,,,,0x80000000" complete_cpuset="0x00008000,,,,0x80000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="195" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="31" cpuset="0x00008000,,,,0x80000000" complete_cpuset="0x00008000,,,,0x80000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="191">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="193"/>
+                  <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="711"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="32" cpuset="0x00010000,,,0x00000001,0x0" complete_cpuset="0x00010000,,,0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="202" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="32" cpuset="0x00010000,,,0x00000001,0x0" complete_cpuset="0x00010000,,,0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="200" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="32" cpuset="0x00010000,,,0x00000001,0x0" complete_cpuset="0x00010000,,,0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="201" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="32" cpuset="0x00010000,,,0x00000001,0x0" complete_cpuset="0x00010000,,,0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="197">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="199"/>
+                  <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="712"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="33" cpuset="0x00020000,,,0x00000002,0x0" complete_cpuset="0x00020000,,,0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="208" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="33" cpuset="0x00020000,,,0x00000002,0x0" complete_cpuset="0x00020000,,,0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="206" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="33" cpuset="0x00020000,,,0x00000002,0x0" complete_cpuset="0x00020000,,,0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="207" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="33" cpuset="0x00020000,,,0x00000002,0x0" complete_cpuset="0x00020000,,,0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="203">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="205"/>
+                  <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="713"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="34" cpuset="0x00040000,,,0x00000004,0x0" complete_cpuset="0x00040000,,,0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="214" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="34" cpuset="0x00040000,,,0x00000004,0x0" complete_cpuset="0x00040000,,,0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="212" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="34" cpuset="0x00040000,,,0x00000004,0x0" complete_cpuset="0x00040000,,,0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="213" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="34" cpuset="0x00040000,,,0x00000004,0x0" complete_cpuset="0x00040000,,,0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="209">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="211"/>
+                  <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="714"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="35" cpuset="0x00080000,,,0x00000008,0x0" complete_cpuset="0x00080000,,,0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="220" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="35" cpuset="0x00080000,,,0x00000008,0x0" complete_cpuset="0x00080000,,,0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="218" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="35" cpuset="0x00080000,,,0x00000008,0x0" complete_cpuset="0x00080000,,,0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="219" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="35" cpuset="0x00080000,,,0x00000008,0x0" complete_cpuset="0x00080000,,,0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="215">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="217"/>
+                  <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="715"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="36" cpuset="0x00100000,,,0x00000010,0x0" complete_cpuset="0x00100000,,,0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="226" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="36" cpuset="0x00100000,,,0x00000010,0x0" complete_cpuset="0x00100000,,,0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="224" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="36" cpuset="0x00100000,,,0x00000010,0x0" complete_cpuset="0x00100000,,,0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="225" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="36" cpuset="0x00100000,,,0x00000010,0x0" complete_cpuset="0x00100000,,,0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="221">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="223"/>
+                  <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="716"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="37" cpuset="0x00200000,,,0x00000020,0x0" complete_cpuset="0x00200000,,,0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="232" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="37" cpuset="0x00200000,,,0x00000020,0x0" complete_cpuset="0x00200000,,,0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="230" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="37" cpuset="0x00200000,,,0x00000020,0x0" complete_cpuset="0x00200000,,,0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="231" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="37" cpuset="0x00200000,,,0x00000020,0x0" complete_cpuset="0x00200000,,,0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="227">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="229"/>
+                  <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="717"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="38" cpuset="0x00400000,,,0x00000040,0x0" complete_cpuset="0x00400000,,,0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="238" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="38" cpuset="0x00400000,,,0x00000040,0x0" complete_cpuset="0x00400000,,,0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="236" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="38" cpuset="0x00400000,,,0x00000040,0x0" complete_cpuset="0x00400000,,,0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="237" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="38" cpuset="0x00400000,,,0x00000040,0x0" complete_cpuset="0x00400000,,,0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="233">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="235"/>
+                  <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="718"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="39" cpuset="0x00800000,,,0x00000080,0x0" complete_cpuset="0x00800000,,,0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="244" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="39" cpuset="0x00800000,,,0x00000080,0x0" complete_cpuset="0x00800000,,,0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="242" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="39" cpuset="0x00800000,,,0x00000080,0x0" complete_cpuset="0x00800000,,,0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="243" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="39" cpuset="0x00800000,,,0x00000080,0x0" complete_cpuset="0x00800000,,,0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="239">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="241"/>
+                  <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="719"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="40" cpuset="0x01000000,,,0x00000100,0x0" complete_cpuset="0x01000000,,,0x00000100,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="250" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="40" cpuset="0x01000000,,,0x00000100,0x0" complete_cpuset="0x01000000,,,0x00000100,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="248" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="40" cpuset="0x01000000,,,0x00000100,0x0" complete_cpuset="0x01000000,,,0x00000100,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="249" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="40" cpuset="0x01000000,,,0x00000100,0x0" complete_cpuset="0x01000000,,,0x00000100,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="245">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="247"/>
+                  <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="720"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="41" cpuset="0x02000000,,,0x00000200,0x0" complete_cpuset="0x02000000,,,0x00000200,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="256" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="41" cpuset="0x02000000,,,0x00000200,0x0" complete_cpuset="0x02000000,,,0x00000200,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="254" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="41" cpuset="0x02000000,,,0x00000200,0x0" complete_cpuset="0x02000000,,,0x00000200,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="255" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="41" cpuset="0x02000000,,,0x00000200,0x0" complete_cpuset="0x02000000,,,0x00000200,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="251">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="253"/>
+                  <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="721"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Group" cpuset="0x000000ff,0xfc000000,,,0x00fffc00,0x0" complete_cpuset="0x000000ff,0xfc000000,,,0x00fffc00,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="803" kind="1001" subkind="0">
+          <object type="NUMANode" os_index="3" cpuset="0x000000ff,0xfc000000,,,0x00fffc00,0x0" complete_cpuset="0x000000ff,0xfc000000,,,0x00fffc00,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="795" local_memory="541157969920">
+            <page_type size="4096" count="132118645"/>
+            <page_type size="2097152" count="0"/>
+            <page_type size="1073741824" count="0"/>
+          </object>
+          <object type="L2Cache" os_index="42" cpuset="0x04000000,,,0x00000400,0x0" complete_cpuset="0x04000000,,,0x00000400,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="262" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="42" cpuset="0x04000000,,,0x00000400,0x0" complete_cpuset="0x04000000,,,0x00000400,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="260" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="42" cpuset="0x04000000,,,0x00000400,0x0" complete_cpuset="0x04000000,,,0x00000400,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="261" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="42" cpuset="0x04000000,,,0x00000400,0x0" complete_cpuset="0x04000000,,,0x00000400,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="257">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="259"/>
+                  <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="722"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="43" cpuset="0x08000000,,,0x00000800,0x0" complete_cpuset="0x08000000,,,0x00000800,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="268" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="43" cpuset="0x08000000,,,0x00000800,0x0" complete_cpuset="0x08000000,,,0x00000800,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="266" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="43" cpuset="0x08000000,,,0x00000800,0x0" complete_cpuset="0x08000000,,,0x00000800,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="267" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="43" cpuset="0x08000000,,,0x00000800,0x0" complete_cpuset="0x08000000,,,0x00000800,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="263">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="265"/>
+                  <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="723"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="44" cpuset="0x10000000,,,0x00001000,0x0" complete_cpuset="0x10000000,,,0x00001000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="274" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="44" cpuset="0x10000000,,,0x00001000,0x0" complete_cpuset="0x10000000,,,0x00001000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="272" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="44" cpuset="0x10000000,,,0x00001000,0x0" complete_cpuset="0x10000000,,,0x00001000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="273" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="44" cpuset="0x10000000,,,0x00001000,0x0" complete_cpuset="0x10000000,,,0x00001000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="269">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="271"/>
+                  <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="724"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="45" cpuset="0x20000000,,,0x00002000,0x0" complete_cpuset="0x20000000,,,0x00002000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="280" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="45" cpuset="0x20000000,,,0x00002000,0x0" complete_cpuset="0x20000000,,,0x00002000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="278" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="45" cpuset="0x20000000,,,0x00002000,0x0" complete_cpuset="0x20000000,,,0x00002000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="279" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="45" cpuset="0x20000000,,,0x00002000,0x0" complete_cpuset="0x20000000,,,0x00002000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="275">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="277"/>
+                  <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="725"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="46" cpuset="0x40000000,,,0x00004000,0x0" complete_cpuset="0x40000000,,,0x00004000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="286" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="46" cpuset="0x40000000,,,0x00004000,0x0" complete_cpuset="0x40000000,,,0x00004000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="284" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="46" cpuset="0x40000000,,,0x00004000,0x0" complete_cpuset="0x40000000,,,0x00004000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="285" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="46" cpuset="0x40000000,,,0x00004000,0x0" complete_cpuset="0x40000000,,,0x00004000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="281">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="283"/>
+                  <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="726"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="47" cpuset="0x80000000,,,0x00008000,0x0" complete_cpuset="0x80000000,,,0x00008000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="292" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="47" cpuset="0x80000000,,,0x00008000,0x0" complete_cpuset="0x80000000,,,0x00008000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="290" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="47" cpuset="0x80000000,,,0x00008000,0x0" complete_cpuset="0x80000000,,,0x00008000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="291" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="47" cpuset="0x80000000,,,0x00008000,0x0" complete_cpuset="0x80000000,,,0x00008000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="287">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="289"/>
+                  <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="727"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="48" cpuset="0x00000001,,,,0x00010000,0x0" complete_cpuset="0x00000001,,,,0x00010000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="298" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="48" cpuset="0x00000001,,,,0x00010000,0x0" complete_cpuset="0x00000001,,,,0x00010000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="296" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="48" cpuset="0x00000001,,,,0x00010000,0x0" complete_cpuset="0x00000001,,,,0x00010000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="297" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="48" cpuset="0x00000001,,,,0x00010000,0x0" complete_cpuset="0x00000001,,,,0x00010000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="293">
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="295"/>
+                  <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="728"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="49" cpuset="0x00000002,,,,0x00020000,0x0" complete_cpuset="0x00000002,,,,0x00020000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="304" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="49" cpuset="0x00000002,,,,0x00020000,0x0" complete_cpuset="0x00000002,,,,0x00020000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="302" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="49" cpuset="0x00000002,,,,0x00020000,0x0" complete_cpuset="0x00000002,,,,0x00020000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="303" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="49" cpuset="0x00000002,,,,0x00020000,0x0" complete_cpuset="0x00000002,,,,0x00020000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="299">
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="301"/>
+                  <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="729"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="50" cpuset="0x00000004,,,,0x00040000,0x0" complete_cpuset="0x00000004,,,,0x00040000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="310" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="50" cpuset="0x00000004,,,,0x00040000,0x0" complete_cpuset="0x00000004,,,,0x00040000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="308" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="50" cpuset="0x00000004,,,,0x00040000,0x0" complete_cpuset="0x00000004,,,,0x00040000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="309" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="50" cpuset="0x00000004,,,,0x00040000,0x0" complete_cpuset="0x00000004,,,,0x00040000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="305">
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="307"/>
+                  <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="730"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="51" cpuset="0x00000008,,,,0x00080000,0x0" complete_cpuset="0x00000008,,,,0x00080000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="316" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="51" cpuset="0x00000008,,,,0x00080000,0x0" complete_cpuset="0x00000008,,,,0x00080000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="314" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="51" cpuset="0x00000008,,,,0x00080000,0x0" complete_cpuset="0x00000008,,,,0x00080000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="315" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="51" cpuset="0x00000008,,,,0x00080000,0x0" complete_cpuset="0x00000008,,,,0x00080000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="311">
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="313"/>
+                  <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="731"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="52" cpuset="0x00000010,,,,0x00100000,0x0" complete_cpuset="0x00000010,,,,0x00100000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="322" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="52" cpuset="0x00000010,,,,0x00100000,0x0" complete_cpuset="0x00000010,,,,0x00100000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="320" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="52" cpuset="0x00000010,,,,0x00100000,0x0" complete_cpuset="0x00000010,,,,0x00100000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="321" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="52" cpuset="0x00000010,,,,0x00100000,0x0" complete_cpuset="0x00000010,,,,0x00100000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="317">
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="319"/>
+                  <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="732"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="53" cpuset="0x00000020,,,,0x00200000,0x0" complete_cpuset="0x00000020,,,,0x00200000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="328" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="53" cpuset="0x00000020,,,,0x00200000,0x0" complete_cpuset="0x00000020,,,,0x00200000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="326" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="53" cpuset="0x00000020,,,,0x00200000,0x0" complete_cpuset="0x00000020,,,,0x00200000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="327" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="53" cpuset="0x00000020,,,,0x00200000,0x0" complete_cpuset="0x00000020,,,,0x00200000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="323">
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="325"/>
+                  <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="733"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="54" cpuset="0x00000040,,,,0x00400000,0x0" complete_cpuset="0x00000040,,,,0x00400000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="334" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="54" cpuset="0x00000040,,,,0x00400000,0x0" complete_cpuset="0x00000040,,,,0x00400000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="332" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="54" cpuset="0x00000040,,,,0x00400000,0x0" complete_cpuset="0x00000040,,,,0x00400000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="333" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="54" cpuset="0x00000040,,,,0x00400000,0x0" complete_cpuset="0x00000040,,,,0x00400000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="329">
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="331"/>
+                  <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="734"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="55" cpuset="0x00000080,,,,0x00800000,0x0" complete_cpuset="0x00000080,,,,0x00800000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="340" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="55" cpuset="0x00000080,,,,0x00800000,0x0" complete_cpuset="0x00000080,,,,0x00800000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="338" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="55" cpuset="0x00000080,,,,0x00800000,0x0" complete_cpuset="0x00000080,,,,0x00800000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="339" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="55" cpuset="0x00000080,,,,0x00800000,0x0" complete_cpuset="0x00000080,,,,0x00800000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="335">
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="337"/>
+                  <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="735"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="864" bridge_type="0-1" depth="0" bridge_pci="0000:[48-4e]">
+            <object type="Bridge" gp_index="812" bridge_type="1-1" depth="1" bridge_pci="0000:[49-4e]" pci_busid="0000:48:01.0" pci_type="0604 [8086:352a] [8086:0000] 04" pci_link_speed="63.015385">
+              <object type="Bridge" gp_index="823" bridge_type="1-1" depth="2" bridge_pci="0000:[4a-4e]" pci_busid="0000:49:00.0" pci_type="0604 [1000:c030] [1028:236b] b0" pci_link_speed="63.015385">
+                <object type="Bridge" gp_index="836" bridge_type="1-1" depth="3" bridge_pci="0000:[4b-4b]" pci_busid="0000:4a:00.0" pci_type="0604 [1000:c030] [1028:236b] b0" pci_link_speed="7.876923">
+                  <object type="PCIDev" gp_index="828" pci_busid="0000:4b:00.0" pci_type="0108 [144d:a824] [1028:2127] 00" pci_link_speed="7.876923">
+                    <info name="PCISlot" value="167"/>
+                    <object type="OSDev" gp_index="874" name="nvme0c0n1" subtype="Disk" osdev_type="0">
+                      <info name="Size" value="1875374424"/>
+                      <info name="SectorSize" value="512"/>
+                    </object>
+                  </object>
+                </object>
+                <object type="Bridge" gp_index="856" bridge_type="1-1" depth="3" bridge_pci="0000:[4d-4d]" pci_busid="0000:4a:02.0" pci_type="0604 [1000:c030] [1028:236b] b0" pci_link_speed="31.507692">
+                  <info name="PCISlot" value="2"/>
+                  <object type="PCIDev" gp_index="862" pci_busid="0000:4d:00.0" pci_type="0207 [15b3:101b] [15b3:0008] 00" pci_link_speed="31.507692">
+                    <object type="OSDev" gp_index="879" name="hsi0" osdev_type="2">
+                      <info name="Address" value="00:00:10:47:fe:80:00:00:00:00:00:00:04:3f:72:03:00:ae:a2:82"/>
+                      <info name="Port" value="1"/>
+                    </object>
+                    <object type="OSDev" gp_index="885" name="mlx5_0" osdev_type="3">
+                      <info name="NodeGUID" value="043f:7203:00ae:a282"/>
+                      <info name="SysImageGUID" value="043f:7203:00ae:a282"/>
+                      <info name="Port1State" value="4"/>
+                      <info name="Port1LID" value="0xe"/>
+                      <info name="Port1LMC" value="0"/>
+                      <info name="Port1GID0" value="fe80:0000:0000:0000:043f:7203:00ae:a282"/>
+                    </object>
+                  </object>
+                  <object type="PCIDev" gp_index="834" pci_busid="0000:4d:00.1" pci_type="0207 [15b3:101b] [15b3:0008] 00" pci_link_speed="31.507692">
+                    <object type="OSDev" gp_index="876" name="ibs2f1" osdev_type="2">
+                      <info name="Address" value="00:00:11:47:fe:80:00:00:00:00:00:00:04:3f:72:03:00:ae:a2:83"/>
+                      <info name="Port" value="1"/>
+                    </object>
+                    <object type="OSDev" gp_index="883" name="mlx5_1" osdev_type="3">
+                      <info name="NodeGUID" value="043f:7203:00ae:a283"/>
+                      <info name="SysImageGUID" value="043f:7203:00ae:a282"/>
+                      <info name="Port1State" value="1"/>
+                      <info name="Port1LID" value="0xffff"/>
+                      <info name="Port1LMC" value="0"/>
+                      <info name="Port1GID0" value="fe80:0000:0000:0000:043f:7203:00ae:a283"/>
+                    </object>
+                  </object>
+                </object>
+                <object type="Bridge" gp_index="841" bridge_type="1-1" depth="3" bridge_pci="0000:[4e-4e]" pci_busid="0000:4a:03.0" pci_type="0604 [1000:c030] [1028:236b] b0" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="22"/>
+                  <object type="PCIDev" gp_index="855" pci_busid="0000:4e:00.0" pci_type="0302 [10de:2330] [10de:16c0] a1" pci_link_speed="63.015385">
+                    <object type="OSDev" gp_index="886" name="opencl0d0" subtype="OpenCL" osdev_type="5">
+                      <info name="Backend" value="OpenCL"/>
+                      <info name="OpenCLDeviceType" value="GPU"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="OpenCLPlatformIndex" value="0"/>
+                      <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
+                      <info name="OpenCLPlatformDeviceIndex" value="0"/>
+                      <info name="OpenCLComputeUnits" value="132"/>
+                      <info name="OpenCLGlobalMemorySize" value="83026944"/>
+                    </object>
+                    <object type="OSDev" gp_index="890" name="cuda0" subtype="CUDA" osdev_type="5">
+                      <info name="Backend" value="CUDA"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="CUDAGlobalMemorySize" value="83026944"/>
+                      <info name="CUDAL2CacheSize" value="51200"/>
+                      <info name="CUDAMultiProcessors" value="132"/>
+                      <info name="CUDACoresPerMP" value="128"/>
+                      <info name="CUDASharedMemorySizePerMP" value="48"/>
+                    </object>
+                    <object type="OSDev" gp_index="894" name="nvml0" subtype="NVML" osdev_type="1">
+                      <info name="Backend" value="NVML"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="NVIDIASerial" value="0000000000000"/>
+                      <info name="NVIDIAUUID" value="GPU-00000000-0000-0000-0000-000000000000"/>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0xffffffff,0xffffff00,,0x0000ffff,0xffffffff,0xff000000,0x0" complete_cpuset="0xffffffff,0xffffff00,,0x0000ffff,0xffffffff,0xff000000,0x0" nodeset="0x000000f0" complete_nodeset="0x000000f0" gp_index="342">
+      <info name="CPUVendor" value="GenuineIntel"/>
+      <info name="CPUFamilyNumber" value="6"/>
+      <info name="CPUModelNumber" value="143"/>
+      <info name="CPUModel" value="Intel(R) Xeon(R) Platinum 8480+"/>
+      <info name="CPUStepping" value="8"/>
+      <object type="L3Cache" os_index="1" cpuset="0xffffffff,0xffffff00,,0x0000ffff,0xffffffff,0xff000000,0x0" complete_cpuset="0xffffffff,0xffffff00,,0x0000ffff,0xffffffff,0xff000000,0x0" nodeset="0x000000f0" complete_nodeset="0x000000f0" gp_index="349" cache_size="110100480" depth="3" cache_linesize="64" cache_associativity="15" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="Group" cpuset="0x003fff00,,,0x0000003f,0xff000000,0x0" complete_cpuset="0x003fff00,,,0x0000003f,0xff000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="804" kind="1001" subkind="0">
+          <object type="NUMANode" os_index="4" cpuset="0x003fff00,,,0x0000003f,0xff000000,0x0" complete_cpuset="0x003fff00,,,0x0000003f,0xff000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="796" local_memory="541157969920">
+            <page_type size="4096" count="132118645"/>
+            <page_type size="2097152" count="0"/>
+            <page_type size="1073741824" count="0"/>
+          </object>
+          <object type="L2Cache" os_index="64" cpuset="0x00000100,,,,0x01000000,0x0" complete_cpuset="0x00000100,,,,0x01000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="348" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="64" cpuset="0x00000100,,,,0x01000000,0x0" complete_cpuset="0x00000100,,,,0x01000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="346" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="64" cpuset="0x00000100,,,,0x01000000,0x0" complete_cpuset="0x00000100,,,,0x01000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="347" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000100,,,,0x01000000,0x0" complete_cpuset="0x00000100,,,,0x01000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="341">
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="345"/>
+                  <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="736"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="65" cpuset="0x00000200,,,,0x02000000,0x0" complete_cpuset="0x00000200,,,,0x02000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="355" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="65" cpuset="0x00000200,,,,0x02000000,0x0" complete_cpuset="0x00000200,,,,0x02000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="353" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="65" cpuset="0x00000200,,,,0x02000000,0x0" complete_cpuset="0x00000200,,,,0x02000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="354" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000200,,,,0x02000000,0x0" complete_cpuset="0x00000200,,,,0x02000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="350">
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="352"/>
+                  <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="737"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="66" cpuset="0x00000400,,,,0x04000000,0x0" complete_cpuset="0x00000400,,,,0x04000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="361" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="66" cpuset="0x00000400,,,,0x04000000,0x0" complete_cpuset="0x00000400,,,,0x04000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="359" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="66" cpuset="0x00000400,,,,0x04000000,0x0" complete_cpuset="0x00000400,,,,0x04000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="360" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000400,,,,0x04000000,0x0" complete_cpuset="0x00000400,,,,0x04000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="356">
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="358"/>
+                  <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="738"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="67" cpuset="0x00000800,,,,0x08000000,0x0" complete_cpuset="0x00000800,,,,0x08000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="367" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="67" cpuset="0x00000800,,,,0x08000000,0x0" complete_cpuset="0x00000800,,,,0x08000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="365" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="67" cpuset="0x00000800,,,,0x08000000,0x0" complete_cpuset="0x00000800,,,,0x08000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="366" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00000800,,,,0x08000000,0x0" complete_cpuset="0x00000800,,,,0x08000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="362">
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="364"/>
+                  <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="739"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="68" cpuset="0x00001000,,,,0x10000000,0x0" complete_cpuset="0x00001000,,,,0x10000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="373" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="68" cpuset="0x00001000,,,,0x10000000,0x0" complete_cpuset="0x00001000,,,,0x10000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="371" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="68" cpuset="0x00001000,,,,0x10000000,0x0" complete_cpuset="0x00001000,,,,0x10000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="372" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00001000,,,,0x10000000,0x0" complete_cpuset="0x00001000,,,,0x10000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="368">
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="370"/>
+                  <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="740"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="69" cpuset="0x00002000,,,,0x20000000,0x0" complete_cpuset="0x00002000,,,,0x20000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="379" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="69" cpuset="0x00002000,,,,0x20000000,0x0" complete_cpuset="0x00002000,,,,0x20000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="377" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="69" cpuset="0x00002000,,,,0x20000000,0x0" complete_cpuset="0x00002000,,,,0x20000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="378" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00002000,,,,0x20000000,0x0" complete_cpuset="0x00002000,,,,0x20000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="374">
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="376"/>
+                  <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="741"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="70" cpuset="0x00004000,,,,0x40000000,0x0" complete_cpuset="0x00004000,,,,0x40000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="385" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="70" cpuset="0x00004000,,,,0x40000000,0x0" complete_cpuset="0x00004000,,,,0x40000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="383" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="70" cpuset="0x00004000,,,,0x40000000,0x0" complete_cpuset="0x00004000,,,,0x40000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="384" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00004000,,,,0x40000000,0x0" complete_cpuset="0x00004000,,,,0x40000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="380">
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="382"/>
+                  <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="742"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="71" cpuset="0x00008000,,,,0x80000000,0x0" complete_cpuset="0x00008000,,,,0x80000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="391" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="71" cpuset="0x00008000,,,,0x80000000,0x0" complete_cpuset="0x00008000,,,,0x80000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="389" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="71" cpuset="0x00008000,,,,0x80000000,0x0" complete_cpuset="0x00008000,,,,0x80000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="390" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x00008000,,,,0x80000000,0x0" complete_cpuset="0x00008000,,,,0x80000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="386">
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="388"/>
+                  <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="743"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="72" cpuset="0x00010000,,,0x00000001,,0x0" complete_cpuset="0x00010000,,,0x00000001,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="397" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="72" cpuset="0x00010000,,,0x00000001,,0x0" complete_cpuset="0x00010000,,,0x00000001,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="395" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="72" cpuset="0x00010000,,,0x00000001,,0x0" complete_cpuset="0x00010000,,,0x00000001,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="396" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00010000,,,0x00000001,,0x0" complete_cpuset="0x00010000,,,0x00000001,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="392">
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="394"/>
+                  <object type="PU" os_index="176" cpuset="0x00010000,,,,,0x0" complete_cpuset="0x00010000,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="744"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="73" cpuset="0x00020000,,,0x00000002,,0x0" complete_cpuset="0x00020000,,,0x00000002,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="403" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="73" cpuset="0x00020000,,,0x00000002,,0x0" complete_cpuset="0x00020000,,,0x00000002,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="401" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="73" cpuset="0x00020000,,,0x00000002,,0x0" complete_cpuset="0x00020000,,,0x00000002,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="402" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00020000,,,0x00000002,,0x0" complete_cpuset="0x00020000,,,0x00000002,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="398">
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="400"/>
+                  <object type="PU" os_index="177" cpuset="0x00020000,,,,,0x0" complete_cpuset="0x00020000,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="745"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="74" cpuset="0x00040000,,,0x00000004,,0x0" complete_cpuset="0x00040000,,,0x00000004,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="409" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="74" cpuset="0x00040000,,,0x00000004,,0x0" complete_cpuset="0x00040000,,,0x00000004,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="407" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="74" cpuset="0x00040000,,,0x00000004,,0x0" complete_cpuset="0x00040000,,,0x00000004,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="408" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00040000,,,0x00000004,,0x0" complete_cpuset="0x00040000,,,0x00000004,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="404">
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="406"/>
+                  <object type="PU" os_index="178" cpuset="0x00040000,,,,,0x0" complete_cpuset="0x00040000,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="746"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="75" cpuset="0x00080000,,,0x00000008,,0x0" complete_cpuset="0x00080000,,,0x00000008,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="415" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="75" cpuset="0x00080000,,,0x00000008,,0x0" complete_cpuset="0x00080000,,,0x00000008,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="413" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="75" cpuset="0x00080000,,,0x00000008,,0x0" complete_cpuset="0x00080000,,,0x00000008,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="414" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x00080000,,,0x00000008,,0x0" complete_cpuset="0x00080000,,,0x00000008,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="410">
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="412"/>
+                  <object type="PU" os_index="179" cpuset="0x00080000,,,,,0x0" complete_cpuset="0x00080000,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="747"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="76" cpuset="0x00100000,,,0x00000010,,0x0" complete_cpuset="0x00100000,,,0x00000010,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="421" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="76" cpuset="0x00100000,,,0x00000010,,0x0" complete_cpuset="0x00100000,,,0x00000010,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="419" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="76" cpuset="0x00100000,,,0x00000010,,0x0" complete_cpuset="0x00100000,,,0x00000010,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="420" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00100000,,,0x00000010,,0x0" complete_cpuset="0x00100000,,,0x00000010,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="416">
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="418"/>
+                  <object type="PU" os_index="180" cpuset="0x00100000,,,,,0x0" complete_cpuset="0x00100000,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="748"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="77" cpuset="0x00200000,,,0x00000020,,0x0" complete_cpuset="0x00200000,,,0x00000020,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="427" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="77" cpuset="0x00200000,,,0x00000020,,0x0" complete_cpuset="0x00200000,,,0x00000020,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="425" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="77" cpuset="0x00200000,,,0x00000020,,0x0" complete_cpuset="0x00200000,,,0x00000020,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="426" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00200000,,,0x00000020,,0x0" complete_cpuset="0x00200000,,,0x00000020,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="422">
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="424"/>
+                  <object type="PU" os_index="181" cpuset="0x00200000,,,,,0x0" complete_cpuset="0x00200000,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="749"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="871" bridge_type="0-1" depth="0" bridge_pci="0000:[e8-e8]">
+            <object type="PCIDev" gp_index="854" pci_busid="0000:e8:00.0" pci_type="0b40 [8086:4940] [8086:0000] 40" pci_link_speed="0.000000"/>
+          </object>
+          <object type="Bridge" gp_index="872" bridge_type="0-1" depth="0" bridge_pci="0000:[ea-ea]">
+            <object type="PCIDev" gp_index="858" pci_busid="0000:ea:00.0" pci_type="0b40 [8086:2710] [8086:0000] 00" pci_link_speed="0.000000"/>
+          </object>
+        </object>
+        <object type="Group" cpuset="0x0000000f,0xffc00000,,,0x000fffc0,,0x0" complete_cpuset="0x0000000f,0xffc00000,,,0x000fffc0,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="805" kind="1001" subkind="0">
+          <object type="NUMANode" os_index="5" cpuset="0x0000000f,0xffc00000,,,0x000fffc0,,0x0" complete_cpuset="0x0000000f,0xffc00000,,,0x000fffc0,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="797" local_memory="541157969920">
+            <page_type size="4096" count="132118645"/>
+            <page_type size="2097152" count="0"/>
+            <page_type size="1073741824" count="0"/>
+          </object>
+          <object type="L2Cache" os_index="78" cpuset="0x00400000,,,0x00000040,,0x0" complete_cpuset="0x00400000,,,0x00000040,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="433" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="78" cpuset="0x00400000,,,0x00000040,,0x0" complete_cpuset="0x00400000,,,0x00000040,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="431" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="78" cpuset="0x00400000,,,0x00000040,,0x0" complete_cpuset="0x00400000,,,0x00000040,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="432" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00400000,,,0x00000040,,0x0" complete_cpuset="0x00400000,,,0x00000040,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="428">
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="430"/>
+                  <object type="PU" os_index="182" cpuset="0x00400000,,,,,0x0" complete_cpuset="0x00400000,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="750"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="79" cpuset="0x00800000,,,0x00000080,,0x0" complete_cpuset="0x00800000,,,0x00000080,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="439" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="79" cpuset="0x00800000,,,0x00000080,,0x0" complete_cpuset="0x00800000,,,0x00000080,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="437" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="79" cpuset="0x00800000,,,0x00000080,,0x0" complete_cpuset="0x00800000,,,0x00000080,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="438" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="15" cpuset="0x00800000,,,0x00000080,,0x0" complete_cpuset="0x00800000,,,0x00000080,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="434">
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="436"/>
+                  <object type="PU" os_index="183" cpuset="0x00800000,,,,,0x0" complete_cpuset="0x00800000,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="751"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="80" cpuset="0x01000000,,,0x00000100,,0x0" complete_cpuset="0x01000000,,,0x00000100,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="445" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="80" cpuset="0x01000000,,,0x00000100,,0x0" complete_cpuset="0x01000000,,,0x00000100,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="443" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="80" cpuset="0x01000000,,,0x00000100,,0x0" complete_cpuset="0x01000000,,,0x00000100,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="444" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x01000000,,,0x00000100,,0x0" complete_cpuset="0x01000000,,,0x00000100,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="440">
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="442"/>
+                  <object type="PU" os_index="184" cpuset="0x01000000,,,,,0x0" complete_cpuset="0x01000000,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="752"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="81" cpuset="0x02000000,,,0x00000200,,0x0" complete_cpuset="0x02000000,,,0x00000200,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="451" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="81" cpuset="0x02000000,,,0x00000200,,0x0" complete_cpuset="0x02000000,,,0x00000200,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="449" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="81" cpuset="0x02000000,,,0x00000200,,0x0" complete_cpuset="0x02000000,,,0x00000200,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="450" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x02000000,,,0x00000200,,0x0" complete_cpuset="0x02000000,,,0x00000200,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="446">
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="448"/>
+                  <object type="PU" os_index="185" cpuset="0x02000000,,,,,0x0" complete_cpuset="0x02000000,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="753"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="82" cpuset="0x04000000,,,0x00000400,,0x0" complete_cpuset="0x04000000,,,0x00000400,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="457" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="82" cpuset="0x04000000,,,0x00000400,,0x0" complete_cpuset="0x04000000,,,0x00000400,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="455" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="82" cpuset="0x04000000,,,0x00000400,,0x0" complete_cpuset="0x04000000,,,0x00000400,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="456" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x04000000,,,0x00000400,,0x0" complete_cpuset="0x04000000,,,0x00000400,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="452">
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="454"/>
+                  <object type="PU" os_index="186" cpuset="0x04000000,,,,,0x0" complete_cpuset="0x04000000,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="754"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="83" cpuset="0x08000000,,,0x00000800,,0x0" complete_cpuset="0x08000000,,,0x00000800,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="463" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="83" cpuset="0x08000000,,,0x00000800,,0x0" complete_cpuset="0x08000000,,,0x00000800,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="461" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="83" cpuset="0x08000000,,,0x00000800,,0x0" complete_cpuset="0x08000000,,,0x00000800,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="462" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x08000000,,,0x00000800,,0x0" complete_cpuset="0x08000000,,,0x00000800,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="458">
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="460"/>
+                  <object type="PU" os_index="187" cpuset="0x08000000,,,,,0x0" complete_cpuset="0x08000000,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="755"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="84" cpuset="0x10000000,,,0x00001000,,0x0" complete_cpuset="0x10000000,,,0x00001000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="469" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="84" cpuset="0x10000000,,,0x00001000,,0x0" complete_cpuset="0x10000000,,,0x00001000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="467" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="84" cpuset="0x10000000,,,0x00001000,,0x0" complete_cpuset="0x10000000,,,0x00001000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="468" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x10000000,,,0x00001000,,0x0" complete_cpuset="0x10000000,,,0x00001000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="464">
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="466"/>
+                  <object type="PU" os_index="188" cpuset="0x10000000,,,,,0x0" complete_cpuset="0x10000000,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="756"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="85" cpuset="0x20000000,,,0x00002000,,0x0" complete_cpuset="0x20000000,,,0x00002000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="475" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="85" cpuset="0x20000000,,,0x00002000,,0x0" complete_cpuset="0x20000000,,,0x00002000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="473" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="85" cpuset="0x20000000,,,0x00002000,,0x0" complete_cpuset="0x20000000,,,0x00002000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="474" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x20000000,,,0x00002000,,0x0" complete_cpuset="0x20000000,,,0x00002000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="470">
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="472"/>
+                  <object type="PU" os_index="189" cpuset="0x20000000,,,,,0x0" complete_cpuset="0x20000000,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="757"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="86" cpuset="0x40000000,,,0x00004000,,0x0" complete_cpuset="0x40000000,,,0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="481" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="86" cpuset="0x40000000,,,0x00004000,,0x0" complete_cpuset="0x40000000,,,0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="479" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="86" cpuset="0x40000000,,,0x00004000,,0x0" complete_cpuset="0x40000000,,,0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="480" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x40000000,,,0x00004000,,0x0" complete_cpuset="0x40000000,,,0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="476">
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="478"/>
+                  <object type="PU" os_index="190" cpuset="0x40000000,,,,,0x0" complete_cpuset="0x40000000,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="758"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="87" cpuset="0x80000000,,,0x00008000,,0x0" complete_cpuset="0x80000000,,,0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="487" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="87" cpuset="0x80000000,,,0x00008000,,0x0" complete_cpuset="0x80000000,,,0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="485" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="87" cpuset="0x80000000,,,0x00008000,,0x0" complete_cpuset="0x80000000,,,0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="486" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="23" cpuset="0x80000000,,,0x00008000,,0x0" complete_cpuset="0x80000000,,,0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="482">
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="484"/>
+                  <object type="PU" os_index="191" cpuset="0x80000000,,,,,0x0" complete_cpuset="0x80000000,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="759"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="88" cpuset="0x00000001,,,,0x00010000,,0x0" complete_cpuset="0x00000001,,,,0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="493" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="88" cpuset="0x00000001,,,,0x00010000,,0x0" complete_cpuset="0x00000001,,,,0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="491" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="88" cpuset="0x00000001,,,,0x00010000,,0x0" complete_cpuset="0x00000001,,,,0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="492" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x00000001,,,,0x00010000,,0x0" complete_cpuset="0x00000001,,,,0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="488">
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="490"/>
+                  <object type="PU" os_index="192" cpuset="0x00000001,,,,,,0x0" complete_cpuset="0x00000001,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="760"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="89" cpuset="0x00000002,,,,0x00020000,,0x0" complete_cpuset="0x00000002,,,,0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="499" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="89" cpuset="0x00000002,,,,0x00020000,,0x0" complete_cpuset="0x00000002,,,,0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="497" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="89" cpuset="0x00000002,,,,0x00020000,,0x0" complete_cpuset="0x00000002,,,,0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="498" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x00000002,,,,0x00020000,,0x0" complete_cpuset="0x00000002,,,,0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="494">
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="496"/>
+                  <object type="PU" os_index="193" cpuset="0x00000002,,,,,,0x0" complete_cpuset="0x00000002,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="761"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="90" cpuset="0x00000004,,,,0x00040000,,0x0" complete_cpuset="0x00000004,,,,0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="505" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="90" cpuset="0x00000004,,,,0x00040000,,0x0" complete_cpuset="0x00000004,,,,0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="503" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="90" cpuset="0x00000004,,,,0x00040000,,0x0" complete_cpuset="0x00000004,,,,0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="504" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x00000004,,,,0x00040000,,0x0" complete_cpuset="0x00000004,,,,0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="500">
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="502"/>
+                  <object type="PU" os_index="194" cpuset="0x00000004,,,,,,0x0" complete_cpuset="0x00000004,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="762"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="91" cpuset="0x00000008,,,,0x00080000,,0x0" complete_cpuset="0x00000008,,,,0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="511" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="91" cpuset="0x00000008,,,,0x00080000,,0x0" complete_cpuset="0x00000008,,,,0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="509" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="91" cpuset="0x00000008,,,,0x00080000,,0x0" complete_cpuset="0x00000008,,,,0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="510" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="27" cpuset="0x00000008,,,,0x00080000,,0x0" complete_cpuset="0x00000008,,,,0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="506">
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="508"/>
+                  <object type="PU" os_index="195" cpuset="0x00000008,,,,,,0x0" complete_cpuset="0x00000008,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="763"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="870" bridge_type="0-1" depth="0" bridge_pci="0000:[d7-dd]">
+            <object type="Bridge" gp_index="831" bridge_type="1-1" depth="1" bridge_pci="0000:[d8-dd]" pci_busid="0000:d7:01.0" pci_type="0604 [8086:352a] [8086:0000] 04" pci_link_speed="63.015385">
+              <object type="Bridge" gp_index="839" bridge_type="1-1" depth="2" bridge_pci="0000:[d9-dd]" pci_busid="0000:d8:00.0" pci_type="0604 [1000:c030] [1028:236c] b0" pci_link_speed="63.015385">
+                <object type="Bridge" gp_index="830" bridge_type="1-1" depth="3" bridge_pci="0000:[da-da]" pci_busid="0000:d9:00.0" pci_type="0604 [1000:c030] [1028:236c] b0" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="3"/>
+                  <object type="PCIDev" gp_index="843" pci_busid="0000:da:00.0" pci_type="0207 [15b3:1021] [15b3:0041] 00" pci_link_speed="63.015385">
+                    <object type="OSDev" gp_index="877" name="ibp218s0" osdev_type="2">
+                      <info name="Address" value="00:00:10:47:fe:80:00:00:00:00:00:00:a0:88:c2:03:00:09:70:12"/>
+                      <info name="Port" value="1"/>
+                    </object>
+                    <object type="OSDev" gp_index="882" name="mlx5_3" osdev_type="3">
+                      <info name="NodeGUID" value="a088:c203:0009:7012"/>
+                      <info name="SysImageGUID" value="a088:c203:0009:7012"/>
+                      <info name="Port1State" value="1"/>
+                      <info name="Port1LID" value="0xffff"/>
+                      <info name="Port1LMC" value="0"/>
+                      <info name="Port1GID0" value="fe80:0000:0000:0000:a088:c203:0009:7012"/>
+                    </object>
+                  </object>
+                </object>
+                <object type="Bridge" gp_index="813" bridge_type="1-1" depth="3" bridge_pci="0000:[db-db]" pci_busid="0000:d9:01.0" pci_type="0604 [1000:c030] [1028:236c] b0" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="21"/>
+                  <object type="PCIDev" gp_index="837" pci_busid="0000:db:00.0" pci_type="0302 [10de:2330] [10de:16c0] a1" pci_link_speed="63.015385">
+                    <object type="OSDev" gp_index="889" name="opencl0d3" subtype="OpenCL" osdev_type="5">
+                      <info name="Backend" value="OpenCL"/>
+                      <info name="OpenCLDeviceType" value="GPU"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="OpenCLPlatformIndex" value="0"/>
+                      <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
+                      <info name="OpenCLPlatformDeviceIndex" value="3"/>
+                      <info name="OpenCLComputeUnits" value="132"/>
+                      <info name="OpenCLGlobalMemorySize" value="83026944"/>
+                    </object>
+                    <object type="OSDev" gp_index="893" name="cuda3" subtype="CUDA" osdev_type="5">
+                      <info name="Backend" value="CUDA"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="CUDAGlobalMemorySize" value="83026944"/>
+                      <info name="CUDAL2CacheSize" value="51200"/>
+                      <info name="CUDAMultiProcessors" value="132"/>
+                      <info name="CUDACoresPerMP" value="128"/>
+                      <info name="CUDASharedMemorySizePerMP" value="48"/>
+                    </object>
+                    <object type="OSDev" gp_index="897" name="nvml3" subtype="NVML" osdev_type="1">
+                      <info name="Backend" value="NVML"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="NVIDIASerial" value="0000000000000"/>
+                      <info name="NVIDIAUUID" value="GPU-00000000-0000-0000-0000-000000000000"/>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Group" cpuset="0x0003fff0,,,0x00000003,0xfff00000,,0x0" complete_cpuset="0x0003fff0,,,0x00000003,0xfff00000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="806" kind="1001" subkind="0">
+          <object type="NUMANode" os_index="6" cpuset="0x0003fff0,,,0x00000003,0xfff00000,,0x0" complete_cpuset="0x0003fff0,,,0x00000003,0xfff00000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="798" local_memory="541109977088">
+            <page_type size="4096" count="132106928"/>
+            <page_type size="2097152" count="0"/>
+            <page_type size="1073741824" count="0"/>
+          </object>
+          <object type="L2Cache" os_index="92" cpuset="0x00000010,,,,0x00100000,,0x0" complete_cpuset="0x00000010,,,,0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="517" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="92" cpuset="0x00000010,,,,0x00100000,,0x0" complete_cpuset="0x00000010,,,,0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="515" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="92" cpuset="0x00000010,,,,0x00100000,,0x0" complete_cpuset="0x00000010,,,,0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="516" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x00000010,,,,0x00100000,,0x0" complete_cpuset="0x00000010,,,,0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="512">
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="514"/>
+                  <object type="PU" os_index="196" cpuset="0x00000010,,,,,,0x0" complete_cpuset="0x00000010,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="764"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="93" cpuset="0x00000020,,,,0x00200000,,0x0" complete_cpuset="0x00000020,,,,0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="523" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="93" cpuset="0x00000020,,,,0x00200000,,0x0" complete_cpuset="0x00000020,,,,0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="521" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="93" cpuset="0x00000020,,,,0x00200000,,0x0" complete_cpuset="0x00000020,,,,0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="522" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x00000020,,,,0x00200000,,0x0" complete_cpuset="0x00000020,,,,0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="518">
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="520"/>
+                  <object type="PU" os_index="197" cpuset="0x00000020,,,,,,0x0" complete_cpuset="0x00000020,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="765"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="94" cpuset="0x00000040,,,,0x00400000,,0x0" complete_cpuset="0x00000040,,,,0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="529" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="94" cpuset="0x00000040,,,,0x00400000,,0x0" complete_cpuset="0x00000040,,,,0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="527" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="94" cpuset="0x00000040,,,,0x00400000,,0x0" complete_cpuset="0x00000040,,,,0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="528" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x00000040,,,,0x00400000,,0x0" complete_cpuset="0x00000040,,,,0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="524">
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="526"/>
+                  <object type="PU" os_index="198" cpuset="0x00000040,,,,,,0x0" complete_cpuset="0x00000040,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="766"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="95" cpuset="0x00000080,,,,0x00800000,,0x0" complete_cpuset="0x00000080,,,,0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="535" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="95" cpuset="0x00000080,,,,0x00800000,,0x0" complete_cpuset="0x00000080,,,,0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="533" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="95" cpuset="0x00000080,,,,0x00800000,,0x0" complete_cpuset="0x00000080,,,,0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="534" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="31" cpuset="0x00000080,,,,0x00800000,,0x0" complete_cpuset="0x00000080,,,,0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="530">
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="532"/>
+                  <object type="PU" os_index="199" cpuset="0x00000080,,,,,,0x0" complete_cpuset="0x00000080,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="767"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="96" cpuset="0x00000100,,,,0x01000000,,0x0" complete_cpuset="0x00000100,,,,0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="541" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="96" cpuset="0x00000100,,,,0x01000000,,0x0" complete_cpuset="0x00000100,,,,0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="539" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="96" cpuset="0x00000100,,,,0x01000000,,0x0" complete_cpuset="0x00000100,,,,0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="540" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="32" cpuset="0x00000100,,,,0x01000000,,0x0" complete_cpuset="0x00000100,,,,0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="536">
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="538"/>
+                  <object type="PU" os_index="200" cpuset="0x00000100,,,,,,0x0" complete_cpuset="0x00000100,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="768"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="97" cpuset="0x00000200,,,,0x02000000,,0x0" complete_cpuset="0x00000200,,,,0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="547" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="97" cpuset="0x00000200,,,,0x02000000,,0x0" complete_cpuset="0x00000200,,,,0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="545" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="97" cpuset="0x00000200,,,,0x02000000,,0x0" complete_cpuset="0x00000200,,,,0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="546" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="33" cpuset="0x00000200,,,,0x02000000,,0x0" complete_cpuset="0x00000200,,,,0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="542">
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="544"/>
+                  <object type="PU" os_index="201" cpuset="0x00000200,,,,,,0x0" complete_cpuset="0x00000200,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="769"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="98" cpuset="0x00000400,,,,0x04000000,,0x0" complete_cpuset="0x00000400,,,,0x04000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="553" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="98" cpuset="0x00000400,,,,0x04000000,,0x0" complete_cpuset="0x00000400,,,,0x04000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="551" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="98" cpuset="0x00000400,,,,0x04000000,,0x0" complete_cpuset="0x00000400,,,,0x04000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="552" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="34" cpuset="0x00000400,,,,0x04000000,,0x0" complete_cpuset="0x00000400,,,,0x04000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="548">
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="550"/>
+                  <object type="PU" os_index="202" cpuset="0x00000400,,,,,,0x0" complete_cpuset="0x00000400,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="770"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="99" cpuset="0x00000800,,,,0x08000000,,0x0" complete_cpuset="0x00000800,,,,0x08000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="559" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="99" cpuset="0x00000800,,,,0x08000000,,0x0" complete_cpuset="0x00000800,,,,0x08000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="557" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="99" cpuset="0x00000800,,,,0x08000000,,0x0" complete_cpuset="0x00000800,,,,0x08000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="558" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="35" cpuset="0x00000800,,,,0x08000000,,0x0" complete_cpuset="0x00000800,,,,0x08000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="554">
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="556"/>
+                  <object type="PU" os_index="203" cpuset="0x00000800,,,,,,0x0" complete_cpuset="0x00000800,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="771"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="100" cpuset="0x00001000,,,,0x10000000,,0x0" complete_cpuset="0x00001000,,,,0x10000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="565" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="100" cpuset="0x00001000,,,,0x10000000,,0x0" complete_cpuset="0x00001000,,,,0x10000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="563" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="100" cpuset="0x00001000,,,,0x10000000,,0x0" complete_cpuset="0x00001000,,,,0x10000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="564" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="36" cpuset="0x00001000,,,,0x10000000,,0x0" complete_cpuset="0x00001000,,,,0x10000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="560">
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="562"/>
+                  <object type="PU" os_index="204" cpuset="0x00001000,,,,,,0x0" complete_cpuset="0x00001000,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="772"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="101" cpuset="0x00002000,,,,0x20000000,,0x0" complete_cpuset="0x00002000,,,,0x20000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="571" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="101" cpuset="0x00002000,,,,0x20000000,,0x0" complete_cpuset="0x00002000,,,,0x20000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="569" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="101" cpuset="0x00002000,,,,0x20000000,,0x0" complete_cpuset="0x00002000,,,,0x20000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="570" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="37" cpuset="0x00002000,,,,0x20000000,,0x0" complete_cpuset="0x00002000,,,,0x20000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="566">
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="568"/>
+                  <object type="PU" os_index="205" cpuset="0x00002000,,,,,,0x0" complete_cpuset="0x00002000,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="773"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="102" cpuset="0x00004000,,,,0x40000000,,0x0" complete_cpuset="0x00004000,,,,0x40000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="577" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="102" cpuset="0x00004000,,,,0x40000000,,0x0" complete_cpuset="0x00004000,,,,0x40000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="575" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="102" cpuset="0x00004000,,,,0x40000000,,0x0" complete_cpuset="0x00004000,,,,0x40000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="576" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="38" cpuset="0x00004000,,,,0x40000000,,0x0" complete_cpuset="0x00004000,,,,0x40000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="572">
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="574"/>
+                  <object type="PU" os_index="206" cpuset="0x00004000,,,,,,0x0" complete_cpuset="0x00004000,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="774"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="103" cpuset="0x00008000,,,,0x80000000,,0x0" complete_cpuset="0x00008000,,,,0x80000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="583" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="103" cpuset="0x00008000,,,,0x80000000,,0x0" complete_cpuset="0x00008000,,,,0x80000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="581" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="103" cpuset="0x00008000,,,,0x80000000,,0x0" complete_cpuset="0x00008000,,,,0x80000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="582" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="39" cpuset="0x00008000,,,,0x80000000,,0x0" complete_cpuset="0x00008000,,,,0x80000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="578">
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="580"/>
+                  <object type="PU" os_index="207" cpuset="0x00008000,,,,,,0x0" complete_cpuset="0x00008000,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="775"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="104" cpuset="0x00010000,,,0x00000001,,,0x0" complete_cpuset="0x00010000,,,0x00000001,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="589" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="104" cpuset="0x00010000,,,0x00000001,,,0x0" complete_cpuset="0x00010000,,,0x00000001,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="587" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="104" cpuset="0x00010000,,,0x00000001,,,0x0" complete_cpuset="0x00010000,,,0x00000001,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="588" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="40" cpuset="0x00010000,,,0x00000001,,,0x0" complete_cpuset="0x00010000,,,0x00000001,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="584">
+                  <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="586"/>
+                  <object type="PU" os_index="208" cpuset="0x00010000,,,,,,0x0" complete_cpuset="0x00010000,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="776"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="105" cpuset="0x00020000,,,0x00000002,,,0x0" complete_cpuset="0x00020000,,,0x00000002,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="595" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="105" cpuset="0x00020000,,,0x00000002,,,0x0" complete_cpuset="0x00020000,,,0x00000002,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="593" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="105" cpuset="0x00020000,,,0x00000002,,,0x0" complete_cpuset="0x00020000,,,0x00000002,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="594" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="41" cpuset="0x00020000,,,0x00000002,,,0x0" complete_cpuset="0x00020000,,,0x00000002,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="590">
+                  <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="592"/>
+                  <object type="PU" os_index="209" cpuset="0x00020000,,,,,,0x0" complete_cpuset="0x00020000,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="777"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Group" cpuset="0xfffc0000,,,0x0000fffc,,,0x0" complete_cpuset="0xfffc0000,,,0x0000fffc,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="807" kind="1001" subkind="0">
+          <object type="NUMANode" os_index="7" cpuset="0xfffc0000,,,0x0000fffc,,,0x0" complete_cpuset="0xfffc0000,,,0x0000fffc,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="799" local_memory="541141471232">
+            <page_type size="4096" count="132114617"/>
+            <page_type size="2097152" count="0"/>
+            <page_type size="1073741824" count="0"/>
+          </object>
+          <object type="L2Cache" os_index="106" cpuset="0x00040000,,,0x00000004,,,0x0" complete_cpuset="0x00040000,,,0x00000004,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="601" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="106" cpuset="0x00040000,,,0x00000004,,,0x0" complete_cpuset="0x00040000,,,0x00000004,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="599" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="106" cpuset="0x00040000,,,0x00000004,,,0x0" complete_cpuset="0x00040000,,,0x00000004,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="600" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="42" cpuset="0x00040000,,,0x00000004,,,0x0" complete_cpuset="0x00040000,,,0x00000004,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="596">
+                  <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="598"/>
+                  <object type="PU" os_index="210" cpuset="0x00040000,,,,,,0x0" complete_cpuset="0x00040000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="778"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="107" cpuset="0x00080000,,,0x00000008,,,0x0" complete_cpuset="0x00080000,,,0x00000008,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="607" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="107" cpuset="0x00080000,,,0x00000008,,,0x0" complete_cpuset="0x00080000,,,0x00000008,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="605" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="107" cpuset="0x00080000,,,0x00000008,,,0x0" complete_cpuset="0x00080000,,,0x00000008,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="606" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="43" cpuset="0x00080000,,,0x00000008,,,0x0" complete_cpuset="0x00080000,,,0x00000008,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="602">
+                  <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="604"/>
+                  <object type="PU" os_index="211" cpuset="0x00080000,,,,,,0x0" complete_cpuset="0x00080000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="779"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="108" cpuset="0x00100000,,,0x00000010,,,0x0" complete_cpuset="0x00100000,,,0x00000010,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="613" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="108" cpuset="0x00100000,,,0x00000010,,,0x0" complete_cpuset="0x00100000,,,0x00000010,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="611" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="108" cpuset="0x00100000,,,0x00000010,,,0x0" complete_cpuset="0x00100000,,,0x00000010,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="612" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="44" cpuset="0x00100000,,,0x00000010,,,0x0" complete_cpuset="0x00100000,,,0x00000010,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="608">
+                  <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="610"/>
+                  <object type="PU" os_index="212" cpuset="0x00100000,,,,,,0x0" complete_cpuset="0x00100000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="780"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="109" cpuset="0x00200000,,,0x00000020,,,0x0" complete_cpuset="0x00200000,,,0x00000020,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="619" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="109" cpuset="0x00200000,,,0x00000020,,,0x0" complete_cpuset="0x00200000,,,0x00000020,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="617" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="109" cpuset="0x00200000,,,0x00000020,,,0x0" complete_cpuset="0x00200000,,,0x00000020,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="618" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="45" cpuset="0x00200000,,,0x00000020,,,0x0" complete_cpuset="0x00200000,,,0x00000020,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="614">
+                  <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="616"/>
+                  <object type="PU" os_index="213" cpuset="0x00200000,,,,,,0x0" complete_cpuset="0x00200000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="781"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="110" cpuset="0x00400000,,,0x00000040,,,0x0" complete_cpuset="0x00400000,,,0x00000040,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="625" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="110" cpuset="0x00400000,,,0x00000040,,,0x0" complete_cpuset="0x00400000,,,0x00000040,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="623" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="110" cpuset="0x00400000,,,0x00000040,,,0x0" complete_cpuset="0x00400000,,,0x00000040,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="624" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="46" cpuset="0x00400000,,,0x00000040,,,0x0" complete_cpuset="0x00400000,,,0x00000040,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="620">
+                  <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="622"/>
+                  <object type="PU" os_index="214" cpuset="0x00400000,,,,,,0x0" complete_cpuset="0x00400000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="782"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="111" cpuset="0x00800000,,,0x00000080,,,0x0" complete_cpuset="0x00800000,,,0x00000080,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="631" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="111" cpuset="0x00800000,,,0x00000080,,,0x0" complete_cpuset="0x00800000,,,0x00000080,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="629" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="111" cpuset="0x00800000,,,0x00000080,,,0x0" complete_cpuset="0x00800000,,,0x00000080,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="630" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="47" cpuset="0x00800000,,,0x00000080,,,0x0" complete_cpuset="0x00800000,,,0x00000080,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="626">
+                  <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="628"/>
+                  <object type="PU" os_index="215" cpuset="0x00800000,,,,,,0x0" complete_cpuset="0x00800000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="783"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="112" cpuset="0x01000000,,,0x00000100,,,0x0" complete_cpuset="0x01000000,,,0x00000100,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="637" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="112" cpuset="0x01000000,,,0x00000100,,,0x0" complete_cpuset="0x01000000,,,0x00000100,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="635" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="112" cpuset="0x01000000,,,0x00000100,,,0x0" complete_cpuset="0x01000000,,,0x00000100,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="636" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="48" cpuset="0x01000000,,,0x00000100,,,0x0" complete_cpuset="0x01000000,,,0x00000100,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="632">
+                  <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="634"/>
+                  <object type="PU" os_index="216" cpuset="0x01000000,,,,,,0x0" complete_cpuset="0x01000000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="784"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="113" cpuset="0x02000000,,,0x00000200,,,0x0" complete_cpuset="0x02000000,,,0x00000200,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="643" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="113" cpuset="0x02000000,,,0x00000200,,,0x0" complete_cpuset="0x02000000,,,0x00000200,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="641" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="113" cpuset="0x02000000,,,0x00000200,,,0x0" complete_cpuset="0x02000000,,,0x00000200,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="642" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="49" cpuset="0x02000000,,,0x00000200,,,0x0" complete_cpuset="0x02000000,,,0x00000200,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="638">
+                  <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="640"/>
+                  <object type="PU" os_index="217" cpuset="0x02000000,,,,,,0x0" complete_cpuset="0x02000000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="785"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="114" cpuset="0x04000000,,,0x00000400,,,0x0" complete_cpuset="0x04000000,,,0x00000400,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="649" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="114" cpuset="0x04000000,,,0x00000400,,,0x0" complete_cpuset="0x04000000,,,0x00000400,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="647" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="114" cpuset="0x04000000,,,0x00000400,,,0x0" complete_cpuset="0x04000000,,,0x00000400,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="648" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="50" cpuset="0x04000000,,,0x00000400,,,0x0" complete_cpuset="0x04000000,,,0x00000400,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="644">
+                  <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="646"/>
+                  <object type="PU" os_index="218" cpuset="0x04000000,,,,,,0x0" complete_cpuset="0x04000000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="786"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="115" cpuset="0x08000000,,,0x00000800,,,0x0" complete_cpuset="0x08000000,,,0x00000800,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="655" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="115" cpuset="0x08000000,,,0x00000800,,,0x0" complete_cpuset="0x08000000,,,0x00000800,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="653" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="115" cpuset="0x08000000,,,0x00000800,,,0x0" complete_cpuset="0x08000000,,,0x00000800,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="654" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="51" cpuset="0x08000000,,,0x00000800,,,0x0" complete_cpuset="0x08000000,,,0x00000800,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="650">
+                  <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="652"/>
+                  <object type="PU" os_index="219" cpuset="0x08000000,,,,,,0x0" complete_cpuset="0x08000000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="787"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="116" cpuset="0x10000000,,,0x00001000,,,0x0" complete_cpuset="0x10000000,,,0x00001000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="661" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="116" cpuset="0x10000000,,,0x00001000,,,0x0" complete_cpuset="0x10000000,,,0x00001000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="659" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="116" cpuset="0x10000000,,,0x00001000,,,0x0" complete_cpuset="0x10000000,,,0x00001000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="660" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="52" cpuset="0x10000000,,,0x00001000,,,0x0" complete_cpuset="0x10000000,,,0x00001000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="656">
+                  <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="658"/>
+                  <object type="PU" os_index="220" cpuset="0x10000000,,,,,,0x0" complete_cpuset="0x10000000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="788"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="117" cpuset="0x20000000,,,0x00002000,,,0x0" complete_cpuset="0x20000000,,,0x00002000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="667" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="117" cpuset="0x20000000,,,0x00002000,,,0x0" complete_cpuset="0x20000000,,,0x00002000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="665" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="117" cpuset="0x20000000,,,0x00002000,,,0x0" complete_cpuset="0x20000000,,,0x00002000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="666" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="53" cpuset="0x20000000,,,0x00002000,,,0x0" complete_cpuset="0x20000000,,,0x00002000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="662">
+                  <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="664"/>
+                  <object type="PU" os_index="221" cpuset="0x20000000,,,,,,0x0" complete_cpuset="0x20000000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="789"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="118" cpuset="0x40000000,,,0x00004000,,,0x0" complete_cpuset="0x40000000,,,0x00004000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="673" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="118" cpuset="0x40000000,,,0x00004000,,,0x0" complete_cpuset="0x40000000,,,0x00004000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="671" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="118" cpuset="0x40000000,,,0x00004000,,,0x0" complete_cpuset="0x40000000,,,0x00004000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="672" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="54" cpuset="0x40000000,,,0x00004000,,,0x0" complete_cpuset="0x40000000,,,0x00004000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="668">
+                  <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="670"/>
+                  <object type="PU" os_index="222" cpuset="0x40000000,,,,,,0x0" complete_cpuset="0x40000000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="790"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="119" cpuset="0x80000000,,,0x00008000,,,0x0" complete_cpuset="0x80000000,,,0x00008000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="679" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="L1Cache" os_index="119" cpuset="0x80000000,,,0x00008000,,,0x0" complete_cpuset="0x80000000,,,0x00008000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="677" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="119" cpuset="0x80000000,,,0x00008000,,,0x0" complete_cpuset="0x80000000,,,0x00008000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="678" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="55" cpuset="0x80000000,,,0x00008000,,,0x0" complete_cpuset="0x80000000,,,0x00008000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="674">
+                  <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="676"/>
+                  <object type="PU" os_index="223" cpuset="0x80000000,,,,,,0x0" complete_cpuset="0x80000000,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="791"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="869" bridge_type="0-1" depth="0" bridge_pci="0000:[c7-ce]">
+            <object type="Bridge" gp_index="815" bridge_type="1-1" depth="1" bridge_pci="0000:[c8-ce]" pci_busid="0000:c7:01.0" pci_type="0604 [8086:352a] [8086:0000] 04" pci_link_speed="63.015385">
+              <object type="Bridge" gp_index="826" bridge_type="1-1" depth="2" bridge_pci="0000:[c9-ce]" pci_busid="0000:c8:00.0" pci_type="0604 [1000:c030] [1028:236c] b0" pci_link_speed="63.015385">
+                <object type="Bridge" gp_index="853" bridge_type="1-1" depth="3" bridge_pci="0000:[cb-cb]" pci_busid="0000:c9:01.0" pci_type="0604 [1000:c030] [1028:236c] b0" pci_link_speed="63.015385">
+                  <info name="PCISlot" value="23"/>
+                  <object type="PCIDev" gp_index="824" pci_busid="0000:cb:00.0" pci_type="0302 [10de:2330] [10de:16c0] a1" pci_link_speed="63.015385">
+                    <object type="OSDev" gp_index="888" name="opencl0d2" subtype="OpenCL" osdev_type="5">
+                      <info name="Backend" value="OpenCL"/>
+                      <info name="OpenCLDeviceType" value="GPU"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="OpenCLPlatformIndex" value="0"/>
+                      <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
+                      <info name="OpenCLPlatformDeviceIndex" value="2"/>
+                      <info name="OpenCLComputeUnits" value="132"/>
+                      <info name="OpenCLGlobalMemorySize" value="83026944"/>
+                    </object>
+                    <object type="OSDev" gp_index="892" name="cuda2" subtype="CUDA" osdev_type="5">
+                      <info name="Backend" value="CUDA"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="CUDAGlobalMemorySize" value="83026944"/>
+                      <info name="CUDAL2CacheSize" value="51200"/>
+                      <info name="CUDAMultiProcessors" value="132"/>
+                      <info name="CUDACoresPerMP" value="128"/>
+                      <info name="CUDASharedMemorySizePerMP" value="48"/>
+                    </object>
+                    <object type="OSDev" gp_index="896" name="nvml2" subtype="NVML" osdev_type="1">
+                      <info name="Backend" value="NVML"/>
+                      <info name="GPUVendor" value="NVIDIA Corporation"/>
+                      <info name="GPUModel" value="NVIDIA H100 80GB HBM3"/>
+                      <info name="NVIDIASerial" value="0000000000000"/>
+                      <info name="NVIDIAUUID" value="GPU-00000000-0000-0000-0000-000000000000"/>
+                    </object>
+                  </object>
+                </object>
+                <object type="Bridge" gp_index="847" bridge_type="1-1" depth="3" bridge_pci="0000:[ce-ce]" pci_busid="0000:c9:1f.0" pci_type="0604 [1000:c030] [1028:236c] b0" pci_link_speed="63.015385">
+                  <object type="PCIDev" gp_index="846" pci_busid="0000:ce:00.0" pci_type="0107 [1000:00b2] [1028:236c] b0" pci_link_speed="63.015385"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="OSDev" gp_index="875" name="sda" subtype="Disk" osdev_type="0">
+      <info name="Size" value="160432128"/>
+      <info name="SectorSize" value="512"/>
+      <info name="LinuxDeviceID" value="8:0"/>
+      <info name="Vendor" value="LIO-ORG"/>
+      <info name="Model" value="FILEIO"/>
+      <info name="Revision" value="4.0"/>
+      <info name="SerialNumber" value="000000000000"/>
+    </object>
+  </object>
+  <distances2 type="NUMANode" nbobjs="8" kind="5" name="NUMALatency" indexing="os">
+    <indexes length="16">0 1 2 3 4 5 6 7 </indexes>
+    <u64values length="30">10 12 12 12 21 21 21 21 12 10 </u64values>
+    <u64values length="30">12 12 21 21 21 21 12 12 10 12 </u64values>
+    <u64values length="30">21 21 21 21 12 12 12 10 21 21 </u64values>
+    <u64values length="30">21 21 21 21 21 21 10 12 12 12 </u64values>
+    <u64values length="30">21 21 21 21 12 10 12 12 21 21 </u64values>
+    <u64values length="30">21 21 12 12 10 12 21 21 21 21 </u64values>
+    <u64values length="12">12 12 12 10 </u64values>
+  </distances2>
+  <distances2 type="OSDev" nbobjs="4" kind="9" name="NVLinkBandwidth" indexing="gp">
+    <indexes length="16">894 895 896 897 </indexes>
+    <u64values length="72">1000000 150000 150000 150000 150000 1000000 150000 150000 150000 150000 </u64values>
+    <u64values length="44">1000000 150000 150000 150000 150000 1000000 </u64values>
+  </distances2>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.numa_memory"/>
+  <support name="discovery.disallowed_pu"/>
+  <support name="discovery.disallowed_numa"/>
+  <support name="discovery.cpukind_efficiency"/>
+  <support name="cpubind.set_thisproc_cpubind"/>
+  <support name="cpubind.get_thisproc_cpubind"/>
+  <support name="cpubind.set_proc_cpubind"/>
+  <support name="cpubind.get_proc_cpubind"/>
+  <support name="cpubind.set_thisthread_cpubind"/>
+  <support name="cpubind.get_thisthread_cpubind"/>
+  <support name="cpubind.set_thread_cpubind"/>
+  <support name="cpubind.get_thread_cpubind"/>
+  <support name="cpubind.get_thisproc_last_cpu_location"/>
+  <support name="cpubind.get_proc_last_cpu_location"/>
+  <support name="cpubind.get_thisthread_last_cpu_location"/>
+  <support name="membind.set_thisthread_membind"/>
+  <support name="membind.get_thisthread_membind"/>
+  <support name="membind.set_area_membind"/>
+  <support name="membind.get_area_membind"/>
+  <support name="membind.alloc_membind"/>
+  <support name="membind.firsttouch_membind"/>
+  <support name="membind.bind_membind"/>
+  <support name="membind.interleave_membind"/>
+  <support name="membind.migrate_membind"/>
+  <support name="membind.get_area_memlocation"/>
+  <support name="custom.exported_support"/>
+  <memattr name="Bandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="792" value="219100" initiator_cpuset="0x3fff0000,,,0x00003fff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="793" value="219100" initiator_cpuset="0x00000fff,0xc0000000,,,0x0fffc000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="794" value="219100" initiator_cpuset="0x03fff000,,,0x000003ff,0xf0000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="795" value="219100" initiator_cpuset="0x000000ff,0xfc000000,,,0x00fffc00,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="796" value="219100" initiator_cpuset="0x003fff00,,,0x0000003f,0xff000000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="797" value="219100" initiator_cpuset="0x0000000f,0xffc00000,,,0x000fffc0,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="798" value="219100" initiator_cpuset="0x0003fff0,,,0x00000003,0xfff00000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="799" value="219100" initiator_cpuset="0xfffc0000,,,0x0000fffc,,,0x0"/>
+  </memattr>
+  <memattr name="Latency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="792" value="91" initiator_cpuset="0x3fff0000,,,0x00003fff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="793" value="91" initiator_cpuset="0x00000fff,0xc0000000,,,0x0fffc000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="794" value="91" initiator_cpuset="0x03fff000,,,0x000003ff,0xf0000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="795" value="91" initiator_cpuset="0x000000ff,0xfc000000,,,0x00fffc00,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="796" value="91" initiator_cpuset="0x003fff00,,,0x0000003f,0xff000000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="797" value="91" initiator_cpuset="0x0000000f,0xffc00000,,,0x000fffc0,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="798" value="91" initiator_cpuset="0x0003fff0,,,0x00000003,0xfff00000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="799" value="91" initiator_cpuset="0xfffc0000,,,0x0000fffc,,,0x0"/>
+  </memattr>
+  <memattr name="ReadBandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="792" value="262100" initiator_cpuset="0x3fff0000,,,0x00003fff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="793" value="262100" initiator_cpuset="0x00000fff,0xc0000000,,,0x0fffc000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="794" value="262100" initiator_cpuset="0x03fff000,,,0x000003ff,0xf0000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="795" value="262100" initiator_cpuset="0x000000ff,0xfc000000,,,0x00fffc00,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="796" value="262100" initiator_cpuset="0x003fff00,,,0x0000003f,0xff000000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="797" value="262100" initiator_cpuset="0x0000000f,0xffc00000,,,0x000fffc0,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="798" value="262100" initiator_cpuset="0x0003fff0,,,0x00000003,0xfff00000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="799" value="262100" initiator_cpuset="0xfffc0000,,,0x0000fffc,,,0x0"/>
+  </memattr>
+  <memattr name="WriteBandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="792" value="176100" initiator_cpuset="0x3fff0000,,,0x00003fff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="793" value="176100" initiator_cpuset="0x00000fff,0xc0000000,,,0x0fffc000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="794" value="176100" initiator_cpuset="0x03fff000,,,0x000003ff,0xf0000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="795" value="176100" initiator_cpuset="0x000000ff,0xfc000000,,,0x00fffc00,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="796" value="176100" initiator_cpuset="0x003fff00,,,0x0000003f,0xff000000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="797" value="176100" initiator_cpuset="0x0000000f,0xffc00000,,,0x000fffc0,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="798" value="176100" initiator_cpuset="0x0003fff0,,,0x00000003,0xfff00000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="799" value="176100" initiator_cpuset="0xfffc0000,,,0x0000fffc,,,0x0"/>
+  </memattr>
+  <memattr name="ReadLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="792" value="91" initiator_cpuset="0x3fff0000,,,0x00003fff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="793" value="91" initiator_cpuset="0x00000fff,0xc0000000,,,0x0fffc000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="794" value="91" initiator_cpuset="0x03fff000,,,0x000003ff,0xf0000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="795" value="91" initiator_cpuset="0x000000ff,0xfc000000,,,0x00fffc00,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="796" value="91" initiator_cpuset="0x003fff00,,,0x0000003f,0xff000000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="797" value="91" initiator_cpuset="0x0000000f,0xffc00000,,,0x000fffc0,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="798" value="91" initiator_cpuset="0x0003fff0,,,0x00000003,0xfff00000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="799" value="91" initiator_cpuset="0xfffc0000,,,0x0000fffc,,,0x0"/>
+  </memattr>
+  <memattr name="WriteLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="792" value="91" initiator_cpuset="0x3fff0000,,,0x00003fff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="793" value="91" initiator_cpuset="0x00000fff,0xc0000000,,,0x0fffc000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="794" value="91" initiator_cpuset="0x03fff000,,,0x000003ff,0xf0000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="795" value="91" initiator_cpuset="0x000000ff,0xfc000000,,,0x00fffc00,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="796" value="91" initiator_cpuset="0x003fff00,,,0x0000003f,0xff000000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="797" value="91" initiator_cpuset="0x0000000f,0xffc00000,,,0x000fffc0,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="798" value="91" initiator_cpuset="0x0003fff0,,,0x00000003,0xfff00000,,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="799" value="91" initiator_cpuset="0xfffc0000,,,0x0000fffc,,,0x0"/>
+  </memattr>
+  <cpukind cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff">
+    <info name="FrequencyMaxMHz" value="3800"/>
+  </cpukind>
+</topology>

--- a/t/hwloc-data/tuo.CPX.xml
+++ b/t/hwloc-data/tuo.CPX.xml
@@ -1,0 +1,2200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f" gp_index="1">
+    <info name="DMIProductName" value="HPE_CRAY_EX255a"/>
+    <info name="DMIProductVersion" value="1.8.0"/>
+    <info name="DMIBoardVendor" value="HPE"/>
+    <info name="DMIBoardName" value="HPE CRAY EX255a"/>
+    <info name="DMIBoardVersion" value="ParryPeak"/>
+    <info name="DMIBoardAssetTag" value="UNKNOWN"/>
+    <info name="DMIChassisVendor" value="HPE"/>
+    <info name="DMIChassisType" value="17"/>
+    <info name="DMIChassisVersion" value="HPE Cray EX Supercomputers"/>
+    <info name="DMIChassisAssetTag" value="UNKNOWN"/>
+    <info name="DMIBIOSVendor" value="HPE"/>
+    <info name="DMIBIOSVersion" value="1.8.0"/>
+    <info name="DMIBIOSDate" value="11/18/2025"/>
+    <info name="DMISysVendor" value="HPE"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/user.slice"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.18.0-553.124.1.2toss.t4.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Fri May 15 11:02:50 PDT 2026"/>
+    <info name="HostName" value="testhost-amd"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="2.12.2"/>
+    <info name="ProcessName" value="lstopo"/>
+    <object type="Package" os_index="0" cpuset="0x00ffffff,,,0x00ffffff" complete_cpuset="0x00ffffff,,,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="3">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,,,0x00ffffff" complete_cpuset="0x00ffffff,,,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="694" local_memory="134081638400">
+        <page_type size="4096" count="32734775"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="0" cpuset="0x000000ff,,,0x000000ff" complete_cpuset="0x000000ff,,,0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6"/>
+                <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="598"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11">
+                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13"/>
+                <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="599"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17">
+                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19"/>
+                <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="600"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23">
+                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25"/>
+                <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="601"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29">
+                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31"/>
+                <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="602"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35">
+                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37"/>
+                <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="603"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41">
+                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43"/>
+                <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="604"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="52" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="50" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="51" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="47">
+                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="49"/>
+                <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="605"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="1" cpuset="0x0000ff00,,,0x0000ff00" complete_cpuset="0x0000ff00,,,0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="59" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="58" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="56" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="57" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="53">
+                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="55"/>
+                <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="606"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="65" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="63" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="64" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="60">
+                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="62"/>
+                <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="607"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="71" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="69" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="70" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="66">
+                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="68"/>
+                <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="608"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="77" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="75" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="76" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="72">
+                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="74"/>
+                <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="609"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="83" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="81" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="82" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="78">
+                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="80"/>
+                <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="610"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="89" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="87" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="88" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="84">
+                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="86"/>
+                <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="611"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="95" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="93" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="94" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="90">
+                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="92"/>
+                <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="612"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="101" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="99" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="100" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="96">
+                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="98"/>
+                <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="613"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="2" cpuset="0x00ff0000,,,0x00ff0000" complete_cpuset="0x00ff0000,,,0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="108" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="107" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="105" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="106" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="102">
+                <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="104"/>
+                <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="614"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="114" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="112" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="113" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="109">
+                <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="111"/>
+                <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="615"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="120" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="118" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="119" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="115">
+                <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="117"/>
+                <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="616"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="126" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="124" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="125" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="121">
+                <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="123"/>
+                <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="617"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="132" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="130" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="131" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="127">
+                <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="129"/>
+                <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="618"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="138" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="136" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="137" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="133">
+                <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="135"/>
+                <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="619"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="144" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="142" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="143" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="139">
+                <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="141"/>
+                <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="620"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="150" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="148" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="149" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="145">
+                <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="147"/>
+                <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="621"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="865" bridge_type="0-1" depth="0" bridge_pci="0000:[00-02]">
+        <object type="Bridge" gp_index="807" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="753" pci_busid="0000:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="918" name="hsi0" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:d2"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="835" bridge_type="1-1" depth="1" bridge_pci="0000:[02-02]" pci_busid="0000:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="726" pci_busid="0000:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="919" name="rsmi0" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="920" name="rsmi1" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="921" name="rsmi2" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="922" name="rsmi3" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="923" name="rsmi4" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="924" name="rsmi5" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="867" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
+        <object type="Bridge" gp_index="738" bridge_type="1-1" depth="1" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.1" pci_type="0604 [1022:14fd] [1022:1234] 00" pci_link_speed="0.250000">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="791" pci_busid="0000:81:00.0" pci_type="0200 [8086:1537] [ffff:0000] 03" pci_link_speed="0.250000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I210 Gigabit Backplane Connection"/>
+            <object type="OSDev" gp_index="916" name="enp129s0" osdev_type="2">
+              <info name="Address" value="00:40:a6:89:c9:20"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" complete_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="152">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="1" cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" complete_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="695" local_memory="134972620800">
+        <page_type size="4096" count="32952300"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="4" cpuset="0xff000000,,,0xff000000" complete_cpuset="0xff000000,,,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="159" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="32" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="158" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="32" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="156" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="32" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="157" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="151">
+                <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="155"/>
+                <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="622"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="33" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="165" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="33" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="163" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="33" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="164" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="160">
+                <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="162"/>
+                <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="623"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="34" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="171" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="34" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="169" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="34" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="170" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="166">
+                <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="168"/>
+                <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="624"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="35" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="177" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="35" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="175" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="35" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="176" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="172">
+                <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="174"/>
+                <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="625"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="36" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="183" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="36" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="181" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="36" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="182" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="178">
+                <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="180"/>
+                <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="626"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="37" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="189" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="37" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="187" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="37" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="188" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="184">
+                <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="186"/>
+                <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="627"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="38" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="195" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="38" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="193" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="38" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="194" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="190">
+                <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="192"/>
+                <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="628"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="39" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="201" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="39" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="199" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="39" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="200" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="196">
+                <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="198"/>
+                <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="629"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="5" cpuset="0x000000ff,,,0x000000ff,0x0" complete_cpuset="0x000000ff,,,0x000000ff,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="208" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="40" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="207" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="40" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="205" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="40" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="206" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="202">
+                <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="204"/>
+                <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="630"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="41" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="214" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="41" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="212" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="41" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="213" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="209">
+                <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="211"/>
+                <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="631"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="42" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="220" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="42" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="218" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="42" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="219" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="215">
+                <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="217"/>
+                <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="632"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="43" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="226" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="43" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="224" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="43" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="225" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="221">
+                <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="223"/>
+                <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="633"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="44" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="232" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="44" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="230" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="44" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="231" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="227">
+                <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="229"/>
+                <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="634"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="45" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="238" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="45" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="236" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="45" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="237" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="233">
+                <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="235"/>
+                <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="635"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="46" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="244" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="46" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="242" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="46" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="243" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="239">
+                <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="241"/>
+                <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="636"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="47" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="250" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="47" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="248" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="47" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="249" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="245">
+                <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="247"/>
+                <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="637"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="6" cpuset="0x0000ff00,,,0x0000ff00,0x0" complete_cpuset="0x0000ff00,,,0x0000ff00,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="257" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="48" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="256" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="48" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="254" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="48" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="255" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="251">
+                <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="253"/>
+                <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="638"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="49" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="263" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="49" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="261" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="49" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="262" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="258">
+                <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="260"/>
+                <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="639"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="50" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="269" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="50" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="267" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="50" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="268" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="264">
+                <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="266"/>
+                <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="640"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="51" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="275" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="51" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="273" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="51" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="274" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="270">
+                <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="272"/>
+                <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="641"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="52" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="281" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="52" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="279" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="52" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="280" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="276">
+                <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="278"/>
+                <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="642"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="53" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="287" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="53" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="285" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="53" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="286" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="282">
+                <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="284"/>
+                <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="643"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="54" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="293" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="54" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="291" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="54" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="292" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="288">
+                <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="290"/>
+                <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="644"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="55" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="299" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="55" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="297" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="55" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="298" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="294">
+                <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="296"/>
+                <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="645"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="869" bridge_type="0-1" depth="0" bridge_pci="0001:[00-02]">
+        <object type="Bridge" gp_index="732" bridge_type="1-1" depth="1" bridge_pci="0001:[01-01]" pci_busid="0001:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="850" pci_busid="0001:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="915" name="hsi1" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:d3"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="763" bridge_type="1-1" depth="1" bridge_pci="0001:[02-02]" pci_busid="0001:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="823" pci_busid="0001:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="925" name="rsmi6" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="926" name="rsmi7" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="927" name="rsmi8" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="928" name="rsmi9" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="929" name="rsmi10" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="930" name="rsmi11" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="871" bridge_type="0-1" depth="0" bridge_pci="0001:[80-94]">
+        <object type="Bridge" gp_index="833" bridge_type="1-1" depth="1" bridge_pci="0001:[81-94]" pci_busid="0001:80:03.1" pci_type="0604 [1022:14fd] [1022:1234] 00" pci_link_speed="7.876923">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="Bridge" gp_index="714" bridge_type="1-1" depth="2" bridge_pci="0001:[82-94]" pci_busid="0001:81:00.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+            <info name="PCIVendor" value="PMC-Sierra Inc."/>
+            <object type="Bridge" gp_index="858" bridge_type="1-1" depth="3" bridge_pci="0001:[83-83]" pci_busid="0001:82:00.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="832" pci_busid="0001:83:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="1"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="883" name="nvme0n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:0"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="897" name="nvme0n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:5"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="810" bridge_type="1-1" depth="3" bridge_pci="0001:[84-84]" pci_busid="0001:82:01.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="808" pci_busid="0001:84:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="2"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="887" name="nvme1n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:6"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="905" name="nvme1n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:1"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="758" bridge_type="1-1" depth="3" bridge_pci="0001:[85-85]" pci_busid="0001:82:02.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="779" pci_busid="0001:85:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="3"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="895" name="nvme2n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:3"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="910" name="nvme2n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:7"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="703" bridge_type="1-1" depth="3" bridge_pci="0001:[86-86]" pci_busid="0001:82:03.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="755" pci_busid="0001:86:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="4"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="886" name="nvme3n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:2"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="900" name="nvme3n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:19"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="824" bridge_type="1-1" depth="3" bridge_pci="0001:[87-87]" pci_busid="0001:82:04.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="727" pci_busid="0001:87:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="5"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="890" name="nvme4n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:18"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="909" name="nvme4n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:4"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="771" bridge_type="1-1" depth="3" bridge_pci="0001:[88-88]" pci_busid="0001:82:05.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="699" pci_busid="0001:88:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="6"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="898" name="nvme5n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:12"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="913" name="nvme5n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:17"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="717" bridge_type="1-1" depth="3" bridge_pci="0001:[89-89]" pci_busid="0001:82:06.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="842" pci_busid="0001:89:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="7"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="888" name="nvme6n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:10"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="903" name="nvme6n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:13"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="788" bridge_type="1-1" depth="3" bridge_pci="0001:[8b-8b]" pci_busid="0001:82:08.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="860" pci_busid="0001:8b:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="9"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="893" name="nvme7n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:15"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="911" name="nvme7n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:8"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="734" bridge_type="1-1" depth="3" bridge_pci="0001:[8c-8c]" pci_busid="0001:82:09.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="837" pci_busid="0001:8c:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="10"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="884" name="nvme8n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:14"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="901" name="nvme8n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:9"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="775" bridge_type="1-1" depth="3" bridge_pci="0001:[8d-8d]" pci_busid="0001:82:0a.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="811" pci_busid="0001:8d:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="11"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="891" name="nvme9n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:11"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="907" name="nvme9n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:23"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="722" bridge_type="1-1" depth="3" bridge_pci="0001:[8e-8e]" pci_busid="0001:82:0b.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="784" pci_busid="0001:8e:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="12"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="881" name="nvme10n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:24"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="899" name="nvme10n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:16"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="840" bridge_type="1-1" depth="3" bridge_pci="0001:[8f-8f]" pci_busid="0001:82:0c.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="757" pci_busid="0001:8f:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="13"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="889" name="nvme11n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:26"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="904" name="nvme11n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:31"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="737" bridge_type="1-1" depth="3" bridge_pci="0001:[91-91]" pci_busid="0001:82:0e.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="765" pci_busid="0001:91:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="15"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="894" name="nvme12n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:28"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="912" name="nvme12n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:20"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="856" bridge_type="1-1" depth="3" bridge_pci="0001:[92-92]" pci_busid="0001:82:0f.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="736" pci_busid="0001:92:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="16"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="885" name="nvme13n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:27"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="902" name="nvme13n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:22"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="804" bridge_type="1-1" depth="3" bridge_pci="0001:[93-93]" pci_busid="0001:82:10.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="710" pci_busid="0001:93:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="17"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="892" name="nvme14n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:21"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="908" name="nvme14n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:29"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="750" bridge_type="1-1" depth="3" bridge_pci="0001:[94-94]" pci_busid="0001:82:11.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="852" pci_busid="0001:94:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="18"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="882" name="nvme15n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:25"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="896" name="nvme15n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:30"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="2" cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" complete_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="301">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="2" cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" complete_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="696" local_memory="134972628992">
+        <page_type size="4096" count="32952302"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="8" cpuset="0x00ff0000,,,0x00ff0000,0x0" complete_cpuset="0x00ff0000,,,0x00ff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="308" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="64" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="307" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="64" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="305" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="64" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="306" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="300">
+                <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="304"/>
+                <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="646"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="65" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="314" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="65" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="312" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="65" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="313" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="309">
+                <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="311"/>
+                <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="647"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="66" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="320" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="66" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="318" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="66" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="319" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="315">
+                <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="317"/>
+                <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="648"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="67" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="326" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="67" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="324" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="67" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="325" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="321">
+                <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="323"/>
+                <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="649"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="68" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="332" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="68" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="330" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="68" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="331" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="327">
+                <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="329"/>
+                <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="650"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="69" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="338" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="69" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="336" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="69" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="337" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="333">
+                <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="335"/>
+                <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="651"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="70" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="344" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="70" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="342" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="70" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="343" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="339">
+                <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="341"/>
+                <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="652"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="71" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="350" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="71" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="348" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="71" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="349" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="345">
+                <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="347"/>
+                <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="653"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="9" cpuset="0xff000000,,,0xff000000,0x0" complete_cpuset="0xff000000,,,0xff000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="357" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="72" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="356" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="72" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="354" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="72" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="355" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="351">
+                <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="353"/>
+                <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="654"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="73" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="363" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="73" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="361" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="73" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="362" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="358">
+                <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="360"/>
+                <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="655"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="74" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="369" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="74" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="367" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="74" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="368" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="364">
+                <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="366"/>
+                <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="656"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="75" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="375" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="75" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="373" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="75" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="374" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="370">
+                <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="372"/>
+                <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="657"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="76" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="381" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="76" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="379" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="76" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="380" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="376">
+                <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="378"/>
+                <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="658"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="77" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="387" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="77" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="385" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="77" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="386" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="382">
+                <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="384"/>
+                <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="659"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="78" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="393" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="78" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="391" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="78" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="392" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="388">
+                <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="390"/>
+                <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="660"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="79" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="399" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="79" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="397" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="79" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="398" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="394">
+                <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="396"/>
+                <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="661"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="10" cpuset="0x000000ff,,,0x000000ff,,0x0" complete_cpuset="0x000000ff,,,0x000000ff,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="406" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="80" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="405" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="80" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="403" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="80" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="404" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="400">
+                <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="402"/>
+                <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="662"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="81" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="412" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="81" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="410" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="81" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="411" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="407">
+                <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="409"/>
+                <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="663"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="82" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="418" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="82" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="416" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="82" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="417" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="413">
+                <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="415"/>
+                <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="664"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="83" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="424" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="83" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="422" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="83" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="423" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="419">
+                <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="421"/>
+                <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="665"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="84" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="430" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="84" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="428" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="84" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="429" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="425">
+                <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="427"/>
+                <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="666"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="85" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="436" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="85" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="434" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="85" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="435" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="431">
+                <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="433"/>
+                <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="667"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="86" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="442" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="86" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="440" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="86" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="441" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="437">
+                <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="439"/>
+                <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="668"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="87" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="448" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="87" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="446" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="87" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="447" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="443">
+                <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="445"/>
+                <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="669"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="873" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+        <object type="Bridge" gp_index="827" bridge_type="1-1" depth="1" bridge_pci="0002:[01-01]" pci_busid="0002:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="776" pci_busid="0002:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="917" name="hsi2" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:12"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="857" bridge_type="1-1" depth="1" bridge_pci="0002:[02-02]" pci_busid="0002:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="748" pci_busid="0002:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="931" name="rsmi12" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="932" name="rsmi13" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="933" name="rsmi14" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="934" name="rsmi15" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="935" name="rsmi16" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="936" name="rsmi17" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="3" cpuset="0xffffff00,,,0xffffff00,,0x0" complete_cpuset="0xffffff00,,,0xffffff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="450">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="3" cpuset="0xffffff00,,,0xffffff00,,0x0" complete_cpuset="0xffffff00,,,0xffffff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="697" local_memory="134960783360">
+        <page_type size="4096" count="32949410"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="12" cpuset="0x0000ff00,,,0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,,0x0000ff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="457" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="96" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="456" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="96" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="454" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="96" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="455" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="449">
+                <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="453"/>
+                <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="670"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="97" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="463" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="97" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="461" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="97" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="462" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="458">
+                <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="460"/>
+                <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="671"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="98" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="469" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="98" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="467" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="98" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="468" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="464">
+                <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="466"/>
+                <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="672"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="99" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="475" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="99" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="473" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="99" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="474" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="470">
+                <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="472"/>
+                <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="673"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="100" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="481" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="100" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="479" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="100" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="480" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="476">
+                <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="478"/>
+                <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="674"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="101" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="487" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="101" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="485" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="101" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="486" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="482">
+                <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="484"/>
+                <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="675"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="102" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="493" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="102" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="491" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="102" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="492" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="488">
+                <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="490"/>
+                <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="676"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="103" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="499" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="103" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="497" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="103" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="498" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="494">
+                <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="496"/>
+                <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="677"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="13" cpuset="0x00ff0000,,,0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,,0x00ff0000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="506" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="104" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="505" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="104" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="503" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="104" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="504" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="500">
+                <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="502"/>
+                <object type="PU" os_index="176" cpuset="0x00010000,,,,,0x0" complete_cpuset="0x00010000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="678"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="105" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="512" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="105" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="510" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="105" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="511" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="507">
+                <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="509"/>
+                <object type="PU" os_index="177" cpuset="0x00020000,,,,,0x0" complete_cpuset="0x00020000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="679"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="106" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="518" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="106" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="516" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="106" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="517" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="513">
+                <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="515"/>
+                <object type="PU" os_index="178" cpuset="0x00040000,,,,,0x0" complete_cpuset="0x00040000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="680"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="107" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="524" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="107" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="522" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="107" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="523" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="519">
+                <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="521"/>
+                <object type="PU" os_index="179" cpuset="0x00080000,,,,,0x0" complete_cpuset="0x00080000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="681"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="108" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="530" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="108" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="528" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="108" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="529" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="525">
+                <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="527"/>
+                <object type="PU" os_index="180" cpuset="0x00100000,,,,,0x0" complete_cpuset="0x00100000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="682"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="109" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="536" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="109" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="534" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="109" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="535" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="531">
+                <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="533"/>
+                <object type="PU" os_index="181" cpuset="0x00200000,,,,,0x0" complete_cpuset="0x00200000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="683"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="110" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="542" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="110" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="540" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="110" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="541" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="537">
+                <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="539"/>
+                <object type="PU" os_index="182" cpuset="0x00400000,,,,,0x0" complete_cpuset="0x00400000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="684"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="111" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="548" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="111" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="546" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="111" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="547" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="543">
+                <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="545"/>
+                <object type="PU" os_index="183" cpuset="0x00800000,,,,,0x0" complete_cpuset="0x00800000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="685"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="14" cpuset="0xff000000,,,0xff000000,,0x0" complete_cpuset="0xff000000,,,0xff000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="555" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="112" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="554" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="112" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="552" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="112" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="553" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="549">
+                <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="551"/>
+                <object type="PU" os_index="184" cpuset="0x01000000,,,,,0x0" complete_cpuset="0x01000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="686"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="113" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="561" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="113" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="559" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="113" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="560" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="556">
+                <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="558"/>
+                <object type="PU" os_index="185" cpuset="0x02000000,,,,,0x0" complete_cpuset="0x02000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="687"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="114" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="567" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="114" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="565" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="114" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="566" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="562">
+                <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="564"/>
+                <object type="PU" os_index="186" cpuset="0x04000000,,,,,0x0" complete_cpuset="0x04000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="688"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="115" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="573" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="115" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="571" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="115" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="572" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="568">
+                <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="570"/>
+                <object type="PU" os_index="187" cpuset="0x08000000,,,,,0x0" complete_cpuset="0x08000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="689"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="116" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="579" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="116" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="577" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="116" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="578" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="574">
+                <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="576"/>
+                <object type="PU" os_index="188" cpuset="0x10000000,,,,,0x0" complete_cpuset="0x10000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="690"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="117" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="585" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="117" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="583" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="117" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="584" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="580">
+                <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="582"/>
+                <object type="PU" os_index="189" cpuset="0x20000000,,,,,0x0" complete_cpuset="0x20000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="691"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="118" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="591" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="118" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="589" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="118" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="590" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="586">
+                <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="588"/>
+                <object type="PU" os_index="190" cpuset="0x40000000,,,,,0x0" complete_cpuset="0x40000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="692"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="119" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="597" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="119" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="595" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="119" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="596" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="592">
+                <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="594"/>
+                <object type="PU" os_index="191" cpuset="0x80000000,,,,,0x0" complete_cpuset="0x80000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="693"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="877" bridge_type="0-1" depth="0" bridge_pci="0003:[00-02]">
+        <object type="Bridge" gp_index="754" bridge_type="1-1" depth="1" bridge_pci="0003:[01-01]" pci_busid="0003:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="701" pci_busid="0003:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="914" name="hsi3" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:13"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="786" bridge_type="1-1" depth="1" bridge_pci="0003:[02-02]" pci_busid="0003:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="844" pci_busid="0003:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="937" name="rsmi18" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi19 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="938" name="rsmi19" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi20 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="939" name="rsmi20" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi21 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="940" name="rsmi21" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi22 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="941" name="rsmi22" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi23 "/>
+            </object>
+            <object type="OSDev" gp_index="942" name="rsmi23" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="134617fa77bd3aae"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 rsmi12 rsmi13 rsmi14 rsmi15 rsmi16 rsmi17 rsmi18 rsmi19 rsmi20 rsmi21 rsmi22 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="OSDev" gp_index="906" name="sda" subtype="Disk" osdev_type="0">
+      <info name="Size" value="66060288"/>
+      <info name="SectorSize" value="512"/>
+      <info name="LinuxDeviceID" value="8:0"/>
+      <info name="Vendor" value="LIO-ORG"/>
+      <info name="Model" value="FILEIO"/>
+      <info name="Revision" value="4.0"/>
+      <info name="SerialNumber" value="000000000000"/>
+    </object>
+  </object>
+  <distances2 type="NUMANode" nbobjs="4" kind="5" name="NUMALatency" indexing="os">
+    <indexes length="8">0 1 2 3 </indexes>
+    <u64values length="30">10 32 32 32 32 10 32 32 32 32 </u64values>
+    <u64values length="18">10 32 32 32 32 10 </u64values>
+  </distances2>
+  <distances2 type="OSDev" nbobjs="24" kind="9" name="XGMIBandwidth" indexing="gp">
+    <indexes length="40">919 920 921 922 923 924 925 926 927 928 </indexes>
+    <indexes length="40">929 930 931 932 933 934 935 936 937 938 </indexes>
+    <indexes length="16">939 940 941 942 </indexes>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="43">100000 100000 100000 100000 100000 1000000 </u64values>
+  </distances2>
+  <distances2 type="OSDev" nbobjs="24" kind="5" name="XGMIHops" indexing="gp">
+    <indexes length="40">919 920 921 922 923 924 925 926 927 928 </indexes>
+    <indexes length="40">929 930 931 932 933 934 935 936 937 938 </indexes>
+    <indexes length="16">939 940 941 942 </indexes>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="12">1 1 1 1 1 0 </u64values>
+  </distances2>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.numa_memory"/>
+  <support name="discovery.disallowed_pu"/>
+  <support name="discovery.disallowed_numa"/>
+  <support name="discovery.cpukind_efficiency"/>
+  <support name="cpubind.set_thisproc_cpubind"/>
+  <support name="cpubind.get_thisproc_cpubind"/>
+  <support name="cpubind.set_proc_cpubind"/>
+  <support name="cpubind.get_proc_cpubind"/>
+  <support name="cpubind.set_thisthread_cpubind"/>
+  <support name="cpubind.get_thisthread_cpubind"/>
+  <support name="cpubind.set_thread_cpubind"/>
+  <support name="cpubind.get_thread_cpubind"/>
+  <support name="cpubind.get_thisproc_last_cpu_location"/>
+  <support name="cpubind.get_proc_last_cpu_location"/>
+  <support name="cpubind.get_thisthread_last_cpu_location"/>
+  <support name="membind.set_thisthread_membind"/>
+  <support name="membind.get_thisthread_membind"/>
+  <support name="membind.set_area_membind"/>
+  <support name="membind.get_area_membind"/>
+  <support name="membind.alloc_membind"/>
+  <support name="membind.firsttouch_membind"/>
+  <support name="membind.bind_membind"/>
+  <support name="membind.interleave_membind"/>
+  <support name="membind.migrate_membind"/>
+  <support name="membind.get_area_memlocation"/>
+  <support name="custom.exported_support"/>
+  <memattr name="Latency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="139" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="139" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="139" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="139" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="ReadBandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="5451776" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="5451776" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="5451776" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="5451776" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="ReadLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="182" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="182" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="182" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="182" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="WriteLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="96" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="96" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="96" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="96" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <cpukind cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff">
+    <info name="FrequencyMaxMHz" value="3700"/>
+  </cpukind>
+</topology>

--- a/t/hwloc-data/tuo.SPX.xml
+++ b/t/hwloc-data/tuo.SPX.xml
@@ -1,0 +1,1924 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f" gp_index="1">
+    <info name="DMIProductName" value="HPE_CRAY_EX255a"/>
+    <info name="DMIProductVersion" value="1.8.0"/>
+    <info name="DMIBoardVendor" value="HPE"/>
+    <info name="DMIBoardName" value="HPE CRAY EX255a"/>
+    <info name="DMIBoardVersion" value="ParryPeak"/>
+    <info name="DMIBoardAssetTag" value="UNKNOWN"/>
+    <info name="DMIChassisVendor" value="HPE"/>
+    <info name="DMIChassisType" value="17"/>
+    <info name="DMIChassisVersion" value="HPE Cray EX Supercomputers"/>
+    <info name="DMIChassisAssetTag" value="UNKNOWN"/>
+    <info name="DMIBIOSVendor" value="HPE"/>
+    <info name="DMIBIOSVersion" value="1.8.0"/>
+    <info name="DMIBIOSDate" value="11/18/2025"/>
+    <info name="DMISysVendor" value="HPE"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/user.slice"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.18.0-553.124.1.2toss.t4.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Fri May 15 11:02:50 PDT 2026"/>
+    <info name="HostName" value="testhost-amd"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="2.12.2"/>
+    <info name="ProcessName" value="lstopo"/>
+    <object type="Package" os_index="0" cpuset="0x00ffffff,,,0x00ffffff" complete_cpuset="0x00ffffff,,,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="3">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,,,0x00ffffff" complete_cpuset="0x00ffffff,,,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="694" local_memory="134127484928">
+        <page_type size="4096" count="32745968"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="0" cpuset="0x000000ff,,,0x000000ff" complete_cpuset="0x000000ff,,,0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6"/>
+                <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="598"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11">
+                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13"/>
+                <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="599"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17">
+                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19"/>
+                <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="600"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23">
+                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25"/>
+                <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="601"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29">
+                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31"/>
+                <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="602"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35">
+                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37"/>
+                <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="603"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41">
+                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43"/>
+                <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="604"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="52" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="50" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="51" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="47">
+                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="49"/>
+                <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="605"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="1" cpuset="0x0000ff00,,,0x0000ff00" complete_cpuset="0x0000ff00,,,0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="59" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="58" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="56" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="57" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="53">
+                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="55"/>
+                <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="606"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="65" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="63" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="64" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="60">
+                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="62"/>
+                <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="607"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="71" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="69" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="70" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="66">
+                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="68"/>
+                <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="608"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="77" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="75" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="76" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="72">
+                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="74"/>
+                <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="609"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="83" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="81" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="82" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="78">
+                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="80"/>
+                <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="610"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="89" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="87" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="88" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="84">
+                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="86"/>
+                <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="611"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="95" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="93" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="94" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="90">
+                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="92"/>
+                <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="612"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="101" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="99" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="100" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="96">
+                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="98"/>
+                <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="613"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="2" cpuset="0x00ff0000,,,0x00ff0000" complete_cpuset="0x00ff0000,,,0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="108" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="107" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="105" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="106" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="102">
+                <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="104"/>
+                <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="614"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="114" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="112" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="113" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="109">
+                <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="111"/>
+                <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="615"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="120" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="118" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="119" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="115">
+                <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="117"/>
+                <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="616"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="126" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="124" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="125" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="121">
+                <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="123"/>
+                <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="617"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="132" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="130" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="131" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="127">
+                <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="129"/>
+                <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="618"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="138" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="136" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="137" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="133">
+                <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="135"/>
+                <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="619"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="144" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="142" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="143" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="139">
+                <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="141"/>
+                <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="620"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="150" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="148" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="149" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="145">
+                <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="147"/>
+                <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="621"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="865" bridge_type="0-1" depth="0" bridge_pci="0000:[00-02]">
+        <object type="Bridge" gp_index="807" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="753" pci_busid="0000:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="915" name="hsi0" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:61"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="835" bridge_type="1-1" depth="1" bridge_pci="0000:[02-02]" pci_busid="0000:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="726" pci_busid="0000:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="919" name="rsmi0" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="3a76b3ad1f88ac8d"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi1 rsmi2 rsmi3 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="867" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
+        <object type="Bridge" gp_index="738" bridge_type="1-1" depth="1" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.1" pci_type="0604 [1022:14fd] [1022:1234] 00" pci_link_speed="0.250000">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="791" pci_busid="0000:81:00.0" pci_type="0200 [8086:1537] [ffff:0000] 03" pci_link_speed="0.250000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I210 Gigabit Backplane Connection"/>
+            <object type="OSDev" gp_index="916" name="enp129s0" osdev_type="2">
+              <info name="Address" value="00:40:a6:89:18:43"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" complete_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="152">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="1" cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" complete_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="695" local_memory="134972620800">
+        <page_type size="4096" count="32952300"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="4" cpuset="0xff000000,,,0xff000000" complete_cpuset="0xff000000,,,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="159" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="32" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="158" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="32" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="156" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="32" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="157" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="151">
+                <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="155"/>
+                <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="622"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="33" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="165" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="33" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="163" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="33" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="164" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="160">
+                <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="162"/>
+                <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="623"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="34" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="171" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="34" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="169" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="34" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="170" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="166">
+                <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="168"/>
+                <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="624"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="35" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="177" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="35" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="175" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="35" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="176" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="172">
+                <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="174"/>
+                <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="625"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="36" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="183" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="36" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="181" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="36" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="182" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="178">
+                <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="180"/>
+                <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="626"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="37" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="189" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="37" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="187" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="37" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="188" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="184">
+                <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="186"/>
+                <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="627"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="38" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="195" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="38" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="193" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="38" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="194" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="190">
+                <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="192"/>
+                <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="628"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="39" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="201" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="39" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="199" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="39" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="200" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="196">
+                <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="198"/>
+                <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="629"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="5" cpuset="0x000000ff,,,0x000000ff,0x0" complete_cpuset="0x000000ff,,,0x000000ff,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="208" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="40" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="207" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="40" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="205" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="40" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="206" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="202">
+                <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="204"/>
+                <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="630"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="41" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="214" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="41" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="212" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="41" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="213" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="209">
+                <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="211"/>
+                <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="631"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="42" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="220" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="42" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="218" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="42" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="219" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="215">
+                <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="217"/>
+                <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="632"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="43" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="226" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="43" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="224" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="43" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="225" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="221">
+                <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="223"/>
+                <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="633"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="44" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="232" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="44" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="230" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="44" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="231" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="227">
+                <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="229"/>
+                <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="634"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="45" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="238" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="45" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="236" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="45" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="237" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="233">
+                <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="235"/>
+                <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="635"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="46" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="244" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="46" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="242" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="46" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="243" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="239">
+                <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="241"/>
+                <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="636"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="47" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="250" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="47" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="248" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="47" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="249" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="245">
+                <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="247"/>
+                <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="637"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="6" cpuset="0x0000ff00,,,0x0000ff00,0x0" complete_cpuset="0x0000ff00,,,0x0000ff00,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="257" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="48" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="256" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="48" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="254" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="48" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="255" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="251">
+                <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="253"/>
+                <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="638"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="49" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="263" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="49" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="261" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="49" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="262" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="258">
+                <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="260"/>
+                <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="639"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="50" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="269" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="50" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="267" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="50" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="268" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="264">
+                <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="266"/>
+                <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="640"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="51" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="275" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="51" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="273" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="51" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="274" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="270">
+                <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="272"/>
+                <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="641"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="52" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="281" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="52" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="279" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="52" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="280" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="276">
+                <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="278"/>
+                <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="642"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="53" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="287" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="53" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="285" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="53" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="286" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="282">
+                <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="284"/>
+                <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="643"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="54" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="293" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="54" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="291" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="54" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="292" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="288">
+                <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="290"/>
+                <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="644"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="55" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="299" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="55" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="297" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="55" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="298" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="294">
+                <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="296"/>
+                <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="645"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="869" bridge_type="0-1" depth="0" bridge_pci="0001:[00-02]">
+        <object type="Bridge" gp_index="732" bridge_type="1-1" depth="1" bridge_pci="0001:[01-01]" pci_busid="0001:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="850" pci_busid="0001:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="918" name="hsi1" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:60"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="763" bridge_type="1-1" depth="1" bridge_pci="0001:[02-02]" pci_busid="0001:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="823" pci_busid="0001:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="920" name="rsmi1" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="3a76b3ad1f88ac8d"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi2 rsmi3 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="871" bridge_type="0-1" depth="0" bridge_pci="0001:[80-94]">
+        <object type="Bridge" gp_index="833" bridge_type="1-1" depth="1" bridge_pci="0001:[81-94]" pci_busid="0001:80:03.1" pci_type="0604 [1022:14fd] [1022:1234] 00" pci_link_speed="7.876923">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="Bridge" gp_index="714" bridge_type="1-1" depth="2" bridge_pci="0001:[82-94]" pci_busid="0001:81:00.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+            <info name="PCIVendor" value="PMC-Sierra Inc."/>
+            <object type="Bridge" gp_index="858" bridge_type="1-1" depth="3" bridge_pci="0001:[83-83]" pci_busid="0001:82:00.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="832" pci_busid="0001:83:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="1"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="883" name="nvme0n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:0"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="897" name="nvme0n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:12"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="810" bridge_type="1-1" depth="3" bridge_pci="0001:[84-84]" pci_busid="0001:82:01.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="808" pci_busid="0001:84:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="2"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="887" name="nvme1n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:11"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="905" name="nvme1n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:3"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="758" bridge_type="1-1" depth="3" bridge_pci="0001:[85-85]" pci_busid="0001:82:02.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="779" pci_busid="0001:85:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="3"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="895" name="nvme2n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:1"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="910" name="nvme2n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:8"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="703" bridge_type="1-1" depth="3" bridge_pci="0001:[86-86]" pci_busid="0001:82:03.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="755" pci_busid="0001:86:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="4"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="886" name="nvme3n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:4"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="900" name="nvme3n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:9"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="824" bridge_type="1-1" depth="3" bridge_pci="0001:[87-87]" pci_busid="0001:82:04.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="727" pci_busid="0001:87:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="5"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="890" name="nvme4n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:10"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="909" name="nvme4n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:2"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="771" bridge_type="1-1" depth="3" bridge_pci="0001:[88-88]" pci_busid="0001:82:05.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="699" pci_busid="0001:88:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="6"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="898" name="nvme5n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:7"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="913" name="nvme5n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:21"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="717" bridge_type="1-1" depth="3" bridge_pci="0001:[89-89]" pci_busid="0001:82:06.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="842" pci_busid="0001:89:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="7"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="888" name="nvme6n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:6"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="903" name="nvme6n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:20"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="788" bridge_type="1-1" depth="3" bridge_pci="0001:[8b-8b]" pci_busid="0001:82:08.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="860" pci_busid="0001:8b:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="9"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="893" name="nvme7n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:18"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="911" name="nvme7n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:5"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="734" bridge_type="1-1" depth="3" bridge_pci="0001:[8c-8c]" pci_busid="0001:82:09.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="837" pci_busid="0001:8c:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="10"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="884" name="nvme8n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:27"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="901" name="nvme8n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:13"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="775" bridge_type="1-1" depth="3" bridge_pci="0001:[8d-8d]" pci_busid="0001:82:0a.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="811" pci_busid="0001:8d:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="11"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="891" name="nvme9n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:17"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="907" name="nvme9n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:29"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="722" bridge_type="1-1" depth="3" bridge_pci="0001:[8e-8e]" pci_busid="0001:82:0b.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="784" pci_busid="0001:8e:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="12"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="881" name="nvme10n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:24"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="899" name="nvme10n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:14"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="840" bridge_type="1-1" depth="3" bridge_pci="0001:[8f-8f]" pci_busid="0001:82:0c.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="757" pci_busid="0001:8f:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="13"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="889" name="nvme11n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:16"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="904" name="nvme11n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:25"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="737" bridge_type="1-1" depth="3" bridge_pci="0001:[91-91]" pci_busid="0001:82:0e.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="765" pci_busid="0001:91:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="15"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="894" name="nvme12n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:26"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="912" name="nvme12n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:15"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="856" bridge_type="1-1" depth="3" bridge_pci="0001:[92-92]" pci_busid="0001:82:0f.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="736" pci_busid="0001:92:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="16"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="885" name="nvme13n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:31"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="902" name="nvme13n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:22"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="804" bridge_type="1-1" depth="3" bridge_pci="0001:[93-93]" pci_busid="0001:82:10.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="710" pci_busid="0001:93:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="17"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="892" name="nvme14n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:19"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="908" name="nvme14n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:28"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="750" bridge_type="1-1" depth="3" bridge_pci="0001:[94-94]" pci_busid="0001:82:11.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="852" pci_busid="0001:94:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="18"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="882" name="nvme15n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:23"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="896" name="nvme15n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:30"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="2" cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" complete_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="301">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="2" cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" complete_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="696" local_memory="134926782464">
+        <page_type size="4096" count="32941109"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="8" cpuset="0x00ff0000,,,0x00ff0000,0x0" complete_cpuset="0x00ff0000,,,0x00ff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="308" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="64" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="307" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="64" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="305" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="64" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="306" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="300">
+                <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="304"/>
+                <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="646"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="65" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="314" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="65" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="312" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="65" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="313" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="309">
+                <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="311"/>
+                <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="647"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="66" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="320" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="66" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="318" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="66" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="319" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="315">
+                <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="317"/>
+                <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="648"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="67" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="326" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="67" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="324" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="67" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="325" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="321">
+                <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="323"/>
+                <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="649"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="68" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="332" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="68" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="330" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="68" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="331" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="327">
+                <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="329"/>
+                <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="650"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="69" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="338" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="69" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="336" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="69" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="337" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="333">
+                <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="335"/>
+                <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="651"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="70" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="344" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="70" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="342" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="70" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="343" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="339">
+                <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="341"/>
+                <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="652"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="71" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="350" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="71" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="348" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="71" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="349" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="345">
+                <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="347"/>
+                <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="653"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="9" cpuset="0xff000000,,,0xff000000,0x0" complete_cpuset="0xff000000,,,0xff000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="357" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="72" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="356" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="72" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="354" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="72" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="355" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="351">
+                <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="353"/>
+                <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="654"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="73" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="363" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="73" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="361" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="73" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="362" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="358">
+                <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="360"/>
+                <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="655"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="74" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="369" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="74" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="367" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="74" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="368" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="364">
+                <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="366"/>
+                <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="656"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="75" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="375" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="75" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="373" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="75" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="374" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="370">
+                <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="372"/>
+                <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="657"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="76" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="381" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="76" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="379" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="76" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="380" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="376">
+                <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="378"/>
+                <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="658"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="77" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="387" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="77" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="385" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="77" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="386" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="382">
+                <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="384"/>
+                <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="659"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="78" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="393" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="78" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="391" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="78" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="392" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="388">
+                <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="390"/>
+                <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="660"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="79" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="399" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="79" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="397" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="79" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="398" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="394">
+                <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="396"/>
+                <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="661"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="10" cpuset="0x000000ff,,,0x000000ff,,0x0" complete_cpuset="0x000000ff,,,0x000000ff,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="406" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="80" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="405" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="80" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="403" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="80" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="404" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="400">
+                <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="402"/>
+                <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="662"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="81" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="412" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="81" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="410" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="81" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="411" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="407">
+                <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="409"/>
+                <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="663"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="82" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="418" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="82" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="416" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="82" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="417" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="413">
+                <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="415"/>
+                <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="664"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="83" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="424" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="83" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="422" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="83" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="423" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="419">
+                <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="421"/>
+                <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="665"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="84" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="430" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="84" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="428" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="84" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="429" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="425">
+                <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="427"/>
+                <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="666"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="85" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="436" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="85" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="434" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="85" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="435" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="431">
+                <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="433"/>
+                <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="667"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="86" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="442" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="86" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="440" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="86" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="441" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="437">
+                <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="439"/>
+                <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="668"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="87" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="448" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="87" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="446" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="87" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="447" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="443">
+                <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="445"/>
+                <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="669"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="873" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+        <object type="Bridge" gp_index="827" bridge_type="1-1" depth="1" bridge_pci="0002:[01-01]" pci_busid="0002:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="776" pci_busid="0002:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="914" name="hsi2" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:a1"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="857" bridge_type="1-1" depth="1" bridge_pci="0002:[02-02]" pci_busid="0002:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="748" pci_busid="0002:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="921" name="rsmi2" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="3a76b3ad1f88ac8d"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi3 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="3" cpuset="0xffffff00,,,0xffffff00,,0x0" complete_cpuset="0xffffff00,,,0xffffff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="450">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="3" cpuset="0xffffff00,,,0xffffff00,,0x0" complete_cpuset="0xffffff00,,,0xffffff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="697" local_memory="134960807936">
+        <page_type size="4096" count="32949416"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="12" cpuset="0x0000ff00,,,0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,,0x0000ff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="457" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="96" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="456" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="96" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="454" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="96" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="455" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="449">
+                <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="453"/>
+                <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="670"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="97" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="463" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="97" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="461" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="97" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="462" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="458">
+                <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="460"/>
+                <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="671"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="98" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="469" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="98" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="467" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="98" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="468" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="464">
+                <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="466"/>
+                <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="672"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="99" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="475" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="99" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="473" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="99" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="474" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="470">
+                <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="472"/>
+                <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="673"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="100" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="481" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="100" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="479" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="100" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="480" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="476">
+                <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="478"/>
+                <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="674"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="101" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="487" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="101" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="485" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="101" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="486" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="482">
+                <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="484"/>
+                <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="675"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="102" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="493" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="102" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="491" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="102" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="492" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="488">
+                <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="490"/>
+                <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="676"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="103" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="499" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="103" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="497" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="103" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="498" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="494">
+                <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="496"/>
+                <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="677"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="13" cpuset="0x00ff0000,,,0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,,0x00ff0000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="506" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="104" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="505" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="104" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="503" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="104" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="504" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="500">
+                <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="502"/>
+                <object type="PU" os_index="176" cpuset="0x00010000,,,,,0x0" complete_cpuset="0x00010000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="678"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="105" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="512" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="105" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="510" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="105" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="511" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="507">
+                <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="509"/>
+                <object type="PU" os_index="177" cpuset="0x00020000,,,,,0x0" complete_cpuset="0x00020000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="679"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="106" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="518" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="106" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="516" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="106" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="517" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="513">
+                <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="515"/>
+                <object type="PU" os_index="178" cpuset="0x00040000,,,,,0x0" complete_cpuset="0x00040000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="680"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="107" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="524" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="107" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="522" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="107" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="523" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="519">
+                <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="521"/>
+                <object type="PU" os_index="179" cpuset="0x00080000,,,,,0x0" complete_cpuset="0x00080000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="681"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="108" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="530" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="108" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="528" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="108" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="529" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="525">
+                <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="527"/>
+                <object type="PU" os_index="180" cpuset="0x00100000,,,,,0x0" complete_cpuset="0x00100000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="682"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="109" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="536" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="109" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="534" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="109" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="535" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="531">
+                <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="533"/>
+                <object type="PU" os_index="181" cpuset="0x00200000,,,,,0x0" complete_cpuset="0x00200000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="683"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="110" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="542" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="110" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="540" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="110" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="541" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="537">
+                <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="539"/>
+                <object type="PU" os_index="182" cpuset="0x00400000,,,,,0x0" complete_cpuset="0x00400000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="684"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="111" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="548" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="111" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="546" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="111" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="547" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="543">
+                <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="545"/>
+                <object type="PU" os_index="183" cpuset="0x00800000,,,,,0x0" complete_cpuset="0x00800000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="685"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="14" cpuset="0xff000000,,,0xff000000,,0x0" complete_cpuset="0xff000000,,,0xff000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="555" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="112" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="554" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="112" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="552" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="112" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="553" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="549">
+                <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="551"/>
+                <object type="PU" os_index="184" cpuset="0x01000000,,,,,0x0" complete_cpuset="0x01000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="686"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="113" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="561" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="113" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="559" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="113" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="560" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="556">
+                <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="558"/>
+                <object type="PU" os_index="185" cpuset="0x02000000,,,,,0x0" complete_cpuset="0x02000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="687"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="114" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="567" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="114" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="565" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="114" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="566" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="562">
+                <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="564"/>
+                <object type="PU" os_index="186" cpuset="0x04000000,,,,,0x0" complete_cpuset="0x04000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="688"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="115" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="573" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="115" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="571" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="115" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="572" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="568">
+                <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="570"/>
+                <object type="PU" os_index="187" cpuset="0x08000000,,,,,0x0" complete_cpuset="0x08000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="689"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="116" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="579" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="116" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="577" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="116" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="578" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="574">
+                <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="576"/>
+                <object type="PU" os_index="188" cpuset="0x10000000,,,,,0x0" complete_cpuset="0x10000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="690"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="117" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="585" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="117" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="583" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="117" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="584" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="580">
+                <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="582"/>
+                <object type="PU" os_index="189" cpuset="0x20000000,,,,,0x0" complete_cpuset="0x20000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="691"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="118" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="591" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="118" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="589" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="118" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="590" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="586">
+                <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="588"/>
+                <object type="PU" os_index="190" cpuset="0x40000000,,,,,0x0" complete_cpuset="0x40000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="692"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="119" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="597" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="119" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="595" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="119" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="596" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="592">
+                <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="594"/>
+                <object type="PU" os_index="191" cpuset="0x80000000,,,,,0x0" complete_cpuset="0x80000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="693"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="877" bridge_type="0-1" depth="0" bridge_pci="0003:[00-02]">
+        <object type="Bridge" gp_index="754" bridge_type="1-1" depth="1" bridge_pci="0003:[01-01]" pci_busid="0003:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="701" pci_busid="0003:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="917" name="hsi3" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:a0"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="786" bridge_type="1-1" depth="1" bridge_pci="0003:[02-02]" pci_busid="0003:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="844" pci_busid="0003:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="922" name="rsmi3" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="3a76b3ad1f88ac8d"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="OSDev" gp_index="906" name="sda" subtype="Disk" osdev_type="0">
+      <info name="Size" value="66060288"/>
+      <info name="SectorSize" value="512"/>
+      <info name="LinuxDeviceID" value="8:0"/>
+      <info name="Vendor" value="LIO-ORG"/>
+      <info name="Model" value="FILEIO"/>
+      <info name="Revision" value="4.0"/>
+      <info name="SerialNumber" value="000000000000"/>
+    </object>
+  </object>
+  <distances2 type="NUMANode" nbobjs="4" kind="5" name="NUMALatency" indexing="os">
+    <indexes length="8">0 1 2 3 </indexes>
+    <u64values length="30">10 32 32 32 32 10 32 32 32 32 </u64values>
+    <u64values length="18">10 32 32 32 32 10 </u64values>
+  </distances2>
+  <distances2 type="OSDev" nbobjs="4" kind="9" name="XGMIBandwidth" indexing="gp">
+    <indexes length="16">919 920 921 922 </indexes>
+    <u64values length="72">1000000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="44">1000000 100000 100000 100000 100000 1000000 </u64values>
+  </distances2>
+  <distances2 type="OSDev" nbobjs="4" kind="5" name="XGMIHops" indexing="gp">
+    <indexes length="16">919 920 921 922 </indexes>
+    <u64values length="20">0 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="12">0 1 1 1 1 0 </u64values>
+  </distances2>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.numa_memory"/>
+  <support name="discovery.disallowed_pu"/>
+  <support name="discovery.disallowed_numa"/>
+  <support name="discovery.cpukind_efficiency"/>
+  <support name="cpubind.set_thisproc_cpubind"/>
+  <support name="cpubind.get_thisproc_cpubind"/>
+  <support name="cpubind.set_proc_cpubind"/>
+  <support name="cpubind.get_proc_cpubind"/>
+  <support name="cpubind.set_thisthread_cpubind"/>
+  <support name="cpubind.get_thisthread_cpubind"/>
+  <support name="cpubind.set_thread_cpubind"/>
+  <support name="cpubind.get_thread_cpubind"/>
+  <support name="cpubind.get_thisproc_last_cpu_location"/>
+  <support name="cpubind.get_proc_last_cpu_location"/>
+  <support name="cpubind.get_thisthread_last_cpu_location"/>
+  <support name="membind.set_thisthread_membind"/>
+  <support name="membind.get_thisthread_membind"/>
+  <support name="membind.set_area_membind"/>
+  <support name="membind.get_area_membind"/>
+  <support name="membind.alloc_membind"/>
+  <support name="membind.firsttouch_membind"/>
+  <support name="membind.bind_membind"/>
+  <support name="membind.interleave_membind"/>
+  <support name="membind.migrate_membind"/>
+  <support name="membind.get_area_memlocation"/>
+  <support name="custom.exported_support"/>
+  <memattr name="Latency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="139" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="139" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="139" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="139" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="ReadBandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="5451776" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="5451776" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="5451776" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="5451776" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="ReadLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="182" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="182" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="182" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="182" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="WriteLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="96" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="96" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="96" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="96" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <cpukind cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff">
+    <info name="FrequencyMaxMHz" value="3700"/>
+  </cpukind>
+</topology>

--- a/t/hwloc-data/tuo.TPX.xml
+++ b/t/hwloc-data/tuo.TPX.xml
@@ -1,0 +1,2016 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f" gp_index="1">
+    <info name="DMIProductName" value="HPE_CRAY_EX255a"/>
+    <info name="DMIProductVersion" value="1.8.0"/>
+    <info name="DMIBoardVendor" value="HPE"/>
+    <info name="DMIBoardName" value="HPE CRAY EX255a"/>
+    <info name="DMIBoardVersion" value="ParryPeak"/>
+    <info name="DMIBoardAssetTag" value="UNKNOWN"/>
+    <info name="DMIChassisVendor" value="HPE"/>
+    <info name="DMIChassisType" value="17"/>
+    <info name="DMIChassisVersion" value="HPE Cray EX Supercomputers"/>
+    <info name="DMIChassisAssetTag" value="UNKNOWN"/>
+    <info name="DMIBIOSVendor" value="HPE"/>
+    <info name="DMIBIOSVersion" value="1.8.0"/>
+    <info name="DMIBIOSDate" value="11/18/2025"/>
+    <info name="DMISysVendor" value="HPE"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/user.slice"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="4.18.0-553.124.1.2toss.t4.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Fri May 15 11:02:50 PDT 2026"/>
+    <info name="HostName" value="testhost-amd"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="2.12.2"/>
+    <info name="ProcessName" value="lstopo"/>
+    <object type="Package" os_index="0" cpuset="0x00ffffff,,,0x00ffffff" complete_cpuset="0x00ffffff,,,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="3">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff,,,0x00ffffff" complete_cpuset="0x00ffffff,,,0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="694" local_memory="134081638400">
+        <page_type size="4096" count="32734775"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="0" cpuset="0x000000ff,,,0x000000ff" complete_cpuset="0x000000ff,,,0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+                <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6"/>
+                <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="598"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11">
+                <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13"/>
+                <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="599"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17">
+                <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19"/>
+                <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="600"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23">
+                <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25"/>
+                <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="601"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29">
+                <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31"/>
+                <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="602"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35">
+                <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37"/>
+                <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="603"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41">
+                <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43"/>
+                <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="604"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="52" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="50" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="51" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="47">
+                <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="49"/>
+                <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="605"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="1" cpuset="0x0000ff00,,,0x0000ff00" complete_cpuset="0x0000ff00,,,0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="59" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="58" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="56" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="57" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="53">
+                <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="55"/>
+                <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="606"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="65" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="63" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="64" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="60">
+                <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="62"/>
+                <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="607"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="71" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="69" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="70" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="66">
+                <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="68"/>
+                <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="608"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="77" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="75" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="76" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="72">
+                <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="74"/>
+                <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="609"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="83" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="81" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="82" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="78">
+                <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="80"/>
+                <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="610"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="89" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="87" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="88" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="84">
+                <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="86"/>
+                <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="611"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="95" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="93" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="94" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="90">
+                <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="92"/>
+                <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="612"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="101" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="99" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="100" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="96">
+                <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="98"/>
+                <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="613"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="2" cpuset="0x00ff0000,,,0x00ff0000" complete_cpuset="0x00ff0000,,,0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="108" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="107" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="105" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="106" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="102">
+                <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="104"/>
+                <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="614"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="114" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="112" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="113" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="109">
+                <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="111"/>
+                <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="615"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="120" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="118" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="119" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="115">
+                <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="117"/>
+                <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="616"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="126" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="124" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="125" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="121">
+                <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="123"/>
+                <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="617"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="132" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="130" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="131" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="127">
+                <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="129"/>
+                <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="618"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="138" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="136" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="137" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="133">
+                <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="135"/>
+                <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="619"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="144" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="142" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="143" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="139">
+                <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="141"/>
+                <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="620"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="150" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="148" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="149" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="145">
+                <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="147"/>
+                <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="621"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="865" bridge_type="0-1" depth="0" bridge_pci="0000:[00-02]">
+        <object type="Bridge" gp_index="807" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="753" pci_busid="0000:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="916" name="hsi0" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:50"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="835" bridge_type="1-1" depth="1" bridge_pci="0000:[02-02]" pci_busid="0000:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="726" pci_busid="0000:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="919" name="rsmi0" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 "/>
+            </object>
+            <object type="OSDev" gp_index="920" name="rsmi1" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 "/>
+            </object>
+            <object type="OSDev" gp_index="921" name="rsmi2" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="867" bridge_type="0-1" depth="0" bridge_pci="0000:[80-81]">
+        <object type="Bridge" gp_index="738" bridge_type="1-1" depth="1" bridge_pci="0000:[81-81]" pci_busid="0000:80:03.1" pci_type="0604 [1022:14fd] [1022:1234] 00" pci_link_speed="0.250000">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="791" pci_busid="0000:81:00.0" pci_type="0200 [8086:1537] [ffff:0000] 03" pci_link_speed="0.250000">
+            <info name="PCIVendor" value="Intel Corporation"/>
+            <info name="PCIDevice" value="I210 Gigabit Backplane Connection"/>
+            <object type="OSDev" gp_index="914" name="enp129s0" osdev_type="2">
+              <info name="Address" value="00:40:a6:89:19:b5"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" complete_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="152">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="1" cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" complete_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="695" local_memory="134972620800">
+        <page_type size="4096" count="32952300"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="4" cpuset="0xff000000,,,0xff000000" complete_cpuset="0xff000000,,,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="159" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="32" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="158" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="32" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="156" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="32" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="157" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="151">
+                <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="155"/>
+                <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="622"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="33" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="165" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="33" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="163" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="33" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="164" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="160">
+                <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="162"/>
+                <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="623"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="34" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="171" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="34" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="169" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="34" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="170" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="166">
+                <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="168"/>
+                <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="624"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="35" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="177" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="35" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="175" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="35" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="176" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="172">
+                <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="174"/>
+                <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="625"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="36" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="183" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="36" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="181" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="36" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="182" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="178">
+                <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="180"/>
+                <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="626"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="37" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="189" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="37" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="187" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="37" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="188" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="184">
+                <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="186"/>
+                <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="627"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="38" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="195" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="38" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="193" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="38" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="194" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="190">
+                <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="192"/>
+                <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="628"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="39" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="201" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="39" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="199" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="39" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="200" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="196">
+                <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="198"/>
+                <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="629"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="5" cpuset="0x000000ff,,,0x000000ff,0x0" complete_cpuset="0x000000ff,,,0x000000ff,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="208" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="40" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="207" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="40" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="205" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="40" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="206" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="202">
+                <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="204"/>
+                <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="630"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="41" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="214" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="41" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="212" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="41" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="213" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="209">
+                <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="211"/>
+                <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="631"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="42" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="220" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="42" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="218" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="42" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="219" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="215">
+                <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="217"/>
+                <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="632"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="43" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="226" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="43" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="224" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="43" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="225" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="221">
+                <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="223"/>
+                <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="633"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="44" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="232" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="44" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="230" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="44" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="231" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="227">
+                <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="229"/>
+                <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="634"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="45" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="238" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="45" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="236" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="45" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="237" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="233">
+                <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="235"/>
+                <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="635"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="46" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="244" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="46" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="242" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="46" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="243" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="239">
+                <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="241"/>
+                <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="636"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="47" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="250" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="47" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="248" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="47" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="249" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="245">
+                <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="247"/>
+                <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="637"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="6" cpuset="0x0000ff00,,,0x0000ff00,0x0" complete_cpuset="0x0000ff00,,,0x0000ff00,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="257" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="48" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="256" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="48" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="254" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="48" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="255" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="251">
+                <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="253"/>
+                <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="638"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="49" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="263" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="49" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="261" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="49" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="262" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="258">
+                <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="260"/>
+                <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="639"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="50" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="269" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="50" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="267" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="50" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="268" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="264">
+                <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="266"/>
+                <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="640"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="51" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="275" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="51" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="273" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="51" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="274" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="270">
+                <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="272"/>
+                <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="641"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="52" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="281" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="52" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="279" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="52" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="280" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="276">
+                <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="278"/>
+                <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="642"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="53" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="287" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="53" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="285" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="53" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="286" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="282">
+                <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="284"/>
+                <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="643"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="54" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="293" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="54" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="291" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="54" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="292" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="288">
+                <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="290"/>
+                <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="644"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="55" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="299" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="55" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="297" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="55" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="298" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="294">
+                <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="296"/>
+                <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="645"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="869" bridge_type="0-1" depth="0" bridge_pci="0001:[00-02]">
+        <object type="Bridge" gp_index="732" bridge_type="1-1" depth="1" bridge_pci="0001:[01-01]" pci_busid="0001:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="850" pci_busid="0001:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="918" name="hsi1" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:51"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="763" bridge_type="1-1" depth="1" bridge_pci="0001:[02-02]" pci_busid="0001:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="823" pci_busid="0001:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="922" name="rsmi3" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 "/>
+            </object>
+            <object type="OSDev" gp_index="923" name="rsmi4" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 "/>
+            </object>
+            <object type="OSDev" gp_index="924" name="rsmi5" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="871" bridge_type="0-1" depth="0" bridge_pci="0001:[80-94]">
+        <object type="Bridge" gp_index="833" bridge_type="1-1" depth="1" bridge_pci="0001:[81-94]" pci_busid="0001:80:03.1" pci_type="0604 [1022:14fd] [1022:1234] 00" pci_link_speed="7.876923">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="Bridge" gp_index="714" bridge_type="1-1" depth="2" bridge_pci="0001:[82-94]" pci_busid="0001:81:00.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+            <info name="PCIVendor" value="PMC-Sierra Inc."/>
+            <object type="Bridge" gp_index="858" bridge_type="1-1" depth="3" bridge_pci="0001:[83-83]" pci_busid="0001:82:00.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="832" pci_busid="0001:83:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="1"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="883" name="nvme0n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:0"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="897" name="nvme0n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:6"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="810" bridge_type="1-1" depth="3" bridge_pci="0001:[84-84]" pci_busid="0001:82:01.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="808" pci_busid="0001:84:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="2"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="887" name="nvme1n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:5"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="905" name="nvme1n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:1"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="758" bridge_type="1-1" depth="3" bridge_pci="0001:[85-85]" pci_busid="0001:82:02.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="779" pci_busid="0001:85:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="3"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="895" name="nvme2n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:2"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="910" name="nvme2n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:7"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="703" bridge_type="1-1" depth="3" bridge_pci="0001:[86-86]" pci_busid="0001:82:03.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="755" pci_busid="0001:86:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="4"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="886" name="nvme3n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:4"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="900" name="nvme3n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:12"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="824" bridge_type="1-1" depth="3" bridge_pci="0001:[87-87]" pci_busid="0001:82:04.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="727" pci_busid="0001:87:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="5"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="890" name="nvme4n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:11"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="909" name="nvme4n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:3"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="771" bridge_type="1-1" depth="3" bridge_pci="0001:[88-88]" pci_busid="0001:82:05.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="699" pci_busid="0001:88:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="6"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="898" name="nvme5n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:10"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="913" name="nvme5n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:16"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="717" bridge_type="1-1" depth="3" bridge_pci="0001:[89-89]" pci_busid="0001:82:06.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="842" pci_busid="0001:89:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="7"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="888" name="nvme6n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:8"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="903" name="nvme6n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:13"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="788" bridge_type="1-1" depth="3" bridge_pci="0001:[8b-8b]" pci_busid="0001:82:08.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="860" pci_busid="0001:8b:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="9"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="893" name="nvme7n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:14"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="911" name="nvme7n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:9"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="734" bridge_type="1-1" depth="3" bridge_pci="0001:[8c-8c]" pci_busid="0001:82:09.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="837" pci_busid="0001:8c:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="10"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="884" name="nvme8n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:29"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="901" name="nvme8n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:18"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="775" bridge_type="1-1" depth="3" bridge_pci="0001:[8d-8d]" pci_busid="0001:82:0a.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="811" pci_busid="0001:8d:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="11"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="891" name="nvme9n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:15"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="907" name="nvme9n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:24"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="722" bridge_type="1-1" depth="3" bridge_pci="0001:[8e-8e]" pci_busid="0001:82:0b.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="784" pci_busid="0001:8e:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="12"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="881" name="nvme10n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:30"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="899" name="nvme10n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:22"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="840" bridge_type="1-1" depth="3" bridge_pci="0001:[8f-8f]" pci_busid="0001:82:0c.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="757" pci_busid="0001:8f:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="13"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="889" name="nvme11n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:17"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="904" name="nvme11n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:27"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="737" bridge_type="1-1" depth="3" bridge_pci="0001:[91-91]" pci_busid="0001:82:0e.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="765" pci_busid="0001:91:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="15"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="894" name="nvme12n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:26"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="912" name="nvme12n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:20"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="856" bridge_type="1-1" depth="3" bridge_pci="0001:[92-92]" pci_busid="0001:82:0f.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="736" pci_busid="0001:92:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="16"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="885" name="nvme13n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:28"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="902" name="nvme13n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:19"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="804" bridge_type="1-1" depth="3" bridge_pci="0001:[93-93]" pci_busid="0001:82:10.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="710" pci_busid="0001:93:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="17"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="892" name="nvme14n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:21"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="908" name="nvme14n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:25"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" gp_index="750" bridge_type="1-1" depth="3" bridge_pci="0001:[94-94]" pci_busid="0001:82:11.0" pci_type="0604 [11f8:4200] [11f8:beef] 00" pci_link_speed="7.876923">
+              <info name="PCIVendor" value="PMC-Sierra Inc."/>
+              <object type="PCIDev" gp_index="852" pci_busid="0001:94:00.0" pci_type="0108 [1e0f:0014] [1e0f:0063] 01" pci_link_speed="0.000000">
+                <info name="PCISlot" value="18"/>
+                <info name="PCIVendor" value="KIOXIA Corporation"/>
+                <info name="PCIDevice" value="NVMe SSD Controller CM7 EDSFF"/>
+                <object type="OSDev" gp_index="882" name="nvme15n1" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="13107200"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:23"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+                <object type="OSDev" gp_index="896" name="nvme15n2" subtype="Disk" osdev_type="0">
+                  <info name="Size" value="65536"/>
+                  <info name="SectorSize" value="4096"/>
+                  <info name="LinuxDeviceID" value="259:31"/>
+                  <info name="Model" value="KIOXIA KCM7DRJE1T92"/>
+                  <info name="SerialNumber" value="000000000000"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="2" cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" complete_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="301">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="2" cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" complete_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="696" local_memory="134972628992">
+        <page_type size="4096" count="32952302"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="8" cpuset="0x00ff0000,,,0x00ff0000,0x0" complete_cpuset="0x00ff0000,,,0x00ff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="308" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="64" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="307" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="64" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="305" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="64" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="306" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="300">
+                <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="304"/>
+                <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="646"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="65" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="314" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="65" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="312" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="65" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="313" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="309">
+                <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="311"/>
+                <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="647"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="66" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="320" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="66" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="318" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="66" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="319" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="315">
+                <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="317"/>
+                <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="648"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="67" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="326" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="67" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="324" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="67" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="325" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="321">
+                <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="323"/>
+                <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="649"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="68" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="332" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="68" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="330" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="68" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="331" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="327">
+                <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="329"/>
+                <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="650"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="69" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="338" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="69" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="336" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="69" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="337" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="333">
+                <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="335"/>
+                <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="651"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="70" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="344" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="70" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="342" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="70" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="343" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="339">
+                <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="341"/>
+                <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="652"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="71" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="350" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="71" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="348" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="71" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="349" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="345">
+                <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="347"/>
+                <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="653"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="9" cpuset="0xff000000,,,0xff000000,0x0" complete_cpuset="0xff000000,,,0xff000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="357" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="72" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="356" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="72" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="354" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="72" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="355" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="351">
+                <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="353"/>
+                <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="654"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="73" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="363" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="73" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="361" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="73" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="362" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="358">
+                <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="360"/>
+                <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="655"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="74" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="369" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="74" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="367" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="74" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="368" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="364">
+                <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="366"/>
+                <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="656"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="75" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="375" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="75" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="373" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="75" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="374" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="370">
+                <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="372"/>
+                <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="657"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="76" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="381" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="76" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="379" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="76" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="380" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="376">
+                <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="378"/>
+                <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="658"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="77" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="387" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="77" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="385" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="77" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="386" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="382">
+                <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="384"/>
+                <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="659"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="78" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="393" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="78" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="391" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="78" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="392" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="388">
+                <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="390"/>
+                <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="660"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="79" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="399" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="79" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="397" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="79" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="398" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="394">
+                <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="396"/>
+                <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="661"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="10" cpuset="0x000000ff,,,0x000000ff,,0x0" complete_cpuset="0x000000ff,,,0x000000ff,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="406" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="80" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="405" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="80" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="403" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="80" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="404" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="400">
+                <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="402"/>
+                <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="662"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="81" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="412" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="81" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="410" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="81" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="411" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="407">
+                <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="409"/>
+                <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="663"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="82" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="418" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="82" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="416" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="82" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="417" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="413">
+                <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="415"/>
+                <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="664"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="83" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="424" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="83" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="422" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="83" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="423" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="419">
+                <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="421"/>
+                <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="665"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="84" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="430" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="84" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="428" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="84" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="429" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="425">
+                <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="427"/>
+                <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="666"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="85" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="436" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="85" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="434" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="85" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="435" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="431">
+                <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="433"/>
+                <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="667"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="86" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="442" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="86" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="440" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="86" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="441" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="437">
+                <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="439"/>
+                <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="668"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="87" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="448" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="87" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="446" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="87" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="447" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="443">
+                <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="445"/>
+                <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="669"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="873" bridge_type="0-1" depth="0" bridge_pci="0002:[00-02]">
+        <object type="Bridge" gp_index="827" bridge_type="1-1" depth="1" bridge_pci="0002:[01-01]" pci_busid="0002:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="776" pci_busid="0002:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="915" name="hsi2" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:90"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="857" bridge_type="1-1" depth="1" bridge_pci="0002:[02-02]" pci_busid="0002:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="748" pci_busid="0002:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="925" name="rsmi6" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi7 rsmi8 rsmi9 rsmi10 rsmi11 "/>
+            </object>
+            <object type="OSDev" gp_index="926" name="rsmi7" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi8 rsmi9 rsmi10 rsmi11 "/>
+            </object>
+            <object type="OSDev" gp_index="927" name="rsmi8" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi9 rsmi10 rsmi11 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="3" cpuset="0xffffff00,,,0xffffff00,,0x0" complete_cpuset="0xffffff00,,,0xffffff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="450">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="144"/>
+      <info name="CPUModel" value="AMD Instinct MI300A Accelerator                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="3" cpuset="0xffffff00,,,0xffffff00,,0x0" complete_cpuset="0xffffff00,,,0xffffff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="697" local_memory="134960820224">
+        <page_type size="4096" count="32949419"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+      </object>
+      <object type="L3Cache" os_index="12" cpuset="0x0000ff00,,,0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,,0x0000ff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="457" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="96" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="456" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="96" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="454" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="96" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="455" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="0" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="449">
+                <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="453"/>
+                <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="670"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="97" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="463" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="97" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="461" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="97" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="462" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="1" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="458">
+                <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="460"/>
+                <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="671"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="98" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="469" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="98" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="467" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="98" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="468" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="2" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="464">
+                <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="466"/>
+                <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="672"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="99" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="475" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="99" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="473" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="99" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="474" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="3" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="470">
+                <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="472"/>
+                <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="673"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="100" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="481" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="100" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="479" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="100" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="480" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="4" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="476">
+                <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="478"/>
+                <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="674"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="101" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="487" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="101" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="485" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="101" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="486" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="5" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="482">
+                <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="484"/>
+                <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="675"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="102" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="493" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="102" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="491" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="102" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="492" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="6" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="488">
+                <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="490"/>
+                <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="676"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="103" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="499" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="103" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="497" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="103" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="498" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="7" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="494">
+                <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="496"/>
+                <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="677"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="13" cpuset="0x00ff0000,,,0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,,0x00ff0000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="506" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="104" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="505" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="104" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="503" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="104" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="504" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="8" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="500">
+                <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="502"/>
+                <object type="PU" os_index="176" cpuset="0x00010000,,,,,0x0" complete_cpuset="0x00010000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="678"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="105" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="512" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="105" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="510" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="105" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="511" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="9" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="507">
+                <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="509"/>
+                <object type="PU" os_index="177" cpuset="0x00020000,,,,,0x0" complete_cpuset="0x00020000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="679"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="106" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="518" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="106" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="516" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="106" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="517" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="10" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="513">
+                <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="515"/>
+                <object type="PU" os_index="178" cpuset="0x00040000,,,,,0x0" complete_cpuset="0x00040000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="680"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="107" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="524" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="107" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="522" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="107" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="523" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="11" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="519">
+                <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="521"/>
+                <object type="PU" os_index="179" cpuset="0x00080000,,,,,0x0" complete_cpuset="0x00080000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="681"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="108" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="530" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="108" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="528" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="108" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="529" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="12" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="525">
+                <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="527"/>
+                <object type="PU" os_index="180" cpuset="0x00100000,,,,,0x0" complete_cpuset="0x00100000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="682"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="109" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="536" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="109" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="534" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="109" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="535" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="13" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="531">
+                <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="533"/>
+                <object type="PU" os_index="181" cpuset="0x00200000,,,,,0x0" complete_cpuset="0x00200000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="683"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="110" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="542" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="110" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="540" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="110" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="541" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="14" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="537">
+                <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="539"/>
+                <object type="PU" os_index="182" cpuset="0x00400000,,,,,0x0" complete_cpuset="0x00400000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="684"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="111" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="548" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="111" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="546" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="111" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="547" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="15" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="543">
+                <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="545"/>
+                <object type="PU" os_index="183" cpuset="0x00800000,,,,,0x0" complete_cpuset="0x00800000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="685"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L3Cache" os_index="14" cpuset="0xff000000,,,0xff000000,,0x0" complete_cpuset="0xff000000,,,0xff000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="555" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+        <info name="Inclusive" value="0"/>
+        <object type="L2Cache" os_index="112" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="554" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="112" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="552" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="112" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="553" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="16" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="549">
+                <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="551"/>
+                <object type="PU" os_index="184" cpuset="0x01000000,,,,,0x0" complete_cpuset="0x01000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="686"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="113" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="561" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="113" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="559" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="113" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="560" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="17" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="556">
+                <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="558"/>
+                <object type="PU" os_index="185" cpuset="0x02000000,,,,,0x0" complete_cpuset="0x02000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="687"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="114" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="567" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="114" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="565" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="114" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="566" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="18" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="562">
+                <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="564"/>
+                <object type="PU" os_index="186" cpuset="0x04000000,,,,,0x0" complete_cpuset="0x04000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="688"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="115" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="573" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="115" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="571" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="115" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="572" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="19" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="568">
+                <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="570"/>
+                <object type="PU" os_index="187" cpuset="0x08000000,,,,,0x0" complete_cpuset="0x08000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="689"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="116" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="579" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="116" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="577" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="116" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="578" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="20" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="574">
+                <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="576"/>
+                <object type="PU" os_index="188" cpuset="0x10000000,,,,,0x0" complete_cpuset="0x10000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="690"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="117" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="585" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="117" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="583" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="117" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="584" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="21" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="580">
+                <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="582"/>
+                <object type="PU" os_index="189" cpuset="0x20000000,,,,,0x0" complete_cpuset="0x20000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="691"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="118" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="591" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="118" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="589" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="118" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="590" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="22" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="586">
+                <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="588"/>
+                <object type="PU" os_index="190" cpuset="0x40000000,,,,,0x0" complete_cpuset="0x40000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="692"/>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L2Cache" os_index="119" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="597" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="1"/>
+          <object type="L1Cache" os_index="119" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="595" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="Inclusive" value="0"/>
+            <object type="L1iCache" os_index="119" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="596" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="Inclusive" value="0"/>
+              <object type="Core" os_index="23" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="592">
+                <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="594"/>
+                <object type="PU" os_index="191" cpuset="0x80000000,,,,,0x0" complete_cpuset="0x80000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="693"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Bridge" gp_index="877" bridge_type="0-1" depth="0" bridge_pci="0003:[00-02]">
+        <object type="Bridge" gp_index="754" bridge_type="1-1" depth="1" bridge_pci="0003:[01-01]" pci_busid="0003:00:01.1" pci_type="0604 [1022:14fc] [1022:1234] 00" pci_link_speed="31.507692">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="701" pci_busid="0003:01:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+            <info name="PCIVendor" value="Cray Inc"/>
+            <info name="PCIDevice" value="Cassini 1 [Slingshot 200Gb]"/>
+            <object type="OSDev" gp_index="917" name="hsi3" subtype="Slingshot" osdev_type="2">
+              <info name="Address" value="02:00:00:00:21:91"/>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="786" bridge_type="1-1" depth="1" bridge_pci="0003:[02-02]" pci_busid="0003:00:07.1" pci_type="0604 [1022:14fe] [1022:14fe] 00" pci_link_speed="63.015385">
+          <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+          <object type="PCIDev" gp_index="844" pci_busid="0003:02:00.0" pci_type="1200 [1002:74a0] [1002:74a0] 00" pci_link_speed="63.015385">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+            <info name="PCIDevice" value="Aqua Vanjaram [Instinct MI300A]"/>
+            <object type="OSDev" gp_index="928" name="rsmi9" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value="Aqua Vanjaram [Instinct MI300A]"/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="RSMIGTTSize" value="536870912"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi10 rsmi11 "/>
+            </object>
+            <object type="OSDev" gp_index="929" name="rsmi10" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi11 "/>
+            </object>
+            <object type="OSDev" gp_index="930" name="rsmi11" subtype="RSMI" osdev_type="1">
+              <info name="Backend" value="RSMI"/>
+              <info name="GPUVendor" value="AMD"/>
+              <info name="GPUModel" value=""/>
+              <info name="AMDUUID" value="0000000000000000"/>
+              <info name="XGMIHiveID" value="d2f005aa524b41a7"/>
+              <info name="XGMIPeers" value="rsmi0 rsmi1 rsmi2 rsmi3 rsmi4 rsmi5 rsmi6 rsmi7 rsmi8 rsmi9 rsmi10 "/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="OSDev" gp_index="906" name="sda" subtype="Disk" osdev_type="0">
+      <info name="Size" value="66060288"/>
+      <info name="SectorSize" value="512"/>
+      <info name="LinuxDeviceID" value="8:0"/>
+      <info name="Vendor" value="LIO-ORG"/>
+      <info name="Model" value="FILEIO"/>
+      <info name="Revision" value="4.0"/>
+      <info name="SerialNumber" value="000000000000"/>
+    </object>
+  </object>
+  <distances2 type="NUMANode" nbobjs="4" kind="5" name="NUMALatency" indexing="os">
+    <indexes length="8">0 1 2 3 </indexes>
+    <u64values length="30">10 32 32 32 32 10 32 32 32 32 </u64values>
+    <u64values length="18">10 32 32 32 32 10 </u64values>
+  </distances2>
+  <distances2 type="OSDev" nbobjs="12" kind="9" name="XGMIBandwidth" indexing="gp">
+    <indexes length="40">919 920 921 922 923 924 925 926 927 928 </indexes>
+    <indexes length="8">929 930 </indexes>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 1000000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 100000 1000000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 100000 100000 100000 100000 1000000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 1000000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 1000000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 100000 100000 100000 1000000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 1000000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 1000000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">100000 100000 100000 100000 100000 100000 100000 1000000 100000 100000 </u64values>
+    <u64values length="70">100000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="71">1000000 100000 100000 100000 100000 100000 100000 100000 100000 100000 </u64values>
+    <u64values length="29">100000 100000 100000 1000000 </u64values>
+  </distances2>
+  <distances2 type="OSDev" nbobjs="12" kind="5" name="XGMIHops" indexing="gp">
+    <indexes length="40">919 920 921 922 923 924 925 926 927 928 </indexes>
+    <indexes length="8">929 930 </indexes>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 0 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 0 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 0 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 0 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 0 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 0 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 0 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 0 1 1 1 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 0 1 1 </u64values>
+    <u64values length="20">1 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="20">0 1 1 1 1 1 1 1 1 1 </u64values>
+    <u64values length="8">1 1 1 0 </u64values>
+  </distances2>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.numa_memory"/>
+  <support name="discovery.disallowed_pu"/>
+  <support name="discovery.disallowed_numa"/>
+  <support name="discovery.cpukind_efficiency"/>
+  <support name="cpubind.set_thisproc_cpubind"/>
+  <support name="cpubind.get_thisproc_cpubind"/>
+  <support name="cpubind.set_proc_cpubind"/>
+  <support name="cpubind.get_proc_cpubind"/>
+  <support name="cpubind.set_thisthread_cpubind"/>
+  <support name="cpubind.get_thisthread_cpubind"/>
+  <support name="cpubind.set_thread_cpubind"/>
+  <support name="cpubind.get_thread_cpubind"/>
+  <support name="cpubind.get_thisproc_last_cpu_location"/>
+  <support name="cpubind.get_proc_last_cpu_location"/>
+  <support name="cpubind.get_thisthread_last_cpu_location"/>
+  <support name="membind.set_thisthread_membind"/>
+  <support name="membind.get_thisthread_membind"/>
+  <support name="membind.set_area_membind"/>
+  <support name="membind.get_area_membind"/>
+  <support name="membind.alloc_membind"/>
+  <support name="membind.firsttouch_membind"/>
+  <support name="membind.bind_membind"/>
+  <support name="membind.interleave_membind"/>
+  <support name="membind.migrate_membind"/>
+  <support name="membind.get_area_memlocation"/>
+  <support name="custom.exported_support"/>
+  <memattr name="Latency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="139" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="139" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="139" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="139" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="ReadBandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="5451776" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="5451776" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="5451776" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="5451776" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="ReadLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="182" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="182" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="182" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="182" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <memattr name="WriteLatency" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="694" value="96" initiator_cpuset="0x00ffffff,,,0x00ffffff"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="695" value="96" initiator_cpuset="0x0000ffff,0xff000000,,0x0000ffff,0xff000000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="696" value="96" initiator_cpuset="0x000000ff,0xffff0000,,0x000000ff,0xffff0000,0x0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="697" value="96" initiator_cpuset="0xffffff00,,,0xffffff00,,0x0"/>
+  </memattr>
+  <cpukind cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff">
+    <info name="FrequencyMaxMHz" value="3700"/>
+  </cpukind>
+</topology>

--- a/t/t0042-rhwloc-gpu-dedup.t
+++ b/t/t0042-rhwloc-gpu-dedup.t
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+test_description='Test GPU deduplication in rhwloc'
+
+. `dirname $0`/sharness.sh
+
+XMLDIR=${SHARNESS_TEST_SRCDIR}/hwloc-data
+
+test_expect_success 'NVIDIA system with multi-backend deduplication' '
+	test -f ${XMLDIR}/ipa20.xml &&
+	count=$(flux R encode --xml=${XMLDIR}/ipa20.xml | \
+	        flux R decode --count gpu) &&
+	test_debug "echo NVIDIA ipa20: $count GPUs" &&
+	test "$count" = "4"
+'
+
+test_expect_success 'AMD system in SPX mode (4 GPUs baseline)' '
+	test -f ${XMLDIR}/tuo.SPX.xml &&
+	count=$(flux R encode --xml=${XMLDIR}/tuo.SPX.xml | \
+	        flux R decode --count gpu) &&
+	test_debug "echo AMD SPX mode: $count GPUs" &&
+	test "$count" = "4"
+'
+
+test_expect_success 'AMD system in CPX mode (24 partitioned GPUs from 4 physical)' '
+	test -f ${XMLDIR}/tuo.CPX.xml &&
+	count=$(flux R encode --xml=${XMLDIR}/tuo.CPX.xml | \
+	        flux R decode --count gpu) &&
+	test_debug "echo AMD CPX mode: $count GPUs" &&
+	test "$count" = "24"
+'
+
+test_expect_success 'AMD system in TPX mode (12 partitioned GPUs from 4 physical)' '
+	test -f ${XMLDIR}/tuo.TPX.xml &&
+	count=$(flux R encode --xml=${XMLDIR}/tuo.TPX.xml | \
+	        flux R decode --count gpu) &&
+	test_debug "echo AMD TPX mode: $count GPUs" &&
+	test "$count" = "12"
+'
+
+test_expect_success 'FLUX_HWLOC_GPU_NO_DEDUP disables deduplication on NVIDIA' '
+	test -f ${XMLDIR}/ipa20.xml &&
+	count=$(FLUX_HWLOC_GPU_NO_DEDUP=1 \
+	        flux R encode --xml=${XMLDIR}/ipa20.xml | \
+	        flux R decode --count gpu) &&
+	test_debug "echo NVIDIA with NO_DEDUP: $count GPUs" &&
+	test "$count" = "12"
+'
+
+test_expect_success 'FLUX_HWLOC_GPU_NO_DEDUP on AMD CPX shows all partitions' '
+	test -f ${XMLDIR}/tuo.CPX.xml &&
+	count=$(FLUX_HWLOC_GPU_NO_DEDUP=1 \
+	        flux R encode --xml=${XMLDIR}/tuo.CPX.xml | \
+	        flux R decode --count gpu) &&
+	test_debug "echo AMD CPX with NO_DEDUP: $count GPUs" &&
+	test "$count" = "24"
+'
+
+test_done


### PR DESCRIPTION
Problem: Commit 2b828c1 introduced GPU deduplication based on PCI device ID to handle NVIDIA GPUs appearing under multiple hwloc backends (CUDA, NVML, OpenCL). This breaks AMD CPX/TPX GPU partitioning modes where a single physical GPU is split into multiple logical GPUs that share the same PCI device. 

Fix by tracking (PCI device, backend) tuples instead of just PCI device. GPUs with the same PCI device but different backends are duplicates (NVIDIA case), while GPUs with the same PCI device and same backend are distinct (AMD partitions). This approach is necessary because different backends report different metadata - UUIDs only appear in some backends, making UUID-based deduplication infeasible.

Also add a new `FLUX_HWLOC_GPU_NO_DEDUP` environment variable to disable deduplication as an escape hatch and 
test coverage with real XML output from affected systems.

Once this PR is approved I'll create a patched RPM for v0.85.0.