### PR TITLE
shell: limit job input written to the KVS to 10M

### DIFF
--- a/doc/man1/common/job-shell-options.rst
+++ b/doc/man1/common/job-shell-options.rst
@@ -49,6 +49,12 @@
        those resources assigned to the current job. By default, the XML is
        not restricted.
 
+   * - :option:`input.limit`
+     - Set KVS input limit to SIZE bytes, where SIZE may be a floating point
+       value including optional SI units: k, K, M, G. If this limit is
+       exceeded, a fatal job exception is raised. This value is ignored
+       if input is directed from a file with :option:`--input`.
+
    * - :option:`output.limit`
      - Set KVS output limit to SIZE bytes, where SIZE may be a floating point
        value including optional SI units: k, K, M, G. This value is ignored

--- a/doc/man7/flux-shell-options.rst
+++ b/doc/man7/flux-shell-options.rst
@@ -483,6 +483,20 @@ INPUT/OUTPUT
 
     $ flux run --input=/tmp/input.data myapp
 
+.. option:: input.limit=SIZE
+
+  Limit KVS input to *SIZE* bytes. If exceeded, a fatal job exception
+  is raised.
+
+  - *SIZE* format: number with optional SI suffix (k, K, M, G)
+  - Maximum: 32M
+  - Default: 10M
+  - Ignored for file input
+
+  .. code-block:: console
+
+    $ flux run -o input.limit=1M myapp
+
 .. option:: output.batch-timeout=FSD
 
   Set the KVS output batch-timeout to a time period in Flux Standard Duration.

