### PR TITLE
speed up KVS traversal in `flux dump` and `flux fsck` by pipelining content loads

### DIFF
--- a/src/cmd/builtin/dump.c
+++ b/src/cmd/builtin/dump.c
@@ -22,34 +22,19 @@
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libkvs/treeobj.h"
 #include "src/common/libkvs/kvs_checkpoint.h"
+#include "src/common/libkvs/kvs_treewalk.h"
 #include "src/common/libutil/fsd.h"
 #include "src/common/libutil/blobref.h"
 #include "src/common/libcontent/content.h"
-#include "ccan/ptrint/ptrint.h"
 #include "ccan/str/str.h"
 
 #include "builtin.h"
 
-struct dump_valref_data
-{
+/* Passed as the kvs_treewalk callback argument. */
+struct dump {
     flux_t *h;
-    json_t *treeobj;
-    const flux_msg_t **msgs;
-    const char *path;
-    int total_size;
-    int index;
-    int count;
-    int in_flight;
-    int errorcount;
-    int errnum;
+    struct archive *ar;
 };
-
-static void get_blobref (struct dump_valref_data *dvd);
-
-static void dump_treeobj (struct archive *ar,
-                          flux_t *h,
-                          const char *path,
-                          json_t *treeobj);
 
 static bool sd_notify_flag;
 static bool verbose;
@@ -174,71 +159,37 @@ static void dump_write_data (struct archive *ar, const void *data, int size)
                  "assuming non-fatal libarchive write size reporting error");
 }
 
-static void get_blobref_continuation (flux_future_t *f, void *arg)
-{
-    struct dump_valref_data *dvd = arg;
-    const flux_msg_t *msg;
-    size_t len;
-    int index;
-
-    index = ptr2int (flux_future_aux_get (f, "index"));
-    if (flux_future_get (f, (const void **)&msg) < 0
-        || flux_response_decode_raw (msg, NULL, NULL, &len) < 0) {
-        read_error ("%s: missing blobref %d: %s",
-                    dvd->path,
-                    index,
-                    future_strerror (f, errno));
-        flux_future_destroy (f);
-        dvd->in_flight--;
-        dvd->errorcount++;
-        dvd->errnum = errno;    /* we'll report the last errno */
-        return;
-    }
-    dvd->in_flight--;
-    dvd->total_size += len;
-    if (index >= dvd->count)
-        log_msg_exit ("invalid index specified: %d, count = %d",
-                      index,
-                      dvd->count);
-    dvd->msgs[index] = flux_msg_incref (msg);
-
-    /* if an error has occurred, we won't get more blobrefs */
-    if (dvd->index < dvd->count
-        && !dvd->errorcount) {
-        get_blobref (dvd);
-        dvd->in_flight++;
-        dvd->index++;
-    }
-    flux_future_destroy (f);
-}
-
-static void get_blobref (struct dump_valref_data *dvd)
-{
-    const char *blobref;
-    flux_future_t *f;
-
-    blobref = treeobj_get_blobref (dvd->treeobj, dvd->index);
-
-    if (!(f = content_load_byblobref (dvd->h, blobref, content_flags))
-        || flux_future_then (f, -1, get_blobref_continuation, dvd) < 0
-        || flux_future_aux_set (f, "index", int2ptr (dvd->index), NULL) < 0)
-        log_err_exit ("%s: cannot load blobref %d", dvd->path, dvd->index);
-}
-
-/* Write a valref archive entry from the array of stashed content.load
- * response messages.  The total size of the value must be calculated and
- * written in the entry header before any data, so all blobs comprising the
- * valref must be loaded before calling this.  'msgs' has 'count' entries and
- * 'total_size' is the sum of their payload lengths.
+/* kvs_treewalk valref_done callback: write a valref archive entry from the
+ * array of completed content.load responses.  The total size of the value
+ * must be calculated and written in the entry header before any data, so all
+ * blobs are accumulated by the walker before this is called.  A blob load
+ * error (only possible with --ignore-failed-read, else the walker's error
+ * path would have exited) causes the whole entry to be skipped.
  */
-static void dump_write_valref (struct archive *ar,
-                               flux_t *h,
-                               const char *path,
-                               const flux_msg_t **msgs,
-                               int count,
-                               int total_size)
+static void dump_valref (void *arg,
+                         const char *path,
+                         json_t *treeobj,
+                         int count,
+                         const struct kvs_treewalk_blob *blobs)
 {
+    struct dump *d = arg;
+    struct archive *ar = d->ar;
     struct archive_entry *entry;
+    int total_size = 0;
+
+    for (int i = 0; i < count; i++) {
+        size_t len;
+        if (blobs[i].errnum) {
+            read_error ("%s: missing blobref %d: %s",
+                        path,
+                        i,
+                        strerror (blobs[i].errnum));
+            return;
+        }
+        if (flux_response_decode_raw (blobs[i].msg, NULL, NULL, &len) < 0)
+            log_err_exit ("error processing stashed valref responses");
+        total_size += len;
+    }
 
     if (!(entry = archive_entry_new ()))
         log_msg_exit ("error creating archive entry");
@@ -255,75 +206,21 @@ static void dump_write_valref (struct archive *ar,
     for (int i = 0; i < count; i++) {
         const void *data;
         size_t len;
-        if (flux_response_decode_raw (msgs[i], NULL, &data, &len) < 0)
+        if (flux_response_decode_raw (blobs[i].msg, NULL, &data, &len) < 0)
             log_err_exit ("error processing stashed valref responses");
         if (len > 0)
             dump_write_data (ar, data, len);
     }
     archive_entry_free (entry);
-    progress (h, 1);
+    if (verbose)
+        fprintf (stderr, "%s\n", path);
+    progress (d->h, 1);
 }
 
-static void dump_valref (struct archive *ar,
-                         flux_t *h,
-                         const char *path,
-                         json_t *treeobj)
+static void dump_val (void *arg, const char *path, json_t *treeobj)
 {
-    int count = treeobj_get_count (treeobj);
-    const flux_msg_t **msgs;
-    struct dump_valref_data dvd = {0};
-
-    /* Load all data comprising the valref before starting the archive
-     * entry. This is because the total size of the value must
-     * calculated and written before any data, and any load errors
-     * must be detected so the whole entry can be skipped if
-     * --ignore-failed-read.
-     */
-    /* N.B. first attempt was to save the futures in an array, but ran into:
-     *   flux: ev_epoll.c:134: epoll_modify: Assertion `("libev: I/O watcher
-     *    with invalid fd found in epoll_ctl", errno != EBADF && errno != ELOOP
-     *    && errno != EINVAL)' failed.
-     * while archiving a resource.eventlog with 781 entries.  Instead of
-     * retaining the futures for a second pass, just retain references to the
-     * content.load response messages.
-     */
-    if (!(msgs = calloc (count, sizeof (msgs[0]))))
-        log_err_exit ("could not create messages array");
-
-    dvd.h = h;
-    dvd.treeobj = treeobj;
-    dvd.msgs = msgs;
-    dvd.path = path;
-    dvd.count = count;
-
-    while (dvd.in_flight < async_max && dvd.index < dvd.count) {
-        get_blobref (&dvd);
-        dvd.in_flight++;
-        dvd.index++;
-    }
-
-    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
-        log_err_exit ("flux_reactor_run");
-
-    if (dvd.errorcount) {
-        errno = dvd.errnum;
-        goto cleanup;
-    }
-
-    dump_write_valref (ar, h, path, msgs, dvd.count, dvd.total_size);
-cleanup:
-    for (int i = 0; i < dvd.count; i++) {
-        if (msgs[i])
-            flux_msg_decref (msgs[i]);
-    }
-    free (msgs);
-}
-
-static void dump_val (struct archive *ar,
-                      flux_t *h,
-                      const char *path,
-                      json_t *treeobj)
-{
+    struct dump *d = arg;
+    struct archive *ar = d->ar;
     struct archive_entry *entry;
     void *data;
     size_t len;
@@ -340,17 +237,18 @@ static void dump_val (struct archive *ar,
     if (archive_write_header (ar, entry) != ARCHIVE_OK)
         log_msg_exit ("%s", archive_error_string (ar));
     dump_write_data (ar, data, len);
-    progress (h, 1);
+    if (verbose)
+        fprintf (stderr, "%s\n", path);
+    progress (d->h, 1);
 
     archive_entry_free (entry);
     free (data);
 }
 
-static void dump_symlink (struct archive *ar,
-                          flux_t *h,
-                          const char *path,
-                          json_t *treeobj)
+static void dump_symlink (void *arg, const char *path, json_t *treeobj)
 {
+    struct dump *d = arg;
+    struct archive *ar = d->ar;
     struct archive_entry *entry;
     const char *ns;
     const char *target;
@@ -371,123 +269,64 @@ static void dump_symlink (struct archive *ar,
     archive_entry_set_symlink (entry, target);
     if (archive_write_header (ar, entry) != ARCHIVE_OK)
         log_msg_exit ("%s", archive_error_string (ar));
-    progress (h, 1);
+    if (verbose)
+        fprintf (stderr, "%s\n", path);
+    progress (d->h, 1);
 
     free (target_with_ns);
     archive_entry_free (entry);
 }
 
-static void dump_dir (struct archive *ar,
-                      flux_t *h,
-                      const char *path,
-                      json_t *treeobj)
+/* kvs_treewalk error callback: a dirref could not be loaded/decoded.  Report
+ * it (read_error exits unless --ignore-failed-read), pruning the subtree.
+ */
+static void dump_error (void *arg,
+                        const char *path,
+                        enum kvs_treewalk_error error,
+                        int errnum)
 {
-    json_t *dict = treeobj_get_data (treeobj);
-    const char *name;
-    json_t *entry;
-
-    json_object_foreach (dict, name, entry) {
-        char *newpath;
-        if (asprintf (&newpath, "%s/%s", path, name) < 0)
-            log_msg_exit ("out of memory");
-        dump_treeobj (ar, h, newpath, entry); // recurse
-        free (newpath);
+    switch (error) {
+        case KVS_TREEWALK_ERROR_LOAD:
+            read_error ("%s: missing blobref: %s", path, strerror (errnum));
+            break;
+        case KVS_TREEWALK_ERROR_BADCOUNT:
+            log_msg_exit ("%s: blobref count is not 1", path);
+            break;
+        case KVS_TREEWALK_ERROR_DECODE:
+            log_err_exit ("%s: could not decode directory", path);
+            break;
+        case KVS_TREEWALK_ERROR_NOTDIR:
+            log_msg_exit ("%s: dirref references non-directory", path);
+            break;
+        case KVS_TREEWALK_ERROR_INVALID:
+            log_msg_exit ("%s: invalid tree object", path);
+            break;
     }
 }
 
-static void dump_dirref (struct archive *ar,
-                         flux_t *h,
-                         const char *path,
-                         json_t *treeobj)
+static const struct kvs_treewalk_ops dump_ops = {
+    .value = dump_val,
+    .symlink = dump_symlink,
+    .valref_done = dump_valref,
+    .error = dump_error,
+};
+
+static void dump_root (flux_t *h, struct archive *ar, const char *blobref)
 {
-    flux_future_t *f;
-    const void *buf;
-    size_t buflen;
-    json_t *treeobj_deref = NULL;
+    struct dump d = { .h = h, .ar = ar };
+    struct kvs_treewalk *tw;
 
-    if (treeobj_get_count (treeobj) != 1)
-        log_msg_exit ("%s: blobref count is not 1", path);
-    if (!(f = content_load_byblobref (h,
-                                      treeobj_get_blobref (treeobj, 0),
-                                      content_flags))
-        || content_load_get (f, &buf, &buflen) < 0) {
-        read_error ("%s: missing blobref: %s",
-                    path,
-                    future_strerror (f, errno));
-        flux_future_destroy (f);
-        return;
-    }
-    if (!(treeobj_deref = treeobj_decodeb (buf, buflen)))
-        log_err_exit ("%s: could not decode directory", path);
-    if (!treeobj_is_dir (treeobj_deref))
-        log_msg_exit ("%s: dirref references non-directory", path);
-    dump_dir (ar, h, path, treeobj_deref); // recurse
-    json_decref (treeobj_deref);
-    flux_future_destroy (f);
-}
-
-static void dump_treeobj (struct archive *ar,
-                          flux_t *h,
-                          const char *path,
-                          json_t *treeobj)
-{
-    if (treeobj_validate (treeobj) < 0)
-        log_msg_exit ("%s: invalid tree object", path);
-    if (treeobj_is_symlink (treeobj)) {
-        if (verbose)
-            fprintf (stderr, "%s\n", path);
-        dump_symlink (ar, h, path, treeobj);
-    }
-    else if (treeobj_is_val (treeobj)) {
-        if (verbose)
-            fprintf (stderr, "%s\n", path);
-        dump_val (ar, h, path, treeobj);
-    }
-    else if (treeobj_is_valref (treeobj)) {
-        if (verbose)
-            fprintf (stderr, "%s\n", path);
-        dump_valref (ar, h, path, treeobj);
-    }
-    else if (treeobj_is_dirref (treeobj)) {
-        dump_dirref (ar, h, path, treeobj); // recurse
-    }
-    else if (treeobj_is_dir (treeobj)) {
-        dump_dir (ar, h, path, treeobj); // recurse
-    }
-}
-
-static void dump_blobref (struct archive *ar,
-                          flux_t *h,
-                          const char *blobref)
-{
-    flux_future_t *f;
-    const void *buf;
-    size_t buflen;
-    json_t *treeobj;
-    json_t *dict;
-    const char *key;
-    json_t *entry;
-
-    if (!(f = content_load_byblobref (h, blobref, content_flags))
-        || content_load_get (f, &buf, &buflen) < 0) {
-        read_error ("cannot load root tree object: %s",
-                    future_strerror (f, errno));
-        flux_future_destroy (f);
-        return;
-    }
-    if (!(treeobj = treeobj_decodeb (buf, buflen)))
-        log_err_exit ("cannot decode root tree object");
-    if (treeobj_validate (treeobj) < 0)
-        log_msg_exit ("invalid root tree object");
-    if (!treeobj_is_dir (treeobj))
-        log_msg_exit ("root tree object is not a directory");
-
-    dict = treeobj_get_data (treeobj);
-    json_object_foreach (dict, key, entry) {
-        dump_treeobj (ar, h, key, entry);
-    }
-    json_decref (treeobj);
-    flux_future_destroy (f);
+    if (!(tw = kvs_treewalk_create (h,
+                                    blobref,
+                                    '/',
+                                    async_max,
+                                    content_flags,
+                                    &dump_ops,
+                                    &d)))
+        log_err_exit ("error creating kvs treewalk");
+    if (kvs_treewalk_run (tw) < 0)
+        log_err_exit ("error walking kvs");
+    kvs_treewalk_destroy (tw);
 }
 
 static int cmd_dump (optparse_t *p, int ac, char *av[])
@@ -550,7 +389,7 @@ static int cmd_dump (optparse_t *p, int ac, char *av[])
                           future_strerror (f, errno));
 
         dump_time = timestamp;
-        dump_blobref (ar, h, blobref);
+        dump_root (h, ar, blobref);
         flux_future_destroy (f);
     }
     else {
@@ -561,7 +400,7 @@ static int cmd_dump (optparse_t *p, int ac, char *av[])
             || flux_kvs_getroot_get_blobref (f, &blobref) < 0)
             log_msg_exit ("error fetching current KVS root: %s",
                           future_strerror (f, errno));
-        dump_blobref (ar, h, blobref);
+        dump_root (h, ar, blobref);
         flux_future_destroy (f);
     }
 

--- a/src/cmd/builtin/dump.c
+++ b/src/cmd/builtin/dump.c
@@ -225,6 +225,45 @@ static void get_blobref (struct dump_valref_data *dvd)
         log_err_exit ("%s: cannot load blobref %d", dvd->path, dvd->index);
 }
 
