### PR TITLE
job-exec: post `shell-exit` event and terminate jobs stuck after leader shell exit

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -39,6 +39,21 @@ service-override
 job-shell
    (optional) Override the compiled-in default job shell path.
 
+shell-exit-timeout
+   (optional) Time to wait after the leader shell (rank 0) exits normally
+   before raising a fatal exception if other shells remain active.
+   Set to ``"none"`` to disable. The default is ``"30s"``.
+
+   This keeps a job from hanging when a remote shell or wrapper fails to
+   exit after the leader terminates. When the timeout expires, the
+   resulting exception begins the job termination sequence, cleaning up
+   the presumably stuck shells.
+
+   .. note::
+      The timeout does not apply if the job already has a fatal exception
+      (cancel, timeout, etc) when rank 0 exits. In that case the normal
+      termination sequence already ensures that remaining shells exit.
+
 kill-timeout
    (optional) The amount of time in Flux Standard Duration (FSD) to wait
    after ``SIGTERM`` is sent to a job before sending ``SIGKILL``. FSD is

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -42,6 +42,7 @@
 #include "src/common/libutil/basename.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/fsd.h"
 #include "src/common/libsubprocess/bulk-exec.h"
 
 #include "job-exec.h"
@@ -494,7 +495,43 @@ fail:
     return rc;
 }
 
