### PR TITLE
[WIP] Add basic communication mechanism for dynamic allocations

### DIFF
--- a/MY_README.md
+++ b/MY_README.md
@@ -1,0 +1,93 @@
+#MY_README.md 
+
+## Running Test Program
+### Single Instance
+```
+flux start --setattr=log-stderr-level=7
+
+cd ${FLUX_PMIX_DIR}/t
+
+flux run -o verbose=2 -o pmi=pmix src/alloc
+```
+### Multi-Instance
+```
+flux start --setattr=log-stderr-level=7
+
+flux alloc --setattr=log-stderr-level=7 -N1
+
+cd ${FLUX_PMIX_DIR}/t
+
+flux run -o verbose=2 -o pmi=pmix src/alloc
+```
+
+
+## Sequences:
+
+## Start 
+-> src/cmd/flux.c
+
+    -> src/cmd/flux-start.c
+
+        -> src/broker/broker.c
+
+## Run
+
+## Alloc
+    pmix_client: PMIx_allocation_request
+        pmix_server: alloc_server_callback
+            pmix_plugin: threadshift, rpc('shell.dyn_alloc_request)
+                shell: rpc('job_manager.dyn_alloc_request)
+                    job_manager: rpc('job_manager.dyn_alloc_request)
+                    ...
+                    job_manager rpc('sched.dyn_alloc_request)
+                        scheduler DECISION
+                    job_manager: response
+                    ...
+                    job_manager: response
+                shell: response
+            pmix_plugin: callback
+        pmix_server: callback
+    pmix_client
+
+
+## RPC
+### Send an rpc request and register cb for response:
+static flux_future_t *send_request (flux_t *h, struct cbdata *cbdata)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_rpc_pack (h,
+                             "namespace.dyn_alloc_request",
+                             FLUX_NODEID_ANY,
+                             0,
+                             "{s:b s:b}",
+                             "follow", 1,
+                             "nobacklog", 1))
+        || flux_future_then (f,
+                             -1,
+                             dyn_alloc_response_cb,
+                             cbdata) < 0) {
+        flux_future_destroy (f);
+        return NULL;
+    }
+    return f;
+}
+
+### Register cb for receiving requests
+
+flux_msg_handler_addvec -> add callbacks for rpc calls
+
+### Unpack request
+
+if (flux_rpc_get_unpack (f, "{s:O}", "data", &xdata) < 0){
+    flux_log(ctx->h, LOG_WARNING, "pmix-alloc request: %s", future_strerror (f, errno));
+    flux_respond_error(ctx->h, ctx->msg, -1, "unable to unpack response");
+    goto out;
+}
+
+if(0 > (rc = flux_respond_pack(ctx->h, ctx->msg,  "{s:O}", "data", xdata))){
+    flux_log(ctx->h, LOG_WARNING, "flux_respond_pack failed with %d", rc);
+    flux_respond_error(ctx->h, ctx->msg, -1, "unable to pack response");
+    goto out;
+};
+

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -923,6 +923,23 @@ class Scheduler(BrokerModule):
             raise
         super().run()
 
+
+    @request_handler("sched.dyn_alloc_request", prefix=False)
+    def _handle_dyn_alloc_request(self, msg):
+        self.log(syslog.LOG_DEBUG, f"dyn_alloc_request callback called")
+        try:
+            self.log(syslog.LOG_DEBUG, str(msg.payload))
+            p = msg.payload
+            data = p["data"]
+            resp = {
+                "data": data,
+            }
+            rc = self.handle.respond(msg, resp)
+            self.log(syslog.LOG_DEBUG, f"respond returned "+str(rc))
+        except Exception as exc:
+            self.log(syslog.LOG_ERR, f"dyn_alloc callback raised: {exc}")
+            self.stop_error()
+
     # ------------------------------------------------------------------
     # RFC 27 sched message handlers (registered by BrokerModule)
     # ------------------------------------------------------------------

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -49,6 +49,12 @@ struct alloc {
     flux_watcher_t *idle;
     unsigned int alloc_limit;   // will have a value of 0 in mode=unlimited
     char *sched_sender;         // scheduler uuid for disconnect processing
+    flux_t *parent_instance;
+};
+
+struct alloc_ctx {
+    flux_t *h;
+    const flux_msg_t *msg;
 };
 
 static void requeue_pending (struct alloc *alloc, struct job *job)
@@ -638,6 +644,132 @@ bool alloc_sched_ready (struct alloc *alloc)
     return alloc->scheduler_is_online;
 }
 
