### PR TITLE
support `admin` role which allows users to bypass private mode permissions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,21 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([])], [
 ])
 LDFLAGS=$saved_LDFLAGS
 
+# ld --wrap is used by some unit tests to interpose libc functions.
+# It is a GNU ld/lld/gold feature; the macos linker does not support it.
+saved_LDFLAGS="$LDFLAGS"
+LDFLAGS="-Wl,--wrap=getpwnam_r $LDFLAGS"
+AC_MSG_CHECKING([whether ld supports --wrap])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([])], [
+  AC_MSG_RESULT([yes])
+  have_ld_wrap=yes
+  ],[
+  AC_MSG_RESULT([no])
+  have_ld_wrap=no
+])
+LDFLAGS=$saved_LDFLAGS
+AM_CONDITIONAL([HAVE_LD_WRAP], [test "x$have_ld_wrap" = xyes])
+
 LT_INIT
 AC_PROG_AWK
 

--- a/doc/man3/flux_msg_handler_allow_rolemask.rst
+++ b/doc/man3/flux_msg_handler_allow_rolemask.rst
@@ -38,6 +38,11 @@ FLUX_ROLE_OWNER
 FLUX_ROLE_USER
    Requests from users / guests can be matched.
 
+FLUX_ROLE_ADMIN
+   Requests from guests assigned the admin role (see
+   :man5:`flux-config-access`) are matched.  This role confers elevated
+   privilege beyond FLUX_ROLE_USER but less than FLUX_ROLE_OWNER.
+
 FLUX_ROLE_LOCAL
    Requests from the same broker as the receiver are matched.
 

--- a/doc/man5/flux-config-access.rst
+++ b/doc/man5/flux-config-access.rst
@@ -30,10 +30,43 @@ allow-root-owner
 private-mode
    (optional) Boolean value to limit visibility of job data to guests.
    When true, job queries from guests are limited to their own jobs and
-   aggregate job statistics are unavailable to them. The instance owner is
-   unaffected. This key is only meaningful when ``allow-guest-user`` is true.
-   If set to false or not present, guests may view all users' jobs.
+   aggregate job statistics are unavailable to them. The instance owner and
+   users with the ``admin`` role are unaffected. This key is only meaningful
+   when ``allow-guest-user`` is true.  If set to false or not present, guests
+   may view all users' jobs.
 
+roles
+   (optional) A table of named roles that assign elevated capabilities to
+   guests.  See `ROLES`_ below.  This key is only meaningful when
+   ``allow-guest-user`` is true.
+
+
+ROLES
+=====
+
+The ``access.roles`` table assigns supplemental roles to guest users based
+on user name and group membership.  Currently only the ``admin`` role is
+supported, which confers privileges beyond an ordinary guest but less than
+the instance owner.  Services may open selected operations to users with the
+``admin`` role.
+
+Each named role may contain the following keys:
+
+users
+   (optional) An array of user names that are assigned the role.
+
+groups
+   (optional) An array of group names whose members are assigned the role.
+
+User and group names are resolved at the time of connection.  A name that
+cannot be resolved is logged and ignored rather than causing a connection to
+fail.
+
+.. note::
+   Because these lookups are inline, a slow or stalled name service delays all
+   connection attempts.  A name that cannot be resolved fails closed and does
+   not compromise security, but administrators should ensure the name service
+   fails fast so that transient failures do not stall connections.
 
 EXAMPLE
 =======
@@ -44,6 +77,16 @@ EXAMPLE
    allow-guest-user = true
    allow-root-owner = true
    private-mode = true
+
+   [access.roles.admin]
+   users = [ "alice", "bob" ]
+   groups = [ "flux" ]
+
+If only configured by group, a one-line form may be used::
+
+   [access]
+   allow-guest-user = true
+   roles.admin.groups = [ "flux" ]
 
 
 RESOURCES

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1255,6 +1255,8 @@ static int roletostr (uint32_t role, const char *sep, char *buf, int buflen)
         n = snprintf (buf, buflen, "%suser", sep);
     else if (role == FLUX_ROLE_LOCAL)
         n = snprintf (buf, buflen, "%slocal", sep);
+    else if (role == FLUX_ROLE_ADMIN)
+        n = snprintf (buf, buflen, "%sadmin", sep);
     else
         n = snprintf (buf, buflen, "%s0x%x", sep, role);
     if (n >= buflen)

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -225,8 +225,16 @@ enum {
     FLUX_ROLE_OWNER = 1,
     FLUX_ROLE_USER = 2,
     FLUX_ROLE_LOCAL = 4,
+    FLUX_ROLE_ADMIN = 8,
     FLUX_ROLE_ALL = 0xFFFFFFFF,
 };
+
+/* Roles that are exempt from per-user access restrictions such as job
+ * private mode: the owner has full control and the admin role is granted
+ * elevated visibility (see RFC 12).
+ */
+#define FLUX_ROLE_PRIVILEGED (FLUX_ROLE_OWNER | FLUX_ROLE_ADMIN)
+
 int flux_msg_set_rolemask (flux_msg_t *msg, uint32_t rolemask);
 int flux_msg_get_rolemask (const flux_msg_t *msg, uint32_t *rolemask);
 

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -1163,7 +1163,7 @@ void check_print_rolemask (void)
     char *buf = NULL;
     size_t size = 0;
 
-    rolemask = FLUX_ROLE_LOCAL | FLUX_ROLE_USER | 0x10;
+    rolemask = FLUX_ROLE_LOCAL | FLUX_ROLE_USER | FLUX_ROLE_ADMIN | 0x10;
     if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST))
         || flux_msg_set_rolemask (msg, rolemask) < 0)
         BAIL_OUT ("failed to create test request");
@@ -1172,7 +1172,7 @@ void check_print_rolemask (void)
     flux_msg_fprint (fp, msg);
     fclose (fp); // close flushes content
     diag ("%s", buf);