--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -205,12 +205,9 @@ void attach_completed_check (struct attach_ctx *ctx)
      * futures so we can exit the reactor */
     if (!ctx->eventlog_watch_count) {
         if (ctx->stdin_rpcs) {
-            flux_future_t *f = zlist_pop (ctx->stdin_rpcs);
-            while (f) {
+            flux_future_t *f;
+            while ((f = zlist_pop (ctx->stdin_rpcs)))
                 flux_future_destroy (f);
-                zlist_remove (ctx->stdin_rpcs, f);
-                f = zlist_pop (ctx->stdin_rpcs);
-            }
         }
         flux_watcher_stop (ctx->sigint_w);
         flux_watcher_stop (ctx->sigtstp_w);

--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -1370,6 +1370,12 @@ void attach_event_continuation (flux_future_t *f, void *arg)
 
         ctx->fatal_exception = (severity == 0);
 
+        /*  If this is a fatal exception, stop stdin immediately to avoid
+         *   continuing to send data that will fail.
+         */
+        if (severity == 0 && ctx->stdin_w)
+            flux_watcher_stop (ctx->stdin_w);
+
         /*  If this job has an interactive pty and the pty is not yet attached,
          *   destroy the pty to avoid a potential hang attempting to connect
          *   to job pty that will never exist.

--- a/src/shell/input/util.c
+++ b/src/shell/input/util.c
@@ -18,10 +18,92 @@
 #include <flux/shell.h>
 
 #include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/parse_size.h"
 #include "src/common/libeventlog/eventlog.h"
+#include "src/common/libioencode/ioencode.h"
+#include "ccan/str/str.h"
 
 #include "util.h"
 #include "internal.h"
+
+/* Set a low maximum input limit for now. Moderate amounts of input
+ * written to the KVS cause issues in current Flux due to improper buffering
+ * resulting in lots of KVS appends. When this is addressed, this limit could
+ * be raised.
+ */
+#define INPUT_LIMIT_MAX   33554432 /* 32M */
+#define INPUT_EVENT_DATA  "data"
+#define INPUT_STATS_KEY   "input_stats"
+
+struct input_stats {
+    flux_shell_t *shell;
+    size_t stdin_bytes;
+    size_t limit_bytes;
+};
+
+static void input_stats_destroy (struct input_stats *stats)
+{
+    free (stats);
+}
+
+static int get_input_limit (struct input_stats *stats)
+{
+    json_t *val = NULL;
+    uint64_t size;
+    const char *limit_string = "10M";
+
+    if (flux_shell_getopt_unpack (stats->shell,
+                                  "input",
+                                  "{s?o}",
+                                  "limit", &val) < 0) {
+        shell_log_error ("Unable to unpack shell input.limit");
+        return -1;
+    }
+    if (val != NULL) {
+        if (json_is_integer (val)) {
+            json_int_t limit = json_integer_value (val);
+            if (limit <= 0 || limit > INPUT_LIMIT_MAX) {
+                shell_log ("Invalid KVS input.limit=%ld", (long) limit);
+                return -1;
+            }
+            stats->limit_bytes = (size_t) limit;
+            return 0;
+        }
+        if (!(limit_string = json_string_value (val))) {
+            shell_log_error ("Unable to convert input.limit to string");
+            return -1;
+        }
+    }
+    if (parse_size (limit_string, &size) < 0
+        || size == 0
+        || size > INPUT_LIMIT_MAX) {
+        shell_log ("Invalid KVS input.limit=%s", limit_string);
+        return -1;
+    }
+    stats->limit_bytes = (size_t) size;
+    return 0;
+}
+
+static struct input_stats *get_input_stats (flux_shell_t *shell)
+{
+    struct input_stats *stats;
+
+    stats = flux_shell_aux_get (shell, INPUT_STATS_KEY);
+    if (!stats) {
+        if (!(stats = calloc (1, sizeof (*stats))))
+            return NULL;
+        stats->shell = shell;
+        if (get_input_limit (stats) < 0
+            || flux_shell_aux_set (shell,
+                                   INPUT_STATS_KEY,
+                                   stats,
+                                   (flux_free_f) input_stats_destroy) < 0) {
+            input_stats_destroy (stats);
+            return NULL;
+        }
+    }
+    return stats;
+}
 
 static void input_put_kvs_completion (flux_future_t *f, void *arg)
 {
@@ -36,6 +118,25 @@ static void input_put_kvs_completion (flux_future_t *f, void *arg)
         shell_log_errno ("flux_shell_remove_completion_ref");
 }
 
+static void check_input_limit (flux_shell_t *shell, int len)
+{
+    struct input_stats *stats;
+
+    if (!(stats = get_input_stats (shell)))
+        shell_die_errno (1, "failed to get input stats");
+
+    stats->stdin_bytes += len;
+
+    if (stats->stdin_bytes > stats->limit_bytes) {
+        shell_die (1,
+                   "stdin exceeds %s limit. "
+                   "Try file input (flux submit --input=FILE) "
+                   "or redirect input to your command to avoid the KVS "
+                   "for large amounts of input",
+                   encode_size (stats->limit_bytes));
+    }
+}
+
 int input_eventlog_put_event (flux_shell_t *shell,
                               const char *name,
                               json_t *context)
@@ -47,6 +148,12 @@ int input_eventlog_put_event (flux_shell_t *shell,
     char *entrystr = NULL;
     int saved_errno;
     int rc = -1;
+    int len = 0;
+
+    if (streq (name, INPUT_EVENT_DATA)) {
+        if (iodecode (context, NULL, NULL, NULL, &len, NULL) == 0)
+            check_input_limit (shell, len);
+    }
 
     if (!(h = flux_shell_get_flux (shell)))
         goto error;
@@ -117,6 +224,14 @@ int input_eventlog_init (flux_shell_t *shell)
 {
     json_t *o = NULL;
     int rc = -1;
+
+    /*  Validate input.limit early so invalid values are caught
+     *  at job initialization rather than when stdin is first written.
+     */
+    if (!get_input_stats (shell)) {
+        shell_log_errno ("failed to initialize input stats");
+        goto error;
+    }
 
     if (!(o = eventlog_entry_pack (0,
                                    "header",

--- a/src/shell/input/util.h
+++ b/src/shell/input/util.h
@@ -22,7 +22,9 @@
 int input_eventlog_init (flux_shell_t *shell);
 
 /*  Put an input eventlog entry `name` defined in `context` to the KVS input
- *  eventlog.
+ *  eventlog. Returns 0 on success, -1 on error.
+ *  Note: If stdin data exceeds the configured limit (default 10M), this
+ *  function will call shell_die() with a fatal error.
  */
 int input_eventlog_put_event (flux_shell_t *shell,
                               const char *name,

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -240,4 +240,68 @@ test_expect_success 'flux-shell: no fatal exception after stdin sent to exited t
 	echo | flux job attach -XE ${id} &&
 	flux job wait-event -t 5 -v ${id} clean
 '
+
+#
+# input limit tests
+#
+
+test_expect_success 'flux-shell: stdin limit with small value causes job exception' '
+	test_expect_code 1 sh -c "dd if=/dev/zero bs=1024 count=20 2>/dev/null | \
+		flux run -o input.limit=1K cat >/dev/null 2>limit1.err" &&
+	test_debug "cat limit1.err" &&
+	grep "stdin exceeds 1K limit" limit1.err &&
+	grep "Try file input" limit1.err
+'
+
+test_expect_success 'flux-shell: stdin under limit succeeds' '
+	dd if=/dev/zero bs=512 count=1 2>/dev/null | \
+		flux run -o input.limit=1K cat >/dev/null
+'
+
+test_expect_success 'flux-shell: setting limit to 100K works' '
+	dd if=/dev/zero bs=1K count=50 2>/dev/null | \
+		flux run -o input.limit=100K cat >/dev/null
+'
+
+test_expect_success 'flux-shell: invalid input.limit string is rejected (text)' '
+	test_must_fail flux run -o input.limit=foo hostname
+'
+
+test_expect_success 'flux-shell: invalid input.limit string is rejected (zero)' '
+	test_must_fail flux run -o input.limit=0 hostname
+'
+
+test_expect_success 'flux-shell: invalid input.limit is rejected (negative)' '
+	test_must_fail flux run -o input.limit=-1 hostname
+'
+
+test_expect_success 'flux-shell: input.limit exceeding max (32M) is rejected' '
+	test_must_fail flux run -o input.limit=33M hostname
+'
+
+test_expect_success 'flux-shell: input.limit exceeding max (1G) is rejected' '
+	test_must_fail flux run -o input.limit=1G hostname
+'
+
+test_expect_success 'flux-shell: input.limit at max (32M) works' '
+	flux run -o input.limit=32M hostname
+'
+
+test_expect_success 'flux-shell: input.limit as integer works' '
+	dd if=/dev/zero bs=512 count=1 2>/dev/null | \
+		flux run -o input.limit=1024 cat >/dev/null
+'
+
+test_expect_success 'flux-shell: input.limit as integer exceeding max is rejected' '
+	test_must_fail flux run -o input.limit=34603008 hostname
+'
+
+test_expect_success 'flux-shell: flux job attach stops sending stdin on exception' '
+	jobid=$(flux submit -o input.limit=1K cat) &&
+	test_expect_code 1 sh -c "dd if=/dev/zero bs=1024 count=20 2>/dev/null | \
+		flux job attach $jobid 2>attach-stop.err" &&
+	test_debug "cat attach-stop.err" &&
+	grep "stdin exceeds 1K limit" attach-stop.err
+'
+
 test_done


### PR DESCRIPTION
As noted in #7649, large amounts of data written to a job's stdin from `flux job attach` can cause the KVS to get stuck. The job shell already prevents writing too much output to the KVS, but there's no limit on input.

This PR adds an `input.limit` shell option (default 10M max 32M) akin to the `output.limit` option. When the input limit is reached, the job shell raises a fatal exception since truncating input may cause a hang and sending an early EOF would result in undefined behavior.

A couple other fixes were also required to allow `flux job attach` to behave when the limit exception is raised.