### PR TITLE
job-manager: remove bottleneck in history plugin to speed up restart with many jobs

### DIFF
--- a/src/modules/job-manager/plugins/history.c
+++ b/src/modules/job-manager/plugins/history.c
@@ -24,6 +24,7 @@
 #include "src/common/libutil/hola.h"
 #include "src/common/libutil/slice.h"
 #include "src/common/libutil/errprintf.h"
+#include "src/common/libjob/job_hash.h"
 
 struct job_entry {
     flux_jobid_t id;
@@ -33,6 +34,9 @@ struct job_entry {
 struct history {
     flux_plugin_t *p;
     struct hola *users; // userid => job list
+    zhashx_t *index;    // jobid => list handle (for O(1) find/delete)
+                        // invariant: every users list entry has exactly one
+                        // index entry; remove from both together
 };
 
 #define COMPARE_NUM_REVERSE(a,b) ((a)>(b)?-1:(a)<(b)?1:0)
@@ -108,6 +112,7 @@ static void history_destroy (struct history *hist)
     if (hist) {
         int saved_errno = errno;
         hola_destroy (hist->users);
+        zhashx_destroy (&hist->index);
         free (hist);
         errno = saved_errno;
     };
@@ -128,10 +133,44 @@ static struct history *history_create (flux_plugin_t *p)
     hola_set_hash_key_hasher (hist->users, userid_hasher);
     hola_set_list_destructor (hist->users, job_entry_destructor);
     hola_set_list_comparator (hist->users, job_entry_comparator);
+
+    /* Index jobid->list handle so duplicate check on job.inactive-add
+     * and the lookup on job.inactive-remove are O(1) instead of a linear
+     * scan of the user's job list (hola_list_find). The index borrows the
+     * job_entry's id as key and stores no values of its own, so no key/value
+     * duplicator or destructor is needed.
+     */
+    if (!(hist->index = job_hash_create ()))
+        goto error;
+
     return hist;
 error:
     history_destroy (hist);
     return NULL;
+}
+
+/* Insert entry into the user's t_submit-ordered list and record its list
+ * handle in the jobid index. Insertion searches from the front of the list
+ * (low_value=true) because new jobs have the largest t_submit and the list is
+ * sorted largest-first.
+ *
+ * On failure, 'entry' is consumed (freed) and -1 is returned.
+ */
+static int job_entry_insert (struct history *hist,
+                             const void *key,
+                             struct job_entry *entry)
+{
+    void *handle;
+
+    if (!(handle = hola_list_insert (hist->users, key, entry, true))) {
+        job_entry_destroy (entry);
+        return -1;
+    }
+    if (zhashx_insert (hist->index, &entry->id, handle) < 0) {
+        hola_list_delete (hist->users, key, handle); // frees entry
+        return -1;
+    }
+    return 0;
 }
 
 static int jobtap_cb (flux_plugin_t *p,
@@ -156,21 +195,27 @@ static int jobtap_cb (flux_plugin_t *p,
     key = userid2key (userid);
     if (streq (topic, "job.inactive-remove")) {
         void *handle;
-        if ((handle = hola_list_find (hist->users, key, entry)))
+        if ((handle = zhashx_lookup (hist->index, &entry->id))) {
+            zhashx_delete (hist->index, &entry->id);
             hola_list_delete (hist->users, key, handle);
+        }
         job_entry_destroy (entry);
     }
     else if (streq (topic, "job.inactive-add")) {
-        if (hola_list_find (hist->users, key, entry)) {
+        /* A job that transitioned active->inactive already has an entry from
+         * job.new, so skip the duplicate. At restart, replayed inactive jobs
+         * arrive here without a prior job.new and are added.
+         */
+        if (zhashx_lookup (hist->index, &entry->id)) {
             job_entry_destroy (entry);
             return 0;
         }
-        if (!hola_list_insert (hist->users, key, entry, true))
-            goto error;
+        if (job_entry_insert (hist, key, entry) < 0) // consumes entry
+            return -1;
     }
     else if (streq (topic, "job.new")) {
-        if (!hola_list_insert (hist->users, key, entry, true))
-            goto error;
+        if (job_entry_insert (hist, key, entry) < 0) // consumes entry
+            return -1;
     }
     return 0;
 error:

--- a/t/t2812-flux-job-last.t
+++ b/t/t2812-flux-job-last.t
@@ -46,6 +46,36 @@ test_expect_success 'flux-job last lists inactive jobs after instance restart' '
 		flux job last "[:]" >lastdump.out &&
 	test_cmp lastdump.exp lastdump.out
 '
+# Rewrite the submit event timestamp (== t_submit) of a job's eventlog in
+# the KVS so that multiple jobs can be forced to share an identical t_submit.
+force_t_submit() {
+	local id=$1
+	local ts=$2
+	local kd=$(flux job id --to=kvs $id)
+	flux kvs get -r ${kd}.eventlog | flux python -c "
+import sys, json
+lines = sys.stdin.read().splitlines()
+e = json.loads(lines[0])
+e['timestamp'] = $ts
+lines[0] = json.dumps(e)
+sys.stdout.write('\n'.join(lines) + '\n')
+" | flux kvs put -r ${kd}.eventlog=-
+}
+
+# The history plugin keys jobs by id, not t_submit, so jobs sharing a
+# t_submit must all survive a restart (replay).  Before this was fixed,
+# the t_submit-based duplicate check dropped all but one such job.
+test_expect_success 'flux-job last keeps jobs sharing a t_submit after restart' '
+	ids=$(flux submit --cc=1-3 --wait true | sort) &&
+	flux queue idle &&
+	for id in $ids; do force_t_submit $id 1000000000.0; done &&
+	flux module reload job-manager &&
+	flux job last "[:]" >shared_tsubmit.out &&
+	for id in $ids; do
+		grep -q $id shared_tsubmit.out || return 1
+	done
+'
+
 # issue #4931
 test_expect_success 'flux-job last does not list purged jobs' '
 	flux job purge --force --num-limit=0 &&


### PR DESCRIPTION
Profiling Flux restart with lots of inactive jobs in the KVS called out the history jobtap plugin as a large contributor to the time spent waiting for the job-manager to initialize. As the count of inactive jobs increases, the history plugin's processing of inactive jobs dwarfs all other startup time. Profiling revealed this is due to a worst-case O(N^2) duplicate check at `job.inactive-add`, made worse by a redundant call to `job.inactive-add` in the job manager for every inactive job (to be fixed in a future PR).

This PR adds an index by jobid to the history plugin so that lookups by jobid go from O(M) for a user with M jobs to O(1). This improves startup time with 64K jobs (single user, so worst-case) from ~250s to ~40s. Since lookups are improved in general, this also improves the `job.inactive-remove` performace when users have a lot of inactive jobs.

Also, as noted in the commit, this fixes a latent bug in the duplicate check when two jobs share a `t_submit`. Very unlikely, but a test is added here to preserve the correct behavior.