### PR TITLE
job-manager: drop redundant inactive-add loop on restart

### DIFF
--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -482,12 +482,6 @@ int restart_from_kvs (struct job_manager *ctx)
     zlistx_destroy (&active_jobs);
     flux_log (ctx->h, LOG_INFO, "restart: %d running jobs", ctx->running_jobs);
 
-    job = zhashx_first (ctx->inactive_jobs);
-    while (job) {
-        (void)jobtap_call (ctx->jobtap, job, "job.inactive-add", NULL);
-        job = zhashx_next (ctx->inactive_jobs);
-    }
-
     /* Restore misc state.
      */
     if (restart_restore_state (ctx) < 0) {


### PR DESCRIPTION
Problem: After replaying jobs from the KVS, `restart_from_kvs()` loops over the inactive_jobs hash calling the `job.inactive-add` jobtap callback for each job. But `event_job_action()`, invoked per job during the replay itself, already calls `job.inactive-add` when it moves a job into the `inactive_jobs` hash. Every inactive job thus gets the callback twice, an extra O(N) pass on a path that already dominates restart of an instance with many inactive jobs.

This loop has in fact been a no-op from when it was added in 2023 until early 2026: it advanced with `zhashx_next(active_jobs)` while iterating inactive_jobs, so it only ever visited one job (fixed in 7b1285cc2). Inactive jobs were correctly reported by flux job last across restart throughout that window, confirming the replay path is the one that matters.

Remove the redundant loop.