### PR TITLE
scheduler: limit jobspec recursion depth

### DIFF
--- a/src/bindings/python/flux/resource/Rv1Pool.py
+++ b/src/bindings/python/flux/resource/Rv1Pool.py
@@ -53,6 +53,11 @@ from flux.resource.ResourcePoolImplementation import (
 )
 from flux.resource.Rv1Set import Rv1Set
 
+# Maximum resource nesting depth accepted by the recursive jobspec parser.
+# jobspecs nest only a handful of levels (node/slot/core/gpu); this bound is
+# far above any legitimate request but well below Python's recursion limit.
+MAX_RESOURCE_DEPTH = 100
+
 
 class ResourceRequest:
     """Parsed resource request extracted from a jobspec.
@@ -177,7 +182,12 @@ class ResourceRequest:
             "nodefactor": 1,  # product of non-node counts above node level
         }
 
-        def walk(res_list, nodefactor):
+        def walk(res_list, nodefactor, depth=0):
+            if depth > MAX_RESOURCE_DEPTH:
+                raise ValueError(
+                    f"jobspec resource nesting exceeds maximum depth "
+                    f"{MAX_RESOURCE_DEPTH}"
+                )
             for vertex in res_list:
                 rtype = vertex.get("type", "")
                 count = ResourceCount.from_count_spec(vertex.get("count", 1))
@@ -188,7 +198,7 @@ class ResourceRequest:
                     if vertex.get("exclusive", False):
                         state["exclusive"] = True
                     if children:
-                        walk(children, nodefactor)
+                        walk(children, nodefactor, depth + 1)
                 else:
                     # Non-node: accumulate nodefactor (use min for ranges),
                     # then record known types and recurse.
@@ -203,7 +213,7 @@ class ResourceRequest:
                         state["gpu_per_slot"] = count.min
                     # else: unknown type — ignore, continue recursing
                     if children:
-                        walk(children, new_nf)
+                        walk(children, new_nf, depth + 1)
 
         walk(resources, 1)
 

--- a/src/bindings/python/flux/scheduler.py
+++ b/src/bindings/python/flux/scheduler.py
@@ -768,7 +768,12 @@ class Scheduler(BrokerModule):
         """
         try:
             rr = self.resources.parse_resource_request(jobspec)
-        except (KeyError, IndexError, ValueError) as exc:
+        except Exception as exc:
+            # jobspec is untrusted input: any parse failure (including a
+            # RecursionError from a pathologically nested request) must deny
+            # the job rather than escape to _handle_alloc() and stop the
+            # scheduler module.
+            self.log.error(f"alloc: cannot parse jobspec for {jobid}: {exc}")
             request.deny(f"cannot parse jobspec: {exc}")
             return
         heapq.heappush(
@@ -870,14 +875,19 @@ class Scheduler(BrokerModule):
         try:
             rr = self.resources.parse_resource_request(jobspec)
             self.resources.check_feasibility(rr)
-        except (KeyError, IndexError, ValueError) as exc:
-            self.handle.respond_error(msg, errno.EINVAL, str(exc))
-            return
         except InfeasibleRequest as exc:
             self.handle.respond_error(msg, errno.EOVERFLOW, str(exc))
             return
         except OSError as exc:
             self.handle.respond_error(msg, exc.errno, str(exc))
+            return
+        except Exception as exc:
+            # jobspec is untrusted input: any parse failure (including a
+            # RecursionError from a pathologically nested request) must error
+            # the RPC rather than escape to _handle_feasibility() and stop the
+            # scheduler module.
+            self.log.error(f"feasibility: cannot parse jobspec: {exc}")
+            self.handle.respond_error(msg, errno.EINVAL, str(exc))
             return
         self.handle.respond(msg, None)
 

--- a/t/python/t0039-rv1pool.py
+++ b/t/python/t0039-rv1pool.py
@@ -1254,6 +1254,28 @@ class TestFromJobspec(unittest.TestCase):
                     .get("rack_exclusive")
                 )
 
+    def test_deeply_nested_jobspec_raises_valueerror(self):
+        """A pathologically nested jobspec is denied, not a RecursionError.
+
+        Untrusted jobspec input must not be able to overflow the recursive
+        parser and crash the scheduler module (issue #7687); the depth guard
+        turns it into a catchable ValueError.
+        """
+        node = {"type": "core", "count": 1}
+        for _ in range(2000):
+            node = {"type": "slot", "count": 1, "with": [node]}
+        jobspec = {
+            "version": 1,
+            "resources": [node],
+            "tasks": [],
+            "attributes": {"system": {"duration": 60.0}},
+        }
+        for pool in self._pools():
+            with self.subTest(pool=type(pool).__name__):
+                with self.assertRaises(ValueError) as ctx:
+                    pool.parse_resource_request(jobspec)
+                self.assertIn("depth", str(ctx.exception))
+
 
 class TestFromJobspecNonV1(unittest.TestCase):
     """Tests for from_jobspec() with non-V1 resource hierarchies (regression of #6632).


### PR DESCRIPTION
This provides both of the fixes proposed (and well explained) in #7687.