### PR TITLE
content-sqlite: add query and backup RPCs and `flux sqlite` command

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -29,6 +29,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-fsck.1 \
 	man1/flux-archive.1 \
 	man1/flux-content.1 \
+	man1/flux-sqlite.1 \
 	man1/flux-config.1 \
 	man1/flux-proxy.1 \
 	man1/flux-queue.1 \

--- a/doc/man1/flux-sqlite.rst
+++ b/doc/man1/flux-sqlite.rst
@@ -65,6 +65,21 @@ as they could corrupt the database.
 
    Use column mode output with aligned columns.
 
+.. option:: -p, --param PARAM
+
+   Add a parameter to the query. This option can be specified multiple
+   times for queries with multiple placeholders (``?``). Parameters are
+   automatically typed:
+
+   * Integers and floats are parsed to their respective types
+   * The literal string ``null`` becomes SQL NULL
+   * ``blob:HEXSTRING`` encodes a hex string as a BLOB (e.g.,
+     ``blob:a1b2c3``)
+   * All other values are treated as TEXT
+
+   Parameters enable safe, SQL-injection-proof queries when working with
+   dynamic values.
+
 .. option:: --force
 
    Allow destructive operations (DELETE, VACUUM). This flag prevents
@@ -112,6 +127,20 @@ Check database statistics::
 Query total database size::
 
   $ flux sqlite query "SELECT COUNT(*), SUM(size) FROM objects"
+
+Query with a parameterized integer value::
+
+  $ flux sqlite query -p 100 "SELECT COUNT(*) FROM objects WHERE size > ?"
+
+Query with multiple parameters::
+
+  $ flux sqlite query -p 10 -p 1000 \
+    "SELECT * FROM objects WHERE size > ? AND size < ?"
+
+Delete a specific object by hash using a BLOB parameter::
+
+  $ flux sqlite query --force -p blob:a1b2c3d4e5 \
+    "DELETE FROM objects WHERE hash = ?"
 
 Reclaim space after garbage collection::
 

--- a/doc/man1/flux-sqlite.rst
+++ b/doc/man1/flux-sqlite.rst
@@ -1,0 +1,143 @@
+===============
+flux-sqlite(1)
+===============
+
+
+SYNOPSIS
+========
+
+| **flux** **sqlite** **query** [*OPTIONS*] *query*
+| **flux** **sqlite** **backup** *path*
+
+
+DESCRIPTION
+===========
+
+:program:`flux sqlite` provides administrative access to the content-sqlite
+database via RPC. This allows instance owners to inspect database contents,
+perform maintenance operations, and create backups without direct database
+file access.
+
+All operations require instance owner credentials and are only available
+when the content-sqlite backing store module is loaded.
+
+The content-sqlite database stores content blobs on the leader broker (rank 0)
+and is primarily used by the Flux KVS.
+
+
+COMMANDS
+========
+
+query
+-----
+
+.. program:: flux sqlite query
+
+Execute a SQL query against the content-sqlite database.
+
+Supported SQL operations:
+
+**SELECT**
+   Query database contents. Useful for inspecting stored objects,
+   checking database size, or debugging KVS issues.
+
+**PRAGMA**
+   View or modify database settings such as journal_mode, synchronous mode,
+   page_count, etc.
+
+**DELETE**
+   Remove specific rows from the database. Requires :option:`--force` flag.
+   Use with caution as deleted blobs cannot be recovered.
+
+**VACUUM**
+   Reclaim space from deleted rows by rebuilding the database file.
+   Requires :option:`--force` flag. This operation can be slow on large
+   databases.
+
+Other SQL operations (INSERT, UPDATE, CREATE, DROP, etc.) are not allowed
+as they could corrupt the database.
+
+.. option:: -H, --header
+
+   Print column headers in output.
+
+.. option:: -c, --column
+
+   Use column mode output with aligned columns.
+
+.. option:: --force
+
+   Allow destructive operations (DELETE, VACUUM). This flag prevents
+   accidental data loss by requiring explicit confirmation for operations
+   that modify or optimize the database.
+
+backup
+------
+
+.. program:: flux sqlite backup
+
+Create an online backup of the content-sqlite database using SQLite's
+backup API. The backup is created atomically and consistently, even while
+the database is being actively used.
+
+The backup *path* must be an absolute path and cannot be the same as the
+source database file.
+
+This operation does not require the :option:`--force` flag as it is
+non-destructive.
+
+
+EXAMPLES
+========
+
+Query the number of objects in the database::
+
+  $ flux sqlite query "SELECT COUNT(*) FROM objects"
+  42
+
+View database settings::
+
+  $ flux sqlite query "PRAGMA journal_mode"
+  wal
+
+Inspect the schema::
+
+  $ flux sqlite query -H -c "PRAGMA table_info(objects)"
+
+Check database statistics::
+
+  $ flux sqlite query "PRAGMA page_count"
+  $ flux sqlite query "PRAGMA page_size"
+
+Query total database size::
+
+  $ flux sqlite query "SELECT COUNT(*), SUM(size) FROM objects"
+
+Reclaim space after garbage collection::
+
+  $ flux sqlite query --force "VACUUM"
+
+Create a backup::
+
+  $ flux sqlite backup /tmp/content-backup.db
+
+
+CAVEATS
+=======
+
+**Destructive Operations**
+
+DELETE and VACUUM operations permanently modify the database. Deleted
+content blobs cannot be recovered. Always verify queries carefully and
+consider creating a backup before destructive operations.
+
+RESOURCES
+=========
+
+.. include:: common/resources.rst
+
+
+SEE ALSO
+========
+
+:man1:`flux-content`, :man1:`flux-kvs`, :man1:`flux-dump`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -27,6 +27,7 @@ man_pages = [
     ('man1/flux-version', 'flux-version', 'Display flux version information', [author], 1),
     ('man1/flux-config', 'flux-config', 'Manage/query Flux configuration', [author], 1),
     ('man1/flux-content', 'flux-content', 'access content service', [author], 1),
+    ('man1/flux-sqlite', 'flux-sqlite', 'query and backup content-sqlite database', [author], 1),
     ('man1/flux-cron', 'flux-cron', 'Cron-like utility for Flux', [author], 1),
     ('man1/flux-dmesg', 'flux-dmesg', 'access broker ring buffer', [author], 1),
     ('man1/flux-dump', 'flux-dump', 'Write KVS snapshot to portable archive', [author], 1),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1210,3 +1210,6 @@ pc
 pricount
 resultp
 stateful
+wal
+SQLite
+SQLite's

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1213,3 +1213,4 @@ stateful
 wal
 SQLite
 SQLite's
+HEXSTRING

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -2128,6 +2128,7 @@ _flux_sqlite()
     query_OPTS="\
         -H --header \
         -c --column \
+        -p --param= \
         --force \
     "
     backup_OPTS=""

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -2120,6 +2120,26 @@ _flux_content()
     fi
 }
 
