### PR TITLE
job-exec: improve determination of ranks to drain due to timeout or exit before first barrier

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -464,6 +464,33 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
                              rank);
 }
 
+static int drain_barrier_pending_ranks (struct jobinfo *job,
+                                        struct exec_ctx *ctx,
+                                        const struct idset *ranks)
+{
+    struct idset *drain_ranks;
+    char *drain_ids = NULL;
+    int rc = -1;
+
+    if (!(drain_ranks = idset_intersect (ranks, ctx->barrier_pending_ranks))
+        || !(drain_ids = idset_encode (drain_ranks, IDSET_FLAG_RANGE)))
+        goto fail;
+
+
+    if (idset_count (drain_ranks) > 0
+        && jobinfo_drain_ranks (job,
+                                drain_ids,
+                                "%s terminated before first barrier",
+                                idf58 (job->id)) < 0)
+        goto fail;
+
+    rc = 0;
+
+fail:
+    idset_destroy (drain_ranks);
+    free (drain_ids);
+    return rc;
+}
 
 static void exit_cb (struct bulk_exec *exec,
                      void *arg,
@@ -507,17 +534,13 @@ static void exit_cb (struct bulk_exec *exec,
          * or incorrect MUNGE key)
          */
         if (job->multiuser
-            && jobinfo_drain_ranks (job,
-                                    ids,
-                                    "%s terminated before first barrier",
-                                    idf58 (job->id)) < 0)
+            && drain_barrier_pending_ranks (job, ctx, ranks) < 0)
             flux_log_error (job->h,
                             "failed to drain %s (rank%s %s) for job %s",
                             hosts ? hosts : "(unknown)",
                             idset_count (ranks) ? "s" : "",
                             ids ? ids : "(unknown)",
                             idf58 (job->id));