-    ok (buf && strstr (buf, "rolemask=user,local,0x10") != NULL,
+    ok (buf && strstr (buf, "rolemask=user,local,admin,0x10") != NULL,
         "flux_msg_fprint() rolemask string is correct");
     free (buf);
     flux_msg_destroy (msg);

--- a/src/common/librouter/Makefile.am
+++ b/src/common/librouter/Makefile.am
@@ -57,6 +57,12 @@ TESTS = \
 	test_msg_hash.t \
 	test_rpc_track.t
 
+# test_roleconf_wrap uses ld --wrap to fake the passwd/group database, which
+# is not supported by all linkers (e.g. macos).  Built only where available.
+if HAVE_LD_WRAP
+TESTS += test_roleconf_wrap.t
+endif
+
 check_PROGRAMS = \
         $(TESTS)
 
@@ -106,6 +112,14 @@ test_roleconf_t_SOURCES = test/roleconf.c
 test_roleconf_t_CPPFLAGS = $(test_cppflags)
 test_roleconf_t_LDADD = $(test_ldadd)
 test_roleconf_t_LDFLAGS = $(test_ldflags)
+
+if HAVE_LD_WRAP
+test_roleconf_wrap_t_SOURCES = test/roleconf_wrap.c
+test_roleconf_wrap_t_CPPFLAGS = $(test_cppflags)
+test_roleconf_wrap_t_LDADD = $(test_ldadd)
+test_roleconf_wrap_t_LDFLAGS = $(test_ldflags) \
+	-Wl,--wrap=getpwnam_r,--wrap=getpwuid_r,--wrap=getgrnam_r
+endif
 
 test_usock_t_SOURCES = test/usock.c
 test_usock_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/librouter/Makefile.am
+++ b/src/common/librouter/Makefile.am
@@ -22,6 +22,8 @@ librouter_la_SOURCES = \
 	sendfd.c \
 	auth.c \
 	auth.h \
+	roleconf.c \
+	roleconf.h \
 	usock.c \
 	usock.h \
 	disconnect.h \

--- a/src/common/librouter/Makefile.am
+++ b/src/common/librouter/Makefile.am
@@ -45,6 +45,7 @@ TESTS = \
 	test_sendfd.t \
         test_disconnect.t \
 	test_auth.t \
+	test_roleconf.t \
 	test_usock.t \
 	test_usock_echo.t \
 	test_usock_epipe.t \
@@ -100,6 +101,11 @@ test_auth_t_SOURCES = test/auth.c
 test_auth_t_CPPFLAGS = $(test_cppflags)
 test_auth_t_LDADD = $(test_ldadd)
 test_auth_t_LDFLAGS = $(test_ldflags)
+
+test_roleconf_t_SOURCES = test/roleconf.c
+test_roleconf_t_CPPFLAGS = $(test_cppflags)
+test_roleconf_t_LDADD = $(test_ldadd)
+test_roleconf_t_LDFLAGS = $(test_ldflags)
 
 test_usock_t_SOURCES = test/usock.c
 test_usock_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/librouter/roleconf.c
+++ b/src/common/librouter/roleconf.c
@@ -1,0 +1,439 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* roleconf.c - assign supplemental message roles from [access.roles] config
+ *
+ * See roleconf.h for the configuration format and rationale.
+ *
+ * roleconf_create() parses [access.roles] and retains the configured user
+ * and group names.  roleconf_match() resolves them against the connecting
+ * uid inline, via the name service:
+ * - 'users': resolve each configured name with getpwnam_r(3) and compare.
+ * - 'groups': resolve the connecting uid's name with getpwuid_r(3), then
+ *   check each configured group's member list (gr_mem) with getgrnam_r(3).
+ *
+ * Cost is O(number of configured users + groups) name service lookups per
+ * call, independent of group size and of the total passwd/group database.
+ *
+ * Defensive rules:
+ * - "admin" is the only accepted role name; any other is a hard config error.
+ * - Unresolvable user/group names are logged and skipped, not fatal, so a
+ *   name service hiccup cannot wedge (re)configuration or deny in a way that
+ *   surprises.  A lookup failure always errs toward fewer privileges.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <grp.h>
+
+#define LLOG_SUBSYSTEM "roleconf"
+#include "roleconf.h"
+
+/* Name service scratch buffer sizing.  A stack buffer of NSS_BUFSIZE_INIT
+ * bytes serves the common case with no allocation; a passwd or group entry
+ * too large for it (e.g. a group with very many members) is retried with a
+ * heap buffer grown on ERANGE, up to NSS_BUFSIZE_MAX.
+ */
+#define NSS_BUFSIZE_INIT 4096
+#define NSS_BUFSIZE_MAX  (1024 * 1024)
+
+/* A configured role: the rolemask it confers and the configured user and
+ * group names (retained and resolved inline by roleconf_match()).
+ */
+struct role {
+    uint32_t mask;
+    json_t *users;              /* array of configured user name strings */
+    json_t *groups;             /* array of configured group name strings */
+};
+
+struct roleconf {
+    struct role *roles;
+    size_t roles_len;
+
+    llog_writer_f llog;
+    void *llog_data;
+};
+
+/* Map a [access.roles.<name>] key to the rolemask it confers.
+ * Returns FLUX_ROLE_NONE for an unknown name.
+ */
+static uint32_t role_name2mask (const char *name)
+{
+    if (name && strcmp (name, "admin") == 0)
+        return FLUX_ROLE_ADMIN;
+    return FLUX_ROLE_NONE;
+}
+
+/* Validate that 'o' is an array of strings.
+ * Returns 0 or -1 (EINVAL).
+ */
+static int check_string_array (json_t *o)
+{
+    size_t index;
+    json_t *val;
+
+    if (!json_is_array (o)) {
+        errno = EINVAL;
+        return -1;
+    }
+    json_array_foreach (o, index, val) {
+        if (!json_is_string (val)) {
+            errno = EINVAL;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* Grow the heap scratch buffer for an NSS retry: double *szp and reallocate
+ * *heapp to match, returning the new buffer, or NULL on allocation failure
+ * (*heapp is left intact for the caller to free).  Consolidates the realloc
+ * so the buffer-grow logic lives in exactly one place.
+ */
+static char *nss_buf_grow (char **bufp, size_t *szp)
+{
+    size_t newsz = *szp * 2;
+    char *tmp = realloc (*bufp, newsz);
+    if (!tmp)
+        return NULL;
+    *bufp = tmp;
+    *szp = newsz;
+    return tmp;
+}
+
+/* Look up 'name' in the user database and store its uid in '*uidp'.
+ *
+ * Uses the reentrant getpwnam_r(3) since broker modules run as threads
+ * sharing the process name service state.  Returns:
+ *    1  success ('*uidp' set)
+ *    0  no such user (or a name service error, which callers treat as such
+ *       so a lookup failure denies rather than grants privilege)
+ *   -1  local allocation failure (errno set)
+ *
+ * A stack buffer serves the common case; only an ERANGE result (entry too
+ * large) falls back to a grown heap buffer.
+ *
+ * N.B. POSIX specifies "not found" as return 0 with result==NULL, but real
+ * NSS backends may instead return e.g. ENOENT/ESRCH.  We therefore key off
+ * result==NULL for "not found" (and any error other than ERANGE), which
+ * yields a deny.
+ */
+static int lookup_uid_by_name (const char *name, uid_t *uidp)
+{
+    char stackbuf[NSS_BUFSIZE_INIT];
+    char *buf = stackbuf;
+    char *heapbuf = NULL;
+    size_t bufsize = sizeof (stackbuf);
+    struct passwd pwd;
+    struct passwd *result = NULL;
+    int rc = -1;
+
+    for (;;) {
+        int e = getpwnam_r (name, &pwd, buf, bufsize, &result);
+
+        if (e != ERANGE || bufsize >= NSS_BUFSIZE_MAX)
+            break;
+        if (!(buf = nss_buf_grow (&heapbuf, &bufsize)))
+            goto done;          /* allocation failure: rc stays -1 */
+    }
+    if (result) {
+        *uidp = result->pw_uid;
+        rc = 1;
+    }
+    else {
+        /* result==NULL means name not found or name service error
+         * return rc = 0
+         */
+        rc = 0;
+    }
+done:
+    free (heapbuf);
+    return rc;
+}
+
+/* Look up 'uid' in the user database and return a malloc'd copy of its login
+ * name, or NULL if not found or on error (the caller treats NULL as "matches
+ * no group").  Caller frees.  Uses the reentrant getpwuid_r(3).
+ *
+ * A stack buffer serves the common case; only an ERANGE result falls back to
+ * a grown heap buffer.
+ */
+static char *lookup_name_by_uid (uid_t uid)
+{
+    char stackbuf[NSS_BUFSIZE_INIT];
+    char *buf = stackbuf;
+    char *heapbuf = NULL;
+    size_t bufsize = sizeof (stackbuf);
+    struct passwd pwd;
+    struct passwd *result = NULL;
+    char *name = NULL;
+
+    for (;;) {
+        int e = getpwuid_r (uid, &pwd, buf, bufsize, &result);
+
+        if (e != ERANGE || bufsize >= NSS_BUFSIZE_MAX)
+            break;
+        if (!(buf = nss_buf_grow (&heapbuf, &bufsize)))
+            goto done;
+    }
+    if (result)
+        name = strdup (result->pw_name);
+done:
+    free (heapbuf);
+    return name;
+}
+
+/* Return true if 'username' is listed in the member list of 'group'.
+ * Unresolvable groups are logged and skipped (return false).
+ * Uses the reentrant getgrnam_r(3).
+ *
+ * Matching is by the group's member list (gr_mem); see roleconf.h.
+ */
+static bool user_in_group (struct roleconf *roleconf,
+                           const char *username,
+                           const char *group)
+{
+    char stackbuf[NSS_BUFSIZE_INIT];
+    char *buf = stackbuf;
+    char *heapbuf = NULL;
+    size_t bufsize = sizeof (stackbuf);
+    struct group grp;
+    struct group *result = NULL;
+    bool found = false;
+
+    for (;;) {
+        int e = getgrnam_r (group, &grp, buf, bufsize, &result);
+
+        if (e != ERANGE || bufsize >= NSS_BUFSIZE_MAX)
+            break;
+        if (!(buf = nss_buf_grow (&heapbuf, &bufsize)))
+            goto done;          /* allocation failure: deny */
+    }
+    if (!result) {              /* not found or name service error: skip */
+        llog_warning (roleconf,
+                      "[access.roles] ignoring unknown group '%s'",
+                      group ? group : "(null)");
+        goto done;
+    }
+    for (char **mem = result->gr_mem; mem && *mem; mem++) {
+        if (strcmp (*mem, username) == 0) {
+            found = true;
+            break;
+        }
+    }
+done:
+    free (heapbuf);
+    return found;
+}
+
+/* Return true if the configured 'users' list names 'uid'.
+ * Unresolvable user names are logged and skipped.
+ */
+static bool match_users (struct roleconf *roleconf,
+                         struct role *role,
+                         uid_t uid)
+{
+    size_t index;
+    json_t *val;
+
+    json_array_foreach (role->users, index, val) {
+        const char *name = json_string_value (val);
+        uid_t u;
+        int n = lookup_uid_by_name (name, &u);
+
+        if (n < 0)
+            return false;       /* allocation failure: deny */
+        if (n == 0) {
+            llog_warning (roleconf,
+                          "[access.roles] ignoring unknown user '%s'",
+                          name ? name : "(null)");
+            continue;
+        }
+        if (u == uid)
+            return true;
+    }
+    return false;
+}
+
+/* Return true if a configured group of 'role' lists 'username' as a member.
+ */
+static bool match_groups (struct roleconf *roleconf,
+                          struct role *role,
+                          const char *username)
+{
+    size_t index;
+    json_t *val;
+
+    json_array_foreach (role->groups, index, val) {
+        if (user_in_group (roleconf, username, json_string_value (val)))
+            return true;
+    }
+    return false;
+}
+
+/* Parse one [access.roles.<name>] entry, retaining its configured names.
+ */
+static int parse_role (struct role *role,
+                       const char *name,
+                       json_t *entry,
+                       flux_error_t *errp)
+{
+    json_t *users = NULL;
+    json_t *groups = NULL;
+    json_error_t jerror;
+
+    if ((role->mask = role_name2mask (name)) == FLUX_ROLE_NONE) {
+        errprintf (errp, "unknown role '%s' in [access.roles]", name);
+        errno = EINVAL;
+        return -1;
+    }
+    if (json_unpack_ex (entry,
+                        &jerror,
+                        0,
+                        "{s?o s?o !}",
+                        "users", &users,
+                        "groups", &groups) < 0) {
+        errprintf (errp,
+                   "[access.roles.%s]: %s",
+                   name,
+                   jerror.text);
+        errno = EINVAL;
+        return -1;
+    }
+    if (users) {
+        if (check_string_array (users) < 0) {
+            errprintf (errp,
+                       "[access.roles.%s] users must be a string array",
+                       name);
+            errno = EINVAL;
+            return -1;
+        }
+        role->users = json_incref (users);
+    }
+    if (groups) {
+        if (check_string_array (groups) < 0) {
+            errprintf (errp,
+                       "[access.roles.%s] groups must be a string array",
+                       name);
+            errno = EINVAL;
+            return -1;
+        }
+        role->groups = json_incref (groups);
+    }
+    return 0;
+}
+
+static void role_fini (struct role *role)
+{
+    if (role) {
+        json_decref (role->users);
+        json_decref (role->groups);
+    }
+}
+
+struct roleconf *roleconf_create (json_t *roles,
+                                  llog_writer_f llog,
+                                  void *llog_data,
+                                  flux_error_t *errp)
+{
+    struct roleconf *roleconf;
+    const char *name;
+    json_t *entry;
+    size_t count;
+
+    if (!(roleconf = calloc (1, sizeof (*roleconf)))) {
+        errprintf (errp, "out of memory");
+        return NULL;
+    }
+    roleconf->llog = llog;
+    roleconf->llog_data = llog_data;
+
+    if (!roles || json_is_null (roles))
+        return roleconf;
+
+    if (!json_is_object (roles)) {
+        errprintf (errp, "[access.roles] must be a table");
+        errno = EINVAL;
+        goto error;
+    }
+    if ((count = json_object_size (roles)) == 0)
+        return roleconf;
+    if (!(roleconf->roles = calloc (count, sizeof (roleconf->roles[0])))) {
+        errprintf (errp, "out of memory");
+        goto error;
+    }
+    json_object_foreach (roles, name, entry) {
+        /* Count the slot before parsing so that a parse failure after a
+         * partial json_incref() is still cleaned up by roleconf_destroy().
+         */
+        struct role *role = &roleconf->roles[roleconf->roles_len++];
+        if (parse_role (role, name, entry, errp) < 0)
+            goto error;
+    }
+    return roleconf;
+error:
+    roleconf_destroy (roleconf);
+    return NULL;
+}
+
+void roleconf_destroy (struct roleconf *roleconf)
+{
+    if (roleconf) {
+        int saved_errno = errno;
+        for (size_t i = 0; i < roleconf->roles_len; i++)
+            role_fini (&roleconf->roles[i]);
+        free (roleconf->roles);
+        free (roleconf);
+        errno = saved_errno;
+    }
+}
+
+uint32_t roleconf_match (struct roleconf *roleconf, uid_t uid)
+{
+    uint32_t mask = FLUX_ROLE_NONE;
+    char *username = NULL;
+    bool username_resolved = false;
+
+    if (!roleconf)
+        return FLUX_ROLE_NONE;
+
+    for (size_t i = 0; i < roleconf->roles_len; i++) {
+        struct role *role = &roleconf->roles[i];
+
+        if ((mask & role->mask))        /* already granted */
+            continue;
+        if (match_users (roleconf, role, uid)) {
+            mask |= role->mask;
+            continue;
+        }
+        if (role->groups) {
+            /* Resolve the connecting uid's name once, lazily. */
+            if (!username_resolved) {
+                username = lookup_name_by_uid (uid);
+                username_resolved = true;
+            }
+            if (username && match_groups (roleconf, role, username))
+                mask |= role->mask;
+        }
+    }
+    free (username);
+    return mask;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/librouter/roleconf.h
+++ b/src/common/librouter/roleconf.h
@@ -1,0 +1,80 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _ROUTER_ROLECONF_H
+#define _ROUTER_ROLECONF_H
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/llog.h"
+
+/* roleconf: assign supplemental message roles to guest connections based
+ * on the connecting user's uid, as configured in the [access.roles] table.
+ *
+ * Only the "admin" role (FLUX_ROLE_ADMIN) is currently supported, e.g.
+ *
+ *   [access.roles.admin]
+ *   users = ["alice", "bob"]
+ *   groups = ["flux"]
+ *
+ * The configured user and group names are retained and resolved against the
+ * connecting uid inline by roleconf_match(), via the name service.  There is
+ * no caching: membership changes take effect on the next connection.
+ *
+ * N.B. group matching tests only the group's member list (struct group
+ * gr_mem), i.e. the members listed for the group in the group database.
+ * A user matches a group if listed in that group's member list, which for
+ * a user's primary group is commonly the case.
+ *
+ * This module is deliberately kept free of message, connection, and reactor
+ * details so that it may be unit tested in isolation.
+ */
+
+struct roleconf;
+
+/* Create a roleconf from the value of the [access.roles] table, which may
+ * be NULL when unconfigured (matches nothing). 'roles' is only accessed
+ * during this call; the caller retains ownership. The configured names are
+ * copied but not resolved until roleconf_match() is called.
+ *
+ * 'llog' (optional, may be NULL) and 'llog_data' receive warning messages
+ * about unresolvable users/groups (emitted from roleconf_match()). Pass
+ * flux_llog / a flux_t handle to route these to the broker log.
+ *
+ * Returns a new object on success, or NULL with errno set and 'errp'
+ * filled in on error (e.g. malformed config).
+ */
+struct roleconf *roleconf_create (json_t *roles,
+                                  llog_writer_f llog,
+                                  void *llog_data,
+                                  flux_error_t *errp);
+
+void roleconf_destroy (struct roleconf *roleconf);
+
+/* Return the supplemental rolemask (e.g. FLUX_ROLE_ADMIN) to be added to
+ * the credential of a guest connecting with the given 'uid', or
+ * FLUX_ROLE_NONE (0) if the uid matches no configured role.
+ *
+ * This resolves the configured users and groups against 'uid' via the name
+ * service (getpwnam_r/getpwuid_r/getgrnam_r), costing O(configured users +
+ * groups) lookups.  'roleconf' may be NULL, in which case FLUX_ROLE_NONE is
+ * returned.
+ */
+uint32_t roleconf_match (struct roleconf *roleconf, uid_t uid);
+
+#endif /* !_ROUTER_ROLECONF_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/librouter/test/roleconf.c
+++ b/src/common/librouter/test/roleconf.c
@@ -1,0 +1,321 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <grp.h>
+#include <string.h>
+#include <errno.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/librouter/roleconf.h"
+
+/* Test fixtures resolved from the running user, so the test is portable:
+ * these names are guaranteed to resolve.
+ */
+static uid_t my_uid;
+static const char *my_user;
+
+/* A group whose member list (gr_mem) contains my_user, or NULL if none could
+ * be found.  roleconf matches on gr_mem, so the positive group tests are
+ * skipped when this is NULL (e.g. in a minimal container).
+ */
+static const char *my_memb_group;
+
+/* Return true if group 'gr' lists 'user' in its member list. */
+static bool group_has_member (struct group *gr, const char *user)
+{
+    for (char **mem = gr->gr_mem; mem && *mem; mem++) {
+        if (strcmp (*mem, user) == 0)
+            return true;
+    }
+    return false;
+}
+
+/* Find a group that lists my_user in its member list by scanning the
+ * group database.  Sets my_memb_group (strdup'd) or leaves it NULL.  Uses
+ * getgrent(3) rather than getgrouplist(3), whose signature differs between
+ * glibc (gid_t *) and BSD/macos (int *).
+ */
+static void find_membership_group (void)
+{
+    struct group *gr;
+
+    setgrent ();
+    while ((gr = getgrent ())) {
+        if (group_has_member (gr, my_user)) {
+            my_memb_group = strdup (gr->gr_name);
+            break;
+        }
+    }
+    endgrent ();
+}
+
+static void get_ids (void)
+{
+    struct passwd *pw;
+
+    my_uid = getuid ();
+    if (!(pw = getpwuid (my_uid)))
+        BAIL_OUT ("getpwuid(%ju) failed", (uintmax_t)my_uid);
+    if (!(my_user = strdup (pw->pw_name)))
+        BAIL_OUT ("out of memory");
+    find_membership_group ();
+    diag ("running as user=%s(%ju) membership-group=%s",
+          my_user, (uintmax_t)my_uid, my_memb_group ? my_memb_group : "(none)");
+}
+
+/* Build a [access.roles] table object from a JSON pattern. */
+static json_t *roles (const char *fmt, ...)
+{
+    json_error_t error;
+    json_t *o;
+    va_list ap;
+
+    va_start (ap, fmt);
+    o = json_vpack_ex (&error, 0, fmt, ap);
+    va_end (ap);
+    if (!o)
+        BAIL_OUT ("json_pack: %s", error.text);
+    return o;
+}
+
+static void test_null_and_empty (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o;
+
+    ok (roleconf_match (NULL, my_uid) == FLUX_ROLE_NONE,
+        "roleconf_match rc=NULL returns FLUX_ROLE_NONE");
+
+    rc = roleconf_create (NULL, NULL, NULL, &error);
+    ok (rc != NULL,
+        "roleconf_create roles=NULL works");
+    ok (roleconf_match (rc, my_uid) == FLUX_ROLE_NONE,
+        "roleconf_match on empty config returns FLUX_ROLE_NONE");
+    roleconf_destroy (rc);
+
+    o = json_object ();
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc != NULL && roleconf_match (rc, my_uid) == FLUX_ROLE_NONE,
+        "roleconf_create with empty table matches nothing");
+    roleconf_destroy (rc);
+    json_decref (o);
+}
+
+static void test_admin_by_user (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o;
+
+    o = roles ("{s:{s:[s]}}", "admin", "users", my_user);
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc != NULL,
+        "roleconf_create admin users=[me] works");
+    ok (rc && roleconf_match (rc, my_uid) == FLUX_ROLE_ADMIN,
+        "roleconf_match returns FLUX_ROLE_ADMIN for configured user");
+    ok (rc && roleconf_match (rc, my_uid + 1) == FLUX_ROLE_NONE,
+        "roleconf_match returns FLUX_ROLE_NONE for other user");
+    roleconf_destroy (rc);
+    json_decref (o);
+}
+
+/* The same user listed more than once must still match. */
+static void test_duplicate_user (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o;
+
+    o = roles ("{s:{s:[s,s,s]}}",
+               "admin",
+               "users", my_user, my_user, my_user);
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc && roleconf_match (rc, my_uid) == FLUX_ROLE_ADMIN,
+        "duplicate user entries still match");
+    roleconf_destroy (rc);
+    json_decref (o);
+}
+
+static void test_admin_by_group (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o;
+
+    skip (my_memb_group == NULL,
+          2,
+          "no group lists this user as a member");
+    o = roles ("{s:{s:[s]}}", "admin", "groups", my_memb_group);
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc != NULL,
+        "roleconf_create admin groups=[mygroup] works");
+    ok (rc && roleconf_match (rc, my_uid) == FLUX_ROLE_ADMIN,
+        "roleconf_match returns FLUX_ROLE_ADMIN via group membership");
+    roleconf_destroy (rc);
+    json_decref (o);
+    end_skip;
+}
+
+static void test_users_and_groups (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o;
+
+    skip (my_memb_group == NULL,
+          1,
+          "no group lists this user as a member");
+    /* Both users and groups configured; either avenue grants the role. */
+    o = roles ("{s:{s:[s] s:[s]}}",
+               "admin",
+               "users", my_user,
+               "groups", my_memb_group);
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc && roleconf_match (rc, my_uid) == FLUX_ROLE_ADMIN,
+        "admin with both users and groups grants admin");
+    roleconf_destroy (rc);
+    json_decref (o);
+    end_skip;
+}
+
+static void test_unknown_names_skipped (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o;
+
+    /* A bogus user alongside a valid one: bogus is skipped, valid matches. */
+    o = roles ("{s:{s:[s,s]}}",
+               "admin",
+               "users", "nonexistent-user-xyzzy", my_user);
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc != NULL,
+        "roleconf_create succeeds despite unknown user name");
+    ok (rc && roleconf_match (rc, my_uid) == FLUX_ROLE_ADMIN,
+        "valid user still matches when listed with an unknown one");
+    roleconf_destroy (rc);
+    json_decref (o);
+
+    /* Only a bogus group: config loads, matches nothing. */
+    o = roles ("{s:{s:[s]}}",
+               "admin",
+               "groups", "nonexistent-group-xyzzy");
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc != NULL,
+        "roleconf_create succeeds despite unknown group name");
+    ok (rc && roleconf_match (rc, my_uid) == FLUX_ROLE_NONE,
+        "unknown group grants nothing");
+    roleconf_destroy (rc);
+    json_decref (o);
+}
+
+static void test_bad_config (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o;
+
+    /* Unknown role name is a hard error. */
+    o = roles ("{s:{s:[s]}}", "operator", "users", my_user);
+    errno = 0;
+    error.text[0] = '\0';
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc == NULL && errno == EINVAL,
+        "roleconf_create fails with EINVAL on unknown role name");
+    diag ("%s", error.text);
+    json_decref (o);
+
+    /* Unknown key within a role is a hard error. */
+    o = roles ("{s:{s:[s]}}", "admin", "userz", my_user);
+    errno = 0;
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc == NULL && errno == EINVAL,
+        "roleconf_create fails with EINVAL on unknown role key");
+    diag ("%s", error.text);
+    json_decref (o);
+
+    /* users must be an array of strings. */
+    o = roles ("{s:{s:i}}", "admin", "users", 42);
+    errno = 0;
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc == NULL && errno == EINVAL,
+        "roleconf_create fails with EINVAL when users is not an array");
+    diag ("%s", error.text);
+    json_decref (o);
+
+    o = roles ("{s:{s:[i]}}", "admin", "users", 42);
+    errno = 0;
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc == NULL && errno == EINVAL,
+        "roleconf_create fails with EINVAL on non-string user entry");
+    diag ("%s", error.text);
+    json_decref (o);
+
+    /* groups must be an array of strings (distinct code path from users). */
+    o = roles ("{s:{s:i}}", "admin", "groups", 42);
+    errno = 0;
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc == NULL && errno == EINVAL,
+        "roleconf_create fails with EINVAL when groups is not an array");
+    diag ("%s", error.text);
+    json_decref (o);
+
+    o = roles ("{s:{s:[i]}}", "admin", "groups", 42);
+    errno = 0;
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc == NULL && errno == EINVAL,
+        "roleconf_create fails with EINVAL on non-string group entry");
+    diag ("%s", error.text);
+    json_decref (o);
+
+    /* roles table that is not an object. */
+    o = json_string ("nope");
+    errno = 0;
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc == NULL && errno == EINVAL,
+        "roleconf_create fails with EINVAL when roles is not a table");
+    diag ("%s", error.text);
+    json_decref (o);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    get_ids ();
+
+    test_null_and_empty ();
+    test_admin_by_user ();
+    test_duplicate_user ();
+    test_admin_by_group ();
+    test_users_and_groups ();
+    test_unknown_names_skipped ();
+    test_bad_config ();
+
+    free ((char *)my_user);
+    free ((char *)my_memb_group);
+
+    done_testing ();
+
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/librouter/test/roleconf_wrap.c
+++ b/src/common/librouter/test/roleconf_wrap.c
@@ -1,0 +1,369 @@
+/************************************************************\
+ * Copyright 2026 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* roleconf_wrap.c - roleconf tests against a faked passwd/group database
+ *
+ * The real getpwnam_r(3)/getpwuid_r(3)/getgrnam_r(3) are interposed at link
+ * time via ld --wrap (see Makefile.am), so these tests run against a fully
+ * controlled in-memory database rather than the host's.  This makes
+ * group-based role resolution deterministic and, in particular, lets us
+ * verify that adding or removing a user from the admin group immediately
+ * changes FLUX_ROLE_ADMIN on the next roleconf_match().
+ *
+ * N.B. ld --wrap is not portable (e.g. the macos linker lacks it), so this
+ * test is only built where configure detects support.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <string.h>
+#include <errno.h>
+#include <pwd.h>
+#include <grp.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/librouter/roleconf.h"
+
+/* Fake user database: name -> uid.  NULL-name sentinel terminates. */
+struct fake_user {
+    const char *name;
+    uid_t uid;
+};
+
+static struct fake_user fake_users[] = {
+    { "alice", 1001 },
+    { "bob",   1002 },
+    { "carol", 1003 },
+    { NULL,    0 },
+};
+
+/* Fake admin group membership: a NULL-terminated, mutable member list.
+ * Tests rewrite this vector to simulate membership changes, which take
+ * effect on the next roleconf_match() (no refresh step).
+ */
+static char *admin_members[8] = { "alice", "bob", NULL };
+
+#define ADMIN_GID 5000
+
+/* When nonzero, the wrapped lookups below return ERANGE unless 'buflen' is at
+ * least this many bytes, forcing roleconf's ERANGE buffer-grow path.  Set by
+ * test_erange_grow() and reset to 0 afterward.
+ */
+static size_t erange_min_buflen = 0;
+
+/* --- interposed libc functions (see ld --wrap in Makefile.am) --- */
+
+extern int __real_getpwnam_r (const char *name,
+                              struct passwd *pwd,
+                              char *buf,
+                              size_t buflen,
+                              struct passwd **result);
+
+int __wrap_getpwnam_r (const char *name,
+                       struct passwd *pwd,
+                       char *buf,
+                       size_t buflen,
+                       struct passwd **result)
+{
+    if (buflen < erange_min_buflen) {
+        *result = NULL;
+        return ERANGE;
+    }
+    for (struct fake_user *u = fake_users; u->name; u++) {
+        if (strcmp (u->name, name) == 0) {
+            pwd->pw_name = (char *)u->name;
+            pwd->pw_uid = u->uid;
+            pwd->pw_gid = u->uid;
+            *result = pwd;
+            return 0;
+        }
+    }
+    *result = NULL;             /* not found */
+    return 0;
+}
+
+extern int __real_getpwuid_r (uid_t uid,
+                              struct passwd *pwd,
+                              char *buf,
+                              size_t buflen,
+                              struct passwd **result);
+
+int __wrap_getpwuid_r (uid_t uid,
+                       struct passwd *pwd,
+                       char *buf,
+                       size_t buflen,
+                       struct passwd **result)
+{
+    if (buflen < erange_min_buflen) {
+        *result = NULL;
+        return ERANGE;
+    }
+    for (struct fake_user *u = fake_users; u->name; u++) {
+        if (u->uid == uid) {
+            pwd->pw_name = (char *)u->name;
+            pwd->pw_uid = u->uid;
+            pwd->pw_gid = u->uid;
+            *result = pwd;
+            return 0;
+        }
+    }
+    *result = NULL;             /* not found */
+    return 0;
+}
+
+extern int __real_getgrnam_r (const char *name,
+                              struct group *grp,
+                              char *buf,
+                              size_t buflen,
+                              struct group **result);
+
+int __wrap_getgrnam_r (const char *name,
+                       struct group *grp,
+                       char *buf,
+                       size_t buflen,
+                       struct group **result)
+{
+    if (buflen < erange_min_buflen) {
+        *result = NULL;
+        return ERANGE;
+    }
+    if (strcmp (name, "admins") == 0) {
+        grp->gr_name = "admins";
+        grp->gr_gid = ADMIN_GID;
+        grp->gr_mem = admin_members;
+        *result = grp;
+        return 0;
+    }
+    *result = NULL;             /* not found */
+    return 0;
+}
+
+/* --- helpers --- */
+
+static json_t *admin_group_config (void)
+{
+    json_error_t error;
+    json_t *o = json_pack_ex (&error, 0,
+                              "{s:{s:[s]}}", "admin", "groups", "admins");
+    if (!o)
+        BAIL_OUT ("json_pack: %s", error.text);
+    return o;
+}
+
+static void test_group_membership (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o = admin_group_config ();
+
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc != NULL,
+        "roleconf_create with faked admin group works");
+    ok (rc && roleconf_match (rc, 1001) == FLUX_ROLE_ADMIN,
+        "alice (member) gets FLUX_ROLE_ADMIN");
+    ok (rc && roleconf_match (rc, 1002) == FLUX_ROLE_ADMIN,
+        "bob (member) gets FLUX_ROLE_ADMIN");
+    ok (rc && roleconf_match (rc, 1003) == FLUX_ROLE_NONE,
+        "carol (non-member) gets FLUX_ROLE_NONE");
+
+    roleconf_destroy (rc);
+    json_decref (o);
+}
+
+/* Adding a member to the group grants admin on the next match, with no
+ * refresh step (roleconf resolves membership inline).
+ */
+static void test_membership_add (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o = admin_group_config ();
+
+    admin_members[0] = "alice";
+    admin_members[1] = NULL;    /* group = { alice } */
+
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc && roleconf_match (rc, 1002) == FLUX_ROLE_NONE,
+        "bob is not admin before being added to the group");
+
+    admin_members[1] = "bob";
+    admin_members[2] = NULL;
+    ok (rc && roleconf_match (rc, 1002) == FLUX_ROLE_ADMIN,
+        "bob becomes admin immediately after being added");
+
+    roleconf_destroy (rc);
+    json_decref (o);
+}
+
+/* Removing a member revokes admin on the next match. */
+static void test_membership_remove (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o = admin_group_config ();
+
+    admin_members[0] = "alice";
+    admin_members[1] = "bob";
+    admin_members[2] = NULL;    /* group = { alice, bob } */
+
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc && roleconf_match (rc, 1002) == FLUX_ROLE_ADMIN,
+        "bob is admin before removal");
+
+    admin_members[1] = NULL;    /* group = { alice } */
+    ok (rc && roleconf_match (rc, 1002) == FLUX_ROLE_NONE,
+        "bob loses admin immediately after removal");
+    ok (rc && roleconf_match (rc, 1001) == FLUX_ROLE_ADMIN,
+        "alice retains admin after bob's removal");
+
+    roleconf_destroy (rc);
+    json_decref (o);
+}
+
+/* A gr_mem entry that does not match the connecting user's name is simply
+ * not a match; it must not disturb the other members' matches.
+ */
+static void test_extra_group_member (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o = admin_group_config ();
+
+    admin_members[0] = "alice";
+    admin_members[1] = "carol";   /* a member who never connects here */
+    admin_members[2] = "bob";
+    admin_members[3] = NULL;
+
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc && roleconf_match (rc, 1001) == FLUX_ROLE_ADMIN,
+        "alice matches despite an unrelated member in the list");
+    ok (rc && roleconf_match (rc, 1002) == FLUX_ROLE_ADMIN,
+        "bob (listed after the unrelated member) still matches");
+
+    roleconf_destroy (rc);
+    json_decref (o);
+}
+
+/* A connecting uid with no passwd entry cannot be resolved to a name, so it
+ * matches no group and is denied (fail closed).
+ */
+static void test_unknown_connecting_uid (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o = admin_group_config ();
+
+    admin_members[0] = "alice";
+    admin_members[1] = NULL;
+
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc && roleconf_match (rc, 9999) == FLUX_ROLE_NONE,
+        "uid with no passwd entry is denied the group role");
+
+    roleconf_destroy (rc);
+    json_decref (o);
+}
+
+/* A uid present in both users= and the admin group matches. */
+static void test_user_and_group_dedup (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_error_t jerror;
+    json_t *o;
+
+    admin_members[0] = "alice";
+    admin_members[1] = "bob";
+    admin_members[2] = NULL;
+
+    /* alice appears both explicitly and via the group. */
+    o = json_pack_ex (&jerror, 0,
+                      "{s:{s:[s] s:[s]}}",
+                      "admin",
+                      "users", "alice",
+                      "groups", "admins");
+    if (!o)
+        BAIL_OUT ("json_pack: %s", jerror.text);
+
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc && roleconf_match (rc, 1001) == FLUX_ROLE_ADMIN,
+        "uid listed in both users and group still matches");
+    ok (rc && roleconf_match (rc, 1002) == FLUX_ROLE_ADMIN,
+        "group-only member matches alongside the duplicated user");
+
+    roleconf_destroy (rc);
+    json_decref (o);
+}
+
+/* Force the ERANGE buffer-grow path: the wrapped lookups return ERANGE until
+ * the buffer exceeds the initial (stack) size, so roleconf must grow onto the
+ * heap and retry.  The result must be identical to the non-grow case.
+ * 20000 bytes forces two doublings (4096 -> 8192 -> 16384), so the retry
+ * realloc()s an already-heap-allocated buffer; run under valgrind this
+ * confirms the grow path neither leaks nor corrupts.
+ */
+static void test_erange_grow (void)
+{
+    struct roleconf *rc;
+    flux_error_t error;
+    json_t *o;
+
+    admin_members[0] = "alice";
+    admin_members[1] = NULL;
+
+    erange_min_buflen = 20000;
+
+    /* users= path exercises getpwnam_r grow */
+    o = json_pack_ex (NULL, 0, "{s:{s:[s]}}", "admin", "users", "alice");
+    if (!o)
+        BAIL_OUT ("json_pack failed");
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc && roleconf_match (rc, 1001) == FLUX_ROLE_ADMIN,
+        "users match works when getpwnam_r requires a grown buffer");
+    ok (rc && roleconf_match (rc, 1003) == FLUX_ROLE_NONE,
+        "users non-match works when getpwnam_r requires a grown buffer");
+    roleconf_destroy (rc);
+    json_decref (o);
+
+    /* groups= path exercises getpwuid_r + getgrnam_r grow */
+    o = admin_group_config ();
+    rc = roleconf_create (o, NULL, NULL, &error);
+    ok (rc && roleconf_match (rc, 1001) == FLUX_ROLE_ADMIN,
+        "group match works when getpwuid_r/getgrnam_r require a grown buffer");
+    roleconf_destroy (rc);
+    json_decref (o);
+
+    erange_min_buflen = 0;
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_group_membership ();
+    test_membership_add ();
+    test_membership_remove ();
+    test_extra_group_member ();
+    test_unknown_connecting_uid ();
+    test_user_and_group_dedup ();
+    test_erange_grow ();
+
+    done_testing ();
+
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -33,6 +33,7 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/librouter/usock.h"
 #include "src/common/librouter/router.h"