+/* Write a valref archive entry from the array of stashed content.load
+ * response messages.  The total size of the value must be calculated and
+ * written in the entry header before any data, so all blobs comprising the
+ * valref must be loaded before calling this.  'msgs' has 'count' entries and
+ * 'total_size' is the sum of their payload lengths.
+ */
+static void dump_write_valref (struct archive *ar,
+                               flux_t *h,
+                               const char *path,
+                               const flux_msg_t **msgs,
+                               int count,
+                               int total_size)
+{
+    struct archive_entry *entry;
+
+    if (!(entry = archive_entry_new ()))
+        log_msg_exit ("error creating archive entry");
+    archive_entry_set_pathname (entry, path);
+    archive_entry_set_size (entry, total_size);
+    archive_entry_set_perm (entry, 0644);
+    archive_entry_set_filetype (entry, AE_IFREG);
+    archive_entry_set_mtime (entry, dump_time, 0);
+    archive_entry_set_uid (entry, dump_uid);
+    archive_entry_set_gid (entry, dump_gid);
+
+    if (archive_write_header (ar, entry) != ARCHIVE_OK)
+        log_msg_exit ("%s", archive_error_string (ar));
+    for (int i = 0; i < count; i++) {
+        const void *data;
+        size_t len;
+        if (flux_response_decode_raw (msgs[i], NULL, &data, &len) < 0)
+            log_err_exit ("error processing stashed valref responses");
+        if (len > 0)
+            dump_write_data (ar, data, len);
+    }
+    archive_entry_free (entry);
+    progress (h, 1);
+}
+
 static void dump_valref (struct archive *ar,
                          flux_t *h,
                          const char *path,
@@ -232,7 +271,6 @@ static void dump_valref (struct archive *ar,
 {
     int count = treeobj_get_count (treeobj);
     const flux_msg_t **msgs;
-    struct archive_entry *entry;
     struct dump_valref_data dvd = {0};
 
     /* Load all data comprising the valref before starting the archive
@@ -272,30 +310,7 @@ static void dump_valref (struct archive *ar,
         goto cleanup;
     }
 
-    if (!(entry = archive_entry_new ()))
-        log_msg_exit ("error creating archive entry");
-    archive_entry_set_pathname (entry, path);
-    archive_entry_set_size (entry, dvd.total_size);
-    archive_entry_set_perm (entry, 0644);
-    archive_entry_set_filetype (entry, AE_IFREG);
-    archive_entry_set_mtime (entry, dump_time, 0);
-    archive_entry_set_uid (entry, dump_uid);
-    archive_entry_set_gid (entry, dump_gid);
-
-    if (archive_write_header (ar, entry) != ARCHIVE_OK)
-        log_msg_exit ("%s", archive_error_string (ar));
-    for (int i = 0; i < dvd.count; i++) {
-        const void *data;
-        size_t len;
-        if (flux_response_decode_raw (msgs[i], NULL, &data, &len) < 0)
-            log_err_exit ("error processing stashed valref responses");
-        if (len > 0)
-            dump_write_data (ar, data, len);
-        flux_msg_decref (msgs[i]);
-        msgs[i] = NULL;
-    }
-    archive_entry_free (entry);
-    progress (h, 1);
+    dump_write_valref (ar, h, path, msgs, dvd.count, dvd.total_size);
 cleanup:
     for (int i = 0; i < dvd.count; i++) {
         if (msgs[i])

--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -21,17 +21,21 @@
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libkvs/treeobj.h"
 #include "src/common/libkvs/kvs_checkpoint.h"
+#include "src/common/libkvs/kvs_treewalk.h"
 #include "src/common/libutil/fsd.h"
 #include "src/common/libutil/timestamp.h"
 #include "src/common/libutil/blobref.h"
 #include "src/common/libcontent/content.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
-#include "ccan/ptrint/ptrint.h"
 #include "ccan/str/str.h"
 
 #include "builtin.h"
 
-#define BLOBREF_ASYNC_MAX 1000
+/* Max concurrent content load/validate requests kept in flight while walking
+ * the KVS.  The walk is offline (the KVS module is not servicing it), so a
+ * large window simply saturates the content backing store.
+ */
+#define FSCK_WALK_WINDOW 1000
 /* regex for "job.xxxx.xxxx.xxxx.xxxx", where 'x' is a hex character */
 #define KVS_JOB_PATH_REGEX \
     "^job.[0-9a-fA-F]{4}\\.[0-9a-fA-F]{4}\\.[0-9a-fA-F]{4}\\.[0-9a-fA-F]{4}"
@@ -56,36 +60,16 @@ struct fsck_ctx {
     zlist_t *pending_repairs;   // struct fsck_repair * recorded during walk
 };
 
-/* A repair recorded during the tree walk and applied to ctx->root after the
- * walk completes.  Deferring keeps repair (which mutates the in-memory root)
- * out of the traversal, in preparation for converting the walk to an
- * event-driven form where inline mutation is unsafe.  'replacement' is the
- * rebuilt value to file under lost+found (valref repair), or NULL to only
- * unlink the path (missing dirref).
+/* A repair recorded during the (read-only) tree walk and applied to ctx->root
+ * afterward, since applying it mutates the in-memory root and may issue
+ * blocking content loads, neither of which is safe inside a walk callback.
+ * 'replacement' is the rebuilt value to file under lost+found (valref repair),
+ * or NULL to only unlink the path (missing dirref).
  */
 struct fsck_repair {
     char *path;
     json_t *replacement;
 };
-
-struct fsck_valref_data
-{
-    struct fsck_ctx *ctx;
-    json_t *treeobj;
-    int index;
-    int count;
-    int in_flight;
-    const char *path;
-    int errorcount;
-    int errnum;
-    zlist_t *missing_indexes;
-};
-
-static void fsck_treeobj (struct fsck_ctx *ctx,
-                          const char *path,
-                          json_t *treeobj);
-
-static void valref_validate (struct fsck_valref_data *fvd);
 
 static void vmsg (struct fsck_ctx *ctx, const char *fmt, va_list ap)
 {
@@ -119,103 +103,42 @@ void errmsg (struct fsck_ctx *ctx, const char *fmt, ...)
     va_end (ap);
 }
 
-static void save_missing_ref_index (struct fsck_valref_data *fvd, int index)
+/* kvs_treewalk valref_request override: validate that a blob exists in the
+ * backing store without transferring its content.  "validate" was added in
+ * v0.77.0; fall back to "load" on older targets (see check_validate_available).
+ */
+static flux_future_t *fsck_valref_request (void *arg, const char *blobref)
 {
-    int *cpy;
-
-    if (!fvd->missing_indexes) {
-        if (!(fvd->missing_indexes = zlist_new ()))
-            log_err_exit ("cannot create missing indexes list");
-    }
-
-    if (!(cpy = malloc (sizeof (index))))
-        log_err_exit ("cannot allocate memory for index");
-    *cpy = index;
-
-    if (zlist_append (fvd->missing_indexes, cpy) < 0)
-        log_err_exit ("cannot append index to list");
-    zlist_freefn (fvd->missing_indexes, cpy, (zlist_free_fn *) free, true);
-}
-
-static void valref_validate_continuation (flux_future_t *f, void *arg)
-{
-    struct fsck_valref_data *fvd = arg;
-
-    if (flux_rpc_get (f, NULL) < 0) {
-        int index = ptr2int (flux_future_aux_get (f, "index"));
-        if (fvd->ctx->verbose) {
-            if (errno == ENOENT)
-                errmsg (fvd->ctx,
-                        "%s: missing blobref index=%d",
-                        fvd->path,
-                        index);
-            else
-                errmsg (fvd->ctx,
-                        "%s: error retrieving blobref index=%d: %s",
-                        fvd->path,
-                        index,
-                        future_strerror (f, errno));
-        }
-        fvd->errorcount++;
-        fvd->errnum = errno;     /* we'll report the last errno */
-        if (fvd->ctx->repair && errno == ENOENT)
-            save_missing_ref_index (fvd, index);
-    }
-    fvd->in_flight--;
-
-    if (fvd->index < fvd->count) {
-        valref_validate (fvd);
-        fvd->in_flight++;
-        fvd->index++;
-    }
-
-    flux_future_destroy (f);
-}
-
-static void valref_validate (struct fsck_valref_data *fvd)
-{
-    const char *topic = fvd->ctx->validate_available ?
+    struct fsck_ctx *ctx = arg;
+    const char *topic = ctx->validate_available ?
         "content-backing.validate" : "content-backing.load";
     uint32_t hash[BLOBREF_MAX_DIGEST_SIZE];
     ssize_t hash_size;
-    const char *blobref;
-    flux_future_t *f;
-
-    blobref = treeobj_get_blobref (fvd->treeobj, fvd->index);
 
     if ((hash_size = blobref_strtohash (blobref, hash, sizeof (hash))) < 0)
-        log_err_exit ("cannot get hash from ref string");
-
-    if (!(f = flux_rpc_raw (fvd->ctx->h, topic, hash, hash_size, 0, 0)))
-        log_err_exit ("failed to validate valref blob");
-    if (flux_future_then (f, -1, valref_validate_continuation, fvd) < 0)
-        log_err_exit ("cannot validate valref blob");
-    if (flux_future_aux_set (f, "index", int2ptr (fvd->index), NULL) < 0)
-        log_err_exit ("could not save index value");
+        return NULL;
+    return flux_rpc_raw (ctx->h, topic, hash, hash_size, 0, 0);
 }
 
+/* Build a repaired valref from the original, dropping the blobs that failed
+ * to validate (blobs[i].errnum == ENOENT).  If every blob was bad the value
+ * becomes an empty val object.
+ */
 static json_t *repair_valref (struct fsck_ctx *ctx,
                               json_t *treeobj,
-                              struct fsck_valref_data *fvd)
+                              int count,
+                              const struct kvs_treewalk_blob *blobs)
 {
     json_t *repaired;
-    int *missing;
-    int i;
-    int count = treeobj_get_count (treeobj);
 
     if (!(repaired = treeobj_create_valref (NULL)))
         log_err_exit ("cannot create treeobj valref");
 
-    missing = zlist_pop (fvd->missing_indexes);
-    for (i = 0; i < count; i++) {
-        const char *blobref = treeobj_get_blobref (treeobj, i);
-        if (!missing || i != (*missing)) {
-            if (treeobj_append_blobref (repaired, blobref) < 0)
+    for (int i = 0; i < count; i++) {
+        if (!blobs[i].errnum) {
+            if (treeobj_append_blobref (repaired,
+                                        treeobj_get_blobref (treeobj, i)) < 0)
                 log_err_exit ("cannot append blobref to valref");
-        }
-        else {
-            free (missing);
-            missing = zlist_pop (fvd->missing_indexes);
         }
     }
 
@@ -372,10 +295,9 @@ static void save_kvs_job_path (struct fsck_ctx *ctx, const char *path)
     }
 }
 
-/* Record a repair to apply to ctx->root after the walk completes, rather than
- * mutating the root mid-traversal.  'replacement' is filed under lost+found
- * (valref repair) and the path is unlinked; a NULL 'replacement' only unlinks
- * (missing dirref).  Ownership of 'replacement' transfers here.
+/* Record a repair to apply to ctx->root after the walk completes.  Applying
+ * it now would mutate the root mid-traversal and (for lost+found) issue
+ * blocking content loads from within a walk callback.
  */
 static void record_repair (struct fsck_ctx *ctx,
                            const char *path,
@@ -404,8 +326,126 @@ static void fsck_repair_destroy (struct fsck_repair *r)
     }
 }
 
+/* kvs_treewalk valref_done callback: a value's blobs have all been validated.
+ * Report any that are missing (one error per key; per-blob detail in verbose
+ * mode) and, in repair mode, record a rebuilt value for lost+found.
+ */
+static void fsck_valref_done (void *arg,
+                              const char *path,
+                              json_t *treeobj,
+                              int count,
+                              const struct kvs_treewalk_blob *blobs)
+{
+    struct fsck_ctx *ctx = arg;
+    int errorcount = 0;
+    int missingcount = 0;
+    int last_errnum = 0;
+
+    for (int i = 0; i < count; i++) {
+        if (!blobs[i].errnum)
+            continue;
+        errorcount++;
+        last_errnum = blobs[i].errnum;
+        if (blobs[i].errnum == ENOENT)
+            missingcount++;
+        if (ctx->verbose) {
+            if (blobs[i].errnum == ENOENT)
+                errmsg (ctx, "%s: missing blobref index=%d", path, i);
+            else
+                errmsg (ctx,
+                        "%s: error retrieving blobref index=%d: %s",
+                        path,
+                        i,
+                        strerror (blobs[i].errnum));
+        }
+    }
+    if (errorcount == 0)
+        return;
+
+    /* each invalid blobref is output above in verbose mode */
+    if (!ctx->verbose) {
+        if (last_errnum == ENOENT)
+            errmsg (ctx, "%s: missing blobref(s)", path);
+        else
+            errmsg (ctx,
+                    "%s: error retrieving blobref(s): %s",
+                    path,
+                    strerror (last_errnum));
+    }
+    ctx->errorcount++;
+
+    /* can only recover if errors were all bad (missing) references */
+    if (ctx->repair && errorcount == missingcount) {
+        record_repair (ctx, path, repair_valref (ctx, treeobj, count, blobs));
+        ctx->repair_count++;
+        warn (ctx, "%s repaired and moved to lost+found", path);
+        if (ctx->job_aware)
+            save_kvs_job_path (ctx, path);
+    }
+}
+
+/* kvs_treewalk error callback: a dirref could not be loaded, decoded, or
+ * validated.  Report it (the subtree is pruned by the walker) and, for a
+ * missing dirref in repair mode, record the path for unlinking.
+ */
+static void fsck_error (void *arg,
+                        const char *path,
+                        enum kvs_treewalk_error error,
+                        int errnum)
+{
+    struct fsck_ctx *ctx = arg;
+
+    switch (error) {
+        case KVS_TREEWALK_ERROR_INVALID:
+            errmsg (ctx, "%s: invalid tree object", path);
+            break;
+        case KVS_TREEWALK_ERROR_BADCOUNT:
+            errmsg (ctx, "%s: invalid dirref treeobj count", path);
+            break;
+        case KVS_TREEWALK_ERROR_LOAD:
+            if (errnum == ENOENT)
+                errmsg (ctx, "%s: missing dirref blobref", path);
+            else
+                errmsg (ctx,
+                        "%s: error retrieving dirref blobref: %s",
+                        path,
+                        strerror (errnum));
+            if (ctx->repair && errnum == ENOENT) {
+                record_repair (ctx, path, NULL); // unlink only
+                warn (ctx, "%s unlinked due to missing blobref", path);
+                ctx->unlink_dir_count++;
+            }
+            break;
+        case KVS_TREEWALK_ERROR_DECODE:
+            errmsg (ctx, "%s: could not decode directory", path);
+            break;
+        case KVS_TREEWALK_ERROR_NOTDIR:
+            errmsg (ctx, "%s: dirref references non-directory", path);
+            break;
+    }
+    ctx->errorcount++;
+}
+
+/* kvs_treewalk visit callback: verbose path listing, matching the order the
+ * old recursion printed (every object as it is reached).
+ */
+static void fsck_visit (void *arg, const char *path, json_t *treeobj)
+{
+    struct fsck_ctx *ctx = arg;
+    if (ctx->verbose)
+        warn (ctx, "%s", path);
+}
+
+static const struct kvs_treewalk_ops fsck_ops = {
+    .visit = fsck_visit,
+    .valref_request = fsck_valref_request,
+    .valref_done = fsck_valref_done,
+    .error = fsck_error,
+};
+
 /* Apply the repairs recorded during the walk: file the rebuilt value under
- * lost+found (valref repair) and/or unlink the bad path.
+ * lost+found (valref repair) and/or unlink the bad path.  Done after the walk
+ * because these mutate ctx->root and may issue blocking content loads.
  */
 static void apply_repairs (struct fsck_ctx *ctx)
 {
@@ -414,6 +454,10 @@ static void apply_repairs (struct fsck_ctx *ctx)
     if (!ctx->pending_repairs)
         return;
     while ((r = zlist_pop (ctx->pending_repairs))) {
+        /* A replacement (valref repair) is filed under lost+found and the
+         * original path unlinked; with no replacement (missing dirref) the
+         * path is only unlinked.
+         */
         if (r->replacement)
             put_lost_and_found (ctx, r->path, r->replacement);
         unlink_path (ctx, r->path);
@@ -421,202 +465,60 @@ static void apply_repairs (struct fsck_ctx *ctx)
     }
 }
 
-static void fsck_valref (struct fsck_ctx *ctx,
-                         const char *path,
-                         json_t *treeobj)
-{
-    struct fsck_valref_data fvd = {0};
-
-    fvd.ctx = ctx;
-    fvd.treeobj = treeobj;
-    fvd.count = treeobj_get_count (treeobj);
-    fvd.path = path;
-
-    while (fvd.in_flight < BLOBREF_ASYNC_MAX
-           && fvd.index < fvd.count) {
-        valref_validate (&fvd);
-        fvd.in_flight++;
-        fvd.index++;
-    }
-
-    if (flux_reactor_run (flux_get_reactor (ctx->h), 0) < 0)
-        log_err_exit ("flux_reactor_run");
-
-    if (fvd.errorcount) {
-        /* each invalid blobref will be output in verbose mode */
-        if (!ctx->verbose) {
-            if (fvd.errnum == ENOENT)
-                errmsg (ctx, "%s: missing blobref(s)", path);
-            else
-                errmsg (ctx,
-                        "%s: error retrieving blobref(s): %s",
-                        path,
-                        strerror (fvd.errnum));
-        }
-        ctx->errorcount++;
-
-        /* can only recover if errors were all bad references */
-        if (ctx->repair
-            && fvd.missing_indexes
-            && fvd.errorcount == zlist_size (fvd.missing_indexes)) {
-            json_t *repaired = repair_valref (ctx, treeobj, &fvd);
-
-            record_repair (ctx, path, repaired); // applied after the walk
-
-            ctx->repair_count++;
-
-            warn (ctx, "%s repaired and moved to lost+found", path);
-
-            if (ctx->job_aware)
-                save_kvs_job_path (ctx, path);
-        }
-    }
-
-    zlist_destroy (&fvd.missing_indexes);
-}
-
-
-static void fsck_val (struct fsck_ctx *ctx,
-                      const char *path,
-                      json_t *treeobj)
-{
-    /* Do nothing for now */
-}
-
-static void fsck_symlink (struct fsck_ctx *ctx,
-                          const char *path,
-                          json_t *treeobj)
-{
-    /* Do nothing for now */
-}
-
-static void fsck_dir (struct fsck_ctx *ctx,
-                      const char *path,
-                      json_t *treeobj)
-{
-    json_t *dict = treeobj_get_data (treeobj);
-    const char *name;
-    json_t *entry;
-
-    json_object_foreach (dict, name, entry) {
-        char *newpath;
-        if (asprintf (&newpath, "%s.%s", path, name) < 0)
-            log_msg_exit ("out of memory");
-        fsck_treeobj (ctx, newpath, entry); // recurse
-        free (newpath);
-    }
-}
-
-static void fsck_dirref (struct fsck_ctx *ctx,
-                         const char *path,
-                         json_t *treeobj)
-{
-    flux_future_t *f = NULL;
-    const void *buf;
-    size_t buflen;
-    json_t *treeobj_deref = NULL;
-    int count;
-
-    count = treeobj_get_count (treeobj);
-    if (count != 1) {
-        errmsg (ctx,
-                "%s: invalid dirref treeobj count=%d",
-                path,
-                count);
-        ctx->errorcount++;
-        return;
-    }
-    if (!(f = content_load_byblobref (ctx->h,
-                                      treeobj_get_blobref (treeobj, 0),
-                                      CONTENT_FLAG_CACHE_BYPASS))
-        || content_load_get (f, &buf, &buflen) < 0) {
-        if (errno == ENOENT)
-            errmsg (ctx, "%s: missing dirref blobref", path);
-        else
-            errmsg (ctx,
-                    "%s: error retrieving dirref blobref: %s",
-                    path,
-                    future_strerror (f, errno));
-        ctx->errorcount++;
-        if (ctx->repair && errno == ENOENT) {
-            record_repair (ctx, path, NULL); // unlink only, after the walk
-            warn (ctx, "%s unlinked due to missing blobref", path);
-            ctx->unlink_dir_count++;
-        }
-        goto cleanup;
-    }
-    if (!(treeobj_deref = treeobj_decodeb (buf, buflen))) {
-        errmsg (ctx, "%s: could not decode directory", path);
-        ctx->errorcount++;
-        goto cleanup;
-    }
-    if (!treeobj_is_dir (treeobj_deref)) {
-        errmsg (ctx, "%s: dirref references non-directory", path);
-        ctx->errorcount++;
-        goto cleanup;
-    }
-    fsck_dir (ctx, path, treeobj_deref); // recurse
-cleanup:
-    json_decref (treeobj_deref);
-    flux_future_destroy (f);
-}
-
-static void fsck_treeobj (struct fsck_ctx *ctx,
-                          const char *path,
-                          json_t *treeobj)
-{
-    if (treeobj_validate (treeobj) < 0) {
-        errmsg (ctx, "%s: invalid tree object", path);
-        ctx->errorcount++;
-        return;
-    }
-    if (ctx->verbose)
-        warn (ctx, "%s", path);
-    if (treeobj_is_symlink (treeobj))
-        fsck_symlink (ctx, path, treeobj);
-    else if (treeobj_is_val (treeobj))
-        fsck_val (ctx, path, treeobj);
-    else if (treeobj_is_valref (treeobj))
-        fsck_valref (ctx, path, treeobj);
-    else if (treeobj_is_dirref (treeobj))
-        fsck_dirref (ctx, path, treeobj); // recurse
-    else if (treeobj_is_dir (treeobj))
-        fsck_dir (ctx, path, treeobj); // recurse
-}
-
 static void fsck_blobref (struct fsck_ctx *ctx, const char *blobref)
 {
-    flux_future_t *f;
-    const void *buf;
-    size_t buflen;
-    json_t *dict;
-    const char *key;
-    json_t *entry;
+    struct kvs_treewalk *tw;
 
-    if (!(f = content_load_byblobref (ctx->h,
-                                      blobref,
-                                      CONTENT_FLAG_CACHE_BYPASS))
-        || content_load_get (f, &buf, &buflen) < 0) {
-        errmsg (ctx,
-                "cannot load root tree object: %s",
-                future_strerror (f, errno));
-        ctx->errorcount++;
+    if (!(tw = kvs_treewalk_create (ctx->h,
+                                    blobref,
+                                    '.',
+                                    FSCK_WALK_WINDOW,
+                                    CONTENT_FLAG_CACHE_BYPASS,
+                                    &fsck_ops,
+                                    ctx)))
+        log_err_exit ("error creating kvs treewalk");
+    /* Retain the decoded root for repair (lost+found/unlink) after the walk.
+     * kvs_treewalk loads its own copy internally; this is a separate fetch of
+     * the same root object.
+     */
+    if (ctx->repair) {
+        flux_future_t *f;
+        const void *buf;
+        size_t buflen;
+        if (!(f = content_load_byblobref (ctx->h,
+                                          blobref,
+                                          CONTENT_FLAG_CACHE_BYPASS))
+            || content_load_get (f, &buf, &buflen) < 0) {
+            errmsg (ctx,
+                    "cannot load root tree object: %s",
+                    future_strerror (f, errno));
+            ctx->errorcount++;
+            flux_future_destroy (f);
+            kvs_treewalk_destroy (tw);
+            return;
+        }
+        if (!(ctx->root = treeobj_decodeb (buf, buflen))
+            || treeobj_validate (ctx->root) < 0)
+            log_msg_exit ("blobref does not refer to a valid RFC 11 tree "
+                          "object");
+        if (!treeobj_is_dir (ctx->root))
+            log_msg_exit ("root tree object is not a directory");
         flux_future_destroy (f);
-        return;
     }
-    if (!(ctx->root = treeobj_decodeb (buf, buflen))
-        || treeobj_validate (ctx->root) < 0)
-        log_msg_exit ("blobref does not refer to a valid RFC 11 tree object");
-    if (!treeobj_is_dir (ctx->root))
-        log_msg_exit ("root tree object is not a directory");
-
-    dict = treeobj_get_data (ctx->root);
-    json_object_foreach (dict, key, entry) {
-        fsck_treeobj (ctx, key, entry);
+    if (kvs_treewalk_run (tw) < 0) {
+        /* a fatal walk error (e.g. failure to load the root) is reported as
+         * an error here; per-object errors went through fsck_error already */
+        if (ctx->errorcount == 0) {
+            errmsg (ctx,
+                    "cannot load root tree object: %s",
+                    strerror (errno));
+            ctx->errorcount++;
+        }
     }
-    flux_future_destroy (f);
+    kvs_treewalk_destroy (tw);
 
-    apply_repairs (ctx);
+    if (ctx->repair)
+        apply_repairs (ctx);
 }
 
 static json_t *lookup_job_subdir (struct fsck_ctx *ctx,

--- a/src/cmd/builtin/fsck.c
+++ b/src/cmd/builtin/fsck.c
@@ -53,6 +53,19 @@ struct fsck_ctx {
     int errorcount;
     regex_t jobpath;
     zlist_t *repaired_jobdirs;
+    zlist_t *pending_repairs;   // struct fsck_repair * recorded during walk
+};
+
+/* A repair recorded during the tree walk and applied to ctx->root after the
+ * walk completes.  Deferring keeps repair (which mutates the in-memory root)
+ * out of the traversal, in preparation for converting the walk to an
+ * event-driven form where inline mutation is unsafe.  'replacement' is the
+ * rebuilt value to file under lost+found (valref repair), or NULL to only
+ * unlink the path (missing dirref).
+ */
+struct fsck_repair {
+    char *path;
+    json_t *replacement;
 };
 
 struct fsck_valref_data
@@ -359,6 +372,55 @@ static void save_kvs_job_path (struct fsck_ctx *ctx, const char *path)
     }
 }
 
+/* Record a repair to apply to ctx->root after the walk completes, rather than
+ * mutating the root mid-traversal.  'replacement' is filed under lost+found
+ * (valref repair) and the path is unlinked; a NULL 'replacement' only unlinks
+ * (missing dirref).  Ownership of 'replacement' transfers here.
+ */
+static void record_repair (struct fsck_ctx *ctx,
+                           const char *path,
+                           json_t *replacement)
+{
+    struct fsck_repair *r;
+
+    if (!ctx->pending_repairs) {
+        if (!(ctx->pending_repairs = zlist_new ()))
+            log_err_exit ("cannot create repair list");
+    }
+    if (!(r = calloc (1, sizeof (*r)))
+        || !(r->path = strdup (path)))
+        log_err_exit ("cannot allocate repair record");
+    r->replacement = replacement; // takes ownership (may be NULL)
+    if (zlist_append (ctx->pending_repairs, r) < 0)
+        log_err_exit ("cannot append repair record");
+}
+
+static void fsck_repair_destroy (struct fsck_repair *r)
+{
+    if (r) {
+        json_decref (r->replacement);
+        free (r->path);
+        free (r);
+    }
+}
+
+/* Apply the repairs recorded during the walk: file the rebuilt value under
+ * lost+found (valref repair) and/or unlink the bad path.
+ */
+static void apply_repairs (struct fsck_ctx *ctx)
+{
+    struct fsck_repair *r;
+
+    if (!ctx->pending_repairs)
+        return;
+    while ((r = zlist_pop (ctx->pending_repairs))) {
+        if (r->replacement)
+            put_lost_and_found (ctx, r->path, r->replacement);
+        unlink_path (ctx, r->path);
+        fsck_repair_destroy (r);
+    }
+}
+
 static void fsck_valref (struct fsck_ctx *ctx,
                          const char *path,
                          json_t *treeobj)
@@ -399,15 +461,11 @@ static void fsck_valref (struct fsck_ctx *ctx,
             && fvd.errorcount == zlist_size (fvd.missing_indexes)) {
             json_t *repaired = repair_valref (ctx, treeobj, &fvd);
 
-            put_lost_and_found (ctx, path, repaired);
-
-            unlink_path (ctx, path);
+            record_repair (ctx, path, repaired); // applied after the walk
 
             ctx->repair_count++;
 
             warn (ctx, "%s repaired and moved to lost+found", path);
-
-            json_decref (repaired);
 
             if (ctx->job_aware)
                 save_kvs_job_path (ctx, path);
@@ -481,7 +539,7 @@ static void fsck_dirref (struct fsck_ctx *ctx,
                     future_strerror (f, errno));
         ctx->errorcount++;
         if (ctx->repair && errno == ENOENT) {
-            unlink_path (ctx, path);
+            record_repair (ctx, path, NULL); // unlink only, after the walk
             warn (ctx, "%s unlinked due to missing blobref", path);
             ctx->unlink_dir_count++;
         }
@@ -557,6 +615,8 @@ static void fsck_blobref (struct fsck_ctx *ctx, const char *blobref)
         fsck_treeobj (ctx, key, entry);
     }
     flux_future_destroy (f);
+
+    apply_repairs (ctx);
 }
 
 static json_t *lookup_job_subdir (struct fsck_ctx *ctx,
@@ -985,6 +1045,8 @@ static int cmd_fsck (optparse_t *p, int ac, char *av[])
     }
 
     zlist_destroy (&ctx.repair_treeobjs);
+    zlist_destroy (&ctx.pending_repairs);
+    zlist_destroy (&ctx.repaired_jobdirs);
     json_decref (ctx.root);
     flux_close (ctx.h);
 

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -55,7 +55,8 @@ TESTS = \
 	test_treeobj.t \
 	test_kvs_checkpoint.t \
 	test_kvs_copy.t \
-	test_kvs_util.t
+	test_kvs_util.t \
+	test_kvs_treewalk.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -121,3 +122,9 @@ test_kvs_copy_t_LDADD = $(test_ldadd)
 test_kvs_util_t_SOURCES = test/kvs_util.c
 test_kvs_util_t_CPPFLAGS = $(test_cppflags)
 test_kvs_util_t_LDADD = $(test_ldadd)
+
+test_kvs_treewalk_t_SOURCES = test/treewalk.c
+test_kvs_treewalk_t_CPPFLAGS = $(test_cppflags)
+test_kvs_treewalk_t_LDADD = \
+	$(top_builddir)/src/common/libtestutil/libtestutil.la \
+	$(test_ldadd)

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -31,7 +31,9 @@ libkvs_la_SOURCES = \
 	treeobj.c \
 	kvs_copy.c \
 	kvs_util.c \
-	kvs_util_private.h
+	kvs_util_private.h \
+	kvs_treewalk.c \
+	kvs_treewalk.h
 
 fluxcoreinclude_HEADERS = \
 	kvs.h \

--- a/src/common/libkvs/kvs_treewalk.c
+++ b/src/common/libkvs/kvs_treewalk.c
@@ -1,0 +1,442 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* kvs_treewalk.c - walk a KVS treeobj hierarchy with a bounded content.load
+ * window. See kvs_treewalk.h for the model.
+ *
+ * The walk maintains one FIFO work queue of content.load requests not yet
+ * issued, and keeps up to 'window' of them in flight at once. Each completed
+ * dirref load decodes a directory object and feeds its entries back into the
+ * walk (enqueuing the next level of dirref/valref loads); each completed
+ * valref blob is accumulated until its value is whole, then handed to the
+ * caller. The window is shared by dirref and valref loads alike, so the walk
+ * stays saturated regardless of tree shape. When the queue drains and no
+ * loads remain in flight, the reactor is stopped.
+ *
+ * inline dir, val, and symlink objects need no RPC and are handled
+ * synchronously as they are discovered.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <flux/core.h>
+
+#include "src/common/libcontent/content.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+#include "treeobj.h"
+#include "kvs_treewalk.h"
+
+/* Accumulator shared by the blob loads of one valref. valref_done can only
+ * be called once every blob has completed.
+ */
+struct valref_obj {
+    char *path;
+    json_t *treeobj;            // borrowed reference to the valref object
+    struct kvs_treewalk_blob *blobs;  // [count] results in index order
+    int count;
+    int remaining;              // blobs not yet completed
+};
+
+/* One pending content.load: either a dirref directory object (vobj == NULL)
+ * or one blob of a valref value (vobj != NULL).
+ */
+struct load_op {
+    struct kvs_treewalk *tw;
+    char *blobref;
+    char *path;                 // dirref: full path of the directory
+    struct valref_obj *vobj;    // valref: shared accumulator, else NULL
+    int blob_index;             // valref: index of this blob within the value
+};
+
+struct kvs_treewalk {
+    flux_t *h;
+    char *root_blobref;
+    char sep;
+    int window;
+    int content_flags;
+    struct kvs_treewalk_ops ops;
+    void *arg;
+    zlistx_t *workq;           // FIFO of struct load_op * awaiting issue
+    int in_flight;             // content.load requests currently outstanding
+    int errnum;                // first fatal (internal) error, else 0
+};
+
+static void classify (struct kvs_treewalk *tw,
+                      const char *path,
+                      json_t *treeobj);
+static void treewalk_pump (struct kvs_treewalk *tw);
+
+/* Record a fatal internal error (OOM or request-send failure) that aborts the
+ * whole walk. The first error wins. The walk unwinds: classify()/walk_dir()
+ * stop descending, and load_continuation() stops the reactor once it sees
+ * this set. kvs_treewalk_run() then returns -1 with this errno.
+ */
+static void treewalk_fatal (struct kvs_treewalk *tw, int errnum)
+{
+    if (tw->errnum == 0)
+        tw->errnum = errnum;
+}
+
+static void report_error (struct kvs_treewalk *tw,
+                          const char *path,
+                          enum kvs_treewalk_error error,
+                          int errnum)
+{
+    if (tw->ops.error)
+        tw->ops.error (tw->arg, path, error, errnum);
+}
+
+static void valref_obj_destroy (struct valref_obj *vobj)
+{
+    if (vobj) {
+        int saved_errno = errno;
+        if (vobj->blobs) {
+            for (int i = 0; i < vobj->count; i++)
+                flux_msg_decref (vobj->blobs[i].msg);
+            free (vobj->blobs);
+        }
+        json_decref (vobj->treeobj);
+        free (vobj->path);
+        free (vobj);
+        errno = saved_errno;
+    }
+}
+
+static struct valref_obj *valref_obj_create (const char *path,
+                                             json_t *treeobj,
+                                             int count)
+{
+    struct valref_obj *vobj;
+
+    if (!(vobj = calloc (1, sizeof (*vobj)))
+        || !(vobj->path = strdup (path))
+        || !(vobj->blobs = calloc (count, sizeof (vobj->blobs[0])))) {
+        valref_obj_destroy (vobj);
+        return NULL;
+    }
+    vobj->treeobj = json_incref (treeobj);
+    vobj->count = count;
+    vobj->remaining = count;
+    return vobj;
+}
+
+static void load_op_destroy (struct load_op *op)
+{
+    if (op) {
+        int saved_errno = errno;
+        free (op->blobref);
+        free (op->path);
+        free (op);
+        errno = saved_errno;
+    }
+}
+
+/* zlistx_destructor_fn footprint */
+static void load_op_destructor (void **item)
+{
+    if (item) {
+        load_op_destroy (*item);
+        *item = NULL;
+    }
+}
+
+/* Enqueue one content.load (issued later by treewalk_pump()). 'vobj' is NULL
+ * for a dirref directory object, or the shared accumulator for a valref blob.
+ */
+static void enqueue_load (struct kvs_treewalk *tw,
+                          const char *blobref,
+                          const char *path,
+                          struct valref_obj *vobj,
+                          int blob_index)
+{
+    struct load_op *op;
+
+    if (!(op = calloc (1, sizeof (*op)))
+        || !(op->blobref = strdup (blobref))
+        || (path && !(op->path = strdup (path)))) {
+        load_op_destroy (op);
+        treewalk_fatal (tw, errno);
+        return;
+    }
+    op->tw = tw;
+    op->vobj = vobj;
+    op->blob_index = blob_index;
+    if (!zlistx_add_end (tw->workq, op)) {
+        load_op_destroy (op);
+        treewalk_fatal (tw, ENOMEM);
+    }
+}
+
+/* Walk the entries of a directory object, joining each child onto 'path'.
+ * The root is reached with path="", so its children use bare names; deeper
+ * children are "dir<sep>name".
+ */
+static void walk_dir (struct kvs_treewalk *tw,
+                      const char *path,
+                      json_t *treeobj)
+{
+    json_t *dict = treeobj_get_data (treeobj);
+    const char *name;
+    json_t *entry;
+
+    json_object_foreach (dict, name, entry) {
+        char *newpath;
+        if (tw->errnum) // a fatal error aborted the walk
+            return;
+        if (*path == '\0')
+            newpath = strdup (name);
+        else if (asprintf (&newpath, "%s%c%s", path, tw->sep, name) < 0)
+            newpath = NULL;
+        if (!newpath) {
+            treewalk_fatal (tw, ENOMEM);
+            return;
+        }
+        classify (tw, newpath, entry);
+        free (newpath);
+    }
+}
+
+/* Classify one object discovered at 'path' and either handle it now (inline
+ * types) or enqueue the content.load(s) needed to dump it (dirref, valref).
+ */
+static void classify (struct kvs_treewalk *tw,
+                      const char *path,
+                      json_t *treeobj)
+{
+    if (treeobj_validate (treeobj) < 0) {
+        report_error (tw, path, KVS_TREEWALK_ERROR_INVALID, 0);
+        return;
+    }
+    if (tw->ops.visit)
+        tw->ops.visit (tw->arg, path, treeobj);
+
+    if (treeobj_is_dir (treeobj)) {
+        walk_dir (tw, path, treeobj);
+    }
+    else if (treeobj_is_dirref (treeobj)) {
+        if (treeobj_get_count (treeobj) != 1) {
+            report_error (tw, path, KVS_TREEWALK_ERROR_BADCOUNT, 0);
+            return;
+        }
+        enqueue_load (tw, treeobj_get_blobref (treeobj, 0), path, NULL, 0);
+    }
+    else if (treeobj_is_valref (treeobj)) {
+        /* count >= 1: treeobj_validate() above rejects an empty valref. */
+        int count = treeobj_get_count (treeobj);
+        struct valref_obj *vobj;
+
+        if (!(vobj = valref_obj_create (path, treeobj, count))) {
+            treewalk_fatal (tw, errno);
+            return;
+        }
+        for (int i = 0; i < count; i++)
+            enqueue_load (tw,
+                          treeobj_get_blobref (treeobj, i),
+                          NULL,
+                          vobj,
+                          i);
+    }
+    else if (treeobj_is_val (treeobj)) {
+        if (tw->ops.value)
+            tw->ops.value (tw->arg, path, treeobj);
+    }
+    else if (treeobj_is_symlink (treeobj)) {
+        if (tw->ops.symlink)
+            tw->ops.symlink (tw->arg, path, treeobj);
+    }
+}
+
+/* A dirref directory object finished loading: decode it and walk its entries.
+ * On a load/decode/type error, prune this subtree (its children are never
+ * discovered).
+ */
+static void dirref_complete (struct load_op *op, flux_future_t *f)
+{
+    struct kvs_treewalk *tw = op->tw;
+    const void *buf;
+    size_t buflen;
+    json_t *treeobj;
+
+    if (content_load_get (f, &buf, &buflen) < 0) {
+        report_error (tw, op->path, KVS_TREEWALK_ERROR_LOAD, errno);
+        return;
+    }
+    if (!(treeobj = treeobj_decodeb (buf, buflen))) {
+        report_error (tw, op->path, KVS_TREEWALK_ERROR_DECODE, 0);
+        return;
+    }
+    if (!treeobj_is_dir (treeobj)) {
+        report_error (tw, op->path, KVS_TREEWALK_ERROR_NOTDIR, 0);
+        json_decref (treeobj);
+        return;
+    }
+    walk_dir (tw, op->path, treeobj);
+    json_decref (treeobj);
+}
+
+/* One blob of a valref finished loading: stash its result. When the last
+ * blob arrives, hand the whole value to the caller.
+ */
+static void valref_complete (struct load_op *op, flux_future_t *f)
+{
+    struct kvs_treewalk *tw = op->tw;
+    struct valref_obj *vobj = op->vobj;
+    const flux_msg_t *msg;
+
+    if (flux_future_get (f, (const void **)&msg) < 0) {
+        vobj->blobs[op->blob_index].errnum = errno;
+    }
+    else {
+        vobj->blobs[op->blob_index].msg = flux_msg_incref (msg);
+        vobj->blobs[op->blob_index].errnum = 0;
+    }
+    if (--vobj->remaining == 0) {
+        if (tw->ops.valref_done)
+            tw->ops.valref_done (tw->arg,
+                                 vobj->path,
+                                 vobj->treeobj,
+                                 vobj->count,
+                                 vobj->blobs);
+        valref_obj_destroy (vobj);
+    }
+}
+
+/* Common continuation for every content.load: dispatch by op type, refill the
+ * window, and stop the reactor once the walk is complete.
+ */
+static void load_continuation (flux_future_t *f, void *arg)
+{
+    struct load_op *op = arg;
+    struct kvs_treewalk *tw = op->tw;
+
+    tw->in_flight--;
+    if (op->vobj)
+        valref_complete (op, f);
+    else
+        dirref_complete (op, f);
+    flux_future_destroy (f);
+    load_op_destroy (op);
+
+    treewalk_pump (tw);
+
+    /* Stop on normal completion (queue drained, nothing in flight) or as soon
+     * as a fatal error has aborted the walk.
+     */
+    if (tw->errnum || (tw->in_flight == 0 && zlistx_size (tw->workq) == 0))
+        flux_reactor_stop (flux_get_reactor (tw->h));
+}
+
+/* Issue one queued load. valref blobs may use a caller-supplied request (e.g.
+ * to validate existence instead of transferring content); everything else
+ * uses content_load_byblobref() with the walk's content flags.
+ */
+static flux_future_t *issue_load (struct kvs_treewalk *tw, struct load_op *op)
+{
+    if (op->vobj && tw->ops.valref_request)
+        return tw->ops.valref_request (tw->arg, op->blobref);
+    return content_load_byblobref (tw->h, op->blobref, tw->content_flags);
+}
+
+/* Issue queued content.load requests until the window is full or the queue
+ * drains.
+ */
+static void treewalk_pump (struct kvs_treewalk *tw)
+{
+    struct load_op *op;
+
+    while (!tw->errnum
+           && tw->in_flight < tw->window
+           && (op = zlistx_detach (tw->workq, NULL))) {
+        flux_future_t *f;
+
+        if (!(f = issue_load (tw, op))
+            || flux_future_then (f, -1, load_continuation, op) < 0) {
+            treewalk_fatal (tw, errno);
+            flux_future_destroy (f);
+            load_op_destroy (op);
+            return;
+        }
+        tw->in_flight++;
+    }
+}
+
+int kvs_treewalk_run (struct kvs_treewalk *tw)
+{
+    if (!tw) {
+        errno = EINVAL;
+        return -1;
+    }
+    /* The root is a blob that decodes to a directory object, i.e. an implicit
+     * dirref with path "".
+     */
+    enqueue_load (tw, tw->root_blobref, "", NULL, 0);
+    treewalk_pump (tw);
+    /* Run the reactor only if a load is actually in flight.  If the initial
+     * pump failed (e.g. OOM) nothing is outstanding, so running would block
+     * forever; fall through to the error return instead.
+     */
+    if (tw->in_flight > 0
+        && flux_reactor_run (flux_get_reactor (tw->h), 0) < 0)
+        return -1;
+    if (tw->errnum) {
+        errno = tw->errnum;
+        return -1;
+    }
+    return 0;
+}
+
+struct kvs_treewalk *kvs_treewalk_create (flux_t *h,
+                                          const char *root_blobref,
+                                          char sep,
+                                          int window,
+                                          int content_flags,
+                                          const struct kvs_treewalk_ops *ops,
+                                          void *arg)
+{
+    struct kvs_treewalk *tw;
+
+    if (!h || !root_blobref || window <= 0 || !ops) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(tw = calloc (1, sizeof (*tw)))
+        || !(tw->root_blobref = strdup (root_blobref))
+        || !(tw->workq = zlistx_new ()))
+        goto error;
+    zlistx_set_destructor (tw->workq, load_op_destructor);
+    tw->h = h;
+    tw->sep = sep;
+    tw->window = window;
+    tw->content_flags = content_flags;
+    tw->ops = *ops;
+    tw->arg = arg;
+    return tw;
+error:
+    kvs_treewalk_destroy (tw);
+    return NULL;
+}
+
+void kvs_treewalk_destroy (struct kvs_treewalk *tw)
+{
+    if (tw) {
+        int saved_errno = errno;
+        zlistx_destroy (&tw->workq);
+        free (tw->root_blobref);
+        free (tw);
+        errno = saved_errno;
+    }
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/common/libkvs/kvs_treewalk.h
+++ b/src/common/libkvs/kvs_treewalk.h
@@ -1,0 +1,131 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _KVS_TREEWALK_H
+#define _KVS_TREEWALK_H
+
+#include <flux/core.h>
+#include <jansson.h>
+
+/* Walk a KVS RFC 11 tree object hierarchy, depth first, starting from a root
+ * blobref. The directory objects (dirref) and value blobs (valref) that must
+ * be fetched from the content store are requested through a single bounded
+ * window of in-flight content requests shared across the whole walk, driven
+ * by one reactor. This hides the content round-trip latency that otherwise
+ * dominates an offline walk of a large KVS (e.g. an instance with many
+ * inactive jobs).
+ *
+ * The caller supplies callbacks (kvs_treewalk_ops) that implement the
+ * per-object policy: what to do with a value, symlink, or completed valref,
+ * and how to report an error. The walker owns the mechanism (queue, window,
+ * dirref recursion, valref blob fan-out, completion ordering); the callbacks
+ * own the meaning.
+ *
+ * Objects are visited in request completion order, which is deterministic but
+ * not the same as a strict depth-first key order. Callbacks run one at a time
+ * on the reactor thread, so a callback must NOT run a nested reactor or make a
+ * blocking content RPC (that would deadlock); defer such work until after
+ * kvs_treewalk_run() returns.
+ */
+
+struct kvs_treewalk;
+
+/* Error category reported to the error callback. */
+enum kvs_treewalk_error {
+    KVS_TREEWALK_ERROR_INVALID,   // tree object failed validation
+    KVS_TREEWALK_ERROR_BADCOUNT,  // dirref blobref count != 1
+    KVS_TREEWALK_ERROR_LOAD,      // content load failed (errnum is set)
+    KVS_TREEWALK_ERROR_DECODE,    // loaded dirref object could not be decoded
+    KVS_TREEWALK_ERROR_NOTDIR,    // dirref object is not a directory
+};
+
+/* Result of one valref blob load, in valref index order. 'msg' is the
+ * content.load response message (borrowed; valid only for the duration of the
+ * valref_done callback) or NULL if the load failed, in which case 'errnum'
+ * holds the error.
+ */
+struct kvs_treewalk_blob {
+    const flux_msg_t *msg;
+    int errnum;
+};
+
+struct kvs_treewalk_ops {
+    /* Called once for every object as it is discovered, before dispatch.
+     * Useful for verbose path listing.  May be NULL.
+     */
+    void (*visit) (void *arg, const char *path, json_t *treeobj);
+
+    /* Inline value (val) and symbolic link (symlink) objects.  May be NULL.
+     */
+    void (*value) (void *arg, const char *path, json_t *treeobj);
+    void (*symlink) (void *arg, const char *path, json_t *treeobj);
+
+    /* Optional override for how each valref blob is fetched. When this
+     * field is left NULL, the walker fetches blob content with
+     * content_load_byblobref() and the walk's content flags. When supplied,
+     * it is called to start the request for one blob and must return the
+     * resulting future, or NULL with errno set on failure. Set this to send
+     * a different request, e.g. to validate that a blob exists without
+     * transferring its content.
+     */
+    flux_future_t *(*valref_request) (void *arg, const char *blobref);
+
+    /* Called once when all blobs of a valref have completed, with results in
+     * index order. 'treeobj' is the valref object (for access to blobrefs).
+     * May be NULL.
+     */
+    void (*valref_done) (void *arg,
+                         const char *path,
+                         json_t *treeobj,
+                         int count,
+                         const struct kvs_treewalk_blob *blobs);
+
+    /* Called when a dirref cannot be loaded, decoded, or validated.  The
+     * subtree is pruned (its children are not visited).  The callback may
+     * exit the process to make the error fatal, or return to continue.  May
+     * be NULL (errors are then silently pruned).
+     */
+    void (*error) (void *arg,
+                   const char *path,
+                   enum kvs_treewalk_error error,
+                   int errnum);
+};
+
+/* Create a tree walker.
+ *  root_blobref  - blobref of the root directory object
+ *  sep           - path separator joining directory entries ('/' or '.')
+ *  window        - max concurrent content.load requests (> 0)
+ *  content_flags - CONTENT_FLAG_* for the default loads (dirref and valref)
+ *  ops, arg      - caller callbacks and opaque argument.  'arg' is stored in
+ *                  the walker and passed back to each callback; the caller
+ *                  must keep it valid until kvs_treewalk_destroy().
+ * Returns walker on success, NULL on failure with errno set.
+ */
+struct kvs_treewalk *kvs_treewalk_create (flux_t *h,
+                                          const char *root_blobref,
+                                          char sep,
+                                          int window,
+                                          int content_flags,
+                                          const struct kvs_treewalk_ops *ops,
+                                          void *arg);
+
+/* Run the walk to completion on the handle's reactor.
+ * Returns 0 on success, -1 on a reactor error. Per-object errors are
+ * reported through the error callback, not here.
+ */
+int kvs_treewalk_run (struct kvs_treewalk *tw);
+
+void kvs_treewalk_destroy (struct kvs_treewalk *tw);
+
+#endif /* !_KVS_TREEWALK_H */
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/common/libkvs/test/treewalk.c
+++ b/src/common/libkvs/test/treewalk.c
@@ -1,0 +1,552 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <errno.h>
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+#include "src/common/libutil/blobref.h"
+#include "src/common/libcontent/content.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
+
+#include "treeobj.h"
+#include "kvs_treewalk.h"
+
+static const char *hashtype = "sha1";
+
+/* In-memory content store shared by the test server: a JSON object mapping
+ * blobref string -> base64-ish raw blob (stored as a json string of bytes).
+ * We store the raw bytes via a json binary-safe container (json_stringn).
+ */
+struct blobstore {
+    json_t *map;        // blobref => json_string (raw bytes, len via json)
+};
+
+/* Store raw data, return its blobref (caller must free). */
+static char *store (struct blobstore *bs, const void *data, size_t len)
+{
+    char ref[BLOBREF_MAX_STRING_SIZE];
+    json_t *val;
+
+    if (blobref_hash (hashtype, data, len, ref, sizeof (ref)) < 0)
+        BAIL_OUT ("blobref_hash failed");
+    if (!(val = json_stringn (data, len)))
+        BAIL_OUT ("json_stringn failed");
+    if (json_object_set_new (bs->map, ref, val) < 0)
+        BAIL_OUT ("json_object_set failed");
+    return strdup (ref);
+}
+
+/* Encode a treeobj and store it, returning its blobref (caller frees). */
+static char *store_treeobj (struct blobstore *bs, json_t *obj)
+{
+    char *s;
+    char *ref;
+    if (!(s = treeobj_encode (obj)))
+        BAIL_OUT ("treeobj_encode failed");
+    ref = store (bs, s, strlen (s));
+    free (s);
+    return ref;
+}
+
+/* Test server: answer content.load (raw hash request) from the blobstore.
+ */
+static void load_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    struct blobstore *bs = arg;
+    const void *hash;
+    size_t hash_len;
+    char ref[BLOBREF_MAX_STRING_SIZE];
+    json_t *val;
+    const char *data;
+    size_t len;
+
+    if (flux_request_decode_raw (msg, NULL, &hash, &hash_len) < 0)
+        goto error;
+    if (blobref_hashtostr (hashtype, hash, hash_len, ref, sizeof (ref)) < 0)
+        goto error;
+    if (!(val = json_object_get (bs->map, ref))) {
+        errno = ENOENT;
+        goto error;
+    }
+    data = json_string_value (val);
+    len = json_string_length (val);
+    if (flux_respond_raw (h, msg, data, len) < 0)
+        BAIL_OUT ("flux_respond_raw failed");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        BAIL_OUT ("flux_respond_error failed");
+}
+
+static int server_cb (flux_t *h, void *arg)
+{
+    struct flux_msg_handler_spec spec[] = {
+        { FLUX_MSGTYPE_REQUEST, "content.load", load_cb, 0 },
+        FLUX_MSGHANDLER_TABLE_END,
+    };
+    flux_msg_handler_t **handlers = NULL;
+    int rc;
+
+    if (flux_msg_handler_addvec (h, spec, arg, &handlers) < 0)
+        BAIL_OUT ("flux_msg_handler_addvec failed");
+    rc = flux_reactor_run (flux_get_reactor (h), 0);
+    flux_msg_handler_delvec (handlers);
+    return rc;
+}
+
+/* ------------------------------------------------------------------------ */
+/* Walk result collection */
+
+struct collector {
+    flux_t *h;                  // handle, for callbacks that issue requests
+    zlistx_t *visited;          // paths visited (visit cb), in order
+    int values;
+    int symlinks;
+    int valrefs_done;
+    int valref_total_bytes;
+    int valref_blob_errors;
+    int errors;
+    int valref_requests;        // times valref_request override was called
+    enum kvs_treewalk_error last_error;
+};
+
+static void diag_visit (void *arg, const char *path, json_t *treeobj)
+{
+    struct collector *c = arg;
+    zlistx_add_end (c->visited, strdup (path));
+}
+
+static void on_value (void *arg, const char *path, json_t *treeobj)
+{
+    struct collector *c = arg;
+    c->values++;
+}
+
+static void on_symlink (void *arg, const char *path, json_t *treeobj)
+{
+    struct collector *c = arg;
+    c->symlinks++;
+}
+
+static void on_valref_done (void *arg,
+                            const char *path,
+                            json_t *treeobj,
+                            int count,
+                            const struct kvs_treewalk_blob *blobs)
+{
+    struct collector *c = arg;
+    c->valrefs_done++;
+    for (int i = 0; i < count; i++) {
+        if (blobs[i].errnum) {
+            c->valref_blob_errors++;
+            continue;
+        }
+        const void *data;
+        size_t len;
+        if (flux_response_decode_raw (blobs[i].msg, NULL, &data, &len) == 0)
+            c->valref_total_bytes += len;
+    }
+}
+
+static void on_error (void *arg,
+                     const char *path,
+                     enum kvs_treewalk_error error,
+                     int errnum)
+{
+    struct collector *c = arg;
+    c->errors++;
+    c->last_error = error;
+}
+
+/* valref_request override that still fetches via content.load (the blobstore
+ * has no validate service), just to exercise the override seam.
+ */
+static flux_future_t *on_valref_request (void *arg, const char *blobref)
+{
+    struct collector *c = arg;
+    c->valref_requests++;
+    return content_load_byblobref (c->h, blobref, 0);
+}
+
+/* valref_request override that always fails, simulating a request-send error
+ * so the walk aborts with a fatal error.
+ */
+static flux_future_t *on_valref_request_fail (void *arg, const char *blobref)
+{
+    errno = ENOMEM;
+    return NULL;
+}
+
+static struct kvs_treewalk_ops test_ops = {
+    .visit = diag_visit,
+    .value = on_value,
+    .symlink = on_symlink,
+    .valref_done = on_valref_done,
+    .error = on_error,
+};
+
+static void collector_init (struct collector *c, flux_t *h)
+{
+    memset (c, 0, sizeof (*c));
+    c->h = h;
+    if (!(c->visited = zlistx_new ()))
+        BAIL_OUT ("zlistx_new failed");
+    /* items are plain strdup()'d strings, freed explicitly in
+     * collector_fini
+     */
+}
+
+static bool visited_has (struct collector *c, const char *path)
+{
+    char *s;
+    for (s = zlistx_first (c->visited); s; s = zlistx_next (c->visited)) {
+        if (streq (s, path))
+            return true;
+    }
+    return false;
+}
+
+static void collector_fini (struct collector *c)
+{
+    char *s;
+    while ((s = zlistx_detach (c->visited, NULL)))
+        free (s);
+    zlistx_destroy (&c->visited);
+}
+
+/* ------------------------------------------------------------------------ */
+
+/* Build a tree:
+ *   root/
+ *     val      = "hello"                (inline val)
+ *     link     -> target                (symlink)
+ *     big      = valref [b1, b2, b3]    (3 blobs, 12 bytes)
+ *     sub/     = dirref -> { deep = "x" (inline val) }
+ * Returns root blobref (caller frees).
+ */
+static char *build_tree (struct blobstore *bs, int window_blobs)
+{
+    json_t *root, *sub;
+    json_t *valref, *dirref_sub;
+    char *r1, *r2, *r3, *subref, *rootref;
+
+    /* valref blobs */
+    r1 = store (bs, "aaaa", 4);
+    r2 = store (bs, "bbbb", 4);
+    r3 = store (bs, "cccc", 4);
+    if (!(valref = treeobj_create_valref (r1))
+        || treeobj_append_blobref (valref, r2) < 0
+        || treeobj_append_blobref (valref, r3) < 0)
+        BAIL_OUT ("create valref failed");
+
+    /* subdir with one inline val, stored as a dirref */
+    if (!(sub = treeobj_create_dir ()))
+        BAIL_OUT ("create dir failed");
+    json_t *deepval = treeobj_create_val ("x", 1);
+    if (!deepval || treeobj_insert_entry (sub, "deep", deepval) < 0)
+        BAIL_OUT ("insert deep failed");
+    json_decref (deepval);
+    subref = store_treeobj (bs, sub);
+    if (!(dirref_sub = treeobj_create_dirref (subref)))
+        BAIL_OUT ("create dirref failed");
+
+    /* root dir */
+    if (!(root = treeobj_create_dir ()))
+        BAIL_OUT ("create root failed");
+    json_t *v = treeobj_create_val ("hello", 5);
+    json_t *l = treeobj_create_symlink (NULL, "target");
+    if (!v || !l
+        || treeobj_insert_entry (root, "val", v) < 0
+        || treeobj_insert_entry (root, "link", l) < 0
+        || treeobj_insert_entry (root, "big", valref) < 0
+        || treeobj_insert_entry (root, "sub", dirref_sub) < 0)
+        BAIL_OUT ("insert root entries failed");
+    json_decref (v);
+    json_decref (l);
+    json_decref (valref);
+    json_decref (dirref_sub);
+    json_decref (sub);
+
+    rootref = store_treeobj (bs, root);
+    json_decref (root);
+    free (r1);
+    free (r2);
+    free (r3);
+    free (subref);
+    return rootref;
+}
+
+static void test_basic_walk (flux_t *h, struct blobstore *bs, int window)
+{
+    char *rootref = build_tree (bs, window);
+    struct collector c;
+    struct kvs_treewalk *tw;
+
+    collector_init (&c, h);
+    tw = kvs_treewalk_create (h, rootref, '/', window, 0, &test_ops, &c);
+    ok (tw != NULL, "kvs_treewalk_create window=%d works", window);
+    ok (kvs_treewalk_run (tw) == 0, "kvs_treewalk_run window=%d ok", window);
+
+    ok (c.errors == 0, "no errors reported (got %d)", c.errors);
+    ok (c.values == 2, "two val objects visited (val + sub/deep) (got %d)",
+        c.values);
+    ok (c.symlinks == 1, "one symlink visited (got %d)", c.symlinks);
+    ok (c.valrefs_done == 1, "one valref completed (got %d)", c.valrefs_done);
+    ok (c.valref_total_bytes == 12,
+        "valref delivered 12 bytes (got %d)", c.valref_total_bytes);
+    ok (c.valref_blob_errors == 0, "no valref blob errors");
+
+    ok (visited_has (&c, "val"), "visited root child 'val' (bare name)");
+    ok (visited_has (&c, "sub"), "visited 'sub' dirref");
+    ok (visited_has (&c, "sub/deep"),
+        "visited 'sub/deep' (joined with '/')");
+
+    kvs_treewalk_destroy (tw);
+    collector_fini (&c);
+    free (rootref);
+}
+
+static void test_separator (flux_t *h, struct blobstore *bs)
+{
+    char *rootref = build_tree (bs, 4);
+    struct collector c;
+    struct kvs_treewalk *tw;
+
+    collector_init (&c, h);
+    tw = kvs_treewalk_create (h, rootref, '.', 4, 0, &test_ops, &c);
+    ok (kvs_treewalk_run (tw) == 0, "walk with '.' separator ok");
+    ok (visited_has (&c, "sub.deep"),
+        "deep path joined with '.' separator");
+    kvs_treewalk_destroy (tw);
+    collector_fini (&c);
+    free (rootref);
+}
+
+static void test_missing_dirref (flux_t *h, struct blobstore *bs)
+{
+    json_t *root;
+    char *rootref;
+    struct collector c;
+    struct kvs_treewalk *tw;
+    /* a dirref pointing at a blobref that is not in the store */
+    const char *bogus = "sha1-1234567890123456789012345678901234567890";
+    json_t *dr = treeobj_create_dirref (bogus);
+
+    if (!(root = treeobj_create_dir ())
+        || treeobj_insert_entry (root, "baddir", dr) < 0)
+        BAIL_OUT ("create root failed");
+    json_decref (dr);
+    rootref = store_treeobj (bs, root);
+    json_decref (root);
+
+    collector_init (&c, h);
+    tw = kvs_treewalk_create (h, rootref, '/', 4, 0, &test_ops, &c);
+    ok (kvs_treewalk_run (tw) == 0,
+        "walk with dangling dirref completes (run returns 0)");
+    ok (c.errors == 1, "one error reported (got %d)", c.errors);
+    ok (c.last_error == KVS_TREEWALK_ERROR_LOAD,
+        "error category is LOAD");
+    kvs_treewalk_destroy (tw);
+    collector_fini (&c);
+    free (rootref);
+}
+
+static void test_missing_valref_blob (flux_t *h, struct blobstore *bs)
+{
+    json_t *root, *valref;
+    char *rootref, *good;
+    struct collector c;
+    struct kvs_treewalk *tw;
+    const char *bogus = "sha1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    good = store (bs, "good", 4);
+    if (!(valref = treeobj_create_valref (good))
+        || treeobj_append_blobref (valref, bogus) < 0)
+        BAIL_OUT ("create valref failed");
+    if (!(root = treeobj_create_dir ())
+        || treeobj_insert_entry (root, "v", valref) < 0)
+        BAIL_OUT ("create root failed");
+    json_decref (valref);
+    rootref = store_treeobj (bs, root);
+    json_decref (root);
+
+    collector_init (&c, h);
+    tw = kvs_treewalk_create (h, rootref, '/', 4, 0, &test_ops, &c);
+    ok (kvs_treewalk_run (tw) == 0, "walk with bad valref blob completes");
+    ok (c.valrefs_done == 1, "valref_done still called with partial result");
+    ok (c.valref_blob_errors == 1,
+        "one valref blob reported missing (got %d)", c.valref_blob_errors);
+    kvs_treewalk_destroy (tw);
+    collector_fini (&c);
+    free (rootref);
+    free (good);
+}
+
+/* Build a tree whose subdirectory is an INLINE dir (not a dirref), to
+ * exercise the treeobj_is_dir recursion in classify():
+ *   root/
+ *     inline/   = dir { leaf = "y" }   (inline dir, no separate blob)
+ * Returns root blobref (caller frees).
+ */
+static char *build_inline_dir_tree (struct blobstore *bs)
+{
+    json_t *root, *sub, *leaf;
+    char *rootref;
+
+    if (!(sub = treeobj_create_dir ()))
+        BAIL_OUT ("create dir failed");
+    if (!(leaf = treeobj_create_val ("y", 1))
+        || treeobj_insert_entry (sub, "leaf", leaf) < 0)
+        BAIL_OUT ("insert leaf failed");
+    json_decref (leaf);
+
+    if (!(root = treeobj_create_dir ())
+        || treeobj_insert_entry (root, "inline", sub) < 0)
+        BAIL_OUT ("create root failed");
+    json_decref (sub);
+
+    rootref = store_treeobj (bs, root);
+    json_decref (root);
+    return rootref;
+}
+
+/* An inline (not dirref) subdirectory is walked without an extra content
+ * load, and its children are visited with the joined path.
+ */
+static void test_inline_dir (flux_t *h, struct blobstore *bs)
+{
+    char *rootref = build_inline_dir_tree (bs);
+    struct collector c;
+    struct kvs_treewalk *tw;
+
+    collector_init (&c, h);
+    tw = kvs_treewalk_create (h, rootref, '/', 4, 0, &test_ops, &c);
+    ok (kvs_treewalk_run (tw) == 0, "walk with inline subdir ok");
+    ok (c.errors == 0, "inline subdir: no errors (got %d)", c.errors);
+    ok (c.values == 1, "inline subdir: leaf value visited (got %d)",
+        c.values);
+    ok (visited_has (&c, "inline"), "visited inline dir entry");
+    ok (visited_has (&c, "inline/leaf"),
+        "visited inline/leaf (recursed into inline dir)");
+    kvs_treewalk_destroy (tw);
+    collector_fini (&c);
+    free (rootref);
+}
+
+/* A valref_request override routes valref blob fetches through the caller;
+ * the walk otherwise behaves identically.
+ */
+static void test_valref_request_override (flux_t *h, struct blobstore *bs)
+{
+    char *rootref = build_tree (bs, 4);
+    struct collector c;
+    struct kvs_treewalk *tw;
+    struct kvs_treewalk_ops ops = test_ops;
+    ops.valref_request = on_valref_request;
+
+    collector_init (&c, h);
+    tw = kvs_treewalk_create (h, rootref, '/', 4, 0, &ops, &c);
+    ok (kvs_treewalk_run (tw) == 0, "walk with valref_request override ok");
+    ok (c.valref_requests == 3,
+        "override issued for each of 3 valref blobs (got %d)",
+        c.valref_requests);
+    ok (c.valrefs_done == 1 && c.valref_total_bytes == 12,
+        "valref still delivered in full via override");
+    kvs_treewalk_destroy (tw);
+    collector_fini (&c);
+    free (rootref);
+}
+
+/* When issuing a request fails, the walk aborts and kvs_treewalk_run()
+ * returns -1 with the failure errno.
+ */
+static void test_request_failure (flux_t *h, struct blobstore *bs)
+{
+    char *rootref = build_tree (bs, 4);
+    struct collector c;
+    struct kvs_treewalk *tw;
+    struct kvs_treewalk_ops ops = test_ops;
+    ops.valref_request = on_valref_request_fail;
+
+    collector_init (&c, h);
+    tw = kvs_treewalk_create (h, rootref, '/', 4, 0, &ops, &c);
+    errno = 0;
+    ok (kvs_treewalk_run (tw) < 0 && errno == ENOMEM,
+        "walk aborts with -1/ENOMEM when a request cannot be issued");
+    kvs_treewalk_destroy (tw);
+    collector_fini (&c);
+    free (rootref);
+}
+
+static void test_invalid_args (flux_t *h)
+{
+    struct collector c;
+    collector_init (&c, h);
+    ok (kvs_treewalk_create (NULL, "sha1-x", '/', 4, 0, &test_ops, &c) == NULL
+        && errno == EINVAL,
+        "create with NULL handle returns EINVAL");
+    ok (kvs_treewalk_create (h, NULL, '/', 4, 0, &test_ops, &c) == NULL
+        && errno == EINVAL,
+        "create with NULL root returns EINVAL");
+    ok (kvs_treewalk_create (h, "sha1-x", '/', 0, 0, &test_ops, &c) == NULL
+        && errno == EINVAL,
+        "create with window=0 returns EINVAL");
+    lives_ok ({kvs_treewalk_destroy (NULL);},
+        "kvs_treewalk_destroy (NULL) is a no-op");
+    collector_fini (&c);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    struct blobstore bs;
+
+    plan (NO_PLAN);
+
+    if (!(bs.map = json_object ()))
+        BAIL_OUT ("json_object failed");
+    if (!(h = test_server_create (0, server_cb, &bs)))
+        BAIL_OUT ("test_server_create failed");
+
+    test_invalid_args (h);
+    /* exercise window saturation behavior at small and large windows */
+    test_basic_walk (h, &bs, 1);
+    test_basic_walk (h, &bs, 2);
+    test_basic_walk (h, &bs, 64);
+    test_separator (h, &bs);
+    test_inline_dir (h, &bs);
+    test_valref_request_override (h, &bs);
+    test_missing_dirref (h, &bs);
+    test_missing_valref_blob (h, &bs);
+    test_request_failure (h, &bs);
+
+    if (test_server_stop (h) < 0)
+        BAIL_OUT ("test_server_stop failed");
+    flux_close (h);
+    json_decref (bs.map);
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
Problem: `flux dump` takes excessive time during shutdown on system instances with a lot of jobs. This is a quality of life concern for sysadmins. Similarly, when invoked, `flux fsck` can run for a long time at startup when there are many jobs in the KVS.

This PR adds a new internal interface to libkvs for walking a KVS tree from the root with a window of outstanding content.load RPCs (`kvs_treewalk`). Both `flux dump` and `flux fsck`, which use a similar pattern for walking the KVS, are then updated to use `kvs_treewalk` instead of the synchronous read-then-process method currently employed.

For `flux dump`, the number of outstanding load requests is set to the existing `--maxreqs` option (2 by default, 128 when called during rc3). For `flux fsck`, it is set internally to 1000 (the same value as the previous BLOBREF_ASYNC_MAX).

Results at 64K jobs:
* `flux dump` at `--maxreqs=128`: 89s -> 27s (~3.3x faster)
* `flux fsck`: 62s -> 12s (~5.2x faster)
