### PR TITLE
improve handling of job standard input

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -166,9 +166,11 @@ all tasks (the default) or delivered to a subset of tasks. See the
 When input is read from the KVS, all job shells watch the input eventlog and
 deliver data to matching tasks as it appears. For interactive jobs, the rank 0
 (leader) shell registers a standard input service to which clients (typically
-:man1:`flux job attach`) write input. The leader shell then writes this data
-to the input eventlog for distribution to all other shells in the job. The
-input eventlog acts as a permanent record of job input.
+:man1:`flux job attach`) write input. The leader shell batches input eventlog
+entries for a configurable period (see ``input.batch-timeout`` in
+:man7:`flux-shell-options`) before posting them to the ``guest.input``
+eventlog for distribution to all other shells in the job. EOF is always
+flushed immediately. The input eventlog acts as a permanent record of job input.
 
 For file-based input, each task's stdin is connected directly to the input
 file. An RFC 24 ``redirect`` event is posted to the input eventlog as a

--- a/doc/man7/flux-shell-options.rst
+++ b/doc/man7/flux-shell-options.rst
@@ -497,6 +497,19 @@ INPUT/OUTPUT
 
     $ flux run -o input.limit=1M myapp
 
+.. option:: input.batch-timeout=FSD
+
+  Set the KVS input batch-timeout to a time period in Flux Standard Duration.
+  This is the period over which the leader shell collects entries destined
+  for the input eventlog before committing them to the KVS. A longer period
+  results in less load on the KVS, while a shorter period makes input appear
+  sooner after it was written by :command:`flux job attach`. The
+  default is 0.5s. EOF is always flushed immediately regardless of this setting.
+
+  .. code-block:: console
+
+   $ flux run -o input.batch-timeout=0.01 myapp
+
 .. option:: output.batch-timeout=FSD
 
   Set the KVS output batch-timeout to a time period in Flux Standard Duration.

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -661,6 +661,7 @@ class Jobspec(object):
             self.setattr_shell_option("output.stdout.buffer.type", "none")
             self.setattr_shell_option("output.stderr.buffer.type", "none")
             self.setattr_shell_option("output.batch-timeout", 0.05)
+            self.setattr_shell_option("input.batch-timeout", 0.0)
         else:
             try:
                 del_treedict(
@@ -677,6 +678,12 @@ class Jobspec(object):
                     del_treedict(
                         self.attributes,
                         "system.shell.options.output.batch-timeout",
+                        remove_empty=True,
+                    )
+                if self.getattr("shell.options.input.batch-timeout") == 0.0:
+                    del_treedict(
+                        self.attributes,
+                        "system.shell.options.input.batch-timeout",
                         remove_empty=True,
                     )
             except KeyError:

--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -726,12 +726,16 @@ static void valid_or_exit_for_debug (struct attach_ctx *ctx)
 static void attach_setup_stdin (struct attach_ctx *ctx)
 {
     flux_watcher_t *w;
-    int flags = 0;
+    int flags;
 
     if (ctx->readonly)
         return;
 
-    if (!ctx->unbuffered)
+    if (ctx->unbuffered)
+        flags = 0;
+    else if (!isatty (STDIN_FILENO))
+        flags = FBUF_WATCHER_FULL_BUFFER;
+    else
         flags = FBUF_WATCHER_LINE_BUFFER;
 
     /* fbuf_read_watcher_create() requires O_NONBLOCK on

--- a/src/cmd/job/attach.c
+++ b/src/cmd/job/attach.c
@@ -744,7 +744,7 @@ static void attach_setup_stdin (struct attach_ctx *ctx)
 
     w = fbuf_read_watcher_create (flux_get_reactor (ctx->h),
                                   STDIN_FILENO,
-                                  1 << 20,
+                                  1 << 17,
                                   attach_stdin_cb,
                                   flags,
                                   ctx);

--- a/src/common/libsubprocess/fbuf_watcher.c
+++ b/src/common/libsubprocess/fbuf_watcher.c
@@ -40,6 +40,7 @@ struct rbwatcher {
     bool eof_read;  /* flag, if EOF on stream seen */
     bool eof_sent;  /* flag, if EOF to user sent */
     bool line;      /* flag, if line buffered */
+    bool full;      /* flag, if fully buffered */
     void *data;
 };
 
@@ -72,6 +73,14 @@ static bool data_to_read (struct rbwatcher *rbw, bool *is_eof)
             if (rbw->eof_read && fbuf_bytes (rbw->fbuf))
                 return true;
         }
