### PR TITLE
resource: change default history from 0 to 90d

### DIFF
--- a/doc/man5/flux-config-resource.rst
+++ b/doc/man5/flux-config-resource.rst
@@ -162,7 +162,8 @@ history
    purposes.  When the resource module is reloaded, such as during a
    flux restart, entries older than the most recent resource state
    checkpoint are truncated by default.  "0" means truncate all
-   eligible entries; "inf" means never truncate. Default: "0".
+   eligible entries; "inf" means never truncate. Default: temporarily "90d",
+   eventually "0".
 
 .. note::
    Resource checkpoints were added in flux-core-0.86.0. Prior

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -149,7 +149,7 @@ static int parse_config (struct resource_ctx *ctx,
     int no_update_watch = 0;
     int rediscover = 0;
     int journal_max = 100000;
-    const char *history = NULL;
+    const char *history = "90d"; // temporarily changed from NULL #7669
     double history_time = 0.0;
     json_t *o = NULL;
     json_t *config = NULL;

--- a/t/t2319-resource-history.t
+++ b/t/t2319-resource-history.t
@@ -78,7 +78,8 @@ test_expect_success 'drain status is identical to before the reload' '
 	test_cmp drain_status2.exp drain_status2.out
 '
 
-test_expect_success 'resource eventlog has truncated events' '
+# Default temporarily changed from 0 (no history) to 90d #7669
+test_expect_failure 'resource eventlog has truncated events' '
 	test $(has_resource_event drain | wc -l) -eq 0
 '
 


### PR DESCRIPTION
Problem: `resource.history` cannot be configured prior to the flux-core release that adds the history truncation feature, so preventing unwanted truncation is awkward.

Change the default history from 0 to 90d so this is less of a pain.   Convert one test to an expected failure, with the thought that the default is likely to change back to 0 after a grace period.

Fixes #7669