### PR TITLE
doc: update jansson version refs in documentation

### DIFF
--- a/config/x_ac_jansson.m4
+++ b/config/x_ac_jansson.m4
@@ -2,10 +2,16 @@
 # sles15-sp5    ships 2.9  (flux-framework/flux-core#5544)
 # centos7/TOSS3 ships 2.10 (flux-framework/flux-core#3239)
 # centos8/TOSS4 ships 2.11
+# el9           ships 2.14
+# el10          ships 2.14
 # Ubuntu 18.04  ships 2.11
 # Ubuntu 20.04  ships 2.12
+# Ubuntu 22.04  ships 2.13
+# Ubuntu 24.04  ships 2.14
+# Ubuntu 26.04  ships 2.14
 #
 # Some modern jansson features used in flux-core:
+# - json_pack ("o*")     from 2.11
 # - json_pack ("O?")     from 2.8
 # - json_string_length() from 2.7
 #

--- a/doc/man3/common/json_pack.rst
+++ b/doc/man3/common/json_pack.rst
@@ -10,6 +10,12 @@ the corresponding argument or arguments.
 **s?** (string)['const char \*']
    Like **s**, but if the argument is NULL, outputs a JSON null value.
 
+**s*** (string) ['const char \*']
+    Like **s**, but if the argument is NULL, do not output any value.
+    This format can only be used inside an object or an array. If used
+    inside an object, the corresponding key is additionally suppressed
+    when the value is omitted.
+
 **s#** (string)['const char \*', 'int']
    Convert a UTF-8 buffer of a given length to a JSON string.
 
@@ -59,6 +65,12 @@ the corresponding argument or arguments.
    Like **o** and **O**, respectively, but if the argument is NULL,
    output a JSON null value.
 
+**o***, **O*** (any value) ['json_t \*']
+    Like **o** and **O**, respectively, but if the argument is
+    NULL, do not output any value. This format can only be used
+    inside an object or an array. If used inside an object, the
+    corresponding key is additionally suppressed.
+
 **[fmt]** (array)
    Build an array with contents from the inner format string. **fmt** may
    contain objects and arrays, i.e. recursive value building is supported.
@@ -72,6 +84,6 @@ the corresponding argument or arguments.
 
 Whitespace, **:** (colon) and **,** (comma) are ignored.
 
-These descriptions came from the Jansson 2.9 manual.
+These descriptions came from the Jansson 2.11 manual.
 
-See also: Jansson API: Building Values: http://jansson.readthedocs.io/en/2.9/apiref.html#building-values
+See also: Jansson API: Building Values: http://jansson.readthedocs.io/en/2.11/apiref.html#building-values

--- a/doc/man3/common/json_unpack.rst
+++ b/doc/man3/common/json_unpack.rst
@@ -40,6 +40,9 @@ the corresponding argument or arguments.
 
 **O** (any value)['json_t \*']
    Like **o**, but the JSON value's reference count is incremented.
+   Storage pointers should be initialized NULL before using unpack.
+   The caller is responsible for releasing all references incremented
+   by unpack, even when an error occurs.
 
 **[fmt]** (array)
    Convert each item in the JSON array according to the inner format
@@ -48,10 +51,10 @@ the corresponding argument or arguments.
 
 **{fmt}** (object)
    Convert each item in the JSON object according to the inner format
-   string **fmt**. The first, third, etc. format specifier represent a
-   key, and must by **s**. The corresponding argument to unpack functions
+   string **fmt**. The first, third, etc. format specifier represents a
+   key, and must be **s**. The corresponding argument to unpack functions
    is read as the object key. The second, fourth, etc. format specifier
-   represent a value and is written to the address given as the corresponding
+   represents a value and is written to the address given as the corresponding
    argument. Note that every other argument is read from and every other
    is written to. **fmt** may contain objects and arrays as values, i.e.
    recursive value extraction is supported. Any **s** representing a key
@@ -66,6 +69,6 @@ the corresponding argument or arguments.
 
 Whitespace, **:** (colon) and **,** (comma) are ignored.
 
-These descriptions came from the Jansson 2.9 manual.
+These descriptions came from the Jansson 2.11 manual.
 
-See also: Jansson API: Parsing and Validating Values: http://jansson.readthedocs.io/en/2.9/apiref.html#parsing-and-validating-values
+See also: Jansson API: Parsing and Validating Values: http://jansson.readthedocs.io/en/2.11/apiref.html#parsing-and-validating-values

--- a/doc/man3/flux_shell_get_info.rst
+++ b/doc/man3/flux_shell_get_info.rst
@@ -92,4 +92,4 @@ RESOURCES
 
 .. include:: common/resources.rst
 
-Jansson: https://jansson.readthedocs.io/en/2.9/apiref.html
+Jansson: https://jansson.readthedocs.io/en/2.11/apiref.html

--- a/doc/man3/flux_shell_get_jobspec_info.rst
+++ b/doc/man3/flux_shell_get_jobspec_info.rst
@@ -74,4 +74,4 @@ RESOURCES
 
 .. include:: common/resources.rst
 
-Jansson: https://jansson.readthedocs.io/en/2.9/apiref.html
+Jansson: https://jansson.readthedocs.io/en/2.11/apiref.html


### PR DESCRIPTION
Problem: documentation in several places refers to Jansson 2.9, but the minimum version is now 2.11

Update the references and information for 2.11

Follow up from #7554 as I neglected to update documentation there :upside_down_face: 