### PR TITLE
python: improve CLI option parsing with `FluxArgumentParser`

### DIFF
--- a/doc/man1/common/job-other-options.rst
+++ b/doc/man1/common/job-other-options.rst
@@ -125,3 +125,15 @@
 
    Enable job debug events, primarily for debugging Flux itself.
    The specific effects of this option may change in the future.
+
+These commands use POSIX-style option parsing: option processing stops at
+the first non-option argument.  COMMAND (or SCRIPT for
+:man1:`flux-batch`) and all following arguments are passed to the job
+verbatim and are never interpreted as Flux options.  A ``--`` separator
+may be used to explicitly mark the end of Flux options and is consumed by
+the parser; arguments following ``--`` are passed to the job unchanged.
+For :man1:`flux-alloc`, a user-supplied ``--`` is forwarded to the
+``flux broker`` command of the new instance.
+
+Long options may not be abbreviated; for example, ``--time-limit`` must
+be spelled out in full and cannot be shortened to ``--time``.

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -17,6 +17,7 @@ nobase_fluxpy_PYTHON = \
 	brokermod.py \
 	proctitle.py \
 	cli/__init__.py \
+	cli/argparse.py \
 	cli/base.py \
 	cli/alloc.py \
 	cli/batch.py \

--- a/src/bindings/python/flux/cli/argparse.py
+++ b/src/bindings/python/flux/cli/argparse.py
@@ -71,9 +71,35 @@ class FluxArgumentParser(argparse.ArgumentParser):
             "formatter_class",
             help_formatter(argwidth=argwidth, raw_description=raw_description),
         )
-        kwargs.setdefault("allow_abbrev", False)
+        if sys.version_info >= (3, 8):
+            # allow_abbrev=False is safe on 3.8+: bpo-26967 moved the gate
+            # inside _get_option_tuples so short-option concatenation (-vvv,
+            # -n4) still works.
+            kwargs.setdefault("allow_abbrev", False)
+        # else: leave allow_abbrev at its default (True) so _parse_optional
+        # still reaches _get_option_tuples (needed for short-option
+        # concatenation on 3.6/3.7); long-option abbreviations are disabled
+        # instead by the _get_option_tuples override below (bpo-26967 backport).
         super().__init__(*args, **kwargs)
         self.posix = posix
+
+    if sys.version_info < (3, 8):
+
+        def _get_option_tuples(self, option_string):
+            # bpo-26967 backport: reject long-option prefix matching while
+            # preserving short-option concatenation handling.
+            # On 3.6/3.7, allow_abbrev=False would have gated the entire
+            # _get_option_tuples call in _parse_optional, breaking -vvv/-n4.
+            # Instead we leave allow_abbrev=True and intercept here: for long
+            # options (starting with two prefix chars) return [] to suppress
+            # abbreviation matching; for short options fall through to super()
+            # so concatenation works normally.
+            # 3.6/3.7 are frozen/EOL so this private-method override cannot
+            # drift. Verified against the real CPython 3.6 argparse.py.
+            chars = self.prefix_chars
+            if option_string[0] in chars and option_string[1] in chars:
+                return []
+            return super()._get_option_tuples(option_string)
 
     def add_argument(self, *args, hidden_aliases=(), **kwargs):
         return _add_with_hidden(super(), *args, hidden_aliases=hidden_aliases, **kwargs)

--- a/src/bindings/python/flux/cli/argparse.py
+++ b/src/bindings/python/flux/cli/argparse.py
@@ -1,0 +1,90 @@
+##############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import argparse
+
+
+class _FluxArgumentGroup(argparse._ArgumentGroup):
+    """ArgumentGroup that supports hidden_aliases in add_argument()."""
+
+    def add_argument(self, *args, hidden_aliases=(), **kwargs):
+        if isinstance(hidden_aliases, str):
+            raise TypeError(
+                "hidden_aliases must be a tuple or list, not a str. "
+                "Did you mean hidden_aliases=(%r,)?" % hidden_aliases
+            )
+        action = super().add_argument(*list(args) + list(hidden_aliases), **kwargs)
+        if hidden_aliases:
+            action.hidden_option_strings = set(hidden_aliases)
+        return action
+
+
+class _FluxMutuallyExclusiveGroup(argparse._MutuallyExclusiveGroup):
+    """MutuallyExclusiveGroup that supports hidden_aliases in add_argument()."""
+
+    def add_argument(self, *args, hidden_aliases=(), **kwargs):
+        if isinstance(hidden_aliases, str):
+            raise TypeError(
+                "hidden_aliases must be a tuple or list, not a str. "
+                "Did you mean hidden_aliases=(%r,)?" % hidden_aliases
+            )
+        action = super().add_argument(*list(args) + list(hidden_aliases), **kwargs)
+        if hidden_aliases:
+            action.hidden_option_strings = set(hidden_aliases)
+        return action
+
+
+class FluxArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser with Flux defaults: allow_abbrev=False, FluxHelpFormatter.
+
+    Additional keyword arguments:
+        raw_description (bool): preserve whitespace in description/epilog.
+            Silently ignored if formatter_class is passed explicitly.
+        argwidth (int): max column for help alignment (default 40).
+            Silently ignored if formatter_class is passed explicitly.
+
+    add_argument() accepts an extra keyword argument:
+        hidden_aliases (tuple): option strings recognized by the parser but
+            suppressed from --help output (e.g. singular forms of plural flags).
+            Must be a tuple or list; passing a bare string raises TypeError.
+    """
+
+    def __init__(self, *args, raw_description=False, argwidth=40, **kwargs):
+        # Lazy import avoids a circular dependency: flux.util re-exports this
+        # class while also defining help_formatter, which is needed here.
+        from flux.util import help_formatter
+
+        kwargs.setdefault(
+            "formatter_class",
+            help_formatter(argwidth=argwidth, raw_description=raw_description),
+        )
+        kwargs.setdefault("allow_abbrev", False)
+        super().__init__(*args, **kwargs)
+
+    def add_argument(self, *args, hidden_aliases=(), **kwargs):
+        if isinstance(hidden_aliases, str):
+            raise TypeError(
+                "hidden_aliases must be a tuple or list, not a str. "
+                "Did you mean hidden_aliases=(%r,)?" % hidden_aliases
+            )
+        action = super().add_argument(*list(args) + list(hidden_aliases), **kwargs)
+        if hidden_aliases:
+            action.hidden_option_strings = set(hidden_aliases)
+        return action
+
+    def add_argument_group(self, *args, **kwargs):
+        group = _FluxArgumentGroup(self, *args, **kwargs)
+        self._action_groups.append(group)
+        return group
+
+    def add_mutually_exclusive_group(self, **kwargs):
+        group = _FluxMutuallyExclusiveGroup(self, **kwargs)
+        self._mutually_exclusive_groups.append(group)
+        return group

--- a/src/bindings/python/flux/cli/argparse.py
+++ b/src/bindings/python/flux/cli/argparse.py
@@ -9,36 +9,36 @@
 ##############################################################
 
 import argparse
+import sys
+
+from flux.util import help_formatter
+
+
+def _add_with_hidden(container, *args, hidden_aliases=(), **kwargs):
+    """Call container.add_argument with optional hidden_aliases support."""
+    if isinstance(hidden_aliases, str):
+        raise TypeError(
+            "hidden_aliases must be a tuple or list, not a str. "
+            "Did you mean hidden_aliases=(%r,)?" % hidden_aliases
+        )
+    action = container.add_argument(*args, *hidden_aliases, **kwargs)
+    if hidden_aliases:
+        action.hidden_option_strings = set(hidden_aliases)
+    return action
 
 
 class _FluxArgumentGroup(argparse._ArgumentGroup):
     """ArgumentGroup that supports hidden_aliases in add_argument()."""
 
     def add_argument(self, *args, hidden_aliases=(), **kwargs):
-        if isinstance(hidden_aliases, str):
-            raise TypeError(
-                "hidden_aliases must be a tuple or list, not a str. "
-                "Did you mean hidden_aliases=(%r,)?" % hidden_aliases
-            )
-        action = super().add_argument(*list(args) + list(hidden_aliases), **kwargs)
-        if hidden_aliases:
-            action.hidden_option_strings = set(hidden_aliases)
-        return action
+        return _add_with_hidden(super(), *args, hidden_aliases=hidden_aliases, **kwargs)
 
 
 class _FluxMutuallyExclusiveGroup(argparse._MutuallyExclusiveGroup):
     """MutuallyExclusiveGroup that supports hidden_aliases in add_argument()."""
 
     def add_argument(self, *args, hidden_aliases=(), **kwargs):
-        if isinstance(hidden_aliases, str):
-            raise TypeError(
-                "hidden_aliases must be a tuple or list, not a str. "
-                "Did you mean hidden_aliases=(%r,)?" % hidden_aliases
-            )
-        action = super().add_argument(*list(args) + list(hidden_aliases), **kwargs)
-        if hidden_aliases:
-            action.hidden_option_strings = set(hidden_aliases)
-        return action
+        return _add_with_hidden(super(), *args, hidden_aliases=hidden_aliases, **kwargs)
 
 
 class FluxArgumentParser(argparse.ArgumentParser):
@@ -49,6 +49,14 @@ class FluxArgumentParser(argparse.ArgumentParser):
             Silently ignored if formatter_class is passed explicitly.
         argwidth (int): max column for help alignment (default 40).
             Silently ignored if formatter_class is passed explicitly.
+        posix (bool): stop consuming options at the first non-option argument
+            (POSIX getopt behavior). Intended for submission commands where
+            tokens after the job command must not be consumed as Flux options.
+            posix=True requires exactly one trailing positional with
+            nargs=argparse.REMAINDER and supports no other positionals.
+            Clustered short options whose last option takes a separate value
+            (e.g. ``-vn 4``) are not supported in posix mode and will error;
+            use ``-vn4`` or ``-v -n 4`` instead.
 
     add_argument() accepts an extra keyword argument:
         hidden_aliases (tuple): option strings recognized by the parser but
@@ -56,28 +64,19 @@ class FluxArgumentParser(argparse.ArgumentParser):
             Must be a tuple or list; passing a bare string raises TypeError.
     """
 
