### PR TITLE
ci: run some sharness tests under asan

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -4,7 +4,7 @@ jobs:
   check-asan:
     name: address-sanitizer check
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
     - uses: actions/checkout@v7.0.0
       with:
@@ -15,7 +15,7 @@ jobs:
       run: |
         sudo sysctl -w kernel.randomize_va_space=0
     - name: docker-run-checks with ASan
-      timeout-minutes: 40
+      timeout-minutes: 100
       env:
         PRELOAD: /usr/lib64/libasan.so.8
         ASAN_OPTIONS: detect_leaks=0:start_deactivated=true:replace_str=true:verify_asan_link_order=false
@@ -23,7 +23,7 @@ jobs:
         TAP_DRIVER_QUIET: t
       run: >
         src/test/docker/docker-run-checks.sh \
-          --image=fedora40 --unit-test-only -j4 \
+          --image=fedora40 --asan-test-only -j4 \
           -- --with-flux-security --enable-sanitizer=address
 
     - name: after failure

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -15,7 +15,7 @@
 #  CPPCHECK      Run cppcheck if set to "t"
 #  DISTCHECK     Run `make distcheck` if set
 #  RECHECK       Run `make recheck` if `make check` fails the first time
-#  UNIT_TEST_ONLY Only run `make check` under ./src
+#  ASAN_TEST_ONLY Only run `make check` under ./src and asan tests under ./t
 #  QUICK_CHECK   Run only `make TESTS=` and a simple test
 #  PRELOAD       Set as LD_PRELOAD for make and tests
 #  POISON        Install poison libflux and flux(1) in image
@@ -173,8 +173,11 @@ if test -n "$PRELOAD" ; then
   CHECKCMDS="/usr/bin/env 'LD_PRELOAD=$PRELOAD' ${CHECKCMDS}"
 fi
 
-if test -n "$UNIT_TEST_ONLY"; then
-  CHECKCMDS="(cd src && $CHECKCMDS)"
+if test -n "$ASAN_TEST_ONLY"; then
+  ASAN_TESTS=$(cd t && grep -l ci=asan *.t)
+  CHECKCMDS="(make check TESTS= && \
+              cd src && $CHECKCMDS && \
+              cd ../t && make check TESTS=\"$ASAN_TESTS\")"
 fi
 
 if test -n "$QUICK_CHECK"; then

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -25,7 +25,7 @@ declare -r prog=${0##*/}
 die() { echo -e "$prog: $@"; exit 1; }
 
 #
-declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,unit-test-only,quick-check,inception,platform:,workdir:,system"
+declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,asan-test-only,quick-check,inception,platform:,workdir:,system"
 declare -r short_opts="hqIdi:S:j:t:D:Prup:"
 declare usage="
 Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
@@ -49,7 +49,7 @@ Options:\n\
  -j, --jobs=N                  Value for make -j (default=$JOBS)\n
  -d, --distcheck               Run 'make distcheck' instead of 'make check'\n\
  -r, --recheck                 Run 'make recheck' after failure\n\
- -u, --unit-test-only          Only run unit tests\n\
+ -u, --asan-test-only          Only run asan tests\n\
      --quick-check             Only run 'make check TESTS=' and one basic test\n\
  -P, --no-poison               Do not install poison libflux and flux(1)\n\
  -D, --build-directory=DIRNAME Name of a subdir to build in, will be made\n\
@@ -85,7 +85,7 @@ while true; do
       -I|--interactive)            INTERACTIVE="/bin/bash";    shift   ;;
       -d|--distcheck)              DISTCHECK=t;                shift   ;;
       -r|--recheck)                RECHECK=t;                  shift   ;;
-      -u|--unit-test-only)         UNIT_TEST_ONLY=t;           shift   ;;
+      -u|--asan-test-only)         ASAN_TEST_ONLY=t;           shift   ;;
       --quick-check)               QUICK_CHECK=t;              shift   ;;
       -D|--build-directory)        BUILD_DIR="$2";             shift 2 ;;
       --build-arg)                 BUILD_ARG=" --build-arg $2" shift 2 ;;
@@ -213,7 +213,7 @@ export INCEPTION
 export JOBS
 export DISTCHECK
 export RECHECK
-export UNIT_TEST_ONLY
+export ASAN_TEST_ONLY
 export QUICK_CHECK
 export BUILD_DIR
 export COVERAGE
@@ -257,7 +257,7 @@ else
         -e CPPCHECK \
         -e DISTCHECK \
         -e RECHECK \
-        -e UNIT_TEST_ONLY \
+        -e ASAN_TEST_ONLY \
         -e QUICK_CHECK \
         -e chain_lint \
         -e JOBS \

--- a/src/test/docker/docker-run-systest.sh
+++ b/src/test/docker/docker-run-systest.sh
@@ -209,7 +209,7 @@ checks_group "$msg" \
     -e CPPCHECK=$CPPCHECK \
     -e DISTCHECK=$DISTCHECK \
     -e RECHECK=$RECHECK \
-    -e UNIT_TEST_ONLY=$UNIT_TEST_ONLY \
+    -e ASAN_TEST_ONLY=$ASAN_TEST_ONLY \
     -e chain_lint=$chain_lint \
     -e JOBS=$JOBS \
     -e USER=$USER \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -492,7 +492,11 @@ dist_check_SCRIPTS = \
 	job-exec/imp-fail.sh \
 	job-list/list-id.py \
 	job-list/job-list-helper.sh \
-	ingest/bad-validate.py
+	ingest/bad-validate.py \
+	asan-scripts/no-asan.sh \
+	asan-scripts/ps \
+	asan-scripts/pkill \
+	asan-scripts/dd
 
 check_PROGRAMS = \
 	content/content_validate \

--- a/t/asan-scripts/dd
+++ b/t/asan-scripts/dd
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Wrapper for dd command to run without ASAN
+dir=$(dirname $0)
+$dir/no-asan.sh dd "$@"