+static void shell_exit_timer_cb (flux_reactor_t *r,
+                                 flux_watcher_t *w,
+                                 int revents,
+                                 void *arg)
+{
+    struct jobinfo *job = arg;
+    struct bulk_exec *exec = job->data;
+    struct idset *active = bulk_exec_active_ranks (exec);
+    char *ids = NULL;
+    char *hosts = NULL;
+    char fsd_buf[64];
+    double timeout = config_get_shell_exit_timeout ();
+
+    flux_watcher_stop (w);
+
+    if (!active)
+        return;
+
+    ids = idset_encode (active, IDSET_FLAG_RANGE);
+    hosts = flux_hostmap_lookup (job->h, ids, NULL);
+    (void) fsd_format_duration (fsd_buf, sizeof (fsd_buf), timeout);
+
+    jobinfo_fatal_error (job,
+                         0,
+                         "job shells still active on %s"
+                         " (rank%s %s) %s after leader shell exit",
+                         hosts ? hosts : "(unknown)",
+                         idset_count (active) > 1 ? "s" : "",
+                         ids ? ids : "(unknown)",
+                         fsd_buf);
+    free (ids);
+    free (hosts);
+    idset_destroy (active);
+}
+
 /*  Post the shell-exit event when the leader shell (shell rank 0) exits.
+ *  Also arm the shell_exit_timer if configured and shells remain active.
  *  Called at most once per job (guarded by ctx->shell_exit_posted).
  */
 static void post_shell_exit_event (struct bulk_exec *exec,
@@ -507,6 +544,7 @@ static void post_shell_exit_event (struct bulk_exec *exec,
     struct idset *active = NULL;
     char *active_ids = NULL;
     int wait_status = 0;
+    double timeout;
 
     if (ctx->shell_exit_posted)
         return;
@@ -549,6 +587,31 @@ static void post_shell_exit_event (struct bulk_exec *exec,
         flux_log_error (job->h,
                         "failed to post shell-exit event for job %s",
                         idf58 (job->id));
+
+    timeout = config_get_shell_exit_timeout ();
+    if (timeout > 0.
+        && active
+        && idset_count (active) > 0
+        && !job->exception_in_progress) {
+        flux_reactor_t *reactor = flux_get_reactor (job->h);
+        job->shell_exit_timer =
+            flux_timer_watcher_create (reactor,
+                                       timeout,
+                                       0.,
+                                       shell_exit_timer_cb,
+                                       job);
+        if (job->shell_exit_timer)
+            flux_watcher_start (job->shell_exit_timer);
+        else {
+            /*  Without the timer the job could hang indefinitely waiting
+             *  for the remaining shells, so raise an exception now rather
+             *  than just logging the error.
+             */
+            jobinfo_fatal_error (job,
+                                 errno,
+                                 "failed to create shell exit timer");
+        }
+    }
 
     free (active_ids);
     idset_destroy (active);

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -72,6 +72,8 @@ struct exec_ctx {
 
     int exit_count;
 
+    bool shell_exit_posted; /* true after shell-exit event is posted */
+
     flux_watcher_t *shell_barrier_timer;
 };
 
@@ -492,6 +494,66 @@ fail:
     return rc;
 }
 
+/*  Post the shell-exit event when the leader shell (shell rank 0) exits.
+ *  Called at most once per job (guarded by ctx->shell_exit_posted).
+ */
+static void post_shell_exit_event (struct bulk_exec *exec,
+                                   struct jobinfo *job,
+                                   struct exec_ctx *ctx,
+                                   unsigned int leader_rank)
+{
+    flux_subprocess_t *p;
+    int rc;
+    struct idset *active = NULL;
+    char *active_ids = NULL;
+    int wait_status = 0;
+
+    if (ctx->shell_exit_posted)
+        return;
+    ctx->shell_exit_posted = true;
+
+    p = bulk_exec_get_subprocess (exec, leader_rank);
+    if (p)
+        wait_status = flux_subprocess_status (p);
+
+    /*  The shell-exit event is informational only (to notify eventlog
+     *  consumers that rank 0 shell services are unavailable). If encoding
+     *  or posting fails, log but continue - the timer below is the critical
+     *  safety mechanism to prevent hanging jobs.
+     */
+    if ((active = bulk_exec_active_ranks (exec))
+        && idset_count (active) > 0
+        && !(active_ids = idset_encode (active, IDSET_FLAG_RANGE)))
+        flux_log_error (job->h,
+                        "%s: failed to encode %zu active_ranks for %s",
+                        "shell-exit",
+                        idset_count (active),
+                        idf58 (job->id));
+
+    if (active_ids) {
+        rc = jobinfo_emit_event_pack_nowait (job,
+                                             "shell-exit",
+                                             "{s:i s:i s:s}",
+                                             "rank", (int) leader_rank,
+                                             "wait_status", wait_status,
+                                             "active_ranks", active_ids);
+    }
+    else {
+        rc = jobinfo_emit_event_pack_nowait (job,
+                                             "shell-exit",
+                                             "{s:i s:i}",
+                                             "rank", (int) leader_rank,
+                                             "wait_status", wait_status);
+    }
+    if (rc < 0)
+        flux_log_error (job->h,
+                        "failed to post shell-exit event for job %s",
+                        idf58 (job->id));
+
+    free (active_ids);
+    idset_destroy (active);
+}
+
 static void exit_cb (struct bulk_exec *exec,
                      void *arg,
                      const struct idset *ranks)
@@ -499,8 +561,19 @@ static void exit_cb (struct bulk_exec *exec,
     struct jobinfo *job = arg;
     struct exec_ctx *ctx = bulk_exec_aux_get (exec, "ctx");
 
-    /*  Nothing to do here if the job consists of only one shell.
-     *  (or, if we fail to to get ctx object (highly unlikely))
+    /*  Post shell-exit event if the leader shell (shell rank 0) is in the
+     *  set of exiting ranks.  This must be done before the single-shell
+     *  early-return so the event is posted for single-shell jobs too.
+     *  ctx may be NULL in highly unlikely error scenarios; skip if so.
+     */
+    if (ctx) {
+        unsigned int leader_rank = resource_set_nth_rank (job->R, 0);
+        if (idset_test (ranks, leader_rank))
+            post_shell_exit_event (exec, job, ctx, leader_rank);
+    }
+
+    /*  Nothing more to do here if the job consists of only one shell.
+     *  (or, if we fail to get ctx object (highly unlikely))
      */
     if (bulk_exec_total (exec) == 1
         || !(ctx = bulk_exec_aux_get (exec, "ctx")))

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -31,6 +31,8 @@
 
 static const char *default_cwd = "/tmp";
 
+#define DEFAULT_SHELL_EXIT_TIMEOUT 30.
+
 struct exec_config {
     const char *default_job_shell;
     const char *flux_imp_path;
@@ -41,6 +43,7 @@ struct exec_config {
     int sdexec_stop_timer_signal;
     int sdexec_constrain_resources;
     double default_barrier_timeout;
+    double shell_exit_timeout;  /* <=0 means disabled */
 };
 
 /* Global configs initialized in config_init() */
@@ -131,11 +134,16 @@ double config_get_default_barrier_timeout (void)
     return exec_conf.default_barrier_timeout;
 }
 
+double config_get_shell_exit_timeout (void)
+{
+    return exec_conf.shell_exit_timeout;
+}
+
 int config_get_stats (json_t **config_stats)
 {
     json_t *o = NULL;
 
-    if (!(o = json_pack ("{s:s? s:s? s:s? s:s? s:i s:f s:i s:i s:i}",
+    if (!(o = json_pack ("{s:s? s:s? s:s? s:s? s:i s:f s:f s:i s:i s:i}",
                          "default_cwd", default_cwd,
                          "default_job_shell", exec_conf.default_job_shell,
                          "flux_imp_path", exec_conf.flux_imp_path,
@@ -144,6 +152,8 @@ int config_get_stats (json_t **config_stats)
                          exec_conf.exec_service_override,
                          "default_barrier_timeout",
                          exec_conf.default_barrier_timeout,
+                         "shell_exit_timeout",
+                         exec_conf.shell_exit_timeout,
                          "sdexec_stop_timer_sec",
                          derive_sdexec_stop_timer_sec (),
                          "sdexec_stop_timer_signal",
@@ -182,6 +192,7 @@ static void exec_config_init (struct exec_config *ec)
     ec->sdexec_stop_timer_signal = 10; // SIGUSR1
     ec->sdexec_constrain_resources = 0;
     ec->default_barrier_timeout = 1800.;
+    ec->shell_exit_timeout = DEFAULT_SHELL_EXIT_TIMEOUT;
 }
 
 /*  Initialize configurations for use by job-exec bulk-exec
@@ -195,6 +206,7 @@ int config_setup (flux_t *h,
 {
     struct exec_config tmpconf;
     const char *barrier_timeout = NULL;
+    const char *shell_exit_timeout = NULL;
     flux_error_t err;
 
     /* Per trws comment in 97421e88987535260b10d6a19551cea625f26ce4
@@ -327,6 +339,29 @@ int config_setup (flux_t *h,
         return -1;
     }
 
+    /*  Check configuration for exec.shell-exit-timeout */
+    if (flux_conf_unpack (conf,
+                          &err,
+                          "{s?{s?s}}",
+                          "exec",
+                            "shell-exit-timeout", &shell_exit_timeout) < 0) {
+        errprintf (errp,
+                   "error reading config value"
+                   " exec.shell-exit-timeout: %s",
+                   err.text);
+        return -1;
+    }
+    if (shell_exit_timeout) {
+        if (streq (shell_exit_timeout, "none"))
+            tmpconf.shell_exit_timeout = 0.;
+        else if (fsd_parse_duration (shell_exit_timeout,
+                                     &tmpconf.shell_exit_timeout) < 0) {
+                errprintf (errp,
+                           "invalid shell-exit-timeout: %s",
+                           shell_exit_timeout);
+                return -1;
+        }
+    }
 
     if (argv && argc) {
         /* Finally, override values on cmdline */
@@ -337,6 +372,21 @@ int config_setup (flux_t *h,
                 tmpconf.flux_imp_path = argv[i]+4;
             else if (strstarts (argv[i], "service="))
                 tmpconf.exec_service = argv[i]+8;
+            else if (strstarts (argv[i], "shell-exit-timeout=")) {
+                const char *val = argv[i] + 19;
+                if (streq (val, "none"))
+                    tmpconf.shell_exit_timeout = 0.;
+                else {
+                    double d;
+                    if (fsd_parse_duration (val, &d) < 0) {
+                        errprintf (errp,
+                                   "invalid shell-exit-timeout: %s",
+                                   val);
+                        return -1;
+                    }
+                    tmpconf.shell_exit_timeout = d;
+                }
+            }
         }
     }
 

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -36,6 +36,8 @@ bool config_get_exec_service_override (void);
 
 double config_get_default_barrier_timeout (void);
 
+double config_get_shell_exit_timeout (void);
+
 int config_get_stats (json_t **config_stats);
 
 const char *config_get_sdexec_stop_timer_sec (void);

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -41,8 +41,8 @@
  * After initialization is complete, the exec service emits a "starting"
  * event to the exec eventlog and calls the implementation "start" method.
  * Once all job shells or equivalent are running, the exec implementation
- * should invoke jobinfo_started(), which emits a "running" event to the
- * exec eventlog and sends the "start" response to the job-manager.
+ * should invoke jobinfo_started(), which sends the "start" response to
+ * the job-manager.
  *
  * JOB FINISH/CLEANUP:
  *

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -181,6 +181,7 @@ void jobinfo_decref (struct jobinfo *job)
         flux_watcher_destroy (job->kill_shell_timer);
         flux_watcher_destroy (job->max_kill_timer);
         flux_watcher_destroy (job->expiration_timer);
+        flux_watcher_destroy (job->shell_exit_timer);
         zhashx_delete (job->ctx->jobs, &job->id);
         if (job->impl && job->impl->exit)
             (*job->impl->exit) (job);
@@ -392,6 +393,11 @@ static void jobinfo_complete (struct jobinfo *job, const struct idset *ranks)
 {
     flux_t *h = job->ctx->h;
     job->running = 0;
+
+    /* Stop shell_exit_timer so it cannot fire on a job that is already
+     * completing normally.
+     */
+    flux_watcher_stop (job->shell_exit_timer);
 
     if (job->exception_in_progress) {
         if (job->exception_wait_status >= 0)
@@ -774,6 +780,11 @@ static void jobinfo_cancel (struct jobinfo *job)
     /*  If a kill-timer is already active, the cancellation is in progress */
     if (job->kill_timer)
         return;
+
+    /*  Stop shell_exit_timer if active - an exception has occurred so the
+     *  normal shell exit monitoring no longer applies.
+     */
+    flux_watcher_stop (job->shell_exit_timer);
 
     if (job->impl->cancel)
         (*job->impl->cancel) (job);

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -109,6 +109,11 @@ struct jobinfo {
 
     flux_watcher_t       *expiration_timer;
 
+    /* Timer armed when the leader shell exits to raise a fatal exception
+     * if remaining shells do not exit within shell-exit-timeout.
+     */
+    flux_watcher_t       *shell_exit_timer;
+
     double                t0;        /* timestamp we initially saw this job */
 
     /* Exec implementation for this job */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -223,6 +223,7 @@ TESTSCRIPTS = \
 	t2414-imp-exec-helper.t \
 	t2415-sdexec-device.t \
 	t2416-sdexec-constrain-resources.t \
+	t2417-job-exec-shell-exit.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \
 	t2600-job-shell-rcalc.t \

--- a/t/t2417-job-exec-shell-exit.t
+++ b/t/t2417-job-exec-shell-exit.t
@@ -1,0 +1,235 @@
+#!/bin/sh
+
+test_description='Test job-exec shell-exit event and shell-exit-timeout'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 2 job
+
+FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"
+
+# Create a wrapper that runs the real flux-shell but then hangs forever
+# on non-leader broker ranks after the real shell exits.  The real remote
+# shell sends output eof during teardown, which causes the leader to exit
+# normally -- but job-exec's subprocess for that rank stays alive.
+# Use "exec sleep inf" so there is exactly one process for the kill machinery
+# to land on and no orphan is left behind.
+test_expect_success 'create stuck job shell wrapper' '
+	cat >stuck-shell.sh <<-EOF &&
+	#!/bin/sh
+	rank=\$(flux getattr rank)
+	${FLUX_SHELL} "\$@"
+	rc=\$?
+	test "\$rank" -ne 0 && exec sleep inf
+	exit \$rc
+	EOF
+	chmod +x stuck-shell.sh
+'
+
+# Create a wrapper that delays exit on non-leader ranks by 2 seconds only,
+# used to test that the timer is properly stopped on normal completion.
+test_expect_success 'create slow-exit job shell wrapper' '
+	cat >slow-shell.sh <<-EOF &&
+	#!/bin/sh
+	rank=\$(flux getattr rank)
+	${FLUX_SHELL} "\$@"
+	rc=\$?
+	test "\$rank" -ne 0 && sleep 2
+	exit \$rc
+	EOF
+	chmod +x slow-shell.sh
+'
+
+# ---------------------------------------------------------------------------
+# Config validation (run first so later tests start clean)
+# ---------------------------------------------------------------------------
+
+test_expect_success 'invalid shell-exit-timeout fails config load' '
+	test_expect_code 1 flux config load <<-EOF
+	[exec]
+	shell-exit-timeout = "notfsd"
+	EOF
+'
+test_expect_success 'valid FSD shell-exit-timeout loads successfully' '
+	flux config load <<-EOF &&
+	[exec]
+	shell-exit-timeout = "1m"
+	EOF
+	flux module reload job-exec &&
+	flux module stats job-exec \
+	    | jq -e ".\"bulk-exec\".config.shell_exit_timeout == 60."
+'
+test_expect_success 'shell-exit-timeout = "none" disables the timer' '
+	flux config load <<-EOF &&
+	[exec]
+	shell-exit-timeout = "none"
+	EOF
+	flux module reload job-exec &&
+	flux module stats job-exec \
+	    | jq -e ".\"bulk-exec\".config.shell_exit_timeout == 0."
+'
+test_expect_success 'reload job-exec to defaults' '
+	flux config load </dev/null &&
+	flux module reload job-exec
+'
+
+# ---------------------------------------------------------------------------
+# shell-exit event is posted with correct context
+# ---------------------------------------------------------------------------
+
+test_expect_success 'reload job-exec with shell-exit-timeout=none' '
+	flux module reload job-exec shell-exit-timeout=none
+'
+test_expect_success 'submit stuck-shell job' '
+	id=$(flux submit -N2 -n2 -o exit-timeout=none \
+	     --setattr=exec.job_shell=$(pwd)/stuck-shell.sh true) &&
+	echo $id >stuck-id.txt
+'
+test_expect_success 'shell-exit event is posted' '
+	id=$(cat stuck-id.txt) &&
+	flux job wait-event -p exec -vt 30 $id shell-exit
+'
+test_expect_success 'shell-exit event has correct wait_status and rank' '
+	id=$(cat stuck-id.txt) &&
+	flux job wait-event -p exec --format=json -t 10 $id shell-exit \
+	    | jq -e ".context.wait_status == 0 and .context.rank == 0"
+'
+test_expect_success 'shell-exit event has active_ranks = "1"' '
+	id=$(cat stuck-id.txt) &&
+	flux job wait-event -p exec --format=json -t 10 $id shell-exit \
+	    | jq -e ".context.active_ranks == \"1\""
+'
+test_expect_success 'cancel stuck job and wait for clean' '
+	id=$(cat stuck-id.txt) &&
+	flux cancel $id &&
+	flux job wait-event -t 30 $id clean
+'
+test_expect_success 'reload job-exec to defaults' '
+	flux module reload job-exec
+'
+
+# ---------------------------------------------------------------------------
+# shell-exit-timeout raises exception and job reaches INACTIVE
+# ---------------------------------------------------------------------------
+
+test_expect_success 'reload job-exec with shell-exit-timeout=0.2s' '
+	flux module reload job-exec shell-exit-timeout=0.2s
+'
+test_expect_success 'submit stuck-shell job for timer test' '
+	id=$(flux submit -N2 -n2 -o exit-timeout=none \
+	     --setattr=exec.job_shell=$(pwd)/stuck-shell.sh true) &&
+	echo $id >stuck-timer-id.txt
+'
+test_expect_success 'timer raises exec exception' '
+	id=$(cat stuck-timer-id.txt) &&
+	flux job wait-event -t 30 -m type=exec $id exception
+'
+test_expect_success 'exception note mentions timeout duration' '
+	id=$(cat stuck-timer-id.txt) &&
+	flux job wait-event -t 10 --format=json -m type=exec $id exception \
+	    | jq -e ".context.note | test(\"0.2\")"
+'
+test_expect_success 'job reaches clean without manual intervention' '
+	id=$(cat stuck-timer-id.txt) &&
+	flux job wait-event -t 30 $id clean
+'
+test_expect_success 'reload job-exec to defaults' '
+	flux module reload job-exec
+'
+
+# ---------------------------------------------------------------------------
+# timer is stopped on normal completion (no false positive)
+# ---------------------------------------------------------------------------
+
+test_expect_success 'reload job-exec with shell-exit-timeout=10s' '
+	flux module reload job-exec shell-exit-timeout=10s
+'
+test_expect_success 'submit slow-shell job (exits 2s after leader)' '
+	id=$(flux submit -N2 -n2 -o exit-timeout=none \
+	     --setattr=exec.job_shell=$(pwd)/slow-shell.sh true) &&
+	echo $id >slow-id.txt
+'
+test_expect_success 'job completes with exit status 0' '
+	id=$(cat slow-id.txt) &&
+	flux job wait-event -t 30 $id clean &&
+	flux job status $id
+'
+test_expect_success 'no exception event in eventlog' '
+	id=$(cat slow-id.txt) &&
+	test_must_fail flux job wait-event -t 2 $id exception
+'
+test_expect_success 'reload job-exec to defaults' '
+	flux module reload job-exec
+'
+
+# ---------------------------------------------------------------------------
+# timer is stopped when job exception occurs before it fires
+# ---------------------------------------------------------------------------
+
+test_expect_success 'reload job-exec with shell-exit-timeout=30s' '
+	flux module reload job-exec shell-exit-timeout=30s
+'
+test_expect_success 'submit stuck-shell job for cancel test' '
+	id=$(flux submit -N2 -n2 -o exit-timeout=none \
+	     --setattr=exec.job_shell=$(pwd)/stuck-shell.sh true) &&
+	echo $id >stuck-cancel-id.txt
+'
+test_expect_success 'wait for shell-exit event' '
+	id=$(cat stuck-cancel-id.txt) &&
+	flux job wait-event -p exec -t 30 $id shell-exit
+'
+test_expect_success 'cancel job before timer expires' '
+	id=$(cat stuck-cancel-id.txt) &&
+	flux cancel $id
+'
+test_expect_success 'job receives cancel exception' '
+	id=$(cat stuck-cancel-id.txt) &&
+	flux job wait-event -t 10 -m type=cancel $id exception
+'
+test_expect_success 'no exec exception with shell-exit-timeout note' '
+	id=$(cat stuck-cancel-id.txt) &&
+	flux job eventlog -p exec $id >eventlog.out &&
+	test_must_fail grep "shell-exit-timeout" eventlog.out
+'
+test_expect_success 'job reaches clean state' '
+	id=$(cat stuck-cancel-id.txt) &&
+	flux job wait-event -t 30 $id clean
+'
+test_expect_success 'reload job-exec to defaults' '
+	flux module reload job-exec
+'
+
+# ---------------------------------------------------------------------------
+# single-shell and normal jobs unaffected
+# ---------------------------------------------------------------------------
+
+test_expect_success 'single-node job gets shell-exit event' '
+	id=$(flux submit -N1 true) &&
+	flux job wait-event -p exec -t 30 $id shell-exit
+'
+test_expect_success 'single-node shell-exit has wait_status == 0' '
+	id=$(flux job last) &&
+	flux job wait-event -p exec --format=json -t 10 $id shell-exit \
+	    | jq -e ".context.wait_status == 0"
+'
+test_expect_success 'single-node shell-exit has no active_ranks key' '
+	id=$(flux job last) &&
+	flux job wait-event -p exec --format=json -t 10 $id shell-exit \
+	    | jq -e ".context | has(\"active_ranks\") | not"
+'
+
+# ---------------------------------------------------------------------------
+# abnormal leader exit gives nonzero wait_status
+# ---------------------------------------------------------------------------
+
+test_expect_success 'submit job with task killed by signal' '
+	id=$(flux submit -N1 sh -c "kill -9 \$\$") &&
+	flux job wait-event -t 30 $id clean
+'
+test_expect_success 'shell-exit event has nonzero wait_status' '
+	id=$(flux job last) &&
+	flux job wait-event -p exec --format=json -t 10 $id shell-exit \
+	    | jq -e ".context.wait_status != 0"
+'
+
+test_done


### PR DESCRIPTION
This PR addresses a problem in which a job can remain in `RUN` state indefinitely when the rank 0 (leader) job shell exits but shells on other ranks do not (see #7673). The shell `exit-timeout` (doom plugin) cannot handle this case because it dies with the leader shell, and nothing else arms kill machinery after a normal leader shell exit. Once the leader is gone, key services like the MPIR proctable and job I/O are permanently unavailable, so there is no point in letting the job linger. 

This PR adds the following to the job-exec module:

  - Post a `shell-exit` event to the job execution eventlog when termination of the leader shell is observed, with the leader's broker rank, wait tatus, and an idset of broker ranks with shells still active, as recently specified in RFC 50 (flux-framework/rfc#522). This marks the loss of leader shell services in the job record and could let tools like `flux job attach` abort an MPIR proctable gather early, or at least notify a debugger that the job is in the state of completing.

 - Add an `exec.shell-exit-timeout` config key (FSD or `"none"`, default `30s`). If shells remain active that long after the leader shell exits, a fatal exception is raised on the job so it terminates instead of hanging. It seemed logical to copy the default from the shell `exit-timeout` (also `30s`), since this timeout serves the same purpose.
 - 
Fixes #7673