### PR TITLE
rc3: dump with --no-cache during offline garbage collection

### DIFF
--- a/etc/modprobe/rc3.py
+++ b/etc/modprobe/rc3.py
@@ -47,8 +47,8 @@ def content_dump(context):
 
     print(f"dumping content to {dumpfile}")
     context.bash(
-        "flux dump --sd-notify --quiet --ignore-failed-read --maxreqs=128 "
-        + f"--checkpoint {dumpfile}"
+        "flux dump --sd-notify --quiet --ignore-failed-read --no-cache "
+        + f"--maxreqs=128 --checkpoint {dumpfile}"
     )
     if dumplink:
         os.symlink(Path(dumpfile).name, dumplink)


### PR DESCRIPTION
Problem: The offline garbage collection path (content.dump=auto, used by flux shutdown `--gc`) runs flux-dump through the broker content cache. The dump reads each blob exactly once, so caching is pure overhead: every blob takes an extra hop (cache miss then backing store) and is then inserted into the cache, churning it over the entire store for no reuse.

Pass `--no-cache` so the dump reads straight from the backing store. The broker is shutting down, so the cache is discarded anyway. Measured ~2x faster at 64K jobs (28s -> 12s), with byte-identical dump output.

Note: I'm not sure if there's a reason `--no-cache` wasn't used in rc3 already. If there's an obvious reason I missed, I apologize and we can close this PR.