-    def __init__(self, *args, raw_description=False, argwidth=40, **kwargs):
-        # Lazy import avoids a circular dependency: flux.util re-exports this
-        # class while also defining help_formatter, which is needed here.
-        from flux.util import help_formatter
-
+    def __init__(
+        self, *args, posix=False, raw_description=False, argwidth=40, **kwargs
+    ):
         kwargs.setdefault(
             "formatter_class",
             help_formatter(argwidth=argwidth, raw_description=raw_description),
         )
         kwargs.setdefault("allow_abbrev", False)
         super().__init__(*args, **kwargs)
+        self.posix = posix
 
     def add_argument(self, *args, hidden_aliases=(), **kwargs):
-        if isinstance(hidden_aliases, str):
-            raise TypeError(
-                "hidden_aliases must be a tuple or list, not a str. "
-                "Did you mean hidden_aliases=(%r,)?" % hidden_aliases
-            )
-        action = super().add_argument(*list(args) + list(hidden_aliases), **kwargs)
-        if hidden_aliases:
-            action.hidden_option_strings = set(hidden_aliases)
-        return action
+        return _add_with_hidden(super(), *args, hidden_aliases=hidden_aliases, **kwargs)
 
     def add_argument_group(self, *args, **kwargs):
         group = _FluxArgumentGroup(self, *args, **kwargs)
@@ -88,3 +87,92 @@ class FluxArgumentParser(argparse.ArgumentParser):
         group = _FluxMutuallyExclusiveGroup(self, **kwargs)
         self._mutually_exclusive_groups.append(group)
         return group
+
+    def _count_option_args(self, action, remaining):
+        """Return number of separate value args this option will consume."""
+        nargs = action.nargs
+        if nargs is None:
+            return 1
+        if isinstance(nargs, int):
+            return min(nargs, len(remaining))
+        if nargs == "?":
+            if remaining and self._parse_optional(remaining[0]) is None:
+                return 1
+            return 0
+        if nargs in ("+", "*"):
+            # Greedily count consecutive non-option tokens.
+            # _parse_optional is portable across 3.6-3.13 when tested via
+            # "is None" (all versions return None for non-options, tuple or
+            # list for options).
+            count = 0
+            for tok in remaining:
+                if self._parse_optional(tok) is None:
+                    count += 1
+                else:
+                    break
+            return count
+        return 0  # store_true/false, REMAINDER: no separate value args
+
+    def _split_posix(self, arg_strings):
+        """Split arg_strings at the first non-option into (options, positionals).
+
+        Uses self.prefix_chars and self._option_string_actions to classify
+        tokens. For nargs='?' options, calls self._parse_optional via
+        _count_option_args to check whether the next token is a value or a
+        new option; that call is portable across Python 3.6-3.13 because it
+        only tests the result for "is None". For nargs='+'/'*', consecutive
+        non-option tokens are consumed greedily.
+
+        Negative-number-like tokens (e.g. '-1', '-3.14') are treated as
+        non-options when the parser has no negative-number optionals, matching
+        standard argparse behavior.
+
+        A user-supplied '--' is preserved as the first element of positionals
+        so commands that pass it through to a subprocess (e.g. flux alloc
+        passing it to flux broker) work correctly.
+        """
+        i = 0
+        while i < len(arg_strings):
+            arg = arg_strings[i]
+            if arg == "--":
+                return arg_strings[:i], arg_strings[i:]
+            if not arg or arg[0] not in self.prefix_chars or len(arg) == 1:
+                return arg_strings[:i], arg_strings[i:]
+            # Treat negative-number-like tokens as non-options when there are
+            # no negative-number optionals, matching stock argparse behavior.
+            if (
+                self._negative_number_matcher.match(arg)
+                and not self._has_negative_number_optionals
+            ):
+                return arg_strings[:i], arg_strings[i:]
+            i += 1
+            is_long = arg[1] in self.prefix_chars
+            if (is_long and "=" in arg) or (not is_long and len(arg) > 2):
+                continue  # value embedded in this token, no next arg consumed
+            action = self._option_string_actions.get(arg)
+            if action is not None:
+                i += self._count_option_args(action, arg_strings[i:])
+        return arg_strings, []
+
+    def parse_args(self, args=None, namespace=None):
+        if self.posix:
+            all_args = list(args) if args is not None else sys.argv[1:]
+            options, positionals = self._split_posix(all_args)
+            result = super().parse_args(options, namespace)
+            # Inject positionals into the REMAINDER dest. argparse sets it to []
+            # when no positionals are present; we replace that with the real value,
+            # prepending any value that super().parse_args() already put there
+            # (e.g. negative numbers that argparse matched as non-options).
+            remainder_found = False
+            for action in self._actions:
+                if action.nargs == argparse.REMAINDER:
+                    existing = getattr(result, action.dest, [])
+                    if existing:
+                        positionals = existing + positionals
+                    setattr(result, action.dest, positionals)
+                    remainder_found = True
+                    break
+            if positionals and not remainder_found:
+                self.error("unrecognized arguments: %s" % " ".join(positionals))
+            return result
+        return super().parse_args(args, namespace)

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -372,6 +372,7 @@ class MiniCmd:
             usage=usage,
             description=description,
             add_help=False,