--- a/t/asan-scripts/no-asan.sh
+++ b/t/asan-scripts/no-asan.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Wrapper to run command without ASAN
+#
+# assume called from within asan-scripts directory, so we want to
+# find the non-ASAN command from $PATH
+
+find_non_asan_command() {
+    name=$1
+    oldIFS=$IFS
+    IFS=:
+    for d in $PATH; do
+        if [ -x "$d/$name" ]; then
+            if echo "$d" | grep -q 'asan-scripts'; then
+                continue
+            fi
+            echo "$d/$name"
+            break
+        fi
+    done
+    IFS=$oldIFS
+}
+
+unset LD_PRELOAD
+unset ASAN_OPTIONS
+cmdname=$1
+shift
+realcmd=$(find_non_asan_command $cmdname)
+$realcmd "$@"

--- a/t/asan-scripts/pkill
+++ b/t/asan-scripts/pkill
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Wrapper for pkill command to run without ASAN
+dir=$(dirname $0)
+$dir/no-asan.sh pkill "$@"

--- a/t/asan-scripts/ps
+++ b/t/asan-scripts/ps
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Wrapper for ps command to run without ASAN
+dir=$(dirname $0)
+$dir/no-asan.sh ps "$@"

--- a/t/module/testmod.c
+++ b/t/module/testmod.c
@@ -50,10 +50,20 @@ static void segfault (flux_t *h,
     kill (getpid (), SIGSEGV);
 }
 
+static void killevent (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    flux_log (h, LOG_CRIT, "kill event received: raising SIGKILL");
+    kill (getpid (), SIGKILL);
+}
+
 static struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "info", info, 0 },
     { FLUX_MSGTYPE_EVENT, "panic", panic, 0 },
     { FLUX_MSGTYPE_EVENT, "segfault", segfault, 0 },
+    { FLUX_MSGTYPE_EVENT, "kill", killevent, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -109,7 +119,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     }
 
     const char *module_name = flux_aux_get (h, "flux::name");
