### PR TITLE
content-sqlite: add group commit to improve performance of bursty stores

### DIFF
--- a/etc/modprobe/rc1.py
+++ b/etc/modprobe/rc1.py
@@ -98,7 +98,12 @@ def restore(context):
         return
     print(f"restoring content from {dumpfile}")
     if dumpfile.exists():
-        cmd = f"flux restore --sd-notify --quiet --checkpoint --size-limit=100M {dumpfile}"
+        # Restore straight to the backing store with a wide request window to
+        # keep it busy (content-sqlite coalesces the burst into few commits).
+        cmd = (
+            "flux restore --sd-notify --quiet --checkpoint --size-limit=100M "
+            f"--no-cache --maxreqs=100000 {dumpfile}"
+        )
         context.bash(cmd)
         context.set("dump_restored", True)
     if dumplink and dumplink.exists():

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -126,6 +126,7 @@ const char *sql_count_sweep_candidates = "SELECT COUNT(*) FROM objects WHERE epo
 struct content_stats {
     tstat_t load;
     tstat_t store;
+    tstat_t batch;  // stores per group-committed transaction
 };
 
 struct content_sqlite {
@@ -341,6 +342,7 @@ static int batch_commit (struct content_sqlite *ctx)
         return -1;
     }
     ctx->in_batch = false;
+    tstat_push (&ctx->stats.batch, ctx->batch_count);
     ctx->batch_count = 0;
     batch_respond_pending (ctx, 0);
     return 0;
@@ -651,6 +653,7 @@ void store_cb (flux_t *h,
     }
     p->msg = flux_msg_incref (msg);
     list_add_tail (&ctx->batch_pending, &p->list);
+    ctx->batch_count++;
     tstat_push (&ctx->stats.store, monotime_since (t0));
 
     /* Commit when the burst drains (opportunistic), or a ceiling is hit.
@@ -662,7 +665,7 @@ void store_cb (flux_t *h,
      * never drains.
      */
     bool drained = !(flux_pollevents (h) & FLUX_POLLIN);
