### PR TITLE
broker: add timeout on built-in module unload

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -162,6 +162,11 @@ broker.cleanup-timeout
    rank 0 broker waits for cleanup actions to complete when the broker has
    received a terminating signal.  Default: ``none``.
 
+broker.unload-builtins-timeout
+   The amount of time (in RFC 23 Flux Standard Duration format) that the
+   broker waits for builtin modules to unload during shutdown before giving
+   up and moving on to exit.  Default: ``60s``.
+
 broker.rc1_path
    The command line executed by the broker for rc1.
    Default: ``flux modprobe rc1``.

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -109,6 +109,7 @@ static struct registered_attr attrtab[] = {
     { "broker.shutdown-warn", ATTR_IMMUTABLE },
     { "broker.shutdown-timeout", ATTR_IMMUTABLE },
     { "broker.cleanup-timeout", 0 },
+    { "broker.unload-builtins-timeout", 0 },
     { "broker.rc1_path", 0 },
     { "broker.rc3_path", 0 },
     { "broker.rc2_none", 0 },

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -26,6 +26,9 @@
 #include "src/common/libutil/errprintf.h"
 #include "ccan/array_size/array_size.h"
 #include "ccan/str/str.h"
+#ifndef HAVE_STRLCAT
+#include "src/common/libmissing/strlcat.h"
+#endif
 
 #include "state_machine.h"
 
@@ -64,6 +67,11 @@ struct goodbye {
     flux_watcher_t *timer;
 };
 
+struct unload_builtins {
+    double timeout;
+    flux_watcher_t *timer;
+};
+
 struct monitor {
     struct flux_msglist *requests;
 
@@ -95,6 +103,7 @@ struct state_machine {
     struct cleanup cleanup;
     struct shutdown shutdown;
     struct goodbye goodbye;
+    struct unload_builtins unload_builtins;
 
     struct systemd sd;
 
@@ -206,6 +215,7 @@ static const double default_shutdown_warn = 60; // log slow shutdown
 static const double default_shutdown_timeout = -1;
 static const double default_cleanup_timeout = -1;
 static const double default_sd_stop_timeout = -1;
+static const double default_unload_builtins_timeout = 60;
 static const double goodbye_timeout = 60;
 
 static void state_action (struct state_machine *s, broker_state_t state)
@@ -776,6 +786,35 @@ static void action_goodbye (struct state_machine *s)
     flux_watcher_start (s->goodbye.timer);
 }
 
+static void unload_builtins_timer_cb (flux_reactor_t *r,
+                                      flux_watcher_t *w,
+                                      int revents,
+                                      void *arg)
+{
+    struct state_machine *s = arg;
+
+    if (s->state == STATE_UNLOAD_BUILTINS) {
+        module_t *p;
+        char modules[1024] = "";
+
+        p = modhash_first (s->ctx->modhash);
+        while (p) {
+            const char *name = module_get_name (p);
+            if (modules[0] != '\0')
+                strlcat (modules, " ", sizeof (modules));
+            strlcat (modules, name, sizeof (modules));
+            p = modhash_next (s->ctx->modhash);
+        }
+
+        flux_log (s->ctx->h,
+                  LOG_ERR,
+                  "unloading built-in broker module timed out after %.1fs: %s",
+                  s->unload_builtins.timeout,
+                  modules);
+        state_machine_post (s, "builtins-unload-fail");
+    }
+}
+
 static void unload_builtins_continuation (flux_future_t *f, void *arg)
 {
     struct state_machine *s = arg;
@@ -787,8 +826,10 @@ static void unload_builtins_continuation (flux_future_t *f, void *arg)
                   future_strerror (f, errno));
         state_machine_post (s, "builtins-unload-fail");
     }
-    else
+    else {
+        flux_watcher_stop (s->unload_builtins.timer);
         state_machine_post (s, "builtins-done");
+    }
 }
 
 /* Unload builtin modules, then stop the broker's reactor.
@@ -803,6 +844,12 @@ static void action_unload_builtins (struct state_machine *s)
         || flux_future_then (f, -1, unload_builtins_continuation, s) < 0) {
         flux_log_error (h, "unload builtins initiation");
         state_machine_post (s, "builtins-unload-fail");
+    }
+    if (s->unload_builtins.timeout >= 0) {
+        flux_timer_watcher_reset (s->unload_builtins.timer,
+                                  s->unload_builtins.timeout,
+                                  0.);
+        flux_watcher_start (s->unload_builtins.timer);
     }
 }
 
@@ -1600,6 +1647,7 @@ void state_machine_destroy (struct state_machine *s)
         flux_watcher_destroy (s->shutdown.timer);
         flux_future_destroy (s->shutdown.health_f);
         flux_watcher_destroy (s->goodbye.timer);
+        flux_watcher_destroy (s->unload_builtins.timer);
         free (s);
         errno = saved_errno;
     }
@@ -1648,7 +1696,12 @@ struct state_machine *state_machine_create (struct broker *ctx,
                                                            goodbye_timeout,
                                                            0.,
                                                            goodbye_timer_cb,
-                                                           s)))
+                                                           s))
+        || !(s->unload_builtins.timer = flux_timer_watcher_create (r,
+                                                                    0.,
+                                                                    0.,
+                                                                    unload_builtins_timer_cb,
+                                                                    s)))
         goto error;
     flux_watcher_start (s->prep);
     flux_watcher_start (s->check);
@@ -1696,6 +1749,13 @@ struct state_machine *state_machine_create (struct broker *ctx,
                            "broker.shutdown-timeout",
                            &s->shutdown.timeout,
                            default_shutdown_timeout,
+                           errp) < 0) {
+        goto error_hasmsg;
+    }
+    if (timeout_configure (s,
+                           "broker.unload-builtins-timeout",
+                           &s->unload_builtins.timeout,
+                           default_unload_builtins_timeout,
                            errp) < 0) {
         goto error_hasmsg;
     }

--- a/src/modules/overlay/overlay.c
+++ b/src/modules/overlay/overlay.c
@@ -51,6 +51,11 @@
 #include "boot_pmi.h"
 #include "boot_config.h"
 
+/* Module debug flag to create zombie socket that blocks zmq_ctx_term().
+ * Enable with: flux module debug --setbit 1 overlay
+ */
+#define DEBUG_ZOMBIESOCKET 1
+
 /* How long to wait (seconds) for a peer broker's TCP ACK before disconnecting.
  * This can be configured via TOML and on the broker command line.
  */
