### PR TITLE
add `access.private-mode` config key which restricts guest users to their own jobs

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -21,6 +21,11 @@ jobs and information can be listed using options listed below.
 Alternately, specific job ids can be listed on the command line to
 only list those job IDs.
 
+When the instance is configured with ``private-mode`` in the ``access``
+table (see :man5:`flux-config-access`), users other than the instance owner
+may list only their own jobs, and the :option:`--stats` and
+:option:`--stats-only` options are unavailable to them.
+
 
 OPTIONS
 =======
@@ -702,4 +707,4 @@ FLUX RFC
 SEE ALSO
 ========
 
-:man1:`flux-pstree`
+:man1:`flux-pstree`, :man5:`flux-config-access`

--- a/doc/man5/flux-config-access.rst
+++ b/doc/man5/flux-config-access.rst
@@ -27,6 +27,13 @@ allow-root-owner
    (optional) Boolean value to assign ``owner`` role to root user.  If set to false
    or not present, root is treated like any other guest.
 
+private-mode
+   (optional) Boolean value to limit visibility of job data to guests.
+   When true, job queries from guests are limited to their own jobs and
+   aggregate job statistics are unavailable to them. The instance owner is
+   unaffected. This key is only meaningful when ``allow-guest-user`` is true.
+   If set to false or not present, guests may view all users' jobs.
+
 
 EXAMPLE
 =======
@@ -36,6 +43,7 @@ EXAMPLE
    [access]
    allow-guest-user = true
    allow-root-owner = true
+   private-mode = true
 
 
 RESOURCES

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -476,8 +476,9 @@ void summary_pane_jobstats (struct summary_pane *sum, flux_future_t *f)
     const char *filter_queue;
 
     if (flux_rpc_get_unpack (f, "o", &o) < 0) {
-        if (errno != ENOSYS)
+        if (errno != ENOSYS && errno != EPERM)
             fatal (errno, "error getting job-list.job-stats RPC response");
+        goto out;
     }
 
     /* can return NULL filter_queue for "all" queues */

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -206,6 +206,9 @@ error:
  * allow-root-owner = true
  *   Allow root user to have instance owner role
  *
+ * private-mode = true
+ *   Restrict guests to viewing only their own jobs (consumed by job-list).
+ *
  * Missing [access] keys are interpreted as false.
  * [access] keys other than the above are not allowed.
  */