-    const char *topics[] = { "panic", "segfault" };
+    const char *topics[] = { "panic", "segfault", "kill" };
 
     for (int i = 0; i < ARRAY_SIZE (topics); i++) {
         char topic[256];

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -5,6 +5,10 @@
 
 # add scripts directory to path
 export PATH="${SHARNESS_TEST_SRCDIR}/scripts:$PATH"
+# prefix asan-scripts directory if running with ASAN
+if flux version | grep -q +asan; then
+    export PATH="${SHARNESS_TEST_SRCDIR}/asan-scripts:$PATH"
+fi
 # only load namespaced plugins from flux.cli.plugins in tests
 export FLUX_CLI_PLUGINPATH_OVERRIDE=""
 

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -656,8 +656,10 @@ test_expect_success 'flux-help command list can be extended' '
 	grep "^test two commands" help2.out &&
 	grep "a test two" help2.out
 '
+# N.B. Set NO_ASAN, as there appears to be errors in 'man', which is executed
+# internally in `flux help`.
 command -v man >/dev/null && test_set_prereq HAVE_MAN
-test_expect_success HAVE_MAN 'flux-help command can display manpages for subcommands' '
+test_expect_success NO_ASAN,HAVE_MAN 'flux-help command can display manpages for subcommands' '
 	PWD=$(pwd) &&
 	mkdir -p man/man1 &&
 	cat <<-EOF > man/man1/flux-foo.1 &&
@@ -667,7 +669,7 @@ test_expect_success HAVE_MAN 'flux-help command can display manpages for subcomm
 	EOF
 	MANPATH=${PWD}/man FLUX_IGNORE_NO_DOCS=y flux help foo | grep "^FOO(1)"
 '
-test_expect_success HAVE_MAN 'flux-help command can display manpages for api calls' '
+test_expect_success NO_ASAN,HAVE_MAN 'flux-help command can display manpages for api calls' '
 	PWD=$(pwd) &&
 	mkdir -p man/man3 &&
 	cat <<-EOF > man/man3/flux_foo.3 &&

--- a/t/t0002-request.t
+++ b/t/t0002-request.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test basic request/response handling
 

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test basic module management
 

--- a/t/t0004-event.t
+++ b/t/t0004-event.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test event propagation'
 

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -146,6 +146,7 @@ test_expect_success 'flux exec exits with code 126 for non executable' '
 	grep "Permission denied" exec.stderr2
 '
 
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
 test_expect_success NO_ASAN 'flux exec passes non-zero exit status' '
 	test_expect_code 2 flux exec -n sh -c "exit 2" &&
 	test_expect_code 3 flux exec -n sh -c "exit 3" &&
@@ -158,6 +159,7 @@ test_expect_success 'flux exec fails with --with-imp if no IMP configured' '
 	grep "exec\.imp path not found in config" exec-no-imp.out
 '
 
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
 test_expect_success NO_ASAN 'flux exec outputs tasks with errors' '
 	! flux exec -n sh -c "exit 2" > 2.out 2>&1 &&
         grep "\[0-3\]: Exit 2" 2.out &&

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test broker exec functionality, used by later tests
 

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test broker rexec functionality
 

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -164,7 +164,8 @@ test_expect_success 'simulated module segfault causes module to exit' '
 	sh -c "while flux module stats testmod; do true; done" &&
 	flux dmesg >segfault.out
 '
-test_expect_success 'segfault is reported' '
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
+test_expect_success NO_ASAN 'segfault is reported' '
 	grep "killed by Segmentation fault" segfault.out
 '
 test_expect_success 'broker treats this the same as spurious module exit' '

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -158,18 +158,27 @@ test_expect_success NO_CHAIN_LINT 'start background streaming RPC' '
 test_expect_success NO_CHAIN_LINT 'wait for first response to RPC' '
 	$waitfile -t 15 stream.out
 '
-test_expect_success 'simulated module segfault causes module to exit' '
+# N.B. simulated segfault will lead to an error log being generated.
+# So when running under ASAN, skip this test and run the next one,
+# which will just kill the module.
+test_expect_success NO_ASAN 'simulated module segfault causes module to exit (sigsegv)' '
 	flux dmesg -C &&
 	flux event pub testmod.segfault &&
 	sh -c "while flux module stats testmod; do true; done" &&
-	flux dmesg >segfault.out
+	flux dmesg >module_fail.out
+'
+test_expect_success ASAN 'make module exit (kill)' '
+	flux dmesg -C &&
+	flux event pub testmod.kill &&
+	sh -c "while flux module stats testmod; do true; done" &&
+	flux dmesg >module_fail.out
 '
 # N.B. skip under ASAN, as it may capture segfault signal and report differently
 test_expect_success NO_ASAN 'segfault is reported' '
-	grep "killed by Segmentation fault" segfault.out
+	grep "killed by Segmentation fault" module_fail.out
 '
 test_expect_success 'broker treats this the same as spurious module exit' '
-	grep "module runtime failure" segfault.out
+	grep "module runtime failure" module_fail.out
 '
 test_expect_success NO_CHAIN_LINT 'streaming RPC was terminated' '
 	pid=$(cat stream.pid) &&

--- a/t/t0006-module-exec.t
+++ b/t/t0006-module-exec.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test flux-module-exec'
 

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Stress test the local connector with flood pings
 '

--- a/t/t0008-attr.t
+++ b/t/t0008-attr.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 
 

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test broker log ring buffer'
 

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test various flux utilities
 

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test broker content service'
 

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test content-sqlite service'
 

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t0015-cron.t
+++ b/t/t0015-cron.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux cron service'
 

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -3,6 +3,8 @@
 test_description='Test flux cron service'
 
 . $(dirname $0)/sharness.sh
+
+# N.B. skip under ASAN, LD_PRELOAD is modified
 if ! test_have_prereq NO_ASAN; then
     skip_all='skipping faketime tests since AddressSanitizer is active'
     test_done

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux cron service'
 

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test broker security'
 

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test content-files backing store service'
 

--- a/t/t0019-tbon-config.t
+++ b/t/t0019-tbon-config.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test the brokers tbon.* configuration'
 

--- a/t/t0021-archive-cmd.t
+++ b/t/t0021-archive-cmd.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux-archive'
 

--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t0023-jobspec1-validate.t
+++ b/t/t0023-jobspec1-validate.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t0024-jjc-reader.t
+++ b/t/t0024-jjc-reader.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test broker state machine'
 

--- a/t/t0026-flux-R.t
+++ b/t/t0026-flux-R.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux-R front-end command'
 

--- a/t/t0027-broker-groups.t
+++ b/t/t0027-broker-groups.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test broker groups'
 

--- a/t/t0028-module-python-exec.t
+++ b/t/t0028-module-python-exec.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test flux-module-python-exec'
 

--- a/t/t0029-archive-mmap.t
+++ b/t/t0029-archive-mmap.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux-archive'
 

--- a/t/t0030-marshall.t
+++ b/t/t0030-marshall.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t0031-constraint-parser.t
+++ b/t/t0031-constraint-parser.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t0032-directives-parser.t
+++ b/t/t0032-directives-parser.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t0033-filemap-cmd.t
+++ b/t/t0033-filemap-cmd.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux-filemap'
 

--- a/t/t0034-broker-getenv.t
+++ b/t/t0034-broker-getenv.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test broker.getenv and broker.setenv RPCs'
 

--- a/t/t0035-content-sqlite-checkpoint.t
+++ b/t/t0035-content-sqlite-checkpoint.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test content-sqlite checkpointing'
 

--- a/t/t0036-broker-rundir.t
+++ b/t/t0036-broker-rundir.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test broker rundir and statedir behavior'
 

--- a/t/t0037-content-files-checkpoint.t
+++ b/t/t0037-content-files-checkpoint.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test content-files checkpointing'
 

--- a/t/t0038-rreq-reader.t
+++ b/t/t0038-rreq-reader.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t0039-shape-parser.t
+++ b/t/t0039-shape-parser.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test python flux.shape.parser standalone operation'
 

--- a/t/t0040-flux-sproc.t
+++ b/t/t0040-flux-sproc.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux-sproc command'
 

--- a/t/t0041-broker-conf-builtin.t
+++ b/t/t0041-broker-conf-builtin.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test broker.conf-builtin RPC'
 

--- a/t/t0044-gc-cmd.t
+++ b/t/t0044-gc-cmd.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux-gc online garbage collection'
 

--- a/t/t0090-content-enospc.t
+++ b/t/t0090-content-enospc.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test content ENOSPC corner cases'
 

--- a/t/t0099-admin-system-scripts.t
+++ b/t/t0099-admin-system-scripts.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux admin system-scripts command'
 

--- a/t/t0100-modprobe.t
+++ b/t/t0100-modprobe.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux modprobe'
 

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test flux-kvs and kvs in flux session
 

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='kvs internals tests in a flux session
 

--- a/t/t1003-kvs-stress.t
+++ b/t/t1003-kvs-stress.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Stress test KVS in flux session'
 

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux-kvs and kvs in flux session
 

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux-kvs and kvs in flux session
 

--- a/t/t1007-kvs-lookup-watch.t
+++ b/t/t1007-kvs-lookup-watch.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test KVS get --watch && --waitcreate && --stream'
 

--- a/t/t1009-kvs-copy.t
+++ b/t/t1009-kvs-copy.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test flux-kvs copy
 Test flux-kvs copy and flux-kvs move.

--- a/t/t1010-kvs-commit-sync.t
+++ b/t/t1010-kvs-commit-sync.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test flux-kvs commit sync.'
 

--- a/t/t1011-kvs-checkpoint-period.t
+++ b/t/t1011-kvs-checkpoint-period.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test kvs module checkpoint-period config.'
 

--- a/t/t1012-kvs-checkpoint.t
+++ b/t/t1012-kvs-checkpoint.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t1013-kvs-initial-rootref.t
+++ b/t/t1013-kvs-initial-rootref.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test kvs module initial-rootref option'
 

--- a/t/t1102-cmddriver.t
+++ b/t/t1102-cmddriver.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test command driver
 

--- a/t/t1103-apidisconnect.t
+++ b/t/t1103-apidisconnect.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test api disconnect generation
 '

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -1,5 +1,4 @@
 #!/bin/sh
-#
 
 test_description='Test flux-proxy'
 

--- a/t/t1107-heartbeat.t
+++ b/t/t1107-heartbeat.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test heartbeat module'
 

--- a/t/t1200-stats-basic.t
+++ b/t/t1200-stats-basic.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test stats collection and sending'
 

--- a/t/t2004-hydra.t
+++ b/t/t2004-hydra.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test that MPICH Hydra can launch Flux'
 

--- a/t/t2008-althash.t
+++ b/t/t2008-althash.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test alternate hash config
 

--- a/t/t2010-kvs-snapshot-restore.t
+++ b/t/t2010-kvs-snapshot-restore.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test KVS snapshot/restore'
 

--- a/t/t2100-job-ingest.t
+++ b/t/t2100-job-ingest.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job ingest service'
 

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test job validator'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2111-job-ingest-config.t
+++ b/t/t2111-job-ingest-config.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test job ingest config file'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2112-job-ingest-frobnicator.t
+++ b/t/t2112-job-ingest-frobnicator.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test job frobnicator command'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2113-job-ingest-pipeline.t
+++ b/t/t2113-job-ingest-pipeline.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test job ingest pipeline'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test flux job command'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager service'
 

--- a/t/t2203-job-manager-single.t
+++ b/t/t2203-job-manager-single.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager service with sched-simple (single)'
 

--- a/t/t2204-job-manager-limited.t
+++ b/t/t2204-job-manager-limited.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager service with sched-simple (limited)'
 

--- a/t/t2205-job-manager-unlimited.t
+++ b/t/t2205-job-manager-unlimited.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager service with sched-simple (unlimited)'
 

--- a/t/t2206-job-manager-annotate.t
+++ b/t/t2206-job-manager-annotate.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager annotate service'
 

--- a/t/t2208-job-manager-wait.t
+++ b/t/t2208-job-manager-wait.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager wait handling'
 

--- a/t/t2209-job-manager-bugs.t
+++ b/t/t2209-job-manager-bugs.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 
 test_description='Regression tests for job-manager bugs'

--- a/t/t2210-job-manager-events-journal.t
+++ b/t/t2210-job-manager-events-journal.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager journal service'
 

--- a/t/t2211-job-manager-jobspec.t
+++ b/t/t2211-job-manager-jobspec.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Checkout job manager redacted jobspec'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test job manager jobtap plugin interface'
 

--- a/t/t2213-job-manager-hold-single.t
+++ b/t/t2213-job-manager-hold-single.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager job hold (single mode)'
 

--- a/t/t2214-job-manager-hold-limited.t
+++ b/t/t2214-job-manager-hold-limited.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager job hold (limited)'
 

--- a/t/t2215-job-manager-hold-unlimited.t
+++ b/t/t2215-job-manager-hold-unlimited.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager job hold (unlimited mode)'
 

--- a/t/t2216-job-manager-priority-order-single.t
+++ b/t/t2216-job-manager-priority-order-single.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager urgency change to job (mode=single)'
 

--- a/t/t2217-job-manager-priority-order-limited.t
+++ b/t/t2217-job-manager-priority-order-limited.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager scheduler priority ordering (limited)'
 

--- a/t/t2218-job-manager-priority-order-unlimited.t
+++ b/t/t2218-job-manager-priority-order-unlimited.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager scheduler priority ordering (unlimited)'
 

--- a/t/t2219-job-manager-restart.t
+++ b/t/t2219-job-manager-restart.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t2220-job-manager-R.t
+++ b/t/t2220-job-manager-R.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test job manager internal copy of R'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2221-job-manager-limit-duration.t
+++ b/t/t2221-job-manager-limit-duration.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager limit-duration plugin'
 

--- a/t/t2222-job-manager-limit-job-size.t
+++ b/t/t2222-job-manager-limit-job-size.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager limit-job-size plugin'
 

--- a/t/t2223-job-manager-queue-priority-order-limited.t
+++ b/t/t2223-job-manager-queue-priority-order-limited.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager scheduler queue priority ordering (limited)'
 

--- a/t/t2224-job-manager-queue-priority-order-unlimited.t
+++ b/t/t2224-job-manager-queue-priority-order-unlimited.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job manager scheduler queue priority ordering (unlimited)'
 

--- a/t/t2226-housekeeping.t
+++ b/t/t2226-housekeeping.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test job manager housekeeping'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job info service eventlog watch'
 

--- a/t/t2232-job-info-security.t
+++ b/t/t2232-job-info-security.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job info service security'
 

--- a/t/t2233-job-info-update.t
+++ b/t/t2233-job-info-update.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job info service lookup w/ update and update-watch'
 

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test flux queue command'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2241-queue-cmd-list.t
+++ b/t/t2241-queue-cmd-list.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test flux queue command'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2245-policy-config.t
+++ b/t/t2245-policy-config.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test RFC 33 policy config verification
 

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job list services'
 

--- a/t/t2261-job-list-update.t
+++ b/t/t2261-job-list-update.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job list services w/ changing job data'
 

--- a/t/t2262-job-list-stats.t
+++ b/t/t2262-job-list-stats.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test streaming flux job statistics RPC'
 

--- a/t/t2270-job-dependencies.t
+++ b/t/t2270-job-dependencies.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test job dependencies'
 

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test job dependency after* support'
 

--- a/t/t2272-job-begin-time.t
+++ b/t/t2272-job-begin-time.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test job begin-time dependencies'
 

--- a/t/t2273-job-alloc-bypass.t
+++ b/t/t2273-job-alloc-bypass.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test alloc-bypass job manager plugin'
 

--- a/t/t2274-manager-perilog-per-rank.t
+++ b/t/t2274-manager-perilog-per-rank.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test perilog jobtap plugin with per-rank=true'
 

--- a/t/t2275-job-duration-validator.t
+++ b/t/t2275-job-duration-validator.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test job duration validator plugin in job-manager'
 

--- a/t/t2276-job-requires.t
+++ b/t/t2276-job-requires.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test job constraints'
 

--- a/t/t2277-dependency-singleton.t
+++ b/t/t2277-dependency-singleton.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test job dependency singleton support'
 

--- a/t/t2280-job-memo.t
+++ b/t/t2280-job-memo.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test flux job memo command'
 
 . $(dirname $0)/job-manager/sched-helper.sh

--- a/t/t2290-job-update.t
+++ b/t/t2290-job-update.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test flux update command'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2291-job-update-queue.t
+++ b/t/t2291-job-update-queue.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test update of job queue'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2292-job-update-running.t
+++ b/t/t2292-job-update-running.t
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# ci=asan
+
 test_description='Test update of running jobs'
 
 . $(dirname $0)/sharness.sh

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='simple sched-simple tests'
 

--- a/t/t2302-sched-simple-up-down.t
+++ b/t/t2302-sched-simple-up-down.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='sched-simple up/down/drain tests'
 

--- a/t/t2303-sched-hello.t
+++ b/t/t2303-sched-hello.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='test sched hello
 

--- a/t/t2304-sched-simple-alloc-check.t
+++ b/t/t2304-sched-simple-alloc-check.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='check that sched-simple never double books resources'
 

--- a/t/t2305-sched-slow.t
+++ b/t/t2305-sched-slow.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='test a scheduler that is slow to respond
 '

--- a/t/t2306-sched-fifo.t
+++ b/t/t2306-sched-fifo.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='sched-fifo Python scheduler tests'
 

--- a/t/t2307-sched-backfill.t
+++ b/t/t2307-sched-backfill.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='sched-backfill EASY backfill scheduler tests'
 

--- a/t/t2308-sched-generator.t
+++ b/t/t2308-sched-generator.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='test scheduler generator protocol and stats-get RPC'
 

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test resource module'
 

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test resource drain/undrain'
 

--- a/t/t2312-resource-exclude.t
+++ b/t/t2312-resource-exclude.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test resource exclusion'
 

--- a/t/t2313-resource-acquire.t
+++ b/t/t2313-resource-acquire.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test resource acquire'
 

--- a/t/t2314-resource-monitor.t
+++ b/t/t2314-resource-monitor.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test resource monitoring'
 

--- a/t/t2315-resource-system.t
+++ b/t/t2315-resource-system.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test resource module with system instance config'
 

--- a/t/t2316-resource-rediscover.t
+++ b/t/t2316-resource-rediscover.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test resource module forced rediscovery'
 

--- a/t/t2317-resource-shrink.t
+++ b/t/t2317-resource-shrink.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test resource shrink when not using resource configuration'
 

--- a/t/t2318-resource-verify.t
+++ b/t/t2318-resource-verify.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test resource module verify configuration'
 

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='flux-resource list tests'
 

--- a/t/t2351-resource-status-input.t
+++ b/t/t2351-resource-status-input.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='flux-resource status output format tests'
 

--- a/t/t2352-resource-cmd-config.t
+++ b/t/t2352-resource-cmd-config.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='flux-resource config tests'
 

--- a/t/t2353-resource-eventlog.t
+++ b/t/t2353-resource-eventlog.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test resource eventlog upgrade
 

--- a/t/t2354-resource-status.t
+++ b/t/t2354-resource-status.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='flux-resource status general tests'
 

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job execution service in simulated mode'
 

--- a/t/t2401-job-exec-hello.t
+++ b/t/t2401-job-exec-hello.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job exec hello protocol with multiple providers'
 

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job execution service with dummy job shell'
 

--- a/t/t2403-job-exec-conf.t
+++ b/t/t2403-job-exec-conf.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job exec configuration'
 

--- a/t/t2406-job-exec-cleanup.t
+++ b/t/t2406-job-exec-cleanup.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job exec job cleanup via SIGKILL'
 

--- a/t/t2407-sdbus.t
+++ b/t/t2407-sdbus.t
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # ci=system
 
 test_description='Test flux systemd sd-bus bridge standalone'

--- a/t/t2408-sdbus-recovery.t
+++ b/t/t2408-sdbus-recovery.t
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # ci=system
 
 test_description='Test flux systemd sd-bus bridge recovery'

--- a/t/t2409-sdexec.t
+++ b/t/t2409-sdexec.t
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # ci=system
 
 test_description='Test flux systemd execution'

--- a/t/t2410-sdexec-memlimit.t
+++ b/t/t2410-sdexec-memlimit.t
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # ci=system
 test_description='Test sdexec cgroups memory controller manipulation
 

--- a/t/t2411-sdexec-job.t
+++ b/t/t2411-sdexec-job.t
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # ci=system
 
 test_description='Test sdexec job launch'

--- a/t/t2412-sdmon.t
+++ b/t/t2412-sdmon.t
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # ci=system
 
 test_description='Test flux systemd monitoring'

--- a/t/t2413-sdmon-resource.t
+++ b/t/t2413-sdmon-resource.t
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # ci=system
 
 test_description='Test flux systemd monitoring'

--- a/t/t2414-imp-exec-helper.t
+++ b/t/t2414-imp-exec-helper.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux imp_exec_helper builtin'
 

--- a/t/t2415-sdexec-device.t
+++ b/t/t2415-sdexec-device.t
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # ci=system
 test_description='Test imp_exec_helper device containment with systemd'
 

--- a/t/t2416-sdexec-constrain-resources.t
+++ b/t/t2416-sdexec-constrain-resources.t
@@ -1,4 +1,5 @@
 #!/bin/sh
+#
 # ci=system
 test_description='Test sdexec cgroups cpuset controller manipulation
 

--- a/t/t2501-job-status.t
+++ b/t/t2501-job-status.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job status'
 

--- a/t/t2600-job-shell-rcalc.t
+++ b/t/t2600-job-shell-rcalc.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell'
 
 . `dirname $0`/sharness.sh

--- a/t/t2603-job-shell-initrc.t
+++ b/t/t2603-job-shell-initrc.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell initrc.lua implementation'
 
 . `dirname $0`/sharness.sh

--- a/t/t2604-job-shell-affinity-xmlfile.t
+++ b/t/t2604-job-shell-affinity-xmlfile.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test FLUX_HWLOC_XMLFILE with cpu-affinity=dry-run'
 

--- a/t/t2604-job-shell-affinity.t
+++ b/t/t2604-job-shell-affinity.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell default affinity implementation'
 
 . `dirname $0`/sharness.sh

--- a/t/t2606-job-shell-output-flow.t
+++ b/t/t2606-job-shell-output-flow.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell output flow control'
 
 . `dirname $0`/sharness.sh

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell'
 
 . `dirname $0`/sharness.sh

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell'
 
 . `dirname $0`/sharness.sh

--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell logging implementation'
 
 . `dirname $0`/sharness.sh

--- a/t/t2609-job-shell-events.t
+++ b/t/t2609-job-shell-events.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell emitted events'
 
 . `dirname $0`/sharness.sh

--- a/t/t2610-job-shell-mpir.t
+++ b/t/t2610-job-shell-mpir.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell MPIR and ptrace support'
 
 . `dirname $0`/sharness.sh

--- a/t/t2611-debug-emulate.t
+++ b/t/t2611-debug-emulate.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test parallel debugger support in emulation mode'
 
 . `dirname $0`/sharness.sh

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -1,5 +1,5 @@
 #!/bin/sh
-#
+
 test_description='Test flux-shell pty support'
 
 . `dirname $0`/sharness.sh

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -131,10 +131,12 @@ test_expect_success 'pty: no hang when invalid command is run under pty' '
 # Note: test below uses printf(1) to send [Ctrl-SPACE (NUL), newline, Ctrl-D]
 # over the pty connection and expects ^@ (the standard representation of NUL)
 # to appear in output.
+#
+# N.B. set NO_ASAN, results in cat: memory exhausted error
 nul_ctrl_d() {
 	python3 -c 'print("\x00\n\x04", end=None)'
 }
-test_expect_success 'pty: NUL (Ctrl-SPACE) character not dropped' '
+test_expect_success NO_ASAN 'pty: NUL (Ctrl-SPACE) character not dropped' '
 	nul_ctrl_d | flux run -vvv -o pty.interactive -o pty.capture cat -v &&
 	flux job eventlog -HL -p output $(flux job last) &&
 	flux job eventlog -HL -p output $(flux job last) | grep \\^@

--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell per-resource and batch support'
 
 . `dirname $0`/sharness.sh

--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -46,7 +46,9 @@ test_expect_success 'flux-shell: per-resource type=node works' '
 	EOF
 	test_cmp per-node.expected per-node.out
 '
-test_expect_success 'flux-shell: historical batch jobspec still work' '
+# N.B. legacy test jobspecs may not setup things correctly to allow
+# ASAN (e.g. overwrite environment), so disable under ASAN
+test_expect_success NO_ASAN 'flux-shell: historical batch jobspec still work' '
 	for spec in $SHARNESS_TEST_SRCDIR/batch/jobspec/*.json; do
 		input=$(basename $spec) &&
 		cat $spec |

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -59,7 +59,8 @@ test_expect_success 'flux-shell: exit-on-error catches lost shell' '
 	test_must_fail run_timeout 30 flux run \
 		-n2 -N2 -o exit-on-error ./test2.sh
 '
-test_expect_success 'flux-shell: create script - rank 1 kills itself with SIGSEGV' '
+# N.B. skip under ASAN, as it may capture segfault signal and report differently
+test_expect_success NO_ASAN 'flux-shell: create script - rank 1 kills itself with SIGSEGV' '
 	cat >sigtest.sh <<-"EOT" &&
 	#!/bin/sh
 	test $FLUX_TASK_RANK -eq 1 && kill -SEGV $$
@@ -67,12 +68,12 @@ test_expect_success 'flux-shell: create script - rank 1 kills itself with SIGSEG
 	EOT
 	chmod +x sigtest.sh
 '
-test_expect_success 'flux-shell: exit-on-error preserves failing task signal in finish status' '
+test_expect_success NO_ASAN 'flux-shell: exit-on-error preserves failing task signal in finish status' '
 	jobid=$(flux submit -n2 -o exit-on-error ./sigtest.sh) &&
 	flux job wait-event -t 30 $jobid finish | grep "status=35584" &&
 	flux job eventlog $jobid | grep exception | grep "Segmentation fault"
 '
-test_expect_success 'flux-shell: exit-timeout preserves failing task signal in finish status' '
+test_expect_success NO_ASAN 'flux-shell: exit-timeout preserves failing task signal in finish status' '
 	jobid=$(flux submit -n2 -o exit-timeout=1s ./sigtest.sh) &&
 	flux job wait-event -t 30 $jobid finish | grep "status=35584" &&
 	flux job eventlog $jobid | grep exception | grep "Segmentation fault"

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -1,5 +1,5 @@
 #!/bin/sh
-#
+
 test_description='Test flux-shell task exit support'
 
 . `dirname $0`/sharness.sh

--- a/t/t2615-job-shell-rlimit.t
+++ b/t/t2615-job-shell-rlimit.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell rlimit support'
 
 . `dirname $0`/sharness.sh

--- a/t/t2616-job-shell-taskmap-hostfile.t
+++ b/t/t2616-job-shell-taskmap-hostfile.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test hostfile taskmap plugin support'
 
 . `dirname $0`/sharness.sh

--- a/t/t2616-job-shell-taskmap.t
+++ b/t/t2616-job-shell-taskmap.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-submit/flux-shell taskmap plugin support'
 
 . `dirname $0`/sharness.sh

--- a/t/t2617-job-shell-stage-in.t
+++ b/t/t2617-job-shell-stage-in.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell stage-in plugin support'
 
 . `dirname $0`/sharness.sh

--- a/t/t2618-job-shell-signal.t
+++ b/t/t2618-job-shell-signal.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell signal before timelimit support'
 
 . `dirname $0`/sharness.sh

--- a/t/t2619-job-shell-hwloc.t
+++ b/t/t2619-job-shell-hwloc.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell hwloc.xmlfile'
 
 . `dirname $0`/sharness.sh

--- a/t/t2620-job-shell-mustache.t
+++ b/t/t2620-job-shell-mustache.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell mustache template rendering'
 
 . `dirname $0`/sharness.sh

--- a/t/t2621-job-shell-plugin-fork.t
+++ b/t/t2621-job-shell-plugin-fork.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell behavior when plugin calls fork(2)'
 
 . `dirname $0`/sharness.sh

--- a/t/t2622-job-shell-sysmon.t
+++ b/t/t2622-job-shell-sysmon.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell sysmon plugin'
 
 . `dirname $0`/sharness.sh

--- a/t/t2623-job-shell-oom.t
+++ b/t/t2623-job-shell-oom.t
@@ -1,5 +1,7 @@
 #!/bin/sh
 #
+# ci=asan
+
 test_description='Test flux-shell oom plugin'
 
 . `dirname $0`/sharness.sh

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux submit command'
 

--- a/t/t2711-python-cli-run.t
+++ b/t/t2711-python-cli-run.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux run command'
 

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='flux batch specific tests'
 

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -119,7 +119,7 @@ test_expect_success NO_ASAN 'flux batch: job results are expected' '
 	grep "size=2 nodes=2" flux-${id4}.out &&
 	grep "size=2 nodes=2" flux-${id5}.out
 '
-test_expect_success MULTICORE 'flux batch: exclusive flag worked' '
+test_expect_success NO_ASAN,MULTICORE 'flux batch: exclusive flag worked' '
 	test $(flux job info ${id4} R | flux R decode --count=core) -gt 2 &&
 	test $(flux job info ${id5} R | flux R decode --count=core) -gt 2
 '

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -100,6 +100,7 @@ test_expect_success 'flux batch --exclusive works' '
 		jq -S ".resources[0]" | \
 		jq -e ".type == \"node\" and .exclusive"
 '
+# N.B. slow under ASAN, skip
 test_expect_success NO_ASAN 'flux batch: submit a series of jobs' '
 	id1=$(flux batch --flags=waitable -n1 batch-script.sh) &&
 	id2=$(flux batch --flags=waitable -n4 batch-script.sh) &&

--- a/t/t2715-python-cli-cancel.t
+++ b/t/t2715-python-cli-cancel.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux cancel command'
 

--- a/t/t2716-python-cli-batch-conf.t
+++ b/t/t2716-python-cli-batch-conf.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='flux batch --conf tests'
 

--- a/t/t2718-python-cli-job-shape.t
+++ b/t/t2718-python-cli-job-shape.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test command line plugin for RFC 46 job shape'
 

--- a/t/t2720-python-cli-multi-prog.t
+++ b/t/t2720-python-cli-multi-prog.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='flux multi-prog'
 

--- a/t/t2800-jobs-cmd-multiuser.t
+++ b/t/t2800-jobs-cmd-multiuser.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux jobs command with multiple user jobs'
 

--- a/t/t2800-jobs-config.t
+++ b/t/t2800-jobs-config.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux jobs command config file support'
 

--- a/t/t2800-jobs-instance-info.t
+++ b/t/t2800-jobs-instance-info.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux jobs command with instance.* attributes'
 

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -191,7 +191,9 @@ test_expect_success 'flux-uri mock testing of slurm resolver works' '
 	test_debug "cat squeue2.err" &&
 	grep -i "empty nodelist" squeue2.err
 '
-test_expect_success 'setup fake csm_allocation_query for mock lsf testing' '
+# N.B. Internally the lsf resolver will eventually run 'ps', which hangs
+# under ASAN.  So set NO_ASAN for lsf tests below.
+test_expect_success NO_ASAN 'setup fake csm_allocation_query for mock lsf testing' '
 	cat <<-EOF >csm_allocation_query &&
 	#!/bin/sh
 	test -n "\$LSF_FAIL" && exit 4
@@ -203,7 +205,7 @@ test_expect_success 'setup fake csm_allocation_query for mock lsf testing' '
 	export CSM_ALLOCATION_QUERY=$(pwd)/csm_allocation_query &&
 	export FLUX_SSH=${SHARNESS_TEST_SRCDIR}/scripts/tssh
 '
-test_expect_success 'flux-uri mock testing of lsf resolver works' '
+test_expect_success NO_ASAN 'flux-uri mock testing of lsf resolver works' '
 	echo $FLUX_URI >lsf.exp &&
 	SHELL=/bin/sh flux uri --local lsf:$LSB_JOBID >lsf.out &&
 	test_cmp lsf.exp lsf.out

--- a/t/t2803-flux-pstree.t
+++ b/t/t2803-flux-pstree.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test the flux-pstree command'
 

--- a/t/t2804-uptime-cmd.t
+++ b/t/t2804-uptime-cmd.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux uptime command'
 

--- a/t/t2805-startlog-cmd.t
+++ b/t/t2805-startlog-cmd.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux startlog command'
 

--- a/t/t2806-config-cmd.t
+++ b/t/t2806-config-cmd.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux config get'
 

--- a/t/t2807-dump-cmd.t
+++ b/t/t2807-dump-cmd.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux dump/restore'
 

--- a/t/t2809-job-purge.t
+++ b/t/t2809-job-purge.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux job purge and flux job purge-id'
 

--- a/t/t2810-kvs-garbage-collect.t
+++ b/t/t2810-kvs-garbage-collect.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile

--- a/t/t2811-flux-pgrep.t
+++ b/t/t2811-flux-pgrep.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test the flux-pgrep/pkill commands'
 

--- a/t/t2812-flux-job-last.t
+++ b/t/t2812-flux-job-last.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test the flux job last command'
 

--- a/t/t2814-hostlist-cmd.t
+++ b/t/t2814-hostlist-cmd.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux hostlist command'
 

--- a/t/t2815-post-job-event.t
+++ b/t/t2815-post-job-event.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux post-job-event command'
 

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux fsck command'
 

--- a/t/t2900-job-timelimits.t
+++ b/t/t2900-job-timelimits.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test job time limit functionality'
 

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test that Flux can launch MPI'
 

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -16,6 +16,7 @@ run_program() {
 	run_timeout $timeout flux run $OPTS -n${ntasks} -N${nnodes} $*
 }
 
+# N.B. set NO_ASAN, we are modifying LD_PRELOAD
 test_expect_success NO_ASAN "spectrum mpi only enabled with option" '
 	LD_PRELOAD_saved=${LD_PRELOAD} &&
 	unset LD_PRELOAD &&
@@ -28,6 +29,7 @@ test_expect_success NO_ASAN "spectrum mpi only enabled with option" '
 	grep /opt/ibm/spectrum spectrum.out
 '
 
+# N.B. set NO_ASAN, we are modifying LD_PRELOAD
 test_expect_success NO_ASAN "spectrum mpi also enabled with spectrum@version" '
 	LD_PRELOAD_saved=${LD_PRELOAD} &&
 	unset LD_PRELOAD &&

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description="Test that Flux's MPI personalities work"
 

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description="Test Flux PMI implementation"
 

--- a/t/t3003-mpi-abort.t
+++ b/t/t3003-mpi-abort.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test that MPI_Abort works'
 

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -1,5 +1,4 @@
 #!/bin/sh
-#
 
 test_description='Test that Flux can launch Flux'
 

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -121,7 +121,8 @@ test_expect_success 'job FLUX_JOB_ID_PATH=/id' '
 test_expect_success 'flux_open("/") works at top-level' '
 	flux python -c "import flux; print(flux.Flux(\"/\").attr_get(\"instance-level\"));"
 '
-test_expect_success 'flux_open(3) accepts path-like URIs: "/", "../.." etc' '
+# N.B. Set NO_ASAN, suspected python related false positives w/ ASAN, See #7624
+test_expect_success NO_ASAN 'flux_open(3) accepts path-like URIs: "/", "../.." etc' '
 	cat <<-EOF >flux_open.py &&
 	import unittest
 	import flux

--- a/t/t3200-instance-restart.t
+++ b/t/t3200-instance-restart.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test instance restart'
 

--- a/t/t3201-crontabs.t
+++ b/t/t3201-crontabs.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test rc1 loading of crontab files'
 

--- a/t/t3202-instance-restart-testexec.t
+++ b/t/t3202-instance-restart-testexec.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test instance restart and still running jobs with testexec'
 

--- a/t/t3203-instance-recovery.t
+++ b/t/t3203-instance-recovery.t
@@ -1,5 +1,4 @@
 #!/bin/sh
-#
 
 test_description='Test instance recovery mode'
 

--- a/t/t3300-system-basic.t
+++ b/t/t3300-system-basic.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test the tools used to test the system instance.
 

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test system instance with late joining broker
 

--- a/t/t3302-system-offline.t
+++ b/t/t3302-system-offline.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test job submission when upstream is down
 

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Verify subtree health transitions and tools
 

--- a/t/t3304-system-rpctrack-down.t
+++ b/t/t3304-system-rpctrack-down.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test downstream RPC tracking
 

--- a/t/t3305-system-rpctrack-up.t
+++ b/t/t3305-system-rpctrack-up.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Test upstream RPC tracking and disconnect command
 

--- a/t/t3306-system-routercrash.t
+++ b/t/t3306-system-routercrash.t
@@ -52,9 +52,19 @@ test_expect_success 'construct FLUX_URI for rank 2 (child of 1)' '
 
 # Choice of signal 11 (SIGSEGV) is deliberate here.
 # The broker should not trap this signal - see flux-framework/flux-core#4230.
-test_expect_success 'kill -11 broker 1' '
+# N.B. under ASAN, the segfault signal will result in a log file being
+# generated and broker will exit with different error code.  Skip and see
+# following test for ASAN workaround.
+test_expect_success NO_ASAN 'kill -11 broker 1' '
 	$startctl kill 1 11 &&
 	test_expect_code 139 $startctl wait 1
+'
+
+# N.B. prior test will not work under ASAN but we still need broker to
+# die for later tests.  Send SIGKILL when running under ASAN.
+test_expect_success ASAN 'kill -9 broker 1' '
+	$startctl kill 1 9 &&
+	test_expect_code 137 $startctl wait 1
 '
 
 test_expect_success 'wait broker.online to reach count of one' '

--- a/t/t3306-system-routercrash.t
+++ b/t/t3306-system-routercrash.t
@@ -1,5 +1,4 @@
 #!/bin/sh
-#
 
 test_description='Hard fail a router node and verify child restarts
 

--- a/t/t3307-system-leafcrash.t
+++ b/t/t3307-system-leafcrash.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Hard fail a leaf node and verify transition thru lost
 

--- a/t/t3308-system-torpid.t
+++ b/t/t3308-system-torpid.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Check torpid broker detection
 '

--- a/t/t3310-system-heartbeat.t
+++ b/t/t3310-system-heartbeat.t
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# ci=asan
 
 test_description='Deprive a leaf node of heartbeats and make it sad'
 

--- a/t/t3400-overlay-trace.t
+++ b/t/t3400-overlay-trace.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux overlay trace'
 

--- a/t/t3401-module-trace.t
+++ b/t/t3401-module-trace.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test flux module trace'
 

--- a/t/t4100-slurm-expiration-sync.t
+++ b/t/t4100-slurm-expiration-sync.t
@@ -1,4 +1,6 @@
 #!/bin/sh
+#
+# ci=asan
 
 test_description='Test Slurm expiration synchronization'
 

--- a/t/t6010-fake-resources.t
+++ b/t/t6010-fake-resources.t
@@ -8,6 +8,8 @@
 #
 # SPDX-License-Identifier: LGPL-3.0
 #
+# ci=asan
+#
 
 test_description='Test fake-resources modprobe rc1 task'
 


### PR DESCRIPTION
Next iteration of work, built on top of #7538.

Per suggestion, run a subset of sharness tests using a "ci=asan" tag.  

WIP, I'm sure there will be iteration as we figure out how long this takes, which tests we want to keep or not keep.  For the time being, removed valgrind (obviously), system tests, python/lua tests, and regression tests.  But kept everything else for now.  I imagine I'll remove some as I iterate.  (example: do i really need to run "fake resources" tests under asan?  probably not)