### PR TITLE
overlay: apply tbon.tcp_user_timeout to parent socket too

### DIFF
--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -39,7 +39,7 @@ torpid_max
 
 tcp_user_timeout
    (optional) The amount of time (in RFC 23 Flux Standard Duration format) that
-   a broker waits for a TBON child connection to acknowledge transmitted TCP
+   a broker waits for a TBON connection to acknowledge transmitted TCP
    data before forcibly closing the connection.  A value of 0 means use the
    system default.  This value affects how Flux responds to an abruptly turned
    off node.  The configured value may be overridden by setting the

--- a/src/modules/overlay/overlay.c
+++ b/src/modules/overlay/overlay.c
@@ -1619,6 +1619,14 @@ int overlay_connect (struct overlay *ov)
                 return -1;
         }
 #endif
+#ifdef ZMQ_TCP_MAXRT
+        if (ov->tcp_user_timeout > 0) {
+            if (zsetsockopt_int (ov->parent.zsock,
+                                 ZMQ_TCP_MAXRT,
+                                 ov->tcp_user_timeout * 1000) < 0)
+                return -1;
+        }
+#endif
         if (cert_apply (ov->cert, ov->parent.zsock) < 0)
             return -1;
         if (zmq_connect (ov->parent.zsock, ov->parent.uri) < 0)


### PR DESCRIPTION
Problem: parent TBON sockets are subject to the very slow system default TCP_USER_TIMEOUT values when parent becomes unresponsive (e.g. when TCP packets are not acknowledged).

We already tune this down to a reasonable value for child connections.  Do this for the parent too.

Maybe this will help things move along when we hit a scenario like
- #7654 