@@ -216,15 +219,18 @@ static int parse_config (struct connector_local *ctx,
     flux_error_t error;
     int allow_guest_user = 0;
     int allow_root_owner = 0;
+    int private_mode = 0;       /* unused here; validated for job-list */
 
     if (flux_conf_unpack (conf,
                           &error,
-                          "{s?{s?b s?b !}}",
+                          "{s?{s?b s?b s?b !}}",
                           "access",
                             "allow-guest-user",
                             &allow_guest_user,
                             "allow-root-owner",
-                            &allow_root_owner) < 0) {
+                            &allow_root_owner,
+                            "private-mode",
+                            &private_mode) < 0) {
         errprintf (errp,
                    "error parsing [access] configuration: %s",
                    error.text);

--- a/src/modules/job-list/Makefile.am
+++ b/src/modules/job-list/Makefile.am
@@ -19,6 +19,8 @@ noinst_LTLIBRARIES = libjob-list.la
 libjob_list_la_SOURCES = \
 	job-list.c \
 	job-list.h \
+	auth.h \
+	auth.c \
 	job_state.h \
 	job_state.c \
 	job_data.h \

--- a/src/modules/job-list/Makefile.am
+++ b/src/modules/job-list/Makefile.am
@@ -43,7 +43,8 @@ libjob_list_la_SOURCES = \
 TESTS = \
 	test_job_data.t \
 	test_match.t \
-	test_state_match.t
+	test_state_match.t \
+	test_auth.t
 
 test_ldadd = \
 	$(builddir)/libjob-list.la \
@@ -89,6 +90,14 @@ test_state_match_t_CPPFLAGS = \
 test_state_match_t_LDADD = \
 	$(test_ldadd)
 test_state_match_t_LDFLAGS = \
+	$(test_ldflags)
+
+test_auth_t_SOURCES = test/auth.c
+test_auth_t_CPPFLAGS = \
+	$(test_cppflags)
+test_auth_t_LDADD = \
+	$(test_ldadd)
+test_auth_t_LDFLAGS = \
 	$(test_ldflags)
 
 EXTRA_DIST = \

--- a/src/modules/job-list/auth.c
+++ b/src/modules/job-list/auth.c
@@ -1,0 +1,161 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <jansson.h>
+
+#include "src/common/libutil/errprintf.h"
+
+#include "auth.h"
+#include "match.h"
+#include "job_data.h"
+
+struct job_auth {
+    flux_t *h;
+    bool private_mode;
+};
+
+static int config_parse_private_mode (struct job_auth *auth,
+                                      const flux_conf_t *conf,
+                                      flux_error_t *errp)
+{
+    int private_mode = 0;
+    flux_error_t error;
+
+    if (flux_conf_unpack (conf,
+                          &error,
+                          "{s?{s?b}}",
+                          "access",
+                          "private-mode", &private_mode) < 0) {
+        errprintf (errp,
+                   "error reading [access] config: %s",
+                   error.text);
+        return -1;
+    }
+
+    auth->private_mode = private_mode ? true : false;
+    return 0;
+}
+
+struct job_auth *job_auth_create (flux_t *h)
+{
+    struct job_auth *auth;
+    flux_error_t error;
+
+    if (!(auth = calloc (1, sizeof (*auth))))
+        return NULL;
+    auth->h = h;
+
+    if (config_parse_private_mode (auth, flux_get_conf (h), &error) < 0) {
+        flux_log (h, LOG_ERR, "%s", error.text);
+        job_auth_destroy (auth);
+        return NULL;
+    }
+
+    return auth;
+}
+
+void job_auth_destroy (struct job_auth *auth)
+{
+    if (auth) {
+        int saved_errno = errno;
+        free (auth);
+        errno = saved_errno;
+    }
+}
+
+int job_auth_config_reload (struct job_auth *auth,
+                            const flux_conf_t *conf,
+                            flux_error_t *errp)
+{
+    return config_parse_private_mode (auth, conf, errp);
+}
+
+static bool job_auth_restricted (struct job_auth *auth,
+                                 struct flux_msg_cred cred)
+{
+    return auth->private_mode && !(cred.rolemask & FLUX_ROLE_OWNER);
+}
+
+bool job_auth_msg_restricted (struct job_auth *auth, const flux_msg_t *msg)
+{
+    struct flux_msg_cred cred;
+
+    if (flux_msg_get_cred (msg, &cred) < 0)
+        return true;
+    if (job_auth_restricted (auth, cred)) {
+        errno = EPERM;
+        return true;
+    }
+
+    return false;
+}
+
+int job_auth_constraint (struct job_auth *auth,
+                         const flux_msg_t *msg,
+                         json_t **constraintp,
+                         flux_error_t *errp)
+{
+    struct flux_msg_cred cred;
+
+    if (flux_msg_get_cred (msg, &cred) < 0) {
+        errprintf (errp, "failed to get message credential");
+        return -1;
+    }
+    if (!job_auth_restricted (auth, cred)) {
+        *constraintp = NULL;
+        return 0;
+    }
+
+    if (!(*constraintp = json_pack ("{s:[i]}", "userid", cred.userid))) {
+        errprintf (errp, "out of memory");
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return 0;
+}
+
+int job_auth_check_job (struct job_auth *auth,
+                        struct match_ctx *mctx,
+                        const flux_msg_t *msg,
+                        const struct job *job,
+                        flux_error_t *errp)
+{
+    json_t *constraint = NULL;
+    struct list_constraint *c;
+    int ret;
+
+    if (job_auth_constraint (auth, msg, &constraint, errp) < 0)
+        return -1;
+
+    if (!constraint)
+        return 1;
+
+    if (!(c = list_constraint_create (mctx, constraint, errp))) {
+        json_decref (constraint);
+        return -1;
+    }
+    json_decref (constraint);
+
+    ret = job_match (job, c, errp);
+    list_constraint_destroy (c);
+    return ret;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-list/auth.h
+++ b/src/modules/job-list/auth.h
@@ -1,0 +1,70 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_LIST_AUTH_H
+#define _FLUX_JOB_LIST_AUTH_H
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdbool.h>
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "match.h"
+#include "job_data.h"
+
+struct job_auth;
+
+/* Create policy object; reads [access] private-mode from flux_get_conf(h).
+ * Logs and returns NULL on config error.
+ */
+struct job_auth *job_auth_create (flux_t *h);
+
+void job_auth_destroy (struct job_auth *auth);
+
+/* Re-read [access] private-mode from conf. Returns 0, or -1 with errp set. */
+int job_auth_config_reload (struct job_auth *auth,
+                            const flux_conf_t *conf,
+                            flux_error_t *errp);
+
+/* Return true if request msg must be restricted to their own jobs:
+ * i.e. private mode enabled and msg credential cannot be obtained or
+ * lacks FLUX_ROLE_OWNER.
+ */
+bool job_auth_msg_restricted (struct job_auth *auth, const flux_msg_t *msg);
+
+/* Produce an RFC31 constraint (JSON, new reference) to AND into a request's
+ * constraint, or set *constraintp = NULL when no restriction applies (owner,
+ * or private mode off). The built-in policy returns {"userid":[<uid>]}.
+ * Returns 0 on success, -1 with errp set on error.
+ */
+int job_auth_constraint (struct job_auth *auth,
+                         const flux_msg_t *msg,
+                         json_t **constraintp,
+                         flux_error_t *errp);
+
+/* Check whether a single job is visible to msg under the current policy.
+ * Returns 1 if visible, 0 if not, -1 with errp set on error. Implemented by
+ * compiling the job_auth_constraint() result via match.h and running
+ * job_match(); returns 1 immediately when not restricted.
+ */
+int job_auth_check_job (struct job_auth *auth,
+                        struct match_ctx *mctx,
+                        const flux_msg_t *msg,
+                        const struct job *job,
+                        flux_error_t *errp);
+
+#endif /* !_FLUX_JOB_LIST_AUTH_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-list/idsync.c
+++ b/src/modules/job-list/idsync.c
@@ -264,6 +264,8 @@ static void idsync_data_respond (struct idsync_ctx *isctx,
     json_t *o = NULL;
     int rc;
 
+    err_init (&err);
+
     /* Enforce access policy: in private mode a non-owner may not see
      * another user's job.  Report it as if the job does not exist.
      */
@@ -288,7 +290,10 @@ static void idsync_data_respond (struct idsync_ctx *isctx,
     return;
 
 error:
-    if (flux_respond_error (isctx->h, isd->msg, errno, err.text) < 0)
+    if (flux_respond_error (isctx->h,
+                            isd->msg,
+                            errno,
+                            err.text[0] != '\0' ? err.text : NULL) < 0)
         flux_log_error (isctx->h, "%s: flux_respond_error", __FUNCTION__);
 }
 

--- a/src/modules/job-list/idsync.c
+++ b/src/modules/job-list/idsync.c
@@ -18,9 +18,12 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libjob/job_hash.h"
+#include "src/common/libutil/errprintf.h"
 
 #include "idsync.h"
 #include "job_util.h"
+#include "auth.h"
+#include "match.h"
 
 /* Used in waits hash, need to store job id within data structure for lookup */
 struct idsync_wait_list {
@@ -116,6 +119,14 @@ error:
     idsync_ctx_destroy (isctx);
     errno = saved_errno;
     return NULL;
+}
+
+void idsync_ctx_set_auth (struct idsync_ctx *isctx,
+                          struct job_auth *auth,
+                          struct match_ctx *mctx)
+{
+    isctx->auth = auth;
+    isctx->mctx = mctx;
 }
 
 void idsync_ctx_destroy (struct idsync_ctx *isctx)
@@ -250,7 +261,22 @@ static void idsync_data_respond (struct idsync_ctx *isctx,
                                  struct job *job)
 {
     flux_error_t err;
-    json_t *o;
+    json_t *o = NULL;
+    int rc;
+
+    /* Enforce access policy: in private mode a non-owner may not see
+     * another user's job.  Report it as if the job does not exist.
+     */
+    if ((rc = job_auth_check_job (isctx->auth,
+                                  isctx->mctx,
+                                  isd->msg,
+                                  job,
+                                  &err)) < 0)
+        goto error;
+    if (rc == 0) {
+        errno = ENOENT;
+        goto error;
+    }
 
     if (!(o = job_to_json (job, isd->attrs, &err)))
         goto error;

--- a/src/modules/job-list/idsync.h
+++ b/src/modules/job-list/idsync.h
@@ -17,10 +17,15 @@
 
 #include "job_data.h"
 
+struct job_auth;
+struct match_ctx;
+
 struct idsync_ctx {
     flux_t *h;
     zlistx_t *lookups;
     zhashx_t *waits;
+    struct job_auth *auth;      /* set via idsync_ctx_set_auth() */
+    struct match_ctx *mctx;
 };
 
 struct idsync_data {
@@ -36,6 +41,13 @@ struct idsync_data {
 struct idsync_ctx *idsync_ctx_create (flux_t *h);
 
 void idsync_ctx_destroy (struct idsync_ctx *isctx);
+
+/* Provide the access policy and match context used to enforce job
+ * visibility when responding to deferred (waiting) id lookups.
+ */
+void idsync_ctx_set_auth (struct idsync_ctx *isctx,
+                          struct job_auth *auth,
+                          struct match_ctx *mctx);
 
 void idsync_data_destroy (void *data);
 

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -144,6 +144,10 @@ static void config_reload_cb (flux_t *h,
         errstr = error.text;
         goto error_decref;
     }
+    if (job_auth_config_reload (ctx->auth, conf, &error) < 0) {
+        errstr = error.text;
+        goto error_decref;
+    }
     if (flux_set_conf_new (h, conf) < 0) {
         errstr = "error updating config";
         goto error_decref;
@@ -220,6 +224,7 @@ static void list_ctx_destroy (struct list_ctx *ctx)
             idsync_ctx_destroy (ctx->isctx);
         if (ctx->mctx)
             match_ctx_destroy (ctx->mctx);
+        job_auth_destroy (ctx->auth);
         free (ctx);
         errno = saved_errno;
     }
@@ -242,6 +247,8 @@ static struct list_ctx *list_ctx_create (flux_t *h)
     if (!(ctx->deferred_requests = flux_msglist_create ()))
         goto error;
     if (!(ctx->mctx = match_ctx_create (ctx->h)))
+        goto error;
+    if (!(ctx->auth = job_auth_create (h)))
         goto error;
     return ctx;
 error:

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -250,6 +250,7 @@ static struct list_ctx *list_ctx_create (flux_t *h)
         goto error;
     if (!(ctx->auth = job_auth_create (h)))
         goto error;
+    idsync_ctx_set_auth (ctx->isctx, ctx->auth, ctx->mctx);
     return ctx;
 error:
     list_ctx_destroy (ctx);

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -52,6 +52,12 @@ static void stats_cb (flux_t *h,
         return;
     }
 
+    /* In private mode, module statistics are not available to users
+     * without the owner role.
+     */
+    if (job_auth_msg_restricted (ctx->auth, msg))
+        goto error;
+
     int pending = zlistx_size (ctx->jsctx->pending);
     int running = zlistx_size (ctx->jsctx->running);
     int inactive = zlistx_size (ctx->jsctx->inactive);
@@ -251,6 +257,7 @@ static struct list_ctx *list_ctx_create (flux_t *h)
     if (!(ctx->auth = job_auth_create (h)))
         goto error;
     idsync_ctx_set_auth (ctx->isctx, ctx->auth, ctx->mctx);
+    job_stats_set_auth (ctx->jsctx->statsctx, ctx->auth);
     return ctx;
 error:
     list_ctx_destroy (ctx);

--- a/src/modules/job-list/job-list.h
+++ b/src/modules/job-list/job-list.h
@@ -18,6 +18,7 @@
 #include "job_state.h"
 #include "idsync.h"
 #include "match.h"
+#include "auth.h"
 
 struct list_ctx {
     flux_t *h;
@@ -26,6 +27,7 @@ struct list_ctx {
     struct idsync_ctx *isctx;
     struct flux_msglist *deferred_requests;
     struct match_ctx *mctx;
+    struct job_auth *auth;
 };
 
 const char **job_attrs (void);

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -265,6 +265,8 @@ void list_cb (flux_t *h,
     double since = 0.;
     json_t *constraint = NULL;
     json_t *legacy_constraint = NULL;
+    json_t *auth_constraint = NULL;
+    json_t *combined_constraint = NULL;
     struct list_constraint *c = NULL;
     struct state_constraint *statec = NULL;
     flux_error_t error;
@@ -322,6 +324,30 @@ void list_cb (flux_t *h,
         errno = EPROTO;
         goto error;
     }
+
+    /* In private mode, restrict non-owners to their own jobs by ANDing an
+     * access policy constraint with the requested constraint.
+     */
+    if (job_auth_constraint (ctx->auth, msg, &auth_constraint, &error) < 0) {
+        errprintf (&err, "%s", error.text);
+        goto error;
+    }
+    if (auth_constraint) {
+        if (constraint)
+            combined_constraint = json_pack ("{s:[OO]}",
+                                             "and",
+                                             constraint,
+                                             auth_constraint);
+        else
+            combined_constraint = json_incref (auth_constraint);
+        if (!combined_constraint) {
+            errprintf (&err, "failed to build access policy constraint");
+            errno = ENOMEM;
+            goto error;
+        }
+        constraint = combined_constraint;
+    }
+
     if (!(c = list_constraint_create (ctx->mctx, constraint, &error))) {
         errprintf (&err,
                    "invalid payload: constraint object invalid: %s",
@@ -383,6 +409,8 @@ void list_cb (flux_t *h,
     list_constraint_destroy (c);
     state_constraint_destroy (statec);
     json_decref (legacy_constraint);
+    json_decref (auth_constraint);
+    json_decref (combined_constraint);
     return;
 
 error:
@@ -392,6 +420,8 @@ error:
     list_constraint_destroy (c);
     state_constraint_destroy (statec);
     json_decref (legacy_constraint);
+    json_decref (auth_constraint);
+    json_decref (combined_constraint);
 }
 
 void check_id_valid_continuation (flux_future_t *f, void *arg)

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -38,6 +38,27 @@ json_t *get_job_by_id (struct job_state_ctx *jsctx,
                        flux_job_state_t state,
                        bool *stall);
 
+/* Enforce access policy for a single job lookup. Returns 0 if 'job' is
+ * visible to the user that sent 'msg', or -1 with errno set (ENOENT when
+ * the job exists but is not visible to the user in private mode, so error
+ * matches what user would see for an invalid jobid where ENOENT is passed
+ * through the from KVS lookup).
+ */
+static int check_job_visible (struct list_ctx *ctx,
+                              const flux_msg_t *msg,
+                              const struct job *job)
+{
+    int rc;
+
+    if ((rc = job_auth_check_job (ctx->auth, ctx->mctx, msg, job, NULL)) < 0)
+        return -1;
+    if (rc == 0) {
+        errno = ENOENT;
+        return -1;
+    }
+    return 0;
+}
+
 /* Put jobs from list onto jobs array, breaking if max_entries has
  * been reached. Returns 1 if jobs array is full, 0 if continue, -1
  * one error with errno set:
@@ -449,6 +470,13 @@ void check_id_valid_continuation (flux_future_t *f, void *arg)
         }
         else {
             json_t *o;
+            if (check_job_visible (jsctx->ctx, isd->msg, job) < 0) {
+                if (flux_respond_error (jsctx->h, isd->msg, errno, NULL) < 0)
+                    flux_log_error (jsctx->h,
+                                    "%s: flux_respond_error",
+                                    __FUNCTION__);
+                goto cleanup;
+            }
             if (!(o = get_job_by_id (jsctx,
                                      NULL,
                                      isd->msg,
@@ -531,6 +559,12 @@ json_t *get_job_by_id (struct job_state_ctx *jsctx,
         }
         return NULL;
     }
+
+    /*  Enforce access policy: in private mode a non-owner may not see
+     *  another user's job.  Report it as if the job does not exist.
+     */
+    if (check_job_visible (jsctx->ctx, msg, job) < 0)
+        return NULL;
 
     /*  Always return job in inactive state, even if a requested state was
      *  provided. This avoids no response when a job does not enter a given

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -21,6 +21,7 @@
 
 #include "stats.h"
 #include "job_data.h"
+#include "auth.h"
 
 #define BATCH_DELAY 0.2
 
@@ -32,7 +33,14 @@ struct job_stats_ctx {
     struct flux_msglist *watchers;
     flux_watcher_t *timer;
     bool timer_running;
+    struct job_auth *auth;
 };
+
+void job_stats_set_auth (struct job_stats_ctx *statsctx,
+                         struct job_auth *auth)
+{
+    statsctx->auth = auth;
+}
 
 static void arm_timer (struct job_stats_ctx *statsctx);
 
@@ -410,6 +418,12 @@ static void job_stats_cb (flux_t *h,
                           void *arg)
 {
     struct job_stats_ctx *statsctx = arg;
+
+    /* In private mode, aggregate job statistics are not available to
+     * users without the owner role.
+     */
+    if (job_auth_msg_restricted (statsctx->auth, msg))
+        goto error;
 
     if (flux_msg_is_streaming (msg)) {
         if (flux_msglist_append (statsctx->watchers, msg) < 0)

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -16,6 +16,8 @@
 
 #include "job_data.h"
 
+struct job_auth;
+
 struct job_stats {
     unsigned int state_count[FLUX_JOB_NR_STATES];
     unsigned int successful;
@@ -28,6 +30,12 @@ struct job_stats {
 struct job_stats_ctx *job_stats_ctx_create (flux_t *h);
 
 void job_stats_ctx_destroy (struct job_stats_ctx *statsctx);
+
+/* Provide the access policy used to restrict job-stats requests from
+ * guests when private mode is enabled.
+ */
+void job_stats_set_auth (struct job_stats_ctx *statsctx,
+                         struct job_auth *auth);
 
 void job_stats_update (struct job_stats_ctx *statsctx,
                        struct job *job,

--- a/src/modules/job-list/test/auth.c
+++ b/src/modules/job-list/test/auth.c
@@ -1,0 +1,147 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/modules/job-list/auth.h"
+#include "src/modules/job-list/match.h"
+#include "src/modules/job-list/job_data.h"
+
+static struct flux_msg_cred owner = { .userid = 1000,
+                                      .rolemask = FLUX_ROLE_OWNER };
+static struct flux_msg_cred guest = { .userid = 1234,
+                                      .rolemask = FLUX_ROLE_USER };
+
+/* Verify constraint is {"userid":[<uid>]} */
+static int is_userid_constraint (json_t *c, int uid)
+{
+    json_t *ids;
+    return json_is_object (c)
+        && (ids = json_object_get (c, "userid"))
+        && json_is_array (ids)
+        && json_array_size (ids) == 1
+        && json_integer_value (json_array_get (ids, 0)) == uid;
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    struct job_auth *auth;
+    struct match_ctx *mctx;
+    flux_msg_t *msg_owner = NULL;
+    flux_msg_t *msg_guest = NULL;
+    flux_conf_t *conf;
+    flux_error_t error;
+    json_t *o;
+    struct job guest_job = { .userid = guest.userid };
+    struct job owner_job = { .userid = owner.userid };
+
+    plan (NO_PLAN);
+
+    if (!(h = flux_open ("loop://", 0)))
+        BAIL_OUT ("could not create loop handle");
+    if (!(mctx = match_ctx_create (h)))
+        BAIL_OUT ("match_ctx_create failed");
+
+    if (!(auth = job_auth_create (h)))
+        BAIL_OUT ("job_auth_create failed");
+    ok (true, "job_auth_create works with no [access] config");
+
+    if (!(msg_owner = flux_msg_create (FLUX_MSGTYPE_REQUEST))
+        || !(msg_guest = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        BAIL_OUT ("flux_msg_create failed");
+
+    ok (flux_msg_set_cred (msg_owner, owner) == 0
+        && flux_msg_set_cred (msg_guest, guest) == 0,
+        "add owner and guest credentials to test request messages");
+
+    errno = 0;
+    ok (job_auth_msg_restricted (auth, NULL) && errno == EINVAL,
+        "job_auth_msg_restricted (auth, NULL) rejects with EINVAL");
+
+    /* private mode off (default): nobody is restricted */
+    ok (!job_auth_msg_restricted (auth, msg_owner),
+        "job_auth_msg_restricted: owner not restricted when private mode off");
+    ok (!job_auth_msg_restricted (auth, msg_guest),
+        "job_auth_msg_restricted: guest not restricted when private mode off");
+
+    o = (json_t *)&error; /* non-NULL sentinel */
+    ok (job_auth_constraint (auth, msg_guest, &o, &error) == 0 && o == NULL,
+        "job_auth_constraint returns no constraint when private mode is off");
+
+    ok (job_auth_check_job (auth, mctx, msg_guest, &owner_job, &error) == 1,
+        "job_auth_check_job: guest can see any job when private mode is off");
+
+    /* job_auth_config_reload: bad private-mode type */
+    if (!(conf = flux_conf_pack ("{s:{s:s}}", "access", "private-mode", "yes")))
+        BAIL_OUT ("flux_conf_pack failed");
+    ok (job_auth_config_reload (auth, conf, &error) < 0,
+        "job_auth_config_reload fails when private-mode is wrong type");
+    ok (strlen (error.text) > 0,
+        "error message is set on bad private-mode type");
+    flux_conf_decref (conf);
+
+    /* job_auth_config_reload: bad access table type */
+    if (!(conf = flux_conf_pack ("{s:s}", "access", "not-a-table")))
+        BAIL_OUT ("flux_conf_pack failed");
+    ok (job_auth_config_reload (auth, conf, &error) < 0,
+        "job_auth_config_reload fails when [access] is not a table");
+    ok (strlen (error.text) > 0,
+        "error message is set on bad [access] type");
+    flux_conf_decref (conf);
+
+    /* enable private mode via config reload */
+    if (!(conf = flux_conf_pack ("{s:{s:b}}", "access", "private-mode", 1)))
+        BAIL_OUT ("flux_conf_pack failed");
+    ok (job_auth_config_reload (auth, conf, &error) == 0,
+        "job_auth_config_reload enables private mode");
+    flux_conf_decref (conf);
+
+    /* private mode on: only non-owner is restricted */
+    ok (!job_auth_msg_restricted (auth, msg_owner),
+        "job_auth_msg_restricted: owner allowed with private mode enabled");
+    ok (job_auth_msg_restricted (auth, msg_guest),
+        "job_auth_msg_restricted: guest restricted with private mode enabled");
+
+    o = (json_t *)&error; /* non-NULL sentinel */
+    ok (job_auth_constraint (auth, msg_owner, &o, &error) == 0 && o == NULL,
+        "owner gets no constraint when private mode is on");
+
+    o = NULL;
+    ok (job_auth_constraint (auth, msg_guest, &o, &error) == 0 && o != NULL,
+        "guest gets a constraint when private mode is on");
+    ok (is_userid_constraint (o, guest.userid),
+        "guest constraint is {\"userid\":[<uid>]}");
+    json_decref (o);
+
+    ok (job_auth_check_job (auth, mctx, msg_owner, &owner_job, &error) == 1,
+        "job_auth_check_job: owner can see any job in private mode");
+    ok (job_auth_check_job (auth, mctx, msg_guest, &guest_job, &error) == 1,
+        "job_auth_check_job: guest can see own job in private mode");
+    ok (job_auth_check_job (auth, mctx, msg_guest, &owner_job, &error) == 0,
+        "job_auth_check_job: guest cannot see other user's job in private mode");
+
+    flux_msg_destroy (msg_owner);
+    flux_msg_destroy (msg_guest);
+    job_auth_destroy (auth);
+    match_ctx_destroy (mctx);
+    flux_close (h);
+
+    done_testing ();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/getattr.c
+++ b/src/modules/job-manager/getattr.c
@@ -112,14 +112,20 @@ void getattr_handle_request (flux_t *h,
         goto error;
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))
         && !(job = zhashx_lookup (ctx->inactive_jobs, &id))) {
-        errstr = "unknown job";
-        errno = EINVAL;
+        if (ctx->private_mode && !(cred.rolemask & FLUX_ROLE_OWNER))
+            errno = EPERM;
+        else {
+            errstr = "unknown job";
+            errno = EINVAL;
+        }
         goto error;
     }
-    /* Security: guests can only access their own jobs
+    /* Security: guests can only access their own jobs. In private mode,
+     * suppress the errstr so existence of the job is not revealed.
      */
     if (flux_msg_cred_authorize (cred, job->userid) < 0) {
-        errstr = "guests can only reprioritize their own jobs";
+        if (!ctx->private_mode)
+            errstr = "guests can only reprioritize their own jobs";
         goto error;
     }
     if (!(dict = make_dict (job, attrs, &error))) {

--- a/src/modules/job-manager/getattr.c
+++ b/src/modules/job-manager/getattr.c
@@ -125,7 +125,7 @@ void getattr_handle_request (flux_t *h,
      */
     if (flux_msg_cred_authorize (cred, job->userid) < 0) {
         if (!ctx->private_mode)
-            errstr = "guests can only reprioritize their own jobs";
+            errstr = "guests can only access their own jobs";
         goto error;
     }
     if (!(dict = make_dict (job, attrs, &error))) {

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -48,9 +48,16 @@ void getinfo_handle_request (flux_t *h,
                              void *arg)
 {
     struct job_manager *ctx = arg;
+    struct flux_msg_cred cred;
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
         goto error;
+    if (flux_msg_get_cred (msg, &cred) < 0)
+        goto error;
+    if (ctx->private_mode && !(cred.rolemask & FLUX_ROLE_OWNER)) {
+        errno = EPERM;
+        goto error;
+    }
     if (flux_respond_pack (h,
                            msg,
                            "{s:I}",
@@ -79,10 +86,17 @@ static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     struct job_manager *ctx = arg;
+    struct flux_msg_cred cred;
     json_t *journal = journal_get_stats (ctx->journal);
     json_t *housekeeping = housekeeping_get_stats (ctx->housekeeping);
     if (!housekeeping || !journal)
         goto error;
+    if (flux_msg_get_cred (msg, &cred) < 0)
+        goto error;
+    if (ctx->private_mode && !(cred.rolemask & FLUX_ROLE_OWNER)) {
+        errno = EPERM;
+        goto error;
+    }
     if (flux_respond_pack (h,
                            msg,
                            "{s:O s:i s:i s:I s:O}",
@@ -102,6 +116,23 @@ static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     json_decref (housekeeping);
     json_decref (journal);
+}
+
+static int private_mode_update (const flux_conf_t *conf,
+                                flux_error_t *error,
+                                void *arg)
+{
+    struct job_manager *ctx = arg;
+    int private_mode = 0;
+
+    if (flux_conf_unpack (conf,
+                          error,
+                          "{s?{s?b}}",
+                          "access",
+                            "private-mode", &private_mode) < 0)
+        return -1;
+    ctx->private_mode = private_mode ? true : false;
+    return 1;
 }
 
 static const struct flux_msg_handler_spec htab[] = {
@@ -243,6 +274,13 @@ int mod_main (flux_t *h, int argc, char **argv)
     }
     if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {
         flux_log_error (h, "flux_msghandler_add");
+        goto done;
+    }
+    if (conf_register_callback (ctx.conf,
+                                &error,
+                                private_mode_update,
+                                &ctx) < 0) {
+        flux_log (h, LOG_ERR, "error parsing access config: %s", error.text);
         goto done;
     }
     if (restart_from_kvs (&ctx) < 0) // logs its own error messages

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -16,6 +16,7 @@
 struct job_manager {
     flux_t *h;
     flux_msg_handler_t **handlers;
+    bool private_mode;
     zhashx_t *active_jobs;
     zhashx_t *inactive_jobs;
     int running_jobs; // count of jobs in RUN | CLEANUP state

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -172,6 +172,7 @@ TESTSCRIPTS = \
 	t2261-job-list-update.t \
 	t2262-job-list-stats.t \
 	t2263-job-list-private.t \
+	t2264-job-manager-private.t \
 	t2270-job-dependencies.t \
 	t2271-job-dependency-after.t \
 	t2272-job-begin-time.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -171,6 +171,7 @@ TESTSCRIPTS = \
 	t2260-job-list.t \
 	t2261-job-list-update.t \
 	t2262-job-list-stats.t \
+	t2263-job-list-private.t \
 	t2270-job-dependencies.t \
 	t2271-job-dependency-after.t \
 	t2272-job-begin-time.t \

--- a/t/t2263-job-list-private.t
+++ b/t/t2263-job-list-private.t
@@ -1,0 +1,243 @@
+#!/bin/sh
+
+test_description='Test job-list private mode'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+owner_uid=$(id -u)
+other_uid=$((owner_uid + 100))
+
+fj_wait_event() {
+	flux job wait-event --timeout=20 "$@"
+}
+
+wait_idsync() {
+	local num=$1
+	test_wait_until "flux module stats --parse idsync.waits job-list \
+          && [ \$(flux module stats --parse idsync.waits job-list) -eq $num ]"
+}
+
+set_userid() {
+	export FLUX_HANDLE_USERID=$1
+	export FLUX_HANDLE_ROLEMASK=0x2
+}
+
+unset_userid() {
+	unset FLUX_HANDLE_USERID
+	unset FLUX_HANDLE_ROLEMASK
+}
+
+count_jobs() {
+	flux jobs -a -n -o "{id}" | wc -l
+}
+
+enable_private_mode() {
+	flux config load <<-EOT
+	[access]
+	private-mode = true
+	EOT
+}
+
+disable_private_mode() {
+	flux config load </dev/null
+}
+
+#
+# All jobs in this test are owned by the instance owner.  Guests are
+# simulated by setting the message userid/rolemask, so a guest whose userid
+# matches the job owner can see the jobs and a guest with a different userid
+# cannot.  This exercises private mode without requiring flux-security.
+#
+
+test_expect_success 'submit jobs as instance owner' '
+	flux submit --wait true >/dev/null &&
+	flux submit --wait --job-name=secretjob true >/dev/null &&
+	test $(count_jobs) -eq 2
+'
+test_expect_success 'save an owner job id' '
+	flux jobs -a -n -o "{id}" | head -n1 >ownerjob
+'
+test_expect_success 'private mode off: guest with different uid sees all jobs' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test $(count_jobs) -eq 2
+'
+test_expect_success 'enable private mode' '
+	enable_private_mode
+'
+test_expect_success 'private mode on: guest with non-owner uid sees no jobs' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test $(count_jobs) -eq 0
+'
+test_expect_success 'private mode on: guest with owner uid sees own jobs' '
+	set_userid $owner_uid &&
+	test_when_finished unset_userid &&
+	test $(count_jobs) -eq 2
+'
+test_expect_success 'private mode on: owner sees all jobs' '
+	test $(count_jobs) -eq 2
+'
+test_expect_success 'private mode on: guest cannot list-id another user job' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail flux job list-ids $(cat ownerjob) >/dev/null
+'
+test_expect_success 'private mode on: guest can list-id own job' '
+	set_userid $owner_uid &&
+	test_when_finished unset_userid &&
+	flux job list-ids $(cat ownerjob) >/dev/null
+'
+test_expect_success 'private mode on: owner can list-id any job' '
+	flux job list-ids $(cat ownerjob) >/dev/null
+'
+test_expect_success 'private mode on: guest job-stats fails (EPERM)' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail flux jobs --stats
+'
+test_expect_success 'private mode on: guest module stats fails (EPERM)' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail flux module stats job-list
+'
+test_expect_success 'private mode on: owner job-stats succeeds' '
+	flux jobs --stats >/dev/null &&
+	flux module stats job-list >/dev/null
+'
+test_expect_success 'disable private mode' '
+	disable_private_mode
+'
+test_expect_success 'private mode off: guest with non-owner uid sees all jobs' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test $(count_jobs) -eq 2
+'
+test_expect_success 'private mode off: guest job-stats succeeds' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	flux jobs --stats
+'
+
+#
+# Verify that an idsync waiter registered by a guest while private mode is
+# on is denied when the job reaches the requested state.  This exercises the
+# rc==0 branch in idsync_data_respond.
+#
+test_expect_success NO_CHAIN_LINT 'private mode on: list-id idsync waiter denied (rc==0 in idsync_data_respond)' '
+	# Enable private mode first so auth is set before any idsync fires.
+	enable_private_mode &&
+        test_when_finished disable_private_mode &&
+	# Pause job-list state events.  While paused, the job is not in the
+	# job-list index, so a list-id request goes through the KVS-lookup
+	# idsync path and parks in idsync_wait_valid.
+	${RPC} job-list.job-state-pause 0 </dev/null &&
+	newjob=$(flux submit hostname) &&
+	# Wait for the job to complete so it is in KVS before the guest queries.
+	fj_wait_event $newjob clean >/dev/null &&
+	FLUX_HANDLE_USERID=$other_uid FLUX_HANDLE_ROLEMASK=0x2 \
+	    flux job list-ids --wait-state=inactive $newjob \
+	    >listid2.out 2>listid2.err &
+	listid_pid=$! &&
+	# Confirm waiter is registered before unpausing.
+	wait_idsync 1 &&
+	# Unpause: job-list processes backlog and idsync_data_respond fires.
+	# With private mode on, it hits rc==0 and returns ENOENT.
+	${RPC} job-list.job-state-unpause 0 </dev/null &&
+	test_must_fail wait $listid_pid &&
+	grep -i "no such file or directory" listid2.err
+'
+
+#
+# Verify that user-supplied constraints cannot bypass the private-mode
+# auth constraint.  All jobs belong to the instance owner; a guest with
+# a different uid should see zero jobs regardless of what constraint they
+# supply.
+#
+
+test_expect_success 'enable private mode for constraint tests' '
+	enable_private_mode
+'
+test_expect_success 'private mode on: --user=owner-uid returns no jobs for guest' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test $(flux jobs -a -n -o "{id}" --user=$owner_uid | wc -l) -eq 0
+'
+test_expect_success 'private mode on: --name=secretjob returns no jobs for guest' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test $(flux jobs -a -n -o "{id}" --name=secretjob | wc -l) -eq 0
+'
+test_expect_success 'private mode on: list with no constraint as guest sees no jobs' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test $(flux python -c "
+import flux
+f = flux.Flux()
+pay = {\"max_entries\": 1000, \"attrs\": [\"id\"]}
+print(len(f.rpc(\"job-list.list\", pay).get()[\"jobs\"]))
+") -eq 0
+'
+test_expect_success 'private mode on: direct userid constraint for owner returns no jobs' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test $(flux python -c "
+import flux, json
+f = flux.Flux()
+pay = {\"max_entries\": 1000, \"attrs\": [\"id\"],
+	   \"constraint\": {\"userid\": [$owner_uid]}}
+print(len(f.rpc(\"job-list.list\", pay).get()[\"jobs\"]))
+") -eq 0
+'
+test_expect_success 'private mode on: or-constraint broadening returns no other-user jobs' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test $(flux python -c "
+import flux, json
+f = flux.Flux()
+pay = {\"max_entries\": 1000, \"attrs\": [\"id\"],
+	   \"constraint\": {\"or\": [{\"userid\": [$owner_uid]},
+	                             {\"userid\": [$other_uid]}]}}
+print(len(f.rpc(\"job-list.list\", pay).get()[\"jobs\"]))
+") -eq 0
+'
+test_expect_success 'private mode on: not-constraint cannot expose other-user jobs' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test $(flux python -c "
+import flux, json
+f = flux.Flux()
+pay = {\"max_entries\": 1000, \"attrs\": [\"id\"],
+	   \"constraint\": {\"not\": [{\"userid\": [$other_uid]}]}}
+print(len(f.rpc(\"job-list.list\", pay).get()[\"jobs\"]))
+") -eq 0
+'
+test_expect_success 'submit a running job for list-id private mode tests' '
+	sleepjob=$(flux submit sleep 300) &&
+	flux job list-ids --wait-state=RUN $sleepjob >/dev/null
+'
+test_expect_success 'private mode on: guest cannot list-id a running job' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail flux job list-ids $sleepjob >/dev/null
+'
+# Submit without --wait so job-list may not have processed the event yet,
+# giving the idsync KVS-lookup path a chance to be exercised.
+test_expect_success 'private mode on: guest cannot list-id a freshly submitted job' '
+	newjob=$(flux submit sleep 300) &&
+	set_userid $other_uid &&
+	test_must_fail flux job list-ids $newjob >/dev/null &&
+	unset_userid &&
+	flux cancel $newjob
+'
+test_expect_success 'cancel running job from list-id tests' '
+	flux cancel $sleepjob
+'
+test_expect_success 'disable private mode after constraint tests' '
+	disable_private_mode
+'
+test_done

--- a/t/t2264-job-manager-private.t
+++ b/t/t2264-job-manager-private.t
@@ -1,0 +1,169 @@
+#!/bin/sh
+
+test_description='Test job-manager private mode'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+flux version | grep -q libflux-security && test_set_prereq FLUX_SECURITY
+
+owner_uid=$(id -u)
+other_uid=$((owner_uid + 100))
+
+submit_as_guest()
+{
+	flux run --dry-run "$@" | \
+	  flux python ${SHARNESS_TEST_SRCDIR}/scripts/sign-as.py $other_uid \
+	    >job.signed
+	FLUX_HANDLE_USERID=$other_uid flux job submit --flags=signed job.signed
+}
+
+set_userid() {
+	export FLUX_HANDLE_USERID=$1
+	export FLUX_HANDLE_ROLEMASK=0x2
+}
+
+unset_userid() {
+	unset FLUX_HANDLE_USERID
+	unset FLUX_HANDLE_ROLEMASK
+}
+
+enable_private_mode() {
+	flux config load <<-EOT
+	[access]
+	private-mode = true
+	EOT
+}
+
+disable_private_mode() {
+	flux config load </dev/null
+}
+
+job_manager_getinfo() {
+	flux python -c "import flux; print(flux.Flux().rpc('job-manager.getinfo',{}).get_str())"
+}
+
+job_manager_getattr() {
+	flux python -c "import flux; print(flux.Flux().rpc(\"job-manager.getattr\",{\"id\":"$1",\"attrs\":[\"$2\"]}).get_str())"
+}
+
+test_expect_success 'submit a job as instance owner' '
+	jobid=$(flux submit true)
+'
+test_expect_success 'save jobid as integer' '
+	flux job id --to=dec $jobid >jobid_int.out
+'
+test_expect_success FLUX_SECURITY 'submit a job as guest user' '
+	guestid=$(submit_as_guest --urgency=hold hostname) &&
+	flux job id --to=dec $guestid >guestid.out
+'
+
+test_expect_success 'private mode off: guest can call stats-get' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	flux module stats job-manager
+'
+test_expect_success 'private mode off: guest can call getinfo' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	job_manager_getinfo
+'
+test_expect_success FLUX_SECURITY 'private mode off: guest getattr on own job' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	job_manager_getattr $(cat guestid.out) jobspec
+'
+test_expect_success 'private mode off: guest gets EINVAL for unknown job' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail job_manager_getattr 1 jobspec 2>err.out &&
+	grep -i "unknown job" err.out
+'
+test_expect_success 'private mode off: guest gets EPERM for other user job' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail job_manager_getattr $(cat jobid_int.out) jobspec 2>err.out &&
+	grep -i "guests can only access their own jobs" err.out
+'
+
+test_expect_success 'enable private mode' '
+	enable_private_mode
+'
+test_expect_success 'private mode on: guest stats-get fails with EPERM' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail flux module stats job-manager 2>private-stats.err &&
+	test_debug "cat private-stats.err" &&
+	grep "not permitted" private-stats.err
+'
+test_expect_success 'private mode on: owner stats-get succeeds' '
+	flux module stats job-manager >/dev/null
+'
+test_expect_success 'private mode on: guest getinfo fails with EPERM' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail job_manager_getinfo 2>private-getinfo.err &&
+	test_debug "cat private-getinfo.err" &&
+	grep "not permitted" private-getinfo.err
+'
+test_expect_success 'private mode on: owner getinfo succeeds' '
+	job_manager_getinfo
+'
+test_expect_success 'private mode on: guest gets EPERM for unknown job (not EINVAL)' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail job_manager_getattr 1 jobspec 2>err.out &&
+	test_must_fail grep -i "unknown job" err.out
+'
+test_expect_success 'private mode on: guest gets EPERM for another users job' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail job_manager_getattr $(cat jobid_int.out) jobspec \
+		2>private-getattr.err &&
+	test_debug "cat private-getattr.err" &&
+	grep "not permitted" private-getattr.err
+'
+test_expect_success FLUX_SECURITY 'private mode on: guest getattr on own job' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	job_manager_getattr $(cat guestid.out) jobspec
+'
+test_expect_success 'private mode on: owner getattr succeeds' '
+	job_manager_getattr $(cat jobid_int.out) jobspec
+'
+
+test_expect_success 'disable private mode' '
+	disable_private_mode
+'
+test_expect_success 'private mode off: guest can call stats-get again' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	flux module stats job-manager
+'
+test_expect_success 'private mode off: guest can call getinfo again' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	job_manager_getinfo
+'
+test_expect_success 'private mode off: guest gets EINVAL for unknown job again' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail job_manager_getattr 1 jobspec 2>err.out &&
+	grep -i "unknown job" err.out
+'
+test_expect_success 'private mode off: guest gets EPERM for other user job again' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail job_manager_getattr $(cat jobid_int.out) jobspec 2>err.out &&
+	grep -i "guests can only access their own jobs" err.out
+'
+test_expect_success FLUX_SECURITY \
+'private mode off: guest getattr on own job still works' '
+	set_userid $other_uid &&
+	test_when_finished unset_userid &&
+	job_manager_getattr $(cat guestid.out) jobspec
+'
+
+
+test_done

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -12,6 +12,8 @@ testssh="${SHARNESS_TEST_SRCDIR}/scripts/tssh"
 
 export FLUX_URI_RESOLVE_LOCAL=t
 
+other_uid=$(($(id -u) + 100))
+
 # To ensure no raciness in tests below, ensure the job-list
 # module knows about submitted jobs in desired states
 job_list_wait_state() {
@@ -437,4 +439,21 @@ test_expect_success NO_CHAIN_LINT 'flux-top cycles left and right work' '
 		flux top --queue=batch
 '
 
+test_expect_success 'enable private mode' '
+	flux config load <<-EOT
+	[access]
+	private-mode = true
+	EOT
+'
+test_expect_success 'flux-top works as guest in private mode (zeroed stats)' '
+	FLUX_HANDLE_USERID=$other_uid FLUX_HANDLE_ROLEMASK=0x2 \
+	    $runpty flux top --test-exit --test-exit-dump=private.out >/dev/null &&
+	grep "0 pending" private.out &&
+	grep "0 running" private.out &&
+	grep "0 complete" private.out &&
+	grep "0 failed" private.out
+'
+test_expect_success 'disable private mode' '
+	flux config load </dev/null
+'
 test_done


### PR DESCRIPTION
This PR adds support for a new `access.private-mode` configuration option to implement "private mode" as described in the recently merged changes to [RFC 43](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_43.html). 

When private mode is enabled, guest users may see only information about their own jobs.

The changes touch two modules. When private mode is enabled:

- **job-list**: in private mode, `list` and `list-id` return only the requesting user's jobs — `list-id` reports another user's job as nonexistent so its existence is not disclosed — and job statistics are denied to guests with `EPERM`.
- **job-manager**: `stats-get` and `getinfo` return `EPERM` to guests, and `getattr` returns a uniform `EPERM` regardless of whether the target job exists.

Additional fixes required:
- **flux-top**: handles the resulting EPERM from `job-stats` gracefully.
- **connector-local**: accepts the new `access.private-mode` key.

We'll let this PR close #7589 and open a separate issue for the `FLUX_ROLE_ADMIN` idea to fully lock down generic `flux module stats` RPC endpoints.

Fixes #7589