+            posix=True,
         )
         parser.add_argument(
             "--help",

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -20,6 +20,7 @@ import sys
 
 import flux
 from flux import debugged, job, util
+from flux.cli.argparse import FluxArgumentParser
 from flux.cli.plugin import CLIPluginRegistry
 from flux.idset import IDset
 from flux.job import JobspecV1, JobWatcher
@@ -366,11 +367,10 @@ class MiniCmd:
         """
         if usage is None:
             usage = f"{prog} [OPTIONS...] COMMAND [ARGS...]"
-        parser = argparse.ArgumentParser(
+        parser = FluxArgumentParser(
             prog=prog,
             usage=usage,
             description=description,
-            formatter_class=flux.util.help_formatter(),
             add_help=False,
         )
         parser.add_argument(
@@ -450,6 +450,7 @@ class MiniCmd:
         )
         parser.add_argument(
             "--requires",
+            hidden_aliases=("--require",),
             action="append",
             help="Specify job constraints in RFC 35 syntax",
             metavar="CONSTRAINT",
@@ -564,6 +565,7 @@ class MiniCmd:
         )
         parser.add_argument(
             "--dry-run",
+            hidden_aliases=("--dry",),
             action="store_true",
             help="Don't actually submit job, just emit jobspec",
         )
@@ -1195,6 +1197,7 @@ class BatchAllocCmd(MiniCmd):
         )
         self.parser.add_argument(
             "--broker-opts",
+            hidden_aliases=("--broker-opt",),
             metavar="OPTS",
             default=None,
             action="append",

--- a/src/bindings/python/flux/cli/fortune.py
+++ b/src/bindings/python/flux/cli/fortune.py
@@ -8,13 +8,12 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import argparse
 import random
 import sys
 from datetime import datetime
 
-import flux.util
 from flux.cli import base
+from flux.cli.argparse import FluxArgumentParser
 
 # Choice of decorating symbols
 symbols = ["@", "*", "**", "!", "$", "%", "^", "O", "o", "|", "x", "8", "*", "{*}", "-"]
@@ -54,11 +53,10 @@ class FortuneCmd(base.MiniCmd):
         if usage is None:
             usage = f"{prog} [OPTIONS...] COMMAND [ARGS...]"
 
-        parser = argparse.ArgumentParser(
+        parser = FluxArgumentParser(
             prog=prog,
             usage=usage,
             description=description,
-            formatter_class=flux.util.help_formatter(),
         )
         parser.add_argument(
             "-c",

--- a/src/bindings/python/flux/job/frobnicator/frobnicator.py
+++ b/src/bindings/python/flux/job/frobnicator/frobnicator.py
@@ -8,11 +8,11 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import argparse
 import os
 from abc import abstractmethod
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.importer import import_path, import_plugins
 from flux.job import Jobspec
 
@@ -78,9 +78,7 @@ class JobFrobnicator:
             pluginpath = []
 
         if parser is None:
-            parser = argparse.ArgumentParser(
-                formatter_class=flux.util.help_formatter(), add_help=False
-            )
+            parser = FluxArgumentParser(add_help=False)
 
         self.parser = parser
         self.parser_group = self.parser.add_argument_group("Options")
@@ -88,7 +86,9 @@ class JobFrobnicator:
             "Options provided by plugins"
         )
 
-        self.parser_group.add_argument("--plugins", action="append", default=[])
+        self.parser_group.add_argument(
+            "--plugins", hidden_aliases=("--plugin",), action="append", default=[]
+        )
 
         args, self.remaining_args = self.parser.parse_known_args(argv)
         if not args.plugins:

--- a/src/bindings/python/flux/job/validator/validator.py
+++ b/src/bindings/python/flux/job/validator/validator.py
@@ -8,12 +8,12 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import argparse
 import concurrent.futures
 import json
 from abc import ABC, abstractmethod
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.importer import import_path, import_plugins
 
 
@@ -149,16 +149,16 @@ class JobValidator:
         #  Setup parser so we can parse --plugin and plugins can attach
         #   their own options
         if parser is None:
-            parser = argparse.ArgumentParser(
-                formatter_class=flux.util.help_formatter(), add_help=False
-            )
+            parser = FluxArgumentParser(add_help=False)
 
         self.parser = parser
         self.parser_group = self.parser.add_argument_group("Validator options")
         self.plugins_group = self.parser.add_argument_group(
             "Options provided by plugins"
         )
-        self.parser_group.add_argument("--plugins", action="append", default=[])
+        self.parser_group.add_argument(
+            "--plugins", hidden_aliases=("--plugin",), action="append", default=[]
+        )
 
         #  Parse provided argv, but only parse known args, save
         #   remaining arguments for plugin configuration once plugins

--- a/src/bindings/python/flux/sdexec/map.py
+++ b/src/bindings/python/flux/sdexec/map.py
@@ -90,7 +90,7 @@ import errno
 import math
 from pathlib import Path
 
-import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.idset import IDset
 from flux.resource import ResourceSet
 
@@ -563,16 +563,14 @@ def _get_system_xml(xml_file=None):
 
 def main(args=None):
     """CLI entry point: show systemd unit properties for given resource IDs."""
-    import argparse
     import importlib
     import json
     import sys
 
-    parser = argparse.ArgumentParser(
+    parser = FluxArgumentParser(
         prog="flux python -m flux.sdexec.map",
         description="Show systemd unit properties that would be emitted for "
         "the given Flux resource IDs on this system.",
-        formatter_class=flux.util.help_formatter(),
     )
     parser.add_argument(
         "--cores", metavar="IDSET", default="", help="logical cores (e.g. '0-3')"

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -144,8 +144,10 @@ def help_formatter(argwidth=40, raw_description=False):
                 (metavar,) = self._metavar_formatter(action, action.dest)(1)
                 return metavar
 
-            hidden = getattr(action, "hidden_option_strings", set())
-            opts = [o for o in action.option_strings if o not in hidden]
+            opts = list(action.option_strings)
+            if hasattr(action, "hidden_option_strings"):
+                hidden = action.hidden_option_strings
+                opts = [o for o in opts if o not in hidden]
 
             #  Default optstring is `-l, --long-opt`
             optstring = ", ".join(opts)

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -144,7 +144,8 @@ def help_formatter(argwidth=40, raw_description=False):
                 (metavar,) = self._metavar_formatter(action, action.dest)(1)
                 return metavar
 
-            opts = list(action.option_strings)
+            hidden = getattr(action, "hidden_option_strings", set())
+            opts = [o for o in action.option_strings if o not in hidden]
 
             #  Default optstring is `-l, --long-opt`
             optstring = ", ".join(opts)

--- a/src/cmd/flux-admin.py
+++ b/src/cmd/flux-admin.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import flux
 import flux.util
+from flux.cli.argparse import FluxArgumentParser
 from flux.conf_builtin import conf_builtin_get
 from flux.rpc import RPC
 
@@ -538,15 +539,13 @@ LOGGER = logging.getLogger("flux-admin")
 def main():
     sys.stdout = open(sys.stdout.fileno(), "w", encoding="utf8")
 
-    parser = argparse.ArgumentParser(prog="flux-admin")
+    parser = FluxArgumentParser(prog="flux-admin")
     subparsers = parser.add_subparsers(
         title="subcommands", description="", dest="subcommand"
     )
     subparsers.required = True
 
-    cleanup_push_parser = subparsers.add_parser(
-        "cleanup-push", formatter_class=flux.util.help_formatter()
-    )
+    cleanup_push_parser = subparsers.add_parser("cleanup-push")
     cleanup_push_parser.add_argument(
         "cmdline", help="Command line", nargs=argparse.REMAINDER
     )
@@ -554,7 +553,6 @@ def main():
 
     system_scripts_parser = subparsers.add_parser(
         "system-scripts",
-        formatter_class=flux.util.help_formatter(),
         help="Show configured system scripts (prolog, epilog, housekeeping)",
     )
     system_scripts_parser.add_argument(

--- a/src/cmd/flux-cancel.py
+++ b/src/cmd/flux-cancel.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import argparse
 import logging
 import os
 import pwd
@@ -17,6 +16,7 @@ import sys
 from operator import itemgetter
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.job import cancel_async
 
 LOGGER = logging.getLogger("flux-cancel")
@@ -26,15 +26,18 @@ def parse_args():
     description = """
     Cancel pending or running jobs with an optional exception note.
     """
-    parser = argparse.ArgumentParser(
+    parser = FluxArgumentParser(
         prog="flux-cancel",
         usage="flux cancel [OPTIONS] [JOBID...]",
         description=description,
-        formatter_class=flux.util.help_formatter(),
     )
     parser.add_argument("--all", action="store_true", help="Target all jobs")
     parser.add_argument(
-        "-n", "--dry-run", action="store_true", help="Do not cancel any jobs"
+        "-n",
+        "--dry-run",
+        hidden_aliases=("--dry",),
+        action="store_true",
+        help="Do not cancel any jobs",
     )
     parser.add_argument(
         "-q",
@@ -52,6 +55,7 @@ def parse_args():
     parser.add_argument(
         "-S",
         "--states",
+        hidden_aliases=("--state",),
         action="append",
         help="List of job states to target (default=active)",
     )

--- a/src/cmd/flux-hostlist.py
+++ b/src/cmd/flux-hostlist.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import argparse
 import logging
 import os
 import select
@@ -17,6 +16,7 @@ import sys
 
 import flux
 import flux.util
+from flux.cli.argparse import FluxArgumentParser
 from flux.hostlist import Hostlist
 from flux.idset import IDset
 from flux.job import JobID, job_list_id
@@ -40,10 +40,10 @@ option is used, in which case the default is 'local'.
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
+    parser = FluxArgumentParser(
         prog="flux-hostlist",
         epilog=sources_description,
-        formatter_class=flux.util.help_formatter(raw_description=True),
+        raw_description=True,
     )
     group = parser.add_mutually_exclusive_group()
     group.add_argument(

--- a/src/cmd/flux-housekeeping.py
+++ b/src/cmd/flux-housekeeping.py
@@ -9,13 +9,13 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import argparse
 import logging
 import sys
 import time
 
 import flux
 import flux.util
+from flux.cli.argparse import FluxArgumentParser
 from flux.hostlist import Hostlist
 from flux.idset import IDset
 from flux.job import JobID
@@ -195,15 +195,13 @@ def housekeeping_kill(args):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(prog="flux-housekeeping")
+    parser = FluxArgumentParser(prog="flux-housekeeping")
     subparsers = parser.add_subparsers(
         title="subcommands", description="", dest="subcommand"
     )
     subparsers.required = True
 
-    list_parser = subparsers.add_parser(
-        "list", formatter_class=flux.util.help_formatter()
-    )
+    list_parser = subparsers.add_parser("list")
     list_parser.add_argument(
         "-i",
         "--include",
@@ -228,9 +226,7 @@ def parse_args():
     )
     list_parser.set_defaults(func=housekeeping_list)
 
-    kill_parser = subparsers.add_parser(
-        "kill", formatter_class=flux.util.help_formatter()
-    )
+    kill_parser = subparsers.add_parser("kill")
     kill_parser.add_argument(
         "-s",
         "--signal",

--- a/src/cmd/flux-job-exec-override.py
+++ b/src/cmd/flux-job-exec-override.py
@@ -9,11 +9,11 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import argparse
 import logging
 import sys
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.job import JobID
 
 LOGGER = logging.getLogger("flux-job-exec-override")
@@ -44,21 +44,17 @@ def job_exec_finish(args):
 
 @flux.util.CLIMain(LOGGER)
 def main():
-    parser = argparse.ArgumentParser(prog="flux-job-exec")
+    parser = FluxArgumentParser(prog="flux-job-exec")
     subparsers = parser.add_subparsers(
         title="subcommands", description="", dest="subcommand"
     )
     subparsers.required = True
 
-    start_parser = subparsers.add_parser(
-        "start", formatter_class=flux.util.help_formatter()
-    )
+    start_parser = subparsers.add_parser("start")
     start_parser.add_argument("jobid", metavar="JOBID", type=JobID, help="target JOBID")
     start_parser.set_defaults(func=job_exec_start)
 
-    finish_parser = subparsers.add_parser(
-        "finish", formatter_class=flux.util.help_formatter()
-    )
+    finish_parser = subparsers.add_parser("finish")
     finish_parser.add_argument(
         "jobid", metavar="JOBID", type=JobID, help="target JOBID"
     )

--- a/src/cmd/flux-job-frobnicator.py
+++ b/src/cmd/flux-job-frobnicator.py
@@ -16,6 +16,7 @@ import os
 import sys
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.job import Jobspec
 from flux.job.frobnicator import JobFrobnicator
 from flux.proctitle import set_proctitle
@@ -54,9 +55,8 @@ def main():
 
     set_proctitle("job-frobnicator")
 
-    parser = argparse.ArgumentParser(
+    parser = FluxArgumentParser(
         prog="flux-job-frobnicator",
-        formatter_class=flux.util.help_formatter(),
         description="Modify Flux jobs from lines of JSON input on stdin",
         add_help=False,
     )

--- a/src/cmd/flux-job-validator.py
+++ b/src/cmd/flux-job-validator.py
@@ -16,6 +16,7 @@ import os
 import sys
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.job.validator import JobValidator
 from flux.proctitle import set_proctitle
 
@@ -53,9 +54,8 @@ def main():
 
     set_proctitle("job-validator")
 
-    parser = argparse.ArgumentParser(
+    parser = FluxArgumentParser(
         prog="flux-job-validator",
-        formatter_class=flux.util.help_formatter(),
         description="Validate Flux jobs from lines of JSON input on stdin",
         add_help=False,
     )

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -18,6 +18,7 @@ import os
 import sys
 
 import flux.constants
+from flux.cli.argparse import FluxArgumentParser
 from flux.hostlist import Hostlist
 from flux.idset import IDset
 from flux.job import JobID, JobInfo, JobInfoFormat, JobList, job_fields_to_attrs
@@ -29,7 +30,6 @@ from flux.util import (
     FilterActionUser,
     FilterTrueAction,
     UtilConfig,
-    help_formatter,
 )
 
 LOGGER = logging.getLogger("flux-jobs")
@@ -227,7 +227,7 @@ def fetch_jobs(args, fields):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(prog="flux-jobs", formatter_class=help_formatter())
+    parser = FluxArgumentParser(prog="flux-jobs")
     # -a equivalent to -s "pending,running,inactive" and -u set to userid
     parser.add_argument("-a", action=FilterTrueAction, help="List jobs in all states")
     # -A equivalent to -s "pending,running,inactive" and -u set to "all"

--- a/src/cmd/flux-jobtap.py
+++ b/src/cmd/flux-jobtap.py
@@ -14,6 +14,7 @@ import logging
 import sys
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.util import TreedictAction
 
 
@@ -64,15 +65,13 @@ LOGGER = logging.getLogger("flux-jobtap")
 
 @flux.util.CLIMain(LOGGER)
 def main():
-    parser = argparse.ArgumentParser(prog="flux-jobtap")
+    parser = FluxArgumentParser(prog="flux-jobtap")
     subparsers = parser.add_subparsers(
         title="subcommands", description="", dest="subcommand"
     )
     subparsers.required = True
 
-    load_parser = subparsers.add_parser(
-        "load", formatter_class=flux.util.help_formatter()
-    )
+    load_parser = subparsers.add_parser("load")
     load_parser.add_argument(
         "-r",
         "--remove",
@@ -90,9 +89,7 @@ def main():
     )
     load_parser.set_defaults(func=jobtap_load)
 
-    remove_parser = subparsers.add_parser(
-        "remove", formatter_class=flux.util.help_formatter()
-    )
+    remove_parser = subparsers.add_parser("remove")
     remove_parser.add_argument(
         "plugin",
         help="Plugin name or pattern to remove. "
@@ -100,9 +97,7 @@ def main():
     )
     remove_parser.set_defaults(func=jobtap_remove)
 
-    list_parser = subparsers.add_parser(
-        "list", formatter_class=flux.util.help_formatter()
-    )
+    list_parser = subparsers.add_parser("list")
     list_parser.add_argument(
         "-a",
         "--all",
@@ -111,9 +106,7 @@ def main():
     )
     list_parser.set_defaults(func=jobtap_list)
 
-    query_parser = subparsers.add_parser(
-        "query", formatter_class=flux.util.help_formatter()
-    )
+    query_parser = subparsers.add_parser("query")
     query_parser.add_argument("plugin", help="Plugin name to query")
     query_parser.set_defaults(func=jobtap_query)
 

--- a/src/cmd/flux-modprobe.py
+++ b/src/cmd/flux-modprobe.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import argparse
 import json
 import logging
 import os
@@ -18,9 +17,10 @@ from collections import deque
 
 import flux
 import flux.kvs
+from flux.cli.argparse import FluxArgumentParser
 from flux.job._utils import list_split
 from flux.modprobe import Modprobe
-from flux.util import CLIMain, Tree, help_formatter
+from flux.util import CLIMain, Tree
 
 
 def disable_modules(M, modules=None):
@@ -138,19 +138,20 @@ def list_dependencies(args):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
+    parser = FluxArgumentParser(
         prog="flux-modprobe",
         description="Task and module load/unload management for Flux",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        raw_description=True,
     )
     subparsers = parser.add_subparsers(
         title="subcommands", description="", dest="subcommand"
     )
     subparsers.required = True
 
-    load_parser = subparsers.add_parser("load", formatter_class=help_formatter())
+    load_parser = subparsers.add_parser("load")
     load_parser.add_argument(
         "--dry-run",
+        hidden_aliases=("--dry",),
         action="store_true",
         help="Don't do anything. Print what would be run",
     )
@@ -162,7 +163,7 @@ def parse_args():
     )
     load_parser.set_defaults(func=load)
 
-    remove_parser = subparsers.add_parser("remove", formatter_class=help_formatter())
+    remove_parser = subparsers.add_parser("remove")
     remove_parser.add_argument(
         "modules",
         metavar="MODULE",
@@ -176,10 +177,7 @@ def parse_args():
     )
     remove_parser.set_defaults(func=remove)
 
-    run_parser = subparsers.add_parser(
-        "run",
-        formatter_class=help_formatter(),
-    )
+    run_parser = subparsers.add_parser("run")
     run_parser.add_argument(
         "--show-deps",
         action="store_true",
@@ -198,7 +196,7 @@ def parse_args():
     )
     run_parser.set_defaults(func=run)
 
-    rc1_parser = subparsers.add_parser("rc1", formatter_class=help_formatter())
+    rc1_parser = subparsers.add_parser("rc1")
     rc1_parser.add_argument(
         "--timing",
         action="store_true",
@@ -219,7 +217,7 @@ def parse_args():
     )
     rc1_parser.set_defaults(func=rc1)
 
-    rc3_parser = subparsers.add_parser("rc3", formatter_class=help_formatter())
+    rc3_parser = subparsers.add_parser("rc3")
     rc3_parser.add_argument(
         "-v", "--verbose", action="store_true", help="Print tasks as they are executed"
     )
@@ -230,9 +228,7 @@ def parse_args():
     )
     rc3_parser.set_defaults(func=rc3)
 
-    list_deps_parser = subparsers.add_parser(
-        "list-dependencies", formatter_class=help_formatter()
-    )
+    list_deps_parser = subparsers.add_parser("list-dependencies")
     list_deps_parser.add_argument(
         "-S",
         "--set-alternative",
@@ -263,7 +259,7 @@ def parse_args():
     )
     list_deps_parser.set_defaults(func=list_dependencies)
 
-    show_parser = subparsers.add_parser("show", formatter_class=help_formatter())
+    show_parser = subparsers.add_parser("show")
     show_parser.add_argument(
         "-S",
         "--set-alternative",

--- a/src/cmd/flux-multi-prog.py
+++ b/src/cmd/flux-multi-prog.py
@@ -9,14 +9,13 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import argparse
 import logging
 import os
 import re
 import shlex
 import sys
 
-import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.idset import IDset
 from flux.util import CLIMain
 
@@ -109,11 +108,10 @@ def parse_args():
     description = """
     Run a parallel program with a different executable and arguments for each task
     """
-    parser = argparse.ArgumentParser(
+    parser = FluxArgumentParser(
         prog="flux-multi-prog",
         usage="flux multi-prog [OPTIONS] CONFIG",
         description=description,
-        formatter_class=flux.util.help_formatter(),
     )
     parser.add_argument(
         "-n",

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -18,6 +18,7 @@ from itertools import islice
 from pathlib import PurePath
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.job import JobID, JobInfoFormat, JobList
 from flux.util import FilterActionSetUpdate, UtilConfig
 
@@ -138,9 +139,7 @@ def fetch_jobs(args, flux_handle=None):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        prog=PROGRAM, formatter_class=flux.util.help_formatter()
-    )
+    parser = FluxArgumentParser(prog=PROGRAM)
     parser.add_argument(
         "-a",
         action="store_true",

--- a/src/cmd/flux-post-job-event.py
+++ b/src/cmd/flux-post-job-event.py
@@ -13,6 +13,7 @@ import argparse
 import logging
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.job import JobID
 from flux.util import TreedictAction
 
@@ -35,7 +36,7 @@ LOGGER = logging.getLogger("flux-job-post-event")
 
 @flux.util.CLIMain(LOGGER)
 def main():
-    parser = argparse.ArgumentParser(prog="flux-job-post-event")
+    parser = FluxArgumentParser(prog="flux-job-post-event")
     parser.add_argument("id", help="jobid to which event shall be posted")
     parser.add_argument("name", help="name of event to post")
     parser.add_argument(

--- a/src/cmd/flux-pstree.py
+++ b/src/cmd/flux-pstree.py
@@ -9,13 +9,13 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import argparse
 import concurrent.futures
 import logging
 import sys
 
 import flux
 import flux.uri
+from flux.cli.argparse import FluxArgumentParser
 from flux.job import JobID, JobInfo, JobInfoFormat, JobList
 from flux.util import FilterAction, FilterTrueAction, Tree, YesNoAction
 
@@ -208,9 +208,7 @@ def load_tree(
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        prog="flux-pstree", formatter_class=flux.util.help_formatter()
-    )
+    parser = FluxArgumentParser(prog="flux-pstree")
     parser.add_argument(
         "-a",
         "--all",

--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -15,6 +15,7 @@ import logging
 import sys
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.queue import QueueList
 from flux.util import AltField, FilterActionSetUpdate, UtilConfig, parse_fsd
 
@@ -442,9 +443,7 @@ def common_parser_create(subparsers, command):
     Create an options parser for one of the flux-queue subcommands that
     take a common set of arguments. (status, enable, disable, start, stop)
     """
-    command_parser = subparsers.add_parser(
-        command, formatter_class=flux.util.help_formatter()
-    )
+    command_parser = subparsers.add_parser(command)
     command_parser.add_argument(
         "-q",
         "--queue",
@@ -496,15 +495,13 @@ def main():
         sys.stdout.fileno(), "w", encoding="utf8", errors="surrogateescape"
     )
 
-    parser = argparse.ArgumentParser(prog="flux-queue")
+    parser = FluxArgumentParser(prog="flux-queue")
     subparsers = parser.add_subparsers(
         title="subcommands", description="", dest="subcommand"
     )
     subparsers.required = True
 
-    list_parser = subparsers.add_parser(
-        "list", formatter_class=flux.util.help_formatter()
-    )
+    list_parser = subparsers.add_parser("list")
     list_parser.add_argument(
         "-q",
         "--queue",
@@ -528,9 +525,7 @@ def main():
     for command in ("status", "enable", "disable", "start", "stop"):
         common_parser_create(subparsers, command)
 
-    drain_parser = subparsers.add_parser(
-        "drain", formatter_class=flux.util.help_formatter()
-    )
+    drain_parser = subparsers.add_parser("drain")
     drain_parser.add_argument(
         "-t",
         "--timeout",
@@ -541,9 +536,7 @@ def main():
     )
     drain_parser.set_defaults(func=drain)
 
-    idle_parser = subparsers.add_parser(
-        "idle", formatter_class=flux.util.help_formatter()
-    )
+    idle_parser = subparsers.add_parser("idle")
     idle_parser.add_argument(
         "-t",
         "--timeout",

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -20,6 +20,7 @@ import time
 from itertools import combinations
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.eventlog import EventLogFormatter
 from flux.hostlist import Hostlist
 from flux.idset import IDset
@@ -984,20 +985,16 @@ def main():
         sys.stdout.fileno(), "w", encoding="utf8", errors="surrogateescape"
     )
 
-    parser = argparse.ArgumentParser(prog="flux-resource")
+    parser = FluxArgumentParser(prog="flux-resource")
     subparsers = parser.add_subparsers(
         title="subcommands", description="", dest="subcommand"
     )
     subparsers.required = True
 
-    acquire_mute_parser = subparsers.add_parser(
-        "acquire-mute", formatter_class=flux.util.help_formatter()
-    )
+    acquire_mute_parser = subparsers.add_parser("acquire-mute")
     acquire_mute_parser.set_defaults(func=acquire_mute)
 
-    drain_parser = subparsers.add_parser(
-        "drain", formatter_class=flux.util.help_formatter()
-    )
+    drain_parser = subparsers.add_parser("drain")
     drain_parser.add_argument(
         "-f",
         "--force",
@@ -1050,9 +1047,7 @@ def main():
     drain_parser.add_argument("reason", help="Reason", nargs=argparse.REMAINDER)
     drain_parser.set_defaults(func=drain)
 
-    undrain_parser = subparsers.add_parser(
-        "undrain", formatter_class=flux.util.help_formatter()
-    )
+    undrain_parser = subparsers.add_parser("undrain")
     undrain_parser.add_argument(
         "-u",
         "--update",
@@ -1074,9 +1069,7 @@ def main():
     undrain_parser.add_argument("reason", help="Reason", nargs=argparse.REMAINDER)
     undrain_parser.set_defaults(func=undrain)
 
-    status_parser = subparsers.add_parser(
-        "status", formatter_class=flux.util.help_formatter()
-    )
+    status_parser = subparsers.add_parser("status")
     status_parser.add_argument(
         "-o",
         "--format",
@@ -1087,6 +1080,7 @@ def main():
     status_parser.add_argument(
         "-s",
         "--states",
+        hidden_aliases=("--state",),
         metavar="STATE,...",
         help="Output resources in given states",
     )
@@ -1124,9 +1118,7 @@ def main():
     )
     status_parser.set_defaults(func=status)
 
-    list_parser = subparsers.add_parser(
-        "list", formatter_class=flux.util.help_formatter()
-    )
+    list_parser = subparsers.add_parser("list")
     list_parser.add_argument(
         "-o",
         "--format",
@@ -1137,6 +1129,7 @@ def main():
     list_parser.add_argument(
         "-s",
         "--states",
+        hidden_aliases=("--state",),
         metavar="STATE,...",
         default="free,allocated,down",
         help="Output resources in given states",
@@ -1176,12 +1169,11 @@ def main():
     list_parser.set_defaults(func=list_handler)
 
     # flux-resource info:
-    info_parser = subparsers.add_parser(
-        "info", formatter_class=flux.util.help_formatter()
-    )
+    info_parser = subparsers.add_parser("info")
     info_parser.add_argument(
         "-s",
         "--states",
+        hidden_aliases=("--state",),
         metavar="STATE,...",
         help="Show output only for resources in given states",
     )
@@ -1215,9 +1207,7 @@ def main():
     )
     info_parser.set_defaults(func=info)
 
-    reload_parser = subparsers.add_parser(
-        "reload", formatter_class=flux.util.help_formatter()
-    )
+    reload_parser = subparsers.add_parser("reload")
     reload_parser.set_defaults(func=reload)
     reload_parser.add_argument("path", help="path to R or hwloc <rank>.xml dir")
     reload_parser.add_argument(
@@ -1235,11 +1225,12 @@ def main():
         help="allow resources to contain invalid ranks",
     )
 
-    R_parser = subparsers.add_parser("R", formatter_class=flux.util.help_formatter())
+    R_parser = subparsers.add_parser("R")
     R_parser.set_defaults(func=emit_R)
     R_parser.add_argument(
         "-s",
         "--states",
+        hidden_aliases=("--state",),
         metavar="STATE,...",
         default="all",
         help="Emit R for resources in given states",
@@ -1262,9 +1253,7 @@ def main():
     R_parser.add_argument("--from-stdin", action="store_true", help=argparse.SUPPRESS)
     R_parser.add_argument("--config-file", help=argparse.SUPPRESS)
 
-    eventlog_parser = subparsers.add_parser(
-        "eventlog", formatter_class=flux.util.help_formatter()
-    )
+    eventlog_parser = subparsers.add_parser("eventlog")
     eventlog_parser.add_argument(
         "-f",
         "--format",

--- a/src/cmd/flux-slurm-expiration-sync.py
+++ b/src/cmd/flux-slurm-expiration-sync.py
@@ -18,7 +18,6 @@ flux_job_timeleft(3) reflects the Slurm job's expiration.
 
 """
 
-import argparse
 import logging
 import signal
 import sys
@@ -26,6 +25,7 @@ import time
 
 import flux
 import flux.slurm as slurm
+from flux.cli.argparse import FluxArgumentParser
 from flux.resource import ResourceJournalConsumer
 from flux.util import fsd
 
@@ -85,7 +85,7 @@ def wait_for_resource_define(fh):
 @flux.util.CLIMain(LOGGER)
 def main():
 
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = FluxArgumentParser(description=__doc__)
     parser.add_argument(
         "--poll-interval",
         type=float,

--- a/src/cmd/flux-sproc.py
+++ b/src/cmd/flux-sproc.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import argparse
 import errno
 import logging
 import os
@@ -17,6 +16,7 @@ import sys
 
 import flux
 import flux.subprocess as subprocess
+from flux.cli.argparse import FluxArgumentParser
 
 
 def exit_with_status(status):
@@ -122,14 +122,14 @@ LOGGER = logging.getLogger("flux-sproc")
 
 @flux.util.CLIMain(LOGGER)
 def main():
-    parser = argparse.ArgumentParser(prog="flux-sproc")
+    parser = FluxArgumentParser(prog="flux-sproc")
     subparsers = parser.add_subparsers(
         title="supported subcommands", description="", dest="subcommand"
     )
     subparsers.required = True
 
     # Parent parser with common arguments
-    common_parser = argparse.ArgumentParser(add_help=False)
+    common_parser = FluxArgumentParser(add_help=False)
     common_parser.add_argument(
         "-r",
         "--rank",
@@ -149,7 +149,6 @@ def main():
     kill_parser = subparsers.add_parser(
         "kill",
         parents=[common_parser],
-        formatter_class=flux.util.help_formatter(),
     )
     kill_parser.add_argument(
         "-w",
@@ -165,7 +164,6 @@ def main():
     wait_parser = subparsers.add_parser(
         "wait",
         parents=[common_parser],
-        formatter_class=flux.util.help_formatter(),
     )
     wait_parser.add_argument("pid")
     wait_parser.set_defaults(func=wait)
@@ -174,7 +172,6 @@ def main():
     ps_parser = subparsers.add_parser(
         "ps",
         parents=[common_parser],
-        formatter_class=flux.util.help_formatter(),
     )
     ps_parser.add_argument(
         "-o",

--- a/src/cmd/flux-update.py
+++ b/src/cmd/flux-update.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import argparse
 import json
 import logging
 import math
@@ -19,6 +18,7 @@ import time
 import flux
 import flux.job
 import flux.util
+from flux.cli.argparse import FluxArgumentParser
 from flux.job import event_watch
 
 LOGGER = logging.getLogger("flux-update")
@@ -169,12 +169,11 @@ class JobspecUpdates:
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        prog="flux-update", formatter_class=flux.util.help_formatter()
-    )
+    parser = FluxArgumentParser(prog="flux-update")
     parser.add_argument(
         "-n",
         "--dry-run",
+        hidden_aliases=("--dry",),
         action="store_true",
         help="Do not apply any updates, just emit update payload to stdout",
     )

--- a/src/cmd/flux-uri.py
+++ b/src/cmd/flux-uri.py
@@ -9,12 +9,12 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import argparse
 import logging
 import os
 import sys
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.uri import FluxURIResolver
 
 LOGGER = logging.getLogger("flux-uri")
@@ -31,11 +31,11 @@ def main():
     plugins = [f"  {x}\t\t{y}" for x, y in resolver.plugins().items()]
     plugin_list = "Supported resolver schemes:\n" + "\n".join(plugins)
 
-    parser = argparse.ArgumentParser(
+    parser = FluxArgumentParser(
         prog="flux-uri",
         description="Resolve TARGET to a Flux URI",
         epilog=plugin_list,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        raw_description=True,
     )
     parser.add_argument(
         "--remote",

--- a/src/cmd/flux-watch.py
+++ b/src/cmd/flux-watch.py
@@ -9,26 +9,19 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import argparse
 import logging
 import os
 import sys
 
 import flux
+from flux.cli.argparse import FluxArgumentParser
 from flux.job import JobID, JobList
 from flux.job.watcher import JobWatcher
-from flux.util import (
-    FilterAction,
-    FilterActionSetUpdate,
-    FilterTrueAction,
-    help_formatter,
-)
+from flux.util import FilterAction, FilterActionSetUpdate, FilterTrueAction
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        prog="flux-watch", formatter_class=help_formatter()
-    )
+    parser = FluxArgumentParser(prog="flux-watch")
     parser.add_argument(
         "-a",
         "--active",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -349,6 +349,7 @@ TESTSCRIPTS = \
 	python/t0043-scheduler-pool.py \
 	python/t0045-job-shape-parser.py \
 	python/t0046-job-watcher.py \
+	python/t0047-flux-argument-parser.py \
 	python/t0100-modprobe.py \
 	python/t1000-service-add-remove.py \
 	python/t6010-fake-resources.py

--- a/t/python/t0047-flux-argument-parser.py
+++ b/t/python/t0047-flux-argument-parser.py
@@ -9,6 +9,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import argparse
 import io
 import unittest
 
@@ -181,6 +182,216 @@ class TestHiddenAliases(unittest.TestCase):
         p = FluxArgumentParser(prog="test")
         with self.assertRaises(TypeError):
             p.add_argument("--states", hidden_aliases="--state")
+
+
+class TestPosixMode(unittest.TestCase):
+    def _make_parser(self, **kwargs):
+        p = FluxArgumentParser(prog="flux-run", posix=True, **kwargs)
+        p.add_argument("-n", "--ntasks", type=int, default=1)
+        p.add_argument("-t", "--time-limit", default=None)
+        p.add_argument("command", nargs=argparse.REMAINDER)
+        return p
+
+    def test_option_before_command_parsed(self):
+        """Flux option before command is consumed by Flux parser"""
+        args = self._make_parser().parse_args(["--ntasks=4", "myjob"])
+        self.assertEqual(args.ntasks, 4)
+        self.assertIn("myjob", args.command)
+
+    def test_option_after_command_not_consumed(self):
+        """Option-like token after command NOT consumed by Flux parser"""
+        args = self._make_parser().parse_args(["myjob", "--ntasks=8"])
+        self.assertEqual(args.ntasks, 1)  # default; --ntasks=8 was not parsed
+        self.assertIn("--ntasks=8", args.command)
+
+    def test_flux_option_then_command_then_cmd_option(self):
+        """Flux option + command + command option handled correctly"""
+        args = self._make_parser().parse_args(["--ntasks=4", "myjob", "--ntasks=8"])
+        self.assertEqual(args.ntasks, 4)
+        self.assertIn("--ntasks=8", args.command)
+        self.assertIn("myjob", args.command)
+
+    def test_explicit_double_dash_preserved(self):
+        """User-supplied '--' preserved in REMAINDER for downstream use"""
+        args = self._make_parser().parse_args(
+            ["--ntasks=4", "--", "myjob", "--ntasks=8"]
+        )
+        self.assertEqual(args.ntasks, 4)
+        # '--' is preserved so commands that pass it to a subprocess
+        # (e.g. flux alloc → flux broker) can do so; run/submit strip
+        # it in init_jobspec
+        self.assertIn("--", args.command)
+        self.assertIn("myjob", args.command)
+        self.assertIn("--ntasks=8", args.command)
+
+    def test_posix_no_implicit_double_dash(self):
+        """POSIX mode does not insert '--' into REMAINDER when none given"""
+        args = self._make_parser().parse_args(["--ntasks=4", "myjob", "--ntasks=8"])
+        self.assertNotIn("--", args.command)
+
+    def test_short_option_separate_value_skipped(self):
+        """Short option with separate value skipped, not positional"""
+        args = self._make_parser().parse_args(["-n", "4", "myjob", "--ntasks=8"])
+        self.assertEqual(args.ntasks, 4)
+        # '4' was the value of -n, not positional
+        self.assertNotIn("4", args.command)
+        self.assertIn("myjob", args.command)
+
+    def test_short_option_embedded_value_skipped(self):
+        """Short option with embedded value (-n4) not positional"""
+        args = self._make_parser().parse_args(["-n4", "myjob", "--ntasks=8"])
+        self.assertEqual(args.ntasks, 4)
+        self.assertNotIn("-n4", args.command)
+        self.assertIn("myjob", args.command)
+
+    def test_empty_args(self):
+        """Empty arg list returns empty command"""
+        p = FluxArgumentParser(prog="test", posix=True)
+        p.add_argument("command", nargs=argparse.REMAINDER)
+        args = p.parse_args([])
+        self.assertEqual(args.command, [])
+
+    def test_posix_false_does_not_preprocess(self):
+        """posix=False (default) leaves arg_strings untouched"""
+        p = FluxArgumentParser(prog="test")  # posix=False by default
+        p.add_argument("--ntasks", type=int, default=1)
+        p.add_argument("command", nargs=argparse.REMAINDER)
+        # Without posix mode, --ntasks after myjob is still consumed
+        # by Flux parser (standard GNU argparse behavior with REMAINDER)
+        args = p.parse_args(["myjob", "--ntasks=4"])
+        # REMAINDER captures everything from first positional including
+        # options
+        self.assertIn("myjob", args.command)
+
+    def test_negative_number_in_command(self):
+        """Negative number in command position preserved in REMAINDER"""
+        # Stock argparse treats -1 as a non-option (negative number),
+        # so it lands in REMAINDER. posix mode must match that behavior.
+        args = self._make_parser().parse_args(["-1", "myjob"])
+        self.assertIn("-1", args.command)
+        self.assertIn("myjob", args.command)
+
+    def test_negative_number_terminates_option_processing(self):
+        """Negative number terminates option processing in POSIX mode"""
+        # In POSIX mode, a negative number acts as a non-option argument
+        # that terminates option processing. Subsequent option-like
+        # tokens should go into REMAINDER rather than being parsed.
+        args = self._make_parser().parse_args(["-1", "--ntasks=8", "myjob"])
+        self.assertEqual(args.ntasks, 1)  # default; not parsed
+        self.assertIn("-1", args.command)
+        self.assertIn("--ntasks=8", args.command)
+        self.assertIn("myjob", args.command)
+
+    def test_empty_string_terminates_option_processing(self):
+        """Empty string terminates option processing in POSIX mode"""
+        # In POSIX mode, an empty string acts as a non-option argument
+        # that terminates option processing. Subsequent option-like
+        # tokens should go into REMAINDER rather than being parsed.
+        args = self._make_parser().parse_args(["", "--ntasks=8", "myjob"])
+        self.assertEqual(args.ntasks, 1)  # default; not parsed
+        self.assertIn("", args.command)
+        self.assertIn("--ntasks=8", args.command)
+        self.assertIn("myjob", args.command)
+
+    def test_posix_no_remainder_stray_positionals_error(self):
+        """posix parser with no REMAINDER errors on stray positionals"""
+        p = FluxArgumentParser(prog="test", posix=True)
+        p.add_argument("--foo", default=None)
+        with self.assertRaises(SystemExit):
+            p.parse_args(["--foo=1", "stray", "args"])
+
+    def test_nargs_plus_posix(self):
+        """nargs='+' in posix mode greedily consumes non-option tokens"""
+        # With nargs='+', _count_option_args greedily consumes all
+        # consecutive non-option tokens, matching stock argparse
+        # behavior. Use '--' to delimit the command start explicitly.
+        p = FluxArgumentParser(prog="test", posix=True)
+        p.add_argument("--multi", nargs="+")
+        p.add_argument("command", nargs=argparse.REMAINDER)
+        args = p.parse_args(["--multi", "a", "b", "myjob"])
+        self.assertEqual(args.multi, ["a", "b", "myjob"])
+        self.assertEqual(args.command, [])
+
+    def test_nargs_star_posix(self):
+        """nargs='*' in posix mode greedily consumes non-option tokens"""
+        p = FluxArgumentParser(prog="test", posix=True)
+        p.add_argument("--multi", nargs="*")
+        p.add_argument("command", nargs=argparse.REMAINDER)
+        args = p.parse_args(["--multi", "a", "b", "myjob"])
+        self.assertEqual(args.multi, ["a", "b", "myjob"])
+        self.assertEqual(args.command, [])
+
+    def test_nargs_question_posix(self):
+        """nargs='?' in posix mode consumes next token if not option"""
+        p = FluxArgumentParser(prog="test", posix=True)
+        p.add_argument("--file", nargs="?", default=None)
+        p.add_argument("--other", default=None)
+        p.add_argument("command", nargs=argparse.REMAINDER)
+        # When next token is not an option, it's consumed as the value
+        args = p.parse_args(["--file", "myfile", "myjob"])
+        self.assertEqual(args.file, "myfile")
+        self.assertIn("myjob", args.command)
+        # When next token looks like an option, it's not consumed
+        args = p.parse_args(["--file", "--other=val", "myjob"])
+        self.assertIsNone(args.file)
+        self.assertEqual(args.other, "val")
+        self.assertIn("myjob", args.command)
+
+    def test_nargs_int_posix(self):
+        """Integer nargs in posix mode consumes exact number of args"""
+        p = FluxArgumentParser(prog="test", posix=True)
+        p.add_argument("--coords", nargs=2)
+        p.add_argument("command", nargs=argparse.REMAINDER)
+        args = p.parse_args(["--coords", "1", "2", "myjob"])
+        self.assertEqual(args.coords, ["1", "2"])
+        self.assertIn("myjob", args.command)
+
+    def test_long_option_with_equals_posix(self):
+        """Long option with embedded = value doesn't consume next token"""
+        p = FluxArgumentParser(prog="test", posix=True)
+        p.add_argument("--file", default=None)
+        p.add_argument("command", nargs=argparse.REMAINDER)
+        args = p.parse_args(["--file=test.txt", "myjob"])
+        self.assertEqual(args.file, "test.txt")
+        self.assertIn("myjob", args.command)
+
+    def test_single_dash_terminates_posix(self):
+        """Single dash terminates option processing in POSIX mode"""
+        p = FluxArgumentParser(prog="test", posix=True)
+        p.add_argument("-n", "--ntasks", type=int, default=1)
+        p.add_argument("command", nargs=argparse.REMAINDER)
+        # A lone '-' is treated as a non-option argument
+        args = p.parse_args(["-", "--ntasks=8", "myjob"])
+        self.assertEqual(args.ntasks, 1)  # default; not parsed
+        self.assertIn("-", args.command)
+        self.assertIn("--ntasks=8", args.command)
+
+    def test_argwidth_parameter(self):
+        """argwidth parameter affects help formatting column width"""
+        p = FluxArgumentParser(prog="test", argwidth=20)
+        p.add_argument("--very-long-option-name", metavar="VALUE", help="test help")
+        buf = io.StringIO()
+        p.print_help(buf)
+        # With narrow argwidth, help text should wrap/indent differently
+        # Just verify it doesn't crash and produces output
+        self.assertIn("--very-long-option-name", buf.getvalue())
+
+    def test_explicit_formatter_class_overrides(self):
+        """Explicit formatter_class overrides raw_description/argwidth"""
+        # When formatter_class is explicitly passed, raw_description and
+        # argwidth should be silently ignored (they're only used to
+        # construct the default)
+        p = FluxArgumentParser(
+            prog="test",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            raw_description=True,  # should be ignored
+            argwidth=10,  # should be ignored
+            description="test\n  description",
+        )
+        buf = io.StringIO()
+        p.print_help(buf)
+        # Should use RawDescriptionHelpFormatter, preserving whitespace
+        self.assertIn("test\n  description", buf.getvalue())
 
 
 if __name__ == "__main__":

--- a/t/python/t0047-flux-argument-parser.py
+++ b/t/python/t0047-flux-argument-parser.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2026 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import io
+import unittest
+
+import subflux  # noqa: F401 - To set up PYTHONPATH
+from flux.cli.argparse import FluxArgumentParser
+from pycotap import TAPTestRunner
+
+
+class TestFluxArgumentParser(unittest.TestCase):
+    def test_allow_abbrev_false(self):
+        """Abbreviated options are rejected"""
+        p = FluxArgumentParser(prog="test")
+        p.add_argument("--foo-bar")
+        with self.assertRaises(SystemExit):
+            p.parse_args(["--foo"])
+
+    def test_exact_option_still_works(self):
+        """Full option names are accepted"""
+        p = FluxArgumentParser(prog="test")
+        p.add_argument("--foo-bar", default="x")
+        args = p.parse_args(["--foo-bar=y"])
+        self.assertEqual(args.foo_bar, "y")
+
+    def test_default_formatter_is_flux(self):
+        """Default formatter produces Flux-style help (=, wide columns)"""
+        p = FluxArgumentParser(prog="test")
+        p.add_argument("--my-option", metavar="VAL", help="test")
+        buf = io.StringIO()
+        p.print_help(buf)
+        self.assertIn("--my-option=VAL", buf.getvalue())
+
+    def test_raw_description(self):
+        """raw_description=True preserves whitespace in description"""
+        p = FluxArgumentParser(prog="test", raw_description=True, description="a\n  b")
+        buf = io.StringIO()
+        p.print_help(buf)
+        self.assertIn("a\n  b", buf.getvalue())
+
+    def test_subparsers_inherit_flux_parser(self):
+        """Subparsers via add_subparsers() are also FluxArgumentParser"""
+        p = FluxArgumentParser(prog="test")
+        subs = p.add_subparsers()
+        sub = subs.add_parser("cmd")
+        self.assertIsInstance(sub, FluxArgumentParser)
+
+    def test_subparser_allow_abbrev_false(self):
+        """Subparsers also reject abbreviated options"""
+        p = FluxArgumentParser(prog="test")
+        subs = p.add_subparsers(dest="cmd")
+        sub = subs.add_parser("run")
+        sub.add_argument("--foo-bar")
+        with self.assertRaises(SystemExit):
+            p.parse_args(["run", "--foo"])
+
+
+class TestHiddenAliases(unittest.TestCase):
+    def _make_parser(self):
+        p = FluxArgumentParser(prog="test")
+        p.add_argument(
+            "--states",
+            hidden_aliases=("--state",),
+            metavar="STATE,...",
+            help="Output resources in given states",
+        )
+        return p
+
+    def test_hidden_alias_recognized(self):
+        """Hidden alias is accepted by the parser"""
+        args = self._make_parser().parse_args(["--state=free"])
+        self.assertEqual(args.states, "free")
+
+    def test_primary_option_still_works(self):
+        """Primary option name is unaffected"""
+        args = self._make_parser().parse_args(["--states=free,down"])
+        self.assertEqual(args.states, "free,down")
+
+    def test_hidden_alias_absent_from_help(self):
+        """Hidden alias does not appear in --help output"""
+        buf = io.StringIO()
+        self._make_parser().print_help(buf)
+        help_text = buf.getvalue()
+        self.assertIn("--states", help_text)
+        # --state must not appear as a standalone option string
+        self.assertNotIn("--state,", help_text)
+        self.assertNotIn("--state=", help_text)
+
+    def test_hidden_alias_on_append_action(self):
+        """hidden_aliases works with action='append'"""
+        p = FluxArgumentParser(prog="test")
+        p.add_argument("--plugins", hidden_aliases=("--plugin",), action="append")
+        args = p.parse_args(["--plugin=foo", "--plugins=bar"])
+        self.assertEqual(args.plugins, ["foo", "bar"])
+
+    def test_hidden_alias_on_argument_group(self):
+        """hidden_aliases works when add_argument called on argument group"""
+        p = FluxArgumentParser(prog="test")
+        grp = p.add_argument_group("Options")
+        grp.add_argument(
+            "--plugins",
+            hidden_aliases=("--plugin",),
+            action="append",
+            default=[],
+        )
+        args = p.parse_args(["--plugin=foo"])
+        self.assertEqual(args.plugins, ["foo"])
+
+    def test_hidden_alias_group_absent_from_help(self):
+        """Hidden alias added via argument group is absent from --help"""
+        p = FluxArgumentParser(prog="test")
+        grp = p.add_argument_group("Options")
+        grp.add_argument(
+            "--plugins",
+            hidden_aliases=("--plugin",),
+            action="append",
+            default=[],
+        )
+        buf = io.StringIO()
+        p.print_help(buf)
+        help_text = buf.getvalue()
+        self.assertIn("--plugins", help_text)
+        self.assertNotIn("--plugin,", help_text)
+        self.assertNotIn("--plugin=", help_text)
+
+    def test_multiple_hidden_aliases(self):
+        """Multiple hidden aliases can be specified"""
+        p = FluxArgumentParser(prog="test")
+        p.add_argument("--states", hidden_aliases=("--state", "--st"), default=None)
+        self.assertEqual(p.parse_args(["--state=x"]).states, "x")
+        self.assertEqual(p.parse_args(["--st=x"]).states, "x")
+        self.assertEqual(p.parse_args(["--states=x"]).states, "x")
+
+    def test_subparser_hidden_alias(self):
+        """hidden_aliases work in subparsers"""
+        p = FluxArgumentParser(prog="test")
+        subs = p.add_subparsers(dest="cmd")
+        sub = subs.add_parser("list")
+        sub.add_argument("--states", hidden_aliases=("--state",), default=None)
+        args = p.parse_args(["list", "--state=free"])
+        self.assertEqual(args.states, "free")
+
+    def test_hidden_alias_on_mutually_exclusive_group(self):
+        """hidden_aliases works in a mutually exclusive group"""
+        p = FluxArgumentParser(prog="test")
+        grp = p.add_mutually_exclusive_group()
+        grp.add_argument(
+            "--states",
+            hidden_aliases=("--state",),
+            default=None,
+        )
+        args = p.parse_args(["--state=free"])
+        self.assertEqual(args.states, "free")
+
+    def test_hidden_alias_mutex_group_absent_from_help(self):
+        """Hidden alias in mutually exclusive group is absent from --help"""
+        p = FluxArgumentParser(prog="test")
+        grp = p.add_mutually_exclusive_group()
+        grp.add_argument(
+            "--states",
+            hidden_aliases=("--state",),
+            default=None,
+        )
+        buf = io.StringIO()
+        p.print_help(buf)
+        help_text = buf.getvalue()
+        self.assertNotIn("--state,", help_text)
+        self.assertNotIn("--state=", help_text)
+
+    def test_hidden_aliases_str_raises_type_error(self):
+        """Passing a bare string as hidden_aliases raises TypeError"""
+        p = FluxArgumentParser(prog="test")
+        with self.assertRaises(TypeError):
+            p.add_argument("--states", hidden_aliases="--state")
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t2272-job-begin-time.t
+++ b/t/t2272-job-begin-time.t
@@ -35,7 +35,7 @@ test_expect_success 'begin-time: elapsed begin-time releases job immediately' '
 	flux job wait-event -vt 15 $jobid clean
 '
 test_expect_success 'begin-time: job with begin-time works' '
-	flux run -vvv --begin=time=+1s hostname
+	flux run -vvv --begin-time=+1s hostname
 '
 test_expect_success 'begin-time: job with begin-time=+1h is still in depend' '
 	flux jobs &&

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -24,6 +24,10 @@ test_expect_success 'flux submit ignores ambiguous args after --' '
 	flux submit -n2 --dry-run -- hostname --n=2 \
 		| jq -e ".tasks[0].command[0] == \"hostname\""
 '
+test_expect_success 'flux submit: Flux option after command is not consumed' '
+	flux submit -n2 --dry-run hostname --job-name=foo \
+		| jq -e ".tasks[0].command == [\"hostname\", \"--job-name=foo\"]"
+'
 test_expect_success 'flux submit + flux job attach works' '
 	jobid=$(flux submit hostname) &&
 	flux job attach $jobid

--- a/t/t2711-python-cli-run.t
+++ b/t/t2711-python-cli-run.t
@@ -19,6 +19,23 @@ test_expect_success 'flux run ignores ambiguous args after --' '
 	flux run -n2 --dry-run -- hostname --n=2 \
 		| jq -e ".tasks[0].command[0] == \"hostname\""
 '
+test_expect_success 'flux run ignores -- after --' '
+	flux run -n2 --dry-run -- -- hostname -n1 \
+		| jq -e ".tasks[0].command[0] == \"--\""
+'
+test_expect_success 'flux run: accepted option after command is not consumed' '
+	flux run -n2 --dry-run hostname --job-name=foo \
+		| jq -e ".tasks[0].command == [\"hostname\", \"--job-name=foo\"]"
+'
+test_expect_success 'flux run: -n4 vs -n 4 --ntasks 4 create same jobspec' '
+	flux run -n4 --dry-run --env=-* -- hostname | jq -S . >j1.json &&
+	flux run -n 4 --dry-run --env=-* -- hostname | jq -S . >j2.json &&
+	flux run --ntasks 4 --dry-run --env=-* -- hostname | jq -S . >j3.json &&
+	flux run --ntasks=4 --dry-run --env=-* -- hostname | jq -S . >j4.json &&
+	test_cmp j1.json j2.json &&
+	test_cmp j2.json j3.json &&
+	test_cmp j3.json j4.json
+'
 test_expect_success 'flux run works' '
 	flux run hostname >run.out &&
 	hostname >run.exp &&

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -31,6 +31,10 @@ test_expect_success 'flux alloc ignores ambiguous option after --' '
 	flux alloc -n1 --dry-run -- myapp --n=2 | \
 	    jq -e ".tasks[0].command == [ \"flux\", \"broker\", \"--\", \"myapp\", \"--n=2\" ]"
 '
+test_expect_success 'flux alloc: Flux option after command is not consumed' '
+	flux alloc -n1 --dry-run myapp --job-name=foo | \
+	    jq -e ".tasks[0].command == [ \"flux\", \"broker\", \"myapp\", \"--job-name=foo\" ]"
+'
 test_expect_success 'flux alloc -N2 requests 2 nodes exclusively' '
 	flux alloc -N2 --dry-run hostname | jq -S ".resources[0]" | jq -e ".type == \"node\" and .exclusive"
 '

--- a/t/t2713-python-cli-bulksubmit.t
+++ b/t/t2713-python-cli-bulksubmit.t
@@ -329,4 +329,12 @@ test_expect_success 'flux bulksubmit --dry-run works with --cc' '
 	EOF
 	test_cmp dry-run-cc.expected dry-run-cc.out
 '
+test_expect_success 'flux bulksubmit: Flux option after command template is not consumed' '
+	flux bulksubmit --dry-run echo {} --job-name=foo ::: a \
+	  >dry-run-posix.out 2>&1 &&
+	cat <<-EOF >dry-run-posix.expected &&
+	bulksubmit: submit echo a --job-name=foo
+	EOF
+	test_cmp dry-run-posix.expected dry-run-posix.out
+'
 test_done

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -49,6 +49,15 @@ test_expect_success 'flux batch --wrap option works with --' '
 	EOF
 	test_cmp script-wrap.expected script-wrap.out
 '
+test_expect_success 'flux batch: Flux option after script is not consumed' '
+	flux batch -n1 --dry-run --wrap foo --job-name=bar | \
+		jq -j .attributes.system.files.script.data >script-posix.out &&
+	cat <<-EOF >script-posix.expected &&
+	#!/bin/sh
+	foo --job-name=bar
+	EOF
+	test_cmp script-posix.expected script-posix.out
+'
 test_expect_success 'flux batch --wrap option works on stdin' '
 	printf "foo\nbar\nbaz\n" | \
 	    flux batch -n1 --dry-run --wrap | \


### PR DESCRIPTION
This PR adds a `FluxArgumentParser` class and uses it throughout the Python CLI commands so they share consistent argument parsing behavior. The changes implemted in `FluxArgumentParser` vs Python `argparse` include:

  - **Don't accept abbreviated options by default** (default `allow_abbrev=False`) On Python 3.6/3.7, where `allow_abbrev=False` would also break short-option concatenation (`-vvv`, `-n4`) due to bpo-26967, the 3.8 fix is backported via a version-gated override instead.
  - A `hidden_aliases` extension to `add_argument()` preserves a few commonly-used former abbreviations (`--dry`, `--state`, `--plugin`, `--require`, `--broker-opt`) without advertising them in `--help`.
  - **Submission commands (`flux run`, `submit`, `alloc`, `batch`, `bulksubmit`) now use POSIX-style option parsing**: With `posix=True`, `FluxArgumentParser` option processing stops at the first non-option argument, so tokens after the job command are never consumed as Flux options regardless of ordering. A `--` separator still works as before.
  - The Flux help formatter is now the default everywhere, removing repetitive `formatter_class=` boilerplate.

Fixes #7644