@@ -2599,6 +2604,47 @@ error:
         flux_log_error (h, "error responding to %s request", topic);
 }
 
+/* Test hook: create socket with pending message to block zmq_ctx_term().
+ * This allows testing of broker.unload-builtins-timeout.
+ */
+static void test_create_zombie_socket (struct overlay *ov)
+{
+    void *zombie;
+    int linger = -1;  // infinite linger - wait forever for pending sends
+    int hwm = 1;
+
+    if (!ov->zctx) {
+        flux_log (ov->h, LOG_DEBUG, "test: no zctx (no overlay peers), skipping");
+        return;
+    }
+
+    flux_log (ov->h, LOG_DEBUG, "test: creating zombie socket");
+
+    if (!(zombie = zmq_socket (ov->zctx, ZMQ_PUSH))) {
+        flux_log_error (ov->h, "test: zmq_socket failed");
+        return;
+    }
+    zmq_setsockopt (zombie, ZMQ_LINGER, &linger, sizeof (linger));
+    zmq_setsockopt (zombie, ZMQ_SNDHWM, &hwm, sizeof (hwm));
+
+    // Connect to unreachable endpoint
+    if (zmq_connect (zombie, "tcp://127.0.0.1:1") < 0) {
+        flux_log_error (ov->h, "test: zmq_connect failed");
+        zmq_close (zombie);
+        return;
+    }
+
+    // Send message - will be queued since endpoint is unreachable
+    if (zmq_send (zombie, "x", 1, 0) < 0) {
+        flux_log_error (ov->h, "test: zmq_send failed");
+        zmq_close (zombie);
+        return;
+    }
+
+    flux_log (ov->h, LOG_DEBUG, "test: zombie socket created successfully");
+    // Don't close - zmq_ctx_term will block waiting for this message
+}
+
 void overlay_destroy (struct overlay *ov)
 {
     if (ov) {
@@ -2640,6 +2686,8 @@ void overlay_destroy (struct overlay *ov)
         flux_msglist_destroy (ov->monitor_requests);
         flux_msglist_destroy (ov->trace_requests);
         topology_decref (ov->topo);
+        if (flux_module_debug_test (ov->h, DEBUG_ZOMBIESOCKET, false))
+            test_create_zombie_socket (ov);
         if (!ov->zctx_external)
             zmq_ctx_term (ov->zctx);
         free (ov->hostname);

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -394,5 +394,28 @@ test_expect_success 'appropriate message was logged' '
 	grep "shutdown timeout" shutdown2.log
 '
 
+test_expect_success 'broker.unload-builtins-timeout default is 60s' '
+	flux start ${ARGS} \
+		flux getattr broker.unload-builtins-timeout >ubto.out &&
+	cat >ubto.exp <<-EOT &&
+	1m
+	EOT
+	test_cmp ubto.exp ubto.out
+'
+
+test_expect_success 'run instance with hanging overlay unload' '
+	test_must_fail_or_be_terminated flux start -s2 \
+		-Slog-filename=unload.log \
+		-Sbroker.rc1_path= \
+		-Sbroker.rc3_path= \
+		-Sbroker.unload-builtins-timeout=2s \
+		bash -c "flux module debug --setbit 1 overlay"
+'
+
+test_expect_success 'appropriate message was logged' '
+	grep "unloading built-in broker module timed out" unload.log &&
+	grep "overlay" unload.log
+'
+
 
 test_done


### PR DESCRIPTION
This adds a default 60s timeout on the broker `unload-builtins` state.  When the timer fires, the broker logs a message listing modules that haven't yet unloaded and exits, e.g. (with the timeout reduced to 2s)
```
Jun 05 22:34:00.746669 UTC 2026 broker.info[0]: goodbye: goodbye->unload-builtins 0.038499ms
Jun 05 22:34:00.746674 UTC 2026 broker.debug[0]: rmmod overlay
Jun 05 22:34:00.746677 UTC 2026 broker.debug[0]: rmmod rexec
Jun 05 22:34:00.746679 UTC 2026 broker.debug[0]: rmmod groups
Jun 05 22:34:00.746681 UTC 2026 broker.debug[0]: rmmod connector-local
Jun 05 22:34:00.746684 UTC 2026 broker.debug[0]: rmmod config
Jun 05 22:34:00.746974 UTC 2026 broker.debug[0]: module groups exited
Jun 05 22:34:00.747029 UTC 2026 broker.debug[0]: module rexec exited
Jun 05 22:34:00.747040 UTC 2026 broker.debug[0]: module connector-local exited
Jun 05 22:34:00.747049 UTC 2026 broker.debug[0]: module config exited
Jun 05 22:34:02.749779 UTC 2026 broker.err[0]: unloading built-in broker module timed out after 2.0s: overlay
Jun 05 22:34:02.749986 UTC 2026 broker.info[0]: builtins-unload-fail: unload-builtins->exit 2.00331s
Jun 05 22:34:02.750021 UTC 2026 broker.err[0]: broker module 'overlay' was not properly shut down
Jun 05 22:34:12.765692 UTC 2026 broker.debug[0]: overlay thread was canceled
Jun 05 22:34:12.765790 UTC 2026 broker.debug[0]: module overlay exited

```
Maybe this will help us run down at least the final portion of
- #7654 