-
         free (ids);
         free (hosts);
     }

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -63,6 +63,13 @@ struct exec_ctx {
     struct idset *barrier_pending_ranks;
     int barrier_enter_count;
     int barrier_completion_count;
+
+    /*  terminated_before_barrier will be set to true if one shell terminates
+     *  before the first barrier *and* the first exception. This allows other
+     *  ranks to be drained when they exit too.
+     */
+    bool terminated_before_barrier;
+
     int exit_count;
 
     flux_watcher_t *shell_barrier_timer;
@@ -478,7 +485,8 @@ static void exit_cb (struct bulk_exec *exec,
      *   case we raise a job exception because the shell or IMP may not
      *   have had a chance to do so.
      */
-    if (ctx->barrier_completion_count == 0) {
+    if (ctx->barrier_completion_count == 0
+        && (!job->exception_in_progress || ctx->terminated_before_barrier)) {
         char *ids = idset_encode (ranks, IDSET_FLAG_RANGE);
         char *hosts = flux_hostmap_lookup (job->h, ids, NULL);
         jobinfo_fatal_error (job, 0,
@@ -486,6 +494,13 @@ static void exit_cb (struct bulk_exec *exec,
                               hosts ? hosts : "(unknown)",
                               idset_count (ranks) ? "s" : "",
                               ids ? ids : "(unknown)");
+
+        /* Set the terminated-before-first-barrier flag. This will allow
+         * other terminating tasks to also raise their own exception and
+         * possibly drain affected ranks, even though exception_in_progress
+         * is now true.
+         */
+        ctx->terminated_before_barrier = true;
 
         /* If this job was run under the IMP, drain the affected ranks since
          * this could indicate an unrecoverable node issue (like missing

--- a/t/job-exec/dummy.sh
+++ b/t/job-exec/dummy.sh
@@ -147,7 +147,37 @@ test_mock_failure() {
             ;;
     esac
 }
-
+barrier_hang()
+{
+    FAIL_MODE=$(json_get "$JOBSPEC" '.attributes.system.environment.FAIL_MODE')
+    case "$FAIL_MODE" in
+        hang-on-rank*)
+            #  Cause one shell rank to hang before the first barrier.
+            #  Other ranks continue:
+            #
+            if test $JOB_SHELL_RANK -eq ${FAIL_MODE##*rank}; then
+                log "Got FAIL_MODE=$FAIL_MODE sleeping on $JOB_SHELL_RANK"
+                sleep 30
+            fi
+            ;;
+        exit-on-rank*)
+            #  Cause one shell rank to hang then exit before the first barrier
+            #  ensuring other ranks make it to the barrier
+            #
+            if test $JOB_SHELL_RANK -eq ${FAIL_MODE##*rank}; then
+                log "Got FAIL_MODE=$FAIL_MODE sleep then exit on $JOB_SHELL_RANK"
+                sleep 2
+                exit
+            fi
+            ;;
+        hang-on-all)
+            log "Got FAIL_MODE=$FAIL_MODE sleeping on $JOB_SHELL_RANK"
+            sleep 30
+            ;;
+        *)
+            ;;
+    esac
+}
 barrier() {
     if [[ ${NNODES} -gt 1 ]]; then
         echo enter >&1
@@ -163,6 +193,7 @@ barrier() {
 #
 get_job_shell_rank
 get_nnodes
+barrier_hang
 barrier
 get_duration
 get_command

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -25,7 +25,7 @@ if ! test -d conf.d; then
 fi
 
 export FLUX_CONF_DIR=$(pwd)/conf.d
-test_under_flux 2 job
+test_under_flux 4
 
 test_expect_success 'job-exec: module configured to use IMP' '
 	flux module stats -p bulk-exec.config.flux_imp_path job-exec | grep ${IMP}
@@ -93,7 +93,62 @@ test_expect_success NO_ASAN 'job-exec: kill multiuser job works' '
 	flux cancel ${id} &&
 	test_expect_code 143 run_timeout 30 flux job status -v ${id}
 '
-
+# Ensure barrier-timeout drains only affected rank on multiuser flux (#7663)
+test_expect_success 'job-exec: barrier timeout raises job exception' '
+	flux run --dry-run -N4 \
+		--env=FAIL_MODE=hang-on-rank3 \
+		--setattr=exec.bulkexec.barrier-timeout=0.5 \
+		sleep 30 \
+		| flux python ${SIGN_AS} 42 >signed.json &&
+	jobid=$(FLUX_HANDLE_USERID=42 \
+		flux job submit --flags=signed signed.json) &&
+	flux job wait-event -vHt 60 $jobid exception
+'
+test_expect_success 'job-exec: only the affected rank is drained' '
+	test_debug "flux resource drain" &&
+	test "$(flux resource drain -no {ranks})" = "3" &&
+	flux resource drain -no {reason} | grep "start timeout"
+'
+test_expect_success 'job-exec: undrain all ranks' '
+	flux resource list &&
+	flux resource undrain $(flux resource drain -no {ranks})
+'
+# Ensure exit-before-first barrier drains only affected rank
+test_expect_success 'job-exec: barrier timeout raises job exception' '
+	flux run --dry-run -N4 \
+		--env=FAIL_MODE=exit-on-rank3 \
+		sleep 30 \
+		| flux python ${SIGN_AS} 42 >signed.json &&
+	jobid=$(FLUX_HANDLE_USERID=42 \
+		flux job submit --flags=signed signed.json) &&
+	flux job wait-event -vHt 60 $jobid exception
+'
+test_expect_success 'job-exec: only the affected rank is drained' '
+	test_debug "flux resource drain -o long" &&
+	test "$(flux resource drain -no {ranks})" = "3" &&
+	flux resource drain -no {reason} | grep "terminated before first"
+'
+test_expect_success 'job-exec: undrain all ranks' '
+	flux resource list &&
+	flux resource undrain $(flux resource drain -no {ranks})
+'
+# Ensure "exited before first barrier" doesn't drain ranks when exception
+# occurs before first barrier
+test_expect_success 'job-exec: barrier timeout raises job exception' '
+	flux run --dry-run -N4 \
+		--env=FAIL_MODE=hang-on-all \
+		--setattr=exec.bulkexec.barrier-timeout=0.5 \
+		sleep 30 \
+		| flux python ${SIGN_AS} 42 >signed.json &&
+	jobid=$(FLUX_HANDLE_USERID=42 \
+		flux job submit --flags=signed signed.json) &&
+	flux job wait-event -vHt 60 $jobid start &&
+	flux cancel $jobid &&
+	flux job wait-event -vHt 60 $jobid clean
+'
+test_expect_success 'job-exec: no ranks were drained' '
+	test "$(flux resource drain -no {ranks})" = ""
+'
 #  Configure failing IMP
 test_expect_success 'job-exec: reconfig with failing dummy IMP' '
 	cat <<-EOF >conf.d/exec.toml


### PR DESCRIPTION
As noted in #7663, any time a rank exits before the first barrier in a multiuser job, that rank will be drained. This means that if the barrier timeout is hit due to one hung node, all nodes in the will be drained instead of just the affected node. Even worse, any exception that occurs before the first barrier could also drain all ranks in the job.

This PR addresses the current issue by only draining a rank that is exiting before the first barrier if there is not an existing job exception in progress. A job exception means the exiting shells are expected and normal as they are terminated. However, this check alone would cause only the first exiting rank to be drained in this case, since after that there's now an exception in progress. Therefore, a new flag is added that is set to true when any rank is drained due to this check, which then allows future exiting ranks to also be drained, so the check becomes conceptually: If the first barrier was still in progress AND (there was no exception OR the exit-before-barrier flag is set), then drain this rank.

While testing this change, I noticed another case where ranks are unnecessarily drained. The code does not currently check if the exiting ranks reached the barrier, but are now exited because a different task exited before the barrier. A commit here now only drains ranks that are in the `barrier_pending` set.

This should make draining ranks in these conditions more reliable. However, we may want to revisit this scheme of draining ranks that do not reach the barrier. There are still cases where nodes will be unnecessarily drained, e.g. if a user has a bug in their shell `initrc.lua`, or if a shell exits early on a bad node before any other job shells can enter the barrier.