+    }
+    else if (rbw->full) {
+        /* Only return data when buffer is full */
+        if (!fbuf_space (rbw->fbuf))
+            return true;
+        /* Or on EOF to flush remaining data */
+        if (rbw->eof_read && fbuf_bytes (rbw->fbuf))
+            return true;
     }
     else {
         if (fbuf_bytes (rbw->fbuf) > 0)
@@ -215,6 +224,16 @@ static struct flux_watcher_ops rbwatcher_ops = {
     .is_active = rbwatcher_is_active,
 };
 
+static int validate_read_watcher_flags (int flags)
+{
+    if ((flags & FBUF_WATCHER_LINE_BUFFER)
+        && (flags & FBUF_WATCHER_FULL_BUFFER)) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
 flux_watcher_t *fbuf_read_watcher_create (flux_reactor_t *r,
                                           int fd,
                                           int size,
@@ -225,7 +244,8 @@ flux_watcher_t *fbuf_read_watcher_create (flux_reactor_t *r,
     struct rbwatcher *rbw;
     flux_watcher_t *w;
 
-    if (validate_fd_nonblock (fd) < 0)
+    if (validate_fd_nonblock (fd) < 0
+        || validate_read_watcher_flags (flags) < 0)
         return NULL;
     if (!(w = watcher_create (r, sizeof (*rbw), &rbwatcher_ops, cb, arg)))
         goto error;
@@ -234,6 +254,8 @@ flux_watcher_t *fbuf_read_watcher_create (flux_reactor_t *r,
     rbw->refcnt = 1;
     if ((flags & FBUF_WATCHER_LINE_BUFFER))
         rbw->line = true;
+    if ((flags & FBUF_WATCHER_FULL_BUFFER))
+        rbw->full = true;
     if (!(rbw->fbuf = fbuf_create (size))
         || !(rbw->prepare_w = flux_prepare_watcher_create (r,
                                                            rbwatcher_prepare_cb,
@@ -289,8 +311,12 @@ const char *fbuf_read_watcher_get_data (flux_watcher_t *w, int *lenp)
         if (!(*lenp) && !fbuf_space (rbw->fbuf))
             return fbuf_read (rbw->fbuf, -1, lenp);
      }
-    /* Not line-buffered, or reading last bit of data which does
-     * not contain a newline. Read any data:
+    else if (rbw->full) {
+        /* Fully buffered: read all available data */
+        return fbuf_read (rbw->fbuf, -1, lenp);
+    }
+    /* Not line-buffered or fully-buffered, or reading last bit of
+     * data which does not contain a newline. Read any data:
      */
     return fbuf_read (rbw->fbuf, -1, lenp);
 }

--- a/src/common/libsubprocess/fbuf_watcher.c
+++ b/src/common/libsubprocess/fbuf_watcher.c
@@ -468,6 +468,11 @@ flux_watcher_t *fbuf_write_watcher_create (flux_reactor_t *r,
 
     if (validate_fd_nonblock (fd) < 0)
         return NULL;
+    /* Buffering flags are not supported for write watchers */
+    if ((flags & (FBUF_WATCHER_LINE_BUFFER | FBUF_WATCHER_FULL_BUFFER))) {
+        errno = EINVAL;
+        return NULL;
+    }
     if (!(w = watcher_create (r, sizeof (*wbw), &wbwatcher_ops, cb, arg)))
         goto error;
     wbw = watcher_get_data (w);

--- a/src/common/libsubprocess/fbuf_watcher.h
+++ b/src/common/libsubprocess/fbuf_watcher.h
@@ -16,6 +16,7 @@
 
 enum {
     FBUF_WATCHER_LINE_BUFFER = 1, /* line buffer data before invoking callback */
+    FBUF_WATCHER_FULL_BUFFER = 2, /* full buffer data before invoking callback */
 };
 
 /* read watcher

--- a/src/common/libsubprocess/test/fbuf_watcher.c
+++ b/src/common/libsubprocess/test/fbuf_watcher.c
@@ -167,6 +167,46 @@ static void buffer_read_data (flux_reactor_t *r, flux_watcher_t *w,
     return;
 }
 
+static void buffer_read_full (flux_reactor_t *r,
+                              flux_watcher_t *w,
+                              int revents,
+                              void *arg)
+{
+    int *count = arg;
+
+    if (revents & FLUX_POLLERR) {
+        ok (false,
+            "buffer: read full callback incorrectly called with FLUX_POLLERR");
+    }
+    else if (revents & FLUX_POLLIN) {
+        const void *ptr;
+        int len;
+
+        ok ((ptr = fbuf_read_watcher_get_data (w, &len)) != NULL,
+            "buffer: read full data from buffer success");
+
+        if ((*count) == 0) {
+            /* First callback when buffer is full (1024 bytes) */
+            ok (len == 1024,
+                "buffer: read full returned full buffer size");
+        }
+        else if ((*count) == 1) {
+            /* Second callback on EOF with remaining data */
+            ok (len == 24,
+                "buffer: read full returned remaining data on EOF");
+        }
+    }
+    else {
+        ok (false,
+            "buffer: read full callback failed to return FLUX_POLLIN: %d", revents);
+    }
+
+    (*count)++;
+    /* Stop after each callback so we can control the test flow */
+    flux_watcher_stop (w);
+    return;
+}
+
 
 static void buffer_write (flux_reactor_t *r, flux_watcher_t *w,
                           int revents, void *arg)
@@ -301,6 +341,18 @@ static void test_buffer (flux_reactor_t *reactor)
 
     /* read buffer test */
 
+    errno = 0;
+    w = fbuf_read_watcher_create (reactor,
+                                  fd[0],
+                                  1024,
+                                  buffer_read,
+                                  FBUF_WATCHER_LINE_BUFFER
+                                  | FBUF_WATCHER_FULL_BUFFER,
+                                  &count);
+    ok (w == NULL && errno == EINVAL,
+        "buffer: read buffer create with invalid flags returns EINVAL");
+
+
     count = 0;
     w = fbuf_read_watcher_create (reactor,
                                   fd[0],
@@ -422,6 +474,66 @@ static void test_buffer (flux_reactor_t *reactor)
 
     flux_watcher_stop (w);
     flux_watcher_destroy (w);
+
+    /* read fully buffered test */
+
+    count = 0;
+    w = fbuf_read_watcher_create (reactor,
+                                  fd[0],
+                                  1024,
+                                  buffer_read_full,
+                                  FBUF_WATCHER_FULL_BUFFER,
+                                  &count);
+    ok (w != NULL,
+        "buffer: read full buffer created");
+
+    fb = fbuf_read_watcher_get_buffer (w);
+
+    ok (fb != NULL,
+        "buffer: buffer retrieved");
+
+    /* Write exactly 1024 bytes to fill buffer */
+    {
+        char buf[1024];
+        memset (buf, 'x', sizeof (buf));
+        ok (write (fd[1], buf, 1024) == 1024,
+            "buffer: write 1024 bytes to socketpair success");
+    }
+
+    flux_watcher_start (w);
+
+    ok (flux_reactor_run (reactor, 0) == 0,
+        "buffer: reactor ran to completion");
+
+    ok (count == 1,
+        "buffer: read full callback called once (buffer full)");
+
+    /* Now write 24 more bytes and close to trigger EOF */
+    ok (write (fd[1], "extra data after buffer", 23) == 23,
+        "buffer: write 23 more bytes to socketpair success");
+    ok (write (fd[1], "\n", 1) == 1,
+        "buffer: write final byte to socketpair success");
+
+    close (fd[1]);
+    fd[1] = -1;
+
+    flux_watcher_start (w);
+
+    ok (flux_reactor_run (reactor, 0) == 0,
+        "buffer: reactor ran to completion for EOF");
+
+    ok (count == 2,
+        "buffer: read full callback called twice (EOF with remaining data)");
+
+    flux_watcher_stop (w);
+    flux_watcher_destroy (w);
+
+    /* Recreate socketpair for next tests */
+    close (fd[0]);
+    ok (socketpair (PF_LOCAL, SOCK_STREAM, 0, fd) == 0,
+        "buffer: socketpair created for write tests");
+    ok (fd_set_nonblocking (fd[0]) >= 0 && fd_set_nonblocking (fd[1]) >= 0,
+        "buffer: fd_set_nonblocking for write tests");
 
 
     /* write buffer test */

--- a/src/common/libsubprocess/test/fbuf_watcher.c
+++ b/src/common/libsubprocess/test/fbuf_watcher.c
@@ -703,6 +703,26 @@ static void test_buffer (flux_reactor_t *reactor)
     ok (fd_set_nonblocking (pfds[1]) >= 0,
         "buffer: fd_set_nonblocking");
 
+    errno = 0;
+    w = fbuf_write_watcher_create (reactor,
+                                   pfds[1],
+                                   1024,
+                                   buffer_write,
+                                   FBUF_WATCHER_LINE_BUFFER,
+                                   &count);
+    ok (w == NULL && errno == EINVAL,
+        "buffer: write_watcher_create returns EINVAL if LINE_BUFFER flag set");
+
+    errno = 0;
+    w = fbuf_write_watcher_create (reactor,
+                                   pfds[1],
+                                   1024,
+                                   buffer_write,
+                                   FBUF_WATCHER_FULL_BUFFER,
+                                   &count);
+    ok (w == NULL && errno == EINVAL,
+        "buffer: write_watcher_create returns EINVAL if FULL_BUFFER flag set");
+
     w = fbuf_write_watcher_create (reactor,
                                    pfds[1],
                                    1024,

--- a/src/shell/input/kvs.c
+++ b/src/shell/input/kvs.c
@@ -119,10 +119,12 @@ static void input_eventlog_cb (flux_future_t *f, void *arg)
                                                stream,
                                                data,
                                                len) < 0) {
-                        if (errno != EPIPE)
+                        if (errno != EPIPE && errno != ENOSPC)
                             shell_die_errno (1, "flux_subprocess_write");
-                        else
-                            eof = true; /* Pretend that we got eof */
+                        if (errno == ENOSPC)
+                            shell_warn ("task %d: buffer full, closing stdin",
+                                        task->rank);
+                        eof = true; /* Pretend that we got eof */
                     }
                 }
                 if (eof) {

--- a/src/shell/input/service.c
+++ b/src/shell/input/service.c
@@ -194,9 +194,20 @@ static int input_service_init (flux_plugin_t *p,
     return 0;
 }
 
+static int input_service_reconnect (flux_plugin_t *p,
+                                    const char *topic,
+                                    flux_plugin_arg_t *args,
+                                    void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    input_eventlog_reconnect (shell);
+    return 0;
+}
+
 struct shell_builtin builtin_input_service = {
     .name = FLUX_SHELL_PLUGIN_NAME,
     .init = input_service_init,
+    .reconnect = input_service_reconnect,
 };
 
 /*

--- a/src/shell/input/service.c
+++ b/src/shell/input/service.c
@@ -106,8 +106,12 @@ static void input_service_stdin_cb (flux_t *h,
     }
     if (input_eventlog_put_event (in->shell, "data", o) < 0)
         goto error;
-    if (eof && subtract_idset (in->open_tasks, ranks, ids) < 0)
-        shell_log_errno ("failed to remove '%s' from open tasks", ranks);
+    if (eof) {
+        /* Flush eventlogger immediately on EOF to ensure prompt delivery */
+        input_eventlog_flush (in->shell);
+        if (subtract_idset (in->open_tasks, ranks, ids) < 0)
+            shell_log_errno ("failed to remove '%s' from open tasks", ranks);
+    }
     if (flux_respond (h, msg, NULL) < 0)
         shell_log_errno ("flux_respond");
     idset_destroy (ids);

--- a/src/shell/input/util.c
+++ b/src/shell/input/util.c
@@ -34,47 +34,47 @@
  */
 #define INPUT_LIMIT_MAX   33554432 /* 32M */
 #define INPUT_EVENT_DATA  "data"
-#define INPUT_STATS_KEY   "input_stats"
+#define INPUT_CTX_KEY     "input_ctx"
 #define DEFAULT_BATCH_TIMEOUT 0.5
 
-struct input_stats {
+struct input_ctx {
     flux_shell_t *shell;
     size_t stdin_bytes;
     size_t limit_bytes;
     struct eventlogger *ev;
 };
 
-static void input_stats_destroy (struct input_stats *stats)
+static void input_ctx_destroy (struct input_ctx *ctx)
 {
-    if (stats) {
+    if (ctx) {
         int saved_errno = errno;
-        if (stats->ev && eventlogger_flush (stats->ev) < 0)
+        if (ctx->ev && eventlogger_flush (ctx->ev) < 0)
             shell_log_errno ("eventlogger_flush");
-        eventlogger_destroy (stats->ev);
-        free (stats);
+        eventlogger_destroy (ctx->ev);
+        free (ctx);
         errno = saved_errno;
     }
 }
 
 static void input_ref (struct eventlogger *ev, void *arg)
 {
-    struct input_stats *stats = arg;
-    flux_shell_add_completion_ref (stats->shell, "input.txn");
+    struct input_ctx *ctx = arg;
+    flux_shell_add_completion_ref (ctx->shell, "input.txn");
 }
 
 static void input_unref (struct eventlogger *ev, void *arg)
 {
-    struct input_stats *stats = arg;
-    flux_shell_remove_completion_ref (stats->shell, "input.txn");
+    struct input_ctx *ctx = arg;
+    flux_shell_remove_completion_ref (ctx->shell, "input.txn");
 }
 
-static int get_input_limit (struct input_stats *stats)
+static int get_input_limit (struct input_ctx *ctx)
 {
     json_t *val = NULL;
     uint64_t size;
     const char *limit_string = "10M";
 
-    if (flux_shell_getopt_unpack (stats->shell,
+    if (flux_shell_getopt_unpack (ctx->shell,
                                   "input",
                                   "{s?o}",
                                   "limit", &val) < 0) {
@@ -88,7 +88,7 @@ static int get_input_limit (struct input_stats *stats)
                 shell_log ("Invalid KVS input.limit=%ld", (long) limit);
                 return -1;
             }
-            stats->limit_bytes = (size_t) limit;
+            ctx->limit_bytes = (size_t) limit;
             return 0;
         }
         if (!(limit_string = json_string_value (val))) {
@@ -102,16 +102,16 @@ static int get_input_limit (struct input_stats *stats)
         shell_log ("Invalid KVS input.limit=%s", limit_string);
         return -1;
     }
-    stats->limit_bytes = (size_t) size;
+    ctx->limit_bytes = (size_t) size;
     return 0;
 }
 
-static struct input_stats *get_input_stats (flux_shell_t *shell)
+static struct input_ctx *get_input_ctx (flux_shell_t *shell)
 {
-    struct input_stats *stats;
+    struct input_ctx *ctx;
 
-    stats = flux_shell_aux_get (shell, INPUT_STATS_KEY);
-    if (!stats) {
+    ctx = flux_shell_aux_get (shell, INPUT_CTX_KEY);
+    if (!ctx) {
         flux_t *h;
         double batch_timeout = DEFAULT_BATCH_TIMEOUT;
         struct eventlogger_ops ops = {
@@ -119,9 +119,9 @@ static struct input_stats *get_input_stats (flux_shell_t *shell)
             .idle = input_unref
         };
 
-        if (!(stats = calloc (1, sizeof (*stats))))
+        if (!(ctx = calloc (1, sizeof (*ctx))))
             return NULL;
-        stats->shell = shell;
+        ctx->shell = shell;
 
         if (flux_shell_getopt_unpack (shell,
                                       "input",
@@ -136,42 +136,42 @@ static struct input_stats *get_input_stats (flux_shell_t *shell)
         if (!(h = flux_shell_get_flux (shell)))
             goto error;
 
-        if (!(stats->ev = eventlogger_create (h, batch_timeout, &ops, stats))) {
+        if (!(ctx->ev = eventlogger_create (h, batch_timeout, &ops, ctx))) {
             shell_log_errno ("eventlogger_create");
             goto error;
         }
 
-        if (get_input_limit (stats) < 0
+        if (get_input_limit (ctx) < 0
             || flux_shell_aux_set (shell,
-                                   INPUT_STATS_KEY,
-                                   stats,
-                                   (flux_free_f) input_stats_destroy) < 0) {
+                                   INPUT_CTX_KEY,
+                                   ctx,
+                                   (flux_free_f) input_ctx_destroy) < 0) {
             goto error;
         }
     }
-    return stats;
+    return ctx;
 error:
-    input_stats_destroy (stats);
+    input_ctx_destroy (ctx);
     return NULL;
 }
 
 
 static void check_input_limit (flux_shell_t *shell, int len)
 {
-    struct input_stats *stats;
+    struct input_ctx *ctx;
 
-    if (!(stats = get_input_stats (shell)))
-        shell_die_errno (1, "failed to get input stats");
+    if (!(ctx = get_input_ctx (shell)))
+        shell_die_errno (1, "failed to get input ctx");
 
-    stats->stdin_bytes += len;
+    ctx->stdin_bytes += len;
 
-    if (stats->stdin_bytes > stats->limit_bytes) {
+    if (ctx->stdin_bytes > ctx->limit_bytes) {
         shell_die (1,
                    "stdin exceeds %s limit. "
                    "Try file input (flux submit --input=FILE) "
                    "or redirect input to your command to avoid the KVS "
                    "for large amounts of input",
-                   encode_size (stats->limit_bytes));
+                   encode_size (ctx->limit_bytes));
     }
 }
 
@@ -179,7 +179,7 @@ int input_eventlog_put_event (flux_shell_t *shell,
                               const char *name,
                               json_t *context)
 {
-    struct input_stats *stats;
+    struct input_ctx *ctx;
     int len = 0;
 
     if (streq (name, INPUT_EVENT_DATA)) {
@@ -187,10 +187,10 @@ int input_eventlog_put_event (flux_shell_t *shell,
             check_input_limit (shell, len);
     }
 
-    if (!(stats = get_input_stats (shell)))
+    if (!(ctx = get_input_ctx (shell)))
         return -1;
 
-    return eventlogger_append_pack (stats->ev,
+    return eventlogger_append_pack (ctx->ev,
                                     0,
                                     "input",
                                     name,
@@ -239,8 +239,8 @@ int input_eventlog_init (flux_shell_t *shell)
     /*  Validate input.limit early so invalid values are caught
      *  at job initialization rather than when stdin is first written.
      */
-    if (!get_input_stats (shell)) {
-        shell_log_errno ("failed to initialize input stats");
+    if (!get_input_ctx (shell)) {
+        shell_log_errno ("failed to initialize input ctx");
         goto error;
     }
 

--- a/src/shell/input/util.c
+++ b/src/shell/input/util.c
@@ -208,6 +208,16 @@ void input_eventlog_flush (flux_shell_t *shell)
     }
 }
 
+void input_eventlog_reconnect (flux_shell_t *shell)
+{
+    /* during a reconnect, response to event logging may not occur,
+     * thus input_unref() may not be called. Clear all completion
+     * references to inflight transactions.
+     */
+    while (flux_shell_remove_completion_ref (shell, "input.txn") == 0)
+        ;
+}
+
 static int input_kvs_eventlog_init (flux_shell_t *shell, json_t *header)
 {
     flux_kvs_txn_t *txn = NULL;

--- a/src/shell/input/util.c
+++ b/src/shell/input/util.c
@@ -20,6 +20,7 @@
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/parse_size.h"
 #include "src/common/libeventlog/eventlog.h"
+#include "src/common/libeventlog/eventlogger.h"
 #include "src/common/libioencode/ioencode.h"
 #include "ccan/str/str.h"
 
@@ -34,16 +35,37 @@
 #define INPUT_LIMIT_MAX   33554432 /* 32M */
 #define INPUT_EVENT_DATA  "data"
 #define INPUT_STATS_KEY   "input_stats"
+#define DEFAULT_BATCH_TIMEOUT 0.5
 
 struct input_stats {
     flux_shell_t *shell;
     size_t stdin_bytes;
     size_t limit_bytes;
+    struct eventlogger *ev;
 };
 
 static void input_stats_destroy (struct input_stats *stats)
 {
-    free (stats);
+    if (stats) {
+        int saved_errno = errno;
+        if (stats->ev && eventlogger_flush (stats->ev) < 0)
+            shell_log_errno ("eventlogger_flush");
+        eventlogger_destroy (stats->ev);
+        free (stats);
+        errno = saved_errno;
+    }
+}
+
+static void input_ref (struct eventlogger *ev, void *arg)
+{
+    struct input_stats *stats = arg;
+    flux_shell_add_completion_ref (stats->shell, "input.txn");
+}
+
+static void input_unref (struct eventlogger *ev, void *arg)
+{
+    struct input_stats *stats = arg;
+    flux_shell_remove_completion_ref (stats->shell, "input.txn");
 }
 
 static int get_input_limit (struct input_stats *stats)
@@ -90,33 +112,49 @@ static struct input_stats *get_input_stats (flux_shell_t *shell)
 
     stats = flux_shell_aux_get (shell, INPUT_STATS_KEY);
     if (!stats) {
+        flux_t *h;
+        double batch_timeout = DEFAULT_BATCH_TIMEOUT;
+        struct eventlogger_ops ops = {
+            .busy = input_ref,
+            .idle = input_unref
+        };
+
         if (!(stats = calloc (1, sizeof (*stats))))
             return NULL;
         stats->shell = shell;
+
+        if (flux_shell_getopt_unpack (shell,
+                                      "input",
+                                      "{s?F}",
+                                      "batch-timeout", &batch_timeout) < 0) {
+            shell_log_errno ("invalid input.batch-timeout option");
+            goto error;
+        }
+
+        shell_debug ("input batch timeout = %.3fs", batch_timeout);
+
+        if (!(h = flux_shell_get_flux (shell)))
+            goto error;
+
+        if (!(stats->ev = eventlogger_create (h, batch_timeout, &ops, stats))) {
+            shell_log_errno ("eventlogger_create");
+            goto error;
+        }
+
         if (get_input_limit (stats) < 0
             || flux_shell_aux_set (shell,
                                    INPUT_STATS_KEY,
                                    stats,
                                    (flux_free_f) input_stats_destroy) < 0) {
-            input_stats_destroy (stats);
-            return NULL;
+            goto error;
         }
     }
     return stats;
+error:
+    input_stats_destroy (stats);
+    return NULL;
 }
 
-static void input_put_kvs_completion (flux_future_t *f, void *arg)
-{
-    flux_shell_t *shell = arg;
-
-    if (flux_future_get (f, NULL) < 0)
-        /* failing to write stdin to input is a fatal error */
-        shell_die (1, "input_service_put_kvs: %s", strerror (errno));
-    flux_future_destroy (f);
-
-    if (flux_shell_remove_completion_ref (shell, "input.kvs") < 0)
-        shell_log_errno ("flux_shell_remove_completion_ref");
-}
 
 static void check_input_limit (flux_shell_t *shell, int len)
 {
@@ -141,13 +179,7 @@ int input_eventlog_put_event (flux_shell_t *shell,
                               const char *name,
                               json_t *context)
 {
-    flux_t *h;
-    flux_kvs_txn_t *txn = NULL;
-    flux_future_t *f = NULL;
-    json_t *entry = NULL;
-    char *entrystr = NULL;
-    int saved_errno;
-    int rc = -1;
+    struct input_stats *stats;
     int len = 0;
 
     if (streq (name, INPUT_EVENT_DATA)) {
@@ -155,36 +187,15 @@ int input_eventlog_put_event (flux_shell_t *shell,
             check_input_limit (shell, len);
     }
 
-    if (!(h = flux_shell_get_flux (shell)))
-        goto error;
-    if (!(entry = eventlog_entry_pack (0.0, name, "O", context)))
-        goto error;
-    if (!(entrystr = eventlog_entry_encode (entry)))
-        goto error;
-    if (!(txn = flux_kvs_txn_create ()))
-        goto error;
-    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "input", entrystr) < 0)
-        goto error;
-    if (!(f = flux_kvs_commit (h, NULL, 0, txn)))
-        goto error;
-    if (flux_future_then (f, -1, input_put_kvs_completion, shell) < 0)
-        goto error;
-    if (flux_shell_add_completion_ref (shell, "input.kvs") < 0) {
-        shell_log_errno ("flux_shell_remove_completion_ref");
-        goto error;
-    }
-    /* f memory responsibility of input_service_put_kvs_completion()
-     * callback */
-    f = NULL;
-    rc = 0;
- error:
-    saved_errno = errno;
-    flux_kvs_txn_destroy (txn);
-    free (entrystr);
-    json_decref (entry);
-    flux_future_destroy (f);
-    errno = saved_errno;
-    return rc;
+    if (!(stats = get_input_stats (shell)))
+        return -1;
+
+    return eventlogger_append_pack (stats->ev,
+                                    0,
+                                    "input",
+                                    name,
+                                    "O",
+                                    context);
 }
 
 static int input_kvs_eventlog_init (flux_shell_t *shell, json_t *header)

--- a/src/shell/input/util.c
+++ b/src/shell/input/util.c
@@ -198,6 +198,16 @@ int input_eventlog_put_event (flux_shell_t *shell,
                                     context);
 }
 
+void input_eventlog_flush (flux_shell_t *shell)
+{
+    struct input_ctx *ctx;
+
+    if ((ctx = get_input_ctx (shell))) {
+        if (eventlogger_flush (ctx->ev) < 0)
+            shell_log_errno ("eventlogger_flush");
+    }
+}
+
 static int input_kvs_eventlog_init (flux_shell_t *shell, json_t *header)
 {
     flux_kvs_txn_t *txn = NULL;

--- a/src/shell/input/util.h
+++ b/src/shell/input/util.h
@@ -35,5 +35,11 @@ int input_eventlog_put_event (flux_shell_t *shell,
  */
 void input_eventlog_flush (flux_shell_t *shell);
 
+/*  Clear all pending input completion references during a reconnect.
+ *  During a reconnect, responses to event logging may not occur, so
+ *  completion references for inflight transactions must be cleared.
+ */
+void input_eventlog_reconnect (flux_shell_t *shell);
+
 #endif /* !SHELL_INPUT_INTERNAL_H */
 

--- a/src/shell/input/util.h
+++ b/src/shell/input/util.h
@@ -30,5 +30,10 @@ int input_eventlog_put_event (flux_shell_t *shell,
                               const char *name,
                               json_t *context);
 
+/*  Flush any pending batched input eventlog entries to KVS immediately.
+ *  This should be called when EOF is sent to ensure prompt delivery.
+ */
+void input_eventlog_flush (flux_shell_t *shell);
+
 #endif /* !SHELL_INPUT_INTERNAL_H */
 

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -104,6 +104,14 @@ struct shell_task *shell_task_create (flux_shell_t *shell,
     task->size = info->total_ntasks;
     if (!(task->cmd = flux_cmd_create (0, NULL, NULL)))
         goto error;
+    /* Set larger stdin buffer to handle bursty input from batching.
+     * With input batching, multiple events can arrive rapidly before
+     * task starts consuming stdin. Default 4MB buffer can fill quickly,
+     * causing ENOSPC and stdin to close prematurely. 32MB provides
+     * sufficient headroom for typical use cases.
+     */
+    if (flux_cmd_setopt (task->cmd, "stdin_BUFSIZE", "32M") < 0)
+        goto error;
     json_array_foreach (info->jobspec->command, i, entry) {
         if (flux_cmd_argv_append (task->cmd, json_string_value (entry)) < 0)
             goto error;

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -53,9 +53,10 @@ test_expect_success LONGTEST 'flux-shell: 10K line lptest piped input works' '
 # to read the stdin data and write to the target task, but the cancel could
 # come before that since there is no way to synchronize. Thus, the test may
 # give false positive results (ok) but never a false negative (no ok).
+# Disable input batching to reduce the race window.
 #
 test_expect_success NO_CHAIN_LINT 'flux-shell: ignores SIGPIPE if task closes stdin' '
-	id=$(flux submit sh -c "exec <&-; sleep 60") &&
+	id=$(flux submit -o input.batch-timeout=0 sh -c "exec <&-; sleep 60") &&
 	flux job wait-event $id start &&
 	flux job wait-event -vp exec $id shell.start &&
 	(echo foo | flux job attach $id &) &&
@@ -247,7 +248,7 @@ test_expect_success 'flux-shell: no fatal exception after stdin sent to exited t
 
 test_expect_success 'flux-shell: stdin limit with small value causes job exception' '
 	test_expect_code 1 sh -c "dd if=/dev/zero bs=1024 count=20 2>/dev/null | \
-		flux run -o input.limit=1K cat >/dev/null 2>limit1.err" &&
+		flux run -o input.limit=1K -o input.batch-timeout=0 cat >/dev/null 2>limit1.err" &&
 	test_debug "cat limit1.err" &&
 	grep "stdin exceeds 1K limit" limit1.err &&
 	grep "Try file input" limit1.err
@@ -297,7 +298,7 @@ test_expect_success 'flux-shell: input.limit as integer exceeding max is rejecte
 '
 
 test_expect_success 'flux-shell: flux job attach stops sending stdin on exception' '
-	jobid=$(flux submit -o input.limit=1K cat) &&
+	jobid=$(flux submit -o input.limit=1K -o input.batch-timeout=0 cat) &&
 	test_expect_code 1 sh -c "dd if=/dev/zero bs=1024 count=20 2>/dev/null | \
 		flux job attach $jobid 2>attach-stop.err" &&
 	test_debug "cat attach-stop.err" &&

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -304,4 +304,34 @@ test_expect_success 'flux-shell: flux job attach stops sending stdin on exceptio
 	grep "stdin exceeds 1K limit" attach-stop.err
 '
 
+#
+# input.batch-timeout tests
+#
+
+test_expect_success 'flux-shell: input.batch-timeout option works' '
+	flux run -o input.batch-timeout=1.0 -o verbose=2 \
+		cat < input_stdin_file > batch1.out 2> batch1.err &&
+	test_cmp input_stdin_file batch1.out &&
+	grep "input batch timeout = 1.000s" batch1.err
+'
+
+test_expect_success 'flux-shell: input.batch-timeout default is 0.5s' '
+	flux run -o verbose=2 \
+		cat < input_stdin_file > batch2.out 2> batch2.err &&
+	test_cmp input_stdin_file batch2.out &&
+	grep "input batch timeout = 0.500s" batch2.err
+'
+
+test_expect_success 'flux-shell: input.batch-timeout=0 disables batching' '
+	flux run -o input.batch-timeout=0 -o verbose=2 \
+		cat < input_stdin_file > batch3.out 2> batch3.err &&
+	test_cmp input_stdin_file batch3.out &&
+	grep "input batch timeout = 0.000s" batch3.err
+'
+
+test_expect_success 'flux-shell: invalid input.batch-timeout is rejected' '
+	test_must_fail flux run -o input.batch-timeout=foo hostname 2>batchbad.err &&
+	grep "invalid input.batch-timeout option" batchbad.err
+'
+
 test_done


### PR DESCRIPTION
This PR adds improvements to the way job standard input is handled based on testing described in #7649.
The changes include:
 - addition of a fully buffered mode to buffered read watcher, and use this in `flux job attach` for stdin
 - decrease size of `flux job attach` input buffer from 1M to 128K to balance message size and count for fully buffered data
 - switch the job shell input plugin to use event batching like the output plugin
 - increase input buffer size of job tasks to 32M. The efficiency improvements from the bullets above made it much more likely that `flux_subprocess_write()` returns `ENOSPC` and this decreases that risk.
 - Better handling of `ENOSPC` when writing to tasks in the job shell. Treat it like `EPIPE` and just close stdin and log a warning.

As shown in the results in #764, this not only speeds up processing of large amounts of stdin, but reduces the impact on KVS.

The one remaining issue is that eventually we should implement flow control when task buffers become full. This would require some kind of coordination between `flux job attach` and the job shell

Fixes #7649