+# flux-sqlite(1) completions
+_flux_sqlite()
+{
+    local cmd=$1
+    local subcmds="query backup"
+    query_OPTS="\
+        -H --header \
+        -c --column \
+        --force \
+    "
+    backup_OPTS=""
+
+    if [[ $cmd != "sqlite" ]]; then
+        var="${cmd//-/_}_OPTS"
+        COMPREPLY=( $(compgen -W "${!var} -h --help" -- "$cur") )
+    else
+        COMPREPLY=( $(compgen -W "${subcmds}" -- "$cur") )
+    fi
+}
+
 # flux-start(1) completions
 _flux_start()
 {
@@ -2594,6 +2614,9 @@ _flux_core()
         ;;
     content)
         _flux_content $subcmd
+        ;;
+    sqlite)
+        _flux_sqlite $subcmd
         ;;
     start)
         _flux_start $subcmd

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -134,6 +134,7 @@ dist_fluxcmd_SCRIPTS = \
 	flux-modprobe.py \
 	flux-sproc.py \
 	flux-slurm-expiration-sync.py \
+	flux-sqlite.py \
 	flux-python$(PYTHON_VERSION)
 
 fluxcmd_PROGRAMS = \

--- a/src/cmd/flux-sqlite.py
+++ b/src/cmd/flux-sqlite.py
@@ -10,6 +10,7 @@
 ##############################################################
 
 import argparse
+import base64
 import sys
 
 import flux
@@ -19,10 +20,40 @@ def query(args):
     """Execute SQL query against content-sqlite database"""
     h = flux.Flux()
     try:
-        future = h.rpc(
-            "content-sqlite.query",
-            {"query": args.query, "force": args.force},
-        )
+        req = {"query": args.query, "force": args.force}
+
+        # Add parameters if provided
+        if args.params:
+            params = []
+            for param in args.params:
+                # Try to parse as different types
+                if param.lower() == "null":
+                    params.append(None)
+                elif param.startswith("blob:"):
+                    # BLOB parameter: base64-encode the hex string
+                    hex_str = param[5:]
+                    blob_bytes = bytes.fromhex(hex_str)
+                    params.append(base64.b64encode(blob_bytes).decode("ascii"))
+                else:
+                    # Try integer
+                    try:
+                        params.append(int(param))
+                        continue
+                    except ValueError:
+                        # Not an integer, try float
+                        pass
+                    # Try float
+                    try:
+                        params.append(float(param))
+                        continue
+                    except ValueError:
+                        # Not a float, treat as string
+                        pass
+                    # Default to string
+                    params.append(param)
+            req["params"] = params
+
+        future = h.rpc("content-sqlite.query", req)
         result = future.get()
 
         if "error" in result:
@@ -122,6 +153,13 @@ def main():
         "--force",
         action="store_true",
         help="Allow destructive operations (DELETE, VACUUM)",
+    )
+    query_parser.add_argument(
+        "-p",
+        "--param",
+        dest="params",
+        action="append",
+        help="Query parameter (use 'null' for NULL, 'blob:hex' for BLOB)",
     )
     query_parser.set_defaults(func=query)
 

--- a/src/cmd/flux-sqlite.py
+++ b/src/cmd/flux-sqlite.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+##############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import argparse
+import sys
+
+import flux
+
+
+def query(args):
+    """Execute SQL query against content-sqlite database"""
+    h = flux.Flux()
+    try:
+        future = h.rpc(
+            "content-sqlite.query",
+            {"query": args.query, "force": args.force},
+        )
+        result = future.get()
+
+        if "error" in result:
+            print(f"Error: {result['error']}", file=sys.stderr)
+            sys.exit(1)
+
+        rows = result.get("rows", [])
+        columns = result.get("columns", [])
+
+        if not rows:
+            return
+
+        # Calculate column widths for column mode
+        widths = []
+        if args.column and columns and rows:
+            for i, col in enumerate(columns):
+                max_width = len(str(col))
+                for row in rows:
+                    if i < len(row):
+                        max_width = max(max_width, len(str(row[i])))
+                widths.append(max_width)
+
+        # Print headers if requested
+        if args.header and columns:
+            if args.column:
+                header_line = "  ".join(
+                    col.ljust(widths[i]) for i, col in enumerate(columns)
+                )
+                print(header_line)
+                print("-" * len(header_line))
+            else:
+                print("|".join(columns))
+
+        # Print rows
+        for row in rows:
+            if args.column:
+                if columns:
+                    print(
+                        "  ".join(
+                            str(row[i]).ljust(widths[i]) if i < len(row) else ""
+                            for i in range(len(columns))
+                        )
+                    )
+                else:
+                    print("  ".join(str(val) for val in row))
+            else:
+                print("|".join(str(val) for val in row))
+
+    except OSError as e:
+        print(f"RPC error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def backup(args):
+    """Create database backup using SQLite backup API"""
+    h = flux.Flux()
+    try:
+        future = h.rpc("content-sqlite.backup", {"path": args.path})
+        future.get()
+        print(f"Backup created: {args.path}")
+    except OSError as e:
+        print(f"RPC error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="flux-sqlite")
+    subparsers = parser.add_subparsers(
+        title="subcommands",
+        description="",
+        dest="subcommand",
+    )
+    subparsers.required = True
+
+    # Query subcommand
+    query_parser = subparsers.add_parser(
+        "query",
+        help="Execute SQL query",
+    )
+    query_parser.add_argument(
+        "query",
+        help="SQL query to execute (SELECT, PRAGMA, DELETE, or VACUUM)",
+    )
+    query_parser.add_argument(
+        "-H",
+        "--header",
+        action="store_true",
+        help="Print column headers",
+    )
+    query_parser.add_argument(
+        "-c",
+        "--column",
+        action="store_true",
+        help="Column mode output",
+    )
+    query_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow destructive operations (DELETE, VACUUM)",
+    )
+    query_parser.set_defaults(func=query)
+
+    # Backup subcommand
+    backup_parser = subparsers.add_parser(
+        "backup",
+        help="Create database backup",
+    )
+    backup_parser.add_argument(
+        "path",
+        help="Path to backup file",
+    )
+    backup_parser.set_defaults(func=backup)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()
+
+# vi: ts=4 sw=4 expandtab

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -17,6 +17,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <sys/statvfs.h>
+#include <stdbool.h>
 #include <sqlite3.h>
 #include <lz4.h>
 #include <flux/core.h>
@@ -32,6 +33,7 @@
 
 #include "src/common/libcontent/content-util.h"
 #include "ccan/str/str.h"
+#include "ccan/base64/base64.h"
 
 const size_t lzo_buf_chunksize = 1024*1024;
 const size_t compression_threshold = 256; /* compress blobs >= this size */
@@ -1131,13 +1133,15 @@ static void query_cb (flux_t *h,
     sqlite3_stmt *stmt = NULL;
     json_t *rows = NULL;
     json_t *columns = NULL;
+    json_t *params = NULL;
     int force = 0;
 
     if (flux_request_unpack (msg,
                              NULL,
-                             "{s:s s?b}",
+                             "{s:s s?b s?o}",
                              "query", &query,
-                             "force", &force) < 0) {
+                             "force", &force,
+                             "params", &params) < 0) {
         errstr = "failed to unpack query request";
         goto error;
     }
@@ -1175,6 +1179,113 @@ static void query_cb (flux_t *h,
     if (sqlite3_prepare_v2 (ctx->db, query, -1, &stmt, NULL) != SQLITE_OK) {
         errstr = sqlite3_errmsg (ctx->db);
         set_errno_from_sqlite_error (ctx);
+        goto error;
+    }
+
+    /* Bind parameters if provided */
+    int expected_params = sqlite3_bind_parameter_count (stmt);
+    if (params) {
+        int actual_params = json_array_size (params);
+
+        if (actual_params != expected_params) {
+            errstr = "parameter count mismatch";
+            errno = EINVAL;
+            goto error;
+        }
+
+        for (size_t i = 0; i < actual_params; i++) {
+            json_t *val = json_array_get (params, i);
+            int rc;
+
+            if (json_is_string (val)) {
+                const char *str = json_string_value (val);
+                size_t str_len = strlen (str);
+                /* Check if string could be valid base64:
+                 * - Length must be multiple of 4 (with padding)
+                 * - Should contain only valid base64 characters
+                 * This distinguishes BLOB params (base64-encoded) from TEXT
+                 */
+                bool try_base64 = (str_len > 0 && str_len % 4 == 0);
+                if (try_base64) {
+                    /* Verify all characters are in base64 alphabet */
+                    for (size_t j = 0; j < str_len; j++) {
+                        if (!base64_char_in_alphabet (&base64_maps_rfc4648,
+                                                       str[j])
+                            && str[j] != '=') {
+                            try_base64 = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (try_base64) {
+                    /* Looks like base64 - try to decode as BLOB */
+                    size_t decoded_max = base64_decoded_length (str_len);
+                    char *decoded = malloc (decoded_max);
+                    if (!decoded) {
+                        errno = ENOMEM;
+                        goto error;
+                    }
+                    ssize_t decoded_len = base64_decode (decoded,
+                                                         decoded_max,
+                                                         str,
+                                                         str_len);
+                    if (decoded_len >= 0) {
+                        /* Successfully decoded - bind as BLOB */
+                        rc = sqlite3_bind_blob (stmt,
+                                               i + 1,
+                                               decoded,
+                                               decoded_len,
+                                               free);
+                    }
+                    else {
+                        /* Decode failed - bind as TEXT */
+                        free (decoded);
+                        rc = sqlite3_bind_text (stmt,
+                                               i + 1,
+                                               str,
+                                               -1,
+                                               SQLITE_TRANSIENT);
+                    }
+                }
+                else {
+                    /* Not base64 format - bind as TEXT */
+                    rc = sqlite3_bind_text (stmt,
+                                           i + 1,
+                                           str,
+                                           -1,
+                                           SQLITE_TRANSIENT);
+                }
+            }
+            else if (json_is_integer (val)) {
+                rc = sqlite3_bind_int64 (stmt,
+                                        i + 1,
+                                        json_integer_value (val));
+            }
+            else if (json_is_real (val)) {
+                rc = sqlite3_bind_double (stmt,
+                                         i + 1,
+                                         json_real_value (val));
+            }
+            else if (json_is_null (val)) {
+                rc = sqlite3_bind_null (stmt, i + 1);
+            }
+            else {
+                errstr = "unsupported parameter type";
+                errno = EINVAL;
+                goto error;
+            }
+
+            if (rc != SQLITE_OK) {
+                errstr = sqlite3_errmsg (ctx->db);
+                set_errno_from_sqlite_error (ctx);
+                goto error;
+            }
+        }
+    }
+    else if (expected_params > 0) {
+        errstr = "query has parameters but none provided";
+        errno = EINVAL;
         goto error;
     }
 

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -1040,6 +1040,232 @@ static void content_sqlite_destroy (struct content_sqlite *ctx)
     }
 }
 
+static void backup_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    struct content_sqlite *ctx = arg;
+    const char *path = NULL;
+    const char *errstr = NULL;
+    sqlite3 *dest_db = NULL;
+    sqlite3_backup *backup = NULL;
+    int rc;
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "path", &path) < 0) {
+        errstr = "failed to unpack backup request";
+        goto error;
+    }
+
+    /* Validate path is absolute */
+    if (path[0] != '/') {
+        errstr = "backup path must be absolute";
+        errno = EINVAL;
+        goto error;
+    }
+
+    /* Ensure we're not backing up to the same file */
+    if (strcmp (path, ctx->dbfile) == 0) {
+        errstr = "backup path cannot be the same as source database";
+        errno = EINVAL;
+        goto error;
+    }
+
+    /* Open destination database */
+    rc = sqlite3_open (path, &dest_db);
+    if (rc != SQLITE_OK) {
+        errstr = sqlite3_errmsg (dest_db);
+        errno = EIO;
+        goto error;
+    }
+
+    /* Initialize backup */
+    backup = sqlite3_backup_init (dest_db, "main", ctx->db, "main");
+    if (!backup) {
+        errstr = sqlite3_errmsg (dest_db);
+        errno = EIO;
+        goto error;
+    }
+
+    /* Perform backup - copy all pages at once */
+    rc = sqlite3_backup_step (backup, -1);
+    if (rc != SQLITE_DONE) {
+        errstr = sqlite3_errstr (rc);
+        errno = EIO;
+        goto error;
+    }
+
+    /* Finalize backup */
+    rc = sqlite3_backup_finish (backup);
+    backup = NULL;
+    if (rc != SQLITE_OK) {
+        errstr = sqlite3_errstr (rc);
+        errno = EIO;
+        goto error;
+    }
+
+    sqlite3_close (dest_db);
+
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "backup: flux_respond");
+
+    return;
+
+error:
+    if (backup)
+        sqlite3_backup_finish (backup);
+    if (dest_db)
+        sqlite3_close (dest_db);
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "backup: flux_respond_error");
+}
+
+static void query_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
+{
+    struct content_sqlite *ctx = arg;
+    const char *query = NULL;
+    const char *errstr = NULL;
+    sqlite3_stmt *stmt = NULL;
+    json_t *rows = NULL;
+    json_t *columns = NULL;
+    int force = 0;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s?b}",
+                             "query", &query,
+                             "force", &force) < 0) {
+        errstr = "failed to unpack query request";
+        goto error;
+    }
+
+    /* Skip leading whitespace */
+    while (*query && isspace (*query))
+        query++;
+
+    /* Allow SELECT, PRAGMA, DELETE, and VACUUM for admin operations.
+     * Other operations (INSERT, UPDATE, CREATE, DROP) are not allowed
+     * since they could corrupt the database.
+     */
+    if (strncasecmp (query, "SELECT", 6) != 0
+        && strncasecmp (query, "PRAGMA", 6) != 0
+        && strncasecmp (query, "DELETE", 6) != 0
+        && strncasecmp (query, "VACUUM", 6) != 0) {
+        errstr = "only SELECT, PRAGMA, DELETE, and VACUUM queries are allowed";
+        errno = EPERM;
+        goto error;
+    }
+
+    /* DELETE and VACUUM require --force flag */
+    if ((strncasecmp (query, "DELETE", 6) == 0
+         || strncasecmp (query, "VACUUM", 6) == 0) && !force) {
+        errstr = "DELETE and VACUUM require --force flag";
+        errno = EPERM;
+        goto error;
+    }
+
+    if (!(rows = json_array ()) || !(columns = json_array ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+
+    if (sqlite3_prepare_v2 (ctx->db, query, -1, &stmt, NULL) != SQLITE_OK) {
+        errstr = sqlite3_errmsg (ctx->db);
+        set_errno_from_sqlite_error (ctx);
+        goto error;
+    }
+
+    /* Get column names */
+    int ncols = sqlite3_column_count (stmt);
+    for (int i = 0; i < ncols; i++) {
+        const char *name = sqlite3_column_name (stmt, i);
+        json_t *col = json_string (name ? name : "");
+        if (!col || json_array_append_new (columns, col) < 0) {
+            errno = ENOMEM;
+            goto error;
+        }
+    }
+
+    /* Execute and fetch rows */
+    while (sqlite3_step (stmt) == SQLITE_ROW) {
+        json_t *row = json_array ();
+        if (!row) {
+            errno = ENOMEM;
+            goto error;
+        }
+        for (int i = 0; i < ncols; i++) {
+            json_t *val = NULL;
+            const char *text;
+            int type = sqlite3_column_type (stmt, i);
+            switch (type) {
+                case SQLITE_INTEGER:
+                    val = json_integer (sqlite3_column_int64 (stmt, i));
+                    break;
+                case SQLITE_FLOAT:
+                    val = json_real (sqlite3_column_double (stmt, i));
+                    break;
+                case SQLITE_TEXT:
+                    text = (const char *)sqlite3_column_text (stmt, i);
+                    val = json_string (text);
+                    break;
+                case SQLITE_BLOB: {
+                    const void *blob = sqlite3_column_blob (stmt, i);
+                    int size = sqlite3_column_bytes (stmt, i);
+                    char *hex = malloc (size * 2 + 1);
+                    if (!hex) {
+                        json_decref (row);
+                        errno = ENOMEM;
+                        goto error;
+                    }
+                    for (int j = 0; j < size; j++)
+                        sprintf (hex + j*2, "%02x",
+                                ((unsigned char *)blob)[j]);
+                    val = json_string (hex);
+                    free (hex);
+                    break;
+                }
+                case SQLITE_NULL:
+                default:
+                    val = json_null ();
+                    break;
+            }
+            if (!val || json_array_append_new (row, val) < 0) {
+                json_decref (row);
+                errno = ENOMEM;
+                goto error;
+            }
+        }
+        if (json_array_append_new (rows, row) < 0) {
+            errno = ENOMEM;
+            goto error;
+        }
+    }
+
+    sqlite3_finalize (stmt);
+
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:O s:O}",
+                           "rows", rows,
+                           "columns", columns) < 0)
+        flux_log_error (h, "query: flux_respond_pack");
+
+    json_decref (rows);
+    json_decref (columns);
+    return;
+
+error:
+    if (stmt)
+        sqlite3_finalize (stmt);
+    json_decref (rows);
+    json_decref (columns);
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "query: flux_respond_error");
+}
+
 static const struct flux_msg_handler_spec htab[] = {
     {
         FLUX_MSGTYPE_REQUEST,
@@ -1076,6 +1302,18 @@ static const struct flux_msg_handler_spec htab[] = {
         "content-sqlite.stats-get",
         stats_get_cb,
         FLUX_ROLE_USER
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-sqlite.query",
+        query_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content-sqlite.backup",
+        backup_cb,
+        0
     },
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -107,6 +107,7 @@ TESTSCRIPTS = \
 	t0024-jjc-reader.t \
 	t0026-flux-R.t \
 	t0042-rhwloc-gpu-dedup.t \
+	t0043-content-sqlite-query.t \
 	t0090-content-enospc.t \
 	t0099-admin-system-scripts.t \
 	t0100-modprobe.t \

--- a/t/t0043-content-sqlite-query.t
+++ b/t/t0043-content-sqlite-query.t
@@ -120,27 +120,81 @@ test_expect_success 'flux sqlite backup fails as guest' '
 	grep -q "owner credentials" backup-guest.err
 '
 
-test_expect_success 'flux sqlite query handles FLOAT type with expression' '
-	flux sqlite query "SELECT 3.14 as float_col" >float.out &&
-	grep -q "3.14" float.out
+# Parameterized query tests
+test_expect_success 'store test data for parameter tests' '
+	echo "param test 1" | flux content store --bypass-cache >param1.out &&
+	echo "param test 2" | flux content store --bypass-cache >param2.out &&
+	echo "param test 3" | flux content store --bypass-cache >param3.out
 '
 
-test_expect_success 'flux sqlite query handles NULL type with expression' '
-	flux sqlite query "SELECT NULL as null_col" >null.out &&
-	grep -q "None" null.out
+test_expect_success 'flux sqlite query with INTEGER parameter works' '
+	flux sqlite query -p 1 "SELECT COUNT(*) FROM objects WHERE size = ?" >param-int.out &&
+	test -s param-int.out
 '
 
-test_expect_success 'flux sqlite query handles BLOB type from objects table' '
-	flux sqlite query "SELECT object FROM objects LIMIT 1" >blob.out &&
-	test -s blob.out
+test_expect_success 'flux sqlite query with TEXT parameter works' '
+	flux sqlite query -p "objects" \
+		"SELECT COUNT(*) FROM sqlite_master WHERE type = '\''table'\'' AND tbl_name = ?" >param-text.out &&
+	grep -q "1" param-text.out
 '
 
-test_expect_success 'flux sqlite query handles mixed types in one query' '
-	flux sqlite query "SELECT 42 as int_val, 3.14 as float_val, \"text\" as text_val, NULL as null_val" >mixed.out &&
-	grep -q "42" mixed.out &&
-	grep -q "3.14" mixed.out &&
-	grep -q "text" mixed.out &&
-	grep -q "None" mixed.out
+test_expect_success 'flux sqlite query with NULL parameter works' '
+	flux sqlite query -p null \
+		"SELECT COUNT(*) FROM objects WHERE size = ?" >param-null.out &&
+	grep -q "0" param-null.out
+'
+
+test_expect_success 'flux sqlite query with REAL parameter works' '
+	flux sqlite query -p 3.14 \
+		"SELECT typeof(?)" >param-real.out &&
+	grep -q "real" param-real.out
+'
+
+test_expect_success 'flux sqlite query with BLOB parameter works' '
+	HASH=$(cat param1.out) &&
+	HEXHASH=$(echo $HASH | sed "s/sha1-//") &&
+	flux sqlite query -p "blob:$HEXHASH" \
+		"SELECT typeof(?)" >param-blob.out &&
+	grep -q "blob" param-blob.out
+'
+
+test_expect_success 'flux sqlite query with multiple parameters works' '
+	flux sqlite query -p 5 -p 20 \
+		"SELECT COUNT(*) FROM objects WHERE size > ? AND size < ?" >param-multi.out &&
+	test -s param-multi.out
+'
+
+test_expect_success 'flux sqlite query parameter count mismatch (too few params) fails' '
+	test_must_fail flux sqlite query -p 1 \
+		"SELECT COUNT(*) FROM objects WHERE size = ? OR size = ?" 2>param-mismatch.err &&
+	grep -q "parameter count mismatch" param-mismatch.err
+'
+
+test_expect_success 'flux sqlite query parameter count mismatch (too many params) fails' '
+	test_must_fail flux sqlite query -p 1 -p 2 -p 3 \
+		"SELECT COUNT(*) FROM objects WHERE size = ?" 2>param-mismatch2.err &&
+	grep -q "parameter count mismatch" param-mismatch2.err
+'
+
+test_expect_success 'flux sqlite query with placeholder but no params fails' '
+	test_must_fail flux sqlite query \
+		"SELECT COUNT(*) FROM objects WHERE size = ?" 2>no-params.err &&
+	grep -q "query has parameters but none provided" no-params.err
+'
+
+test_expect_success 'flux sqlite query with parameters to invalid column fails gracefully' '
+	test_must_fail flux sqlite query -p 1 \
+		"SELECT COUNT(*) FROM objects WHERE nonexistent_column = ?" 2>invalid-col.err
+'
+
+test_expect_success 'flux sqlite query DELETE with BLOB parameters works' '
+	HASH=$(cat param1.out) &&
+	HEXHASH=$(echo $HASH | sed "s/sha1-//") &&
+	COUNT_BEFORE=$(flux sqlite query "SELECT COUNT(*) FROM objects") &&
+	flux sqlite query --force -p "blob:$HEXHASH" \
+		"DELETE FROM objects WHERE hash = ?" &&
+	COUNT_AFTER=$(flux sqlite query "SELECT COUNT(*) FROM objects") &&
+	test "$COUNT_AFTER" -le "$COUNT_BEFORE"
 '
 
 test_expect_success 'remove content-sqlite module' '

--- a/t/t0043-content-sqlite-query.t
+++ b/t/t0043-content-sqlite-query.t
@@ -1,0 +1,154 @@
+#!/bin/sh
+
+test_description='Test flux sqlite query and backup commands'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 1 minimal
+
+command -v sqlite3 >/dev/null 2>&1 && test_set_prereq SQLITE3
+
+test_expect_success 'load content and content-sqlite modules' '
+	flux module load content &&
+	flux module load content-sqlite
+'
+
+test_expect_success 'store some test data' '
+	echo "test data 1" | flux content store --bypass-cache >hash1.out &&
+	echo "test data 2" | flux content store --bypass-cache >hash2.out &&
+	echo "test data 3" | flux content store --bypass-cache >hash3.out
+'
+
+test_expect_success 'flux sqlite query SELECT works' '
+	flux sqlite query "SELECT COUNT(*) FROM objects" >count.out &&
+	grep -q "3" count.out
+'
+
+test_expect_success 'flux sqlite query with --header flag works' '
+	flux sqlite query -H "SELECT COUNT(*) FROM objects" >header.out &&
+	grep -q "COUNT" header.out
+'
+
+test_expect_success 'flux sqlite query with --column flag works' '
+	flux sqlite query -c "SELECT COUNT(*) FROM objects" >column.out &&
+	test -s column.out
+'
+
+test_expect_success 'flux sqlite query PRAGMA works' '
+	flux sqlite query "PRAGMA journal_mode" >pragma.out &&
+	test -s pragma.out
+'
+
+test_expect_success 'flux sqlite query multi-line query with leading whitespace works' '
+	flux sqlite query "
+		SELECT COUNT(*)
+		FROM objects
+	" >multiline.out &&
+	grep -q "3" multiline.out
+'
+
+test_expect_success 'flux sqlite query DELETE without --force fails' '
+	test_must_fail flux sqlite query "DELETE FROM objects WHERE rowid = 1" 2>delete-noforce.err &&
+	grep -q "force" delete-noforce.err
+'
+
+test_expect_success 'flux sqlite query DELETE with --force works' '
+	flux sqlite query --force "DELETE FROM objects WHERE rowid = 1" &&
+	flux sqlite query "SELECT COUNT(*) FROM objects" >count3.out &&
+	grep -q "2" count3.out
+'
+
+test_expect_success 'flux sqlite query VACUUM without --force fails' '
+	test_must_fail flux sqlite query "VACUUM" 2>vacuum-noforce.err &&
+	grep -q "force" vacuum-noforce.err
+'
+
+test_expect_success 'flux sqlite query VACUUM with --force works' '
+	flux sqlite query --force "VACUUM"
+'
+
+test_expect_success 'flux sqlite query rejects INSERT' '
+	test_must_fail flux sqlite query "INSERT INTO objects VALUES (1,2,3,4,5)" 2>insert.err &&
+	grep -q "only SELECT, PRAGMA, DELETE, and VACUUM" insert.err
+'
+
+test_expect_success 'flux sqlite query rejects UPDATE' '
+	test_must_fail flux sqlite query "UPDATE objects SET hash = NULL" 2>update.err &&
+	grep -q "only SELECT, PRAGMA, DELETE, and VACUUM" update.err
+'
+
+test_expect_success 'flux sqlite query rejects DROP' '
+	test_must_fail flux sqlite query "DROP TABLE objects" 2>drop.err &&
+	grep -q "only SELECT, PRAGMA, DELETE, and VACUUM" drop.err
+'
+
+test_expect_success 'flux sqlite backup creates backup file' '
+	BACKUP=$(pwd)/backup.db &&
+	flux sqlite backup $BACKUP &&
+	test -f $BACKUP
+'
+
+test_expect_success SQLITE3 'backup file contains data' '
+	BACKUP=$(pwd)/backup.db &&
+	test -s $BACKUP &&
+	sqlite3 $BACKUP "SELECT COUNT(*) FROM objects" >backup-count.out &&
+	grep -q "2" backup-count.out
+'
+
+test_expect_success 'flux sqlite backup rejects relative path' '
+	test_must_fail flux sqlite backup backup-relative.db \
+		2>backup-relative.err &&
+	grep -q "absolute" backup-relative.err
+'
+
+test_expect_success 'flux sqlite backup rejects same path as source' '
+	DBPATH=$(flux getattr statedir)/content.sqlite &&
+	test_must_fail flux sqlite backup $DBPATH 2>backup-same.err &&
+	grep -q "same as source" backup-same.err
+'
+
+test_expect_success 'flux sqlite query fails as guest' '
+	test_must_fail env FLUX_HANDLE_ROLEMASK=0x2 \
+		flux sqlite query "SELECT COUNT(*) FROM objects" 2>guest.err &&
+	grep -q "owner credentials" guest.err
+'
+
+test_expect_success 'flux sqlite backup fails as guest' '
+	BACKUP=$(pwd)/backup-guest.db &&
+	test_must_fail env FLUX_HANDLE_ROLEMASK=0x2 \
+		flux sqlite backup $BACKUP 2>backup-guest.err &&
+	grep -q "owner credentials" backup-guest.err
+'
+
+test_expect_success 'flux sqlite query handles FLOAT type with expression' '
+	flux sqlite query "SELECT 3.14 as float_col" >float.out &&
+	grep -q "3.14" float.out
+'
+
+test_expect_success 'flux sqlite query handles NULL type with expression' '
+	flux sqlite query "SELECT NULL as null_col" >null.out &&
+	grep -q "None" null.out
+'
+
+test_expect_success 'flux sqlite query handles BLOB type from objects table' '
+	flux sqlite query "SELECT object FROM objects LIMIT 1" >blob.out &&
+	test -s blob.out
+'
+
+test_expect_success 'flux sqlite query handles mixed types in one query' '
+	flux sqlite query "SELECT 42 as int_val, 3.14 as float_val, \"text\" as text_val, NULL as null_val" >mixed.out &&
+	grep -q "42" mixed.out &&
+	grep -q "3.14" mixed.out &&
+	grep -q "text" mixed.out &&
+	grep -q "None" mixed.out
+'
+
+test_expect_success 'remove content-sqlite module' '
+	flux module remove content-sqlite
+'
+
+test_expect_success 'remove content module' '
+	flux module remove content
+'
+
+test_done


### PR DESCRIPTION
It is impossible to run queries or backup the content-sqlite db of a live flux instance because the module has the db exclusively locked.

This simple PR just adds query and backup RPCs to the content-sqlite module to allow examination and backup of the db for an online Flux instance. A `flux sqlite [query|backup]` command is added for convenience.

I'm not experienced at all with sqlite, and let Claude write the backed marshaling of the query into a sqlite query. Hopefully it got it right, but that code should get extra scrutiny.

The DELETE and VACUUM sqlite commands require a `--force` flag since they're destructive. I added them because they were useful in some other experiments I've been running. They likely wouldn't be used in production for now I assume.