+#include "src/common/librouter/roleconf.h"
 #include "src/broker/module.h"
 
 enum {
@@ -47,6 +48,7 @@ struct connector_local {
     uid_t instance_owner;
     int allow_guest_user;
     int allow_root_owner;
+    struct roleconf *roleconf;
     flux_msg_handler_t **handlers;
 };
 
@@ -74,13 +76,16 @@ static int client_authenticate (struct connector_local *ctx,
         goto error;
     }
     /* Assign roles based on connecting uid and configured policy.
+     * The owner role confers maximum privilege, so supplemental roles from
+     * [access.roles] are only considered for guests.  This also keeps the
+     * common owner-connection path free of any name service lookups.
      */
     if (cuid == ctx->instance_owner)
         rolemask = FLUX_ROLE_OWNER;
     else if (ctx->allow_root_owner && cuid == 0)
         rolemask = FLUX_ROLE_OWNER;
     else if (ctx->allow_guest_user)
-        rolemask = FLUX_ROLE_USER;
+        rolemask = FLUX_ROLE_USER | roleconf_match (ctx->roleconf, cuid);
 
     if (rolemask == FLUX_ROLE_NONE) {
         flux_log (ctx->h,
@@ -209,6 +214,10 @@ error:
  * private-mode = true
  *   Restrict guests to viewing only their own jobs (consumed by job-list).
  *
+ * roles = { admin = { users = [...], groups = [...] } }
+ *   Assign supplemental roles (currently only FLUX_ROLE_ADMIN) to guests
+ *   based on uid and group membership.  Parsed by librouter/roleconf.
+ *
  * Missing [access] keys are interpreted as false.
  * [access] keys other than the above are not allowed.
  */
@@ -220,22 +229,34 @@ static int parse_config (struct connector_local *ctx,
     int allow_guest_user = 0;
     int allow_root_owner = 0;
     int private_mode = 0;       /* unused here; validated for job-list */
+    json_t *roles = NULL;
+    struct roleconf *roleconf;
 
     if (flux_conf_unpack (conf,
                           &error,
-                          "{s?{s?b s?b s?b !}}",
+                          "{s?{s?b s?b s?b s?o !}}",
                           "access",
                             "allow-guest-user",
                             &allow_guest_user,
                             "allow-root-owner",
                             &allow_root_owner,
                             "private-mode",
-                            &private_mode) < 0) {
+                            &private_mode,
+                            "roles",
+                            &roles) < 0) {
         errprintf (errp,
                    "error parsing [access] configuration: %s",
                    error.text);
         return -1;
     }
+    /* Build the new roleconf before committing any change, so a bad
+     * [access.roles] table leaves the running configuration untouched.
+     */
+    if (!(roleconf = roleconf_create (roles, flux_llog, ctx->h, errp)))
+        return -1;
+
+    roleconf_destroy (ctx->roleconf);
+    ctx->roleconf = roleconf;
     ctx->allow_guest_user = allow_guest_user;
     ctx->allow_root_owner = allow_root_owner;
     flux_log (ctx->h,
@@ -393,6 +414,7 @@ done:
     flux_msg_handler_delvec (ctx.handlers);
     usock_server_destroy (ctx.server); // destroy before router
     router_destroy (ctx.router);
+    roleconf_destroy (ctx.roleconf);
     return rc;
 }
 

--- a/src/modules/job-list/auth.c
+++ b/src/modules/job-list/auth.c
@@ -87,7 +87,10 @@ int job_auth_config_reload (struct job_auth *auth,
 static bool job_auth_restricted (struct job_auth *auth,
                                  struct flux_msg_cred cred)
 {
-    return auth->private_mode && !(cred.rolemask & FLUX_ROLE_OWNER);
+    /* Privileged roles (owner and admin) are exempt from private mode: both
+     * may view all users' jobs.  All other guests are limited to their own.
+     */
+    return auth->private_mode && !(cred.rolemask & FLUX_ROLE_PRIVILEGED);
 }
 
 bool job_auth_msg_restricted (struct job_auth *auth, const flux_msg_t *msg)

--- a/src/modules/job-list/auth.h
+++ b/src/modules/job-list/auth.h
@@ -38,7 +38,7 @@ int job_auth_config_reload (struct job_auth *auth,
 
 /* Return true if request msg must be restricted to their own jobs:
  * i.e. private mode enabled and msg credential cannot be obtained or
- * lacks FLUX_ROLE_OWNER.
+ * lacks a privileged role (FLUX_ROLE_OWNER or FLUX_ROLE_ADMIN).
  */
 bool job_auth_msg_restricted (struct job_auth *auth, const flux_msg_t *msg);
 

--- a/src/modules/job-list/test/auth.c
+++ b/src/modules/job-list/test/auth.c
@@ -23,6 +23,9 @@ static struct flux_msg_cred owner = { .userid = 1000,
                                       .rolemask = FLUX_ROLE_OWNER };
 static struct flux_msg_cred guest = { .userid = 1234,
                                       .rolemask = FLUX_ROLE_USER };
+static struct flux_msg_cred admin = { .userid = 5678,
+                                      .rolemask = FLUX_ROLE_USER
+                                                | FLUX_ROLE_ADMIN };
 
 /* Verify constraint is {"userid":[<uid>]} */
 static int is_userid_constraint (json_t *c, int uid)
@@ -42,6 +45,7 @@ int main (int argc, char *argv[])
     struct match_ctx *mctx;
     flux_msg_t *msg_owner = NULL;
     flux_msg_t *msg_guest = NULL;
+    flux_msg_t *msg_admin = NULL;
     flux_conf_t *conf;
     flux_error_t error;
     json_t *o;
@@ -60,12 +64,14 @@ int main (int argc, char *argv[])
     ok (true, "job_auth_create works with no [access] config");
 
     if (!(msg_owner = flux_msg_create (FLUX_MSGTYPE_REQUEST))
-        || !(msg_guest = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        || !(msg_guest = flux_msg_create (FLUX_MSGTYPE_REQUEST))
+        || !(msg_admin = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
         BAIL_OUT ("flux_msg_create failed");
 
     ok (flux_msg_set_cred (msg_owner, owner) == 0
-        && flux_msg_set_cred (msg_guest, guest) == 0,
-        "add owner and guest credentials to test request messages");
+        && flux_msg_set_cred (msg_guest, guest) == 0
+        && flux_msg_set_cred (msg_admin, admin) == 0,
+        "add owner, guest, and admin credentials to test request messages");
 
     errno = 0;
     ok (job_auth_msg_restricted (auth, NULL) && errno == EINVAL,
@@ -76,6 +82,8 @@ int main (int argc, char *argv[])
         "job_auth_msg_restricted: owner not restricted when private mode off");
     ok (!job_auth_msg_restricted (auth, msg_guest),
         "job_auth_msg_restricted: guest not restricted when private mode off");
+    ok (!job_auth_msg_restricted (auth, msg_admin),
+        "job_auth_msg_restricted: admin not restricted when private mode off");
 
     o = (json_t *)&error; /* non-NULL sentinel */
     ok (job_auth_constraint (auth, msg_guest, &o, &error) == 0 && o == NULL,
@@ -114,10 +122,16 @@ int main (int argc, char *argv[])
         "job_auth_msg_restricted: owner allowed with private mode enabled");
     ok (job_auth_msg_restricted (auth, msg_guest),
         "job_auth_msg_restricted: guest restricted with private mode enabled");
+    ok (!job_auth_msg_restricted (auth, msg_admin),
+        "job_auth_msg_restricted: admin allowed with private mode enabled");
 
     o = (json_t *)&error; /* non-NULL sentinel */
     ok (job_auth_constraint (auth, msg_owner, &o, &error) == 0 && o == NULL,
         "owner gets no constraint when private mode is on");
+
+    o = (json_t *)&error; /* non-NULL sentinel */
+    ok (job_auth_constraint (auth, msg_admin, &o, &error) == 0 && o == NULL,
+        "admin gets no constraint when private mode is on");
 
     o = NULL;
     ok (job_auth_constraint (auth, msg_guest, &o, &error) == 0 && o != NULL,
@@ -132,9 +146,12 @@ int main (int argc, char *argv[])
         "job_auth_check_job: guest can see own job in private mode");
     ok (job_auth_check_job (auth, mctx, msg_guest, &owner_job, &error) == 0,
         "job_auth_check_job: guest cannot see other user's job in private mode");
+    ok (job_auth_check_job (auth, mctx, msg_admin, &owner_job, &error) == 1,
+        "job_auth_check_job: admin can see any job in private mode");
 
     flux_msg_destroy (msg_owner);
     flux_msg_destroy (msg_guest);
+    flux_msg_destroy (msg_admin);
     job_auth_destroy (auth);
     match_ctx_destroy (mctx);
     flux_close (h);

--- a/src/modules/job-manager/getattr.c
+++ b/src/modules/job-manager/getattr.c
@@ -112,7 +112,7 @@ void getattr_handle_request (flux_t *h,
         goto error;
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))
         && !(job = zhashx_lookup (ctx->inactive_jobs, &id))) {
-        if (ctx->private_mode && !(cred.rolemask & FLUX_ROLE_OWNER))
+        if (ctx->private_mode && !(cred.rolemask & FLUX_ROLE_PRIVILEGED))
             errno = EPERM;
         else {
             errstr = "unknown job";
@@ -120,7 +120,9 @@ void getattr_handle_request (flux_t *h,
         }
         goto error;
     }
-    /* Security: guests can only access their own jobs. In private mode,
+    /* Security: guests can only access their own jobs.  The admin role does
+     * not change this: it only exempts a guest from private mode (existence
+     * hiding above), not from per-job access control.  In private mode,
      * suppress the errstr so existence of the job is not revealed.
      */
     if (flux_msg_cred_authorize (cred, job->userid) < 0) {

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -54,7 +54,7 @@ void getinfo_handle_request (flux_t *h,
         goto error;
     if (flux_msg_get_cred (msg, &cred) < 0)
         goto error;
-    if (ctx->private_mode && !(cred.rolemask & FLUX_ROLE_OWNER)) {
+    if (ctx->private_mode && !(cred.rolemask & FLUX_ROLE_PRIVILEGED)) {
         errno = EPERM;
         goto error;
     }
@@ -93,7 +93,7 @@ static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     if (flux_msg_get_cred (msg, &cred) < 0)
         goto error;
-    if (ctx->private_mode && !(cred.rolemask & FLUX_ROLE_OWNER)) {
+    if (ctx->private_mode && !(cred.rolemask & FLUX_ROLE_PRIVILEGED)) {
         errno = EPERM;
         goto error;
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -411,6 +411,7 @@ dist_check_SCRIPTS = \
 	system/0005-exec.t \
 	system/0006-perilog.t \
 	system/0007-fsck.t \
+	system/0008-access-roles.t \
 	issues/t0441-kvs-put-get.sh \
 	issues/t0505-msg-handler-reg.lua \
 	issues/t0821-kvs-segfault.sh \

--- a/t/system/0008-access-roles.t
+++ b/t/system/0008-access-roles.t
@@ -1,0 +1,45 @@
+#
+#  Verify [access.roles] admin assignment end-to-end in a system instance.
+#
+#  The test runs as a guest (id -u != security.owner).  We reconfigure the
+#  running instance (as the instance owner, via sudo) to grant the admin role
+#  to this guest user, then verify the connector-local module stamps
+#  FLUX_ROLE_ADMIN (0x8) onto the guest's credential -- exercising the real
+#  client_authenticate() -> roleconf_match() path that cannot be reached from
+#  a single-user test instance.  The config is restored on completion so other
+#  system tests are unaffected.
+#
+#  Credential bits: FLUX_ROLE_USER=0x2, FLUX_ROLE_LOCAL=0x4, FLUX_ROLE_ADMIN=0x8
+#
+test_expect_success 'running as a guest (not the instance owner)' '
+	test $(flux getattr security.owner) -ne $(id -u)
+'
+test_expect_success 'guest is an ordinary user before admin role is configured' '
+	flux ping --count=1 --userid broker >ping-before.out &&
+	test_debug "cat ping-before.out" &&
+	grep -q "userid=$(id -u) rolemask=0x6" ping-before.out
+'
+test_expect_success 'configure admin role for this guest user' '
+	cleanup "sudo flux config reload" &&
+	flux config get |
+	    jq ".access.roles.admin.users = [\"$(id -un)\"]" |
+	    sudo flux config load &&
+	flux config get | jq .access
+'
+test_expect_success 'guest in admin role is assigned FLUX_ROLE_ADMIN' '
+	flux ping --count=1 --userid broker >ping-admin.out &&
+	test_debug "cat ping-admin.out" &&
+	grep -q "userid=$(id -u) rolemask=0xe" ping-admin.out
+'
+#
+#  A different guest (user1), not listed in the admin role, must still get an
+#  ordinary guest credential while the admin role is configured for us.
+#
+test_expect_success 'have a second guest user' '
+	sudo -u user1 id && test_set_prereq HAVE_USER1
+'
+test_expect_success HAVE_USER1 'other guest is not assigned admin' '
+	sudo -u user1 flux ping --count=1 --userid broker >ping-user1.out &&
+	test_debug "cat ping-user1.out" &&
+	grep -q "userid=$(id -u user1) rolemask=0x6" ping-user1.out
+'

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -88,6 +88,93 @@ test_expect_success 'connector-local restored private access policy' '
 	grep allow-guest-user=false dmesg6.out
 '
 
+test_expect_success 'connector-local accepts [access.roles.admin] users' '
+	cat >access.toml <<-EOT &&
+	[access]
+	allow-guest-user = true
+	[access.roles.admin]
+	users = [ "$(id -un)" ]
+	EOT
+	flux config reload
+'
+
+test_expect_success 'connector-local accepts admin groups one-liner' '
+	cat >access.toml <<-EOT &&
+	[access]
+	allow-guest-user = true
+	roles.admin.groups = [ "$(id -gn)" ]
+	EOT
+	flux config reload
+'
+
+test_expect_success 'connector-local tolerates unknown admin user name' '
+	cat >access.toml <<-EOT &&
+	[access]
+	allow-guest-user = true
+	[access.roles.admin]
+	users = [ "nosuchuser-xyzzy" ]
+	EOT
+	flux config reload
+'
+
+test_expect_success 'connector-local rejects unknown role name' '
+	cat >access.toml <<-EOT &&
+	[access]
+	allow-guest-user = true
+	[access.roles.operator]
+	users = [ "$(id -un)" ]
+	EOT
+	test_must_fail flux config reload 2>roles1.err &&
+	grep -i "unknown role" roles1.err
+'
+
+test_expect_success 'connector-local rejects unknown key in admin role' '
+	cat >access.toml <<-EOT &&
+	[access]
+	allow-guest-user = true
+	[access.roles.admin]
+	userz = [ "$(id -un)" ]
+	EOT
+	test_must_fail flux config reload
+'
+
+test_expect_success 'connector-local rejects non-array admin users' '
+	cat >access.toml <<-EOT &&
+	[access]
+	allow-guest-user = true
+	[access.roles.admin]
+	users = "$(id -un)"
+	EOT
+	test_must_fail flux config reload
+'
+
+# N.B. connector-local only applies [access.roles] to guest connections
+# (peer uid != instance owner).  A single-user test instance cannot make such
+# a connection (SO_PEERCRED reports the owner uid, and FLUX_HANDLE_ROLEMASK
+# spoofing is client-side and bypasses client_authenticate()).  The guest
+# credential-stamping path is covered end-to-end by the system test
+# t/system/0008-access-roles.t; here we only confirm that configuring an
+# admin role does not perturb the owner's own connection.
+test_expect_success 'owner rolemask unaffected by [access.roles.admin] config' '
+	cat >access.toml <<-EOT &&
+	[access]
+	allow-guest-user = true
+	[access.roles.admin]
+	users = [ "$(id -un)" ]
+	EOT
+	flux config reload &&
+	flux ping --count=1 --userid broker >ping-owner.out &&
+	grep -q "userid=$(id -u) rolemask=0x5" ping-owner.out
+'
+
+# Restore default policy so later tests are unaffected
+test_expect_success 'connector-local restored policy after roles tests' '
+	cat >access.toml <<-EOT &&
+	[access]
+	EOT
+	flux config reload
+'
+
 test_expect_success 'simulated local connector auth failure returns EPERM' '
 	flux getattr size &&
 	flux module debug --set 1 connector-local &&

--- a/t/t2263-job-list-private.t
+++ b/t/t2263-job-list-private.t
@@ -26,6 +26,12 @@ set_userid() {
 	export FLUX_HANDLE_ROLEMASK=0x2
 }
 
+# Simulate a guest that has been assigned the admin role (USER|ADMIN).
+set_admin() {
+	export FLUX_HANDLE_USERID=$1
+	export FLUX_HANDLE_ROLEMASK=0xa
+}
+
 unset_userid() {
 	unset FLUX_HANDLE_USERID
 	unset FLUX_HANDLE_ROLEMASK
@@ -108,6 +114,27 @@ test_expect_success 'private mode on: guest module stats fails (EPERM)' '
 test_expect_success 'private mode on: owner job-stats succeeds' '
 	flux jobs --stats >/dev/null &&
 	flux module stats job-list >/dev/null
+'
+test_expect_success 'private mode on: admin with non-owner uid sees all jobs' '
+	set_admin $other_uid &&
+	test_when_finished unset_userid &&
+	test $(count_jobs) -eq 2
+'
+test_expect_success 'private mode on: admin can list-id another user job' '
+	set_admin $other_uid &&
+	test_when_finished unset_userid &&
+	flux job list-ids $(cat ownerjob) >/dev/null
+'
+test_expect_success 'private mode on: admin job-stats succeeds' '
+	set_admin $other_uid &&
+	test_when_finished unset_userid &&
+	flux jobs --stats >/dev/null &&
+	flux module stats job-list >/dev/null
+'
+test_expect_success 'private mode on: admin --user=owner-uid returns owner jobs' '
+	set_admin $other_uid &&
+	test_when_finished unset_userid &&
+	test $(flux jobs -a -n -o "{id}" --user=$owner_uid | wc -l) -eq 2
 '
 test_expect_success 'disable private mode' '
 	disable_private_mode

--- a/t/t2264-job-manager-private.t
+++ b/t/t2264-job-manager-private.t
@@ -24,6 +24,12 @@ set_userid() {
 	export FLUX_HANDLE_ROLEMASK=0x2
 }
 
+# Simulate a guest that has been assigned the admin role (USER|ADMIN).
+set_admin() {
+	export FLUX_HANDLE_USERID=$1
+	export FLUX_HANDLE_ROLEMASK=0xa
+}
+
 unset_userid() {
 	unset FLUX_HANDLE_USERID
 	unset FLUX_HANDLE_ROLEMASK
@@ -131,6 +137,59 @@ test_expect_success FLUX_SECURITY 'private mode on: guest getattr on own job' '
 '
 test_expect_success 'private mode on: owner getattr succeeds' '
 	job_manager_getattr $(cat jobid_int.out) jobspec
+'
+test_expect_success 'private mode on: admin stats-get succeeds' '
+	set_admin $other_uid &&
+	test_when_finished unset_userid &&
+	flux module stats job-manager >/dev/null
+'
+test_expect_success 'private mode on: admin getinfo succeeds' '
+	set_admin $other_uid &&
+	test_when_finished unset_userid &&
+	job_manager_getinfo
+'
+test_expect_success 'private mode on: admin gets EINVAL for unknown job (not EPERM)' '
+	set_admin $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail job_manager_getattr 1 jobspec 2>admin-unknown.err &&
+	grep -i "unknown job" admin-unknown.err
+'
+# The admin role only exempts a guest from private mode (listing and stats);
+# it does not grant read access to another user's job data.
+test_expect_success 'private mode on: admin cannot getattr another user job' '
+	set_admin $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail job_manager_getattr $(cat jobid_int.out) jobspec
+'
+# The admin role confers elevated *visibility*, not write access: an admin
+# must not be able to mutate another user's job.  Use a running owner job so
+# the credential check is reached (inactive jobs fail earlier with ENOENT).
+test_expect_success 'submit a running owner job for admin mutate tests' '
+	sleepid=$(flux submit sleep 300) &&
+	flux job wait-event --timeout=20 $sleepid start
+'
+test_expect_success 'admin cannot cancel another user job' '
+	set_admin $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail flux cancel $sleepid 2>admin-cancel.err &&
+	grep -i "not permitted\|only.*their own" admin-cancel.err
+'
+test_expect_success 'admin cannot change urgency of another user job' '
+	set_admin $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail flux job urgency $sleepid 31 2>admin-urg.err &&
+	grep -i "not permitted\|only.*their own" admin-urg.err
+'
+test_expect_success 'admin cannot raise an exception on another user job' '
+	set_admin $other_uid &&
+	test_when_finished unset_userid &&
+	test_must_fail flux job raise --severity=0 --type=test $sleepid \
+		2>admin-raise.err &&
+	grep -i "not permitted\|only.*their own" admin-raise.err
+'
+test_expect_success 'cancel running owner job from admin mutate tests' '
+	flux cancel $sleepid &&
+	flux job wait-event --timeout=20 $sleepid clean
 '
 
 test_expect_success 'disable private mode' '


### PR DESCRIPTION
This PR adds the `admin` role for messages and a method to configure it in connector-local as described in #7686.
The role can be configured by user and/or group. The connector-local module caches the list of admin users by walking the groups on reconfig. The admin role membership is then refreshed at a configurable interval (15m by default). This keeps NSS lookups out of the connection hot path.

A new rolemask `FLUX_ROLE_PRIVILEGED` is added with `FLUX_ROLE_OWNER | FLUX_ROLE_ADMIN` and then the private mode controls in job-list and job-manager are extended to this rolemask.


Fixes #7686