-    if (drained || ++ctx->batch_count >= BATCH_COUNT_MAX) {
+    if (drained || ctx->batch_count >= BATCH_COUNT_MAX) {
         if (batch_commit (ctx) < 0)
             flux_log_error (h, "store: batch commit failed");
     }
@@ -1019,6 +1022,7 @@ void stats_get_cb (flux_t *h,
     flux_error_t error;
     json_t *load_time = NULL;
     json_t *store_time = NULL;
+    json_t *batch_size = NULL;
     json_t *checkpoints = NULL;
 
     if (sqlite3_exec (ctx->db,
@@ -1031,7 +1035,8 @@ void stats_get_cb (flux_t *h,
         goto error;
     }
     if (!(load_time = pack_tstat (&ctx->stats.load))
-        || !(store_time = pack_tstat (&ctx->stats.store)))
+        || !(store_time = pack_tstat (&ctx->stats.store))
+        || !(batch_size = pack_tstat (&ctx->stats.batch)))
         goto error;
     if (!(checkpoints = stats_checkpoints (ctx, &error))) {
         errmsg = error.text;
@@ -1039,20 +1044,23 @@ void stats_get_cb (flux_t *h,
     }
     if (flux_respond_pack (h,
                            msg,
-                           "{s:I s:I s:I s:I s:O s:O s:{s:s s:s} s:O}",
+                           "{s:I s:I s:I s:I s:O s:O s:O s:{s:s s:s s:f} s:O}",
                            "object_count", count,
                            "current_epoch", ctx->current_epoch,
                            "dbfile_size", get_file_size (ctx->dbfile),
                            "dbfile_free", get_fs_free (ctx->dbfile),
                            "load_time", load_time,
                            "store_time", store_time,
+                           "batch_size", batch_size,
                            "config",
                              "journal_mode", ctx->journal_mode,
                              "synchronous", ctx->synchronous,
+                             "batch_timeout", ctx->batch_timeout,
                            "checkpoints", checkpoints) < 0)
         flux_log_error (h, "error responding to stats-get request");
     json_decref (load_time);
     json_decref (store_time);
+    json_decref (batch_size);
     json_decref (checkpoints);
     return;
 error:
@@ -1060,6 +1068,7 @@ error:
         flux_log_error (h, "error responding to stats-get request");
     json_decref (load_time);
     json_decref (store_time);
+    json_decref (batch_size);
     json_decref (checkpoints);
 }
 

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -29,9 +29,11 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libutil/tstat.h"
 #include "src/common/libutil/monotime.h"
+#include "src/common/libutil/fsd.h"
 #include "src/common/libkvs/kvs_checkpoint.h"
 
 #include "src/common/libcontent/content-util.h"
+#include "src/common/libccan/ccan/list/list.h"
 #include "ccan/str/str.h"
 
 const size_t lzo_buf_chunksize = 1024*1024;
@@ -148,6 +150,50 @@ struct content_sqlite {
     int max_checkpoints;
     bool truncate;
     int64_t current_epoch;
+
+    /* Group commit: when batch_timeout > 0, store inserts are grouped into
+     * an explicit transaction to amortize per-commit WAL overhead across
+     * many blobs. A store request is NOT answered until the transaction
+     * that includes it has committed, preserving content's guarantee that a
+     * store response implies the blob is durable.  Responses for all stores
+     * in a batch are therefore held on batch_pending and sent together by
+     * batch_commit().
+     *
+     * Grouping is opportunistic: the open batch is committed as soon as no
+     * more store requests are queued behind the current one
+     * (flux_pollevents), i.e. the burst has drained.  Under a sustained
+     * burst (e.g. flux-restore) stores pile into large transactions, while
+     * an isolated runtime store commits at once with no durability lag (no
+     * delay is ever added to wait for a batch to fill).  Two ceilings bound
+     * a batch that would otherwise never drain:
+     *  - batch_timeout seconds since the batch opened (bounds response
+     *  latency and WAL growth under a continuous burst), - BATCH_COUNT_MAX
+     *  stores accumulated (hard WAL-growth safety cap),
+     * plus boundaries: checkpoint-put and shutdown.
+     */
+    int batch_count;    // stores in the currently open transaction
+    bool in_batch;      // an explicit transaction is open
+    double batch_timeout;  // >0 enables group commit; max open-batch age
+    flux_watcher_t *batch_timer;  // one-shot, armed while a batch is open
+    struct list_head batch_pending; // store responses awaiting commit
+};
+
+/* Hard ceiling on stores per group-committed transaction if a burst never
+ * lets the recv queue drain.  Not user-tunable: the opportunistic drain check
+ * and batch_timeout are the normal commit triggers; this only caps a
+ * pathological continuous burst.  Note this bounds the store count, not bytes:
+ * batch_timeout is the primary bound on how long WAL growth can accumulate.
+ */
+#define BATCH_COUNT_MAX 65536
+
+/* A store request whose response is deferred until its batch commits. 'hash'
+ * is the computed blobref to return (always ctx->hash_size bytes); 'msg' is
+ * the borrowed request (ref held).
+ */
+struct pending_store {
+    struct list_node list;
+    const flux_msg_t *msg;
+    uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
 };
 
 static int set_config (char **conf, const char *val)
@@ -223,6 +269,92 @@ static void set_errno_from_sqlite_error (struct content_sqlite *ctx)
             errno = EINVAL;
             break;
     }
+}
+
+/* Begin an explicit write transaction for group-committed stores, and arm the
+ * timeout so the batch cannot stay open indefinitely when stores arrive
+ * slowly (which would keep blobs non-durable and grow the WAL unbounded).
+ */
+static int batch_begin (struct content_sqlite *ctx)
+{
+    if (sqlite3_exec (ctx->db, "BEGIN", NULL, NULL, NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "batch: BEGIN");
+        set_errno_from_sqlite_error (ctx);
+        return -1;
+    }
+    ctx->in_batch = true;
+    ctx->batch_count = 0;
+    if (ctx->batch_timer) {
+        flux_timer_watcher_reset (ctx->batch_timer, ctx->batch_timeout, 0.);
+        flux_watcher_start (ctx->batch_timer);
+    }
+    return 0;
+}
+
+static void pending_store_destroy (struct pending_store *p)
+{
+    if (p) {
+        int saved_errno = errno;
+        flux_msg_decref (p->msg);
+        free (p);
+        errno = saved_errno;
+    }
+}
+
+/* Answer every deferred store response held for the just-completed batch.
+ * On success each gets its blobref; on failure each gets 'errnum'.
+ */
+static void batch_respond_pending (struct content_sqlite *ctx, int errnum)
+{
+    struct pending_store *p;
+
+    while ((p = list_pop (&ctx->batch_pending, struct pending_store, list))) {
+        if (errnum == 0) {
+            if (flux_respond_raw (ctx->h, p->msg, p->hash, ctx->hash_size) < 0)
+                flux_log_error (ctx->h, "store: flux_respond_raw");
+        }
+        else {
+            if (flux_respond_error (ctx->h, p->msg, errnum, NULL) < 0)
+                flux_log_error (ctx->h, "store: flux_respond_error");
+        }
+        pending_store_destroy (p);
+    }
+}
+
+/* Commit the open group-commit transaction, if any, disarm the timeout,
+ * and only then answer the deferred store responses (a response must not
+ * precede the durable commit).  Called on the size cap, at boundaries
+ * (checkpoint-put, shutdown), and from the batch timeout.
+ */
+static int batch_commit (struct content_sqlite *ctx)
+{
+    if (!ctx->in_batch)
+        return 0;
+    if (ctx->batch_timer)
+        flux_watcher_stop (ctx->batch_timer);
+    if (sqlite3_exec (ctx->db, "COMMIT", NULL, NULL, NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "batch: COMMIT");
+        set_errno_from_sqlite_error (ctx);
+        ctx->in_batch = false;
+        ctx->batch_count = 0;
+        batch_respond_pending (ctx, errno); // commit failed: fail them all
+        return -1;
+    }
+    ctx->in_batch = false;
+    ctx->batch_count = 0;
+    batch_respond_pending (ctx, 0);
+    return 0;
+}
+
+/* Batch timeout: commit whatever has accumulated so it doesn't age further. */
+static void batch_timer_cb (flux_reactor_t *r,
+                            flux_watcher_t *w,
+                            int revents,
+                            void *arg)
+{
+    struct content_sqlite *ctx = arg;
+    if (batch_commit (ctx) < 0)
+        flux_log_error (ctx->h, "batch: timed commit failed");
 }
 
 static int grow_lzo_buf (struct content_sqlite *ctx, size_t size)
@@ -473,6 +605,7 @@ void store_cb (flux_t *h,
     size_t size;
     uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
     int hash_size;
+    struct pending_store *p;
     struct timespec t0;
 
     if (flux_request_decode_raw (msg, NULL, &data, &size) < 0) {
@@ -480,15 +613,59 @@ void store_cb (flux_t *h,
         goto error;
     }
     monotime (&t0);
-    if ((hash_size = content_sqlite_store (ctx,
-                                           data,
-                                           size,
-                                           hash,
-                                           sizeof (hash))) < 0)
+    /* Unbatched: store and respond immediately (the store is durable per the
+     * synchronous/journal_mode settings once the autocommit returns).
+     */
+    if (ctx->batch_timeout == 0.) {
+        if ((hash_size = content_sqlite_store (ctx,
+                                               data,
+                                               size,
+                                               hash,
+                                               sizeof (hash))) < 0)
+            goto error;
+        tstat_push (&ctx->stats.store, monotime_since (t0));
+        if (flux_respond_raw (h, msg, hash, hash_size) < 0)
+            flux_log_error (h, "store: flux_respond_raw");
+        return;
+    }
+    /* Batched: run the INSERT inside an open transaction and defer the
+     * response until batch_commit() makes the blob durable (see policy at
+     * struct content_sqlite).
+     */
+    if (!ctx->in_batch) {
+        if (batch_begin (ctx) < 0)
+            goto error;
+    }
+    if (!(p = calloc (1, sizeof (*p))))
         goto error;
+    if (content_sqlite_store (ctx, data, size, p->hash, sizeof (p->hash)) < 0) {
+        /* This store failed; fail it directly.  Earlier stores in the batch
+         * are valid, so commit them (releasing their deferred responses)
+         * rather than losing the open transaction.
+         */
+        int saved_errno = errno;
+        pending_store_destroy (p);
+        (void)batch_commit (ctx);
+        errno = saved_errno;
+        goto error;
+    }
+    p->msg = flux_msg_incref (msg);
+    list_add_tail (&ctx->batch_pending, &p->list);
     tstat_push (&ctx->stats.store, monotime_since (t0));
-    if (flux_respond_raw (h, msg, hash, hash_size) < 0)
-        flux_log_error (h, "store: flux_respond_raw");
+
+    /* Commit when the burst drains (opportunistic), or a ceiling is hit.
+     * The deferred responses are released by batch_commit().  FLUX_POLLIN
+     * on our handle means another request is already queued behind this
+     * one, so the burst has not drained yet and the batch keeps growing.
+     * This per-store check keeps an isolated store from waiting for the
+     * timeout; the timeout and BATCH_COUNT_MAX bound the batch if the queue
+     * never drains.
+     */
+    bool drained = !(flux_pollevents (h) & FLUX_POLLIN);
+    if (drained || ++ctx->batch_count >= BATCH_COUNT_MAX) {
+        if (batch_commit (ctx) < 0)
+            flux_log_error (h, "store: batch commit failed");
+    }
     return;
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
@@ -607,6 +784,12 @@ void checkpoint_put_cb (flux_t *h,
                              NULL,
                              "{s:o}",
                              "value", &o) < 0)
+        goto error;
+    /* Flush any pending group-committed stores before recording a checkpoint
+     * that may reference them, so the checkpoint is never durable ahead of its
+     * blobs.
+     */
+    if (batch_commit (ctx) < 0)
         goto error;
     if (!(value = json_dumps (o, JSON_COMPACT))) {
         errstr = "failed to encode checkpoint value";
@@ -733,6 +916,8 @@ static void content_sqlite_closedb (struct content_sqlite *ctx)
 {
     if (ctx) {
         int saved_errno = errno;
+        /* Commit any pending group-committed stores before teardown. */
+        (void)batch_commit (ctx);
         if (ctx->validate_stmt) {
             if (sqlite3_finalize (ctx->validate_stmt) != SQLITE_OK)
                 log_sqlite_error (ctx, "sqlite_finalize validate_stmt");
@@ -935,6 +1120,14 @@ static void mark_cb (flux_t *h,
         goto error;
     }
 
+    /* Flush any pending group-committed stores first.  The mark below opens
+     * its own transaction (SQLite has no nested transactions, so a BEGIN would
+     * otherwise fail), and the UPDATE must see the just-stored blobs it may be
+     * asked to mark.
+     */
+    if (batch_commit (ctx) < 0)
+        goto error;
+
     /* Wrap the batch in a single transaction.  In autocommit mode each
      * sqlite3_step() below would be its own implicit transaction, so a mark of
      * N hashes would incur N commits (N WAL-frame appends and fsync-class
@@ -1111,6 +1304,13 @@ static void sweep_cb (flux_t *h,
         errno = ENOMEM;
         goto error;
     }
+
+    /* Flush any pending group-committed stores first, so the select scans and
+     * the delete below run against committed table state (and the delete's own
+     * BEGIN does not fail -- SQLite has no nested transactions).
+     */
+    if (batch_commit (ctx) < 0)
+        goto error;
 
     /* Collect the batch of garbage rowids first, then delete them.  Draining
      * the SELECT fully before issuing any DELETE avoids modifying the table
@@ -1689,6 +1889,7 @@ static void content_sqlite_destroy (struct content_sqlite *ctx)
     if (ctx) {
         int saved_errno = errno;
         flux_msg_handler_delvec (ctx->handlers);
+        flux_watcher_destroy (ctx->batch_timer);
         free (ctx->dbfile);
         free (ctx->lzo_buf);
         free (ctx->hashfun);
@@ -1774,6 +1975,8 @@ static struct content_sqlite *content_sqlite_create (flux_t *h)
     if (set_config (&ctx->synchronous, "NORMAL") < 0)
         goto error;
     ctx->max_checkpoints = MAX_CHECKPOINTS_DEFAULT;
+    ctx->batch_timeout = 0.1;   // enable group commit by default (0 disables)
+    list_head_init (&ctx->batch_pending);
 
     /* Some tunables:
      * - the hash function, e.g. sha1, sha256
@@ -1856,15 +2059,23 @@ static int process_config (struct content_sqlite *ctx,
     const char *journal_mode = NULL;
     const char *synchronous = NULL;
     int tmp_max_checkpoints = ctx->max_checkpoints;
+    const char *batch_timeout = NULL;
 
     if (flux_conf_unpack (conf,
                           &error,
-                          "{s?{s?s s?s s?i}}",
+                          "{s?{s?s s?s s?i s?s}}",
                           "content-sqlite",
                             "journal_mode", &journal_mode,
                             "synchronous", &synchronous,
-                            "max_checkpoints", &tmp_max_checkpoints) < 0) {
+                            "max_checkpoints", &tmp_max_checkpoints,
+                            "batch_timeout", &batch_timeout) < 0) {
         flux_log_error (ctx->h, "%s", error.text);
+        return -1;
+    }
+    if (batch_timeout && fsd_parse_duration (batch_timeout,
+                                             &ctx->batch_timeout) < 0) {
+        flux_log (ctx->h, LOG_ERR, "invalid content-sqlite.batch_timeout");
+        errno = EINVAL;
         return -1;
     }
     if (journal_mode) {
@@ -1934,6 +2145,15 @@ static int process_args (struct content_sqlite *ctx,
             }
             ctx->max_checkpoints = tmp_max_checkpoints;
         }
+        else if (strstarts (argv[i], "batch-timeout=")) {
+            double tmp;
+            if (fsd_parse_duration (argv[i] + 14, &tmp) < 0) {
+                flux_log (ctx->h, LOG_ERR, "invalid batch-timeout specified");
+                errno = EINVAL;
+                return -1;
+            }
+            ctx->batch_timeout = tmp;
+        }
         else if (streq ("truncate", argv[i])) {
             *truncate = true;
         }
@@ -1961,6 +2181,19 @@ int mod_main (flux_t *h, int argc, char **argv)
         goto done;
     if (process_args (ctx, argc, argv, &truncate) < 0)
         goto done;
+    /* Create the batch timeout watcher only when group commit is enabled;
+     * the NULL batch_timer otherwise signals batching is off.
+     */
+    if (ctx->batch_timeout > 0.
+        && !(ctx->batch_timer = flux_timer_watcher_create (
+                                        flux_get_reactor (h),
+                                        ctx->batch_timeout,
+                                        0.,
+                                        batch_timer_cb,
+                                        ctx))) {
+        flux_log_error (h, "flux_timer_watcher_create");
+        goto done;
+    }
     if (content_sqlite_opendb (ctx, truncate) < 0)
         goto done;
     if (content_sqlite_table_exists (ctx, "checkpt", &exists) < 0

--- a/src/modules/content/cache.c
+++ b/src/modules/content/cache.c
@@ -524,10 +524,19 @@ error:
  */
 static void cache_resume_flush (struct content_cache *cache)
 {
-    if (cache->acct_dirty == 0 || (cache->rank == 0 && !cache->backing))
+    if (cache->acct_dirty == 0 || (cache->rank == 0 && !cache->backing)) {
         flush_respond (cache);
-    else
-        (void)cache_flush (cache); /* resume flushing, subject to limits */
+        return;
+    }
+    (void)cache_flush (cache); /* resume flushing, subject to limits */
+    /* If no stores remain in progress yet dirty entries linger, no further
+     * store completion will arrive to drive a parked flush: the lingering
+     * entries had their stores fail (e.g. ENOSPC) and are not requeued for
+     * retry.  Respond now (flush_respond reports the sticky error) rather
+     * than leave the flush request hanging.
+     */
+    if (cache->flush_batch_count == 0)
+        flush_respond (cache);
 }
 
 static void cache_store_continuation (flux_future_t *f, void *arg)
@@ -561,8 +570,17 @@ static void cache_store_continuation (flux_future_t *f, void *arg)
         goto error;
     }
     cache_entry_dirty_clear (cache, e);
-    /* clear flush errno if backing store functional/recovered */
-    cache->flush_errno = 0;
+    /* Clear flush errno only once the cache is fully clean. A single store
+     * success does not prove the backing store recovered: a backing module
+     * that group-commits (content-sqlite) can fail a large transaction on
+     * ENOSPC, freeing space so a later, smaller store succeeds even though
+     * the earlier entries failed and remain dirty. Clearing on that success
+     * would drop the sticky error while dirty entries linger, so a subsequent
+     * content.flush would neither flush them nor report the error -- it would
+     * hang (see the flush_errno guard in content_flush_request()).
+     */
+    if (cache->acct_dirty == 0)
+        cache->flush_errno = 0;
     flux_future_destroy (f);
     cache_resume_flush (cache);
     return;
@@ -907,9 +925,16 @@ static void flush_respond (struct content_cache *cache)
                                   "flush");
     }
     else {
-        errno = EIO;
-        if (cache->rank == 0 && !cache->backing)
+        /* Dirty entries remain.  Prefer the recorded backing-store error
+         * (e.g. ENOSPC) so the caller sees the true cause; fall back to
+         * ENOSYS with no backing store, else EIO.
+         */
+        if (cache->flush_errno)
+            errno = cache->flush_errno;
+        else if (cache->rank == 0 && !cache->backing)
             errno = ENOSYS;
+        else
+            errno = EIO;
         request_list_respond_error (&cache->flush_requests,
                                     cache->h,
                                     errno,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -500,6 +500,7 @@ check_PROGRAMS = \
 	loop/issue2337 \
 	loop/issue2711 \
 	kvs/content-spam \
+	kvs/content-gc-race \
 	kvs/torture \
 	kvs/dtree \
 	kvs/blobref \
@@ -696,6 +697,11 @@ kvs_content_spam_SOURCES = kvs/content-spam.c
 kvs_content_spam_CPPFLAGS = $(test_cppflags)
 kvs_content_spam_LDADD = $(test_ldadd)
 kvs_content_spam_LDFLAGS = $(test_ldflags)
+
+kvs_content_gc_race_SOURCES = kvs/content-gc-race.c
+kvs_content_gc_race_CPPFLAGS = $(test_cppflags)
+kvs_content_gc_race_LDADD = $(test_ldadd)
+kvs_content_gc_race_LDFLAGS = $(test_ldflags)
 
 kvs_torture_SOURCES = kvs/torture.c
 kvs_torture_CPPFLAGS = $(test_cppflags)

--- a/t/kvs/content-gc-race.c
+++ b/t/kvs/content-gc-race.c
@@ -1,0 +1,147 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* content-gc-race MODE
+ *
+ * Regression test for the interaction between content-sqlite group commit
+ * and the online-GC mark/sweep primitives.  Group commit holds an explicit
+ * sqlite transaction open across a burst of store requests; mark and sweep
+ * each open their own transaction, so they must first flush any open batch
+ * (SQLite has no nested transactions, and the GC pass must see committed
+ * table state).
+ *
+ * A shell test using the one-shot 'rpc' tool cannot exercise this: each
+ * request drains the module recv queue before the next arrives, so a batch
+ * is never open when mark/sweep runs.  Here we pipeline a burst of stores
+ * followed immediately by a mark or sweep on a single handle -- all requests
+ * are sent before any response is collected -- so the mark/sweep lands while
+ * the store batch is still open.
+ *
+ * MODE is "mark" or "sweep".  Exit 0 if the GC RPC and every store succeed;
+ * nonzero (promptly, via bounded waits) otherwise.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/blobref.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libcontent/content.h"
+#include "ccan/str/str.h"
+
+/* Enough in-flight requests that the store batch is still open when the
+ * trailing mark/sweep is processed, but small enough to run in milliseconds.
+ */
+#define BURST 200
+
+/* Bound every wait so a reintroduced bug (which leaves the batch open and its
+ * deferred store responses unsent) fails in seconds instead of hanging.
+ */
+#define WAIT_TIMEOUT 10.
+
+static void get_or_die (flux_future_t *f, const char *what)
+{
+    if (flux_future_wait_for (f, WAIT_TIMEOUT) < 0)
+        log_msg_exit ("%s: timed out (batch left uncommitted?)", what);
+    if (flux_rpc_get (f, NULL) < 0)
+        log_err_exit ("%s", what);
+}
+
+int main (int ac, char *av[])
+{
+    flux_t *h;
+    const char *hashfun;
+    const char *mode;
+    flux_future_t *fstore[BURST];
+    flux_future_t *fgc;
+    char data[64];
+    char blobref[BLOBREF_MAX_STRING_SIZE];
+    int i;
+
+    if (ac != 2 || (!streq (av[1], "mark") && !streq (av[1], "sweep")))
+        log_msg_exit ("Usage: content-gc-race mark|sweep");
+    mode = av[1];
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+    if (!(hashfun = flux_attr_get (h, "content.hash")))
+        log_err_exit ("getattr content.hash");
+
+    /* Blobref of the first blob in the burst, computed locally so the mark
+     * request can be built without waiting for the store response.
+     */
+    snprintf (data, sizeof (data), "gc-race seq=0");
+    if (blobref_hash (hashfun,
+                      data,
+                      strlen (data),
+                      blobref,
+                      sizeof (blobref)) < 0)
+        log_err_exit ("blobref_hash");
+
+    /* Fire the store burst without collecting responses, so all requests
+     * queue on the module and a group-commit batch stays open.
+     */
+    for (i = 0; i < BURST; i++) {
+        snprintf (data, sizeof (data), "gc-race seq=%d", i);
+        if (!(fstore[i] = content_store (h, data, strlen (data), 0)))
+            log_err_exit ("content_store seq=%d", i);
+    }
+
+    /* Queue the GC RPC behind the burst, while the batch is still open. */
+    if (streq (mode, "mark")) {
+        if (!(fgc = flux_rpc_pack (h,
+                                   "content-backing.mark",
+                                   FLUX_NODEID_ANY,
+                                   0,
+                                   "{s:I s:[s]}",
+                                   "epoch", (json_int_t)1,
+                                   "hashes", blobref)))
+            log_err_exit ("mark rpc");
+    }
+    else {
+        /* Sweep everything below epoch 1 in a single generous window.  The
+         * burst is stamped at epoch 0 (no checkpoint taken), so it is all
+         * sweep-eligible; the point is that the sweep runs against committed
+         * state after flushing the open batch, not the delete count itself.
+         */
+        if (!(fgc = flux_rpc_pack (h,
+                                   "content-backing.sweep",
+                                   FLUX_NODEID_ANY,
+                                   0,
+                                   "{s:I s:I s:I s:i s:i}",
+                                   "epoch", (json_int_t)1,
+                                   "cursor", (json_int_t)0,
+                                   "high_water", (json_int_t)INT64_MAX,
+                                   "delete_cap", 1000000,
+                                   "window", 1000000)))
+            log_err_exit ("sweep rpc");
+    }
+
+    /* Collect: the GC RPC must succeed, and so must every deferred store
+     * (batch_commit within the GC handler releases their responses).
+     */
+    get_or_die (fgc, mode);
+    flux_future_destroy (fgc);
+    for (i = 0; i < BURST; i++) {
+        get_or_die (fstore[i], "store");
+        flux_future_destroy (fstore[i]);
+    }
+
+    flux_close (h);
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -303,6 +303,70 @@ test_expect_success 'invalid config fails (synchronous)' '
 	rm content-sqlite.toml
 '
 
+#
+# Group commit (batch-timeout)
+#
+test_expect_success 'group commit is enabled by default with a bounded timeout' '
+	flux start -Sbroker.rc1_path= -Sbroker.rc3_path= \
+	    "flux module load content; \
+	    flux module load content-sqlite; \
+	    flux module stats content-sqlite; \
+	    flux module remove content-sqlite; \
+	    flux module remove content" >batch_default.out &&
+	jq -e ".config.batch_timeout > 0.0" <batch_default.out &&
+	jq -e ".config.batch_timeout <= 1.0" <batch_default.out
+'
+test_expect_success 'batch-timeout module option enables group commit' '
+	flux start -Sbroker.rc1_path= -Sbroker.rc3_path= \
+	    "flux module load content; \
+	    flux module load content-sqlite batch-timeout=10s; \
+	    flux module stats content-sqlite; \
+	    flux module remove content-sqlite; \
+	    flux module remove content" >batch_on.out &&
+	jq -e ".config.batch_timeout == 10.0" <batch_on.out
+'
+test_expect_success 'invalid batch-timeout module option fails' '
+	flux start -Sbroker.rc1_path= -Sbroker.rc3_path= \
+	    "flux module load content; \
+	    flux module load content-sqlite batch-timeout=foo; \
+	    flux module remove -f content-sqlite; \
+	    flux module remove content" 2>batch_bad.err &&
+	grep "content-sqlite: Invalid argument" batch_bad.err
+'
+test_expect_success 'batch_timeout config file works' '
+	cat >content-sqlite.toml <<-EOT &&
+	[content-sqlite]
+	batch_timeout = "0.25s"
+	EOT
+	flux start --config-path=$(pwd) \
+	    -Sbroker.rc1_path="$rc1_kvs" -Sbroker.rc3_path="$rc3_kvs" \
+	    flux module stats content-sqlite >batch_conf.out &&
+	jq -e ".config.batch_timeout == 0.25" <batch_conf.out &&
+	rm content-sqlite.toml
+'
+test_expect_success 'invalid batch_timeout config fails' '
+	cat >content-sqlite.toml <<-EOT &&
+	[content-sqlite]
+	batch_timeout = "foo"
+	EOT
+	test_must_fail flux start --config-path=$(pwd) \
+	    -Sbroker.rc1_path="$rc1_kvs" -Sbroker.rc3_path="$rc3_kvs" \
+	    flux module stats content-sqlite &&
+	rm content-sqlite.toml
+'
+test_expect_success 'reload content-sqlite with group commit enabled' '
+	flux module reload -f content-sqlite truncate batch-timeout=10s
+'
+test_expect_success 'concurrent stores are grouped into transactions' '
+	${SPAMUTIL} 500 200 >/dev/null &&
+	flux content flush &&
+	flux module stats content-sqlite >groupcommit.out &&
+	jq -e ".batch_size.count > 0" <groupcommit.out &&
+	jq -e ".batch_size.max > 1" <groupcommit.out
+'
+test_expect_success 'restore default group commit config for later tests' '
+	flux module reload -f content-sqlite
+'
 
 # Will create in WAL mode since statedir is set
 recreate_database()

--- a/t/t0043-content-sqlite-gc.t
+++ b/t/t0043-content-sqlite-gc.t
@@ -17,6 +17,7 @@ test_under_flux 1 minimal
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 BLOBREF=${FLUX_BUILD_DIR}/t/kvs/blobref
+GC_RACE=${FLUX_BUILD_DIR}/t/kvs/content-gc-race
 
 test_expect_success 'load content and content-sqlite modules' '
 	flux module load content &&
@@ -192,6 +193,31 @@ test_expect_success 'sweep below the new epoch keeps the re-stamped blob, drops 
 	test $(sweep_all 2) -eq 1 &&
 	test "$(flux content load --bypass-cache $(cat J.ref))" = "content-J" &&
 	test_must_fail flux content load --bypass-cache $(cat K.ref)
+'
+
+#
+# mark/sweep must flush an open group-commit batch
+#
+# Group commit holds a sqlite transaction open across a store burst; mark and
+# sweep open their own transaction and must flush that batch first (no nested
+# transactions, and the GC pass must see committed state).  content-gc-race
+# pipelines a store burst immediately followed by a mark/sweep on one handle,
+# so the GC RPC lands while the batch is still open -- something the one-shot
+# rpc tool cannot reproduce.  Run with a short batch timeout so the batch does
+# not simply age out before the GC request is processed.
+#
+
+test_expect_success 'reload content-sqlite with a long batch timeout' '
+	flux module reload content-sqlite truncate batch-timeout=60s
+'
+test_expect_success 'mark flushes an open group-commit batch' '
+	$GC_RACE mark
+'
+test_expect_success 'sweep flushes an open group-commit batch' '
+	$GC_RACE sweep
+'
+test_expect_success 'restore default content-sqlite config' '
+	flux module reload content-sqlite truncate
 '
 
 #


### PR DESCRIPTION
Problem: content-sqlite commits every blob in its own implicit transaction. Storing a large number of blobs in a burst — for example the offline `flux restore` of a restart dump with many inactive jobs — pays per-commit WAL overhead once per blob, which dominates the operation.

This PR adds opportunistic group commit to content-sqlite. When enabled, store INSERTs are grouped into a single explicit transaction, and a store request is not answered until that transaction is fully committed — preserving the guarantee that a store response implies the blob is durable.

A batch is committed as soon as no further store request is queued behind the current one, detected via `flux_pollevents()`:  `FLUX_POLLIN` on the module's handle means another request is already waiting, so the burst has not drained yet and the batch keeps growing. This makes grouping of INSERTs self-tuning — a sustained burst piles into a large transaction, while an isolated store commits immediately with no added latency (no delay is ever introduced to wait for a batch to fill).

Two limits are introduced to ensure an ever growing batch has an explicit ceiling:
- A `batch-timeout` (default 0.1s) puts an upper limit on the latency and growth of a batch
- An internal `BATCH_COUNT_MAX` sets a hard limit of the total number of stores in a batch

The 0.1s default for `batch-timeout` shows no impact on job throughput, but gives a large return for the flux-restore phase (with some caveats, see below)

Results:

These results are for a restart dump with 64K inactive jobs → 587,272 objects. `batch` stats are stores coalesced per
committed transaction, reported by `flux module stats content-sqlite`.

  | restore config | time | commits | mean/txn | max/txn |
  |---|---|---|---|---|
  | group commit off (baseline) | 50.3s | — | — | — |
  | **default** (0.1s, cached path) | 41.3s | 3,773 | 156 | 256 |
  | default + `--no-cache` | 43.2s | 10,112 | 64 | 256 |
  | `--no-cache --maxreqs=100000` | **17.8s** | 131 | 4,972 | 20,931 |

As shown above, simply enabling the group commit default already collapses 587K commits into a few thousand transactions on the normal path. On the cached path the content cache's flush window caps concurrency (max 256/txn). Bypassing the cache and using a large number of outstanding requests lets the backing store see the full burst and coalesce far more aggressively, improving the restore time by ~3x.

Therefore, in this PR, rc1 is adjusted to run `flux restore` with `--no-cache --maxreqs=100000` to get the full speedup.

Note: This PR is probably just a nice-to-have, as we already introduced a 1.5-2x speedup with the sliding store window on `flux restore` in #7701. Perturbing the content-sqlite module for gains only in `flux restore` is probably slightly questionable, and I'm unsure if the grouping will have any measurable effects outside of this one use case (maybe noticed a benefit in the throughput test _without_ real execution). So I won't be surprised if this one is met with some skepticism, especially if Flux won't need to restore on every restart with online GC.


