### PR TITLE
flux-fsck: allow online check if --repair is not specified

### DIFF
--- a/doc/man1/flux-fsck.rst
+++ b/doc/man1/flux-fsck.rst
@@ -18,6 +18,9 @@ The :program:`flux fsck` checks the integrity of the KVS backing
 store.  By default, it starts with the most recent checkpoint (root version)
 written to the backing store.
 
+Read-only integrity checks can run while the KVS is loaded. The :option:`--repair`
+option requires the KVS to be unloaded.
+
 
 OPTIONS
 =======
@@ -50,7 +53,7 @@ OPTIONS
    unlinked. All damaged keys and their disposition are listed on
    stderr. This process creates a new root reference for these
    changes, and commits it as the current KVS checkpoint at the end of
-   the scan. The KVS is required to be unloaded during repair.
+   the scan. The KVS must be unloaded when using this option.
 
    This option should be considered :ref:`EXPERIMENTAL <fsck_experimental>`
    at this time.

--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -907,8 +907,8 @@ static int cmd_fsck (optparse_t *p, int ac, char *av[])
     ctx.h = builtin_get_flux_handle (p);
     ctx.isatty = isatty (STDERR_FILENO);
 
-    if (kvs_is_running (&ctx))
-        log_msg_exit ("please unload kvs module before using flux-fsck");
+    if (ctx.repair && kvs_is_running (&ctx))
+        log_msg_exit ("please unload kvs module before using flux-fsck --repair");
 
     if ((blobref = optparse_get_str (p, "rootref", NULL))) {
         if (blobref_validate (blobref) < 0)

--- a/t/t2816-fsck-cmd.t
+++ b/t/t2816-fsck-cmd.t
@@ -17,9 +17,6 @@ test_expect_success 'load content and content-sqlite module' '
 test_expect_success 'load kvs' '
 	flux module load kvs
 '
-test_expect_success 'flux-fsck fails if kvs loaded' '
-	test_must_fail flux fsck
-'
 test_expect_success 'create some kvs content' '
 	flux kvs put testdir.a=test &&
 	flux kvs getroot -b > a.rootref &&
@@ -46,6 +43,13 @@ test_expect_success 'create some kvs content' '
 # exists but we do this just to be extra sure
 test_expect_success 'call sync to ensure we have checkpointed' '
 	flux kvs sync
+'
+test_expect_success 'flux-fsck works with kvs loaded (read-only)' '
+	flux fsck
+'
+test_expect_success 'flux-fsck --repair fails if kvs loaded' '
+	test_must_fail flux fsck --repair 2>repair_kvs_loaded.err &&
+	grep "please unload kvs module" repair_kvs_loaded.err
 '
 test_expect_success 'save some treeobjs for later' '
 	flux kvs get --treeobj testdir.b > testdirb.out &&


### PR DESCRIPTION
Problem: `flux-fsck` refuses to run when the kvs is loaded, even when `--repair` is not specified, but read-only integrity checks are safe to run against a loaded kvs.
    
Only require the kvs module to be unloaded when `--repair` is specified.

Split from
- #7681