### PR TITLE
fix `zlistx_sort()` sorting bug

### DIFF
--- a/src/common/libczmqcontainers/zlistx.c
+++ b/src/common/libczmqcontainers/zlistx.c
@@ -481,6 +481,8 @@ zlistx_sort (zlistx_t *self)
     bool swapped = false;
     while (gap > 1 || swapped) {
         gap = (size_t) ((double) gap / 1.3);
+        if (gap < 1)
+            gap = 1;
         node_t *base = self->head->next;
         node_t *test = self->head->next;
         size_t jump = gap;


### PR DESCRIPTION
Problem: zlistx_sort() can leave a list incompletely sorted. Its comb sort shrinks the gap by dividing by 1.3 each pass, but does not clamp the result to a minimum of 1. The gap therefore steps from 1 to 0, and a gap of 0 compares each node to itself and never swaps, so the outer loop exits before the repeated gap-of-1 passes that comb sort needs to finish ordering. Adjacent out-of-order pairs survive: a test over random lists mis-sorts roughly a quarter of them.

This affects every in-tree caller, including job_priority_queue_sort() in the job-manager, where it can perturb job priority ordering.

Clamp the gap to a minimum of 1, matching the upstream fix in czmq commit 7b54a58ef ("Fix zlistx_sort edge case").