+/* recives RESPONSE from scheduler/parent instance for dynamic allocation request. 
+ * forwards response to requestor  
+ * Note: arg is the original request msg
+ */
+static void dyn_alloc_response_completion (flux_future_t *f, void *arg)
+{
+    json_t *xdata = NULL;
+    struct alloc_ctx *ctx = arg;
+    int rc;
+
+
+    flux_log(ctx->h, LOG_DEBUG, "received allocation response from paren/scheduler");
+
+    /* TODO: DO whatever is necessary for LEVEL 'job_manager' before forwarding response to shell */
+
+    if (flux_rpc_get_unpack (f, "{s:O}", "data", &xdata) < 0){
+        flux_log(ctx->h, LOG_WARNING, "pmix-alloc request: %s", future_strerror (f, errno));
+        flux_respond_error(ctx->h, ctx->msg, -1, "unable to unpack response");
+        goto out;
+    }
+
+    if(0 > (rc = flux_respond_pack(ctx->h, ctx->msg,  "{s:O}", "data", xdata))){
+        flux_log(ctx->h, LOG_WARNING, "flux_respond_pack failed with %d", rc);
+        flux_respond_error(ctx->h, ctx->msg, -1, "unable to pack response");
+        goto out;
+    };
+    flux_log(ctx->h, LOG_DEBUG, "forwarded allocation response");
+
+out:
+    flux_msg_decref(ctx->msg);
+    free(ctx);
+}
+
+
+/* recives REQUEST from shell/child instance for dynamic allocation request. 
+ * forwards REQUEST to parent or local scheduler  
+ * Note: arg is job_ctx
+ */
+static void dyn_alloc_request (flux_t *h,
+                            flux_msg_handler_t *mh,
+                            const flux_msg_t *msg,
+                            void *arg)
+{
+    json_t *xdata = NULL;
+    char *error_msg = NULL;
+    struct job_manager *job_ctx = arg;
+    struct alloc *alloc = job_ctx->alloc;
+    struct alloc_ctx *ctx; 
+    flux_future_t *f = NULL;
+    int directive;
+
+    flux_log (h, LOG_DEBUG, "recived allocation request");
+
+    /* TODO: DO whatever is necessary for LEVEL 'job_manager' before forwarding request to parent/scheduler */
+
+    ctx = calloc(1, sizeof(*ctx));
+    ctx->h = h;
+    ctx->msg = flux_msg_incref(msg);
+
+    if (flux_msg_unpack (msg, "{s:i s:O}", "directive", &directive, "data", &xdata) < 0){
+        error_msg = "failed to unpack request data";
+        flux_log_error (h, "%s: %s", __FUNCTION__, error_msg);
+        goto error;
+    }
+
+    if(alloc->parent_instance){
+
+        flux_log (h, LOG_DEBUG, "forwarding allocation request to parent instance");
+        
+        /* forward to parent instance */
+        if( !(f = flux_rpc_pack(alloc->parent_instance, 
+                    "job-manager.dyn_alloc_request", 
+                    FLUX_NODEID_ANY, 
+                    0, 
+                    "{s:i s:O}",
+                    "directive", directive,
+                    "data", xdata )) 
+            || flux_future_then (f,
+                                 -1,
+                                 dyn_alloc_response_completion,
+                                 (void *) ctx) < 0) 
+        {
+            error_msg = "failed to send allocation to parent instance";
+            flux_log (h, LOG_DEBUG, error_msg);
+            goto error;
+        }
+        flux_log (ctx->h, LOG_DEBUG, "forwarded allocation request to parent instance");
+    }else if(alloc->scheduler_is_online){
+        
+        /* forward to scheduler */
+        if (!(f = flux_rpc_pack (ctx->h,
+                                 "sched.dyn_alloc_request",
+                                 0,
+                                 0,
+                                 "{s:O}",
+                                 "data", xdata))
+            ||  flux_future_then (f,
+                                 -1.,
+                                 dyn_alloc_response_completion,
+                                 (void *) ctx) < 0) 
+        {
+            error_msg = "failed to forward request to local scheduler";
+            flux_log_error (h, "%s: %s", __FUNCTION__, error_msg);
+            goto error;
+            return;
+        }
+        flux_log (ctx->h, LOG_DEBUG, "forwarded allocation request to scheduler");
+    }else{
+        error_msg = "failed to forward request: no scheduler or parent instance found";
+        flux_log_error (h, "%s: %s", __FUNCTION__, error_msg);
+        goto error;
+    }
+
+    json_decref (xdata);
+    return;
+
+error:
+    if(f) flux_future_destroy (f);
+    if(xdata) json_decref (xdata);
+    flux_respond_error(h, msg, -1, error_msg);
+
+    flux_msg_decref(ctx->msg);
+    free(ctx);
+}
+
+
 static void alloc_query_cb (flux_t *h,
                             flux_msg_handler_t *mh,
                             const flux_msg_t *msg,
@@ -766,6 +898,11 @@ static const struct flux_msg_handler_spec htab[] = {
         resource_status_cb,
         0
     },
+    {   FLUX_MSGTYPE_REQUEST,
+        "job-manager.dyn_alloc_request",
+        dyn_alloc_request,
+        0
+    },
     {   FLUX_MSGTYPE_RESPONSE,
         "sched.alloc",
         alloc_response_cb,
@@ -777,6 +914,7 @@ static const struct flux_msg_handler_spec htab[] = {
 struct alloc *alloc_ctx_create (struct job_manager *ctx)
 {
     struct alloc *alloc;
+    const char *parent_uri;
     flux_reactor_t *r = flux_get_reactor (ctx->h);
 
     if (!(alloc = calloc (1, sizeof (*alloc))))
@@ -794,6 +932,11 @@ struct alloc *alloc_ctx_create (struct job_manager *ctx)
         errno = ENOMEM;
         goto error;
     }
+    alloc->parent_instance = NULL;
+    if ((parent_uri = flux_attr_get (ctx->h, "parent-uri"))){
+        alloc->parent_instance = flux_open (parent_uri, 0);
+    }
+
     flux_watcher_start (alloc->prep);
     flux_watcher_start (alloc->check);
     return alloc;

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -932,9 +932,21 @@ struct alloc *alloc_ctx_create (struct job_manager *ctx)
         errno = ENOMEM;
         goto error;
     }
+
+    /* If we have a parent, connect to it so we can forward alloc requests */
     alloc->parent_instance = NULL;
     if ((parent_uri = flux_attr_get (ctx->h, "parent-uri"))){
-        alloc->parent_instance = flux_open (parent_uri, 0);
+        if(! (alloc->parent_instance = flux_open (parent_uri, 0)) ){
+            goto error;
+        }
+        /*  Associate the main flux_t handle reactor with the parent handle
+         *  reactor so that events from both can be handled with the single
+         *  reactor instance:
+         */
+        if (flux_set_reactor (alloc->parent_instance, flux_get_reactor (ctx->h)) < 0) {
+            flux_log_error (ctx->h, "flux_set_reactor");
+            goto error;
+        }
     }
 
     flux_watcher_start (alloc->prep);

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -116,7 +116,8 @@ flux_shell_SOURCES = \
 	files.c \
 	hwloc.c \
 	rexec.c \
-	env-expand.c
+	env-expand.c \
+	alloc_request.c
 
 if HAVE_INOTIFY
 flux_shell_SOURCES += oom.c

--- a/src/shell/alloc_request.c
+++ b/src/shell/alloc_request.c
@@ -1,0 +1,137 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* alloc request handling
+ *
+ * Handle 'shell-<id>.dyn_alloc_request' by forwarding request to job manager
+ */
+#define FLUX_SHELL_PLUGIN_NAME "alloc_request_handler"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+
+#include "builtins.h"
+
+#include <jansson.h>
+
+
+struct alloc_ctx {
+    flux_t *h;
+    const flux_msg_t *msg;
+};
+
+/* receives RESPONSE from job manager for dynamic allocation request. 
+ * forwards RESPONSE to client/pmix_plugin  
+ */
+static void dyn_alloc_response_cb (flux_future_t *f, void *arg)
+{
+    json_t *xdata = NULL;
+    struct alloc_ctx *ctx = arg;
+    int rc;
+
+    shell_debug("received allocation response from job-manager");
+
+    /* TODO: DO whatever is necessary for LEVEL 'shell' before forwarding response to pmix_plugin */
+
+    if (flux_rpc_get_unpack (f, "{s:O}", "data", &xdata) < 0){
+        shell_warn ("pmix-alloc request: %s", future_strerror (f, errno));
+        flux_respond_error(ctx->h, ctx->msg, -1, "unable to unpack response");
+        goto out;
+    }
+
+    if(0 > (rc = flux_respond_pack(ctx->h, ctx->msg,  "{s:O}", "data", xdata))){
+        shell_warn("flux_respond_pack failed with %d", rc);
+        flux_respond_error(ctx->h, ctx->msg, -1, "unable to pack response");
+        goto out;
+    };
+    shell_debug("forwarded allocation response");
+
+out:
+    flux_msg_decref(ctx->msg);
+    free(ctx);
+}
+
+/* recives REQUEST from client/pmix_plugin for dynamic allocation request. 
+ * forwards REQUEST to job manager  
+ */
+static void dyn_alloc_request_cb (flux_t *h, flux_msg_handler_t *mh,
+                     const flux_msg_t *msg, void *arg)
+{
+    //json_t *xproc;
+    //pmix_proc_t proc;
+    json_t *payload;
+    int directive;
+    flux_future_t *f;
+    shell_debug ("received allocation request");
+
+   
+    /* TODO: DO whatever is necessary for LEVEL 'shell' before forwarding request to job manager */
+
+
+
+    struct alloc_ctx *ctx = calloc(1, sizeof(*ctx));
+    ctx->h = h;
+    ctx->msg = flux_msg_incref(msg);
+
+
+    if(0 < flux_msg_unpack (msg,
+                         "{s:i s:O}",
+                         //"proc", &xproc,
+                         "directive", &directive,
+                         "data", &payload)){
+        
+        shell_warn ("error unpacking interthread alloc_upcall message");
+        return;
+    }
+    /* Send alloc request to job manager */
+    if( !(f = flux_rpc_pack(h, 
+                "job-manager.dyn_alloc_request", 
+                FLUX_NODEID_ANY, 
+                0, 
+                "{s:i s:O}",
+                "directive", directive,
+                "data", payload )) 
+        || flux_future_then (f,
+                             -1,
+                             dyn_alloc_response_cb,
+                             (void *) ctx) < 0) 
+    {
+        if(f) flux_future_destroy (f);
+    }
+    shell_debug ("forward allocation request to job-manager");
+
+}
+
+static int alloc_request_init (flux_plugin_t *p,
+                            const char *topic,
+                            flux_plugin_arg_t *args,
+                            void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    if (!shell)
+        return -1;
+    if (flux_shell_service_register (shell, "dyn_alloc_request", dyn_alloc_request_cb, shell) < 0)
+        return -1;
+    return 0;
+}
+
+struct shell_builtin builtin_alloc_reuest = {
+    .name = FLUX_SHELL_PLUGIN_NAME,
+    .init = alloc_request_init,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -58,6 +58,8 @@ extern struct shell_builtin builtin_hwloc;
 extern struct shell_builtin builtin_rexec;
 extern struct shell_builtin builtin_env_expand;
 extern struct shell_builtin builtin_sysmon;
+extern struct shell_builtin builtin_alloc_reuest;
+
 
 static struct shell_builtin * builtins [] = {
     &builtin_tmpdir,
@@ -90,6 +92,7 @@ static struct shell_builtin * builtins [] = {
     &builtin_rexec,
     &builtin_env_expand,
     &builtin_sysmon,
+    &builtin_alloc_reuest,
     &builtin_list_end,
 };
 
@@ -99,7 +102,6 @@ static int shell_load_builtin (flux_shell_t *shell,
     flux_plugin_t *p = flux_plugin_create ();
     if (!p)
         return -1;
-
     if (flux_plugin_aux_set (p, "flux::shell", shell, NULL) < 0
         || flux_plugin_set_name (p, sb->name) < 0
         || flux_plugin_add_handler (p, "shell.validate", sb->validate, NULL) < 0


### PR DESCRIPTION
Dynamic allocations (malleability) require interaction between allocations and the scheduler. This mechanism allows applications to indicate support for resource reconfiguration, while schedulers (depending on policy) can respond with corresponding reconfiguration commands.

This pull request introduces a first draft of the communication mechanism enabling this interaction. Feedback is very welcome.

As a next step, we plan to implement partial release of allocated resources back to the scheduler.

The figure below illustrates the interaction between different Flux components:

<img width="810" height="630" alt="flux_interaction_levels drawio" src="https://github.com/user-attachments/assets/13ee3a4d-3318-4673-8a8a-007d83fced89" />
